### PR TITLE
claude/fix-infinite-loading-requests-dKoY8

### DIFF
--- a/docs/bugs/bug-infinite-load-requests.md
+++ b/docs/bugs/bug-infinite-load-requests.md
@@ -445,3 +445,83 @@ Pistes préparées (à dégainer *après* tri) :
     pour donner plus de marge avant saturation.
   - Semaphore + cache court sur les fan-outs upstream (Google News RSS,
     trafilatura) pour cap la parallélisation.
+
+---
+
+## Résolution — 2026-04-15 (branche `claude/fix-infinite-loading-requests-dKoY8`)
+
+Après vérification `pg_stat_activity` sur prod : **4 sessions idle in
+transaction, age moyen 53 min**, signature de queries pointant sur Site B
+(~57 % de la fuite) et Site A (~36 %). Fix architectural codé selon le plan
+1-3 + hygiène transverse, dans cet ordre :
+
+### P1 — Pipeline éditoriale (Site B)
+
+Pattern : **session_maker injecté + short sessions** pour toute opération DB
+à l'intérieur de la pipeline, avec **commit explicite de la session injectée
+AVANT l'appel LLM** pour libérer la connexion au pool.
+
+Services modifiés (chacun accepte désormais `session_maker=None` optionnel +
+helper `_short_session()` qui délègue au maker si présent, sinon retombe sur
+la session injectée — 100 % rétro-compatible) :
+
+- `app/services/editorial/deep_matcher.py` — `_load_deep_articles` ouvre
+  une session courte le temps du SELECT puis la ferme, les appels LLM
+  (`match_for_topics`) tournent **hors transaction**.
+- `app/services/editorial/writer.py` — `_recent_highlight_content_ids`,
+  `record_highlight` (commit=True), `get_coup_de_coeur` (2 queries) et
+  `select_actu_decalee` → short sessions.
+- `app/services/perspective_service.py` — `resolve_bias` + `search_internal_perspectives`
+  → short sessions. Les calls Google News / Mistral restent hors transaction.
+- `app/services/editorial/pipeline.py` — propage `session_maker` aux trois
+  services ci-dessus ; SELECT logos encapsulé en short session.
+- `app/services/digest_selector.py` — reçoit `session_maker`, le passe à
+  `EditorialPipelineService`, **commit la session injectée juste avant
+  `compute_global_context`** pour rendre la connexion au pool.
+- `app/services/digest_service.py` — expose `session_maker` sur le
+  constructeur et le passe à `DigestSelector`.
+
+Call sites mis à jour :
+- `app/routers/digest.py` : `get_digest`, `_gen_variant`, `generate_digest`
+  instancient `DigestService(db, session_maker=async_session_maker)`.
+- `app/jobs/digest_generation_job.py` : 3 sites (l. 168, 595, 865) passent
+  `session_maker=async_session_maker` à `EditorialPipelineService` et
+  `DigestSelector`.
+
+Test ajouté :
+`tests/editorial/test_deep_matcher.py::test_uses_session_maker_and_does_not_touch_injected_session`
+— verrouille l'invariant "quand un maker est fourni, la session injectée
+n'est JAMAIS touchée" (échec = régression directe vers le leak).
+
+### P2 — RSS sync (Site A)
+
+Pattern : **short session par entry**, I/O externes (httpx, trafilatura,
+_fetch_html_head) **hors session**. `_save_content` renvoie désormais un
+tuple `(is_new, content_id, needs_enrich, url)` pour que l'enrichissement
+trafilatura se fasse après commit+close. Fichier : `app/services/sync_service.py`
+(~400 lignes impactées). Test `test_save_content_deduplication` adapté au
+nouveau contrat de retour.
+
+### P3 — Hygiène transverse
+
+- `app/main.py` — `socket.setdefaulttimeout(30)` posé très tôt. Filet contre
+  un thread executor bloqué byte-par-byte par un upstream stall.
+- `app/services/briefing_service.py:269-290` — `feedparser.parse(url)`
+  remplacé par pattern `httpx.AsyncClient.get(...) + feedparser.parse(content)`
+  (timeout=10s explicite). Même landmine corrigée à `digest_selector.py:1526`.
+
+### Validation
+
+- `pytest tests/editorial/ tests/test_sync_service.py -q` → 100 passed
+- `pytest tests/editorial/test_deep_matcher.py -q` → 11 passed (dont le test
+  session_maker ajouté)
+- Full non-DB suite (462 passed, 13 skipped). Les tests DB-dépendants
+  échouent uniquement parce que le Postgres local n'est pas disponible —
+  indépendant de ce fix.
+
+### À suivre post-merge
+
+1. Observer `pg_stat_activity` pendant 48 h. Les sessions idle in transaction
+   de + de 5 min doivent disparaître.
+2. **Nettoyage P0** (PR séparée) : retirer le scheduled restart 01h/09h/17h
+   Paris une fois la pg_stat_activity clean confirmée sur 48 h.

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -165,7 +165,12 @@ class DigestGenerationJob:
             try:
                 from app.services.editorial.pipeline import EditorialPipelineService
 
-                pipeline = EditorialPipelineService(session)
+                # session_maker : la pipeline ouvre ses propres sessions
+                # courtes pendant les 3-5 min de LLM ; évite d'agripper la
+                # session batch pour toute la durée. Cf. bug-infinite-load-requests.md P1.
+                pipeline = EditorialPipelineService(
+                    session, session_maker=async_session_maker
+                )
                 if pipeline.llm.is_ready and user_ids:
                     global_candidates = await self._get_global_candidates(session)
                     if global_candidates:
@@ -592,7 +597,12 @@ class DigestGenerationJob:
                         sensitive_themes = None
 
                     # Sélectionner les articles via DigestSelector
