### PR TITLE
refactor(digest): merge "De quoi on parle" into "Pas de recul" + env hooks

### DIFF
--- a/.claude-hooks/post-edit-auto-test.sh
+++ b/.claude-hooks/post-edit-auto-test.sh
@@ -8,6 +8,11 @@ file=$(echo "$CLAUDE_TOOL_INPUT" | python3 -c "import sys,json; print(json.load(
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 
+# Paths des outils installés
+PYTEST="${PROJECT_DIR}/.venv/bin/pytest"
+FLUTTER="/opt/flutter/bin/flutter"
+export CI=true
+
 # Backend Python: lance pytest sur les tests liés
 if [[ "$file" == *"packages/api/app/"*".py" ]]; then
   module=$(basename "$file" .py)
@@ -15,13 +20,13 @@ if [[ "$file" == *"packages/api/app/"*".py" ]]; then
 
   if [ -f "$test_file" ]; then
     echo "AUTO-TEST: pytest $test_file"
-    cd "$PROJECT_DIR/packages/api" && python -m pytest "$test_file" -x -q --tb=short 2>&1 | tail -20
+    cd "$PROJECT_DIR/packages/api" && PYTHONPATH="$PROJECT_DIR/packages/api" "$PYTEST" "$test_file" -x -q --tb=short 2>&1 | tail -20
   else
     # Cherche un test correspondant dans les sous-dossiers
     found=$(find "$PROJECT_DIR/packages/api/tests" -name "test_*${module}*.py" -type f 2>/dev/null | head -1)
     if [ -n "$found" ]; then
       echo "AUTO-TEST: pytest $found"
-      cd "$PROJECT_DIR/packages/api" && python -m pytest "$found" -x -q --tb=short 2>&1 | tail -20
+      cd "$PROJECT_DIR/packages/api" && PYTHONPATH="$PROJECT_DIR/packages/api" "$PYTEST" "$found" -x -q --tb=short 2>&1 | tail -20
     else
       echo "AUTO-TEST: Pas de test trouvé pour $module — pense à en créer un."
     fi
@@ -36,10 +41,10 @@ if [[ "$file" == *"apps/mobile/lib/"*".dart" ]]; then
 
   if [ -f "$test_file" ]; then
     echo "AUTO-TEST: flutter test $test_file"
-    cd "$PROJECT_DIR/apps/mobile" && flutter test "$test_file" --no-pub 2>&1 | tail -20
+    cd "$PROJECT_DIR/apps/mobile" && "$FLUTTER" test "$test_file" --no-pub 2>&1 | tail -20
   else
     echo "AUTO-TEST: flutter analyze (pas de test unitaire trouvé pour $relative)"
-    cd "$PROJECT_DIR/apps/mobile" && flutter analyze --no-pub "lib/$relative" 2>&1 | tail -10
+    cd "$PROJECT_DIR/apps/mobile" && "$FLUTTER" analyze --no-pub "lib/$relative" 2>&1 | tail -10
   fi
 fi
 

--- a/.claude-hooks/stop-verify-tests.sh
+++ b/.claude-hooks/stop-verify-tests.sh
@@ -5,6 +5,11 @@
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 
+# Paths des outils installés
+PYTEST="${PROJECT_DIR}/.venv/bin/pytest"
+FLUTTER="/opt/flutter/bin/flutter"
+export CI=true
+
 # Détecte les fichiers modifiés (staged + unstaged) par rapport à la branche base
 changed_files=$(git -C "$PROJECT_DIR" diff --name-only HEAD 2>/dev/null || git -C "$PROJECT_DIR" diff --name-only 2>/dev/null)
 
@@ -22,7 +27,7 @@ errors=()
 if $has_python; then
   echo "STOP-VERIFY: Lancement pytest..."
   if [ -d "$PROJECT_DIR/packages/api" ]; then
-    output=$(cd "$PROJECT_DIR/packages/api" && python -m pytest -x -q --tb=short 2>&1)
+    output=$(cd "$PROJECT_DIR/packages/api" && PYTHONPATH="$PROJECT_DIR/packages/api" "$PYTEST" -x -q --tb=short 2>&1)
     rc=$?
     echo "$output" | tail -15
     if [ $rc -ne 0 ]; then
@@ -37,7 +42,7 @@ fi
 if $has_dart; then
   echo "STOP-VERIFY: Lancement flutter test..."
   if [ -d "$PROJECT_DIR/apps/mobile" ]; then
-    output=$(cd "$PROJECT_DIR/apps/mobile" && flutter test --no-pub 2>&1)
+    output=$(cd "$PROJECT_DIR/apps/mobile" && "$FLUTTER" test --no-pub 2>&1)
     rc=$?
     echo "$output" | tail -15
     if [ $rc -ne 0 ]; then

--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,107 +1,100 @@
-# PR — Personnalisation des sujets sensibles (mode Serein)
+# PR — Fusion "De quoi on parle" dans "Pas de recul" + wiring env tests
+
+Branche : `claude/remove-digest-section-jCCzy` → `main`
+Commits :
+- `ca0b858` refactor(digest): merge "De quoi on parle" into "Pas de recul" card
+- `72f6871` chore(env): wire Flutter + pytest paths in test hooks
+
+---
 
 ## Quoi
-Permet à chaque utilisateur de définir ses propres "sujets sensibles" dans le mode Serein, en plus des 4 thèmes exclus par défaut (society, international, economy, politics). L'UI est exposée à deux endroits : une étape conditionnelle dans l'onboarding (si et seulement si l'utilisateur choisit "Rester serein") et une section dans l'écran Mes Intérêts des settings.
+
+Deux changements distincts sur la même branche :
+
+1. **Refactor UI digest (ca0b858)** — Suppression de la sous-carte grise *"De quoi on parle ?"* qui précédait la carte *"Pas de recul"*. L'`intro_text` du topic est désormais affiché **en tête** de la carte "Pas de recul" (même carte, sans cadre additionnel). Le champ `recul_intro` (phrase italique d'accroche vers l'article de recul) est supprimé de toute la stack (prompts LLM, schémas Pydantic, pipeline, serializer DB, modèles Flutter, widgets, tests) car redondant avec la phrase 2 de `intro_text`.
+2. **Chore env (72f6871)** — Les hooks `post-edit-auto-test.sh` et `stop-verify-tests.sh` utilisent maintenant des chemins absolus vers `./.venv/bin/pytest` et `/opt/flutter/bin/flutter`, avec `PYTHONPATH` et `CI=true` pré-configurés, pour que les tests se lancent correctement depuis les hooks Claude Code.
 
 ## Pourquoi
-Le filtre Serein était identique pour tous les utilisateurs. Certains veulent éviter la tech, le sport ou l'économie — sujets non anxiogènes par défaut mais qui peuvent l'être selon le contexte personnel. Cette feature donne à l'utilisateur le contrôle sur ce qu'il considère "stressant".
+
+**Refactor** : L'ancienne UI affichait deux cartes contiguës pour un même topic (gris "De quoi on parle" + bleu "Prendre du recul"), ce qui créait une lourdeur visuelle (deux bordures, deux couleurs, deux paragraphes) pour une info logiquement continue — le texte du topic **fait le pont** vers l'article de recul. Par ailleurs, `recul_intro` dupliquait la fonction de la phrase 2 de `intro_text` (les deux servaient d'accroche vers l'article de recul). Fusionner réduit la dette éditoriale côté LLM (un seul champ à générer) et allège l'écran.
+
+**Env** : Sans chemins absolus, les hooks ne trouvaient ni `pytest` ni `flutter` dans le PATH de l'agent, donc `stop-verify-tests.sh` ne vérifiait rien. Maintenant les hooks s'exécutent réellement.
 
 ## Fichiers modifiés
 
-### Backend
-- `packages/api/app/schemas/user.py` — Ajout champ `sensitive_themes: list[str] | None` dans `OnboardingAnswers`
-- `packages/api/app/services/user_service.py` — Persistance de `sensitive_themes` (JSON serialize) dans la boucle upsert de préférences onboarding
-- `packages/api/app/services/recommendation/filter_presets.py` — `apply_serein_filter()`, `_legacy_serein_keyword_filter()`, `is_cluster_serein_compatible()` acceptent `sensitive_themes` (union avec `SEREIN_EXCLUDED_THEMES`)
-- `packages/api/app/services/recommendation_service.py` — Charge `sensitive_themes` depuis `user_prefs` et passe au filtre (feed)
-- `packages/api/app/services/digest_selector.py` — Param propagé dans `select_for_user()` → `_get_candidates()` → 2 appels `apply_serein_filter`
-- `packages/api/app/services/digest_service.py` — Charge `sensitive_themes` (requête DB) dans `get_or_create_digest()`, passe à `select_for_user()` et `_get_emergency_candidates()` (3 appels)
-- `packages/api/app/services/topic_selector.py` — Param propagé jusqu'à `is_cluster_serein_compatible()`
-- `packages/api/tests/test_serein_filter.py` — 9 nouveaux tests (4 DB-backed + 5 unitaires)
+### Backend (ca0b858)
+- `packages/api/config/editorial_prompts.yaml` — retrait de `recul_intro` des structures + schemas JSON des prompts `writing` et `writing_serene`. Ajout d'une ligne dans la section PONTS clarifiant que la phrase 2 d'`intro_text` joue le rôle.
+- `packages/api/app/services/editorial/schemas.py` — suppression de `recul_intro` sur `MatchedDeepArticle` et `SubjectWriting`.
+- `packages/api/app/services/editorial/writer.py` — retrait du mapping `recul_intro` depuis la réponse LLM.
+- `packages/api/app/services/editorial/pipeline.py` — retrait du bloc qui propageait `sw.recul_intro` vers `s.deep_article.recul_intro`.
+- `packages/api/app/services/digest_service.py` — retrait de la sérialisation/désérialisation de `recul_intro` pour `DigestTopicArticle` (lignes ~1400 et ~1792).
+- `packages/api/app/schemas/digest.py` — retrait du champ `recul_intro` sur `DigestTopicArticle` et `DigestItem`.
 
-### Mobile
-- `apps/mobile/lib/features/onboarding/providers/onboarding_provider.dart` — Champ `sensitiveThemes` dans `OnboardingAnswers`, enum `Section2Question.sensitiveThemes`, navigation conditionnelle dans `selectDigestMode()`, méthode `selectSensitiveThemes()`, back navigation ajustée
-- `apps/mobile/lib/features/onboarding/screens/questions/sensitive_themes_question.dart` (**NOUVEAU**) — Écran chips thèmes, bouton "Continuer sans filtrer" / "Filtrer N thèmes"
-- `apps/mobile/lib/features/onboarding/screens/onboarding_screen.dart` — Case `sensitiveThemes` dans `_buildSection2Content()`
-- `apps/mobile/lib/features/onboarding/onboarding_strings.dart` — 4 nouvelles constantes
-- `apps/mobile/lib/core/api/user_api_service.dart` — `sensitive_themes` dans `_formatAnswersForApi()`
-- `apps/mobile/lib/features/digest/providers/sensitive_themes_provider.dart` (**NOUVEAU**) — StateNotifier fire-and-forget avec `toggle()`, `loadIfNeeded()`, `initFromApi()`
-- `apps/mobile/lib/features/digest/repositories/digest_repository.dart` — Ajout `getPreferences()` (GET /users/preferences)
-- `apps/mobile/lib/features/custom_topics/screens/my_interests_screen.dart` — Section `_SensitiveThemesSection` (visible uniquement si serein activé)
+### Mobile (ca0b858)
+- `apps/mobile/lib/features/digest/models/digest_models.dart` — suppression du champ `@JsonKey(name: 'recul_intro') String? reculIntro` sur `DigestItem`.
+- `apps/mobile/lib/features/digest/models/digest_models.freezed.dart` — **édité à la main** (13 occurrences : mixin getter, 2 copyWith abstract+impl, constructor, final getter, toString, equals, hashCode) car `build_runner` indisponible dans l'env.
+- `apps/mobile/lib/features/digest/models/digest_models.g.dart` — retrait des 2 lignes `recul_intro` (from/to Json) — édité à la main aussi.
+- `apps/mobile/lib/features/digest/widgets/pas_de_recul_block.dart` — param renommé `reculIntro` → `introText` ; affiché **en haut de la carte** (non italique, lineHeight 1.5) au-dessus de `title + source`. Dartdoc mise à jour.
+- `apps/mobile/lib/features/digest/widgets/topic_section.dart` — suppression complète du bloc "De quoi on parle ?" (≈60 lignes). Remplacé par : soit `PasDeReculBlock(introText: topic.introText, ...)` si un deep article existe, soit un paragraphe discret (padding horizontal 12, fontSize 14, pas de carte) sinon.
+- `apps/mobile/test/features/digest/widgets/pas_de_recul_block_test.dart` — tests mis à jour pour `introText`.
+
+### Config / Docs (ca0b858 + 72f6871)
+- `docs/maintenance/maintenance-merge-intro-pas-de-recul.md` — doc de maintenance (contexte, objectif, liste des changements, mockup ASCII, cas traités, tests, hors périmètre).
+- `.claude-hooks/post-edit-auto-test.sh` — `PYTEST`/`FLUTTER`/`CI=true` + `PYTHONPATH` dans les commandes.
+- `.claude-hooks/stop-verify-tests.sh` — idem.
+- `apps/mobile/pubspec.lock` — régénéré par `flutter pub get`.
 
 ## Zones à risque
 
-- **`apply_serein_filter()`** — Appelé dans 6 endroits distincts (feed + digest + emergency candidates). La signature a changé mais tous les callers ont été mis à jour avec `sensitive_themes=None` par défaut (rétro-compatible).
-- **`digest_service.py` `get_or_create_digest()`** — Ajoute une requête DB supplémentaire par digest pour charger `sensitive_themes`. Faible impact (requête sur index primaire `user_id + preference_key`), mais à noter si la latence du digest devient sensible.
-- **Navigation onboarding conditionnelle** — `section2QuestionCount` passe de 5 à 6, ce qui affecte la barre de progression (légère). La question `sensitiveThemes` ne s'affiche qu'en mode serein ; en mode "pour_vous", l'utilisateur passe de `digestMode` directement à Section 3 (comme avant). Le back-navigation depuis Section 3 est ajusté en conséquence.
+1. **`digest_models.freezed.dart` édité à la main** — 13 points de modification mécaniques mais pas régénérés par `build_runner`. Si le reviewer a `build_runner` dispo, il est recommandé de lancer `flutter pub run build_runner build --delete-conflicting-outputs` pour valider qu'il produit le même fichier (ou pour l'écraser proprement).
+2. **Pipeline éditorial LLM** — `editorial_prompts.yaml` + `writer.py` + `pipeline.py` : si un digest généré avant cette PR est rechargé depuis DB, `recul_intro` sera silencieusement ignoré (le `.get()` supprimé ne lisait plus) — aucun crash, juste perte du champ orphelin.
+3. **Sérialisation DB des digests** — `digest_service.py` n'écrit plus `recul_intro` ; un ancien JSON stocké contient encore la clé mais elle n'est plus lue. Pas de migration nécessaire (JSONB).
+4. **Widgets digest** — `topic_section.dart` a perdu une grosse section ; vérifier en runtime sur un topic avec deep article ET sur un topic sans, pour s'assurer que le fallback paragraphe discret s'affiche bien.
 
 ## Points d'attention pour le reviewer
 
-1. **Stockage JSON dans une colonne `string`** — `sensitive_themes` est sérialisé en `'["tech","sport"]'` dans `user_preferences` (key-value existant). Pas de migration Alembic. Cohérent avec le pattern existant, mais le parsing JSON doit être robuste si la valeur est corrompue — actuellement un `json.loads()` non protégé côté backend dans `digest_service.py`. Edge case si la préférence est malformée.
-
-2. **`loadIfNeeded()` dans le provider mobile** — La première ouverture de "Mes Intérêts" en mode serein déclenche un GET `/users/preferences` en background. Pas de loading state affiché (chips restent vides jusqu'au retour API). Choix délibéré pour ne pas bloquer l'UI (same pattern que serein toggle).
-
-3. **Section2Question count = 6 mais totalSteps = 16** — Les non-serein utilisateurs sautent `sensitiveThemes`, donc ils ont un total effectif de 15 étapes, mais `totalSteps` est 16. La barre de progression fait un micro-saut entre `digestMode` et Section 3. Acceptable UX, mais à valider visuellement.
-
-4. **`is_cluster_serein_compatible()`** — La fonction est appelée synchroniquement dans `_score_clusters()` avec `sensitive_themes` passé en paramètre. Le param est propagé depuis `select_for_user()` mais n'est pas chargé à l'intérieur du `TopicSelector` lui-même — il dépend du caller (`DigestSelector`) pour le passer correctement.
+- **Cohérence prompts ↔ schémas** — les 2 prompts (`writing` et `writing_serene`) doivent produire du JSON qui colle à `SubjectWriting` sans `recul_intro`. J'ai relu les YAML mais vérifier qu'aucun exemple few-shot n'y fait référence.
+- **La phrase 2 d'`intro_text` joue bien le rôle de pont** — c'est déjà le cas dans le prompt existant (section PONTS), mais j'ai ajouté une ligne d'insistance. Si le reviewer juge l'instruction insuffisante, on peut durcir le prompt avec un exemple.
+- **UX : paragraphe discret sans carte pour topics sans deep article** — choix délibéré pour préserver `intro_text` sans réintroduire de lourdeur visuelle. Si le PO préfère tout simplement masquer `intro_text` dans ce cas, c'est 3 lignes à retirer dans `topic_section.dart`.
+- **Freezed hand-edit** — stratégie à valider. Alternative : régénérer proprement dans un commit de suivi.
 
 ## Ce qui N'A PAS changé (mais pourrait sembler affecté)
 
-- **`SEREIN_EXCLUDED_THEMES`** — Liste hardcodée inchangée. Les `sensitive_themes` s'y ajoutent par union, ne la remplacent pas.
-- **`SEREIN_KEYWORDS`** — Inchangé. Les mots-clés anxiogènes sont toujours appliqués indépendamment des thèmes.
-- **`Content.is_serene`** — La priorité LLM (is_serene=True passe toujours, is_serene=False est toujours exclu) est inchangée. `sensitive_themes` n'affecte que le fallback legacy (is_serene=NULL).
-- **`DualDigestResponse`** — Pas modifié. `sensitive_themes` n'est pas retourné dans la réponse du digest (chargé séparément côté mobile via `loadIfNeeded()`).
-- **Alembic** — Aucune migration. La table `user_preferences` existante est réutilisée (key-value).
+- **Aucune migration Alembic** — `recul_intro` vivait uniquement dans le JSON `topics` de la table digest ; pas de colonne SQL à retirer.
+- **Backend API contract** — les endpoints `/digest/*` continuent à renvoyer tous les autres champs à l'identique ; seul `recul_intro` disparaît du payload.
+- **Autres blocs éditoriaux** (Pépite, Coup de cœur, Actu décalée, Quote) — non touchés.
+- **36 tests Flutter pré-existants en échec sur `main`** — vérifié en stashant et re-testant sur `main` avant cette PR ; ce ne sont PAS des régressions introduites ici (hors périmètre).
+- **Tests backend DB-dépendants** (~29) — fail localement faute de Postgres ; CI Postgres les exécutera.
 
 ## Comment tester
 
 ### Backend
 ```bash
-cd packages/api
-
-# Tests unitaires (sans DB)
-.venv/bin/python -m pytest tests/test_serein_filter.py::TestIsClusterSereinCompatibleSensitiveThemes -v
-# → 5 tests doivent passer
-
-# Tests d'intégration (nécessite Supabase local)
-.venv/bin/python -m pytest tests/test_serein_filter.py -v
-```
-
-**Test manuel API :**
-```bash
-# 1. Mettre à jour les sujets sensibles
-curl -X PUT /api/users/preferences \
-  -H "Authorization: Bearer <token>" \
-  -d '{"key": "sensitive_themes", "value": "[\"tech\",\"sport\"]"}'
-
-# 2. Vérifier GET /api/users/preferences contient sensitive_themes
-curl /api/users/preferences -H "Authorization: Bearer <token>"
-
-# 3. Vérifier que le digest serein exclut les articles tech/sport
-#    (appeler GET /api/digest?serein=true et inspecter les sources des articles retournés)
+cd /home/user/facteur/packages/api
+PYTHONPATH=/home/user/facteur/packages/api ../../.venv/bin/pytest tests/editorial -v
+# -> 85/85 pass attendu
+PYTHONPATH=/home/user/facteur/packages/api ../../.venv/bin/pytest -x -q --tb=short
+# -> les DB-dep fail, le reste passe
 ```
 
 ### Mobile
+```bash
+cd /home/user/facteur/apps/mobile
+CI=true /opt/flutter/bin/flutter test --no-pub test/features/digest/widgets/pas_de_recul_block_test.dart
+# -> tests du widget refactore (introText)
+CI=true /opt/flutter/bin/flutter analyze --no-pub
+```
 
-**Onboarding serein :**
-1. Lancer l'app → Refaire l'onboarding (Settings → Refaire le questionnaire)
-2. Section 2 → choisir "Oui, rester serein"
-3. L'écran "Sujets sensibles" doit apparaître avec 9 chips
-4. Sélectionner quelques thèmes → bouton "Filtrer N thèmes"
-5. Vérifier que `PUT /api/users/preferences` avec `key=sensitive_themes` est appelé (Charles/Proxyman)
+### Runtime / visuel (a faire cote reviewer)
+1. Lancer un digest qui contient au moins 1 topic avec deep article et 1 topic sans.
+2. **Topic avec deep article** : la carte "Pas de recul" doit afficher `intro_text` en haut (paragraphe non italique) puis le titre de l'article + la source + la fleche. Aucune carte grise avant.
+3. **Topic sans deep article** : un paragraphe discret (padding lateral, pas de cadre, fontSize 14) affichant `intro_text`. Aucune carte "Pas de recul" en dessous.
+4. Generer un nouveau digest via la pipeline LLM (ou forcer un run) et verifier que le JSON produit ne contient plus `recul_intro` et que la phrase 2 d'`intro_text` joue bien le role d'accroche vers l'article de recul.
 
-**Onboarding non-serein :**
-1. Même flow → choisir "Non, tout voir"
-2. L'écran "Sujets sensibles" NE DOIT PAS apparaître
-3. Navigation directe vers Section 3 (thèmes)
-
-**Back navigation :**
-1. Onboarding serein → arriver sur l'écran thèmes (Section 3, index 0)
-2. Appuyer retour → doit revenir sur "Sujets sensibles", PAS "digestMode"
-
-**Settings Mes Intérêts :**
-1. Activer le mode serein (toggle dans le digest)
-2. Aller dans Settings → Mes Intérêts
-3. Section "SUJETS SENSIBLES" doit apparaître en bas (avec icône serein verte)
-4. Chips pré-remplies avec les préférences existantes (GET `/users/preferences` appelé)
-5. Toggler un thème → `PUT /api/users/preferences` avec `sensitive_themes` mis à jour (fire-and-forget)
-6. Désactiver le mode serein → Section disparaît
+### Regenerer freezed proprement (optionnel mais conseille avant merge)
+```bash
+cd /home/user/facteur/apps/mobile
+/opt/flutter/bin/flutter pub run build_runner build --delete-conflicting-outputs
+git diff lib/features/digest/models/digest_models.freezed.dart
+# -> diff attendu : vide (ou cosmetique)
+```

--- a/apps/mobile/lib/features/digest/models/digest_models.dart
+++ b/apps/mobile/lib/features/digest/models/digest_models.dart
@@ -78,7 +78,6 @@ class DigestItem with _$DigestItem {
     @JsonKey(name: 'recommendation_reason')
     DigestRecommendationReason? recommendationReason,
     @JsonKey(name: 'note_text') String? noteText,
-    @JsonKey(name: 'recul_intro') String? reculIntro,
     String? badge, // "actu", "pas_de_recul", "pepite", "coup_de_coeur"
   }) = _DigestItem;
 

--- a/apps/mobile/lib/features/digest/models/digest_models.freezed.dart
+++ b/apps/mobile/lib/features/digest/models/digest_models.freezed.dart
@@ -700,8 +700,6 @@ mixin _$DigestItem {
       throw _privateConstructorUsedError;
   @JsonKey(name: 'note_text')
   String? get noteText => throw _privateConstructorUsedError;
-  @JsonKey(name: 'recul_intro')
-  String? get reculIntro => throw _privateConstructorUsedError;
   String? get badge => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -743,7 +741,6 @@ abstract class $DigestItemCopyWith<$Res> {
       @JsonKey(name: 'recommendation_reason')
       DigestRecommendationReason? recommendationReason,
       @JsonKey(name: 'note_text') String? noteText,
-      @JsonKey(name: 'recul_intro') String? reculIntro,
       String? badge});
 
   $SourceMiniCopyWith<$Res>? get source;
@@ -784,7 +781,6 @@ class _$DigestItemCopyWithImpl<$Res, $Val extends DigestItem>
     Object? isDismissed = null,
     Object? recommendationReason = freezed,
     Object? noteText = freezed,
-    Object? reculIntro = freezed,
     Object? badge = freezed,
   }) {
     return _then(_value.copyWith(
@@ -872,10 +868,6 @@ class _$DigestItemCopyWithImpl<$Res, $Val extends DigestItem>
           ? _value.noteText
           : noteText // ignore: cast_nullable_to_non_nullable
               as String?,
-      reculIntro: freezed == reculIntro
-          ? _value.reculIntro
-          : reculIntro // ignore: cast_nullable_to_non_nullable
-              as String?,
       badge: freezed == badge
           ? _value.badge
           : badge // ignore: cast_nullable_to_non_nullable
@@ -944,7 +936,6 @@ abstract class _$$DigestItemImplCopyWith<$Res>
       @JsonKey(name: 'recommendation_reason')
       DigestRecommendationReason? recommendationReason,
       @JsonKey(name: 'note_text') String? noteText,
-      @JsonKey(name: 'recul_intro') String? reculIntro,
       String? badge});
 
   @override
@@ -985,7 +976,6 @@ class __$$DigestItemImplCopyWithImpl<$Res>
     Object? isDismissed = null,
     Object? recommendationReason = freezed,
     Object? noteText = freezed,
-    Object? reculIntro = freezed,
     Object? badge = freezed,
   }) {
     return _then(_$DigestItemImpl(
@@ -1073,10 +1063,6 @@ class __$$DigestItemImplCopyWithImpl<$Res>
           ? _value.noteText
           : noteText // ignore: cast_nullable_to_non_nullable
               as String?,
-      reculIntro: freezed == reculIntro
-          ? _value.reculIntro
-          : reculIntro // ignore: cast_nullable_to_non_nullable
-              as String?,
       badge: freezed == badge
           ? _value.badge
           : badge // ignore: cast_nullable_to_non_nullable
@@ -1114,7 +1100,6 @@ class _$DigestItemImpl implements _DigestItem {
       @JsonKey(name: 'is_dismissed') this.isDismissed = false,
       @JsonKey(name: 'recommendation_reason') this.recommendationReason,
       @JsonKey(name: 'note_text') this.noteText,
-      @JsonKey(name: 'recul_intro') this.reculIntro,
       this.badge})
       : _topics = topics;
 
@@ -1192,14 +1177,11 @@ class _$DigestItemImpl implements _DigestItem {
   @JsonKey(name: 'note_text')
   final String? noteText;
   @override
-  @JsonKey(name: 'recul_intro')
-  final String? reculIntro;
-  @override
   final String? badge;
 
   @override
   String toString() {
-    return 'DigestItem(contentId: $contentId, title: $title, url: $url, thumbnailUrl: $thumbnailUrl, description: $description, htmlContent: $htmlContent, topics: $topics, contentType: $contentType, durationSeconds: $durationSeconds, publishedAt: $publishedAt, source: $source, rank: $rank, reason: $reason, isFollowedSource: $isFollowedSource, isPaid: $isPaid, isRead: $isRead, isSaved: $isSaved, isLiked: $isLiked, isDismissed: $isDismissed, recommendationReason: $recommendationReason, noteText: $noteText, reculIntro: $reculIntro, badge: $badge)';
+    return 'DigestItem(contentId: $contentId, title: $title, url: $url, thumbnailUrl: $thumbnailUrl, description: $description, htmlContent: $htmlContent, topics: $topics, contentType: $contentType, durationSeconds: $durationSeconds, publishedAt: $publishedAt, source: $source, rank: $rank, reason: $reason, isFollowedSource: $isFollowedSource, isPaid: $isPaid, isRead: $isRead, isSaved: $isSaved, isLiked: $isLiked, isDismissed: $isDismissed, recommendationReason: $recommendationReason, noteText: $noteText, badge: $badge)';
   }
 
   @override
@@ -1239,8 +1221,6 @@ class _$DigestItemImpl implements _DigestItem {
                 other.recommendationReason == recommendationReason) &&
             (identical(other.noteText, noteText) ||
                 other.noteText == noteText) &&
-            (identical(other.reculIntro, reculIntro) ||
-                other.reculIntro == reculIntro) &&
             (identical(other.badge, badge) || other.badge == badge));
   }
 
@@ -1269,7 +1249,6 @@ class _$DigestItemImpl implements _DigestItem {
         isDismissed,
         recommendationReason,
         noteText,
-        reculIntro,
         badge
       ]);
 
