### PR TITLE
docs: add /go command for verify→simplify→PR workflow

### DIFF
--- a/.claude/commands/go.md
+++ b/.claude/commands/go.md
@@ -1,0 +1,111 @@
+# /go — Vérifier, simplifier, ouvrir la PR
+
+Tu viens de terminer une tâche (feature, bug, maintenance). `/go` est l'étape
+**VERIFY → SIMPLIFY → PR** : tu dois **prouver** que ton code marche avant de
+demander une review, puis ouvrir la PR.
+
+Règle absolue : si une étape échoue, tu **corriges** avant de passer à la
+suivante. Ne jamais marquer une étape OK sans preuve (output de test, screenshot,
+requête réseau).
+
+---
+
+## 1. VERIFY — Tester bout-en-bout
+
+Choisis les vérifications selon ce qui a été modifié dans le diff
+(`git diff --stat origin/main...HEAD`).
+
+### Backend modifié (`packages/api/**`)
+
+1. **Tests unitaires** : `cd packages/api && pytest -v` — 0 échec requis.
+2. **Démarre l'API locale** en arrière-plan :
+   `cd packages/api && uvicorn app.main:app --port 8080 --reload`
+3. **Teste les endpoints touchés** avec `curl` (cas nominal + au moins 1 cas
+   limite : auth manquante, payload invalide, ressource inexistante). Capture
+   status code + body.
+4. **Script QA dédié** s'il existe : `bash docs/qa/scripts/verify_<task>.sh`.
+5. Arrête le serveur une fois les tests passés.
+
+### Mobile / UI modifié (`apps/mobile/**`)
+
+1. **Tests Flutter** : `cd apps/mobile && flutter test` puis `flutter analyze`.
+2. **Validation navigateur via Playwright MCP** (viewport 390x844) :
+   - Démarre l'API locale si la feature en dépend
+   - Navigate vers la route touchée, screenshot avant/après chaque interaction
+   - Vérifie `read_console_messages(onlyErrors: true)` — aucune erreur JS
+   - Vérifie `read_network_requests` — aucun 4xx/5xx inattendu
+   - Teste au moins 1 edge case (saisie vide, double-clic, retour arrière)
+3. Si un `.context/qa-handoff.md` existe, exécute tous ses scénarios.
+
+### Migration Alembic
+
+1. `cd packages/api && alembic heads` — exactement 1 head.
+2. `alembic upgrade head` sur une DB locale — doit passer sans erreur.
+3. **Ne JAMAIS exécuter Alembic sur Railway** (règle LOCKED de CLAUDE.md).
+
+### Suite complète (toujours, à la fin)
+
+```bash
+cd packages/api && pytest -v
+cd apps/mobile && flutter test && flutter analyze
+```
+
+Le hook `stop-verify-tests.sh` refusera de te laisser conclure si des tests
+échouent — anticipe-le.
+
+---
+
+## 2. SIMPLIFY — Invoke la skill `simplify`
+
+Invoque la skill `simplify` via le Skill tool. Elle relit le diff et corrige
+les problèmes de réutilisation, qualité et efficacité. Re-run VERIFY (étape 1)
+si `simplify` a modifié du code.
+
+---
+
+## 3. PR — Créer la pull request
+
+1. Vérifie la branche courante : elle doit commencer par `claude/` (jamais
+   `staging`, jamais `main`).
+2. Vérifie qu'il n'y a rien d'oublié :
+   `git status` (clean) · `git log origin/main..HEAD --oneline` (≥1 commit).
+3. Push : `git push -u origin <branche>` (retry 4x avec backoff 2s/4s/8s/16s
+   si échec réseau).
+4. **Crée la PR avec `mcp__github__create_pull_request`** — base `main`
+   **obligatoire**. Repo : `boujonlaurin-dotcom/facteur`.
+5. Si `.context/pr-handoff.md` existe, utilise son contenu comme body.
+   Sinon, génère un body :
+
+   ```markdown
+   ## Quoi
+   <résumé 2-3 lignes>
+
+   ## Pourquoi
+   <contexte métier / bug résolu>
+
+   ## Comment ça a été vérifié
+   - [ ] pytest (N tests OK)
+   - [ ] flutter test + analyze OK
+   - [ ] Scénarios Playwright OK (si UI)
+   - [ ] /simplify passé
+
+   ## Zones à risque
+   <modules sensibles touchés>
+   ```
+
+6. **STOP** et notifie : `PR #<num> prête pour review — <url>`.
+7. Propose à l'utilisateur de s'abonner aux events CI/review via
+   `mcp__github__subscribe_pr_activity`.
+
+---
+
+## Règles non négociables
+
+- `--base main` **toujours**. `staging` est DÉPRÉCIÉ — toute tentative sera
+  bloquée par `pre-bash-no-staging.sh`.
+- Ne jamais `--no-verify`, `--force-with-lease` sur `main`, ni amender un commit
+  déjà poussé.
+- Si VERIFY échoue à la 2e tentative après fix, **stop** et demande à
+  l'utilisateur au lieu de boucler.
+- Ne crée pas de fichiers de planning / rapport intermédiaires — le body de
+  PR et les commits sont la seule documentation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,15 @@ Après le GO utilisateur, implémente et teste en autonomie :
 4. **Suite complète** : lance la suite de tests complète (`pytest -v` backend, `flutter test` mobile) et corrige tout échec
 5. Le hook `stop-verify-tests.sh` vérifie automatiquement que les tests passent avant de terminer — si un test échoue, l'agent doit corriger avant de pouvoir conclure
 
