### PR TITLE
infra(cli): provision sentry-cli alongside railway/supabase

### DIFF
--- a/.claude-hooks/session-start.sh
+++ b/.claude-hooks/session-start.sh
@@ -2,7 +2,7 @@
 # =============================================================================
 # session-start.sh — Hook SessionStart Claude Code
 #
-# Auto-installe Railway CLI et Supabase CLI si absents.
+# Auto-installe Railway CLI, Supabase CLI et Sentry CLI si absents.
 # Non-bloquant : toujours exit 0 même en cas d'échec réseau.
 #
 # Note : les CLIs nécessitent un accès réseau à github.com pour les binaires.
@@ -96,7 +96,50 @@ install_supabase_cli() {
   fi
 }
 
+install_sentry_cli() {
+  if command -v sentry-cli &>/dev/null; then
+    echo "[session-start] sentry-cli OK ($(sentry-cli --version 2>/dev/null | head -1))"
+    return 0
+  fi
+
+  echo "[session-start] sentry-cli absent — tentative d'installation via script officiel..."
+  if command -v curl &>/dev/null; then
+    # Script officiel Sentry : https://sentry.io/get-cli/
+    # Installe dans /usr/local/bin par défaut, ou ~/.local/bin via INSTALL_DIR.
+    if [ -w /usr/local/bin ]; then
+      curl -sL https://sentry.io/get-cli/ | bash 2>&1 || true
+    else
+      mkdir -p "$HOME/.local/bin"
+      curl -sL https://sentry.io/get-cli/ | INSTALL_DIR="$HOME/.local/bin" bash 2>&1 || true
+      if [ -x "$HOME/.local/bin/sentry-cli" ] && ! command -v sentry-cli &>/dev/null; then
+        export PATH="$HOME/.local/bin:$PATH"
+        persist_path_in_bashrc 'export PATH="$HOME/.local/bin:$PATH"'
+      fi
+    fi
+
+    if command -v sentry-cli &>/dev/null; then
+      echo "[session-start] sentry-cli installé ($(sentry-cli --version 2>/dev/null | head -1))."
+    else
+      echo "[session-start] WARN: sentry-cli install failed (accès sentry.io requis)"
+      echo "[session-start] → Lancer manuellement : bash scripts/setup-cli-tools.sh"
+    fi
+  else
+    echo "[session-start] WARN: curl absent — impossible d'installer sentry-cli"
+  fi
+}
+
 install_railway_cli
 install_supabase_cli
+install_sentry_cli
+
+# Fallback idempotent : si l'un des CLI reste manquant après les tentatives
+# individuelles, relancer le script de setup unifié. `|| true` neutralise le
+# `set -euo pipefail` du script et préserve le contrat non-bloquant du hook.
+if ! command -v railway &>/dev/null \
+  || ! command -v supabase &>/dev/null \
+  || ! command -v sentry-cli &>/dev/null; then
+  echo "[session-start] Au moins un CLI manquant — fallback via setup-cli-tools.sh..."
+  bash scripts/setup-cli-tools.sh 2>&1 | tail -20 || true
+fi
 
 exit 0  # Toujours non-bloquant

--- a/scripts/setup-cli-tools.sh
+++ b/scripts/setup-cli-tools.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # =============================================================================
-# setup-cli-tools.sh — Installation des CLI Railway et Supabase
+# setup-cli-tools.sh — Installation des CLI Railway, Supabase et Sentry
 #
 # À exécuter une fois sur une machine de développement avec accès à github.com.
 # Prérequis : curl, Node.js >= 18
@@ -56,6 +56,23 @@ else
   echo "[OK] Supabase CLI installé: $(supabase --version 2>/dev/null)"
 fi
 
