### PR TITLE
fix(feed): pull-to-refresh effectif en mode chronologique

### DIFF
--- a/docs/bugs/bug-feed-refresh-chronological.md
+++ b/docs/bugs/bug-feed-refresh-chronological.md
@@ -1,0 +1,49 @@
+# Bug: Pull-to-refresh sans effet en mode chronologique
+
+## Problème
+
+Le geste pull-to-refresh sur le feed est censé renouveler les articles affichés.
+
+- **Mode chronologique (défaut, aucun chip sélectionné)** : aucun effet visible, les mêmes articles réapparaissent dans le même ordre.
+- **Seuls les articles lus (`SEEN`/`CONSUMED`) ou sauvegardés (`is_saved`)** disparaissent après refresh — parce qu'ils sont filtrés au niveau SQL pour une raison indépendante de l'impression.
+
+## Root cause
+
+Le geste pull-to-refresh déclenche `POST /feed/refresh` (`packages/api/app/routers/feed.py:228`) qui upsert `UserContentStatus.last_impressed_at = now()` pour chaque `content_id` visible (≥90% viewport, capturé côté mobile).
+
+Cette valeur est uniquement consommée par l'`ImpressionLayer` (`packages/api/app/services/recommendation/layers/impression.py`) qui applique un malus de scoring tiéré (`-100 pts` si <1h, étiqueté _"invisible après refresh"_).
+
+En mode chronologique, `_apply_chronological_diversification` (`packages/api/app/services/recommendation_service.py:756`) n'applique **aucun scoring** — il trie purement par `published_at DESC`. Le malus de l'`ImpressionLayer` est complètement ignoré. Le filtre d'exclusion SQL (`recommendation_service.py:2113-2143`) ne considérait que `is_hidden`, `is_saved`, `status IN (SEEN, CONSUMED)` — jamais `last_impressed_at`.
+
+Le même problème touchait le marqueur `manually_impressed` ("j'ai déjà vu cet article") : `-120 pts` permanent en scoring, mais ignoré en chronologique.
+
+## Fix appliqué
+
+Étendre le filtre d'exclusion SQL de `_get_candidates` dans la branche "default feed" (sans filtre explicite) pour exclure :
+
+- Les articles avec `last_impressed_at > now() - ScoringWeights.IMPRESSION_HIDE_WINDOW_HOURS` (1h)
+- Les articles avec `manually_impressed = TRUE`
+
+Alignement fidèle sur la sémantique `IMPRESSION_VERY_RECENT` déjà documentée dans `ScoringWeights`.
+
+### Fichiers modifiés
+
+- `packages/api/app/services/recommendation/scoring_config.py` — ajout constante `IMPRESSION_HIDE_WINDOW_HOURS = 1`
+- `packages/api/app/services/recommendation_service.py` (branche default feed de `_get_candidates`) — extension du `or_()` dans `exists_stmt`
+
+### Portée
+
+Appliqué uniquement à la branche "default feed". Les filtres explicites (source / theme / topic / entity / keyword) conservent leur sémantique relâchée existante (l'utilisateur veut parcourir tout le contenu pour la facette sélectionnée).
+
+## Tests
+
+Voir `packages/api/tests/test_feed_chronological_refresh.py` :
+
+- Articles impressionés <1h exclus du feed par défaut
+- Articles impressionés >1h réapparaissent
+- Filtre explicite par source ignore l'impression (articles encore visibles)
+- `manually_impressed = TRUE` exclut l'article du feed par défaut
+
+## Comportement de l'undo
+
+`POST /feed/refresh/undo` restaure `last_impressed_at` à sa valeur précédente. Si la valeur restaurée est `NULL` ou >1h, l'article redevient éligible → l'undo fonctionne.

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -204,6 +204,11 @@ class ScoringWeights:
 
     IMPRESSION_MANUAL = -120.0  # "J'ai déjà vu" — malus permanent, pas de decay
 
+    # Fenêtre pendant laquelle un article récemment impressionné est exclu du
+    # feed chronologique par défaut (pull-to-refresh). Aligné sur le tier
+    # IMPRESSION_VERY_RECENT (<1h = "invisible après refresh").
+    IMPRESSION_HIDE_WINDOW_HOURS = 1
+
     # --- SOURCE AFFINITY (Learned from interactions) ---
 
     # Maximum bonus for a source with highest engagement.

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -2129,7 +2129,14 @@ class RecommendationService:
                 UserContentStatus.is_hidden,
             )
         else:
-            # Default feed: exclude hidden, saved, seen, consumed
+            # Default feed: exclude hidden, saved, seen, consumed, et les
+            # articles récemment impressionés (pull-to-refresh) ou marqués
+            # comme "déjà vus". Traduit en SQL la sémantique de
+            # ImpressionLayer (<1h = "invisible après refresh") qui est
+            # sinon ignorée par le tri chronologique.
+            impression_cutoff = datetime.datetime.now(
+                datetime.UTC
+            ) - datetime.timedelta(hours=ScoringWeights.IMPRESSION_HIDE_WINDOW_HOURS)
             exists_stmt = exists().where(
                 UserContentStatus.content_id == Content.id,
                 UserContentStatus.user_id == user_id,
@@ -2139,6 +2146,8 @@ class RecommendationService:
                     UserContentStatus.status.in_(
                         [ContentStatus.SEEN, ContentStatus.CONSUMED]
                     ),
+                    UserContentStatus.last_impressed_at > impression_cutoff,
+                    UserContentStatus.manually_impressed.is_(True),
                 ),
             )
 

--- a/packages/api/tests/test_feed_chronological_refresh.py
+++ b/packages/api/tests/test_feed_chronological_refresh.py
@@ -15,17 +15,37 @@ from sqlalchemy.dialects.postgresql import insert
 
 from app.models.content import Content, UserContentStatus
 from app.models.enums import ContentStatus, ContentType
+from app.models.source import Source, SourceType
 from app.services.recommendation_service import RecommendationService
 
 
 @pytest.fixture
-async def test_contents(db_session, test_source):
-    """Create 2 Content rows from the same source, published now."""
+async def curated_source(db_session):
+    """Source curée (is_curated=True) requise pour passer le filtre de _get_candidates
+    sans followed_source_ids — la branche par défaut filtre sur Source.is_curated."""
+    source = Source(
+        id=uuid4(),
+        name="Curated Test Source",
+        url="https://curated-test.com",
+        feed_url=f"https://curated-test.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=True,
+    )
+    db_session.add(source)
+    await db_session.commit()
+    return source
+
+
+@pytest.fixture
+async def test_contents(db_session, curated_source):
+    """Create 2 Content rows from a curated source, published now."""
     contents = []
     for i in range(2):
         c = Content(
             id=uuid4(),
-            source_id=test_source.id,
+            source_id=curated_source.id,
             title=f"Chrono refresh article {i}",
             url=f"https://example.com/chrono-{i}-{uuid4()}",
             guid=f"chrono-guid-{uuid4()}",
@@ -125,7 +145,7 @@ class TestChronologicalRefreshFilter:
         assert target.id in {c.id for c in candidates}
 
     async def test_explicit_source_filter_ignores_impression(
-        self, db_session, test_contents, test_source, user_id
+        self, db_session, test_contents, curated_source, user_id
     ):
         """source_id explicite → articles impressionés encore visibles."""
         target, _ = test_contents
@@ -142,7 +162,7 @@ class TestChronologicalRefreshFilter:
             user_id=user_id,
             limit_candidates=50,
             mode=None,
-            source_id=test_source.id,
+            source_id=curated_source.id,
         )
 
         assert target.id in {c.id for c in candidates}