@@ -1315,7 +1294,6 @@ abstract class _DigestItem implements DigestItem {
       @JsonKey(name: 'recommendation_reason')
       final DigestRecommendationReason? recommendationReason,
       @JsonKey(name: 'note_text') final String? noteText,
-      @JsonKey(name: 'recul_intro') final String? reculIntro,
       final String? badge}) = _$DigestItemImpl;
 
   factory _DigestItem.fromJson(Map<String, dynamic> json) =
@@ -1380,9 +1358,6 @@ abstract class _DigestItem implements DigestItem {
   @override
   @JsonKey(name: 'note_text')
   String? get noteText;
-  @override
-  @JsonKey(name: 'recul_intro')
-  String? get reculIntro;
   @override
   String? get badge;
   @override

--- a/apps/mobile/lib/features/digest/models/digest_models.g.dart
+++ b/apps/mobile/lib/features/digest/models/digest_models.g.dart
@@ -95,7 +95,6 @@ _$DigestItemImpl _$$DigestItemImplFromJson(Map<String, dynamic> json) =>
           : DigestRecommendationReason.fromJson(
               json['recommendation_reason'] as Map<String, dynamic>),
       noteText: json['note_text'] as String?,
-      reculIntro: json['recul_intro'] as String?,
       badge: json['badge'] as String?,
     );
 
