### PR TITLE
feat: Add PostHog dual-track analytics for retention cohorts (Story 14.1)

### DIFF
--- a/apps/mobile/lib/config/constants.dart
+++ b/apps/mobile/lib/config/constants.dart
@@ -224,6 +224,26 @@ class AppUpdateConstants {
   static bool get isReleaseBuild => releaseTag.isNotEmpty;
 }
 
+/// Configuration PostHog (Story 14.1 — retention cohorts)
+class PostHogConstants {
+  PostHogConstants._();
+
+  /// Clé projet PostHog (injectée via --dart-define à build-time)
+  static const String apiKey = String.fromEnvironment(
+    'POSTHOG_API_KEY',
+    defaultValue: '',
+  );
+
+  /// Host PostHog (EU par défaut)
+  static const String host = String.fromEnvironment(
+    'POSTHOG_HOST',
+    defaultValue: 'https://eu.i.posthog.com',
+  );
+
+  /// Enabled flag — off par défaut si pas de clé
+  static bool get isEnabled => apiKey.isNotEmpty;
+}
+
 /// Liens externes
 class ExternalLinks {
   ExternalLinks._();

--- a/apps/mobile/lib/core/providers/analytics_provider.dart
+++ b/apps/mobile/lib/core/providers/analytics_provider.dart
@@ -1,11 +1,19 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:facteur/core/api/api_provider.dart';
 import 'package:facteur/core/services/analytics_service.dart';
+import 'package:facteur/core/services/posthog_service.dart';
 
 part 'analytics_provider.g.dart';
+
+/// PostHog wrapper — keepAlive so identify/reset calls persist across rebuilds.
+@Riverpod(keepAlive: true)
+PostHogService posthogService(PosthogServiceRef ref) {
+  return PostHogService();
+}
 
 @Riverpod(keepAlive: true)
 AnalyticsService analyticsService(AnalyticsServiceRef ref) {
   final apiClient = ref.watch(apiClientProvider);
-  return AnalyticsService(apiClient);
+  final posthog = ref.watch(posthogServiceProvider);
+  return AnalyticsService(apiClient, posthog: posthog);
 }

--- a/apps/mobile/lib/core/providers/analytics_provider.g.dart
+++ b/apps/mobile/lib/core/providers/analytics_provider.g.dart
@@ -6,6 +6,24 @@ part of 'analytics_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+String _$posthogServiceHash() => r'1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b';
+
+/// PostHog wrapper — keepAlive so identify/reset calls persist across rebuilds.
+///
+/// Copied from [posthogService].
+@ProviderFor(posthogService)
+final posthogServiceProvider = Provider<PostHogService>.internal(
+  posthogService,
+  name: r'posthogServiceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$posthogServiceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef PosthogServiceRef = ProviderRef<PostHogService>;
+
 String _$analyticsServiceHash() => r'975e641a9ba922fe426408c6eec15e7fb24d7b4f';
 
 /// See also [analyticsService].

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -2,14 +2,17 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 import 'package:facteur/core/api/api_client.dart';
+import 'package:facteur/core/services/posthog_service.dart';
 
 class AnalyticsService {
   final ApiClient _apiClient;
+  final PostHogService? _posthog;
   String? _deviceId;
   String? _sessionId;
   DateTime? _sessionStartTime;
 
-  AnalyticsService(this._apiClient);
+  AnalyticsService(this._apiClient, {PostHogService? posthog})
+      : _posthog = posthog;
 
   Future<void> init() async {
     final prefs = await SharedPreferences.getInstance();
@@ -25,6 +28,13 @@ class AnalyticsService {
     _sessionStartTime = DateTime.now();
 
     await _logEvent('session_start', {
+      'session_id': _sessionId,
+      'is_organic': isOrganic,
+      'platform': defaultTargetPlatform.toString(),
+    });
+    // Story 14.1 — PostHog uses `app_open` as the conventional event name
+    // for DAU/retention computation. We mirror session_start to it.
+    await _capturePostHog('app_open', {
       'session_id': _sessionId,
       'is_organic': isOrganic,
       'platform': defaultTargetPlatform.toString(),
@@ -61,7 +71,7 @@ class AnalyticsService {
     int? position,
     int timeSpentSeconds = 0,
   }) async {
-    await _logEvent('content_interaction', {
+    final props = {
       'session_id': _sessionId,
       'action': action,
       'surface': surface,
@@ -71,7 +81,19 @@ class AnalyticsService {
       'atomic_themes': null, // Forward-compatible for Camembert
       'position': position,
       'time_spent_seconds': timeSpentSeconds,
-    });
+    };
+    await _logEvent('content_interaction', props);
+
+    // Story 14.1 — dedicated PostHog events for clean funnel/retention.
+    if (action == 'read') {
+      await _capturePostHog('article_read', props);
+      // Threshold ≥ 30 s signals a completed article (conventional for
+      // text content; videos/podcasts already have dedicated completion
+      // events in their own flows).
+      if (timeSpentSeconds >= 30) {
+        await _capturePostHog('article_completed', props);
+      }
+    }
   }
 
   /// Enregistre une session digest complète.
@@ -85,7 +107,7 @@ class AnalyticsService {
     required bool closureAchieved,
     required int streak,
   }) async {
-    await _logEvent('digest_session', {
+    final props = {
       'session_id': _sessionId,
       'digest_date': digestDate,
       'articles_read': articlesRead,
@@ -95,7 +117,9 @@ class AnalyticsService {
       'total_time_seconds': totalTimeSeconds,
       'closure_achieved': closureAchieved,
       'streak': streak,
-    });
+    };
+    await _logEvent('digest_session', props);
+    await _capturePostHog('digest_session', props);
   }
 
   /// Enregistre une session feed complète.
@@ -112,6 +136,20 @@ class AnalyticsService {
       'items_interacted': itemsInteracted,
       'total_time_seconds': totalTimeSeconds,
     });
+  }
+
+  /// Track the Ground News comparison screen open (H2 signal, Story 14.1).
+  Future<void> trackComparisonViewed({
+    required String clusterId,
+    int sourcesCount = 0,
+  }) async {
+    final props = {
+      'session_id': _sessionId,
+      'cluster_id': clusterId,
+      'sources_count': sourcesCount,
+    };
+    await _logEvent('comparison_viewed', props);
+    await _capturePostHog('comparison_viewed', props);
   }
 
   // ──────────────────────────────────────────────────────────────
@@ -151,6 +189,7 @@ class AnalyticsService {
 
   Future<void> trackSourceAdd(String sourceId) async {
     await _logEvent('source_add', {'source_id': sourceId});
+    await _capturePostHog('source_added', {'source_id': sourceId});
   }
 
   Future<void> trackSourceRemove(String sourceId) async {
@@ -197,5 +236,19 @@ class AnalyticsService {
       // Fail silently for analytics but log to console
       debugPrint('Analytics Error ($eventType): $e');
     }
+  }
+
+  /// Push un event vers PostHog — fire-and-forget, silencieux si désactivé.
+  /// PostHog requiert des propriétés `Object` (pas nullable) donc on filtre.
+  Future<void> _capturePostHog(
+    String event,
+    Map<String, dynamic> rawProps,
+  ) async {
+    if (_posthog == null || !_posthog.isEnabled) return;
+    final cleanProps = <String, Object>{};
+    rawProps.forEach((key, value) {
+      if (value != null) cleanProps[key] = value as Object;
+    });
+    await _posthog.capture(event: event, properties: cleanProps);
   }
 }

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -157,17 +157,30 @@ class AnalyticsService {
   // ──────────────────────────────────────────────────────────────
 
   /// @deprecated Use [trackContentInteraction] with action='read' instead.
+  ///
+  /// Story 14.1 — even though this is deprecated, it's still the only call
+  /// site for feed/detail reading flows (which carry real `timeSpentSeconds`).
+  /// We MUST mirror to PostHog from here too, otherwise `article_read` and
+  /// `article_completed` PostHog events would never fire from the surfaces
+  /// where users actually spend reading time. The digest "save" flow that
+  /// uses `trackContentInteraction` hardcodes `timeSpentSeconds: 0`.
   Future<void> trackArticleRead(
     String contentId,
     String sourceId,
     int timeSpentSeconds,
   ) async {
-    await _logEvent('article_read', {
+    final props = {
       'session_id': _sessionId,
       'content_id': contentId,
       'source_id': sourceId,
       'time_spent_seconds': timeSpentSeconds,
-    });
+    };
+    await _logEvent('article_read', props);
+
+    await _capturePostHog('article_read', props);
+    if (timeSpentSeconds >= 30) {
+      await _capturePostHog('article_completed', props);
+    }
   }
 
   /// @deprecated Use [trackFeedSession] instead.

--- a/apps/mobile/lib/core/services/posthog_service.dart
+++ b/apps/mobile/lib/core/services/posthog_service.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/foundation.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+import 'package:facteur/config/constants.dart';
+
+/// Wrapper minimal autour du SDK PostHog pour Facteur (Story 14.1).
+///
+/// Dual-track avec l'analytics maison (`/analytics/events`) : tout passe
+/// par [AnalyticsService._logEvent], qui appelle ce service en fire-and-forget.
+/// Si [PostHogConstants.isEnabled] est faux (dev sans clé), toutes les
+/// méthodes sont des no-op silencieux.
+///
+/// L'état `_initialized` est statique : le SDK PostHog étant lui-même un
+/// singleton global, tous les wrappers (main.dart init + provider Riverpod)
+/// partagent le même statut.
+class PostHogService {
+  static bool _initialized = false;
+
+  bool get isEnabled => PostHogConstants.isEnabled;
+
+  /// Configure et démarre le SDK. Doit être appelé une seule fois au boot.
+  Future<void> init() async {
+    if (_initialized || !isEnabled) return;
+    try {
+      final config = PostHogConfig(PostHogConstants.apiKey)
+        ..host = PostHogConstants.host
+        ..captureApplicationLifecycleEvents = true
+        ..debug = kDebugMode;
+      await Posthog().setup(config);
+      _initialized = true;
+    } catch (e) {
+      debugPrint('PostHog init failed: $e');
+    }
+  }
+
+  /// Associe le distinct_id PostHog à l'user Supabase et pose les user
+  /// properties de cohorte (acquisition_source, is_creator_ytbeur…).
+  Future<void> identify({
+    required String userId,
+    Map<String, Object>? properties,
+  }) async {
+    if (!_initialized) return;
+    try {
+      await Posthog().identify(
+        userId: userId,
+        userProperties: properties,
+      );
+    } catch (e) {
+      debugPrint('PostHog identify failed: $e');
+    }
+  }
+
+  /// Capture un event produit.
+  Future<void> capture({
+    required String event,
+    Map<String, Object>? properties,
+  }) async {
+    if (!_initialized) return;
+    try {
+      await Posthog().capture(
+        eventName: event,
+        properties: properties,
+      );
+    } catch (e) {
+      debugPrint('PostHog capture failed ($event): $e');
+    }
+  }
+
+  /// Reset le distinct_id (appelé au logout pour éviter de mélanger
+  /// les comptes sur un même device).
+  Future<void> reset() async {
+    if (!_initialized) return;
+    try {
+      await Posthog().reset();
+    } catch (e) {
+      debugPrint('PostHog reset failed: $e');
+    }
+  }
+
+  /// Visible pour tests uniquement — reset l'état statique.
+  @visibleForTesting
+  static void resetForTesting() => _initialized = false;
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:home_widget/home_widget.dart';
 import 'app.dart';
 import 'config/constants.dart';
 import 'core/auth/supabase_storage.dart';
+import 'core/services/posthog_service.dart';
 import 'core/services/push_notification_service.dart';
 import 'core/ui/notification_service.dart';
 
@@ -154,6 +155,34 @@ Future<void> main() async {
     debugPrint('Main: Supabase initialized correctly.');
     final hasSession = Supabase.instance.client.auth.currentSession != null;
     debugPrint('Main: Supabase Session restored immediately: $hasSession');
+
+    // Story 14.1 — init PostHog after Supabase so we can piggyback on the
+    // auth state stream to identify/reset the distinct_id automatically.
+    final posthog = PostHogService();
+    await posthog.init();
+    if (hasSession) {
+      final user = Supabase.instance.client.auth.currentUser;
+      if (user != null) {
+        await posthog.identify(userId: user.id);
+      }
+    }
+    Supabase.instance.client.auth.onAuthStateChange.listen((data) {
+      switch (data.event) {
+        case AuthChangeEvent.signedIn:
+        case AuthChangeEvent.tokenRefreshed:
+        case AuthChangeEvent.userUpdated:
+          final user = data.session?.user;
+          if (user != null) {
+            posthog.identify(userId: user.id);
+          }
+          break;
+        case AuthChangeEvent.signedOut:
+          posthog.reset();
+          break;
+        default:
+          break;
+      }
+    });
   } catch (e) {
     debugPrint('ERROR: Failed to initialize Supabase: $e');
     _runErrorApp(

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -61,6 +61,9 @@ dependencies:
 
   # Error Tracking
   sentry_flutter: ^9.9.2
+
+  # Product Analytics (Story 14.1 — retention cohorts)
+  posthog_flutter: ^5.0.0
   google_fonts: ^7.0.0
   flutter_animate: ^4.5.2
   haptic_feedback: ^0.6.4+3

--- a/apps/mobile/test/core/services/analytics_service_dual_track_test.dart
+++ b/apps/mobile/test/core/services/analytics_service_dual_track_test.dart
@@ -1,0 +1,163 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:facteur/core/api/api_client.dart';
+import 'package:facteur/core/services/analytics_service.dart';
+import 'package:facteur/core/services/posthog_service.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+class _MockDio extends Mock implements Dio {}
+
+class _RecordingPostHog extends PostHogService {
+  final List<({String event, Map<String, Object>? properties})> captured = [];
+  bool _enabled = true;
+
+  @override
+  bool get isEnabled => _enabled;
+
+  void setEnabled(bool v) => _enabled = v;
+
+  @override
+  Future<void> capture({
+    required String event,
+    Map<String, Object>? properties,
+  }) async {
+    captured.add((event: event, properties: properties));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+
+  late _MockApiClient api;
+  late _MockDio dio;
+  late _RecordingPostHog posthog;
+
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  setUp(() {
+    api = _MockApiClient();
+    dio = _MockDio();
+    when(() => api.dio).thenReturn(dio);
+    when(
+      () => dio.post(any(), data: any(named: 'data')),
+    ).thenAnswer(
+      (_) async => Response(
+        requestOptions: RequestOptions(path: ''),
+        statusCode: 201,
+      ),
+    );
+    posthog = _RecordingPostHog();
+  });
+
+  test('startSession mirrors session_start to app_open on PostHog', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.startSession(isOrganic: true);
+
+    expect(posthog.captured.map((e) => e.event), contains('app_open'));
+    // Backend logging still happens.
+    verify(
+      () => dio.post('analytics/events', data: any(named: 'data')),
+    ).called(1);
+  });
+
+  test('content_interaction read >30s emits article_read + article_completed',
+      () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.trackContentInteraction(
+      action: 'read',
+      surface: 'digest',
+      contentId: 'c1',
+      sourceId: 's1',
+      timeSpentSeconds: 45,
+    );
+
+    final events = posthog.captured.map((e) => e.event).toList();
+    expect(events, containsAll(<String>['article_read', 'article_completed']));
+  });
+
+  test('content_interaction read <30s emits article_read but NOT completed',
+      () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.trackContentInteraction(
+      action: 'read',
+      surface: 'digest',
+      contentId: 'c1',
+      sourceId: 's1',
+      timeSpentSeconds: 12,
+    );
+
+    final events = posthog.captured.map((e) => e.event).toList();
+    expect(events, contains('article_read'));
+    expect(events, isNot(contains('article_completed')));
+  });
+
+  test('save action does not emit article_read', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.trackContentInteraction(
+      action: 'save',
+      surface: 'feed',
+      contentId: 'c1',
+      sourceId: 's1',
+    );
+
+    expect(posthog.captured, isEmpty);
+  });
+
+  test('trackSourceAdd fires source_added on PostHog', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.trackSourceAdd('source-42');
+
+    expect(
+      posthog.captured.map((e) => e.event),
+      contains('source_added'),
+    );
+  });
+
+  test('trackComparisonViewed fires comparison_viewed on PostHog', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.trackComparisonViewed(clusterId: 'k-1', sourcesCount: 5);
+
+    final entry = posthog.captured.firstWhere(
+      (e) => e.event == 'comparison_viewed',
+    );
+    expect(entry.properties?['cluster_id'], 'k-1');
+    expect(entry.properties?['sources_count'], 5);
+  });
+
+  test('PostHog disabled → no captures but backend still called', () async {
+    posthog.setEnabled(false);
+    final service = AnalyticsService(api, posthog: posthog);
+
+    await service.trackSourceAdd('src');
+    await service.trackContentInteraction(
+      action: 'read',
+      surface: 'feed',
+      contentId: 'c',
+      sourceId: 's',
+      timeSpentSeconds: 60,
+    );
+
+    expect(posthog.captured, isEmpty);
+    verify(
+      () => dio.post('analytics/events', data: any(named: 'data')),
+    ).called(2);
+  });
+
+  test('backend failure does not crash analytics layer', () async {
+    when(() => dio.post(any(), data: any(named: 'data')))
+        .thenThrow(DioException(requestOptions: RequestOptions(path: '')));
+
+    final service = AnalyticsService(api, posthog: posthog);
+    // Must not throw
+    await service.trackSourceAdd('src');
+    // PostHog still fired (independent of backend).
+    expect(posthog.captured.map((e) => e.event), contains('source_added'));
+  });
+}

--- a/apps/mobile/test/core/services/analytics_service_dual_track_test.dart
+++ b/apps/mobile/test/core/services/analytics_service_dual_track_test.dart
@@ -150,6 +150,28 @@ void main() {
     ).called(2);
   });
 
+  test('trackArticleRead mirrors article_read + article_completed when >=30s',
+      () async {
+    // Story 14.1 — feed/detail surfaces still call the legacy
+    // trackArticleRead, so it must mirror to PostHog with the same
+    // threshold logic as trackContentInteraction. Otherwise
+    // article_completed would never fire from real reading flows.
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.trackArticleRead('c1', 's1', 45);
+
+    final events = posthog.captured.map((e) => e.event).toList();
+    expect(events, containsAll(<String>['article_read', 'article_completed']));
+  });
+
+  test('trackArticleRead <30s emits article_read but NOT completed', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.trackArticleRead('c1', 's1', 12);
+
+    final events = posthog.captured.map((e) => e.event).toList();
+    expect(events, contains('article_read'));
+    expect(events, isNot(contains('article_completed')));
+  });
+
   test('backend failure does not crash analytics layer', () async {
     when(() => dio.post(any(), data: any(named: 'data')))
         .thenThrow(DioException(requestOptions: RequestOptions(path: '')));

--- a/apps/mobile/test/core/services/posthog_service_test.dart
+++ b/apps/mobile/test/core/services/posthog_service_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/constants.dart';
+import 'package:facteur/core/services/posthog_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('isEnabled reflects PostHogConstants.apiKey presence', () {
+    final service = PostHogService();
+    expect(service.isEnabled, PostHogConstants.apiKey.isNotEmpty);
+  });
+
+  test('identify/capture/reset are no-ops before init (no crash)', () async {
+    final service = PostHogService();
+    // Must not throw — all calls are guarded by _initialized.
+    await service.identify(userId: 'u-1');
+    await service.capture(event: 'test', properties: const {'k': 'v'});
+    await service.reset();
+  });
+}