-                    selector = DigestSelector(session)
+                    # session_maker propagé → pipeline LLM utilisera des
+                    # sessions courtes et commit()ra user_session avant LLM
+                    # pour libérer la connexion au pool.
+                    selector = DigestSelector(
+                        session, session_maker=async_session_maker
+                    )
                     digest_items = await selector.select_for_user(
                         user_id=user_id,
                         limit=user_target,
@@ -861,8 +871,10 @@ async def generate_digest_for_user(
             except (ValueError, TypeError):
                 sensitive_themes = None
 
-            # Générer
-            selector = DigestSelector(session)
+            # Générer — session_maker pour que la pipeline LLM (si format
+            # éditorial activé) ouvre des sessions courtes et n'agrippe pas
+            # la session de regen. Cf. bug-infinite-load-requests.md (P1).
+            selector = DigestSelector(session, session_maker=async_session_maker)
             digest_items = await selector.select_for_user(
                 user_id=user_id,
                 limit=DiversityConstraints.TARGET_DIGEST_SIZE,

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -3,9 +3,19 @@
 import asyncio
 import logging
 import os
+import socket
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
+
+# Ceinture + bretelles : un timeout socket par défaut empêche un appel synchrone
+# (urllib via feedparser, trafilatura, libs tierces) de bloquer indéfiniment un
+# thread de l'executor par défaut quand l'upstream stalle byte-par-byte.
+# 30 s couvre largement les RSS/HTML lents tout en garantissant qu'aucun
+# `run_in_executor(...)` ne reste vivant au-delà même si `asyncio.wait_for`
+# cancel sa coroutine. Cf. docs/bugs/bug-infinite-load-requests.md (thread
+# poisoning avéré sur trafilatura et landmine sur feedparser.parse(url)).
+socket.setdefaulttimeout(30)
 
 # Bornes du startup digest catchup. Cf. docs/bugs/bug-infinite-load-requests.md :
 # sans timeout, une génération qui hang sur un upstream (Mistral, Google News,

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -193,7 +193,11 @@ async def get_digest(
     - is_completed: Whether user has completed this digest
     - completed_at: Completion timestamp (if completed)
     """
-    service = DigestService(db)
+    # `session_maker` permet à la pipeline éditoriale d'ouvrir ses propres
+    # sessions courtes pendant le travail LLM (3-5 min). Sans ça, la session
+    # de `Depends(get_db)` reste idle-in-transaction pendant tout le LLM et
+    # épuise le pool. Cf. docs/bugs/bug-infinite-load-requests.md (P1).
+    service = DigestService(db, session_maker=async_session_maker)
     user_uuid = UUID(current_user_id)
     start = time.monotonic()
 
@@ -315,7 +319,7 @@ async def get_both_digests(
     # appear to "load indefinitely".
     async def _gen_variant(is_serene: bool) -> DigestResponse | None:
         async with async_session_maker() as session:
-            svc = DigestService(session)
+            svc = DigestService(session, session_maker=async_session_maker)
             return await asyncio.wait_for(
                 svc.get_or_create_digest(user_uuid, target_date, is_serene=is_serene),
                 timeout=DIGEST_BOTH_VARIANT_TIMEOUT_S,
@@ -523,7 +527,10 @@ async def generate_digest(
 
     Returns the complete DigestResponse with items (same format as GET endpoint).
     """
-    service = DigestService(db)
+    # Cf. bug-infinite-load-requests.md (P1) — la pipeline éditoriale doit
+    # pouvoir ouvrir ses propres sessions courtes hors de la session FastAPI
+    # pour libérer la connexion au pool pendant 3-5 min de travail LLM.
+    service = DigestService(db, session_maker=async_session_maker)
     user_uuid = UUID(current_user_id)
 
     # Generate digest, with optional force regeneration

--- a/packages/api/app/services/briefing_service.py
+++ b/packages/api/app/services/briefing_service.py
@@ -16,6 +16,7 @@ from uuid import UUID
 # top3_job NE DOIT PAS être importé ici.
 # -> On va déplacer les helpers de fetch ici en méthodes statiques ou privées.
 import feedparser
+import httpx
 import structlog
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
@@ -269,9 +270,21 @@ class BriefingService:
         une_guids: set[str] = set()
 
         async def parse_feed(url: str) -> list[str]:
+            # Pattern httpx + feedparser.parse(content) au lieu de
+            # feedparser.parse(url) — ce dernier utilise urllib en interne sans
+            # respecter de timeout côté coroutine, et `asyncio.wait_for` ne peut
+            # pas tuer le thread bloqué. Cf. docs/bugs/bug-infinite-load-requests.md
+            # (landmine documentée). Aucune source aujourd'hui n'a une_feed_url,
+            # mais la régression future est évitée.
             try:
+                async with httpx.AsyncClient(
+                    timeout=10.0, follow_redirects=True
+                ) as client:
+                    resp = await client.get(url)
+                    resp.raise_for_status()
+                    content = resp.text
                 loop = asyncio.get_event_loop()
-                feed = await loop.run_in_executor(None, feedparser.parse, url)
+                feed = await loop.run_in_executor(None, feedparser.parse, content)
                 return [
                     entry.id if hasattr(entry, "id") else entry.link
                     for entry in feed.entries[:5]

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -30,6 +30,7 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import or_, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
@@ -306,15 +307,18 @@ class DigestSelector:
                             # session_maker pour ses ops DB internes, donc
                             # on n'a plus besoin de tenir self.session
                             # pendant tout ce temps.
+                            # On commit inconditionnellement (session_maker
+                            # fourni ou non) : à ce stade il n'y a aucune
+                            # écriture pendante, donc commit = noop métier +
+                            # libère la connexion physique dans tous les cas.
                             # cf. docs/bugs/bug-infinite-load-requests.md (P1)
-                            if self.session_maker is not None:
-                                try:
-                                    await self.session.commit()
-                                except Exception:
-                                    logger.warning(
-                                        "digest_selector_precommit_failed",
-                                        user_id=str(user_id),
-                                    )
+                            try:
+                                await self.session.commit()
+                            except SQLAlchemyError:
+                                logger.warning(
+                                    "digest_selector_precommit_failed",
+                                    user_id=str(user_id),
+                                )
                             global_ctx = await pipeline.compute_global_context(
                                 candidates, mode=mode
                             )

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -30,7 +30,7 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import or_, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
 from app.models.content import Content, UserContentStatus
@@ -161,8 +161,18 @@ class DigestSelector:
         digest_items = await selector.select_for_user(user_id)
     """
 
-    def __init__(self, session: AsyncSession):
+    def __init__(
+        self,
+        session: AsyncSession,
+        session_maker: async_sessionmaker[AsyncSession] | None = None,
+    ):
+        # `session_maker` permet à la pipeline éditoriale d'ouvrir ses propres
+        # sessions courtes pendant les 3-5 min de travail LLM. `self.session`
+        # reste utilisée pour les ops rapides (build_context, get_candidates,
+        # < 1s cumulé) mais sera commit()ée juste avant la pipeline pour
+        # libérer la connexion au pool. Cf. bug-infinite-load-requests.md.
         self.session = session
+        self.session_maker = session_maker
         self.rec_service = RecommendationService(session)
         self.constraints = DiversityConstraints()
         self.importance_detector = ImportanceDetector()
@@ -276,7 +286,9 @@ class DigestSelector:
 
                 try:
                     step_start = time.time()
-                    pipeline = EditorialPipelineService(self.session)
+                    pipeline = EditorialPipelineService(
+                        self.session, session_maker=self.session_maker
+                    )
 
                     if not pipeline.llm.is_ready:
                         logger.warning("digest_editorial_no_api_key")
@@ -289,6 +301,20 @@ class DigestSelector:
                         if global_ctx is None:
                             global_ctx = _get_cached_editorial_ctx(_cache_date, mode)
                         if global_ctx is None:
+                            # CRITICAL: libérer la connexion au pool avant
+                            # les 3-5 min de LLM. La pipeline utilise
+                            # session_maker pour ses ops DB internes, donc
+                            # on n'a plus besoin de tenir self.session
+                            # pendant tout ce temps.
+                            # cf. docs/bugs/bug-infinite-load-requests.md (P1)
+                            if self.session_maker is not None:
+                                try:
+                                    await self.session.commit()
+                                except Exception:
+                                    logger.warning(
+                                        "digest_selector_precommit_failed",
+                                        user_id=str(user_id),
+                                    )
                             global_ctx = await pipeline.compute_global_context(
                                 candidates, mode=mode
                             )
@@ -1521,9 +1547,20 @@ class DigestSelector:
         une_guids: set[str] = set()
 
         async def parse_feed(url: str) -> list[str]:
+            # Pattern httpx + feedparser.parse(content) — fp.parse(url) utilise
+            # urllib en interne sans timeout côté coroutine. Cf.
+            # docs/bugs/bug-infinite-load-requests.md.
+            import httpx as _httpx
+
             try:
+                async with _httpx.AsyncClient(
+                    timeout=10.0, follow_redirects=True
+                ) as client:
+                    resp = await client.get(url)
+                    resp.raise_for_status()
+                    content = resp.text
                 loop = asyncio.get_event_loop()
-                feed = await loop.run_in_executor(None, fp.parse, url)
+                feed = await loop.run_in_executor(None, fp.parse, content)
                 return [
                     entry.id if hasattr(entry, "id") else entry.link
                     for entry in feed.entries[:5]

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -26,7 +26,7 @@ import yaml
 from sqlalchemy import and_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
 from app.models.content import Content, UserContentStatus
@@ -286,9 +286,19 @@ class DigestService:
     - StreakService: For completion gamification
     """
 
-    def __init__(self, session: AsyncSession):
+    def __init__(
+        self,
+        session: AsyncSession,
+        session_maker: async_sessionmaker[AsyncSession] | None = None,
+    ):
+        # `session_maker` est propagé au DigestSelector/EditorialPipeline :
+        # la pipeline LLM ouvre ses propres sessions courtes pour ses ops
+        # DB, et DigestSelector commit la session avant d'appeler la
+        # pipeline (libère la connexion au pool pendant 3-5 min).
+        # Cf. docs/bugs/bug-infinite-load-requests.md (P1 — site B).
         self.session = session
-        self.selector = DigestSelector(session)
+        self.session_maker = session_maker
+        self.selector = DigestSelector(session, session_maker=session_maker)
         self.streak_service = StreakService(session)
 
     async def get_or_create_digest(

--- a/packages/api/app/services/editorial/deep_matcher.py
+++ b/packages/api/app/services/editorial/deep_matcher.py
@@ -10,10 +10,11 @@ No time limit on deep articles (can be months old).
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 
 import structlog
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
 from app.models.content import Content
@@ -34,11 +35,30 @@ class DeepMatcher:
         session: AsyncSession,
         llm: EditorialLLMClient,
         config: EditorialConfig,
+        session_maker: async_sessionmaker[AsyncSession] | None = None,
     ) -> None:
+        # Préférer `session_maker` pour ouvrir des sessions courtes autour
+        # de chaque opération DB. Cf. docs/bugs/bug-infinite-load-requests.md
+        # (P1). `session` est conservé pour compat ascendante (tests, appels
+        # legacy) ; il est utilisé uniquement si `session_maker` est None.
         self._session = session
+        self._session_maker = session_maker
         self._llm = llm
         self._config = config
         self._detector = ImportanceDetector()
+
+    @asynccontextmanager
+    async def _short_session(self):
+        """Open a short-lived session, or fall back to the injected one."""
+        if self._session_maker is None:
+            yield self._session
+            return
+        async with self._session_maker() as session:
+            try:
+                yield session
+            except Exception:
+                await session.rollback()
+                raise
 
     async def match_for_topics(
         self,
@@ -175,7 +195,12 @@ class DeepMatcher:
         }
 
     async def _load_deep_articles(self) -> list[Content]:
-        """Load all articles from deep sources (no time limit)."""
+        """Load all articles from deep sources (no time limit).
+
+        Ouvre une session courte dédiée : la requête dure <1s et les
+        objets Content restent utilisables hors session (expire_on_commit=False,
+        selectinload sur `source`). Cf. bug-infinite-load-requests.md (P1).
+        """
         stmt = (
             select(Content)
             .join(Content.source)
@@ -187,8 +212,9 @@ class DeepMatcher:
             .order_by(Content.published_at.desc())
             .limit(3000)  # Safety cap
         )
-        result = await self._session.execute(stmt)
-        return list(result.scalars().all())
+        async with self._short_session() as session:
+            result = await session.execute(stmt)
+            return list(result.scalars().all())
 
     async def _expand_query(self, topic: SelectedTopic) -> set[str]:
         """Generate semantically adjacent keywords via small LLM."""

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 
 import asyncio
 import time
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from urllib.parse import urlparse
 from uuid import UUID
 
 import structlog
 from sqlalchemy import or_, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.content import Content
 from app.models.source import Source
@@ -48,15 +49,39 @@ logger = structlog.get_logger()
 class EditorialPipelineService:
     """Orchestrates the editorial digest pipeline."""
 
-    def __init__(self, session: AsyncSession) -> None:
+    def __init__(
+        self,
+        session: AsyncSession,
+        session_maker: async_sessionmaker[AsyncSession] | None = None,
+    ) -> None:
+        # `session_maker` est la voie préférée : chaque requête DB s'exécute
+        # dans une session courte au lieu de tenir `self.session` ouverte
+        # pendant 3-5 min de pipeline LLM. Cf. bug-infinite-load-requests.md
+        # (site B, P1). `session` reste pour compat ascendante.
         self.session = session
+        self.session_maker = session_maker
         self.config = load_editorial_config()
         self.llm = EditorialLLMClient()
         self.curation = CurationService(self.llm, self.config)
         self.actu_matcher = ActuMatcher(
             actu_max_age_hours=self.config.pipeline.actu_max_age_hours
         )
-        self.deep_matcher = DeepMatcher(session, self.llm, self.config)
+        self.deep_matcher = DeepMatcher(
+            session, self.llm, self.config, session_maker=session_maker
+        )
+
+    @asynccontextmanager
+    async def _short_session(self):
+        """Open a short-lived session, or fall back to the injected one."""
+        if self.session_maker is None:
+            yield self.session
+            return
+        async with self.session_maker() as session:
+            try:
+                yield session
+            except Exception:
+                await session.rollback()
+                raise
 
     async def compute_global_context(
         self,
@@ -276,7 +301,12 @@ class EditorialPipelineService:
                 )
 
         # ÉTAPE 3C: Perspective analysis (batch, parallel)
-        perspective_service = PerspectiveService(db=self.session)
+        # Pass session_maker: chaque resolve_bias / search_internal s'exécute
+        # dans sa propre session courte, évitant 6-10 parallel DB calls sur
+        # la même session tenue pendant la phase perspectives (~30s).
+        perspective_service = PerspectiveService(
+            db=self.session, session_maker=self.session_maker
+        )
         step_start = time.time()
 
         async def _process_perspectives(
@@ -353,8 +383,10 @@ class EditorialPipelineService:
                         ),
                         Source.logo_url.is_not(None),
                     )
-                    result = await self.session.execute(stmt)
-                    for row in result.all():
+                    async with self._short_session() as session:
+                        result = await session.execute(stmt)
+                        logo_rows = list(result.all())
+                    for row in logo_rows:
                         try:
                             parsed = urlparse(row.url)
                             domain = parsed.netloc
@@ -453,7 +485,9 @@ class EditorialPipelineService:
 
         # ÉTAPES 4+5+6: Writing + Pépite + Coup de coeur (parallel)
         step_start = time.time()
-        writer = EditorialWriterService(self.session, self.llm, self.config)
+        writer = EditorialWriterService(
+            self.session, self.llm, self.config, session_maker=self.session_maker
+        )
 
         selected_topic_ids = {s.topic_id for s in subjects}
         selected_content_ids: set[UUID] = set()

--- a/packages/api/app/services/editorial/writer.py
+++ b/packages/api/app/services/editorial/writer.py
@@ -12,6 +12,7 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import func, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
@@ -206,7 +207,7 @@ class EditorialWriterService:
             async with self._short_session() as session:
                 result = await session.execute(stmt)
                 return set(result.scalars().all())
-        except Exception:
+        except SQLAlchemyError:
             # Table may not yet exist (migration not applied) — graceful fail.
             logger.exception("editorial_writer.recent_highlights_query_failed")
             return set()
@@ -225,7 +226,7 @@ class EditorialWriterService:
                     )
                 )
                 await session.flush()
-        except Exception:
+        except SQLAlchemyError:
             logger.exception(
                 "editorial_writer.record_highlight_failed",
                 kind=kind,

--- a/packages/api/app/services/editorial/writer.py
+++ b/packages/api/app/services/editorial/writer.py
@@ -6,12 +6,13 @@ Story 10.24: Fills all null editorial text fields via LLM + DB query.
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from datetime import UTC, date, datetime, timedelta
 from uuid import UUID
 
 import structlog
 from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
 from app.models.content import Content, UserContentStatus
@@ -45,10 +46,36 @@ class EditorialWriterService:
         session: AsyncSession,
         llm: EditorialLLMClient,
         config: EditorialConfig,
+        session_maker: async_sessionmaker[AsyncSession] | None = None,
     ) -> None:
+        # Cf. docs/bugs/bug-infinite-load-requests.md (P1).
+        # Ouvrir une session courte par op DB évite de tenir la connexion
+        # pendant les appels LLM (write_editorial / select_pepite durent
+        # plusieurs secondes chacun). `session` reste utilisé en fallback
+        # pour compat ascendante.
         self._session = session
+        self._session_maker = session_maker
         self._llm = llm
         self._config = config
+
+    @asynccontextmanager
+    async def _short_session(self, commit: bool = False):
+        """Open a short-lived session (or fall back to the injected one).
+
+        When `commit=True`, the session is committed on nominal exit — used
+        by writes (`record_highlight`). Reads use `commit=False`.
+        """
+        if self._session_maker is None:
+            yield self._session
+            return
+        async with self._session_maker() as session:
+            try:
+                yield session
+                if commit:
+                    await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
 
     # ------------------------------------------------------------------
     # ÉTAPE 4: Editorial writing (1 LLM call)
@@ -176,8 +203,9 @@ class EditorialWriterService:
             EditorialHighlightsHistory.target_date > cutoff,
         )
         try:
-            result = await self._session.execute(stmt)
-            return set(result.scalars().all())
+            async with self._short_session() as session:
+                result = await session.execute(stmt)
+                return set(result.scalars().all())
         except Exception:
             # Table may not yet exist (migration not applied) — graceful fail.
             logger.exception("editorial_writer.recent_highlights_query_failed")
@@ -188,14 +216,15 @@ class EditorialWriterService:
     ) -> None:
         """Persist a pépite / coup de cœur pick to the rotation history."""
         try:
