### PR TITLE
feat: FeedbackInline UI adjustments + ArticleSheet pulse-glow hint

### DIFF
--- a/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
+++ b/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
@@ -85,10 +85,16 @@ class TopicChip extends StatelessWidget {
   }
 
   /// Opens the unified article sheet with blur backdrop.
+  ///
+  /// [highlightInitialSection] triggers a pulse-glow on the primary control
+  /// (slider or main CTA) of [initialSection] — used when the sheet is opened
+  /// from the post-swipe feedback banner to hint the user toward the slider
+  /// they should adjust.
   static Future<void> showArticleSheet(
     BuildContext context,
     Content content, {
     ArticleSheetSection initialSection = ArticleSheetSection.topic,
+    bool highlightInitialSection = false,
   }) {
     final topicSlug = content.topics.isNotEmpty ? content.topics.first : '';
     final topicLabel =
@@ -105,6 +111,7 @@ class TopicChip extends StatelessWidget {
           topicSlug: topicSlug,
           topicLabel: topicLabel,
           initialSection: initialSection,
+          highlightInitialSection: highlightInitialSection,
         ),
       ),
     );
@@ -122,12 +129,18 @@ class ArticleSheet extends ConsumerStatefulWidget {
   final String topicLabel;
   final ArticleSheetSection initialSection;
 
+  /// When true, the slider/CTA of [initialSection] pulses for ~2s after the
+  /// sheet opens. Used to hint the user toward the control they should
+  /// adjust when entering via the post-swipe feedback banner.
+  final bool highlightInitialSection;
+
   const ArticleSheet({
     super.key,
     required this.content,
     required this.topicSlug,
     required this.topicLabel,
     this.initialSection = ArticleSheetSection.topic,
+    this.highlightInitialSection = false,
   });
 
   @override
@@ -247,6 +260,8 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
                     colorScheme: colorScheme,
                     colors: colors,
                     textTheme: textTheme,
+                    shouldHighlight: widget.highlightInitialSection &&
+                        widget.initialSection == ArticleSheetSection.topic,
                   ),
                 ],
               ],
@@ -322,9 +337,12 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
                 if (_sourceExpanded) ...[
                   const SizedBox(height: FacteurSpacing.space3),
                   _buildSourceContent(
-                      colorScheme: colorScheme,
-                      colors: colors,
-                      textTheme: textTheme),
+                    colorScheme: colorScheme,
+                    colors: colors,
+                    textTheme: textTheme,
+                    shouldHighlight: widget.highlightInitialSection &&
+                        widget.initialSection == ArticleSheetSection.source,
+                  ),
                 ],
               ],
 
@@ -440,6 +458,7 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
     required ColorScheme colorScheme,
     required FacteurColors colors,
     required TextTheme textTheme,
