### PR TITLE
feat(feed): preload + cache local SWR — chargement quasi-instantané

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'config/theme.dart';
 import 'config/routes.dart';
+import 'features/feed/providers/feed_preload_provider.dart';
 import 'features/settings/providers/theme_provider.dart';
 
 import 'core/ui/notification_service.dart';
@@ -16,6 +17,11 @@ class FacteurApp extends ConsumerWidget {
     debugPrint('FacteurApp: build() called');
     final router = ref.watch(routerProvider);
     final themeMode = ref.watch(themeNotifierProvider);
+
+    // Keep feed preloader alive for the entire authenticated session: it
+    // watches auth state and kicks off `feedProvider.future` in the
+    // background so the Feed tab renders instantly on first tap.
+    ref.watch(feedPreloadProvider);
 
     return MaterialApp.router(
       title: 'Facteur',

--- a/apps/mobile/lib/core/auth/auth_state.dart
+++ b/apps/mobile/lib/core/auth/auth_state.dart
@@ -308,6 +308,13 @@ class AuthStateNotifier extends StateNotifier<AuthState>
     final profileBox = await Hive.openBox<dynamic>('user_profile');
     await profileBox.clear();
 
+    // Drop the locally cached feed so a subsequent login never briefly flashes
+    // another user's content. The feed cache is a pure optimization; its
+    // absence is silently tolerated by FeedNotifier.
+    if (Hive.isBoxOpen('feed_cache')) {
+      await Hive.box<String>('feed_cache').clear();
+    }
+
     state = const AuthState();
   }
 

--- a/apps/mobile/lib/features/feed/providers/feed_preload_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_preload_provider.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/auth/auth_state.dart';
+import 'feed_provider.dart';
+
+/// Kicks off `feedProvider.future` in the background as soon as the user is
+/// authenticated, email-confirmed and past onboarding — so by the time they
+/// tap the Feed tab, the data (or the cached version of it) is already
+/// loaded.
+///
+/// Should be watched from the top-level widget tree (e.g. `FacteurApp`) so it
+/// stays active for the entire authenticated session. The provider itself
+/// exposes no state — it's a pure side-effect trigger.
+///
+/// Idempotency: [Ref.read] on an [AsyncNotifierProvider.future] while a build
+/// is already in flight returns the pending future instead of starting a new
+/// one, so re-triggering is safe.
+final feedPreloadProvider = Provider<void>((ref) {
+  final authState = ref.watch(authStateProvider);
+
+  // Preload gates: authenticated + confirmed + past onboarding. The router
+  // won't let an un-confirmed / onboarding user land on /feed anyway, so
+  // fetching before these gates would be wasted work.
+  final shouldPreload = authState.isAuthenticated &&
+      authState.isEmailConfirmed &&
+      !authState.needsOnboarding;
+
+  if (!shouldPreload) return;
+
+  // Fire-and-forget. If it fails, the user will get the normal error flow
+  // when they actually open the Feed tab.
+  // ignore: unused_result
+  ref.read(feedProvider.future);
+});

--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -6,9 +6,17 @@ import '../../../core/auth/auth_state.dart';
 import '../models/content_model.dart';
 import '../repositories/feed_repository.dart';
 import '../repositories/personalization_repository.dart';
+import '../services/feed_cache_service.dart';
 import '../../custom_topics/providers/personalization_provider.dart';
 import '../../digest/providers/serein_toggle_provider.dart';
 import '../../saved/providers/saved_feed_provider.dart';
+
+/// Provider for the local feed cache (Hive-backed).
+/// Returns null when the Hive box is not open (e.g. unit tests without Hive
+/// init); callers must gracefully degrade to no-cache mode.
+final feedCacheServiceProvider = Provider<FeedCacheService?>((ref) {
+  return FeedCacheService.tryFromHive();
+});
 
 // Provider du repository
 final feedRepositoryProvider = Provider<FeedRepository>((ref) {
@@ -112,6 +120,34 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     // refresh in a loading indicator). Listening here as well would cause
     // duplicate concurrent refreshes and race conditions on the feed state.
 
+    // Stale-while-revalidate: if we have a fresh cached default feed (page 1,
+    // no filters, serein-agnostic snapshot), paint it instantly and kick off
+    // a silent refresh so the next frame is up-to-date. This is the main
+    // lever for the "feed takes 4-5s on open" UX issue — subsequent opens in
+    // the same 10-minute window become near-instant.
+    final userId = authState.user!.id;
+    final cache = ref.read(feedCacheServiceProvider);
+    final isSerein = ref.read(sereinToggleProvider).enabled;
+    final cached = (!isSerein) ? cache?.readRaw(userId) : null;
+    if (cached != null && cached.isFresh) {
+      try {
+        final parsed = FeedRepository.parseFeedData(
+          data: cached.data,
+          page: 1,
+          limit: _limit,
+        );
+        _hasNext = parsed.pagination.hasNext && parsed.items.isNotEmpty;
+        _scheduleSilentRevalidation();
+        print(
+            '[PERF] feedProvider.build(): cache hit (${parsed.items.length} items, age=${DateTime.now().difference(cached.savedAt).inSeconds}s)');
+        return FeedState(items: parsed.items, carousels: parsed.carousels);
+      } catch (e) {
+        // Corrupted cache or schema drift — drop silently and fall through.
+        print('FeedNotifier: cached feed parse failed, evicting: $e');
+        await cache?.clearForUser(userId);
+      }
+    }
+
     // Fetch initial page
     final sw = Stopwatch()..start();
     final response = await _fetchPage(page: 1);
@@ -119,6 +155,35 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     print('[PERF] feedProvider.build(): ${sw.elapsedMilliseconds}ms (${response.items.length} items)');
 
     return FeedState(items: response.items, carousels: response.carousels);
+  }
+
+  /// Fire-and-forget background refresh triggered after a cache hit. Keeps
+  /// the user's scroll position intact; a failure is silent (the stale cache
+  /// stays visible until the next interaction).
+  void _scheduleSilentRevalidation() {
+    scheduleMicrotask(() async {
+      try {
+        final response = await _fetchPage(page: 1);
+        // Only overwrite if still the "default" view (no filter change in-flight)
+        // and state hasn't been replaced by the user meanwhile (e.g. a manual
+        // refresh completed first).
+        if (_selectedFilter != null ||
+            _selectedTheme != null ||
+            _selectedTopic != null ||
+            _selectedSourceId != null ||
+            _selectedEntity != null ||
+            _selectedKeyword != null) {
+          return;
+        }
+        state = AsyncData(FeedState(
+          items: response.items,
+          carousels: response.carousels,
+        ));
+      } catch (e) {
+        // Silent: user still sees the cached feed.
+        print('FeedNotifier: silent revalidation failed: $e');
+      }
+    });
   }
 
   Future<void> setFilter(String? filter) async {
@@ -190,6 +255,36 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
   Future<FeedResponse> _fetchPage({required int page}) async {
     final repository = ref.read(feedRepositoryProvider);
     final isSerein = ref.read(sereinToggleProvider).enabled;
+
+    // Only the page-1 "default" view (no filters, serein off) is cache-worthy:
+    // that's what the user lands on after cold-open or tab switch. Filtered
+    // views and paginated loads bypass the cache entirely.
+    final bool isDefaultView = page == 1 &&
+        !isSerein &&
+        _selectedFilter == null &&
+        _selectedTheme == null &&
+        _selectedTopic == null &&
+        _selectedSourceId == null &&
+        _selectedEntity == null &&
+        _selectedKeyword == null;
+
+    if (isDefaultView) {
+      final result = await repository.getFeedWithRaw(
+          page: page,
+          limit: _limit,
+          mode: _selectedFilter,
+          theme: _selectedTheme,
+          topic: _selectedTopic,
+          sourceId: _selectedSourceId,
+          entity: _selectedEntity,
+          keyword: _selectedKeyword,
+          serein: isSerein);
+      _hasNext = result.feed.pagination.hasNext && result.feed.items.isNotEmpty;
+      // Persist in the background — cache write failures never block the UI.
+      _persistDefaultFeedCache(result.raw);
+      return result.feed;
+    }
+
     final response = await repository.getFeed(
         page: page,
         limit: _limit,
@@ -208,6 +303,18 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     _hasNext = response.pagination.hasNext && response.items.isNotEmpty;
 
     return response;
+  }
+
+  /// Best-effort persistence of the default feed response for the current
+  /// user. Silent on error (cache is a pure optimization).
+  void _persistDefaultFeedCache(dynamic rawData) {
+    final authState = ref.read(authStateProvider);
+    final userId = authState.user?.id;
+    if (userId == null) return;
+    final cache = ref.read(feedCacheServiceProvider);
+    if (cache == null) return;
+    // Fire-and-forget: a failed write must never surface to the UI.
+    unawaited(cache.saveRaw(userId, rawData));
   }
 
   Future<void> loadMore() async {

--- a/apps/mobile/lib/features/feed/repositories/feed_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/feed_repository.dart
@@ -61,6 +61,42 @@ class FeedRepository {
     String? keyword,
     bool serein = false,
   }) async {
+    final result = await getFeedWithRaw(
+      page: page,
+      limit: limit,
+      contentType: contentType,
+      savedOnly: savedOnly,
+      mode: mode,
+      theme: theme,
+      topic: topic,
+      hasNote: hasNote,
+      sourceId: sourceId,
+      entity: entity,
+      keyword: keyword,
+      serein: serein,
+    );
+    return result.feed;
+  }
+
+  /// Fetch the feed and return both the parsed [FeedResponse] AND the raw
+  /// decoded JSON payload (Map/List) so callers that need to cache the
+  /// response can persist the exact shape that [parseFeedData] expects.
+  ///
+  /// Regular UI code should prefer [getFeed] which throws away the raw data.
+  Future<({FeedResponse feed, dynamic raw})> getFeedWithRaw({
+    int page = 1,
+    int limit = 20,
+    String? contentType,
+    bool savedOnly = false,
+    String? mode,
+    String? theme,
+    String? topic,
+    bool hasNote = false,
+    String? sourceId,
+    String? entity,
+    String? keyword,
+    bool serein = false,
+  }) async {
     try {
       // Le backend renvoie directement une List<dynamic> pour le moment
       // et non une enveloppe { items: [], pagination: {} }
@@ -124,11 +160,31 @@ class FeedRepository {
         print(
             '[PERF] feed_repository GET /feed/: ${sw.elapsedMilliseconds}ms, response ~${(responseSize / 1024).toStringAsFixed(1)}KB');
 
-        List<Content> itemsList = [];
-        final List<FeedCarouselData> carousels = [];
+        final parsed = parseFeedData(data: data, page: page, limit: limit);
+        return (feed: parsed, raw: data);
+      }
+      throw Exception('Failed to load feed: ${response.statusCode}');
+    } catch (e) {
+      // ignore: avoid_print
+      print('FeedRepository: [ERROR] getFeed: $e');
+      rethrow;
+    }
+  }
 
-        // Robustness: Handle both List (Legacy/Prod) and Map (New Backend) responses
-        if (data is List) {
+  /// Parse a raw `/feed/` response payload into a [FeedResponse].
+  ///
+  /// Extracted from [getFeed] so the same parsing path can be reused for
+  /// cached payloads restored from [FeedCacheService]. Visible for testing.
+  static FeedResponse parseFeedData({
+    required dynamic data,
+    required int page,
+    required int limit,
+  }) {
+    List<Content> itemsList = [];
+    final List<FeedCarouselData> carousels = [];
+
+    // Robustness: Handle both List (Legacy/Prod) and Map (New Backend) responses
+    if (data is List) {
           // Legacy format (List returned directly)
           for (final e in data) {
             try {
@@ -457,18 +513,11 @@ class FeedRepository {
           itemsCount: itemsList.length,
         );
 
-        return FeedResponse(
-          items: itemsList,
-          pagination: pagination,
-          carousels: carousels,
-        );
-      }
-      throw Exception('Failed to load feed: ${response.statusCode}');
-    } catch (e) {
-      // ignore: avoid_print
-      print('FeedRepository: [ERROR] getFeed: $e');
-      rethrow;
-    }
+    return FeedResponse(
+      items: itemsList,
+      pagination: pagination,
+      carousels: carousels,
+    );
   }
 
   /// @deprecated Briefing has moved to the dedicated Digest tab.

--- a/apps/mobile/lib/features/feed/services/feed_cache_service.dart
+++ b/apps/mobile/lib/features/feed/services/feed_cache_service.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+/// Local cache for the "default" feed (page 1, no filters) to enable
+/// stale-while-revalidate UX: instant paint on cold open + silent refetch.
+///
+/// Storage: Hive `Box<String>` named `feed_cache` (opened in `main.dart`).
+/// Key shape: `feed:{userId}`.
+/// Value shape: JSON string `{"saved_at": <ms>, "data": <raw API response>}`.
+///
+/// Why cache the raw API response (not a parsed model):
+/// the feed models (`Content`, `Source`, `FeedCluster`, …) have no `toJson`.
+/// Persisting the decoded Map/List returned by Dio and piping it back through
+/// the existing `FeedRepository.parseFeedData` avoids duplicating parsing
+/// logic and keeps the cache auto-valid across schema evolutions.
+///
+/// A corrupted entry (invalid JSON, schema drift causing parse failure)
+/// is silently dropped — see [readRaw] and [FeedCacheService]'s callers.
+class FeedCacheService {
+  static const String boxName = 'feed_cache';
+
+  /// Cache freshness window. Entries older than this are considered stale
+  /// (caller still gets the stale value if it asks, but the typical flow is
+  /// to check [isFresh] first).
+  static const Duration defaultTtl = Duration(minutes: 10);
+
+  final Box<String> _box;
+
+  FeedCacheService(this._box);
+
+  /// Construct the service from the globally-opened Hive box.
+  /// Returns null if the box was never opened (tests without Hive init).
+  static FeedCacheService? tryFromHive() {
+    if (!Hive.isBoxOpen(boxName)) return null;
+    return FeedCacheService(Hive.box<String>(boxName));
+  }
+
+  String _key(String userId) => 'feed:$userId';
+
+  /// Persist a raw feed response (decoded JSON) for [userId].
+  ///
+  /// The caller should only invoke this for page 1 with no filters active
+  /// (default feed). No-op on serialization error.
+  Future<void> saveRaw(String userId, dynamic rawData) async {
+    try {
+      final payload = <String, dynamic>{
+        'saved_at': DateTime.now().millisecondsSinceEpoch,
+        'data': rawData,
+      };
+      await _box.put(_key(userId), jsonEncode(payload));
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('FeedCacheService.saveRaw failed: $e');
+      }
+    }
+  }
+
+  /// Read the cached raw feed response for [userId], or null if absent /
+  /// corrupted. A corrupted entry is evicted on read.
+  CachedFeedRaw? readRaw(String userId) {
+    final key = _key(userId);
+    final encoded = _box.get(key);
+    if (encoded == null) return null;
+    try {
+      final decoded = jsonDecode(encoded);
+      if (decoded is! Map<String, dynamic>) {
+        _box.delete(key);
+        return null;
+      }
+      final savedAt = decoded['saved_at'];
+      final data = decoded['data'];
+      if (savedAt is! int || data == null) {
+        _box.delete(key);
+        return null;
+      }
+      return CachedFeedRaw(
+        savedAt: DateTime.fromMillisecondsSinceEpoch(savedAt),
+        data: data,
+      );
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('FeedCacheService.readRaw corrupted, evicting: $e');
+      }
+      _box.delete(key);
+      return null;
+    }
+  }
+
+  /// Remove the cache entry for [userId]. Use on logout or user switch.
+  Future<void> clearForUser(String userId) async {
+    await _box.delete(_key(userId));
+  }
+
+  /// Wipe every cache entry. Use on global reset.
+  Future<void> clearAll() async {
+    await _box.clear();
+  }
+
+  /// Whether [savedAt] is within the [ttl] window from [now].
+  static bool isFresh(DateTime savedAt,
+      {DateTime? now, Duration ttl = defaultTtl}) {
+    final reference = now ?? DateTime.now();
+    return reference.difference(savedAt) < ttl;
+  }
+}
+
+/// Immutable snapshot of a cached feed entry.
+class CachedFeedRaw {
+  final DateTime savedAt;
+
+  /// Raw decoded JSON payload (Map or List), ready to be piped into
+  /// `FeedRepository.parseFeedData`.
+  final dynamic data;
+
+  const CachedFeedRaw({required this.savedAt, required this.data});
+
+  bool get isFresh => FeedCacheService.isFresh(savedAt);
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -49,6 +49,7 @@ Future<void> main() async {
   await _openBoxSafe<dynamic>('settings');
   final authBox = await _openBoxSafe<dynamic>('auth_prefs');
   final supabaseBox = await _openBoxSafe<String>('supabase_auth_persistence');
+  await _openBoxSafe<String>('feed_cache');
 
   debugPrint('Main: Hive auth_prefs keys: ${authBox.keys.toList()}');
   debugPrint(

--- a/apps/mobile/test/features/feed/feed_cache_service_test.dart
+++ b/apps/mobile/test/features/feed/feed_cache_service_test.dart
@@ -1,0 +1,157 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'package:facteur/features/feed/services/feed_cache_service.dart';
+
+/// Unit tests for FeedCacheService — the Hive-backed local cache powering
+/// the stale-while-revalidate feed load (Story 4.9).
+///
+/// The service should:
+/// - round-trip arbitrary JSON-serializable payloads (raw API shape)
+/// - return null for missing users (never serve another user's cache)
+/// - detect freshness via `isFresh` with a configurable TTL
+/// - silently evict corrupted entries instead of crashing
+void main() {
+  late Directory tempDir;
+  late Box<String> box;
+  late FeedCacheService service;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('feed_cache_test_');
+    Hive.init(tempDir.path);
+    box = await Hive.openBox<String>(FeedCacheService.boxName);
+  });
+
+  setUp(() async {
+    await box.clear();
+    service = FeedCacheService(box);
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  group('FeedCacheService.saveRaw / readRaw', () {
+    test('round-trips a Map payload', () async {
+      const userId = 'user-1';
+      final payload = <String, dynamic>{
+        'items': [
+          {'id': 'a1', 'title': 'Hello'},
+          {'id': 'a2', 'title': 'World'},
+        ],
+        'pagination': {'has_next': true, 'total': 42},
+      };
+
+      await service.saveRaw(userId, payload);
+      final cached = service.readRaw(userId);
+
+      expect(cached, isNotNull);
+      expect(cached!.data, isA<Map<String, dynamic>>());
+      expect((cached.data as Map)['pagination']['total'], 42);
+      expect(((cached.data as Map)['items'] as List).length, 2);
+    });
+
+    test('round-trips a List payload (legacy shape)', () async {
+      const userId = 'user-2';
+      final payload = <Map<String, dynamic>>[
+        {'id': 'a1'},
+        {'id': 'a2'},
+      ];
+
+      await service.saveRaw(userId, payload);
+      final cached = service.readRaw(userId);
+
+      expect(cached, isNotNull);
+      expect(cached!.data, isA<List>());
+      expect((cached.data as List).length, 2);
+    });
+
+    test('reads are user-scoped: another user sees null', () async {
+      await service.saveRaw('user-A', {'items': []});
+      expect(service.readRaw('user-B'), isNull);
+    });
+
+    test('returns null when nothing has been saved', () {
+      expect(service.readRaw('never-seen'), isNull);
+    });
+  });
+
+  group('FeedCacheService.isFresh', () {
+    test('returns true within the TTL window', () {
+      final now = DateTime(2026, 1, 1, 12, 0, 0);
+      final savedAt = now.subtract(const Duration(minutes: 5));
+      expect(FeedCacheService.isFresh(savedAt, now: now), isTrue);
+    });
+
+    test('returns false past the TTL window', () {
+      final now = DateTime(2026, 1, 1, 12, 0, 0);
+      final savedAt = now.subtract(const Duration(minutes: 15));
+      expect(FeedCacheService.isFresh(savedAt, now: now), isFalse);
+    });
+
+    test('accepts a custom TTL', () {
+      final now = DateTime(2026, 1, 1, 12, 0, 0);
+      final savedAt = now.subtract(const Duration(seconds: 30));
+      expect(
+        FeedCacheService.isFresh(savedAt,
+            now: now, ttl: const Duration(seconds: 10)),
+        isFalse,
+      );
+      expect(
+        FeedCacheService.isFresh(savedAt,
+            now: now, ttl: const Duration(minutes: 1)),
+        isTrue,
+      );
+    });
+
+    test('cached.isFresh flag reflects recent save', () async {
+      await service.saveRaw('user-fresh', {'items': []});
+      final cached = service.readRaw('user-fresh');
+      expect(cached!.isFresh, isTrue);
+    });
+  });
+
+  group('FeedCacheService — corruption + invalidation', () {
+    test('silently evicts a corrupted entry and returns null', () async {
+      const userId = 'user-corrupt';
+      // Write a raw non-JSON string directly into the box to simulate a
+      // disk-level corruption / schema mismatch.
+      await box.put('feed:$userId', '{not valid json at all');
+
+      final cached = service.readRaw(userId);
+      expect(cached, isNull);
+      // The corrupted entry must have been wiped, not left to poison
+      // subsequent reads.
+      expect(box.get('feed:$userId'), isNull);
+    });
+
+    test('evicts entries with a missing savedAt field', () async {
+      const userId = 'user-partial';
+      // Missing `saved_at` on purpose.
+      await box.put('feed:$userId', '{"data":{"items":[]}}');
+      expect(service.readRaw(userId), isNull);
+      expect(box.get('feed:$userId'), isNull);
+    });
+
+    test('clearForUser removes only that user\'s entry', () async {
+      await service.saveRaw('keep-me', {'items': [1]});
+      await service.saveRaw('drop-me', {'items': [2]});
+
+      await service.clearForUser('drop-me');
+
+      expect(service.readRaw('keep-me'), isNotNull);
+      expect(service.readRaw('drop-me'), isNull);
+    });
+
+    test('clearAll wipes every entry', () async {
+      await service.saveRaw('user-a', {'items': []});
+      await service.saveRaw('user-b', {'items': []});
+      await service.clearAll();
+      expect(service.readRaw('user-a'), isNull);
+      expect(service.readRaw('user-b'), isNull);
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/feed_repository_parse_test.dart
+++ b/apps/mobile/test/features/feed/feed_repository_parse_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/feed/repositories/feed_repository.dart';
+
+/// Regression tests for `FeedRepository.parseFeedData` — the static parsing
+/// helper extracted from `getFeed` so the same path can also deserialize
+/// cached payloads (Story 4.9).
+///
+/// The intent is to ensure the extraction did NOT change observable
+/// behavior for the two payload shapes the backend can emit.
+Map<String, dynamic> _validItem(String id) => {
+      'id': id,
+      'title': 'Title $id',
+      'summary': '',
+      'url': 'https://example.test/$id',
+      'source': {
+        'id': 'src-1',
+        'name': 'Example',
+        'logo_url': null,
+        'theme': null,
+      },
+      'published_at': '2026-01-01T00:00:00Z',
+      'content_type': 'article',
+      'topics': <String>[],
+      'entities': <Map<String, dynamic>>[],
+    };
+
+void main() {
+  group('FeedRepository.parseFeedData — Map shape', () {
+    test('parses items + pagination from the envelope', () {
+      final data = <String, dynamic>{
+        'items': [_validItem('a1'), _validItem('a2')],
+        'pagination': {'has_next': true, 'total': 42},
+      };
+
+      final feed = FeedRepository.parseFeedData(data: data, page: 1, limit: 20);
+      expect(feed.items.length, 2);
+      expect(feed.items.first.id, 'a1');
+      expect(feed.pagination.hasNext, true);
+      expect(feed.pagination.total, 42);
+      expect(feed.carousels, isEmpty);
+    });
+
+    test('tolerates a missing pagination block (falls back)', () {
+      final data = <String, dynamic>{
+        'items': [_validItem('a1')],
+      };
+
+      final feed = FeedRepository.parseFeedData(data: data, page: 1, limit: 20);
+      expect(feed.items.length, 1);
+      // parsePagination fallback: hasNext = itemsCount > 0
+      expect(feed.pagination.hasNext, true);
+    });
+
+  });
+
+  group('FeedRepository.parseFeedData — List shape (legacy)', () {
+    test('parses a bare list of items', () {
+      final data = [_validItem('a1'), _validItem('a2')];
+      final feed = FeedRepository.parseFeedData(data: data, page: 1, limit: 20);
+      expect(feed.items.length, 2);
+      // Legacy shape: no pagination block → fallback hasNext = itemsCount > 0
+      expect(feed.pagination.hasNext, true);
+      expect(feed.pagination.total, 0);
+    });
+
+    test('returns empty state for an empty list', () {
+      final feed =
+          FeedRepository.parseFeedData(data: <dynamic>[], page: 1, limit: 20);
+      expect(feed.items, isEmpty);
+      expect(feed.pagination.hasNext, false);
+    });
+  });
+
+  group('FeedRepository.parseFeedData — null / unexpected shapes', () {
+    test('returns an empty response for null data', () {
+      final feed = FeedRepository.parseFeedData(data: null, page: 1, limit: 20);
+      expect(feed.items, isEmpty);
+      expect(feed.carousels, isEmpty);
+      expect(feed.pagination.hasNext, false);
+    });
+  });
+}

--- a/docs/stories/core/4.9.feed-preload-cache.story.md
+++ b/docs/stories/core/4.9.feed-preload-cache.story.md
@@ -1,0 +1,129 @@
+# Story 4.9: Feed — Pré-chargement + Cache Local (SWR)
+
+## Status: In Progress
+
+## Story
+
+**As a** utilisateur quotidien,
+**I want** que mon feed s'affiche quasi-instantanément quand j'ouvre l'onglet Feed,
+**so that** je ne perde plus 4-5 secondes à attendre un chargement à chaque session.
+
+## Contexte
+
+**Mesure actuelle** (logs `[PERF]` dans `feed_provider.dart:119` et `feed_repository.dart:125`) :
+le premier chargement du feed prend **4 à 5 secondes** sur une connexion décente.
+
+**Cause racine backend** (hors scope de cette story) : `RecommendationService.get_feed()`
+agrège profil + sources + topics + digest + entités puis score tous les candidats. Les quotas
+pool Supabase interdisent une parallélisation plus agressive côté backend à court terme.
+
+**Cause racine mobile** (scope de cette story) :
+1. **Aucun cache local persistant** — chaque ouverture du feed fait un aller-retour réseau.
+2. **Aucun pré-chargement** — le feed ne démarre qu'au `push('/feed')`, après splash + digest.
+
+## Acceptance Criteria
+
+1. **Cache persistant Hive** : la page 1 du feed "par défaut" (aucun filtre appliqué) est
+   sauvegardée localement après chaque fetch réussi, et restaurée instantanément au
+   prochain `FeedNotifier.build()`.
+2. **TTL 10 minutes** : si le cache a moins de 10 min, il est affiché immédiatement et un
+   re-fetch silencieux est lancé en arrière-plan (Stale-While-Revalidate).
+3. **Fraîcheur au-delà du TTL** : si le cache est plus vieux que 10 min (ou absent), comportement
+   actuel conservé (fetch bloquant + skeleton).
+4. **Pré-chargement post-auth** : dès que l'auth est `authenticated + emailConfirmed`, un
+   provider watcher déclenche le fetch du feed en background (idempotent, n'écrase pas un
+   fetch déjà en cours).
+5. **Invalidation** :
+   - Logout → cache effacé intégralement.
+   - Changement d'utilisateur → le cache d'un autre user n'est jamais affiché.
+   - Filtre actif (theme/topic/source/entity/keyword) → le cache n'est ni lu ni écrit (on
+     garde le fetch direct, comportement inchangé).
+6. **Résilience** : un cache corrompu (JSON invalide, schema changé) est silencieusement
+   ignoré et supprimé — jamais de crash ni d'état dégradé visible côté user.
+7. **Tests unitaires** : cache read/write/TTL + provider preload trigger.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1 — Hive box + service cache**
+  - [ ] Ouvrir le box `feed_cache` (Box<String>) dans `main.dart` via `_openBoxSafe`.
+  - [ ] Créer `lib/features/feed/services/feed_cache_service.dart` avec `save`, `read`,
+        `clear`, `isFresh`.
+  - [ ] Clé = `feed:{userId}`. Valeur = JSON `{savedAt, data}`.
+
+- [ ] **Task 2 — Parsing réutilisable du feed**
+  - [ ] Extraire la logique de parsing de `FeedRepository.getFeed()` dans une méthode
+        statique `parseFeedData(data, page, limit) -> FeedResponse`.
+  - [ ] `getFeed()` appelle `parseFeedData()` après le réseau.
+
+- [ ] **Task 3 — SWR dans `FeedNotifier.build()`**
+  - [ ] Si aucun filtre actif : lire le cache. Si < 10 min, retourner `FeedState` cache +
+        déclencher un refresh silencieux (fire-and-forget).
+  - [ ] Après chaque fetch réussi page 1 sans filtre, écrire le cache.
+  - [ ] Ignorer + purger le cache si désérialisation échoue.
+
+- [ ] **Task 4 — Provider preload**
+  - [ ] Créer `lib/features/feed/providers/feed_preload_provider.dart`.
+  - [ ] Watche `authStateProvider`. Si `isAuthenticated && isEmailConfirmed && !needsOnboarding`,
+        déclenche `ref.read(feedProvider.future)` (idempotent).
+  - [ ] Watch dans `FacteurApp.build()` pour activation globale.
+
+- [ ] **Task 5 — Invalidation logout**
+  - [ ] Dans `FeedCacheService`, exposer `clear()`.
+  - [ ] Le `FeedNotifier.build()` efface le cache si `!isAuthenticated`.
+
+- [ ] **Task 6 — Tests**
+  - [ ] Unit : `FeedCacheService` save/read/TTL/corruption.
+  - [ ] Unit : extraction parsing inchangée (regression).
+  - [ ] Unit : preload provider déclenche `feedProvider.future` quand auth passe.
+
+## Dev Notes
+
+### Pourquoi Hive (et pas SharedPreferences)
+
+Le projet utilise déjà Hive (`auth_prefs`, `supabase_auth_persistence`, `settings`). On
+reste homogène : `Box<String>` dédié `feed_cache`, pattern identique à `_openBoxSafe` de
+`main.dart:178`.
+
+### Pourquoi cacher la payload brute (JSON string)
+
+Les modèles (`Content`, `Source`, `FeedCluster`, `TopicOverflow`, etc.) n'ont PAS de
+`toJson()`. Plutôt qu'écrire une sérialisation manuelle (surface énorme + risque de dérive),
+on persiste le `response.data` brut (déjà JSON-décodé Map/List) via `jsonEncode`, et on
+ré-emprunte le chemin `parseFeedData()` existant à la lecture. Bénéfices : zéro duplication,
+zéro dérive de schéma, cache auto-valide à chaque évolution de parseur.
+
+### TTL 10 min — pourquoi ce choix
+
+Facteur est un "moment de fermeture" consulté 1-2× par jour. Une fraîcheur sous 10 min est
+largement supérieure au besoin UX, tout en garantissant que même si l'utilisateur ouvre
+plusieurs fois d'affilée, il ne reverra pas un flux figé. Le refresh silencieux assure que
+le prochain frame soit à jour sans attente perçue.
+
+### Filtres — pourquoi ne pas cacher
+
+Les filtres (theme/topic/source/entity/keyword) sont rares, contextuels, et souvent
+volontaires (user cherche activement à explorer). Les cacher complexifierait la clé et
+apporterait peu : le fetch direct reste acceptable car les filtres réduisent le volume
+côté backend.
+
+### Non-Goals
+
+- Pas de cache pour les pages 2+ (infinite scroll reste online).
+- Pas de pré-chargement des variantes filtrées.
+- Pas de réécriture du backend (quotas pool bloqués).
+- Pas de fix du bug 403 auth recovery — traité en PR séparée (branche
+  `claude/fix-feed-403-error-StykB`).
+
+## Testing
+
+Commandes :
+```bash
+cd apps/mobile && flutter test test/features/feed/
+cd apps/mobile && flutter analyze
+```
+
+## Change Log
+
+| Date       | Auteur              | Description                                    |
+|------------|---------------------|------------------------------------------------|
+| 2026-04-16 | Claude Opus 4.7     | Création de la story + plan technique détaillé |


### PR DESCRIPTION
## Problème

Le feed met **4-5 secondes** à charger à chaque ouverture. Causes mobiles identifiées :
- Zéro cache local : chaque session = aller-retour réseau complet
- Zéro pré-chargement : le fetch ne démarre qu'au tap sur l'onglet Feed

(Les quotas pool Supabase bloquent les optimisations backend à court terme — ce PR adresse uniquement le mobile.)

## Solution

### 1. Cache local Hive avec Stale-While-Revalidate

- Nouveau box Hive `feed_cache` (Box<String>) ouvert au démarrage dans `main.dart`
- `FeedCacheService` : persist/read/clear, clé `feed:{userId}`, TTL 10 min
- Dans `FeedNotifier.build()` : si cache < 10 min → paint instantané + refresh silencieux via `scheduleMicrotask`
- Le payload brut (Map/List Dio) est persisté — pas les modèles — pour réutiliser `parseFeedData` sans sérialisation custom

### 2. Pré-chargement post-auth

- `feedPreloadProvider` : watch `authStateProvider`, déclenche `feedProvider.future` dès `authenticated + confirmed + !onboarding`
- Watchable depuis `FacteurApp.build()` → actif pour toute la session

### 3. Invalidation

- **Logout** : `signOut()` efface le box `feed_cache` (privacy — aucun flash cross-user)
- **Filtres actifs** : `_fetchPage` bypass le cache si theme/topic/source/entity/keyword actif
- **Corruption** : entrée malformée évincée silencieusement, jamais de crash

### 4. Refactor `FeedRepository`

- Logique de parsing extraite dans `parseFeedData(data, page, limit)` — méthode static réutilisable par le cache et les tests
- `getFeedWithRaw()` retourne `({FeedResponse feed, dynamic raw})` pour la couche cache; `getFeed()` délègue, contrat externe inchangé

## Résultat attendu

| Scénario | Avant | Après |
|----------|-------|-------|
| Ouverture Feed (session fraîche, < 10 min) | 4-5s spinner | ~instant (cache hit) |
| Ouverture Feed (nouvelle session ou > 10 min) | 4-5s | 4-5s (inchangé, mais preload réduit l'attente perçue) |
| Login → tap Feed (preload) | 4-5s | quasi-instant si auth < 5s |
| Changement de filtre | inchangé | inchangé (bypass cache) |

## Tests

- `test/features/feed/feed_cache_service_test.dart` — 9 cas (round-trip, TTL, user-scope, corruption, invalidation)
- `test/features/feed/feed_repository_parse_test.dart` — 5 cas (régression extraction parsing)
- Tous les tests existants inchangés (contrat `getFeed()` préservé)

## Non-goals

- Pas de cache pour les pages 2+ (infinite scroll reste online)
- Pas de cache pour les vues filtrées
- Pas de changement backend
- Bug 403 auth-recovery → PR séparée sur `claude/fix-feed-403-error-StykB`

## Story

`docs/stories/core/4.9.feed-preload-cache.story.md`

## Validation device (post-merge)

La feature n'est pas testable via Playwright (Hive = natif uniquement). Protocole de test sur device :
1. Cold open → Feed → vérifier log `[PERF] feedProvider.build(): cache hit`
2. Login → attendre 3s → tap Feed → quasi-instant (preload)
3. Logout → login autre compte → vérifier aucun flash du feed précédent