-            self._session.add(
-                EditorialHighlightsHistory(
-                    kind=kind,
-                    content_id=content_id,
-                    target_date=target_date or today_paris(),
+            async with self._short_session(commit=True) as session:
+                session.add(
+                    EditorialHighlightsHistory(
+                        kind=kind,
+                        content_id=content_id,
+                        target_date=target_date or today_paris(),
+                    )
                 )
-            )
-            await self._session.flush()
+                await session.flush()
         except Exception:
             logger.exception(
                 "editorial_writer.record_highlight_failed",
@@ -406,8 +435,9 @@ class EditorialWriterService:
         )
 
         try:
-            result = await self._session.execute(stmt)
-            row = result.first()
+            async with self._short_session() as session:
+                result = await session.execute(stmt)
+                row = result.first()
         except Exception:
             # Likely the editorial_highlights_history table is missing
             # (migration not yet applied); fall back to the simple query.
@@ -424,8 +454,9 @@ class EditorialWriterService:
             .where(Content.id == row.id)
             .options(selectinload(Content.source))
         )
-        content_result = await self._session.execute(content_stmt)
-        content = content_result.scalar_one_or_none()
+        async with self._short_session() as session:
+            content_result = await session.execute(content_stmt)
+            content = content_result.scalar_one_or_none()
 
         source_name = (
             content.source.name if content and content.source else "Source inconnue"
@@ -481,8 +512,9 @@ class EditorialWriterService:
             .limit(15)
         )
 