--- a/docs/analytics/posthog-dashboard-setup.md
+++ b/docs/analytics/posthog-dashboard-setup.md
@@ -1,0 +1,113 @@
+# PostHog — Setup dashboards & alertes (Story 14.1)
+
+> Guide reproductible pour configurer le projet PostHog EU. Tout est manuel côté UI PostHog, on versionne ici la recette.
+
+## 1. Projet & clés
+
+- **Projet** : `Facteur Prod` (région EU).
+- **Clés à injecter** :
+  - Backend (Railway) : `POSTHOG_API_KEY`, `POSTHOG_HOST=https://eu.i.posthog.com`, `POSTHOG_ENABLED=true`.
+  - Mobile (CI + dart-define) : `POSTHOG_API_KEY`, `POSTHOG_HOST=https://eu.i.posthog.com`.
+
+## 2. Events à vérifier
+
+Après un build avec les clés en place, vérifier dans PostHog → *Activity* que ces events arrivent :
+
+| Event | Source | Usage dashboard |
+|-------|--------|------------------|
+| `app_open` | Mobile (`session_start` mirror) | DAU, Retention D1/D7/D30 |
+| `article_read` | Mobile (`content_interaction action=read`) | Funnel activation |
+| `article_completed` | Mobile (≥ 30 s de lecture) | Taux de complétion |
+| `digest_session` | Mobile (fin du digest) | Closure rate |
+| `comparison_viewed` | Mobile (Ground News screen) | Signal H2 |
+| `source_added` | Mobile (`trackSourceAdd`) | Personnalisation |
+| `signup_completed` | Backend (onboarding save) | Cohort anchor pour rétention |
+| `waitlist_signup` | Backend (public `/api/waitlist`) | Qualité du canal |
+| `digest_generated` | Backend (job quotidien) | Ops / capacity |
+
+## 3. User properties
+
+Positionnées via `identify()` :
+
+- `acquisition_source` : `waitlist` | `invite` | `creator` | `organic` (via `PATCH /api/admin/users/{id}/cohorts`).
+- `is_creator_ytbeur` : bool, dérivé de `POSTHOG_CREATOR_EMAILS`.
+- `is_close_to_laurin` : bool, dérivé de `POSTHOG_CLOSE_CIRCLE_EMAILS`.
+
+## 4. Insights à créer
+
+### Tier 1 — La survie
+
+1. **DAU**
+   - Type : *Trends* → *Unique users*
+   - Event : `app_open`
+   - Interval : *Day*
+   - Filter : last 30 days
+
+2. **Rétention D1 / D7 / D30**
+   - Type : *Retention*
+   - Target event : `app_open`
+   - Cohortize by : `signup_completed` (*First time user performed event*)
+   - Period : *Day*, intervals 1 / 7 / 30
+   - Viser : D1 > 30 %, D7 > 15 %, D30 > 10 %.
+
+### Tier 2 — L'engagement
+
+3. **Sessions / user / jour**
+   - Type : *Trends* → *Total count* of `app_open`
+   - Math : *Average by user*
+   - Interval : *Day*
+
+4. **Taux de complétion du flux**
+   - Type : *Funnels*
+   - Steps : `app_open` → `article_read` → `digest_session (closure_achieved=true)`
+   - Conversion window : 1 day
+
+5. **Temps moyen par session**
+   - *Trends* → `session_end.duration_seconds` average.
+
+6. **Sources ajoutées**
+   - *Trends* → total `source_added` / DAU.
+
+### Tier 3 — Cohortes spéciales
+
+Créer 3 cohortes dans *People → Cohorts* :
+
+- **YTbeurs** : `is_creator_ytbeur = true`
+- **Proches de Laurin** : `is_close_to_laurin = true`
+- **Waitlist vs Invite** : filter sur `acquisition_source`
+
+Dupliquer les insights Tier 1/2 en breakdown par cohorte pour comparer.
+
+## 5. Alertes
+
+- **Chute DAU > 30 % day-over-day** :
+  - Dashboard DAU → kebab → *Create alert*
+  - Condition : *Value changes by more than 30 % decreasing*
+  - Frequency : daily 09:00 Europe/Paris
+  - Channel : webhook Slack `#facteur-alerts` (ou email Laurin si pas de Slack)
+
+- **Digest job failures** :
+  - Insight : `digest_generated` → breakdown `stats.failed`
+  - Alert : `stats.failed > 10` déclenche même canal.
+
+## 6. Funnel recommandé
+
+```
+signup_completed → article_read → digest_session → app_open (lendemain)
+```
+
+À utiliser pour quantifier le drop entre "inscrit" et "activé habituel".
+
+## 7. Rollout
+
+1. Activer `POSTHOG_ENABLED=true` sur Railway staging.
+2. Lancer un run manuel `/api/internal/briefing` + ouvrir l'app sur device dev.
+3. Vérifier que les 9 events de la section 2 apparaissent.
+4. Activer en production (`POSTHOG_ENABLED=true`).
+5. Créer les insights de la section 4 dans l'ordre.
+6. Documenter l'URL du dashboard dans `docs/etat-avancement-mvp.md`.
+
+## 8. Kill-switch
+
+- Désactiver rapidement : sur Railway, mettre `POSTHOG_ENABLED=false` + redeploy.
+- Côté mobile : un build sans `POSTHOG_API_KEY` (dart-define vide) désactive le SDK.

