### PR TITLE
feat(sources): Smart search UX polish

### DIFF
--- a/apps/mobile/lib/features/sources/screens/add_source_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/add_source_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../../config/theme.dart';
 import '../../../core/providers/analytics_provider.dart';
@@ -29,15 +28,44 @@ class AddSourceScreen extends ConsumerStatefulWidget {
 class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
   String _currentQuery = '';
   final Set<String> _addedSourceIds = {};
+  late final TextEditingController _searchController;
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
 
   // ─── Smart Search Actions ──────────────────────────────────────
+
+  void _runSearch([String? query]) {
+    final value = (query ?? _searchController.text).trim();
+    if (value.isEmpty) return;
+    if (_searchController.text != value) {
+      _searchController.text = value;
+    }
+    setState(() => _currentQuery = value);
+  }
+
+  void _clearSearch() {
+    _searchController.clear();
+    setState(() => _currentQuery = '');
+  }
 
   Future<void> _addSource(SmartSearchResult result) async {
     try {
       final repository = ref.read(sourcesRepositoryProvider);
       final sourceId = result.sourceId;
+      final hasCatalogId =
+          sourceId != null && sourceId.isNotEmpty && sourceId != 'null';
 
-      if (sourceId != null && sourceId.isNotEmpty && sourceId != 'null') {
+      if (hasCatalogId) {
         await repository.trustSource(sourceId);
         setState(() => _addedSourceIds.add(sourceId));
       } else {
@@ -48,10 +76,30 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
         await repository.addCustomSource(result.feedUrl, name: result.name);
       }
 
-      if (mounted) {
+      if (!mounted) return;
+      ref.invalidate(userSourcesProvider);
+
+      if (hasCatalogId) {
+        // Default new sources to max priority (3/3) — user explicitly opted-in.
+        await repository.updateSourceWeight(sourceId, 2.0);
+        if (!mounted) return;
+
+        // Open modal so user can fine-tune subscription + priority right away.
+        final source = Source(
+          id: sourceId,
+          name: result.name,
+          url: result.url,
+          type: _parseSourceType(result.type),
+          description: result.description,
+          logoUrl: result.faviconUrl,
+          isCurated: result.isCurated,
+          isTrusted: true,
+          priorityMultiplier: 2.0,
+        );
+        _showSourceModal(source, recentItems: result.recentItems);
+      } else {
         NotificationService.showSuccess(
             'Source ajoutee ! Ses contenus apparaitront dans ton feed.');
-        ref.invalidate(userSourcesProvider);
       }
     } catch (e) {
       if (mounted) {
@@ -70,7 +118,7 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
       logoUrl: result.faviconUrl,
       isCurated: result.isCurated,
     );
-    _showSourceModal(source);
+    _showSourceModal(source, recentItems: result.recentItems);
   }
 
   SourceType _parseSourceType(String type) {
@@ -85,15 +133,6 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
         return SourceType.video;
       default:
         return SourceType.article;
-    }
-  }
-
-  void _openAtlasFlux() async {
-    final Uri url = Uri.parse('https://atlasflux.saynete.net/');
-    if (!await launchUrl(url, mode: LaunchMode.externalApplication)) {
-      if (mounted) {
-        NotificationService.showError('Impossible d\'ouvrir AtlasFlux');
-      }
     }
   }
 
@@ -116,14 +155,41 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
     }
   }
 
-  void _showSourceModal(Source source) {
+  void _showSourceModal(
+    Source source, {
+    List<SmartSearchRecentItem>? recentItems,
+  }) {
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (_) => SourceDetailModal(
         source: source,
+        recentItems: recentItems,
         onToggleTrust: () => _toggleTrustSource(source),
+        onPriorityChanged: source.id.isNotEmpty
+            ? (multiplier) {
+                ref
+                    .read(userSourcesProvider.notifier)
+                    .updateWeight(source.id, multiplier);
+              }
+            : null,
+        onToggleSubscription: source.id.isNotEmpty
+            ? () {
+                final current = ref
+                        .read(userSourcesProvider)
+                        .valueOrNull
+                        ?.firstWhere(
+                          (s) => s.id == source.id,
+                          orElse: () => source,
+                        )
+                        .hasSubscription ??
+                    source.hasSubscription;
+                ref
+                    .read(userSourcesProvider.notifier)
+                    .toggleSubscription(source.id, current);
+              }
+            : null,
         onCopyFeedUrl: source.isCustom && (source.url?.isNotEmpty ?? false)
             ? () async {
                 await Clipboard.setData(ClipboardData(text: source.url!));
@@ -161,7 +227,10 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             SmartSearchField(
-              onSearch: (query) => setState(() => _currentQuery = query),
+              controller: _searchController,
+              onSubmit: (value) => _runSearch(value),
+              onClear: _clearSearch,
+              onSearch: () => _runSearch(),
             ),
             const SizedBox(height: 16),
             _buildContent(),
@@ -189,6 +258,7 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
   }
 
   void _onExampleTap(String text) {
+    _searchController.text = text;
     setState(() => _currentQuery = text);
     ref.read(analyticsServiceProvider).trackAddSourceExampleTap(text);
   }
@@ -199,6 +269,8 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        _buildSourceTypesRow(),
+        const SizedBox(height: 20),
         ExampleChips(onTap: _onExampleTap),
         const SizedBox(height: 24),
         const ThemeExplorer(),
@@ -210,7 +282,7 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
           },
         ),
         const SizedBox(height: 24),
-        _buildAtlasFluxCard(),
+        _buildInspirationHints(),
         const SizedBox(height: 24),
       ],
     );
