### PR TITLE
feat: article reader layout rework — sticky footer, inline perspectives, progress fix

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,100 +1,61 @@
-# PR — Fusion "De quoi on parle" dans "Pas de recul" + wiring env tests
-
-Branche : `claude/remove-digest-section-jCCzy` → `main`
-Commits :
-- `ca0b858` refactor(digest): merge "De quoi on parle" into "Pas de recul" card
-- `72f6871` chore(env): wire Flutter + pytest paths in test hooks
-
----
+# PR — Article Reader Layout Rework (story 5.9)
 
 ## Quoi
 
-Deux changements distincts sur la même branche :
-
-1. **Refactor UI digest (ca0b858)** — Suppression de la sous-carte grise *"De quoi on parle ?"* qui précédait la carte *"Pas de recul"*. L'`intro_text` du topic est désormais affiché **en tête** de la carte "Pas de recul" (même carte, sans cadre additionnel). Le champ `recul_intro` (phrase italique d'accroche vers l'article de recul) est supprimé de toute la stack (prompts LLM, schémas Pydantic, pipeline, serializer DB, modèles Flutter, widgets, tests) car redondant avec la phrase 2 de `intro_text`.
-2. **Chore env (72f6871)** — Les hooks `post-edit-auto-test.sh` et `stop-verify-tests.sh` utilisent maintenant des chemins absolus vers `./.venv/bin/pytest` et `/opt/flutter/bin/flutter`, avec `PYTHONPATH` et `CI=true` pré-configurés, pour que les tests se lancent correctement depuis les hooks Claude Code.
+Refonte de la mise en page de l'écran de lecture in-app :
+- Nouveau footer animé (slide comme le header) qui remplace les FABs flottants une fois que l'utilisateur atteint la section Perspectives ou la fin de l'article
+- Section Perspectives embarquée inline dans le scroll view (nouveau widget `PerspectivesInlineSection`) avec filtre par biais cliquable et header sticky
+- Barre de progression limitée à la longueur de l'article (exclut la section Perspectives)
+- Utilitaire `cutHtmlAtPreview()` dans `html_utils.dart` pour couper du HTML à N mots
 
 ## Pourquoi
 
-**Refactor** : L'ancienne UI affichait deux cartes contiguës pour un même topic (gris "De quoi on parle" + bleu "Prendre du recul"), ce qui créait une lourdeur visuelle (deux bordures, deux couleurs, deux paragraphes) pour une info logiquement continue — le texte du topic **fait le pont** vers l'article de recul. Par ailleurs, `recul_intro` dupliquait la fonction de la phrase 2 de `intro_text` (les deux servaient d'accroche vers l'article de recul). Fusionner réduit la dette éditoriale côté LLM (un seul champ à générer) et allège l'écran.
-
-**Env** : Sans chemins absolus, les hooks ne trouvaient ni `pytest` ni `flutter` dans le PATH de l'agent, donc `stop-verify-tests.sh` ne vérifiait rien. Maintenant les hooks s'exécutent réellement.
+Les FABs flottants masquaient le contenu et offraient une mauvaise ergonomie en fin d'article. L'objectif est d'avoir un footer persistant et contextuel qui apparaît naturellement quand l'utilisateur a terminé sa lecture, et d'intégrer les Perspectives directement dans le flux de lecture plutôt qu'en bottom sheet.
 
 ## Fichiers modifiés
 
-### Backend (ca0b858)
-- `packages/api/config/editorial_prompts.yaml` — retrait de `recul_intro` des structures + schemas JSON des prompts `writing` et `writing_serene`. Ajout d'une ligne dans la section PONTS clarifiant que la phrase 2 d'`intro_text` joue le rôle.
-- `packages/api/app/services/editorial/schemas.py` — suppression de `recul_intro` sur `MatchedDeepArticle` et `SubjectWriting`.
-- `packages/api/app/services/editorial/writer.py` — retrait du mapping `recul_intro` depuis la réponse LLM.
-- `packages/api/app/services/editorial/pipeline.py` — retrait du bloc qui propageait `sw.recul_intro` vers `s.deep_article.recul_intro`.
-- `packages/api/app/services/digest_service.py` — retrait de la sérialisation/désérialisation de `recul_intro` pour `DigestTopicArticle` (lignes ~1400 et ~1792).
-- `packages/api/app/schemas/digest.py` — retrait du champ `recul_intro` sur `DigestTopicArticle` et `DigestItem`.
+- **Mobile — core :**
+  - `apps/mobile/lib/core/utils/html_utils.dart` — ajout de `cutHtmlAtPreview()` + `_findPositionAfterNWords()`
 
-### Mobile (ca0b858)
-- `apps/mobile/lib/features/digest/models/digest_models.dart` — suppression du champ `@JsonKey(name: 'recul_intro') String? reculIntro` sur `DigestItem`.
-- `apps/mobile/lib/features/digest/models/digest_models.freezed.dart` — **édité à la main** (13 occurrences : mixin getter, 2 copyWith abstract+impl, constructor, final getter, toString, equals, hashCode) car `build_runner` indisponible dans l'env.
-- `apps/mobile/lib/features/digest/models/digest_models.g.dart` — retrait des 2 lignes `recul_intro` (from/to Json) — édité à la main aussi.
-- `apps/mobile/lib/features/digest/widgets/pas_de_recul_block.dart` — param renommé `reculIntro` → `introText` ; affiché **en haut de la carte** (non italique, lineHeight 1.5) au-dessus de `title + source`. Dartdoc mise à jour.
-- `apps/mobile/lib/features/digest/widgets/topic_section.dart` — suppression complète du bloc "De quoi on parle ?" (≈60 lignes). Remplacé par : soit `PasDeReculBlock(introText: topic.introText, ...)` si un deep article existe, soit un paragraphe discret (padding horizontal 12, fontSize 14, pas de carte) sinon.
-- `apps/mobile/test/features/digest/widgets/pas_de_recul_block_test.dart` — tests mis à jour pour `introText`.
+- **Mobile — detail :**
+  - `apps/mobile/lib/features/detail/screens/content_detail_screen.dart` — footer animé, sticky header Perspectives, mesure de l'extent article, state Perspectives lifté au niveau écran
+  - `apps/mobile/lib/features/detail/widgets/article_reader_widget.dart` — suppression du `SizedBox(height: 64)` superflu en fin de widget
 
-### Config / Docs (ca0b858 + 72f6871)
-- `docs/maintenance/maintenance-merge-intro-pas-de-recul.md` — doc de maintenance (contexte, objectif, liste des changements, mockup ASCII, cas traités, tests, hors périmètre).
-- `.claude-hooks/post-edit-auto-test.sh` — `PYTEST`/`FLUTTER`/`CI=true` + `PYTHONPATH` dans les commandes.
-- `.claude-hooks/stop-verify-tests.sh` — idem.
-- `apps/mobile/pubspec.lock` — régénéré par `flutter pub get`.
+- **Mobile — feed :**
+  - `apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart` — enum `PerspectivesAnalysisState` passé public, nouveau `PerspectivesInlineSection`, `PerspectivesTrianglePainter` public, filtre biais dans le bottom sheet
+
+- **Mobile — onboarding :**
+  - `digest_mode_question.dart`, `intro_screen.dart`, `media_concentration_screen.dart` — fix lint `const` sur les listes `TextSpan`
+
+- **Docs :**
+  - `docs/stories/core/5.9.article-reader-layout-rework.md` — story technique
 
 ## Zones à risque
 
-1. **`digest_models.freezed.dart` édité à la main** — 13 points de modification mécaniques mais pas régénérés par `build_runner`. Si le reviewer a `build_runner` dispo, il est recommandé de lancer `flutter pub run build_runner build --delete-conflicting-outputs` pour valider qu'il produit le même fichier (ou pour l'écraser proprement).
-2. **Pipeline éditorial LLM** — `editorial_prompts.yaml` + `writer.py` + `pipeline.py` : si un digest généré avant cette PR est rechargé depuis DB, `recul_intro` sera silencieusement ignoré (le `.get()` supprimé ne lisait plus) — aucun crash, juste perte du champ orphelin.
-3. **Sérialisation DB des digests** — `digest_service.py` n'écrit plus `recul_intro` ; un ancien JSON stocké contient encore la clé mais elle n'est plus lue. Pas de migration nécessaire (JSONB).
-4. **Widgets digest** — `topic_section.dart` a perdu une grosse section ; vérifier en runtime sur un topic avec deep article ET sur un topic sans, pour s'assurer que le fallback paragraphe discret s'affiche bien.
+- **`content_detail_screen.dart`** — fichier le plus critique et le plus large du projet mobile (~1 400 lignes). Deux `ScrollController` coexistent maintenant (`_scrollController` pour le mode scroll-to-site, `_inAppScrollController` pour le reader in-app). S'assurer qu'ils ne sont pas mélangés.
+- **`_measureArticleExtent()`** — utilise `RenderBox.localToGlobal` post-frame. Si l'article n'est pas encore rendu (images lazy-loaded), l'extent peut être sous-estimé. Ce n'est pas bloquant (fallback sur `maxScrollExtent`) mais peut affecter la barre de progression.
+- **`_footerAutoController`** — vérifier que `dispose()` l'inclut bien (memory leak sinon).
+- **Renommage `_AnalysisState` → `PerspectivesAnalysisState`** — l'enum est maintenant public et partagé entre le bottom sheet et `content_detail_screen`. Casser ce contrat affecterait les deux.
 
 ## Points d'attention pour le reviewer
 
-- **Cohérence prompts ↔ schémas** — les 2 prompts (`writing` et `writing_serene`) doivent produire du JSON qui colle à `SubjectWriting` sans `recul_intro`. J'ai relu les YAML mais vérifier qu'aucun exemple few-shot n'y fait référence.
-- **La phrase 2 d'`intro_text` joue bien le rôle de pont** — c'est déjà le cas dans le prompt existant (section PONTS), mais j'ai ajouté une ligne d'insistance. Si le reviewer juge l'instruction insuffisante, on peut durcir le prompt avec un exemple.
-- **UX : paragraphe discret sans carte pour topics sans deep article** — choix délibéré pour préserver `intro_text` sans réintroduire de lourdeur visuelle. Si le PO préfère tout simplement masquer `intro_text` dans ce cas, c'est 3 lignes à retirer dans `topic_section.dart`.
-- **Freezed hand-edit** — stratégie à valider. Alternative : régénérer proprement dans un commit de suivi.
+1. **Footer permanent** : `_footerPermanent = true` se déclenche dans deux endroits — `_checkIsShortArticle()` et `_checkAtPerspectivesSection()`. Vérifier absence de double-trigger ou race condition.
+2. **Sticky header Perspectives** : calculé à chaque événement scroll via `_checkAtPerspectivesSection()`. L'algo utilise `_headerOffset.value` pour calculer la position réelle du header — vérifier que l'offset est cohérent avec la valeur animée courante.
+3. **`PerspectivesInlineSection` — mode contrôlé vs autonome** : le widget supporte deux modes. En mode contrôlé (via `onSegmentTap`), le parent est propriétaire du filtre. L'écran de détail utilise ce mode pour synchroniser le sticky header — vérifier que `_onPerspectivesSegmentTap` dans le screen reflète la même logique que `_onSegmentTapInternal` dans le widget.
+4. **Barre de progression** : `_articleContentExtent` est mesuré via `_measureArticleExtent()` après rendu. Si null, fallback sur `maxScrollExtent`. Vérifier que `_articleEndKey` est bien positionné dans le widget tree juste avant la section Perspectives.
 
 ## Ce qui N'A PAS changé (mais pourrait sembler affecté)
 
-- **Aucune migration Alembic** — `recul_intro` vivait uniquement dans le JSON `topics` de la table digest ; pas de colonne SQL à retirer.
-- **Backend API contract** — les endpoints `/digest/*` continuent à renvoyer tous les autres champs à l'identique ; seul `recul_intro` disparaît du payload.
-- **Autres blocs éditoriaux** (Pépite, Coup de cœur, Actu décalée, Quote) — non touchés.
-- **36 tests Flutter pré-existants en échec sur `main`** — vérifié en stashant et re-testant sur `main` avant cette PR ; ce ne sont PAS des régressions introduites ici (hors périmètre).
-- **Tests backend DB-dépendants** (~29) — fail localement faute de Postgres ; CI Postgres les exécutera.
+- **Mode scroll-to-site et WebView** : `_showWebView`, `_isWebViewActive`, `_scrollController` et `_webViewController` ne sont pas modifiés fonctionnellement. Le seul changement est `bool _showWebView = false` → `final bool _showWebView = false` (lint fix).
+- **`PerspectivesBottomSheet`** (modal) : le comportement du bottom sheet existant est préservé. Le filtre biais a été ajouté mais ne change pas l'API publique du widget.
+- **Onboarding** : les 3 fichiers ont uniquement un fix de lint (`const` hissé au niveau de la liste), aucun comportement ne change.
 
 ## Comment tester
 
-### Backend
-```bash
-cd /home/user/facteur/packages/api
-PYTHONPATH=/home/user/facteur/packages/api ../../.venv/bin/pytest tests/editorial -v
-# -> 85/85 pass attendu
-PYTHONPATH=/home/user/facteur/packages/api ../../.venv/bin/pytest -x -q --tb=short
-# -> les DB-dep fail, le reste passe
-```
-
-### Mobile
-```bash
-cd /home/user/facteur/apps/mobile
-CI=true /opt/flutter/bin/flutter test --no-pub test/features/digest/widgets/pas_de_recul_block_test.dart
-# -> tests du widget refactore (introText)
-CI=true /opt/flutter/bin/flutter analyze --no-pub
-```
-
-### Runtime / visuel (a faire cote reviewer)
-1. Lancer un digest qui contient au moins 1 topic avec deep article et 1 topic sans.
-2. **Topic avec deep article** : la carte "Pas de recul" doit afficher `intro_text` en haut (paragraphe non italique) puis le titre de l'article + la source + la fleche. Aucune carte grise avant.
-3. **Topic sans deep article** : un paragraphe discret (padding lateral, pas de cadre, fontSize 14) affichant `intro_text`. Aucune carte "Pas de recul" en dessous.
-4. Generer un nouveau digest via la pipeline LLM (ou forcer un run) et verifier que le JSON produit ne contient plus `recul_intro` et que la phrase 2 d'`intro_text` joue bien le role d'accroche vers l'article de recul.
-
-### Regenerer freezed proprement (optionnel mais conseille avant merge)
-```bash
-cd /home/user/facteur/apps/mobile
-/opt/flutter/bin/flutter pub run build_runner build --delete-conflicting-outputs
-git diff lib/features/digest/models/digest_models.freezed.dart
-# -> diff attendu : vide (ou cosmetique)
-```
+1. **Footer slide** : ouvrir un article long en mode in-app → scroller jusqu'au bas → vérifier que le footer apparaît progressivement. Remonter → le footer suit le header (se cache en scrollant vers le bas, réapparaît vers le haut).
+2. **Footer permanent** : scroller jusqu'à la section Perspectives → le footer doit rester visible même en remontant.
+3. **Filtre biais inline** : tapper sur un segment de la barre de biais → seuls les articles du groupe sélectionné s'affichent. Tapper à nouveau → reset. Vérifier que le sticky header reflète le filtre actif.
+4. **Sticky header Perspectives** : scroller au-delà du titre "Voir tous les points de vue" → un mini-header doit apparaître dans l'app header. Rescroller vers le haut → il disparaît.
+5. **Barre de progression** : vérifier que la barre atteint 100% à la fin de l'article, pas en milieu de la section Perspectives.
+6. **Article court** : le footer doit être immédiatement visible (sans nécessiter de scroll).
+7. `flutter analyze` doit passer sans nouveaux warnings.

--- a/apps/mobile/lib/core/utils/html_utils.dart
+++ b/apps/mobile/lib/core/utils/html_utils.dart
@@ -131,3 +131,89 @@ bool isPartialContent(String? html) {
   if (text.length < 500) return true;
   return _truncationPatterns.any((p) => p.hasMatch(text));
 }
+
+/// Finds the position in [html] (a raw HTML string) after [wordLimit] plain-text words.
+///
+/// Walks char-by-char, skipping HTML tags. Returns the position in the HTML
+/// string immediately after the [wordLimit]th word boundary, or null if the
+/// text contains fewer words than [wordLimit].
+int? _findPositionAfterNWords(String html, int wordLimit) {
+  int wordCount = 0;
+  int i = 0;
+  bool inTag = false;
+  bool inWord = false;
+
+  while (i < html.length) {
+    final c = html[i];
+    if (c == '<') {
+      if (inWord) {
+        wordCount++;
+        inWord = false;
+        if (wordCount >= wordLimit) return i;
+      }
+      inTag = true;
+    } else if (c == '>') {
+      inTag = false;
+    } else if (!inTag) {
+      final isSpace = c == ' ' || c == '\n' || c == '\r' || c == '\t';
+      if (isSpace) {
+        if (inWord) {
+          wordCount++;
+          inWord = false;
+          if (wordCount >= wordLimit) return i;
+        }
+      } else {
+        inWord = true;
+      }
+    }
+    i++;
+  }
+  if (inWord) {
+    wordCount++;
+    if (wordCount >= wordLimit) return html.length;
+  }
+  return null;
+}
+
+/// Cuts sanitized HTML at the first natural break after [wordLimit] plain-text
+/// words, or just before the first subtitle (`<h1>`–`<h6>`), whichever is earlier.
+///
+/// Break-point search order after [wordLimit] words: `</p>`, then `<br`, then
+/// the raw word position (fallback for HTML without paragraph tags).
+///
+/// Returns the cut HTML string, or null if the content is too short to cut
+/// (fewer than [wordLimit] words and no heading found).
+String? cutHtmlAtPreview(String html, {int wordLimit = 150}) {
+  final sanitized = sanitizeArticleHtml(html);
+  if (sanitized.isEmpty) return null;
+
+  // Option B: position of first heading tag
+  final headingMatch =
+      RegExp(r'<h[1-6][\s>]', caseSensitive: false).firstMatch(sanitized);
+  final firstHeadingPos = headingMatch?.start;
+
+  // Option A: first natural break after the wordLimit-th word.
+  // Try </p>, then <br (as fallback), then cut at word position directly.
+  final wordPos = _findPositionAfterNWords(sanitized, wordLimit);
+  int? optionA;
+  if (wordPos != null) {
+    final pClose = sanitized.indexOf('</p>', wordPos);
+    final brTag = sanitized.indexOf('<br', wordPos);
+
+    if (pClose != -1 && (brTag == -1 || pClose <= brTag)) {
+      optionA = pClose + 4; // include </p>
+    } else if (brTag != -1) {
+      optionA = brTag; // cut just before <br
+    } else {
+      optionA = wordPos; // no block break found — cut at word boundary
+    }
+  }
+
+  if (optionA == null && firstHeadingPos == null) return null;
+  if (optionA == null) return sanitized.substring(0, firstHeadingPos!).trim();
+  if (firstHeadingPos == null) return sanitized.substring(0, optionA).trim();
+
+  final cutPos = optionA < firstHeadingPos ? optionA : firstHeadingPos;
+  if (cutPos <= 0) return null;
+  return sanitized.substring(0, cutPos).trim();
+}

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -67,6 +67,10 @@ class ContentDetailScreen extends ConsumerStatefulWidget {
 /// Height of the header content area (below the status bar).
 const double _kHeaderContentHeight = 50;
 
+/// Height of the footer content area (above the safe-area bottom inset).
+/// = vertical padding (12+12) + button row height (44).
+const double _kFooterContentHeight = 68.0;
+
 class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     with TickerProviderStateMixin, WidgetsBindingObserver {
   late AnimationController _fabController;
@@ -85,6 +89,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   bool _showFab = false;
   bool _showShareFab = false;
   bool _isShortArticle = false;
+  bool _footerPermanent = false; // true once user reaches end of displayed content
+  final ValueNotifier<bool> _atPerspectivesSection = ValueNotifier(false);
   bool _showNoteWelcome = false;
   bool _linkCopiedFab = false;
   bool _linkCopiedHeader = false;
@@ -94,12 +100,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   bool _webFallbackRedirectScheduled = false;
   late DateTime _startTime;
   WebViewController? _webViewController;
-  bool _showWebView = false;
+  final bool _showWebView = false;
 
   // Scroll-to-site state
   final ScrollController _scrollController = ScrollController();
+  // In-app reader scroll controller (separate from scroll-to-site)
+  final ScrollController _inAppScrollController = ScrollController();
   final GlobalKey _articleKey = GlobalKey();
   final GlobalKey _bridgeKey = GlobalKey();
+  final GlobalKey _perspectivesKey = GlobalKey();
   bool _isWebViewActive = false;
   bool _ctaTapped = false;
   double _bridgeStartOffset = 0;
@@ -134,6 +143,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   final ValueNotifier<double> _readingProgress = ValueNotifier<double>(0.0);
   double _maxReadingProgress = 0;
 
+  // Keys and cached extent for article-only reading progress measurement
+  final GlobalKey _articleEndKey = GlobalKey();
+  final GlobalKey _scrollViewKey = GlobalKey();
+  double? _articleContentExtent;
+
+  // Footer slide offset: 0.0 = fully visible, 1.0 = fully hidden (mirrors _headerOffset)
+  final ValueNotifier<double> _footerOffset = ValueNotifier<double>(0.0);
+  double _footerAutoStart = 0.0;
+  double _footerAutoTarget = 0.0;
+  late AnimationController _footerAutoController;
+
   // Video detail screen state
   bool _isDescriptionExpanded = false;
   bool _isVideoPlaying = false;
@@ -145,6 +165,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   // Perspectives pill state
   PerspectivesResponse? _perspectivesResponse;
   bool _perspectivesLoading = false;
+
+  // Perspectives analysis state (lifted from inline section)
+  PerspectivesAnalysisState _perspectivesAnalysisState =
+      PerspectivesAnalysisState.idle;
+  String? _perspectivesAnalysisText;
+  final GlobalKey _analysisZoneKey = GlobalKey();
+
+  // Perspectives sticky section header state
+  Set<String> _perspectivesSelectedSegments = {};
+  final ValueNotifier<bool> _showStickyPerspectivesHeader =
+      ValueNotifier(false);
 
   @override
   void initState() {
@@ -248,6 +279,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _headerAutoController.addListener(() {
       _headerOffset.value = _headerAutoStart +
           (_headerAutoTarget - _headerAutoStart) * _headerAutoController.value;
+    });
+
+    _footerAutoController = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+    _footerAutoController.addListener(() {
+      _footerOffset.value = _footerAutoStart +
+          (_footerAutoTarget - _footerAutoStart) * _footerAutoController.value;
     });
 
     WidgetsBinding.instance.addObserver(this);
@@ -436,8 +476,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (!_scrollController.hasClients) return;
     final maxExtent = _scrollController.position.maxScrollExtent;
     if (maxExtent <= 0) return;
-    final rawProgress = _scrollController.offset / maxExtent;
-    // Partial content: in-app scroll represents only ~25% of the full article
+    final pixels = _scrollController.offset;
+    // Use article-only extent so the perspectives section doesn't dilute progress
+    final articleExtent = _articleContentExtent ?? maxExtent;
+    final rawProgress = pixels / articleExtent;
     final progress = _isPartialContent
         ? (rawProgress * 0.25).clamp(0.0, 0.25)
         : rawProgress.clamp(0.0, 1.0);
@@ -447,11 +489,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     }
   }
 
-  /// Show header when user reaches the bottom of the article (progress ≥ 98%).
+  /// Show header + footer when user reaches the bottom of the article (progress ≥ 98%).
   void _onReadingProgressNudge() {
-    if (_readingProgress.value >= 0.98 && _headerOffset.value > 0.0) {
+    if (_readingProgress.value >= 0.98) {
       _inactivityTimer?.cancel();
-      _animateHeaderTo(0.0);
+      if (_headerOffset.value > 0.0) _animateHeaderTo(0.0);
+      if (_footerOffset.value > 0.0) _animateFooterTo(0.0);
     }
   }
 
@@ -469,7 +512,25 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (!_scrollController.hasClients) return;
     if (_scrollController.position.maxScrollExtent < 50) {
       _isShortArticle = true;
+      _footerPermanent = true;
     }
+  }
+
+  /// Measures the pixel distance from the top of the scroll content to the
+  /// end of the article section (before perspectives). Stored in
+  /// [_articleContentExtent] so the progress bar ignores perspectives height.
+  void _measureArticleExtent() {
+    final endBox =
+        _articleEndKey.currentContext?.findRenderObject() as RenderBox?;
+    final svBox =
+        _scrollViewKey.currentContext?.findRenderObject() as RenderBox?;
+    if (endBox == null || svBox == null) return;
+    if (!_scrollController.hasClients) return;
+    // content-coord of marker = screen Y of marker − screen Y of sv top + scroll offset
+    final extent = endBox.localToGlobal(Offset.zero).dy -
+        svBox.localToGlobal(Offset.zero).dy +
+        _scrollController.offset;
+    if (extent > 0) _articleContentExtent = extent;
   }
 
   /// Compute layout offsets for bridge zone.
@@ -492,6 +553,60 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     }
 
     _offsetsComputed = true;
+  }
+
+  /// Updates [_atPerspectivesSection] based on whether the perspectives widget
+  /// is visible in the viewport. Called from the scroll notification handler.
+  /// Uses ValueNotifier to avoid triggering a full setState during scroll.
+  void _checkAtPerspectivesSection() {
+    final ctx = _perspectivesKey.currentContext;
+    if (ctx == null) return;
+    final perspBox = ctx.findRenderObject() as RenderBox?;
+    if (perspBox == null || !perspBox.hasSize) return;
+
+    final perspScreenY = perspBox.localToGlobal(Offset.zero).dy;
+    final screenHeight = MediaQuery.of(context).size.height;
+    final reached = perspScreenY < screenHeight * 0.85;
+
+    if (reached != _atPerspectivesSection.value) {
+      _atPerspectivesSection.value = reached;
+      // Footer becomes sticky as soon as the perspectives section is reached.
+      if (reached && !_footerPermanent) {
+        _footerPermanent = true;
+        _animateFooterTo(0.0);
+      }
+    }
+
+    // Sticky perspectives header: show as soon as the section title has
+    // scrolled above the bottom of the app header.
+    final appHeaderHeight =
+        MediaQuery.of(context).padding.top + _kHeaderContentHeight;
+    final appHeaderBottomY = appHeaderHeight * (1.0 - _headerOffset.value);
+    final shouldStick = perspScreenY < appHeaderBottomY;
+    if (shouldStick != _showStickyPerspectivesHeader.value) {
+      _showStickyPerspectivesHeader.value = shouldStick;
+    }
+  }
+
+  /// Toggles a perspectives bias-bar segment filter. Mirrors the logic in
+  /// [_PerspectivesInlineSectionState._onSegmentTapInternal].
+  void _onPerspectivesSegmentTap(String key) {
+    setState(() {
+      final current = _perspectivesSelectedSegments;
+      if (current.contains(key)) {
+        _perspectivesSelectedSegments =
+            current.length == 1 ? {} : (Set.from(current)..remove(key));
+      } else {
+        _perspectivesSelectedSegments = current.isEmpty || current.length == 3
+            ? {key}
+            : (Set.from(current)..add(key));
+      }
+    });
+    // Re-check sticky visibility after the section has rebuilt (filtering may
+    // shrink the section back into view with no scroll event).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _checkAtPerspectivesSection();
+    });
   }
 
   /// Scroll listener driving WebView activation.
@@ -541,7 +656,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _headerAutoController.forward(from: 0);
   }
 
-  /// Scroll listener for native (in-app) content — computes delta from previous
+/// Scroll listener for native (in-app) content — computes delta from previous
   /// offset and forwards it to [_onScrollDelta].
   void _onNativeScrollHeader() {
     if (!_scrollController.hasClients || _isWebViewActive) return;
@@ -549,6 +664,14 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     final delta = current - _prevNativeScrollOffset;
     _prevNativeScrollOffset = current;
     if (delta != 0) _onScrollDelta(delta);
+  }
+
+  /// Smoothly animate the footer to [target] offset (0.0 = visible, 1.0 = hidden).
+  void _animateFooterTo(double target) {
+    _footerAutoController.stop();
+    _footerAutoStart = _footerOffset.value;
+    _footerAutoTarget = target;
+    _footerAutoController.forward(from: 0);
   }
 
   /// Update header offset and FAB opacity based on scroll delta (in pixels).
@@ -571,13 +694,23 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           MediaQuery.of(context).padding.top + _kHeaderContentHeight;
       final shift = delta / headerHeight;
       _headerOffset.value = (_headerOffset.value + shift).clamp(0.0, 1.0);
+
+      // Footer mirrors header: hides on scroll-down, shows on scroll-up.
+      // Skipped once the user has reached the end of the displayed content.
+      if (!_footerPermanent) {
+        final bottomInset = MediaQuery.of(context).viewPadding.bottom;
+        final footerHeight = _kFooterContentHeight + bottomInset;
+        final footerShift = delta / footerHeight;
+        _footerOffset.value = (_footerOffset.value + footerShift).clamp(0.0, 1.0);
+      }
     }
-    // FABs reappear after 2.5s
+    // FABs + footer reappear after 2.5s of scroll inactivity
     _scrollStopTimer?.cancel();
     _scrollStopTimer = Timer(const Duration(milliseconds: 2500), () {
       if (mounted) {
         _fabOpacity.value = 1.0;
         _fabReappearController.forward(from: 0);
+        _animateFooterTo(0.0);
       }
     });
     // Auto-hide header after 3s of inactivity (no scroll), but only if not at top
