### PR TITLE
fix: editorial digest robustness — retry + no topics fallback

### DIFF
--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -196,6 +196,16 @@ class DigestGenerationJob:
                                 ctx = await pipeline.compute_global_context(
                                     mode_candidates, mode=mode
                                 )
+                                # Retry once if precompute failed
+                                if ctx is None:
+                                    logger.warning(
+                                        "digest_generation_editorial_ctx_retry",
+                                        mode=mode,
+                                    )
+                                    await asyncio.sleep(5)
+                                    ctx = await pipeline.compute_global_context(
+                                        mode_candidates, mode=mode
+                                    )
                                 if ctx:
                                     from app.services.digest_selector import (
                                         _set_cached_editorial_ctx,
@@ -548,17 +558,17 @@ class DigestGenerationJob:
                     # All users get editorial format — no per-user branching
                     expected_version = "editorial_v1"
 
+                    stale_digest = None
                     if existing and existing.format_version != expected_version:
                         logger.info(
-                            "digest_generation_stale_format_deleted",
+                            "digest_generation_stale_format_deferred",
                             user_id=str(user_id),
                             target_date=str(target_date),
                             is_serene=is_serene,
                             cached=existing.format_version,
                             expected=expected_version,
                         )
-                        await session.delete(existing)
-                        await session.flush()
+                        stale_digest = existing
                         existing = None
 
                     if existing:
@@ -629,6 +639,11 @@ class DigestGenerationJob:
                             is_serene=is_serene,
                         )
                         if digest:
+                            # Delete stale (non-editorial) digest now that
+                            # the new editorial_v1 is safely created.
+                            if stale_digest:
+                                await session.delete(stale_digest)
+                                await session.flush()
                             self.stats["success"] += 1
                             await state_mark_success(
                                 session, user_id, target_date, is_serene
@@ -667,47 +682,23 @@ class DigestGenerationJob:
                         )
                         continue
 
