### PR TITLE
infra(hooks): honest install status for session-start

### DIFF
--- a/.claude-hooks/session-start.sh
+++ b/.claude-hooks/session-start.sh
@@ -10,6 +10,13 @@
 # indépendamment via npx (npm registry accessible).
 # =============================================================================
 
+persist_path_in_bashrc() {
+  local line="$1"
+  local bashrc="$HOME/.bashrc"
+  [ -f "$bashrc" ] || touch "$bashrc"
+  grep -qxF "$line" "$bashrc" 2>/dev/null || echo "$line" >> "$bashrc"
+}
+
 install_railway_cli() {
   if command -v railway &>/dev/null; then
     echo "[session-start] railway OK ($(railway --version 2>/dev/null | head -1))"
@@ -19,10 +26,18 @@ install_railway_cli() {
   echo "[session-start] railway absent — tentative d'installation via script officiel..."
   if command -v curl &>/dev/null; then
     # Script officiel Railway : https://railway.app/install.sh
-    if bash <(curl -fsSL https://railway.app/install.sh) 2>&1; then
-      echo "[session-start] railway installé."
+    # Le script dépose souvent le binaire dans ~/.railway/bin/ sans toucher le PATH du shell courant.
+    bash <(curl -fsSL https://railway.app/install.sh) 2>&1 || true
+
+    if [ -x "$HOME/.railway/bin/railway" ]; then
+      export PATH="$HOME/.railway/bin:$PATH"
+      persist_path_in_bashrc 'export PATH="$HOME/.railway/bin:$PATH"'
+    fi
+
+    if command -v railway &>/dev/null; then
+      echo "[session-start] railway installé ($(railway --version 2>/dev/null | head -1))."
     else
-      echo "[session-start] WARN: Impossible d'installer railway (accès github.com requis)"
+      echo "[session-start] WARN: railway install failed (PATH issue? check ~/.railway/bin)"
       echo "[session-start] → Lancer manuellement : bash scripts/setup-cli-tools.sh"
     fi
   else
@@ -53,12 +68,23 @@ install_supabase_cli() {
 
   if command -v curl &>/dev/null; then
     if curl -fsSL "$url" -o "${tmp_dir}/supabase.tar.gz" 2>&1; then
-      tar -xzf "${tmp_dir}/supabase.tar.gz" -C "${tmp_dir}"
+      tar -xzf "${tmp_dir}/supabase.tar.gz" -C "${tmp_dir}" 2>/dev/null || true
+      mkdir -p "$HOME/.local/bin"
       install -m 755 "${tmp_dir}/supabase" /usr/local/bin/supabase 2>/dev/null \
-        || cp "${tmp_dir}/supabase" ~/.local/bin/supabase 2>/dev/null \
-        || echo "[session-start] WARN: Impossible d'installer supabase dans PATH"
+        || cp "${tmp_dir}/supabase" "$HOME/.local/bin/supabase" 2>/dev/null \
+        || true
       rm -rf "$tmp_dir"
-      echo "[session-start] supabase installé."
+
+      if [ -x "$HOME/.local/bin/supabase" ] && ! command -v supabase &>/dev/null; then
+        export PATH="$HOME/.local/bin:$PATH"
+        persist_path_in_bashrc 'export PATH="$HOME/.local/bin:$PATH"'
+      fi
+
+      if command -v supabase &>/dev/null; then
+        echo "[session-start] supabase installé ($(supabase --version 2>/dev/null | head -1))."
+      else
+        echo "[session-start] WARN: supabase install failed (PATH issue? check ~/.local/bin)"
+      fi
     else
       rm -rf "$tmp_dir"
       echo "[session-start] WARN: Impossible de télécharger supabase (accès github.com requis)"

--- a/scripts/test-session-start-hook.sh
+++ b/scripts/test-session-start-hook.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Test : le hook session-start imprime WARN: et sort 0 quand l'install échoue.
+# Isolation : HOME temporaire + stub curl qui exit 1 (simule offline).
+set -u
+
+HOOK="$(cd "$(dirname "$0")/.." && pwd)/.claude-hooks/session-start.sh"
+
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: hook introuvable à $HOOK"
+  exit 1
+fi
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+mkdir -p "$SANDBOX/stubs"
+cat > "$SANDBOX/stubs/curl" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+chmod +x "$SANDBOX/stubs/curl"
+
+OUTPUT=$(
+  HOME="$SANDBOX" \
+  PATH="$SANDBOX/stubs:/usr/bin:/bin" \
+  bash "$HOOK" 2>&1
+)
+RC=$?
+
+echo "--- Hook output ---"
+echo "$OUTPUT"
+echo "--- Exit code: $RC ---"
+
+fail=0
+if ! grep -q "WARN:" <<< "$OUTPUT"; then
+  echo "FAIL: expected 'WARN:' in output"
+  fail=1
+fi
+if [ "$RC" -ne 0 ]; then
+  echo "FAIL: expected exit 0, got $RC"
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "PASS"
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
## Problem

`.claude-hooks/session-start.sh` imprimait `[session-start] railway installé.` dès que le script officiel `https://railway.app/install.sh` retournait 0 — sans vérifier que `railway` était réellement dans le `$PATH` du shell courant. Or le script officiel dépose le binaire dans `~/.railway/bin/`, hors PATH par défaut.

Même pattern côté Supabase : le `echo "supabase installé."` s'exécutait inconditionnellement après la cascade `install /usr/local/bin` → `cp ~/.local/bin`, même si les deux étapes échouaient.

Résultat : les agents recevaient un message faussement rassurant puis un `which railway` vide.

## Fix

- Re-check `command -v railway` (resp. `supabase`) **après** l'appel au script d'install.
- Si binaire présent dans `~/.railway/bin` / `~/.local/bin` mais hors PATH → `export PATH=...` + persistance idempotente dans `~/.bashrc` (`grep -qxF` avant append).
- Si binaire toujours introuvable → message explicite `WARN: ... install failed (PATH issue? check ~/.railway/bin)`.
- `exit 0` non-bloquant préservé.

## Test

`scripts/test-session-start-hook.sh` :
- Sandbox `HOME=$(mktemp -d)` + stub `curl` qui exit 1 (simule offline).
- Lance le hook.
- Assert : output contient `WARN:` **et** exit code == 0.

```
$ bash scripts/test-session-start-hook.sh
...
[session-start] WARN: railway install failed (PATH issue? check ~/.railway/bin)
...
--- Exit code: 0 ---
PASS
```

Idempotence PATH vérifiée : 2 runs successifs → 1 seule ligne `export PATH="$HOME/.railway/bin:$PATH"` dans `~/.bashrc`.

## Fichiers modifiés

- `.claude-hooks/session-start.sh` — +33/-7 LOC
- `scripts/test-session-start-hook.sh` — +49 LOC (nouveau)

## Test plan

- [x] `bash scripts/test-session-start-hook.sh` → PASS
- [x] Smoke test local : `bash .claude-hooks/session-start.sh` avec railway/supabase déjà installés → "OK" short-path
- [x] Idempotence bashrc : 2 runs avec binaire mock → 1 seule ligne persistée

🤖 Generated with [Claude Code](https://claude.com/claude-code)