### PR TITLE
fix(api): Round 4 — reduce /api/feed/ to 2 concurrent sessions

### DIFF
--- a/docs/bugs/bug-infinite-load-requests.md
+++ b/docs/bugs/bug-infinite-load-requests.md
@@ -627,3 +627,84 @@ sont ouverts en parallèle.
   `PendingRollbackError`.
 - `/api/health/pool` : `checked_out` < 10 en steady state.
 - Test solo 01:35 Paris post-restart : pas de reproduction du crash.
+
+---
+
+## Round 4 — 2026-04-16 (burst /api/feed/ web app)
+
+### Constat
+
+Round 3 deployé (release `0a7aa275`, merge `2026-04-16 08:52 UTC`).
+Quatre heures plus tard (`12:50–12:51 UTC`, release `9eade82e` = main +
+PR #415/#416), Sentry remonte un nouveau pic massif **NON couvert par
+Round 3** :
+
+| Sentry ID | Type | Culprit | Events |
+|-----------|------|---------|--------|
+| PYTHON-1C/D/E/F/G/H/J/M | `QueuePool limit … overflow 10 reached` | `feed.get_personalized_feed` (×6), `users.get_streak`, `custom_topics.list_topics`, `digest.get_both_digests` | 8 issues |
+| PYTHON-Y/1B/1K/1M/1N/15/16 | `InternalError: DbHandler exited` | `feed.get_personalized_feed` (×3), `users.get_streak`, `custom_topics.list_topics`, `sources.get_sources`, `collections.list_collections` | 7 issues |
+| PYTHON-14 | `PendingRollbackError` | `community.get_community_recommendations` | 1 issue |
+
+User unique `61140df7-1029-4d46-811e-7f309574c556`, **Chrome 147 web**
+(pas iPhone/Dart — handoff précédent erroné). 16 issues distinctes en
+~70 secondes — burst de requêtes parallèles depuis l'app web.
+
+### Cause racine (R4)
+
+**`/api/feed/` tient 3 connexions DB simultanées par requête** :
+- `db: AsyncSession = Depends(get_db)` (session principale, vivante toute
+  la requête)
+- `_batch_user_context()` ouvre une short session dédiée
+- `_batch_personalization()` ouvre une autre short session dédiée
+- Les deux short sessions tournent en parallèle via `asyncio.gather`.
+
+Pool config (Round 1/2) : `pool_size=10 + max_overflow=10 = 20` max.
+À 3 conn/req, le plafond effectif est **~6-7 requêtes feed concurrentes**.
+Un burst d'ouverture d'app web (Chrome ouvre `/api/feed/`,
+`/api/users/streak`, `/api/digest/both`, `/api/sources/`,
+`/api/collections/`, etc. en parallèle) sature le pool en quelques
+secondes. Les requêtes suivantes attendent `pool_timeout=30s` puis
+remontent `QueuePool limit reached`. Pendant que le pool est saturé,
+Supabase peut tuer des connexions idle → `DbHandler exited` cascade.
+
+Round 3 (listener `_invalidate_on_supabase_kill` + per-user session
+`top3_job` + semaphore trafilatura) ne touchait pas `/api/feed/` —
+le listener invalide les slots morts mais ne réduit pas la pression
+de connexions vivantes tenues trop longtemps.
+
+### Fix Round 4
+
+**F4.1 — `/api/feed/` : 3 sessions → 2 sessions** (`app/services/recommendation_service.py::RecommendationService.get_feed`).
+
+Le batch `_batch_user_context()` (3 SELECTs profile + sources + subtopics)
+réutilise désormais `self.session` au lieu d'ouvrir une nouvelle short
+session. `_batch_personalization()` reste sur sa propre short session
+parallèle. `asyncio.gather` préserve le parallélisme entre les deux
+batches (sessions distinctes, pas de "concurrent operations on same
+session").
+
+Net : **2 conn/req** (au lieu de 3), plafond ~10 feeds concurrents
+(au lieu de ~6). Aucun changement sur `pool_size`/`max_overflow`/
+`pool_timeout`/`pool_recycle`.
+
+### À ne PAS faire (refusé pour cette PR)
+
+- Augmenter `pool_size`/`max_overflow` : interdit sans diff métrique
+  solide (cf. handoff). Masquerait l'amplification.
+- Retirer `_scheduled_restart` : conserver pendant 48 h post-F1.1.
+- Ajouter un nouvel endpoint pool-stats : `/api/health/pool` existe déjà
+  (`app/main.py:455`) avec `status`/`usage_pct`/Sentry warning à 75 %.
+- Ajouter `wait_for` budgets endpoint-level sur `/feed/`, `/streak/`,
+  etc. : changerait la nature du timeout sans réduire la cause
+  (saturation). À envisager seulement si le burst persiste post-F4.1.
+
+### Validation attendue (post-déploiement)
+
+- Sentry : 0 événement `QueuePool limit` sur `feed.get_personalized_feed`
+  pendant 24 h.
+- `/api/health/pool` pendant un burst Chrome (rapid tab switches) :
+  `checked_out + overflow ≤ 14` (vs ~20 avant).
+- Log `feed_phase1_context` `duration_ms` : régression acceptable
+  (< +200ms p50).
+- 48 h Sentry watch : pas de récurrence des signatures Round 3
+  (`db_connection_invalidated_by_signature` reste rare).

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -135,9 +135,17 @@ class RecommendationService:
         3. Appliquer la pénalité de fatigue de source (Diversité).
         4. Trier et paginer.
         """
-        # 1. Fetch user context in parallel using 2 batched sessions
-        # Queries are grouped into 2 sessions (instead of 5) to limit pool
-        # pressure while still cutting latency vs fully sequential execution.
+        # 1. Fetch user context in parallel using 2 sessions
+        # Round 4 fix (docs/bugs/bug-infinite-load-requests.md — burst
+        # 2026-04-16 12:50 UTC) : la version précédente ouvrait DEUX short
+        # sessions via async_session_maker() en plus de la session injectée
+        # `self.session` → 3 connexions concurrentes par requête /api/feed/.
+        # Pool 10+10=20 → saturation à ~6-7 requêtes feed concurrentes
+        # (Sentry PYTHON-1C/1D/1F/1G/1J et al). On réutilise maintenant
+        # `self.session` pour le batch user_context, en gardant
+        # _batch_personalization() en parallèle sur sa propre short session
+        # → 2 connexions/req, plafond ~10 feeds concurrents, sans toucher
+        # le pool config ni l'invariant de parallélisme du gather.
         from datetime import date as date_module
 
         from sqlalchemy.orm import joinedload
@@ -167,12 +175,12 @@ class RecommendationService:
             DailyDigest.target_date == date_module.today(),
         )
 
-        async def _batch_user_context():
-            async with async_session_maker() as s:
-                profile = await s.scalar(profile_stmt)
-                sources = (await s.execute(sources_stmt)).all()
-                subtopics = (await s.scalars(subtopics_stmt)).all()
-                return profile, sources, subtopics
+        async def _user_context_on_self():
+            # Réutilise la session injectée — pas de nouvelle connexion pool.
+            profile = await self.session.scalar(profile_stmt)
+            sources = (await self.session.execute(sources_stmt)).all()
+            subtopics = (await self.session.scalars(subtopics_stmt)).all()
+            return profile, sources, subtopics
 
         async def _batch_personalization():
             async with async_session_maker() as s:
@@ -182,11 +190,14 @@ class RecommendationService:
                 muted_entities = await _load_muted_entities_safe(s, user_id)
                 return pz, digest, muted_entities
 
+        # gather() préserve le parallélisme : self.session et la short
+        # session de _batch_personalization sont des sessions distinctes,
+        # aucun risque de "concurrent operations on same session".
         (
             (user_profile, followed_sources_rows, subtopics_rows),
             (personalization, digest_row, muted_entities),
         ) = await asyncio.gather(
-            _batch_user_context(),
+            _user_context_on_self(),
             _batch_personalization(),
         )
 


### PR DESCRIPTION
## Summary

Round 3 (#414) merged 2026-04-16 08:52 UTC. Four hours later (12:50–12:51 UTC, release \`9eade82e\`), Sentry showed a fresh burst of pool exhaustion **on endpoints not covered by Round 3**:

- 8× \`QueuePool limit of size 10 overflow 10 reached\` (top culprit: \`feed.get_personalized_feed\` ×6; also \`users.get_streak\`, \`custom_topics.list_topics\`, \`digest.get_both_digests\`)
- 7× \`InternalError: DbHandler exited\` (\`feed\` ×3 + others)
- 1× \`PendingRollbackError\` on \`community.get_community_recommendations\`
- All from one user on Chrome 147 web hammering many endpoints in parallel

## Root cause

\`RecommendationService.get_feed\` held **3 concurrent DB sessions per request**: the injected \`db\` (\`Depends(get_db)\`) plus \`_batch_user_context()\` and \`_batch_personalization()\` opening separate short sessions via \`async_session_maker()\`. Pool \`10 + max_overflow 10 = 20\` → saturation at ~6–7 concurrent feed requests. Round 3 fixes (handle_error listener, per-user top3 sessions, trafilatura semaphore) didn't touch \`/api/feed/\`.

## Fix

Collapse \`_batch_user_context\` onto \`self.session\` (already injected). Keep \`_batch_personalization\` on its own parallel short session. \`asyncio.gather\` still parallelizes (distinct sessions, no concurrent-ops conflict).

**Net: 2 conn/req (was 3), ceiling ~10 concurrent feeds (was ~6).** No pool config change.

## Why not other options

- **Bump \`pool_size\`/\`max_overflow\`**: explicitly forbidden by handoff without metric diff. Would mask amplification.
- **Remove \`_scheduled_restart\`**: 48h hold post-F1.1.
- **Add \`/internal/pool-stats\`**: \`/api/health/pool\` already exists at \`app/main.py:455\` with \`status\`/\`usage_pct\`/Sentry warning at 75 % — strictly more capable than the planned endpoint. Dropped to avoid duplication.

## Test plan

- [x] Non-DB tests: 576 passed, 13 skipped (39 errors are DB-dependent tests requiring local Postgres — same baseline as Round 3 validation).
- [x] \`tests/test_health_pool.py\` still passes (no regression on existing pool endpoint).
- [x] \`tests/test_feed_carousels.py\`, \`test_community_recommendations.py\`, \`test_learning_service.py\` pass (70/70).
- [ ] Post-deploy Sentry watch (30 min): \`QueuePool limit\` on \`feed.get_personalized_feed\` → 0.
- [ ] Post-deploy \`/api/health/pool\` during Chrome rapid-load burst: \`checked_out + overflow ≤ 14\` (vs ~20 before).
- [ ] 48h Sentry watch: no recurrence of \`DbHandler exited\` cascade or \`PendingRollbackError\`.

## Files changed

- \`packages/api/app/services/recommendation_service.py\` — \`get_feed\` (3 → 2 sessions)
- \`docs/bugs/bug-infinite-load-requests.md\` — Round 4 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)