-        result = await self._session.execute(stmt)
-        eligible = list(result.scalars().all())
+        async with self._short_session() as session:
+            result = await session.execute(stmt)
+            eligible = list(result.scalars().all())
 
         if not eligible:
             logger.info("editorial_writer.no_actu_decalee_candidates")

--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -8,11 +8,13 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from urllib.parse import quote
 
+from contextlib import asynccontextmanager
+
 import certifi
 import httpx
 import structlog
 from sqlalchemy import func, or_, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 logger = structlog.get_logger(__name__)
 
@@ -163,12 +165,37 @@ class PerspectiveService:
         # header consistently shows exactly this number, results are likely
         # truncated — bump this cap or audit upstream filters.
         max_results: int = 10,
+        session_maker: async_sessionmaker[AsyncSession] | None = None,
     ):
+        # Préférer `session_maker` : chaque requête DB s'exécute dans une
+        # session courte, évitant de tenir une connexion pendant les
+        # appels Google News / LLM qui dominent le temps du service.
+        # Cf. docs/bugs/bug-infinite-load-requests.md (P1).
         self.db = db
+        self._session_maker = session_maker
         self.timeout = timeout
         self.max_results = max_results
         # Cache for DB bias lookups within a single request
         self._bias_cache: dict[str, str] = {}
