### PR TITLE
Fix serein digest reusing normal-mode articles + cap sport/faits divers

### DIFF
--- a/docs/bugs/bug-digest-serein-collision-2026-04-13.md
+++ b/docs/bugs/bug-digest-serein-collision-2026-04-13.md
@@ -144,6 +144,21 @@ les deux modes** :
   appliqué si TOUT est sport.
 - Aucun changement au modèle DB, aucune migration Alembic.
 
+## Status — 2026-04-13 (après implémentation)
+
+- [x] Fix 1 — `_get_global_candidates(mode)` filtre serein au SQL.
+- [x] Fix 2 — `compute_global_context` filtre les clusters non-serein-compatibles.
+- [x] Fix 3 — cap sport + faits divers dans les deux modes, avec escape-hatch
+  si le pool non-low-priority est trop pauvre (< 5 clusters).
+- [x] Tests de régression (44/44 tests pertinents passent sur Python 3.12) :
+  - `tests/test_low_priority_cap.py` — unit tests sur les helpers (12 tests).
+  - `tests/editorial/test_pipeline_mode_filters.py` — intégration pipeline
+    (4 tests : serein exclut les clusters anxieux, pour_vous les garde, cap
+    sport limite à 1, cap skippé si pool trop petit).
+  - `tests/test_digest_generation_job.py::TestGlobalCandidatePool` — 2
+    nouveaux tests vérifient que la SQL du pool serein JOIN `sources` et
+    filtre via `Source.theme`, et que le pool pour_vous reste inchangé.
+
 ## Hors scope
 
 - Tagging `is_serene` pour les articles existants non taggés (job séparé).

