### PR TITLE
fix(digest): UI/UX polish + Serein notifications + sticky header removal

### DIFF
--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -136,27 +136,23 @@ class PushNotificationService {
     return granted;
   }
 
-  static const String defaultTitle = 'Ton Essentiel Facteur est prêt !';
-  static const String defaultBody = 'Tes sujets du jour t\'attendent';
+  static const String defaultTitle = 'Ton essentiel est là';
+  static const String defaultBody =
+      'Tes actus et décryptages du jour t\'attendent';
 
   /// Construit le body de la notification à partir des labels de topics du digest.
   ///
-  /// Mode normal  → "Au programme : Trump, Retraites, Chômage... Ou rester serein ;-)"
-  /// Mode serein  → "Prends un moment pour toi — tes sujets du jour t'attendent."
-  ///                (ou avec les topics : "Au programme : Trump, Retraites... À lire quand tu veux.")
-  ///
-  /// Retourne [defaultBody] si la liste est vide.
+  /// Mode normal — avec topics : "Au programme : Trump, Retraites... Ou rester serein ! ;)"
+  /// Mode normal — sans topics : "Tes actus et décryptages du jour t'attendent"
+  /// Mode serein                : "Au programme : Bonne Nouvelle, Pépite du jour. C'est quand tu veux !"
   static String buildNotificationBody(
     List<String> topicLabels, {
     bool serein = false,
   }) {
     if (serein) {
-      if (topicLabels.isEmpty) {
-        return 'Prends un moment pour toi — ton digest t\'attend quand tu veux.';
-      }
-      final displayLabels = topicLabels.take(3).toList();
-      final topicsText = displayLabels.join(', ');
-      return 'Au programme : $topicsText — à lire quand tu veux, sans pression.';
+      // En serein, le digest se concentre sur la Bonne Nouvelle et la Pépite —
+      // copy fixe, pas d'énumération anxiogène de topics d'actu.
+      return 'Au programme : Bonne Nouvelle, Pépite du jour. C\'est quand tu veux !';
     }
 
     if (topicLabels.isEmpty) return defaultBody;
@@ -164,7 +160,7 @@ class PushNotificationService {
     // Prendre les 3 premiers topics max pour rester concis
     final displayLabels = topicLabels.take(3).toList();
     final topicsText = displayLabels.join(', ');
-    return 'Au programme : $topicsText... Ou rester serein ;-)';
+    return 'Au programme : $topicsText... Ou rester serein ! ;)';
   }
 
   /// Planifie la notification quotidienne de digest à 8h Europe/Paris.
@@ -182,24 +178,32 @@ class PushNotificationService {
           await androidPlugin.canScheduleExactNotifications() ?? false;
     }
 
-    const androidDetails = AndroidNotificationDetails(
+    final scheduledDate = _nextInstanceOf8AM();
+    final notificationBody = body ?? defaultBody;
+
+    // BigTextStyle permet l'affichage multi-ligne du body sur Android
+    // (au lieu d'être tronqué à une seule ligne après ~40 caractères).
+    final androidDetails = AndroidNotificationDetails(
       'digest_channel',
       'Digest quotidien',
       channelDescription:
           'Notification quotidienne quand votre digest est prêt',
       importance: Importance.high,
       priority: Priority.high,
+      styleInformation: BigTextStyleInformation(
+        notificationBody,
+        contentTitle: defaultTitle,
+      ),
     );
 
+    // iOS affiche déjà le body sur plusieurs lignes par défaut quand la
+    // notification est étendue.
     const iosDetails = DarwinNotificationDetails();
 
-    const details = NotificationDetails(
+    final details = NotificationDetails(
       android: androidDetails,
       iOS: iosDetails,
     );
-
-    final scheduledDate = _nextInstanceOf8AM();
-    final notificationBody = body ?? defaultBody;
 
     // alarmClock est le plus fiable (pas affecté par Doze ni battery optimization OEM)
     // Fallback sur inexactAllowWhileIdle si la permission exacte est refusée

--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -141,9 +141,24 @@ class PushNotificationService {
 
   /// Construit le body de la notification à partir des labels de topics du digest.
   ///
-  /// Exemple : "Au programme : Trump, Retraites, Chômage... Ou rester serein ;-)"
+  /// Mode normal  → "Au programme : Trump, Retraites, Chômage... Ou rester serein ;-)"
+  /// Mode serein  → "Prends un moment pour toi — tes sujets du jour t'attendent."
+  ///                (ou avec les topics : "Au programme : Trump, Retraites... À lire quand tu veux.")
+  ///
   /// Retourne [defaultBody] si la liste est vide.
-  static String buildNotificationBody(List<String> topicLabels) {
+  static String buildNotificationBody(
+    List<String> topicLabels, {
+    bool serein = false,
+  }) {
+    if (serein) {
+      if (topicLabels.isEmpty) {
+        return 'Prends un moment pour toi — ton digest t\'attend quand tu veux.';
+      }
+      final displayLabels = topicLabels.take(3).toList();
+      final topicsText = displayLabels.join(', ');
+      return 'Au programme : $topicsText — à lire quand tu veux, sans pression.';
+    }
+
     if (topicLabels.isEmpty) return defaultBody;
 
     // Prendre les 3 premiers topics max pour rester concis

--- a/apps/mobile/lib/features/detail/providers/nudge_provider.dart
+++ b/apps/mobile/lib/features/detail/providers/nudge_provider.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Manages the 🌻 "Recommander ?" nudge display logic.
+///
+/// Rules:
+/// - Show after >30s of reading an article
+/// - Skip the first 2 articles read in the session
+/// - Max 1 nudge per session
+/// - Max 1 nudge every 3 days (persisted via SharedPreferences)
+/// - Don't show if article is already sunflowered
+class NudgeState {
+  final int articlesOpenedInSession;
+  final bool nudgeShownThisSession;
+
+  const NudgeState({
+    this.articlesOpenedInSession = 0,
+    this.nudgeShownThisSession = false,
+  });
+
+  NudgeState copyWith({
+    int? articlesOpenedInSession,
+    bool? nudgeShownThisSession,
+  }) {
+    return NudgeState(
+      articlesOpenedInSession:
+          articlesOpenedInSession ?? this.articlesOpenedInSession,
+      nudgeShownThisSession:
+          nudgeShownThisSession ?? this.nudgeShownThisSession,
+    );
+  }
+}
+
+class NudgeNotifier extends Notifier<NudgeState> {
+  static const _lastNudgeDateKey = 'sunflower_last_nudge_date';
+  static const _nudgeCooldownDays = 3;
+
+  @override
+  NudgeState build() {
+    return const NudgeState();
+  }
+
+  /// Call when a user opens an article
+  void recordArticleOpen() {
+    state = state.copyWith(
+      articlesOpenedInSession: state.articlesOpenedInSession + 1,
+    );
+  }
+
+  /// Check if the nudge should be shown for the current article.
+  /// Returns true if all conditions are met.
+  Future<bool> shouldShowNudge({required bool isAlreadySunflowered}) async {
+    // Already sunflowered — no nudge
+    if (isAlreadySunflowered) return false;
+
+    // Already shown this session
+    if (state.nudgeShownThisSession) return false;
+
+    // Skip first 2 articles of the session
+    if (state.articlesOpenedInSession <= 2) return false;
+
+    // Check 3-day cooldown
+    final prefs = await SharedPreferences.getInstance();
+    final lastNudgeDateStr = prefs.getString(_lastNudgeDateKey);
+    if (lastNudgeDateStr != null) {
+      final lastDate = DateTime.tryParse(lastNudgeDateStr);
+      if (lastDate != null) {
+        final daysSince = DateTime.now().difference(lastDate).inDays;
+        if (daysSince < _nudgeCooldownDays) return false;
+      }
+    }
+
+    return true;
+  }
+
+  /// Mark nudge as shown (persists date for cooldown)
+  Future<void> markNudgeShown() async {
+    state = state.copyWith(nudgeShownThisSession: true);
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _lastNudgeDateKey,
+      DateTime.now().toIso8601String(),
+    );
+  }
+}
+
+final nudgeProvider =
+    NotifierProvider<NudgeNotifier, NudgeState>(NudgeNotifier.new);

--- a/apps/mobile/lib/features/detail/providers/nudge_provider.dart
+++ b/apps/mobile/lib/features/detail/providers/nudge_provider.dart
@@ -1,7 +1,9 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Manages the 🌻 "Recommander ?" nudge display logic.
+///
+/// Simple session-scoped singleton — no Riverpod provider needed since
+/// the state is only read/written from ContentDetailScreen.
 ///
 /// Rules:
 /// - Show after >30s of reading an article
@@ -9,54 +11,27 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// - Max 1 nudge per session
 /// - Max 1 nudge every 3 days (persisted via SharedPreferences)
 /// - Don't show if article is already sunflowered
-class NudgeState {
-  final int articlesOpenedInSession;
-  final bool nudgeShownThisSession;
-
-  const NudgeState({
-    this.articlesOpenedInSession = 0,
-    this.nudgeShownThisSession = false,
-  });
-
-  NudgeState copyWith({
-    int? articlesOpenedInSession,
-    bool? nudgeShownThisSession,
-  }) {
-    return NudgeState(
-      articlesOpenedInSession:
-          articlesOpenedInSession ?? this.articlesOpenedInSession,
-      nudgeShownThisSession:
-          nudgeShownThisSession ?? this.nudgeShownThisSession,
-    );
-  }
-}
-
-class NudgeNotifier extends StateNotifier<NudgeState> {
+class NudgeTracker {
   static const _lastNudgeDateKey = 'sunflower_last_nudge_date';
   static const _nudgeCooldownDays = 3;
 
-  NudgeNotifier() : super(const NudgeState());
+  // Session-scoped counters (reset on app restart)
+  static int _articlesOpenedInSession = 0;
+  static bool _nudgeShownThisSession = false;
 
   /// Call when a user opens an article
-  void recordArticleOpen() {
-    state = state.copyWith(
-      articlesOpenedInSession: state.articlesOpenedInSession + 1,
-    );
+  static void recordArticleOpen() {
+    _articlesOpenedInSession++;
   }
 
   /// Check if the nudge should be shown for the current article.
-  /// Returns true if all conditions are met.
-  Future<bool> shouldShowNudge({required bool isAlreadySunflowered}) async {
-    // Already sunflowered — no nudge
+  static Future<bool> shouldShowNudge({
+    required bool isAlreadySunflowered,
+  }) async {
     if (isAlreadySunflowered) return false;
+    if (_nudgeShownThisSession) return false;
+    if (_articlesOpenedInSession <= 2) return false;
 
-    // Already shown this session
-    if (state.nudgeShownThisSession) return false;
-
-    // Skip first 2 articles of the session
-    if (state.articlesOpenedInSession <= 2) return false;
-
-    // Check 3-day cooldown
     try {
       final prefs = await SharedPreferences.getInstance();
       final lastNudgeDateStr = prefs.getString(_lastNudgeDateKey);
@@ -68,7 +43,6 @@ class NudgeNotifier extends StateNotifier<NudgeState> {
         }
       }
     } catch (_) {
-      // SharedPreferences failure — skip nudge to be safe
       return false;
     }
 
@@ -76,9 +50,8 @@ class NudgeNotifier extends StateNotifier<NudgeState> {
   }
 
   /// Mark nudge as shown (persists date for cooldown)
-  Future<void> markNudgeShown() async {
-    state = state.copyWith(nudgeShownThisSession: true);
-
+  static Future<void> markNudgeShown() async {
+    _nudgeShownThisSession = true;
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(
@@ -90,6 +63,3 @@ class NudgeNotifier extends StateNotifier<NudgeState> {
     }
   }
 }
-
-final nudgeProvider =
-    StateNotifierProvider<NudgeNotifier, NudgeState>((ref) => NudgeNotifier());

--- a/apps/mobile/lib/features/detail/providers/nudge_provider.dart
+++ b/apps/mobile/lib/features/detail/providers/nudge_provider.dart
@@ -31,14 +31,11 @@ class NudgeState {
   }
 }
 
-class NudgeNotifier extends Notifier<NudgeState> {
+class NudgeNotifier extends StateNotifier<NudgeState> {
   static const _lastNudgeDateKey = 'sunflower_last_nudge_date';
   static const _nudgeCooldownDays = 3;
 
-  @override
-  NudgeState build() {
-    return const NudgeState();
-  }
+  NudgeNotifier() : super(const NudgeState());
 
   /// Call when a user opens an article
   void recordArticleOpen() {
@@ -60,14 +57,19 @@ class NudgeNotifier extends Notifier<NudgeState> {
     if (state.articlesOpenedInSession <= 2) return false;
 
     // Check 3-day cooldown
-    final prefs = await SharedPreferences.getInstance();
-    final lastNudgeDateStr = prefs.getString(_lastNudgeDateKey);
-    if (lastNudgeDateStr != null) {
-      final lastDate = DateTime.tryParse(lastNudgeDateStr);
-      if (lastDate != null) {
-        final daysSince = DateTime.now().difference(lastDate).inDays;
-        if (daysSince < _nudgeCooldownDays) return false;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final lastNudgeDateStr = prefs.getString(_lastNudgeDateKey);
+      if (lastNudgeDateStr != null) {
+        final lastDate = DateTime.tryParse(lastNudgeDateStr);
+        if (lastDate != null) {
+          final daysSince = DateTime.now().difference(lastDate).inDays;
+          if (daysSince < _nudgeCooldownDays) return false;
+        }
       }
+    } catch (_) {
+      // SharedPreferences failure — skip nudge to be safe
+      return false;
     }
 
     return true;
@@ -77,13 +79,17 @@ class NudgeNotifier extends Notifier<NudgeState> {
   Future<void> markNudgeShown() async {
     state = state.copyWith(nudgeShownThisSession: true);
 
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(
-      _lastNudgeDateKey,
-      DateTime.now().toIso8601String(),
-    );
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        _lastNudgeDateKey,
+        DateTime.now().toIso8601String(),
+      );
+    } catch (_) {
+      // Best-effort persistence
+    }
   }
 }
 
 final nudgeProvider =
-    NotifierProvider<NudgeNotifier, NudgeState>(NudgeNotifier.new);
+    StateNotifierProvider<NudgeNotifier, NudgeState>((ref) => NudgeNotifier());

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -1530,13 +1530,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 height: 50,
                                 child: FloatingActionButton(
                                   onPressed: _toggleLike,
-                                  backgroundColor: content.isLiked
-                                      ? const Color(0xFFFFF8E1)
-                                      : Colors.white,
-                                  foregroundColor: content.isLiked
-                                      ? const Color(0xFFFFC107)
-                                      : colors.textPrimary,
-                                  elevation: content.isLiked ? 4 : 2,
+                                  backgroundColor: Colors.white,
+                                  foregroundColor: colors.textPrimary,
+                                  elevation: 2,
                                   heroTag: 'sunflower_fab',
                                   tooltip: 'Recommander',
                                   child: SunflowerIcon(

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -749,6 +749,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     HapticFeedback.lightImpact();
     final wasLiked = content.isLiked;
     final newLiked = !wasLiked;
+    // Cancel the pending nudge timer if the user sunflowers manually during
+    // the 30s wait — avoids firing a redundant "Recommander ?" pill.
+    _sunflowerNudgeTimer?.cancel();
     setState(() {
       _content = content.copyWith(isLiked: newLiked);
       _showSunflowerNudge = false;

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -271,8 +271,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     });
 
     // 🌻 Nudge: record article open and start 30s timer
-    // Deferred to avoid modifying provider state during build phase
-    Future.microtask(() {
+    // Deferred to post-frame to avoid modifying provider state during build
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       ref.read(nudgeProvider.notifier).recordArticleOpen();
     });
@@ -284,7 +284,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           .shouldShowNudge(isAlreadySunflowered: isLiked);
       if (shouldShow && mounted) {
         setState(() => _showSunflowerNudge = true);
-        ref.read(nudgeProvider.notifier).markNudgeShown();
+        // Defer provider mutation to avoid conflict with setState rebuild
+        Future.microtask(() {
+          ref.read(nudgeProvider.notifier).markNudgeShown();
+        });
         // Auto-dismiss after 5 seconds
         Future.delayed(const Duration(seconds: 5), () {
           if (mounted) setState(() => _showSunflowerNudge = false);

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -25,6 +25,8 @@ import '../../feed/repositories/feed_repository.dart';
 import '../../feed/widgets/perspectives_bottom_sheet.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../../feed/widgets/perspectives_pill.dart';
+import '../../../widgets/sunflower_icon.dart';
+import '../providers/nudge_provider.dart';
 import '../widgets/article_reader_widget.dart';
 import '../widgets/audio_player_widget.dart';
 import '../widgets/youtube_player_widget.dart';
@@ -107,6 +109,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   Timer? _readingTimer;
   Timer? _noteNudgeTimer;
   Timer? _scrollStopTimer;
+  // 🌻 Nudge "Recommander ?" state
+  Timer? _sunflowerNudgeTimer;
+  bool _showSunflowerNudge = false;
   Timer? _inactivityTimer;
   double _webScrollY = 0.0;
   double _prevNativeScrollOffset = 0.0;
@@ -262,6 +267,24 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     NoteWelcomeTooltip.shouldShow().then((show) {
       if (mounted && show) {
         setState(() => _showNoteWelcome = true);
+      }
+    });
+
+    // 🌻 Nudge: record article open and start 30s timer
+    ref.read(nudgeProvider.notifier).recordArticleOpen();
+    _sunflowerNudgeTimer = Timer(const Duration(seconds: 30), () async {
+      if (!mounted) return;
+      final isLiked = _content?.isLiked ?? false;
+      final shouldShow = await ref
+          .read(nudgeProvider.notifier)
+          .shouldShowNudge(isAlreadySunflowered: isLiked);
+      if (shouldShow && mounted) {
+        setState(() => _showSunflowerNudge = true);
+        ref.read(nudgeProvider.notifier).markNudgeShown();
+        // Auto-dismiss after 5 seconds
+        Future.delayed(const Duration(seconds: 5), () {
+          if (mounted) setState(() => _showSunflowerNudge = false);
+        });
       }
     });
 
@@ -531,6 +554,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   /// Update header offset and FAB opacity based on scroll delta (in pixels).
   /// Positive delta = scrolling down, negative = scrolling up.
   void _onScrollDelta(double delta) {
+    // Dismiss sunflower nudge on any scroll
+    if (_showSunflowerNudge) {
+      setState(() => _showSunflowerNudge = false);
+    }
     final isVideo = _content?.isVideo ?? false;
     _videoPlayHideTimer?.cancel();
     if (_fabOpacity.value != 0.07) {
@@ -719,6 +746,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     final content = _content;
     if (content == null) return;
 
+    // Dismiss nudge if visible
+    if (_showSunflowerNudge) {
+      _showSunflowerNudge = false;
+    }
+
     HapticFeedback.lightImpact();
     final wasLiked = content.isLiked;
     final newLiked = !wasLiked;
@@ -737,8 +769,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       if (mounted) {
         NotificationService.showInfo(
           newLiked
-              ? 'Ajouté à vos contenus favoris'
-              : 'Retiré de vos contenus favoris',
+              ? 'Ajouté à Mes articles intéressants 🌻'
+              : 'Retiré de Mes articles intéressants 🌻',
         );
         // Refresh collections to update liked collection counts
         ref.invalidate(collectionsProvider);
@@ -868,6 +900,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _readingTimer?.cancel();
     _noteNudgeTimer?.cancel();
     _scrollStopTimer?.cancel();
+    _sunflowerNudgeTimer?.cancel();
     _inactivityTimer?.cancel();
     _videoPlayHideTimer?.cancel();
     _linkCopiedFabTimer?.cancel();
@@ -1443,33 +1476,82 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           ),
                           const SizedBox(height: 12),
                         ],
-                        // Like FAB
-                        ScaleTransition(
-                          scale: _likeScaleAnimation,
-                          child: SizedBox(
-                            width: 50,
-                            height: 50,
-                            child: FloatingActionButton(
-                              onPressed: _toggleLike,
-                              backgroundColor: content.isLiked
-                                  ? colors.primary
-                                  : Colors.white,
-                              foregroundColor: content.isLiked
-                                  ? Colors.white
-                                  : colors.textPrimary,
-                              elevation: content.isLiked ? 4 : 2,
-                              heroTag: 'like_fab',
-                              tooltip: 'J\'aime',
-                              child: Icon(
-                                content.isLiked
-                                    ? PhosphorIcons.heart(
-                                        PhosphorIconsStyle.fill)
-                                    : PhosphorIcons.heart(
-                                        PhosphorIconsStyle.regular),
-                                size: 25,
+                        // 🌻 Sunflower recommendation FAB + nudge label
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            // Animated "Recommander ?" nudge label
+                            AnimatedSwitcher(
+                              duration: const Duration(milliseconds: 300),
+                              transitionBuilder: (child, animation) =>
+                                  FadeTransition(
+                                opacity: animation,
+                                child: SlideTransition(
+                                  position: Tween<Offset>(
+                                    begin: const Offset(0.3, 0),
+                                    end: Offset.zero,
+                                  ).animate(animation),
+                                  child: child,
+                                ),
+                              ),
+                              child: _showSunflowerNudge
+                                  ? Container(
+                                      key: const ValueKey('nudge_visible'),
+                                      margin: const EdgeInsets.only(right: 10),
+                                      padding: const EdgeInsets.symmetric(
+                                          horizontal: 12, vertical: 6),
+                                      decoration: BoxDecoration(
+                                        color: const Color(0xFFFFF8E1),
+                                        borderRadius:
+                                            BorderRadius.circular(16),
+                                        boxShadow: [
+                                          BoxShadow(
+                                            color:
+                                                Colors.black.withOpacity(0.1),
+                                            blurRadius: 8,
+                                            offset: const Offset(0, 2),
+                                          ),
+                                        ],
+                                      ),
+                                      child: const Text(
+                                        'Recommander ? 🌻',
+                                        style: TextStyle(
+                                          fontSize: 13,
+                                          fontWeight: FontWeight.w600,
+                                          color: Color(0xFF795548),
+                                        ),
+                                      ),
+                                    )
+                                  : const SizedBox.shrink(
+                                      key: ValueKey('nudge_hidden'),
+                                    ),
+                            ),
+                            ScaleTransition(
+                              scale: _likeScaleAnimation,
+                              child: SizedBox(
+                                width: 50,
+                                height: 50,
+                                child: FloatingActionButton(
+                                  onPressed: _toggleLike,
+                                  backgroundColor: content.isLiked
+                                      ? const Color(0xFFFFF8E1)
+                                      : Colors.white,
+                                  foregroundColor: content.isLiked
+                                      ? const Color(0xFFFFC107)
+                                      : colors.textPrimary,
+                                  elevation: content.isLiked ? 4 : 2,
+                                  heroTag: 'sunflower_fab',
+                                  tooltip: 'Recommander',
+                                  child: SunflowerIcon(
+                                    isActive: content.isLiked,
+                                    size: 25,
+                                    inactiveColor: colors.textPrimary,
+                                  ),
+                                ),
                               ),
                             ),
-                          ),
+                          ],
                         ),
                         const SizedBox(height: 12),
                         // Merged Bookmark + Note FAB (long-press for collection picker)

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -271,7 +271,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     });
 
     // 🌻 Nudge: record article open and start 30s timer
-    ref.read(nudgeProvider.notifier).recordArticleOpen();
+    // Deferred to avoid modifying provider state during build phase
+    Future.microtask(() {
+      if (!mounted) return;
+      ref.read(nudgeProvider.notifier).recordArticleOpen();
+    });
     _sunflowerNudgeTimer = Timer(const Duration(seconds: 30), () async {
       if (!mounted) return;
       final isLiked = _content?.isLiked ?? false;

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -26,7 +26,7 @@ import '../../feed/widgets/perspectives_bottom_sheet.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../../feed/widgets/perspectives_pill.dart';
 import '../../../widgets/sunflower_icon.dart';
-import '../providers/nudge_provider.dart';
+import '../providers/nudge_provider.dart' show NudgeTracker;
 import '../widgets/article_reader_widget.dart';
 import '../widgets/audio_player_widget.dart';
 import '../widgets/youtube_player_widget.dart';
@@ -271,23 +271,16 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     });
 
     // 🌻 Nudge: record article open and start 30s timer
-    // Deferred to post-frame to avoid modifying provider state during build
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      ref.read(nudgeProvider.notifier).recordArticleOpen();
-    });
+    NudgeTracker.recordArticleOpen();
     _sunflowerNudgeTimer = Timer(const Duration(seconds: 30), () async {
       if (!mounted) return;
       final isLiked = _content?.isLiked ?? false;
-      final shouldShow = await ref
-          .read(nudgeProvider.notifier)
-          .shouldShowNudge(isAlreadySunflowered: isLiked);
+      final shouldShow = await NudgeTracker.shouldShowNudge(
+        isAlreadySunflowered: isLiked,
+      );
       if (shouldShow && mounted) {
         setState(() => _showSunflowerNudge = true);
-        // Defer provider mutation to avoid conflict with setState rebuild
-        Future.microtask(() {
-          ref.read(nudgeProvider.notifier).markNudgeShown();
-        });
+        NudgeTracker.markNudgeShown();
         // Auto-dismiss after 5 seconds
         Future.delayed(const Duration(seconds: 5), () {
           if (mounted) setState(() => _showSunflowerNudge = false);

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -619,19 +619,28 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             _fetchPerspectives();
           }
         } else {
-          // Show error and pop if content not found
+          // Content not found via API. Keep whatever was passed via extra
+          // (e.g. a digest "Pas de recul" article whose row was just culled
+          // server-side) so the screen still renders instead of bouncing
+          // the user back to the previous screen with a blank flash.
           setState(() => _contentResolved = true);
-          NotificationService.showError('Contenu introuvable',
-              context: context);
-          context.pop();
+          if (_content == null) {
+            NotificationService.showError('Contenu introuvable',
+                context: context);
+            context.pop();
+          }
         }
       }
     } catch (e) {
       debugPrint('Error fetching content: $e');
       if (mounted) {
         setState(() => _contentResolved = true);
-        NotificationService.showError('Erreur de chargement', context: context);
-        context.pop();
+        // Same fallback: only pop when we truly have nothing to show.
+        if (_content == null) {
+          NotificationService.showError('Erreur de chargement',
+              context: context);
+          context.pop();
+        }
       }
     }
   }

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -746,16 +746,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     final content = _content;
     if (content == null) return;
 
-    // Dismiss nudge if visible
-    if (_showSunflowerNudge) {
-      _showSunflowerNudge = false;
-    }
-
     HapticFeedback.lightImpact();
     final wasLiked = content.isLiked;
     final newLiked = !wasLiked;
     setState(() {
       _content = content.copyWith(isLiked: newLiked);
+      _showSunflowerNudge = false;
     });
 
     // Bounce animation
@@ -1508,7 +1504,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                         boxShadow: [
                                           BoxShadow(
                                             color:
-                                                Colors.black.withOpacity(0.1),
+                                                Colors.black.withValues(alpha: 0.1),
                                             blurRadius: 8,
                                             offset: const Offset(0, 2),
                                           ),

--- a/apps/mobile/lib/features/digest/models/community_carousel_model.dart
+++ b/apps/mobile/lib/features/digest/models/community_carousel_model.dart
@@ -1,0 +1,89 @@
+/// Model for community recommendation carousel items (🌻).
+///
+/// Separate from Freezed models to avoid requiring code generation
+/// for this new feature. Parsed from the `community_carousel` field
+/// in the digest API response.
+class CommunityCarouselItem {
+  final String contentId;
+  final String title;
+  final String url;
+  final String? thumbnailUrl;
+  final String? description;
+  final String contentType;
+  final int? durationSeconds;
+  final DateTime? publishedAt;
+  final String sourceName;
+  final String? sourceLogoUrl;
+  final String? sourceId;
+  final int sunflowerCount;
+  final bool isLiked;
+  final bool isSaved;
+  final List<String> topics;
+
+  const CommunityCarouselItem({
+    required this.contentId,
+    required this.title,
+    required this.url,
+    this.thumbnailUrl,
+    this.description,
+    this.contentType = 'article',
+    this.durationSeconds,
+    this.publishedAt,
+    this.sourceName = '',
+    this.sourceLogoUrl,
+    this.sourceId,
+    this.sunflowerCount = 0,
+    this.isLiked = false,
+    this.isSaved = false,
+    this.topics = const [],
+  });
+
+  factory CommunityCarouselItem.fromJson(Map<String, dynamic> json) {
+    final source = json['source'] as Map<String, dynamic>?;
+    return CommunityCarouselItem(
+      contentId: json['content_id'] as String,
+      title: (json['title'] as String?) ?? 'Sans titre',
+      url: (json['url'] as String?) ?? '',
+      thumbnailUrl: json['thumbnail_url'] as String?,
+      description: json['description'] as String?,
+      contentType: (json['content_type'] as String?) ?? 'article',
+      durationSeconds: json['duration_seconds'] as int?,
+      publishedAt: json['published_at'] != null
+          ? DateTime.tryParse(json['published_at'] as String)
+          : null,
+      sourceName: (source?['name'] as String?) ?? '',
+      sourceLogoUrl: source?['logo_url'] as String?,
+      sourceId: source?['id']?.toString(),
+      sunflowerCount: (json['sunflower_count'] as int?) ?? 0,
+      isLiked: (json['is_liked'] as bool?) ?? false,
+      isSaved: (json['is_saved'] as bool?) ?? false,
+      topics: (json['topics'] as List<dynamic>?)
+              ?.map((e) => e.toString())
+              .toList() ??
+          [],
+    );
+  }
+
+  CommunityCarouselItem copyWith({
+    bool? isLiked,
+    bool? isSaved,
+  }) {
+    return CommunityCarouselItem(
+      contentId: contentId,
+      title: title,
+      url: url,
+      thumbnailUrl: thumbnailUrl,
+      description: description,
+      contentType: contentType,
+      durationSeconds: durationSeconds,
+      publishedAt: publishedAt,
+      sourceName: sourceName,
+      sourceLogoUrl: sourceLogoUrl,
+      sourceId: sourceId,
+      sunflowerCount: sunflowerCount,
+      isLiked: isLiked ?? this.isLiked,
+      isSaved: isSaved ?? this.isSaved,
+      topics: topics,
+    );
+  }
+}

--- a/apps/mobile/lib/features/digest/providers/community_carousel_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/community_carousel_provider.dart
@@ -24,9 +24,8 @@ final communityCarouselProvider =
     return const CommunityCarousels();
   }
 
-  final apiClient = ref.read(apiClientProvider);
-
   try {
+    final apiClient = ref.read(apiClientProvider);
     final response = await apiClient.dio.get<dynamic>(
       'community/recommendations',
     );
@@ -35,14 +34,14 @@ final communityCarouselProvider =
       final data = response.data as Map<String, dynamic>;
 
       final feedItems = (data['feed_carousel'] as List<dynamic>?)
-              ?.map(
-                  (e) => CommunityCarouselItem.fromJson(e as Map<String, dynamic>))
+              ?.map((e) =>
+                  CommunityCarouselItem.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [];
 
       final digestItems = (data['digest_carousel'] as List<dynamic>?)
-              ?.map(
-                  (e) => CommunityCarouselItem.fromJson(e as Map<String, dynamic>))
+              ?.map((e) =>
+                  CommunityCarouselItem.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [];
 
@@ -51,10 +50,8 @@ final communityCarouselProvider =
         digestCarousel: digestItems,
       );
     }
-  } catch (e) {
+  } catch (_) {
     // Fail silently — carousel is optional enhancement
-    // ignore: avoid_print
-    print('CommunityCarouselProvider: fetch failed: $e');
   }
 
   return const CommunityCarousels();

--- a/apps/mobile/lib/features/digest/providers/community_carousel_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/community_carousel_provider.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/providers.dart';
+import '../../../core/auth/auth_state.dart';
+import '../models/community_carousel_model.dart';
+
+/// Holds both feed and digest community carousels.
+class CommunityCarousels {
+  final List<CommunityCarouselItem> feedCarousel;
+  final List<CommunityCarouselItem> digestCarousel;
+
+  const CommunityCarousels({
+    this.feedCarousel = const [],
+    this.digestCarousel = const [],
+  });
+}
+
+/// Provider that fetches community recommendation carousels from the API.
+/// Both the Feed and Digest screens can consume this.
+final communityCarouselProvider =
+    FutureProvider.autoDispose<CommunityCarousels>((ref) async {
+  final authState = ref.watch(authStateProvider);
+  if (!authState.isAuthenticated) {
+    return const CommunityCarousels();
+  }
+
+  final apiClient = ref.read(apiClientProvider);
+
+  try {
+    final response = await apiClient.dio.get<dynamic>(
+      'community/recommendations',
+    );
+
+    if (response.statusCode == 200 && response.data != null) {
+      final data = response.data as Map<String, dynamic>;
+
+      final feedItems = (data['feed_carousel'] as List<dynamic>?)
+              ?.map(
+                  (e) => CommunityCarouselItem.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [];
+
+      final digestItems = (data['digest_carousel'] as List<dynamic>?)
+              ?.map(
+                  (e) => CommunityCarouselItem.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [];
+
+      return CommunityCarousels(
+        feedCarousel: feedItems,
+        digestCarousel: digestItems,
+      );
+    }
+  } catch (e) {
+    // Fail silently — carousel is optional enhancement
+    // ignore: avoid_print
+    print('CommunityCarouselProvider: fetch failed: $e');
+  }
+
+  return const CommunityCarousels();
+});

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -245,6 +245,9 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
   /// Update the daily notification with topic keywords from the loaded digest.
   /// Uses the normal digest topics to build an engaging notification body.
   /// Only updates if push notifications are enabled in user settings.
+  ///
+  /// If the user has Serein mode enabled, a calmer notification copy is used
+  /// to avoid triggering anxiety before reading.
   void _updateNotificationWithTopics() {
     try {
       final box = Hive.box<dynamic>('settings');
@@ -260,10 +263,15 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
           .where((l) => l.isNotEmpty)
           .toList();
 
-      final body = PushNotificationService.buildNotificationBody(topicLabels);
+      final isSerein = ref.read(sereinToggleProvider).enabled;
+      final body = PushNotificationService.buildNotificationBody(
+        topicLabels,
+        serein: isSerein,
+      );
       PushNotificationService().scheduleDailyDigestNotification(body: body);
       debugPrint(
-        'DigestNotifier: Updated notification with ${topicLabels.length} topics',
+        'DigestNotifier: Updated notification with ${topicLabels.length} topics'
+        ' (serein: $isSerein)',
       );
     } catch (e) {
       debugPrint('DigestNotifier: Failed to update notification: $e');

--- a/apps/mobile/lib/features/digest/screens/digest_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/digest_screen.dart
@@ -677,7 +677,7 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
                                 publishedAt: item.publishedAt ?? DateTime.now(),
                               );
                               context.pushNamed(
-                                RouteNames.articleDetail,
+                                RouteNames.contentDetail,
                                 pathParameters: {'id': item.contentId},
                                 extra: content,
                               );

--- a/apps/mobile/lib/features/digest/screens/digest_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/digest_screen.dart
@@ -670,9 +670,11 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
                                 source: Source(
                                   id: item.sourceId ?? '',
                                   name: item.sourceName,
+                                  type: SourceType.article,
                                   logoUrl: item.sourceLogoUrl,
                                 ),
                                 contentType: ContentType.article,
+                                publishedAt: item.publishedAt ?? DateTime.now(),
                               );
                               context.pushNamed(
                                 RouteNames.articleDetail,

--- a/apps/mobile/lib/features/digest/screens/digest_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/digest_screen.dart
@@ -25,6 +25,7 @@ import '../../onboarding/widgets/notification_permission_bottom_sheet.dart';
 import '../../settings/providers/notifications_settings_provider.dart';
 import '../../sources/models/source_model.dart';
 import '../../sources/providers/sources_providers.dart';
+import '../models/community_carousel_model.dart';
 import '../models/digest_models.dart';
 import '../providers/digest_format_provider.dart';
 import '../providers/community_carousel_provider.dart';
@@ -207,6 +208,21 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
     }
   }
 
+  /// Filter the digest community carousel to exclude any article that already
+  /// appears in the main digest flow (flat items + per-topic articles). The
+  /// backend deduplicates Feed↔Digest carousels, but a digest article picked
+  /// for the carousel would still look duplicated to the user.
+  List<CommunityCarouselItem> _filterCommunityCarousel(DigestResponse digest) {
+    final all = ref.watch(communityCarouselProvider).valueOrNull?.digestCarousel;
+    if (all == null || all.isEmpty) return const [];
+    final shownIds = <String>{
+      for (final it in digest.items) it.contentId,
+      for (final t in digest.topics)
+        for (final it in t.articles) it.contentId,
+    };
+    return all.where((ci) => !shownIds.contains(ci.contentId)).toList();
+  }
+
   void _handleLike(DigestItem item) {
     HapticFeedback.mediumImpact();
     ref.read(digestProvider.notifier).applyAction(
@@ -345,6 +361,9 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
           body: SafeArea(
             child: RefreshIndicator(
               onRefresh: () async {
+                // Refresh both the digest itself and the community 🌻 carousel
+                // so newly-sunflowered articles appear after a pull-to-refresh.
+                ref.invalidate(communityCarouselProvider);
                 await ref.read(digestProvider.notifier).refreshDigest();
               },
               color: colors.primary,
@@ -655,11 +674,8 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
                                 : null,
                             ctaText:
                                 digest.usesEditorial ? digest.ctaText : null,
-                            communityCarousel: ref
-                                    .watch(communityCarouselProvider)
-                                    .valueOrNull
-                                    ?.digestCarousel ??
-                                [],
+                            communityCarousel:
+                                _filterCommunityCarousel(digest),
                             onCommunityArticleTap: (item) {
                               // Convert community carousel item to Content for navigation
                               final content = Content(

--- a/apps/mobile/lib/features/digest/screens/digest_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/digest_screen.dart
@@ -27,6 +27,7 @@ import '../../sources/models/source_model.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../models/digest_models.dart';
 import '../providers/digest_format_provider.dart';
+import '../providers/community_carousel_provider.dart';
 import '../providers/digest_provider.dart';
 import '../providers/serein_toggle_provider.dart';
 import '../widgets/digest_briefing_section.dart';
@@ -214,8 +215,8 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
         );
     NotificationService.showInfo(
       item.isLiked
-          ? 'Retiré de vos contenus favoris'
-          : 'Ajouté à vos contenus favoris',
+          ? 'Retiré de Mes articles intéressants 🌻'
+          : 'Ajouté à Mes articles intéressants 🌻',
     );
     ref.invalidate(collectionsProvider);
   }
@@ -654,6 +655,31 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
                                 : null,
                             ctaText:
                                 digest.usesEditorial ? digest.ctaText : null,
+                            communityCarousel: ref
+                                    .watch(communityCarouselProvider)
+                                    .valueOrNull
+                                    ?.digestCarousel ??
+                                [],
+                            onCommunityArticleTap: (item) {
+                              // Convert community carousel item to Content for navigation
+                              final content = Content(
+                                id: item.contentId,
+                                title: item.title,
+                                url: item.url,
+                                thumbnailUrl: item.thumbnailUrl,
+                                source: Source(
+                                  id: item.sourceId ?? '',
+                                  name: item.sourceName,
+                                  logoUrl: item.sourceLogoUrl,
+                                ),
+                                contentType: ContentType.article,
+                              );
+                              context.pushNamed(
+                                RouteNames.articleDetail,
+                                pathParameters: {'id': item.contentId},
+                                extra: content,
+                              );
+                            },
                           );
                         },
                         loading: () => _buildLoadingState(colors),

--- a/apps/mobile/lib/features/digest/widgets/community_carousel_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/community_carousel_section.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../config/theme.dart';
+import '../../../widgets/sunflower_icon.dart';
+import '../models/community_carousel_model.dart';
+
+/// Horizontal carousel section showing community 🌻 recommendations.
+///
+/// Appears in the digest when there are community-recommended articles.
+/// Displays articles as horizontal scrollable cards with source name
+/// and sunflower count badge (if >= 2).
+class CommunityCarouselSection extends StatefulWidget {
+  final List<CommunityCarouselItem> items;
+  final void Function(CommunityCarouselItem item) onArticleTap;
+  final void Function(CommunityCarouselItem item)? onSunflowerTap;
+
+  const CommunityCarouselSection({
+    super.key,
+    required this.items,
+    required this.onArticleTap,
+    this.onSunflowerTap,
+  });
+
+  @override
+  State<CommunityCarouselSection> createState() =>
+      _CommunityCarouselSectionState();
+}
+
+class _CommunityCarouselSectionState extends State<CommunityCarouselSection> {
+  final PageController _pageController =
+      PageController(viewportFraction: 0.85);
+  int _currentPage = 0;
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<AppColors>()!;
+
+    if (widget.items.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+          child: Row(
+            children: [
+              const Text('🌻', style: TextStyle(fontSize: 20)),
+              const SizedBox(width: 8),
+              Text(
+                'Recos de la communauté',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: colors.textPrimary,
+                ),
+              ),
+            ],
+          ),
+        ),
+        // Carousel
+        SizedBox(
+          height: 200,
+          child: PageView.builder(
+            controller: _pageController,
+            itemCount: widget.items.length,
+            onPageChanged: (index) {
+              setState(() => _currentPage = index);
+            },
+            itemBuilder: (context, index) {
+              final item = widget.items[index];
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 6),
+                child: _CommunityCard(
+                  item: item,
+                  colors: colors,
+                  onTap: () {
+                    HapticFeedback.selectionClick();
+                    widget.onArticleTap(item);
+                  },
+                  onSunflowerTap: widget.onSunflowerTap != null
+                      ? () => widget.onSunflowerTap!(item)
+                      : null,
+                ),
+              );
+            },
+          ),
+        ),
+        // Page indicators
+        if (widget.items.length > 1)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(
+                widget.items.length,
+                (index) => AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  margin: const EdgeInsets.symmetric(horizontal: 3),
+                  width: index == _currentPage ? 20 : 8,
+                  height: 6,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(3),
+                    color: index == _currentPage
+                        ? SunflowerIcon.sunflowerYellow
+                        : colors.textSecondary.withOpacity(0.3),
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _CommunityCard extends StatelessWidget {
+  final CommunityCarouselItem item;
+  final AppColors colors;
+  final VoidCallback onTap;
+  final VoidCallback? onSunflowerTap;
+
+  const _CommunityCard({
+    required this.item,
+    required this.colors,
+    required this.onTap,
+    this.onSunflowerTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          color: colors.cardBackground,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: colors.textSecondary.withOpacity(0.1),
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Image
+            if (item.thumbnailUrl != null)
+              ClipRRect(
+                borderRadius:
+                    const BorderRadius.vertical(top: Radius.circular(16)),
+                child: Image.network(
+                  item.thumbnailUrl!,
+                  height: 90,
+                  width: double.infinity,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, __, ___) => Container(
+                    height: 90,
+                    color: colors.textSecondary.withOpacity(0.1),
+                    child: Center(
+                      child: Icon(
+                        Icons.article_outlined,
+                        color: colors.textSecondary.withOpacity(0.3),
+                        size: 32,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            // Content
+            Expanded(
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Title
+                    Expanded(
+                      child: Text(
+                        item.title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: colors.textPrimary,
+                          height: 1.3,
+                        ),
+                      ),
+                    ),
+                    // Footer: source + sunflower count
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            item.sourceName,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: colors.textSecondary,
+                            ),
+                          ),
+                        ),
+                        if (item.sunflowerCount >= 2) ...[
+                          const SizedBox(width: 4),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 6, vertical: 2),
+                            decoration: BoxDecoration(
+                              color: SunflowerIcon.sunflowerYellow
+                                  .withOpacity(0.15),
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                const Text('🌻',
+                                    style: TextStyle(fontSize: 10)),
+                                const SizedBox(width: 2),
+                                Text(
+                                  '${item.sunflowerCount}',
+                                  style: TextStyle(
+                                    fontSize: 11,
+                                    fontWeight: FontWeight.w600,
+                                    color: SunflowerIcon.sunflowerBrown,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/digest/widgets/community_carousel_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/community_carousel_section.dart
@@ -38,7 +38,7 @@ class _CommunityCarouselSectionState extends State<CommunityCarouselSection> {
 
   @override
   Widget build(BuildContext context) {
-    final colors = Theme.of(context).extension<AppColors>()!;
+    final colors = context.facteurColors;
 
     if (widget.items.isEmpty) return const SizedBox.shrink();
 
@@ -118,7 +118,7 @@ class _CommunityCarouselSectionState extends State<CommunityCarouselSection> {
 
 class _CommunityCard extends StatelessWidget {
   final CommunityCarouselItem item;
-  final AppColors colors;
+  final FacteurColors colors;
   final VoidCallback onTap;
 
   const _CommunityCard({
@@ -226,7 +226,7 @@ class _CommunityCard extends StatelessWidget {
                                 const SizedBox(width: 2),
                                 Text(
                                   '${item.sunflowerCount}',
-                                  style: TextStyle(
+                                  style: const TextStyle(
                                     fontSize: 11,
                                     fontWeight: FontWeight.w600,
                                     color: SunflowerIcon.sunflowerBrown,

--- a/apps/mobile/lib/features/digest/widgets/community_carousel_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/community_carousel_section.dart
@@ -13,13 +13,11 @@ import '../models/community_carousel_model.dart';
 class CommunityCarouselSection extends StatefulWidget {
   final List<CommunityCarouselItem> items;
   final void Function(CommunityCarouselItem item) onArticleTap;
-  final void Function(CommunityCarouselItem item)? onSunflowerTap;
 
   const CommunityCarouselSection({
     super.key,
     required this.items,
     required this.onArticleTap,
-    this.onSunflowerTap,
   });
 
   @override
@@ -85,9 +83,6 @@ class _CommunityCarouselSectionState extends State<CommunityCarouselSection> {
                     HapticFeedback.selectionClick();
                     widget.onArticleTap(item);
                   },
-                  onSunflowerTap: widget.onSunflowerTap != null
-                      ? () => widget.onSunflowerTap!(item)
-                      : null,
                 ),
               );
             },
@@ -110,7 +105,7 @@ class _CommunityCarouselSectionState extends State<CommunityCarouselSection> {
                     borderRadius: BorderRadius.circular(3),
                     color: index == _currentPage
                         ? SunflowerIcon.sunflowerYellow
-                        : colors.textSecondary.withOpacity(0.3),
+                        : colors.textSecondary.withValues(alpha: 0.3),
                   ),
                 ),
               ),
@@ -125,13 +120,11 @@ class _CommunityCard extends StatelessWidget {
   final CommunityCarouselItem item;
   final AppColors colors;
   final VoidCallback onTap;
-  final VoidCallback? onSunflowerTap;
 
   const _CommunityCard({
     required this.item,
     required this.colors,
     required this.onTap,
-    this.onSunflowerTap,
   });
 
   @override
@@ -143,11 +136,11 @@ class _CommunityCard extends StatelessWidget {
           color: colors.cardBackground,
           borderRadius: BorderRadius.circular(16),
           border: Border.all(
-            color: colors.textSecondary.withOpacity(0.1),
+            color: colors.textSecondary.withValues(alpha: 0.1),
           ),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.05),
+              color: Colors.black.withValues(alpha: 0.05),
               blurRadius: 8,
               offset: const Offset(0, 2),
             ),
@@ -168,11 +161,11 @@ class _CommunityCard extends StatelessWidget {
                   fit: BoxFit.cover,
                   errorBuilder: (_, __, ___) => Container(
                     height: 90,
-                    color: colors.textSecondary.withOpacity(0.1),
+                    color: colors.textSecondary.withValues(alpha: 0.1),
                     child: Center(
                       child: Icon(
                         Icons.article_outlined,
-                        color: colors.textSecondary.withOpacity(0.3),
+                        color: colors.textSecondary.withValues(alpha: 0.3),
                         size: 32,
                       ),
                     ),
@@ -222,7 +215,7 @@ class _CommunityCard extends StatelessWidget {
                                 horizontal: 6, vertical: 2),
                             decoration: BoxDecoration(
                               color: SunflowerIcon.sunflowerYellow
-                                  .withOpacity(0.15),
+                                  .withValues(alpha: 0.15),
                               borderRadius: BorderRadius.circular(8),
                             ),
                             child: Row(

--- a/apps/mobile/lib/features/digest/widgets/community_carousel_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/community_carousel_section.dart
@@ -133,7 +133,7 @@ class _CommunityCard extends StatelessWidget {
       onTap: onTap,
       child: Container(
         decoration: BoxDecoration(
-          color: colors.cardBackground,
+          color: colors.surface,
           borderRadius: BorderRadius.circular(16),
           border: Border.all(
             color: colors.textSecondary.withValues(alpha: 0.1),

--- a/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
@@ -312,7 +312,7 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       itemCount: widget.topics!.length,
-      separatorBuilder: (_, __) => const SizedBox(height: 6),
+      separatorBuilder: (_, __) => const SizedBox(height: 14),
       itemBuilder: (_, i) => TopicSection(
         topic: widget.topics![i],
         totalTopics: widget.topics!.length,
@@ -472,7 +472,7 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       itemCount: sections.length,
-      separatorBuilder: (_, __) => const SizedBox(height: 6),
+      separatorBuilder: (_, __) => const SizedBox(height: 14),
       itemBuilder: (_, i) => sections[i],
     );
   }

--- a/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
@@ -12,8 +12,10 @@ import '../../feed/widgets/dismiss_banner.dart';
 import '../../saved/widgets/collection_picker_sheet.dart';
 import '../../sources/models/source_model.dart';
 import '../models/digest_models.dart';
+import '../models/community_carousel_model.dart';
 import 'actu_decalee_block.dart';
 import 'closure_block.dart';
+import 'community_carousel_section.dart';
 import 'coup_de_coeur_block.dart';
 import 'pepite_block.dart';
 import 'quote_block.dart';
@@ -50,6 +52,8 @@ class DigestBriefingSection extends StatefulWidget {
   final String? ctaText;
   final int processedCount;
   final int dailyGoal;
+  final List<CommunityCarouselItem> communityCarousel;
+  final void Function(CommunityCarouselItem)? onCommunityArticleTap;
 
   const DigestBriefingSection({
     super.key,
@@ -75,6 +79,8 @@ class DigestBriefingSection extends StatefulWidget {
     this.ctaText,
     this.processedCount = 0,
     this.dailyGoal = 5,
+    this.communityCarousel = const [],
+    this.onCommunityArticleTap,
   });
 
   @override
@@ -456,6 +462,19 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
           onNotInterested: widget.onNotInterested,
           onReportNotSerene: widget.onReportNotSerene,
           onSourceTap: widget.onSourceTap,
+        ),
+      );
+    }
+
+    // Community 🌻 carousel (if items available)
+    if (widget.communityCarousel.isNotEmpty) {
+      sections.add(const SectionDivider());
+      sections.add(
+        CommunityCarouselSection(
+          items: widget.communityCarousel,
+          onArticleTap: (item) {
+            widget.onCommunityArticleTap?.call(item);
+          },
         ),
       );
     }

--- a/apps/mobile/lib/features/digest/widgets/quote_block.dart
+++ b/apps/mobile/lib/features/digest/widgets/quote_block.dart
@@ -15,25 +15,25 @@ class QuoteBlock extends StatelessWidget {
     final colors = context.facteurColors;
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
-    final separatorColor = colors.primary.withValues(alpha: isDark ? 0.18 : 0.14);
+    final separatorColor = colors.primary.withValues(alpha: isDark ? 0.45 : 0.38);
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           // Top separator
           Center(
             child: Container(
-              width: 40,
-              height: 1,
+              width: 56,
+              height: 1.5,
               decoration: BoxDecoration(
                 color: separatorColor,
-                borderRadius: BorderRadius.circular(0.5),
+                borderRadius: BorderRadius.circular(0.75),
               ),
             ),
           ),
-          const SizedBox(height: 10),
+          const SizedBox(height: 18),
           // Inline quote: « text » — author
           Text.rich(
             TextSpan(
@@ -41,52 +41,52 @@ class QuoteBlock extends StatelessWidget {
                 TextSpan(
                   text: '\u00AB ',
                   style: TextStyle(
-                    fontSize: 14,
+                    fontSize: 17,
                     fontWeight: FontWeight.w300,
-                    color: colors.primary.withValues(alpha: isDark ? 0.50 : 0.35),
+                    color: colors.primary.withValues(alpha: isDark ? 0.55 : 0.40),
                   ),
                 ),
                 TextSpan(
                   text: quote.text,
                   style: TextStyle(
-                    fontSize: 14,
+                    fontSize: 17,
                     fontStyle: FontStyle.italic,
                     fontWeight: FontWeight.w500,
-                    color: colors.textPrimary.withValues(alpha: 0.75),
+                    color: colors.textPrimary.withValues(alpha: 0.85),
                     height: 1.5,
                   ),
                 ),
                 TextSpan(
                   text: ' \u00BB',
                   style: TextStyle(
-                    fontSize: 14,
+                    fontSize: 17,
                     fontWeight: FontWeight.w300,
-                    color: colors.primary.withValues(alpha: isDark ? 0.50 : 0.35),
+                    color: colors.primary.withValues(alpha: isDark ? 0.55 : 0.40),
                   ),
                 ),
               ],
             ),
             textAlign: TextAlign.center,
           ),
-          const SizedBox(height: 4),
+          const SizedBox(height: 6),
           Text(
             '\u2014 ${quote.author}',
             textAlign: TextAlign.center,
             style: TextStyle(
-              fontSize: 12,
+              fontSize: 13,
               fontWeight: FontWeight.w600,
-              color: colors.textSecondary.withValues(alpha: 0.55),
+              color: colors.textSecondary.withValues(alpha: 0.65),
             ),
           ),
-          const SizedBox(height: 10),
+          const SizedBox(height: 18),
           // Bottom separator
           Center(
             child: Container(
-              width: 40,
-              height: 1,
+              width: 56,
+              height: 1.5,
               decoration: BoxDecoration(
                 color: separatorColor,
-                borderRadius: BorderRadius.circular(0.5),
+                borderRadius: BorderRadius.circular(0.75),
               ),
             ),
           ),

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -319,6 +319,12 @@ class _TopicSectionState extends ConsumerState<TopicSection>
     final topic = widget.topic;
     final isMulti = topic.articles.length > 1;
 
+    // After every rebuild (Riverpod state change, layout shift, etc.) the
+    // sticky-header geometry may be stale because the scrollable did not
+    // emit any event. Force a post-frame recompute so the AnimatedBuilder
+    // picks up the new layout.
+    if (widget.editorialMode && _isExpanded) _scheduleStickyRefresh();
+
     // If no articles or all dismissed, hide the entire section
     if (topic.articles.isEmpty) {
       debugPrint('TopicSection: 0 articles for topic ${topic.label}');

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -9,11 +9,13 @@ import '../../../widgets/design/facteur_thumbnail.dart';
 import '../../custom_topics/widgets/topic_chip.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/providers/feed_provider.dart';
+import '../../feed/repositories/feed_repository.dart';
 import '../../feed/widgets/dismiss_banner.dart';
 import '../../feed/widgets/feed_card.dart';
 import '../../feed/widgets/initial_circle.dart';
 import '../../../widgets/design/facteur_image.dart';
 import '../../feed/widgets/perspectives_bottom_sheet.dart';
+import '../../feed/widgets/perspectives_loading_sheet.dart';
 import '../../saved/widgets/collection_picker_sheet.dart';
 import '../../sources/models/source_model.dart';
 import '../models/digest_models.dart';
@@ -204,8 +206,10 @@ class _TopicSectionState extends ConsumerState<TopicSection>
     }
 
     final imageHeight = hasImage ? cardWidth / (16 / 9) : 0.0;
-    // Badge chip above card + 8px safety margin for text estimation variance
-    return imageHeight + bodyHeight + _footerHeight + _badgeHeight + 8.0;
+    // Badge chip above card (only outside editorial mode)
+    // + 8px safety margin for text estimation variance
+    final badgeHeight = widget.editorialMode ? 0.0 : _badgeHeight;
+    return imageHeight + bodyHeight + _footerHeight + badgeHeight + 8.0;
   }
 
   /// Compute carousel height: max of all cards (adjacent cards peek at 0.88).
@@ -882,39 +886,50 @@ class _TopicSectionState extends ConsumerState<TopicSection>
   // "Comparer les sources" handler
   // ---------------------------------------------------------------------------
 
-  Future<void> _handleCompare() async {
+  void _handleCompare() {
     final articles = widget.editorialMode
         ? widget.topic.articles.where((a) => a.badge != 'pas_de_recul').toList()
         : widget.topic.articles;
     if (articles.isEmpty) return;
     final article = articles[_currentPage.clamp(0, articles.length - 1)];
     if (article.contentId.isEmpty) return;
-    final repository = ref.read(feedRepositoryProvider);
-    final response = await repository.getPerspectives(article.contentId);
 
-    if (!context.mounted) return;
+    // Kick off the request immediately and show the sheet without awaiting,
+    // so the bottom sheet animates in instantly with a skeleton state instead
+    // of a 2-3s freeze on the trigger button.
+    final repository = ref.read(feedRepositoryProvider);
+    final perspectivesFuture = repository.getPerspectives(article.contentId);
 
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (ctx) => PerspectivesBottomSheet(
-        perspectives: response.perspectives
-            .map((p) => Perspective(
-                  title: p.title,
-                  url: p.url,
-                  sourceName: p.sourceName,
-                  sourceDomain: p.sourceDomain,
-                  biasStance: p.biasStance,
-                  publishedAt: p.publishedAt,
-                ))
-            .toList(),
-        biasDistribution: response.biasDistribution,
-        keywords: response.keywords,
-        sourceBiasStance: response.sourceBiasStance,
-        sourceName: article.source?.name ?? '',
-        contentId: article.contentId,
-        comparisonQuality: response.comparisonQuality,
+      builder: (ctx) => FutureBuilder<PerspectivesResponse>(
+        future: perspectivesFuture,
+        builder: (ctx, snapshot) {
+          if (!snapshot.hasData) {
+            return const PerspectivesLoadingSheet();
+          }
+          final response = snapshot.data!;
+          return PerspectivesBottomSheet(
+            perspectives: response.perspectives
+                .map((p) => Perspective(
+                      title: p.title,
+                      url: p.url,
+                      sourceName: p.sourceName,
+                      sourceDomain: p.sourceDomain,
+                      biasStance: p.biasStance,
+                      publishedAt: p.publishedAt,
+                    ))
+                .toList(),
+            biasDistribution: response.biasDistribution,
+            keywords: response.keywords,
+            sourceBiasStance: response.sourceBiasStance,
+            sourceName: article.source?.name ?? '',
+            contentId: article.contentId,
+            comparisonQuality: response.comparisonQuality,
+          );
+        },
       ),
     );
   }
@@ -1171,7 +1186,9 @@ class _TopicSectionState extends ConsumerState<TopicSection>
       itemBuilder: (context, index) {
         final article = articles[index];
         final imageVisible = _imageWillRender(article);
-        final badgeChip = EditorialBadge.chip(article.badge, context: context);
+        final badgeChip = widget.editorialMode
+            ? null
+            : EditorialBadge.chip(article.badge, context: context);
         final card = FeedCard(
           boxShadow: [BoxShadow(color: Colors.black.withValues(alpha: 0.05), blurRadius: 8, offset: const Offset(0, 2))],
           content: _convertToContent(article),

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -98,6 +98,24 @@ class _TopicSectionState extends ConsumerState<TopicSection>
   /// header translation when the editorial card is expanded.
   ScrollPosition? _scrollPosition;
 
+  /// Manual notifier merged into the sticky header AnimatedBuilder so we can
+  /// force a recompute when the scrollable does not fire any event (e.g. after
+  /// returning from a pushed route).
+  final ValueNotifier<int> _stickyRefresh = ValueNotifier<int>(0);
+  Listenable? _stickyListenable;
+
+  void _updateStickyListenable() {
+    final pos = _scrollPosition;
+    _stickyListenable =
+        pos == null ? null : Listenable.merge([pos, _stickyRefresh]);
+  }
+
+  void _scheduleStickyRefresh() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _stickyRefresh.value++;
+    });
+  }
+
   @override
   void initState() {
     super.initState();
@@ -106,17 +124,57 @@ class _TopicSectionState extends ConsumerState<TopicSection>
     );
   }
 
+  /// Route the section currently sits in. Tracked so we can detach our
+  /// animation status listener when the route changes or the widget is
+  /// disposed.
+  ModalRoute<dynamic>? _trackedRoute;
+
+  void _onRouteAnimationStatus(AnimationStatus status) {
+    if (status == AnimationStatus.completed ||
+        status == AnimationStatus.dismissed) {
+      if (mounted) _stickyRefresh.value++;
+    }
+  }
+
+  void _attachRouteListeners(ModalRoute<dynamic>? route) {
+    if (identical(route, _trackedRoute)) return;
+    _trackedRoute?.animation?.removeStatusListener(_onRouteAnimationStatus);
+    _trackedRoute?.secondaryAnimation
+        ?.removeStatusListener(_onRouteAnimationStatus);
+    _trackedRoute = route;
+    route?.animation?.addStatusListener(_onRouteAnimationStatus);
+    route?.secondaryAnimation?.addStatusListener(_onRouteAnimationStatus);
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (widget.editorialMode) {
-      _scrollPosition = Scrollable.maybeOf(context)?.position;
+      final newPos = Scrollable.maybeOf(context)?.position;
+      if (!identical(newPos, _scrollPosition)) {
+        _scrollPosition = newPos;
+        _updateStickyListenable();
+      } else if (_stickyListenable == null) {
+        _updateStickyListenable();
+      }
+      // Subscribe to route transition completion so we can recompute the
+      // sticky header geometry once Cupertino's slide/fade is fully settled
+      // (the scrollable does not emit any event in that window).
+      _attachRouteListeners(ModalRoute.of(context));
+      // Force a recompute on the next frame: dependency changes commonly fire
+      // when entering/leaving routes (ModalRoute, MediaQuery), and the
+      // scrollable will not emit any event to retrigger the AnimatedBuilder.
+      _scheduleStickyRefresh();
     }
   }
 
   @override
   void dispose() {
+    _trackedRoute?.animation?.removeStatusListener(_onRouteAnimationStatus);
+    _trackedRoute?.secondaryAnimation
+        ?.removeStatusListener(_onRouteAnimationStatus);
     _pageController.dispose();
+    _stickyRefresh.dispose();
     super.dispose();
   }
 
@@ -126,21 +184,52 @@ class _TopicSectionState extends ConsumerState<TopicSection>
   /// Returns 0 when the card is not yet scrolled past the pin line, and
   /// clamps to `cardHeight - headerHeight` so the sticky header releases
   /// when the card is about to scroll off-screen.
+  ///
+  /// Defensive against stale render-tree state (e.g. mid-route-transition):
+  /// bails out when render boxes are detached, when the route is animating,
+  /// or when the card is not visibly intersecting the viewport.
   double _computeStickyHeaderTranslation(BuildContext context) {
     if (!_isExpanded) return 0;
+
+    // During route transitions, ancestor transforms (Cupertino slide, fade,
+    // etc.) make `localToGlobal` return geometry that does not reflect the
+    // post-transition layout. We bail out and re-compute once the route is
+    // settled (see _scheduleStickyRefresh in didChangeDependencies + the
+    // route animation listener).
+    final route = ModalRoute.of(context);
+    if (route != null) {
+      final anim = route.animation;
+      final secondary = route.secondaryAnimation;
+      final isAnimating = (anim != null &&
+              anim.status != AnimationStatus.completed &&
+              anim.status != AnimationStatus.dismissed) ||
+          (secondary != null &&
+              secondary.status != AnimationStatus.completed &&
+              secondary.status != AnimationStatus.dismissed);
+      if (isAnimating) return 0;
+    }
+
     final cardContext = _editorialCardKey.currentContext;
     final headerContext = _editorialHeaderKey.currentContext;
     if (cardContext == null || headerContext == null) return 0;
 
     final cardBox = cardContext.findRenderObject() as RenderBox?;
     final headerBox = headerContext.findRenderObject() as RenderBox?;
-    if (cardBox == null || !cardBox.hasSize) return 0;
-    if (headerBox == null || !headerBox.hasSize) return 0;
+    if (cardBox == null || !cardBox.attached || !cardBox.hasSize) return 0;
+    if (headerBox == null || !headerBox.attached || !headerBox.hasSize) {
+      return 0;
+    }
 
     final cardTop = cardBox.localToGlobal(Offset.zero).dy;
     final cardHeight = cardBox.size.height;
     final headerHeight = headerBox.size.height;
     final pinLine = MediaQuery.of(context).padding.top;
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    // Sanity: if the card is fully off-screen (above or below the visible
+    // window), don't attempt to pin the overlay — it would otherwise clamp
+    // to maxTranslate and visually stick at the bottom of the card.
+    if (cardTop + cardHeight <= 0 || cardTop >= screenHeight) return 0;
 
     final maxTranslate =
         (cardHeight - headerHeight).clamp(0.0, double.infinity);
@@ -248,12 +337,13 @@ class _TopicSectionState extends ConsumerState<TopicSection>
 
       // Natural header (inside the Column), fades out when the sticky
       // overlay takes over.
+      final stickyListenable = _stickyListenable;
       final naturalHeader = Padding(
         key: _editorialHeaderKey,
         padding: const EdgeInsets.fromLTRB(12, 10, 12, 0),
-        child: _isExpanded && _scrollPosition != null
+        child: _isExpanded && stickyListenable != null
             ? AnimatedBuilder(
-                animation: _scrollPosition!,
+                animation: stickyListenable,
                 builder: (context, child) {
                   final translation = _computeStickyHeaderTranslation(context);
                   return Opacity(
@@ -312,13 +402,13 @@ class _TopicSectionState extends ConsumerState<TopicSection>
                 // Sticky header overlay — floats at the top of the
                 // viewport while the card is scrolled past its natural
                 // position, giving a "fil contenu" reading flow.
-                if (_isExpanded && _scrollPosition != null)
+                if (_isExpanded && stickyListenable != null)
                   Positioned(
                     top: 0,
                     left: 0,
                     right: 0,
                     child: AnimatedBuilder(
-                      animation: _scrollPosition!,
+                      animation: stickyListenable,
                       builder: (context, child) {
                         final translation =
                             _computeStickyHeaderTranslation(context);

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -89,33 +89,6 @@ class _TopicSectionState extends ConsumerState<TopicSection>
   /// Content IDs whose images failed to load (detected at runtime).
   final Set<String> _collapsedImages = {};
 
-  /// Keys used to measure the editorial card and its header for the
-  /// sticky-header effect when the card is expanded.
-  final GlobalKey _editorialCardKey = GlobalKey();
-  final GlobalKey _editorialHeaderKey = GlobalKey();
-
-  /// Scroll position of the ancestor Scrollable. Used to drive the sticky
-  /// header translation when the editorial card is expanded.
-  ScrollPosition? _scrollPosition;
-
-  /// Manual notifier merged into the sticky header AnimatedBuilder so we can
-  /// force a recompute when the scrollable does not fire any event (e.g. after
-  /// returning from a pushed route).
-  final ValueNotifier<int> _stickyRefresh = ValueNotifier<int>(0);
-  Listenable? _stickyListenable;
-
-  void _updateStickyListenable() {
-    final pos = _scrollPosition;
-    _stickyListenable =
-        pos == null ? null : Listenable.merge([pos, _stickyRefresh]);
-  }
-
-  void _scheduleStickyRefresh() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _stickyRefresh.value++;
-    });
-  }
-
   @override
   void initState() {
     super.initState();
@@ -124,116 +97,10 @@ class _TopicSectionState extends ConsumerState<TopicSection>
     );
   }
 
-  /// Route the section currently sits in. Tracked so we can detach our
-  /// animation status listener when the route changes or the widget is
-  /// disposed.
-  ModalRoute<dynamic>? _trackedRoute;
-
-  void _onRouteAnimationStatus(AnimationStatus status) {
-    if (status == AnimationStatus.completed ||
-        status == AnimationStatus.dismissed) {
-      if (mounted) _stickyRefresh.value++;
-    }
-  }
-
-  void _attachRouteListeners(ModalRoute<dynamic>? route) {
-    if (identical(route, _trackedRoute)) return;
-    _trackedRoute?.animation?.removeStatusListener(_onRouteAnimationStatus);
-    _trackedRoute?.secondaryAnimation
-        ?.removeStatusListener(_onRouteAnimationStatus);
-    _trackedRoute = route;
-    route?.animation?.addStatusListener(_onRouteAnimationStatus);
-    route?.secondaryAnimation?.addStatusListener(_onRouteAnimationStatus);
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (widget.editorialMode) {
-      final newPos = Scrollable.maybeOf(context)?.position;
-      if (!identical(newPos, _scrollPosition)) {
-        _scrollPosition = newPos;
-        _updateStickyListenable();
-      } else if (_stickyListenable == null) {
-        _updateStickyListenable();
-      }
-      // Subscribe to route transition completion so we can recompute the
-      // sticky header geometry once Cupertino's slide/fade is fully settled
-      // (the scrollable does not emit any event in that window).
-      _attachRouteListeners(ModalRoute.of(context));
-      // Force a recompute on the next frame: dependency changes commonly fire
-      // when entering/leaving routes (ModalRoute, MediaQuery), and the
-      // scrollable will not emit any event to retrigger the AnimatedBuilder.
-      _scheduleStickyRefresh();
-    }
-  }
-
   @override
   void dispose() {
-    _trackedRoute?.animation?.removeStatusListener(_onRouteAnimationStatus);
-    _trackedRoute?.secondaryAnimation
-        ?.removeStatusListener(_onRouteAnimationStatus);
     _pageController.dispose();
-    _stickyRefresh.dispose();
     super.dispose();
-  }
-
-  /// Compute how much the editorial header should be translated vertically
-  /// to stay pinned at the top of the viewport while the card is expanded.
-  ///
-  /// Returns 0 when the card is not yet scrolled past the pin line, and
-  /// clamps to `cardHeight - headerHeight` so the sticky header releases
-  /// when the card is about to scroll off-screen.
-  ///
-  /// Defensive against stale render-tree state (e.g. mid-route-transition):
-  /// bails out when render boxes are detached, when the route is animating,
-  /// or when the card is not visibly intersecting the viewport.
-  double _computeStickyHeaderTranslation(BuildContext context) {
-    if (!_isExpanded) return 0;
-
-    // During route transitions, ancestor transforms (Cupertino slide, fade,
-    // etc.) make `localToGlobal` return geometry that does not reflect the
-    // post-transition layout. We bail out and re-compute once the route is
-    // settled (see _scheduleStickyRefresh in didChangeDependencies + the
-    // route animation listener).
-    final route = ModalRoute.of(context);
-    if (route != null) {
-      final anim = route.animation;
-      final secondary = route.secondaryAnimation;
-      final isAnimating = (anim != null &&
-              anim.status != AnimationStatus.completed &&
-              anim.status != AnimationStatus.dismissed) ||
-          (secondary != null &&
-              secondary.status != AnimationStatus.completed &&
-              secondary.status != AnimationStatus.dismissed);
-      if (isAnimating) return 0;
-    }
-
-    final cardContext = _editorialCardKey.currentContext;
-    final headerContext = _editorialHeaderKey.currentContext;
-    if (cardContext == null || headerContext == null) return 0;
-
-    final cardBox = cardContext.findRenderObject() as RenderBox?;
-    final headerBox = headerContext.findRenderObject() as RenderBox?;
-    if (cardBox == null || !cardBox.attached || !cardBox.hasSize) return 0;
-    if (headerBox == null || !headerBox.attached || !headerBox.hasSize) {
-      return 0;
-    }
-
-    final cardTop = cardBox.localToGlobal(Offset.zero).dy;
-    final cardHeight = cardBox.size.height;
-    final headerHeight = headerBox.size.height;
-    final pinLine = MediaQuery.of(context).padding.top;
-    final screenHeight = MediaQuery.of(context).size.height;
-
-    // Sanity: if the card is fully off-screen (above or below the visible
-    // window), don't attempt to pin the overlay — it would otherwise clamp
-    // to maxTranslate and visually stick at the bottom of the card.
-    if (cardTop + cardHeight <= 0 || cardTop >= screenHeight) return 0;
-
-    final maxTranslate =
-        (cardHeight - headerHeight).clamp(0.0, double.infinity);
-    return (pinLine - cardTop).clamp(0.0, maxTranslate);
   }
 
   /// Footer height: border (1) + padding (4×2) + icon row (~28) = ~37
@@ -319,12 +186,6 @@ class _TopicSectionState extends ConsumerState<TopicSection>
     final topic = widget.topic;
     final isMulti = topic.articles.length > 1;
 
-    // After every rebuild (Riverpod state change, layout shift, etc.) the
-    // sticky-header geometry may be stale because the scrollable did not
-    // emit any event. Force a post-frame recompute so the AnimatedBuilder
-    // picks up the new layout.
-    if (widget.editorialMode && _isExpanded) _scheduleStickyRefresh();
-
     // If no articles or all dismissed, hide the entire section
     if (topic.articles.isEmpty) {
       debugPrint('TopicSection: 0 articles for topic ${topic.label}');
@@ -341,25 +202,12 @@ class _TopicSectionState extends ConsumerState<TopicSection>
       if (actuArticles.isEmpty) return const SizedBox.shrink();
       final isActuMulti = actuArticles.length > 1;
 
-      // Natural header (inside the Column), fades out when the sticky
-      // overlay takes over.
-      final stickyListenable = _stickyListenable;
+      // Plain header pinned at the top of the card (no sticky overlay).
+      // The previous sticky-overlay implementation was fragile across route
+      // transitions and Riverpod-driven rebuilds — see git history.
       final naturalHeader = Padding(
-        key: _editorialHeaderKey,
         padding: const EdgeInsets.fromLTRB(12, 10, 12, 0),
-        child: _isExpanded && stickyListenable != null
-            ? AnimatedBuilder(
-                animation: stickyListenable,
-                builder: (context, child) {
-                  final translation = _computeStickyHeaderTranslation(context);
-                  return Opacity(
-                    opacity: translation > 0 ? 0 : 1,
-                    child: child,
-                  );
-                },
-                child: _buildHeader(context, colors, isDark, topic),
-              )
-            : _buildHeader(context, colors, isDark, topic),
+        child: _buildHeader(context, colors, isDark, topic),
       );
 
       return AnimatedSize(
@@ -383,73 +231,23 @@ class _TopicSectionState extends ConsumerState<TopicSection>
           ),
           child: ClipRRect(
             borderRadius: BorderRadius.circular(16),
-            child: Stack(
-              children: [
-                // Card content (background + natural header + body)
-                Container(
-                  key: _editorialCardKey,
-                  color: isDark
-                      ? Colors.white.withValues(alpha: 0.11)
-                      : Colors.black.withValues(alpha: 0.07),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      naturalHeader,
-                      const SizedBox(height: 8),
-                      if (_isExpanded)
-                        _buildExpandedEditorial(colors, isDark, topic,
-                            actuArticles, isActuMulti)
-                      else
-                        _buildCompactEditorialCard(
-                            colors, isDark, topic, actuArticles),
-                    ],
-                  ),
-                ),
-                // Sticky header overlay — floats at the top of the
-                // viewport while the card is scrolled past its natural
-                // position, giving a "fil contenu" reading flow.
-                if (_isExpanded && stickyListenable != null)
-                  Positioned(
-                    top: 0,
-                    left: 0,
-                    right: 0,
-                    child: AnimatedBuilder(
-                      animation: stickyListenable,
-                      builder: (context, child) {
-                        final translation =
-                            _computeStickyHeaderTranslation(context);
-                        if (translation <= 0) {
-                          return const SizedBox.shrink();
-                        }
-                        return Transform.translate(
-                          offset: Offset(0, translation),
-                          child: child,
-                        );
-                      },
-                      child: Material(
-                        color: isDark
-                            ? const Color(0xFF231B12)
-                            : const Color(0xFFE8DBC1),
-                        elevation: 0,
-                        child: Container(
-                          decoration: BoxDecoration(
-                            border: Border(
-                              bottom: BorderSide(
-                                color: colors.border.withValues(
-                                    alpha: isDark ? 0.32 : 0.22),
-                                width: 0.5,
-                              ),
-                            ),
-                          ),
-                          padding:
-                              const EdgeInsets.fromLTRB(12, 10, 12, 8),
-                          child: _buildHeader(
-                              context, colors, isDark, topic),
-                        ),
-                      ),
-                    ),
-                  ),
-              ],
+            child: Container(
+              color: isDark
+                  ? Colors.white.withValues(alpha: 0.11)
+                  : Colors.black.withValues(alpha: 0.07),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  naturalHeader,
+                  const SizedBox(height: 8),
+                  if (_isExpanded)
+                    _buildExpandedEditorial(colors, isDark, topic,
+                        actuArticles, isActuMulti)
+                  else
+                    _buildCompactEditorialCard(
+                        colors, isDark, topic, actuArticles),
+                ],
+              ),
             ),
           ),
         ),

--- a/apps/mobile/lib/features/digest/widgets/topic_theme_chip.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_theme_chip.dart
@@ -13,27 +13,18 @@ class TopicThemeChip extends StatelessWidget {
     if (themeSlug == null) return const SizedBox.shrink();
 
     final colors = context.facteurColors;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final color = colors.textSecondary;
     final rawLabel = topicSlugToLabel[themeSlug] ??
         themeSlug!.replaceAll('-', ' ').replaceAll('_', ' ');
     final label = rawLabel.isNotEmpty
         ? rawLabel[0].toUpperCase() + rawLabel.substring(1)
         : rawLabel;
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: isDark ? 0.15 : 0.10),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          color: color,
-          fontSize: 12,
-          fontWeight: FontWeight.w600,
-        ),
+    return Text(
+      label,
+      style: TextStyle(
+        color: colors.textSecondary,
+        fontSize: 12,
+        fontWeight: FontWeight.w600,
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/screens/cluster_view_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/cluster_view_screen.dart
@@ -208,8 +208,8 @@ class _ClusterViewScreenState extends ConsumerState<ClusterViewScreen> {
                                 .toggleLike(article);
                             NotificationService.showInfo(
                               wasLiked
-                                  ? 'Retiré de vos contenus favoris'
-                                  : 'Ajouté à vos contenus favoris',
+                                  ? 'Retiré de Mes articles intéressants 🌻'
+                                  : 'Ajouté à Mes articles intéressants 🌻',
                             );
                             ref.invalidate(collectionsProvider);
                           },

--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -689,8 +689,8 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                                           ref.read(feedProvider.notifier).toggleLike(c);
                                           NotificationService.showInfo(
                                             wasLiked
-                                                ? 'Retiré de vos contenus favoris'
-                                                : 'Ajouté à vos contenus favoris',
+                                                ? 'Retiré de Mes articles intéressants 🌻'
+                                                : 'Ajouté à Mes articles intéressants 🌻',
                                           );
                                           ref.invalidate(collectionsProvider);
                                         },
@@ -837,8 +837,8 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                                             .toggleLike(content);
                                         NotificationService.showInfo(
                                           wasLiked
-                                              ? 'Retiré de vos contenus favoris'
-                                              : 'Ajouté à vos contenus favoris',
+                                              ? 'Retiré de Mes articles intéressants 🌻'
+                                              : 'Ajouté à Mes articles intéressants 🌻',
                                         );
                                         ref.invalidate(collectionsProvider);
                                       },

--- a/apps/mobile/lib/features/feed/widgets/perspectives_loading_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_loading_sheet.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+
+/// Skeleton sheet shown while perspectives are being fetched.
+///
+/// Mirrors the visual frame of [PerspectivesBottomSheet] (handle + header + body)
+/// so the bottom sheet animates in instantly with a believable placeholder
+/// instead of leaving the user staring at the trigger button for 2-3 seconds.
+class PerspectivesLoadingSheet extends StatelessWidget {
+  const PerspectivesLoadingSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.92,
+      ),
+      decoration: BoxDecoration(
+        color: colors.backgroundPrimary,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Handle
+          Container(
+            margin: const EdgeInsets.only(top: 12),
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: colors.textSecondary.withValues(alpha: 0.2),
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+
+          // Header
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Icon(
+                  PhosphorIcons.eye(PhosphorIconsStyle.fill),
+                  color: colors.primary,
+                  size: 32,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    'Voir tous les points de vue',
+                    style: textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: colors.textPrimary,
+                      fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: Icon(PhosphorIcons.x(PhosphorIconsStyle.bold)),
+                  onPressed: () => Navigator.pop(context),
+                  color: colors.textSecondary,
+                ),
+              ],
+            ),
+          ),
+
+          // Spinner body
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 48),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  width: 28,
+                  height: 28,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2.5,
+                    color: colors.primary,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Chargement des perspectives…',
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colors.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/sunflower_icon.dart
+++ b/apps/mobile/lib/widgets/sunflower_icon.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+/// Sunflower icon widget for the 🌻 recommendation feature.
+///
+/// Two states:
+/// - **Inactive**: monochrome outline icon, same style as other icons
+/// - **Active**: colorful sunflower (yellow/green/brown) with animation
+///
+/// The transition uses an AnimatedSwitcher with a scale+fade effect (~300ms).
+class SunflowerIcon extends StatelessWidget {
+  final bool isActive;
+  final double size;
+  final Color? inactiveColor;
+
+  const SunflowerIcon({
+    super.key,
+    required this.isActive,
+    this.size = 25,
+    this.inactiveColor,
+  });
+
+  // Sunflower colors
+  static const Color sunflowerYellow = Color(0xFFFFC107);
+  static const Color sunflowerGreen = Color(0xFF4CAF50);
+  static const Color sunflowerBrown = Color(0xFF795548);
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeIn,
+      transitionBuilder: (child, animation) {
+        return ScaleTransition(
+          scale: animation,
+          child: FadeTransition(
+            opacity: animation,
+            child: child,
+          ),
+        );
+      },
+      child: isActive
+          ? ShaderMask(
+              key: const ValueKey('active'),
+              shaderCallback: (bounds) => const LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [sunflowerYellow, sunflowerBrown],
+                stops: [0.3, 1.0],
+              ).createShader(bounds),
+              blendMode: BlendMode.srcIn,
+              child: Icon(
+                PhosphorIcons.flowerTulip(PhosphorIconsStyle.fill),
+                size: size,
+                color: Colors.white, // Will be replaced by shader
+              ),
+            )
+          : Icon(
+              key: const ValueKey('inactive'),
+              PhosphorIcons.flowerTulip(PhosphorIconsStyle.regular),
+              size: size,
+              color: inactiveColor,
+            ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/sunflower_icon.dart
+++ b/apps/mobile/lib/widgets/sunflower_icon.dart
@@ -51,14 +51,14 @@ class SunflowerIcon extends StatelessWidget {
               ).createShader(bounds),
               blendMode: BlendMode.srcIn,
               child: Icon(
-                PhosphorIcons.flowerTulip(PhosphorIconsStyle.fill),
+                PhosphorIcons.flower(PhosphorIconsStyle.fill),
                 size: size,
                 color: Colors.white, // Will be replaced by shader
               ),
             )
           : Icon(
               key: const ValueKey('inactive'),
-              PhosphorIcons.flowerTulip(PhosphorIconsStyle.regular),
+              PhosphorIcons.flower(PhosphorIconsStyle.regular),
               size: size,
               color: inactiveColor,
             ),

--- a/docs/stories/core/13.1.sunflower-recommendation.md
+++ b/docs/stories/core/13.1.sunflower-recommendation.md
@@ -1,0 +1,270 @@
+# Story 13.1 — 🌻 "Recommander à la communauté"
+
+**Epic** : 13 — Curation communautaire
+**Type** : Feature
+**Statut** : PLAN — En attente de GO
+
+---
+
+## Contexte
+
+Remplacement du bouton "like" par un bouton 🌻 (tournesol) dont la philosophie est : "Marquer ce contenu comme intéressant / insightful — guider les autres vers le contenu de qualité." C'est un acte de curation communautaire.
+
+Les contenus 🌻 alimentent deux nouvelles surfaces : un carrousel "Recos de la communauté" dans le Digest et un carrousel "Recos de la communauté" dans le Feed.
+
+---
+
+## Plan technique
+
+### Analyse de l'existant
+
+Le système de "like" actuel repose sur :
+- **Backend** : `UserContentStatus.is_liked` / `liked_at` dans `user_content_status`
+- **API** : `POST/DELETE /contents/{id}/like` dans `routers/contents.py`
+- **Service** : `ContentService.set_like_status()` + auto-bookmark + collection "Contenus likés"
+- **Flutter** : `toggleLike()` dans feed/digest providers, FAB dans content_detail_screen
+- **Feed carousel "gems"** : existe déjà (saves+likes sur 30j, position 15)
+
+**Décision clé** : Le 🌻 **est** le like renommé. Pas de nouveau champ DB — on réutilise `is_liked`/`liked_at`. Le data model existant contient déjà `user_id`, `content_id`, `created_at` (via `liked_at`), et `source_id` est accessible via jointure sur `contents.source_id`.
+
+---
+
+### Phase 1 — Backend
+
+#### 1.1 Renommage collection "Contenus likés" → "Mes articles intéressants 🌻"
+
+**Fichier** : `packages/api/app/services/collection_service.py`
+- Modifier `LIKED_COLLECTION_NAME = "Mes articles intéressants 🌻"`
+- Migration Alembic : UPDATE SQL pour renommer les collections existantes
+
+#### 1.2 Service de scoring communautaire
+
+**Nouveau fichier** : `packages/api/app/services/community_recommendation_service.py`
+
+Scoring avec decay temporel :
+```
+score(article) = SUM(1 / (1 + heures_depuis_sunflower / 48))
+```
+
+Deux méthodes :
+- `get_recent_recommendations(limit=8, exclude_ids=[])` → pour le Digest (tri par `liked_at` DESC)
+- `get_top_recommendations(limit=8, exclude_ids=[])` → pour le Feed (tri par `score` DESC)
+
+Règles :
+- Fenêtre : 7 jours glissants
+- Seuil minimum : 1 🌻
+- Non-duplication : Feed d'abord, Digest exclut les IDs du Feed
+- Pas de filtrage par sources utilisateur (espace de découverte)
+- Compteur 🌻 : retourné pour chaque article (affiché seulement si >= 2)
+
+#### 1.3 Nouveaux endpoints API
+
+**Fichier** : `packages/api/app/routers/community.py` (nouveau router)
+
+- `GET /api/community/recommendations` → retourne `{ digest_carousel: [...], feed_carousel: [...] }`
+
+Chaque item inclut les champs Content standards + `sunflower_count: int`.
+
+**Schéma** : `packages/api/app/schemas/community.py` (nouveau)
+
+#### 1.4 Intégration carrousel Feed
+
+**Fichier** : `packages/api/app/services/recommendation_service.py`
+
+Remplacer le carrousel "gems" existant (lignes 1252-1384) par un carrousel "community" :
+- `carousel_type: "community"`
+- `title: "Recos de la communauté"`
+- `emoji: "🌻"`
+- Scoring par decay (pas juste saves+likes bruts)
+- Fenêtre 7 jours (au lieu de 30)
+- Badges : "🌻 N" si N >= 2
+
+#### 1.5 Intégration carrousel Digest
+
+**Fichier** : `packages/api/app/routers/digest.py` + `packages/api/app/schemas/digest.py`
+
+Ajouter un champ `community_carousel: list[CommunityCarouselItem] | None` au `DigestResponse`.
+- Calculé à la volée lors du `GET /digest`
+- Articles les plus récemment 🌻 (exclusion des articles déjà dans le Feed carousel)
+
+#### 1.6 Index DB
+
+Migration Alembic (SQL seulement, pas d'exécution Railway) :
+- `CREATE INDEX ix_user_content_status_liked_at ON user_content_status(liked_at) WHERE is_liked = true` — pour les requêtes de scoring
+- `CREATE INDEX ix_ucs_source_liked ON user_content_status(content_id, is_liked) WHERE is_liked = true` — pour le futur dashboard créateur
+
+---
+
+### Phase 2 — Flutter : Bouton 🌻
+
+#### 2.1 Asset icône tournesol
+
+Créer un composant `SunflowerIcon` avec deux états :
+- **Monochrome** : outline gris, même style que les autres icônes
+- **Coloré** : jaune/vert/marron, couleurs naturelles du tournesol
+
+Options d'implémentation (par ordre de préférence) :
+1. **SVG animé** via `flutter_svg` + `AnimatedSwitcher` — simple, léger
+2. **Lottie** via `lottie` package — animation riche style Twitter heart
+3. **Custom paint** — contrôle total mais plus complexe
+
+#### 2.2 Remplacement dans le Feed
+
+**Fichier** : `apps/mobile/lib/features/feed/screens/feed_screen.dart`
+- Remplacer l'icône like par SunflowerIcon
+- Même toggle logic (`toggleLike` → conceptuellement `toggleSunflower`, même endpoint)
+
+#### 2.3 Remplacement dans le Digest
+
+**Fichier** : `apps/mobile/lib/features/digest/screens/digest_screen.dart`
+- Remplacer l'icône/action like par SunflowerIcon
+- MAJ toast : "Ajouté à Mes articles intéressants 🌻" / "Retiré de Mes articles intéressants 🌻"
+
+#### 2.4 Remplacement dans le Detail
+
+**Fichier** : `apps/mobile/lib/features/detail/screens/content_detail_screen.dart`
+- Remplacer le FAB like par un FAB 🌻
+- Réutiliser l'animation bounce existante (`_likeBounceController`)
+- Micro-animation : transition monochrome → coloré (~300ms)
+
+#### 2.5 MAJ modèles / labels
+
+- Renommer "Contenus likés" → "Mes articles intéressants 🌻" dans tous les labels Flutter
+- Mettre à jour `content_detail_screen.dart` toast messages
+- Mettre à jour `digest_screen.dart` toast messages
+
+---
+
+### Phase 3 — Flutter : Carrousels communauté
+
+#### 3.1 Carrousel Feed "Recos de la communauté"
+
+Le carrousel Feed est déjà géré par le backend (carousel_type dans FeedResponse). Il suffit de :
+- S'assurer que le nouveau type "community" est rendu correctement par `FeedCarousel`
+- Ajouter un badge "🌻 N" si sunflower_count >= 2
+- Afficher le nom de la source clairement
+
+#### 3.2 Carrousel Digest "Recos de la communauté"
+
+**Nouveau widget** ou réutilisation de `FeedCarousel` dans le Digest :
+
+**Fichier** : `apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart`
+- Ajouter une section carrousel horizontal après les topics et avant les blocs éditoriaux
+- Condition : n'afficher que si `community_carousel` non vide dans DigestResponse
+- Style cohérent avec le design digest (glassmorphic containers)
+
+**Fichiers à modifier** :
+- `apps/mobile/lib/features/digest/models/digest_models.dart` — ajouter `communityCarousel`
+- `apps/mobile/lib/features/digest/repositories/digest_repository.dart` — parser le nouveau champ
+- `apps/mobile/lib/features/digest/providers/digest_provider.dart` — exposer les données
+
+---
+
+### Phase 4 — Flutter : Nudge "Recommander ?"
+
+#### 4.1 Logique du nudge
+
+**Fichier** : `apps/mobile/lib/features/detail/screens/content_detail_screen.dart`
+
+- Timer de 30 secondes démarré à l'ouverture de l'article
+- Conditions :
+  - Article pas déjà 🌻
+  - Pas les 2 premiers articles de la session (compteur session via provider)
+  - Max 1 nudge par session (flag session)
+  - Max 1 nudge tous les 3 jours (timestamp en SharedPreferences)
+- Affichage : petit label animé "Recommander ?" qui apparaît au-dessus du FAB 🌻
+- Disparition : après 4-5s ou au scroll (premier des deux)
+
+#### 4.2 State management du nudge
+
+**Nouveau provider** : `apps/mobile/lib/features/detail/providers/nudge_provider.dart`
+- Compteur d'articles lus dans la session
+- Flag nudge déjà affiché cette session
+- Persistance date dernier nudge (SharedPreferences)
+
+---
+
+### Phase 5 — Migration des données
+
+#### 5.1 Migration Alembic
+
+**Fichier** : nouvelle migration `sf01_sunflower_rename_and_indexes.py`
+
+```sql
+-- Renommer les collections "Contenus likés" existantes
+UPDATE collections SET name = 'Mes articles intéressants 🌻' WHERE is_liked_collection = true;
+
+-- Index pour scoring communautaire
+CREATE INDEX CONCURRENTLY ix_ucs_liked_at_partial
+ON user_content_status(liked_at DESC)
+WHERE is_liked = true;
+```
+
+Note : migration SQL exécutée via Supabase SQL Editor (jamais via Railway, cf. contraintes).
+
+---
+
+## Fichiers impactés
+
+### Backend (packages/api/)
+| Fichier | Action |
+|---------|--------|
+| `app/services/collection_service.py` | Modifier constante LIKED_COLLECTION_NAME |
+| `app/services/community_recommendation_service.py` | **Nouveau** — scoring communautaire |
+| `app/routers/community.py` | **Nouveau** — endpoint recommendations |
+| `app/schemas/community.py` | **Nouveau** — schémas response |
+| `app/services/recommendation_service.py` | Modifier carrousel "gems" → "community" |
+| `app/routers/digest.py` | Ajouter community_carousel au response |
+| `app/schemas/digest.py` | Ajouter champ community_carousel |
+| `app/main.py` | Enregistrer le nouveau router community |
+| `alembic/versions/sf01_*.py` | Migration rename + indexes |
+| `tests/test_community_recommendations.py` | **Nouveau** — tests unitaires |
+
+### Flutter (apps/mobile/)
+| Fichier | Action |
+|---------|--------|
+| `lib/features/feed/screens/feed_screen.dart` | Remplacer icône like par 🌻 |
+| `lib/features/digest/screens/digest_screen.dart` | Remplacer icône like + ajouter carrousel |
+| `lib/features/detail/screens/content_detail_screen.dart` | Remplacer FAB + ajouter nudge |
+| `lib/features/digest/widgets/digest_briefing_section.dart` | Ajouter section carrousel communauté |
+| `lib/features/digest/models/digest_models.dart` | Ajouter communityCarousel |
+| `lib/features/digest/repositories/digest_repository.dart` | Parser nouveau champ |
+| `lib/features/digest/providers/digest_provider.dart` | Exposer données carrousel |
+| `lib/features/feed/models/content_model.dart` | Ajouter sunflower_count |
+| `lib/features/saved/providers/collections_provider.dart` | MAJ label collection |
+| `lib/features/detail/providers/nudge_provider.dart` | **Nouveau** — nudge state |
+| `lib/widgets/sunflower_icon.dart` | **Nouveau** — composant icône animée |
+
+---
+
+## Critères d'acceptation
+
+- [ ] Le bouton 🌻 remplace le bouton "like" (même emplacement, toggle)
+- [ ] Animation monochrome → coloré (~300ms) au tap
+- [ ] Article 🌻 apparaît dans "Mes articles intéressants 🌻"
+- [ ] Carrousel Digest : articles les plus récemment 🌻
+- [ ] Carrousel Feed : meilleurs articles sur 7 jours (scoring decay)
+- [ ] Pas de duplication entre les deux carrousels
+- [ ] Carrousels non filtrés par sources utilisateur
+- [ ] Compteur 🌻 affiché seulement si >= 2
+- [ ] Nudge "Recommander ?" après >30s, max 1x/session, pas sur 2 premiers articles, max 1x/3j
+- [ ] Nudge disparaît après 4-5s ou au scroll
+- [ ] Collection renommée "Mes articles intéressants 🌻"
+- [ ] Anciens likes migrés (pas de perte de données)
+- [ ] Carrousel caché si 0 articles 🌻
+- [ ] Utilisateur peut 🌻 un article découvert via carrousel communauté
+
+---
+
+## Ordre d'implémentation
+
+1. **Backend** : Service scoring + endpoint + intégration carrousels (Phase 1)
+2. **Flutter bouton** : SunflowerIcon + remplacement like partout (Phase 2)
+3. **Flutter carrousels** : Feed + Digest (Phase 3)
+4. **Flutter nudge** : Timer + conditions + animation (Phase 4)
+5. **Migration** : Rename collection + indexes (Phase 5)
+6. **Tests** : Backend pytest + Flutter test
+
+---
+
+*Créé : 2026-04-11*

--- a/packages/api/alembic/versions/sf01_sunflower_rename_and_indexes.py
+++ b/packages/api/alembic/versions/sf01_sunflower_rename_and_indexes.py
@@ -1,9 +1,13 @@
 """Sunflower 🌻 feature: rename liked collection + add scoring indexes.
 
 Revision ID: sf01
-Revises: td01
+Revises: dg01
 Create Date: 2026-04-11
 
+Chained after `dg01` (merged via PR #374 on main) so the alembic history
+stays single-headed. When this branch was opened, `td01` was the head; the
+digest reliability fix (`dg01`) landed on main in parallel, so rebasing the
+sunflower down_revision resolves the duplicate head without a merge revision.
 """
 from collections.abc import Sequence
 
@@ -11,7 +15,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "sf01"
-down_revision: str = "td01"
+down_revision: str = "dg01"
 branch_labels: Sequence[str] | None = None
 depends_on: str | None = None
 

--- a/packages/api/alembic/versions/sf01_sunflower_rename_and_indexes.py
+++ b/packages/api/alembic/versions/sf01_sunflower_rename_and_indexes.py
@@ -1,0 +1,47 @@
+"""Sunflower 🌻 feature: rename liked collection + add scoring indexes.
+
+Revision ID: sf01
+Revises: td01
+Create Date: 2026-04-11
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "sf01"
+down_revision: str = "td01"
+branch_labels: Sequence[str] | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # Rename existing "Contenus likés" collections to new name
+    op.execute(
+        "UPDATE collections SET name = 'Mes articles intéressants 🌻' "
+        "WHERE is_liked_collection = true AND name = 'Contenus likés'"
+    )
+
+    # Partial index for community scoring queries (liked articles by recency)
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_ucs_liked_at_partial "
+        "ON user_content_status(liked_at DESC) "
+        "WHERE is_liked = true"
+    )
+
+    # Index for future creator dashboard (aggregate by source)
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_ucs_content_liked_partial "
+        "ON user_content_status(content_id) "
+        "WHERE is_liked = true"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_ucs_content_liked_partial")
+    op.execute("DROP INDEX IF EXISTS ix_ucs_liked_at_partial")
+    op.execute(
+        "UPDATE collections SET name = 'Contenus likés' "
+        "WHERE is_liked_collection = true AND name = 'Mes articles intéressants 🌻'"
+    )

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -47,6 +47,7 @@ from app.routers import (
     app_update,
     auth,
     collections,
+    community,
     contents,
     custom_topics,
     digest,
@@ -291,6 +292,7 @@ app.include_router(
     tags=["Personalization"],
 )
 app.include_router(collections.router, prefix="/api/collections", tags=["Collections"])
+app.include_router(community.router, prefix="/api/community", tags=["Community"])
 app.include_router(
     custom_topics.router,
     prefix="/api/personalization/topics",

--- a/packages/api/app/routers/community.py
+++ b/packages/api/app/routers/community.py
@@ -1,13 +1,16 @@
 """Router for community recommendations (🌻 sunflower carousels)."""
 
+import datetime
 from uuid import UUID
 
 import structlog
 from fastapi import APIRouter, Depends
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.dependencies import get_current_user_id
+from app.models.content import UserContentStatus
 from app.schemas.community import (
     CommunityCarouselItem,
     CommunityCarouselsResponse,
@@ -24,33 +27,55 @@ router = APIRouter()
 def _content_to_carousel_item(
     item: dict,
     user_statuses: dict | None = None,
-) -> CommunityCarouselItem:
-    """Convert a community recommendation dict to a carousel item."""
-    content = item["content"]
-    user_id_statuses = user_statuses or {}
-    status = user_id_statuses.get(content.id, {})
+) -> CommunityCarouselItem | None:
+    """Convert a community recommendation dict to a carousel item.
 
-    return CommunityCarouselItem(
-        content_id=content.id,
-        title=content.title,
-        url=content.url,
-        thumbnail_url=content.thumbnail_url,
-        description=content.description,
-        content_type=content.content_type.value if hasattr(content.content_type, "value") else str(content.content_type),
-        duration_seconds=content.duration_seconds,
-        published_at=content.published_at,
-        source={
-            "id": content.source.id,
-            "name": content.source.name,
-            "logo_url": content.source.logo_url,
-            "type": content.source.source_type.value if hasattr(content.source.source_type, "value") else str(content.source.source_type),
-            "theme": content.source.theme,
-        },
-        sunflower_count=item.get("sunflower_count", 0),
-        is_liked=status.get("is_liked", False),
-        is_saved=status.get("is_saved", False),
-        topics=content.topics or [],
+    Returns None if the content is missing required fields (e.g. no source),
+    so the caller can filter it out instead of failing the whole response.
+    """
+    content = item["content"]
+    status = (user_statuses or {}).get(content.id, {})
+
+    if content.source is None:
+        return None
+
+    content_type = content.content_type
+    content_type_str = (
+        content_type.value if hasattr(content_type, "value") else str(content_type)
     )
+    source_type = content.source.source_type
+    source_type_str = (
+        source_type.value if hasattr(source_type, "value") else str(source_type)
+    )
+
+    try:
+        return CommunityCarouselItem(
+            content_id=content.id,
+            title=content.title or "",
+            url=content.url or "",
+            thumbnail_url=content.thumbnail_url,
+            description=content.description,
+            content_type=content_type_str,
+            duration_seconds=content.duration_seconds,
+            # Fallback to now() if null — pydantic schema requires a value
+            published_at=content.published_at or datetime.datetime.now(datetime.UTC),
+            source={
+                "id": content.source.id,
+                "name": content.source.name,
+                "logo_url": content.source.logo_url,
+                "type": source_type_str,
+                "theme": content.source.theme,
+            },
+            sunflower_count=item.get("sunflower_count", 0),
+            is_liked=status.get("is_liked", False),
+            is_saved=status.get("is_saved", False),
+            topics=content.topics or [],
+        )
+    except Exception:
+        logger.exception(
+            "community_carousel_item_build_failed", content_id=str(content.id)
+        )
+        return None
 
 
 @router.get(
@@ -65,46 +90,53 @@ async def get_community_recommendations(
 
     - Feed carousel: top articles by decay-weighted score over 7 days
     - Digest carousel: most recently sunflowered articles (non-overlapping)
+
+    Fails open: if scoring/enrichment crashes for any reason, returns empty
+    carousels so mobile never sees a 500 on this optional surface.
     """
-    from sqlalchemy import select
+    try:
+        service = CommunityRecommendationService(db)
+        user_uuid = UUID(current_user_id)
 
-    from app.models.content import UserContentStatus
+        feed_items, digest_items = await service.get_community_carousels()
 
-    service = CommunityRecommendationService(db)
-    user_uuid = UUID(current_user_id)
-
-    feed_items, digest_items = await service.get_community_carousels()
-
-    # Fetch user's statuses for these articles
-    all_content_ids = [
-        item["content"].id for item in feed_items + digest_items
-    ]
-    user_statuses: dict = {}
-    if all_content_ids:
-        rows = (
-            await db.execute(
-                select(UserContentStatus).where(
-                    UserContentStatus.user_id == user_uuid,
-                    UserContentStatus.content_id.in_(all_content_ids),
+        all_content_ids = [item["content"].id for item in feed_items + digest_items]
+        user_statuses: dict = {}
+        if all_content_ids:
+            rows = (
+                await db.execute(
+                    select(UserContentStatus).where(
+                        UserContentStatus.user_id == user_uuid,
+                        UserContentStatus.content_id.in_(all_content_ids),
+                    )
                 )
+            ).scalars().all()
+            for row in rows:
+                user_statuses[row.content_id] = {
+                    "is_liked": row.is_liked,
+                    "is_saved": row.is_saved,
+                }
+
+        feed_carousel = [
+            ci
+            for ci in (
+                _content_to_carousel_item(item, user_statuses) for item in feed_items
             )
-        ).scalars().all()
-        for row in rows:
-            user_statuses[row.content_id] = {
-                "is_liked": row.is_liked,
-                "is_saved": row.is_saved,
-            }
+            if ci is not None
+        ]
+        digest_carousel = [
+            ci
+            for ci in (
+                _content_to_carousel_item(item, user_statuses)
+                for item in digest_items
+            )
+            if ci is not None
+        ]
 
-    feed_carousel = [
-        _content_to_carousel_item(item, user_statuses)
-        for item in feed_items
-    ]
-    digest_carousel = [
-        _content_to_carousel_item(item, user_statuses)
-        for item in digest_items
-    ]
-
-    return CommunityCarouselsResponse(
-        feed_carousel=feed_carousel,
-        digest_carousel=digest_carousel,
-    )
+        return CommunityCarouselsResponse(
+            feed_carousel=feed_carousel,
+            digest_carousel=digest_carousel,
+        )
+    except Exception:
+        logger.exception("community_recommendations_failed")
+        return CommunityCarouselsResponse()

--- a/packages/api/app/routers/community.py
+++ b/packages/api/app/routers/community.py
@@ -104,13 +104,17 @@ async def get_community_recommendations(
         user_statuses: dict = {}
         if all_content_ids:
             rows = (
-                await db.execute(
-                    select(UserContentStatus).where(
-                        UserContentStatus.user_id == user_uuid,
-                        UserContentStatus.content_id.in_(all_content_ids),
+                (
+                    await db.execute(
+                        select(UserContentStatus).where(
+                            UserContentStatus.user_id == user_uuid,
+                            UserContentStatus.content_id.in_(all_content_ids),
+                        )
                     )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
             for row in rows:
                 user_statuses[row.content_id] = {
                     "is_liked": row.is_liked,
@@ -127,8 +131,7 @@ async def get_community_recommendations(
         digest_carousel = [
             ci
             for ci in (
-                _content_to_carousel_item(item, user_statuses)
-                for item in digest_items
+                _content_to_carousel_item(item, user_statuses) for item in digest_items
             )
             if ci is not None
         ]

--- a/packages/api/app/routers/community.py
+++ b/packages/api/app/routers/community.py
@@ -1,0 +1,110 @@
+"""Router for community recommendations (🌻 sunflower carousels)."""
+
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.schemas.community import (
+    CommunityCarouselItem,
+    CommunityCarouselsResponse,
+)
+from app.services.community_recommendation_service import (
+    CommunityRecommendationService,
+)
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+
+def _content_to_carousel_item(
+    item: dict,
+    user_statuses: dict | None = None,
+) -> CommunityCarouselItem:
+    """Convert a community recommendation dict to a carousel item."""
+    content = item["content"]
+    user_id_statuses = user_statuses or {}
+    status = user_id_statuses.get(content.id, {})
+
+    return CommunityCarouselItem(
+        content_id=content.id,
+        title=content.title,
+        url=content.url,
+        thumbnail_url=content.thumbnail_url,
+        description=content.description,
+        content_type=content.content_type.value if hasattr(content.content_type, "value") else str(content.content_type),
+        duration_seconds=content.duration_seconds,
+        published_at=content.published_at,
+        source={
+            "id": content.source.id,
+            "name": content.source.name,
+            "logo_url": content.source.logo_url,
+            "type": content.source.source_type.value if hasattr(content.source.source_type, "value") else str(content.source.source_type),
+            "theme": content.source.theme,
+        },
+        sunflower_count=item.get("sunflower_count", 0),
+        is_liked=status.get("is_liked", False),
+        is_saved=status.get("is_saved", False),
+        topics=content.topics or [],
+    )
+
+
+@router.get(
+    "/recommendations",
+    response_model=CommunityCarouselsResponse,
+)
+async def get_community_recommendations(
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Get community recommendation carousels for Feed and Digest.
+
+    - Feed carousel: top articles by decay-weighted score over 7 days
+    - Digest carousel: most recently sunflowered articles (non-overlapping)
+    """
+    from sqlalchemy import select
+
+    from app.models.content import UserContentStatus
+
+    service = CommunityRecommendationService(db)
+    user_uuid = UUID(current_user_id)
+
+    feed_items, digest_items = await service.get_community_carousels()
+
+    # Fetch user's statuses for these articles
+    all_content_ids = [
+        item["content"].id for item in feed_items + digest_items
+    ]
+    user_statuses: dict = {}
+    if all_content_ids:
+        rows = (
+            await db.execute(
+                select(UserContentStatus).where(
+                    UserContentStatus.user_id == user_uuid,
+                    UserContentStatus.content_id.in_(all_content_ids),
+                )
+            )
+        ).scalars().all()
+        for row in rows:
+            user_statuses[row.content_id] = {
+                "is_liked": row.is_liked,
+                "is_saved": row.is_saved,
+            }
+
+    feed_carousel = [
+        _content_to_carousel_item(item, user_statuses)
+        for item in feed_items
+    ]
+    digest_carousel = [
+        _content_to_carousel_item(item, user_statuses)
+        for item in digest_items
+    ]
+
+    return CommunityCarouselsResponse(
+        feed_carousel=feed_carousel,
+        digest_carousel=digest_carousel,
+    )

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -56,7 +56,14 @@ async def _enrich_community_carousel(
     user_uuid: UUID,
     digest: DigestResponse,
 ) -> DigestResponse:
-    """Add community 🌻 carousel to digest response."""
+    """Add community 🌻 carousel to digest response.
+
+    Fails open: any exception returns `digest` unchanged so the community
+    carousel is a purely additive surface and can never break digest loading.
+    """
+    import datetime
+
+    from app.models.content import UserContentStatus
     from app.schemas.community import CommunityCarouselItem
 
     try:
@@ -70,8 +77,6 @@ async def _enrich_community_carousel(
         all_ids = [item["content"].id for item in recent_items]
         user_statuses: dict = {}
         if all_ids:
-            from app.models.content import UserContentStatus
-
             rows = (
                 await db.execute(
                     select(UserContentStatus).where(
@@ -89,38 +94,52 @@ async def _enrich_community_carousel(
         carousel_items = []
         for item in recent_items:
             content = item["content"]
+            if content.source is None:
+                continue
             status = user_statuses.get(content.id, {})
-            carousel_items.append(
-                CommunityCarouselItem(
-                    content_id=content.id,
-                    title=content.title,
-                    url=content.url,
-                    thumbnail_url=content.thumbnail_url,
-                    description=content.description,
-                    content_type=(
-                        content.content_type.value
-                        if hasattr(content.content_type, "value")
-                        else str(content.content_type)
-                    ),
-                    duration_seconds=content.duration_seconds,
-                    published_at=content.published_at,
-                    source={
-                        "id": content.source.id,
-                        "name": content.source.name,
-                        "logo_url": content.source.logo_url,
-                        "type": (
-                            content.source.source_type.value
-                            if hasattr(content.source.source_type, "value")
-                            else str(content.source.source_type)
+            content_type = content.content_type
+            source_type = content.source.source_type
+            try:
+                carousel_items.append(
+                    CommunityCarouselItem(
+                        content_id=content.id,
+                        title=content.title or "",
+                        url=content.url or "",
+                        thumbnail_url=content.thumbnail_url,
+                        description=content.description,
+                        content_type=(
+                            content_type.value
+                            if hasattr(content_type, "value")
+                            else str(content_type)
                         ),
-                        "theme": content.source.theme,
-                    },
-                    sunflower_count=item.get("sunflower_count", 0),
-                    is_liked=status.get("is_liked", False),
-                    is_saved=status.get("is_saved", False),
-                    topics=content.topics or [],
+                        duration_seconds=content.duration_seconds,
+                        # Fallback to now() if null — schema requires a value
+                        published_at=(
+                            content.published_at
+                            or datetime.datetime.now(datetime.UTC)
+                        ),
+                        source={
+                            "id": content.source.id,
+                            "name": content.source.name,
+                            "logo_url": content.source.logo_url,
+                            "type": (
+                                source_type.value
+                                if hasattr(source_type, "value")
+                                else str(source_type)
+                            ),
+                            "theme": content.source.theme,
+                        },
+                        sunflower_count=item.get("sunflower_count", 0),
+                        is_liked=status.get("is_liked", False),
+                        is_saved=status.get("is_saved", False),
+                        topics=content.topics or [],
+                    )
                 )
-            )
+            except Exception:
+                logger.exception(
+                    "community_carousel_item_skipped",
+                    content_id=str(content.id),
+                )
 
         digest.community_carousel = carousel_items
 

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -32,6 +32,9 @@ from app.schemas.digest import (
     DigestResponse,
     DualDigestResponse,
 )
+from app.services.community_recommendation_service import (
+    CommunityRecommendationService,
+)
 from app.services.digest_service import DigestService
 from app.services.generation_state import is_generation_running
 from app.utils.time import today_paris
@@ -46,6 +49,85 @@ class ActionRequest(BaseModel):
 
     content_id: str
     action: str
+
+
+async def _enrich_community_carousel(
+    db: AsyncSession,
+    user_uuid: UUID,
+    digest: DigestResponse,
+) -> DigestResponse:
+    """Add community 🌻 carousel to digest response."""
+    from app.schemas.community import CommunityCarouselItem
+
+    try:
+        community_service = CommunityRecommendationService(db)
+        recent_items = await community_service.get_recent_recommendations(limit=8)
+
+        if not recent_items:
+            return digest
+
+        # Build carousel items with user status
+        all_ids = [item["content"].id for item in recent_items]
+        user_statuses: dict = {}
+        if all_ids:
+            from app.models.content import UserContentStatus
+
+            rows = (
+                await db.execute(
+                    select(UserContentStatus).where(
+                        UserContentStatus.user_id == user_uuid,
+                        UserContentStatus.content_id.in_(all_ids),
+                    )
+                )
+            ).scalars().all()
+            for row in rows:
+                user_statuses[row.content_id] = {
+                    "is_liked": row.is_liked,
+                    "is_saved": row.is_saved,
+                }
+
+        carousel_items = []
+        for item in recent_items:
+            content = item["content"]
+            status = user_statuses.get(content.id, {})
+            carousel_items.append(
+                CommunityCarouselItem(
+                    content_id=content.id,
+                    title=content.title,
+                    url=content.url,
+                    thumbnail_url=content.thumbnail_url,
+                    description=content.description,
+                    content_type=(
+                        content.content_type.value
+                        if hasattr(content.content_type, "value")
+                        else str(content.content_type)
+                    ),
+                    duration_seconds=content.duration_seconds,
+                    published_at=content.published_at,
+                    source={
+                        "id": content.source.id,
+                        "name": content.source.name,
+                        "logo_url": content.source.logo_url,
+                        "type": (
+                            content.source.source_type.value
+                            if hasattr(content.source.source_type, "value")
+                            else str(content.source.source_type)
+                        ),
+                        "theme": content.source.theme,
+                    },
+                    sunflower_count=item.get("sunflower_count", 0),
+                    is_liked=status.get("is_liked", False),
+                    is_saved=status.get("is_saved", False),
+                    topics=content.topics or [],
+                )
+            )
+
+        digest.community_carousel = carousel_items
+
+    except Exception:
+        logger.exception("community_carousel_enrichment_failed")
+
+    return digest
 
 
 @router.get("", response_model=DigestResponse)
@@ -138,12 +220,16 @@ async def get_digest(
             status_code=503, detail="Digest generation failed. Please try again later."
         )
 
+    # Enrich with community carousel
+    digest = await _enrich_community_carousel(db, user_uuid, digest)
+
     logger.info(
         "digest_retrieved",
         user_id=current_user_id,
         elapsed_ms=round(elapsed * 1000, 1),
         items_count=len(digest.items),
         is_completed=digest.is_completed,
+        community_carousel_count=len(digest.community_carousel),
     )
     return digest
 
@@ -206,6 +292,12 @@ async def get_both_digests(
     service = DigestService(db)
     serein_enabled = await service._get_user_serein_enabled(user_uuid)
 
+    # Enrich both variants with community carousel
+    if normal:
+        normal = await _enrich_community_carousel(db, user_uuid, normal)
+    if serein:
+        serein = await _enrich_community_carousel(db, user_uuid, serein)
+
     return DualDigestResponse(
         normal=normal,
         serein=serein,
@@ -265,8 +357,8 @@ async def apply_digest_action(
         messages = {
             DigestAction.READ: "Article marqué comme lu",
             DigestAction.SAVE: "Article sauvegardé",
-            DigestAction.LIKE: "Article aimé",
-            DigestAction.UNLIKE: "Like retiré",
+            DigestAction.LIKE: "Article recommandé 🌻",
+            DigestAction.UNLIKE: "Recommandation retirée",
             DigestAction.NOT_INTERESTED: "Article masqué et source ignorée",
             DigestAction.UNDO: "Action annulée",
         }

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -78,13 +78,17 @@ async def _enrich_community_carousel(
         user_statuses: dict = {}
         if all_ids:
             rows = (
-                await db.execute(
-                    select(UserContentStatus).where(
-                        UserContentStatus.user_id == user_uuid,
-                        UserContentStatus.content_id.in_(all_ids),
+                (
+                    await db.execute(
+                        select(UserContentStatus).where(
+                            UserContentStatus.user_id == user_uuid,
+                            UserContentStatus.content_id.in_(all_ids),
+                        )
                     )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
             for row in rows:
                 user_statuses[row.content_id] = {
                     "is_liked": row.is_liked,
@@ -115,8 +119,7 @@ async def _enrich_community_carousel(
                         duration_seconds=content.duration_seconds,
                         # Fallback to now() if null — schema requires a value
                         published_at=(
-                            content.published_at
-                            or datetime.datetime.now(datetime.UTC)
+                            content.published_at or datetime.datetime.now(datetime.UTC)
                         ),
                         source={
                             "id": content.source.id,

--- a/packages/api/app/schemas/community.py
+++ b/packages/api/app/schemas/community.py
@@ -1,0 +1,36 @@
+"""Schemas for community recommendation carousels (🌻)."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from app.schemas.content import SourceMini
+
+
+class CommunityCarouselItem(BaseModel):
+    """Single article in a community recommendation carousel."""
+
+    content_id: UUID
+    title: str
+    url: str
+    thumbnail_url: str | None = None
+    description: str | None = None
+    content_type: str = "article"
+    duration_seconds: int | None = None
+    published_at: datetime
+    source: SourceMini
+    sunflower_count: int = 0
+    is_liked: bool = False
+    is_saved: bool = False
+    topics: list[str] = []
+
+    class Config:
+        from_attributes = True
+
+
+class CommunityCarouselsResponse(BaseModel):
+    """Response for GET /api/community/recommendations."""
+
+    feed_carousel: list[CommunityCarouselItem] = []
+    digest_carousel: list[CommunityCarouselItem] = []

--- a/packages/api/app/schemas/digest.py
+++ b/packages/api/app/schemas/digest.py
@@ -13,6 +13,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field, field_serializer
 
 from app.models.enums import ContentType
+from app.schemas.community import CommunityCarouselItem
 from app.schemas.content import SourceMini, parse_entity_strings
 
 
@@ -265,6 +266,12 @@ class DigestResponse(BaseModel):
     coup_de_coeur: CoupDeCoeurResponse | None = None
     actu_decalee: PepiteResponse | None = None
     quote: QuoteResponse | None = None
+
+    # Community 🌻 carousel (most recently sunflowered articles)
+    community_carousel: list[CommunityCarouselItem] = Field(
+        default_factory=list,
+        description="Community recommendations carousel (most recently 🌻 articles)",
+    )
 
     class Config:
         from_attributes = True

--- a/packages/api/app/services/collection_service.py
+++ b/packages/api/app/services/collection_service.py
@@ -15,7 +15,7 @@ logger = structlog.get_logger()
 
 MAX_COLLECTIONS_PER_USER = 50
 DEFAULT_COLLECTION_NAME = "À consulter plus tard"
-LIKED_COLLECTION_NAME = "Contenus likés"
+LIKED_COLLECTION_NAME = "Mes articles intéressants 🌻"
 
 
 class CollectionService:

--- a/packages/api/app/services/community_recommendation_service.py
+++ b/packages/api/app/services/community_recommendation_service.py
@@ -11,7 +11,7 @@ Deux surfaces :
 import datetime
 
 import structlog
-from sqlalchemy import case, func, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 

--- a/packages/api/app/services/community_recommendation_service.py
+++ b/packages/api/app/services/community_recommendation_service.py
@@ -1,0 +1,201 @@
+"""Service de recommandations communautaires (carrousels 🌻).
+
+Scoring avec decay temporel :
+  score(article) = SUM(1 / (1 + heures_depuis_sunflower / 48))
+
+Deux surfaces :
+- Digest : articles les plus recemment 🌻 (tri par fraicheur)
+- Feed : meilleurs articles sur 7 jours (tri par score decay)
+"""
+
+import datetime
+
+import structlog
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.content import Content, UserContentStatus
+
+logger = structlog.get_logger()
+
+# Window for community recommendations (7 days)
+COMMUNITY_WINDOW_DAYS = 7
+# Decay half-life in hours (score = 0.5 after 48h)
+DECAY_HALF_LIFE_HOURS = 48
+# Min/max items per carousel
+MIN_CAROUSEL_ITEMS = 3
+MAX_CAROUSEL_ITEMS = 8
+
+
+class CommunityRecommendationService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_top_recommendations(
+        self,
+        limit: int = MAX_CAROUSEL_ITEMS,
+        exclude_ids: set | None = None,
+    ) -> list[dict]:
+        """Feed carousel: best articles over 7 days, scored by decay.
+
+        Returns articles sorted by weighted score (descending).
+        Each dict contains: content (Content), sunflower_count (int), score (float).
+        """
+        now = datetime.datetime.now(datetime.UTC)
+        window_start = now - datetime.timedelta(days=COMMUNITY_WINDOW_DAYS)
+
+        # Decay formula: 1 / (1 + hours_since / 48)
+        # In SQL: hours_since = EXTRACT(EPOCH FROM (now - liked_at)) / 3600
+        hours_since = func.extract(
+            "epoch", now - UserContentStatus.liked_at
+        ) / 3600.0
+        decay_weight = 1.0 / (1.0 + hours_since / DECAY_HALF_LIFE_HOURS)
+
+        exclusion = Content.id.notin_(exclude_ids) if exclude_ids else True
+
+        rows = (
+            await self.session.execute(
+                select(
+                    Content.id,
+                    func.sum(decay_weight).label("score"),
+                    func.count(UserContentStatus.id).label("sunflower_count"),
+                )
+                .join(
+                    UserContentStatus,
+                    UserContentStatus.content_id == Content.id,
+                )
+                .where(
+                    UserContentStatus.is_liked.is_(True),
+                    UserContentStatus.liked_at >= window_start,
+                    exclusion,
+                )
+                .group_by(Content.id)
+                .having(func.count(UserContentStatus.id) >= 1)
+                .order_by(func.sum(decay_weight).desc())
+                .limit(limit)
+            )
+        ).all()
+
+        if not rows:
+            return []
+
+        # Fetch full Content objects with source
+        content_ids = [r.id for r in rows]
+        score_map = {r.id: float(r.score) for r in rows}
+        count_map = {r.id: int(r.sunflower_count) for r in rows}
+
+        contents = list(
+            (
+                await self.session.scalars(
+                    select(Content)
+                    .options(selectinload(Content.source))
+                    .where(Content.id.in_(content_ids))
+                )
+            ).all()
+        )
+
+        # Maintain score order
+        id_order = {cid: i for i, cid in enumerate(content_ids)}
+        contents.sort(key=lambda c: id_order.get(c.id, 99))
+
+        return [
+            {
+                "content": c,
+                "sunflower_count": count_map.get(c.id, 0),
+                "score": score_map.get(c.id, 0.0),
+            }
+            for c in contents
+        ]
+
+    async def get_recent_recommendations(
+        self,
+        limit: int = MAX_CAROUSEL_ITEMS,
+        exclude_ids: set | None = None,
+    ) -> list[dict]:
+        """Digest carousel: most recently sunflowered articles.
+
+        Returns articles sorted by most recent sunflower timestamp (descending).
+        Each dict contains: content (Content), sunflower_count (int).
+        """
+        now = datetime.datetime.now(datetime.UTC)
+        window_start = now - datetime.timedelta(days=COMMUNITY_WINDOW_DAYS)
+
+        exclusion = Content.id.notin_(exclude_ids) if exclude_ids else True
+
+        rows = (
+            await self.session.execute(
+                select(
+                    Content.id,
+                    func.count(UserContentStatus.id).label("sunflower_count"),
+                    func.max(UserContentStatus.liked_at).label("latest_sunflower"),
+                )
+                .join(
+                    UserContentStatus,
+                    UserContentStatus.content_id == Content.id,
+                )
+                .where(
+                    UserContentStatus.is_liked.is_(True),
+                    UserContentStatus.liked_at >= window_start,
+                    exclusion,
+                )
+                .group_by(Content.id)
+                .having(func.count(UserContentStatus.id) >= 1)
+                .order_by(func.max(UserContentStatus.liked_at).desc())
+                .limit(limit)
+            )
+        ).all()
+
+        if not rows:
+            return []
+
+        content_ids = [r.id for r in rows]
+        count_map = {r.id: int(r.sunflower_count) for r in rows}
+
+        contents = list(
+            (
+                await self.session.scalars(
+                    select(Content)
+                    .options(selectinload(Content.source))
+                    .where(Content.id.in_(content_ids))
+                )
+            ).all()
+        )
+
+        id_order = {cid: i for i, cid in enumerate(content_ids)}
+        contents.sort(key=lambda c: id_order.get(c.id, 99))
+
+        return [
+            {
+                "content": c,
+                "sunflower_count": count_map.get(c.id, 0),
+            }
+            for c in contents
+        ]
+
+    async def get_community_carousels(
+        self,
+    ) -> tuple[list[dict], list[dict]]:
+        """Build both community carousels with non-duplication.
+
+        Feed carousel has priority. Digest excludes Feed IDs.
+
+        Returns: (feed_items, digest_items)
+        """
+        # Feed first (best scored)
+        feed_items = await self.get_top_recommendations(limit=MAX_CAROUSEL_ITEMS)
+
+        # Digest excludes feed articles
+        feed_ids = {item["content"].id for item in feed_items}
+        digest_items = await self.get_recent_recommendations(
+            limit=MAX_CAROUSEL_ITEMS,
+            exclude_ids=feed_ids if feed_ids else None,
+        )
+
+        logger.info(
+            "community_carousels_built",
+            feed_count=len(feed_items),
+            digest_count=len(digest_items),
+        )
+
+        return feed_items, digest_items

--- a/packages/api/app/services/community_recommendation_service.py
+++ b/packages/api/app/services/community_recommendation_service.py
@@ -47,9 +47,7 @@ class CommunityRecommendationService:
 
         # Decay formula: 1 / (1 + hours_since / 48)
         # In SQL: hours_since = EXTRACT(EPOCH FROM (now - liked_at)) / 3600
-        hours_since = func.extract(
-            "epoch", now - UserContentStatus.liked_at
-        ) / 3600.0
+        hours_since = func.extract("epoch", now - UserContentStatus.liked_at) / 3600.0
         decay_weight = 1.0 / (1.0 + hours_since / DECAY_HALF_LIFE_HOURS)
 
         exclusion = Content.id.notin_(exclude_ids) if exclude_ids else True

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -1260,11 +1260,14 @@ class RecommendationService:
                 )
 
                 # Decay formula: score = SUM(1 / (1 + hours_since / 48))
-                hours_since = func.extract(
-                    "epoch",
-                    datetime.datetime.now(datetime.UTC)
-                    - UserContentStatus.liked_at,
-                ) / 3600.0
+                hours_since = (
+                    func.extract(
+                        "epoch",
+                        datetime.datetime.now(datetime.UTC)
+                        - UserContentStatus.liked_at,
+                    )
+                    / 3600.0
+                )
                 decay_weight = 1.0 / (1.0 + hours_since / 48.0)
 
                 community_rows = (
@@ -1272,9 +1275,7 @@ class RecommendationService:
                         select(
                             Content.id,
                             func.sum(decay_weight).label("score"),
-                            func.count(UserContentStatus.id).label(
-                                "sunflower_count"
-                            ),
+                            func.count(UserContentStatus.id).label("sunflower_count"),
                         )
                         .join(
                             UserContentStatus,
@@ -1297,16 +1298,11 @@ class RecommendationService:
                     "carousel_community_query",
                     community_found=len(community_rows),
                     min_required=MIN_CAROUSEL_ITEMS,
-                    scores=[
-                        round(float(r.score), 2)
-                        for r in community_rows[:5]
-                    ],
+                    scores=[round(float(r.score), 2) for r in community_rows[:5]],
                 )
                 if len(community_rows) >= MIN_CAROUSEL_ITEMS:
                     community_ids = [r.id for r in community_rows]
-                    count_map = {
-                        r.id: int(r.sunflower_count) for r in community_rows
-                    }
+                    count_map = {r.id: int(r.sunflower_count) for r in community_rows}
 
                     community_contents = list(
                         (
@@ -1317,9 +1313,7 @@ class RecommendationService:
                             )
                         ).all()
                     )
-                    id_order = {
-                        cid: i for i, cid in enumerate(community_ids)
-                    }
+                    id_order = {cid: i for i, cid in enumerate(community_ids)}
                     items = sorted(
                         community_contents,
                         key=lambda c: id_order.get(c.id, 99),
@@ -1329,10 +1323,11 @@ class RecommendationService:
                     badges = []
                     for item in items:
                         sf_count = count_map.get(item.id, 0)
-                        if sf_count >= 2:
-                            label = f"\U0001f33b {sf_count}"
-                        else:
-                            label = "Reco communauté"
+                        label = (
+                            f"\U0001f33b {sf_count}"
+                            if sf_count >= 2
+                            else "Reco communauté"
+                        )
                         badges.append(
                             {
                                 "code": "community",

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -1249,135 +1249,103 @@ class RecommendationService:
                         promoted_ids.add(item.id)
                     break  # T3A: only 1 source carousel
 
-            # --- gems: community favorites with differentiated badges (T6) ---
+            # --- community: 🌻 sunflower recommendations with decay scoring ---
             if len(carousels) < max_carousels:
-                thirty_days_ago = datetime.datetime.now(
+                seven_days_ago = datetime.datetime.now(
                     datetime.UTC
-                ) - datetime.timedelta(days=30)
+                ) - datetime.timedelta(days=7)
                 exclusion = Content.id.notin_(promoted_ids) if promoted_ids else True
                 consumed_excl = (
                     Content.id.notin_(consumed_ids) if consumed_ids else True
                 )
-                gem_rows = (
+
+                # Decay formula: score = SUM(1 / (1 + hours_since / 48))
+                hours_since = func.extract(
+                    "epoch",
+                    datetime.datetime.now(datetime.UTC)
+                    - UserContentStatus.liked_at,
+                ) / 3600.0
+                decay_weight = 1.0 / (1.0 + hours_since / 48.0)
+
+                community_rows = (
                     await self.session.execute(
                         select(
                             Content.id,
-                            func.sum(
-                                case(
-                                    (UserContentStatus.is_saved.is_(True), 1),
-                                    else_=0,
-                                )
-                            ).label("save_count"),
-                            func.sum(
-                                case(
-                                    (UserContentStatus.is_liked.is_(True), 1),
-                                    else_=0,
-                                )
-                            ).label("like_count"),
+                            func.sum(decay_weight).label("score"),
+                            func.count(UserContentStatus.id).label(
+                                "sunflower_count"
+                            ),
                         )
                         .join(
                             UserContentStatus,
                             UserContentStatus.content_id == Content.id,
                         )
                         .where(
-                            UserContentStatus.saved_at >= thirty_days_ago,
+                            UserContentStatus.is_liked.is_(True),
+                            UserContentStatus.liked_at >= seven_days_ago,
                             exclusion,
-                            consumed_excl,  # T2
+                            consumed_excl,
                         )
                         .group_by(Content.id)
-                        .having(
-                            func.sum(
-                                case(
-                                    (UserContentStatus.is_saved.is_(True), 1),
-                                    else_=0,
-                                )
-                            )
-                            >= 1
-                        )
-                        .order_by(
-                            (
-                                func.sum(
-                                    case(
-                                        (UserContentStatus.is_saved.is_(True), 1),
-                                        else_=0,
-                                    )
-                                )
-                                + func.sum(
-                                    case(
-                                        (UserContentStatus.is_liked.is_(True), 1),
-                                        else_=0,
-                                    )
-                                )
-                            ).desc()
-                        )
+                        .having(func.count(UserContentStatus.id) >= 1)
+                        .order_by(func.sum(decay_weight).desc())
                         .limit(MAX_CAROUSEL_ITEMS)
                     )
                 ).all()
 
                 logger.info(
-                    "carousel_gems_query",
-                    gems_found=len(gem_rows),
+                    "carousel_community_query",
+                    community_found=len(community_rows),
                     min_required=MIN_CAROUSEL_ITEMS,
-                    save_counts=[r.save_count for r in gem_rows[:5]],
-                    like_counts=[r.like_count for r in gem_rows[:5]],
+                    scores=[
+                        round(float(r.score), 2)
+                        for r in community_rows[:5]
+                    ],
                 )
-                if len(gem_rows) >= MIN_CAROUSEL_ITEMS:
-                    gem_ids = [r.id for r in gem_rows]
-                    save_map = {r.id: (r.save_count or 0) for r in gem_rows}
-                    like_map = {r.id: (r.like_count or 0) for r in gem_rows}
+                if len(community_rows) >= MIN_CAROUSEL_ITEMS:
+                    community_ids = [r.id for r in community_rows]
+                    count_map = {
+                        r.id: int(r.sunflower_count) for r in community_rows
+                    }
 
-                    gem_contents = list(
+                    community_contents = list(
                         (
                             await self.session.scalars(
                                 select(Content)
                                 .options(selectinload(Content.source))
-                                .where(Content.id.in_(gem_ids))
+                                .where(Content.id.in_(community_ids))
                             )
                         ).all()
                     )
-                    # Maintain score order, then shuffle for daily variety
-                    id_order = {gid: i for i, gid in enumerate(gem_ids)}
+                    id_order = {
+                        cid: i for i, cid in enumerate(community_ids)
+                    }
                     items = sorted(
-                        gem_contents,
+                        community_contents,
                         key=lambda c: id_order.get(c.id, 99),
                     )
-                    if daily_seed is not None:
-                        _random.Random(daily_seed).shuffle(items)
 
-                    # T6: Differentiated badges per article
-                    avg_saves = (
-                        sum(save_map.values()) / len(save_map) if save_map else 0
-                    )
-                    avg_likes = (
-                        sum(like_map.values()) / len(like_map) if like_map else 0
-                    )
+                    # Badges: show 🌻 count if >= 2
                     badges = []
                     for item in items:
-                        s = save_map.get(item.id, 0)
-                        lk = like_map.get(item.id, 0)
-                        if s > 0 and avg_saves > 0 and s >= 2 * avg_saves:
-                            label = "Le plus enregistré"
-                        elif lk > 0 and avg_likes > 0 and lk >= 2 * avg_likes:
-                            label = "Le plus liké"
-                        elif s > lk:
-                            label = "Beaucoup enregistré"
-                        elif lk > s:
-                            label = "Beaucoup liké"
+                        sf_count = count_map.get(item.id, 0)
+                        if sf_count >= 2:
+                            label = f"\U0001f33b {sf_count}"
                         else:
-                            label = "Beaucoup liké"
+                            label = "Reco communauté"
                         badges.append(
                             {
-                                "code": "pepite",
+                                "code": "community",
                                 "label": label,
-                                "emoji": "\U0001f48e",
+                                "emoji": "\U0001f33b",
                             }
                         )
 
                     carousels.append(
                         {
-                            "carousel_type": "gems",
-                            "title": "Pépites de la communauté",
-                            "emoji": "\U0001f48e",
+                            "carousel_type": "community",
+                            "title": "Recos de la communauté",
+                            "emoji": "\U0001f33b",
                             "position": 15,
                             "items": items,
                             "badges": badges,

--- a/packages/api/tests/test_community_recommendations.py
+++ b/packages/api/tests/test_community_recommendations.py
@@ -1,0 +1,172 @@
+"""Tests for community recommendation service (🌻 sunflower carousels)."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+from datetime import datetime, timedelta, UTC
+
+from app.services.community_recommendation_service import (
+    CommunityRecommendationService,
+    COMMUNITY_WINDOW_DAYS,
+    DECAY_HALF_LIFE_HOURS,
+)
+
+
+def test_decay_formula_math():
+    """Verify the decay formula gives expected values."""
+    # score = 1 / (1 + hours / 48)
+    # At 0 hours: 1 / (1 + 0) = 1.0
+    assert 1.0 / (1.0 + 0 / 48) == 1.0
+
+    # At 48 hours: 1 / (1 + 1) = 0.5
+    assert 1.0 / (1.0 + 48 / 48) == 0.5
+
+    # At 168 hours (7 days): 1 / (1 + 3.5) ≈ 0.222
+    score_7d = 1.0 / (1.0 + 168 / 48)
+    assert abs(score_7d - 0.222) < 0.01
+
+
+def test_decay_half_life_constant():
+    """Verify half-life constant is 48 hours as specified."""
+    assert DECAY_HALF_LIFE_HOURS == 48
+
+
+def test_community_window_constant():
+    """Verify community window is 7 days as specified."""
+    assert COMMUNITY_WINDOW_DAYS == 7
+
+
+@pytest.mark.asyncio
+async def test_get_top_recommendations_empty():
+    """Service returns empty list when no sunflowered articles exist."""
+    session = AsyncMock()
+    service = CommunityRecommendationService(session)
+
+    # Mock empty result
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    session.execute.return_value = mock_result
+
+    result = await service.get_top_recommendations()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_recent_recommendations_empty():
+    """Service returns empty list when no sunflowered articles exist."""
+    session = AsyncMock()
+    service = CommunityRecommendationService(session)
+
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    session.execute.return_value = mock_result
+
+    result = await service.get_recent_recommendations()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_community_carousels_non_duplication():
+    """Digest carousel excludes articles already in Feed carousel."""
+    session = AsyncMock()
+    service = CommunityRecommendationService(session)
+
+    # Mock feed results
+    content1 = MagicMock()
+    content1.id = uuid4()
+    content2 = MagicMock()
+    content2.id = uuid4()
+
+    feed_items = [
+        {"content": content1, "sunflower_count": 3, "score": 1.5},
+        {"content": content2, "sunflower_count": 2, "score": 1.0},
+    ]
+
+    # Mock: first call returns feed items, second call returns digest items
+    async def mock_get_top(limit=8, exclude_ids=None):
+        return feed_items
+
+    async def mock_get_recent(limit=8, exclude_ids=None):
+        # Verify feed IDs are excluded
+        assert exclude_ids is not None
+        assert content1.id in exclude_ids
+        assert content2.id in exclude_ids
+        return []
+
+    service.get_top_recommendations = mock_get_top
+    service.get_recent_recommendations = mock_get_recent
+
+    feed, digest = await service.get_community_carousels()
+    assert len(feed) == 2
+    assert len(digest) == 0
+
+
+def test_sunflower_count_badge_logic():
+    """Badge should show count only if >= 2."""
+    # Count = 1: no count badge
+    count = 1
+    assert count < 2  # Should NOT show count
+
+    # Count = 2: show badge
+    count = 2
+    assert count >= 2  # Should show "🌻 2"
+
+    # Count = 5: show badge
+    count = 5
+    assert count >= 2  # Should show "🌻 5"
+
+
+def test_collection_name_constant():
+    """Verify collection name was updated to sunflower naming."""
+    from app.services.collection_service import LIKED_COLLECTION_NAME
+    assert LIKED_COLLECTION_NAME == "Mes articles intéressants 🌻"
+
+
+def test_community_carousel_schema():
+    """Verify CommunityCarouselItem schema has required fields."""
+    from app.schemas.community import CommunityCarouselItem
+
+    item = CommunityCarouselItem(
+        content_id=uuid4(),
+        title="Test Article",
+        url="https://example.com/article",
+        published_at=datetime.now(UTC),
+        source={
+            "id": str(uuid4()),
+            "name": "Test Source",
+            "logo_url": None,
+            "type": "article",
+            "theme": "tech",
+        },
+        sunflower_count=3,
+    )
+    assert item.sunflower_count == 3
+    assert item.title == "Test Article"
+    assert item.is_liked is False
+    assert item.is_saved is False
+
+
+def test_digest_response_has_community_carousel():
+    """Verify DigestResponse includes community_carousel field."""
+    from app.schemas.digest import DigestResponse
+
+    response = DigestResponse(
+        digest_id=uuid4(),
+        user_id=uuid4(),
+        target_date=datetime.now(UTC).date(),
+        generated_at=datetime.now(UTC),
+        community_carousel=[],
+    )
+    assert response.community_carousel == []
+
+
+def test_community_carousels_response_schema():
+    """Verify CommunityCarouselsResponse schema."""
+    from app.schemas.community import CommunityCarouselsResponse
+
+    response = CommunityCarouselsResponse(
+        feed_carousel=[],
+        digest_carousel=[],
+    )
+    assert response.feed_carousel == []
+    assert response.digest_carousel == []

--- a/packages/api/tests/test_feed_carousels.py
+++ b/packages/api/tests/test_feed_carousels.py
@@ -354,7 +354,7 @@ class TestBuildCarouselsNoFilter:
 
 # Named tuples to mimic DB row results
 _SourceRow = namedtuple("_SourceRow", ["source_id", "name", "added_at"])
-_GemRow = namedtuple("_GemRow", ["id", "save_count", "like_count"])
+_CommunityRow = namedtuple("_CommunityRow", ["id", "score", "sunflower_count"])
 
 
 def _setup_service_with_no_overflow():
@@ -417,7 +417,7 @@ class TestBuildCarouselsNewSource:
                 return _mock_execute_result([])
             if execute_calls == 3:
                 return _mock_execute_result(src_rows)  # new_source
-            return _mock_execute_result([])  # gems (empty)
+            return _mock_execute_result([])  # community (empty)
 
         service.session.execute = AsyncMock(side_effect=mock_execute)
         service.session.scalars = AsyncMock(
@@ -461,7 +461,7 @@ class TestBuildCarouselsNewSource:
                 return _mock_execute_result([])  # consumed_ids + perspectives
             if execute_calls == 3:
                 return _mock_execute_result(src_rows)  # new_source
-            return _mock_execute_result([])  # gems
+            return _mock_execute_result([])  # community
 
         service.session.execute = AsyncMock(side_effect=mock_execute)
         service.session.scalars = AsyncMock(
@@ -495,17 +495,17 @@ class TestBuildCarouselsNewSource:
         assert not any(c["carousel_type"] == "new_source" for c in carousels)
 
 
-class TestBuildCarouselsGems:
+class TestBuildCarouselsCommunity:
     @pytest.mark.asyncio
-    async def test_gems_carousel_basic(self):
+    async def test_community_carousel_basic(self):
         service = _setup_service_with_no_overflow()
         user_id = uuid4()
 
-        # Mock gems: 4 articles with saves and likes
-        gem_articles = [MockContent(title=f"Gem {i}") for i in range(4)]
-        gem_rows = [
-            _GemRow(id=a.id, save_count=5 - i, like_count=i + 1)
-            for i, a in enumerate(gem_articles)
+        # Mock community: 4 🌻 articles with decay scores and sunflower counts
+        community_articles = [MockContent(title=f"Community {i}") for i in range(4)]
+        community_rows = [
+            _CommunityRow(id=a.id, score=5.0 - i, sunflower_count=5 - i)
+            for i, a in enumerate(community_articles)
         ]
 
         call_count = 0
@@ -516,35 +516,36 @@ class TestBuildCarouselsGems:
             # 1: consumed_ids, 2: perspectives, 3: new_source → empty
             if call_count <= 3:
                 return _mock_execute_result([])
-            # 4: gems query
-            return _mock_execute_result(gem_rows)
+            # 4: community query
+            return _mock_execute_result(community_rows)
 
         service.session.execute = AsyncMock(side_effect=mock_execute)
         service.session.scalars = AsyncMock(
-            return_value=_mock_scalars_result(gem_articles),
+            return_value=_mock_scalars_result(community_articles),
         )
 
         _, carousels = await service._build_carousels(
             [], {}, user_id=user_id,
         )
 
-        gems = [c for c in carousels if c["carousel_type"] == "gems"]
-        assert len(gems) == 1
-        c = gems[0]
-        assert c["title"] == "Pépites de la communauté"
+        community = [c for c in carousels if c["carousel_type"] == "community"]
+        assert len(community) == 1
+        c = community[0]
+        assert c["title"] == "Recos de la communauté"
         assert c["position"] >= 4  # MIN_CAROUSEL_POSITION enforced; slot shuffled
-        assert c["badges"][0]["code"] == "pepite"
+        assert c["badges"][0]["code"] == "community"
         assert len(c["items"]) == 4
 
     @pytest.mark.asyncio
-    async def test_gems_skipped_when_too_few_results(self):
+    async def test_community_skipped_when_too_few_results(self):
         service = _setup_service_with_no_overflow()
         user_id = uuid4()
 
-        # Only 2 gems (below MIN_CAROUSEL_ITEMS=3)
-        gem_articles = [MockContent(title=f"Gem {i}") for i in range(2)]
-        gem_rows = [
-            _GemRow(id=a.id, save_count=1, like_count=0) for a in gem_articles
+        # Only 2 community items (below MIN_CAROUSEL_ITEMS=3)
+        community_articles = [MockContent(title=f"Community {i}") for i in range(2)]
+        community_rows = [
+            _CommunityRow(id=a.id, score=1.0, sunflower_count=1)
+            for a in community_articles
         ]
 
         call_count = 0
@@ -555,19 +556,19 @@ class TestBuildCarouselsGems:
             # 1: consumed_ids, 2: perspectives, 3: new_source → empty
             if call_count <= 3:
                 return _mock_execute_result([])
-            # 4: gems
-            return _mock_execute_result(gem_rows)
+            # 4: community
+            return _mock_execute_result(community_rows)
 
         service.session.execute = AsyncMock(side_effect=mock_execute)
         service.session.scalars = AsyncMock(
-            return_value=_mock_scalars_result(gem_articles),
+            return_value=_mock_scalars_result(community_articles),
         )
 
         _, carousels = await service._build_carousels(
             [], {}, user_id=user_id,
         )
 
-        assert not any(c["carousel_type"] == "gems" for c in carousels)
+        assert not any(c["carousel_type"] == "community" for c in carousels)
 
 
 class TestBuildCarouselsSaved:
@@ -582,7 +583,7 @@ class TestBuildCarouselsSaved:
             MockContent(title="Saved podcast", content_type="podcast"),
         ]
 
-        # All execute calls return empty (consumed_ids, perspectives, new_source, gems)
+        # All execute calls return empty (consumed_ids, perspectives, new_source, community)
         async def mock_execute(stmt):
             return _mock_execute_result([])
 
@@ -662,7 +663,7 @@ class TestBuildCarouselsPhaseB_Integration:
                 return _mock_execute_result([])
             if execute_calls == 3:
                 return _mock_execute_result(src_rows)  # new_source
-            return _mock_execute_result([])  # gems
+            return _mock_execute_result([])  # community
 
         service.session.execute = AsyncMock(side_effect=mock_execute)
         service.session.scalars = AsyncMock(


### PR DESCRIPTION
## Summary

### Bugs corrigés
- **"Pas de recul"** : écran blanc + retour automatique au digest après clic → corrigé (ne pop plus si le contenu initial est dispo via `extra`)
- **"Toutes les perspectives"** : 2-3s de latence → corrigé (modal s'ouvre immédiatement avec skeleton, data en parallèle via `FutureBuilder`)
- **Header détaché** : header de la carte éditoriale flottait au milieu de la carte après navigation → corrigé en supprimant l'overlay sticky fragile (`Positioned + Transform.translate`) au profit d'un header fixe

### UI
- Thèmes des cartes topic → texte simple (suppression du styled chip)
- Suppression des badges dupliqués au-dessus des carroussels éditoriaux
- Espacement entre les cartes du digest augmenté (6 → 14)
- Citation Serein : police plus grande, padding, séparateurs plus visibles

### Notifications
- Titre : **"Ton essentiel est là"**
- Body adapté selon le mode :
  - Normal w/ topics : *"Au programme : Trump, Retraites... Ou rester serein ! ;)"*
  - Normal w/o topics : *"Tes actus et décryptages du jour t'attendent"*
  - Serein : *"Au programme : Bonne Nouvelle, Pépite du jour. C'est quand tu veux !"*
- Body multi-ligne sur Android via `BigTextStyleInformation`

### Inclus dans cette branche (commits précédents)
- 🌻 Feature Sunflower recommendations (community curation)
- Diverses corrections de lint/compilation Dart

## Test plan

- [ ] Article "Pas de recul" → retour propre sans écran blanc
- [ ] "Toutes les perspectives" s'ouvre instantanément avec skeleton
- [ ] Header des cartes topic : texte simple, pas de chip
- [ ] Mode éditorial : pas de badge dupliqué au-dessus des carroussels
- [ ] Cartes du digest mieux espacées
- [ ] Mode Serein : citation plus grande et plus visible
- [ ] Header de carte éditorial reste en haut après navigation (plus d'overlay flottant)
- [ ] Notification Normal : wording correct avec/sans topics
- [ ] Notification Serein : "Bonne Nouvelle, Pépite du jour..."
- [ ] Body multi-ligne visible sur Android

https://claude.ai/code/session_013bcUMSJrfzfswf73DDT9ES