### PR TITLE
fix(api): Round 3 — invalidate Supabase-killed conns + per-user session isolation

### DIFF
--- a/docs/bugs/bug-infinite-load-requests.md
+++ b/docs/bugs/bug-infinite-load-requests.md
@@ -525,3 +525,105 @@ nouveau contrat de retour.
    de + de 5 min doivent disparaître.
 2. **Nettoyage P0** (PR séparée) : retirer le scheduled restart 01h/09h/17h
    Paris une fois la pg_stat_activity clean confirmée sur 48 h.
+
+---
+
+## Round 3 — 2026-04-16 (analyse Sentry live)
+
+### Constat
+
+Round 2 deployé (release Sentry `654588e3…`, alembic `ln01`). Crash persistant
+malgré :
+- Site F OK (logs `digest_generation_timeout` tracés correctement 01:20-01:22
+  Paris, 5 événements d'affilée).
+- Request-budget middleware actif, mais **pas déclenché** : le pool saturé
+  tue la requête avec `QueuePool limit … reached` avant que le budget 60s
+  ne soit atteint.
+
+Traces Sentry du 2026-04-15 au 2026-04-16, 1 seul user testant (UA `Dart/3.10`,
+IP `86.252.7.47`) :
+
+| UTC | Sentry | Culprit | Signature |
+|-----|--------|---------|-----------|
+| 23:00 | PYTHON-4 | `apscheduler.executors.default` | `OperationalError: server closed the connection unexpectedly` |
+| 23:11 | PYTHON-5 | `app.database.init_db` | `InternalError: DbHandler exited` sur `SELECT pg_catalog.version()` |
+| 23:11 | PYTHON-6 | `app.main.readiness_check` | `PendingRollbackError: Can't reconnect until invalid transaction is rolled back` |
+| 23:35 | PYTHON-E | `app.routers.feed.get_personalized_feed` | `QueuePool limit of size 10 overflow 10, connection timed out` |
+| 23:37 | PYTHON-M | `app.routers.digest.get_both_digests` | idem |
+
+### Cause racine (R1 / R2 / R3)
+
+**R1 — Supabase/PgBouncer tue les connexions de façon asynchrone.** Les
+signatures `DbHandler exited`, `server closed the connection unexpectedly`,
+`consuming input failed` n'étaient PAS classées comme `is_disconnect=True`
+par SQLAlchemy. Résultat : le slot restait dans le pool en état invalide,
+toutes les requêtes suivantes levaient `PendingRollbackError`, le pool
+se remplissait de zombies jusqu'à `QueuePool limit reached`.
+
+**R2 — `_scheduled_restart` (01/09/17h Paris) amplifiait la fuite.** SIGTERM
+sur un process avec un job APScheduler en cours → connexion DB coupée brutalement
+côté pooler → `server closed the connection unexpectedly`. Au redémarrage,
+Supabase renvoyait parfois un pooler dans un état dégradé (`DbHandler exited`
+dès le `SELECT pg_catalog.version()` d'`init_db`).
+
+**R3 — Sessions partagées entre users dans `top3_job.py`.** Une seule
+session ouverte pour tout le batch : échec sur user N → session en
+`PendingRollbackError` → tous les users N+1 à N+M échouaient en cascade.
+Contribution directe à la saturation du pool.
+
+### Fixes Round 3 (ce document)
+
+**F0.1 — Table manquante `source_search_cache`** (SQL via Supabase SQL Editor).
+Non liée aux crashes, mais fait du bruit dans Sentry (PYTHON-S, PYTHON-1).
+
+**F0.2 — Coercion `DigestTopic.divergence_analysis`**
+(`app/services/editorial/pipeline.py`, `app/services/digest_service.py`).
+Le LLM renvoyait parfois un dict, le schéma Pydantic attendait une string.
+Erreur de validation qui cassait `get_both_digests` (PYTHON-R) indépendamment
+du pool.
+
+**F0.3 — Parse défensif `DailyDigest.items`**
+(`app/services/recommendation_service.py:269+`). Si `items` est stocké en
+string JSON au lieu de list, `feed_digest_exclusion_failed` loggait un
+warning et le feed n'excluait pas les articles déjà dans le digest.
+
+**F1.1 — Listener SQLAlchemy `handle_error` pour invalidation pool**
+(`app/database.py`). `event.listens_for(engine.sync_engine, "handle_error")`
+détecte les signatures Supabase-kill (`server closed the connection`,
+`dbhandler exited`, `consuming input failed`, etc.) et force
+`is_disconnect=True`. SQLAlchemy évacue alors le slot au lieu de le
+remettre dans le pool avec une connexion morte.
+
+**F1.2 — Hardening `get_db()`** (`app/database.py`). `rollback()` et
+`close()` maintenant wrappés en try/except pour que l'échec d'un
+cleanup sur connexion déjà morte ne masque pas l'exception originale du
+handler (plus de cascade confuse de `PendingRollbackError` dans Sentry).
+
+**F1.3 — Isolation session par user dans `top3_job.py`**
+(`app/workers/top3_job.py`). Chaque user ouvre maintenant sa propre
+session courte via `async_session_maker()` avec rollback explicite sur
+exception. Une erreur sur user N n'empoisonne plus le reste du batch.
+- `sync_all_sources` déjà conforme depuis P2.
+- `run_digest_generation::_process_batch` déjà conforme (session fresh
+  par user dans `process_with_limit`).
+- `_digest_watchdog` déjà conforme.
+
+**F2.3 — Semaphore trafilatura** (`app/routers/contents.py`).
+`asyncio.Semaphore(3)` module-level qui borne à 3 extractions concurrentes.
+Empêche `get_content_detail` / `get_perspectives` / `update_content_status`
+(PYTHON-F/H/J) de saturer l'executor + le pool quand plusieurs articles
+sont ouverts en parallèle.
+
+### À ne PAS retirer encore
+
+- `_scheduled_restart` à conserver pendant la validation 48 h des fixes
+  F1.x. S'il se confirme que Sentry ne remonte plus `QueuePool limit` ni
+  `PendingRollbackError`, on pourra proposer un retrait en PR séparée.
+
+### Validation attendue
+
+- Sentry : 0 événement `QueuePool limit` sur 24 h.
+- Sentry : `DbHandler exited` rare (< 5/jour) et sans cascade
+  `PendingRollbackError`.
+- `/api/health/pool` : `checked_out` < 10 en steady state.
+- Test solo 01:35 Paris post-restart : pas de reproduction du crash.

--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -116,6 +116,46 @@ async_session_maker = async_sessionmaker(
 )
 
 
+# Round 3 fix (docs/bugs/bug-infinite-load-requests.md — Sentry PYTHON-4/5/6) :
+# Supabase/PgBouncer tue parfois des connexions de façon asynchrone et renvoie
+# des erreurs qui ne sont PAS automatiquement classées comme "disconnect" par
+# SQLAlchemy. Résultat : le slot reste dans le pool en état invalid, toutes
+# les requêtes suivantes lèvent PendingRollbackError, le pool se remplit de
+# zombies, QueuePool limit reached → "infinite loading".
+#
+# Ce listener force `is_disconnect=True` sur les signatures Supabase-spécifiques
+# pour que SQLAlchemy évacue le slot et en crée un neuf à la prochaine demande.
+_DISCONNECT_SIGNATURES = (
+    "server closed the connection",
+    "dbhandler exited",
+    "consuming input failed",
+    "connection reset by peer",
+    "connection is closed",
+    "ssl connection has been closed",
+    "terminating connection",
+)
+
+
+if _use_queue_pool:
+
+    @event.listens_for(engine.sync_engine, "handle_error")
+    def _invalidate_on_supabase_kill(exception_context):
+        exc = exception_context.original_exception
+        if exc is None:
+            return
+        msg = str(exc).lower()
+        matched = next((s for s in _DISCONNECT_SIGNATURES if s in msg), None)
+        if matched is None:
+            return
+        # Force SQLAlchemy à marquer la connexion morte → évacuée du pool.
+        exception_context.is_disconnect = True
+        logger.warning(
+            "db_connection_invalidated_by_signature",
+            signature=matched,
+            exc_type=type(exc).__name__,
+        )
+
+
 class Base(DeclarativeBase):
     """Base class pour les modèles SQLAlchemy."""
 
@@ -208,13 +248,32 @@ async def get_db() -> AsyncSession:
     the rollback branch and relies solely on ``finally`` to close the
     session.  If ``close()`` itself is interrupted the connection leaks
     into an "idle in transaction" state, gradually filling the pool.
+
+    Round 3 hardening : rollback et close sont wrappés en try/except pour que
+    l'échec d'un cleanup (sur connexion déjà morte) ne masque pas l'exception
+    originale du handler. Sinon Starlette/Sentry capturent une cascade confuse
+    de PendingRollbackError au lieu de la vraie cause.
     """
     async with async_session_maker() as session:
         try:
             yield session
             await session.commit()
         except BaseException:
-            await session.rollback()
+            try:
+                await session.rollback()
+            except Exception as rollback_exc:
+                logger.debug(
+                    "get_db_rollback_failed",
+                    error=str(rollback_exc),
+                    exc_type=type(rollback_exc).__name__,
+                )
             raise
         finally:
-            await session.close()
+            try:
+                await session.close()
+            except Exception as close_exc:
+                logger.debug(
+                    "get_db_close_failed",
+                    error=str(close_exc),
+                    exc_type=type(close_exc).__name__,
+                )

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -29,6 +29,15 @@ logger = structlog.get_logger()
 
 router = APIRouter()
 
+# Round 3 fix (docs/bugs/bug-infinite-load-requests.md — F2.3) :
+# trafilatura.extract peut prendre 10-15s par article. Sans borne, N
+# ouvertures simultanées monopolisent N threads de l'executor par défaut
+# + pressurisent le pool DB au retour (réouverture session pour persist).
+# Cap à 3 extractions concurrentes globales : un user qui ouvre rapidement
+# plusieurs articles ne déclenche pas une tempête parallèle qui sature
+# l'executor ET le pool.
+_EXTRACTION_SEMAPHORE = asyncio.Semaphore(3)
+
 
 @router.get(
     "/{content_id}",
@@ -87,12 +96,15 @@ async def get_content_detail(
                 logger.warning("content_detail_precommit_failed", exc_info=True)
 
             try:
-                result = await asyncio.wait_for(
-                    asyncio.get_event_loop().run_in_executor(
-                        None, extractor.extract, content_data["url"]
-                    ),
-                    timeout=15.0,
-                )
+                # Bornage global (F2.3) : bloque si 3 extractions déjà en
+                # cours pour éviter la saturation executor/pool.
+                async with _EXTRACTION_SEMAPHORE:
+                    result = await asyncio.wait_for(
+                        asyncio.get_event_loop().run_in_executor(
+                            None, extractor.extract, content_data["url"]
+                        ),
+                        timeout=15.0,
+                    )
 
                 # Persist enrichment via a short-lived session.
                 async with async_session_maker() as write_session:

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -1844,6 +1844,21 @@ class DigestService:
                 )
 
             if topic_articles:
+                # Round 3 fix (Sentry PYTHON-R) : certains digests persistés
+                # en DB avant le fix source contiennent un dict imbriqué au
+                # lieu d'une string. Coerce défensivement au boundary pour ne
+                # pas casser les digests historiques côté read.
+                _divergence_raw = subject.get("divergence_analysis")
+                if isinstance(_divergence_raw, dict):
+                    import json as _json
+
+                    _divergence_str = _json.dumps(_divergence_raw, ensure_ascii=False)
+                elif _divergence_raw is not None and not isinstance(
+                    _divergence_raw, str
+                ):
+                    _divergence_str = str(_divergence_raw)
+                else:
+                    _divergence_str = _divergence_raw
                 response_topics.append(
                     DigestTopic(
                         topic_id=subject.get("topic_id", ""),
@@ -1862,7 +1877,7 @@ class DigestService:
                         perspective_count=subject.get("perspective_count", 0),
                         bias_distribution=subject.get("bias_distribution"),
                         bias_highlights=subject.get("bias_highlights"),
-                        divergence_analysis=subject.get("divergence_analysis"),
+                        divergence_analysis=_divergence_str,
                         divergence_level=subject.get("divergence_level"),
                         perspective_sources=subject.get("perspective_sources"),
                         representative_content_id=subject.get(

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -441,7 +441,23 @@ class EditorialPipelineService:
                         article_description=representative.description,
                     )
                     if isinstance(divergence_result, dict):
-                        subject.divergence_analysis = divergence_result.get("analysis")
+                        analysis_raw = divergence_result.get("analysis")
+                        # Round 3 fix (Sentry PYTHON-R) : le LLM peut renvoyer
+                        # un dict imbriqué (ex: {"contexte": "...", "liens": [...]})
+                        # au lieu d'une string plate. Pydantic rejette → 500 sur
+                        # /digest/both. Coerce en string propre ici, source du bug.
+                        if isinstance(analysis_raw, dict):
+                            import json as _json
+
+                            subject.divergence_analysis = _json.dumps(
+                                analysis_raw, ensure_ascii=False
+                            )
+                        elif analysis_raw is not None and not isinstance(
+                            analysis_raw, str
+                        ):
+                            subject.divergence_analysis = str(analysis_raw)
+                        else:
+                            subject.divergence_analysis = analysis_raw
                         subject.divergence_level = divergence_result.get(
                             "divergence_level"
                         )

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -267,11 +267,23 @@ class RecommendationService:
             return results
 
         # 2. Process digest exclusion (already fetched in Phase 1)
+        # Round 3 fix (Sentry warning feed_digest_exclusion_failed, type
+        # "string indices must be integers") : certains rows DailyDigest.items
+        # ont été persistés en string JSON au lieu de list — probablement via
+        # une insertion qui a passé le JSON déjà sérialisé. Parse défensif ici
+        # pour couvrir les deux représentations sans resérialiser en DB.
         digest_content_ids: list[UUID] = []
         try:
-            if digest_row and digest_row.items:
+            items_raw = digest_row.items if digest_row else None
+            if isinstance(items_raw, str):
+                import json as _json
+
+                items_raw = _json.loads(items_raw)
+            if items_raw:
                 digest_content_ids = [
-                    UUID(item["content_id"]) for item in digest_row.items
+                    UUID(item["content_id"])
+                    for item in items_raw
+                    if isinstance(item, dict) and item.get("content_id")
                 ]
         except Exception as e:
             logger.warning("feed_digest_exclusion_failed", error=str(e))

--- a/packages/api/app/workers/top3_job.py
+++ b/packages/api/app/workers/top3_job.py
@@ -22,13 +22,19 @@ async def generate_daily_top3_job(trigger_manual: bool = False):
     start_time = datetime.utcnow()
 
     try:
-        async with async_session_maker() as session:
-            # 1. Prepare Global Context (Une, Trending)
-            briefing_service = BriefingService(session)
-
+        # Round 3 fix (docs/bugs/bug-infinite-load-requests.md — F1.3) :
+        # Chaque user utilise SA PROPRE session courte. L'ancienne version
+        # partageait une seule session pour tous les users du batch : une
+        # erreur sur user N pouvait laisser la session en état invalid
+        # (PendingRollbackError), et tous les users N+1 à N+M échouaient
+        # en cascade sur cette même connexion empoisonnée. Pire, ça
+        # contribuait à saturer le pool Supabase (connexions check-outées
+        # sans rollback propre).
+        # 1. Global context : session courte dédiée.
+        async with async_session_maker() as ctx_session:
+            briefing_service_ctx = BriefingService(ctx_session)
             logger.info("daily_top3_building_context")
-            # On pré-calcule le contexte global une seule fois pour tout le batch
-            global_context = await briefing_service._build_global_context()
+            global_context = await briefing_service_ctx._build_global_context()
 
             une_ids = global_context.get("une_ids", set())
             trending_ids = global_context.get("trending_ids", set())
@@ -39,50 +45,58 @@ async def generate_daily_top3_job(trigger_manual: bool = False):
                 trending_count=len(trending_ids),
             )
 
-            # 2. Get Users Eligible
-            # On prend les utilisateurs ayant complété l'onboarding
+            # 2. Get Users Eligible (même session courte — lecture seule)
             stmt = select(UserProfile.user_id).where(UserProfile.onboarding_completed)
-            result = await session.execute(stmt)
-            user_ids = result.scalars().all()
+            result = await ctx_session.execute(stmt)
+            user_ids = list(result.scalars().all())
 
-            total_users = len(user_ids)
-            logger.info("daily_top3_users_found", count=total_users)
+        total_users = len(user_ids)
+        logger.info("daily_top3_users_found", count=total_users)
 
-            # 3. Process Users (Batch)
-            processed_count = 0
-            errors_count = 0
+        # 3. Process Users (une session courte PAR user)
+        processed_count = 0
+        errors_count = 0
 
-            for user_id in user_ids:
-                try:
-                    # On appelle la génération explicite
-                    # Note: generate_briefing_for_user gère l'idempotence (ON CONFLICT DO NOTHING)
-                    # mais pour être plus propre on pourrait checker l'existence avant.
-                    # BriefingService.get_or_create fait le check, mais ici on veut forcer/assurer la génération.
-                    # On va utiliser generate_briefing_for_user directement avec le contexte pré-calculé.
+        for user_id in user_ids:
+            try:
+                async with async_session_maker() as user_session:
+                    try:
+                        briefing_service = BriefingService(user_session)
+                        await briefing_service.generate_briefing_for_user(
+                            user_id=user_id, global_context=global_context
+                        )
+                    except Exception:
+                        # Rollback explicite avant de fermer — évite de
+                        # laisser la session en état invalide dans le pool.
+                        try:
+                            await user_session.rollback()
+                        except Exception as rb_exc:
+                            logger.debug(
+                                "daily_top3_rollback_failed",
+                                user_id=str(user_id),
+                                error=str(rb_exc),
+                            )
+                        raise
+                processed_count += 1
 
-                    await briefing_service.generate_briefing_for_user(
-                        user_id=user_id, global_context=global_context
-                    )
-                    processed_count += 1
+                # Petit sleep pour éviter de saturer CPU/DB si beaucoup d'users
+                if processed_count % 50 == 0:
+                    await asyncio.sleep(0.1)
 
-                    # Petit sleep pour éviter de saturer CPU/DB si beaucoup d'users
-                    if processed_count % 50 == 0:
-                        await asyncio.sleep(0.1)
+            except Exception as e:
+                errors_count += 1
+                logger.error(
+                    "daily_top3_user_failed", user_id=str(user_id), error=str(e)
+                )
 
-                except Exception as e:
-                    errors_count += 1
-                    logger.error(
-                        "daily_top3_user_failed", user_id=str(user_id), error=str(e)
-                    )
-
-            duration = (datetime.utcnow() - start_time).total_seconds()
-            logger.info(
-                "daily_top3_job_completed",
-                duration_seconds=duration,
-                users_processed=processed_count,
-                errors=errors_count,
-                total=total_users,
-            )
+        duration = (datetime.utcnow() - start_time).total_seconds()
+        logger.info(
+            "daily_top3_job_completed",
+            duration_seconds=duration,
+            users_processed=processed_count,
+            errors=errors_count,
+            total=total_users,
+        )
 
     except Exception as e:
         logger.critical("daily_top3_job_crashed", error=str(e))


### PR DESCRIPTION
## Summary

Résout les crashes "infinite loading" persistants post-Round 2, confirmés en prod le 2026-04-15 à 01:35 Paris (user testait SEUL, Sentry PYTHON-E `QueuePool limit of size 10 overflow 10 reached`).

**Cause racine identifiée via Sentry** : Supabase/PgBouncer tue des connexions de façon asynchrone avec des signatures (`DbHandler exited`, `server closed the connection unexpectedly`, `consuming input failed`) que SQLAlchemy ne classe PAS comme disconnect. Les slots restent "valides" dans le pool mais pointent vers des conns mortes → `PendingRollbackError` cascade → pool se remplit de zombies → `QueuePool limit reached`.

## Fixes

- **F1.1** `database.py` — listener `handle_error` force `is_disconnect=True` sur les signatures Supabase-kill. SQLAlchemy évacue alors le slot au lieu de le garder.
- **F1.2** `database.py` — `get_db()` wrap rollback/close en try/except pour ne pas masquer l'exception originale du handler dans Sentry.
- **F1.3** `top3_job.py` — session courte par user (était partagée pour tout le batch : échec user N empoisonnait users N+1..M).
- **F2.3** `contents.py` — `asyncio.Semaphore(3)` borne les extractions trafilatura concurrentes (évitait saturation executor + pool).
- **F0.2** `editorial/pipeline.py` + `digest_service.py` — coerce dict `divergence_analysis` en JSON string (PYTHON-R cassait `/api/digest` indépendamment du pool).
- **F0.3** `recommendation_service.py` — parse défensif `DailyDigest.items` (warning `feed_digest_exclusion_failed`).

## Audits sans modif (déjà conformes)
- `rss_sync.py` ✓ `_short_session()` post-P2
- `digest_generation_job.py::_process_batch` ✓ fresh session par user
- `storage_cleanup.py` ✓

## Action requise côté prod (avant merge)

SQL à exécuter dans **Supabase SQL Editor** (table manquante, fait du bruit dans Sentry, F0.1) :

```sql
CREATE TABLE IF NOT EXISTS source_search_cache (
    query_hash VARCHAR(64) PRIMARY KEY,
    query_raw TEXT NOT NULL,
    payload JSONB NOT NULL,
    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
    expires_at TIMESTAMPTZ NOT NULL
);
CREATE INDEX IF NOT EXISTS ix_source_search_cache_expires_at
    ON source_search_cache (expires_at);
-- SELECT version_num FROM alembic_version;  -- à vérifier d'abord
UPDATE alembic_version SET version_num = 'ss01_search_cache'
 WHERE version_num = 'sf02';
```

## Test plan

- [x] 60 tests pass (pool, digest, content, top3, storage, digest_both_timeout)
- [ ] Post-deploy : `/api/health/pool` — `checked_out` < 10 en steady state
- [ ] Post-deploy 24h : 0 event `QueuePool limit` dans Sentry
- [ ] Post-deploy 24h : `DbHandler exited` rare (< 5/jour) et sans cascade `PendingRollbackError`
- [ ] Reproduction solo 01:35 Paris post-restart : pas de crash

## À ne PAS retirer encore

`_scheduled_restart` 01/09/17h Paris — à conserver jusqu'à validation 48h. PR séparée pour retrait si Sentry clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)