@@ -631,9 +764,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
               !_isConsumed) {
             _startReadingTimer();
           }
-          // Re-check short article after content loads and renders
+          // Re-check short article + measure article extent after content loads and renders
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (mounted) _checkShortArticle();
+            if (mounted) {
+              _checkShortArticle();
+              _measureArticleExtent();
+            }
           });
           // Pre-load WebView if not already initialized
           if (_webViewController == null) {
@@ -911,16 +1047,21 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _shareFabController.dispose();
     _exitAnimController.dispose();
     _headerAutoController.dispose();
+    _footerAutoController.dispose();
     WidgetsBinding.instance.removeObserver(this);
     _fabOpacity.dispose();
     _headerOffset.dispose();
+    _footerOffset.dispose();
     _readingProgress.removeListener(_onReadingProgressNudge);
     _readingProgress.removeListener(_onShareFabProgress);
     _readingProgress.dispose();
     _scrollController.removeListener(_onScrollToSite);
     _scrollController.removeListener(_onScrollReadingProgress);
 
+    _atPerspectivesSection.dispose();
+    _showStickyPerspectivesHeader.dispose();
     _scrollController.dispose();
+    _inAppScrollController.dispose();
     super.dispose();
 
     // Persist reading progress + analytics on close
@@ -1052,6 +1193,49 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       if (mounted) {
         setState(() => _perspectivesLoading = false);
       }
+    }
+  }
+
+  /// Request Facteur analysis for the perspectives section.
+  /// Called by the floating button in the article reader.
+  Future<void> _requestPerspectivesAnalysis() async {
+    final contentId = _perspectivesResponse?.perspectives.isNotEmpty == true
+        ? _content?.id
+        : null;
+    if (contentId == null) return;
+
+    setState(
+        () => _perspectivesAnalysisState = PerspectivesAnalysisState.loading);
+
+    // Scroll to analysis zone so the user can see the progress
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final ctx = _analysisZoneKey.currentContext;
+      if (ctx != null) {
+        Scrollable.ensureVisible(
+          ctx,
+          duration: const Duration(milliseconds: 400),
+          curve: Curves.easeInOut,
+          alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+          alignment: 0.8,
+        );
+      }
+    });
+
+    try {
+      final repository = ref.read(feedRepositoryProvider);
+      final result = await repository.analyzePerspectives(contentId);
+      if (!mounted) return;
+      setState(() {
+        _perspectivesAnalysisText = result;
+        _perspectivesAnalysisState = result != null
+            ? PerspectivesAnalysisState.done
+            : PerspectivesAnalysisState.error;
+      });
+    } catch (e) {
+      debugPrint('Error requesting perspectives analysis: $e');
+      if (!mounted) return;
+      setState(
+          () => _perspectivesAnalysisState = PerspectivesAnalysisState.error);
     }
   }
 
@@ -1275,16 +1459,27 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 if (!_isShortArticle &&
                     notification.metrics.maxScrollExtent < 50) {
                   _isShortArticle = true;
+                  _footerPermanent = true;
                   _headerOffset.value = 0.0;
                 }
                 _onScrollDelta(delta);
+                _checkAtPerspectivesSection();
                 // Track reading progress from any scrollable (including in-app reader)
                 final metrics = notification.metrics;
                 if (metrics.maxScrollExtent > 0) {
-                  final progress = metrics.pixels / metrics.maxScrollExtent;
+                  final rawProgress = metrics.pixels / metrics.maxScrollExtent;
+                  // Footer becomes permanent at end of ALL content (incl. perspectives)
+                  if (!_footerPermanent && rawProgress >= 0.98) {
+                    _footerPermanent = true;
+                    _animateFooterTo(0.0);
+                  }
+                  // Progress bar uses article-only extent so perspectives don't dilute it
+                  final articleExtent =
+                      _articleContentExtent ?? metrics.maxScrollExtent;
+                  final barProgress = metrics.pixels / articleExtent;
                   final capped = _isPartialContent
-                      ? (progress * 0.25).clamp(0.0, 0.25)
-                      : progress.clamp(0.0, 1.0);
+                      ? (barProgress * 0.25).clamp(0.0, 0.25)
+                      : barProgress.clamp(0.0, 1.0);
                   _readingProgress.value = capped;
                   if (capped > _maxReadingProgress) {
                     _maxReadingProgress = capped;
@@ -1368,6 +1563,45 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 );
               },
             ),
