### PR TITLE
Fix digest 503 loop: graceful fallback + content protection

### DIFF
--- a/docs/bugs/bug-digest-total-failure-2026-04-12.md
+++ b/docs/bugs/bug-digest-total-failure-2026-04-12.md
@@ -241,14 +241,84 @@ Rule Sentry sur `digest_endpoint_unhandled_error` ou `digest_existing_render_fai
 
 ## Checklist pour l'agent suivant
 
-- [ ] Lire ce document en entier
-- [ ] Lire `docs/bugs/bug-digest-legacy-format.md` (contexte PR #381)
-- [ ] Vérifier status des migrations Supabase (Étape 1-2 ci-dessus)
-- [ ] Récupérer logs Sentry/Railway pour l'erreur exacte
-- [ ] Si migrations pas appliquées : faire appliquer + merger PR #384
-- [ ] Si migrations OK : investiguer le `raise` H1 (tester en local)
-- [ ] Appliquer Fix 2 (graceful fallback au lieu de raise)
-- [ ] Appliquer Fix 4 (protection storage_cleanup)
-- [ ] Ajouter Fix 5 (diag endpoint) pour future visibilité
-- [ ] Écrire test de régression pour chaque fix
-- [ ] Tester end-to-end via Playwright MCP
+- [x] Lire ce document en entier
+- [x] Lire `docs/bugs/bug-digest-legacy-format.md` (contexte PR #381)
+- [ ] Vérifier status des migrations Supabase (Étape 1-2 ci-dessus) — **à faire manuellement en prod** (pas d'accès MCP Supabase dans cet environnement). L'endpoint `/api/digest/diag` ajouté en Session #4 répond désormais à cette question en 1 requête HTTP.
+- [ ] Récupérer logs Sentry/Railway pour l'erreur exacte — **à faire manuellement en prod** (pas d'accès MCP Sentry/Railway dans cet environnement).
+- [x] Si migrations pas appliquées : faire appliquer + merger PR #384 — **PR #384 mergée** (commit squash sur `main`).
+- [x] Si migrations OK : investiguer le `raise` H1 (tester en local) — H1 confirmée par lecture du code ; Fix 2 appliqué.
+- [x] Appliquer Fix 2 (graceful fallback au lieu de raise) — voir Session #4 ci-dessous.
+- [x] Appliquer Fix 4 (protection storage_cleanup) — voir Session #4 ci-dessous.
+- [x] Ajouter Fix 5 (diag endpoint) pour future visibilité — voir Session #4 ci-dessous.
+- [x] Écrire test de régression pour chaque fix — `test_digest_content_refs.py` (10 tests), `test_storage_cleanup.py` (2 tests ajoutés), `test_digest_service.py` (`TestRenderFailureFallback`, 2 tests).
+- [ ] Tester end-to-end via Playwright MCP — changements backend-only, pas d'UI impactée (cf. CLAUDE.md section Validation Feature via Chrome : "Quand ne PAS utiliser — Changements backend-only (API, workers, migrations)").
+
+## Session #4 — résilience systémique (cette PR)
+
+Objectif : casser le potentiel de boucle 503 **définitivement** en rendant chaque
+couche tolérante à la corruption des autres, sans attendre la confirmation
+Supabase/Sentry.
+
+### Fix 2 — Graceful fallback sur render failure (H1)
+
+`packages/api/app/services/digest_service.py` — le `raise` brutal de PR #381
+est remplacé par le mécanisme existant `stale_format_digest` (deferred
+deletion). Quand `_build_digest_response` échoue sur un digest moderne :
+
+1. On mémorise le record corrompu dans `stale_format_digest`.
+2. On met `existing_digest = None` pour retomber dans le chemin de génération.
+3. Le record corrompu est supprimé **après** qu'un remplaçant ait été produit
+   avec succès (chemin déjà existant, lignes ~671-674).
+
+Si la régénération plante aussi, le record corrompu reste en DB mais le
+prochain appel tentera à nouveau le fallback au lieu de retourner 503 en boucle.
+
+Tests : `TestRenderFailureFallback` dans `tests/test_digest_service.py`.
+
+### Fix 4 — Protection du Content référencé par un digest récent
+
+Nouveau module `packages/api/app/services/digest_content_refs.py` avec
+`extract_content_ids(items, format_version)` qui marche sur les 3 layouts
+JSONB (`flat_v1`, `topics_v1`, `editorial_v1`) de façon tolérante (UUID
+malformés → skip, clés manquantes → skip, `None` → `set()`).
+
+`packages/api/app/workers/storage_cleanup.py` :
+
+- Nouvelle constante `DIGEST_REFERENCE_PROTECTION_DAYS = 90`.
+- Nouvelle fonction `_collect_referenced_content_ids(session)` qui lit toutes
+  les lignes `daily_digest` des 90 derniers jours et collecte les content_ids.
+- Le DELETE/count partage désormais une liste `common_conditions` qui inclut
+  `~Content.id.in_(referenced_list)` quand la liste est non-vide.
+- Nouvelle stat retournée : `preserved_digest_refs`.
+
+Tests : `tests/test_digest_content_refs.py` (10 tests couvrant les 3 layouts +
+edge cases), `tests/test_storage_cleanup.py` (2 tests ajoutés — NOT IN clause
+vérifiée en inspectant le SQL compilé).
+
+### Fix 5 — Endpoint diag scopé au user authentifié
+
+`packages/api/app/routers/digest.py` — `GET /api/digest/diag` retourne en 1
+requête HTTP :
+
+- `today_digest` / `yesterday_digest` (existence, format, is_serene)
+- `state` (entrées `DigestGenerationState` pour la date cible)
+- `render_test` — live invocation de `_build_digest_response` avec capture
+  de `error_type` + message (au lieu de 503)
+- `migrations` — lit `alembic_version` + probe `information_schema` pour
+  `sources.tone`, `sources.serein_default`, `digest_generation_state`,
+  `editorial_highlights_history`
+
+Chaque section est wrappée dans un try/except : une table manquante ne casse
+pas les autres probes. L'endpoint est scopé au user authentifié (pas de
+query param `user_id` — cohérence avec le reste de `/api/digest/*`).
+
+### Ce qui reste à faire côté ops (hors scope code)
+
+1. **Vérifier/appliquer `td01` + `dg01` sur Supabase production** — le SQL
+   idempotent est dans la description de PR #384 (déjà mergée). Une fois
+   appliqué, `GET /api/digest/diag` le confirmera.
+2. **Vérifier Sentry** pour `digest_existing_render_failed` /
+   `digest_endpoint_unhandled_error` sur 2026-04-12 pour identifier la
+   cause racine de la régression totale. Avec Fix 2, même sans ce
+   diagnostic, le symptôme "503 en boucle" ne peut plus se produire.
+3. **Fix 6 (alerte Sentry dédiée)** — reste à configurer côté Sentry UI.

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -11,14 +11,14 @@ Safe reuse of existing services through DigestService.
 
 import asyncio
 import time
-from datetime import date
+from datetime import date, timedelta
 from uuid import UUID
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import async_session_maker, get_db
@@ -393,3 +393,159 @@ async def generate_digest(
 
     # Return the complete digest response with items
     return digest
+
+
+@router.get("/diag")
+async def digest_diagnostics(
+    target_date: date | None = Query(
+        None, description="Date for digest (default: today)"
+    ),
+    serein: bool = Query(False, description="Check the serene variant"),
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+) -> dict:
+    """Diagnostic snapshot for the authenticated user's digest pipeline.
+
+    Returns in a single request everything needed to answer "why is my
+    digest broken?":
+
+    - ``today_digest`` / ``yesterday_digest``: existence + format_version
+    - ``state``: rows from ``digest_generation_state`` for today (both
+      variants). Returns ``"table_missing"`` if migration dg01 isn't applied.
+    - ``render_test``: actually invokes ``_build_digest_response`` on the
+      existing digest, reporting whether it renders and if not, the
+      exception type + message. This is the key signal for detecting a
+      corrupted JSONB payload that would otherwise cause a 503 loop.
+    - ``migrations``: current alembic revision + presence of the 3
+      migration-sensitive tables/columns (td01, dg01, mg03).
+
+    Scoped to the authenticated user only — never accepts a user_id query
+    parameter — so this is safe to leave on in production.
+    """
+    user_uuid = UUID(current_user_id)
+    effective_date = target_date or today_paris()
+    yesterday = effective_date - timedelta(days=1)
+
+    async def _digest_snapshot(d: date, is_serene: bool) -> dict:
+        row = await db.scalar(
+            select(DailyDigest).where(
+                DailyDigest.user_id == user_uuid,
+                DailyDigest.target_date == d,
+                DailyDigest.is_serene == is_serene,
+            )
+        )
+        if row is None:
+            return {"exists": False}
+        return {
+            "exists": True,
+            "digest_id": str(row.id),
+            "format_version": row.format_version,
+            "is_serene": row.is_serene,
+            "generated_at": row.generated_at.isoformat() if row.generated_at else None,
+        }
+
+    today_digest = await _digest_snapshot(effective_date, serein)
+    yesterday_digest = await _digest_snapshot(yesterday, serein)
+
+    # State table: may not exist if migration dg01 isn't applied.
+    state_info: dict | list
+    try:
+        from app.models.digest_generation_state import DigestGenerationState
+
+        state_rows = (
+            (
+                await db.execute(
+                    select(DigestGenerationState).where(
+                        DigestGenerationState.user_id == user_uuid,
+                        DigestGenerationState.target_date == effective_date,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        state_info = [
+            {
+                "is_serene": s.is_serene,
+                "status": s.status,
+                "attempts": s.attempts,
+                "last_error": (s.last_error[:200] if s.last_error else None),
+                "started_at": s.started_at.isoformat() if s.started_at else None,
+                "finished_at": s.finished_at.isoformat() if s.finished_at else None,
+            }
+            for s in state_rows
+        ]
+    except Exception as e:
+        state_info = {"error": type(e).__name__, "detail": str(e)[:200]}
+
+    # Render test: actually try to build the response from the existing
+    # digest so callers can see the exact exception type instead of
+    # guessing from a generic 503.
+    render_test: dict = {"attempted": False}
+    if today_digest.get("exists"):
+        render_test = {"attempted": True, "ok": False}
+        try:
+            svc = DigestService(db)
+            digest_row = await db.scalar(
+                select(DailyDigest).where(
+                    DailyDigest.id == UUID(today_digest["digest_id"])
+                )
+            )
+            if digest_row is not None:
+                await svc._build_digest_response(digest_row, user_uuid)
+                render_test["ok"] = True
+        except Exception as e:
+            render_test["error_type"] = type(e).__name__
+            render_test["error"] = str(e)[:500]
+
+    # Migration probes: best-effort, degrade gracefully.
+    migrations: dict = {}
+    try:
+        version_row = await db.execute(
+            text("SELECT version_num FROM alembic_version LIMIT 1")
+        )
+        migrations["alembic_version"] = version_row.scalar_one_or_none()
+    except Exception as e:
+        migrations["alembic_version_error"] = f"{type(e).__name__}: {str(e)[:120]}"
+
+    for table_name, column_name, label in (
+        ("sources", "tone", "td01_sources_tone"),
+        ("sources", "serein_default", "td01_sources_serein_default"),
+        ("digest_generation_state", None, "dg01_digest_generation_state"),
+        ("editorial_highlights_history", None, "dg01_editorial_highlights_history"),
+    ):
+        try:
+            if column_name:
+                probe = await db.execute(
+                    text(
+                        "SELECT 1 FROM information_schema.columns "
+                        "WHERE table_name = :t AND column_name = :c"
+                    ),
+                    {"t": table_name, "c": column_name},
+                )
+            else:
+                probe = await db.execute(
+                    text(
+                        "SELECT 1 FROM information_schema.tables WHERE table_name = :t"
+                    ),
+                    {"t": table_name},
+                )
+            migrations[label] = probe.scalar_one_or_none() is not None
+        except Exception as e:
+            migrations[label] = f"error: {type(e).__name__}"
+            logger.warning(
+                "digest_diag_migration_probe_failed",
+                label=label,
+                error=str(e),
+            )
+
+    return {
+        "user_id": current_user_id,
+        "target_date": str(effective_date),
+        "serein": serein,
+        "today_digest": today_digest,
+        "yesterday_digest": yesterday_digest,
+        "state": state_info,
+        "render_test": render_test,
+        "migrations": migrations,
+    }

--- a/packages/api/app/services/digest_content_refs.py
+++ b/packages/api/app/services/digest_content_refs.py
@@ -1,0 +1,88 @@
+"""Helpers to extract content_id references from DailyDigest JSONB payloads.
+
+The digest is stored in 3 possible layouts, depending on `format_version`:
+
+- **flat_v1**: ``items`` is a JSON *array* of ``{"content_id": ..., ...}``.
+- **topics_v1**: ``items`` is a JSON *object*
+  ``{"format": "topics_v1", "topics": [{"articles": [{"content_id": ...}, ...]}, ...]}``.
+- **editorial_v1**: ``items`` is a JSON *object* with structured keys:
+  ``subjects[i].actu_article.content_id``,
+  ``subjects[i].extra_actu_articles[j].content_id``,
+  ``subjects[i].deep_article.content_id``,
+  plus top-level ``pepite.content_id``, ``coup_de_coeur.content_id``,
+  ``actu_decalee.content_id``.
+
+Any code that needs to know which Content rows are still referenced by live
+digests (e.g. the RSS storage cleanup worker, or the diag endpoint) should
+use these helpers instead of re-implementing the layout walk.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+
+def _safe_uuid(value: Any) -> UUID | None:
+    """Parse ``value`` as UUID, returning None on any error."""
+    if not value:
+        return None
+    try:
+        return UUID(str(value))
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+def extract_content_ids(items: Any, format_version: str | None) -> set[UUID]:
+    """Return every content_id referenced by a digest's ``items`` payload.
+
+    Tolerates malformed payloads (missing keys, None entries, bad UUIDs):
+    anything unparseable is silently skipped — the caller only wants "what
+    IDs does this digest legitimately reference?", not validation.
+    """
+    ids: set[UUID] = set()
+    if items is None:
+        return ids
+
+    fmt = format_version or "flat_v1"
+
+    if fmt == "editorial_v1" and isinstance(items, dict):
+        for subject in items.get("subjects") or []:
+            if not isinstance(subject, dict):
+                continue
+            actu = subject.get("actu_article")
+            if isinstance(actu, dict):
+                if (cid := _safe_uuid(actu.get("content_id"))) is not None:
+                    ids.add(cid)
+            for extra in subject.get("extra_actu_articles") or []:
+                if isinstance(extra, dict):
+                    if (cid := _safe_uuid(extra.get("content_id"))) is not None:
+                        ids.add(cid)
+            deep = subject.get("deep_article")
+            if isinstance(deep, dict):
+                if (cid := _safe_uuid(deep.get("content_id"))) is not None:
+                    ids.add(cid)
+        for key in ("pepite", "coup_de_coeur", "actu_decalee"):
+            node = items.get(key)
+            if isinstance(node, dict):
+                if (cid := _safe_uuid(node.get("content_id"))) is not None:
+                    ids.add(cid)
+        return ids
+
+    if fmt == "topics_v1" and isinstance(items, dict):
+        for topic in items.get("topics") or []:
+            if not isinstance(topic, dict):
+                continue
+            for art in topic.get("articles") or []:
+                if isinstance(art, dict):
+                    if (cid := _safe_uuid(art.get("content_id"))) is not None:
+                        ids.add(cid)
+        return ids
+
+    # flat_v1 (and unknown legacy formats): items is an array
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, dict):
+                if (cid := _safe_uuid(item.get("content_id"))) is not None:
+                    ids.add(cid)
+    return ids

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -398,9 +398,18 @@ class DigestService:
                 try:
                     return await self._build_digest_response(existing_digest, user_id)
                 except Exception:
-                    # Render failed — but only delete if it's already flat_v1.
-                    # Never destroy a modern-format digest: better to let the
-                    # request fail than silently replace it with flat_v1.
+                    # Render failed. Previously we `raise`d for modern formats
+                    # to avoid silently downgrading to flat_v1, but that turned
+                    # any persistently-corrupted record into an all-day 503
+                    # loop for the user (each request hits the same broken
+                    # JSONB and fails). Instead: defer deletion via the same
+                    # `stale_format_digest` machinery used for version
+                    # mismatches and fall through to regeneration. The
+                    # deferred-delete logic below (step 4) replaces the
+                    # corrupted record only when a fresh one is ready. If
+                    # regeneration also fails, the stale-format fallback path
+                    # will serve the old record (or yesterday's) as a last
+                    # resort — still better than 503 forever.
                     logger.exception(
                         "digest_existing_render_failed",
                         user_id=str(user_id),
@@ -411,10 +420,13 @@ class DigestService:
                         "editorial_v1",
                         "topics_v1",
                     ):
-                        raise
-                    # flat_v1 is expendable — delete and regenerate
-                    await self.session.delete(existing_digest)
-                    await self.session.flush()
+                        # Defer deletion, fall through to regeneration.
+                        stale_format_digest = existing_digest
+                        existing_digest = None
+                    else:
+                        # flat_v1 is expendable — delete and regenerate
+                        await self.session.delete(existing_digest)
+                        await self.session.flush()
         # 1b. No digest for today — try serving yesterday's digest instantly
         # while triggering a real background regeneration so the next read
         # gets fresh content. Without the background trigger this fallback

--- a/packages/api/app/workers/storage_cleanup.py
+++ b/packages/api/app/workers/storage_cleanup.py
@@ -1,6 +1,7 @@
 """Worker de nettoyage du storage RSS."""
 
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 import structlog
 from sqlalchemy import delete, func, select
@@ -8,10 +9,37 @@ from sqlalchemy import delete, func, select
 from app.config import get_settings
 from app.database import async_session_maker
 from app.models.content import Content, UserContentStatus
+from app.models.daily_digest import DailyDigest
 from app.models.source import Source
+from app.services.digest_content_refs import extract_content_ids
 
 logger = structlog.get_logger()
 settings = get_settings()
+
+# Any Content referenced by a digest generated in the last N days must be
+# preserved — otherwise rendering that digest crashes with
+# editorial_article_not_found and triggers a 503 for the owning user.
+# 90 days covers the longest realistic streak fallback window.
+DIGEST_REFERENCE_PROTECTION_DAYS = 90
+
+
+async def _collect_referenced_content_ids(session) -> set[UUID]:
+    """Return every content_id referenced by a digest from the last 90 days.
+
+    Walks all three JSONB layouts (flat_v1, topics_v1, editorial_v1) in
+    Python so we don't have to maintain three parallel JSONB queries. In
+    production the digest table is small (~O(users × days × variants)), so
+    pulling the raw rows is cheap.
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=DIGEST_REFERENCE_PROTECTION_DAYS)
+    stmt = select(DailyDigest.items, DailyDigest.format_version).where(
+        DailyDigest.generated_at >= cutoff
+    )
+    result = await session.execute(stmt)
+    referenced: set[UUID] = set()
+    for items, format_version in result.all():
+        referenced |= extract_content_ids(items, format_version)
+    return referenced
 
 
 async def cleanup_old_articles() -> dict:
@@ -45,15 +73,27 @@ async def cleanup_old_articles() -> dict:
                 .where(Source.source_tier == "deep")
             )
 
+            # Set: content_ids référencés par un digest des 90 derniers jours.
+            # Supprimer l'un d'entre eux casserait le rendu du digest (l'article
+            # référencé n'existe plus côté Content) → 503 pour l'owner.
+            referenced_ids = await _collect_referenced_content_ids(session)
+            referenced_list = list(referenced_ids)
+            preserved_digest_refs = len(referenced_list)
+
+            # Conditions communes entre le count et le delete :
+            # exclut bookmarks, deep sources et contents référencés par un
+            # digest récent.
+            common_conditions = [
+                Content.published_at < cutoff_date,
+                ~Content.id.in_(bookmarked_subquery),
+                ~Content.id.in_(deep_source_subquery),
+            ]
+            if referenced_list:
+                common_conditions.append(~Content.id.in_(referenced_list))
+
             # Count avant purge (pour logging)
             count_result = await session.execute(
-                select(func.count())
-                .select_from(Content)
-                .where(
-                    Content.published_at < cutoff_date,
-                    ~Content.id.in_(bookmarked_subquery),  # Exclure bookmarks
-                    ~Content.id.in_(deep_source_subquery),  # Exclure deep sources
-                )
+                select(func.count()).select_from(Content).where(*common_conditions)
             )
             to_delete = count_result.scalar_one()
 
@@ -85,22 +125,19 @@ async def cleanup_old_articles() -> dict:
                     reason="no_old_articles",
                     preserved_bookmarks=preserved_bookmarks,
                     preserved_deep=preserved_deep,
+                    preserved_digest_refs=preserved_digest_refs,
                 )
                 return {
                     "deleted_count": 0,
                     "retention_days": retention_days,
                     "preserved_bookmarks": preserved_bookmarks,
                     "preserved_deep": preserved_deep,
+                    "preserved_digest_refs": preserved_digest_refs,
                 }
 
-            # Delete - exclut les bookmarks et deep sources, FK CASCADE gèrent user_content_status, daily_top3, classification_queue
-            result = await session.execute(
-                delete(Content).where(
-                    Content.published_at < cutoff_date,
-                    ~Content.id.in_(bookmarked_subquery),
-                    ~Content.id.in_(deep_source_subquery),
-                )
-            )
+            # Delete - réutilise les mêmes conditions que le count. FK CASCADE
+            # gère user_content_status, daily_top3, classification_queue.
+            result = await session.execute(delete(Content).where(*common_conditions))
             deleted_count = result.rowcount
 
             await session.commit()
@@ -110,6 +147,7 @@ async def cleanup_old_articles() -> dict:
                 deleted_count=deleted_count,
                 preserved_bookmarks=preserved_bookmarks,
                 preserved_deep=preserved_deep,
+                preserved_digest_refs=preserved_digest_refs,
                 retention_days=retention_days,
                 cutoff_date=cutoff_date.isoformat(),
             )
@@ -119,6 +157,7 @@ async def cleanup_old_articles() -> dict:
                 "retention_days": retention_days,
                 "preserved_bookmarks": preserved_bookmarks,
                 "preserved_deep": preserved_deep,
+                "preserved_digest_refs": preserved_digest_refs,
             }
 
         except Exception as e:

--- a/packages/api/tests/test_digest_content_refs.py
+++ b/packages/api/tests/test_digest_content_refs.py
@@ -1,0 +1,122 @@
+"""Tests for digest_content_refs.extract_content_ids.
+
+These are the guardrail: cleanup workers and diag tools rely on this
+extractor to know which Content rows are still referenced by live
+digests. Any change to the persisted JSONB layouts must be reflected
+here or the RSS cleanup will start deleting referenced articles again.
+"""
+
+from uuid import uuid4
+
+from app.services.digest_content_refs import extract_content_ids
+
+
+def test_flat_v1_list_layout():
+    a, b = uuid4(), uuid4()
+    items = [
+        {"content_id": str(a), "rank": 1},
+        {"content_id": str(b), "rank": 2},
+    ]
+    assert extract_content_ids(items, "flat_v1") == {a, b}
+
+
+def test_flat_v1_is_default_when_format_version_none():
+    a = uuid4()
+    assert extract_content_ids([{"content_id": str(a)}], None) == {a}
+
+
+def test_topics_v1_walks_nested_articles():
+    a, b, c = uuid4(), uuid4(), uuid4()
+    items = {
+        "format": "topics_v1",
+        "topics": [
+            {"topic_id": "t1", "articles": [{"content_id": str(a)}]},
+            {
+                "topic_id": "t2",
+                "articles": [{"content_id": str(b)}, {"content_id": str(c)}],
+            },
+        ],
+    }
+    assert extract_content_ids(items, "topics_v1") == {a, b, c}
+
+
+def test_editorial_v1_walks_all_slots():
+    actu, extra, deep, pep, cdc, decalee = (
+        uuid4(),
+        uuid4(),
+        uuid4(),
+        uuid4(),
+        uuid4(),
+        uuid4(),
+    )
+    items = {
+        "format_version": "editorial_v1",
+        "subjects": [
+            {
+                "actu_article": {"content_id": str(actu)},
+                "extra_actu_articles": [{"content_id": str(extra)}],
+                "deep_article": {"content_id": str(deep)},
+            }
+        ],
+        "pepite": {"content_id": str(pep)},
+        "coup_de_coeur": {"content_id": str(cdc)},
+        "actu_decalee": {"content_id": str(decalee)},
+    }
+    assert extract_content_ids(items, "editorial_v1") == {
+        actu,
+        extra,
+        deep,
+        pep,
+        cdc,
+        decalee,
+    }
+
+
+def test_editorial_v1_tolerates_missing_subjects():
+    pep = uuid4()
+    items = {"pepite": {"content_id": str(pep)}}
+    assert extract_content_ids(items, "editorial_v1") == {pep}
+
+
+def test_editorial_v1_tolerates_null_slots():
+    """Pydantic serialization can produce explicit nulls for absent slots."""
+    items = {
+        "subjects": [
+            {
+                "actu_article": None,
+                "extra_actu_articles": [],
+                "deep_article": None,
+            }
+        ],
+        "pepite": None,
+        "coup_de_coeur": None,
+        "actu_decalee": None,
+    }
+    assert extract_content_ids(items, "editorial_v1") == set()
+
+
+def test_malformed_uuid_is_skipped_not_raised():
+    good = uuid4()
+    items = [{"content_id": "not-a-uuid"}, {"content_id": str(good)}]
+    assert extract_content_ids(items, "flat_v1") == {good}
+
+
+def test_missing_content_id_key_is_skipped():
+    items = [{"rank": 1}, {"content_id": str(uuid4())}]
+    assert len(extract_content_ids(items, "flat_v1")) == 1
+
+
+def test_none_items_returns_empty_set():
+    assert extract_content_ids(None, "flat_v1") == set()
+    assert extract_content_ids(None, "editorial_v1") == set()
+
+
+def test_wrong_layout_for_format_falls_back_to_flat_walker():
+    """editorial_v1 metadata + list items: graceful degradation to flat walk.
+
+    If the persisted layout ever disagrees with the declared format, we'd
+    rather still collect whatever ids we can find than silently return
+    nothing and then delete the referenced Content rows.
+    """
+    cid = uuid4()
+    assert extract_content_ids([{"content_id": str(cid)}], "editorial_v1") == {cid}

--- a/packages/api/tests/test_digest_service.py
+++ b/packages/api/tests/test_digest_service.py
@@ -618,3 +618,170 @@ class TestDeferredStaleFormatDeletion:
         # (we only delete it AFTER we have items to store)
         for call in mock_session.delete.call_args_list:
             assert call.args[0] is not stale_digest
+
+
+# ─── Tests: render-failure graceful fallback (Fix 2) ──────────────────────────
+
+
+class TestRenderFailureFallback:
+    """A corrupted existing digest must not cause an infinite 503 loop.
+
+    Prior behaviour (PR #381): if ``_build_digest_response`` raised for an
+    ``editorial_v1`` / ``topics_v1`` record, the service re-raised. With the
+    digest still in DB, every subsequent request hit the same broken JSONB
+    and failed — a user was locked out for the whole day.
+
+    New behaviour: treat it like a stale-format record. Defer deletion, fall
+    through to regeneration, and let the deferred-delete logic replace the
+    corrupted record once a fresh one is ready.
+    """
+
+    @pytest.mark.asyncio
+    async def test_modern_format_render_failure_falls_through_to_regen(
+        self, service, mock_session
+    ):
+        """If editorial_v1 render fails, selector must still be invoked."""
+        from app.schemas.digest import DigestResponse
+
+        user_id = uuid4()
+        today = date.today()
+
+        corrupted = Mock()
+        corrupted.id = uuid4()
+        corrupted.target_date = today
+        corrupted.format_version = "editorial_v1"
+        corrupted.user_id = user_id
+        corrupted.is_serene = False
+
+        fresh_response = DigestResponse(
+            digest_id=uuid4(),
+            user_id=user_id,
+            target_date=today,
+            generated_at=datetime.utcnow(),
+            items=[],
+            format_version="editorial_v1",
+        )
+
+        async def fake_get_existing(uid, d, is_serene=False):
+            # Today's corrupted digest is returned once; no yesterday digest.
+            if d == today:
+                return corrupted
+            return None
+
+        # Selector returns an empty list — enough to reach the emergency/
+        # stale-fallback branches without crashing. The key assertion is
+        # that selector is INVOKED: that proves we fell through instead of
+        # raising.
+        service.selector = Mock()
+        service.selector.select_for_user = AsyncMock(return_value=[])
+
+        _prefs_result = Mock()
+        _prefs_result.scalar_one_or_none = Mock(return_value=None)
+        mock_session.execute.return_value = _prefs_result
+
+        call_log: list[str] = []
+
+        async def fake_build(digest, user_id):
+            if digest is corrupted:
+                call_log.append("corrupted")
+                raise KeyError("actu_article")
+            call_log.append("fresh")
+            return fresh_response
+
+        with (
+            patch("app.services.user_service.UserService") as mock_user_svc_cls,
+            patch.object(
+                service, "_get_existing_digest", side_effect=fake_get_existing
+            ),
+            patch.object(
+                service,
+                "_get_user_digest_format",
+                new_callable=AsyncMock,
+                return_value="editorial",
+            ),
+            patch.object(
+                service,
+                "_get_emergency_candidates",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch.object(service, "_build_digest_response", side_effect=fake_build),
+        ):
+            mock_user_svc_cls.return_value.get_or_create_profile = AsyncMock()
+            result = await service.get_or_create_digest(
+                user_id=user_id, target_date=today
+            )
+
+        # Selector ran → we did not re-raise the KeyError.
+        service.selector.select_for_user.assert_awaited()
+        # The first build call is for the corrupted digest. If the fix
+        # regressed to `raise`, we never would have gotten here.
+        assert call_log[0] == "corrupted"
+        # The corrupted record is deferred-deleted (not destroyed immediately
+        # on render failure). It survives when generation fails, which is
+        # exactly what enables the stale-fallback to serve *something*.
+        # (An exact "was/wasn't deleted" assertion depends on whether
+        # generation also failed here; the key regression is the absence
+        # of a re-raise, checked by reaching this line.)
+        assert result is None or result is fresh_response or hasattr(
+            result, "is_stale_fallback"
+        )
+
+    @pytest.mark.asyncio
+    async def test_modern_format_render_failure_does_not_delete_immediately(
+        self, service, mock_session
+    ):
+        """The corrupted record must only be deleted after a replacement exists."""
+        user_id = uuid4()
+        today = date.today()
+
+        corrupted = Mock()
+        corrupted.id = uuid4()
+        corrupted.target_date = today
+        corrupted.format_version = "topics_v1"
+        corrupted.user_id = user_id
+        corrupted.is_serene = False
+
+        async def fake_get_existing(uid, d, is_serene=False):
+            if d == today:
+                return corrupted
+            return None
+
+        service.selector = Mock()
+        service.selector.select_for_user = AsyncMock(return_value=[])
+
+        _prefs_result = Mock()
+        _prefs_result.scalar_one_or_none = Mock(return_value=None)
+        mock_session.execute.return_value = _prefs_result
+
+        async def fake_build(digest, user_id):
+            raise RuntimeError("boom")
+
+        with (
+            patch("app.services.user_service.UserService") as mock_user_svc_cls,
+            patch.object(
+                service, "_get_existing_digest", side_effect=fake_get_existing
+            ),
+            patch.object(
+                service,
+                "_get_user_digest_format",
+                new_callable=AsyncMock,
+                return_value="topics",
+            ),
+            patch.object(
+                service,
+                "_get_emergency_candidates",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch.object(service, "_build_digest_response", side_effect=fake_build),
+        ):
+            mock_user_svc_cls.return_value.get_or_create_profile = AsyncMock()
+            await service.get_or_create_digest(user_id=user_id, target_date=today)
+
+        # The corrupted record must survive the render failure path. The
+        # previous raise-on-modern-format behaviour never reached any
+        # delete logic either, but the new path must also refrain from
+        # pre-emptively wiping the only digest the user has.
+        for call in mock_session.delete.call_args_list:
+            assert call.args[0] is not corrupted

--- a/packages/api/tests/test_storage_cleanup.py
+++ b/packages/api/tests/test_storage_cleanup.py
@@ -3,6 +3,22 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+
+@pytest.fixture(autouse=True)
+def _empty_referenced_ids():
+    """By default, pretend no digest references any content.
+
+    The digest-reference exclusion query is not the subject of the legacy
+    tests below — they care about bookmarks / deep sources. Tests that need
+    to exercise the reference exclusion override this explicitly.
+    """
+    with patch(
+        "app.workers.storage_cleanup._collect_referenced_content_ids",
+        new=AsyncMock(return_value=set()),
+    ):
+        yield
 
 
 @pytest.mark.asyncio
@@ -233,3 +249,109 @@ async def test_cleanup_preserves_bookmarked_articles():
     assert result["preserved_deep"] == 8  # Deep source articles kept
     assert result["retention_days"] == 20
     mock_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_digest_referenced_content():
+    """Content referenced by a recent digest must be excluded from cleanup.
+
+    Regression for the ``editorial_article_not_found`` → 503 loop: if a
+    Content row referenced by today's editorial_v1 digest gets purged by
+    the RSS cleanup worker, ``_build_editorial_response`` crashes on
+    ``content_map.get(content_id)`` for every subsequent request.
+    """
+    referenced_id = uuid4()
+    mock_session = AsyncMock()
+
+    mock_count_to_delete = MagicMock()
+    mock_count_to_delete.scalar_one.return_value = 100
+
+    mock_count_preserved = MagicMock()
+    mock_count_preserved.scalar_one.return_value = 5
+
+    mock_count_deep = MagicMock()
+    mock_count_deep.scalar_one.return_value = 2
+
+    mock_delete_result = MagicMock()
+    mock_delete_result.rowcount = 100
+
+    mock_session.execute.side_effect = [
+        mock_count_to_delete,
+        mock_count_preserved,
+        mock_count_deep,
+        mock_delete_result,
+    ]
+
+    mock_session_maker = MagicMock()
+    mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_maker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    # Override the autouse fixture: signal that one content is referenced.
+    with patch(
+        "app.workers.storage_cleanup._collect_referenced_content_ids",
+        new=AsyncMock(return_value={referenced_id}),
+    ), patch(
+        "app.workers.storage_cleanup.async_session_maker", mock_session_maker
+    ), patch("app.workers.storage_cleanup.settings") as mock_settings:
+        mock_settings.rss_retention_days = 20
+
+        from app.workers.storage_cleanup import cleanup_old_articles
+
+        result = await cleanup_old_articles()
+
+    assert result["preserved_digest_refs"] == 1
+    # The DELETE statement must reference a NOT IN clause that excludes
+    # the digest-referenced content. The last execute() call is the DELETE.
+    delete_call_args = mock_session.execute.call_args_list[-1]
+    delete_stmt = delete_call_args.args[0]
+    # Compile to bound SQL so we can assert the param made it through.
+    # SQLAlchemy renders PG UUIDs in hex form, without dashes.
+    compiled = str(
+        delete_stmt.compile(compile_kwargs={"literal_binds": True})
+    )
+    assert referenced_id.hex in compiled
+    # And the DELETE has an extra NOT IN clause beyond the bookmarks /
+    # deep-source ones — signalled by multiple "NOT IN" occurrences.
+    assert compiled.count("NOT IN") >= 3
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skip_path_reports_preserved_digest_refs():
+    """Even when nothing is deleted, the preserved_digest_refs stat is returned."""
+    referenced_id = uuid4()
+    mock_session = AsyncMock()
+
+    mock_count_to_delete = MagicMock()
+    mock_count_to_delete.scalar_one.return_value = 0  # nothing to delete
+
+    mock_count_preserved = MagicMock()
+    mock_count_preserved.scalar_one.return_value = 0
+
+    mock_count_deep = MagicMock()
+    mock_count_deep.scalar_one.return_value = 0
+
+    mock_session.execute.side_effect = [
+        mock_count_to_delete,
+        mock_count_preserved,
+        mock_count_deep,
+    ]
+
+    mock_session_maker = MagicMock()
+    mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_maker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "app.workers.storage_cleanup._collect_referenced_content_ids",
+        new=AsyncMock(return_value={referenced_id}),
+    ), patch(
+        "app.workers.storage_cleanup.async_session_maker", mock_session_maker
+    ), patch("app.workers.storage_cleanup.settings") as mock_settings:
+        mock_settings.rss_retention_days = 20
+
+        from app.workers.storage_cleanup import cleanup_old_articles
+
+        result = await cleanup_old_articles()
+
+    assert result["deleted_count"] == 0
+    assert result["preserved_digest_refs"] == 1
+    mock_session.commit.assert_not_called()


### PR DESCRIPTION
## What

Implements three complementary fixes to prevent the digest 503 loop caused by corrupted JSONB payloads:

1. **Fix 2 — Graceful render failure fallback**: When `_build_digest_response` fails on a modern-format digest (editorial_v1/topics_v1), defer deletion and fall through to regeneration instead of re-raising. Uses the existing `stale_format_digest` mechanism to replace the corrupted record only after a fresh one is ready.

2. **Fix 4 — Content reference protection**: New `digest_content_refs.py` module extracts content_ids from all three JSONB layouts (flat_v1, topics_v1, editorial_v1) with graceful degradation. The storage cleanup worker now excludes any Content referenced by digests from the last 90 days, preventing deletion of articles that would crash digest rendering.

3. **Fix 5 — Diagnostic endpoint**: New `GET /api/digest/diag` endpoint (scoped to authenticated user) returns in a single request: digest existence/format, generation state, live render test with exception details, and migration status. Enables rapid diagnosis without Sentry/Railway access.

## Why

**Problem**: A corrupted digest JSONB payload (e.g., missing `actu_article` key in editorial_v1) causes `_build_digest_response` to raise. With the digest still in DB, every subsequent request hits the same broken record and fails — locking the user out for the whole day (or until manual intervention).

**Root causes**:
- PR #381 added a `raise` for modern formats to avoid silent downgrade to flat_v1, but this turned any persistent corruption into an all-day 503 loop.
- Storage cleanup worker could delete Content rows referenced by live digests, causing `editorial_article_not_found` crashes on every render attempt.
- No visibility into digest state without Sentry/Railway access.

**Solution**: Make each layer tolerant to failures in the others:
- Digest service treats render failures like stale-format records (defer deletion, regenerate).
- Storage cleanup excludes digest-referenced content from purge.
- Diag endpoint provides immediate visibility into render failures and migration status.

## Type

- [x] Bug fix

## Checklist

- [x] Tests pass locally (`cd packages/api && pytest -v`)
  - Added `TestRenderFailureFallback` (2 tests) in `test_digest_service.py`
  - Added `test_digest_content_refs.py` (10 tests covering all 3 layouts + edge cases)
  - Added 2 tests in `test_storage_cleanup.py` verifying NOT IN clause and stat reporting
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [x] If touching auth/DB: read Safety Guardrails
  - Diag endpoint is scoped to authenticated user only (no user_id query param)
  - Storage cleanup uses existing session/transaction patterns
- [x] Peer Review Conductor completed (separate workspace)

## Staging

- [x] N/A (backend-only changes; no UI impact)

## Notes

- Requires migrations `td01` (sources.tone/serein_default) and `dg01` (digest_generation_state) to be applied on production. The `/api/digest/diag` endpoint will report their status.
- The graceful fallback in Fix 2 reuses the existing deferred-delete logic (lines ~671-674 in digest_service.py), so no new transaction patterns are introduced.
- All three fixes are independent and can be deployed separately, but together they form a complete defense against the 503 loop.

https://claude.ai/code/session_01LsaSQQeLiBdthWWUnD6HKd