--- a/packages/api/tests/test_feed_chronological_refresh.py
+++ b/packages/api/tests/test_feed_chronological_refresh.py
@@ -1,0 +1,173 @@
+"""Tests pour l'exclusion des articles récemment impressionés du feed chronologique.
+
+Vérifie que le filtre SQL de `_get_candidates` :
+- Exclut les articles avec `last_impressed_at` dans la dernière heure (default feed)
+- Ré-inclut les articles dont l'impression date de plus d'une heure
+- N'exclut pas les articles impressionés en cas de filtre explicite (source_id)
+- Exclut les articles avec `manually_impressed = True`
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.dialects.postgresql import insert
+
+from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentStatus, ContentType
+from app.services.recommendation_service import RecommendationService
+
+
+@pytest.fixture
+async def test_contents(db_session, test_source):
+    """Create 2 Content rows from the same source, published now."""
+    contents = []
+    for i in range(2):
+        c = Content(
+            id=uuid4(),
+            source_id=test_source.id,
+            title=f"Chrono refresh article {i}",
+            url=f"https://example.com/chrono-{i}-{uuid4()}",
+            guid=f"chrono-guid-{uuid4()}",
+            published_at=datetime.now(UTC),
+            content_type=ContentType.ARTICLE,
+        )
+        db_session.add(c)
+        contents.append(c)
+    await db_session.commit()
+    return contents
+
+
+@pytest.fixture
+def user_id() -> UUID:
+    return uuid4()
+
+
+async def _set_impression(
+    db_session,
+    user_id: UUID,
+    content_id: UUID,
+    *,
+    last_impressed_at: datetime | None = None,
+    manually_impressed: bool = False,
+):
+    """Upsert a UserContentStatus row with the given impression state."""
+    now = datetime.now(UTC)
+    stmt = (
+        insert(UserContentStatus)
+        .values(
+            user_id=user_id,
+            content_id=content_id,
+            status=ContentStatus.UNSEEN.value,
+            last_impressed_at=last_impressed_at,
+            manually_impressed=manually_impressed,
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_update(
+            index_elements=["user_id", "content_id"],
+            set_={
+                "last_impressed_at": last_impressed_at,
+                "manually_impressed": manually_impressed,
+                "updated_at": now,
+            },
+        )
+    )
+    await db_session.execute(stmt)
+    await db_session.commit()
+
+
+class TestChronologicalRefreshFilter:
+    async def test_recently_impressed_article_excluded_from_default_feed(
+        self, db_session, test_contents, user_id
+    ):
+        """<1h impression → article absent du feed par défaut (mode=None)."""
+        target, other = test_contents
+
+        await _set_impression(
+            db_session,
+            user_id,
+            target.id,
+            last_impressed_at=datetime.now(UTC) - timedelta(minutes=5),
+        )
+
+        service = RecommendationService(db_session)
+        candidates = await service._get_candidates(
+            user_id=user_id,
+            limit_candidates=50,
+            mode=None,
+        )
+
+        candidate_ids = {c.id for c in candidates}
+        assert target.id not in candidate_ids
+        assert other.id in candidate_ids
+
+    async def test_old_impression_article_reappears(
+        self, db_session, test_contents, user_id
+    ):
+        """>1h impression → article re-éligible au feed par défaut."""
+        target, _ = test_contents
+
+        await _set_impression(
+            db_session,
+            user_id,
+            target.id,
+            last_impressed_at=datetime.now(UTC) - timedelta(hours=2),
+        )
+
+        service = RecommendationService(db_session)
+        candidates = await service._get_candidates(
+            user_id=user_id,
+            limit_candidates=50,
+            mode=None,
+        )
+
+        assert target.id in {c.id for c in candidates}
+
+    async def test_explicit_source_filter_ignores_impression(
+        self, db_session, test_contents, test_source, user_id
+    ):
+        """source_id explicite → articles impressionés encore visibles."""
+        target, _ = test_contents
+
+        await _set_impression(
+            db_session,
+            user_id,
+            target.id,
+            last_impressed_at=datetime.now(UTC) - timedelta(minutes=5),
+        )
+
+        service = RecommendationService(db_session)
+        candidates = await service._get_candidates(
+            user_id=user_id,
+            limit_candidates=50,
+            mode=None,
+            source_id=test_source.id,
+        )
+
+        assert target.id in {c.id for c in candidates}
+
+    async def test_manually_impressed_article_excluded(
+        self, db_session, test_contents, user_id
+    ):
+        """manually_impressed=True → article définitivement exclu du feed défaut."""
+        target, other = test_contents
+
+        await _set_impression(
+            db_session,
+            user_id,
+            target.id,
+            last_impressed_at=None,
+            manually_impressed=True,
+        )
+
+        service = RecommendationService(db_session)
+        candidates = await service._get_candidates(
+            user_id=user_id,
+            limit_candidates=50,
+            mode=None,
+        )
+
+        candidate_ids = {c.id for c in candidates}
+        assert target.id not in candidate_ids
+        assert other.id in candidate_ids


### PR DESCRIPTION
## What

Rend le pull-to-refresh du feed effectif en mode chronologique (défaut). Étend le filtre SQL `exists_stmt` de `_get_candidates` (branche default feed) pour exclure les articles récemment impressionés (`last_impressed_at > now() - 1h`) ou marqués comme "déjà vus" (`manually_impressed = TRUE`). Ajoute la constante `ScoringWeights.IMPRESSION_HIDE_WINDOW_HOURS = 1` alignée sur le tier existant `IMPRESSION_VERY_RECENT` ("invisible après refresh").

## Why

En mode chronologique, `_apply_chronological_diversification` trie par `published_at DESC` sans scoring, donc le malus de `ImpressionLayer` était complètement ignoré. Résultat : pull-to-refresh n'avait aucun effet visible, seuls les articles lus ou sauvegardés (filtrés SQL pour d'autres raisons) disparaissaient. Cette PR traduit en filtre SQL la sémantique déjà documentée de l'`ImpressionLayer`, rendant le geste conforme à son intention pour les modes For You et chronologique.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`) — intégration requiert Docker + supabase local (non dispo dans le worktree)
- [ ] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails — N/A (feed scoring uniquement)
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)