@@ -342,53 +414,114 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
     );
   }
 
-  Widget _buildAtlasFluxCard() {
+  Widget _buildSourceTypesRow() {
     final colors = context.facteurColors;
+    final types = <(IconData, String)>[
+      (PhosphorIcons.newspaper(PhosphorIconsStyle.fill), 'Médias'),
+      (PhosphorIcons.envelope(PhosphorIconsStyle.fill), 'Newsletters'),
+      (PhosphorIcons.youtubeLogo(PhosphorIconsStyle.fill), 'YouTube'),
+      (PhosphorIcons.redditLogo(PhosphorIconsStyle.fill), 'Reddit'),
+      (PhosphorIcons.microphone(PhosphorIconsStyle.fill), 'Podcasts'),
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Ajoutez n\'importe quelle source à Facteur !',
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                color: context.facteurColors.textPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+        const SizedBox(height: 10),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: types
+              .map((t) => Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(t.$1, size: 14, color: colors.textSecondary),
+                      const SizedBox(width: 5),
+                      Text(
+                        t.$2,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: colors.textSecondary,
+                            ),
+                      ),
+                    ],
+                  ))
+              .toList(),
+        ),
+      ],
+    );
+  }
 
+  Widget _buildInspirationHints() {
+    final colors = context.facteurColors;
+    const hints = <String>[
+      'Une newsletter qui s\'accumule dans la boîte mail',
+      'Une chaîne YouTube recommandée par un proche',
+      'Un compte Instagram ou LinkedIn d\'expert',
+      'Un subreddit qui revient souvent dans les conversations',
+    ];
     return Container(
-      padding: const EdgeInsets.all(20),
+      padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: colors.primary.withOpacity(0.1),
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: colors.primary.withOpacity(0.3)),
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colors.border),
       ),
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(PhosphorIcons.books(PhosphorIconsStyle.light),
-              size: 32, color: colors.primary),
+          Row(
+            children: [
+              Icon(PhosphorIcons.lightbulb(PhosphorIconsStyle.fill),
+                  size: 18, color: colors.primary),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Quelques conseils',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: colors.textPrimary,
+                      ),
+                ),
+              ),
+            ],
+          ),
           const SizedBox(height: 12),
