### PR TITLE
feat: 🌻 Sunflower recommendations (replace likes with community curation)

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -768,8 +768,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       if (mounted) {
         NotificationService.showInfo(
           newLiked
-              ? 'Ajouté à Mes articles intéressants 🌻'
-              : 'Retiré de Mes articles intéressants 🌻',
+              ? 'Ajouté à Mes contenus recommandés 🌻'
+              : 'Retiré de Mes contenus recommandés 🌻',
         );
         // Refresh collections to update liked collection counts
         ref.invalidate(collectionsProvider);
@@ -1533,9 +1533,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 height: 50,
                                 child: FloatingActionButton(
                                   onPressed: _toggleLike,
-                                  backgroundColor: Colors.white,
-                                  foregroundColor: colors.textPrimary,
-                                  elevation: 2,
+                                  backgroundColor: content.isLiked
+                                      ? colors.primary
+                                      : Colors.white,
+                                  foregroundColor: content.isLiked
+                                      ? Colors.white
+                                      : colors.textPrimary,
+                                  elevation: content.isLiked ? 4 : 2,
                                   heroTag: 'sunflower_fab',
                                   tooltip: 'Recommander',
                                   child: SunflowerIcon(

--- a/apps/mobile/lib/features/digest/screens/digest_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/digest_screen.dart
@@ -231,8 +231,8 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
         );
     NotificationService.showInfo(
       item.isLiked
-          ? 'Retiré de Mes articles intéressants 🌻'
-          : 'Ajouté à Mes articles intéressants 🌻',
+          ? 'Retiré de Mes contenus recommandés 🌻'
+          : 'Ajouté à Mes contenus recommandés 🌻',
     );
     ref.invalidate(collectionsProvider);
   }

--- a/apps/mobile/lib/features/digest/widgets/community_carousel_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/community_carousel_section.dart
@@ -215,7 +215,12 @@ class _CommunityCard extends StatelessWidget {
                                 horizontal: 6, vertical: 2),
                             decoration: BoxDecoration(
                               color: SunflowerIcon.sunflowerYellow
-                                  .withOpacity(0.15),
+                                  .withOpacity(0.18),
+                              border: Border.all(
+                                color: SunflowerIcon.sunflowerYellow
+                                    .withOpacity(0.55),
+                                width: 1,
+                              ),
                               borderRadius: BorderRadius.circular(8),
                             ),
                             child: Row(

--- a/apps/mobile/lib/features/feed/screens/cluster_view_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/cluster_view_screen.dart
@@ -208,8 +208,8 @@ class _ClusterViewScreenState extends ConsumerState<ClusterViewScreen> {
                                 .toggleLike(article);
                             NotificationService.showInfo(
                               wasLiked
-                                  ? 'Retiré de Mes articles intéressants 🌻'
-                                  : 'Ajouté à Mes articles intéressants 🌻',
+                                  ? 'Retiré de Mes contenus recommandés 🌻'
+                                  : 'Ajouté à Mes contenus recommandés 🌻',
                             );
                             ref.invalidate(collectionsProvider);
                           },

--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -702,8 +702,8 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                                           ref.read(feedProvider.notifier).toggleLike(c);
                                           NotificationService.showInfo(
                                             wasLiked
-                                                ? 'Retiré de Mes articles intéressants 🌻'
-                                                : 'Ajouté à Mes articles intéressants 🌻',
+                                                ? 'Retiré de Mes contenus recommandés 🌻'
+                                                : 'Ajouté à Mes contenus recommandés 🌻',
                                           );
                                           ref.invalidate(collectionsProvider);
                                         },
@@ -850,8 +850,8 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                                             .toggleLike(content);
                                         NotificationService.showInfo(
                                           wasLiked
-                                              ? 'Retiré de Mes articles intéressants 🌻'
-                                              : 'Ajouté à Mes articles intéressants 🌻',
+                                              ? 'Retiré de Mes contenus recommandés 🌻'
+                                              : 'Ajouté à Mes contenus recommandés 🌻',
                                         );
                                         ref.invalidate(collectionsProvider);
                                       },

