### PR TITLE
fix(digest): unblock Railway web build — async _handleCompare

### DIFF
--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -751,7 +751,7 @@ class _TopicSectionState extends ConsumerState<TopicSection>
   // "Comparer les sources" handler
   // ---------------------------------------------------------------------------
 
-  void _handleCompare() {
+  Future<void> _handleCompare() async {
     final articles = widget.editorialMode
         ? widget.topic.articles.where((a) => a.badge != 'pas_de_recul').toList()
         : widget.topic.articles;
@@ -766,12 +766,7 @@ class _TopicSectionState extends ConsumerState<TopicSection>
     if (pivotId.isEmpty) return;
     final repository = ref.read(feedRepositoryProvider);
     final response = await repository.getPerspectives(pivotId);
-
-    // Kick off the request immediately and show the sheet without awaiting,
-    // so the bottom sheet animates in instantly with a skeleton state instead
-    // of a 2-3s freeze on the trigger button.
-    final repository = ref.read(feedRepositoryProvider);
-    final perspectivesFuture = repository.getPerspectives(article.contentId);
+    if (!mounted) return;
 
     showModalBottomSheet<void>(
       context: context,


### PR DESCRIPTION
PR #390 added a new await-based pivot fetch inside _handleCompare but left the function signature as `void` and kept the previous `final repository = ...` + `final perspectivesFuture = ...` lines. Result: two compile errors (await in non-async function + duplicate variable declaration) that break `flutter build web --release` on Railway and blocked the last deploy.

Fix:
- `void _handleCompare()` → `Future<void> _handleCompare() async`
- Remove the now-dead duplicate `repository` declaration and the unused `perspectivesFuture` variable (the FutureBuilder that used it was already replaced by PR #390 with a synchronous PerspectivesBottomSheet constructor).
- Guard the post-await showModalBottomSheet with `if (!mounted) return;` to avoid using a disposed BuildContext if the user navigates away during the getPerspectives request.

https://claude.ai/code/session_018vGP3JDU3rmpq9GbPfrEyx

## What

<!-- Brief description of the change -->

## Why

<!-- What problem does this solve? -->

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)
