### PR TITLE
infra(mcp): document sentry MCP activation + readiness log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Icon
 *.pem
 secrets.yaml
 credentials.json
+.claude/settings.local.json
 
 # IDEs and editors
 .vscode/*

--- a/docs/infra/mcp-sentry-setup.md
+++ b/docs/infra/mcp-sentry-setup.md
@@ -1,0 +1,45 @@
+# MCP Sentry — Activation & secrets
+
+Le MCP Sentry (`mcp-servers/sentry/server.py`) expose les issues/events Sentry à Claude Code (agent perf-watch). Il est déclaré dans `.claude/settings.json` et lit 3 variables d'env : `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`.
+
+## 1. Générer le token
+
+Sentry → Settings → Account → API → **Auth Tokens** → *Create New Token*.
+
+**Scopes minimum requis** :
+- `project:read`
+- `event:read`
+- `issue:read`
+
+## 2. Peupler les secrets (CC-on-web)
+
+Créer/éditer `.claude/settings.local.json` (gitignored, jamais committé) :
+
+```json
+{
+  "env": {
+    "SENTRY_AUTH_TOKEN": "<TOKEN>",
+    "SENTRY_ORG": "<ORG_SLUG>",
+    "SENTRY_PROJECT": "<PROJECT_SLUG>"
+  }
+}
+```
+
+Redémarrer la session Claude Code pour que les vars soient picked up.
+
+## 3. Vérifier l'activation
+
+```bash
+python mcp-servers/sentry/server.py
+```
+
+Attendu sur **stderr** : `sentry_mcp_ready status=configured org=<slug> project=<slug>`. Si `status=missing_credentials`, le `.claude/settings.local.json` n'est pas chargé — vérifier la syntaxe JSON et redémarrer la session.
+
+## 4. Renouvellement (90 jours)
+
+Les tokens Sentry expirent. Cycle trimestriel :
+
+1. Générer un nouveau token (étape 1) avec les mêmes scopes.
+2. Remplacer `SENTRY_AUTH_TOKEN` dans `.claude/settings.local.json`.
+3. Révoquer l'ancien token dans Sentry → Auth Tokens.
+4. Redémarrer la session CC, re-vérifier le log readiness (étape 3).

--- a/mcp-servers/sentry/server.py
+++ b/mcp-servers/sentry/server.py
@@ -13,6 +13,7 @@ Nécessite les variables d'environnement :
 """
 
 import os
+import sys
 import httpx
 from mcp.server.fastmcp import FastMCP
 
@@ -295,4 +296,11 @@ async def search_errors(
 
 
 if __name__ == "__main__":
+    config_status = "missing_credentials" if _check_config() else "configured"
+    print(
+        f"sentry_mcp_ready status={config_status} "
+        f"org={SENTRY_ORG or 'unset'} project={SENTRY_PROJECT or 'unset'}",
+        file=sys.stderr,
+        flush=True,
+    )
     mcp.run()


### PR DESCRIPTION
## Summary

QW3-infra : activer le MCP Sentry pour que l'agent perf-watch puisse interroger les issues sans CLI locale.

- **`mcp-servers/sentry/server.py`** : log `sentry_mcp_ready` au startup (stderr, format `status=<configured|missing_credentials> org=<slug> project=<slug>`). Réutilise `_check_config()`. `stderr` pour préserver le protocole stdio MCP sur stdout.
- **`docs/infra/mcp-sentry-setup.md`** (nouveau, 30 lignes) : génération du token Sentry (scopes `project:read`, `event:read`, `issue:read`), peuplement via `.claude/settings.local.json` (gitignored), vérif d'activation, renouvellement 90 jours.
- **`.gitignore`** : ajout `.claude/settings.local.json` pour protéger les contributeurs (chez Laurin il est déjà couvert par le global git ignore).

**Aucun secret committé.**

## Test plan

- [x] `python3 -m py_compile mcp-servers/sentry/server.py` — syntaxe OK
- [x] Logique du log isolée et testée dans les 2 états :
  - sans creds → `sentry_mcp_ready status=missing_credentials org=unset project=unset`
  - avec creds → `sentry_mcp_ready status=configured org=facteur project=facteur-api`
- [ ] **À tester par Laurin** après merge : créer `.claude/settings.local.json` avec les vrais secrets, redémarrer la session CC, vérifier que les tools `list_issues` / `get_issue_events` répondent.

## Notes

- Branche basée sur `main` (rebase pour drop le commit QW2 sentry-cli qui est l'objet d'une PR séparée).
- Le ticket référence `.context/perf-watch/2026-04-17-cto-h1-quickwins.md` qui n'existe pas dans le repo (ni sur main, ni sur la branche). Référence non vérifiable — alignement strict sur la spec du ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)