+    bool shouldHighlight = false,
   }) {
     if (isFollowed && matchedTopic != null) {
       return Column(
@@ -520,37 +539,40 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
                       ? algoProfile.normalizeWeight(
                           algoProfile.subtopicWeights[topicSlug]!)
                       : null;
-                  return TopicPrioritySlider(
-                    currentMultiplier: matchedTopic.priorityMultiplier,
-                    onChanged: (multiplier) async {
-                      try {
-                        await ref
-                            .read(customTopicsProvider.notifier)
-                            .updatePriority(matchedTopic.id, multiplier);
-                      } on DioException catch (e) {
-                        if (context.mounted) {
-                          final detail = e.response?.data;
-                          final msg =
-                              (detail is Map && detail['detail'] is String)
-                                  ? detail['detail'] as String
-                                  : 'Erreur lors de la mise à jour';
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text(msg),
-                              duration: const Duration(seconds: 3),
-                            ),
-                          );
-                        }
-                      }
-                    },
-                    usageWeight: topicUsage,
-                    onReset: topicUsage != null
-                        ? () async {
-                            final client = ref.read(apiClientProvider);
-                            await client.post('/users/subtopics/$topicSlug/reset');
-                            ref.invalidate(algorithmProfileProvider);
+                  return _PulseHighlight(
+                    active: shouldHighlight,
+                    child: TopicPrioritySlider(
+                      currentMultiplier: matchedTopic.priorityMultiplier,
+                      onChanged: (multiplier) async {
+                        try {
+                          await ref
+                              .read(customTopicsProvider.notifier)
+                              .updatePriority(matchedTopic.id, multiplier);
+                        } on DioException catch (e) {
+                          if (context.mounted) {
+                            final detail = e.response?.data;
+                            final msg =
+                                (detail is Map && detail['detail'] is String)
+                                    ? detail['detail'] as String
+                                    : 'Erreur lors de la mise à jour';
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text(msg),
+                                duration: const Duration(seconds: 3),
+                              ),
+                            );
                           }
-                        : null,
+                        }
+                      },
+                      usageWeight: topicUsage,
+                      onReset: topicUsage != null
+                          ? () async {
+                              final client = ref.read(apiClientProvider);
+                              await client.post('/users/subtopics/$topicSlug/reset');
+                              ref.invalidate(algorithmProfileProvider);
+                            }
+                          : null,
+                    ),
                   );
                 }),
               ],
@@ -590,49 +612,52 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        SizedBox(
-          width: double.infinity,
-          child: FilledButton.icon(
-            onPressed: () async {
-              try {
-                await ref
-                    .read(customTopicsProvider.notifier)
-                    .followTopic(widget.topicLabel,
-                        slugParent: widget.topicSlug);
-              } on DioException catch (e) {
-                if (context.mounted) {
-                  final detail = e.response?.data;
-                  final msg = (detail is Map && detail['detail'] is String)
-                      ? detail['detail'] as String
-                      : 'Erreur lors de l\'ajout de ${widget.topicLabel}';
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(msg),
-                      duration: const Duration(seconds: 3),
-                    ),
-                  );
+        _PulseHighlight(
+          active: shouldHighlight,
+          child: SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: () async {
+                try {
+                  await ref
+                      .read(customTopicsProvider.notifier)
+                      .followTopic(widget.topicLabel,
+                          slugParent: widget.topicSlug);
+                } on DioException catch (e) {
+                  if (context.mounted) {
+                    final detail = e.response?.data;
+                    final msg = (detail is Map && detail['detail'] is String)
+                        ? detail['detail'] as String
+                        : 'Erreur lors de l\'ajout de ${widget.topicLabel}';
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(msg),
+                        duration: const Duration(seconds: 3),
+                      ),
+                    );
+                  }
                 }
-              }
-            },
-            icon: Icon(
-              PhosphorIcons.plus(),
-              size: 16,
-              color: Colors.white,
-            ),
-            label: const Text(
-              'Suivre ce sujet',
-              style: TextStyle(
+              },
+              icon: Icon(
+                PhosphorIcons.plus(),
+                size: 16,
                 color: Colors.white,
-                fontWeight: FontWeight.w600,
-                fontSize: 15,
               ),
-            ),
-            style: FilledButton.styleFrom(
-              backgroundColor: colorScheme.primary,
-              foregroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(vertical: 14),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(FacteurRadius.medium),
+              label: const Text(
+                'Suivre ce sujet',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 15,
+                ),
+              ),
+              style: FilledButton.styleFrom(
+                backgroundColor: colorScheme.primary,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(FacteurRadius.medium),
+                ),
               ),
             ),
           ),
@@ -710,6 +735,7 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
     required ColorScheme colorScheme,
     required FacteurColors colors,
     required TextTheme textTheme,
