### PR TITLE
fix: smart search 500 + pool exhaustion + mobile themes parsing

### DIFF
--- a/apps/mobile/lib/features/sources/models/theme_source_model.dart
+++ b/apps/mobile/lib/features/sources/models/theme_source_model.dart
@@ -9,7 +9,7 @@ class FollowedTheme {
   factory FollowedTheme.fromJson(Map<String, dynamic> json) {
     return FollowedTheme(
       slug: json['slug'] as String,
-      name: json['name'] as String,
+      name: (json['label'] ?? json['name']) as String,
     );
   }
 }
@@ -26,11 +26,30 @@ class ThemeSourcesResponse {
   });
 
   factory ThemeSourcesResponse.fromJson(Map<String, dynamic> json) {
+    // Backend returns {"groups": [{"label": "Curées", "sources": [...]}, ...]}
+    final groups = json['groups'];
+    if (groups is List) {
+      return ThemeSourcesResponse(
+        curated: _extractGroupSources(groups, 'Curées'),
+        candidates: _extractGroupSources(groups, 'Candidates'),
+        community: _extractGroupSources(groups, 'Communauté'),
+      );
+    }
+    // Fallback for flat format
     return ThemeSourcesResponse(
       curated: _parseSourceList(json['curated']),
       candidates: _parseSourceList(json['candidates']),
       community: _parseSourceList(json['community']),
     );
+  }
+
+  static List<Source> _extractGroupSources(List<dynamic> groups, String label) {
+    for (final group in groups) {
+      if (group is Map<String, dynamic> && group['label'] == label) {
+        return _parseSourceList(group['sources']);
+      }
+    }
+    return [];
   }
 
   static List<Source> _parseSourceList(dynamic data) {

--- a/apps/mobile/lib/features/sources/repositories/sources_repository.dart
+++ b/apps/mobile/lib/features/sources/repositories/sources_repository.dart
@@ -167,11 +167,14 @@ class SourcesRepository {
     try {
       final response =
           await _apiClient.dio.get<dynamic>('sources/themes-followed');
-      if (response.statusCode == 200 && response.data is List) {
-        return (response.data as List)
-            .map((json) =>
-                FollowedTheme.fromJson(json as Map<String, dynamic>))
-            .toList();
+      if (response.statusCode == 200 && response.data is Map) {
+        final themes = (response.data as Map<String, dynamic>)['themes'];
+        if (themes is List) {
+          return themes
+              .map((json) =>
+                  FollowedTheme.fromJson(json as Map<String, dynamic>))
+              .toList();
+        }
       }
       return [];
     } catch (e) {

--- a/packages/api/app/schemas/source.py
+++ b/packages/api/app/schemas/source.py
@@ -126,7 +126,7 @@ class SmartSearchResultItem(BaseModel):
     name: str
     type: str
     url: str
-    feed_url: str
+    feed_url: str | None = None
     favicon_url: str | None = None
     description: str | None = None
     in_catalog: bool = False

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -414,9 +414,7 @@ class SmartSourceSearchService:
         if not urls:
             return []
 
-        detections = await asyncio.gather(
-            *(self._try_detect_feed(url) for url in urls)
-        )
+        detections = await asyncio.gather(*(self._try_detect_feed(url) for url in urls))
         return [
             self._build_result(url, "google_news", user_themes, det)
             for url, det in zip(urls, detections, strict=True)
@@ -467,7 +465,9 @@ class SmartSourceSearchService:
                 self._build_result(
                     url, "mistral", user_themes, det, name, fallback_type=stype
                 )
-                for (url, name, stype), det in zip(urls_and_meta, detections, strict=True)
+                for (url, name, stype), det in zip(
+                    urls_and_meta, detections, strict=True
+                )
             ]
 
         except Exception as e:

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -1,5 +1,6 @@
 """Smart source search orchestrator — cascading pipeline."""
 
+import asyncio
 import re
 import time
 from datetime import UTC, datetime
@@ -152,8 +153,8 @@ class SmartSourceSearchService:
         # (a) Catalog ILIKE
         catalog_results = await self._search_catalog(normalized, user_themes)
         for r in catalog_results:
-            if r["feed_url"] not in seen_urls:
-                seen_urls.add(r["feed_url"])
+            if r["url"] not in seen_urls:
+                seen_urls.add(r["url"])
                 results.append(r)
         layers_called.append("catalog")
 
@@ -168,8 +169,8 @@ class SmartSourceSearchService:
         if query_type == "youtube_handle" or "youtube" in normalized:
             yt_results = await self._search_youtube(query, user_themes)
             for r in yt_results:
-                if r["feed_url"] not in seen_urls:
-                    seen_urls.add(r["feed_url"])
+                if r["url"] not in seen_urls:
+                    seen_urls.add(r["url"])
                     results.append(r)
             layers_called.append("youtube")
 
@@ -177,8 +178,8 @@ class SmartSourceSearchService:
         if query_type == "reddit_sub" or "reddit" in normalized or "r/" in normalized:
             reddit_results = await self._search_reddit(query, user_themes)
             for r in reddit_results:
-                if r["feed_url"] not in seen_urls:
-                    seen_urls.add(r["feed_url"])
+                if r["url"] not in seen_urls:
+                    seen_urls.add(r["url"])
                     results.append(r)
             layers_called.append("reddit")
 
@@ -188,8 +189,8 @@ class SmartSourceSearchService:
             brave_results = await self._search_brave(normalized, user_themes)
             _brave_calls_month += 1
             for r in brave_results:
-                if r["feed_url"] not in seen_urls:
-                    seen_urls.add(r["feed_url"])
+                if r["url"] not in seen_urls:
+                    seen_urls.add(r["url"])
                     results.append(r)
             layers_called.append("brave")
 
@@ -209,8 +210,8 @@ class SmartSourceSearchService:
         # (e) Google News RSS
         gnews_results = await self._search_google_news(normalized, user_themes)
         for r in gnews_results:
-            if r["feed_url"] not in seen_urls:
-                seen_urls.add(r["feed_url"])
+            if r["url"] not in seen_urls:
+                seen_urls.add(r["url"])
                 results.append(r)
         layers_called.append("google_news")
 
@@ -224,8 +225,8 @@ class SmartSourceSearchService:
             mistral_results = await self._search_mistral(normalized, user_themes)
             _mistral_calls_month += 1
             for r in mistral_results:
-                if r["feed_url"] not in seen_urls:
-                    seen_urls.add(r["feed_url"])
+                if r["url"] not in seen_urls:
+                    seen_urls.add(r["url"])
                     results.append(r)
             layers_called.append("mistral")
 
@@ -328,100 +329,98 @@ class SmartSourceSearchService:
             )
         return items
 
-    async def _search_brave(self, query: str, user_themes: list[str]) -> list[dict]:
-        """Search Brave, then validate top URLs via feed discovery."""
-        brave_results = await self.brave.search(query)
-        items = []
-
-        for br in brave_results[:5]:
-            url = br.get("url", "")
-            if not url:
-                continue
-            try:
-                detected = await self.rss_parser.detect(url)
-                items.append(
+    async def _try_detect_feed(self, url: str) -> dict | None:
+        """Try RSS feed detection on a URL. Returns enrichment dict or None."""
+        try:
+            detected = await self.rss_parser.detect(url)
+            return {
+                "feed_url": detected.feed_url,
+                "name": detected.title,
+                "type": detected.feed_type,
+                "favicon_url": detected.logo_url,
+                "description": detected.description,
+                "recent_items": [
                     {
-                        "name": detected.title,
-                        "type": detected.feed_type,
-                        "url": url,
-                        "feed_url": detected.feed_url,
-                        "favicon_url": detected.logo_url,
-                        "description": detected.description,
-                        "in_catalog": False,
-                        "is_curated": False,
-                        "source_id": None,
-                        "recent_items": [
-                            {
-                                "title": e["title"],
-                                "published_at": e.get("published_at", ""),
-                            }
-                            for e in detected.entries[:3]
-                        ],
-                        "score": _compute_score(
-                            "brave",
-                            False,
-                            False,
-                            0,
-                            None,
-                            False,
-                            any(
-                                t in (detected.title or "").lower() for t in user_themes
-                            ),
-                        ),
-                        "source_layer": "brave",
+                        "title": e["title"],
+                        "published_at": e.get("published_at", ""),
                     }
-                )
-            except (ValueError, Exception):
-                continue
+                    for e in detected.entries[:3]
+                ],
+            }
+        except (ValueError, Exception) as e:
+            logger.debug("smart_search.feed_detect_failed", url=url, error=str(e))
+            return None
 
-        return items
+    def _build_result(
+        self,
+        url: str,
+        layer: str,
+        user_themes: list[str],
+        feed_meta: dict | None,
+        fallback_name: str = "",
+        fallback_description: str = "",
+        fallback_type: str = "article",
+    ) -> dict:
+        """Build a search result dict, enriched with feed metadata if available."""
+        name = (feed_meta or {}).get("name") or fallback_name or url
+        return {
+            "name": name,
+            "type": (feed_meta or {}).get("type") or fallback_type,
+            "url": url,
+            "feed_url": (feed_meta or {}).get("feed_url"),
+            "favicon_url": (feed_meta or {}).get("favicon_url"),
+            "description": (feed_meta or {}).get("description") or fallback_description,
+            "in_catalog": False,
+            "is_curated": False,
+            "source_id": None,
+            "recent_items": (feed_meta or {}).get("recent_items", []),
+            "score": _compute_score(
+                layer,
+                False,
+                False,
+                0,
+                None,
+                False,
+                any(t in name.lower() for t in user_themes),
+            ),
+            "source_layer": layer,
+        }
+
+    async def _search_brave(self, query: str, user_themes: list[str]) -> list[dict]:
+        """Search Brave, then optionally enrich top URLs via feed discovery."""
+        brave_results = await self.brave.search(query)
+        urls_and_meta = [
+            (br.get("url", ""), br.get("title", ""), br.get("description", ""))
+            for br in brave_results[:5]
+            if br.get("url")
+        ]
+        if not urls_and_meta:
+            return []
+
+        detections = await asyncio.gather(
+            *(self._try_detect_feed(url) for url, _, _ in urls_and_meta)
+        )
+        return [
+            self._build_result(url, "brave", user_themes, det, title, desc)
+            for (url, title, desc), det in zip(urls_and_meta, detections)
+        ]
 
     async def _search_google_news(
         self, query: str, user_themes: list[str]
     ) -> list[dict]:
-        """Search Google News RSS, extract domains, validate feeds."""
+        """Search Google News RSS, extract domains, optionally enrich feeds."""
         base_urls = await self.google_news.search(query)
-        items = []
+        urls = [u for u in base_urls[:5] if u]
+        if not urls:
+            return []
 
-        for base_url in base_urls[:5]:
-            try:
-                detected = await self.rss_parser.detect(base_url)
-                items.append(
-                    {
-                        "name": detected.title,
-                        "type": detected.feed_type,
-                        "url": base_url,
-                        "feed_url": detected.feed_url,
-                        "favicon_url": detected.logo_url,
-                        "description": detected.description,
-                        "in_catalog": False,
-                        "is_curated": False,
-                        "source_id": None,
-                        "recent_items": [
-                            {
-                                "title": e["title"],
-                                "published_at": e.get("published_at", ""),
-                            }
-                            for e in detected.entries[:3]
-                        ],
-                        "score": _compute_score(
-                            "google_news",
-                            False,
-                            False,
-                            0,
-                            None,
-                            False,
-                            any(
-                                t in (detected.title or "").lower() for t in user_themes
-                            ),
-                        ),
-                        "source_layer": "google_news",
-                    }
-                )
-            except (ValueError, Exception):
-                continue
-
-        return items
+        detections = await asyncio.gather(
+            *(self._try_detect_feed(url) for url in urls)
+        )
+        return [
+            self._build_result(url, "google_news", user_themes, det)
+            for url, det in zip(urls, detections)
+        ]
 
     async def _search_mistral(self, query: str, user_themes: list[str]) -> list[dict]:
         """Mistral-small fallback: suggest feed URLs for query."""
@@ -453,49 +452,23 @@ class SmartSourceSearchService:
                 return []
 
             suggestions = result.get("suggestions", [])
-            items = []
-            for s in suggestions[:5]:
-                url = s.get("url", "")
-                if not url:
-                    continue
-                try:
-                    detected = await self.rss_parser.detect(url)
-                    items.append(
-                        {
-                            "name": detected.title,
-                            "type": detected.feed_type,
-                            "url": url,
-                            "feed_url": detected.feed_url,
-                            "favicon_url": detected.logo_url,
-                            "description": detected.description,
-                            "in_catalog": False,
-                            "is_curated": False,
-                            "source_id": None,
-                            "recent_items": [
-                                {
-                                    "title": e["title"],
-                                    "published_at": e.get("published_at", ""),
-                                }
-                                for e in detected.entries[:3]
-                            ],
-                            "score": _compute_score(
-                                "mistral",
-                                False,
-                                False,
-                                0,
-                                None,
-                                False,
-                                any(
-                                    t in (detected.title or "").lower()
-                                    for t in user_themes
-                                ),
-                            ),
-                            "source_layer": "mistral",
-                        }
-                    )
-                except (ValueError, Exception):
-                    continue
-            return items
+            urls_and_meta = [
+                (s.get("url", ""), s.get("name", ""), s.get("type", "article"))
+                for s in suggestions[:5]
+                if s.get("url")
+            ]
+            if not urls_and_meta:
+                return []
+
+            detections = await asyncio.gather(
+                *(self._try_detect_feed(url) for url, _, _ in urls_and_meta)
+            )
+            return [
+                self._build_result(
+                    url, "mistral", user_themes, det, name, fallback_type=stype
+                )
+                for (url, name, stype), det in zip(urls_and_meta, detections)
+            ]
 
         except Exception as e:
             logger.warning("smart_search.mistral_failed", error=str(e))

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -402,7 +402,7 @@ class SmartSourceSearchService:
         )
         return [
             self._build_result(url, "brave", user_themes, det, title, desc)
-            for (url, title, desc), det in zip(urls_and_meta, detections)
+            for (url, title, desc), det in zip(urls_and_meta, detections, strict=True)
         ]
 
     async def _search_google_news(
@@ -419,7 +419,7 @@ class SmartSourceSearchService:
         )
         return [
             self._build_result(url, "google_news", user_themes, det)
-            for url, det in zip(urls, detections)
+            for url, det in zip(urls, detections, strict=True)
         ]
 
     async def _search_mistral(self, query: str, user_themes: list[str]) -> list[dict]:
@@ -467,7 +467,7 @@ class SmartSourceSearchService:
                 self._build_result(
                     url, "mistral", user_themes, det, name, fallback_type=stype
                 )
-                for (url, name, stype), det in zip(urls_and_meta, detections)
+                for (url, name, stype), det in zip(urls_and_meta, detections, strict=True)
             ]
 
         except Exception as e:

--- a/packages/api/app/services/sync_service.py
+++ b/packages/api/app/services/sync_service.py
@@ -90,15 +90,21 @@ class SyncService:
         async def sync_with_semaphore(source: Source):
             async with semaphore:
                 if self.session_maker:
+                    # Read source in a SHORT session, then close it before I/O.
+                    # process_source() uses _short_session() for all DB ops,
+                    # so it does NOT need an outer session held open.
                     async with self.session_maker() as session:
                         stmt = select(Source).where(Source.id == source.id)
                         res = await session.execute(stmt)
                         source_obj = res.scalar_one()
+                        # Detach from session so attributes remain accessible
+                        await session.commit()
+                        session.expunge(source_obj)
+                    # Session is now CLOSED — pool connection returned.
 
-                        # Shallow copy isolates session state without creating a new httpx client
-                        task_service = copy.copy(self)
-                        task_service.session = session
-                        return await task_service.process_source(source_obj)
+                    task_service = copy.copy(self)
+                    task_service.session = None  # No long-lived session
+                    return await task_service.process_source(source_obj)
                 else:
                     return await self.process_source(source)
 


### PR DESCRIPTION
## What

Fixes 3 simultaneous production bugs: `POST /api/sources/smart-search` returning 500 (RSS validation silently dropped all results), DB pool exhaustion causing connection aborts on all endpoints during RSS sync, and mobile theme endpoints failing due to response format mismatch.

## Why

Smart search: `rss_parser.detect()` was a mandatory filter — any site without an easily discoverable RSS feed caused a silent result drop (100% of Brave/GoogleNews/Mistral results lost in prod). Pool exhaustion: sync worker held 5 DB sessions open for 4–20 min each during external I/O, saturating the 20-connection pool. Mobile: backend sends `{"themes": [...]}` and `{"groups": [...]}` but mobile expected a raw `List` and flat `curated/candidates/community` keys.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)

> ⚠️ Action manuelle requise : ajouter `BRAVE_API_KEY` dans les variables Railway prod pour activer le layer Brave du smart search.