-          Text(
-            'Toujours en manque d\'inspiration ?',
-            style: Theme.of(context)
-                .textTheme
-                .titleSmall
-                ?.copyWith(color: colors.textPrimary),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 8),
-          Text(
-            'Plongez dans la bibliotheque francophone AtlasFlux.',
-            style: Theme.of(context)
-                .textTheme
-                .bodySmall
-                ?.copyWith(color: colors.textSecondary),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 16),
-          OutlinedButton.icon(
-            onPressed: _openAtlasFlux,
-            icon: Icon(
-                PhosphorIcons.arrowSquareOut(PhosphorIconsStyle.regular),
-                size: 18,
-                color: colors.primary),
-            label: Text('Explorer AtlasFlux',
-                style: TextStyle(color: colors.primary)),
-            style: OutlinedButton.styleFrom(
-              side: BorderSide(color: colors.primary),
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8)),
-            ),
-          )
+          ...hints.map((hint) => Padding(
+                padding: const EdgeInsets.only(bottom: 6),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(top: 7),
+                      child: Container(
+                        width: 4,
+                        height: 4,
+                        decoration: BoxDecoration(
+                          color: colors.textTertiary,
+                          shape: BoxShape.circle,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        hint,
+                        style:
+                            Theme.of(context).textTheme.bodySmall?.copyWith(
+                                  color: colors.textSecondary,
+                                  height: 1.4,
+                                ),
+                      ),
+                    ),
+                  ],
+                ),
+              )),
         ],
       ),
     );

--- a/apps/mobile/lib/features/sources/widgets/example_chips.dart
+++ b/apps/mobile/lib/features/sources/widgets/example_chips.dart
@@ -3,17 +3,44 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
 