+    bool shouldHighlight = false,
   }) {
     return Builder(builder: (context) {
       final sourcesAsync = ref.watch(userSourcesProvider);
@@ -727,35 +753,38 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
         return Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton.icon(
-                onPressed: () async {
-                  await ref
-                      .read(userSourcesProvider.notifier)
-                      .toggleTrust(widget.content.source.id, false);
-                  ref.invalidate(userSourcesProvider);
-                },
-                icon: Icon(
-                  PhosphorIcons.plus(),
-                  size: 16,
-                  color: Colors.white,
-                ),
-                label: const Text(
-                  'Suivre cette source',
-                  style: TextStyle(
+            _PulseHighlight(
+              active: shouldHighlight,
+              child: SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: () async {
+                    await ref
+                        .read(userSourcesProvider.notifier)
+                        .toggleTrust(widget.content.source.id, false);
+                    ref.invalidate(userSourcesProvider);
+                  },
+                  icon: Icon(
+                    PhosphorIcons.plus(),
+                    size: 16,
                     color: Colors.white,
-                    fontWeight: FontWeight.w600,
-                    fontSize: 15,
                   ),
-                ),
-                style: FilledButton.styleFrom(
-                  backgroundColor: colorScheme.primary,
-                  foregroundColor: Colors.white,
-                  padding: const EdgeInsets.symmetric(vertical: 14),
-                  shape: RoundedRectangleBorder(
-                    borderRadius:
-                        BorderRadius.circular(FacteurRadius.medium),
+                  label: const Text(
+                    'Suivre cette source',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w600,
+                      fontSize: 15,
+                    ),
+                  ),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: colorScheme.primary,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(
+                      borderRadius:
+                          BorderRadius.circular(FacteurRadius.medium),
+                    ),
                   ),
                 ),
               ),
@@ -892,17 +921,20 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
                       final algoProfile = ref.watch(algorithmProfileProvider).valueOrNull;
                       final sourceId = widget.content.source.id;
                       final sourceUsage = algoProfile?.sourceAffinities[sourceId];
-                      return PrioritySlider(
-                        currentMultiplier: currentMultiplier,
-                        onChanged: (multiplier) {
-                          ref
-                              .read(userSourcesProvider.notifier)
-                              .updateWeight(
-                                widget.content.source.id,
-                                multiplier,
-                              );
-                        },
-                        usageWeight: sourceUsage,
+                      return _PulseHighlight(
+                        active: shouldHighlight,
+                        child: PrioritySlider(
+                          currentMultiplier: currentMultiplier,
+                          onChanged: (multiplier) {
+                            ref
+                                .read(userSourcesProvider.notifier)
+                                .updateWeight(
+                                  widget.content.source.id,
+                                  multiplier,
+                                );
+                          },
+                          usageWeight: sourceUsage,
+                        ),
                       );
                     }),
                   ],
@@ -1333,6 +1365,97 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Pulse-glow highlight used to draw attention to a control inside
+/// [ArticleSheet] when the sheet is opened from the post-swipe feedback
+/// banner.
+///
+/// Renders a terracotta [BoxShadow] that fades in/out for 3 cycles of 700 ms,
+/// starting 300 ms after build (so the sheet's slide-in animation finishes
+/// first). When [active] is `false`, renders [child] verbatim (no shadow,
+/// no animation, no rebuilds).
+class _PulseHighlight extends StatefulWidget {
+  final Widget child;
+  final bool active;
+
+  const _PulseHighlight({required this.child, required this.active});
+
+  @override
+  State<_PulseHighlight> createState() => _PulseHighlightState();
+}
+
+class _PulseHighlightState extends State<_PulseHighlight>
+    with SingleTickerProviderStateMixin {
+  static const _cycleDuration = Duration(milliseconds: 700);
+  static const _startDelay = Duration(milliseconds: 300);
+  static const _cycles = 3;
+
+  late final AnimationController _ctrl;
+  late final Animation<double> _glow;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(vsync: this, duration: _cycleDuration);
+    _glow = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 0.0, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeOut)),
+        weight: 50,
+      ),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 0.0)
+            .chain(CurveTween(curve: Curves.easeIn)),
+        weight: 50,
+      ),
+    ]).animate(_ctrl);
+
+    if (widget.active) {
+      Future.delayed(_startDelay, () {
+        if (!mounted) return;
+        _ctrl.repeat();
+        Future.delayed(_cycleDuration * _cycles, () {
+          if (!mounted) return;
+          _ctrl.stop();
+          _ctrl.value = 0;
+        });
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.active) return widget.child;
+    return AnimatedBuilder(
+      animation: _glow,
+      builder: (_, child) {
+        final v = _glow.value;
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(FacteurRadius.medium),
+            boxShadow: v > 0
+                ? [
+                    BoxShadow(
+                      color: _terracotta.withOpacity(0.45 * v),
+                      blurRadius: 16 * v,
+                      spreadRadius: 2 * v,
+                    ),
+                  ]
+                : const [],
+          ),
+          child: child,
+        );
+      },
+      child: widget.child,
     );
   }
 }