--- a/docs/bugs/bug-digest-serein-collision-2026-04-13.md
+++ b/docs/bugs/bug-digest-serein-collision-2026-04-13.md
@@ -1,0 +1,151 @@
+# Bug — Le digest Serein reprend les articles du mode Normal (2026-04-13)
+
+> **Critique** — utilisateur (Laurin) rapporte depuis 2 jours : "la pipeline de
+> digest serein ne marche plus du tout — reprend les articles du mode Normal".
+> En parallèle : demande produit pour réduire les faits divers + sport dans
+> les deux modes.
+
+## Symptôme
+
+- Le digest serein contient sensiblement les mêmes 4-5 sujets que le digest
+  Normal (pour_vous), avec uniquement le ton éditorial qui change.
+- Demande produit additionnelle : limiter les faits divers + sport (pas de
+  filtre actif aujourd'hui sur ces deux catégories).
+
+## Cause racine
+
+Pipeline éditorial actuel (`editorial_v1`, format de production) :
+
+1. `digest_generation_job._get_global_candidates(session)` — fetch les **200
+   articles les plus récents** (48h), **sans aucun filtrage serein**.
+2. Boucle `for mode in ("pour_vous", "serein")` qui appelle
+   `pipeline.compute_global_context(global_candidates, mode=mode)` avec **le
+   même pool** pour les deux modes.
+3. Dans `compute_global_context` :
+   - `ImportanceDetector.build_topic_clusters(contents)` clusterise sur le pool
+     non filtré → **clusters identiques entre les deux modes**.
+   - `CurationService.select_topics(clusters, ...)` est **mode-agnostique** :
+     le LLM choisit les "top 4 sujets les plus importants" sans tenir compte du
+     mode → mêmes sujets sélectionnés pour pour_vous et serein.
+   - `ActuMatcher.match_global` est aussi mode-agnostique → mêmes articles
+     d'actu rattachés.
+   - Seules différences mode-spécifiques :
+     - À la une (`select_bonne_nouvelle` vs `select_a_la_une`)
+     - Prompt d'écriture (ton)
+     - `actu_decalee` ajouté pour serein
+4. Le filtre serein (`apply_serein_filter` + `is_cluster_serein_compatible`)
+   existe et fonctionne, mais il n'est appliqué **que** dans le legacy
+   `topic_selector.py` (output_format=`topics_v1`), pas dans le pipeline
+   éditorial.
+
+Régression introduite par PR #374 (commit `fd072fd`, 2026-04-09) — le
+pre-compute "dual variant" du contexte éditorial a été ajouté pour éviter le
+on-demand sur le toggle serein, mais le pool global candidats n'a jamais été
+filtré par mode.
+
+Pourquoi "depuis 2 jours" ? Le pre-compute date du 09-04 mais le format
+`editorial_v1` est devenu obligatoire/sticky avec PR #381 (10-04, "Prevent
+digest format downgrade to legacy flat_v1"). Avant, un fallback `topics_v1`
+était possible et le filtre serein s'appliquait via `topic_selector`. Depuis
+#381, tous les digests sont en `editorial_v1`, ce qui expose le bug.
+
+## Plan de correction
+
+### Fix 1 — Filtrer le pool serein au niveau SQL (couche basse)
+
+`packages/api/app/jobs/digest_generation_job.py:253-285`
+
+`_get_global_candidates` reçoit un nouveau param `mode` :
+- `mode == "serein"` → applique `apply_serein_filter` (defaults
+  `SEREIN_EXCLUDED_THEMES` + keywords) sur la query SQLAlchemy avant
+  `.limit(200)`.
+- `mode == "pour_vous"` → comportement actuel (aucun filtre).
+
+Appel mis à jour ligne 170 :
+```python
+for mode in ("pour_vous", "serein"):
+    global_candidates = await self._get_global_candidates(session, mode=mode)
+```
+
+### Fix 2 — Filtrer les clusters au niveau pipeline (défense en profondeur)
+
+`packages/api/app/services/editorial/pipeline.py:80-93`
+
+Dans `compute_global_context`, après `build_topic_clusters` :
+- Si `mode == "serein"`, exclure les clusters dont
+  `is_cluster_serein_compatible(cluster) == False` AVANT toute sélection (À
+  la une, curation LLM, etc.).
+- Garantit que même si le filtre SQL laisse passer un article (cas
+  `is_serene IS NULL` non taggé par LLM), le clustering ne regroupe pas un
+  sujet anxiogène pour serein.
+
+### Fix 3 — Pénaliser faits divers + sport dans LES DEUX modes
+
+Nouvelle constante partagée dans
+`packages/api/app/services/recommendation/filter_presets.py` :
+
+```python
+LOW_PRIORITY_KEYWORDS = [
+    # Faits divers (déjà partiellement dans SEREIN_KEYWORDS, mais ici utilisé
+    # aussi pour pour_vous comme déprioritisation, pas exclusion)
+    "fait divers", "faits divers", "fait-divers",
+    "accident", "incendie", "noyade", "agression",
+    # Sport (NOUVEAU — pas exclu, juste déprioritisé)
+    "football", "rugby", "tennis", "basket", "ligue 1", "ligue 2",
+    "champions league", "ligue des champions", "roland-garros",
+    "tour de france", "formule 1", "f1", "moto gp", "jeux olympiques",
+    "psg", "om", "ol", "asse", "rcl", "asm",
+]
+```
+
+Nouvelle fonction `is_low_priority_cluster(cluster) -> bool` (analogue à
+`is_cluster_serein_compatible` : > 50% des articles matchent ou theme dominant
+== "sport").
+
+`packages/api/app/services/editorial/pipeline.py` — après clustering, **dans
+les deux modes** :
+- Identifier les low-priority clusters.
+- Quota dur : maximum 1 cluster sport + 1 cluster faits divers parmi les 5
+  sujets sélectionnés (configurable). Si le LLM en choisit plus, on remplace
+  par le suivant trending non-low-priority.
+
+### Fix 4 — Tests de régression
+
+- `tests/test_digest_serein_pipeline.py` (nouveau) :
+  - Un cluster contenant uniquement des articles "guerre Ukraine" est
+    EXCLU du contexte serein (mais inclus pour pour_vous).
+  - Le pool global serein ne contient pas d'articles `is_serene=False`.
+  - Mode `serein` et `pour_vous` produisent des `subjects` différents quand
+    des sujets anxiogènes dominent l'actualité.
+
+- `tests/test_low_priority_cap.py` (nouveau) :
+  - Si 4 clusters trending sont du sport, max 1 sport apparaît dans le digest.
+  - Si seulement du sport est disponible, le quota est levé pour atteindre
+    target_count (pas de digest vide).
+
+## Fichiers modifiés
+
+| Fichier | Modification |
+|---------|--------------|
+| `packages/api/app/jobs/digest_generation_job.py` | `_get_global_candidates(mode)` + appel boucle |
+| `packages/api/app/services/editorial/pipeline.py` | Filtre serein post-clustering + cap low-priority |
+| `packages/api/app/services/recommendation/filter_presets.py` | Nouvelles constantes + `is_low_priority_cluster` |
+| `packages/api/tests/test_digest_serein_pipeline.py` | Nouveau (regression serein) |
+| `packages/api/tests/test_low_priority_cap.py` | Nouveau (cap sport/faits divers) |
+
+## Risques
+
+- Pool serein réduit → si très peu d'articles `is_serene=True` ce matin,
+  fallback keyword-only (déjà géré par `apply_serein_filter`). Si le pool est
+  trop pauvre (< 5 clusters), la curation LLM logge déjà `insufficient_clusters`
+  et utilise ce qu'elle a.
+- Le cap sport/faits divers peut frustrer pendant une compétition majeure
+  (Coupe du Monde) — mitigé par "À la une" qui reste libre + le quota n'est pas
+  appliqué si TOUT est sport.
+- Aucun changement au modèle DB, aucune migration Alembic.
+
+## Hors scope
+
+- Tagging `is_serene` pour les articles existants non taggés (job séparé).
+- Refonte complète de la curation LLM (le prompt actuel reste mode-agnostique).
+- Préférences utilisateur "muet sport" (déjà disponible via mute_themes).

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -171,8 +171,25 @@ class DigestGenerationJob:
                     if global_candidates:
                         for mode in ("pour_vous", "serein"):
                             try:
+                                # Serein: re-fetch a mode-specific pool
+                                # filtered by apply_serein_filter at the SQL
+                                # level so the editorial pipeline clusters on
+                                # serein-compatible articles only.
+                                mode_candidates = (
+                                    global_candidates
+                                    if mode == "pour_vous"
+                                    else await self._get_global_candidates(
+                                        session, mode="serein"
+                                    )
+                                )
+                                if not mode_candidates:
+                                    logger.warning(
+                                        "digest_generation_editorial_empty_pool",
+                                        mode=mode,
+                                    )
+                                    continue
                                 ctx = await pipeline.compute_global_context(
-                                    global_candidates, mode=mode
+                                    mode_candidates, mode=mode
                                 )
                                 if ctx:
                                     from app.services.digest_selector import (
@@ -253,6 +270,7 @@ class DigestGenerationJob:
     async def _get_global_candidates(
         self,
         session: AsyncSession,
+        mode: str = "pour_vous",
     ) -> list[Any]:
         """Fetch a user-agnostic global candidate pool for editorial context.
 
@@ -260,20 +278,34 @@ class DigestGenerationJob:
         regardless of whether the first user in the list has a warm pool.
         Falls back to a broad recent-content query so the pipeline never
         cold-paths because of one unlucky user.
+
+        Args:
+            session: Async SQLAlchemy session.
+            mode: "pour_vous" (default, no filter) or "serein" (apply
+                ``apply_serein_filter`` so anxious articles are excluded
+                from the clustering pool).
         """
         from datetime import UTC, timedelta
 
         from sqlalchemy.orm import selectinload
 
         from app.models.content import Content
+        from app.models.source import Source
 
         # Content.published_at is stored as tz-aware, so the comparison
         # value must also be tz-aware (and utcnow() is deprecated in 3.12).
         cutoff = datetime.datetime.now(UTC) - timedelta(hours=self.hours_lookback)
+        # Serein filter references Source.theme so we need an explicit join.
+        # The join is harmless for pour_vous (every Content has a Source) but
+        # we keep it behind the mode branch to match existing behaviour.
+        stmt = select(Content).options(selectinload(Content.source))
+        if mode == "serein":
+            from app.services.recommendation.filter_presets import apply_serein_filter
+
+            stmt = stmt.join(Source, Content.source_id == Source.id)
+            stmt = apply_serein_filter(stmt)
         stmt = (
-            select(Content)
-            .options(selectinload(Content.source))
-            .where(Content.published_at >= cutoff)
+            stmt.where(Content.published_at >= cutoff)
             .order_by(Content.published_at.desc())
             .limit(200)
         )
@@ -281,7 +313,11 @@ class DigestGenerationJob:
             result = await session.execute(stmt)
             return list(result.scalars().all())
         except Exception as e:
-            logger.error("digest_generation_global_candidates_failed", error=str(e))
+            logger.error(
+                "digest_generation_global_candidates_failed",
+                mode=mode,
+                error=str(e),
+            )
             return []
 
     async def _prune_old_highlights(

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -118,9 +118,7 @@ class EditorialPipelineService:
         # modes. Clusters are sorted by size desc so the largest — typically
         # the most trending — is kept. Skip the cap if the remaining non-
         # low-priority pool would be too small to pick 5 subjects.
-        sorted_by_size = sorted(
-            clusters, key=lambda c: len(c.source_ids), reverse=True
-        )
+        sorted_by_size = sorted(clusters, key=lambda c: len(c.source_ids), reverse=True)
         capped = cap_low_priority_clusters(sorted_by_size)
         if len(capped) >= 5:
             dropped = len(sorted_by_size) - len(capped)

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -92,6 +92,53 @@ class EditorialPipelineService:
             duration_ms=round(cluster_time * 1000, 2),
         )
 
+        # ÉTAPE 1A-bis: Mode-aware cluster filtering.
+        # 1) Serein — drop clusters flagged anxious (defence-in-depth on top
+        #    of the SQL-level apply_serein_filter already applied upstream).
+        # 2) Both modes — cap faits divers + sport to at most 1 cluster each
+        #    so the digest isn't dominated by these lower-priority topics.
+        from app.services.recommendation.filter_presets import (
+            cap_low_priority_clusters,
+            is_cluster_serein_compatible,
+        )
+
+        pre_filter_count = len(clusters)
+        if mode == "serein":
+            clusters = [c for c in clusters if is_cluster_serein_compatible(c)]
+            logger.info(
+                "editorial_pipeline.serein_cluster_filter",
+                before=pre_filter_count,
+                after=len(clusters),
+            )
+            if not clusters:
+                logger.warning("editorial_pipeline.serein_no_compatible_clusters")
+                return None
+
+        # Cap low-priority clusters (sport + faits divers) — applies to both
+        # modes. Clusters are sorted by size desc so the largest — typically
+        # the most trending — is kept. Skip the cap if the remaining non-
+        # low-priority pool would be too small to pick 5 subjects.
+        sorted_by_size = sorted(
+            clusters, key=lambda c: len(c.source_ids), reverse=True
+        )
+        capped = cap_low_priority_clusters(sorted_by_size)
+        if len(capped) >= 5:
+            dropped = len(sorted_by_size) - len(capped)
+            clusters = capped
+            logger.info(
+                "editorial_pipeline.low_priority_cap_applied",
+                mode=mode,
+                dropped=dropped,
+                remaining=len(clusters),
+            )
+        else:
+            logger.info(
+                "editorial_pipeline.low_priority_cap_skipped",
+                mode=mode,
+                reason="insufficient_non_low_priority_pool",
+                capped_size=len(capped),
+            )
+
         # ÉTAPE 1B: Pré-sélection "À la Une" — cluster le plus couvert
         step_start = time.time()
         trending_clusters = [c for c in clusters if c.is_trending]

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -204,6 +204,126 @@ def get_opposing_biases(user_stance: BiasStance) -> list[BiasStance]:
         ]
 
 
+# --- Constantes "low-priority" (faits divers + sport) ---
+#
+# Utilisé pour déprioritiser ces catégories dans le digest (les deux modes —
+# pour_vous ET serein). Contrairement à SEREIN_KEYWORDS, ces patterns ne
+# servent PAS à exclure les articles : ils servent à limiter le nombre de
+# sujets de chaque catégorie dans le digest (cap à 1 sport + 1 faits divers).
+
+LOW_PRIORITY_FAITS_DIVERS_KEYWORDS = [
+    "fait divers",
+    "faits divers",
+    "fait-divers",
+    "faits-divers",
+    "accident",
+    "incendie",
+    "noyade",
+    "collision",
+    "braquage",
+    "cambriolage",
+]
+
+LOW_PRIORITY_SPORT_KEYWORDS = [
+    "football",
+    "rugby",
+    "tennis",
+    "basket",
+    "handball",
+    "ligue 1",
+    "ligue 2",
+    "champions league",
+    "ligue des champions",
+    "europa league",
+    "coupe du monde",
+    "coupe de france",
+    "roland-garros",
+    "roland garros",
+    "wimbledon",
+    "tour de france",
+    "formule 1",
+    " f1 ",
+    "moto gp",
+    "motogp",
+    "jeux olympiques",
+    "psg",
+    " om ",
+    " ol ",
+    " asse ",
+    " asm ",
+    "mbappé",
+    "mbappe",
+]
+
+LOW_PRIORITY_SPORT_THEMES = {"sport", "sports"}
+
+
+def _match_ratio(cluster: TopicCluster, keywords: list[str]) -> float:
+    """Retourne la part d'articles du cluster matchant au moins un keyword."""
+    if not cluster.contents:
+        return 0.0
+    import re as _re
+
+    pattern = _re.compile("|".join(_re.escape(k) for k in keywords), _re.IGNORECASE)
+
+    def _s(v: object) -> str:
+        # Defensive: Content fields are Optional[str], but MagicMocks in tests
+        # (and SQLAlchemy sentinel values) can slip in. Only use real strings.
+        return v if isinstance(v, str) else ""
+
+    match_count = 0
+    for content in cluster.contents:
+        text = _s(getattr(content, "title", None)) + " " + _s(
+            getattr(content, "description", None)
+        )
+        if pattern.search(text):
+            match_count += 1
+    return match_count / len(cluster.contents)
+
+
+def is_sport_cluster(cluster: TopicCluster) -> bool:
+    """Cluster dominé par le sport (thème OU >50% titres matchent)."""
+    if cluster.theme and cluster.theme.lower() in LOW_PRIORITY_SPORT_THEMES:
+        return True
+    return _match_ratio(cluster, LOW_PRIORITY_SPORT_KEYWORDS) > 0.5
+
+
+def is_faits_divers_cluster(cluster: TopicCluster) -> bool:
+    """Cluster dominé par les faits divers (>50% titres matchent)."""
+    return _match_ratio(cluster, LOW_PRIORITY_FAITS_DIVERS_KEYWORDS) > 0.5
+
+
+def cap_low_priority_clusters(
+    clusters: list[TopicCluster],
+    max_sport: int = 1,
+    max_faits_divers: int = 1,
+) -> list[TopicCluster]:
+    """Limite le nombre de clusters sport + faits divers.
+
+    Conserve l'ordre d'entrée (supposé trié par pertinence/taille) et ne
+    garde que les `max_sport` premiers sport + `max_faits_divers` premiers
+    faits divers. Les autres sont filtrés. Les clusters non low-priority
+    passent tous.
+
+    Utilisé AVANT la sélection LLM pour éviter que 3 matchs de foot + 2
+    faits divers saturent le digest.
+    """
+    kept: list[TopicCluster] = []
+    sport_count = 0
+    fd_count = 0
+    for c in clusters:
+        if is_sport_cluster(c):
+            if sport_count >= max_sport:
+                continue
+            sport_count += 1
+        elif is_faits_divers_cluster(c):
+            if fd_count >= max_faits_divers:
+                continue
+            fd_count += 1
+        kept.append(c)
+    return kept
+
+
 def is_cluster_serein_compatible(
     cluster: TopicCluster, sensitive_themes: list[str] | None = None
 ) -> bool:

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -273,8 +273,10 @@ def _match_ratio(cluster: TopicCluster, keywords: list[str]) -> float:
 
     match_count = 0
     for content in cluster.contents:
-        text = _s(getattr(content, "title", None)) + " " + _s(
-            getattr(content, "description", None)
+        text = (
+            _s(getattr(content, "title", None))
+            + " "
+            + _s(getattr(content, "description", None))
         )
         if pattern.search(text):
             match_count += 1

--- a/packages/api/tests/editorial/test_pipeline_mode_filters.py
+++ b/packages/api/tests/editorial/test_pipeline_mode_filters.py
@@ -1,0 +1,270 @@
+"""Regression tests — serein filter + low-priority cap in the editorial pipeline.
+
+Covers the fix for `bug-digest-serein-collision-2026-04-13`:
+- Serein mode drops clusters flagged as non-serein-compatible BEFORE the
+  curation step, so the serein digest no longer reuses the normal-mode
+  articles when anxious topics dominate the pool.
+- Both modes cap sport + faits divers clusters at 1 each (with a safety
+  escape hatch when the remaining pool is too small).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.services.editorial.schemas import SelectedTopic
+
+
+def _make_content(title="x", description=""):
+    c = MagicMock()
+    c.id = uuid4()
+    c.title = title
+    c.description = description
+    c.source_id = uuid4()
+    c.source = MagicMock()
+    c.source.name = "S"
+    c.entities = None
+    return c
+
+
+def _make_cluster(cid, titles, theme=None, source_count=3):
+    cluster = MagicMock()
+    cluster.cluster_id = cid
+    cluster.label = cid
+    cluster.contents = [_make_content(title=t) for t in titles]
+    cluster.source_ids = {uuid4() for _ in range(source_count)}
+    cluster.theme = theme
+    cluster.is_trending = source_count >= 3
+    return cluster
+
+
+@pytest.fixture
+def mock_deps():
+    with (
+        patch("app.services.editorial.pipeline.load_editorial_config") as mock_config,
+        patch("app.services.editorial.pipeline.EditorialLLMClient") as mock_llm_cls,
+        patch("app.services.editorial.pipeline.CurationService") as mock_curation_cls,
+        patch("app.services.editorial.pipeline.DeepMatcher") as mock_deep_cls,
+        patch("app.services.editorial.pipeline.ActuMatcher") as mock_actu_cls,
+        patch(
+            "app.services.editorial.pipeline.PerspectiveService"
+        ) as mock_perspective_cls,
+    ):
+        from app.services.editorial.config import EditorialConfig, PipelineConfig
+
+        mock_config.return_value = EditorialConfig(pipeline=PipelineConfig())
+
+        mock_llm = MagicMock()
+        mock_llm.is_ready = True
+        mock_llm.close = AsyncMock()
+        mock_llm_cls.return_value = mock_llm
+
+        mock_curation = MagicMock()
+        mock_curation.select_topics = AsyncMock(return_value=[])
+        mock_curation.select_a_la_une = AsyncMock(return_value=None)
+        mock_curation.select_bonne_nouvelle = AsyncMock(return_value=None)
+        mock_curation_cls.return_value = mock_curation
+
+        mock_deep = MagicMock()
+        mock_deep.match_for_topics = AsyncMock(return_value={})
+        mock_deep_cls.return_value = mock_deep
+
+        mock_actu = MagicMock()
+        mock_actu.match_global.side_effect = (
+            lambda subjects, clusters, excluded_source_ids=None, excluded_content_ids=None: subjects
+        )
+        mock_actu_cls.return_value = mock_actu
+
+        mock_perspective = MagicMock()
+        mock_perspective.get_perspectives_hybrid = AsyncMock(return_value=([], []))
+        mock_perspective.resolve_bias = AsyncMock(return_value="center")
+        mock_perspective.analyze_divergences = AsyncMock(return_value=None)
+        mock_perspective_cls.return_value = mock_perspective
+
+        yield {
+            "llm": mock_llm,
+            "curation": mock_curation,
+            "deep": mock_deep,
+            "actu": mock_actu,
+            "perspective": mock_perspective,
+        }
+
+
+class TestSereinClusterFilter:
+    """compute_global_context(mode='serein') drops anxious clusters."""
+
+    @pytest.mark.asyncio
+    async def test_serein_excludes_anxious_clusters(self, mock_deps):
+        from app.services.editorial.pipeline import EditorialPipelineService
+
+        # 3 anxious, 3 neutral; only neutrals should reach the curation step
+        clusters = [
+            _make_cluster(
+                "war", ["Guerre en Ukraine : bombardements"], theme="international"
+            ),
+            _make_cluster(
+                "pol", ["Macron annonce réforme"], theme="politics"
+            ),
+            _make_cluster(
+                "crime", ["Meurtre à Paris", "Agression dans le métro"], theme=None
+            ),
+            _make_cluster("sci", ["Découverte scientifique"], theme="science"),
+            _make_cluster("cult", ["Festival de Cannes"], theme="culture"),
+            _make_cluster("tech", ["Innovation robotique"], theme="technology"),
+        ]
+
+        captured_ids: list[str] = []
+
+        async def _capture_select_topics(
+            available, subjects_count=None, excluded_cluster_ids=None
+        ):
+            for c in available:
+                captured_ids.append(c.cluster_id)
+            return []
+
+        mock_deps["curation"].select_topics.side_effect = _capture_select_topics
+
+        svc = EditorialPipelineService(AsyncMock())
+        with patch(
+            "app.services.editorial.pipeline.ImportanceDetector"
+        ) as mock_detector_cls:
+            mock_detector = MagicMock()
+            mock_detector.build_topic_clusters.return_value = clusters
+            mock_detector_cls.return_value = mock_detector
+            await svc.compute_global_context(
+                [_make_content("x") for _ in range(5)], mode="serein"
+            )
+
+        # Curation must have been called on only non-anxious clusters
+        assert "war" not in captured_ids
+        assert "pol" not in captured_ids
+        assert "crime" not in captured_ids
+        # At least one neutral cluster must have been offered to the curator
+        assert any(c in captured_ids for c in ("sci", "cult", "tech"))
+
+    @pytest.mark.asyncio
+    async def test_pour_vous_keeps_anxious_clusters(self, mock_deps):
+        """Sanity check: pour_vous is NOT filtered by the serein rule."""
+        from app.services.editorial.pipeline import EditorialPipelineService
+
+        clusters = [
+            _make_cluster("war", ["Guerre en Ukraine"], theme="international"),
+            _make_cluster("pol", ["Macron réforme"], theme="politics"),
+            _make_cluster("sci", ["Découverte"], theme="science"),
+            _make_cluster("cult", ["Festival"], theme="culture"),
+            _make_cluster("tech", ["Robotique"], theme="technology"),
+        ]
+
+        captured_ids: list[str] = []
+
+        async def _capture_select_topics(
+            available, subjects_count=None, excluded_cluster_ids=None
+        ):
+            for c in available:
+                captured_ids.append(c.cluster_id)
+            return []
+
+        mock_deps["curation"].select_topics.side_effect = _capture_select_topics
+
+        svc = EditorialPipelineService(AsyncMock())
+        with patch(
+            "app.services.editorial.pipeline.ImportanceDetector"
+        ) as mock_detector_cls:
+            mock_detector = MagicMock()
+            mock_detector.build_topic_clusters.return_value = clusters
+            mock_detector_cls.return_value = mock_detector
+            await svc.compute_global_context(
+                [_make_content("x") for _ in range(5)], mode="pour_vous"
+            )
+
+        # Anxious clusters must still be available to the curator in pour_vous
+        assert "war" in captured_ids
+        assert "pol" in captured_ids
+
+
+class TestLowPrioritySportCap:
+    """Sport clusters are capped at 1 across both modes."""
+
+    @pytest.mark.asyncio
+    async def test_multiple_sport_clusters_capped(self, mock_deps):
+        from app.services.editorial.pipeline import EditorialPipelineService
+
+        # 3 sport clusters + enough non-sport clusters so the cap is applied
+        # (cap is skipped when it would leave < 5 clusters for curation).
+        clusters = [
+            _make_cluster("sport1", ["PSG OM"], theme="sport", source_count=5),
+            _make_cluster("sport2", ["Tennis Roland-Garros"], theme="sport"),
+            _make_cluster("sport3", ["Rugby France Angleterre"], theme="sport"),
+            _make_cluster("pol", ["Élections"], theme="politics", source_count=4),
+            _make_cluster("eco", ["Inflation"], theme="economy", source_count=4),
+            _make_cluster("sci", ["Recherche"], theme="science", source_count=3),
+            _make_cluster("tech", ["IA avancée"], theme="technology", source_count=3),
+            _make_cluster("cult", ["Cinéma"], theme="culture", source_count=3),
+        ]
+
+        captured_ids: list[str] = []
+
+        async def _capture_select_topics(
+            available, subjects_count=None, excluded_cluster_ids=None
+        ):
+            for c in available:
+                captured_ids.append(c.cluster_id)
+            return []
+
+        mock_deps["curation"].select_topics.side_effect = _capture_select_topics
+
+        svc = EditorialPipelineService(AsyncMock())
+        with patch(
+            "app.services.editorial.pipeline.ImportanceDetector"
+        ) as mock_detector_cls:
+            mock_detector = MagicMock()
+            mock_detector.build_topic_clusters.return_value = clusters
+            mock_detector_cls.return_value = mock_detector
+            await svc.compute_global_context(
+                [_make_content("x") for _ in range(5)], mode="pour_vous"
+            )
+
+        sport_kept = [c for c in captured_ids if c.startswith("sport")]
+        assert len(sport_kept) == 1, f"expected 1 sport cluster, got {sport_kept}"
+        assert "sport1" in sport_kept  # largest kept
+
+    @pytest.mark.asyncio
+    async def test_cap_skipped_when_remaining_pool_too_small(self, mock_deps):
+        """When dropping low-priority clusters would leave < 5, we keep them."""
+        from app.services.editorial.pipeline import EditorialPipelineService
+
+        # Pool is mostly sport — cap would reduce to 2 clusters, so skip cap
+        clusters = [
+            _make_cluster("sport1", ["PSG"], theme="sport", source_count=5),
+            _make_cluster("sport2", ["Tennis"], theme="sport"),
+            _make_cluster("sport3", ["Rugby"], theme="sport"),
+            _make_cluster("sport4", ["Basket"], theme="sport"),
+            _make_cluster("pol", ["Élections"], theme="politics"),
+        ]
+
+        captured_ids: list[str] = []
+
+        async def _capture_select_topics(
+            available, subjects_count=None, excluded_cluster_ids=None
+        ):
+            for c in available:
+                captured_ids.append(c.cluster_id)
+            return []
+
+        mock_deps["curation"].select_topics.side_effect = _capture_select_topics
+
+        svc = EditorialPipelineService(AsyncMock())
+        with patch(
+            "app.services.editorial.pipeline.ImportanceDetector"
+        ) as mock_detector_cls:
+            mock_detector = MagicMock()
+            mock_detector.build_topic_clusters.return_value = clusters
+            mock_detector_cls.return_value = mock_detector
+            await svc.compute_global_context(
+                [_make_content("x") for _ in range(5)], mode="pour_vous"
+            )
+
+        sport_kept = [c for c in captured_ids if c.startswith("sport")]
+        # Cap skipped because pruning would leave < 5 clusters
+        assert len(sport_kept) >= 2

--- a/packages/api/tests/test_digest_generation_job.py
+++ b/packages/api/tests/test_digest_generation_job.py
@@ -217,3 +217,52 @@ class TestGlobalCandidatePool:
 
         result = await job._get_global_candidates(mock_session)
         assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_get_global_candidates_serein_applies_filter(self, job):
+        """Serein mode must join on Source and apply the serein filter.
+
+        Regression for bug-digest-serein-collision-2026-04-13: before this
+        fix the editorial batch reused the unfiltered pour_vous pool for
+        serein, which is why serein digests ended up showing the same
+        articles as the normal mode.
+        """
+        mock_session = AsyncMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all = MagicMock(return_value=[])
+        result_mock = MagicMock()
+        result_mock.scalars = MagicMock(return_value=scalars_mock)
+        mock_session.execute = AsyncMock(return_value=result_mock)
+
+        await job._get_global_candidates(mock_session, mode="serein")
+
+        # Inspect the SQL actually executed — it must reference Source (join)
+        # and the serene/keyword filter artefacts.
+        stmt = mock_session.execute.call_args.args[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": False})).lower()
+        # Serein mode joins on sources and filters via the serene condition
+        # (either is_serene=True path or the keyword/theme fallback).
+        assert "join sources" in compiled, (
+            f"serein pool must JOIN sources; got:\n{compiled}"
+        )
+        assert "sources.theme" in compiled, (
+            f"serein pool must reference Source.theme filter; got:\n{compiled}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_global_candidates_pour_vous_no_source_join(self, job):
+        """Pour-vous mode keeps the historical (no-filter) SQL shape."""
+        mock_session = AsyncMock()
+        scalars_mock = MagicMock()
+        scalars_mock.all = MagicMock(return_value=[])
+        result_mock = MagicMock()
+        result_mock.scalars = MagicMock(return_value=scalars_mock)
+        mock_session.execute = AsyncMock(return_value=result_mock)
+
+        await job._get_global_candidates(mock_session, mode="pour_vous")
+
+        stmt = mock_session.execute.call_args.args[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": False})).lower()
+        # No join on sources, no theme filter — historical behaviour preserved
+        assert "join sources" not in compiled
+        assert "sources.theme" not in compiled

--- a/packages/api/tests/test_feed_filters.py
+++ b/packages/api/tests/test_feed_filters.py
@@ -1,6 +1,6 @@
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from app.main import app
 from app.models.enums import FeedFilterMode
 
@@ -8,7 +8,8 @@ from app.models.enums import FeedFilterMode
 async def test_feed_filter_inspiration():
     # Mocking would be better, but for integration test MVP:
     # We expect query params to work without internal server error
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         # Assuming typical auth headers are handled by middleware or mocked dependencies
         # But this requires a running DB or mocked Session.
         # Let's create a simpler unit test style or integration if possible.

--- a/packages/api/tests/test_low_priority_cap.py
+++ b/packages/api/tests/test_low_priority_cap.py
@@ -1,0 +1,162 @@
+"""Tests for low-priority cluster cap (faits divers + sport) and serein
+cluster filter integration at the editorial pipeline level.
+
+Unit tests for the new helpers in
+`app.services.recommendation.filter_presets`:
+- ``is_sport_cluster``
+- ``is_faits_divers_cluster``
+- ``cap_low_priority_clusters``
+
+The pipeline-level integration (serein filter + cap inside
+``EditorialPipelineService.compute_global_context``) is exercised via the
+behavioural assertions on the helpers — the pipeline simply calls them.
+"""
+
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+from app.services.recommendation.filter_presets import (
+    cap_low_priority_clusters,
+    is_faits_divers_cluster,
+    is_sport_cluster,
+)
+
+
+@dataclass
+class _FakeContent:
+    title: str | None = None
+    description: str | None = None
+
+
+@dataclass
+class _FakeCluster:
+    cluster_id: str = "c"
+    label: str = ""
+    tokens: set = field(default_factory=set)
+    contents: list = field(default_factory=list)
+    source_ids: set[UUID] = field(default_factory=set)
+    theme: str | None = None
+
+
+def _make(theme=None, titles=None, source_count=1):
+    contents = [_FakeContent(title=t) for t in (titles or ["x"])]
+    return _FakeCluster(
+        cluster_id=str(uuid4()),
+        contents=contents,
+        theme=theme,
+        source_ids={uuid4() for _ in range(source_count)},
+    )
+
+
+class TestIsSportCluster:
+    def test_theme_sport_is_sport(self):
+        assert is_sport_cluster(_make(theme="sport", titles=["Actu diverse"]))
+
+    def test_keywords_majority_is_sport(self):
+        cluster = _make(
+            theme="society",
+            titles=[
+                "PSG bat l'OM en Ligue 1",
+                "Mbappé marque un doublé",
+                "Tennis Roland-Garros début",
+                "Analyse économique",  # 1/4 non-sport
+            ],
+        )
+        assert is_sport_cluster(cluster)
+
+    def test_non_sport_not_flagged(self):
+        cluster = _make(
+            theme="economy",
+            titles=["Inflation en hausse", "Rapport BCE", "Chômage"],
+        )
+        assert not is_sport_cluster(cluster)
+
+    def test_minority_sport_mentions_not_flagged(self):
+        cluster = _make(
+            theme="politics",
+            titles=[
+                "Macron à l'Élysée",
+                "Débat parlementaire",
+                "Réforme retraites",
+                "Le PSG visite la mairie",  # 1/4
+            ],
+        )
+        assert not is_sport_cluster(cluster)
+
+
+class TestIsFaitsDiversCluster:
+    def test_majority_faits_divers(self):
+        cluster = _make(
+            titles=[
+                "Accident mortel sur l'A7",
+                "Incendie dans un immeuble",
+                "Braquage à main armée",
+                "Actu culturelle",
+            ],
+        )
+        assert is_faits_divers_cluster(cluster)
+
+    def test_non_faits_divers(self):
+        cluster = _make(titles=["Climat G20", "Accord Paris", "Émissions CO2"])
+        assert not is_faits_divers_cluster(cluster)
+
+
+class TestCapLowPriorityClusters:
+    def test_multiple_sport_capped_to_one(self):
+        sport_a = _make(theme="sport", titles=["PSG OM"], source_count=5)
+        sport_b = _make(theme="sport", titles=["Tennis"], source_count=4)
+        sport_c = _make(theme="sport", titles=["Rugby"], source_count=3)
+        politics = _make(theme="politics", titles=["Élections"], source_count=6)
+        economy = _make(theme="economy", titles=["Inflation"], source_count=5)
+
+        kept = cap_low_priority_clusters([sport_a, sport_b, sport_c, politics, economy])
+
+        ids = [c.cluster_id for c in kept]
+        assert sport_a.cluster_id in ids  # first sport kept
+        assert sport_b.cluster_id not in ids  # second sport dropped
+        assert sport_c.cluster_id not in ids  # third sport dropped
+        assert politics.cluster_id in ids
+        assert economy.cluster_id in ids
+
+    def test_multiple_faits_divers_capped_to_one(self):
+        fd_a = _make(
+            titles=["Accident mortel", "Incendie", "Braquage"], source_count=5
+        )
+        fd_b = _make(titles=["Accident", "Incendie", "Collision"], source_count=4)
+        politics = _make(theme="politics", titles=["Réforme"], source_count=3)
+
+        kept = cap_low_priority_clusters([fd_a, fd_b, politics])
+        ids = [c.cluster_id for c in kept]
+        assert fd_a.cluster_id in ids
+        assert fd_b.cluster_id not in ids
+        assert politics.cluster_id in ids
+
+    def test_non_low_priority_all_kept(self):
+        clusters = [
+            _make(theme="politics", titles=["a"]),
+            _make(theme="economy", titles=["b"]),
+            _make(theme="tech", titles=["c"]),
+            _make(theme="science", titles=["d"]),
+        ]
+        kept = cap_low_priority_clusters(clusters)
+        assert len(kept) == 4
+
+    def test_one_sport_one_faits_divers_both_pass(self):
+        sport = _make(theme="sport", titles=["PSG"], source_count=3)
+        fd = _make(titles=["Accident mortel", "Incendie"], source_count=2)
+        politics = _make(theme="politics", titles=["x"])
+        kept = cap_low_priority_clusters([sport, fd, politics])
+        assert len(kept) == 3
+
+    def test_order_preserved(self):
+        a = _make(theme="politics", titles=["a"])
+        b = _make(theme="sport", titles=["b"])
+        c = _make(theme="economy", titles=["c"])
+        kept = cap_low_priority_clusters([a, b, c])
+        assert [k.cluster_id for k in kept] == [a.cluster_id, b.cluster_id, c.cluster_id]
+
+    def test_custom_caps(self):
+        sport_a = _make(theme="sport", titles=["a"])
+        sport_b = _make(theme="sport", titles=["b"])
+        kept = cap_low_priority_clusters([sport_a, sport_b], max_sport=2)
+        assert len(kept) == 2

--- a/packages/api/tests/workers/test_scheduler.py
+++ b/packages/api/tests/workers/test_scheduler.py
@@ -178,8 +178,9 @@ class TestDigestJobConfiguration:
             digest_trigger = captured_triggers.get('daily_digest')
             assert digest_trigger is not None, "daily_digest trigger not found"
             
-            # Verify timezone
-            assert digest_trigger.timezone == pytz.timezone('Europe/Paris'), \
+            # Verify timezone (compare by IANA name — apscheduler may return
+            # either a pytz tz or a zoneinfo.ZoneInfo depending on version).
+            assert str(digest_trigger.timezone) == 'Europe/Paris', \
                 f"Expected Europe/Paris timezone, got {digest_trigger.timezone}"
     
     def test_digest_job_cron_expression(self):


### PR DESCRIPTION
## What

Fixes the serein digest incorrectly reusing articles from the normal (pour_vous) mode, and adds a cap on low-priority clusters (sport + faits divers) across both modes.

**Changes:**
1. **SQL-level serein filtering**: `_get_global_candidates()` now accepts a `mode` parameter. When `mode="serein"`, it applies `apply_serein_filter` at the query level to exclude anxious articles before clustering.
2. **Pipeline-level cluster filtering**: After clustering, `compute_global_context()` filters out non-serein-compatible clusters for serein mode (defence-in-depth).
3. **Low-priority cluster cap**: Both modes now cap sport and faits divers clusters to 1 each (configurable). The cap is skipped if the remaining non-low-priority pool would be too small (< 5 clusters).
4. **Helper functions**: Added `is_sport_cluster()`, `is_faits_divers_cluster()`, and `cap_low_priority_clusters()` in `filter_presets.py`.

## Why

**Root cause (bug-digest-serein-collision-2026-04-13):**
- The editorial batch was fetching a single unfiltered pool of 200 recent articles and using it for both pour_vous and serein modes.
- The clustering and LLM curation steps are mode-agnostic, so both modes ended up selecting the same subjects.
- The existing serein filter (`apply_serein_filter`) only worked in the legacy `topic_selector.py` (topics_v1 format), not in the new editorial_v1 pipeline.
- Regression introduced by PR #374 (pre-compute dual variant) and exposed by PR #381 (editorial_v1 became mandatory).

**Product request:**
- Reduce dominance of sport and faits divers in digests (no active filter existed).

## Type

- [x] Bug fix
- [x] Feature (low-priority cap)

## Checklist

- [x] Tests pass locally (`pytest packages/api/tests/editorial/test_pipeline_mode_filters.py packages/api/tests/test_low_priority_cap.py packages/api/tests/test_digest_generation_job.py::TestGlobalCandidatePool -v`)
- [x] Linting passes
- [x] No new `List[]` imports (uses `list[]`)
- [x] No DB schema changes

## Test Coverage

- **`test_pipeline_mode_filters.py`** (4 tests): Serein excludes anxious clusters, pour_vous keeps them, sport cap limits to 1, cap skipped when pool too small.
- **`test_low_priority_cap.py`** (12 tests): Unit tests for `is_sport_cluster()`, `is_faits_divers_cluster()`, and `cap_low_priority_clusters()` with various edge cases.
- **`test_digest_generation_job.py`** (2 new tests): Verify serein pool joins on Source and applies theme filter; pour_vous pool unchanged.

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (logic change, no DB migration)

https://claude.ai/code/session_01SL7mPfUt3TvKYdbm1AevaZ