### PR TITLE
fix(auth): unfreeze feed on resume — drop ApiClient fallthrough + recoverable refresh

### DIFF
--- a/apps/mobile/lib/core/api/api_client.dart
+++ b/apps/mobile/lib/core/api/api_client.dart
@@ -106,7 +106,13 @@ class ApiClient {
             // Un 403 `email_not_confirmed` peut provenir d'un JWT stale (le
             // user vient de confirmer mais son access token n'a pas encore été
             // roté). On tente un refresh + retry AVANT de verrouiller l'app sur
-            // l'écran de confirmation. Cf. docs/bugs/bug-auth-session-persistence.md
+            // l'écran de confirmation. Cf. docs/bugs/bug-feed-403-auth-recovery.md
+            //
+            // RÈGLE : on ne déclenche `onAuthError(403)` (→ setForceUnconfirmed)
+            // QUE si on a une preuve forte : un 2ème 403 obtenu après retry avec
+            // un JWT frais. Toute autre issue (refresh timeout, session null,
+            // erreur réseau au retry) laisse le 403 bubble up sans verrouiller
+            // l'app — évite le lock irrémédiable sur réseau/DB lent.
             final detail = _extractErrorDetail(error.response?.data);
             final isEmailNotConfirmed = detail == _emailNotConfirmedDetail;
 
@@ -127,7 +133,8 @@ class ApiClient {
                     onAuthRecovered?.call();
                     return handler.resolve(response);
                   } on DioException catch (retryErr) {
-                    // Toujours 403 après refresh → l'email est réellement non confirmé
+                    // Toujours 403 après refresh → l'email est réellement non
+                    // confirmé : seule voie qui déclenche `onAuthError(403)`.
                     if (retryErr.response?.statusCode == 403 &&
                         onAuthError != null) {
                       // ignore: avoid_print
@@ -138,21 +145,22 @@ class ApiClient {
                     _logError(retryErr);
                     return handler.next(retryErr);
                   }
+                } else {
+                  // ignore: avoid_print
+                  print(
+                      '⚠️ ApiClient: 403 — refresh returned null session. Letting original 403 bubble (no lockdown).');
                 }
-              } catch (_) {
-                // Refresh a échoué — fallthrough vers onAuthError
+              } catch (e) {
+                // Refresh timeout ou AuthException — on ne verrouille PAS l'app
+                // sur un échec transitoire. Le 403 original bubble au caller
+                // (FeedNotifier le rendra comme une erreur récupérable).
+                // ignore: avoid_print
+                print(
+                    '⚠️ ApiClient: 403 refresh failed (${e.runtimeType}), not triggering onAuthError — bubbling original 403.');
               }
             }
-
-            // 403 non-email-related OU refresh impossible → comportement legacy
-            if (onAuthError != null && isEmailNotConfirmed) {
-              // ignore: avoid_print
-              print(
-                  '⛔️ ApiClient: 403 email_not_confirmed unrecoverable. Triggering onAuthError(403).');
-              onAuthError!(403);
-            }
-            // Les 403 non-email (ex. rate limit, RLS) ne déclenchent PAS
-            // setForceUnconfirmed : ils bubble tels quels au caller.
+            // Aucun fallthrough vers onAuthError(403) ici : les 403 transients
+            // et non-email (rate limit, RLS) passent tels quels au caller.
           }
 
           // Logger les erreurs (sans les tokens)

--- a/apps/mobile/lib/core/auth/auth_state.dart
+++ b/apps/mobile/lib/core/auth/auth_state.dart
@@ -23,6 +23,14 @@ class AuthState {
   /// Le refresh token a expiré — l'utilisateur doit se reconnecter
   final bool sessionExpired;
 
+  /// Timestamp du dernier event `tokenRefreshed` reçu depuis Supabase.
+  ///
+  /// Utilisé comme signal d'invalidation pour les data providers (ex.
+  /// `feedProvider`) : à chaque rotation de JWT, ce champ change et tous les
+  /// listeners de `authStateProvider` rebuildent avec un access token frais.
+  /// Cf. docs/bugs/bug-feed-403-auth-recovery.md.
+  final DateTime? lastTokenRefreshAt;
+
   const AuthState({
     this.user,
     this.isLoading = false,
@@ -31,6 +39,7 @@ class AuthState {
     this.pendingEmailConfirmation,
     this.forceUnconfirmed = false,
     this.sessionExpired = false,
+    this.lastTokenRefreshAt,
   });
 
   bool get isAuthenticated => user != null;
@@ -69,6 +78,7 @@ class AuthState {
     bool clearPendingEmail = false,
     bool? forceUnconfirmed,
     bool? sessionExpired,
+    DateTime? lastTokenRefreshAt,
   }) {
     return AuthState(
       user: user ?? this.user,
@@ -80,6 +90,7 @@ class AuthState {
           : (pendingEmailConfirmation ?? this.pendingEmailConfirmation),
       forceUnconfirmed: forceUnconfirmed ?? this.forceUnconfirmed,
       sessionExpired: sessionExpired ?? this.sessionExpired,
+      lastTokenRefreshAt: lastTokenRefreshAt ?? this.lastTokenRefreshAt,
     );
   }
 }
@@ -223,6 +234,13 @@ class AuthStateNotifier extends StateNotifier<AuthState>
         'AuthStateNotifier: Auth event: ${data.event}, User: ${user?.email ?? "None"}',
       );
 
