### PR TITLE
fix: article reader UI — 3 regressions (PR #400)

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -1744,7 +1744,18 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 _perspectivesResponse!.perspectives.isEmpty,
                             onTap: () {
                               HapticFeedback.lightImpact();
-                              _showPerspectives(context);
+                              final ctx =
+                                  _perspectivesKey.currentContext;
+                              if (ctx != null) {
+                                Scrollable.ensureVisible(
+                                  ctx,
+                                  duration: const Duration(
+                                      milliseconds: 400),
+                                  curve: Curves.easeInOut,
+                                );
+                              } else {
+                                _showPerspectives(context);
+                              }
                             },
                           ),
                           const SizedBox(height: 12),
@@ -2270,6 +2281,16 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                               ),
                                             ),
                                           ],
+                                          // Editorial badge (digest articles)
+                                          if (content.editorialBadge !=
+                                              null) ...[
+                                            const SizedBox(width: 6),
+                                            EditorialBadge.chip(
+                                                  content.editorialBadge,
+                                                  context: context,
+                                                ) ??
+                                                const SizedBox.shrink(),
+                                          ],
                                           // Gear icon — same scale as bias dot
                                           const SizedBox(width: 4),
                                           Material(
@@ -2387,15 +2408,23 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         .map((t) => t.canonicalName!.toLowerCase())
         .toSet();
 
-    const maxVisible = 3;
+    // Dense layout: 4 tags max across macro-theme + topic + entities.
+    // Remaining entities are grouped into a "+X" overflow chip.
+    const maxTotalVisible = 4;
+
+    final hasMacroTheme = content.topics.isNotEmpty &&
+        getTopicMacroTheme(content.topics.first) != null;
+    final hasTopic = content.topics.isNotEmpty;
+    final reservedForTopics = (hasMacroTheme ? 1 : 0) + (hasTopic ? 1 : 0);
     final entities = content.entities;
-    final visible = entities.take(maxVisible).toList();
-    final overflow = entities.length - maxVisible;
+    final maxEntitiesVisible =
+        (maxTotalVisible - reservedForTopics).clamp(0, entities.length);
+    final visible = entities.take(maxEntitiesVisible).toList();
+    final overflow = entities.length - maxEntitiesVisible;
 
     return [
       // Macro-theme chip (thème du sujet, ex: Cinéma)
-      if (content.topics.isNotEmpty &&
-          getTopicMacroTheme(content.topics.first) != null)
+      if (hasMacroTheme)
         Builder(builder: (context) {
           final macroTheme = getTopicMacroTheme(content.topics.first)!;
           final emoji = getMacroThemeEmoji(macroTheme);
@@ -2421,7 +2450,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           );
         }),
       // Topic chip
-      if (content.topics.isNotEmpty)
+      if (hasTopic)
         GestureDetector(
           onTap: () => TopicChip.showArticleSheet(context, content,
               initialSection: ArticleSheetSection.topic),
@@ -2805,14 +2834,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                   ],
                                 ),
                                 const SizedBox(height: FacteurSpacing.space4),
-                              ],
-                              if (content.editorialBadge != null) ...[
-                                EditorialBadge.chip(
-                                      content.editorialBadge,
-                                      context: context,
-                                    ) ??
-                                    const SizedBox.shrink(),
-                                const SizedBox(height: FacteurSpacing.space2),
                               ],
                               Text(
                                 content.title,
@@ -3309,12 +3330,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                               ..._buildArticleTagWidgets(context, content),
                           ],
                         ),
-                      if (content.editorialBadge != null)
-                        EditorialBadge.chip(
-                              content.editorialBadge,
-                              context: context,
-                            ) ??
-                            const SizedBox.shrink(),
                       Text(
                         content.title,
                         style: textTheme.displayLarge?.copyWith(fontSize: 24),


### PR DESCRIPTION
## What

Fix 3 UI regressions in the article reader introduced by PR #400 (layout rework):

1. **Editorial badge**: Restored to header Row (right of source name) instead of above title
2. **Tag budget**: Restored global 4-chip limit across macro-theme + topic + entities (was 3 for entities only)
3. **Perspectives FAB**: Now scrolls to inline section instead of always opening modal; falls back to modal if section not yet rendered

## Why

PR #400 moved badge positioning and changed tag logic without updating the perspectives FAB behavior. These fixes restore the intended UI from the previous version (3b88d8b6) while preserving all other PR #400 features (inline perspectives section, sticky footer, etc.).

## Type

- [x] Bug fix