--- a/apps/mobile/lib/widgets/sunflower_icon.dart
+++ b/apps/mobile/lib/widgets/sunflower_icon.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 /// Sunflower icon widget for the 🌻 recommendation feature.
 ///
-/// Two states:
-/// - **Inactive**: monochrome outline icon, same style as other icons
-/// - **Active**: colorful sunflower (yellow/green/brown) with animation
+/// Renders the native 🌻 emoji (color on all platforms) with a small
+/// scale/fade animation on state change. The active state is primarily
+/// conveyed by the host's background color (see the FAB in
+/// `content_detail_screen.dart`), so this widget stays visually stable.
 ///
-/// The transition uses an AnimatedSwitcher with a scale+fade effect (~300ms).
+/// `inactiveColor` is accepted for API compatibility with the previous
+/// icon-based implementation but is intentionally unused — emoji glyphs
+/// keep their native colors.
 class SunflowerIcon extends StatelessWidget {
   final bool isActive;
   final double size;
@@ -20,7 +22,8 @@ class SunflowerIcon extends StatelessWidget {
     this.inactiveColor,
   });
 
-  // Sunflower colors
+  // Palette exposed for callers that want to theme non-icon surfaces
+  // (carousel badges, page indicators, etc.).
   static const Color sunflowerYellow = Color(0xFFFFC107);
   static const Color sunflowerGreen = Color(0xFF4CAF50);
   static const Color sunflowerBrown = Color(0xFF795548);
@@ -40,28 +43,17 @@ class SunflowerIcon extends StatelessWidget {
           ),
         );
       },
-      child: isActive
-          ? ShaderMask(
-              key: const ValueKey('active'),
-              shaderCallback: (bounds) => const LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [sunflowerYellow, sunflowerBrown],
-                stops: [0.3, 1.0],
-              ).createShader(bounds),
-              blendMode: BlendMode.srcIn,
-              child: Icon(
-                PhosphorIcons.flower(PhosphorIconsStyle.fill),
-                size: size,
-                color: Colors.white, // Will be replaced by shader
-              ),
-            )
-          : Icon(
-              key: const ValueKey('inactive'),
-              PhosphorIcons.flower(PhosphorIconsStyle.regular),
-              size: size,
-              color: inactiveColor,
-            ),
+      child: Text(
+        '🌻',
+        key: ValueKey('sunflower_${isActive ? 'active' : 'inactive'}'),
+        style: TextStyle(
+          fontSize: size,
+          // Fixed line-height so the emoji sits cleanly centered inside
+          // the FAB (orange when active, white when inactive) without
+          // needing a color filter.
+          height: 1.0,
+        ),
+      ),
     );
   }
 }

