### PR TITLE
infra(cc-web): allow WebFetch to production health endpoint

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:facteur-production.up.railway.app)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Pourquoi

L'agent **perf-watch** est aveugle sur l'état du pool DB entre deux événements Sentry (canal lent, événementiel). L'endpoint `/api/health/pool` (`packages/api/app/main.py:455`) renvoie en continu `{checked_out, overflow, checked_in, usage_pct, status, size, pool_class}` — exactement ce qu'il faut pour un monitoring in-the-loop.

Aujourd'hui WebFetch n'a aucun domaine en allowlist projet, donc l'agent est bloqué par les prompts de permission à chaque scrape.

## Quoi

Ajout d'un seul host à `permissions.allow` de `.claude/settings.json` :

```diff
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:facteur-production.up.railway.app)"
+    ]
+  },
```

Format canonique Claude Code (`WebFetch(domain:<host>)`).

## Garde-fous respectés

- ❌ Pas de wildcard `*`
- ❌ Pas de `*.railway.app`
- ✅ Un seul sous-domaine prod exact
- ✅ Aucune autre permission ajoutée (pas de `Bash(curl …)`)
- ✅ `hooks` et `mcpServers` existants intacts

## Test plan

- [x] `python3 -m json.tool .claude/settings.json` → JSON valide
- [x] WebFetch in-session sur `https://facteur-production.up.railway.app/api/health/pool` → renvoie le JSON attendu (`{"status":"ok","pool_class":"AsyncAdaptedQueuePool","size":10,"checked_in":1,"checked_out":0,"overflow":-9,"usage_pct":0.0}`)
- [ ] Reviewer : depuis une session Claude Code neuve, retenter le WebFetch ci-dessus → doit passer sans prompt de permission.

## Refs

- Ticket : QW4-infra
- Livrable CTO : `.context/perf-watch/2026-04-17-cto-h1-quickwins.md` §QW4
- Endpoint : `packages/api/app/main.py:455`

🤖 Generated with [Claude Code](https://claude.com/claude-code)