-                    # Construire les items JSONB
-                    items = []
-                    for item in digest_items:
-                        items.append(
-                            {
-                                "content_id": str(item.content.id),
-                                "rank": item.rank,
-                                "reason": item.reason,
-                                "score": item.score,
-                                "source_id": str(item.content.source_id)
-                                if item.content.source_id
-                                else None,
-                                "title": item.content.title,
-                                "published_at": item.content.published_at.isoformat()
-                                if item.content.published_at
-                                else None,
-                            }
-                        )
-
-                    # Insérer le digest
-                    digest = DailyDigest(
-                        user_id=user_id,
-                        target_date=target_date,
-                        items=items,
-                        mode=digest_mode,
-                        is_serene=is_serene,
-                        generated_at=datetime.datetime.utcnow(),
-                    )
-
-                    session.add(digest)
-
-                    logger.debug(
-                        "digest_generation_success",
+                    # Unexpected return type — editorial should always
+                    # return EditorialPipelineResult or None/empty.
+                    logger.error(
+                        "digest_generation_unexpected_return_type",
                         user_id=str(user_id),
                         target_date=str(target_date),
                         is_serene=is_serene,
-                        article_count=len(items),
+                        type=type(digest_items).__name__,
                     )
-
-                    self.stats["success"] += 1
-                    await state_mark_success(session, user_id, target_date, is_serene)
+                    self.stats["failed"] += 1
+                    await state_mark_failed(
+                        session,
+                        user_id,
+                        target_date,
+                        is_serene,
+                        f"unexpected return type: {type(digest_items).__name__}",
+                    )
                 except Exception as variant_err:
                     # Record the variant error but keep going so the other
                     # variant still has a chance to generate.

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -237,13 +237,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
                         # "covered" when BOTH normal and serein exist.
                         expected_pairs = total_users * 2
                         pair_subq = (
-                            sa_select(
-                                DailyDigest.user_id, DailyDigest.is_serene
-                            )
+                            sa_select(DailyDigest.user_id, DailyDigest.is_serene)
                             .where(DailyDigest.target_date == today)
-                            .group_by(
-                                DailyDigest.user_id, DailyDigest.is_serene
-                            )
+                            .group_by(DailyDigest.user_id, DailyDigest.is_serene)
                             .subquery()
                         )
                         pair_count = (
@@ -253,11 +249,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
                             or 0
                         )
 
-                        coverage = (
-                            pair_count / expected_pairs
-                            if expected_pairs
-                            else 0
-                        )
+                        coverage = pair_count / expected_pairs if expected_pairs else 0
                         logger.info(
                             "digest_startup_catchup_check",
                             target_date=str(today),

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -232,18 +232,38 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
                             logger.info("digest_startup_catchup_no_users")
                             return
 
-                        digest_count = await session.scalar(
+                        # Count (user_id, is_serene) pairs — aligned
+                        # with the watchdog formula. A user is only
+                        # "covered" when BOTH normal and serein exist.
+                        expected_pairs = total_users * 2
+                        pair_subq = (
                             sa_select(
-                                func.count(func.distinct(DailyDigest.user_id))
-                            ).where(DailyDigest.target_date == today)
+                                DailyDigest.user_id, DailyDigest.is_serene
+                            )
+                            .where(DailyDigest.target_date == today)
+                            .group_by(
+                                DailyDigest.user_id, DailyDigest.is_serene
+                            )
+                            .subquery()
+                        )
+                        pair_count = (
+                            await session.scalar(
+                                sa_select(func.count()).select_from(pair_subq)
+                            )
+                            or 0
                         )
 
-                        coverage = digest_count / total_users
+                        coverage = (
+                            pair_count / expected_pairs
+                            if expected_pairs
+                            else 0
+                        )
                         logger.info(
                             "digest_startup_catchup_check",
                             target_date=str(today),
                             total_users=total_users,
-                            digest_count=digest_count,
+                            expected_pairs=expected_pairs,
+                            pair_count=pair_count,
                             coverage_pct=round(coverage * 100, 1),
                         )
 
@@ -251,7 +271,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
                             logger.info(
                                 "digest_startup_catchup_triggered",
                                 target_date=str(today),
-                                missing=total_users - digest_count,
+                                missing=expected_pairs - pair_count,
                             )
                             try:
                                 await asyncio.wait_for(

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -292,8 +292,12 @@ class DigestSelector:
                     )
 
                     if not pipeline.llm.is_ready:
-                        logger.warning("digest_editorial_no_api_key")
-                        output_format = "topics"
+                        logger.warning(
+                            "digest_editorial_failed_no_fallback",
+                            user_id=str(user_id),
+                            reason="no_api_key",
+                        )
+                        return None
                     else:
                         # Use injected context (batch), then cache, then compute
                         # Cache key in Paris time so reader and batch agree on "today"
@@ -325,8 +329,12 @@ class DigestSelector:
                             if global_ctx is not None:
                                 _set_cached_editorial_ctx(_cache_date, mode, global_ctx)
                         if not global_ctx:
-                            logger.warning("digest_editorial_global_ctx_failed")
-                            output_format = "topics"
+                            logger.warning(
+                                "digest_editorial_failed_no_fallback",
+                                user_id=str(user_id),
+                                reason="global_ctx_failed",
+                            )
+                            return None
                         else:
                             # MVP V2: global digest — actu already matched
                             # in compute_global_context(), no per-user phase
@@ -372,10 +380,11 @@ class DigestSelector:
                             return result
                 except Exception:
                     logger.exception(
-                        "digest_editorial_failed_fallback_topics",
+                        "digest_editorial_failed_no_fallback",
                         user_id=str(user_id),
+                        reason="exception",
                     )
-                    output_format = "topics"
+                    return None
 
             # === TOPIC FORMAT: delegate to TopicSelector ===
             if output_format == "topics":

--- a/packages/api/app/services/editorial/llm_client.py
+++ b/packages/api/app/services/editorial/llm_client.py
@@ -6,6 +6,7 @@ Reuses the existing MISTRAL_API_KEY from classification_service.
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import httpx
@@ -76,49 +77,83 @@ class EditorialLLMClient:
             ],
         }
 
-        try:
-            response = await client.post(MISTRAL_API_URL, json=payload)
-            response.raise_for_status()
+        _RETRYABLE_STATUSES = (429, 500, 502, 503)
+        max_retries = 2
 
-            data = response.json()
-            text = data["choices"][0]["message"]["content"]
+        for attempt in range(max_retries + 1):
+            try:
+                response = await client.post(MISTRAL_API_URL, json=payload)
+                response.raise_for_status()
 
-            # Strip markdown code fences if present
-            text = text.strip()
-            if text.startswith("```"):
-                lines = text.split("\n")
-                text = "\n".join(
-                    lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
-                )
+                data = response.json()
+                text = data["choices"][0]["message"]["content"]
+
+                # Strip markdown code fences if present
                 text = text.strip()
+                if text.startswith("```"):
+                    lines = text.split("\n")
+                    text = "\n".join(
+                        lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
+                    )
+                    text = text.strip()
 
-            parsed = json.loads(text)
+                parsed = json.loads(text)
 