+      // Event tokenRefreshed : on ne short-circuite JAMAIS, on propage un
+      // nouveau `lastTokenRefreshAt` dans le state pour signaler aux data
+      // providers (feedProvider, etc.) qu'ils peuvent re-fetcher avec un
+      // access token frais. Cf. docs/bugs/bug-feed-403-auth-recovery.md.
+      final bool isTokenRefresh =
+          data.event == AuthChangeEvent.tokenRefreshed;
+
       // Éviter les mises à jour inutiles si l'user n'a pas changé.
       // IMPORTANT: si `forceUnconfirmed` est true, on NE court-circuite PAS —
       // tout event Supabase (notamment TOKEN_REFRESHED avec un JWT à jour)
@@ -231,7 +249,7 @@ class AuthStateNotifier extends StateNotifier<AuthState>
       final bool sameUser = state.user?.id == user?.id &&
           !state.isLoading &&
           state.user != null;
-      if (sameUser && !state.forceUnconfirmed) {
+      if (sameUser && !state.forceUnconfirmed && !isTokenRefresh) {
         final bool emailStatusChanged =
             state.user?.emailConfirmedAt != user?.emailConfirmedAt;
         if (!emailStatusChanged) {
@@ -253,6 +271,7 @@ class AuthStateNotifier extends StateNotifier<AuthState>
         user: user,
         isLoading: false,
         forceUnconfirmed: isNowConfirmed ? false : state.forceUnconfirmed,
+        lastTokenRefreshAt: isTokenRefresh ? DateTime.now() : null,
       );
 
       if (user != null) {

--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -262,8 +262,31 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         carousels: response.carousels,
       ));
     } catch (e, stack) {
-      state = AsyncError(e, stack);
-      rethrow;
+      // Recovery policy : ne JAMAIS figer le provider en AsyncError si on a
+      // déjà des items à l'écran. Un AsyncError wipe `state.value` → tous les
+      // handlers guardés sur `if (currentState == null) return;` deviennent
+      // no-op (muteSource, toggleSave, etc.), ET un 2ème pull-to-refresh reste
+      // coincé sur le même cycle d'échec car le provider semble « gelé ».
+      //
+      // On ré-émet donc l'état précédent pour débloquer les retries UI.
+      // L'exception est re-throw via le catch du caller (FeedScreen._refresh
+      // ne catch pas — le RefreshIndicator absorbe le throw et se ferme),
+      // et les handlers optimistes peuvent re-tenter leur opération.
+      //
+      // Cf. docs/bugs/bug-feed-403-auth-recovery.md
+      final previous = state.valueOrNull;
+      if (previous != null) {
+        // ignore: avoid_print
+        print(
+            'FeedNotifier: refresh failed, keeping previous feed state: $e');
+        state = AsyncData(previous);
+      } else {
+        // Premier chargement jamais abouti : AsyncError est la bonne
+        // sémantique (le screen affichera un état d'erreur avec retry).
+        // ignore: avoid_print
+        print('FeedNotifier: refresh failed with no previous state: $e');
+        state = AsyncError(e, stack);
+      }
     }
   }
 

--- a/apps/mobile/test/features/auth/auth_state_test.dart
+++ b/apps/mobile/test/features/auth/auth_state_test.dart
@@ -175,5 +175,49 @@ void main() {
       expect(state.isEmailConfirmed, isTrue,
           reason: 'Apple Sign-In doit être considéré comme confirmé d\'office');
     });
