### PR TITLE
fix: remove duplicate clearForceUnconfirmed — unblocks Railway deploy

### DIFF
--- a/apps/mobile/lib/core/auth/auth_state.dart
+++ b/apps/mobile/lib/core/auth/auth_state.dart
@@ -655,17 +655,6 @@ class AuthStateNotifier extends StateNotifier<AuthState>
     }
   }
 
-  /// Appelé par ApiClient.onAuthRecovered quand une requête aboutit après un
-  /// refresh+retry, prouvant que le backend considère l'user comme confirmé.
-  /// Permet de clear forceUnconfirmed même si le JWT local est encore stale.
-  void clearForceUnconfirmed() {
-    if (state.forceUnconfirmed) {
-      debugPrint(
-          'AuthStateNotifier: ✅ Clearing forceUnconfirmed (backend accepted request).');
-      state = state.copyWith(forceUnconfirmed: false);
-    }
-  }
-
   /// Marque l'utilisateur comme non confirmé (suite à un 403 Backend).
   ///
   /// N'est appelé que par `ApiClient.onAuthError(403)` APRÈS que l'ApiClient


### PR DESCRIPTION
## Problem

Railway deploy fails with:
```
Error: 'clearForceUnconfirmed' is already declared in this scope.
```

PR #376 declared `clearForceUnconfirmed()` at line 608, then the hotfix #379 added a second identical copy at line 661. Dart compiler rejects the duplicate.

## Fix

Remove the second (duplicate) declaration. The first one at line 608 is kept.

## Validation

- `flutter build web --release` → `✓ Built build/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)