+enum _ExampleType { youtube, newsletter, podcast, reddit, media }
+
+class _Example {
+  final String label;
+  final _ExampleType type;
+  const _Example(this.label, this.type);
+}
+
 class ExampleChips extends StatelessWidget {
   final void Function(String text) onTap;
 
   const ExampleChips({super.key, required this.onTap});
 
-  static const _examples = [
-    "Lenny's newsletter",
-    'r/france',
-    '@fireship',
-    'Stratechery',
+  static const _examples = <_Example>[
+    _Example('@HugoDécrypte', _ExampleType.youtube),
+    _Example('@Underscore_', _ExampleType.youtube),
+    _Example('Snowball', _ExampleType.newsletter),
+    _Example('Sismique', _ExampleType.podcast),
+    _Example('GDIY', _ExampleType.podcast),
+    _Example('r/france', _ExampleType.reddit),
+    _Example('Numerama', _ExampleType.media),
+    _Example('Le Grand Continent', _ExampleType.media),
   ];
+
+  IconData _iconFor(_ExampleType type) {
+    switch (type) {
+      case _ExampleType.youtube:
+        return PhosphorIcons.youtubeLogo(PhosphorIconsStyle.fill);
+      case _ExampleType.newsletter:
+        return PhosphorIcons.envelope(PhosphorIconsStyle.fill);
+      case _ExampleType.podcast:
+        return PhosphorIcons.microphone(PhosphorIconsStyle.fill);
+      case _ExampleType.reddit:
+        return PhosphorIcons.redditLogo(PhosphorIconsStyle.fill);
+      case _ExampleType.media:
+        return PhosphorIcons.newspaper(PhosphorIconsStyle.fill);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -28,7 +55,7 @@ class ExampleChips extends StatelessWidget {
                 size: 16, color: colors.textSecondary),
             const SizedBox(width: 6),
             Text(
-              'Essaie :',
+              'Quelques exemples :',
               style: Theme.of(context)
                   .textTheme
                   .bodyMedium
@@ -42,7 +69,9 @@ class ExampleChips extends StatelessWidget {
           runSpacing: 8,
           children: _examples
               .map((example) => ActionChip(
-                    label: Text(example),
+                    avatar: Icon(_iconFor(example.type),
+                        size: 16, color: colors.primary),
+                    label: Text(example.label),
                     labelStyle: Theme.of(context)
                         .textTheme
                         .bodySmall
@@ -52,7 +81,7 @@ class ExampleChips extends StatelessWidget {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(100),
                     ),
-                    onPressed: () => onTap(example),
+                    onPressed: () => onTap(example.label),
                   ))
               .toList(),
         ),

--- a/apps/mobile/lib/features/sources/widgets/smart_search_field.dart
+++ b/apps/mobile/lib/features/sources/widgets/smart_search_field.dart
@@ -1,81 +1,70 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../../config/theme.dart';
 
-class SmartSearchField extends StatefulWidget {
-  final ValueChanged<String> onSearch;
+/// Champ de recherche de sources.
+///
+/// Le déclenchement de la recherche est explicite : `onSubmit` est appelé
+/// uniquement quand l'utilisateur valide (touche "Rechercher" du clavier)
+/// ou quand le parent le déclenche via le bouton "Rechercher" attenant.
+/// Aucun debounce sur les keystrokes — chaque appel coûte du quota
+/// Brave/Mistral côté backend.
+class SmartSearchField extends StatelessWidget {
+  final TextEditingController controller;
+  final ValueChanged<String> onSubmit;
+  final VoidCallback onClear;
+  final VoidCallback? onSearch;
   final bool enabled;
 
   const SmartSearchField({
     super.key,
-    required this.onSearch,
+    required this.controller,
+    required this.onSubmit,
+    required this.onClear,
+    this.onSearch,
     this.enabled = true,
   });
-
-  @override
-  State<SmartSearchField> createState() => _SmartSearchFieldState();
-}
-
-class _SmartSearchFieldState extends State<SmartSearchField> {
-  final _controller = TextEditingController();
-  Timer? _debounce;
-
-  @override
-  void dispose() {
-    _debounce?.cancel();
-    _controller.dispose();
-    super.dispose();
-  }
-
-  void _onChanged(String value) {
-    _debounce?.cancel();
-    _debounce = Timer(const Duration(milliseconds: 350), () {
-      widget.onSearch(value.trim());
-    });
-  }
-
-  void _onSubmitted(String value) {
-    _debounce?.cancel();
-    widget.onSearch(value.trim());
-  }
-
-  void _clear() {
-    _controller.clear();
-    _debounce?.cancel();
-    widget.onSearch('');
-  }
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
 
     return TextField(
-      controller: _controller,
+      controller: controller,
       decoration: InputDecoration(
         hintText: 'Rechercher une source...',
         prefixIcon: Icon(
             PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular)),
         suffixIcon: ValueListenableBuilder<TextEditingValue>(
-          valueListenable: _controller,
+          valueListenable: controller,
           builder: (_, value, __) {
-            if (value.text.isEmpty) return const SizedBox.shrink();
-            return IconButton(
-              icon: Icon(PhosphorIcons.xCircle(PhosphorIconsStyle.fill),
-                  color: colors.textTertiary),
-              onPressed: _clear,
-            );
+            final hasText = value.text.isNotEmpty;
+            if (hasText) {
+              return IconButton(
+                icon: Icon(PhosphorIcons.xCircle(PhosphorIconsStyle.fill),
+                    color: colors.textTertiary),
+                onPressed: onClear,
+              );
+            }
+            if (onSearch != null) {
+              return IconButton(
+                icon: Icon(
+                    PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.bold),
+                    color: colors.primary),
+                onPressed: onSearch,
+              );
+            }
+            return const SizedBox.shrink();
           },
         ),
       ),
       keyboardType: TextInputType.url,
+      textInputAction: TextInputAction.search,
       autocorrect: false,
-      enabled: widget.enabled,
+      enabled: enabled,
       style: Theme.of(context).textTheme.bodyMedium,
-      onChanged: _onChanged,
-      onSubmitted: _onSubmitted,
+      onSubmitted: (value) => onSubmit(value.trim()),
     );
   }
 }

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -3,6 +3,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/theme.dart';
 import '../../../widgets/design/facteur_image.dart';
 import '../../../widgets/design/priority_slider.dart';
+import '../models/smart_search_result.dart';
 import '../models/source_model.dart';
 import '../../../widgets/design/facteur_button.dart';
 
@@ -14,6 +15,7 @@ class SourceDetailModal extends StatelessWidget {
   final VoidCallback? onToggleSubscription;
   final ValueChanged<double>? onPriorityChanged; // Epic 12: frequency slider
   final double? usageWeight;
+  final List<SmartSearchRecentItem>? recentItems;
 
   const SourceDetailModal({
     super.key,
@@ -24,6 +26,7 @@ class SourceDetailModal extends StatelessWidget {
     this.onToggleSubscription,
     this.onPriorityChanged,
     this.usageWeight,
+    this.recentItems,
   });
 
   @override
@@ -92,6 +95,12 @@ class SourceDetailModal extends StatelessWidget {
           ),
           const SizedBox(height: 24),
 
+          // Recent articles (only shown when provided, e.g. from smart search)
+          if (recentItems != null && recentItems!.isNotEmpty) ...[
+            _buildRecentArticles(context, colors),
+            const SizedBox(height: 16),
+          ],
+
           // FQS Score Card
           Container(
             padding: const EdgeInsets.all(16),
@@ -149,27 +158,41 @@ class SourceDetailModal extends StatelessWidget {
                 border: Border.all(
                     color: colors.textTertiary.withOpacity(0.2)),
               ),
-              child: Row(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Icon(
-                    PhosphorIcons.slidersHorizontal(PhosphorIconsStyle.regular),
-                    size: 18,
-                    color: colors.textSecondary,
+                  Row(
+                    children: [
+                      Icon(
+                        PhosphorIcons.slidersHorizontal(
+                            PhosphorIconsStyle.regular),
+                        size: 18,
+                        color: colors.textSecondary,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Fréquence',
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                              color: colors.textPrimary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                      ),
+                      const Spacer(),
+                      PrioritySlider(
+                        key: ValueKey(source.id),
+                        currentMultiplier: source.priorityMultiplier,
+                        onChanged: onPriorityChanged!,
+                        usageWeight: usageWeight,
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 8),
+                  const SizedBox(height: 6),
                   Text(
-                    'Fréquence',
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          color: colors.textPrimary,
-                          fontWeight: FontWeight.w600,
+                    'Ajustez à quel point vous souhaitez voir cette source',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: colors.textSecondary,
+                          height: 1.3,
                         ),
-                  ),
-                  const Spacer(),
-                  PrioritySlider(
-                    key: ValueKey(source.id),
-                    currentMultiplier: source.priorityMultiplier,
-                    onChanged: onPriorityChanged!,
-                    usageWeight: usageWeight,
                   ),
                 ],
               ),
@@ -285,6 +308,65 @@ class SourceDetailModal extends StatelessWidget {
             ],
           ],
           SizedBox(height: MediaQuery.of(context).padding.bottom + 16),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRecentArticles(BuildContext context, FacteurColors colors) {
+    final items = recentItems!.take(3).toList();
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colors.backgroundSecondary,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: colors.textTertiary.withOpacity(0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(PhosphorIcons.newspaperClipping(PhosphorIconsStyle.regular),
+                  size: 18, color: colors.primary),
+              const SizedBox(width: 8),
+              Text(
+                'Derniers articles',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: colors.textPrimary,
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          ...items.map((item) => Padding(
+                padding: const EdgeInsets.only(bottom: 6),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(top: 6),
+                      child: Icon(
+                          PhosphorIcons.dotOutline(PhosphorIconsStyle.fill),
+                          size: 12,
+                          color: colors.primary),
+                    ),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        item.title,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: colors.textSecondary,
+                              height: 1.4,
+                            ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              )),
         ],
       ),
     );

--- a/apps/mobile/lib/features/sources/widgets/source_result_card.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_result_card.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../../config/theme.dart';
-import '../../../../shared/widgets/buttons/primary_button.dart';
 import '../../../../widgets/design/facteur_image.dart';
 import '../models/smart_search_result.dart';
 
@@ -189,10 +188,18 @@ class SourceResultCard extends StatelessWidget {
                           side: BorderSide(color: colors.success),
                         ),
                       )
-                    : PrimaryButton(
-                        label: 'Ajouter',
+                    : ElevatedButton(
                         onPressed: onAdd,
-                        isLoading: false,
+                        style: ElevatedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 12),
+                          backgroundColor: colors.primary,
+                          foregroundColor: colors.textPrimary,
+                          elevation: 0,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        child: const Text('Ajouter'),
                       ),
               ),
             ],

--- a/apps/mobile/lib/features/sources/widgets/source_result_skeleton.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_result_skeleton.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../../config/theme.dart';
 
@@ -15,6 +18,15 @@ class _SourceResultSkeletonState extends State<SourceResultSkeleton>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late final Animation<double> _opacity;
+  int _dotCount = 1;
+  late final Timer _dotTimer;
+
+  static const _messages = [
+    'En train de parcourir le web',
+    'Recherche en cours',
+    'Analyse des sources',
+  ];
+  int _messageIndex = 0;
 
   @override
   void initState() {
@@ -24,24 +36,63 @@ class _SourceResultSkeletonState extends State<SourceResultSkeleton>
       duration: const Duration(milliseconds: 1000),
     )..repeat(reverse: true);
     _opacity = Tween<double>(begin: 0.3, end: 0.7).animate(_controller);
+
+    _dotTimer = Timer.periodic(const Duration(milliseconds: 500), (_) {
+      if (!mounted) return;
+      setState(() {
+        _dotCount = (_dotCount % 3) + 1;
+        if (_dotCount == 1) {
+          _messageIndex = (_messageIndex + 1) % _messages.length;
+        }
+      });
+    });
   }
 
   @override
   void dispose() {
+    _dotTimer.cancel();
     _controller.dispose();
     super.dispose();
   }
 
+  String get _dots => '.' * _dotCount;
+
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: _opacity,
-      builder: (context, _) {
-        return Column(
-          children: List.generate(
-              widget.count, (_) => _buildSkeletonCard(context)),
-        );
-      },
+    final colors = context.facteurColors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 16),
+          child: Row(
+            children: [
+              Icon(
+                PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
+                size: 16,
+                color: colors.primary,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '${_messages[_messageIndex]}$_dots',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: colors.textSecondary,
+                      fontStyle: FontStyle.italic,
+                    ),
+              ),
+            ],
+          ),
+        ),
+        AnimatedBuilder(
+          animation: _opacity,
+          builder: (context, _) {
+            return Column(
+              children: List.generate(
+                  widget.count, (_) => _buildSkeletonCard(context)),
+            );
+          },
+        ),
+      ],
     );
   }
 