@@ -122,7 +121,6 @@ Map<String, dynamic> _$$DigestItemImplToJson(_$DigestItemImpl instance) =>
       'is_dismissed': instance.isDismissed,
       'recommendation_reason': instance.recommendationReason,
       'note_text': instance.noteText,
-      'recul_intro': instance.reculIntro,
       'badge': instance.badge,
     };
 

--- a/apps/mobile/lib/features/digest/widgets/pas_de_recul_block.dart
+++ b/apps/mobile/lib/features/digest/widgets/pas_de_recul_block.dart
@@ -7,15 +7,20 @@ import 'editorial_badge.dart';
 
 /// Companion block for the deep analysis article ("Pas de recul").
 /// Displayed in the expanded toggle state of a topic.
+///
+/// When [introText] is provided, it is rendered at the top of the block as the
+/// subject's editorial context (formerly the separate "De quoi on parle ?"
+/// card, merged here to reduce visual clutter — see
+/// `docs/maintenance/maintenance-merge-intro-pas-de-recul.md`).
 class PasDeReculBlock extends StatelessWidget {
   final DigestItem deepArticle;
-  final String? reculIntro;
+  final String? introText;
   final VoidCallback? onTap;
 
   const PasDeReculBlock({
     super.key,
     required this.deepArticle,
-    this.reculIntro,
+    this.introText,
     this.onTap,
   });
 
@@ -48,19 +53,19 @@ class PasDeReculBlock extends StatelessWidget {
                 child: badgeChip,
               ),
 
-            // Recul intro
-            if (reculIntro != null) ...[
+            // Intro text (subject context + bridge toward the deep article)
+            if (introText != null) ...[
               Text(
-                reculIntro!,
+                introText!,
                 style: TextStyle(
                   fontSize: 14,
-                  fontStyle: FontStyle.italic,
+                  height: 1.5,
                   color: isDark
                       ? Colors.white.withValues(alpha: 0.85)
                       : colors.textSecondary,
                 ),
               ),
-              const SizedBox(height: 8),
+              const SizedBox(height: 10),
             ],
 
             // Title + thumbnail row

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -769,7 +769,7 @@ class _TopicSectionState extends ConsumerState<TopicSection>
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-            // ── Articles (avant "De quoi on parle") ──
+            // ── Articles actu ──
             const SizedBox(height: 8),
             if (isActuMulti) ...[
               LayoutBuilder(
@@ -809,60 +809,31 @@ class _TopicSectionState extends ConsumerState<TopicSection>
               const SizedBox(height: 8),
             ],
 
-            // ── Carte "De quoi on parle ?" ──
-            if (topic.introText != null) ...[
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 6),
-                child: Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: colors.textSecondary.withValues(alpha: 0.23),
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border(
-                      left: BorderSide(
-                        width: 3,
-                        color: colors.textSecondary.withValues(alpha: 0.55),
-                      ),
-                    ),
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'De quoi on parle ?',
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w700,
-                          color: colors.textSecondary.withValues(alpha: 0.85),
-                        ),
-                      ),
-                      const SizedBox(height: 6),
-                      Text(
-                        topic.introText!,
-                        style: TextStyle(
-                          fontSize: 14,
-                          height: 1.5,
-                          color: isDark
-                              ? Colors.white.withValues(alpha: 0.85)
-                              : colors.textSecondary,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(height: 8),
-            ],
-
-            // ── Pas de recul ──
+            // ── Pas de recul (intègre le contexte du sujet) ──
             if (deepArticle != null) ...[
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 6),
                 child: PasDeReculBlock(
                   deepArticle: deepArticle,
-                  reculIntro: deepArticle.reculIntro,
+                  introText: topic.introText,
                   onTap: () => widget.onArticleTap(deepArticle),
+                ),
+              ),
+              const SizedBox(height: 8),
+            ] else if (topic.introText != null) ...[
+              // Fallback : sujet sans deep article → intro text en
+              // paragraphe discret (pas de carte).
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: Text(
+                  topic.introText!,
+                  style: TextStyle(
+                    fontSize: 14,
+                    height: 1.5,
+                    color: isDark
+                        ? Colors.white.withValues(alpha: 0.75)
+                        : colors.textSecondary.withValues(alpha: 0.85),
+                  ),
                 ),
               ),
               const SizedBox(height: 8),

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -884,10 +884,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1417,10 +1417,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.8"
   timeago:
     dependency: "direct main"
     description:

--- a/apps/mobile/test/features/digest/widgets/pas_de_recul_block_test.dart
+++ b/apps/mobile/test/features/digest/widgets/pas_de_recul_block_test.dart
@@ -28,14 +28,14 @@ void main() {
 
   Widget buildWidget({
     DigestItem? deepArticle,
-    String? reculIntro,
+    String? introText,
     VoidCallback? onTap,
   }) {
     return MaterialApp(
       home: Scaffold(
         body: PasDeReculBlock(
           deepArticle: deepArticle ?? article,
-          reculIntro: reculIntro,
+          introText: introText,
           onTap: onTap,
         ),
       ),
@@ -86,15 +86,15 @@ void main() {
       expect(find.text('Le Monde'), findsNothing);
     });
 
-    testWidgets('displays reculIntro when provided', (tester) async {
+    testWidgets('displays introText when provided', (tester) async {
       await tester.pumpWidget(buildWidget(
-        reculIntro: 'Pour prendre de la hauteur...',
+        introText: 'Pour prendre de la hauteur...',
       ));
       expect(find.text('Pour prendre de la hauteur...'), findsOneWidget);
     });
 
-    testWidgets('hides reculIntro when null', (tester) async {
-      await tester.pumpWidget(buildWidget(reculIntro: null));
+    testWidgets('hides introText when null', (tester) async {
+      await tester.pumpWidget(buildWidget(introText: null));
       expect(find.text('Pour prendre de la hauteur...'), findsNothing);
     });
 

--- a/docs/maintenance/maintenance-merge-intro-pas-de-recul.md
+++ b/docs/maintenance/maintenance-merge-intro-pas-de-recul.md
@@ -1,0 +1,90 @@
+# Maintenance — Fusion "De quoi on parle ?" dans "Pas de recul"
+
+> **Branche** : `claude/remove-digest-section-jCCzy`
+> **Date** : 2026-04-13
+> **Type** : Maintenance (UX + simplification pipeline éditorial)
+
+---
+
+## Contexte
+
+Le digest affiche, pour chaque sujet, deux sous-cartes éditoriales contiguës :
+
+1. **"De quoi on parle ?"** (carte grise, `topic.introText`) — 2 phrases de contexte + pont vers l'article deep
+2. **"Pas de recul"** (carte bleue, `deepArticle.reculIntro`) — 1 phrase italique qui relance vers le deep
+
+Ces deux blocs se chevauchent sémantiquement :
+- La phrase 2 de `intro_text` fait déjà le pont vers l'article deep (via les tournures `PONTS` du prompt).
+- `recul_intro` reprend ce rôle d'accroche vers le deep.
+
+Côté visuel : deux blocs pleins, deux bordures latérales, deux couleurs, deux niveaux hiérarchiques → lourdeur perçue.
+
+## Objectif
+
+Fusionner `intro_text` **dans** la carte "Pas de recul" et supprimer `recul_intro` (champ + prompt).
+Pour les sujets **sans article deep**, afficher `intro_text` en paragraphe discret (pas de carte).
+
+## Changements
+
+### Backend (`packages/api`)
+
+| Fichier | Action |
+|---|---|
+| `config/editorial_prompts.yaml` | Supprimer `recul_intro` des deux prompts `writing` et `writing_serene` (bloc STRUCTURE + schéma JSON attendu). |
+| `app/services/editorial/schemas.py` | Retirer `recul_intro` de `MatchedDeepArticle` et `SubjectWriting`. |
+| `app/services/editorial/writer.py` | Retirer le champ `recul_intro` du parsing LLM (construction `SubjectWriting`). |
+| `app/services/editorial/pipeline.py` | Retirer l'injection `s.deep_article.recul_intro = sw.recul_intro`. |
+| `app/services/digest_service.py` | Retirer la sérialisation (`"recul_intro": ...`) et la désérialisation (`recul_intro=art_data.get(...)`). |
+| `app/schemas/digest.py` | Retirer `recul_intro: str | None = None` de `DigestTopicArticle` et `DigestItem`. |
+
+Le prompt `writing` conserve le rôle du pont (phrase 2 de `intro_text` + section `PONTS VERS L'ARTICLE DE FOND` existante).
+
+### Mobile (`apps/mobile`)
+
+| Fichier | Action |
+|---|---|
+| `lib/features/digest/models/digest_models.dart` | Retirer `reculIntro` de `DigestItem`. |
+| `lib/features/digest/widgets/pas_de_recul_block.dart` | Remplacer le paramètre `reculIntro` (italique) par `introText` (texte normal). Le bloc accepte désormais le contexte du sujet en en-tête. |
+| `lib/features/digest/widgets/topic_section.dart` | Supprimer la carte grise "De quoi on parle ?". Injecter `topic.introText` dans `PasDeReculBlock`. Pour les sujets sans deep article mais avec `introText`, afficher un petit paragraphe discret (sans carte, sans bordure, `textSecondary`). |
+| `test/features/digest/widgets/pas_de_recul_block_test.dart` | Renommer les tests `reculIntro` → `introText`. |
+| `lib/features/digest/models/digest_models.freezed.dart` + `.g.dart` | Régénérés via `build_runner`. |
+
+### UI finale
+
+```
+┌──────────────────────────────────────────┐
+│ [badge pas_de_recul]                     │
+│ Le mix éolien-solaire espagnol absorbe   │
+│ le choc gazier là où d'autres pays       │
+│ répercutent la hausse. Vert détaille     │
+│ pourquoi ce modèle reste difficile à     │
+│ répliquer.                               │
+│                                          │
+│ Comment les renouvelables...    [thumb]  │
+│ Vert →                                   │
+└──────────────────────────────────────────┘
+```
+
+Pour les sujets **sans deep** (rare), seulement un paragraphe sous les articles actu :
+
+```
+  31 ouvertures au premier semestre, un plus bas depuis 2016.
+```
+
+## Cas traités
+
+- ✅ Sujet avec deep + intro_text → carte bleue unique avec contexte en haut
+- ✅ Sujet avec deep sans intro_text (fallback LLM) → carte bleue sans contexte (title + source + thumb uniquement)
+- ✅ Sujet sans deep avec intro_text → paragraphe discret sous les articles actu
+- ✅ Sujet sans deep sans intro_text → rien (comportement actuel conservé)
+
+## Tests
+
+- `pytest packages/api` : vérifier que les tests éditoriaux passent après retrait de `recul_intro`
+- `flutter test apps/mobile` : tests du `PasDeReculBlock` adaptés (reculIntro → introText)
+- `flutter analyze` : pas de warnings
+
+## Hors périmètre
+
+- Pas de migration DB (le champ `recul_intro` n'est pas persisté — il ne vit qu'en mémoire dans la structure `EditorialGlobalContext`).
+- Pas de changement de design-system (on réutilise typo + couleurs existantes).

--- a/packages/api/app/schemas/digest.py
+++ b/packages/api/app/schemas/digest.py
@@ -68,7 +68,6 @@ class DigestTopicArticle(BaseModel):
     is_followed_source: bool = False
     recommendation_reason: DigestRecommendationReason | None = None
     badge: str | None = None  # "actu" | "pas_de_recul"
-    recul_intro: str | None = None
     is_read: bool = False
     is_saved: bool = False
     is_liked: bool = False
@@ -153,7 +152,6 @@ class DigestItem(BaseModel):
         None, description="Detailed scoring breakdown with contributions"
     )
     badge: str | None = None  # "actu" | "pas_de_recul" | "pepite" | "coup_de_coeur"
-    recul_intro: str | None = None
 
     # User action tracking (default: no action yet)
     is_read: bool = False

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -1397,7 +1397,6 @@ class DigestService:
                         "badge": "pas_de_recul",
                         "match_reason": s.deep_article.match_reason,
                         "published_at": s.deep_article.published_at.isoformat(),
-                        "recul_intro": s.deep_article.recul_intro,
                     }
                     if s.deep_article
                     else None,
@@ -1789,7 +1788,6 @@ class DigestService:
                     rank=art_idx + 1,
                     reason=reason,
                     badge=art_data.get("badge"),
-                    recul_intro=art_data.get("recul_intro"),
                     is_followed_source=art_data.get("is_user_source", False),
                     recommendation_reason=None,
                     is_read=action_state["is_read"],

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -438,8 +438,6 @@ class EditorialPipelineService:
                 if sw:
                     s.intro_text = sw.intro_text
                     s.transition_text = sw.transition_text
-                    if sw.recul_intro and s.deep_article:
-                        s.deep_article.recul_intro = sw.recul_intro
         elif isinstance(writing_raw, Exception):
             logger.error("editorial_pipeline.writing_exception", error=str(writing_raw))
 

--- a/packages/api/app/services/editorial/schemas.py
+++ b/packages/api/app/services/editorial/schemas.py
@@ -50,7 +50,6 @@ class MatchedDeepArticle(BaseModel):
     published_at: datetime
     match_reason: str
     description: str | None = None
-    recul_intro: str | None = None
 
 
 class EditorialSubject(BaseModel):
@@ -89,7 +88,6 @@ class SubjectWriting(BaseModel):
     topic_id: str
     intro_text: str
     transition_text: str | None = None  # null for last subject
-    recul_intro: str | None = None
 
 
 class WritingOutput(BaseModel):

--- a/packages/api/app/services/editorial/writer.py
+++ b/packages/api/app/services/editorial/writer.py
@@ -139,7 +139,6 @@ class EditorialWriterService:
                     topic_id=s.get("topic_id", ""),
                     intro_text=s.get("intro_text", ""),
                     transition_text=s.get("transition_text"),
-                    recul_intro=s.get("recul_intro"),
                 )
                 for s in raw_subjects
                 if s.get("topic_id") and s.get("intro_text")

--- a/packages/api/config/editorial_prompts.yaml
+++ b/packages/api/config/editorial_prompts.yaml
@@ -106,16 +106,12 @@ writing:
       * NE PAS mentionner le nombre de sources ni les divergences
         mediatiques — ces infos sont affichees separement dans l'UI.
     - transition_text : toujours null (pas de transition entre sujets)
-    - recul_intro (par sujet, seulement si deep_article present) :
-      * 1 phrase courte (8-15 mots) qui donne envie de lire l'article de fond
-      * Pas de paraphrase du titre de l'article deep
-      * Forme impersonnelle, factuelle, dense
-      * Si pas de deep_article : null
     - closure_text : toujours "Bonne lecture !"
     - cta_text : toujours null
 
     PONTS VERS L'ARTICLE DE FOND — varier, ne JAMAIS utiliser 2 fois
-    la meme tournure dans un digest :
+    la meme tournure dans un digest. La phrase 2 de intro_text doit
+    faire ce pont quand un deep_article est present :
     - "[Source] detaille comment/pourquoi..."
     - "Un eclairage de [Source] sur..."
     - "[Source] revient sur les mecanismes de..."
@@ -168,11 +164,11 @@ writing:
     {{
       "header_text": "Votre essentiel du ...",
       "subjects": [
-        {{"topic_id": "...", "intro_text": "...", "transition_text": null, "recul_intro": "...ou null"}},
-        {{"topic_id": "...", "intro_text": "...", "transition_text": null, "recul_intro": "...ou null"}},
-        {{"topic_id": "...", "intro_text": "...", "transition_text": null, "recul_intro": "...ou null"}},
-        {{"topic_id": "...", "intro_text": "...", "transition_text": null, "recul_intro": "...ou null"}},
-        {{"topic_id": "...", "intro_text": "...", "transition_text": null, "recul_intro": "...ou null"}}
+        {{"topic_id": "...", "intro_text": "...", "transition_text": null}},
+        {{"topic_id": "...", "intro_text": "...", "transition_text": null}},
+        {{"topic_id": "...", "intro_text": "...", "transition_text": null}},
+        {{"topic_id": "...", "intro_text": "...", "transition_text": null}},
+        {{"topic_id": "...", "intro_text": "...", "transition_text": null}}
       ],
       "closure_text": "Bonne lecture !",
       "cta_text": null
@@ -220,16 +216,12 @@ writing_serene:
       * NE PAS mentionner le nombre de sources ni les divergences
         mediatiques — ces infos sont affichees separement dans l'UI.
     - transition_text : toujours null
-    - recul_intro (par sujet, seulement si deep_article present) :
-      * 1 phrase courte (8-15 mots) qui donne envie de lire l'article de fond
-      * Pas de paraphrase du titre de l'article deep
-      * Forme impersonnelle, factuelle, dense
-      * Si pas de deep_article : null
     - closure_text : toujours "Bonne lecture !"
     - cta_text : toujours null
 
     PONTS VERS L'ARTICLE DE FOND — varier, ne JAMAIS utiliser 2 fois
-    la meme tournure dans un digest :
+    la meme tournure dans un digest. La phrase 2 de intro_text doit
+    faire ce pont quand un deep_article est present :
     - "[Source] detaille comment/pourquoi..."
     - "Un eclairage de [Source] sur..."
     - "[Source] revient sur les mecanismes de..."
@@ -279,11 +271,11 @@ writing_serene:
     {{
       "header_text": "Votre essentiel du ...",
       "subjects": [
-        {{"topic_id": "...", "intro_text": "...", "transition_text": null, "recul_intro": "...ou null"}},
-        {{"topic_id": "...", "intro_text": "...", "transition_text": null, "recul_intro": "...ou null"}},
-        {{"topic_id": "...", "intro_text": "...", "transition_text": null, "recul_intro": "...ou null"}},
-        {{"topic_id": "...", "intro_text": "...", "transition_text": null, "recul_intro": "...ou null"}},
-        {{"topic_id": "...", "intro_text": "...", "transition_text": null, "recul_intro": "...ou null"}}
+        {{"topic_id": "...", "intro_text": "...", "transition_text": null}},
+        {{"topic_id": "...", "intro_text": "...", "transition_text": null}},
+        {{"topic_id": "...", "intro_text": "...", "transition_text": null}},
+        {{"topic_id": "...", "intro_text": "...", "transition_text": null}},
+        {{"topic_id": "...", "intro_text": "...", "transition_text": null}}
       ],
       "closure_text": "Bonne lecture !",
       "cta_text": null


### PR DESCRIPTION
## What

Two distinct changes on the same branch:

1. **Refactor digest UI (ca0b858)** — Remove the separate grey "De quoi on parle ?" card that preceded "Pas de recul". The topic's `intro_text` is now displayed at the top of the "Pas de recul" card (same card, no extra frame). The `recul_intro` field is removed from the entire stack (LLM prompts, Pydantic schemas, pipeline, DB serializer, Flutter models, widgets, tests) as it was redundant with the second sentence of `intro_text`.

2. **Chore env (72f6871)** — The `post-edit-auto-test.sh` and `stop-verify-tests.sh` hooks now use absolute paths to `./.venv/bin/pytest` and `/opt/flutter/bin/flutter`, with `PYTHONPATH` and `CI=true` pre-configured, so tests run correctly from Claude Code hooks.

## Why

**Refactor**: The old UI displayed two adjacent cards for the same topic (grey "De quoi on parle" + blue "Prendre du recul"), creating visual clutter (two borders, two colors, two paragraphs) for logically continuous information. The topic text already bridges to the deep article via the second sentence of `intro_text`. Additionally, `recul_intro` duplicated the function of that second sentence—both served as hooks toward the deep article. Merging reduces editorial debt on the LLM side (one field to generate instead of two) and lightens the screen.

**Env**: Without absolute paths, the hooks couldn't find `pytest` or `flutter` in the agent's PATH, so `stop-verify-tests.sh` wasn't actually verifying anything. Now the hooks execute correctly.

## Type

- [ ] Feature
- [x] Bug fix
- [x] Maintenance / Refactor

## Changes

### Backend (`packages/api`)
- `config/editorial_prompts.yaml` — Removed `recul_intro` from both `writing` and `writing_serene` prompt structures and JSON schemas. Added clarification that the second sentence of `intro_text` serves as the bridge to the deep article.
- `app/services/editorial/schemas.py` — Removed `recul_intro` from `MatchedDeepArticle` and `SubjectWriting`.
- `app/services/editorial/writer.py` — Removed `recul_intro` field mapping from LLM response parsing.
- `app/services/editorial/pipeline.py` — Removed the block that propagated `sw.recul_intro` to `s.deep_article.recul_intro`.
- `app/schemas/digest.py` — Removed `recul_intro` field from `DigestTopicArticle` and `DigestItem`.
- `app/services/digest_service.py` — Removed serialization/deserialization of `recul_intro` for `DigestTopicArticle`.

### Mobile (`apps/mobile`)
- `lib/features/digest/models/digest_models.dart` — Removed `reculIntro` field from `DigestItem`.
- `lib/features/digest/models/digest_models.freezed.dart` — Hand-edited to remove `reculIntro` from mixin, copyWith, constructor, and equality methods (13 locations). ⚠️ Ideally regenerate with `build_runner` if available.
- `lib/features/digest/models/digest_models.g.dart` — Removed `recul_intro` JSON serialization lines.
- `lib/features/digest/widgets/pas_de_recul_block.dart` — Renamed parameter `reculIntro` → `introText`; now displayed at the top of the card (normal text, not italic, lineHeight 1.5) above title + source. Updated dartdoc.
- `lib/features/digest/widgets/topic_section.dart` — Removed the entire grey "De quoi on parle ?" card block (~60 lines). For topics with a deep article, `introText` is now passed to `PasDeRe

https://claude.ai/code/session_0124nPkqNp833JXUwTEKLsZU