### PR TITLE
Personalize daily digest notification with topic keywords

### DIFF
--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -9,6 +9,9 @@ import 'package:flutter_timezone/flutter_timezone.dart';
 ///
 /// Planifie une notification quotidienne à 8h Europe/Paris pour rappeler
 /// à l'utilisateur que son digest est prêt. Pas de FCM — local uniquement.
+///
+/// Le contenu de la notification peut être mis à jour dynamiquement
+/// avec les topics du digest via [scheduleDailyDigestNotification].
 class PushNotificationService {
   PushNotificationService._();
 
@@ -133,10 +136,29 @@ class PushNotificationService {
     return granted;
   }
 
+  static const String defaultTitle = 'Ton Essentiel Facteur est prêt !';
+  static const String defaultBody = 'Tes sujets du jour t\'attendent';
+
+  /// Construit le body de la notification à partir des labels de topics du digest.
+  ///
+  /// Exemple : "Au programme : Trump, Retraites, Chômage... Ou rester serein ;-)"
+  /// Retourne [defaultBody] si la liste est vide.
+  static String buildNotificationBody(List<String> topicLabels) {
+    if (topicLabels.isEmpty) return defaultBody;
+
+    // Prendre les 3 premiers topics max pour rester concis
+    final displayLabels = topicLabels.take(3).toList();
+    final topicsText = displayLabels.join(', ');
+    return 'Au programme : $topicsText... Ou rester serein ;-)';
+  }
+
   /// Planifie la notification quotidienne de digest à 8h Europe/Paris.
   /// Utilise alarmClock (le plus fiable) avec fallback sur inexactAllowWhileIdle.
   /// Retourne true si la notification est effectivement planifiée.
-  Future<bool> scheduleDailyDigestNotification() async {
+  ///
+  /// [body] optionnel — permet de personnaliser le message avec les topics du digest.
+  /// Si null, utilise [defaultBody].
+  Future<bool> scheduleDailyDigestNotification({String? body}) async {
     final androidPlugin = _plugin.resolvePlatformSpecificImplementation<
         AndroidFlutterLocalNotificationsPlugin>();
     bool canUseExact = true;
@@ -162,6 +184,7 @@ class PushNotificationService {
     );
 
     final scheduledDate = _nextInstanceOf8AM();
+    final notificationBody = body ?? defaultBody;
 
     // alarmClock est le plus fiable (pas affecté par Doze ni battery optimization OEM)
     // Fallback sur inexactAllowWhileIdle si la permission exacte est refusée
@@ -172,8 +195,8 @@ class PushNotificationService {
     // v20: ALL parameters are named
     await _plugin.zonedSchedule(
       id: 0,
-      title: 'Votre digest est prêt !',
-      body: '5 articles sélectionnés pour vous ce matin',
+      title: defaultTitle,
+      body: notificationBody,
       scheduledDate: scheduledDate,
       notificationDetails: details,
       androidScheduleMode: scheduleMode,
@@ -181,7 +204,7 @@ class PushNotificationService {
     );
 
     debugPrint(
-      'PushNotificationService: Scheduled for $scheduledDate (mode: $scheduleMode, exact: $canUseExact)',
+      'PushNotificationService: Scheduled for $scheduledDate (mode: $scheduleMode, exact: $canUseExact, body: "$notificationBody")',
     );
 
     // Vérifier que la notification est bien dans la liste pending

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
 import '../../../core/providers/analytics_provider.dart';
+import '../../../core/services/push_notification_service.dart';
 import '../../../core/services/widget_service.dart';
 import '../../../core/ui/notification_service.dart';
 import '../models/digest_models.dart';
@@ -122,6 +125,8 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
         ref.read(sereinToggleProvider.notifier).initFromApi(dual.sereinEnabled);
         // Push to home screen widget
         _syncWidget();
+        // Update notification with dynamic topic keywords
+        _updateNotificationWithTopics();
         // If either variant was served as yesterday's stale fallback while
         // fresh content is being generated in background, schedule a silent
         // auto-refetch so the user sees today's digest without pulling.
@@ -153,6 +158,7 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
           _normalDigest = digest;
           _cachedDate = _todayDateString;
           ref.read(sereinToggleProvider.notifier).initFromApi(false);
+          _updateNotificationWithTopics();
           _maybeScheduleStaleFallbackRefetch();
           return digest;
         } catch (_) {
@@ -234,6 +240,34 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
   void _syncWidget() {
     final digest = state.value;
     WidgetService.updateWidget(digest: digest);
+  }
+
+  /// Update the daily notification with topic keywords from the loaded digest.
+  /// Uses the normal digest topics to build an engaging notification body.
+  /// Only updates if push notifications are enabled in user settings.
+  void _updateNotificationWithTopics() {
+    try {
+      final box = Hive.box<dynamic>('settings');
+      final pushEnabled =
+          box.get('push_notifications_enabled', defaultValue: true) as bool;
+      if (!pushEnabled) return;
+
+      final digest = _normalDigest;
+      if (digest == null) return;
+
+      final topicLabels = digest.topics
+          .map((t) => t.label)
+          .where((l) => l.isNotEmpty)
+          .toList();
+
+      final body = PushNotificationService.buildNotificationBody(topicLabels);
+      PushNotificationService().scheduleDailyDigestNotification(body: body);
+      debugPrint(
+        'DigestNotifier: Updated notification with ${topicLabels.length} topics',
+      );
+    } catch (e) {
+      debugPrint('DigestNotifier: Failed to update notification: $e');
+    }
   }
 
   /// Clear the in-memory cache (forces next load to call API).


### PR DESCRIPTION
## What

Updated the daily digest notification to dynamically include topic keywords from the loaded digest. The notification body now displays the top 3 topics in an engaging format (e.g., "Au programme : Trump, Retraites, Chômage... Ou rester serein ;-)") instead of a static message.

## Why

This improves user engagement by making the daily notification more relevant and personalized. Users see a preview of what topics are in their digest before opening the app, making the notification more compelling and informative.

## Changes

- **DigestNotifier**: Added `_updateNotificationWithTopics()` method that extracts topic labels from the loaded digest and updates the scheduled notification. Called after digest is loaded (both normal and fallback paths).
- **PushNotificationService**: 
  - Added `buildNotificationBody()` static method to construct notification text from topic labels
  - Added `defaultTitle` and `defaultBody` constants for consistency
  - Modified `scheduleDailyDigestNotification()` to accept optional `body` parameter for dynamic content
  - Updated debug logging to include the notification body

The implementation respects user settings—only updates notifications if push notifications are enabled in settings.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] No new Python imports (Flutter/Dart only change)
- [x] N/A (mobile app change, no auth/DB modifications)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (mobile feature, requires app build/deployment)

https://claude.ai/code/session_01BvBeBAhRziYGCFX2AqBcKQ