+
+    // --- Tests pour lastTokenRefreshAt (signal d'invalidation feedProvider) ---
+    //
+    // Bug : au resume après JWT expiré, refreshUser() rafraîchissait le token
+    // Supabase MAIS ne signalait pas aux data providers qu'ils pouvaient
+    // re-fetcher. Conséquence : feedProvider continuait de servir du state
+    // stale, et la première requête partait avec l'ancien JWT → 403.
+    //
+    // Fix : `lastTokenRefreshAt` est bumpé à chaque event `tokenRefreshed`
+    // reçu du listener Supabase. Les providers qui `ref.watch(authStateProvider)`
+    // voient une nouvelle identité d'AuthState et rebuildent.
+    //
+    // Cf. docs/bugs/bug-feed-403-auth-recovery.md.
+    test('lastTokenRefreshAt default is null', () {
+      const state = AuthState();
+      expect(state.lastTokenRefreshAt, isNull);
+    });
+
+    test('copyWith(lastTokenRefreshAt: now) sets the field', () {
+      const state = AuthState();
+      final ts = DateTime.now();
+      final updated = state.copyWith(lastTokenRefreshAt: ts);
+      expect(updated.lastTokenRefreshAt, ts);
+    });
+
+    test('copyWith without lastTokenRefreshAt preserves the previous value', () {
+      final ts = DateTime.utc(2026, 1, 1);
+      final state = AuthState(lastTokenRefreshAt: ts);
+      final updated = state.copyWith(isLoading: true);
+      expect(updated.lastTokenRefreshAt, ts,
+          reason: 'copyWith must not wipe lastTokenRefreshAt when not passed');
+    });
+
+    test(
+        'two copyWith with different lastTokenRefreshAt produce distinct AuthState instances '
+        '(Riverpod listeners rebuild)', () {
+      final t1 = DateTime.utc(2026, 1, 1, 10, 0, 0);
+      final t2 = DateTime.utc(2026, 1, 1, 10, 45, 0);
+      final s1 = AuthState(lastTokenRefreshAt: t1);
+      final s2 = s1.copyWith(lastTokenRefreshAt: t2);
+      expect(identical(s1, s2), isFalse);
+      expect(s1.lastTokenRefreshAt, t1);
+      expect(s2.lastTokenRefreshAt, t2);
+    });
   });
 }

