### PR TITLE
fix(feed): multiplier floor 0.5 → 0.2 + theme-mismatch malus

### DIFF
--- a/apps/mobile/lib/widgets/design/priority_slider.dart
+++ b/apps/mobile/lib/widgets/design/priority_slider.dart
@@ -9,7 +9,7 @@ const Color _terracotta = Color(0xFFE07A5F);
 /// 3-cran compact slider for priority weighting.
 ///
 /// Maps multiplier values to visual blocks:
-/// - 0.5 (Moins):   [filled] [empty] [empty]
+/// - 0.2 (Moins):   [filled] [empty] [empty]
 /// - 1.0 (Normal):  [filled] [filled] [empty]
 /// - 2.0 (Plus):    [filled] [filled] [filled]
 ///
@@ -40,7 +40,7 @@ class PrioritySlider extends StatefulWidget {
 
 class _PrioritySliderState extends State<PrioritySlider>
     with SingleTickerProviderStateMixin {
-  static const _multipliers = [0.5, 1.0, 2.0];
+  static const _multipliers = [0.2, 1.0, 2.0];
   static const _blockWidth = 28.0;
   static const _blockHeight = 12.0;
   static const _blockGap = 3.0;
@@ -61,7 +61,7 @@ class _PrioritySliderState extends State<PrioritySlider>
     return '';
   }
 
-  /// Normalize a multiplier (0.5/1.0/2.0) to 0.0-1.0 range for comparison.
+  /// Normalize a multiplier (0.2/1.0/2.0) to 0.0-1.0 range for comparison.
   double _multiplierToNormalized(double m) {
     if (m <= 0.5) return 0.0;
     if (m <= 1.0) return 0.5;

--- a/apps/mobile/test/features/custom_topics/widgets/topic_priority_slider_test.dart
+++ b/apps/mobile/test/features/custom_topics/widgets/topic_priority_slider_test.dart
@@ -20,10 +20,10 @@ void main() {
   }
 
   group('TopicPrioritySlider', () {
-    testWidgets('displays 1 filled block for multiplier 0.5',
+    testWidgets('displays 1 filled block for multiplier 0.2',
         (tester) async {
       await tester.pumpWidget(createWidget(
-        currentMultiplier: 0.5,
+        currentMultiplier: 0.2,
         onChanged: (_) {},
       ));
 
@@ -71,7 +71,7 @@ void main() {
       expect(changedValue, 2.0);
     });
 
-    testWidgets('tap on left block area calls onChanged with 0.5',
+    testWidgets('tap on left block area calls onChanged with 0.2',
         (tester) async {
       double? changedValue;
       await tester.pumpWidget(createWidget(
@@ -89,7 +89,7 @@ void main() {
       ));
       await tester.pump();
 
-      expect(changedValue, 0.5);
+      expect(changedValue, 0.2);
     });
 
     testWidgets('same cran tap does not call onChanged',
@@ -116,7 +116,7 @@ void main() {
         (tester) async {
       // Cran 1: "Moins" — always visible
       await tester.pumpWidget(createWidget(
-        currentMultiplier: 0.5,
+        currentMultiplier: 0.2,
         onChanged: (_) {},
       ));
       expect(find.text('Moins'), findsOneWidget);

--- a/docs/maintenance/maintenance-feed-multiplier-floor.md
+++ b/docs/maintenance/maintenance-feed-multiplier-floor.md
@@ -1,0 +1,126 @@
+# Maintenance — Plancher `priority_multiplier` 0.5 → 0.2 + Malus thème non suivi
+
+> **Branche** : `boujonlaurin-dotcom/feed-audit`
+> **Date** : 2026-04-16
+> **Type** : Maintenance (calibration algo feed — scope chronologique)
+
+---
+
+## Contexte
+
+Signalement utilisateur (laurin_boujon@proton.me) sur le **Feed chronologique** :
+1. **Le Monde sur-représenté** : 2-3 articles du Monde parmi les premiers rendus, malgré préférence "Moins" (1/3)
+2. **Thèmes non suivis** qui remontent (moins grave)
+
+Intention produit *(explicite, à préserver)* : un **feed chronologique** qui sélectionne les articles à **ne pas afficher** sur la base des intérêts utilisateurs. Mécanisme soustractif (filtrage), pas additif (scoring).
+
+### Scope
+
+**IN-SCOPE** : feed chronologique uniquement (items principaux `/api/feed` en mode par défaut).
+
+**OUT-OF-SCOPE** (confirmé produit) :
+- Le Digest quotidien
+- Les 3 carousels du feed (hot cluster, perspectives, community 🌻) — rôle **intentionnel de découvrabilité**
+- Les modes scored alternatifs (perspectives, deep_dive, serein)
+- La réforme de la formule "ratio normalisé"
+
+## Audit résumé
+
+### Avant : préférence "Moins" (0.5) trop faible
+
+Dans la formule de diversification chronologique (`recommendation_service.py:774-780`) :
+```
+quota = max(1, ceil(ratio × effective_limit × multiplier))
+```
+
+Avec Le Monde (ratio ≈ 0.10 sur 72h) et `effective_limit = 50` :
+- multiplier 0.5 ("Moins") → `quota = ceil(0.10 × 50 × 0.5) = 3` slots
+- multiplier 0.2 ("Moins" cible) → `quota = ceil(0.10 × 50 × 0.2) = 1` slot
+
+Le plancher 0.5 était insuffisant pour un signal utilisateur fort.
+
+### Avant : thèmes non suivis sans désavantage
+
+`PertinencePillar` applique `THEME_MATCH = +50` en bonus, mais aucun malus quand le contenu est hors thèmes/sous-thèmes suivis. L'article "neutre" reste à score nul, parité avec un cas plus pertinent.
+
+## Changements
+
+### Backend (`packages/api`)
+
+| Fichier | Action |
+|---|---|
+| `app/schemas/source.py:85-98` | Valeurs autorisées `UpdateSourceWeightRequest.priority_multiplier` : `{0.5, 1.0, 2.0}` → `{0.2, 1.0, 2.0}` |
+| `app/routers/custom_topics.py:50-58, 84-92` | Idem pour `CreateTopicRequest` et `UpdateTopicRequest` (le slider Flutter est partagé) |
+| `app/services/recommendation/scoring_config.py` | Ajout constante `THEME_MISMATCH_MALUS = -8.0` |
+| `app/services/recommendation/pillars/pertinence.py` | Nouveau step `_score_theme_mismatch()` appliqué après les 5 steps existants. Conditions d'application : user a au moins un thème OU sous-thème OU custom topic déclaré + aucun n'a matché |
+| `tests/recommendation/test_pertinence_pillar.py` | Nouveau test file (6 cas) : malus appliqué, non appliqué (match thème), non appliqué (sous-thème), cold start, match custom topic, clamp normalisation |
+
+### Mobile (`apps/mobile`)
+
+| Fichier | Action |
+|---|---|
+| `lib/widgets/design/priority_slider.dart:43` | `_multipliers = [0.5, 1.0, 2.0]` → `[0.2, 1.0, 2.0]` |
+| `lib/widgets/design/priority_slider.dart:12-14, 64` | Commentaires MAJ pour refléter 0.2 |
+
+Les comparaisons de seuil (`currentMultiplier <= 0.5`) fonctionnent encore correctement avec `0.2` car `0.2 <= 0.5` → le cran 1 est correctement identifié. Pas de changement de logique.
+
+### Migration DB (one-shot Supabase SQL Editor)
+
+```sql
+-- Applique rétroactivement le nouveau plancher aux rows existantes
+UPDATE user_sources SET priority_multiplier = 0.2 WHERE priority_multiplier = 0.5;
+UPDATE user_topic_profiles SET priority_multiplier = 0.2 WHERE priority_multiplier = 0.5;
+```
+
+**⚠️ À exécuter en post-merge, AVANT que les nouveaux déploiements backend rejettent les requêtes avec 0.5.**
+
+## Effet attendu
+
+### Le Monde (source à forte fréquence) avec "Moins"
+- **Avant** : ~3 articles parmi les 50 premiers rendus
+- **Après** : ~1 article parmi les 50 premiers rendus
+
+### Article hors thèmes/sous-thèmes suivis (modes scored)
+- **Avant** : pertinence brute = 0 → normalisée 0
+- **Après** : pertinence brute = -8 → normalisée 0 (clamp), mais quand couplé à un autre signal positif (format, recency), le malus est soustrait, ce qui désavantage légèrement l'article sans l'exclure
+
+## Ce qui reste hors scope (à considérer ensuite si insuffisant)
+
+- Si Le Monde reste trop présent même à 0.2 : revoir la formule "ratio normalisé" (remplacer par plafond absolu ou ratio inverse)
+- Si les thèmes non suivis remontent encore trop : étendre le malus au feed chronologique pur (probabilistic drop ou quota par thème) — actuellement le malus n'affecte **que les modes scored** car le chronologique n'utilise pas `PillarScoringEngine`
+- Nettoyer les fuites identifiées dans les carousels (cf. audit initial) — traitement séparé, rôle découvrabilité à préserver
+
+## Verification
+
+### Tests automatisés
+```bash
+cd packages/api
+pytest tests/recommendation/test_pertinence_pillar.py -v
+pytest tests/test_custom_topics.py -v
+pytest tests/test_source_management.py -v
+
+cd apps/mobile
+flutter test
+flutter analyze
+```
+
+### Observation manuelle (staging)
+1. Sur l'account `laurin_boujon@proton.me` : dump `GET /api/feed?limit=50` → count Le Monde articles
+2. Appliquer la migration DB (`UPDATE user_sources SET priority_multiplier = 0.2 WHERE ...`)
+3. Re-dump → count Le Monde articles → doit avoir baissé
+4. Toggle "Normal" sur Le Monde → le feed re-inclut Le Monde à quota "Normal"
+
+### Contrat API
+- `PUT /api/sources/{id}/weight` avec `priority_multiplier=0.5` → 422 (rejet attendu)
+- `PUT /api/sources/{id}/weight` avec `priority_multiplier=0.2` → 200
+- Idem sur `POST/PATCH /api/custom-topics/*`
+
+## Rollback
+
+En cas de régression sévère :
+1. Revert le PR
+2. Rétablir les rows à 0.5 :
+   ```sql
+   UPDATE user_sources SET priority_multiplier = 0.5 WHERE priority_multiplier = 0.2;
+   UPDATE user_topic_profiles SET priority_multiplier = 0.5 WHERE priority_multiplier = 0.2;
+   ```

--- a/docs/maintenance/maintenance-feed-multiplier-floor.md
+++ b/docs/maintenance/maintenance-feed-multiplier-floor.md
@@ -54,6 +54,9 @@ Le plancher 0.5 était insuffisant pour un signal utilisateur fort.
 | `app/services/recommendation/scoring_config.py` | Ajout constante `THEME_MISMATCH_MALUS = -8.0` |
 | `app/services/recommendation/pillars/pertinence.py` | Nouveau step `_score_theme_mismatch()` appliqué après les 5 steps existants. Conditions d'application : user a au moins un thème OU sous-thème OU custom topic déclaré + aucun n'a matché |
 | `tests/recommendation/test_pertinence_pillar.py` | Nouveau test file (6 cas) : malus appliqué, non appliqué (match thème), non appliqué (sous-thème), cold start, match custom topic, clamp normalisation |
+| `app/services/learning_service.py:307, 590` | Alignement du plancher learning sur la nouvelle grille : `max(0.5, …)` → `max(0.2, …)`. Évite que le learning propose/applique une valeur rejetée par le validator, et supprime le UP-clamp silencieux d'un user à 0.2 vers 0.5 |
+| `app/routers/sources.py:428` ; `app/services/recommendation/scoring_engine.py:38` ; `app/models/source.py:159` | Docstrings/commentaires alignés `(0.2, 1.0, 2.0)` |
+| `tests/test_learning_service.py` | Mocks `proposed_value` alignés `"0.5"` → `"0.2"` (3 fixtures) |
 
 ### Mobile (`apps/mobile`)
 
@@ -70,6 +73,13 @@ Les comparaisons de seuil (`currentMultiplier <= 0.5`) fonctionnent encore corre
 -- Applique rétroactivement le nouveau plancher aux rows existantes
 UPDATE user_sources SET priority_multiplier = 0.2 WHERE priority_multiplier = 0.5;
 UPDATE user_topic_profiles SET priority_multiplier = 0.2 WHERE priority_multiplier = 0.5;
+
+-- Aligne les propositions LearningService pending (générées avec l'ancien plancher 0.5)
+UPDATE user_learning_proposals
+SET proposed_value = '0.2'
+WHERE proposal_type = 'source_priority'
+  AND proposed_value = '0.5'
+  AND status = 'pending';
 ```
 
 **⚠️ À exécuter en post-merge, AVANT que les nouveaux déploiements backend rejettent les requêtes avec 0.5.**
@@ -123,4 +133,9 @@ En cas de régression sévère :
    ```sql
    UPDATE user_sources SET priority_multiplier = 0.5 WHERE priority_multiplier = 0.2;
    UPDATE user_topic_profiles SET priority_multiplier = 0.5 WHERE priority_multiplier = 0.2;
+   UPDATE user_learning_proposals
+   SET proposed_value = '0.5'
+   WHERE proposal_type = 'source_priority'
+     AND proposed_value = '0.2'
+     AND status = 'pending';
    ```

--- a/packages/api/app/models/source.py
+++ b/packages/api/app/models/source.py
@@ -156,7 +156,7 @@ class UserSource(Base):
     added_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow
     )
-    # Source weighting: explicit priority multiplier (0.5=less, 1.0=normal, 2.0=more)
+    # Source weighting: explicit priority multiplier (0.2=less, 1.0=normal, 2.0=more)
     priority_multiplier: Mapped[float] = mapped_column(
         Float, default=1.0, server_default="1.0"
     )

--- a/packages/api/app/routers/custom_topics.py
+++ b/packages/api/app/routers/custom_topics.py
@@ -51,10 +51,10 @@ class CreateTopicRequest(BaseModel):
     @classmethod
     def validate_create_multiplier(cls, v: float | None) -> float | None:
         if v is not None:
-            allowed = {0.5, 1.0, 2.0}
+            allowed = {0.2, 1.0, 2.0}
             if v not in allowed:
                 raise ValueError(
-                    f"priority_multiplier doit être 0.5, 1.0 ou 2.0 (reçu: {v})"
+                    f"priority_multiplier doit être 0.2, 1.0 ou 2.0 (reçu: {v})"
                 )
         return v
 
@@ -84,10 +84,10 @@ class UpdateTopicRequest(BaseModel):
     @field_validator("priority_multiplier")
     @classmethod
     def validate_multiplier(cls, v: float) -> float:
-        allowed = {0.5, 1.0, 2.0}
+        allowed = {0.2, 1.0, 2.0}
         if v not in allowed:
             raise ValueError(
-                f"priority_multiplier doit être 0.5, 1.0 ou 2.0 (reçu: {v})"
+                f"priority_multiplier doit être 0.2, 1.0 ou 2.0 (reçu: {v})"
             )
         return v
 

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -425,7 +425,7 @@ async def update_source_weight(
     user_id: str = Depends(get_current_user_id),
     db: AsyncSession = Depends(get_db),
 ) -> SourceResponse:
-    """Mettre à jour le poids d'une source (0.5, 1.0, 2.0)."""
+    """Mettre à jour le poids d'une source (0.2, 1.0, 2.0)."""
     service = SourceService(db)
     result = await service.update_source_weight(
         user_id, str(source_id), data.priority_multiplier

--- a/packages/api/app/schemas/source.py
+++ b/packages/api/app/schemas/source.py
@@ -90,10 +90,10 @@ class UpdateSourceWeightRequest(BaseModel):
     @field_validator("priority_multiplier")
     @classmethod
     def validate_multiplier(cls, v: float) -> float:
-        allowed = {0.5, 1.0, 2.0}
+        allowed = {0.2, 1.0, 2.0}
         if v not in allowed:
             raise ValueError(
-                f"priority_multiplier doit être 0.5, 1.0 ou 2.0 (reçu: {v})"
+                f"priority_multiplier doit être 0.2, 1.0 ou 2.0 (reçu: {v})"
             )
         return v
 

--- a/packages/api/app/services/learning_service.py
+++ b/packages/api/app/services/learning_service.py
@@ -304,7 +304,7 @@ class LearningService:
 
             # Signal: user ignores source (low engagement, high multiplier)
             if ratio < SIGNAL_THRESHOLD_SOURCE and multiplier >= 1.0:
-                proposed = max(0.5, multiplier * 0.5)
+                proposed = max(0.2, multiplier * 0.5)
                 delta = abs(multiplier - proposed) / max(multiplier, 1.0)
                 candidates.append(
                     {
@@ -586,8 +586,8 @@ class LearningService:
         if proposal.proposal_type == "source_priority":
             source_id = UUID(proposal.entity_id)
             new_multiplier = float(value)
-            # Clamp to [0.5, 2.0]
-            new_multiplier = max(0.5, min(2.0, new_multiplier))
+            # Clamp to [0.2, 2.0]
+            new_multiplier = max(0.2, min(2.0, new_multiplier))
             await self.db.execute(
                 update(UserSource)
                 .where(

--- a/packages/api/app/services/recommendation/pillars/pertinence.py
+++ b/packages/api/app/services/recommendation/pillars/pertinence.py
@@ -150,7 +150,44 @@ class PertinencePillar(BasePillar):
         score += format_result[0]
         contributions.extend(format_result[1])
 
+        # --- 6. Theme Mismatch Malus ---
+        # Léger désavantage pour les articles hors des thèmes/sous-thèmes suivis,
+        # sans les exclure. Ne s'applique qu'aux utilisateurs ayant déclaré des
+        # préférences (cold start préservé).
+        mismatch_result = self._score_theme_mismatch(
+            theme_score[0], topic_result[0], custom_result[0], context
+        )
+        score += mismatch_result[0]
+        contributions.extend(mismatch_result[1])
+
         return score, contributions
+
+    def _score_theme_mismatch(
+        self,
+        theme_points: float,
+        subtopic_points: float,
+        custom_topic_points: float,
+        context: ScoringContext,
+    ) -> tuple[float, list[PillarContribution]]:
+        """Malus léger quand aucun thème/sous-thème/custom topic ne matche."""
+        has_preferences = bool(
+            context.user_interests
+            or context.user_subtopics
+            or context.user_custom_topics
+        )
+        if not has_preferences:
+            return 0.0, []
+        if theme_points > 0 or subtopic_points > 0 or custom_topic_points > 0:
+            return 0.0, []
+
+        malus = ScoringWeights.THEME_MISMATCH_MALUS
+        return malus, [
+            PillarContribution(
+                label="Thème non suivi",
+                points=malus,
+                is_positive=False,
+            )
+        ]
 
     def _score_theme(
         self, content: Content, context: ScoringContext

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -106,6 +106,12 @@ class ScoringWeights:
     # Réduit de 20→18.
     SUBTOPIC_PRECISION_BONUS = 18.0
 
+    # Malus léger appliqué quand l'article ne matche aucun thème ni sous-thème
+    # suivi par l'utilisateur (et que l'user a déclaré des thèmes/sous-thèmes).
+    # Calibré à ~16% du bonus THEME_MATCH : assez pour désavantager sans exclure.
+    # Ne s'applique pas en cold start (aucun thème/sous-thème suivi).
+    THEME_MISMATCH_MALUS = -8.0
+
     # --- DIGEST DIVERSITY (Revue de presse) ---
 
     # Diviseur appliqué au score du 2ème article d'une même source dans le digest.

--- a/packages/api/app/services/recommendation/scoring_engine.py
+++ b/packages/api/app/services/recommendation/scoring_engine.py
@@ -35,7 +35,7 @@ class ScoringContext:
         impression_data: dict[UUID, tuple] = None,
         # Epic 11: Custom Topics
         user_custom_topics: list = None,
-        # Source Weighting: explicit priority multipliers {source_id: 0.5|1.0|2.0}
+        # Source Weighting: explicit priority multipliers {source_id: 0.2|1.0|2.0}
         source_priority_multipliers: dict[UUID, float] = None,
         # Premium Sources: source_ids where user has a subscription
         subscribed_source_ids: set[UUID] = None,

--- a/packages/api/tests/recommendation/test_pertinence_pillar.py
+++ b/packages/api/tests/recommendation/test_pertinence_pillar.py
@@ -1,0 +1,124 @@
+"""Tests unitaires pour PertinencePillar — Theme Mismatch Malus."""
+from datetime import datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from app.services.recommendation.pillars.pertinence import PertinencePillar
+from app.services.recommendation.scoring_config import ScoringWeights
+from app.services.recommendation.scoring_engine import ScoringContext
+
+
+class MockSource:
+    def __init__(self, theme=None, secondary_themes=None):
+        self.id = uuid4()
+        self.theme = theme
+        self.secondary_themes = secondary_themes or []
+
+
+class MockContent:
+    def __init__(self, theme=None, source_theme=None, topics=None):
+        self.id = uuid4()
+        self.title = "Test"
+        self.description = ""
+        self.theme = theme
+        self.topics = topics or []
+        self.source = MockSource(theme=source_theme)
+        self.source_id = self.source.id
+        self.published_at = datetime.now()
+        self.content_type = None
+        self.duration_seconds = None
+
+
+def _context(
+    user_interests=None, user_subtopics=None, user_custom_topics=None
+):
+    return ScoringContext(
+        user_profile=MagicMock(id=uuid4()),
+        user_interests=set(user_interests or []),
+        user_interest_weights={},
+        followed_source_ids=set(),
+        user_prefs={},
+        now=datetime.now(),
+        user_subtopics=set(user_subtopics or []),
+        user_subtopic_weights={},
+        user_custom_topics=user_custom_topics or [],
+    )
+
+
+class TestThemeMismatchMalus:
+    def test_malus_applied_when_no_match_and_user_has_preferences(self):
+        """User a déclaré des thèmes, article ne matche aucun → malus appliqué."""
+        content = MockContent(theme="sports", source_theme="sports")
+        context = _context(user_interests={"tech", "science"})
+
+        pillar = PertinencePillar()
+        raw, contribs = pillar.compute_raw(content, context)
+
+        assert raw == ScoringWeights.THEME_MISMATCH_MALUS
+        mismatch_contribs = [c for c in contribs if c.label == "Thème non suivi"]
+        assert len(mismatch_contribs) == 1
+        assert mismatch_contribs[0].points == ScoringWeights.THEME_MISMATCH_MALUS
+        assert mismatch_contribs[0].is_positive is False
+
+    def test_no_malus_when_theme_matches(self):
+        """Thème matche → pas de malus."""
+        content = MockContent(theme="tech", source_theme="tech")
+        context = _context(user_interests={"tech"})
+
+        pillar = PertinencePillar()
+        raw, contribs = pillar.compute_raw(content, context)
+
+        assert raw >= ScoringWeights.THEME_MATCH
+        assert not any(c.label == "Thème non suivi" for c in contribs)
+
+    def test_no_malus_when_subtopic_matches(self):
+        """Sous-thème matche → pas de malus, même si thème ne matche pas."""
+        content = MockContent(theme="sports", source_theme="sports", topics=["ai"])
+        context = _context(
+            user_interests={"tech"}, user_subtopics={"ai"}
+        )
+
+        pillar = PertinencePillar()
+        raw, contribs = pillar.compute_raw(content, context)
+
+        assert raw > 0
+        assert not any(c.label == "Thème non suivi" for c in contribs)
+
+    def test_no_malus_on_cold_start(self):
+        """Aucune préférence déclarée → aucun malus."""
+        content = MockContent(theme="sports", source_theme="sports")
+        context = _context()
+
+        pillar = PertinencePillar()
+        raw, contribs = pillar.compute_raw(content, context)
+
+        assert raw == 0.0
+        assert contribs == []
+
+    def test_no_malus_when_custom_topic_matches(self):
+        """Custom topic matche → pas de malus."""
+        topic = MagicMock()
+        topic.slug_parent = "ai"
+        topic.keywords = []
+        topic.topic_name = "IA"
+        topic.priority_multiplier = 1.0
+
+        content = MockContent(theme="sports", source_theme="sports", topics=["ai"])
+        context = _context(user_interests={"tech"}, user_custom_topics=[topic])
+
+        pillar = PertinencePillar()
+        raw, contribs = pillar.compute_raw(content, context)
+
+        assert raw > 0
+        assert not any(c.label == "Thème non suivi" for c in contribs)
+
+    def test_malus_normalized_to_zero_when_no_other_signal(self):
+        """Un raw négatif est clampé à 0 par _normalize (pas d'exclusion dure)."""
+        content = MockContent(theme="sports", source_theme="sports")
+        context = _context(user_interests={"tech"})
+
+        pillar = PertinencePillar()
+        result = pillar.score(content, context)
+
+        assert result.raw_score == ScoringWeights.THEME_MISMATCH_MALUS
+        assert result.normalized_score == 0.0

--- a/packages/api/tests/test_learning_service.py
+++ b/packages/api/tests/test_learning_service.py
@@ -183,7 +183,7 @@ class TestLearningServiceApplyProposals:
         mock_proposal.status = "pending"
         mock_proposal.proposal_type = "source_priority"
         mock_proposal.entity_id = str(source_id)
-        mock_proposal.proposed_value = "0.5"
+        mock_proposal.proposed_value = "0.2"
 
         mock_db.scalar = AsyncMock(return_value=mock_proposal)
         service = LearningService(mock_db)
@@ -210,7 +210,7 @@ class TestLearningServiceApplyProposals:
         mock_proposal.status = "pending"
         mock_proposal.proposal_type = "source_priority"
         mock_proposal.entity_id = str(source_id)
-        mock_proposal.proposed_value = "0.5"
+        mock_proposal.proposed_value = "0.2"
 
         mock_db.scalar = AsyncMock(return_value=mock_proposal)
         service = LearningService(mock_db)
@@ -615,7 +615,7 @@ class TestSchemas:
             entity_id=str(uuid4()),
             entity_label="Le Figaro",
             current_value="1.0",
-            proposed_value="0.5",
+            proposed_value="0.2",
             signal_strength=0.85,
             signal_context=SignalContext(
                 articles_shown=14, articles_clicked=0, period_days=7


### PR DESCRIPTION
## Summary
- **Lower cran "Moins" multiplier 0.5 → 0.2** — strengthens user signal on over-represented sources (Le Monde feedback from laurin_boujon@proton.me, ~3 articles in top 50 despite "Moins")
- **Light theme-mismatch malus (-8 pts)** in `PertinencePillar` — desfavorises articles hors thèmes/sous-thèmes/custom topics suivis, sans exclure (scored modes only, cold start préservé)
- Scope narrow : **feed chronologique uniquement**. Digest, carousels (hot / perspectives / community), modes scored alternatifs → OUT-OF-SCOPE (confirmé produit — rôle découvrabilité préservé)

## Changes
| Area | File | Change |
|---|---|---|
| API | `app/schemas/source.py` | Validator `{0.5, 1.0, 2.0}` → `{0.2, 1.0, 2.0}` |
| API | `app/routers/custom_topics.py` | Idem pour Create/UpdateTopicRequest (slider partagé) |
| API | `app/services/recommendation/scoring_config.py` | `THEME_MISMATCH_MALUS = -8.0` |
| API | `app/services/recommendation/pillars/pertinence.py` | Nouveau step `_score_theme_mismatch()` |
| API | `tests/recommendation/test_pertinence_pillar.py` | 6 cas (match, mismatch, cold start, custom topic, normalize clamp) |
| Mobile | `lib/widgets/design/priority_slider.dart` | `_multipliers = [0.2, 1.0, 2.0]` |
| Mobile | `test/features/custom_topics/widgets/topic_priority_slider_test.dart` | Adaptation 0.5 → 0.2 |
| Docs | `docs/maintenance/maintenance-feed-multiplier-floor.md` | Audit + rollback |

## Post-merge — migration SQL (Supabase SQL Editor)
⚠️ À exécuter AVANT que le nouveau backend déploie, sinon les anciens 0.5 seront rejetés par le validator.
```sql
UPDATE user_sources SET priority_multiplier = 0.2 WHERE priority_multiplier = 0.5;
UPDATE user_topic_profiles SET priority_multiplier = 0.2 WHERE priority_multiplier = 0.5;
```

## Test plan
- [x] `pytest tests/recommendation/test_pertinence_pillar.py` → 6/6 passed
- [x] `flutter test test/features/custom_topics/widgets/topic_priority_slider_test.dart` → 8/8 passed
- [ ] CI green
- [ ] Staging observation : dump `GET /api/feed?limit=50` avant/après migration → count Le Monde baisse
- [ ] Contrat API : `PUT /api/sources/{id}/weight` avec `0.5` → 422 attendu

🤖 Generated with [Claude Code](https://claude.com/claude-code)