+> **Raccourci recommandé** : une fois le code écrit, lance **[`/go`](.claude/commands/go.md)** pour enchaîner automatiquement VERIFY (tests + Playwright + scripts QA) → SIMPLIFY (skill `simplify`) → PR vers `main`. Voir [/go — chaîne verify→simplify→PR](#go--chaîne-verifysimplifypr) plus bas.
+
 ### 3. PR (confirmation requise)
 
 1. Crée la PR vers `main` — **OBLIGATOIRE : `--base main`** (`staging` est DÉPRÉCIÉ, le hook `pre-bash-no-staging.sh` bloquera toute PR sans `--base main`)
 2. **STOP → Notifie "PR #XX prête pour review"**
 3. Attends CI green + Peer Review APPROVED avant merge
+
+> La commande `/go` prend en charge les étapes 2 et 3 (push, création PR avec base `main`, body depuis `.context/pr-handoff.md`, arrêt après "PR #XX prête pour review").
 
 ---
 
@@ -143,3 +147,47 @@ Après la phase VERIFY de l'agent dev et la validation du PO (Laurin), une étap
 
 - [ ] QA Handoff rédigé (`.context/qa-handoff.md`) si feature UI
 - [ ] /validate-feature exécuté si feature UI (rapport QA dans .context/)
+
+---
+
+## /go — chaîne verify→simplify→PR
+
+> **Commande de référence pour conclure une tâche.** Fichier :
+> [`.claude/commands/go.md`](.claude/commands/go.md).
+
+Quand l'agent a fini d'écrire le code, `/go` prend le relais et fait **en
+autonomie** les 3 étapes qui restent — avec la preuve que ça marche :
+
+1. **VERIFY**
+   - Backend : `pytest -v` + démarrage `uvicorn` + `curl` sur les endpoints
+     touchés (cas nominal + 1 cas limite) + `docs/qa/scripts/verify_<task>.sh`
+     si présent.
+   - Mobile : `flutter test && flutter analyze` + Playwright MCP
+     (viewport 390x844, console sans erreurs, réseau sans 4xx/5xx inattendus,
+     edge cases).
+   - Alembic : exactement 1 head, `upgrade head` local OK, jamais sur Railway.
+   - Re-run systématique de la suite complète avant de conclure
+     (anticipe le hook `stop-verify-tests.sh`).
+2. **SIMPLIFY** : invoque la skill `simplify` puis re-run VERIFY si du code a
+   été modifié.
+3. **PR** : push (`-u origin`, retry backoff 2/4/8/16s), création PR via
+   `mcp__github__create_pull_request` vers `main` **obligatoirement**, body
+   repris depuis `.context/pr-handoff.md` s'il existe, puis STOP avec
+   `PR #<num> prête pour review — <url>` et propose
+   `subscribe_pr_activity` pour suivre CI/reviews.
+
+### Quand lancer /go
+
+- **Toujours** en fin de tâche, quelle qu'elle soit (feature, bug, maintenance).
+- Remplace les étapes 2 (phase VERIFY) + 3 du workflow PLAN → CODE+TEST → PR.
+- Compatible avec `/validate-feature` : si la feature touche l'UI, lance
+  `/validate-feature` *avant* `/go` pour générer le rapport QA, puis `/go`
+  enchaîne simplify + PR.
+
+### Règles non négociables de /go
+
+- `--base main` **toujours** (staging bloqué par hook).
+- Jamais `--no-verify`, jamais `--force-with-lease` sur `main`, jamais amender
+  un commit déjà poussé.
+- Si VERIFY échoue à la 2e tentative après fix → **stop** et demande à
+  l'utilisateur au lieu de boucler.

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -83,6 +83,12 @@ git commit -m "fix: <description courte>
 Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
 ```
 
+> **Astuce** : dès que la tâche dépasse le commit simple, lance **`/go`**
+> (voir [.claude/commands/go.md](.claude/commands/go.md)). Elle fait
+> VERIFY (pytest + flutter + Playwright + scripts QA) → SIMPLIFY → push +
+> PR vers `main` automatiquement. Obligatoire pour toute tâche où tu
+> escalades vers [CLAUDE.md](CLAUDE.md).
+
 ### 5. Cleanup (après merge)
 
 ```bash
@@ -136,6 +142,7 @@ git worktree remove ../fix/<nom>
 - Story/Bug Doc OBLIGATOIRE
 - Hooks de sécurité complets
 - Safety Protocols pour zones à risque
+- **`/go`** pour enchaîner VERIFY → SIMPLIFY → PR en fin de tâche
 
 ---
 


### PR DESCRIPTION
## What

Added comprehensive documentation for the `/go` command, a new workflow shortcut that automates the final three stages of task completion: VERIFY (tests + Playwright validation) → SIMPLIFY (code quality) → PR creation.

- Created `.claude/commands/go.md` with detailed step-by-step instructions for each phase
- Updated `CLAUDE.md` to reference `/go` and explain when/how to use it
- Updated `QUICK_START.md` with a tip directing users to `/go` for non-trivial tasks

## Why

The `/go` command consolidates scattered verification, simplification, and PR creation logic into a single, repeatable workflow. This:
- Reduces cognitive load by providing a clear checklist for task completion
- Ensures consistent verification practices (pytest, flutter test, Playwright, QA scripts)
- Enforces safety rules (base `main` only, no staging, proper retry logic)
- Provides a single source of truth for the verify→simplify→PR sequence

## Type

- [ ] Feature
- [x] Maintenance / Refactor

## Checklist

- [x] Documentation is clear and actionable
- [x] References to `/go` added to relevant docs (CLAUDE.md, QUICK_START.md)
- [x] Safety rules documented (no staging, base main, retry logic)
- [x] Alembic migration rules included (never on Railway)
- [x] N/A (docs only change)

## Staging

- [x] N/A (docs/config only change)

https://claude.ai/code/session_01GwcjdLziE7dv33TxYZvkbJ