--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -528,6 +528,23 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     }
   }
 
+  /// Retrait local de l'item du state, sans appel API.
+  ///
+  /// À utiliser quand le hide a déjà été émis ailleurs (ex: résolution du
+  /// FeedbackInline après un swipe-left, où `hideContent` a été appelé
+  /// immédiatement et le banner inline a remplacé la carte en attente d'un
+  /// CTA).
+  void removeFromState(String contentId) {
+    final currentState = state.value;
+    if (currentState == null) return;
+    final updatedItems = List<Content>.from(currentState.items)
+      ..removeWhere((c) => c.id == contentId);
+    state = AsyncData(FeedState(
+      items: updatedItems,
+      carousels: currentState.carousels,
+    ));
+  }
+
   /// Undo a swipe-dismiss: re-insert article at original position.
   Future<void> undoSwipeDismiss(Content content, int originalIndex) async {
     final currentState = state.value;

--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -28,6 +28,7 @@ import '../widgets/compact_theme_chip.dart';
 import '../widgets/animated_feed_card.dart';
 import '../widgets/caught_up_card.dart';
 import '../widgets/swipe_to_open_card.dart';
+import '../widgets/feedback_inline.dart';
 import '../providers/swipe_hint_provider.dart';
 import '../../../widgets/article_preview_modal.dart';
 import '../../saved/widgets/collection_picker_sheet.dart';
@@ -84,6 +85,19 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
 
   // Story 4.5b: Show the undo banner after a viewport-aware pull-to-refresh.
   bool _showUndoBanner = false;
+
+  /// Articles swipe-dismissés en attente de feedback (rendus en banner inline
+  /// à la place de la carte). Le hide API a déjà été appelé au moment du
+  /// swipe ; la résolution (CTA, X, ou viewport-exit) déclenche
+  /// `removeFromState` pour retirer l'item du provider.
+  final Map<String, Content> _pendingFeedback = {};
+
+  void _resolveFeedback(String contentId) {
+    if (!mounted) return;
+    if (!_pendingFeedback.containsKey(contentId)) return;
+    setState(() => _pendingFeedback.remove(contentId));
+    ref.read(feedProvider.notifier).removeFromState(contentId);
+  }
 
   Future<void> _withFeedLoading(Future<void> Function() action) async {
     if (mounted) setState(() => _isFeedRefreshing = true);
@@ -811,6 +825,71 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                                 }
 
                                 final content = contents[contentIndex];
+
+                                // Carte swipe-dismissée → remplacée par le
+                                // banner inline de feedback, à la même position.
+                                // Hide API a déjà été appelé (au swipe).
+                                // Résolution = CTA, X, ou viewport-exit.
+                                if (_pendingFeedback.containsKey(content.id)) {
+                                  return Padding(
+                                    key: ValueKey('feedback_${content.id}'),
+                                    padding:
+                                        const EdgeInsets.only(bottom: 16),
+                                    child: VisibilityDetector(
+                                      key: Key('feedback_vis_${content.id}'),
+                                      onVisibilityChanged: (info) {
+                                        if (info.visibleFraction == 0) {
+                                          _resolveFeedback(content.id);
+                                        }
+                                      },
+                                      child: FeedbackInline(
+                                        onSelectSource: () async {
+                                          await TopicChip.showArticleSheet(
+                                            context,
+                                            content,
+                                            initialSection:
+                                                ArticleSheetSection.source,
+                                            highlightInitialSection: true,
+                                          );
+                                          _resolveFeedback(content.id);
+                                        },
+                                        onSelectTopic: () async {
+                                          await TopicChip.showArticleSheet(
+                                            context,
+                                            content,
+                                            initialSection:
+                                                ArticleSheetSection.topic,
+                                            highlightInitialSection: true,
+                                          );
+                                          _resolveFeedback(content.id);
+                                        },
+                                        onSelectAlreadySeen: () =>
+                                            _resolveFeedback(content.id),
+                                        onUndo: () {
+                                          // Re-surface la carte : annule
+                                          // le hide côté backend et retire
+                                          // simplement l'entrée pending
+                                          // (l'item est toujours dans
+                                          // state.items, donc la FeedCard
+                                          // reprendra sa place).
+                                          unawaited(ref
+                                              .read(feedRepositoryProvider)
+                                              .unhideContent(content.id)
+                                              .catchError((Object e) {
+                                            // ignore: avoid_print
+                                            print(
+                                                'FeedScreen: unhideContent failed for ${content.id}: $e');
+                                          }));
+                                          setState(() => _pendingFeedback
+                                              .remove(content.id));
+                                        },
+                                        onClose: () =>
+                                            _resolveFeedback(content.id),
+                                      ),
+                                    ),
+                                  );
+                                }
+
                                 final isConsumed = ref
                                     .read(feedProvider.notifier)
                                     .isContentConsumed(content.id);
@@ -822,8 +901,22 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
 
                                 Widget cardWidget = SwipeToOpenCard(
                                   onSwipeOpen: () => _showArticleModal(content),
-                                  onSwipeDismiss: () =>
-                                      TopicChip.showArticleSheet(context, content),
+                                  onSwipeDismiss: () {
+                                    // Hide API immédiat — le swipe est
+                                    // l'engagement. Silent failure : l'inline
+                                    // reste affiché même si le réseau échoue
+                                    // (le user peut juste re-tap pour résoudre).
+                                    unawaited(ref
+                                        .read(feedRepositoryProvider)
+                                        .hideContent(content.id)
+                                        .catchError((Object e) {
+                                      // ignore: avoid_print
+                                      print(
+                                          'FeedScreen: hideContent failed for ${content.id}: $e');
+                                    }));
+                                    setState(() =>
+                                        _pendingFeedback[content.id] = content);
+                                  },
                                   enableHintAnimation: showHint,
                                   onHintAnimationComplete: () {
                                     if (!_swipeHintSeen) {

--- a/apps/mobile/lib/features/feed/widgets/feedback_inline.dart
+++ b/apps/mobile/lib/features/feed/widgets/feedback_inline.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+
+/// Terracotta accent — shared "removal" semantic with [SwipeToOpenCard].
+const Color _terracotta = Color(0xFFE07A5F);
+
+/// Compact inline banner that replaces a feed card after a left-swipe dismiss.
+///
+/// Renders ~80px tall with a neutral border and three chips asking the user
+/// *why* they dismissed the article (construire ses préférences, pas juste
+/// masquer) :
+/// - "Moins voir cette source" → opens ArticleSheet on the source section
+/// - "Moins voir ce thème" → opens ArticleSheet on the topic section
+/// - "Déjà vu" → simply resolves the inline (no sheet)
+///
+/// An "Annuler" text button (to the right of the title) re-surfaces the card
+/// (calls `unhideContent` + clears the pending feedback entry). A small X
+/// button resolves silently without feedback.
+///
+/// All resolution logic (removing from feed state, opening sheets) lives in
+/// the parent — this widget just fires callbacks.
+class FeedbackInline extends StatefulWidget {
+  final VoidCallback onSelectSource;
+  final VoidCallback onSelectTopic;
+  final VoidCallback onSelectAlreadySeen;
+  final VoidCallback onUndo;
+  final VoidCallback onClose;
+
+  const FeedbackInline({
+    super.key,
+    required this.onSelectSource,
+    required this.onSelectTopic,
+    required this.onSelectAlreadySeen,
+    required this.onUndo,
+    required this.onClose,
+  });
+
+  @override
+  State<FeedbackInline> createState() => _FeedbackInlineState();
+}
+
+class _FeedbackInlineState extends State<FeedbackInline>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _fadeController;
+  late final Animation<double> _fadeAnim;
+
+  @override
+  void initState() {
+    super.initState();
+    _fadeController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
+    _fadeAnim = CurvedAnimation(
+      parent: _fadeController,
+      curve: Curves.easeOut,
+    );
+    _fadeController.forward();
+  }
+
+  @override
+  void dispose() {
+    _fadeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    return FadeTransition(
+      opacity: _fadeAnim,
+      child: Semantics(
+        container: true,
+        label: 'Article masqué. Indiquez pourquoi pour affiner votre flux, '
+            'ou annulez pour le faire réapparaître.',
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(14, 10, 8, 12),
+          decoration: BoxDecoration(
+            color: colors.backgroundSecondary,
+            borderRadius: BorderRadius.circular(FacteurRadius.small),
+            border: Border.all(color: colors.border),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Améliore ton flux',
+                      style: textTheme.labelMedium?.copyWith(
+                        color: colors.textSecondary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  GestureDetector(
+                    onTap: () {
+                      HapticFeedback.selectionClick();
+                      widget.onUndo();
+                    },
+                    behavior: HitTestBehavior.opaque,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 6, vertical: 4),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            PhosphorIcons.arrowCounterClockwise(
+                                PhosphorIconsStyle.bold),
+                            size: 13,
+                            color: colors.primary,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            'Annuler',
+                            style: textTheme.labelSmall?.copyWith(
+                              color: colors.primary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  GestureDetector(
+                    onTap: () {
+                      HapticFeedback.selectionClick();
+                      widget.onClose();
+                    },
+                    behavior: HitTestBehavior.opaque,
+                    child: Padding(
+                      padding: const EdgeInsets.all(4),
+                      child: Icon(
+                        PhosphorIcons.x(PhosphorIconsStyle.bold),
+                        size: 14,
+                        color: colors.textTertiary,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: [
+                  _Chip(
+                    label: 'Moins voir cette source',
+                    onTap: widget.onSelectSource,
+                    colors: colors,
+                    textTheme: textTheme,
+                  ),
+                  _Chip(
+                    label: 'Moins voir ce thème',
+                    onTap: widget.onSelectTopic,
+                    colors: colors,
+                    textTheme: textTheme,
+                  ),
+                  _Chip(
+                    label: 'Déjà vu',
+                    onTap: widget.onSelectAlreadySeen,
+                    colors: colors,
+                    textTheme: textTheme,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+  final FacteurColors colors;
+  final TextTheme textTheme;
+
+  const _Chip({
+    required this.label,
+    required this.onTap,
+    required this.colors,
+    required this.textTheme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.selectionClick();
+        onTap();
+      },
+      behavior: HitTestBehavior.opaque,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: _terracotta.withOpacity(0.08),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          label,
+          style: textTheme.labelSmall?.copyWith(
+            color: colors.textPrimary,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/feed/widgets/swipe_to_open_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/swipe_to_open_card.dart
@@ -4,12 +4,17 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
 
-/// Wraps a card to allow swiping right to open and optionally left to adjust.
+/// Terracotta accent — discreet "removal" semantic shared with the inline
+/// feedback banner that replaces a dismissed card.
+const Color _terracotta = Color(0xFFE07A5F);
+
+/// Wraps a card to allow swiping right to open and optionally left to dismiss.
 ///
 /// Right swipe: reveals a blue "Lire" background. Past threshold → [onSwipeOpen].
-/// Left swipe: reveals a gray "Régler" background. Past threshold → card snaps
-/// back and [onSwipeDismiss] fires. Left swipe only active when [onSwipeDismiss]
-/// is non-null (backwards compatible).
+/// Left swipe: reveals a discreet terracotta "Masquer" background. Past
+/// threshold → card snaps back and [onSwipeDismiss] fires (parent typically
+/// replaces the card with an inline feedback banner). Left swipe only active
+/// when [onSwipeDismiss] is non-null (backwards compatible).
 ///
 /// [enableHintAnimation]: plays a subtle micro-slide to hint at left-swipe
 /// discoverability. Should only be true once per app lifetime.
@@ -260,15 +265,14 @@ class _SwipeToOpenCardState extends State<SwipeToOpenCard>
                 ),
               ),
             ),
-          // Left-swipe background: gray "Masquer"
+          // Left-swipe background: discreet terracotta "Masquer"
           if (_dragExtent < 0)
             Positioned.fill(
               child: Container(
                 alignment: Alignment.centerRight,
                 padding: const EdgeInsets.only(right: 24),
                 decoration: BoxDecoration(
-                  color: colors.textSecondary
-                      .withOpacity(0.08 * leftProgress),
+                  color: _terracotta.withOpacity(0.07 * leftProgress),
                   borderRadius: BorderRadius.circular(FacteurRadius.small),
                 ),
                 child: Opacity(
@@ -277,18 +281,17 @@ class _SwipeToOpenCardState extends State<SwipeToOpenCard>
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
-                        'Régler',
+                        'Masquer',
                         style: TextStyle(
-                          color: colors.textSecondary.withOpacity(0.5),
+                          color: _terracotta.withOpacity(0.7),
                           fontWeight: FontWeight.w600,
                           fontSize: 14,
                         ),
                       ),
                       const SizedBox(width: 8),
                       Icon(
-                        PhosphorIcons.slidersHorizontal(
-                            PhosphorIconsStyle.bold),
-                        color: colors.textSecondary.withOpacity(0.5),
+                        PhosphorIcons.eyeClosed(PhosphorIconsStyle.bold),
+                        color: _terracotta.withOpacity(0.7),
                         size: 22,
                       ),
                     ],


### PR DESCRIPTION
## What

4 UI/UX refinements to the post-swipe feedback inline banner:

1. **Wordings**: "Améliore ton flux" replaces "Pourquoi masquer?" + chip labels now frame as preference-building ("Moins voir cette source/thème") vs defensive dismissal
2. **Styling**: terracotta border → neutral `colors.border` (matches FeedRefreshUndoBanner); padding aligned exactly with FeedCard (8px to edges)
3. **Undo button**: new "Annuler" text button (↺ + primary color) allows recovery from accidental swipes via `unhideContent` 
4. **ArticleSheet hint**: pulse-glow animation (BoxShadow terracotta, 3 cycles @ 700ms) on the slider/main CTA of the opened section to guide users toward adjusting preferences

## Why

User testing revealed the banner felt visually disconnected and didn't clearly guide users to adjust their preferences. The undo button recovers accidental dismissals (full infra already in place: `unhideContent`, state preservation). The pulse glow provides non-intrusive affordance discovery when entering the sheet from the banner.

## Type

- [x] Feature

## Validation

- `flutter analyze`: 0 new issues (31 pre-existing: `withOpacity` deprecation + unrelated unawaited futures)
- `flutter test test/features/feed`: 39 passed, 6 failed (all 6 pre-existing: feed_sources_test × 5 + feed_refresh_undo_banner_test × 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)