--- a/apps/mobile/test/features/sources/widgets/example_chips_test.dart
+++ b/apps/mobile/test/features/sources/widgets/example_chips_test.dart
@@ -4,53 +4,48 @@ import 'package:facteur/features/sources/widgets/example_chips.dart';
 import 'package:facteur/config/theme.dart';
 
 void main() {
-  group('ExampleChips', () {
-    testWidgets('renders all 4 example chips', (tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: FacteurTheme.lightTheme,
-          home: Scaffold(
-            body: ExampleChips(onTap: (_) {}),
-          ),
-        ),
-      );
+  Widget pumpChips(VoidCallback callback,
+      {void Function(String)? onTap}) {
+    return MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(
+        body: ExampleChips(onTap: onTap ?? (_) {}),
+      ),
+    );
+  }
 
-      expect(find.text("Lenny's newsletter"), findsOneWidget);
+  group('ExampleChips', () {
+    testWidgets('renders the curated FR examples', (tester) async {
+      await tester.pumpWidget(pumpChips(() {}));
+
+      // A few representative labels covering the 4 source types.
+      expect(find.text('@HugoDécrypte'), findsOneWidget);
+      expect(find.text('@Underscore_'), findsOneWidget);
+      expect(find.text('Snowball'), findsOneWidget);
+      expect(find.text('Sismique'), findsOneWidget);
+      expect(find.text('GDIY'), findsOneWidget);
       expect(find.text('r/france'), findsOneWidget);
-      expect(find.text('@fireship'), findsOneWidget);
-      expect(find.text('Stratechery'), findsOneWidget);
+      expect(find.text('Numerama'), findsOneWidget);
+      expect(find.text('Le Grand Continent'), findsOneWidget);
     });
 
     testWidgets('fires callback with correct text on tap', (tester) async {
       String? tappedText;
 
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: FacteurTheme.lightTheme,
-          home: Scaffold(
-            body: ExampleChips(onTap: (text) => tappedText = text),
-          ),
-        ),
-      );
+      await tester.pumpWidget(pumpChips(() {},
+          onTap: (text) => tappedText = text));
 
       await tester.tap(find.text('r/france'));
       expect(tappedText, 'r/france');
 
-      await tester.tap(find.text('@fireship'));
-      expect(tappedText, '@fireship');
+      await tester.tap(find.text('@HugoDécrypte'));
+      expect(tappedText, '@HugoDécrypte');
     });
 
-    testWidgets('displays "Essaie :" label', (tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: FacteurTheme.lightTheme,
-          home: Scaffold(
-            body: ExampleChips(onTap: (_) {}),
-          ),
-        ),
-      );
+    testWidgets('displays "Quelques exemples :" label', (tester) async {
+      await tester.pumpWidget(pumpChips(() {}));
 
-      expect(find.text('Essaie :'), findsOneWidget);
+      expect(find.text('Quelques exemples :'), findsOneWidget);
     });
   });
 }