--- a/apps/mobile/test/features/feed/feed_refresh_recovery_test.dart
+++ b/apps/mobile/test/features/feed/feed_refresh_recovery_test.dart
@@ -1,0 +1,241 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:facteur/features/feed/providers/feed_provider.dart';
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart';
+import 'package:facteur/features/feed/repositories/personalization_repository.dart';
+import 'package:facteur/core/auth/auth_state.dart' as app_auth;
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+/// Regression tests for the auth-recovery fix on FeedNotifier.refresh().
+///
+/// Bug : quand un pull-to-refresh échoue (DioException 403 « stale JWT »,
+/// timeout réseau, 500), le notifier passait en `AsyncError` → `state.value`
+/// devenait `null` → tous les handlers guardés sur `if (currentState == null)
+/// return;` se transformaient en no-op, ET le pull-to-refresh suivant restait
+/// coincé sur le même cycle. Conséquence : « refresh mort » jusqu'au kill+relogin.
+///
+/// Fix : `refresh()` conserve l'état précédent (AsyncData avec les items déjà
+/// chargés) si présent, et ne rethrow plus — le RefreshIndicator termine
+/// proprement, les retries sont possibles.
+///
+/// Cf. docs/bugs/bug-feed-403-auth-recovery.md.
+class MockFeedRepository extends Mock implements FeedRepository {}
+
+class MockPersonalizationRepository extends Mock
+    implements PersonalizationRepository {}
+
+class MockAuthStateNotifier extends StateNotifier<app_auth.AuthState>
+    implements app_auth.AuthStateNotifier {
+  MockAuthStateNotifier()
+      : super(const app_auth.AuthState(
+            user: supabase.User(
+                id: 'u1',
+                appMetadata: {},
+                userMetadata: {},
+                aud: 'authenticated',
+                createdAt: '2023-01-01')));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late MockFeedRepository mockFeedRepo;
+  late MockPersonalizationRepository mockPersoRepo;
+  late MockAuthStateNotifier mockAuthNotifier;
+  late ProviderContainer container;
+
+  final mockSource = Source(
+    id: 's1',
+    name: 'Source 1',
+    url: 'url',
+    type: SourceType.article,
+    theme: 'TECH',
+  );
+
+  Content makeContent(String id) => Content(
+        id: id,
+        title: 'Title $id',
+        url: 'url',
+        contentType: ContentType.article,
+        publishedAt: DateTime.now(),
+        source: mockSource,
+      );
+
+  setUp(() {
+    mockFeedRepo = MockFeedRepository();
+    mockPersoRepo = MockPersonalizationRepository();
+    mockAuthNotifier = MockAuthStateNotifier();
+
+    container = ProviderContainer(
+      overrides: [
+        feedRepositoryProvider.overrideWithValue(mockFeedRepo),
+        personalizationRepositoryProvider.overrideWithValue(mockPersoRepo),
+        app_auth.authStateProvider.overrideWith((ref) => mockAuthNotifier),
+      ],
+    );
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  DioException _dioException({required int statusCode, String? detail}) {
+    final req = RequestOptions(path: '/feed/');
+    return DioException(
+      requestOptions: req,
+      response: Response<dynamic>(
+        requestOptions: req,
+        statusCode: statusCode,
+        data: detail != null ? {'detail': detail} : null,
+      ),
+      type: DioExceptionType.badResponse,
+    );
+  }
+
+  group('FeedNotifier.refresh() — recovery from transient failures', () {
+    test(
+      'DioException 403 after a successful initial load → keeps previous items, no AsyncError freeze',
+      () async {
+        final initialItems = [makeContent('a'), makeContent('b')];
+
+        // First call (build): return 2 items.
+        when(() => mockFeedRepo.getFeed(
+              page: any(named: 'page'),
+              limit: any(named: 'limit'),
+              mode: any(named: 'mode'),
+              theme: any(named: 'theme'),
+              topic: any(named: 'topic'),
+              sourceId: any(named: 'sourceId'),
+              entity: any(named: 'entity'),
+              keyword: any(named: 'keyword'),
+              serein: any(named: 'serein'),
+            )).thenAnswer(
+          (_) async => FeedResponse(
+            items: initialItems,
+            pagination:
+                Pagination(page: 1, perPage: 20, total: 2, hasNext: false),
+          ),
+        );
+
+        final notifier = container.read(feedProvider.notifier);
+        await container.read(feedProvider.future);
+        expect(container.read(feedProvider).value!.items.length, 2);
+
+        // Simulate the 2nd call (refresh) failing with 403 "Email not confirmed".
+        when(() => mockFeedRepo.getFeed(
+              page: any(named: 'page'),
+              limit: any(named: 'limit'),
+              mode: any(named: 'mode'),
+              theme: any(named: 'theme'),
+              topic: any(named: 'topic'),
+              sourceId: any(named: 'sourceId'),
+              entity: any(named: 'entity'),
+              keyword: any(named: 'keyword'),
+              serein: any(named: 'serein'),
+            )).thenThrow(_dioException(
+          statusCode: 403,
+          detail: 'Email not confirmed',
+        ));
+
+        // Act : refresh fails. Must NOT rethrow and must NOT wipe items.
+        await notifier.refresh();
+
+        final asyncState = container.read(feedProvider);
+        expect(asyncState.hasError, isFalse,
+            reason: 'state must not be AsyncError when we have previous items');
+        expect(asyncState.value, isNotNull);
+        expect(asyncState.value!.items.length, 2,
+            reason: 'previous items must be preserved on refresh failure');
+        expect(asyncState.value!.items.map((c) => c.id), ['a', 'b']);
+      },
+    );
+
+    test(
+      'subsequent refresh after a failure can succeed (no frozen provider)',
+      () async {
+        final initialItems = [makeContent('a')];
+        final refreshedItems = [makeContent('x'), makeContent('y')];
+        var callCount = 0;
+
+        when(() => mockFeedRepo.getFeed(
+              page: any(named: 'page'),
+              limit: any(named: 'limit'),
+              mode: any(named: 'mode'),
+              theme: any(named: 'theme'),
+              topic: any(named: 'topic'),
+              sourceId: any(named: 'sourceId'),
+              entity: any(named: 'entity'),
+              keyword: any(named: 'keyword'),
+              serein: any(named: 'serein'),
+            )).thenAnswer((_) async {
+          callCount++;
+          if (callCount == 1) {
+            // initial build
+            return FeedResponse(
+              items: initialItems,
+              pagination:
+                  Pagination(page: 1, perPage: 20, total: 1, hasNext: false),
+            );
+          } else if (callCount == 2) {
+            // first refresh → 500
+            throw _dioException(statusCode: 500);
+          } else {
+            // second refresh → success
+            return FeedResponse(
+              items: refreshedItems,
+              pagination:
+                  Pagination(page: 1, perPage: 20, total: 2, hasNext: false),
+            );
+          }
+        });
+
+        final notifier = container.read(feedProvider.notifier);
+        await container.read(feedProvider.future);
+        expect(container.read(feedProvider).value!.items.length, 1);
+
+        await notifier.refresh(); // fails, items preserved
+        expect(container.read(feedProvider).value!.items.length, 1,
+            reason: 'items preserved after first failed refresh');
+
+        await notifier.refresh(); // succeeds
+        expect(container.read(feedProvider).value!.items.length, 2);
+        expect(container.read(feedProvider).value!.items.map((c) => c.id),
+            ['x', 'y']);
+      },
+    );
+
+    test(
+      'initial load failure (no previous items) → AsyncError is expected',
+      () async {
+        when(() => mockFeedRepo.getFeed(
+              page: any(named: 'page'),
+              limit: any(named: 'limit'),
+              mode: any(named: 'mode'),
+              theme: any(named: 'theme'),
+              topic: any(named: 'topic'),
+              sourceId: any(named: 'sourceId'),
+              entity: any(named: 'entity'),
+              keyword: any(named: 'keyword'),
+              serein: any(named: 'serein'),
+            )).thenThrow(_dioException(statusCode: 500));
+
+        // Trigger build; it should surface as AsyncError since there's no
+        // prior state to fall back to.
+        final async = await container
+            .read(feedProvider.future)
+            .then<Object?>((s) => s)
+            .catchError((Object e) => e);
+
+        expect(async, isA<DioException>());
+        // And the notifier state is AsyncError (correct behaviour for a cold
+        // first load with no items to preserve).
+        expect(container.read(feedProvider).hasError, isTrue);
+      },
+    );
+  });
+}

--- a/docs/bugs/bug-feed-403-auth-recovery.md
+++ b/docs/bugs/bug-feed-403-auth-recovery.md
@@ -1,0 +1,217 @@
+# Bug — Feed 403 "Email not confirmed" au resume + pull-to-refresh gelé
+
+**Statut** : PLAN — en attente GO utilisateur
+**Branche** : `claude/fix-auth-resume-bug-IJWB3`
+**PR cible** : `main` (jamais staging)
+
+## Fichiers critiques
+
+- `apps/mobile/lib/features/feed/providers/feed_provider.dart`
+- `apps/mobile/lib/core/auth/auth_state.dart`
+- `apps/mobile/lib/core/api/api_client.dart`
+- `apps/mobile/lib/features/feed/screens/feed_screen.dart`
+- `packages/api/app/dependencies.py`
+
+## Symptôme utilisateur
+
+1. L'utilisateur est connecté, email confirmé, feed fonctionne.
+2. Il quitte l'app (background) plusieurs heures → JWT Supabase expire (~1h).
+3. Il revient (resume) → le feed affiche **403 "Email not confirmed"**.
+4. Le **pull-to-refresh devient inerte**.
+5. Seule issue : kill l'app + re-login complet.
+
+## Diagnostic — 3 failures qui s'enchaînent
+
+### Maillon 1 : Race JWT stale au resume (auth_state.dart:316-329)
+
+Au `AppLifecycleState.resumed`, `refreshUser()` est appelé en **fire-and-forget**
+(pas d'`await`). En parallèle, le widget tree se reconstruit et le FeedScreen
+peut déclencher un pull-to-refresh immédiat. `ApiClient._dio` lit alors
+`_supabase.auth.currentSession.accessToken` **AVANT** que `refreshSession()`
+n'ait propagé le nouveau token → envoi avec JWT stale.
+
+**Aucune invalidation explicite de `feedProvider`** après le refresh.
+
+### Maillon 2 : ApiClient déclenche `setForceUnconfirmed` sur timeout de refresh (api_client.dart:105-156)
+
+Sur un 403 `Email not confirmed`, le flow :
+
+```dart
+try {
+  final refreshed = await _supabase.auth.refreshSession().timeout(5s);
+  if (refreshed.session != null) { /* retry request */ }
+} catch (_) { /* timeout ou AuthException */ }
+
+// FALLTHROUGH — fires même si refresh a timeout
+if (onAuthError != null && isEmailNotConfirmed) {
+  onAuthError!(403);   // 🔴 BUG : setForceUnconfirmed sur timeout transitoire
+}
+```
+
+Sur réseau lent OU DB Supabase en slow-response, le refresh timeout à 5 s →
+le code tombe dans le fallthrough et **déclenche `setForceUnconfirmed` sans
+avoir de 2nd 403 confirmé par le backend**. L'user part sur l'écran email
+confirmation alors que son email est valide.
+
+### Maillon 3 : FeedNotifier.refresh fige le provider (feed_provider.dart:249-268)
+
+```dart
+Future<void> refresh() async {
+  _page = 1; _hasNext = true; _isLoadingMore = false;
+  try {
+    final response = await _fetchPage(page: 1);
+    state = AsyncData(FeedState(...));
+  } catch (e, stack) {
+    state = AsyncError(e, stack);   // 🔴 Efface les items existants
+    rethrow;                          // 🔴 Propagé à RefreshIndicator
+  }
+}
+```
+
+Après `AsyncError`, `state.value` devient `null`. Tous les handlers du
+FeedScreen qui guardent sur `if (currentState == null) return;` court-circuitent
+→ muteSource, toggleSave, refresh inline, etc. deviennent no-op. Le
+RefreshIndicator reste visible (ScrollView présent), mais un nouveau pull
+réexécute `refresh()` → même échec → AsyncError persistant.
+
+### Maillon 4 (aggravant) : 403 vs 401 asymétrique côté backend (dependencies.py:231-255)
+
+Le backend distingue mal "JWT stale" de "user réellement non-confirmé" :
+- JWT sans `email_verified` + DB confirmé → OK (return user_id)
+- JWT sans `email_verified` + DB non-confirmé → 403 "Email not confirmed"
+- JWT sans `email_verified` + DB unreachable → fail-open return user_id
+
+Le 403 n'indique pas si c'est "vraiment non-confirmé" ou "JWT en cours de
+rotation". Le mobile traite les 2 cas pareil (lock sur confirmation screen).
+
+## Plan de fix
+
+### P0 — Mobile — ApiClient ne déclenche plus `setForceUnconfirmed` sur timeout (api_client.dart)
+
+**Objectif** : ne fire `onAuthError(403)` **que** si on a une preuve forte que
+le user est non-confirmé (2nd 403 après retry avec JWT frais), jamais sur timeout.
+
+- Supprimer le fallthrough final qui appelle `onAuthError!(403)` aveuglément.
+- Conserver l'appel `onAuthError!(403)` uniquement dans la branche `retryErr.statusCode == 403`.
+- Si le `refreshSession()` échoue/timeout : laisser le 403 original bubble up
+  au caller (le FeedNotifier le captera comme erreur normale).
+- Logger clairement chaque chemin (Sentry `addBreadcrumb` + `captureMessage`).
+
+### P1 — Mobile — FeedNotifier.refresh recoverable (feed_provider.dart)
+
+**Objectif** : un pull-to-refresh qui échoue ne doit **plus** effacer le feed
+existant ni geler le provider.
+
+Changement :
+```dart
+Future<void> refresh() async {
+  _page = 1; _hasNext = true; _isLoadingMore = false;
+  try {
+    final response = await _fetchPage(page: 1);
+    state = AsyncData(FeedState(items: response.items, carousels: response.carousels));
+  } catch (e, stack) {
+    // Conserver le state précédent (AsyncData) si présent — sinon seulement
+    // marquer AsyncError. Ne plus rethrow : le RefreshIndicator est terminé,
+    // les erreurs sont reportées via un SnackBar par le FeedScreen.
+    final previous = state.valueOrNull;
+    if (previous != null) {
+      // Re-émettre AsyncData identique pour débloquer le refresh sans wipe.
+      state = AsyncData(previous);
+    } else {
+      state = AsyncError(e, stack);
+    }
+    // Log + bubble vers le caller via un flag de dernier-erreur si utile.
+    print('FeedNotifier: refresh failed: $e');
+  }
+}
+```
+
+Puis côté `FeedScreen._refresh()` : capturer l'erreur propagée (si toujours
+`rethrow`ée par `refreshArticlesWithSnapshot`) et afficher un SnackBar plutôt
+que de laisser le widget bloqué.
+
+**Note** : `refreshArticlesWithSnapshot` appelle déjà `refresh()` en interne
+sans catch — le changement au-dessus suffira.
+
+### P2 — Mobile — Invalidation feedProvider au resume (auth_state.dart + main app)
+
+**Objectif** : quand le JWT est rafraîchi, re-fetcher le feed **proprement**
+au lieu de se retrouver avec des items stale et un access token obsolète.
+
+Solution : exposer un `sessionRefreshTickProvider` (int counter) qui est
+incrémenté par `AuthStateNotifier.refreshUser()` **après succès**. Le
+`feedProvider` et autres data providers (ou le FeedScreen via `ref.listen`)
+peuvent écouter et invalider.
+
+Implémentation minimale (choix retenu) :
+- Dans `FeedNotifier.build()`, ajouter `ref.watch(sessionRefreshTickProvider);`
+  pour forcer un rebuild à chaque refresh d'auth.
+- `AuthStateNotifier.refreshUser()` bumpe le tick via un callback injecté au
+  moment de la construction du notifier **OU** via un StreamController statique
+  consommé par un Provider.
+
+Pattern simple : utiliser `_supabase.auth.onAuthStateChange` event `tokenRefreshed`
+via un `StreamProvider` dédié, et `ref.watch` côté feedProvider. Plus découplé
+que l'injection.
+
+Choix d'implémentation : **utiliser un `StreamProvider<AuthChangeEvent?>` qui
+expose les events `tokenRefreshed` de Supabase**. feedProvider le watch → tout
+refresh de token invalide le feed. Pas de nouvelle API custom.
+
+### P3 — Backend — Sentry tagging + log enrichi (dependencies.py)
+
+**Objectif** : tracer la fréquence du scénario 403 pour mesurer l'impact du fix.
+
+Changements :
+- Sur `logger.warning("auth_user_blocked_unconfirmed", user_id=user_id)` : ajouter
+  `sentry_sdk.capture_message("auth_user_blocked_unconfirmed", level="warning")`
+  avec tags `{"jwt_alg": alg, "provider": provider}`.
+- Sur `logger.warning("auth_db_unreachable_fail_open", ...)` : idem, avec
+  `level="info"` pour tracker le fallback.
+
+**PAS de conversion 403 → 401** ici : le 403 reste sémantiquement correct. La
+vraie fix est côté mobile (P0) qui ne doit pas interpréter un 403 transient
+comme définitif. Refaire le backend ajoutrait de la complexité pour un
+bénéfice marginal.
+
+### P4 — Tests
+
+**Unit — `feed_refresh_recovery_test.dart` (nouveau)**
+- `FeedNotifier.refresh()` face à une DioException 403 : state reste AsyncData
+  avec les items précédents, pas d'AsyncError.
+- `FeedNotifier.refresh()` sur premier appel (pas d'items précédents) : AsyncError OK.
+- Le retry suivant après 403 transient réussit (mock repository).
+
+**Unit — `auth_state_test.dart` (existant, ajouter cases)**
+- `didChangeAppLifecycleState(resumed)` → `refreshUser()` succès → le
+  stream `tokenRefreshed` est émis (ou le counter est bumpé).
+
+**Unit — `api_client_403_test.dart` (nouveau)**
+- 403 `Email not confirmed` + refresh timeout → `onAuthError` **PAS appelé**.
+- 403 + refresh OK + retry 403 → `onAuthError(403)` appelé.
+- 403 + refresh OK + retry 200 → `onAuthRecovered` appelé.
+
+**E2E / Manual** (post-implementation)
+- Scénario résumé dans `.context/qa-handoff.md` si on décide de lancer
+  `/validate-feature` — non bloquant pour ce bug (pas de changement UI
+  visible au-delà d'un SnackBar d'erreur).
+
+## Critères d'acceptation
+
+- [ ] Un user avec email confirmé qui revient de background après 1 h n'est
+      **jamais** redirigé vers l'EmailConfirmationScreen.
+- [ ] Un pull-to-refresh qui échoue (500, timeout, 403 transient) **conserve**
+      les items du feed précédent + affiche un SnackBar d'erreur.
+- [ ] Un 2e pull-to-refresh consécutif (après échec du 1er) a une chance de
+      succéder — pas de state AsyncError gelé.
+- [ ] Tous les tests unitaires existants passent.
+- [ ] 3 nouveaux tests unitaires (feed refresh recovery + api client 403) passent.
+- [ ] Sentry reçoit un event `auth_user_blocked_unconfirmed` pour chaque vrai
+      403 backend (pour mesurer la baseline pré-fix).
+
+## Hors-scope
+
+- Refonte du flow `setForceUnconfirmed` / EmailConfirmationScreen.
+- Nouveau endpoint `/auth/me/email-status` (mentionné dans
+  `bug-auth-session-persistence.md`, traité séparément).
+- Conversion backend 403 → 401 (choix explicite : fix côté mobile suffit).

--- a/packages/api/app/dependencies.py
+++ b/packages/api/app/dependencies.py
@@ -246,9 +246,36 @@ async def get_current_user_id(
                     # DB unreachable — fail-open: user has a valid JWT, allow access
                     # rather than blocking confirmed users due to infrastructure issues
                     logger.warning("auth_db_unreachable_fail_open", user_id=user_id)
+                    # Sentry breadcrumb for baseline tracking of fail-open usage
+                    # (cf. docs/bugs/bug-feed-403-auth-recovery.md)
+                    sentry_sdk.add_breadcrumb(
+                        category="auth",
+                        message="auth_db_unreachable_fail_open",
+                        level="info",
+                        data={"user_id": user_id, "jwt_alg": alg},
+                    )
                     return user_id
                 else:
                     logger.warning("auth_user_blocked_unconfirmed", user_id=user_id)
+                    # Sentry event : permet de mesurer la fréquence des 403
+                    # `Email not confirmed` réellement déclenchés (vs. faux
+                    # positifs récupérés côté mobile par refresh+retry).
+                    # Cf. docs/bugs/bug-feed-403-auth-recovery.md.
+                    with sentry_sdk.push_scope() as scope:
+                        scope.set_tag("auth.reason", "email_not_confirmed")
+                        scope.set_tag("auth.jwt_alg", alg)
+                        scope.set_tag("auth.provider", provider)
+                        scope.set_context(
+                            "auth",
+                            {
+                                "user_id": user_id,
+                                "jwt_email_verified": email_verified,
+                                "db_check": False,
+                            },
+                        )
+                        sentry_sdk.capture_message(
+                            "auth_user_blocked_unconfirmed", level="warning"
+                        )
                     raise HTTPException(
                         status_code=status.HTTP_403_FORBIDDEN,
                         detail="Email not confirmed",


### PR DESCRIPTION
## Contexte

Bug critique : après background → resume, le feed affiche 403 « Email not confirmed » (alors que l'email EST confirmé), et le pull-to-refresh devient inerte. Seul remède utilisateur : kill + relogin.

Story doc : `docs/bugs/bug-feed-403-auth-recovery.md`.

## Root cause (4 maillons)

- **P0 — `api_client.dart`** : un fallthrough après le try/catch déclenchait `onAuthError!(403)` (→ `forceUnconfirmed=true` → redirect login) même quand le refresh+retry avait réussi OU quand le refresh avait timeout. Règle correcte : `onAuthError(403)` ne doit se déclencher QUE si le retry post-refresh renvoie lui-même 403.
- **P1 — `feed_provider.dart`** : `refresh()` passait en `AsyncError + rethrow` → `state.value` devenait `null` → tous les handlers guardés `if (currentState == null) return;` devenaient no-op, ET le pull suivant restait coincé.
- **P2 — `auth_state.dart`** : le listener dédupait les events `tokenRefreshed` (même user), donc `ref.watch(authStateProvider)` dans `feedProvider` ne rebuildait pas → le feed repartait avec l'ancien JWT.
- **P3 — `dependencies.py`** : pas d'instrumentation Sentry pour mesurer la fréquence des vrais 403 vs faux positifs récupérés client-side.

## Fix

- **api_client.dart** : suppression du fallthrough. Log explicite sur chaque branche (retry-403, refresh-null, refresh-exception).
- **feed_provider.dart** : le catch préserve `state.valueOrNull` si présent, sinon `AsyncError`. Plus de `rethrow` — le `RefreshIndicator` se ferme proprement, les retries sont possibles.
- **auth_state.dart** : bypass de la déduplication sur `tokenRefreshed` (guard `!isTokenRefresh`). Ajout d'un champ `lastTokenRefreshAt` bumpé à chaque event refresh (plomberie pour `.select()` futur).
- **dependencies.py** : breadcrumb sur `auth_db_unreachable_fail_open`, Sentry event `auth_user_blocked_unconfirmed` avec tags (`auth.reason`, `auth.jwt_alg`, `auth.provider`) pour mesurer la baseline.

## Tests

- `feed_refresh_recovery_test.dart` (nouveau) : 403 → items préservés ; retry successif → succès ; cold-start failure → AsyncError.
- `auth_state_test.dart` (+4) : `lastTokenRefreshAt` default null, copyWith set/preserve, identités distinctes.

## Review findings (follow-ups post-merge)

Review indépendante a validé les fixes mais soulevé :

- **`lastTokenRefreshAt` probablement redondant** : AuthState n'a pas d'`==` custom, donc chaque `copyWith` produit déjà une nouvelle identité — le vrai fix est le guard `!isTokenRefresh` (ligne 252). Le champ est utile seulement si on l'utilise via `.select((s) => s.lastTokenRefreshAt)`. → follow-up : soit câbler `.select` dans `feedProvider`, soit retirer.
- **Blast radius** : ~11 providers `ref.watch(authStateProvider)` rebuildent sur chaque token refresh (timer 45min + resume). Correct pour `feedProvider`, potentiellement coûteux pour `digestProvider` etc. → follow-up : scoper via `.select((s) => s.user?.id)` les providers qui ne réagissent qu'à l'identité user.
- **Coverage gaps** : ApiClient 403 (3 branches : retry-403 / refresh-null / refresh-throw) non testé — tentative abandonnée (fragilité du mocking Supabase/Dio adapter). Listener `!isTokenRefresh` non testé. → follow-up : fake `SupabaseClient.auth` dédié.

## Test plan

- [x] `feed_refresh_recovery_test.dart` passe (recovery path testé)
- [x] `auth_state_test.dart` passe (plomberie `lastTokenRefreshAt`)
- [x] `dependencies.py` : imports + syntaxe OK
- [ ] CI flutter test complète (validation finale)
- [ ] Manuel E2E : background app 2min → resume → feed charge avec nouveau JWT sans kill
- [ ] Sentry : vérifier apparition des événements `auth_user_blocked_unconfirmed` et breadcrumbs `auth_db_unreachable_fail_open` en staging

https://claude.ai/code/session_0155cvTFnfsH7MFnuhpoig4Z