+
+    @asynccontextmanager
+    async def _short_session(self):
+        """Open a short-lived session, or fall back to self.db."""
+        if self._session_maker is None:
+            if self.db is None:
+                yield None
+                return
+            yield self.db
+            return
+        async with self._session_maker() as session:
+            try:
+                yield session
+            except Exception:
+                await session.rollback()
+                raise
+
+    def _has_db(self) -> bool:
+        return self._session_maker is not None or self.db is not None
 
     async def resolve_bias(self, domain: str, source_name: str | None = None) -> str:
         """Resolve bias for a domain: DOMAIN_BIAS_MAP first, then DB fallback by URL, then by name."""
@@ -183,35 +210,40 @@ class PerspectiveService:
             return self._bias_cache[cache_key]
 
         # 3. DB lookup if session available
-        if self.db:
+        if self._has_db():
             try:
                 from app.models.source import Source
 
-                # 3a. Try domain match on source URL
-                if domain:
-                    stmt = select(Source.bias_stance).where(
-                        Source.url.ilike(f"%{domain}%"),
-                        Source.is_active.is_(True),
-                    )
-                    result = await self.db.execute(stmt)
-                    source_bias = result.scalar_one_or_none()
+                async with self._short_session() as session:
+                    if session is None:
+                        self._bias_cache[cache_key] = "unknown"
+                        return "unknown"
 
-                    if source_bias and source_bias != "unknown":
-                        self._bias_cache[cache_key] = source_bias
-                        return source_bias
+                    # 3a. Try domain match on source URL
+                    if domain:
+                        stmt = select(Source.bias_stance).where(
+                            Source.url.ilike(f"%{domain}%"),
+                            Source.is_active.is_(True),
+                        )
+                        result = await session.execute(stmt)
+                        source_bias = result.scalar_one_or_none()
 
-                # 3b. Fallback: fuzzy match by source name (Google News source name)
-                if source_name and source_name != "Unknown":
-                    stmt = select(Source.bias_stance).where(
-                        Source.name.ilike(f"%{source_name}%"),
-                        Source.is_active.is_(True),
-                    )
-                    result = await self.db.execute(stmt)
-                    source_bias = result.scalar_one_or_none()
+                        if source_bias and source_bias != "unknown":
+                            self._bias_cache[cache_key] = source_bias
+                            return source_bias
 
-                    if source_bias and source_bias != "unknown":
-                        self._bias_cache[cache_key] = source_bias
-                        return source_bias
+                    # 3b. Fallback: fuzzy match by source name (Google News source name)
+                    if source_name and source_name != "Unknown":
+                        stmt = select(Source.bias_stance).where(
+                            Source.name.ilike(f"%{source_name}%"),
+                            Source.is_active.is_(True),
+                        )
+                        result = await session.execute(stmt)
+                        source_bias = result.scalar_one_or_none()
+
+                        if source_bias and source_bias != "unknown":
+                            self._bias_cache[cache_key] = source_bias
+                            return source_bias
             except Exception as e:
                 logger.warning(
                     "resolve_bias_db_error",
@@ -385,7 +417,7 @@ class PerspectiveService:
         self, content, time_window_hours: int = 72
     ) -> list[Perspective]:
         """Search DB for articles sharing PERSON/ORG entities with the source article."""
-        if not self.db:
+        if not self._has_db():
             return []
 
         entity_names = _parse_entity_names(content.entities, types={"PERSON", "ORG"})
@@ -420,8 +452,11 @@ class PerspectiveService:
         )
 
         try:
-            result = await self.db.execute(stmt)
-            rows = result.scalars().all()
+            async with self._short_session() as session:
+                if session is None:
+                    return []
+                result = await session.execute(stmt)
+                rows = result.scalars().all()
         except Exception as e:
             logger.warning("search_internal_perspectives_error", error=str(e))
             return []

--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -4,11 +4,10 @@ import html
 import json
 import re
 import xml.etree.ElementTree as ET
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from urllib.parse import quote
-
-from contextlib import asynccontextmanager
 
 import certifi
 import httpx

--- a/packages/api/app/services/sync_service.py
+++ b/packages/api/app/services/sync_service.py
@@ -3,13 +3,14 @@ import copy
 import datetime
 import html
 import re
-from uuid import uuid4
+from contextlib import asynccontextmanager
+from uuid import UUID, uuid4
 
 import certifi
 import feedparser
 import httpx
 import structlog
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.content import Content
@@ -36,6 +37,28 @@ class SyncService:
 
     async def close(self):
         await self.client.aclose()
+
+    @asynccontextmanager
+    async def _short_session(self):
+        """Yield a short-lived session for one DB operation.
+
+        Cf. docs/bugs/bug-infinite-load-requests.md (P2). On NE TIENT JAMAIS
+        de session ouverte pendant un await externe (httpx, trafilatura). Cette
+        helper ouvre une session, commit en sortie nominale, rollback sur
+        exception, et la ferme. Si `session_maker` n'est pas fourni
+        (constructeur legacy / tests unitaires), on retombe sur `self.session`
+        sans la fermer (compat ascendante).
+        """
+        if self.session_maker is None:
+            yield self.session
+            return
+        async with self.session_maker() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
 
     async def sync_all_sources(self):
         """Synchronise toutes les sources actives avec une limite de concomitance."""
@@ -95,70 +118,117 @@ class SyncService:
         return results
 
     async def process_source(self, source: Source) -> int:
-        """Synchronise une source spécifique."""
+        """Synchronise une source spécifique.
+
+        Refactor P2 (cf. docs/bugs/bug-infinite-load-requests.md) : la session
+        SQLAlchemy n'est PLUS tenue ouverte pendant la boucle de 50 entries. Les
+        I/O externes (httpx, trafilatura, feedparser) s'exécutent hors session ;
+        chaque INSERT/UPDATE ouvre une session courte via `_short_session()`.
+        Avant ce fix, `self.session` restait checked-out pendant 4 à 20 minutes
+        par source × 5 sources en parallèle → fuite massive du pool DB.
+        """
         logger.info("Syncing source", source_name=source.name, feed_url=source.feed_url)
 
+        # Capture les attributs de la source AVANT toute opération asynchrone :
+        # cela évite que la source soit expirée entre temps si la session
+        # appelante a été commit. Les copies sont pures données, donc utilisables
+        # depuis n'importe quelle session.
+        source_id = source.id
+        source_name = source.name
+        source_url = source.feed_url
+        source_paywall_config = getattr(source, "paywall_config", None)
+
         try:
-            # 1. Fetch feed content asynchronously
-            response = await self.client.get(source.feed_url)
+            # 1. Fetch feed content (HORS session DB)
+            response = await self.client.get(source_url)
             response.raise_for_status()
             content = response.text
 
-            # 2. Parse feed (Offload to thread pool to avoid blocking event loop)
-            # feedparser.parse is CPU-bound and synchronous. On large feeds/many feeds,
-            # this blocks the loop and causes timeouts on other endpoints.
-            import asyncio
-
+            # 2. Parse feed (HORS session DB ; offloaded to thread pool, CPU-bound)
             loop = asyncio.get_event_loop()
             feed = await loop.run_in_executor(None, feedparser.parse, content)
 
             if feed.bozo:
                 logger.warning(
                     "Feed parsing warning",
-                    source=source.name,
+                    source=source_name,
                     error=feed.bozo_exception,
                 )
 
             if not feed.entries:
-                logger.warning("No entries found in feed", source=source.name)
+                logger.warning("No entries found in feed", source=source_name)
+                # On met quand même à jour last_synced_at pour ne pas re-tenter
+                # immédiatement.
+                await self._update_source_last_synced(source_id)
                 return 0
 
             new_contents_count = 0
 
-            # 3. Process entries
-            # On prend les 20 plus récents pour éviter de tout reparser à chaque fois
-            # si le flux est énorme
+            # 3. Process entries — chaque itération ouvre des sessions COURTES.
+            # Aucun `await` externe (httpx, trafilatura) ne se produit dans un
+            # `with session:` bloc.
             for entry in feed.entries[:50]:
                 content_data = self._parse_entry(entry, source)
-                if content_data:
-                    # Paywall detection: fetch article HTML head for JSON-LD signal
-                    html_head = None
-                    if content_data.get("content_type") == ContentType.ARTICLE:
-                        html_head = await self._fetch_html_head(
-                            content_data.get("url", "")
-                        )
+                if not content_data:
+                    continue
 
-                    content_data["is_paid"] = detect_paywall(
-                        title=content_data.get("title", ""),
-                        description=content_data.get("description"),
-                        url=content_data.get("url", ""),
-                        html_content=content_data.get("html_content"),
-                        source_id=str(source.id),
-                        paywall_config=getattr(source, "paywall_config", None),
-                        html_head=html_head,
+                # 3a. HTML head fetch (HORS session DB) — paywall detection
+                html_head = None
+                if content_data.get("content_type") == ContentType.ARTICLE:
+                    html_head = await self._fetch_html_head(
+                        content_data.get("url", "")
                     )
-                    is_new = await self._save_content(content_data)
-                    if is_new:
-                        new_contents_count += 1
 
-            # Update last_synced_at
-            source.last_synced_at = datetime.datetime.utcnow()
-            await self.session.commit()
+                # 3b. Paywall detection (pure CPU, HORS session DB)
+                content_data["is_paid"] = detect_paywall(
+                    title=content_data.get("title", ""),
+                    description=content_data.get("description"),
+                    url=content_data.get("url", ""),
+                    html_content=content_data.get("html_content"),
+                    source_id=str(source_id),
+                    paywall_config=source_paywall_config,
+                    html_head=html_head,
+                )
+
+                # 3c. Upsert atomique (session COURTE) — retourne ce qu'il faut
+                # pour décider de l'enrichissement trafilatura suivant.
+                try:
+                    is_new, content_id, needs_enrich, content_url = (
+                        await self._save_content(content_data)
+                    )
+                except Exception as save_err:
+                    logger.warning(
+                        "Failed to save content",
+                        source=source_name,
+                        guid=content_data.get("guid"),
+                        error=str(save_err),
+                    )
+                    continue
+
+                if is_new:
+                    new_contents_count += 1
+
+                # 3d. Trafilatura (HORS session DB, max 20s).
+                if needs_enrich and content_id is not None and content_url:
+                    extraction = await self._run_extraction_safely(content_url)
+                    # 3e. Apply extraction result en session COURTE.
+                    if extraction is not None:
+                        try:
+                            await self._apply_extraction(content_id, extraction)
+                        except Exception as enrich_err:
+                            logger.warning(
+                                "Failed to apply extraction",
+                                content_id=str(content_id),
+                                error=str(enrich_err),
+                            )
+
+            # 4. Update source.last_synced_at en session COURTE.
+            await self._update_source_last_synced(source_id)
 
             return new_contents_count
 
         except Exception as e:
-            logger.error("Error processing source", source=source.name, error=str(e))
+            logger.error("Error processing source", source=source_name, error=str(e))
             raise e
 
     def _parse_entry(self, entry, source: Source) -> dict | None:
@@ -463,134 +533,158 @@ class SyncService:
             return None
         return None
 
-    async def _save_content(self, data: dict) -> bool:
-        """Sauvegarde le contenu en base (Upsert/Ignore). Retourne True si nouveau."""
+    async def _save_content(
+        self, data: dict
+    ) -> tuple[bool, UUID | None, bool, str | None]:
+        """Upsert the content row in a SHORT session and return enrichment hints.
 
-        # Check if exists by guid
-        stmt = select(Content).where(Content.guid == data["guid"])
-        result = await self.session.execute(stmt)
-        existing = result.scalars().first()
+        Returns (is_new, content_id, needs_enrich, content_url) :
+        - is_new : True si une nouvelle ligne a été insérée
+        - content_id : UUID de la ligne à enrichir (None si pas d'enrichissement)
+        - needs_enrich : True si trafilatura doit tenter une extraction
+        - content_url : URL à passer à trafilatura
 
-        if existing:
-            # Backfill thumbnail if missing
-            if not existing.thumbnail_url and data.get("thumbnail_url"):
-                existing.thumbnail_url = data["thumbnail_url"]
-
-            # Also update description if missing
-            if not existing.description and data.get("description"):
-                existing.description = data["description"]
-
-            # Story 5.2: Backfill html_content and audio_url if missing
-            if not existing.html_content and data.get("html_content"):
-                existing.html_content = data["html_content"]
-            if not existing.audio_url and data.get("audio_url"):
-                existing.audio_url = data["audio_url"]
-
-            # Paywall: upgrade false→true only (never downgrade paid→free)
-            if data.get("is_paid") and not existing.is_paid:
-                existing.is_paid = True
-
-            # In-App Reading: enrich with trafilatura if content not full quality
-            if (
-                existing.content_type == ContentType.ARTICLE
-                and existing.content_quality != "full"
-                and not existing.html_content
-            ):
-                await self._enrich_content(existing)
-
-            return False
-
-        # Create new content
-        new_content = Content(
-            id=uuid4(),
-            source_id=data["source_id"],
-            title=data["title"][:500],  # Trucate to fit DB
-            url=data["url"],
-            guid=data["guid"][:500],
-            published_at=data["published_at"],
-            content_type=data["content_type"],
-            description=data["description"],
-            thumbnail_url=data["thumbnail_url"],
-            duration_seconds=data["duration_seconds"],
-            html_content=data.get("html_content"),  # Story 5.2
-            audio_url=data.get("audio_url"),  # Story 5.2
-            is_paid=data.get("is_paid", False),  # Paywall detection
-            created_at=datetime.datetime.utcnow(),
-        )
-
-        self.session.add(new_content)
-        # Flush to get the ID but don't commit transaction yet (handled by caller or auto-flush)
-        # But here we are in a loop, so let's allow session to handle it.
-        # However, to avoid integrity errors on GUID if we process duplicates in same batch,
-        # we should flush.
-        await self.session.flush()
-
-        # In-App Reading: enrich article content with trafilatura
-        if new_content.content_type == ContentType.ARTICLE:
-            await self._enrich_content(new_content)
-
-        # US-2: Add to classification queue for ML processing
-        await self._enqueue_for_classification(new_content, data)
-
-        return True
-
-    async def _enrich_content(self, content: Content) -> None:
-        """Enrich article content with trafilatura if content quality is not full.
-
-        Runs extraction in a thread pool to avoid blocking the event loop.
-        Updates content_quality and duration_seconds based on extracted text.
+        L'extraction trafilatura (await externe long) se fait HORS de cette
+        session pour ne pas tenir le pool. `extraction_attempted_at` est écrit
+        avant le retour pour garantir le cooldown même si l'extraction hang.
         """
-        extractor = ContentExtractor()
+        # Pre-flush priority computation (pure)
+        priority = self._compute_classification_priority(data)
 
-        # Compute quality from existing content if not yet done
-        if not content.content_quality:
-            if content.html_content or content.description:
-                content.content_quality = extractor.compute_quality_for_existing(
-                    content.html_content, content.description
+        async with self._short_session() as session:
+            # Check if exists by guid
+            stmt = select(Content).where(Content.guid == data["guid"])
+            result = await session.execute(stmt)
+            existing = result.scalars().first()
+
+            if existing:
+                # Backfill thumbnail if missing
+                if not existing.thumbnail_url and data.get("thumbnail_url"):
+                    existing.thumbnail_url = data["thumbnail_url"]
+
+                # Also update description if missing
+                if not existing.description and data.get("description"):
+                    existing.description = data["description"]
+
+                # Story 5.2: Backfill html_content and audio_url if missing
+                if not existing.html_content and data.get("html_content"):
+                    existing.html_content = data["html_content"]
+                if not existing.audio_url and data.get("audio_url"):
+                    existing.audio_url = data["audio_url"]
+
+                # Paywall: upgrade false→true only (never downgrade paid→free)
+                if data.get("is_paid") and not existing.is_paid:
+                    existing.is_paid = True
+
+                # Compute current quality if not set
+                if not existing.content_quality:
+                    extractor = ContentExtractor()
+                    if existing.html_content or existing.description:
+                        existing.content_quality = (
+                            extractor.compute_quality_for_existing(
+                                existing.html_content, existing.description
+                            )
+                        )
+
+                needs_enrich = (
+                    existing.content_type == ContentType.ARTICLE
+                    and existing.content_quality != "full"
+                    and not existing.html_content
+                )
+                if needs_enrich:
+                    # Marquer AVANT l'await externe pour garantir le cooldown
+                    # même si trafilatura hang. Cf. bug-infinite-load-requests.md.
+                    existing.extraction_attempted_at = datetime.datetime.now(
+                        datetime.UTC
+                    )
+
+                await session.flush()
+                return (
+                    False,
+                    existing.id if needs_enrich else None,
+                    needs_enrich,
+                    existing.url if needs_enrich else None,
                 )
 
-        # Skip if existing content is already full quality
-        if content.content_quality == "full":
-            return
-
-        content.extraction_attempted_at = datetime.datetime.now(datetime.UTC)
-
-        try:
-            # Run sync trafilatura in thread pool (with 20s timeout)
-            result = await asyncio.wait_for(
-                asyncio.get_event_loop().run_in_executor(
-                    None, extractor.extract, content.url
-                ),
-                timeout=20.0,
+            # Create new content
+            new_content = Content(
+                id=uuid4(),
+                source_id=data["source_id"],
+                title=data["title"][:500],
+                url=data["url"],
+                guid=data["guid"][:500],
+                published_at=data["published_at"],
+                content_type=data["content_type"],
+                description=data["description"],
+                thumbnail_url=data["thumbnail_url"],
+                duration_seconds=data["duration_seconds"],
+                html_content=data.get("html_content"),
+                audio_url=data.get("audio_url"),
+                is_paid=data.get("is_paid", False),
+                created_at=datetime.datetime.utcnow(),
             )
 
+            session.add(new_content)
+            await session.flush()
+
+            content_id_for_enrich: UUID | None = None
+            url_for_enrich: str | None = None
+            needs_enrich = new_content.content_type == ContentType.ARTICLE
+            if needs_enrich:
+                new_content.extraction_attempted_at = datetime.datetime.now(
+                    datetime.UTC
+                )
+                content_id_for_enrich = new_content.id
+                url_for_enrich = new_content.url
+
+            # US-2 : add to classification queue (same SHORT session for atomicity)
+            await self._enqueue_for_classification_in_session(
+                session, new_content.id, priority
+            )
+
+            return (True, content_id_for_enrich, needs_enrich, url_for_enrich)
+
+    async def _run_extraction_safely(self, url: str):
+        """Lance trafilatura en thread pool, borné à 20 s. JAMAIS dans une session.
+
+        Retourne le résultat ContentExtractor ou None en cas d'échec / timeout.
+        """
+        extractor = ContentExtractor()
+        try:
+            return await asyncio.wait_for(
+                asyncio.get_event_loop().run_in_executor(None, extractor.extract, url),
+                timeout=20.0,
+            )
+        except Exception:
+            logger.exception("content_enrichment_failed", url=url)
+            return None
+
+    async def _apply_extraction(self, content_id: UUID, result) -> None:
+        """Applique le résultat trafilatura à la ligne en session COURTE."""
+        async with self._short_session() as session:
+            content = await session.get(Content, content_id)
+            if content is None:
+                return
             if result.html_content:
                 content.html_content = result.html_content
             if result.reading_time_seconds and not content.duration_seconds:
                 content.duration_seconds = result.reading_time_seconds
-
-            # Always set content_quality (even if extraction failed → 'none')
+            # Always set quality (even if extraction returned 'none')
             content.content_quality = result.content_quality
+            await session.flush()
 
-        except Exception:
-            logger.exception(
-                "content_enrichment_failed",
-                content_id=str(content.id),
-                url=content.url,
+    async def _update_source_last_synced(self, source_id: UUID) -> None:
+        """Met à jour `sources.last_synced_at` en session COURTE."""
+        async with self._short_session() as session:
+            await session.execute(
+                update(Source)
+                .where(Source.id == source_id)
+                .values(last_synced_at=datetime.datetime.utcnow())
             )
-            # Ensure quality is set even on failure
-            if not content.content_quality:
-                content.content_quality = extractor.compute_quality_for_existing(
-                    content.html_content, content.description
-                )
 
-    async def _enqueue_for_classification(self, content: Content, data: dict) -> None:
-        """Add content to classification queue with priority based on age."""
-        from app.services.classification_queue_service import ClassificationQueueService
-
-        queue_service = ClassificationQueueService(self.session)
-
-        # Calculate priority based on article age
+    @staticmethod
+    def _compute_classification_priority(data: dict) -> int:
+        """Compute classification priority based on article age."""
         priority = 0
         if data.get("published_at"):
             try:
@@ -601,9 +695,17 @@ class SyncService:
                     priority = 10  # Recent articles - high priority
                 elif hours_old < 72:
                     priority = 5  # 1-3 days old - medium priority
-                # Older articles stay at priority 0
             except (TypeError, AttributeError):
-                # If date comparison fails, use default priority
                 pass
+        return priority
 
-        await queue_service.enqueue(content.id, priority=priority)
+    async def _enqueue_for_classification_in_session(
+        self, session: AsyncSession, content_id: UUID, priority: int
+    ) -> None:
+        """Add content to classification queue inside the given session."""
+        from app.services.classification_queue_service import (
+            ClassificationQueueService,
+        )
+
+        queue_service = ClassificationQueueService(session)
+        await queue_service.enqueue(content_id, priority=priority)

--- a/packages/api/app/services/sync_service.py
+++ b/packages/api/app/services/sync_service.py
@@ -11,6 +11,7 @@ import feedparser
 import httpx
 import structlog
 from sqlalchemy import select, update
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.content import Content
@@ -196,7 +197,7 @@ class SyncService:
                     is_new, content_id, needs_enrich, content_url = (
                         await self._save_content(content_data)
                     )
-                except Exception as save_err:
+                except SQLAlchemyError as save_err:
                     logger.warning(
                         "Failed to save content",
                         source=source_name,
@@ -215,7 +216,7 @@ class SyncService:
                     if extraction is not None:
                         try:
                             await self._apply_extraction(content_id, extraction)
-                        except Exception as enrich_err:
+                        except SQLAlchemyError as enrich_err:
                             logger.warning(
                                 "Failed to apply extraction",
                                 content_id=str(content_id),

--- a/packages/api/app/services/sync_service.py
+++ b/packages/api/app/services/sync_service.py
@@ -176,9 +176,7 @@ class SyncService:
                 # 3a. HTML head fetch (HORS session DB) — paywall detection
                 html_head = None
                 if content_data.get("content_type") == ContentType.ARTICLE:
-                    html_head = await self._fetch_html_head(
-                        content_data.get("url", "")
-                    )
+                    html_head = await self._fetch_html_head(content_data.get("url", ""))
 
                 # 3b. Paywall detection (pure CPU, HORS session DB)
                 content_data["is_paid"] = detect_paywall(
@@ -194,9 +192,12 @@ class SyncService:
                 # 3c. Upsert atomique (session COURTE) — retourne ce qu'il faut
                 # pour décider de l'enrichissement trafilatura suivant.
                 try:
-                    is_new, content_id, needs_enrich, content_url = (
-                        await self._save_content(content_data)
-                    )
+                    (
+                        is_new,
+                        content_id,
+                        needs_enrich,
+                        content_url,
+                    ) = await self._save_content(content_data)
                 except SQLAlchemyError as save_err:
                     logger.warning(
                         "Failed to save content",

--- a/packages/api/tests/editorial/test_deep_matcher.py
+++ b/packages/api/tests/editorial/test_deep_matcher.py
@@ -76,6 +76,48 @@ class TestLoadDeepArticles:
         assert len(result) == 2
         session.execute.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_uses_session_maker_and_does_not_touch_injected_session(self):
+        """P1 fix — when session_maker is provided, each DB op opens a
+        short-lived session. The injected `session` must NOT be used, so
+        the pool isn't held during the LLM pipeline.
+        cf. docs/bugs/bug-infinite-load-requests.md
+        """
+        articles = [_make_deep_content("A")]
+        short_session = _mock_session_with_articles(articles)
+
+        # session_maker is an async context manager factory
+        maker_calls = []
+
+        class _Maker:
+            def __call__(self):
+                maker_calls.append(1)
+                return self
+
+            async def __aenter__(self):
+                return short_session
+
+            async def __aexit__(self, *a):
+                return None
+
+        injected = AsyncMock()  # Would blow up if used
+        injected.execute.side_effect = AssertionError(
+            "injected session must NOT be used when session_maker is set"
+        )
+
+        llm = MagicMock()
+        llm.is_ready = False
+
+        matcher = DeepMatcher(
+            injected, llm, _make_config(), session_maker=_Maker()
+        )
+        result = await matcher._load_deep_articles()
+
+        assert len(result) == 1
+        assert len(maker_calls) == 1
+        short_session.execute.assert_awaited_once()
+        injected.execute.assert_not_called()
+
 
 class TestPrefilter:
     def test_filters_by_jaccard_threshold(self):

--- a/packages/api/tests/editorial/test_writer_rotation.py
+++ b/packages/api/tests/editorial/test_writer_rotation.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
+
+from sqlalchemy.exc import SQLAlchemyError
 from uuid import UUID, uuid4
 
 import pytest
@@ -186,7 +188,9 @@ class TestRecentHighlightsQuery:
     @pytest.mark.asyncio
     async def test_returns_empty_on_query_failure(self, writer, mock_session):
         """If the DB query raises, return empty set (table may not exist yet)."""
-        mock_session.execute = AsyncMock(side_effect=Exception("table missing"))
+        mock_session.execute = AsyncMock(
+            side_effect=SQLAlchemyError("table missing")
+        )
 
         result = await writer._recent_highlight_content_ids("pepite")
         assert result == set()
@@ -225,6 +229,6 @@ class TestRecordHighlight:
     @pytest.mark.asyncio
     async def test_record_highlight_swallows_exception(self, writer, mock_session):
         """If flush fails, the exception is logged but not raised."""
-        mock_session.flush = AsyncMock(side_effect=Exception("boom"))
+        mock_session.flush = AsyncMock(side_effect=SQLAlchemyError("boom"))
         # Must not raise
         await writer.record_highlight("coup_de_coeur", uuid4())

--- a/packages/api/tests/test_sync_service.py
+++ b/packages/api/tests/test_sync_service.py
@@ -116,8 +116,11 @@ async def test_save_content_deduplication(sync_service, mock_session):
         "duration_seconds": None
     }
     
-    is_new = await sync_service._save_content(data)
-    
+    # _save_content now returns a tuple (is_new, content_id, needs_enrich, url)
+    # because the I/O for trafilatura runs OUTSIDE the DB session
+    # (cf. docs/bugs/bug-infinite-load-requests.md, P2).
+    is_new, content_id, needs_enrich, url = await sync_service._save_content(data)
+
     assert is_new is False
     # Check if we updated the existing content
     assert mock_existing.thumbnail_url == "thumb"


### PR DESCRIPTION
Adresse P3 hygiène de bug-infinite-load-requests :
- socket.setdefaulttimeout(30) dans main.py : filet contre un
  thread executor bloqué byte-par-byte par un upstream stall
  (trafilatura, urllib via feedparser).
- briefing_service._fetch_une_guids : remplace feedparser.parse(url)
  par le pattern httpx.get + feedparser.parse(content). Même landmine
  déjà corrigée côté digest_selector.

Refs: docs/bugs/bug-infinite-load-requests.md