--- a/docs/stories/core/14.1.analytics-posthog-retention.story.md
+++ b/docs/stories/core/14.1.analytics-posthog-retention.story.md
@@ -1,0 +1,162 @@
+# Story 14.1 : Analytics & Métriques de Rétention (PostHog)
+
+> **Classification** : Feature
+> **Epic proposé** : 14 — Analytics & Observabilité Produit
+> **Status** : 📝 PLAN (en attente de GO utilisateur)
+> **Branche** : `claude/add-analytics-retention-UPhGB`
+
+---
+
+## Contexte business
+
+Sans métriques, chaque décision produit est un pari aveugle. Benchmark rétention D30 apps info = 2–4 %. Si Facteur fait mieux, c'est un signal fort pour investisseurs/partenaires. Si c'est pareil, il faut pivoter le format. Les 90 prochains jours sont existentiels — on ne peut rien valider sans données de cohortes.
+
+## Objectif
+
+Instrumenter Facteur (mobile + backend) avec **PostHog** pour livrer :
+
+- Un dashboard de **rétention par cohortes** (D1 / D7 / D30) utilisable sans intervention dev.
+- Les **funnels** d'activation (inscription → 1er article lu → flux complété → retour D1 → retour D7).
+- Les **user properties** nécessaires aux cohortes spéciales (waitlist vs invite, proche de Laurin, créateur YTbeur).
+- Les **alertes** de chute brutale de DAU.
+
+## Périmètre de l'existant (à ne pas casser)
+
+Facteur a déjà :
+- Un backend analytics propriétaire (`POST /analytics/events`, table `analytics_events`) utilisé par les endpoints `GET /analytics/digest-metrics`.
+- Un `AnalyticsService` Flutter (`apps/mobile/lib/core/services/analytics_service.dart`) qui émet `session_start`, `session_end`, `content_interaction`, `digest_session`, `feed_session`, `source_add`, `app_first_launch`, etc.
+
+**Décision** : on **conserve** le pipeline existant (il sert aux métriques digest par utilisateur, tant la granularité est fine) et on y **branche PostHog en parallèle** (dual-track). PostHog n'aura **pas** besoin d'accéder à la base — il reçoit les events côté client + quelques events serveur critiques.
+
+## Architecture cible
+
+```
+┌───────────────┐       ┌────────────────────┐
+│ Flutter app   │──┬───▶│ PostHog Cloud EU   │  ← rétention, funnels, cohortes
+│ AnalyticsSvc  │  │    └────────────────────┘
+└───────────────┘  │
+                   └───▶ POST /analytics/events ──▶ analytics_events (existant)
+┌───────────────┐       ┌────────────────────┐
+│ FastAPI       │──────▶│ PostHog Cloud EU   │  ← events serveur (waitlist, invite)
+└───────────────┘       └────────────────────┘
+```
+
+## Plan technique
+
+### 1. Dépendances & config (0.5 j)
+
+- **Mobile** : ajouter `posthog_flutter: ^5.0.0` dans `pubspec.yaml`.
+- **Backend** : ajouter `posthog-python = "^3.7.0"` dans `packages/api/pyproject.toml`.
+- **Env vars** (Railway + `.env.example`) :
+  - `POSTHOG_API_KEY` (projet EU, clé publique)
+  - `POSTHOG_HOST=https://eu.i.posthog.com`
+  - `POSTHOG_ENABLED` (bool, défaut `true` en prod, `false` en dev)
+
+### 2. Couche PostHog mobile (1 j)
+
+Fichier nouveau : `apps/mobile/lib/core/services/posthog_service.dart`
+- `init()` appelé depuis `main.dart` juste après Supabase init (avant `runApp`).
+- Wrapper minimal : `capture(String event, {Map<String, dynamic>? properties})`.
+- `identify(userId, {Map<String, dynamic>? properties})` appelé au login (listener sur `Supabase.instance.client.auth.onAuthStateChange`).
+- `reset()` appelé au logout.
+
+Modifier `analytics_service.dart` :
+- Injecter `PostHogService` via Riverpod (le provider existe déjà dans `core/providers/analytics_provider.dart`).
+- Dans `_logEvent`, dupliquer l'event vers PostHog (fire-and-forget).
+- Mapping explicite des 5 events prioritaires du brief :
+  - `app_open` ← `session_start`
+  - `article_read` ← `content_interaction` (filtré `action=read`)
+  - `article_completed` ← event existant (à ajouter côté reader pour lecture > 30 s ou scroll ≥ 90 %)
+  - `source_added` ← `source_add`
+  - `comparison_viewed` ← nouveau, à tracker dans `features/perspectives/` quand l'écran comparaison est ouvert.
+
+### 3. User properties & cohortes (0.5 j)
+
+Au `identify()` côté mobile, envoyer :
+- `acquisition_source` : lu depuis `UserPreference` (clé `acquisition_source`, valeurs `waitlist` | `invite` | `creator` | `organic`).
+- `is_close_to_laurin` : bool, dérivé d'une liste d'emails en dur côté backend (config PostHog, pas de PII en clair dans le code).
+- `is_creator_ytbeur` : bool, même mécanisme.
+- `cohort_tags` : `list[str]` (PostHog supporte les tableaux).
+
+Backend — petit endpoint admin `PATCH /admin/users/{id}/cohorts` (protégé par `X-Admin-Token`) qui :
+1. Upsert la `UserPreference acquisition_source`.
+2. Envoie `posthog.identify(user_id, properties)` côté serveur pour propagation immédiate.
+
+Pas de migration Alembic nécessaire — on utilise `user_preferences` (clé/valeur) qui existe déjà.
+
+### 4. Events serveur critiques (0.5 j)
+
+Dans `packages/api/app/services/posthog_client.py` (nouveau) :
+- Singleton initialisé depuis `config.py` (désactivé si `POSTHOG_ENABLED=false`).
+- `capture(user_id, event, properties)` + `identify(user_id, properties)`.
+
+Instrumenter :
+- `routers/waitlist.py` → `waitlist_signup` à l'inscription waitlist.
+- `routers/auth.py` ou callback login → `signup_completed` à la création du `UserProfile`.
+- `jobs/daily_digest_worker.py` → `digest_generated` server-side (volume, fallback utilisé ou pas).
+
+### 5. Dashboard PostHog (0.5 j — configuration)
+
+Livrer un fichier `docs/analytics/posthog-dashboard-setup.md` qui décrit step-by-step :
+- Insights à créer : DAU, Retention D1/D7/D30 (cohort par `signup_completed`), Funnel activation.
+- Cohortes à créer : `YTbeurs`, `Proches Laurin`, `Waitlist vs Invite`.
+- Alert : DAU chute > 30 % day-over-day → webhook Slack (ou email Laurin).
+
+(La configuration UI PostHog n'est pas versionnable simplement — on documente pour reproductibilité.)
+
+### 6. Tests (0.5 j)
+
+**Backend** :
+- `tests/test_posthog_client.py` : mock `posthog.capture`, vérifier qu'il n'est pas appelé si `POSTHOG_ENABLED=false`, qu'un user_id invalide ne crash pas.
+- `tests/test_admin_cohorts.py` : endpoint `PATCH /admin/users/{id}/cohorts` auth + upsert preference.
+
+**Mobile** :
+- `test/services/posthog_service_test.dart` : mock PostHog plugin, vérifier init/identify/reset.
+- `test/services/analytics_service_dual_track_test.dart` : un `trackContentInteraction` appelle à la fois l'API backend et PostHog.
+
+Pas de test E2E Playwright nécessaire (pas d'impact visuel).
+
+### 7. Rollout & kill-switch
+
+- `POSTHOG_ENABLED=false` par défaut en dev + tests.
+- En prod, activer uniquement après vérif que les events arrivent dans le projet PostHog EU.
+- Pas d'impact user visible → pas de feature flag UI nécessaire.
+
+## Livrables
+
+| # | Fichier | Type |
+|---|---------|------|
+| 1 | `apps/mobile/pubspec.yaml` | modif |
+| 2 | `apps/mobile/lib/core/services/posthog_service.dart` | nouveau |
+| 3 | `apps/mobile/lib/core/services/analytics_service.dart` | modif (dual-track) |
+| 4 | `apps/mobile/lib/main.dart` | modif (init PostHog) |
+| 5 | `packages/api/pyproject.toml` | modif |
+| 6 | `packages/api/app/config.py` | modif (env vars) |
+| 7 | `packages/api/app/services/posthog_client.py` | nouveau |
+| 8 | `packages/api/app/routers/admin_cohorts.py` | nouveau |
+| 9 | `packages/api/app/routers/waitlist.py`, `auth.py`, `jobs/daily_digest_worker.py` | modif (server events) |
+| 10 | `docs/analytics/posthog-dashboard-setup.md` | nouveau |
+| 11 | Tests backend + mobile | nouveau |
+
+## Estimation totale
+
+**~3 jours** (dev + tests + doc setup PostHog).
+
+## Hors périmètre (à traiter plus tard)
+
+- Export PostHog → Supabase pour analyses avancées.
+- A/B testing via PostHog Feature Flags.
+- Revenue analytics (branché sur RevenueCat).
+
+## Critères d'acceptation
+
+- [ ] Les 5 events prioritaires arrivent dans PostHog avec `user_id` stable.
+- [ ] Un dashboard PostHog affiche DAU + Retention D1/D7/D30 sur données réelles de dev.
+- [ ] Les 4 comptes YTbeurs sont identifiables dans une cohorte dédiée.
+- [ ] `POSTHOG_ENABLED=false` désactive totalement les appels (vérifié par test).
+- [ ] Aucune régression sur les métriques `GET /analytics/digest-metrics` existantes.
+- [ ] Tests backend + mobile verts, CI green.
+
+---
+
+**⏸ STOP — en attente de GO utilisateur avant passage en phase CODE+TEST.**

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -94,6 +94,17 @@ class Settings(BaseSettings):
     # Sentry
     sentry_dsn: str = ""
 
+    # PostHog (Story 14.1 — retention cohorts)
+    posthog_api_key: str = ""
+    posthog_host: str = "https://eu.i.posthog.com"
+    posthog_enabled: bool = False
+    # Cohort identification (comma-separated emails, case-insensitive)
+    posthog_creator_emails: str = ""
+    posthog_close_circle_emails: str = ""
+
+    # Admin endpoints shared secret (Story 14.1)
+    admin_api_token: str = ""
+
     # YouTube Data API v3
     youtube_api_key: str = ""
 

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -267,6 +267,25 @@ class DigestGenerationJob:
                 **self.stats,
             )
 
+            # Story 14.1 — operational event to PostHog for ops dashboards.
+            # Uses a synthetic distinct_id since this is a system-level event.
+            try:
+                from app.services.posthog_client import get_posthog_client
+
+                get_posthog_client().capture(
+                    user_id="system:digest_job",
+                    event="digest_generated",
+                    properties={
+                        "target_date": str(target_date),
+                        "duration_seconds": round(duration, 1),
+                        **self.stats,
+                    },
+                )
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning(
+                    "digest_generation_posthog_failed", error=str(exc)
+                )
+
             return {
                 "success": True,
                 "target_date": str(target_date),

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -282,9 +282,7 @@ class DigestGenerationJob:
                     },
                 )
             except Exception as exc:  # pragma: no cover — defensive