+# ─── Sentry CLI ───────────────────────────────────────────────────────────────
+if command -v sentry-cli &>/dev/null; then
+  echo "[OK] Sentry CLI déjà installé: $(sentry-cli --version 2>/dev/null)"
+else
+  echo "[...] Installation Sentry CLI via script officiel..."
+  # Le script officiel détecte l'OS et installe dans /usr/local/bin
+  # (ou ~/.local/bin via INSTALL_DIR si non writable).
+  if [ -w /usr/local/bin ]; then
+    curl -sL https://sentry.io/get-cli/ | bash
+  else
+    mkdir -p "$HOME/.local/bin"
+    curl -sL https://sentry.io/get-cli/ | INSTALL_DIR="$HOME/.local/bin" bash
+    echo "    Installé dans ~/.local/bin — assure-toi que ce dossier est dans ton PATH"
+  fi
+  echo "[OK] Sentry CLI installé: $(sentry-cli --version 2>/dev/null)"
+fi
+
 # ─── Vérification finale ──────────────────────────────────────────────────────
 echo ""
 echo "=== Vérification ==="
@@ -71,8 +88,9 @@ check_cmd() {
 }
 
 all_ok=true
-check_cmd railway   || all_ok=false
-check_cmd supabase  || all_ok=false
+check_cmd railway    || all_ok=false
+check_cmd supabase   || all_ok=false
+check_cmd sentry-cli || all_ok=false
 
 echo ""
 if [ "$all_ok" = true ]; then
@@ -81,6 +99,7 @@ if [ "$all_ok" = true ]; then
   echo "Variables d'environnement requises (voir .env.example) :"
   echo "  RAILWAY_TOKEN         → railway.app > Account Settings > Tokens"
   echo "  SUPABASE_ACCESS_TOKEN → app.supabase.com > Account > Access Tokens (PAT)"
+  echo "  SENTRY_AUTH_TOKEN     → sentry.io > Settings > Account > Auth Tokens"
 else
   echo "ERREUR: Certains CLI n'ont pas pu être installés."
   echo "Vérification de l'accès réseau à github.com et réessaie."


### PR DESCRIPTION
## Summary

- Étend `scripts/setup-cli-tools.sh` avec un bloc **Sentry CLI** (via `curl -sL https://sentry.io/get-cli/ | bash`), en reprenant le pattern des blocs Railway et Supabase existants.
- Ajoute `install_sentry_cli` au hook `.claude-hooks/session-start.sh`, avec la même logique "honest status" que les autres CLIs (re-vérification `command -v` post-install, PATH-persist dans `~/.bashrc` si install dans `~/.local/bin`).
- Ajoute un **fallback idempotent** en fin de hook : si l'un des 3 CLIs reste manquant après la première passe, relance `setup-cli-tools.sh` — tout en préservant le contrat non-bloquant (`exit 0`).

**Contexte** : l'agent `perf-watch` a besoin de `sentry-cli` en fallback hors MCP pour les sessions nocturnes CC-on-web (cf. `.context/perf-watch/2026-04-17-cto-h1-quickwins.md` §QW2). Aujourd'hui `sentry-cli --version → command not found` après SessionStart.

## Test plan

- [ ] **Conteneur Ubuntu neuf** (sans CLIs) : `bash scripts/setup-cli-tools.sh` → `railway --version && supabase --version && sentry-cli --version` doivent tous renvoyer un numéro de version.
- [ ] **Idempotence** : relancer le script → les 3 blocs doivent afficher `[OK] … déjà installé`.
- [ ] **Hook session-start, conteneur neuf** : `bash .claude-hooks/session-start.sh; echo exit=$?` → exit=0 ET `command -v sentry-cli` résout.
- [ ] **Hook sans réseau** : simuler `curl` en échec → hook affiche `WARN: sentry-cli install failed` et sort `0`. Le fallback `setup-cli-tools.sh` échouera mais `|| true` protège le exit code.
- [ ] **Pas de régression Railway/Supabase** : les blocs existants sont inchangés (diff vide).

## Notes

- Test container non exécuté localement (Docker daemon non démarré sur la machine dev macOS). Validation à faire par reviewer ou en CI devcontainer.
- Pas de modif des MCP servers, pas de modif des secrets — purement tooling CLI.
- LOC : 66 insertions, 4 suppressions sur 2 fichiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)