--- a/packages/api/alembic/versions/sf02_rename_liked_collection.py
+++ b/packages/api/alembic/versions/sf02_rename_liked_collection.py
@@ -1,0 +1,40 @@
+"""Rename 🌻 liked collection to 'Mes contenus recommandés 🌻'.
+
+Revision ID: sf02
+Revises: sf01
+Create Date: 2026-04-13
+
+sf01 already renamed "Contenus likés" → "Mes articles intéressants 🌻" and
+has been applied in production. Alembic tracks revisions by ID, so editing
+sf01 in place would not re-run on envs where it is already applied. This
+follow-up migration performs the final rename to "Mes contenus recommandés
+🌻" and is safe to run on any env regardless of which prior name the row
+currently holds.
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "sf02"
+down_revision: str = "sf01"
+branch_labels: Sequence[str] | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # Idempotent rename — handles both predecessor names so the migration
+    # converges regardless of whether sf01 was already applied.
+    op.execute(
+        "UPDATE collections SET name = 'Mes contenus recommandés 🌻' "
+        "WHERE is_liked_collection = true "
+        "AND name IN ('Contenus likés', 'Mes articles intéressants 🌻')"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE collections SET name = 'Mes articles intéressants 🌻' "
+        "WHERE is_liked_collection = true "
+        "AND name = 'Mes contenus recommandés 🌻'"
+    )

--- a/packages/api/app/services/collection_service.py
+++ b/packages/api/app/services/collection_service.py
@@ -15,7 +15,7 @@ logger = structlog.get_logger()
 
 MAX_COLLECTIONS_PER_USER = 50
 DEFAULT_COLLECTION_NAME = "À consulter plus tard"
-LIKED_COLLECTION_NAME = "Mes articles intéressants 🌻"
+LIKED_COLLECTION_NAME = "Mes contenus recommandés 🌻"
 
 
 class CollectionService:

--- a/packages/api/tests/test_community_recommendations.py
+++ b/packages/api/tests/test_community_recommendations.py
@@ -119,7 +119,7 @@ def test_sunflower_count_badge_logic():
 def test_collection_name_constant():
     """Verify collection name was updated to sunflower naming."""
     from app.services.collection_service import LIKED_COLLECTION_NAME
-    assert LIKED_COLLECTION_NAME == "Mes articles intéressants 🌻"
+    assert LIKED_COLLECTION_NAME == "Mes contenus recommandés 🌻"
 
 
 def test_community_carousel_schema():


### PR DESCRIPTION
## What

Replaces the "like" feature with a 🌻 (sunflower) button that marks content as "interesting/insightful" for community curation. Introduces two new recommendation carousels:
- **Feed carousel**: Top articles by decay-weighted score over 7 days
- **Digest carousel**: Most recently sunflowered articles (non-overlapping with Feed)

Includes a "Recommander ?" nudge that appears after 30s of reading an article (max 1 per session, max 1 per 3 days).

## Why

Shifts the mental model from personal "likes" to community curation. The sunflower emoji better communicates "guide others to quality content" vs. personal preference. Decay-weighted scoring surfaces fresh, high-quality articles rather than all-time favorites. The nudge encourages users to actively recommend content they find valuable.

## Changes

### Backend
- **New service**: `CommunityRecommendationService` with decay-weighted scoring (half-life: 48h, window: 7 days)
- **New router**: `GET /api/community/recommendations` returns both Feed and Digest carousels
- **New schema**: `CommunityCarouselItem` with sunflower count badge (shown if ≥2)
- **Digest integration**: Community carousel added to `DigestResponse`, calculated on-the-fly
- **Feed integration**: Replaced "gems" carousel with "community" carousel using decay scoring
- **Collection rename**: "Contenus likés" → "Mes contenus recommandés 🌻"
- **DB indexes**: Added partial indexes on `user_content_status(liked_at)` for scoring queries
- **Migration**: Alembic migration `sf01` renames collections and creates indexes

### Flutter
- **New widget**: `SunflowerIcon` (emoji-based, animated on state change)
- **New models**: `CommunityCarouselItem`, `CommunityCarousels`
- **New provider**: `communityCarouselProvider` fetches both carousels
- **New nudge system**: `NudgeTracker` manages session-scoped "Recommander ?" display logic
- **UI updates**: 
  - Replaced like icon with sunflower in Feed, Digest, and Detail screens
  - Added community carousel section to Digest
  - Updated toast messages to reference "Mes contenus recommandés 🌻"
  - Added nudge pill in Detail screen (auto-dismisses after 5s or on scroll)

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`packages/api/tests/test_community_recommendations.py` added)
- [x] Linting passes (no `List[]` imports, uses `list[]`)
- [x] No auth/DB safety issues (reuses existing `is_liked`/`liked_at` fields)
- [x] Peer Review Conductor completed

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (feature complete, ready for staging deployment)

## Notes

- **Data model**: Reuses existing `UserContentStatus.is_liked`/`liked_at` — no new DB columns
- **Backward compatibility**: The "like" endpoint remains unchanged; only the UI and scoring logic change
- **Fail-open design**: Community carousel endpoints return empty carousels on error, never breaking digest/feed
- **Non-duplication**: Backend deduplicates Feed↔Digest carousels; Flutter applies additional client-side filtering

https://claude.ai/code/session_018vGP3JDU3rmpq9GbPfrEyx