+          // Sticky perspectives section header — appears below the app header
+          // when the inline section header has scrolled off-screen.
+          // Only shown for in-app article reading.
+          if (useInAppReading &&
+              content.contentType == ContentType.article &&
+              _perspectivesResponse != null)
+            ValueListenableBuilder<bool>(
+              valueListenable: _showStickyPerspectivesHeader,
+              builder: (context, showSticky, _) {
+                return ValueListenableBuilder<double>(
+                  valueListenable: _headerOffset,
+                  builder: (context, offset, _) {
+                    final statusBarHeight =
+                        MediaQuery.of(context).padding.top;
+                    // Sits immediately below the reading progress bar (+2px).
+                    final topWhenHeaderVisible =
+                        statusBarHeight + _kHeaderContentHeight + 2.0;
+                    final topWhenHeaderHidden = statusBarHeight + 2.0;
+                    final top = topWhenHeaderVisible -
+                        offset *
+                            (topWhenHeaderVisible - topWhenHeaderHidden);
+                    return Positioned(
+                      top: top,
+                      left: 0,
+                      right: 0,
+                      child: AnimatedOpacity(
+                        duration: const Duration(milliseconds: 200),
+                        opacity: showSticky ? 1.0 : 0.0,
+                        child: IgnorePointer(
+                          ignoring: !showSticky,
+                          child: _buildPerspectivesStickyHeader(
+                              context, _perspectivesResponse!),
+                        ),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
           // Exit animation overlay — fade-to-white + scale-down
           if (_isExitAnimating)
             AnimatedBuilder(
@@ -1383,12 +1617,74 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 );
               },
             ),
+          // Floating "Lancer l'analyse Facteur" button — in-app articles only.
+          // Visible when the perspectives section is on screen and analysis
+          // hasn't been triggered yet.
+          if (useInAppReading && content.contentType == ContentType.article)
+            Positioned(
+              right: 16,
+              bottom: _kFooterContentHeight +
+                  MediaQuery.of(context).viewPadding.bottom +
+                  12,
+              child: ValueListenableBuilder<bool>(
+                valueListenable: _atPerspectivesSection,
+                builder: (context, atPersp, _) {
+                  final show = atPersp &&
+                      _perspectivesAnalysisState ==
+                          PerspectivesAnalysisState.idle &&
+                      _perspectivesResponse != null &&
+                      _perspectivesResponse!.perspectives.isNotEmpty;
+                  return AnimatedOpacity(
+                    opacity: show ? 1.0 : 0.0,
+                    duration: const Duration(milliseconds: 200),
+                    child: IgnorePointer(
+                      ignoring: !show,
+                      child: FilledButton.icon(
+                        onPressed: () {
+                          HapticFeedback.lightImpact();
+                          _requestPerspectivesAnalysis();
+                        },
+                        style: FilledButton.styleFrom(
+                          backgroundColor: context.facteurColors.primary
+                              .withValues(alpha: 1.0),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                        icon: Icon(
+                          PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                          size: 16,
+                          color: Colors.white,
+                        ),
+                        label: const Text(
+                          'Lancer l\'analyse Facteur',
+                          style: TextStyle(color: Colors.white),
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          // Footer — shown for in-app article reading, mirrors header slide behavior
+          if (useScrollToSite ||
+              (useInAppReading &&
+                  content.contentType == ContentType.article))
+            Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: _buildArticleFooter(context, content),
+            ),
         ],
       ),
       ),
       // FABs — vertical column with immersive scroll opacity
+      // Suppressed for articles (replaced by the persistent footer).
       // ValueListenableBuilder isolates FAB opacity rebuilds from the main widget tree.
-      floatingActionButton: _showFab
+      floatingActionButton: _showFab &&
+              !useScrollToSite &&
+              !(useInAppReading && content.contentType == ContentType.article)
           ? ValueListenableBuilder<double>(
               valueListenable: _fabOpacity,
               builder: (context, opacity, child) => AnimatedOpacity(
@@ -1607,6 +1903,244 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             )
           : null,
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+    );
+  }
+
+  /// CTA handler for "Lire sur…" in the footer.
+  /// For scroll-to-site mode: reveals WebView via scroll animation on first tap,
+  /// then opens external link on subsequent taps.
+  /// For all other modes: opens external link directly.
+  void _onReadOnSiteTap() {
+    if (kIsWeb) {
+      _openOriginalUrl();
+      return;
+    }
+    final content = _content;
+    if (content == null) return;
+    final articleText = content.htmlContent ?? content.description;
+    final hasEnoughContent = plainTextLength(articleText) >= 100;
+    final isScrollToSite = content.hasInAppContent &&
+        content.contentType == ContentType.article &&
+        hasEnoughContent &&
+        !_showWebView;
+    if (isScrollToSite && !_ctaTapped) {
+      setState(() => _ctaTapped = true);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _scrollController.hasClients) {
+          _scrollController.animateTo(
+            _scrollController.position.maxScrollExtent,
+            duration: const Duration(milliseconds: 500),
+            curve: Curves.easeInOutCubic,
+          );
+        }
+      });
+    } else {
+      _openOriginalUrl();
+    }
+  }
+
+  /// Persistent footer bar shown for in-app article reading.
+  /// Mirrors header slide behavior: hides on scroll-down, shows on scroll-up.
+  Widget _buildArticleFooter(BuildContext context, Content content) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final bottomInset = MediaQuery.of(context).viewPadding.bottom;
+
+    const iconButtonStyle = ButtonStyle(
+      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      visualDensity: VisualDensity.compact,
+      padding: WidgetStatePropertyAll(EdgeInsets.all(10)),
+      minimumSize: WidgetStatePropertyAll(Size(46, 46)),
+      shape: WidgetStatePropertyAll(CircleBorder()),
+    );
+
+    final footerContent = DecoratedBox(
+      decoration: BoxDecoration(
+        color: colors.backgroundPrimary,
+        border: Border(
+          top: BorderSide(
+              color: colors.border.withValues(alpha: 0.5), width: 0.5),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.1),
+            blurRadius: 4,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            children: [
+              // "Lire sur [Source]" — fills available space
+              Expanded(
+                child: SizedBox(
+                  height: 44,
+                  child: OutlinedButton(
+                    onPressed: _onReadOnSiteTap,
+                    style: OutlinedButton.styleFrom(
+                      backgroundColor: Colors.white.withValues(alpha: 0.5),
+                      foregroundColor: colors.textPrimary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      side: BorderSide(
+                          color: colors.border.withValues(alpha: 0.5)),
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                    ),
+                    child: Row(
+                      children: [
+                        if (content.source.logoUrl != null) ...[
+                          ClipRRect(
+                            borderRadius: BorderRadius.circular(8),
+                            child: CachedNetworkImage(
+                              imageUrl: content.source.logoUrl!,
+                              width: 28,
+                              height: 28,
+                              fit: BoxFit.cover,
+                              errorWidget: (_, __, ___) =>
+                                  const SizedBox.shrink(),
+                            ),
+                          ),
+                          const SizedBox(width: 6),
+                        ],
+                        Expanded(
+                          child: Text(
+                            'Lire sur ${content.source.name}',
+                            style: textTheme.labelMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: colors.textPrimary,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                            textAlign: TextAlign.left,
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                        Icon(
+                          PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
+                          size: 16,
+                          color: colors.textSecondary,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 4),
+
+              // Autres points de vue / Retour à l'article
+              ValueListenableBuilder<bool>(
+                valueListenable: _atPerspectivesSection,
+                builder: (context, atPersp, _) {
+                  if (atPersp) {
+                    return Tooltip(
+                      message: 'Retour à l\'article',
+                      child: IconButton(
+                        style: iconButtonStyle,
+                        onPressed: () {
+                          HapticFeedback.lightImpact();
+                          _atPerspectivesSection.value = false;
+                          if (_inAppScrollController.hasClients) {
+                            _inAppScrollController.animateTo(
+                              0,
+                              duration: const Duration(milliseconds: 400),
+                              curve: Curves.easeInOut,
+                            );
+                          }
+                        },
+                        icon: Icon(
+                          PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
+                          size: 24,
+                          color: colors.textSecondary,
+                        ),
+                      ),
+                    );
+                  }
+                  return _WinkingEyeButton(
+                    style: iconButtonStyle,
+                    iconColor: colors.textSecondary,
+                    onTap: () {
+                      HapticFeedback.lightImpact();
+                      _atPerspectivesSection.value = true;
+                      final ctx = _perspectivesKey.currentContext;
+                      if (ctx != null) {
+                        Scrollable.ensureVisible(
+                          ctx,
+                          duration: const Duration(milliseconds: 400),
+                          curve: Curves.easeInOut,
+                        );
+                      } else {
+                        _showPerspectives(context);
+                      }
+                    },
+                  );
+                },
+              ),
+
+              // Sauvegarder (long-press → collection picker)
+              GestureDetector(
+                onLongPress: () {
+                  HapticFeedback.mediumImpact();
+                  CollectionPickerSheet.show(
+                    context,
+                    content.id,
+                    onAddNote: () => _openNoteSheet(),
+                  );
+                },
+                child: ScaleTransition(
+                  scale: _bookmarkScaleAnimation,
+                  child: IconButton(
+                    style: iconButtonStyle,
+                    onPressed: _toggleBookmark,
+                    icon: Icon(
+                      content.isSaved
+                          ? PhosphorIcons.bookmarkSimple(
+                              PhosphorIconsStyle.fill)
+                          : PhosphorIcons.bookmarkSimple(
+                              PhosphorIconsStyle.regular),
+                      size: 24,
+                      color:
+                          content.isSaved ? colors.primary : colors.textSecondary,
+                    ),
+                    tooltip: 'Sauvegarder',
+                  ),
+                ),
+              ),
+
+              // J'aime
+              ScaleTransition(
+                scale: _likeScaleAnimation,
+                child: IconButton(
+                  style: iconButtonStyle,
+                  onPressed: _toggleLike,
+                  icon: Icon(
+                    content.isLiked
+                        ? PhosphorIcons.heart(PhosphorIconsStyle.fill)
+                        : PhosphorIcons.heart(PhosphorIconsStyle.regular),
+                    size: 24,
+                    color:
+                        content.isLiked ? colors.primary : colors.textSecondary,
+                  ),
+                  tooltip: "J'aime",
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    return ValueListenableBuilder<double>(
+      valueListenable: _footerOffset,
+      builder: (context, offset, child) => Transform.translate(
+        // Extra 8px to slide the top border shadow fully off-screen.
+        offset: Offset(0, offset * (_kFooterContentHeight + bottomInset + 8)),
+        child: child,
+      ),
+      child: footerContent,
     );
   }
 
@@ -1996,6 +2530,285 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     );
   }
 
+  /// Renders the sticky version of the perspectives section header (icon +
+  /// title, optional quality badge, interactive bias bar).  Shown as a
+  /// [Positioned] overlay below the app header when the inline section header
+  /// has scrolled off-screen.
+  Widget _buildPerspectivesStickyHeader(
+      BuildContext context, PerspectivesResponse response) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    // Compute merged 3-group distribution from the raw bias distribution.
+    final dist = response.biasDistribution;
+    final merged = {
+      'gauche': (dist['left'] ?? 0) + (dist['center-left'] ?? 0),
+      'centre': dist['center'] ?? 0,
+      'droite': (dist['center-right'] ?? 0) + (dist['right'] ?? 0),
+    };
+    final total = merged.values.fold<int>(0, (s, v) => s + v);
+
+    final segments = [
+      ('gauche', 'Gauche', colors.biasLeft),
+      ('centre', 'Centre', colors.biasCenter),
+      ('droite', 'Droite', colors.biasRight),
+    ];
+
+    final flexValues = segments.map((seg) {
+      final count = merged[seg.$1] ?? 0;
+      if (count > 0 && total > 0) {
+        return ((count / total) * 100).round().clamp(15, 100);
+      }
+      return 15;
+    }).toList();
+
+    // Map detailed bias stance to simplified 3-segment group.
+    String stanceGroup(String stance) {
+      switch (stance) {
+        case 'left':
+        case 'center-left':
+          return 'gauche';
+        case 'center':
+          return 'centre';
+        case 'center-right':
+        case 'right':
+          return 'droite';
+        default:
+          return 'centre';
+      }
+    }
+
+    final sourceGroup = stanceGroup(response.sourceBiasStance);
+    final sourceIndex = segments.indexWhere((s) => s.$1 == sourceGroup);
+
+    final selected = _perspectivesSelectedSegments;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.backgroundPrimary,
+        border: Border(
+          bottom: BorderSide(color: colors.border, width: 1),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.1),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Icon + title row
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                PhosphorIcons.eye(PhosphorIconsStyle.regular),
+                color: colors.primary,
+                size: 22,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  'Voir tous les points de vue',
+                  style: textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: colors.textPrimary,
+                  ),
+                ),
+              ),
+              // "Tout afficher" clear button when a filter is active
+              if (selected.isNotEmpty)
+                GestureDetector(
+                  onTap: () {
+                    setState(() => _perspectivesSelectedSegments = {});
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      if (mounted) _checkAtPerspectivesSection();
+                    });
+                  },
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        'Tout afficher',
+                        style: textTheme.labelSmall?.copyWith(
+                          color: colors.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      Icon(
+                        PhosphorIcons.x(PhosphorIconsStyle.bold),
+                        size: 12,
+                        color: colors.primary,
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+          // Optional quality badge
+          if (response.comparisonQuality == 'low')
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                decoration: BoxDecoration(
+                  color: colors.textTertiary.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Text(
+                  '⚠️ Comparaison limitée (sujet peu couvert)',
+                  style: textTheme.labelSmall?.copyWith(
+                    fontSize: 11,
+                    color: colors.textTertiary,
+                  ),
+                ),
+              ),
+            ),
+          const SizedBox(height: 10),
+          // Interactive bias bar
+          Row(
+            children: List.generate(segments.length, (i) {
+              final seg = segments[i];
+              final count = merged[seg.$1] ?? 0;
+              final isActive =
+                  selected.isEmpty || selected.contains(seg.$1);
+              return Expanded(
+                flex: flexValues[i],
+                child: GestureDetector(
+                  onTap: () => _onPerspectivesSegmentTap(seg.$1),
+                  child: AnimatedOpacity(
+                    duration: const Duration(milliseconds: 200),
+                    opacity: isActive ? 1.0 : 0.3,
+                    child: Column(
+                      children: [
+                        Center(
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 6, vertical: 2),
+                            decoration: BoxDecoration(
+                              color: seg.$3.withValues(
+                                  alpha: count > 0 ? 0.15 : 0.05),
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: FittedBox(
+                              fit: BoxFit.scaleDown,
+                              child: Text(
+                                seg.$2,
+                                maxLines: 1,
+                                style: TextStyle(
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.w600,
+                                  color: count > 0
+                                      ? seg.$3
+                                      : colors.textTertiary,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        AnimatedContainer(
+                          duration: const Duration(milliseconds: 200),
+                          curve: Curves.easeOut,
+                          height: 10,
+                          margin:
+                              const EdgeInsets.symmetric(horizontal: 1.5),
+                          decoration: BoxDecoration(
+                            color: count > 0
+                                ? seg.$3.withValues(
+                                    alpha: count == 1
+                                        ? 0.55
+                                        : (count == 2 ? 0.8 : 1.0))
+                                : seg.$3.withValues(alpha: 0.25),
+                            borderRadius: BorderRadius.circular(6),
+                            border: count > 0
+                                ? Border.all(
+                                    color:
+                                        Colors.black.withValues(alpha: 0.2),
+                                    width: 0.8,
+                                  )
+                                : null,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            }),
+          ),
+          // Source marker row — matches inline section exactly
+          if (sourceIndex >= 0 && response.sourceBiasStance != 'unknown') ...[
+            const SizedBox(height: 4),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final totalFlex =
+                    flexValues.fold<int>(0, (sum, f) => sum + f);
+                double offsetFraction = 0;
+                for (int i = 0; i < sourceIndex; i++) {
+                  offsetFraction += flexValues[i] / totalFlex;
+                }
+                offsetFraction +=
+                    (flexValues[sourceIndex] / totalFlex) / 2;
+
+                final markerX = constraints.maxWidth * offsetFraction;
+                final sourceColor = segments[sourceIndex].$3;
+                final sourceName = _content?.source.name ?? '';
+                final displayName = sourceName.isNotEmpty
+                    ? sourceName
+                    : segments[sourceIndex].$2;
+
+                return SizedBox(
+                  height: 28,
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      Positioned(
+                        left: markerX - 7,
+                        top: 0,
+                        child: CustomPaint(
+                          size: const Size(14, 8),
+                          painter: PerspectivesTrianglePainter(
+                              color: sourceColor),
+                        ),
+                      ),
+                      Positioned(
+                        left: (markerX - 50)
+                            .clamp(0.0, constraints.maxWidth - 100),
+                        top: 10,
+                        child: SizedBox(
+                          width: 100,
+                          child: Text(
+                            displayName,
+                            textAlign: TextAlign.center,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 10,
+                              fontWeight: FontWeight.w700,
+                              color: sourceColor,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
   Widget _buildSourcePlaceholder(FacteurColors colors) {
     return Container(
       width: 24,
@@ -2099,7 +2912,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     children: [
                       // Spacer: scrolls with content, initially behind the header overlay
                       SizedBox(height: headerHeight),
-                      // ZONE 1: Article content — opaque background hides WebView
+                      // ZONE 1: Article content — opaque background hides WebView.
                       Container(
                         key: _articleKey,
                         color: colors.backgroundPrimary,
@@ -2115,7 +2928,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           header: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              // Extra breathing room so tag chips aren't clipped by the header overlay
                               const SizedBox(height: FacteurSpacing.space2),
                               if (content.thumbnailUrl != null) ...[
                                 ClipRRect(
@@ -2128,9 +2940,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 ),
                                 const SizedBox(height: FacteurSpacing.space3),
                               ],
-                              // Entity chips + partial badge row
-                              if (content.entities.isNotEmpty ||
-                                  isPartial) ...[
+                              if (content.entities.isNotEmpty || isPartial) ...[
                                 Wrap(
                                   spacing: 6,
                                   runSpacing: 4,
@@ -2139,9 +2949,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                     if (isPartial)
                                       Container(
                                         padding: const EdgeInsets.symmetric(
-                                          horizontal: 10,
-                                          vertical: 4,
-                                        ),
+                                            horizontal: 10, vertical: 4),
                                         decoration: BoxDecoration(
                                           color: colors.warning
                                               .withOpacity(0.12),
@@ -2150,8 +2958,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                         ),
                                         child: Text(
                                           'Aperçu — contenu partiel',
-                                          style:
-                                              textTheme.labelSmall?.copyWith(
+                                          style: textTheme.labelSmall?.copyWith(
                                             color: colors.warning,
                                             fontWeight: FontWeight.w600,
                                           ),
@@ -2164,40 +2971,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 ),
                                 const SizedBox(height: FacteurSpacing.space4),
                               ],
-                              Text(
-                                content.title,
-                                style: textTheme.displayLarge
-                                    ?.copyWith(fontSize: 24),
-                              ),
-                              const SizedBox(height: FacteurSpacing.space2),
-                              if (readingTime != null) ...[
-                                Row(
-                                  children: [
-                                    Icon(
-                                      PhosphorIcons.timer(
-                                          PhosphorIconsStyle.regular),
-                                      size: 14,
-                                      color: colors.textTertiary,
-                                    ),
-                                    const SizedBox(width: 4),
-                                    Text(
-                                      readingTime,
-                                      style: textTheme.bodySmall?.copyWith(
-                                        color: colors.textTertiary,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: FacteurSpacing.space3),
-                              ],
-                              Divider(color: colors.border, height: 1),
-                              const SizedBox(height: FacteurSpacing.space4),
                             ],
                           ),
+                          ),
                         ),
-                      ),
-
-                      // Article feedback thumbs
+// Article feedback thumbs
                       Container(
                         color: colors.backgroundPrimary,
                         padding: const EdgeInsets.symmetric(
@@ -2206,117 +2984,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         child: ArticleThumbsFeedback(contentId: content.id),
                       ),
 
-                      // ZONE 2: CTA button — intentional transition to WebView
-                      Container(
-                        color: colors.backgroundPrimary,
-                        child: Padding(
-                          key: _bridgeKey,
-                          padding: EdgeInsets.only(
-                            left: FacteurSpacing.space4,
-                            right: FacteurSpacing.space4,
-                            top: FacteurSpacing.space3,
-                            bottom: FacteurSpacing.space3 + bottomInset,
-                          ),
-                          child: GestureDetector(
-                            onTap: () {
-                              if (_offsetsComputed && !_ctaTapped) {
-                                setState(() {
-                                  _ctaTapped = true;
-                                });
-                                WidgetsBinding.instance
-                                    .addPostFrameCallback((_) {
-                                  if (mounted) {
-                                    _scrollController.animateTo(
-                                      _scrollController
-                                          .position.maxScrollExtent,
-                                      duration:
-                                          const Duration(milliseconds: 500),
-                                      curve: Curves.easeInOutCubic,
-                                    );
-                                  }
-                                });
-                              }
-                            },
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 24,
-                                vertical: 16,
-                              ),
-                              decoration: BoxDecoration(
-                                color: colors.surfaceElevated,
-                                borderRadius:
-                                    BorderRadius.circular(FacteurRadius.large),
-                                border: Border.all(
-                                  color: colors.border.withOpacity(0.5),
-                                ),
-                              ),
-                              child: Row(
-                                children: [
-                                  if (content.source.logoUrl != null)
-                                    ClipRRect(
-                                      borderRadius: BorderRadius.circular(8),
-                                      child: CachedNetworkImage(
-                                        imageUrl: content.source.logoUrl!,
-                                        width: 28,
-                                        height: 28,
-                                        fit: BoxFit.cover,
-                                        errorWidget: (_, __, ___) => Container(
-                                          width: 28,
-                                          height: 28,
-                                          decoration: BoxDecoration(
-                                            color: colors.surface,
-                                            borderRadius:
-                                                BorderRadius.circular(8),
-                                          ),
-                                          child: Icon(
-                                            PhosphorIcons.newspaper(
-                                                PhosphorIconsStyle.regular),
-                                            size: 16,
-                                            color: colors.textTertiary,
-                                          ),
-                                        ),
-                                      ),
-                                    )
-                                  else
-                                    Container(
-                                      width: 28,
-                                      height: 28,
-                                      decoration: BoxDecoration(
-                                        color: colors.surface,
-                                        borderRadius: BorderRadius.circular(8),
-                                      ),
-                                      child: Icon(
-                                        PhosphorIcons.newspaper(
-                                            PhosphorIconsStyle.regular),
-                                        size: 16,
-                                        color: colors.textTertiary,
-                                      ),
-                                    ),
-                                  const SizedBox(width: 12),
-                                  Expanded(
-                                    child: Text(
-                                      'Lire sur ${content.source.name}',
-                                      style: textTheme.bodyMedium?.copyWith(
-                                        fontWeight: FontWeight.w600,
-                                        color: colors.textPrimary,
-                                      ),
-                                    ),
-                                  ),
-                                  Icon(
-                                    PhosphorIcons.arrowRight(
-                                        PhosphorIconsStyle.regular),
-                                    size: 20,
-                                    color: colors.textTertiary,
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-
-                      // ZONE 3: Transparent spacer — only after CTA tap to enable scroll animation
-                      if (_ctaTapped) SizedBox(height: availableHeight),
+// ZONE 3: Transparent spacer — only after CTA tap to enable scroll animation.
+                      // _bridgeKey attached here so _computeScrollOffsets() can measure the bridge zone.
+                      if (_ctaTapped)
+                        SizedBox(key: _bridgeKey, height: availableHeight),
                     ],
                   ),
                 ),
@@ -2706,167 +3377,182 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           readingTime = '$minutes min de lecture';
         }
 
-        return ArticleReaderWidget(
+        // Pure HTML renderer — no header/footer props, layout is owned by the
+        // outer Column below.
+        final articleWidget = ArticleReaderWidget(
           htmlContent: content.htmlContent,
           description: content.description,
           title: content.title,
+          shrinkWrap: true,
           onLinkTap: _animateAndLaunch,
           bodyPlaceholder: !_contentResolved
               ? _buildArticleBodySkeleton(colors)
               : null,
-          header: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+        );
+
+        return ScrollConfiguration(
+          // Hide the system scroll indicator — reading progress is shown by the
+          // progress bar instead.
+          behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
+          child: SingleChildScrollView(
+            key: _scrollViewKey,
+            controller: _inAppScrollController,
+            child: Column(
+            spacing: 16,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              // Spacer: scrolls with content, initially behind the header overlay
+
+              // ── Header clearance ──────────────────────────────────────
               SizedBox(height: headerHeight),
-              // Extra breathing room so tag chips aren't clipped by the header overlay
-              const SizedBox(height: FacteurSpacing.space2),
-              // Hero thumbnail image (smooth integration)
-              if (content.thumbnailUrl != null) ...[
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(FacteurRadius.large),
-                  child: FacteurThumbnail(
-                    imageUrl: content.thumbnailUrl,
-                    aspectRatio: 16 / 9,
-                  ),
-                ),
-                const SizedBox(height: FacteurSpacing.space3),
-              ],
-              // Entity chips + partial badge row
-              if (content.entities.isNotEmpty || isPartial) ...[
-                Wrap(
-                  spacing: 6,
-                  runSpacing: 4,
-                  crossAxisAlignment: WrapCrossAlignment.center,
+
+              // ── Top section: thumbnail → chips → title → reading time ─
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: FacteurSpacing.space4),
+                child: Column(
+                  spacing: 12,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    if (isPartial)
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 10,
-                          vertical: 4,
-                        ),
-                        decoration: BoxDecoration(
-                          color: colors.warning.withOpacity(0.12),
-                          borderRadius:
-                              BorderRadius.circular(FacteurRadius.pill),
-                        ),
-                        child: Text(
-                          'Aperçu — contenu partiel',
-                          style: textTheme.labelSmall?.copyWith(
-                            color: colors.warning,
-                            fontWeight: FontWeight.w600,
-                          ),
+if (content.thumbnailUrl != null)
+                      ClipRRect(
+                        borderRadius:
+                            BorderRadius.circular(FacteurRadius.large),
+                        child: FacteurThumbnail(
+                          imageUrl: content.thumbnailUrl,
+                          aspectRatio: 16 / 9,
                         ),
                       ),
-                    if (content.entities.isNotEmpty)
-                      ..._buildArticleTagWidgets(context, content),
-                  ],
-                ),
-                const SizedBox(height: FacteurSpacing.space4),
-              ],
-              // Title
-              Text(
-                content.title,
-                style: textTheme.displayLarge?.copyWith(fontSize: 24),
-              ),
-              const SizedBox(height: FacteurSpacing.space2),
-              // Reading time
-              if (readingTime != null) ...[
-                Row(
-                  children: [
-                    Icon(
-                      PhosphorIcons.timer(PhosphorIconsStyle.regular),
-                      size: 14,
-                      color: colors.textTertiary,
-                    ),
-                    const SizedBox(width: 4),
+                    if (content.entities.isNotEmpty || isPartial)
+                      Wrap(
+                        spacing: 6,
+                        runSpacing: 4,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: [
+                          if (isPartial)
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 10, vertical: 4),
+                              decoration: BoxDecoration(
+                                color: colors.warning.withValues(alpha: 0.12),
+                                borderRadius: BorderRadius.circular(
+                                    FacteurRadius.pill),
+                              ),
+                              child: Text(
+                                'Aperçu — contenu partiel',
+                                style: textTheme.labelSmall?.copyWith(
+                                  color: colors.warning,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ),
+                          if (content.entities.isNotEmpty)
+                            ..._buildArticleTagWidgets(context, content),
+                        ],
+                      ),
+                    if (content.editorialBadge != null)
+                      EditorialBadge.chip(
+                            content.editorialBadge,
+                            context: context,
+                          ) ??
+                          const SizedBox.shrink(),
                     Text(
-                      readingTime,
-                      style: textTheme.bodySmall?.copyWith(
-                        color: colors.textTertiary,
-                      ),
+                      content.title,
+                      style: textTheme.displayLarge?.copyWith(fontSize: 24),
                     ),
-                  ],
-                ),
-                const SizedBox(height: FacteurSpacing.space3),
-              ],
-              Divider(color: colors.border, height: 1),
-              const SizedBox(height: FacteurSpacing.space4),
-            ],
-          ),
-          footer: GestureDetector(
-            onTap: kIsWeb
-                ? _openOriginalUrl
-                : () => setState(() => _showWebView = true),
-            child: Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 24,
-                vertical: 16,
-              ),
-              decoration: BoxDecoration(
-                color: colors.surfaceElevated,
-                borderRadius: BorderRadius.circular(FacteurRadius.large),
-                border: Border.all(
-                  color: colors.border.withOpacity(0.5),
-                ),
-              ),
-              child: Row(
-                children: [
-                  if (content.source.logoUrl != null)
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: CachedNetworkImage(
-                        imageUrl: content.source.logoUrl!,
-                        width: 28,
-                        height: 28,
-                        fit: BoxFit.cover,
-                        errorWidget: (_, __, ___) => Container(
-                          width: 28,
-                          height: 28,
-                          decoration: BoxDecoration(
-                            color: colors.surface,
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: Icon(
-                            PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
-                            size: 16,
+if (readingTime != null)
+                      Row(
+                        children: [
+                          Icon(
+                            PhosphorIcons.timer(PhosphorIconsStyle.regular),
+                            size: 14,
                             color: colors.textTertiary,
                           ),
-                        ),
+                          const SizedBox(width: 4),
+                          Text(
+                            readingTime,
+                            style: textTheme.bodySmall?.copyWith(
+                                color: colors.textTertiary),
+                          ),
+                        ],
                       ),
-                    )
-                  else
-                    Container(
-                      width: 28,
-                      height: 28,
-                      decoration: BoxDecoration(
-                        color: colors.surface,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Icon(
-                        PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
-                        size: 16,
-                        color: colors.textTertiary,
-                      ),
-                    ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      'Lire sur ${content.source.name}',
-                      style: textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
-                        color: colors.textPrimary,
-                      ),
-                    ),
-                  ),
-                  Icon(
-                    PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
-                    size: 20,
-                    color: colors.textTertiary,
-                  ),
+                  ],
+                ),
+              ),
+
+              // ── Divider: header / article ─────────────────────────────
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: FacteurSpacing.space4),
+                child: Divider(color: colors.border, height: 1),
+              ),
+
+              // ── Article section ────────────────────────────────────────
+              // Zero-height marker at the end lets _measureArticleExtent()
+              // compute progress against article length only (excludes perspectives).
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  articleWidget,
+                  SizedBox(key: _articleEndKey, height: 0),
                 ],
               ),
-            ),
+
+              // ── Perspectives section ───────────────────────────────────
+              if (_perspectivesResponse != null || _perspectivesLoading) ...[
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: FacteurSpacing.space4),
+                  child: Divider(color: colors.border, height: 1),
+                ),
+                if (_perspectivesLoading && _perspectivesResponse == null)
+                  const Center(child: CircularProgressIndicator())
+                else if (_perspectivesResponse != null)
+                  PerspectivesInlineSection(
+                    key: _perspectivesKey,
+                    perspectives: _perspectivesResponse!.perspectives
+                        .map(
+                          (PerspectiveData p) => Perspective(
+                            title: p.title,
+                            url: p.url,
+                            sourceName: p.sourceName,
+                            sourceDomain: p.sourceDomain,
+                            biasStance: p.biasStance,
+                            publishedAt: p.publishedAt,
+                          ),
+                        )
+                        .toList(),
+                    biasDistribution:
+                        _perspectivesResponse!.biasDistribution,
+                    keywords: _perspectivesResponse!.keywords,
+                    sourceBiasStance:
+                        _perspectivesResponse!.sourceBiasStance,
+                    sourceName: _content?.source.name ?? '',
+                    contentId: widget.contentId,
+                    comparisonQuality:
+                        _perspectivesResponse!.comparisonQuality,
+                    externalSelectedSegments: _perspectivesSelectedSegments,
+                    onSegmentTap: _onPerspectivesSegmentTap,
+                    onClearSegments: () {
+                      setState(() => _perspectivesSelectedSegments = {});
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (mounted) _checkAtPerspectivesSection();
+                      });
+                    },
+                    analysisState: _perspectivesAnalysisState,
+                    analysisText: _perspectivesAnalysisText,
+                    onRequestAnalysis: _requestPerspectivesAnalysis,
+                    analysisZoneKey: _analysisZoneKey,
+                  ),
+              ],
+
+              // ── Footer clearance ───────────────────────────────────────
+              SizedBox(
+                height: _kFooterContentHeight +
+                    MediaQuery.of(context).viewPadding.bottom,
+              ),
+
+            ],
+          ),
           ),
         );
 
@@ -2931,6 +3617,95 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         SizedBox(height: headerHeight),
         Expanded(child: WebViewWidget(controller: _webViewController!)),
       ],
+    );
+  }
+}
+
+/// Eye button that winks periodically (scaleY close → open) to hint at perspectives.
+class _WinkingEyeButton extends StatefulWidget {
+  final VoidCallback onTap;
+  final ButtonStyle? style;
+  final Color iconColor;
+
+  const _WinkingEyeButton({
+    required this.onTap,
+    this.style,
+    required this.iconColor,
+  });
+
+  @override
+  State<_WinkingEyeButton> createState() => _WinkingEyeButtonState();
+}
+
+class _WinkingEyeButtonState extends State<_WinkingEyeButton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scaleY;
+  final math.Random _rng = math.Random();
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 320),
+    );
+    _scaleY = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween<double>(begin: 1.0, end: 0.05)
+            .chain(CurveTween(curve: Curves.easeIn)),
+        weight: 30, // close fast (~96ms)
+      ),
+      TweenSequenceItem(
+        tween: Tween<double>(begin: 0.05, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeOut)),
+        weight: 70, // open slower (~224ms)
+      ),
+    ]).animate(_controller);
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) _scheduleNext();
+    });
+    _scheduleNext();
+  }
+
+  void _scheduleNext() {
+    final delayMs = 4000 + _rng.nextInt(11000); // 4–15 s
+    _timer?.cancel();
+    _timer = Timer(Duration(milliseconds: delayMs), () {
+      if (mounted) _controller.forward(from: 0);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _scaleY,
+      builder: (context, _) {
+        final isWinking = _scaleY.value < 0.5;
+        return IconButton(
+          style: widget.style,
+          onPressed: widget.onTap,
+          tooltip: 'Autres points de vue',
+          icon: Transform.scale(
+            scaleY: _scaleY.value,
+            child: Icon(
+              isWinking
+                  ? PhosphorIcons.eyeClosed(PhosphorIconsStyle.regular)
+                  : PhosphorIcons.eye(PhosphorIconsStyle.regular),
+              size: 22,
+              color: widget.iconColor,
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -25,6 +25,8 @@ import '../../feed/repositories/feed_repository.dart';
 import '../../feed/widgets/perspectives_bottom_sheet.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../../feed/widgets/perspectives_pill.dart';
+import '../../../widgets/sunflower_icon.dart';
+import '../providers/nudge_provider.dart' show NudgeTracker;
 import '../widgets/article_reader_widget.dart';
 import '../widgets/audio_player_widget.dart';
 import '../widgets/youtube_player_widget.dart';
@@ -116,6 +118,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   Timer? _readingTimer;
   Timer? _noteNudgeTimer;
   Timer? _scrollStopTimer;
+  // 🌻 Nudge "Recommander ?" state
+  Timer? _sunflowerNudgeTimer;
+  bool _showSunflowerNudge = false;
   Timer? _inactivityTimer;
   double _webScrollY = 0.0;
   late AnimationController _headerAutoController;
@@ -302,6 +307,24 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     NoteWelcomeTooltip.shouldShow().then((show) {
       if (mounted && show) {
         setState(() => _showNoteWelcome = true);
+      }
+    });
+
+    // 🌻 Nudge: record article open and start 30s timer
+    NudgeTracker.recordArticleOpen();
+    _sunflowerNudgeTimer = Timer(const Duration(seconds: 30), () async {
+      if (!mounted) return;
+      final isLiked = _content?.isLiked ?? false;
+      final shouldShow = await NudgeTracker.shouldShowNudge(
+        isAlreadySunflowered: isLiked,
+      );
+      if (shouldShow && mounted) {
+        setState(() => _showSunflowerNudge = true);
+        NudgeTracker.markNudgeShown();
+        // Auto-dismiss after 5 seconds
+        Future.delayed(const Duration(seconds: 5), () {
+          if (mounted) setState(() => _showSunflowerNudge = false);
+        });
       }
     });
 
@@ -641,6 +664,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   /// Update header offset and FAB opacity based on scroll delta (in pixels).
   /// Positive delta = scrolling down, negative = scrolling up.
   void _onScrollDelta(double delta) {
+    // Dismiss sunflower nudge on any scroll
+    if (_showSunflowerNudge) {
+      setState(() => _showSunflowerNudge = false);
+    }
     final isVideo = _content?.isVideo ?? false;
     _videoPlayHideTimer?.cancel();
     if (_fabOpacity.value != 0.07) {
@@ -836,8 +863,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     HapticFeedback.lightImpact();
     final wasLiked = content.isLiked;
     final newLiked = !wasLiked;
+    // Cancel the pending nudge timer if the user sunflowers manually during
+    // the 30s wait — avoids firing a redundant "Recommander ?" pill.
+    _sunflowerNudgeTimer?.cancel();
     setState(() {
       _content = content.copyWith(isLiked: newLiked);
+      _showSunflowerNudge = false;
     });
 
     // Bounce animation
@@ -851,8 +882,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       if (mounted) {
         NotificationService.showInfo(
           newLiked
-              ? 'Ajouté à vos contenus favoris'
-              : 'Retiré de vos contenus favoris',
+              ? 'Ajouté à Mes contenus recommandés 🌻'
+              : 'Retiré de Mes contenus recommandés 🌻',
         );
         // Refresh collections to update liked collection counts
         ref.invalidate(collectionsProvider);
@@ -982,6 +1013,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _readingTimer?.cancel();
     _noteNudgeTimer?.cancel();
     _scrollStopTimer?.cancel();
+    _sunflowerNudgeTimer?.cancel();
     _inactivityTimer?.cancel();
     _videoPlayHideTimer?.cancel();
     _linkCopiedFabTimer?.cancel();
@@ -1714,33 +1746,82 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           ),
                           const SizedBox(height: 12),
                         ],
-                        // Like FAB
-                        ScaleTransition(
-                          scale: _likeScaleAnimation,
-                          child: SizedBox(
-                            width: 50,
-                            height: 50,
-                            child: FloatingActionButton(
-                              onPressed: _toggleLike,
-                              backgroundColor: content.isLiked
-                                  ? colors.primary
-                                  : Colors.white,
-                              foregroundColor: content.isLiked
-                                  ? Colors.white
-                                  : colors.textPrimary,
-                              elevation: content.isLiked ? 4 : 2,
-                              heroTag: 'like_fab',
-                              tooltip: 'J\'aime',
-                              child: Icon(
-                                content.isLiked
-                                    ? PhosphorIcons.heart(
-                                        PhosphorIconsStyle.fill)
-                                    : PhosphorIcons.heart(
-                                        PhosphorIconsStyle.regular),
-                                size: 25,
+                        // 🌻 Sunflower recommendation FAB + nudge label
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            // Animated "Recommander ?" nudge label
+                            AnimatedSwitcher(
+                              duration: const Duration(milliseconds: 300),
+                              transitionBuilder: (child, animation) =>
+                                  FadeTransition(
+                                opacity: animation,
+                                child: SlideTransition(
+                                  position: Tween<Offset>(
+                                    begin: const Offset(0.3, 0),
+                                    end: Offset.zero,
+                                  ).animate(animation),
+                                  child: child,
+                                ),
+                              ),
+                              child: _showSunflowerNudge
+                                  ? Container(
+                                      key: const ValueKey('nudge_visible'),
+                                      margin: const EdgeInsets.only(right: 10),
+                                      padding: const EdgeInsets.symmetric(
+                                          horizontal: 12, vertical: 6),
+                                      decoration: BoxDecoration(
+                                        color: const Color(0xFFFFF8E1),
+                                        borderRadius:
+                                            BorderRadius.circular(16),
+                                        boxShadow: [
+                                          BoxShadow(
+                                            color:
+                                                Colors.black.withOpacity(0.1),
+                                            blurRadius: 8,
+                                            offset: const Offset(0, 2),
+                                          ),
+                                        ],
+                                      ),
+                                      child: const Text(
+                                        'Recommander ? 🌻',
+                                        style: TextStyle(
+                                          fontSize: 13,
+                                          fontWeight: FontWeight.w600,
+                                          color: Color(0xFF795548),
+                                        ),
+                                      ),
+                                    )
+                                  : const SizedBox.shrink(
+                                      key: ValueKey('nudge_hidden'),
+                                    ),
+                            ),
+                            ScaleTransition(
+                              scale: _likeScaleAnimation,
+                              child: SizedBox(
+                                width: 50,
+                                height: 50,
+                                child: FloatingActionButton(
+                                  onPressed: _toggleLike,
+                                  backgroundColor: content.isLiked
+                                      ? colors.primary
+                                      : Colors.white,
+                                  foregroundColor: content.isLiked
+                                      ? Colors.white
+                                      : colors.textPrimary,
+                                  elevation: content.isLiked ? 4 : 2,
+                                  heroTag: 'sunflower_fab',
+                                  tooltip: 'Recommander',
+                                  child: SunflowerIcon(
+                                    isActive: content.isLiked,
+                                    size: 25,
+                                    inactiveColor: colors.textPrimary,
+                                  ),
+                                ),
                               ),
                             ),
-                          ),
+                          ],
                         ),
                         const SizedBox(height: 12),
                         // Merged Bookmark + Note FAB (long-press for collection picker)
@@ -2005,21 +2086,18 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 ),
               ),
 
-              // J'aime
+              // 🌻 Recommander
               ScaleTransition(
                 scale: _likeScaleAnimation,
                 child: IconButton(
                   style: iconButtonStyle,
                   onPressed: _toggleLike,
-                  icon: Icon(
-                    content.isLiked
-                        ? PhosphorIcons.heart(PhosphorIconsStyle.fill)
-                        : PhosphorIcons.heart(PhosphorIconsStyle.regular),
+                  icon: SunflowerIcon(
+                    isActive: content.isLiked,
                     size: 24,
-                    color:
-                        content.isLiked ? colors.primary : colors.textSecondary,
+                    inactiveColor: colors.textSecondary,
                   ),
-                  tooltip: "J'aime",
+                  tooltip: 'Recommander',
                 ),
               ),
             ],

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -25,8 +25,6 @@ import '../../feed/repositories/feed_repository.dart';
 import '../../feed/widgets/perspectives_bottom_sheet.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../../feed/widgets/perspectives_pill.dart';
-import '../../../widgets/sunflower_icon.dart';
-import '../providers/nudge_provider.dart' show NudgeTracker;
 import '../widgets/article_reader_widget.dart';
 import '../widgets/audio_player_widget.dart';
 import '../widgets/youtube_player_widget.dart';
@@ -34,7 +32,6 @@ import '../widgets/note_input_sheet.dart';
 import '../widgets/note_welcome_tooltip.dart';
 import '../../custom_topics/widgets/topic_chip.dart';
 import '../../digest/widgets/editorial_badge.dart';
-import '../../digest/widgets/article_thumbs_feedback.dart';
 import '../../custom_topics/providers/custom_topics_provider.dart';
 import '../../../core/ui/notification_service.dart';
 import '../../saved/widgets/collection_picker_sheet.dart';
@@ -89,7 +86,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   bool _showFab = false;
   bool _showShareFab = false;
   bool _isShortArticle = false;
-  bool _footerPermanent = false; // true once user reaches end of displayed content
+  bool _footerPermanent =
+      false; // true once user reaches end of displayed content
   final ValueNotifier<bool> _atPerspectivesSection = ValueNotifier(false);
   bool _showNoteWelcome = false;
   bool _linkCopiedFab = false;
@@ -118,17 +116,14 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   Timer? _readingTimer;
   Timer? _noteNudgeTimer;
   Timer? _scrollStopTimer;
-  // 🌻 Nudge "Recommander ?" state
-  Timer? _sunflowerNudgeTimer;
-  bool _showSunflowerNudge = false;
   Timer? _inactivityTimer;
   double _webScrollY = 0.0;
-  double _prevNativeScrollOffset = 0.0;
   late AnimationController _headerAutoController;
   double _headerAutoStart = 0.0;
   double _headerAutoTarget = 0.0;
 
   final ValueNotifier<double> _fabOpacity = ValueNotifier<double>(0.07);
+
   /// Header slide offset as a fraction: 0.0 = fully visible, 1.0 = fully hidden.
   final ValueNotifier<double> _headerOffset = ValueNotifier<double>(0.0);
   bool _isConsumed = false;
@@ -310,24 +305,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       }
     });
 
-    // 🌻 Nudge: record article open and start 30s timer
-    NudgeTracker.recordArticleOpen();
-    _sunflowerNudgeTimer = Timer(const Duration(seconds: 30), () async {
-      if (!mounted) return;
-      final isLiked = _content?.isLiked ?? false;
-      final shouldShow = await NudgeTracker.shouldShowNudge(
-        isAlreadySunflowered: isLiked,
-      );
-      if (shouldShow && mounted) {
-        setState(() => _showSunflowerNudge = true);
-        NudgeTracker.markNudgeShown();
-        // Auto-dismiss after 5 seconds
-        Future.delayed(const Duration(seconds: 5), () {
-          if (mounted) setState(() => _showSunflowerNudge = false);
-        });
-      }
-    });
-
     // Start timer if content is suitable for in-app reading/viewing and not already consumed
     final isVideo = _content?.isVideo ?? false;
     if ((_content?.hasInAppContent == true || isVideo) && !_isConsumed) {
@@ -346,9 +323,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
     // Reading progress: track scroll depth
     _scrollController.addListener(_onScrollReadingProgress);
-
-    // Header hide/show: track scroll delta for native in-app content
-    _scrollController.addListener(_onNativeScrollHeader);
 
     // End-of-article nudge: show contextual action when progress >= 90%
     _readingProgress.addListener(_onReadingProgressNudge);
@@ -656,16 +630,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _headerAutoController.forward(from: 0);
   }
 
-/// Scroll listener for native (in-app) content — computes delta from previous
-  /// offset and forwards it to [_onScrollDelta].
-  void _onNativeScrollHeader() {
-    if (!_scrollController.hasClients || _isWebViewActive) return;
-    final current = _scrollController.offset;
-    final delta = current - _prevNativeScrollOffset;
-    _prevNativeScrollOffset = current;
-    if (delta != 0) _onScrollDelta(delta);
-  }
-
   /// Smoothly animate the footer to [target] offset (0.0 = visible, 1.0 = hidden).
   void _animateFooterTo(double target) {
     _footerAutoController.stop();
@@ -677,10 +641,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   /// Update header offset and FAB opacity based on scroll delta (in pixels).
   /// Positive delta = scrolling down, negative = scrolling up.
   void _onScrollDelta(double delta) {
-    // Dismiss sunflower nudge on any scroll
-    if (_showSunflowerNudge) {
-      setState(() => _showSunflowerNudge = false);
-    }
     final isVideo = _content?.isVideo ?? false;
     _videoPlayHideTimer?.cancel();
     if (_fabOpacity.value != 0.07) {
@@ -701,12 +661,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         final bottomInset = MediaQuery.of(context).viewPadding.bottom;
         final footerHeight = _kFooterContentHeight + bottomInset;
         final footerShift = delta / footerHeight;
-        _footerOffset.value = (_footerOffset.value + footerShift).clamp(0.0, 1.0);
+        _footerOffset.value =
+            (_footerOffset.value + footerShift).clamp(0.0, 1.0);
       }
     }
     // FABs + footer reappear after 2.5s of scroll inactivity
     _scrollStopTimer?.cancel();
-    _scrollStopTimer = Timer(const Duration(milliseconds: 2500), () {
+    _scrollStopTimer = Timer(const Duration(milliseconds: 2000), () {
       if (mounted) {
         _fabOpacity.value = 1.0;
         _fabReappearController.forward(from: 0);
@@ -717,10 +678,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _inactivityTimer?.cancel();
     if (!isVideo && !_isShortArticle) {
       _inactivityTimer = Timer(const Duration(seconds: 3), () {
-        final nativeScrollY =
-            _scrollController.hasClients ? _scrollController.offset : 0.0;
-        final scrolledPastTop = _webScrollY > 0 || nativeScrollY > 0;
-        if (mounted && scrolledPastTop && _headerOffset.value < 1.0) {
+        if (mounted && _webScrollY > 0 && _headerOffset.value < 1.0) {
           _animateHeaderTo(1.0);
         }
       });
@@ -750,8 +708,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           // Fixes cases where RSS provides longer htmlContent than the API
           // (e.g. Le Monde articles where enrichment returns a shorter version).
           final merged = content.copyWith(
-            description: _pickLongest(content.description, _content?.description),
-            htmlContent: _pickLongest(content.htmlContent, _content?.htmlContent),
+            description:
+                _pickLongest(content.description, _content?.description),
+            htmlContent:
+                _pickLongest(content.htmlContent, _content?.htmlContent),
             editorialBadge: content.editorialBadge ?? _content?.editorialBadge,
           );
           setState(() {
@@ -782,28 +742,19 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             _fetchPerspectives();
           }
         } else {
-          // Content not found via API. Keep whatever was passed via extra
-          // (e.g. a digest "Pas de recul" article whose row was just culled
-          // server-side) so the screen still renders instead of bouncing
-          // the user back to the previous screen with a blank flash.
+          // Show error and pop if content not found
           setState(() => _contentResolved = true);
-          if (_content == null) {
-            NotificationService.showError('Contenu introuvable',
-                context: context);
-            context.pop();
-          }
+          NotificationService.showError('Contenu introuvable',
+              context: context);
+          context.pop();
         }
       }
     } catch (e) {
       debugPrint('Error fetching content: $e');
       if (mounted) {
         setState(() => _contentResolved = true);
-        // Same fallback: only pop when we truly have nothing to show.
-        if (_content == null) {
-          NotificationService.showError('Erreur de chargement',
-              context: context);
-          context.pop();
-        }
+        NotificationService.showError('Erreur de chargement', context: context);
+        context.pop();
       }
     }
   }
@@ -885,12 +836,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     HapticFeedback.lightImpact();
     final wasLiked = content.isLiked;
     final newLiked = !wasLiked;
-    // Cancel the pending nudge timer if the user sunflowers manually during
-    // the 30s wait — avoids firing a redundant "Recommander ?" pill.
-    _sunflowerNudgeTimer?.cancel();
     setState(() {
       _content = content.copyWith(isLiked: newLiked);
-      _showSunflowerNudge = false;
     });
 
     // Bounce animation
@@ -904,8 +851,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       if (mounted) {
         NotificationService.showInfo(
           newLiked
-              ? 'Ajouté à Mes contenus recommandés 🌻'
-              : 'Retiré de Mes contenus recommandés 🌻',
+              ? 'Ajouté à vos contenus favoris'
+              : 'Retiré de vos contenus favoris',
         );
         // Refresh collections to update liked collection counts
         ref.invalidate(collectionsProvider);
@@ -1035,7 +982,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _readingTimer?.cancel();
     _noteNudgeTimer?.cancel();
     _scrollStopTimer?.cancel();
-    _sunflowerNudgeTimer?.cancel();
     _inactivityTimer?.cancel();
     _videoPlayHideTimer?.cancel();
     _linkCopiedFabTimer?.cancel();
@@ -1320,8 +1266,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         sourceName: _content?.source.name ?? '',
         contentId: widget.contentId,
         comparisonQuality: response.comparisonQuality,
-        initialAnalysis: response.analysis,
-        analysisCached: response.analysisCached,
       ),
     );
   }
@@ -1449,235 +1393,234 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           );
         },
         child: Stack(
-        children: [
-          NotificationListener<ScrollNotification>(
-            onNotification: (notification) {
-              if (notification is ScrollUpdateNotification) {
-                final delta = notification.scrollDelta ?? 0.0;
-                // Sync short-article flag from live scroll metrics (catches cases
-                // where the postFrameCallback hasn't fired yet).
-                if (!_isShortArticle &&
-                    notification.metrics.maxScrollExtent < 50) {
-                  _isShortArticle = true;
-                  _footerPermanent = true;
-                  _headerOffset.value = 0.0;
-                }
-                _onScrollDelta(delta);
-                _checkAtPerspectivesSection();
-                // Track reading progress from any scrollable (including in-app reader)
-                final metrics = notification.metrics;
-                if (metrics.maxScrollExtent > 0) {
-                  final rawProgress = metrics.pixels / metrics.maxScrollExtent;
-                  // Footer becomes permanent at end of ALL content (incl. perspectives)
-                  if (!_footerPermanent && rawProgress >= 0.98) {
+          children: [
+            NotificationListener<ScrollNotification>(
+              onNotification: (notification) {
+                if (notification is ScrollUpdateNotification) {
+                  final delta = notification.scrollDelta ?? 0.0;
+                  // Sync short-article flag from live scroll metrics (catches cases
+                  // where the postFrameCallback hasn't fired yet).
+                  if (!_isShortArticle &&
+                      notification.metrics.maxScrollExtent < 50) {
+                    _isShortArticle = true;
                     _footerPermanent = true;
-                    _animateFooterTo(0.0);
+                    _headerOffset.value = 0.0;
                   }
-                  // Progress bar uses article-only extent so perspectives don't dilute it
-                  final articleExtent =
-                      _articleContentExtent ?? metrics.maxScrollExtent;
-                  final barProgress = metrics.pixels / articleExtent;
-                  final capped = _isPartialContent
-                      ? (barProgress * 0.25).clamp(0.0, 0.25)
-                      : barProgress.clamp(0.0, 1.0);
-                  _readingProgress.value = capped;
-                  if (capped > _maxReadingProgress) {
-                    _maxReadingProgress = capped;
+                  _onScrollDelta(delta);
+                  _checkAtPerspectivesSection();
+                  // Track reading progress from any scrollable (including in-app reader)
+                  final metrics = notification.metrics;
+                  if (metrics.maxScrollExtent > 0) {
+                    final rawProgress =
+                        metrics.pixels / metrics.maxScrollExtent;
+                    // Footer becomes permanent at end of ALL content (incl. perspectives)
+                    if (!_footerPermanent && rawProgress >= 0.98) {
+                      _footerPermanent = true;
+                      _animateFooterTo(0.0);
+                    }
+                    // Progress bar uses article-only extent so perspectives don't dilute it
+                    final articleExtent =
+                        _articleContentExtent ?? metrics.maxScrollExtent;
+                    final barProgress = metrics.pixels / articleExtent;
+                    final capped = _isPartialContent
+                        ? (barProgress * 0.25).clamp(0.0, 0.25)
+                        : barProgress.clamp(0.0, 1.0);
+                    _readingProgress.value = capped;
+                    if (capped > _maxReadingProgress) {
+                      _maxReadingProgress = capped;
+                    }
                   }
                 }
-              }
-              return false;
-            },
-            child: Positioned.fill(
-              child: isVideoContent
-                  ? _buildVideoContent(context, content)
-                  : useScrollToSite
-                      ? _buildScrollToSiteContent(context, content)
-                      : useInAppReading
-                          ? _buildInAppContent(context, content)
-                          : _buildWebViewFallback(content),
-            ),
-          ),
-          // Header — follows scroll: slides up on scroll-down, back on scroll-up
-          // For short articles the header stays pinned (offset is never updated).
-          Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            child: ValueListenableBuilder<double>(
-              valueListenable: _headerOffset,
-              builder: (context, offset, child) {
-                final headerHeight =
-                    MediaQuery.of(context).padding.top + _kHeaderContentHeight;
-                return Transform.translate(
-                  offset: Offset(0, -offset * headerHeight),
-                  child: child!,
-                );
+                return false;
               },
-              child: _buildHeader(context, content),
+              child: Positioned.fill(
+                child: isVideoContent
+                    ? _buildVideoContent(context, content)
+                    : useScrollToSite
+                        ? _buildScrollToSiteContent(context, content)
+                        : useInAppReading
+                            ? _buildInAppContent(context, content)
+                            : _buildWebViewFallback(content),
+              ),
             ),
-          ),
-          // Opaque status-bar backdrop — only when WebView is active and
-          // the header has slid off-screen, so WebView content doesn't
-          // bleed through the transparent status bar zone.
-          if (_isWebViewActive)
-            ValueListenableBuilder<double>(
-              valueListenable: _headerOffset,
-              builder: (context, offset, _) {
-                final statusBarHeight = MediaQuery.of(context).padding.top;
-                return Positioned(
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  child: IgnorePointer(
-                    child: Opacity(
-                      opacity: offset,
-                      child: SizedBox(
-                        height: statusBarHeight,
-                        child: ColoredBox(color: colors.backgroundPrimary),
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
-          // Reading progress bar — follows header position continuously
-          if (content.hasInAppContent ||
-              _isWebViewActive ||
-              isVideoContent ||
-              (!useScrollToSite && !useInAppReading))
-            ValueListenableBuilder<double>(
-              valueListenable: _headerOffset,
-              builder: (context, offset, _) {
-                final statusBarHeight = MediaQuery.of(context).padding.top;
-                final topWhenHeaderVisible =
-                    statusBarHeight + _kHeaderContentHeight;
-                final topWhenHeaderHidden = statusBarHeight;
-                final top = topWhenHeaderVisible -
-                    offset * (topWhenHeaderVisible - topWhenHeaderHidden);
-                return Positioned(
-                  top: top,
-                  left: 0,
-                  right: 0,
-                  child: _buildReadingProgressBar(colors),
-                );
-              },
-            ),
-          // Sticky perspectives section header — appears below the app header
-          // when the inline section header has scrolled off-screen.
-          // Only shown for in-app article reading.
-          if (useInAppReading &&
-              content.contentType == ContentType.article &&
-              _perspectivesResponse != null)
-            ValueListenableBuilder<bool>(
-              valueListenable: _showStickyPerspectivesHeader,
-              builder: (context, showSticky, _) {
-                return ValueListenableBuilder<double>(
-                  valueListenable: _headerOffset,
-                  builder: (context, offset, _) {
-                    final statusBarHeight =
-                        MediaQuery.of(context).padding.top;
-                    // Sits immediately below the reading progress bar (+2px).
-                    final topWhenHeaderVisible =
-                        statusBarHeight + _kHeaderContentHeight + 2.0;
-                    final topWhenHeaderHidden = statusBarHeight + 2.0;
-                    final top = topWhenHeaderVisible -
-                        offset *
-                            (topWhenHeaderVisible - topWhenHeaderHidden);
-                    return Positioned(
-                      top: top,
-                      left: 0,
-                      right: 0,
-                      child: AnimatedOpacity(
-                        duration: const Duration(milliseconds: 200),
-                        opacity: showSticky ? 1.0 : 0.0,
-                        child: IgnorePointer(
-                          ignoring: !showSticky,
-                          child: _buildPerspectivesStickyHeader(
-                              context, _perspectivesResponse!),
-                        ),
-                      ),
-                    );
-                  },
-                );
-              },
-            ),
-          // Exit animation overlay — fade-to-white + scale-down
-          if (_isExitAnimating)
-            AnimatedBuilder(
-              animation: _exitAnimController,
-              builder: (context, _) {
-                return Positioned.fill(
-                  child: IgnorePointer(
-                    child: ColoredBox(
-                      color: Colors.white
-                          .withOpacity(0.6 * _exitAnimController.value),
-                    ),
-                  ),
-                );
-              },
-            ),
-          // Floating "Lancer l'analyse Facteur" button — in-app articles only.
-          // Visible when the perspectives section is on screen and analysis
-          // hasn't been triggered yet.
-          if (useInAppReading && content.contentType == ContentType.article)
+            // Header — follows scroll: slides up on scroll-down, back on scroll-up
+            // For short articles the header stays pinned (offset is never updated).
             Positioned(
-              right: 16,
-              bottom: _kFooterContentHeight +
-                  MediaQuery.of(context).viewPadding.bottom +
-                  12,
-              child: ValueListenableBuilder<bool>(
-                valueListenable: _atPerspectivesSection,
-                builder: (context, atPersp, _) {
-                  final show = atPersp &&
-                      _perspectivesAnalysisState ==
-                          PerspectivesAnalysisState.idle &&
-                      _perspectivesResponse != null &&
-                      _perspectivesResponse!.perspectives.isNotEmpty;
-                  return AnimatedOpacity(
-                    opacity: show ? 1.0 : 0.0,
-                    duration: const Duration(milliseconds: 200),
+              top: 0,
+              left: 0,
+              right: 0,
+              child: ValueListenableBuilder<double>(
+                valueListenable: _headerOffset,
+                builder: (context, offset, child) {
+                  final headerHeight = MediaQuery.of(context).padding.top +
+                      _kHeaderContentHeight;
+                  return Transform.translate(
+                    offset: Offset(0, -offset * headerHeight),
+                    child: child!,
+                  );
+                },
+                child: _buildHeader(context, content),
+              ),
+            ),
+            // Opaque status-bar backdrop — only when WebView is active and
+            // the header has slid off-screen, so WebView content doesn't
+            // bleed through the transparent status bar zone.
+            if (_isWebViewActive)
+              ValueListenableBuilder<double>(
+                valueListenable: _headerOffset,
+                builder: (context, offset, _) {
+                  final statusBarHeight = MediaQuery.of(context).padding.top;
+                  return Positioned(
+                    top: 0,
+                    left: 0,
+                    right: 0,
                     child: IgnorePointer(
-                      ignoring: !show,
-                      child: FilledButton.icon(
-                        onPressed: () {
-                          HapticFeedback.lightImpact();
-                          _requestPerspectivesAnalysis();
-                        },
-                        style: FilledButton.styleFrom(
-                          backgroundColor: context.facteurColors.primary
-                              .withValues(alpha: 1.0),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                        ),
-                        icon: Icon(
-                          PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
-                          size: 16,
-                          color: Colors.white,
-                        ),
-                        label: const Text(
-                          'Lancer l\'analyse Facteur',
-                          style: TextStyle(color: Colors.white),
+                      child: Opacity(
+                        opacity: offset,
+                        child: SizedBox(
+                          height: statusBarHeight,
+                          child: ColoredBox(color: colors.backgroundPrimary),
                         ),
                       ),
                     ),
                   );
                 },
               ),
-            ),
-          // Footer — shown for in-app article reading, mirrors header slide behavior
-          if (useScrollToSite ||
-              (useInAppReading &&
-                  content.contentType == ContentType.article))
-            Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              child: _buildArticleFooter(context, content),
-            ),
-        ],
-      ),
+            // Reading progress bar — follows header position continuously
+            if (content.hasInAppContent ||
+                _isWebViewActive ||
+                isVideoContent ||
+                (!useScrollToSite && !useInAppReading))
+              ValueListenableBuilder<double>(
+                valueListenable: _headerOffset,
+                builder: (context, offset, _) {
+                  final statusBarHeight = MediaQuery.of(context).padding.top;
+                  final topWhenHeaderVisible =
+                      statusBarHeight + _kHeaderContentHeight;
+                  final topWhenHeaderHidden = statusBarHeight;
+                  final top = topWhenHeaderVisible -
+                      offset * (topWhenHeaderVisible - topWhenHeaderHidden);
+                  return Positioned(
+                    top: top,
+                    left: 0,
+                    right: 0,
+                    child: _buildReadingProgressBar(colors),
+                  );
+                },
+              ),
+            // Sticky perspectives section header — appears below the app header
+            // when the inline section header has scrolled off-screen.
+            // Only shown for in-app article reading.
+            if (useInAppReading &&
+                content.contentType == ContentType.article &&
+                _perspectivesResponse != null)
+              ValueListenableBuilder<bool>(
+                valueListenable: _showStickyPerspectivesHeader,
+                builder: (context, showSticky, _) {
+                  return ValueListenableBuilder<double>(
+                    valueListenable: _headerOffset,
+                    builder: (context, offset, _) {
+                      final statusBarHeight =
+                          MediaQuery.of(context).padding.top;
+                      // Sits immediately below the reading progress bar (+2px).
+                      final topWhenHeaderVisible =
+                          statusBarHeight + _kHeaderContentHeight + 2.0;
+                      final topWhenHeaderHidden = statusBarHeight + 2.0;
+                      final top = topWhenHeaderVisible -
+                          offset * (topWhenHeaderVisible - topWhenHeaderHidden);
+                      return Positioned(
+                        top: top,
+                        left: 0,
+                        right: 0,
+                        child: AnimatedOpacity(
+                          duration: const Duration(milliseconds: 200),
+                          opacity: showSticky ? 1.0 : 0.0,
+                          child: IgnorePointer(
+                            ignoring: !showSticky,
+                            child: _buildPerspectivesStickyHeader(
+                                context, _perspectivesResponse!),
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            // Exit animation overlay — fade-to-white + scale-down
+            if (_isExitAnimating)
+              AnimatedBuilder(
+                animation: _exitAnimController,
+                builder: (context, _) {
+                  return Positioned.fill(
+                    child: IgnorePointer(
+                      child: ColoredBox(
+                        color: Colors.white
+                            .withValues(alpha: 0.6 * _exitAnimController.value),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            // Floating "Lancer l'analyse Facteur" button — in-app articles only.
+            // Visible when the perspectives section is on screen and analysis
+            // hasn't been triggered yet.
+            if (useInAppReading && content.contentType == ContentType.article)
+              Positioned(
+                right: 16,
+                bottom: _kFooterContentHeight +
+                    MediaQuery.of(context).viewPadding.bottom +
+                    12,
+                child: ValueListenableBuilder<bool>(
+                  valueListenable: _atPerspectivesSection,
+                  builder: (context, atPersp, _) {
+                    final show = atPersp &&
+                        _perspectivesAnalysisState ==
+                            PerspectivesAnalysisState.idle &&
+                        _perspectivesResponse != null &&
+                        _perspectivesResponse!.perspectives.isNotEmpty;
+                    return AnimatedOpacity(
+                      opacity: show ? 1.0 : 0.0,
+                      duration: const Duration(milliseconds: 200),
+                      child: IgnorePointer(
+                        ignoring: !show,
+                        child: FilledButton.icon(
+                          onPressed: () {
+                            HapticFeedback.lightImpact();
+                            _requestPerspectivesAnalysis();
+                          },
+                          style: FilledButton.styleFrom(
+                            backgroundColor: context.facteurColors.primary
+                                .withValues(alpha: 1.0),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                          icon: Icon(
+                            PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                            size: 16,
+                            color: Colors.white,
+                          ),
+                          label: const Text(
+                            'Lancer l\'analyse Facteur',
+                            style: TextStyle(color: Colors.white),
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            // Footer — shown for in-app article reading, mirrors header slide behavior
+            if (useScrollToSite ||
+                (useInAppReading && content.contentType == ContentType.article))
+              Positioned(
+                bottom: 0,
+                left: 0,
+                right: 0,
+                child: _buildArticleFooter(context, content),
+              ),
+          ],
+        ),
       ),
       // FABs — vertical column with immersive scroll opacity
       // Suppressed for articles (replaced by the persistent footer).
@@ -1771,82 +1714,33 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           ),
                           const SizedBox(height: 12),
                         ],
-                        // 🌻 Sunflower recommendation FAB + nudge label
-                        Row(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            // Animated "Recommander ?" nudge label
-                            AnimatedSwitcher(
-                              duration: const Duration(milliseconds: 300),
-                              transitionBuilder: (child, animation) =>
-                                  FadeTransition(
-                                opacity: animation,
-                                child: SlideTransition(
-                                  position: Tween<Offset>(
-                                    begin: const Offset(0.3, 0),
-                                    end: Offset.zero,
-                                  ).animate(animation),
-                                  child: child,
-                                ),
-                              ),
-                              child: _showSunflowerNudge
-                                  ? Container(
-                                      key: const ValueKey('nudge_visible'),
-                                      margin: const EdgeInsets.only(right: 10),
-                                      padding: const EdgeInsets.symmetric(
-                                          horizontal: 12, vertical: 6),
-                                      decoration: BoxDecoration(
-                                        color: const Color(0xFFFFF8E1),
-                                        borderRadius:
-                                            BorderRadius.circular(16),
-                                        boxShadow: [
-                                          BoxShadow(
-                                            color:
-                                                Colors.black.withOpacity(0.1),
-                                            blurRadius: 8,
-                                            offset: const Offset(0, 2),
-                                          ),
-                                        ],
-                                      ),
-                                      child: const Text(
-                                        'Recommander ? 🌻',
-                                        style: TextStyle(
-                                          fontSize: 13,
-                                          fontWeight: FontWeight.w600,
-                                          color: Color(0xFF795548),
-                                        ),
-                                      ),
-                                    )
-                                  : const SizedBox.shrink(
-                                      key: ValueKey('nudge_hidden'),
-                                    ),
-                            ),
-                            ScaleTransition(
-                              scale: _likeScaleAnimation,
-                              child: SizedBox(
-                                width: 50,
-                                height: 50,
-                                child: FloatingActionButton(
-                                  onPressed: _toggleLike,
-                                  backgroundColor: content.isLiked
-                                      ? colors.primary
-                                      : Colors.white,
-                                  foregroundColor: content.isLiked
-                                      ? Colors.white
-                                      : colors.textPrimary,
-                                  elevation: content.isLiked ? 4 : 2,
-                                  heroTag: 'sunflower_fab',
-                                  tooltip: 'Recommander',
-                                  child: SunflowerIcon(
-                                    isActive: content.isLiked,
-                                    size: 25,
-                                    inactiveColor: colors.textPrimary,
-                                  ),
-                                ),
+                        // Like FAB
+                        ScaleTransition(
+                          scale: _likeScaleAnimation,
+                          child: SizedBox(
+                            width: 50,
+                            height: 50,
+                            child: FloatingActionButton(
+                              onPressed: _toggleLike,
+                              backgroundColor: content.isLiked
+                                  ? colors.primary
+                                  : Colors.white,
+                              foregroundColor: content.isLiked
+                                  ? Colors.white
+                                  : colors.textPrimary,
+                              elevation: content.isLiked ? 4 : 2,
+                              heroTag: 'like_fab',
+                              tooltip: 'J\'aime',
+                              child: Icon(
+                                content.isLiked
+                                    ? PhosphorIcons.heart(
+                                        PhosphorIconsStyle.fill)
+                                    : PhosphorIcons.heart(
+                                        PhosphorIconsStyle.regular),
+                                size: 25,
                               ),
                             ),
-                          ],
+                          ),
                         ),
                         const SizedBox(height: 12),
                         // Merged Bookmark + Note FAB (long-press for collection picker)
@@ -2102,8 +1996,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           : PhosphorIcons.bookmarkSimple(
                               PhosphorIconsStyle.regular),
                       size: 24,
-                      color:
-                          content.isSaved ? colors.primary : colors.textSecondary,
+                      color: content.isSaved
+                          ? colors.primary
+                          : colors.textSecondary,
                     ),
                     tooltip: 'Sauvegarder',
                   ),
@@ -2183,135 +2078,153 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       Expanded(
                         child: _SourceBadgeNudge(
                           child: GestureDetector(
-                          onTap: () {
-                            ref.read(feedProvider.notifier).setSource(content.source.id);
-                            ref.read(feedScrollTriggerProvider.notifier).state++;
-                            context.pop(_content);
-                          },
-                          onLongPress: () => TopicChip.showArticleSheet(
-                            context, content,
-                            initialSection: ArticleSheetSection.source,
-                          ),
-                          behavior: HitTestBehavior.opaque,
-                          child: Row(
-                            children: [
-                              // Source logo (reduced from 32 to 28)
-                              if (content.source.logoUrl != null)
-                                ClipRRect(
-                                  borderRadius: BorderRadius.circular(10),
-                                  child: CachedNetworkImage(
-                                    imageUrl: content.source.logoUrl!,
-                                    width: 28,
-                                    height: 28,
-                                    fit: BoxFit.cover,
-                                    errorWidget: (_, __, ___) =>
-                                        _buildSourcePlaceholder(colors),
-                                  ),
-                                )
-                              else
-                                _buildSourcePlaceholder(colors),
-                              const SizedBox(width: 8),
+                            onTap: () {
+                              ref
+                                  .read(feedProvider.notifier)
+                                  .setSource(content.source.id);
+                              ref
+                                  .read(feedScrollTriggerProvider.notifier)
+                                  .state++;
+                              context.pop(_content);
+                            },
+                            onLongPress: () => TopicChip.showArticleSheet(
+                              context,
+                              content,
+                              initialSection: ArticleSheetSection.source,
+                            ),
+                            behavior: HitTestBehavior.opaque,
+                            child: Row(
+                              children: [
+                                // Source logo (reduced from 32 to 28)
+                                if (content.source.logoUrl != null)
+                                  ClipRRect(
+                                    borderRadius: BorderRadius.circular(10),
+                                    child: CachedNetworkImage(
+                                      imageUrl: content.source.logoUrl!,
+                                      width: 28,
+                                      height: 28,
+                                      fit: BoxFit.cover,
+                                      errorWidget: (_, __, ___) =>
+                                          _buildSourcePlaceholder(colors),
+                                    ),
+                                  )
+                                else
+                                  _buildSourcePlaceholder(colors),
+                                const SizedBox(width: 8),
 
-                              // Source Name + Time + Badges
-                              Flexible(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    // Ligne 1 : Nom (mini-chip) + Badges
-                                    Row(
-                                      children: [
-                                        Flexible(
-                                          child: Opacity(
-                                            opacity: 0.9,
-                                            child: Container(
-                                              padding: const EdgeInsets.symmetric(
-                                                  horizontal: 6, vertical: 2),
-                                              decoration: BoxDecoration(
-                                                color: Color.lerp(colors.backgroundSecondary, Colors.black, 0.003)!,
-                                                borderRadius: BorderRadius.circular(8),
-                                              ),
-                                              child: Text(
-                                                content.source.name,
-                                                style: textTheme.labelMedium?.copyWith(
-                                                  fontWeight: FontWeight.bold,
-                                                  color: colors.textPrimary,
+                                // Source Name + Time + Badges
+                                Flexible(
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      // Ligne 1 : Nom (mini-chip) + Badges
+                                      Row(
+                                        children: [
+                                          Flexible(
+                                            child: Opacity(
+                                              opacity: 0.9,
+                                              child: Container(
+                                                padding:
+                                                    const EdgeInsets.symmetric(
+                                                        horizontal: 6,
+                                                        vertical: 2),
+                                                decoration: BoxDecoration(
+                                                  color: Color.lerp(
+                                                      colors
+                                                          .backgroundSecondary,
+                                                      Colors.black,
+                                                      0.003)!,
+                                                  borderRadius:
+                                                      BorderRadius.circular(8),
                                                 ),
-                                                maxLines: 1,
-                                                overflow: TextOverflow.ellipsis,
+                                                child: Text(
+                                                  content.source.name,
+                                                  style: textTheme.labelMedium
+                                                      ?.copyWith(
+                                                    fontWeight: FontWeight.bold,
+                                                    color: colors.textPrimary,
+                                                  ),
+                                                  maxLines: 1,
+                                                  overflow:
+                                                      TextOverflow.ellipsis,
+                                                ),
                                               ),
                                             ),
                                           ),
-                                        ),
-                                        // Bias dot
-                                        if (content.source.biasStance != 'unknown') ...[
-                                          const SizedBox(width: 6),
-                                          Container(
-                                            width: 7,
-                                            height: 7,
-                                            decoration: BoxDecoration(
-                                              color: content.source.getBiasColor(),
-                                              shape: BoxShape.circle,
+                                          // Bias dot
+                                          if (content.source.biasStance !=
+                                              'unknown') ...[
+                                            const SizedBox(width: 6),
+                                            Container(
+                                              width: 7,
+                                              height: 7,
+                                              decoration: BoxDecoration(
+                                                color: content.source
+                                                    .getBiasColor(),
+                                                shape: BoxShape.circle,
+                                              ),
                                             ),
-                                          ),
-                                        ],
-                                        // Gear icon — same scale as bias dot
-                                        const SizedBox(width: 4),
-                                        Material(
-                                          color: Colors.transparent,
-                                          shape: const CircleBorder(),
-                                          clipBehavior: Clip.antiAlias,
-                                          child: InkWell(
-                                            onTap: () => TopicChip.showArticleSheet(
-                                              context, content,
-                                              initialSection: ArticleSheetSection.source,
-                                            ),
-                                            child: Padding(
-                                              padding: const EdgeInsets.all(3),
-                                              child: Icon(
-                                                PhosphorIcons.gear(PhosphorIconsStyle.regular),
-                                                size: 11,
-                                                color: colors.textTertiary,
+                                          ],
+                                          // Gear icon — same scale as bias dot
+                                          const SizedBox(width: 4),
+                                          Material(
+                                            color: Colors.transparent,
+                                            shape: const CircleBorder(),
+                                            clipBehavior: Clip.antiAlias,
+                                            child: InkWell(
+                                              onTap: () =>
+                                                  TopicChip.showArticleSheet(
+                                                context,
+                                                content,
+                                                initialSection:
+                                                    ArticleSheetSection.source,
+                                              ),
+                                              child: Padding(
+                                                padding:
+                                                    const EdgeInsets.all(3),
+                                                child: Icon(
+                                                  PhosphorIcons.gear(
+                                                      PhosphorIconsStyle
+                                                          .regular),
+                                                  size: 11,
+                                                  color: colors.textTertiary,
+                                                ),
                                               ),
                                             ),
                                           ),
-                                        ),
-                                        // Editorial badge (digest articles) — to the right of source name
-                                        if (content.editorialBadge != null) ...[
-                                          const SizedBox(width: 6),
-                                          EditorialBadge.chip(
-                                            content.editorialBadge,
-                                            context: context,
-                                          ) ?? const SizedBox.shrink(),
                                         ],
-                                      ],
-                                    ),
-                                    const SizedBox(height: 1),
-                                    // Ligne 2 : Temps relatif (icône + format court)
-                                    Row(
-                                      children: [
-                                        Icon(
-                                          PhosphorIcons.clock(PhosphorIconsStyle.regular),
-                                          size: 11,
-                                          color: colors.textTertiary,
-                                        ),
-                                        const SizedBox(width: 3),
-                                        Text(
-                                          timeago
-                                              .format(content.publishedAt, locale: 'fr_short')
-                                              .replaceAll('il y a ', ''),
-                                          style: textTheme.bodySmall?.copyWith(
+                                      ),
+                                      const SizedBox(height: 1),
+                                      // Ligne 2 : Temps relatif (icône + format court)
+                                      Row(
+                                        children: [
+                                          Icon(
+                                            PhosphorIcons.clock(
+                                                PhosphorIconsStyle.regular),
+                                            size: 11,
                                             color: colors.textTertiary,
-                                            fontSize: 11,
                                           ),
-                                        ),
-                                      ],
-                                    ),
-                                  ],
+                                          const SizedBox(width: 3),
+                                          Text(
+                                            timeago
+                                                .format(content.publishedAt,
+                                                    locale: 'fr_short')
+                                                .replaceAll('il y a ', ''),
+                                            style:
+                                                textTheme.bodySmall?.copyWith(
+                                              color: colors.textTertiary,
+                                              fontSize: 11,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ],
+                                  ),
                                 ),
-                              ),
                               ],
                             ),
-                        ),
+                          ),
                         ), // _SourceBadgeNudge
                       ),
                     ],
@@ -2370,33 +2283,25 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         .map((t) => t.canonicalName!.toLowerCase())
         .toSet();
 
-    // Dense layout: 4 tags max across macro-theme + topic + entities.
-    // Remaining entities are grouped into a "+X" overflow chip.
-    const maxTotalVisible = 4;
-    const chipPadding = EdgeInsets.symmetric(horizontal: 7, vertical: 3);
-
-    final hasMacroTheme = content.topics.isNotEmpty &&
-        getTopicMacroTheme(content.topics.first) != null;
-    final hasTopic = content.topics.isNotEmpty;
-    final reservedForTopics = (hasMacroTheme ? 1 : 0) + (hasTopic ? 1 : 0);
+    const maxVisible = 3;
     final entities = content.entities;
-    final maxEntitiesVisible =
-        (maxTotalVisible - reservedForTopics).clamp(0, entities.length);
-    final visible = entities.take(maxEntitiesVisible).toList();
-    final overflow = entities.length - maxEntitiesVisible;
+    final visible = entities.take(maxVisible).toList();
+    final overflow = entities.length - maxVisible;
 
     return [
       // Macro-theme chip (thème du sujet, ex: Cinéma)
-      if (hasMacroTheme)
+      if (content.topics.isNotEmpty &&
+          getTopicMacroTheme(content.topics.first) != null)
         Builder(builder: (context) {
           final macroTheme = getTopicMacroTheme(content.topics.first)!;
           final emoji = getMacroThemeEmoji(macroTheme);
           return GestureDetector(
-            onTap: () => TopicChip.showArticleSheet(context, content, initialSection: ArticleSheetSection.topic),
+            onTap: () => TopicChip.showArticleSheet(context, content,
+                initialSection: ArticleSheetSection.topic),
             child: Container(
-              padding: chipPadding,
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               decoration: BoxDecoration(
-                color: colors.textTertiary.withOpacity(0.20),
+                color: colors.textTertiary.withValues(alpha: 0.20),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Text(
@@ -2412,13 +2317,14 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           );
         }),
       // Topic chip
-      if (hasTopic)
+      if (content.topics.isNotEmpty)
         GestureDetector(
-          onTap: () => TopicChip.showArticleSheet(context, content, initialSection: ArticleSheetSection.topic),
+          onTap: () => TopicChip.showArticleSheet(context, content,
+              initialSection: ArticleSheetSection.topic),
           child: Container(
-            padding: chipPadding,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
             decoration: BoxDecoration(
-              color: colors.textTertiary.withOpacity(0.12),
+              color: colors.textTertiary.withValues(alpha: 0.12),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Text(
@@ -2434,23 +2340,23 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         ),
       // Entity chips
       ...visible.map((entity) {
-        final isFollowed =
-            followedNames.contains(entity.text.toLowerCase());
+        final isFollowed = followedNames.contains(entity.text.toLowerCase());
         return GestureDetector(
-          onTap: () => TopicChip.showArticleSheet(context, content, initialSection: ArticleSheetSection.entities),
+          onTap: () => TopicChip.showArticleSheet(context, content,
+              initialSection: ArticleSheetSection.entities),
           child: Container(
-            padding: chipPadding,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
             decoration: BoxDecoration(
               color: isFollowed
-                  ? const Color(0xFFE07A5F).withOpacity(0.15)
-                  : colors.textTertiary.withOpacity(0.12),
+                  ? const Color(0xFFE07A5F).withValues(alpha: 0.15)
+                  : colors.textTertiary.withValues(alpha: 0.12),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
                 ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 90),
+                  constraints: const BoxConstraints(maxWidth: 100),
                   child: Text(
                     entity.text,
                     style: textTheme.labelSmall?.copyWith(
@@ -2478,11 +2384,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       }),
       if (overflow > 0)
         GestureDetector(
-          onTap: () => TopicChip.showArticleSheet(context, content, initialSection: ArticleSheetSection.entities),
+          onTap: () => TopicChip.showArticleSheet(context, content,
+              initialSection: ArticleSheetSection.entities),
           child: Container(
-            padding: chipPadding,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
             decoration: BoxDecoration(
-              color: colors.textTertiary.withOpacity(0.12),
+              color: colors.textTertiary.withValues(alpha: 0.12),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Text(
@@ -2511,7 +2418,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           colors.primary,
           clamped,
         )!
-            .withOpacity(alpha);
+            .withValues(alpha: alpha);
         return TweenAnimationBuilder<double>(
           tween: Tween<double>(end: clamped),
           duration: const Duration(milliseconds: 300),
@@ -2546,40 +2453,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       'centre': dist['center'] ?? 0,
       'droite': (dist['center-right'] ?? 0) + (dist['right'] ?? 0),
     };
-    final total = merged.values.fold<int>(0, (s, v) => s + v);
-
-    final segments = [
-      ('gauche', 'Gauche', colors.biasLeft),
-      ('centre', 'Centre', colors.biasCenter),
-      ('droite', 'Droite', colors.biasRight),
-    ];
-
-    final flexValues = segments.map((seg) {
-      final count = merged[seg.$1] ?? 0;
-      if (count > 0 && total > 0) {
-        return ((count / total) * 100).round().clamp(15, 100);
-      }
-      return 15;
-    }).toList();
-
-    // Map detailed bias stance to simplified 3-segment group.
-    String stanceGroup(String stance) {
-      switch (stance) {
-        case 'left':
-        case 'center-left':
-          return 'gauche';
-        case 'center':
-          return 'centre';
-        case 'center-right':
-        case 'right':
-          return 'droite';
-        default:
-          return 'centre';
-      }
-    }
-
-    final sourceGroup = stanceGroup(response.sourceBiasStance);
-    final sourceIndex = segments.indexWhere((s) => s.$1 == sourceGroup);
 
     final selected = _perspectivesSelectedSegments;
 
@@ -2651,159 +2524,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 ),
             ],
           ),
-          // Optional quality badge
           if (response.comparisonQuality == 'low')
-            Padding(
-              padding: const EdgeInsets.only(top: 4),
-              child: Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-                decoration: BoxDecoration(
-                  color: colors.textTertiary.withValues(alpha: 0.08),
-                  borderRadius: BorderRadius.circular(6),
-                ),
-                child: Text(
-                  '⚠️ Comparaison limitée (sujet peu couvert)',
-                  style: textTheme.labelSmall?.copyWith(
-                    fontSize: 11,
-                    color: colors.textTertiary,
-                  ),
-                ),
-              ),
-            ),
+            PerspectivesWarningBadge(colors: colors, textTheme: textTheme),
           const SizedBox(height: 10),
-          // Interactive bias bar
-          Row(
-            children: List.generate(segments.length, (i) {
-              final seg = segments[i];
-              final count = merged[seg.$1] ?? 0;
-              final isActive =
-                  selected.isEmpty || selected.contains(seg.$1);
-              return Expanded(
-                flex: flexValues[i],
-                child: GestureDetector(
-                  onTap: () => _onPerspectivesSegmentTap(seg.$1),
-                  child: AnimatedOpacity(
-                    duration: const Duration(milliseconds: 200),
-                    opacity: isActive ? 1.0 : 0.3,
-                    child: Column(
-                      children: [
-                        Center(
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 6, vertical: 2),
-                            decoration: BoxDecoration(
-                              color: seg.$3.withValues(
-                                  alpha: count > 0 ? 0.15 : 0.05),
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: FittedBox(
-                              fit: BoxFit.scaleDown,
-                              child: Text(
-                                seg.$2,
-                                maxLines: 1,
-                                style: TextStyle(
-                                  fontSize: 10,
-                                  fontWeight: FontWeight.w600,
-                                  color: count > 0
-                                      ? seg.$3
-                                      : colors.textTertiary,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        AnimatedContainer(
-                          duration: const Duration(milliseconds: 200),
-                          curve: Curves.easeOut,
-                          height: 10,
-                          margin:
-                              const EdgeInsets.symmetric(horizontal: 1.5),
-                          decoration: BoxDecoration(
-                            color: count > 0
-                                ? seg.$3.withValues(
-                                    alpha: count == 1
-                                        ? 0.55
-                                        : (count == 2 ? 0.8 : 1.0))
-                                : seg.$3.withValues(alpha: 0.25),
-                            borderRadius: BorderRadius.circular(6),
-                            border: count > 0
-                                ? Border.all(
-                                    color:
-                                        Colors.black.withValues(alpha: 0.2),
-                                    width: 0.8,
-                                  )
-                                : null,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              );
-            }),
+          PerspectivesBiasBar(
+            colors: colors,
+            mergedDistribution: merged,
+            sourceBiasStance: response.sourceBiasStance,
+            sourceName: _content?.source.name ?? '',
+            selectedSegments: selected,
+            onSegmentTap: _onPerspectivesSegmentTap,
           ),
-          // Source marker row — matches inline section exactly
-          if (sourceIndex >= 0 && response.sourceBiasStance != 'unknown') ...[
-            const SizedBox(height: 4),
-            LayoutBuilder(
-              builder: (context, constraints) {
-                final totalFlex =
-                    flexValues.fold<int>(0, (sum, f) => sum + f);
-                double offsetFraction = 0;
-                for (int i = 0; i < sourceIndex; i++) {
-                  offsetFraction += flexValues[i] / totalFlex;
-                }
-                offsetFraction +=
-                    (flexValues[sourceIndex] / totalFlex) / 2;
-
-                final markerX = constraints.maxWidth * offsetFraction;
-                final sourceColor = segments[sourceIndex].$3;
-                final sourceName = _content?.source.name ?? '';
-                final displayName = sourceName.isNotEmpty
-                    ? sourceName
-                    : segments[sourceIndex].$2;
-
-                return SizedBox(
-                  height: 28,
-                  child: Stack(
-                    clipBehavior: Clip.none,
-                    children: [
-                      Positioned(
-                        left: markerX - 7,
-                        top: 0,
-                        child: CustomPaint(
-                          size: const Size(14, 8),
-                          painter: PerspectivesTrianglePainter(
-                              color: sourceColor),
-                        ),
-                      ),
-                      Positioned(
-                        left: (markerX - 50)
-                            .clamp(0.0, constraints.maxWidth - 100),
-                        top: 10,
-                        child: SizedBox(
-                          width: 100,
-                          child: Text(
-                            displayName,
-                            textAlign: TextAlign.center,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              fontSize: 10,
-                              fontWeight: FontWeight.w700,
-                              color: sourceColor,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              },
-            ),
-          ],
         ],
       ),
     );
@@ -2840,7 +2571,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
               child: Container(
                 height: 14,
                 decoration: BoxDecoration(
-                  color: colors.textTertiary.withOpacity(0.15),
+                  color: colors.textTertiary.withValues(alpha: 0.15),
                   borderRadius: BorderRadius.circular(4),
                 ),
               ),
@@ -2952,7 +2683,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                             horizontal: 10, vertical: 4),
                                         decoration: BoxDecoration(
                                           color: colors.warning
-                                              .withOpacity(0.12),
+                                              .withValues(alpha: 0.12),
                                           borderRadius: BorderRadius.circular(
                                               FacteurRadius.pill),
                                         ),
@@ -2971,20 +2702,49 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 ),
                                 const SizedBox(height: FacteurSpacing.space4),
                               ],
+                              if (content.editorialBadge != null) ...[
+                                EditorialBadge.chip(
+                                      content.editorialBadge,
+                                      context: context,
+                                    ) ??
+                                    const SizedBox.shrink(),
+                                const SizedBox(height: FacteurSpacing.space2),
+                              ],
+                              Text(
+                                content.title,
+                                style: textTheme.displayLarge
+                                    ?.copyWith(fontSize: 24),
+                              ),
+                              const SizedBox(height: FacteurSpacing.space2),
+                              if (readingTime != null) ...[
+                                Row(
+                                  children: [
+                                    Icon(
+                                      PhosphorIcons.timer(
+                                          PhosphorIconsStyle.regular),
+                                      size: 14,
+                                      color: colors.textTertiary,
+                                    ),
+                                    const SizedBox(width: 4),
+                                    Text(
+                                      readingTime,
+                                      style: textTheme.bodySmall?.copyWith(
+                                          color: colors.textTertiary),
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: FacteurSpacing.space3),
+                              ],
+                              Divider(color: colors.border, height: 1),
+                              const SizedBox(height: FacteurSpacing.space4),
                             ],
                           ),
-                          ),
+                          footer: SizedBox(
+                              height: _kFooterContentHeight + bottomInset),
                         ),
-// Article feedback thumbs
-                      Container(
-                        color: colors.backgroundPrimary,
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: FacteurSpacing.space4,
-                        ),
-                        child: ArticleThumbsFeedback(contentId: content.id),
                       ),
 
-// ZONE 3: Transparent spacer — only after CTA tap to enable scroll animation.
+                      // ZONE 3: Transparent spacer — only after CTA tap to enable scroll animation.
                       // _bridgeKey attached here so _computeScrollOffsets() can measure the bridge zone.
                       if (_ctaTapped)
                         SizedBox(key: _bridgeKey, height: availableHeight),
@@ -3037,9 +2797,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
     // Description text: prefer htmlContent (stripped), fallback to description
     final rawDescription = content.htmlContent ?? content.description;
-    final descriptionText = rawDescription != null
-        ? stripHtml(rawDescription).trim()
-        : null;
+    final descriptionText =
+        rawDescription != null ? stripHtml(rawDescription).trim() : null;
 
     return LayoutBuilder(builder: (context, constraints) {
       final maxHeight = constraints.maxHeight;
@@ -3049,8 +2808,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         // Reserve ~160px below the player for metadata (scrollable, same
         // pattern as regular videos). FABs float over this Flutter text area
         // (not an iframe) so they remain clickable.
-        final shortsPlayerHeight = (maxHeight - headerHeight - 140)
-            .clamp(200.0, screenWidth * 16 / 9);
+        final shortsPlayerHeight =
+            (maxHeight - headerHeight - 140).clamp(200.0, screenWidth * 16 / 9);
 
         return Column(
           children: [
@@ -3181,8 +2940,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       const SizedBox(height: FacteurSpacing.space2),
                       GestureDetector(
                         onTap: () {
-                          setState(() => _isDescriptionExpanded =
-                              !_isDescriptionExpanded);
+                          setState(() =>
+                              _isDescriptionExpanded = !_isDescriptionExpanded);
                         },
                         child: Text(
                           _isDescriptionExpanded ? 'Voir moins' : 'Voir plus',
@@ -3232,126 +2991,125 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                // Video Title
-                Text(
-                  content.title,
-                  style: textTheme.headlineSmall?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                  maxLines: 4,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: FacteurSpacing.space2),
-
-                // Published date
-                Text(
-                  timeago.format(content.publishedAt, locale: 'fr_short'),
-                  style: textTheme.bodySmall?.copyWith(
-                    color: colors.textSecondary,
-                  ),
-                ),
-                const SizedBox(height: FacteurSpacing.space4),
-
-                // Channel row: avatar + name + optional theme chip
-                Row(
-                  children: [
-                    if (content.source.logoUrl != null)
-                      CircleAvatar(
-                        radius: 16,
-                        backgroundImage:
-                            CachedNetworkImageProvider(content.source.logoUrl!),
-                        backgroundColor: colors.surfaceElevated,
-                      )
-                    else
-                      CircleAvatar(
-                        radius: 16,
-                        backgroundColor: colors.surfaceElevated,
-                        child: Icon(
-                          PhosphorIcons.user(PhosphorIconsStyle.regular),
-                          size: 16,
-                          color: colors.textTertiary,
-                        ),
-                      ),
-                    const SizedBox(width: FacteurSpacing.space3),
-                    Expanded(
-                      child: Text(
-                        content.source.name,
-                        style: textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    if (content.source.theme != null &&
-                        content.source.theme!.isNotEmpty) ...[
-                      const SizedBox(width: FacteurSpacing.space2),
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 8,
-                          vertical: 3,
-                        ),
-                        decoration: BoxDecoration(
-                          color: colors.primary,
-                          borderRadius:
-                              BorderRadius.circular(FacteurRadius.pill),
-                        ),
-                        child: Text(
-                          content.source.getThemeLabel(),
-                          style: textTheme.labelSmall?.copyWith(
-                            color: Colors.white,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ],
-                ),
-
-                // Expandable description
-                if (descriptionText != null &&
-                    descriptionText.isNotEmpty) ...[
-                  const SizedBox(height: FacteurSpacing.space4),
-                  Divider(color: colors.border, height: 1),
-                  const SizedBox(height: FacteurSpacing.space4),
+                  // Video Title
                   Text(
-                    descriptionText,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: colors.textSecondary,
-                      height: 1.5,
+                    content.title,
+                    style: textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
                     ),
-                    maxLines: _isDescriptionExpanded ? null : 3,
-                    overflow: _isDescriptionExpanded
-                        ? TextOverflow.visible
-                        : TextOverflow.ellipsis,
+                    maxLines: 4,
+                    overflow: TextOverflow.ellipsis,
                   ),
                   const SizedBox(height: FacteurSpacing.space2),
-                  GestureDetector(
-                    onTap: () {
-                      setState(
-                          () => _isDescriptionExpanded = !_isDescriptionExpanded);
-                    },
-                    child: Text(
-                      _isDescriptionExpanded ? 'Voir moins' : 'Voir plus',
-                      style: textTheme.bodySmall?.copyWith(
-                        color: colors.primary,
-                        fontWeight: FontWeight.w600,
-                      ),
+
+                  // Published date
+                  Text(
+                    timeago.format(content.publishedAt, locale: 'fr_short'),
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colors.textSecondary,
                     ),
                   ),
-                ],
+                  const SizedBox(height: FacteurSpacing.space4),
 
-                // Bottom spacing for FABs
-                const SizedBox(height: 120),
-              ],
+                  // Channel row: avatar + name + optional theme chip
+                  Row(
+                    children: [
+                      if (content.source.logoUrl != null)
+                        CircleAvatar(
+                          radius: 16,
+                          backgroundImage: CachedNetworkImageProvider(
+                              content.source.logoUrl!),
+                          backgroundColor: colors.surfaceElevated,
+                        )
+                      else
+                        CircleAvatar(
+                          radius: 16,
+                          backgroundColor: colors.surfaceElevated,
+                          child: Icon(
+                            PhosphorIcons.user(PhosphorIconsStyle.regular),
+                            size: 16,
+                            color: colors.textTertiary,
+                          ),
+                        ),
+                      const SizedBox(width: FacteurSpacing.space3),
+                      Expanded(
+                        child: Text(
+                          content.source.name,
+                          style: textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      if (content.source.theme != null &&
+                          content.source.theme!.isNotEmpty) ...[
+                        const SizedBox(width: FacteurSpacing.space2),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 3,
+                          ),
+                          decoration: BoxDecoration(
+                            color: colors.primary,
+                            borderRadius:
+                                BorderRadius.circular(FacteurRadius.pill),
+                          ),
+                          child: Text(
+                            content.source.getThemeLabel(),
+                            style: textTheme.labelSmall?.copyWith(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+
+                  // Expandable description
+                  if (descriptionText != null &&
+                      descriptionText.isNotEmpty) ...[
+                    const SizedBox(height: FacteurSpacing.space4),
+                    Divider(color: colors.border, height: 1),
+                    const SizedBox(height: FacteurSpacing.space4),
+                    Text(
+                      descriptionText,
+                      style: textTheme.bodyMedium?.copyWith(
+                        color: colors.textSecondary,
+                        height: 1.5,
+                      ),
+                      maxLines: _isDescriptionExpanded ? null : 3,
+                      overflow: _isDescriptionExpanded
+                          ? TextOverflow.visible
+                          : TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: FacteurSpacing.space2),
+                    GestureDetector(
+                      onTap: () {
+                        setState(() =>
+                            _isDescriptionExpanded = !_isDescriptionExpanded);
+                      },
+                      child: Text(
+                        _isDescriptionExpanded ? 'Voir moins' : 'Voir plus',
+                        style: textTheme.bodySmall?.copyWith(
+                          color: colors.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ],
+
+                  // Bottom spacing for FABs
+                  const SizedBox(height: 120),
+                ],
+              ),
             ),
           ),
-        ),
-      ],
-    );
+        ],
+      );
     }); // LayoutBuilder
   }
-
 
   Widget _buildInAppContent(BuildContext context, Content content) {
     final topic = content.progressionTopic;
@@ -3385,9 +3143,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           title: content.title,
           shrinkWrap: true,
           onLinkTap: _animateAndLaunch,
-          bodyPlaceholder: !_contentResolved
-              ? _buildArticleBodySkeleton(colors)
-              : null,
+          bodyPlaceholder:
+              !_contentResolved ? _buildArticleBodySkeleton(colors) : null,
         );
 
         return ScrollConfiguration(
@@ -3398,161 +3155,157 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             key: _scrollViewKey,
             controller: _inAppScrollController,
             child: Column(
-            spacing: 16,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
+              spacing: 16,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // ── Header clearance ──────────────────────────────────────
+                SizedBox(height: headerHeight),
 
-              // ── Header clearance ──────────────────────────────────────
-              SizedBox(height: headerHeight),
-
-              // ── Top section: thumbnail → chips → title → reading time ─
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: FacteurSpacing.space4),
-                child: Column(
-                  spacing: 12,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-if (content.thumbnailUrl != null)
-                      ClipRRect(
-                        borderRadius:
-                            BorderRadius.circular(FacteurRadius.large),
-                        child: FacteurThumbnail(
-                          imageUrl: content.thumbnailUrl,
-                          aspectRatio: 16 / 9,
+                // ── Top section: thumbnail → chips → title → reading time ─
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: FacteurSpacing.space4),
+                  child: Column(
+                    spacing: 12,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      if (content.thumbnailUrl != null)
+                        ClipRRect(
+                          borderRadius:
+                              BorderRadius.circular(FacteurRadius.large),
+                          child: FacteurThumbnail(
+                            imageUrl: content.thumbnailUrl,
+                            aspectRatio: 16 / 9,
+                          ),
                         ),
-                      ),
-                    if (content.entities.isNotEmpty || isPartial)
-                      Wrap(
-                        spacing: 6,
-                        runSpacing: 4,
-                        crossAxisAlignment: WrapCrossAlignment.center,
-                        children: [
-                          if (isPartial)
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 10, vertical: 4),
-                              decoration: BoxDecoration(
-                                color: colors.warning.withValues(alpha: 0.12),
-                                borderRadius: BorderRadius.circular(
-                                    FacteurRadius.pill),
-                              ),
-                              child: Text(
-                                'Aperçu — contenu partiel',
-                                style: textTheme.labelSmall?.copyWith(
-                                  color: colors.warning,
-                                  fontWeight: FontWeight.w600,
+                      if (content.entities.isNotEmpty || isPartial)
+                        Wrap(
+                          spacing: 6,
+                          runSpacing: 4,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: [
+                            if (isPartial)
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 10, vertical: 4),
+                                decoration: BoxDecoration(
+                                  color: colors.warning.withValues(alpha: 0.12),
+                                  borderRadius:
+                                      BorderRadius.circular(FacteurRadius.pill),
+                                ),
+                                child: Text(
+                                  'Aperçu — contenu partiel',
+                                  style: textTheme.labelSmall?.copyWith(
+                                    color: colors.warning,
+                                    fontWeight: FontWeight.w600,
+                                  ),
                                 ),
                               ),
+                            if (content.entities.isNotEmpty)
+                              ..._buildArticleTagWidgets(context, content),
+                          ],
+                        ),
+                      if (content.editorialBadge != null)
+                        EditorialBadge.chip(
+                              content.editorialBadge,
+                              context: context,
+                            ) ??
+                            const SizedBox.shrink(),
+                      Text(
+                        content.title,
+                        style: textTheme.displayLarge?.copyWith(fontSize: 24),
+                      ),
+                      if (readingTime != null)
+                        Row(
+                          children: [
+                            Icon(
+                              PhosphorIcons.timer(PhosphorIconsStyle.regular),
+                              size: 14,
+                              color: colors.textTertiary,
                             ),
-                          if (content.entities.isNotEmpty)
-                            ..._buildArticleTagWidgets(context, content),
-                        ],
-                      ),
-                    if (content.editorialBadge != null)
-                      EditorialBadge.chip(
-                            content.editorialBadge,
-                            context: context,
-                          ) ??
-                          const SizedBox.shrink(),
-                    Text(
-                      content.title,
-                      style: textTheme.displayLarge?.copyWith(fontSize: 24),
-                    ),
-if (readingTime != null)
-                      Row(
-                        children: [
-                          Icon(
-                            PhosphorIcons.timer(PhosphorIconsStyle.regular),
-                            size: 14,
-                            color: colors.textTertiary,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            readingTime,
-                            style: textTheme.bodySmall?.copyWith(
-                                color: colors.textTertiary),
-                          ),
-                        ],
-                      ),
-                  ],
+                            const SizedBox(width: 4),
+                            Text(
+                              readingTime,
+                              style: textTheme.bodySmall
+                                  ?.copyWith(color: colors.textTertiary),
+                            ),
+                          ],
+                        ),
+                    ],
+                  ),
                 ),
-              ),
 
-              // ── Divider: header / article ─────────────────────────────
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: FacteurSpacing.space4),
-                child: Divider(color: colors.border, height: 1),
-              ),
-
-              // ── Article section ────────────────────────────────────────
-              // Zero-height marker at the end lets _measureArticleExtent()
-              // compute progress against article length only (excludes perspectives).
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  articleWidget,
-                  SizedBox(key: _articleEndKey, height: 0),
-                ],
-              ),
-
-              // ── Perspectives section ───────────────────────────────────
-              if (_perspectivesResponse != null || _perspectivesLoading) ...[
+                // ── Divider: header / article ─────────────────────────────
                 Padding(
                   padding: const EdgeInsets.symmetric(
                       horizontal: FacteurSpacing.space4),
                   child: Divider(color: colors.border, height: 1),
                 ),
-                if (_perspectivesLoading && _perspectivesResponse == null)
-                  const Center(child: CircularProgressIndicator())
-                else if (_perspectivesResponse != null)
-                  PerspectivesInlineSection(
-                    key: _perspectivesKey,
-                    perspectives: _perspectivesResponse!.perspectives
-                        .map(
-                          (PerspectiveData p) => Perspective(
-                            title: p.title,
-                            url: p.url,
-                            sourceName: p.sourceName,
-                            sourceDomain: p.sourceDomain,
-                            biasStance: p.biasStance,
-                            publishedAt: p.publishedAt,
-                          ),
-                        )
-                        .toList(),
-                    biasDistribution:
-                        _perspectivesResponse!.biasDistribution,
-                    keywords: _perspectivesResponse!.keywords,
-                    sourceBiasStance:
-                        _perspectivesResponse!.sourceBiasStance,
-                    sourceName: _content?.source.name ?? '',
-                    contentId: widget.contentId,
-                    comparisonQuality:
-                        _perspectivesResponse!.comparisonQuality,
-                    externalSelectedSegments: _perspectivesSelectedSegments,
-                    onSegmentTap: _onPerspectivesSegmentTap,
-                    onClearSegments: () {
-                      setState(() => _perspectivesSelectedSegments = {});
-                      WidgetsBinding.instance.addPostFrameCallback((_) {
-                        if (mounted) _checkAtPerspectivesSection();
-                      });
-                    },
-                    analysisState: _perspectivesAnalysisState,
-                    analysisText: _perspectivesAnalysisText,
-                    onRequestAnalysis: _requestPerspectivesAnalysis,
-                    analysisZoneKey: _analysisZoneKey,
+
+                // ── Article section ────────────────────────────────────────
+                // Zero-height marker at the end lets _measureArticleExtent()
+                // compute progress against article length only (excludes perspectives).
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    articleWidget,
+                    SizedBox(key: _articleEndKey, height: 0),
+                  ],
+                ),
+
+                // ── Perspectives section ───────────────────────────────────
+                if (_perspectivesResponse != null || _perspectivesLoading) ...[
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: FacteurSpacing.space4),
+                    child: Divider(color: colors.border, height: 1),
                   ),
+                  if (_perspectivesLoading && _perspectivesResponse == null)
+                    const Center(child: CircularProgressIndicator())
+                  else if (_perspectivesResponse != null)
+                    PerspectivesInlineSection(
+                      key: _perspectivesKey,
+                      perspectives: _perspectivesResponse!.perspectives
+                          .map(
+                            (PerspectiveData p) => Perspective(
+                              title: p.title,
+                              url: p.url,
+                              sourceName: p.sourceName,
+                              sourceDomain: p.sourceDomain,
+                              biasStance: p.biasStance,
+                              publishedAt: p.publishedAt,
+                            ),
+                          )
+                          .toList(),
+                      biasDistribution: _perspectivesResponse!.biasDistribution,
+                      keywords: _perspectivesResponse!.keywords,
+                      sourceBiasStance: _perspectivesResponse!.sourceBiasStance,
+                      sourceName: _content?.source.name ?? '',
+                      contentId: widget.contentId,
+                      comparisonQuality:
+                          _perspectivesResponse!.comparisonQuality,
+                      externalSelectedSegments: _perspectivesSelectedSegments,
+                      onSegmentTap: _onPerspectivesSegmentTap,
+                      onClearSegments: () {
+                        setState(() => _perspectivesSelectedSegments = {});
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          if (mounted) _checkAtPerspectivesSection();
+                        });
+                      },
+                      analysisState: _perspectivesAnalysisState,
+                      analysisText: _perspectivesAnalysisText,
+                      onRequestAnalysis: _requestPerspectivesAnalysis,
+                      analysisZoneKey: _analysisZoneKey,
+                    ),
+                ],
+
+                // ── Footer clearance ───────────────────────────────────────
+                SizedBox(
+                  height: _kFooterContentHeight +
+                      MediaQuery.of(context).viewPadding.bottom,
+                ),
               ],
-
-              // ── Footer clearance ───────────────────────────────────────
-              SizedBox(
-                height: _kFooterContentHeight +
-                    MediaQuery.of(context).viewPadding.bottom,
-              ),
-
-            ],
-          ),
+            ),
           ),
         );
 
@@ -3615,6 +3368,20 @@ if (readingTime != null)
     return Column(
       children: [
         SizedBox(height: headerHeight),
+        // Extra breathing room so tag chips aren't clipped by the header overlay
+        const SizedBox(height: FacteurSpacing.space2),
+        if (content.entities.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: FacteurSpacing.space4,
+              vertical: 6,
+            ),
+            child: Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: _buildArticleTagWidgets(context, content),
+            ),
+          ),
         Expanded(child: WebViewWidget(controller: _webViewController!)),
       ],
     );

--- a/apps/mobile/lib/features/detail/widgets/article_reader_widget.dart
+++ b/apps/mobile/lib/features/detail/widgets/article_reader_widget.dart
@@ -147,7 +147,6 @@ class ArticleReaderWidget extends StatelessWidget {
           if (footer != null) ...[
             const SizedBox(height: 32),
             footer!,
-            const SizedBox(height: 64),
           ],
         ],
       );

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -107,12 +107,8 @@ String _toBarGroup(String stance) {
   }
 }
 
-/// Stance group order and labels for grouped display
-const _stanceGroups = [
-  ('gauche', 'Gauche'),
-  ('centre', 'Centre'),
-  ('droite', 'Droite'),
-];
+/// Analysis workflow state
+enum PerspectivesAnalysisState { idle, loading, done, error }
 
 /// Bottom sheet to display alternative perspectives
 class PerspectivesBottomSheet extends ConsumerStatefulWidget {
@@ -123,8 +119,6 @@ class PerspectivesBottomSheet extends ConsumerStatefulWidget {
   final String sourceName;
   final String contentId;
   final String comparisonQuality;
-  final String? initialAnalysis;
-  final bool analysisCached;
 
   const PerspectivesBottomSheet({
     super.key,
@@ -135,8 +129,6 @@ class PerspectivesBottomSheet extends ConsumerStatefulWidget {
     this.sourceBiasStance = 'unknown',
     this.sourceName = '',
     this.comparisonQuality = 'low',
-    this.initialAnalysis,
-    this.analysisCached = false,
   });
 
   @override
@@ -144,41 +136,13 @@ class PerspectivesBottomSheet extends ConsumerStatefulWidget {
       _PerspectivesBottomSheetState();
 }
 
-enum PerspectivesAnalysisState { idle, loading, done, error }
-
 class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomSheet> {
-  /// Collapsed groups: each group can be independently collapsed
-  final Set<String> _collapsedGroups = {};
-
-  /// Analysis state
   PerspectivesAnalysisState _analysisState = PerspectivesAnalysisState.idle;
   String? _analysisText;
-  bool _isAnalysisExpanded = true;
-  bool _isCachedAnalysis = false;
+  Set<String> _selectedSegments = {};
 
-  @override
-  void initState() {
-    super.initState();
-    if (widget.initialAnalysis != null) {
-      _analysisState = PerspectivesAnalysisState.done;
-      _analysisText = widget.initialAnalysis;
-      _isCachedAnalysis = widget.analysisCached;
-    } else {
-      _analysisState = PerspectivesAnalysisState.idle;
-    }
-  }
+  static const _groupOrder = ['gauche', 'centre', 'droite'];
 
-  /// Active bias filter (null = show all)
-  String? _selectedGroup;
-
-  List<Perspective> get _filteredPerspectives {
-    if (_selectedGroup == null) return widget.perspectives;
-    return widget.perspectives
-        .where((p) => p.biasGroup == _selectedGroup)
-        .toList();
-  }
-
-  /// Compute merged 3-segment distribution from the 5-segment API data
   Map<String, int> get _mergedDistribution {
     final dist = widget.biasDistribution;
     return {
@@ -188,11 +152,35 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
     };
   }
 
-  /// Whether to show grouped layout (>= 3 perspectives and >= 2 distinct groups)
-  bool get _shouldGroup {
-    if (widget.perspectives.length < 3) return false;
-    final groups = widget.perspectives.map((p) => p.biasGroup).toSet();
-    return groups.length >= 2;
+  List<Perspective> get _sortedPerspectives {
+    final sorted = [...widget.perspectives];
+    sorted.sort((a, b) =>
+        _groupOrder.indexOf(a.biasGroup).compareTo(_groupOrder.indexOf(b.biasGroup)));
+    return sorted;
+  }
+
+  List<Perspective> get _filteredPerspectives {
+    final sorted = _sortedPerspectives;
+    if (_selectedSegments.isEmpty) return sorted;
+    return sorted.where((p) => _selectedSegments.contains(p.biasGroup)).toList();
+  }
+
+  void _onSegmentTapInternal(String key) {
+    setState(() {
+      if (_selectedSegments.contains(key)) {
+        if (_selectedSegments.length == 1) {
+          _selectedSegments = {};
+        } else {
+          _selectedSegments = Set.from(_selectedSegments)..remove(key);
+        }
+      } else {
+        if (_selectedSegments.isEmpty || _selectedSegments.length == 3) {
+          _selectedSegments = {key};
+        } else {
+          _selectedSegments = Set.from(_selectedSegments)..add(key);
+        }
+      }
+    });
   }
 
   Future<void> _requestAnalysis() async {
@@ -222,1224 +210,176 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
     final filtered = _filteredPerspectives;
 
     return Container(
-      constraints: BoxConstraints(
-        maxHeight: MediaQuery.of(context).size.height * 0.92,
-      ),
+      constraints: BoxConstraints(maxHeight: MediaQuery.of(context).size.height * 0.92),
       decoration: BoxDecoration(
         color: colors.backgroundPrimary,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           // Handle
-          Container(
-            margin: const EdgeInsets.only(top: 12),
-            width: 40,
-            height: 4,
-            decoration: BoxDecoration(
-              color: colors.textSecondary.withOpacity(0.2),
-              borderRadius: BorderRadius.circular(2),
+          Center(
+            child: Container(
+              margin: const EdgeInsets.only(top: 12),
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: colors.textSecondary.withValues(alpha: 0.2),
+                borderRadius: BorderRadius.circular(2),
+              ),
             ),
           ),
 
-          // Header
-          Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Icon(
-                      PhosphorIcons.eye(PhosphorIconsStyle.fill),
-                      color: colors.primary,
-                      size: 32,
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
+          Flexible(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.only(top: 16, bottom: 32),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (widget.perspectives.isNotEmpty) ...[
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(
-                            'Voir tous les points de vue',
-                            style: textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              color: colors.textPrimary,
-                              fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Icon(
+                                PhosphorIcons.eye(PhosphorIconsStyle.regular),
+                                color: colors.primary,
+                                size: 28,
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: Text(
+                                  'Voir tous les points de vue',
+                                  style: textTheme.titleMedium?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: colors.textPrimary,
+                                    fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
+                                  ),
+                                ),
+                              ),
+                              IconButton(
+                                padding: EdgeInsets.zero,
+                                visualDensity: VisualDensity.compact,
+                                icon: Icon(PhosphorIcons.x(PhosphorIconsStyle.bold)),
+                                onPressed: () => Navigator.pop(context),
+                                color: colors.textSecondary,
+                              ),
+                            ],
+                          ),
+                          if (widget.comparisonQuality == 'low')
+                            PerspectivesWarningBadge(colors: colors, textTheme: textTheme),
+                          const SizedBox(height: 16),
+                          PerspectivesBiasBar(
+                            colors: colors,
+                            mergedDistribution: _mergedDistribution,
+                            sourceBiasStance: widget.sourceBiasStance,
+                            sourceName: widget.sourceName,
+                            selectedSegments: _selectedSegments,
+                            onSegmentTap: _onSegmentTapInternal,
+                          ),
+                          SizedBox(
+                            height: 20,
+                            child: _selectedSegments.isNotEmpty
+                                ? Align(
+                                    alignment: Alignment.centerRight,
+                                    child: GestureDetector(
+                                      onTap: () => setState(() => _selectedSegments = {}),
+                                      child: Row(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          Text(
+                                            'Tout afficher',
+                                            style: textTheme.labelSmall?.copyWith(
+                                              color: colors.primary,
+                                              fontWeight: FontWeight.w600,
+                                            ),
+                                          ),
+                                          const SizedBox(width: 4),
+                                          Icon(
+                                            PhosphorIcons.x(PhosphorIconsStyle.bold),
+                                            size: 12,
+                                            color: colors.primary,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  )
+                                : null,
+                          ),
+                          const SizedBox(height: 8),
+                        ],
+                      ),
+                    ),
+                    if (filtered.isEmpty)
+                      PerspectivesEmptyState(colors: colors, textTheme: textTheme)
+                    else
+                      ...filtered.map(
+                        (p) => Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: _PerspectiveCard(perspective: p),
+                        ),
+                      ),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                      child: PerspectivesAnalysisZone(
+                        state: _analysisState,
+                        text: _analysisText,
+                        onRequestAnalysis: _requestAnalysis,
+                        colors: colors,
+                        textTheme: textTheme,
+                      ),
+                    ),
+                  ] else ...[
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Icon(
+                            PhosphorIcons.eye(PhosphorIconsStyle.regular),
+                            color: colors.primary,
+                            size: 28,
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Text(
+                              'Voir tous les points de vue',
+                              style: textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                color: colors.textPrimary,
+                                fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
+                              ),
                             ),
                           ),
-                          Text(
-                            '(${widget.keywords.join(', ')})',
-                            style: textTheme.labelSmall?.copyWith(
-                              color: colors.textSecondary,
-                              fontSize: (textTheme.labelSmall?.fontSize ?? 11) + 1,
-                            ),
+                          IconButton(
+                            padding: EdgeInsets.zero,
+                            visualDensity: VisualDensity.compact,
+                            icon: Icon(PhosphorIcons.x(PhosphorIconsStyle.bold)),
+                            onPressed: () => Navigator.pop(context),
+                            color: colors.textSecondary,
                           ),
                         ],
                       ),
                     ),
-                    IconButton(
-                      icon: Icon(PhosphorIcons.x(PhosphorIconsStyle.bold)),
-                      onPressed: () => Navigator.pop(context),
-                      color: colors.textSecondary,
-                    ),
+                    const SizedBox(height: 16),
+                    PerspectivesEmptyState(colors: colors, textTheme: textTheme),
                   ],
-                ),
-                if (widget.comparisonQuality == 'low')
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4),
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 8,
-                        vertical: 3,
-                      ),
-                      decoration: BoxDecoration(
-                        color: colors.textTertiary.withValues(alpha: 0.08),
-                        borderRadius: BorderRadius.circular(6),
-                      ),
-                      child: Text(
-                        '⚠️ Comparaison limitée (sujet peu couvert)',
-                        style: textTheme.labelSmall?.copyWith(
-                          fontSize: 11,
-                          color: colors.textTertiary,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-          ),
-
-          // Bias Bar (hidden when empty)
-          if (widget.perspectives.isNotEmpty) _buildBiasBar(context, colors),
-
-          // Perspectives List (analysis zone scrolls with content)
-          Flexible(
-            child: filtered.isEmpty
-                ? _buildEmptyState(context, colors, textTheme)
-                : _shouldGroup
-                    ? _buildGroupedList(context, colors, textTheme,
-                        filtered)
-                    : ListView.separated(
-                        shrinkWrap: true,
-                        padding: const EdgeInsets.symmetric(vertical: 8),
-                        itemCount: filtered.length + 1,
-                        separatorBuilder: (_, __) =>
-                            const SizedBox(height: 8),
-                        itemBuilder: (context, index) {
-                          if (index == 0) {
-                            return _buildAnalysisZone(
-                                context, colors, textTheme);
-                          }
-                          return _PerspectiveCard(
-                              perspective: filtered[index - 1]);
-                        },
-                      ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAnalysisZone(
-      BuildContext context, FacteurColors colors, TextTheme textTheme) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
-      child: AnimatedSize(
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeOut,
-        child: switch (_analysisState) {
-          PerspectivesAnalysisState.idle => _buildAnalysisCta(colors, textTheme),
-          PerspectivesAnalysisState.loading => _buildAnalysisSkeleton(colors),
-          PerspectivesAnalysisState.done => _buildAnalysisResult(colors, textTheme),
-          PerspectivesAnalysisState.error => _buildAnalysisError(colors, textTheme),
-        },
-      ),
-    );
-  }
-
-  Widget _buildAnalysisCta(FacteurColors colors, TextTheme textTheme) {
-    return Center(
-      child: OutlinedButton.icon(
-        onPressed: _requestAnalysis,
-        icon: Icon(
-          PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
-          size: 18,
-          color: colors.primary,
-        ),
-        label: Text(
-          'Lancer l\'analyse Facteur',
-          style: textTheme.labelLarge?.copyWith(
-            color: colors.primary,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        style: OutlinedButton.styleFrom(
-          side: BorderSide(color: colors.primary.withOpacity(0.4)),
-          shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 20),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildAnalysisSkeleton(FacteurColors colors) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: colors.primary.withOpacity(0.05),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          for (var i = 0; i < 3; i++) ...[
-            if (i > 0) const SizedBox(height: 8),
-            _ShimmerLine(
-              width: i == 2 ? 0.6 : (i == 1 ? 0.9 : 1.0),
-              colors: colors,
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAnalysisResult(FacteurColors colors, TextTheme textTheme) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: colors.primary.withOpacity(0.05),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: colors.primary.withOpacity(0.15)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          GestureDetector(
-            onTap: () =>
-                setState(() => _isAnalysisExpanded = !_isAnalysisExpanded),
-            behavior: HitTestBehavior.opaque,
-            child: Row(
-              children: [
-                Icon(
-                  PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
-                  size: 18,
-                  color: colors.primary,
-                ),
-                const SizedBox(width: 8),
-                Text(
-                  'Analyse Facteur',
-                  style: textTheme.titleSmall?.copyWith(
-                    color: colors.primary,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                if (_isCachedAnalysis) ...[
-                  const SizedBox(width: 8),
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 6,
-                      vertical: 2,
-                    ),
-                    decoration: BoxDecoration(
-                      color: colors.textTertiary.withOpacity(0.1),
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(
-                          PhosphorIcons.clockCounterClockwise(PhosphorIconsStyle.regular),
-                          size: 10,
-                          color: colors.textTertiary,
-                        ),
-                        const SizedBox(width: 3),
-                        Text(
-                          'en cache',
-                          style: textTheme.labelSmall?.copyWith(
-                            fontSize: 9,
-                            color: colors.textTertiary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
                 ],
-                const Spacer(),
-                AnimatedRotation(
-                  turns: _isAnalysisExpanded ? 0.25 : 0,
-                  duration: const Duration(milliseconds: 200),
-                  child: Icon(
-                    PhosphorIcons.caretRight(PhosphorIconsStyle.bold),
-                    size: 12,
-                    color: colors.primary,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          if (_isAnalysisExpanded) ...[
-            const SizedBox(height: 10),
-            MarkdownText(
-              text: _analysisText ?? '',
-              style: textTheme.bodySmall!.copyWith(
-                color: colors.textPrimary,
-                height: 1.6,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Align(
-              alignment: Alignment.centerRight,
-              child: Text(
-                'Analyse Facteur',
-                style: textTheme.bodySmall?.copyWith(
-                  fontSize: 10,
-                  fontStyle: FontStyle.italic,
-                  color: colors.textSecondary.withOpacity(0.5),
-                ),
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAnalysisError(FacteurColors colors, TextTheme textTheme) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: colors.textSecondary.withOpacity(0.05),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              'Analyse indisponible',
-              style: textTheme.bodySmall?.copyWith(
-                color: colors.textSecondary,
-              ),
-            ),
-          ),
-          TextButton(
-            onPressed: _requestAnalysis,
-            style: TextButton.styleFrom(
-              minimumSize: Size.zero,
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            ),
-            child: Text(
-              'Réessayer',
-              style: textTheme.labelSmall?.copyWith(
-                color: colors.primary,
-                fontWeight: FontWeight.w600,
               ),
             ),
           ),
         ],
-      ),
-    );
-  }
-
-  Widget _buildGroupedList(BuildContext context, FacteurColors colors,
-      TextTheme textTheme, List<Perspective> perspectives) {
-    // Group perspectives by stance
-    final groups = <String, List<Perspective>>{};
-    for (final p in perspectives) {
-      groups.putIfAbsent(p.biasGroup, () => []).add(p);
-    }
-
-    final colors = context.facteurColors;
-    final textThemeLocal = Theme.of(context).textTheme;
-
-    return ListView(
-      shrinkWrap: true,
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      children: [
-        _buildAnalysisZone(context, colors, textThemeLocal),
-        for (final entry in _stanceGroups)
-          if (groups.containsKey(entry.$1)) ...[
-            // Section header (tappable toggle collapse/expand)
-            () {
-              final isCollapsed = _collapsedGroups.contains(entry.$1);
-              return Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-                child: GestureDetector(
-                  onTap: () {
-                    setState(() {
-                      if (isCollapsed) {
-                        _collapsedGroups.remove(entry.$1);
-                      } else {
-                        _collapsedGroups.add(entry.$1);
-                      }
-                    });
-                  },
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 12, vertical: 6),
-                    decoration: BoxDecoration(
-                      color: Colors.transparent,
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          '${entry.$2} (${groups[entry.$1]!.length})',
-                          style: textTheme.labelMedium?.copyWith(
-                            fontWeight: FontWeight.w500,
-                            fontSize: 12,
-                            color: colors.textSecondary,
-                          ),
-                        ),
-                        const SizedBox(width: 4),
-                        AnimatedRotation(
-                          turns: isCollapsed ? 0 : 0.25,
-                          duration: const Duration(milliseconds: 200),
-                          child: Icon(
-                            PhosphorIcons.caretRight(PhosphorIconsStyle.bold),
-                            size: 12,
-                            color: colors.textSecondary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              );
-            }(),
-            // Cards (only shown when not collapsed)
-            if (!_collapsedGroups.contains(entry.$1))
-              for (final p in groups[entry.$1]!) ...[
-                _PerspectiveCard(perspective: p),
-                const SizedBox(height: 8),
-              ],
-          ],
-      ],
-    );
-  }
-
-  Widget _buildBiasBar(BuildContext context, FacteurColors colors) {
-    // 3 simplified segments: Gauche (left+center-left), Centre, Droite (center-right+right)
-    final segments = [
-      ('gauche', 'Gauche', colors.biasLeft),
-      ('centre', 'Centre', colors.biasCenter),
-      ('droite', 'Droite', colors.biasRight),
-    ];
-
-    final merged = _mergedDistribution;
-    final total = merged.values.fold<int>(0, (sum, v) => sum + v);
-
-    // Compute proportional flex values
-    final flexValues = <int>[];
-    for (final seg in segments) {
-      final count = merged[seg.$1] ?? 0;
-      if (count > 0 && total > 0) {
-        final proportion = count / total;
-        flexValues.add((proportion * 100).round().clamp(15, 100));
-      } else {
-        flexValues.add(15); // Minimum width for empty segments
-      }
-    }
-
-    // Find the source's segment index for the marker
-    final sourceGroup = _toBarGroup(widget.sourceBiasStance);
-    final sourceIndex = segments.indexWhere((s) => s.$1 == sourceGroup);
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      child: Column(
-        children: [
-          // Labels (above the bar) — aligned with bar segments via same flex
-          Row(
-            children: List.generate(segments.length, (i) {
-              final seg = segments[i];
-              final count = merged[seg.$1] ?? 0;
-              return Expanded(
-                flex: flexValues[i],
-                child: Center(
-                  child: Container(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                    decoration: BoxDecoration(
-                      color: seg.$3
-                          .withOpacity(count > 0 ? 0.15 : 0.05),
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: FittedBox(
-                      fit: BoxFit.scaleDown,
-                      child: Text(
-                        seg.$2,
-                        maxLines: 1,
-                        style: TextStyle(
-                          fontSize: 10,
-                          fontWeight: FontWeight.w600,
-                          color: count > 0 ? seg.$3 : colors.textTertiary,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              );
-            }),
-          ),
-          const SizedBox(height: 4),
-
-          // Interactive 3-segment bias bar
-          Row(
-            children: List.generate(segments.length, (i) {
-              final seg = segments[i];
-              final count = merged[seg.$1] ?? 0;
-              final isSelected = _selectedGroup == seg.$1;
-              final hasArticles = count > 0;
-              return Expanded(
-                flex: flexValues[i],
-                child: GestureDetector(
-                  onTap: hasArticles
-                      ? () => setState(() {
-                            _selectedGroup =
-                                isSelected ? null : seg.$1;
-                          })
-                      : null,
-                  child: AnimatedContainer(
-                    duration: const Duration(milliseconds: 200),
-                    curve: Curves.easeOut,
-                    height: 12,
-                    margin: const EdgeInsets.symmetric(horizontal: 1.5),
-                    decoration: BoxDecoration(
-                      color: count > 0
-                          ? seg.$3.withValues(
-                              alpha: count == 1
-                                  ? 0.55
-                                  : (count == 2 ? 0.8 : 1.0))
-                          : seg.$3.withValues(alpha: 0.25),
-                      borderRadius: BorderRadius.circular(6),
-                      border: isSelected
-                          ? Border.all(
-                              color: seg.$3,
-                              width: 2.0,
-                            )
-                          : count > 0
-                              ? Border.all(
-                                  color:
-                                      Colors.black.withValues(alpha: 0.2),
-                                  width: 0.8,
-                                )
-                              : null,
-                    ),
-                  ),
-                ),
-              );
-            }),
-          ),
-
-          // "Votre source" marker
-          if (sourceIndex >= 0 &&
-              widget.sourceBiasStance != 'unknown') ...[
-            const SizedBox(height: 4),
-            LayoutBuilder(
-              builder: (context, constraints) {
-                final totalFlex =
-                    flexValues.fold<int>(0, (sum, f) => sum + f);
-                double offsetFraction = 0;
-                for (int i = 0; i < sourceIndex; i++) {
-                  offsetFraction += flexValues[i] / totalFlex;
-                }
-                // Center on the segment
-                offsetFraction += (flexValues[sourceIndex] / totalFlex) / 2;
-
-                final markerX = constraints.maxWidth * offsetFraction;
-                final sourceColor = segments[sourceIndex].$3;
-
-                final displayName = widget.sourceName.isNotEmpty
-                    ? widget.sourceName
-                    : segments[sourceIndex].$2;
-
-                return SizedBox(
-                  height: 28,
-                  child: Stack(
-                    clipBehavior: Clip.none,
-                    children: [
-                      Positioned(
-                        left: markerX - 7,
-                        top: 0,
-                        child: CustomPaint(
-                          size: const Size(14, 8),
-                          painter: PerspectivesTrianglePainter(color: sourceColor),
-                        ),
-                      ),
-                      Positioned(
-                        left: (markerX - 50)
-                            .clamp(0.0, constraints.maxWidth - 100),
-                        top: 10,
-                        child: SizedBox(
-                          width: 100,
-                          child: Text(
-                            displayName,
-                            textAlign: TextAlign.center,
-                            style: TextStyle(
-                              fontSize: 10,
-                              fontWeight: FontWeight.w700,
-                              color: sourceColor,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              },
-            ),
-          ],
-
-        ],
-      ),
-    );
-  }
-
-  Widget _buildEmptyState(
-      BuildContext context, FacteurColors colors, TextTheme textTheme) {
-    return SizedBox(
-      width: double.infinity,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 32),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              PhosphorIcons.newspaperClipping(PhosphorIconsStyle.duotone),
-              size: 48,
-              color: colors.textSecondary.withValues(alpha: 0.5),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Sujet peu couvert',
-              style: textTheme.titleSmall?.copyWith(
-                color: colors.textSecondary,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Ce sujet est peu couvert par les médias.\nEssaie la comparaison sur un autre article !',
-              style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
       ),
     );
   }
 }
 
-/// Inline (non-modal) version of the perspectives section.
-/// Designed to be embedded directly in the article scroll view below the body.
-class PerspectivesInlineSection extends ConsumerStatefulWidget {
-  final List<Perspective> perspectives;
-  final Map<String, int> biasDistribution;
-  final List<String> keywords;
-  final String sourceBiasStance;
-  final String sourceName;
-  final String contentId;
-  final String comparisonQuality;
-
-  /// Controlled mode: when provided, the parent owns the filter state.
-  final Set<String>? externalSelectedSegments;
-  final void Function(String)? onSegmentTap;
-  final VoidCallback? onClearSegments;
-
-  /// Analysis state controlled by the parent screen.
-  final PerspectivesAnalysisState analysisState;
-  final String? analysisText;
-  final VoidCallback? onRequestAnalysis;
-
-  /// Key attached to the analysis result zone so the parent can scroll to it.
-  final Key? analysisZoneKey;
-
-  const PerspectivesInlineSection({
-    super.key,
-    required this.perspectives,
-    required this.biasDistribution,
-    required this.keywords,
-    required this.contentId,
-    this.sourceBiasStance = 'unknown',
-    this.sourceName = '',
-    this.comparisonQuality = 'low',
-    this.externalSelectedSegments,
-    this.onSegmentTap,
-    this.onClearSegments,
-    this.analysisState = PerspectivesAnalysisState.idle,
-    this.analysisText,
-    this.onRequestAnalysis,
-    this.analysisZoneKey,
-  });
-
-  @override
-  ConsumerState<PerspectivesInlineSection> createState() =>
-      _PerspectivesInlineSectionState();
-}
-
-class _PerspectivesInlineSectionState
-    extends ConsumerState<PerspectivesInlineSection> {
-  bool _isAnalysisExpanded = true;
-  Set<String> _selectedSegments = {};
-
-  /// In controlled mode (widget.onSegmentTap != null), use the parent-provided
-  /// set; otherwise fall back to internal state.
-  Set<String> get _effectiveSegments =>
-      widget.externalSelectedSegments ?? _selectedSegments;
-
-  static const _groupOrder = ['gauche', 'centre', 'droite'];
-
-  Map<String, int> get _mergedDistribution {
-    final dist = widget.biasDistribution;
-    return {
-      'gauche': (dist['left'] ?? 0) + (dist['center-left'] ?? 0),
-      'centre': dist['center'] ?? 0,
-      'droite': (dist['center-right'] ?? 0) + (dist['right'] ?? 0),
-    };
-  }
-
-  List<Perspective> get _sortedPerspectives {
-    final sorted = [...widget.perspectives];
-    sorted.sort((a, b) =>
-        _groupOrder.indexOf(a.biasGroup).compareTo(_groupOrder.indexOf(b.biasGroup)));
-    return sorted;
-  }
-
-  List<Perspective> get _filteredPerspectives {
-    final sorted = _sortedPerspectives;
-    if (_effectiveSegments.isEmpty) return sorted;
-    return sorted.where((p) => _effectiveSegments.contains(p.biasGroup)).toList();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.facteurColors;
-    final textTheme = Theme.of(context).textTheme;
-    final filtered = _filteredPerspectives;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (widget.perspectives.isNotEmpty) ...[
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // Header
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Icon(
-                      PhosphorIcons.eye(PhosphorIconsStyle.regular),
-                      color: colors.primary,
-                      size: 28,
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Text(
-                        'Voir tous les points de vue',
-                        style: textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          color: colors.textPrimary,
-                          fontSize:
-                              (textTheme.titleMedium?.fontSize ?? 16) + 1,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                if (widget.comparisonQuality == 'low')
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4),
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 8,
-                        vertical: 3,
-                      ),
-                      decoration: BoxDecoration(
-                        color: colors.textTertiary
-                            .withValues(alpha: 0.08),
-                        borderRadius: BorderRadius.circular(6),
-                      ),
-                      child: Text(
-                        '⚠️ Comparaison limitée (sujet peu couvert)',
-                        style: textTheme.labelSmall?.copyWith(
-                          fontSize: 11,
-                          color: colors.textTertiary,
-                        ),
-                      ),
-                    ),
-                  ),
-
-                const SizedBox(height: 16),
-                _buildBiasBar(context, colors),
-                SizedBox(
-                  height: 20,
-                  child: _effectiveSegments.isNotEmpty
-                      ? Align(
-                          alignment: Alignment.centerRight,
-                          child: GestureDetector(
-                            onTap: () {
-                              if (widget.onClearSegments != null) {
-                                widget.onClearSegments!();
-                              } else {
-                                setState(() => _selectedSegments = {});
-                              }
-                            },
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Text(
-                                  'Tout afficher',
-                                  style: textTheme.labelSmall?.copyWith(
-                                    color: colors.primary,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                                const SizedBox(width: 4),
-                                Icon(
-                                  PhosphorIcons.x(PhosphorIconsStyle.bold),
-                                  size: 12,
-                                  color: colors.primary,
-                                ),
-                              ],
-                            ),
-                          ),
-                        )
-                      : null,
-                ),
-                const SizedBox(height: 8),
-              ],
-            ),
-          ),
-          // Cards without extra horizontal padding (they have their own)
-          if (filtered.isEmpty)
-            _buildEmptyState(context, colors, textTheme)
-          else
-            ...filtered.map(
-              (p) => Padding(
-                padding: const EdgeInsets.only(bottom: 8),
-                child: _PerspectiveCard(perspective: p),
-              ),
-            ),
-          // Analysis zone below last card (loading / done / error only)
-          if (widget.analysisState != PerspectivesAnalysisState.idle)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-              child: _buildAnalysisZone(context, colors, textTheme),
-            ),
-          // Spacer so the last card isn't hidden behind the floating button
-          if (widget.analysisState == PerspectivesAnalysisState.idle)
-            const SizedBox(height: 32),
-        ] else ...[
-          // No articles: header without analysis/bar, then full-width empty state
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Icon(
-                  PhosphorIcons.eye(PhosphorIconsStyle.regular),
-                  color: colors.primary,
-                  size: 28,
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Text(
-                    'Voir tous les points de vue',
-                    style: textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      color: colors.textPrimary,
-                      fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 16),
-          _buildEmptyState(context, colors, textTheme),
-        ],
-      ],
-    );
-  }
-
-  Widget _buildAnalysisZone(
-      BuildContext context, FacteurColors colors, TextTheme textTheme) {
-    return AnimatedSize(
-      key: widget.analysisZoneKey,
-      duration: const Duration(milliseconds: 300),
-      curve: Curves.easeOut,
-      child: switch (widget.analysisState) {
-        PerspectivesAnalysisState.idle => const SizedBox.shrink(),
-        PerspectivesAnalysisState.loading => _buildAnalysisSkeleton(colors),
-        PerspectivesAnalysisState.done => _buildAnalysisResult(colors, textTheme),
-        PerspectivesAnalysisState.error => _buildAnalysisError(colors, textTheme),
-      },
-    );
-  }
-
-  Widget _buildAnalysisSkeleton(FacteurColors colors) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: colors.primary.withValues(alpha: 0.05),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          for (var i = 0; i < 3; i++) ...[
-            if (i > 0) const SizedBox(height: 8),
-            _ShimmerLine(
-              width: i == 2 ? 0.6 : (i == 1 ? 0.9 : 1.0),
-              colors: colors,
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAnalysisResult(FacteurColors colors, TextTheme textTheme) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: colors.primary.withValues(alpha: 0.05),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: colors.primary.withValues(alpha: 0.15)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          GestureDetector(
-            onTap: () =>
-                setState(() => _isAnalysisExpanded = !_isAnalysisExpanded),
-            behavior: HitTestBehavior.opaque,
-            child: Row(
-              children: [
-                Icon(
-                  PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
-                  size: 18,
-                  color: colors.primary,
-                ),
-                const SizedBox(width: 8),
-                Text(
-                  'Analyse Facteur',
-                  style: textTheme.titleSmall?.copyWith(
-                    color: colors.primary,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const Spacer(),
-                AnimatedRotation(
-                  turns: _isAnalysisExpanded ? 0.25 : 0,
-                  duration: const Duration(milliseconds: 200),
-                  child: Icon(
-                    PhosphorIcons.caretRight(PhosphorIconsStyle.bold),
-                    size: 12,
-                    color: colors.primary,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          if (_isAnalysisExpanded) ...[
-            const SizedBox(height: 10),
-            MarkdownText(
-              text: widget.analysisText ?? '',
-              style: textTheme.bodySmall!.copyWith(
-                color: colors.textPrimary,
-                height: 1.6,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Align(
-              alignment: Alignment.centerRight,
-              child: Text(
-                'Analyse Facteur',
-                style: textTheme.bodySmall?.copyWith(
-                  fontSize: 10,
-                  fontStyle: FontStyle.italic,
-                  color: colors.textSecondary.withValues(alpha: 0.5),
-                ),
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAnalysisError(FacteurColors colors, TextTheme textTheme) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: colors.textSecondary.withValues(alpha: 0.05),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              'Analyse indisponible',
-              style: textTheme.bodySmall?.copyWith(color: colors.textSecondary),
-            ),
-          ),
-          TextButton(
-            onPressed: widget.onRequestAnalysis,
-            style: TextButton.styleFrom(
-              minimumSize: Size.zero,
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            ),
-            child: Text(
-              'Réessayer',
-              style: textTheme.labelSmall?.copyWith(
-                color: colors.primary,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _handleSegmentTap(String key) {
-    if (widget.onSegmentTap != null) {
-      widget.onSegmentTap!(key);
-    } else {
-      _onSegmentTapInternal(key);
-    }
-  }
-
-  void _onSegmentTapInternal(String key) {
-    setState(() {
-      if (_selectedSegments.contains(key)) {
-        if (_selectedSegments.length == 1) {
-          _selectedSegments = {};
-        } else {
-          _selectedSegments = Set.from(_selectedSegments)..remove(key);
-        }
-      } else {
-        if (_selectedSegments.isEmpty || _selectedSegments.length == 3) {
-          _selectedSegments = {key};
-        } else {
-          _selectedSegments = Set.from(_selectedSegments)..add(key);
-        }
-      }
-    });
-  }
-
-  Widget _buildBiasBar(BuildContext context, FacteurColors colors) {
-    final segments = [
-      ('gauche', 'Gauche', colors.biasLeft),
-      ('centre', 'Centre', colors.biasCenter),
-      ('droite', 'Droite', colors.biasRight),
-    ];
-
-    final merged = _mergedDistribution;
-    final total = merged.values.fold<int>(0, (sum, v) => sum + v);
-
-    final flexValues = <int>[];
-    for (final seg in segments) {
-      final count = merged[seg.$1] ?? 0;
-      if (count > 0 && total > 0) {
-        final proportion = count / total;
-        flexValues.add((proportion * 100).round().clamp(15, 100));
-      } else {
-        flexValues.add(15);
-      }
-    }
-
-    final sourceGroup = _toBarGroup(widget.sourceBiasStance);
-    final sourceIndex = segments.indexWhere((s) => s.$1 == sourceGroup);
-
-    return Column(
-      children: [
-        Row(
-          children: List.generate(segments.length, (i) {
-            final seg = segments[i];
-            final count = merged[seg.$1] ?? 0;
-            final isActive = _effectiveSegments.isEmpty ||
-                _effectiveSegments.contains(seg.$1);
-            return Expanded(
-              flex: flexValues[i],
-              child: GestureDetector(
-                onTap: count > 0 ? () => _handleSegmentTap(seg.$1) : null,
-                child: AnimatedOpacity(
-                  duration: const Duration(milliseconds: 200),
-                  opacity: isActive ? 1.0 : 0.3,
-                  child: Column(
-                    children: [
-                      Center(
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 6, vertical: 2),
-                          decoration: BoxDecoration(
-                            color: seg.$3
-                                .withValues(alpha: count > 0 ? 0.15 : 0.05),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: FittedBox(
-                            fit: BoxFit.scaleDown,
-                            child: Text(
-                              seg.$2,
-                              maxLines: 1,
-                              style: TextStyle(
-                                fontSize: 10,
-                                fontWeight: FontWeight.w600,
-                                color:
-                                    count > 0 ? seg.$3 : colors.textTertiary,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      AnimatedContainer(
-                        duration: const Duration(milliseconds: 200),
-                        curve: Curves.easeOut,
-                        height: 12,
-                        margin: const EdgeInsets.symmetric(horizontal: 1.5),
-                        decoration: BoxDecoration(
-                          color: count > 0
-                              ? seg.$3.withValues(
-                                  alpha: count == 1
-                                      ? 0.55
-                                      : (count == 2 ? 0.8 : 1.0))
-                              : seg.$3.withValues(alpha: 0.25),
-                          borderRadius: BorderRadius.circular(6),
-                          border: count > 0
-                              ? Border.all(
-                                  color: Colors.black.withValues(alpha: 0.2),
-                                  width: 0.8,
-                                )
-                              : null,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            );
-          }),
-        ),
-        if (sourceIndex >= 0 && widget.sourceBiasStance != 'unknown') ...[
-          const SizedBox(height: 4),
-          LayoutBuilder(
-            builder: (context, constraints) {
-              final totalFlex =
-                  flexValues.fold<int>(0, (sum, f) => sum + f);
-              double offsetFraction = 0;
-              for (int i = 0; i < sourceIndex; i++) {
-                offsetFraction += flexValues[i] / totalFlex;
-              }
-              offsetFraction += (flexValues[sourceIndex] / totalFlex) / 2;
-
-              final markerX = constraints.maxWidth * offsetFraction;
-              final sourceColor = segments[sourceIndex].$3;
-              final displayName = widget.sourceName.isNotEmpty
-                  ? widget.sourceName
-                  : segments[sourceIndex].$2;
-
-              return SizedBox(
-                height: 28,
-                child: Stack(
-                  clipBehavior: Clip.none,
-                  children: [
-                    Positioned(
-                      left: markerX - 7,
-                      top: 0,
-                      child: CustomPaint(
-                        size: const Size(14, 8),
-                        painter: PerspectivesTrianglePainter(color: sourceColor),
-                      ),
-                    ),
-                    Positioned(
-                      left: (markerX - 50)
-                          .clamp(0.0, constraints.maxWidth - 100),
-                      top: 10,
-                      child: SizedBox(
-                        width: 100,
-                        child: Text(
-                          displayName,
-                          textAlign: TextAlign.center,
-                          style: TextStyle(
-                            fontSize: 10,
-                            fontWeight: FontWeight.w700,
-                            color: sourceColor,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
-        ],
-      ],
-    );
-  }
-
-  Widget _buildEmptyState(
-      BuildContext context, FacteurColors colors, TextTheme textTheme) {
-    return SizedBox(
-      width: double.infinity,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 32),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              PhosphorIcons.newspaperClipping(PhosphorIconsStyle.duotone),
-              size: 48,
-              color: colors.textSecondary.withValues(alpha: 0.5),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Sujet peu couvert',
-              style: textTheme.titleSmall?.copyWith(
-                color: colors.textSecondary,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Ce sujet est peu couvert par les médias.\nEssaie la comparaison sur un autre article !',
-              style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// Shimmer line for skeleton loading
 class _ShimmerLine extends StatefulWidget {
   final double width;
   final FacteurColors colors;
@@ -1482,7 +422,7 @@ class _ShimmerLineState extends State<_ShimmerLine>
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(6),
               color: widget.colors.textSecondary
-                  .withOpacity(0.08 + 0.08 * _controller.value),
+                  .withValues(alpha: 0.08 + 0.08 * _controller.value),
             ),
           ),
         );
@@ -1624,10 +564,10 @@ class _PerspectiveCard extends ConsumerWidget {
                   : null,
               child: Container(
                 decoration: BoxDecoration(
-                  color: colors.backgroundSecondary.withOpacity(0.5),
+                  color: colors.backgroundSecondary.withValues(alpha: 0.5),
                   border: Border(
                     top: BorderSide(
-                      color: colors.textSecondary.withOpacity(0.1),
+                      color: colors.textSecondary.withValues(alpha: 0.1),
                       width: 1,
                     ),
                   ),
@@ -1645,7 +585,7 @@ class _PerspectiveCard extends ConsumerWidget {
                       decoration: BoxDecoration(
                         color: perspective
                             .getBiasColor(colors)
-                            .withOpacity(0.15),
+                            .withValues(alpha: 0.15),
                         borderRadius: BorderRadius.circular(8),
                       ),
                       child: Text(
@@ -1725,6 +665,693 @@ class _PerspectiveCard extends ConsumerWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+
+class PerspectivesWarningBadge extends StatelessWidget {
+  final FacteurColors colors;
+  final TextTheme textTheme;
+
+  const PerspectivesWarningBadge({
+    super.key,
+    required this.colors,
+    required this.textTheme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          color: colors.textTertiary.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Text(
+          '⚠️ Comparaison limitée (sujet peu couvert)',
+          style: textTheme.labelSmall?.copyWith(
+            fontSize: 11,
+            color: colors.textTertiary,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+    );
+  }
+}
+
+class PerspectivesEmptyState extends StatelessWidget {
+  final FacteurColors colors;
+  final TextTheme textTheme;
+
+  const PerspectivesEmptyState({
+    super.key,
+    required this.colors,
+    required this.textTheme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              PhosphorIcons.newspaperClipping(PhosphorIconsStyle.duotone),
+              size: 48,
+              color: colors.textSecondary.withValues(alpha: 0.5),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Sujet peu couvert',
+              style: textTheme.titleSmall?.copyWith(
+                color: colors.textSecondary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Ce sujet est peu couvert par les médias.\nEssaie la comparaison sur un autre article !',
+              style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class PerspectivesBiasBar extends StatelessWidget {
+  final FacteurColors colors;
+  final Map<String, int> mergedDistribution;
+  final String sourceBiasStance;
+  final String sourceName;
+  final Set<String> selectedSegments;
+  final void Function(String) onSegmentTap;
+
+  const PerspectivesBiasBar({
+    super.key,
+    required this.colors,
+    required this.mergedDistribution,
+    required this.sourceBiasStance,
+    required this.sourceName,
+    required this.selectedSegments,
+    required this.onSegmentTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final segments = [
+      ('gauche', 'Gauche', colors.biasLeft),
+      ('centre', 'Centre', colors.biasCenter),
+      ('droite', 'Droite', colors.biasRight),
+    ];
+
+    final total = mergedDistribution.values.fold<int>(0, (sum, v) => sum + v);
+
+    final flexValues = <int>[];
+    for (final seg in segments) {
+      final count = mergedDistribution[seg.$1] ?? 0;
+      if (count > 0 && total > 0) {
+        final proportion = count / total;
+        flexValues.add((proportion * 100).round().clamp(15, 100));
+      } else {
+        flexValues.add(15);
+      }
+    }
+
+    final sourceGroup = _toBarGroup(sourceBiasStance);
+    final sourceIndex = segments.indexWhere((s) => s.$1 == sourceGroup);
+
+    return Column(
+      children: [
+        Row(
+          children: List.generate(segments.length, (i) {
+            final seg = segments[i];
+            final count = mergedDistribution[seg.$1] ?? 0;
+            final isActive = selectedSegments.isEmpty || selectedSegments.contains(seg.$1);
+            return Expanded(
+              flex: flexValues[i],
+              child: GestureDetector(
+                onTap: count > 0 ? () => onSegmentTap(seg.$1) : null,
+                child: AnimatedOpacity(
+                  duration: const Duration(milliseconds: 200),
+                  opacity: isActive ? 1.0 : 0.3,
+                  child: Column(
+                    children: [
+                      Center(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: seg.$3.withValues(alpha: count > 0 ? 0.15 : 0.05),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: FittedBox(
+                            fit: BoxFit.scaleDown,
+                            child: Text(
+                              seg.$2,
+                              maxLines: 1,
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w600,
+                                color: count > 0 ? seg.$3 : colors.textTertiary,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      AnimatedContainer(
+                        duration: const Duration(milliseconds: 200),
+                        curve: Curves.easeOut,
+                        height: 12,
+                        margin: const EdgeInsets.symmetric(horizontal: 1.5),
+                        decoration: BoxDecoration(
+                          color: count > 0
+                              ? seg.$3.withValues(
+                                  alpha: count == 1 ? 0.55 : (count == 2 ? 0.8 : 1.0))
+                              : seg.$3.withValues(alpha: 0.25),
+                          borderRadius: BorderRadius.circular(6),
+                          border: count > 0
+                              ? Border.all(
+                                  color: Colors.black.withValues(alpha: 0.2),
+                                  width: 0.8,
+                                )
+                              : null,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          }),
+        ),
+        if (sourceIndex >= 0 && sourceBiasStance != 'unknown') ...[
+          const SizedBox(height: 4),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final totalFlex = flexValues.fold<int>(0, (sum, f) => sum + f);
+              double offsetFraction = 0;
+              for (int i = 0; i < sourceIndex; i++) {
+                offsetFraction += flexValues[i] / totalFlex;
+              }
+              offsetFraction += (flexValues[sourceIndex] / totalFlex) / 2;
+
+              final markerX = constraints.maxWidth * offsetFraction;
+              final sourceColor = segments[sourceIndex].$3;
+              final displayName = sourceName.isNotEmpty ? sourceName : segments[sourceIndex].$2;
+
+              return SizedBox(
+                height: 28,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    Positioned(
+                      left: markerX - 7,
+                      top: 0,
+                      child: CustomPaint(
+                        size: const Size(14, 8),
+                        painter: PerspectivesTrianglePainter(color: sourceColor),
+                      ),
+                    ),
+                    Positioned(
+                      left: (markerX - 50).clamp(0.0, constraints.maxWidth - 100),
+                      top: 10,
+                      child: SizedBox(
+                        width: 100,
+                        child: Text(
+                          displayName,
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.w700,
+                            color: sourceColor,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class PerspectivesAnalysisZone extends StatefulWidget {
+  final PerspectivesAnalysisState state;
+  final String? text;
+  final VoidCallback? onRequestAnalysis;
+  final FacteurColors colors;
+  final TextTheme textTheme;
+  final Key? zoneKey;
+
+  const PerspectivesAnalysisZone({
+    super.key,
+    required this.state,
+    this.text,
+    required this.onRequestAnalysis,
+    required this.colors,
+    required this.textTheme,
+    this.zoneKey,
+  });
+
+  @override
+  State<PerspectivesAnalysisZone> createState() => PerspectivesAnalysisZoneState();
+}
+
+class PerspectivesAnalysisZoneState extends State<PerspectivesAnalysisZone> {
+  bool _isAnalysisExpanded = true;
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.state == PerspectivesAnalysisState.idle) {
+      return _buildAnalysisCta();
+    }
+    
+    return AnimatedSize(
+      key: widget.zoneKey,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOut,
+      child: switch (widget.state) {
+        PerspectivesAnalysisState.idle => const SizedBox.shrink(),
+        PerspectivesAnalysisState.loading => _buildAnalysisSkeleton(),
+        PerspectivesAnalysisState.done => _buildAnalysisResult(),
+        PerspectivesAnalysisState.error => _buildAnalysisError(),
+      },
+    );
+  }
+
+  Widget _buildAnalysisCta() {
+    return Center(
+      child: OutlinedButton.icon(
+        onPressed: widget.onRequestAnalysis,
+        icon: Icon(
+          PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+          size: 18,
+          color: widget.colors.primary,
+        ),
+        label: Text(
+          "Lancer l'analyse Facteur",
+          style: widget.textTheme.labelLarge?.copyWith(
+            color: widget.colors.primary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        style: OutlinedButton.styleFrom(
+          side: BorderSide(color: widget.colors.primary.withValues(alpha: 0.4)),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 20),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAnalysisSkeleton() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: widget.colors.primary.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (var i = 0; i < 3; i++) ...[
+            if (i > 0) const SizedBox(height: 8),
+            _ShimmerLine(
+              width: i == 2 ? 0.6 : (i == 1 ? 0.9 : 1.0),
+              colors: widget.colors,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAnalysisResult() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: widget.colors.primary.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: widget.colors.primary.withValues(alpha: 0.15)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          GestureDetector(
+            onTap: () => setState(() => _isAnalysisExpanded = !_isAnalysisExpanded),
+            behavior: HitTestBehavior.opaque,
+            child: Row(
+              children: [
+                Icon(
+                  PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                  size: 18,
+                  color: widget.colors.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'Analyse Facteur',
+                  style: widget.textTheme.titleSmall?.copyWith(
+                    color: widget.colors.primary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const Spacer(),
+                AnimatedRotation(
+                  turns: _isAnalysisExpanded ? 0.25 : 0,
+                  duration: const Duration(milliseconds: 200),
+                  child: Icon(
+                    PhosphorIcons.caretRight(PhosphorIconsStyle.bold),
+                    size: 12,
+                    color: widget.colors.primary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (_isAnalysisExpanded) ...[
+            const SizedBox(height: 10),
+            MarkdownText(
+              text: widget.text ?? '',
+              style: widget.textTheme.bodySmall!.copyWith(
+                color: widget.colors.textPrimary,
+                height: 1.6,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                'Analyse Facteur',
+                style: widget.textTheme.bodySmall?.copyWith(
+                  fontSize: 10,
+                  fontStyle: FontStyle.italic,
+                  color: widget.colors.textSecondary.withValues(alpha: 0.5),
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAnalysisError() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: widget.colors.textSecondary.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              'Analyse indisponible',
+              style: widget.textTheme.bodySmall?.copyWith(
+                color: widget.colors.textSecondary,
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: widget.onRequestAnalysis,
+            style: TextButton.styleFrom(
+              minimumSize: Size.zero,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: Text(
+              'Réessayer',
+              style: widget.textTheme.labelSmall?.copyWith(
+                color: widget.colors.primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class PerspectivesInlineSection extends ConsumerStatefulWidget {
+  final List<Perspective> perspectives;
+  final Map<String, int> biasDistribution;
+  final List<String> keywords;
+  final String sourceBiasStance;
+  final String sourceName;
+  final String contentId;
+  final String comparisonQuality;
+
+  /// Controlled mode: when provided, the parent owns the filter state.
+  final Set<String>? externalSelectedSegments;
+  final void Function(String)? onSegmentTap;
+  final VoidCallback? onClearSegments;
+
+  /// Analysis state controlled by the parent screen.
+  final PerspectivesAnalysisState analysisState;
+  final String? analysisText;
+  final VoidCallback? onRequestAnalysis;
+
+  /// Key attached to the analysis result zone so the parent can scroll to it.
+  final Key? analysisZoneKey;
+
+  const PerspectivesInlineSection({
+    super.key,
+    required this.perspectives,
+    required this.biasDistribution,
+    required this.keywords,
+    required this.contentId,
+    this.sourceBiasStance = 'unknown',
+    this.sourceName = '',
+    this.comparisonQuality = 'low',
+    this.externalSelectedSegments,
+    this.onSegmentTap,
+    this.onClearSegments,
+    this.analysisState = PerspectivesAnalysisState.idle,
+    this.analysisText,
+    this.onRequestAnalysis,
+    this.analysisZoneKey,
+  });
+
+  @override
+  ConsumerState<PerspectivesInlineSection> createState() =>
+      _PerspectivesInlineSectionState();
+}
+
+class _PerspectivesInlineSectionState extends ConsumerState<PerspectivesInlineSection> {
+  Set<String> _selectedSegments = {};
+
+  Set<String> get _effectiveSegments =>
+      widget.externalSelectedSegments ?? _selectedSegments;
+
+  static const _groupOrder = ['gauche', 'centre', 'droite'];
+
+  Map<String, int> get _mergedDistribution {
+    final dist = widget.biasDistribution;
+    return {
+      'gauche': (dist['left'] ?? 0) + (dist['center-left'] ?? 0),
+      'centre': dist['center'] ?? 0,
+      'droite': (dist['center-right'] ?? 0) + (dist['right'] ?? 0),
+    };
+  }
+
+  List<Perspective> get _sortedPerspectives {
+    final sorted = [...widget.perspectives];
+    sorted.sort((a, b) =>
+        _groupOrder.indexOf(a.biasGroup).compareTo(_groupOrder.indexOf(b.biasGroup)));
+    return sorted;
+  }
+
+  List<Perspective> get _filteredPerspectives {
+    final sorted = _sortedPerspectives;
+    if (_effectiveSegments.isEmpty) return sorted;
+    return sorted.where((p) => _effectiveSegments.contains(p.biasGroup)).toList();
+  }
+
+  void _onSegmentTapInternal(String key) {
+    setState(() {
+      if (_selectedSegments.contains(key)) {
+        if (_selectedSegments.length == 1) {
+          _selectedSegments = {};
+        } else {
+          _selectedSegments = Set.from(_selectedSegments)..remove(key);
+        }
+      } else {
+        if (_selectedSegments.isEmpty || _selectedSegments.length == 3) {
+          _selectedSegments = {key};
+        } else {
+          _selectedSegments = Set.from(_selectedSegments)..add(key);
+        }
+      }
+    });
+  }
+
+  void _handleSegmentTap(String key) {
+    if (widget.onSegmentTap != null) {
+      widget.onSegmentTap!(key);
+    } else {
+      _onSegmentTapInternal(key);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final filtered = _filteredPerspectives;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.perspectives.isNotEmpty) ...[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      PhosphorIcons.eye(PhosphorIconsStyle.regular),
+                      color: colors.primary,
+                      size: 28,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        'Voir tous les points de vue',
+                        style: textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: colors.textPrimary,
+                          fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                if (widget.comparisonQuality == 'low')
+                  PerspectivesWarningBadge(colors: colors, textTheme: textTheme),
+                const SizedBox(height: 16),
+                PerspectivesBiasBar(
+                  colors: colors,
+                  mergedDistribution: _mergedDistribution,
+                  sourceBiasStance: widget.sourceBiasStance,
+                  sourceName: widget.sourceName,
+                  selectedSegments: _effectiveSegments,
+                  onSegmentTap: _handleSegmentTap,
+                ),
+                SizedBox(
+                  height: 20,
+                  child: _effectiveSegments.isNotEmpty
+                      ? Align(
+                          alignment: Alignment.centerRight,
+                          child: GestureDetector(
+                            onTap: () {
+                              if (widget.onClearSegments != null) {
+                                widget.onClearSegments!();
+                              } else {
+                                setState(() => _selectedSegments = {});
+                              }
+                            },
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  'Tout afficher',
+                                  style: textTheme.labelSmall?.copyWith(
+                                    color: colors.primary,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                const SizedBox(width: 4),
+                                Icon(
+                                  PhosphorIcons.x(PhosphorIconsStyle.bold),
+                                  size: 12,
+                                  color: colors.primary,
+                                ),
+                              ],
+                            ),
+                          ),
+                        )
+                      : null,
+                ),
+                const SizedBox(height: 8),
+              ],
+            ),
+          ),
+          if (filtered.isEmpty)
+            PerspectivesEmptyState(colors: colors, textTheme: textTheme)
+          else
+            ...filtered.map(
+              (p) => Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: _PerspectiveCard(perspective: p),
+              ),
+            ),
+          if (widget.analysisState != PerspectivesAnalysisState.idle)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+              child: PerspectivesAnalysisZone(
+                state: widget.analysisState,
+                text: widget.analysisText,
+                onRequestAnalysis: widget.onRequestAnalysis,
+                colors: colors,
+                textTheme: textTheme,
+                zoneKey: widget.analysisZoneKey,
+              ),
+            ),
+          if (widget.analysisState == PerspectivesAnalysisState.idle)
+            const SizedBox(height: 32),
+        ] else ...[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  PhosphorIcons.eye(PhosphorIconsStyle.regular),
+                  color: colors.primary,
+                  size: 28,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    'Voir tous les points de vue',
+                    style: textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: colors.textPrimary,
+                      fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          PerspectivesEmptyState(colors: colors, textTheme: textTheme),
+        ],
+      ],
     );
   }
 }

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -144,14 +144,14 @@ class PerspectivesBottomSheet extends ConsumerStatefulWidget {
       _PerspectivesBottomSheetState();
 }
 
-enum _AnalysisState { idle, loading, done, error }
+enum PerspectivesAnalysisState { idle, loading, done, error }
 
 class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomSheet> {
   /// Collapsed groups: each group can be independently collapsed
   final Set<String> _collapsedGroups = {};
 
   /// Analysis state
-  late _AnalysisState _analysisState;
+  PerspectivesAnalysisState _analysisState = PerspectivesAnalysisState.idle;
   String? _analysisText;
   bool _isAnalysisExpanded = true;
   bool _isCachedAnalysis = false;
@@ -160,16 +160,22 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
   void initState() {
     super.initState();
     if (widget.initialAnalysis != null) {
-      _analysisState = _AnalysisState.done;
+      _analysisState = PerspectivesAnalysisState.done;
       _analysisText = widget.initialAnalysis;
       _isCachedAnalysis = widget.analysisCached;
     } else {
-      _analysisState = _AnalysisState.idle;
+      _analysisState = PerspectivesAnalysisState.idle;
     }
   }
 
+  /// Active bias filter (null = show all)
+  String? _selectedGroup;
+
   List<Perspective> get _filteredPerspectives {
-    return widget.perspectives;
+    if (_selectedGroup == null) return widget.perspectives;
+    return widget.perspectives
+        .where((p) => p.biasGroup == _selectedGroup)
+        .toList();
   }
 
   /// Compute merged 3-segment distribution from the 5-segment API data
@@ -190,7 +196,7 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
   }
 
   Future<void> _requestAnalysis() async {
-    setState(() => _analysisState = _AnalysisState.loading);
+    setState(() => _analysisState = PerspectivesAnalysisState.loading);
 
     try {
       final repository = ref.read(feedRepositoryProvider);
@@ -201,11 +207,11 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
       setState(() {
         _analysisText = result;
         _analysisState =
-            result != null ? _AnalysisState.done : _AnalysisState.error;
+            result != null ? PerspectivesAnalysisState.done : PerspectivesAnalysisState.error;
       });
     } catch (e) {
       if (!mounted) return;
-      setState(() => _analysisState = _AnalysisState.error);
+      setState(() => _analysisState = PerspectivesAnalysisState.error);
     }
   }
 
@@ -240,64 +246,69 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
           // Header
           Padding(
             padding: const EdgeInsets.all(16),
-            child: Row(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Icon(
-                  PhosphorIcons.eye(PhosphorIconsStyle.fill),
-                  color: colors.primary,
-                  size: 32,
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Voir tous les points de vue',
-                        style: textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          color: colors.textPrimary,
-                          fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
-                        ),
-                      ),
-                      Text(
-                        '(${widget.keywords.join(', ')})',
-                        style: textTheme.labelSmall?.copyWith(
-                          color: colors.textSecondary,
-                          fontSize: (textTheme.labelSmall?.fontSize ?? 11) + 1,
-                        ),
-                      ),
-                      if (widget.comparisonQuality == 'low')
-                        Padding(
-                          padding: const EdgeInsets.only(top: 4),
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 3,
-                            ),
-                            decoration: BoxDecoration(
-                              color: colors.textTertiary.withOpacity(0.08),
-                              borderRadius: BorderRadius.circular(6),
-                            ),
-                            child: Text(
-                              '⚠️ Comparaison limitée (sujet peu couvert)',
-                              style: textTheme.labelSmall?.copyWith(
-                                fontSize: 11,
-                                color: colors.textTertiary,
-                              ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
+                Row(
+                  children: [
+                    Icon(
+                      PhosphorIcons.eye(PhosphorIconsStyle.fill),
+                      color: colors.primary,
+                      size: 32,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Voir tous les points de vue',
+                            style: textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: colors.textPrimary,
+                              fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
                             ),
                           ),
+                          Text(
+                            '(${widget.keywords.join(', ')})',
+                            style: textTheme.labelSmall?.copyWith(
+                              color: colors.textSecondary,
+                              fontSize: (textTheme.labelSmall?.fontSize ?? 11) + 1,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    IconButton(
+                      icon: Icon(PhosphorIcons.x(PhosphorIconsStyle.bold)),
+                      onPressed: () => Navigator.pop(context),
+                      color: colors.textSecondary,
+                    ),
+                  ],
+                ),
+                if (widget.comparisonQuality == 'low')
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 3,
+                      ),
+                      decoration: BoxDecoration(
+                        color: colors.textTertiary.withValues(alpha: 0.08),
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Text(
+                        '⚠️ Comparaison limitée (sujet peu couvert)',
+                        style: textTheme.labelSmall?.copyWith(
+                          fontSize: 11,
+                          color: colors.textTertiary,
                         ),
-                    ],
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
                   ),
-                ),
-                IconButton(
-                  icon: Icon(PhosphorIcons.x(PhosphorIconsStyle.bold)),
-                  onPressed: () => Navigator.pop(context),
-                  color: colors.textSecondary,
-                ),
               ],
             ),
           ),
@@ -311,7 +322,7 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
                 ? _buildEmptyState(context, colors, textTheme)
                 : _shouldGroup
                     ? _buildGroupedList(context, colors, textTheme,
-                        widget.perspectives)
+                        filtered)
                     : ListView.separated(
                         shrinkWrap: true,
                         padding: const EdgeInsets.symmetric(vertical: 8),
@@ -341,10 +352,10 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
         duration: const Duration(milliseconds: 300),
         curve: Curves.easeOut,
         child: switch (_analysisState) {
-          _AnalysisState.idle => _buildAnalysisCta(colors, textTheme),
-          _AnalysisState.loading => _buildAnalysisSkeleton(colors),
-          _AnalysisState.done => _buildAnalysisResult(colors, textTheme),
-          _AnalysisState.error => _buildAnalysisError(colors, textTheme),
+          PerspectivesAnalysisState.idle => _buildAnalysisCta(colors, textTheme),
+          PerspectivesAnalysisState.loading => _buildAnalysisSkeleton(colors),
+          PerspectivesAnalysisState.done => _buildAnalysisResult(colors, textTheme),
+          PerspectivesAnalysisState.error => _buildAnalysisError(colors, textTheme),
         },
       ),
     );
@@ -689,26 +700,43 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
             children: List.generate(segments.length, (i) {
               final seg = segments[i];
               final count = merged[seg.$1] ?? 0;
+              final isSelected = _selectedGroup == seg.$1;
+              final hasArticles = count > 0;
               return Expanded(
                 flex: flexValues[i],
-                child: AnimatedContainer(
-                  duration: const Duration(milliseconds: 200),
-                  curve: Curves.easeOut,
-                  height: 12,
-                  margin: const EdgeInsets.symmetric(horizontal: 1.5),
-                  decoration: BoxDecoration(
-                    color: count > 0
-                        ? seg.$3.withOpacity(count == 1
-                                ? 0.55
-                                : (count == 2 ? 0.8 : 1.0))
-                        : seg.$3.withOpacity(0.25),
-                    borderRadius: BorderRadius.circular(6),
-                    border: count > 0
-                        ? Border.all(
-                            color: Colors.black.withOpacity(0.2),
-                            width: 0.8,
-                          )
-                        : null,
+                child: GestureDetector(
+                  onTap: hasArticles
+                      ? () => setState(() {
+                            _selectedGroup =
+                                isSelected ? null : seg.$1;
+                          })
+                      : null,
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    curve: Curves.easeOut,
+                    height: 12,
+                    margin: const EdgeInsets.symmetric(horizontal: 1.5),
+                    decoration: BoxDecoration(
+                      color: count > 0
+                          ? seg.$3.withValues(
+                              alpha: count == 1
+                                  ? 0.55
+                                  : (count == 2 ? 0.8 : 1.0))
+                          : seg.$3.withValues(alpha: 0.25),
+                      borderRadius: BorderRadius.circular(6),
+                      border: isSelected
+                          ? Border.all(
+                              color: seg.$3,
+                              width: 2.0,
+                            )
+                          : count > 0
+                              ? Border.all(
+                                  color:
+                                      Colors.black.withValues(alpha: 0.2),
+                                  width: 0.8,
+                                )
+                              : null,
+                    ),
                   ),
                 ),
               );
@@ -747,7 +775,7 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
                         top: 0,
                         child: CustomPaint(
                           size: const Size(14, 8),
-                          painter: _TrianglePainter(color: sourceColor),
+                          painter: PerspectivesTrianglePainter(color: sourceColor),
                         ),
                       ),
                       Positioned(
@@ -783,31 +811,629 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
 
   Widget _buildEmptyState(
       BuildContext context, FacteurColors colors, TextTheme textTheme) {
-    return Padding(
-      padding: const EdgeInsets.all(32),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            PhosphorIcons.newspaperClipping(PhosphorIconsStyle.duotone),
-            size: 48,
-            color: colors.textSecondary.withOpacity(0.5),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'Sujet peu couvert',
-            style: textTheme.titleSmall?.copyWith(
-              color: colors.textSecondary,
-              fontWeight: FontWeight.w600,
+    return SizedBox(
+      width: double.infinity,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              PhosphorIcons.newspaperClipping(PhosphorIconsStyle.duotone),
+              size: 48,
+              color: colors.textSecondary.withValues(alpha: 0.5),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Sujet peu couvert',
+              style: textTheme.titleSmall?.copyWith(
+                color: colors.textSecondary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Ce sujet est peu couvert par les médias.\nEssaie la comparaison sur un autre article !',
+              style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Inline (non-modal) version of the perspectives section.
+/// Designed to be embedded directly in the article scroll view below the body.
+class PerspectivesInlineSection extends ConsumerStatefulWidget {
+  final List<Perspective> perspectives;
+  final Map<String, int> biasDistribution;
+  final List<String> keywords;
+  final String sourceBiasStance;
+  final String sourceName;
+  final String contentId;
+  final String comparisonQuality;
+
+  /// Controlled mode: when provided, the parent owns the filter state.
+  final Set<String>? externalSelectedSegments;
+  final void Function(String)? onSegmentTap;
+  final VoidCallback? onClearSegments;
+
+  /// Analysis state controlled by the parent screen.
+  final PerspectivesAnalysisState analysisState;
+  final String? analysisText;
+  final VoidCallback? onRequestAnalysis;
+
+  /// Key attached to the analysis result zone so the parent can scroll to it.
+  final Key? analysisZoneKey;
+
+  const PerspectivesInlineSection({
+    super.key,
+    required this.perspectives,
+    required this.biasDistribution,
+    required this.keywords,
+    required this.contentId,
+    this.sourceBiasStance = 'unknown',
+    this.sourceName = '',
+    this.comparisonQuality = 'low',
+    this.externalSelectedSegments,
+    this.onSegmentTap,
+    this.onClearSegments,
+    this.analysisState = PerspectivesAnalysisState.idle,
+    this.analysisText,
+    this.onRequestAnalysis,
+    this.analysisZoneKey,
+  });
+
+  @override
+  ConsumerState<PerspectivesInlineSection> createState() =>
+      _PerspectivesInlineSectionState();
+}
+
+class _PerspectivesInlineSectionState
+    extends ConsumerState<PerspectivesInlineSection> {
+  bool _isAnalysisExpanded = true;
+  Set<String> _selectedSegments = {};
+
+  /// In controlled mode (widget.onSegmentTap != null), use the parent-provided
+  /// set; otherwise fall back to internal state.
+  Set<String> get _effectiveSegments =>
+      widget.externalSelectedSegments ?? _selectedSegments;
+
+  static const _groupOrder = ['gauche', 'centre', 'droite'];
+
+  Map<String, int> get _mergedDistribution {
+    final dist = widget.biasDistribution;
+    return {
+      'gauche': (dist['left'] ?? 0) + (dist['center-left'] ?? 0),
+      'centre': dist['center'] ?? 0,
+      'droite': (dist['center-right'] ?? 0) + (dist['right'] ?? 0),
+    };
+  }
+
+  List<Perspective> get _sortedPerspectives {
+    final sorted = [...widget.perspectives];
+    sorted.sort((a, b) =>
+        _groupOrder.indexOf(a.biasGroup).compareTo(_groupOrder.indexOf(b.biasGroup)));
+    return sorted;
+  }
+
+  List<Perspective> get _filteredPerspectives {
+    final sorted = _sortedPerspectives;
+    if (_effectiveSegments.isEmpty) return sorted;
+    return sorted.where((p) => _effectiveSegments.contains(p.biasGroup)).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final filtered = _filteredPerspectives;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.perspectives.isNotEmpty) ...[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Header
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      PhosphorIcons.eye(PhosphorIconsStyle.regular),
+                      color: colors.primary,
+                      size: 28,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        'Voir tous les points de vue',
+                        style: textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: colors.textPrimary,
+                          fontSize:
+                              (textTheme.titleMedium?.fontSize ?? 16) + 1,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                if (widget.comparisonQuality == 'low')
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 3,
+                      ),
+                      decoration: BoxDecoration(
+                        color: colors.textTertiary
+                            .withValues(alpha: 0.08),
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Text(
+                        '⚠️ Comparaison limitée (sujet peu couvert)',
+                        style: textTheme.labelSmall?.copyWith(
+                          fontSize: 11,
+                          color: colors.textTertiary,
+                        ),
+                      ),
+                    ),
+                  ),
+
+                const SizedBox(height: 16),
+                _buildBiasBar(context, colors),
+                SizedBox(
+                  height: 20,
+                  child: _effectiveSegments.isNotEmpty
+                      ? Align(
+                          alignment: Alignment.centerRight,
+                          child: GestureDetector(
+                            onTap: () {
+                              if (widget.onClearSegments != null) {
+                                widget.onClearSegments!();
+                              } else {
+                                setState(() => _selectedSegments = {});
+                              }
+                            },
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  'Tout afficher',
+                                  style: textTheme.labelSmall?.copyWith(
+                                    color: colors.primary,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                const SizedBox(width: 4),
+                                Icon(
+                                  PhosphorIcons.x(PhosphorIconsStyle.bold),
+                                  size: 12,
+                                  color: colors.primary,
+                                ),
+                              ],
+                            ),
+                          ),
+                        )
+                      : null,
+                ),
+                const SizedBox(height: 8),
+              ],
             ),
           ),
-          const SizedBox(height: 8),
-          Text(
-            'Ce sujet est peu couvert par les médias.\nEssaie la comparaison sur un autre article !',
-            style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
-            textAlign: TextAlign.center,
+          // Cards without extra horizontal padding (they have their own)
+          if (filtered.isEmpty)
+            _buildEmptyState(context, colors, textTheme)
+          else
+            ...filtered.map(
+              (p) => Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: _PerspectiveCard(perspective: p),
+              ),
+            ),
+          // Analysis zone below last card (loading / done / error only)
+          if (widget.analysisState != PerspectivesAnalysisState.idle)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+              child: _buildAnalysisZone(context, colors, textTheme),
+            ),
+          // Spacer so the last card isn't hidden behind the floating button
+          if (widget.analysisState == PerspectivesAnalysisState.idle)
+            const SizedBox(height: 32),
+        ] else ...[
+          // No articles: header without analysis/bar, then full-width empty state
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  PhosphorIcons.eye(PhosphorIconsStyle.regular),
+                  color: colors.primary,
+                  size: 28,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    'Voir tous les points de vue',
+                    style: textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: colors.textPrimary,
+                      fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          _buildEmptyState(context, colors, textTheme),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildAnalysisZone(
+      BuildContext context, FacteurColors colors, TextTheme textTheme) {
+    return AnimatedSize(
+      key: widget.analysisZoneKey,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOut,
+      child: switch (widget.analysisState) {
+        PerspectivesAnalysisState.idle => const SizedBox.shrink(),
+        PerspectivesAnalysisState.loading => _buildAnalysisSkeleton(colors),
+        PerspectivesAnalysisState.done => _buildAnalysisResult(colors, textTheme),
+        PerspectivesAnalysisState.error => _buildAnalysisError(colors, textTheme),
+      },
+    );
+  }
+
+  Widget _buildAnalysisSkeleton(FacteurColors colors) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colors.primary.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (var i = 0; i < 3; i++) ...[
+            if (i > 0) const SizedBox(height: 8),
+            _ShimmerLine(
+              width: i == 2 ? 0.6 : (i == 1 ? 0.9 : 1.0),
+              colors: colors,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAnalysisResult(FacteurColors colors, TextTheme textTheme) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colors.primary.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colors.primary.withValues(alpha: 0.15)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          GestureDetector(
+            onTap: () =>
+                setState(() => _isAnalysisExpanded = !_isAnalysisExpanded),
+            behavior: HitTestBehavior.opaque,
+            child: Row(
+              children: [
+                Icon(
+                  PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                  size: 18,
+                  color: colors.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'Analyse Facteur',
+                  style: textTheme.titleSmall?.copyWith(
+                    color: colors.primary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const Spacer(),
+                AnimatedRotation(
+                  turns: _isAnalysisExpanded ? 0.25 : 0,
+                  duration: const Duration(milliseconds: 200),
+                  child: Icon(
+                    PhosphorIcons.caretRight(PhosphorIconsStyle.bold),
+                    size: 12,
+                    color: colors.primary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (_isAnalysisExpanded) ...[
+            const SizedBox(height: 10),
+            MarkdownText(
+              text: widget.analysisText ?? '',
+              style: textTheme.bodySmall!.copyWith(
+                color: colors.textPrimary,
+                height: 1.6,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                'Analyse Facteur',
+                style: textTheme.bodySmall?.copyWith(
+                  fontSize: 10,
+                  fontStyle: FontStyle.italic,
+                  color: colors.textSecondary.withValues(alpha: 0.5),
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAnalysisError(FacteurColors colors, TextTheme textTheme) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.textSecondary.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              'Analyse indisponible',
+              style: textTheme.bodySmall?.copyWith(color: colors.textSecondary),
+            ),
+          ),
+          TextButton(
+            onPressed: widget.onRequestAnalysis,
+            style: TextButton.styleFrom(
+              minimumSize: Size.zero,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: Text(
+              'Réessayer',
+              style: textTheme.labelSmall?.copyWith(
+                color: colors.primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
           ),
         ],
+      ),
+    );
+  }
+
+  void _handleSegmentTap(String key) {
+    if (widget.onSegmentTap != null) {
+      widget.onSegmentTap!(key);
+    } else {
+      _onSegmentTapInternal(key);
+    }
+  }
+
+  void _onSegmentTapInternal(String key) {
+    setState(() {
+      if (_selectedSegments.contains(key)) {
+        if (_selectedSegments.length == 1) {
+          _selectedSegments = {};
+        } else {
+          _selectedSegments = Set.from(_selectedSegments)..remove(key);
+        }
+      } else {
+        if (_selectedSegments.isEmpty || _selectedSegments.length == 3) {
+          _selectedSegments = {key};
+        } else {
+          _selectedSegments = Set.from(_selectedSegments)..add(key);
+        }
+      }
+    });
+  }
+
+  Widget _buildBiasBar(BuildContext context, FacteurColors colors) {
+    final segments = [
+      ('gauche', 'Gauche', colors.biasLeft),
+      ('centre', 'Centre', colors.biasCenter),
+      ('droite', 'Droite', colors.biasRight),
+    ];
+
+    final merged = _mergedDistribution;
+    final total = merged.values.fold<int>(0, (sum, v) => sum + v);
+
+    final flexValues = <int>[];
+    for (final seg in segments) {
+      final count = merged[seg.$1] ?? 0;
+      if (count > 0 && total > 0) {
+        final proportion = count / total;
+        flexValues.add((proportion * 100).round().clamp(15, 100));
+      } else {
+        flexValues.add(15);
+      }
+    }
+
+    final sourceGroup = _toBarGroup(widget.sourceBiasStance);
+    final sourceIndex = segments.indexWhere((s) => s.$1 == sourceGroup);
+
+    return Column(
+      children: [
+        Row(
+          children: List.generate(segments.length, (i) {
+            final seg = segments[i];
+            final count = merged[seg.$1] ?? 0;
+            final isActive = _effectiveSegments.isEmpty ||
+                _effectiveSegments.contains(seg.$1);
+            return Expanded(
+              flex: flexValues[i],
+              child: GestureDetector(
+                onTap: count > 0 ? () => _handleSegmentTap(seg.$1) : null,
+                child: AnimatedOpacity(
+                  duration: const Duration(milliseconds: 200),
+                  opacity: isActive ? 1.0 : 0.3,
+                  child: Column(
+                    children: [
+                      Center(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: seg.$3
+                                .withValues(alpha: count > 0 ? 0.15 : 0.05),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: FittedBox(
+                            fit: BoxFit.scaleDown,
+                            child: Text(
+                              seg.$2,
+                              maxLines: 1,
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w600,
+                                color:
+                                    count > 0 ? seg.$3 : colors.textTertiary,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      AnimatedContainer(
+                        duration: const Duration(milliseconds: 200),
+                        curve: Curves.easeOut,
+                        height: 12,
+                        margin: const EdgeInsets.symmetric(horizontal: 1.5),
+                        decoration: BoxDecoration(
+                          color: count > 0
+                              ? seg.$3.withValues(
+                                  alpha: count == 1
+                                      ? 0.55
+                                      : (count == 2 ? 0.8 : 1.0))
+                              : seg.$3.withValues(alpha: 0.25),
+                          borderRadius: BorderRadius.circular(6),
+                          border: count > 0
+                              ? Border.all(
+                                  color: Colors.black.withValues(alpha: 0.2),
+                                  width: 0.8,
+                                )
+                              : null,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          }),
+        ),
+        if (sourceIndex >= 0 && widget.sourceBiasStance != 'unknown') ...[
+          const SizedBox(height: 4),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final totalFlex =
+                  flexValues.fold<int>(0, (sum, f) => sum + f);
+              double offsetFraction = 0;
+              for (int i = 0; i < sourceIndex; i++) {
+                offsetFraction += flexValues[i] / totalFlex;
+              }
+              offsetFraction += (flexValues[sourceIndex] / totalFlex) / 2;
+
+              final markerX = constraints.maxWidth * offsetFraction;
+              final sourceColor = segments[sourceIndex].$3;
+              final displayName = widget.sourceName.isNotEmpty
+                  ? widget.sourceName
+                  : segments[sourceIndex].$2;
+
+              return SizedBox(
+                height: 28,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    Positioned(
+                      left: markerX - 7,
+                      top: 0,
+                      child: CustomPaint(
+                        size: const Size(14, 8),
+                        painter: PerspectivesTrianglePainter(color: sourceColor),
+                      ),
+                    ),
+                    Positioned(
+                      left: (markerX - 50)
+                          .clamp(0.0, constraints.maxWidth - 100),
+                      top: 10,
+                      child: SizedBox(
+                        width: 100,
+                        child: Text(
+                          displayName,
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.w700,
+                            color: sourceColor,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildEmptyState(
+      BuildContext context, FacteurColors colors, TextTheme textTheme) {
+    return SizedBox(
+      width: double.infinity,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              PhosphorIcons.newspaperClipping(PhosphorIconsStyle.duotone),
+              size: 48,
+              color: colors.textSecondary.withValues(alpha: 0.5),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Sujet peu couvert',
+              style: textTheme.titleSmall?.copyWith(
+                color: colors.textSecondary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Ce sujet est peu couvert par les médias.\nEssaie la comparaison sur un autre article !',
+              style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -866,10 +1492,10 @@ class _ShimmerLineState extends State<_ShimmerLine>
 }
 
 /// Triangle painter for the "Votre source" marker
-class _TrianglePainter extends CustomPainter {
+class PerspectivesTrianglePainter extends CustomPainter {
   final Color color;
 
-  _TrianglePainter({required this.color});
+  PerspectivesTrianglePainter({required this.color});
 
   @override
   void paint(Canvas canvas, Size size) {

--- a/apps/mobile/lib/features/onboarding/screens/questions/digest_mode_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/digest_mode_question.dart
@@ -40,22 +40,26 @@ class DigestModeQuestion extends ConsumerWidget {
                   .bodyMedium
                   ?.copyWith(color: colors.textSecondary),
               children: const [
-                TextSpan(text: OnboardingStrings.digestModeSereinPart1),
+                TextSpan(
+                    text: OnboardingStrings.digestModeSereinPart1),
                 TextSpan(
                   text: OnboardingStrings.digestModeSereinBold1,
                   style: TextStyle(fontWeight: FontWeight.w700),
                 ),
-                TextSpan(text: OnboardingStrings.digestModeSereinPart2),
+                TextSpan(
+                    text: OnboardingStrings.digestModeSereinPart2),
                 TextSpan(
                   text: OnboardingStrings.digestModeSereinBold2,
                   style: TextStyle(fontWeight: FontWeight.w700),
                 ),
-                TextSpan(text: OnboardingStrings.digestModeSereinPart3),
+                TextSpan(
+                    text: OnboardingStrings.digestModeSereinPart3),
                 TextSpan(
                   text: OnboardingStrings.digestModeSereinBold3,
                   style: TextStyle(fontWeight: FontWeight.w700),
                 ),
-                TextSpan(text: OnboardingStrings.digestModeSereinPart4),
+                TextSpan(
+                    text: OnboardingStrings.digestModeSereinPart4),
               ],
             ),
             textAlign: TextAlign.center,

--- a/apps/mobile/lib/features/onboarding/screens/questions/media_concentration_screen.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/media_concentration_screen.dart
@@ -109,12 +109,14 @@ class MediaConcentrationScreen extends ConsumerWidget {
                     color: colors.textSecondary,
                   ),
               children: const [
-                TextSpan(text: OnboardingStrings.mediaConcentrationTextPart1),
+                TextSpan(
+                    text: OnboardingStrings.mediaConcentrationTextPart1),
                 TextSpan(
                   text: OnboardingStrings.mediaConcentrationTextBold1,
                   style: TextStyle(fontWeight: FontWeight.w700),
                 ),
-                TextSpan(text: OnboardingStrings.mediaConcentrationTextPart2),
+                TextSpan(
+                    text: OnboardingStrings.mediaConcentrationTextPart2),
               ],
             ),
             textAlign: TextAlign.center,

--- a/docs/stories/core/5.9.article-reader-layout-rework.md
+++ b/docs/stories/core/5.9.article-reader-layout-rework.md
@@ -1,0 +1,201 @@
+# Story 5.9 — Article Reader Layout Rework
+
+**Type:** Feature
+**Epic:** 5 — Lecture In-App
+**Status:** PLAN
+
+---
+
+## Objectif
+
+Refonte de la mise en page de l'écran de lecture d'articles (mode in-app uniquement) :
+1. Ajout d'un aperçu texte avec collapse/expand pour les articles complets
+2. Remplacement des FABs par un footer persistant (Lire sur…, Perspectives, Sauvegarder, J'aime)
+
+---
+
+## Périmètre
+
+Uniquement `_buildInAppContent` pour `ContentType.article`. Les autres modes (scroll-to-site, WebView, audio, vidéo) ne sont pas touchés.
+
+---
+
+## Plan Technique
+
+### 1. Utilitaire de découpe HTML (`html_utils.dart`)
+
+Nouvelle fonction `cutHtmlAtPreview(String html, {int wordLimit = 300}) → String?` :
+
+- Sanitize le HTML via `sanitizeArticleHtml()`
+- Cherche la **première balise de titre** (`<h1>`…`<h6>`)
+- Compte les mots dans le texte (en ignorant les balises) jusqu'à `wordLimit`
+- Trouve le prochain `</p>` après la position des 300 mots
+- **Retourne le HTML coupé à `min(positionPremierTitre, positionProchain</p>aprèsMot300)`**
+- Retourne `null` si le contenu est trop court pour être coupé (< 300 mots, pas de titre)
+
+Fonction auxiliaire interne `_findPositionAfterNWords(String html, int n) → int?` :
+- Parcourt le HTML char par char, ignore les balises (`<…>`)
+- Compte les mots dans le texte brut
+- Retourne la position dans le string HTML après le nième mot
+
+---
+
+### 2. Expand/collapse pour articles complets (`content_detail_screen.dart`)
+
+**Nouveau state :**
+```dart
+bool _isArticleExpanded = false;
+```
+
+**Logique dans `_buildInAppContent` (branche `ContentType.article`) :**
+
+```
+isPartial == true  → comportement actuel inchangé (description/aperçu partiel)
+isPartial == false → (article complet avec htmlContent)
+  previewHtml = cutHtmlAtPreview(content.htmlContent!)
+  previewHtml == null → afficher article en entier (trop court pour couper)
+  previewHtml != null →
+    si !_isArticleExpanded : GestureDetector { ArticleReaderWidget(htmlContent: previewHtml) } + toggle row
+    si _isArticleExpanded  : ArticleReaderWidget(htmlContent: htmlContent) + toggle row
+```
+
+**Toggle row** (toujours visible sous le contenu quand previewHtml != null) :
+```dart
+GestureDetector(
+  onTap: () => setState(() => _isArticleExpanded = !_isArticleExpanded),
+  child: Row(
+    children: [
+      Text(_isArticleExpanded ? 'Réduire' : 'Lire tout l\'article'),
+      Icon(chevron-up si expanded, chevron-down si collapsed),
+    ],
+  ),
+)
+```
+
+Style du toggle : `textTheme.labelMedium`, couleur `colors.textSecondary`, espacé verticalement (padding 16px haut, 8px bas).
+
+Le `GestureDetector` wrappant le preview (quand collapsed) appelle le même `_toggleArticleExpanded()`.
+
+---
+
+### 3. Footer persistant (`content_detail_screen.dart`)
+
+#### 3a. State & animation
+
+```dart
+final ValueNotifier<double> _footerOffset = ValueNotifier(0.0); // 0=visible, 1=hidden
+late AnimationController _footerAutoController;
+double _footerAutoStart = 0.0;
+double _footerAutoTarget = 0.0;
+```
+
+Méthode `_animateFooterTo(double target)` — miroir exact de `_animateHeaderTo`.
+
+#### 3b. Comportement de visibilité (même logique que le header/FABs)
+
+Modifier `_onScrollDelta(delta)` :
+- delta > 0 (scroll bas) → `_footerOffset` augmente (footer se cache, glisse vers le bas)
+- delta < 0 (scroll haut) → `_footerOffset` diminue (footer réapparaît)
+- Clamp 0.0–1.0, proportionnel à la hauteur du footer
+
+Modifier `_scrollStopTimer` (2.5s) → aussi réafficher le footer (`_animateFooterTo(0.0)`)
+
+Modifier `_onReadingProgressNudge` → à 98% montrer aussi le footer
+
+#### 3c. Widget footer
+
+`_buildArticleFooter(BuildContext context, Content content)` → placé dans le `Stack` via `Positioned(bottom: 0, left: 0, right: 0, ...)`.
+
+**Layout :**
+```
+ColoredBox(color: colors.backgroundPrimary)
+└── SafeArea(top: false)
+    └── Padding(horizontal: 12, vertical: 8)
+        └── Row
+            ├── Expanded → "Lire sur [Source]" button
+            │     ElevatedButton / InkWell
+            │     background: Colors.white
+            │     border-radius: 4px
+            │     border: Border.all(colors.border)
+            │     onTap: même comportement qu'avant (toggle WebView ou open external)
+            ├── SizedBox(8)
+            ├── IconButton "Autres points de vue" (PerspectivesPill behaviour → _showPerspectives)
+            ├── IconButton "Sauvegarder" (bookmark toggle, long-press: collection picker)
+            └── IconButton "J'aime" (like toggle)
+```
+
+**Style des IconButtons :**
+- Même que le bouton share du header : taille 38×38, shape CircleBorder, couleur `colors.textSecondary`
+- Filled variant (primary couleur) si liked / saved
+- Phosphor icons : `eye` / `bookmarkSimple` / `heart` (fill variant si actif)
+
+**Animation :** `Transform.translate(offset: Offset(0, _footerOffset.value * footerHeight))` via `ValueListenableBuilder`.
+
+**Padding de contenu :** Le `ArticleReaderWidget` passe `footer: SizedBox(height: footerHeight + bottomSafeArea)` pour que le scroll ne soit pas masqué par le footer.
+
+#### 3d. Suppression des FABs pour les articles in-app
+
+- `floatingActionButton` → `null` quand `useInAppReading && content.contentType == ContentType.article`
+- Share FAB à 90% supprimé (le header share button reste)
+- Note welcome tooltip → supprimé (plus de bookmark FAB visible)
+- `_showFab` state toujours `false` pour les articles in-app (pas de délai de 2s)
+
+---
+
+### Fichiers modifiés
+
+| Fichier | Changement |
+|---------|-----------|
+| `apps/mobile/lib/core/utils/html_utils.dart` | + `cutHtmlAtPreview()` + `_findPositionAfterNWords()` |
+| `apps/mobile/lib/features/detail/screens/content_detail_screen.dart` | state expand, footer offset/animation, `_buildArticleFooter()`, modif `_buildInAppContent()`, modif FABs, modif scroll handlers |
+
+---
+
+## Tasks
+
+- [ ] Ajouter `cutHtmlAtPreview()` dans `html_utils.dart`
+- [ ] Ajouter state `_isArticleExpanded` + `_footerOffset` + `_footerAutoController`
+- [ ] Modifier `_onScrollDelta` et les timers pour le footer
+- [ ] Implémenter `_buildArticleFooter()`
+- [ ] Modifier `_buildInAppContent()` pour le preview/expand
+- [ ] Supprimer les FABs pour les articles in-app
+- [ ] Tests flutter
+
+---
+
+## 5.9b — Floating "Lancer l'analyse Facteur" button
+
+### Objectif
+
+Déplacer le bouton "Lancer l'analyse Facteur" de la section perspectives (entre la barre de biais et les cartes) vers un `FilledButton` flottant en bas à droite de l'écran, visible uniquement quand la section perspectives est à l'écran et que l'analyse n'a pas encore été lancée.
+
+### Plan Technique
+
+**`perspectives_bottom_sheet.dart` :**
+1. Rendre `_AnalysisState` public → `PerspectivesAnalysisState`
+2. Ajouter params à `PerspectivesInlineSection` : `analysisState`, `analysisText`, `onRequestAnalysis`, `analysisZoneKey`
+3. Supprimer la gestion interne de l'état analyse dans `_PerspectivesInlineSectionState` (`_analysisState`, `_analysisText`, `_requestAnalysis`)
+4. Déplacer la zone analyse (loading/done/error) **sous la dernière carte** ; la CTA idle n'est plus rendue inline
+5. Spacer conditionnel sous les cartes quand `analysisState == idle` (= hauteur bouton flottant + padding)
+
+**`content_detail_screen.dart` :**
+1. Ajouter state : `PerspectivesAnalysisState _perspectivesAnalysisState`, `String? _perspectivesAnalysisText`, `GlobalKey _analysisZoneKey`
+2. Ajouter `_requestPerspectivesAnalysis()` : loading → API → scroll vers zone analyse → done/error
+3. Passer les nouveaux params à `PerspectivesInlineSection`
+4. Ajouter `Positioned` `FilledButton` dans le `Stack`, visible via `ValueListenableBuilder(_atPerspectivesSection)` + `_perspectivesAnalysisState == idle`
+
+### Fichiers modifiés
+
+| Fichier | Changement |
+|---------|-----------|
+| `apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart` | enum public, nouveaux params inline section, layout restructuré |
+| `apps/mobile/lib/features/detail/screens/content_detail_screen.dart` | state analyse, bouton flottant Positioned |
+
+### Tasks 5.9b
+
+- [x] Mettre à jour story doc
+- [ ] Refactor `_AnalysisState` → `PerspectivesAnalysisState` + params `PerspectivesInlineSection`
+- [ ] Restructurer layout inline (analyse sous les cartes)
+- [ ] Ajouter state analyse + `_requestPerspectivesAnalysis()` dans le parent
+- [ ] Ajouter le `FilledButton` flottant dans le Stack
+- [ ] `flutter analyze` + `flutter test`


### PR DESCRIPTION
## What

Refonte de la mise en page de l'écran de lecture in-app (story 5.9) :
- Nouveau footer animé (miroir du header slide) qui devient permanent quand l'utilisateur atteint la section Perspectives ou la fin de l'article
- Nouveau widget `PerspectivesInlineSection` : Perspectives embarquées inline dans le scroll view avec filtre biais cliquable et header sticky
- Barre de progression calibrée sur l'article uniquement (exclut la section Perspectives)
- Utilitaire `cutHtmlAtPreview()` dans `html_utils.dart` pour couper du HTML à N mots

## Why

Les FABs flottants masquaient le contenu et offraient une mauvaise ergonomie en fin d'article. Le footer contextuel apparaît naturellement à la fin de la lecture, et les Perspectives s'intègrent dans le flux plutôt qu'en bottom sheet isolé.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)