-            logger.info(
-                "editorial_llm.success",
-                model=model,
-                prompt_tokens=data.get("usage", {}).get("prompt_tokens"),
-                completion_tokens=data.get("usage", {}).get("completion_tokens"),
-            )
-            return parsed
+                logger.info(
+                    "editorial_llm.success",
+                    model=model,
+                    attempt=attempt + 1,
+                    prompt_tokens=data.get("usage", {}).get("prompt_tokens"),
+                    completion_tokens=data.get("usage", {}).get("completion_tokens"),
+                )
+                return parsed
 
-        except httpx.HTTPStatusError as e:
-            logger.error(
-                "editorial_llm.http_error",
-                status_code=e.response.status_code,
-                body=e.response.text[:500],
-            )
-            return None
-        except json.JSONDecodeError as e:
-            logger.error(
-                "editorial_llm.json_parse_error",
-                error=str(e),
-                raw_text=text[:500] if "text" in dir() else "no_text",
-            )
-            return None
-        except Exception as e:
-            logger.error("editorial_llm.unexpected_error", error=str(e))
-            return None
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code in _RETRYABLE_STATUSES and attempt < max_retries:
+                    wait = 3 * (attempt + 1)  # 3s, 6s
+                    logger.warning(
+                        "editorial_llm.retrying",
+                        attempt=attempt + 1,
+                        wait_s=wait,
+                        status_code=e.response.status_code,
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                logger.error(
+                    "editorial_llm.http_error",
+                    status_code=e.response.status_code,
+                    body=e.response.text[:500],
+                    attempts_exhausted=attempt + 1,
+                )
+                return None
+            except httpx.TimeoutException:
+                if attempt < max_retries:
+                    wait = 3 * (attempt + 1)
+                    logger.warning(
+                        "editorial_llm.timeout_retrying",
+                        attempt=attempt + 1,
+                        wait_s=wait,
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                logger.error(
+                    "editorial_llm.timeout_exhausted",
+                    attempts_exhausted=attempt + 1,
+                )
+                return None
+            except json.JSONDecodeError as e:
+                # No retry for parse errors — LLM returned bad JSON
+                logger.error(
+                    "editorial_llm.json_parse_error",
+                    error=str(e),
+                    raw_text=text[:500] if "text" in dir() else "no_text",
+                )
+                return None
+            except Exception as e:
+                logger.error("editorial_llm.unexpected_error", error=str(e))
+                return None
+
+        return None
 
     async def chat_text(
         self,

--- a/packages/api/app/services/editorial/llm_client.py
+++ b/packages/api/app/services/editorial/llm_client.py
@@ -109,7 +109,10 @@ class EditorialLLMClient:
                 return parsed
 
             except httpx.HTTPStatusError as e:
-                if e.response.status_code in _RETRYABLE_STATUSES and attempt < max_retries:
+                if (
+                    e.response.status_code in _RETRYABLE_STATUSES
+                    and attempt < max_retries
+                ):
                     wait = 3 * (attempt + 1)  # 3s, 6s
                     logger.warning(
                         "editorial_llm.retrying",


### PR DESCRIPTION
## Summary

- **Root cause**: Mistral LLM failures caused `select_for_user` to fall back to `topics_v1` (TopicGroup), but the TopicGroup handler was removed from the batch job — crash on `item.content.id` → no digest saved → API served yesterday's stale digest for ~40/60 users
- **Fix**: 6-level retry chain + block topics fallback entirely. If all retries fail, API serves yesterday's editorial digest (existing mechanism)
- **Deferred delete**: stale (non-editorial) digests are only removed after new editorial_v1 is successfully created
- **Startup catchup**: now counts `(user_id, is_serene)` pairs like the watchdog (was counting `DISTINCT user_id`, missing half the variants)

## Changes

| File | Change |
|------|--------|
| `llm_client.py` | 2x retry with 3s/6s backoff on HTTP 429/500/502/503 + timeouts |
| `digest_generation_job.py` | Precompute retry 1x + deferred delete + replace dead TopicGroup code with error log |
| `digest_selector.py` | Return `None` instead of falling back to `output_format="topics"` (3 locations) |
| `main.py` | Startup catchup pair counting aligned with watchdog |

## Test plan

- [x] `pytest tests/test_digest_generation_job.py -x -v` — 7/7 passed
- [x] Full test suite — 553 passed (23 errors are pre-existing DB-connection issues)
- [ ] Post-deploy: verify 60/60 users have editorial_v1 Normal digests in DB
- [ ] Monitor logs: `editorial_llm.retrying`, `digest_generation_editorial_ctx_retry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)