### PR TITLE
claude/fix-onboarding-loading-0iUm9

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,46 +1,121 @@
-# PR — Reader: WebView isolation + Perspectives inline (scroll-to-site) + footer UI
+# PR — Fix onboarding : pré-génération du digest pendant l'animation de conclusion
 
 ## Quoi
 
-3 corrections dans le reader article (`_buildScrollToSiteContent`) et ajustements UI du footer :
-1. **WebView isolation** : `_isWebViewActive` devient un verrou one-way — impossible de revenir au reader après activation de la WebView.
-2. **Perspectives inline en scroll-to-site** : `PerspectivesInlineSection` est maintenant rendue dans le layout scroll-to-site (articles >= 100 chars), ce qui manquait. Le FAB "œil" scroll vers elle au lieu d'ouvrir la modal.
-3. **Footer UI** : footer +20% plus haut, boutons icônes +20%, border-radius "Lire sur" 8→16px, fond orange (alpha 0.18) sur le bouton Tournesol quand actif.
+Trois changements coordonnés pour qu'un nouveau utilisateur voie son Essentiel **immédiatement** après l'onboarding, au lieu d'attendre le batch du lendemain :
+
+1. **Backend onboarding** : `POST /users/onboarding` schedule via `BackgroundTasks` la pré-génération des deux variantes du digest (normal + serein) **après commit**. Réutilise l'helper existant `_schedule_background_regen` (rate-limit, session dédiée, skip si batch en cours), exposé via deux nouvelles fonctions publiques `schedule_digest_regen` et `schedule_initial_digest_generation`.
+2. **Backend digest** : `GET /digest` et `GET /digest/both` renvoient désormais **`202 "preparing"`** (au lieu de `503` ou `200 {normal:null, serein:null}`) quand `get_or_create_digest()` retourne `None`, et déclenchent un regen en arrière-plan. Un seul contrat mobile : 202 = poll, 200 = prêt, 503 = vraie panne.
+3. **Mobile** : retries 202 passent de 3 à 5 avec délais escaladés (5/10/15/20/30s, ~80s total). Le retry 503 reste borné à 3 (constante locale `maxGenerationRetries`) pour ne pas masquer une vraie panne.
 
 ## Pourquoi
 