--- a/apps/mobile/test/features/sources/widgets/smart_search_field_test.dart
+++ b/apps/mobile/test/features/sources/widgets/smart_search_field_test.dart
@@ -4,13 +4,23 @@ import 'package:facteur/features/sources/widgets/smart_search_field.dart';
 import 'package:facteur/config/theme.dart';
 
 void main() {
-  Widget buildTestWidget({required ValueChanged<String> onSearch}) {
+  Widget buildTestWidget({
+    required TextEditingController controller,
+    required ValueChanged<String> onSubmit,
+    required VoidCallback onClear,
+    VoidCallback? onSearch,
+  }) {
     return MaterialApp(
       theme: FacteurTheme.lightTheme,
       home: Scaffold(
         body: Padding(
           padding: const EdgeInsets.all(16),
-          child: SmartSearchField(onSearch: onSearch),
+          child: SmartSearchField(
+            controller: controller,
+            onSubmit: onSubmit,
+            onClear: onClear,
+            onSearch: onSearch,
+          ),
         ),
       ),
     );
@@ -18,76 +28,72 @@ void main() {
 
   group('SmartSearchField', () {
     testWidgets('renders with hint text', (tester) async {
-      await tester.pumpWidget(buildTestWidget(onSearch: (_) {}));
+      final controller = TextEditingController();
+      await tester.pumpWidget(buildTestWidget(
+        controller: controller,
+        onSubmit: (_) {},
+        onClear: () {},
+      ));
 
       expect(find.byType(TextField), findsOneWidget);
       expect(find.text('Rechercher une source...'), findsOneWidget);
     });
 
-    testWidgets('debounces input at 350ms', (tester) async {
+    testWidgets('does NOT fire onSubmit while typing (no debounce)',
+        (tester) async {
       String? lastQuery;
-      await tester.pumpWidget(
-          buildTestWidget(onSearch: (q) => lastQuery = q));
+      final controller = TextEditingController();
+      await tester.pumpWidget(buildTestWidget(
+        controller: controller,
+        onSubmit: (q) => lastQuery = q,
+        onClear: () {},
+      ));
 
       await tester.enterText(find.byType(TextField), 'test');
+      await tester.pump(const Duration(milliseconds: 500));
 
-      // Before debounce fires
-      await tester.pump(const Duration(milliseconds: 200));
-      expect(lastQuery, isNull);
-
-      // After debounce fires
-      await tester.pump(const Duration(milliseconds: 200));
-      expect(lastQuery, 'test');
+      expect(lastQuery, isNull,
+          reason: 'Search must only fire on explicit submit, not on typing.');
     });
 
-    testWidgets('fires immediately on submit', (tester) async {
+    testWidgets('fires onSubmit on keyboard submit (trimmed)', (tester) async {
       String? lastQuery;
-      await tester.pumpWidget(
-          buildTestWidget(onSearch: (q) => lastQuery = q));
+      final controller = TextEditingController();
+      await tester.pumpWidget(buildTestWidget(
+        controller: controller,
+        onSubmit: (q) => lastQuery = q,
+        onClear: () {},
+      ));
 
-      await tester.enterText(find.byType(TextField), 'lemonde.fr');
-      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.enterText(find.byType(TextField), '  lemonde.fr  ');
+      await tester.testTextInput.receiveAction(TextInputAction.search);
       await tester.pump();
 
       expect(lastQuery, 'lemonde.fr');
     });
 
-    testWidgets('clear button appears when text is entered', (tester) async {
-      String? lastQuery;
-      await tester.pumpWidget(
-          buildTestWidget(onSearch: (q) => lastQuery = q));
+    testWidgets('clear button appears when text is entered and triggers onClear',
+        (tester) async {
+      var clearCalled = false;
+      final controller = TextEditingController();
+      await tester.pumpWidget(buildTestWidget(
+        controller: controller,
+        onSubmit: (_) {},
+        onClear: () => clearCalled = true,
+      ));
 
-      // No clear button initially
+      // No clear button initially.
       expect(find.byType(IconButton), findsNothing);
 
-      // Enter text
       await tester.enterText(find.byType(TextField), 'hello');
       await tester.pump();
 
-      // Clear button should appear
       expect(find.byType(IconButton), findsOneWidget);
 
-      // Tap clear
       await tester.tap(find.byType(IconButton));
       await tester.pump();
 
-      expect(lastQuery, '');
-      // TextField should be empty
-      final textField =
-          tester.widget<TextField>(find.byType(TextField));
-      expect(textField.controller?.text, '');
-    });
-
-    testWidgets('trims whitespace from query', (tester) async {
-      String? lastQuery;
-      await tester.pumpWidget(
-          buildTestWidget(onSearch: (q) => lastQuery = q));
-
-      await tester.enterText(find.byType(TextField), '  test  ');
-      await tester.testTextInput.receiveAction(TextInputAction.done);
-      await tester.pump();
-
-      expect(lastQuery, 'test');
+      expect(clearCalled, isTrue);
     });
   });
 }

--- a/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
+++ b/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:facteur/features/sources/widgets/source_detail_modal.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/models/smart_search_result.dart';
 import 'package:facteur/config/theme.dart';
 
 void main() {
@@ -35,6 +36,96 @@ void main() {
     // (In the implementation, we removed the block that used Theme.of(context).textTheme.bodyMedium)
     // We can check if there's only one occurrence of the text.
     expect(find.text('This is the rational for the source evaluation.'),
+        findsOneWidget);
+  });
+
+  testWidgets('renders Derniers articles when recentItems provided',
+      (tester) async {
+    final source = Source(
+      id: 'test-id',
+      name: 'Test Source',
+      type: SourceType.article,
+    );
+    const recent = [
+      SmartSearchRecentItem(title: 'Article récent A'),
+      SmartSearchRecentItem(title: 'Article récent B'),
+      SmartSearchRecentItem(title: 'Article récent C'),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SourceDetailModal(
+              source: source,
+              onToggleTrust: () {},
+              recentItems: recent,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Derniers articles'), findsOneWidget);
+    expect(find.text('Article récent A'), findsOneWidget);
+    expect(find.text('Article récent B'), findsOneWidget);
+    expect(find.text('Article récent C'), findsOneWidget);
+  });
+
+  testWidgets('hides Derniers articles when recentItems is null/empty',
+      (tester) async {
+    final source = Source(
+      id: 'test-id',
+      name: 'Test Source',
+      type: SourceType.article,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SourceDetailModal(
+              source: source,
+              onToggleTrust: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Derniers articles'), findsNothing);
+  });
+
+  testWidgets('shows priority slider with inline help text when trusted',
+      (tester) async {
+    final source = Source(
+      id: 'test-id',
+      name: 'Test Source',
+      type: SourceType.article,
+      isTrusted: true,
+      priorityMultiplier: 2.0,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SourceDetailModal(
+              source: source,
+              onToggleTrust: () {},
+              onPriorityChanged: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Fréquence'), findsOneWidget);
+    expect(
+        find.text('Ajustez à quel point vous souhaitez voir cette source'),
         findsOneWidget);
   });
 }


### PR DESCRIPTION
## What
Smart search UX refinements: recent articles in modal, auto-open post-add with subscription+slider, integrated search button, button sizing, improved copy, animated loading message.

## Why
Improves discovery (shows recent articles for confirmation), reduces friction post-add (immediate modal with config options), reduces API quota waste (no more debounce-on-keystroke), clearer UI affordances (integrated button, prominent title, animated feedback).

## Type
- [x] Feature

## Changes
- **SourceDetailModal**: Added recentItems rendering + inline help text "Ajustez à quel point vous souhaitez voir cette source"
- **AddSourceScreen**: Auto-opens modal post-add with priority defaulted to 3/3 (2.0) + subscription toggle wired; improved title "Ajoutez n'importe quelle source à Facteur !" with 5 type indicators
- **SmartSearchField**: Search button integrated as suffixIcon (toggles clear/search); removed debounce entirely
- **Button sizing**: "Ajouter" matches "Aperçu" (ElevatedButton, vertical padding 12)
- **Text updates**: "Essaie :" → "Quelques exemples :"; inspiration hints renamed "Quelques conseils" with rewritten examples (no tutoiement)
- **Loading state**: Animated "En train de parcourir le web..." with 3-message cycle + dynamic dots
- **Tests**: Updated widget tests; added 3 new tests for modal recent items + slider

## Staging
- [ ] Tests pass: 275/311 (36 pre-existing failures unrelated to sources module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)