### PR TITLE
fix: article header hide-on-scroll + onboarding compile errors

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -109,6 +109,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   Timer? _scrollStopTimer;
   Timer? _inactivityTimer;
   double _webScrollY = 0.0;
+  double _prevNativeScrollOffset = 0.0;
   late AnimationController _headerAutoController;
   double _headerAutoStart = 0.0;
   double _headerAutoTarget = 0.0;
@@ -282,6 +283,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
     // Reading progress: track scroll depth
     _scrollController.addListener(_onScrollReadingProgress);
+
+    // Header hide/show: track scroll delta for native in-app content
+    _scrollController.addListener(_onNativeScrollHeader);
 
     // End-of-article nudge: show contextual action when progress >= 90%
     _readingProgress.addListener(_onReadingProgressNudge);
@@ -514,6 +518,16 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _headerAutoController.forward(from: 0);
   }
 
+  /// Scroll listener for native (in-app) content — computes delta from previous
+  /// offset and forwards it to [_onScrollDelta].
+  void _onNativeScrollHeader() {
+    if (!_scrollController.hasClients || _isWebViewActive) return;
+    final current = _scrollController.offset;
+    final delta = current - _prevNativeScrollOffset;
+    _prevNativeScrollOffset = current;
+    if (delta != 0) _onScrollDelta(delta);
+  }
+
   /// Update header offset and FAB opacity based on scroll delta (in pixels).
   /// Positive delta = scrolling down, negative = scrolling up.
   void _onScrollDelta(double delta) {
@@ -543,7 +557,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _inactivityTimer?.cancel();
     if (!isVideo && !_isShortArticle) {
       _inactivityTimer = Timer(const Duration(seconds: 3), () {
-        if (mounted && _webScrollY > 0 && _headerOffset.value < 1.0) {
+        final nativeScrollY =
+            _scrollController.hasClients ? _scrollController.offset : 0.0;
+        final scrolledPastTop = _webScrollY > 0 || nativeScrollY > 0;
+        if (mounted && scrolledPastTop && _headerOffset.value < 1.0) {
           _animateHeaderTo(1.0);
         }
       });

--- a/apps/mobile/lib/features/onboarding/onboarding_strings.dart
+++ b/apps/mobile/lib/features/onboarding/onboarding_strings.dart
@@ -23,6 +23,17 @@ class OnboardingStrings {
   static const String intro2Title = 'Ton hub d\'infos fiables.';
   static const String intro2Subtitle =
       'Facteur est une app Open-Source pour retrouver le plaisir de s\'informer.\n\nUn espace de confiance, qui mêle transparence, contrôle et sources de qualité.';
+  static const String intro2SubtitlePart1 = 'Facteur est une app Open-Source pour ';
+  static const String intro2SubtitleBold1 = 'retrouver le plaisir de s\'informer';
+  static const String intro2SubtitlePart2 = '. Un espace de ';
+  static const String intro2SubtitleBold2 = 'confiance';
+  static const String intro2SubtitlePart3 = ', qui mêle ';
+  static const String intro2SubtitleBold3 = 'transparence';
+  static const String intro2SubtitlePart4 = ', ';
+  static const String intro2SubtitleBold4 = 'contrôle';
+  static const String intro2SubtitlePart5 = ' et ';
+  static const String intro2SubtitleBold5 = 'sources de qualité';
+  static const String intro2SubtitlePart6 = '.';
   static const String intro2Button = 'Découvrir Facteur';
 
   // Media Concentration
@@ -30,11 +41,16 @@ class OnboardingStrings {
       'Savez-vous qui possède vos médias ?';
   static const String mediaConcentrationText =
       'Cette carte reflète la concentration des médias en France. \n\nFacteur vous aide à comprendre comment se positionnent les médias pour mieux diversifier vos sources.';
+  static const String mediaConcentrationTextPart1 =
+      'Cette carte reflète la concentration des médias en France.\nFacteur vous aide à comprendre comment se positionnent les médias pour mieux ';
+  static const String mediaConcentrationTextBold1 = 'diversifier vos sources';
+  static const String mediaConcentrationTextPart2 = '.';
   static const String mediaConcentrationButton = 'Continuer';
 
   // Q1: Objective (multi-select)
   static const String q1Title =
       "Commençons par vous. \n\nQu'est-ce qui vous épuise le plus avec l'info ?";
+  static const String q1Subtitle = '';
   static const String q1NoiseLabel = 'Le Bruit';
   static const String q1NoiseSubtitle =
       "Trop d'info. Impossible de bien trier";
@@ -81,6 +97,12 @@ class OnboardingStrings {
       'Passer du temps à bien s\'informer est difficile. Travaillons-le !';
   static const String q8Subtitle =
       'Facteur t\'aide à progresser et à rester motivé';
+  static const String q8SubtitlePart1 = 'Facteur vous accompagne avec une ';
+  static const String q8SubtitleBold1 = '🔥 streak quotidienne';
+  static const String q8SubtitlePart2 = ' pour garder le rythme, et une ';
+  static const String q8SubtitleBold2 = '📊 progression hebdomadaire';
+  static const String q8SubtitlePart3 =
+      ' pour valider que vous retenez vraiment l\'info.';
   static const String q8StreakTitle = 'Streak quotidien';
   static const String q8StreakDesc = '';
   static const String q8WeeklyTitle = 'Progression hebdomadaire';
@@ -108,6 +130,25 @@ class OnboardingStrings {
       'Quel mode de récap quotidien préférez-vous ?';
   static const String digestModeSubtitle =
       'Vous pourrez changer à tout moment.';
+
+  // Digest Mode — Rester serein (rich subtitle parts)
+  static const String digestModeSereinPart1 =
+      'Certains sujets peuvent être difficiles à lire. Activez le ';
+  static const String digestModeSereinBold1 = 'mode serein';
+  static const String digestModeSereinPart2 = ' pour ';
+  static const String digestModeSereinBold2 = 'filtrer les contenus anxiogènes';
+  static const String digestModeSereinPart3 = '.\nVous pourrez ';
+  static const String digestModeSereinBold3 = 'changer d\'avis à tout moment';
+  static const String digestModeSereinPart4 =
+      ' grâce au bouton dédié en haut de votre essentiel et du flux.';
+
+  // Sensitive Themes (conditional step after digestMode == 'serein')
+  static const String sensitiveThemesTitle = 'Quels sujets vous pèsent ?';
+  static const String sensitiveThemesSubtitle =
+      'Facteur filtrera ces sujets de votre sélection quotidienne.';
+  static const String sensitiveThemesSkip = 'Passer cette étape';
+  static String sensitiveThemesContinue(int count) =>
+      'Continuer ($count sélectionné${count > 1 ? 's' : ''})';
 
   // Q9: Sources
   static const String q9Title = 'Vos sources, sur mesure.';

--- a/apps/mobile/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/apps/mobile/lib/features/onboarding/screens/onboarding_screen.dart
@@ -19,6 +19,7 @@ import 'questions/sources_question.dart';
 import 'questions/sources_page2_question.dart';
 import 'questions/finalize_question.dart';
 import 'questions/intro_screen.dart';
+import 'questions/sensitive_themes_question.dart';
 
 /// Écran d'onboarding principal
 /// Gère la navigation entre les sections et questions
@@ -61,7 +62,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                     const SizedBox(width: 48),
                   Expanded(
                     child: OnboardingProgressBar(
-                      progress: state.progress,
+                      sectionProgress: state.sectionProgress,
                       section: state.currentSection,
                     ),
                   ),
@@ -168,9 +169,6 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
             ref.read(onboardingProvider.notifier).continueAfterReaction();
           },
         );
-
-      case Section1Question.approach:
-        return const ApproachQuestion(key: ValueKey('approach'));
     }
   }
 
@@ -179,6 +177,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     final question = state.currentSection2Question;
 
     switch (question) {
+      case Section2Question.approach:
+        return const ApproachQuestion(key: ValueKey('approach'));
+
       case Section2Question.responseStyle:
         return const ResponseStyleQuestion(key: ValueKey('response_style'));
 
@@ -190,6 +191,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
       case Section2Question.digestMode:
         return const DigestModeQuestion(key: ValueKey('digest_mode'));
+
+      case Section2Question.sensitiveThemes:
+        return const SensitiveThemesQuestion(key: ValueKey('sensitive_themes'));
     }
   }
 

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -1533,6 +1533,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  visibility_detector:
+    dependency: "direct main"
+    description:
+      name: visibility_detector
+      sha256: dd5cc11e13494f432d15939c3aa8ae76844c42b723398643ce9addb88a5ed420
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0+2"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
## What

- Fix article reader header never hiding on scroll: adds a native scroll listener to `content_detail_screen.dart` that computes delta from `_scrollController` and calls `_onScrollDelta` — previously only wired to the WebView JS bridge. Also fixes the inactivity-timer to check native scroll offset alongside `_webScrollY`.
- Fix 59 onboarding compile errors introduced by #376: restores rich-text split strings (`intro2SubtitlePart1-6/Bold1-5`, `mediaConcentration`, `q8Subtitle`, `digestModeSerein`) that were removed without updating the screens that reference them. Adds new `sensitiveThemes` strings.
- Fix `onboarding_screen.dart`: wrong `progress` → `sectionProgress` param on `OnboardingProgressBar`, `ApproachQuestion` misplaced in Section 1 switch (belongs in Section 2), and missing `SensitiveThemesQuestion` case.

## Why

Header hide/show was broken for all native in-app article content. The onboarding flow crashed at compile time (VSCode couldn't start debug mode).

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)