-- **Bug critique** : après tap "Lire sur...", l'utilisateur pouvait remonter dans l'article et interagir avec le reader au lieu de la WebView. La WebView n'était pas cliquable tant que `_isWebViewActive` était false.
-- **Bug perspectives** : `PerspectivesInlineSection` existait dans `_buildInAppContent` mais pas dans `_buildScrollToSiteContent`, le layout utilisé par tous les articles complets. Le FAB ne trouvait jamais `_perspectivesKey.currentContext` → fallback modal systématique.
-- **UI** : footer jugé trop compact visuellement.
+Bug critique nouveau-user : un utilisateur qui termine l'onboarding **hors fenêtre batch** (le batch tourne à 6h Paris et fige son snapshot d'users à ce moment-là) restait bloqué sur un spinner d'Essentiel jusqu'au batch du lendemain matin.
+
+Trois défauts cumulés (analyse complète dans `docs/bugs/bug-onboarding-digest-loading.md`) :
+
+- Aucun trigger de génération entre la fin de l'onboarding et le batch suivant.
+- `get_or_create_digest()` peut renvoyer `None` pour un compte vide (pas d'historique + sources sans articles dans la fenêtre 168h), et le router transformait ça en `503` qui épuisait le budget retry mobile (3 retries × 30s = 30s vs LLM editorial qui peut prendre 1-3 min).
+- `/digest/both` renvoyait silencieusement `200 OK` avec `normal=null, serein=null` dans le même cas — le mobile ne sait pas quoi en faire.
 
 ## Fichiers modifiés
 
-- Mobile :
-  - `apps/mobile/lib/features/detail/screens/content_detail_screen.dart` — tous les changements
+**Backend (3 fichiers)**
+- `packages/api/app/services/digest_service.py` — +30 lignes : exposition publique de `schedule_digest_regen` (wrapper) et `schedule_initial_digest_generation` (helper qui schedule les 2 variantes pour `today_paris()`).
+- `packages/api/app/routers/users.py` — +23 lignes : `BackgroundTasks` ajouté à `save_onboarding`, appel post-succès à `schedule_initial_digest_generation`.
+- `packages/api/app/routers/digest.py` — +42 lignes : remplacement du `raise HTTPException(503)` par `return JSONResponse(202)` + `schedule_digest_regen` dans `GET /digest` ; ajout d'une branche identique dans `GET /digest/both` quand les deux variantes sont `None`.
+
+**Mobile (1 fichier)**
+- `apps/mobile/lib/features/digest/providers/digest_provider.dart` — +19 lignes : `_digestMaxRetries` 3→5, ajout de 2 délais (20s, 30s), extraction de `maxGenerationRetries=3` local pour le path 503.
+
+**Tests (1 fichier nouveau, 215 lignes)**
+- `packages/api/tests/test_onboarding_digest_pregeneration.py` — 3 régressions : (a) `/digest` None→202+regen, (b) `/digest/both` both-None→202+2×regen, (c) `POST /users/onboarding` schedule bien la BackgroundTask.
+
+**Docs**
+- `docs/bugs/bug-onboarding-digest-loading.md` — 140 lignes : analyse root cause, plan, scope, rollback.
 
 ## Zones à risque
 
-- `_onScrollToSite()` — le verrou one-way empêche `_isWebViewActive` de repasser à `false`. Si la WebView échoue à charger, l'utilisateur ne peut plus revenir au reader sans quitter l'écran. C'est intentionnel (comportement attendu), mais à surveiller si des cas de WebView en erreur remontent.
-- `_buildScrollToSiteContent` — la section perspectives est insérée entre l'article et le spacer transparent. Elle a un fond opaque `colors.backgroundPrimary` pour masquer la WebView sous-jacente. Si ce fond venait à manquer, la WebView serait visible à travers.
-- `_kFooterContentHeight` 68→82 — tous les calculs qui référencent cette constante (offset de slide du footer, clearance en bas des listes) sont impactés. Vérifier visuellement sur iPhone SE (petit écran).
+- **`packages/api/app/services/digest_service.py:_schedule_background_regen`** — c'est le helper interne réutilisé. Pas modifié, mais maintenant appelé depuis 2 nouveaux call sites (onboarding + router fallback). Le rate-limit (1/min par `(user, date, variant)`) protège contre les spawns multiples ; vérifier que la cooldown est cohérente avec la latence pipeline LLM (~60-90s sur cold start).
+- **`packages/api/app/routers/digest.py:get_digest`** — la branche None ne renvoie plus 503 mais 202. Tout client qui interprétait `503 "Digest generation failed"` comme une vraie panne (Sentry, dashboards, alerting) verra son trafic basculer sur 202. À vérifier côté monitoring.
+- **`packages/api/app/routers/users.py:save_onboarding`** — l'ajout de `BackgroundTasks` change la signature. Si un test/mock injectait des kwargs positionnels, ils peuvent se décaler. Vérifié manuellement : `data, background_tasks, user_id=Depends, db=Depends` — l'ordre de FastAPI gère bien les kwargs Depends.
+- **`apps/mobile/.../digest_provider.dart`** — passer de 3 à 5 retries augmente le temps max d'affichage du spinner avant erreur dure (de ~30s à ~80s sur 202). Pour un nouvel user c'est mieux qu'un spinner infini ; pour un user existant qui aurait un bug serveur, c'est 50s d'attente supplémentaires avant erreur visible. Acceptable étant donné qu'on revient au polling 202 propre.
 
 ## Points d'attention pour le reviewer
 
-1. **Verrou one-way** (`_onScrollToSite`, ligne ~619) : `shouldActivate && !_isWebViewActive` remplace `shouldActivate != _isWebViewActive`. Simple mais critique — vérifier que le reset de `_isWebViewActive` se fait bien à la destruction du widget (dispose) et non pendant la session.
-2. **Fond opaque sur les containers perspectives** : chaque container a `color: colors.backgroundPrimary`. Sans ça, la WebView (Layer 0) saignerait visuellement pendant le scroll. Tester sur un article avec perspectives chargées puis taper "Lire sur...".
-3. **`_ctaTapped` vs `_isWebViewActive` pour la transparence** : le `ColoredBox` utilise maintenant `_isWebViewActive` au lieu de `_ctaTapped` pour passer en transparent, évitant l'artefact visuel entre le tap CTA et le seuil d'activation.
-4. **Tournesol** : fond via `SunflowerIcon.sunflowerYellow.withValues(alpha: 0.18)` — constante exposée par le widget, cohérent avec le bookmark qui change d'icône à l'état actif.
+1. **Timing transactionnel onboarding → bg task** — le point critique. L'helper `_schedule_background_regen` ouvre sa propre `AsyncSession`. Pour qu'il voie les `UserSource`, `UserInterest`, `UserSubtopic` créés dans la transaction d'onboarding, il **faut** que la bg task tourne après `db.commit()`. C'est garanti par `BackgroundTasks` de FastAPI : la task est exécutée après que la response est envoyée, donc après que `get_db()` ait commit. Si on avait utilisé `asyncio.create_task` direct dans le handler, la bg session aurait pu lire avant le commit du request → digest vide → boucle.
+
+2. **Redondance saine** — l'onboarding pré-schedule, **et** le router schedule à nouveau si `None` au moment du GET. Voulu : si la pré-gen rate les 60s de cooldown, ou si le pipeline crashe, le poll mobile redéclenche un nouveau spawn. Le rate-limit 1/min empêche les pile-ons.
+
+3. **`schedule_initial_digest_generation` vs `_schedule_background_regen`** — j'ai créé une fonction dédiée plutôt que d'appeler 2× le helper interne depuis le router. Justification : sémantique différente ("je viens de finir l'onboarding, génère mes 2 variantes pour aujourd'hui") vs ("régénère la variante X parce que rien n'existe"). Le wrapper est explicite et facilement greppable.
+
+4. **Test `test_onboarding_schedules_initial_digest_generation`** — utilise `app.dependency_overrides` + mock de `UserService.save_onboarding` et `OnboardingResponse.model_validate`. Si la requête body validation échoue (422 au lieu de 200), le test passe quand même mais sans valider le scheduler — j'ai gardé l'assertion conditionnelle `if resp.status_code == 200` parce que le test cible le routing/scheduling, pas la validation Pydantic. Si tu préfères un test plus strict, on peut construire un payload `OnboardingAnswers` complet.
+
+5. **`get_or_create_digest()` non modifié** — j'ai volontairement laissé le retour `None` à la ligne 690 plutôt que d'y mettre un fallback supplémentaire. Le router est la couche qui transforme "rien à servir" en "réessaie plus tard". Garder ça séparé évite de coupler le service à la sémantique HTTP.
 
 ## Ce qui N'A PAS changé (mais pourrait sembler affecté)
 
-- `_buildInAppContent` — inchangé, les perspectives inline y existent déjà depuis PR #400.
-- `PerspectivesInlineSection` widget — inchangé, utilisé tel quel.
-- `_showPerspectives` / `_showPerspectivesSheet` (modal fallback) — inchangé. Le fallback modal reste pour les cas où la section n'est pas encore rendue (loading).
-- `pubspec.lock` — bump automatique de `flutter_lints` 3→6 et `lints` 3→6, sans changement de fonctionnalité.
+- **Le scheduler batch quotidien (6h Paris)** — pas touché. Le fix vise uniquement la fenêtre entre la fin de l'onboarding et le prochain batch.
+- **`digest_service.get_or_create_digest`** — pas touché. La logique de sélection / emergency fallback / yesterday-fallback reste identique. On corrige uniquement comment le router communique l'absence de résultat au mobile.
+- **L'animation de conclusion mobile (10s)** — pas touchée. C'est cette animation qui sert de "fenêtre de pré-gén" côté serveur ; sa durée est utilisée comme acquise.
+- **Le 503 sur `digest_generation_timeout`** dans `/digest/both` — pas touché. Reste 503 avec `detail: "digest_generation_timeout"` pour préserver le test de régression `test_digest_both_timeout.py` et le path "vraie panne upstream".
+- **Le code Hive / cache local mobile** — pas touché. Les digests servis sont enregistrés normalement.
+- **`UserService.save_onboarding`** — la fonction service elle-même est inchangée. Le scheduler est injecté au niveau du router via `BackgroundTasks`.
 
 ## Comment tester
 
-1. Ouvrir un article complet (>100 chars de contenu).
-2. **Bug 1** : Taper "Lire sur [Source]" → la WebView s'anime. Essayer de scroller vers le haut → impossible de revenir au reader. La WebView est cliquable et interactive.
-3. **Bug 2** : Attendre que les perspectives se chargent (pill FAB). Taper le bouton œil → la page scrolle vers la `PerspectivesInlineSection` intégrée (pas de modal). Vérifier que la section apparaît bien avant le bouton "Lire sur...".
-4. **UI Footer** : Vérifier la hauteur du footer sur iPhone SE et grand écran. Le bouton Tournesol doit avoir un fond orange clair quand l'article est liké.
+### Tests automatisés
+
+```bash
+cd packages/api
+PYTHONPATH=. pytest tests/test_onboarding_digest_pregeneration.py \
+                   tests/test_digest_service.py \
+                   tests/test_digest_both_timeout.py \
+                   tests/test_onboarding_sources.py \
+                   tests/test_user_service_persist.py -v
+```
+
+Attendu : 73 passed.
+
+### Test manuel (E2E)
+
+1. **Préparation** :
+   - Backend local : `cd packages/api && uvicorn app.main:app --port 8080`
+   - Note l'heure courante : si entre 6h00 et 6h05 Paris, attendre, sinon le batch va interférer.
+
+2. **Scénario nominal nouveau user** :
+   - Créer un compte fresh sur le mobile (Supabase auth → user créé).
+   - Compléter tout l'onboarding (sélectionner thèmes, sources, etc.).
+   - Démarrer un timer au début de l'animation de conclusion.
+   - **Attendu** : à la fin de l'animation (10s), l'écran Essentiel doit afficher des articles en **<5s** supplémentaires (la pré-gen a tourné en parallèle).
+
+3. **Vérification logs backend** (cherche dans l'ordre, dans les ~15s après la fin onboarding) :
+   ```
+   onboarding_saved user_id=...
+   digest_background_regen_scheduled user_id=... is_serene=False
+   digest_background_regen_scheduled user_id=... is_serene=True
+   digest_background_regen_completed user_id=... is_serene=False
+   digest_background_regen_completed user_id=... is_serene=True
+   ```
+
+4. **Scénario fallback (génération lente)** :
+   - Stub temporaire : ajouter un `await asyncio.sleep(40)` au début de `DigestSelector.select_for_user` pour simuler un LLM lent.
+   - Refaire l'onboarding fresh.
+   - **Attendu** : le mobile reçoit `202 "preparing"` puis poll 5x (5/10/15/20/30s). Au bout de ~40s, le digest apparaît sans erreur.
+
+5. **Scénario panne dure (503)** :
+   - Stub : `raise Exception("upstream dead")` dans `DigestSelector.select_for_user`.
+   - Refaire l'onboarding.
+   - **Attendu** : le mobile reçoit 503, retry 3 fois, puis affiche l'erreur (pas de boucle infinie).
+
+### Tests Flutter
+
+```bash
+cd apps/mobile && flutter test test/features/digest/
+```
+
+⚠️ **Pas de test unitaire ajouté côté Dart** — le changement se limite à 5 constantes (`_digestMaxRetries`, `_digestRetryDelays`, `maxGenerationRetries`). Le runtime Flutter n'était pas disponible dans le sandbox Claude pour valider, mais le code est syntaxiquement trivial. À valider via `/validate-feature` ou en local avant merge.
+
+### Validation QA web (recommandée)
+
+Lancer `/validate-feature` après création du `qa-handoff.md` correspondant — la feature touche un flux UI critique (onboarding → premier écran).

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -100,11 +100,19 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
     return await _loadBothDigests();
   }
 
-  static const _digestMaxRetries = 3;
+  // Retry budget sized for the "new user just finished onboarding" flow:
+  // the server pre-generates the digest during the 10s conclusion animation,
+  // but the editorial LLM pipeline can take up to ~90s on cold start. 5
+  // retries with escalating delays (~80s total) keep the mobile client
+  // polling on the 202 contract until the digest is ready, without hammering
+  // a server that's already working.
+  static const _digestMaxRetries = 5;
   static const _digestRetryDelays = [
     Duration(seconds: 5),
     Duration(seconds: 10),
     Duration(seconds: 15),
+    Duration(seconds: 20),
+    Duration(seconds: 30),
   ];
 
   Future<DigestResponse?> _loadBothDigests({DateTime? date}) async {
@@ -156,10 +164,15 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
         }
         rethrow;
       } on DigestGenerationException {
-        if (attempt < _digestMaxRetries) {
+        // Real 503 (backend raised HTTPException). Keep the retry budget
+        // bounded to 3 so we don't hammer a genuinely failing server — the
+        // "digest is being prepared" case is already handled by the 202 path
+        // above, so a persistent 503 here signals a real problem.
+        const maxGenerationRetries = 3;
+        if (attempt < maxGenerationRetries) {
           // ignore: avoid_print
           print(
-              'DigestNotifier: 503 error, retry ${attempt + 1}/$_digestMaxRetries...');
+              'DigestNotifier: 503 error, retry ${attempt + 1}/$maxGenerationRetries...');
           await Future<void>.delayed(_digestRetryDelays[attempt]);
           continue;
         }

--- a/docs/bugs/bug-onboarding-digest-loading.md
+++ b/docs/bugs/bug-onboarding-digest-loading.md
@@ -1,6 +1,6 @@
 # Bug — Nouveaux utilisateurs bloqués sur "Essentiel loading..." après onboarding
 
-- **Statut** : PLAN (en attente GO)
+- **Statut** : IMPLEMENTED (tests backend verts, mobile test runtime indisponible dans le sandbox)
 - **Branche** : `claude/fix-onboarding-loading-0iUm9`
 - **Date** : 2026-04-16
 - **Zone à risque** : Backend digest pipeline + onboarding — moyen

--- a/docs/bugs/bug-onboarding-digest-loading.md
+++ b/docs/bugs/bug-onboarding-digest-loading.md
@@ -1,0 +1,140 @@
+# Bug — Nouveaux utilisateurs bloqués sur "Essentiel loading..." après onboarding
+
+- **Statut** : PLAN (en attente GO)
+- **Branche** : `claude/fix-onboarding-loading-0iUm9`
+- **Date** : 2026-04-16
+- **Zone à risque** : Backend digest pipeline + onboarding — moyen
+
+---
+
+## 1. Symptôme
+
+Un utilisateur qui termine l'onboarding **en dehors de la fenêtre batch (6h00 Paris)** arrive sur l'écran "Essentiel" et voit un spinner de chargement **qui ne se termine jamais**. Il faut typiquement attendre le batch du lendemain matin pour que le digest apparaisse.
+
+## 2. Root cause
+
+Trois défauts cumulés dans le pipeline de génération du digest pour les nouveaux users :
+
+### 2.1 Aucun trigger de génération après onboarding
+
+- `POST /api/users/onboarding` (`packages/api/app/services/user_service.py:106-340`) sauvegarde profil, préférences, intérêts, subtopics et `UserSource`, puis retourne immédiatement.
+- **Aucun digest n'est généré** ni planifié.
+- Le batch quotidien (`app/jobs/digest_generation_job.py:378-380`) snapshot `SELECT user_id FROM UserProfile ORDER BY user_id` au démarrage à 6h. Un user qui finit l'onboarding à 14h n'est pas dans le snapshot et ne sera servi qu'au prochain batch.
+
+### 2.2 Génération on-demand fragile pour un compte vide
+
+Quand le mobile appelle `GET /api/digest/both`, le code tombe dans `DigestService.get_or_create_digest()` :
+
+- Pas de `DailyDigest` existant (nouveau user) → `DigestSelector.select_for_user()` s'exécute.
+- L'utilisateur n'a aucun historique de lecture → la sélection principale renvoie `[]`.
+- **Emergency fallback** (`digest_service.py:603-657`) cherche les contenus récents des `UserSource`. Si les sources n'ont pas d'articles indexés dans les 168h, retourne aussi `[]`.
+- Pas de digest de la veille à servir (nouveau user, jour 1) → `return None` à la ligne 690.
+
+### 2.3 La réponse d'erreur bloque la boucle de retry mobile
+
+- Côté serveur, `None` remonte au router qui transforme ça en `HTTPException 503` (`routers/digest.py:268-276`).
+- Côté mobile (`digest_provider.dart:103-166`), la boucle retry :
+  - **202** → retry avec backoff 5s / 10s / 15s (total 30s) — OK
+  - **503** → retry **aussi** avec le même backoff (30s total), puis erreur terminale
+  - Après épuisement → `AsyncError` → l'écran reste bloqué sur le spinner sans message clair
+- La génération LLM peut prendre 1-3 minutes → 30s de retry ne suffisent pas, même si un bg job tourne.
+
+### 2.4 Résultat
+
+Spinner indéfini pour tout utilisateur qui ne tombe pas pile dans la fenêtre batch 6h-7h30.
+
+## 3. Pourquoi `/digest/both` renvoie souvent null
+
+Confirmé par lecture du code : le router `/digest/both` (`routers/digest.py:292-384`) retourne
+`DualDigestResponse(normal=None, serein=None, …)` dès que les deux variantes renvoient `None` (sans 503 ni 202). Le mobile reçoit un 200 avec `normal=null` et tombe probablement dans un état mal géré qui relance la requête.
+
+## 4. Plan de correction
+
+Objectif : **temps de chargement minimal, propre, sans hack**. Le stratégie est de **pré-générer le digest pendant l'animation de conclusion (10s)** et de **rendre les réponses API idempotentes et pollables** pour les cas où la génération prend plus de temps.
+
+### 4.1 Pré-générer le digest à la fin de l'onboarding (cœur du fix)
+
+**Fichiers :**
+- `packages/api/app/routers/users.py:70-86` — `POST /onboarding`
+- `packages/api/app/services/digest_service.py:74` — exposer `_schedule_background_regen` via un helper public dédié
+
+**Action :**
+1. Ajouter un paramètre `background_tasks: BackgroundTasks` au handler `save_onboarding`.
+2. Après succès de `service.save_onboarding(...)`, appeler via `background_tasks.add_task(...)` une nouvelle fonction publique `schedule_initial_digest_generation(user_id)` qui planifie en fire-and-forget la génération des deux variantes (`is_serene=False` et `is_serene=True`) pour `today_paris()`.
+3. L'usage de `BackgroundTasks` de FastAPI garantit l'exécution **après commit + réponse envoyée** → pas de race avec la transaction d'onboarding (les `UserSource` sont visibles).
+4. Réutiliser `_schedule_background_regen()` en interne (rate-limit, gestion d'erreur, session dédiée, skip si batch en cours — tout existe déjà). Renommer en `schedule_digest_regen` (sans underscore) pour clarifier son statut.
+
+**Gain :** l'animation de conclusion dure **10s minimum** (`conclusion_notifier.dart:56`). Pendant ce temps le serveur peut sélectionner les articles + générer le digest. Pour un compte sans historique mais avec des sources (cas nominal post-onboarding), l'emergency-fallback-wrap-as-topics produit un digest "topics_v1" en ~2-5s. Par le temps que le mobile appelle `/digest/both`, le digest existe → réponse immédiate.
+
+### 4.2 Rendre `/digest` et `/digest/both` pollables quand rien n'est prêt
+
+**Fichiers :**
+- `packages/api/app/routers/digest.py:268-276` (GET `/digest`)
+- `packages/api/app/routers/digest.py:380-384` (GET `/digest/both`)
+
+**Action :**
+1. Quand `get_or_create_digest()` retourne `None` :
+   - **Avant** : `raise HTTPException(503)` → mobile tente 3 retries puis échoue.
+   - **Après** : déclencher `schedule_digest_regen(user_id, target_date, is_serene)` et **retourner `202 {"status":"preparing"}`** comme le fait déjà la branche "batch running". Aligne le contrat mobile sur un seul code polling (202).
+2. Dans `/digest/both`, si `normal is None` ou `serein is None` **sans exception**, renvoyer aussi 202 au lieu d'un 200 partiel. Le mobile ne sait pas quoi faire d'un `DualDigestResponse(normal=null, serein=null)`.
+
+**Gain :** le contrat devient simple : "202 = encore pas prêt, repolle" ; "200 = voici ton digest" ; "503 = vraie erreur transitoire". Ça couvre le cas où la génération prend >10s (ex. LLM pipeline editorial_v1 pour les users en format editorial).
+
+### 4.3 Mobile : backoff plus tolérant pour le premier digest
+
+**Fichier :** `apps/mobile/lib/features/digest/providers/digest_provider.dart:103-108`
+
+**Action :**
+- Augmenter les retries 202 à `[5s, 10s, 15s, 20s, 30s]` (total ~80s) — couvre le cas LLM editorial qui peut prendre 60-90s.
+- Les autres chemins (503, timeout) gardent leur logique actuelle (agressivité limitée).
+
+**Pourquoi seulement sur 202 :** le 202 signifie "le serveur sait et travaille dessus", donc on a le droit d'attendre. On **n'augmente pas** le retry sur 503 pour ne pas masquer les vraies pannes.
+
+### 4.4 (Optionnel, séparable) Log / observabilité
+
+- Ajouter un compteur Sentry/structlog `digest_pre_generated_on_onboarding` (succès/échec) pour suivre la qualité du fix en prod.
+- Ajouter un log `digest_first_load_after_onboarding` côté mobile au premier `200 OK` post-onboarding avec `elapsed_ms` — pour mesurer le temps réel de chargement.
+
+## 5. Ce que ce plan **ne** fait **pas** (volontairement)
+
+- Pas de changement du scheduler batch 6h — inutile pour ce fix.
+- Pas de nouveau flag DB (`onboarding_just_completed`) — la table n'en a pas besoin, `UserProfile.onboarding_completed` + `created_at` suffisent.
+- Pas de digest "éditorial synchrone" dans la transaction d'onboarding — on ne veut pas payer 2-5s de LLM dans un endpoint user-facing.
+- Pas de refonte de l'emergency fallback — il fait correctement son job une fois qu'il est déclenché.
+
+## 6. Tests
+
+### 6.1 Tests unitaires backend
+
+- `packages/api/tests/routers/test_users.py` : vérifier que `POST /users/onboarding` ajoute bien une tâche à `BackgroundTasks` avec le bon user_id et les deux variantes.
+- `packages/api/tests/routers/test_digest.py` : vérifier que `GET /digest` et `GET /digest/both` renvoient 202 (pas 503) quand le service retourne `None`, et qu'une bg task est schedulée.
+
+### 6.2 Tests unitaires mobile
+
+- `apps/mobile/test/features/digest/digest_provider_test.dart` : vérifier que 5 retries 202 avec les nouveaux delays sont respectés.
+
+### 6.3 Test E2E manuel (à valider via /validate-feature)
+
+1. Créer un compte neuf
+2. Compléter l'onboarding (choisir des sources, thèmes, etc.)
+3. Observer : l'écran Essentiel doit afficher les articles en **<15s** après la fin de l'animation de conclusion
+4. Vérifier logs backend : `digest_background_regen_scheduled` présent juste après `onboarding_saved`
+
+## 7. Rollback
+
+Changements isolés et additifs :
+- Désactiver la pré-génération : retirer l'appel `background_tasks.add_task` dans `users.py`.
+- Rétablir le 503 : un seul endroit dans `digest.py`.
+- Mobile : les nouveaux delays peuvent rester sans impact.
+
+## 8. Fichiers touchés (estimation)
+
+| Fichier | Lignes modifiées | Nature |
+|---|---|---|
+| `packages/api/app/services/digest_service.py` | ~10 (rename + export) | Refactor |
+| `packages/api/app/routers/users.py` | ~15 | Ajout BackgroundTasks |
+| `packages/api/app/routers/digest.py` | ~30 (2 blocs) | 503→202 |
+| `apps/mobile/lib/features/digest/providers/digest_provider.dart` | ~5 | Backoff tuning |
+| Tests | ~80 | Nouveaux tests |
+
+**Total : ~140 lignes, isolées, réversibles.**

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -273,7 +273,6 @@ async def get_digest(
         # the "batch running" branch above. This is what unblocks the
         # infinite-loading loop for users who just finished onboarding.
         effective_date = target_date or today_paris()
-        schedule_digest_regen(user_uuid, effective_date, serein)
         logger.warning(
             "digest_generation_returned_none_scheduled_regen",
             user_id=current_user_id,
@@ -281,6 +280,7 @@ async def get_digest(
             is_serene=serein,
             elapsed_ms=round(elapsed * 1000, 1),
         )
+        schedule_digest_regen(user_uuid, effective_date, serein)
         return JSONResponse(
             status_code=202,
             content={
@@ -381,18 +381,25 @@ async def get_both_digests(
             detail="digest_generation_timeout",
         )
 
-    # Both variants empty → don't return a 200 with null fields (mobile client
-    # mishandles that as a permanent failure). Schedule regen and ask client to
-    # retry on the same 202 contract as the batch-running branch.
-    if normal is None and serein is None:
+    # If either variant is missing, don't return a 200 with null fields (the
+    # mobile client mishandles null variants as a permanent failure). Schedule
+    # regen for the specific missing variant(s) and ask the client to retry
+    # on the same 202 contract as the batch-running branch. Both-None and
+    # partial-None converge on the same response so the mobile side stays
+    # on a single polling contract.
+    if normal is None or serein is None:
         effective_date = target_date or today_paris()
-        schedule_digest_regen(user_uuid, effective_date, is_serene=False)
-        schedule_digest_regen(user_uuid, effective_date, is_serene=True)
         logger.warning(
             "digest_both_returned_none_scheduled_regen",
             user_id=current_user_id,
             target_date=str(effective_date),
+            normal_missing=normal is None,
+            serein_missing=serein is None,
         )
+        if normal is None:
+            schedule_digest_regen(user_uuid, effective_date, is_serene=False)
+        if serein is None:
+            schedule_digest_regen(user_uuid, effective_date, is_serene=True)
         return JSONResponse(
             status_code=202,
             content={

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -35,7 +35,7 @@ from app.schemas.digest import (
 from app.services.community_recommendation_service import (
     CommunityRecommendationService,
 )
-from app.services.digest_service import DigestService
+from app.services.digest_service import DigestService, schedule_digest_regen
 from app.services.generation_state import is_generation_running
 from app.utils.time import today_paris
 
@@ -266,13 +266,27 @@ async def get_digest(
     elapsed = time.monotonic() - start
 
     if not digest:
+        # Generation returned no content (new user with empty history, sources
+        # without recent articles, etc.). Instead of 503 — which makes the
+        # mobile app bail out after 3 retries — schedule a background regen
+        # and return 202 so the client keeps polling on the same contract as
+        # the "batch running" branch above. This is what unblocks the
+        # infinite-loading loop for users who just finished onboarding.
+        effective_date = target_date or today_paris()
+        schedule_digest_regen(user_uuid, effective_date, serein)
         logger.warning(
-            "digest_generation_returned_none",
+            "digest_generation_returned_none_scheduled_regen",
             user_id=current_user_id,
+            target_date=str(effective_date),
+            is_serene=serein,
             elapsed_ms=round(elapsed * 1000, 1),
         )
-        raise HTTPException(
-            status_code=503, detail="Digest generation failed. Please try again later."
+        return JSONResponse(
+            status_code=202,
+            content={
+                "status": "preparing",
+                "message": "Votre briefing est en cours de préparation...",
+            },
         )
 
     # Enrich with community carousel
@@ -365,6 +379,26 @@ async def get_both_digests(
         raise HTTPException(
             status_code=503,
             detail="digest_generation_timeout",
+        )
+
+    # Both variants empty → don't return a 200 with null fields (mobile client
+    # mishandles that as a permanent failure). Schedule regen and ask client to
+    # retry on the same 202 contract as the batch-running branch.
+    if normal is None and serein is None:
+        effective_date = target_date or today_paris()
+        schedule_digest_regen(user_uuid, effective_date, is_serene=False)
+        schedule_digest_regen(user_uuid, effective_date, is_serene=True)
+        logger.warning(
+            "digest_both_returned_none_scheduled_regen",
+            user_id=current_user_id,
+            target_date=str(effective_date),
+        )
+        return JSONResponse(
+            status_code=202,
+            content={
+                "status": "preparing",
+                "message": "Votre briefing est en cours de préparation...",
+            },
         )
 
     # Use the original session for the lightweight preference read

--- a/packages/api/app/routers/users.py
+++ b/packages/api/app/routers/users.py
@@ -2,8 +2,9 @@
 
 import logging
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import func
 from sqlalchemy import select as sa_select
@@ -24,6 +25,7 @@ from app.schemas.user import (
     UserProfileUpdate,
     UserStatsResponse,
 )
+from app.services.digest_service import schedule_initial_digest_generation
 from app.services.streak_service import StreakService
 from app.services.user_service import UserService
 
@@ -70,20 +72,35 @@ async def update_profile(
 @router.post("/onboarding", response_model=OnboardingResponse)
 async def save_onboarding(
     data: OnboardingRequest,
+    background_tasks: BackgroundTasks,
     user_id: str = Depends(get_current_user_id),
     db: AsyncSession = Depends(get_db),
 ) -> OnboardingResponse:
-    """Sauvegarder les réponses de l'onboarding."""
+    """Sauvegarder les réponses de l'onboarding.
+
+    Pré-génère le digest des deux variantes en tâche de fond : l'animation de
+    conclusion côté mobile dure ~10s, ce qui laisse au scheduler le temps de
+    produire un digest avant le premier `GET /digest/both`. Sans ce trigger,
+    un nouveau user qui termine l'onboarding hors fenêtre batch (6h Paris)
+    attend le lendemain pour voir son Essentiel.
+    """
     service = UserService(db)
     try:
         result = await service.save_onboarding(user_id, data.answers)
-        return OnboardingResponse.model_validate(result)
     except Exception as e:
         logger.error(f"Onboarding save failed for user {user_id}: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to save onboarding data. Please retry.",
         )
+
+    # Schedule digest pre-generation AFTER response is sent and the onboarding
+    # transaction is committed (BackgroundTasks guarantees post-commit timing
+    # via get_db's yield/commit pattern). The background regen helper opens its
+    # own session so it sees the freshly committed UserSource rows.
+    background_tasks.add_task(schedule_initial_digest_generation, UUID(user_id))
+
+    return OnboardingResponse.model_validate(result)
 
 
 @router.get("/preferences", response_model=list[UserPreferenceResponse])

--- a/packages/api/app/routers/users.py
+++ b/packages/api/app/routers/users.py
@@ -100,7 +100,17 @@ async def save_onboarding(
     # own session so it sees the freshly committed UserSource rows.
     background_tasks.add_task(schedule_initial_digest_generation, UUID(user_id))
 
-    return OnboardingResponse.model_validate(result)
+    try:
+        return OnboardingResponse.model_validate(result)
+    except Exception as e:
+        logger.error(
+            f"Onboarding response serialization failed for user {user_id}: {e}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Onboarding saved but response serialization failed.",
+        )
 
 
 @router.get("/preferences", response_model=list[UserPreferenceResponse])

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -250,6 +250,11 @@ def schedule_initial_digest_generation(user_id: UUID) -> None:
     user retries onboarding, we won't spawn duplicate generations.
     """
     target = today_paris()
+    logger.info(
+        "digest_pre_generation_scheduled_on_onboarding",
+        user_id=str(user_id),
+        target_date=str(target),
+    )
     for is_serene in (False, True):
         _schedule_background_regen(user_id, target, is_serene)
 

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -224,6 +224,36 @@ def _schedule_background_regen(
         )
 
 
+def schedule_digest_regen(
+    user_id: UUID,
+    target_date: date,
+    is_serene: bool,
+) -> None:
+    """Public wrapper around the background digest regen scheduler.
+
+    Used by callers outside this module (e.g. the onboarding endpoint pre-warming
+    a new user's digest, or the digest router when on-demand generation returns
+    None). Preserves the rate-limit and batch-running-skip semantics of the
+    private helper.
+    """
+    _schedule_background_regen(user_id, target_date, is_serene)
+
+
+def schedule_initial_digest_generation(user_id: UUID) -> None:
+    """Pre-warm both digest variants for a user who just completed onboarding.
+
+    Invoked from a FastAPI BackgroundTask so it runs after the onboarding
+    request has been committed — meaning the fresh UserSource / UserInterest /
+    UserSubtopic rows are visible to the background session.
+
+    Using the existing rate-limited scheduler means this is idempotent: if the
+    user retries onboarding, we won't spawn duplicate generations.
+    """
+    target = today_paris()
+    for is_serene in (False, True):
+        _schedule_background_regen(user_id, target, is_serene)
+
+
 def _count_digest_items(digest_items) -> int:
     """Count items in either EditorialPipelineResult or list."""
     if isinstance(digest_items, EditorialPipelineResult):

--- a/packages/api/tests/test_onboarding_digest_pregeneration.py
+++ b/packages/api/tests/test_onboarding_digest_pregeneration.py
@@ -19,6 +19,7 @@ These tests lock in:
    variants come back empty, with regen scheduled for both variants.
 """
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
@@ -26,6 +27,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.main import app
+from app.schemas.user import OnboardingResponse, UserProfileResponse
 
 
 @pytest.mark.asyncio
@@ -165,13 +167,53 @@ async def test_onboarding_schedules_initial_digest_generation():
     app.dependency_overrides[get_current_user_id] = _fake_user
     app.dependency_overrides[get_db] = _fake_db
 
+    now = datetime.now(UTC)
+    fake_profile = UserProfileResponse(
+        id=uuid4(),
+        user_id=uuid4(),
+        display_name=None,
+        age_range="25-34",
+        gender="other",
+        onboarding_completed=True,
+        gamification_enabled=True,
+        weekly_goal=5,
+        created_at=now,
+        updated_at=now,
+    )
+    fake_response = OnboardingResponse(
+        profile=fake_profile,
+        interests_created=3,
+        subtopics_created=2,
+        preferences_created=5,
+        sources_created=4,
+        sources_removed=0,
+    )
     fake_result = {
-        "profile": None,
+        "profile": fake_profile,
         "interests_created": 3,
         "subtopics_created": 2,
         "preferences_created": 5,
         "sources_created": 4,
         "sources_removed": 0,
+    }
+
+    # Payload must include all required OnboardingAnswers fields (objective,
+    # approach, response_style) so the request doesn't 422 before reaching the
+    # handler — otherwise the schedule assertion would be silently skipped.
+    # camelCase keys because OnboardingAnswers uses an alias_generator.
+    valid_payload = {
+        "answers": {
+            "objective": "learn",
+            "approach": "direct",
+            "responseStyle": "decisive",
+            "ageRange": "25-34",
+            "gender": "other",
+            "gamificationEnabled": True,
+            "weeklyGoal": 5,
+            "themes": ["tech"],
+            "subtopics": [],
+            "preferredSources": [],
+        }
     }
 
     try:
@@ -182,7 +224,7 @@ async def test_onboarding_schedules_initial_digest_generation():
             ),
             patch(
                 "app.routers.users.OnboardingResponse.model_validate",
-                return_value={},
+                return_value=fake_response,
             ),
             patch(
                 "app.routers.users.schedule_initial_digest_generation"
@@ -192,24 +234,18 @@ async def test_onboarding_schedules_initial_digest_generation():
             async with AsyncClient(
                 transport=transport, base_url="http://test", timeout=5.0
             ) as ac:
-                resp = await ac.post(
-                    "/api/users/onboarding",
-                    json={
-                        "answers": {
-                            "age_range": "25-34",
-                            "gender": "other",
-                            "themes": ["tech"],
-                            "subtopics": [],
-                            "preferred_sources": [],
-                        }
-                    },
-                )
+                resp = await ac.post("/api/users/onboarding", json=valid_payload)
     finally:
         app.dependency_overrides.clear()
 
-    # The endpoint completes (200) and the BackgroundTasks runner invoked our
-    # scheduler. If this assertion fails, new users will fall back to waiting
-    # for the next 6 AM batch.
-    assert resp.status_code in (200, 422), resp.text[:200]
-    if resp.status_code == 200:
-        mock_schedule.assert_called_once()
+    # Strict assertion: if the endpoint doesn't 200, the BackgroundTask never
+    # ran and new users will fall back to waiting for the next 6 AM batch.
+    assert resp.status_code == 200, (
+        f"Expected 200, got {resp.status_code}: {resp.text[:300]}"
+    )
+    mock_schedule.assert_called_once()
+    # Called with the user UUID (positional arg from routers/users.py)
+    called_args, _ = mock_schedule.call_args
+    assert str(called_args[0]) == fake_user_id, (
+        f"Scheduler called with {called_args[0]}, expected {fake_user_id}"
+    )

--- a/packages/api/tests/test_onboarding_digest_pregeneration.py
+++ b/packages/api/tests/test_onboarding_digest_pregeneration.py
@@ -1,0 +1,215 @@
+"""Regression tests for the new-user onboarding → digest loading fix.
+
+Cf. docs/bugs/bug-onboarding-digest-loading.md.
+
+Before this fix:
+1. `POST /users/onboarding` didn't trigger digest generation — new users who
+   finished onboarding outside the 6h Paris batch window waited until the
+   next morning to see any digest.
+2. `GET /digest` and `GET /digest/both` returned 503 (or 200 with null
+   variants) when the on-demand pipeline produced no items for a user without
+   history — the mobile client ran out of retry budget and showed an infinite
+   spinner.
+
+These tests lock in:
+1. Onboarding endpoint schedules initial digest generation via BackgroundTasks.
+2. `GET /digest` returns 202 (not 503) when `get_or_create_digest` returns None,
+   with a background regen scheduled.
+3. `GET /digest/both` returns 202 (not a 200 with null fields) when both
+   variants come back empty, with regen scheduled for both variants.
+"""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_digest_returns_202_when_service_returns_none_and_schedules_regen():
+    """Single-variant endpoint must return 202 + schedule regen, not 503."""
+    from app.database import get_db
+    from app.dependencies import get_current_user_id
+
+    fake_user_id = str(uuid4())
+
+    async def _fake_user():
+        return fake_user_id
+
+    class _FakeDB:
+        async def scalar(self, *args, **kwargs):
+            return None
+
+    async def _fake_db():
+        yield _FakeDB()
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+
+    try:
+        with (
+            patch(
+                "app.routers.digest.is_generation_running", return_value=False
+            ),
+            patch(
+                "app.routers.digest.DigestService.get_or_create_digest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("app.routers.digest.schedule_digest_regen") as mock_regen,
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test", timeout=5.0
+            ) as ac:
+                resp = await ac.get("/api/digest")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 202, (
+        f"Empty digest must surface as 202 (polling contract), not 503 "
+        f"(which exhausts mobile retry budget). Got {resp.status_code}: "
+        f"{resp.text[:200]}"
+    )
+    body = resp.json()
+    assert body.get("status") == "preparing", body
+    mock_regen.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_digest_both_returns_202_when_both_variants_none():
+    """Dual endpoint must not return 200 with null variants — the mobile
+    client mishandles that as a permanent failure."""
+    from app.database import get_db
+    from app.dependencies import get_current_user_id
+
+    fake_user_id = str(uuid4())
+
+    async def _fake_user():
+        return fake_user_id
+
+    class _FakeDB:
+        async def scalar(self, *args, **kwargs):
+            return None
+
+    async def _fake_db():
+        yield _FakeDB()
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+
+    try:
+        with (
+            patch(
+                "app.routers.digest.is_generation_running", return_value=False
+            ),
+            patch(
+                "app.routers.digest.DigestService.get_or_create_digest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("app.routers.digest.schedule_digest_regen") as mock_regen,
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test", timeout=5.0
+            ) as ac:
+                resp = await ac.get("/api/digest/both")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 202, (
+        f"Both variants None must surface as 202, got {resp.status_code}: "
+        f"{resp.text[:200]}"
+    )
+    body = resp.json()
+    assert body.get("status") == "preparing", body
+    # Both variants scheduled for regen (normal + serein)
+    assert mock_regen.call_count == 2, (
+        f"Expected 2 regen calls (normal + serein), got {mock_regen.call_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_onboarding_schedules_initial_digest_generation():
+    """Completing onboarding must enqueue a background task to pre-warm the
+    digest during the 10s mobile conclusion animation."""
+    from app.database import get_db
+    from app.dependencies import get_current_user_id
+
+    fake_user_id = str(uuid4())
+
+    async def _fake_user():
+        return fake_user_id
+
+    class _FakeDB:
+        async def execute(self, *args, **kwargs):
+            class _R:
+                def scalars(self_inner):
+                    class _S:
+                        def all(self_inner2):
+                            return []
+                    return _S()
+            return _R()
+        async def flush(self):
+            return None
+        def add(self, *args, **kwargs):
+            return None
+        async def scalar(self, *args, **kwargs):
+            return None
+
+    async def _fake_db():
+        yield _FakeDB()
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+
+    fake_result = {
+        "profile": None,
+        "interests_created": 3,
+        "subtopics_created": 2,
+        "preferences_created": 5,
+        "sources_created": 4,
+        "sources_removed": 0,
+    }
+
+    try:
+        with (
+            patch(
+                "app.routers.users.UserService.save_onboarding",
+                new=AsyncMock(return_value=fake_result),
+            ),
+            patch(
+                "app.routers.users.OnboardingResponse.model_validate",
+                return_value={},
+            ),
+            patch(
+                "app.routers.users.schedule_initial_digest_generation"
+            ) as mock_schedule,
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test", timeout=5.0
+            ) as ac:
+                resp = await ac.post(
+                    "/api/users/onboarding",
+                    json={
+                        "answers": {
+                            "age_range": "25-34",
+                            "gender": "other",
+                            "themes": ["tech"],
+                            "subtopics": [],
+                            "preferred_sources": [],
+                        }
+                    },
+                )
+    finally:
+        app.dependency_overrides.clear()
+
+    # The endpoint completes (200) and the BackgroundTasks runner invoked our
+    # scheduler. If this assertion fails, new users will fall back to waiting
+    # for the next 6 AM batch.
+    assert resp.status_code in (200, 422), resp.text[:200]
+    if resp.status_code == 200:
+        mock_schedule.assert_called_once()


### PR DESCRIPTION
Bug doc describing root cause (no digest trigger after onboarding,
503 on empty digest blocks mobile retry) and proposed fix (pre-generate
during 10s conclusion animation, 503→202 contract, longer mobile backoff).

https://claude.ai/code/session_01DV9piat6HHuDEgxNfs56BQ