-                logger.warning(
-                    "digest_generation_posthog_failed", error=str(exc)
-                )
+                logger.warning("digest_generation_posthog_failed", error=str(exc))
 
             return {
                 "success": True,

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -65,6 +65,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import get_settings
 from app.database import close_db, get_db, init_db, text
 from app.routers import (
+    admin_cohorts,
     analytics,
     app_update,
     auth,
@@ -310,6 +311,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
         await ml_worker.stop()
         logger.info("lifespan_ml_worker_stopped")
     stop_scheduler()
+    try:
+        from app.services.posthog_client import get_posthog_client
+
+        get_posthog_client().shutdown()
+    except Exception as exc:
+        logger.warning("lifespan_posthog_shutdown_failed", error=str(exc))
     await close_db()
 
 
@@ -366,6 +373,7 @@ app.include_router(
 )
 app.include_router(app_update.router, prefix="/api/app", tags=["AppUpdate"])
 app.include_router(waitlist.router, prefix="/api/waitlist", tags=["Waitlist"])
+app.include_router(admin_cohorts.router, prefix="/api/admin", tags=["Admin"])
 
 
 @app.exception_handler(Exception)

--- a/packages/api/app/routers/__init__.py
+++ b/packages/api/app/routers/__init__.py
@@ -1,6 +1,7 @@
 """Routers API."""
 
 from app.routers import (
+    admin_cohorts,
     analytics,
     app_update,
     auth,
@@ -20,6 +21,7 @@ from app.routers import (
 )
 
 __all__ = [
+    "admin_cohorts",
     "analytics",
     "app_update",
     "auth",

--- a/packages/api/app/routers/admin_cohorts.py
+++ b/packages/api/app/routers/admin_cohorts.py
@@ -1,0 +1,121 @@
+"""Endpoint admin pour tagger les utilisateurs dans des cohortes PostHog.
+
+Story 14.1 — permet à Laurin de marquer un user comme `waitlist`, `invite`,
+`creator` ou `organic` sans toucher à la base via psql.
+Stocke l'info dans `user_preferences` (clé `acquisition_source`) et
+propage immédiatement vers PostHog via `identify()`.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.database import get_db
+from app.models.user import UserPreference
+from app.services.posthog_client import derive_cohort_properties, get_posthog_client
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+ACQUISITION_SOURCE_KEY = "acquisition_source"
+AcquisitionSource = Literal["waitlist", "invite", "creator", "organic"]
+
+
+class CohortUpdateRequest(BaseModel):
+    """Payload pour tagger la cohorte d'un utilisateur."""
+
+    acquisition_source: AcquisitionSource = Field(
+        ...,
+        description="Canal d'acquisition (waitlist, invite, creator, organic)",
+    )
+    email: EmailStr | None = Field(
+        None,
+        description="Email utilisateur — utilisé pour calculer les cohortes spéciales",
+    )
+
+
+class CohortUpdateResponse(BaseModel):
+    user_id: UUID
+    acquisition_source: AcquisitionSource
+    posthog_synced: bool
+
+
+def require_admin_token(
+    x_admin_token: str | None = Header(default=None, alias="X-Admin-Token"),
+) -> None:
+    """Vérifie le header X-Admin-Token contre ADMIN_API_TOKEN.
+
+    Refuse tout accès si le secret est vide en config (fail-closed).
+    """
+    settings = get_settings()
+    expected = settings.admin_api_token
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Admin API disabled: ADMIN_API_TOKEN not configured",
+        )
+    if not x_admin_token or x_admin_token != expected:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing X-Admin-Token header",
+        )
+
+
+@router.patch(
+    "/users/{user_id}/cohorts",
+    response_model=CohortUpdateResponse,
+    dependencies=[Depends(require_admin_token)],
+)
+async def update_user_cohort(
+    user_id: UUID,
+    payload: CohortUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+) -> CohortUpdateResponse:
+    """Upsert acquisition_source dans user_preferences + identify PostHog."""
+    stmt = select(UserPreference).where(
+        UserPreference.user_id == user_id,
+        UserPreference.preference_key == ACQUISITION_SOURCE_KEY,
+    )
+    existing = (await db.execute(stmt)).scalar_one_or_none()
+
+    if existing is None:
+        db.add(
+            UserPreference(
+                user_id=user_id,
+                preference_key=ACQUISITION_SOURCE_KEY,
+                preference_value=payload.acquisition_source,
+            )
+        )
+    else:
+        existing.preference_value = payload.acquisition_source
+
+    await db.commit()
+
+    posthog = get_posthog_client()
+    properties: dict[str, str | bool] = {
+        "acquisition_source": payload.acquisition_source,
+    }
+    properties.update(derive_cohort_properties(payload.email))
+    posthog.identify(user_id, properties=properties)
+
+    logger.info(
+        "admin_cohort_updated",
+        user_id=str(user_id),
+        acquisition_source=payload.acquisition_source,
+        posthog_enabled=posthog.enabled,
+    )
+
+    return CohortUpdateResponse(
+        user_id=user_id,
+        acquisition_source=payload.acquisition_source,
+        posthog_synced=posthog.enabled,
+    )

--- a/packages/api/app/routers/waitlist.py
+++ b/packages/api/app/routers/waitlist.py
@@ -1,5 +1,7 @@
 """Router waitlist — endpoint public pour inscription landing page."""
 
+import hashlib
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,9 +13,19 @@ from app.schemas.waitlist import (
     WaitlistRequest,
     WaitlistResponse,
 )
+from app.services.posthog_client import get_posthog_client
 from app.services.waitlist_service import WaitlistService
 
 router = APIRouter()
+
+
+def _email_distinct_id(email: str) -> str:
+    """Distinct_id stable pour un lead non authentifié (hash de l'email).
+
+    On ne push pas l'email en clair à PostHog — on déterministe un id qui
+    pourra être alias'é au vrai user_id après signup côté mobile.
+    """
+    return "lead_" + hashlib.sha256(email.strip().lower().encode()).hexdigest()[:16]
 
 
 @router.get("/count", response_model=WaitlistCountResponse)
@@ -40,6 +52,17 @@ async def join_waitlist(
         utm_medium=request.utm_medium,
         utm_campaign=request.utm_campaign,
     )
+    if is_new:
+        get_posthog_client().capture(
+            user_id=_email_distinct_id(request.email),
+            event="waitlist_signup",
+            properties={
+                "source": request.source,
+                "utm_source": request.utm_source,
+                "utm_medium": request.utm_medium,
+                "utm_campaign": request.utm_campaign,
+            },
+        )
     return WaitlistResponse(
         message="Merci ! On t'écrit très vite. 💌",
         is_new=is_new,

--- a/packages/api/app/services/posthog_client.py
+++ b/packages/api/app/services/posthog_client.py
@@ -1,0 +1,126 @@
+"""Client PostHog pour analytics produit (rétention, cohortes, funnels).
+
+Story 14.1 — Dual-track avec analytics_events (qui reste pour digest-metrics).
+Les appels PostHog sont fire-and-forget, jamais bloquants pour l'utilisateur.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+from uuid import UUID
+
+import structlog
+from posthog import Posthog
+
+from app.config import get_settings
+
+logger = structlog.get_logger()
+
+
+class PostHogClient:
+    """Wrapper autour du SDK Posthog avec kill-switch et logging."""
+
+    def __init__(
+        self,
+        api_key: str,
+        host: str,
+        enabled: bool,
+    ) -> None:
+        self.enabled = enabled and bool(api_key)
+        self._client: Posthog | None = None
+        if self.enabled:
+            self._client = Posthog(
+                project_api_key=api_key,
+                host=host,
+                # Disable GeoIP server-side — we rely on app-level properties.
+                disable_geoip=True,
+            )
+
+    def capture(
+        self,
+        user_id: UUID | str,
+        event: str,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        """Envoie un event à PostHog. Silencieux si désactivé ou en échec."""
+        if not self.enabled or self._client is None:
+            return
+        try:
+            self._client.capture(
+                distinct_id=str(user_id),
+                event=event,
+                properties=properties or {},
+            )
+        except Exception as exc:
+            logger.warning(
+                "posthog.capture_failed",
+                posthog_event=event,
+                user_id=str(user_id),
+                error=str(exc),
+            )
+
+    def identify(
+        self,
+        user_id: UUID | str,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        """Met à jour les user properties sur PostHog. Silencieux si KO."""
+        if not self.enabled or self._client is None:
+            return
+        try:
+            self._client.identify(
+                distinct_id=str(user_id),
+                properties=properties or {},
+            )
+        except Exception as exc:
+            logger.warning(
+                "posthog.identify_failed",
+                user_id=str(user_id),
+                error=str(exc),
+            )
+
+    def shutdown(self) -> None:
+        """Flush les events avant arrêt du process (appelé au shutdown FastAPI)."""
+        if self._client is not None:
+            try:
+                self._client.shutdown()
+            except Exception as exc:
+                logger.warning("posthog.shutdown_failed", error=str(exc))
+
+
+@lru_cache
+def get_posthog_client() -> PostHogClient:
+    """Singleton PostHogClient initialisé depuis les settings."""
+    settings = get_settings()
+    return PostHogClient(
+        api_key=settings.posthog_api_key,
+        host=settings.posthog_host,
+        enabled=settings.posthog_enabled,
+    )
+
+
+def _parse_email_list(raw: str) -> set[str]:
+    """Parse une liste d'emails séparés par virgule, normalisée en minuscules."""
+    return {email.strip().lower() for email in raw.split(",") if email.strip()}
+
+
+def derive_cohort_properties(email: str | None) -> dict[str, Any]:
+    """Calcule les user properties de cohorte à partir de l'email utilisateur.
+
+    Les listes sont lues depuis la config (POSTHOG_CREATOR_EMAILS,
+    POSTHOG_CLOSE_CIRCLE_EMAILS) pour éviter de committer des PII.
+    """
+    if not email:
+        return {
+            "is_creator_ytbeur": False,
+            "is_close_to_laurin": False,
+        }
+    settings = get_settings()
+    creators = _parse_email_list(settings.posthog_creator_emails)
+    close_circle = _parse_email_list(settings.posthog_close_circle_emails)
+    normalized = email.strip().lower()
+    return {
+        "is_creator_ytbeur": normalized in creators,
+        "is_close_to_laurin": normalized in close_circle,
+    }

--- a/packages/api/app/services/user_service.py
+++ b/packages/api/app/services/user_service.py
@@ -330,6 +330,24 @@ class UserService:
             else 0,
         )
 
+        # Story 14.1 — capture signup_completed server-side for retention cohorts.
+        # Fire-and-forget, never blocks the onboarding response.
+        try:
+            from app.services.posthog_client import get_posthog_client
+
+            get_posthog_client().capture(
+                user_id=user_id,
+                event="signup_completed",
+                properties={
+                    "themes_count": interest_count,
+                    "subtopics_count": subtopic_count,
+                    "sources_count": sources_created,
+                    "gamification_enabled": answers.gamification_enabled,
+                },
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("onboarding_posthog_capture_failed", error=str(exc))
+
         return {
             "profile": profile,
             "interests_created": interest_count,

--- a/packages/api/env.example
+++ b/packages/api/env.example
@@ -30,3 +30,14 @@ CORS_ORIGINS=["http://localhost:3000","http://localhost:8080"]
 
 # Sentry (production only)
 SENTRY_DSN=
+
+# PostHog (Story 14.1 — retention cohorts)
+POSTHOG_API_KEY=
+POSTHOG_HOST=https://eu.i.posthog.com
+POSTHOG_ENABLED=false
+# Comma-separated emails (case-insensitive) for special cohorts
+POSTHOG_CREATOR_EMAILS=
+POSTHOG_CLOSE_CIRCLE_EMAILS=
+
+# Admin endpoints shared secret (required for /api/admin/*)
+ADMIN_API_TOKEN=

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "apscheduler>=3.10.4",
     "structlog>=24.1.0",
     "sentry-sdk[fastapi]>=1.40.0",
+    "posthog>=3.7.0",
     "python-multipart>=0.0.6",
     "alembic>=1.13.1",
     # ML Classification (Story 4.1d)

--- a/packages/api/requirements.txt
+++ b/packages/api/requirements.txt
@@ -40,6 +40,9 @@ structlog==24.1.0
 # Error Tracking
 sentry-sdk[fastapi]==1.40.0
 
+# Product Analytics (Story 14.1 — retention cohorts)
+posthog>=3.7.0
+
 # Multipart (file uploads)
 python-multipart==0.0.6
 

--- a/packages/api/tests/routers/test_admin_cohorts.py
+++ b/packages/api/tests/routers/test_admin_cohorts.py
@@ -1,0 +1,136 @@
+"""Tests for the admin cohorts endpoint (Story 14.1)."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_missing_header_returns_401_when_token_configured():
+    user_id = uuid4()
+    with patch("app.routers.admin_cohorts.get_settings") as mock_settings:
+        mock_settings.return_value.admin_api_token = "s3cr3t"
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.patch(
+                f"/api/admin/users/{user_id}/cohorts",
+                json={"acquisition_source": "waitlist"},
+            )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wrong_header_returns_401():
+    user_id = uuid4()
+    with patch("app.routers.admin_cohorts.get_settings") as mock_settings:
+        mock_settings.return_value.admin_api_token = "s3cr3t"
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.patch(
+                f"/api/admin/users/{user_id}/cohorts",
+                json={"acquisition_source": "waitlist"},
+                headers={"X-Admin-Token": "nope"},
+            )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_empty_token_config_returns_503():
+    """Fail-closed when ADMIN_API_TOKEN is not configured."""
+    user_id = uuid4()
+    with patch("app.routers.admin_cohorts.get_settings") as mock_settings:
+        mock_settings.return_value.admin_api_token = ""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.patch(
+                f"/api/admin/users/{user_id}/cohorts",
+                json={"acquisition_source": "waitlist"},
+                headers={"X-Admin-Token": "anything"},
+            )
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_invalid_acquisition_source_returns_422():
+    user_id = uuid4()
+    with patch("app.routers.admin_cohorts.get_settings") as mock_settings:
+        mock_settings.return_value.admin_api_token = "s3cr3t"
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.patch(
+                f"/api/admin/users/{user_id}/cohorts",
+                json={"acquisition_source": "not-a-valid-value"},
+                headers={"X-Admin-Token": "s3cr3t"},
+            )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_valid_request_calls_identify_and_commits():
+    """End-to-end: token OK + valid body → identify + DB upsert attempted."""
+    user_id = uuid4()
+
+    mock_posthog = MagicMock()
+    mock_posthog.enabled = True
+
+    # Patch the DB session dep to a no-op session that just records writes.
+    from app.database import get_db
+
+    fake_session = MagicMock()
+
+    async def _fake_execute(*args, **kwargs):
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=None)
+        return result
+
+    fake_session.execute = _fake_execute
+    fake_session.add = MagicMock()
+
+    async def _fake_commit():
+        return None
+
+    fake_session.commit = _fake_commit
+
+    async def _override_db():
+        yield fake_session
+
+    app.dependency_overrides[get_db] = _override_db
+
+    try:
+        with (
+            patch("app.routers.admin_cohorts.get_settings") as mock_settings,
+            patch(
+                "app.routers.admin_cohorts.get_posthog_client",
+                return_value=mock_posthog,
+            ),
+            patch(
+                "app.routers.admin_cohorts.derive_cohort_properties",
+                return_value={"is_creator_ytbeur": True, "is_close_to_laurin": False},
+            ),
+        ):
+            mock_settings.return_value.admin_api_token = "s3cr3t"
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                resp = await ac.patch(
+                    f"/api/admin/users/{user_id}/cohorts",
+                    json={
+                        "acquisition_source": "creator",
+                        "email": "someone@youtube.com",
+                    },
+                    headers={"X-Admin-Token": "s3cr3t"},
+                )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["acquisition_source"] == "creator"
+    assert body["posthog_synced"] is True
+    mock_posthog.identify.assert_called_once()
+    identify_kwargs = mock_posthog.identify.call_args.kwargs
+    assert identify_kwargs["properties"]["acquisition_source"] == "creator"
+    assert identify_kwargs["properties"]["is_creator_ytbeur"] is True

--- a/packages/api/tests/services/test_posthog_client.py
+++ b/packages/api/tests/services/test_posthog_client.py
@@ -1,0 +1,100 @@
+"""Tests for the PostHog wrapper (Story 14.1)."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from app.services.posthog_client import PostHogClient, derive_cohort_properties
+
+
+def test_disabled_when_flag_false_no_capture_call():
+    client = PostHogClient(api_key="phc_test", host="https://eu", enabled=False)
+    # _client is None when disabled — no .capture() attribute, no network.
+    assert client._client is None
+    assert client.enabled is False
+    # Must not raise
+    client.capture(user_id=uuid4(), event="anything", properties={})
+
+
+def test_disabled_when_api_key_empty():
+    client = PostHogClient(api_key="", host="https://eu", enabled=True)
+    assert client.enabled is False
+    assert client._client is None
+    client.capture(user_id="abc", event="x")
+
+
+def test_capture_forwards_to_sdk_when_enabled():
+    client = PostHogClient.__new__(PostHogClient)
+    client.enabled = True
+    mock_sdk = MagicMock()
+    client._client = mock_sdk
+
+    uid = uuid4()
+    client.capture(user_id=uid, event="waitlist_signup", properties={"source": "web"})
+
+    mock_sdk.capture.assert_called_once_with(
+        distinct_id=str(uid),
+        event="waitlist_signup",
+        properties={"source": "web"},
+    )
+
+
+def test_capture_swallows_sdk_exceptions():
+    client = PostHogClient.__new__(PostHogClient)
+    client.enabled = True
+    mock_sdk = MagicMock()
+    mock_sdk.capture.side_effect = RuntimeError("network down")
+    client._client = mock_sdk
+
+    # Must not raise — analytics failures never block user flows.
+    client.capture(user_id="u", event="x")
+
+
+def test_identify_forwards_properties():
+    client = PostHogClient.__new__(PostHogClient)
+    client.enabled = True
+    mock_sdk = MagicMock()
+    client._client = mock_sdk
+
+    client.identify(user_id="u-1", properties={"acquisition_source": "waitlist"})
+
+    mock_sdk.identify.assert_called_once_with(
+        distinct_id="u-1",
+        properties={"acquisition_source": "waitlist"},
+    )
+
+
+def test_identify_noop_when_disabled():
+    client = PostHogClient(api_key="", host="https://eu", enabled=False)
+    # Must not raise, must not call anything.
+    client.identify(user_id="u", properties={"a": 1})
+
+
+def test_derive_cohort_properties_empty_email_returns_false_flags():
+    props = derive_cohort_properties(None)
+    assert props == {
+        "is_creator_ytbeur": False,
+        "is_close_to_laurin": False,
+    }
+
+
+def test_derive_cohort_properties_case_insensitive_match():
+    with patch("app.services.posthog_client.get_settings") as mock_settings:
+        mock_settings.return_value.posthog_creator_emails = "Creator@X.com, other@x.com"
+        mock_settings.return_value.posthog_close_circle_emails = "LAURIN@example.com"
+
+        creator_match = derive_cohort_properties("creator@x.com")
+        close_match = derive_cohort_properties("laurin@example.com")
+        no_match = derive_cohort_properties("random@user.com")
+
+    assert creator_match == {
+        "is_creator_ytbeur": True,
+        "is_close_to_laurin": False,
+    }
+    assert close_match == {
+        "is_creator_ytbeur": False,
+        "is_close_to_laurin": True,
+    }
+    assert no_match == {
+        "is_creator_ytbeur": False,
+        "is_close_to_laurin": False,
+    }


### PR DESCRIPTION
## What

Instrument Facteur (mobile + backend) with **PostHog** for product analytics while preserving the existing analytics pipeline. Implements dual-track event capture: events flow to both the legacy `POST /analytics/events` backend and PostHog Cloud EU in parallel.

**Mobile changes:**
- New `PostHogService` wrapper around `posthog_flutter` SDK
- Modified `AnalyticsService` to mirror key events to PostHog (`app_open`, `article_read`, `article_completed`, `source_added`, `comparison_viewed`)
- PostHog initialization in `main.dart` with auth state listener for `identify()`/`reset()`
- Added `PostHogConstants` for API key/host configuration via dart-define

**Backend changes:**
- New `PostHogClient` wrapper with fire-and-forget semantics and graceful degradation
- New admin endpoint `PATCH /api/admin/users/{id}/cohorts` to tag users with acquisition source and special cohorts
- Instrumented `waitlist_signup`, `signup_completed`, and `digest_generated` events
- Configuration via env vars: `POSTHOG_API_KEY`, `POSTHOG_HOST`, `POSTHOG_ENABLED`, plus email lists for cohort derivation

**Documentation:**
- Comprehensive setup guide for PostHog dashboards, insights, and alerts
- Story document outlining business context and technical architecture

## Why

Without retention metrics, product decisions are blind guesses. Facteur needs cohort-based retention (D1/D7/D30), funnel analysis, and user segmentation to validate product-market fit and inform investor/partner conversations. The existing analytics pipeline serves digest-level metrics but lacks the granularity and tooling for cohort analysis. PostHog provides out-of-the-box dashboards, retention calculations, and funnel visualization without requiring custom BI infrastructure.

Dual-track approach preserves backward compatibility: the legacy analytics table continues to power existing digest metrics while PostHog handles retention/cohort analysis independently.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`apps/mobile/test/core/services/analytics_service_dual_track_test.dart`, `packages/api/tests/services/test_posthog_client.py`, `packages/api/tests/routers/test_admin_cohorts.py`)
- [x] Linting passes (no new `List[]` imports, follows existing patterns)
- [x] No auth/DB safety issues (uses existing `user_preferences` table, admin endpoint protected by token)
- [x] Peer Review Conductor completed

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (feature includes comprehensive tests; staging deployment requires PostHog project setup outside code)

## Notes

- PostHog is disabled by default (`POSTHOG_ENABLED=false`) and requires explicit env var configuration
- All PostHog calls are fire-and-forget; failures never block user flows
- Mobile SDK initialization happens after Supabase auth to leverage existing session state
- Backend events use synthetic distinct_ids (e.g., `system:digest_job`) for system-level events
- Email lists for cohort derivation (`POSTHOG_CREATOR_EMAILS`, `POSTHOG_CLOSE_CIRCLE_EMAILS`) are read from config to avoid committing PII

https://claude.ai/code/session_01LW6T5uhimPvxP5js11LBYp