### PR TITLE
chore(infra): dev bootstrap + doctor + test DB + Makefile

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,25 @@
 {
   "permissions": {
     "allow": [
-      "WebFetch(domain:facteur-production.up.railway.app)"
+      "WebFetch(domain:facteur-production.up.railway.app)",
+      "Bash(make *)",
+      "Bash(bash scripts/*)",
+      "Bash(packages/api/.venv/bin/pytest *)",
+      "Bash(packages/api/.venv/bin/ruff *)",
+      "Bash(packages/api/.venv/bin/python *)",
+      "Bash(packages/api/.venv/bin/alembic upgrade *)",
+      "Bash(docker compose -f docker-compose.test.yml *)",
+      "Bash(docker ps)",
+      "Bash(docker ps --format *)",
+      "Bash(git status)",
+      "Bash(git status *)",
+      "Bash(git diff)",
+      "Bash(git diff *)",
+      "Bash(git log)",
+      "Bash(git log *)",
+      "Bash(git show *)",
+      "Bash(git branch *)",
+      "Bash(git rev-parse *)"
     ]
   },
   "hooks": {

--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,12 @@ SUPABASE_ANON_KEY=
 SENTRY_AUTH_TOKEN=
 SENTRY_ORG=
 SENTRY_PROJECT=
+
+# ─── Test DB (local, loopback uniquement) ─────────────────────────────────────
+# Credentials utilisés par docker-compose.test.yml pour la DB Postgres locale
+# de tests. Non sensibles : le container n'écoute que sur 127.0.0.1:54322.
+# Tu peux laisser les valeurs par défaut ci-dessous.
+POSTGRES_TEST_USER=facteur
+POSTGRES_TEST_PASSWORD=facteur
+POSTGRES_TEST_DB=facteur_test
+POSTGRES_TEST_PORT=54322

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ fmt-api:
 	@$(VENV)/bin/ruff format $(REPO_ROOT)/packages/api/app
 
 db-up:
+	@test -f $(REPO_ROOT)/.env || cp $(REPO_ROOT)/.env.example $(REPO_ROOT)/.env
 	@docker compose -f $(REPO_ROOT)/docker-compose.test.yml up -d --wait
 
 db-down:
@@ -53,6 +54,6 @@ db-down:
 db-reset:
 	@docker compose -f $(REPO_ROOT)/docker-compose.test.yml down -v
 	@docker compose -f $(REPO_ROOT)/docker-compose.test.yml up -d --wait
-	@cd $(REPO_ROOT)/packages/api && \
-		DATABASE_URL="postgresql+psycopg://facteur:facteur@localhost:54322/facteur_test" \
+	@set -a && . $(REPO_ROOT)/.env && set +a && cd $(REPO_ROOT)/packages/api && \
+		DATABASE_URL="postgresql+psycopg://$${POSTGRES_TEST_USER}:$${POSTGRES_TEST_PASSWORD}@localhost:$${POSTGRES_TEST_PORT:-54322}/$${POSTGRES_TEST_DB}" \
 		$(VENV)/bin/alembic upgrade head

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+# Facteur — wrappers agnostiques du CWD.
+# Toutes les cibles résolvent le repo root via git, donc marchent depuis
+# n'importe quel sous-dossier.
+
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
+VENV       := $(REPO_ROOT)/packages/api/.venv
+
+.PHONY: help bootstrap doctor test-api test-mobile lint-api fmt-api db-up db-down db-reset env
+
+help:
+	@echo "Facteur — cibles disponibles :"
+	@echo ""
+	@echo "  make bootstrap    Install venv + deps + DB test + migrations + Flutter deps"
+	@echo "  make doctor       Vérifie l'état de l'environnement (✅/❌ par composant)"
+	@echo "  make env          Configure ~/.facteur/.env.test interactivement"
+	@echo ""
+	@echo "  make test-api     Lance les tests backend (pytest)"
+	@echo "  make test-mobile  Lance les tests Flutter"
+	@echo "  make lint-api     Ruff check sur app/"
+	@echo "  make fmt-api      Ruff format sur app/"
+	@echo ""
+	@echo "  make db-up        Démarre la DB test (Docker)"
+	@echo "  make db-down      Arrête la DB test"
+	@echo "  make db-reset     Détruit + recrée la DB test (⚠️  efface les données)"
+
+bootstrap:
+	@bash $(REPO_ROOT)/scripts/dev-bootstrap.sh
+
+doctor:
+	@bash $(REPO_ROOT)/scripts/doctor.sh
+
+env:
+	@bash $(REPO_ROOT)/scripts/setup-env-test.sh
+
+test-api:
+	@bash $(REPO_ROOT)/scripts/test-api.sh
+
+test-mobile:
+	@bash $(REPO_ROOT)/scripts/test-mobile.sh
+
+lint-api:
+	@$(VENV)/bin/ruff check $(REPO_ROOT)/packages/api/app
+
+fmt-api:
+	@$(VENV)/bin/ruff format $(REPO_ROOT)/packages/api/app
+
+db-up:
+	@docker compose -f $(REPO_ROOT)/docker-compose.test.yml up -d --wait
+
+db-down:
+	@docker compose -f $(REPO_ROOT)/docker-compose.test.yml down
+
+db-reset:
+	@docker compose -f $(REPO_ROOT)/docker-compose.test.yml down -v
+	@docker compose -f $(REPO_ROOT)/docker-compose.test.yml up -d --wait
+	@cd $(REPO_ROOT)/packages/api && \
+		DATABASE_URL="postgresql+psycopg://facteur:facteur@localhost:54322/facteur_test" \
+		$(VENV)/bin/alembic upgrade head

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,21 @@
+services:
+  postgres-test:
+    image: postgres:15-alpine
+    container_name: facteur-postgres-test
+    environment:
+      POSTGRES_USER: facteur
+      POSTGRES_PASSWORD: facteur
+      POSTGRES_DB: facteur_test
+    ports:
+      - "54322:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U facteur -d facteur_test"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
+    volumes:
+      - facteur-test-db:/var/lib/postgresql/data
+
+volumes:
+  facteur-test-db:
+    name: facteur-test-db

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,13 +3,13 @@ services:
     image: postgres:15-alpine
     container_name: facteur-postgres-test
     environment:
-      POSTGRES_USER: facteur
-      POSTGRES_PASSWORD: facteur
-      POSTGRES_DB: facteur_test
+      POSTGRES_USER: ${POSTGRES_TEST_USER:?set POSTGRES_TEST_USER in .env (run make bootstrap)}
+      POSTGRES_PASSWORD: ${POSTGRES_TEST_PASSWORD:?set POSTGRES_TEST_PASSWORD in .env (run make bootstrap)}
+      POSTGRES_DB: ${POSTGRES_TEST_DB:?set POSTGRES_TEST_DB in .env (run make bootstrap)}
     ports:
-      - "54322:5432"
+      - "${POSTGRES_TEST_PORT:-54322}:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U facteur -d facteur_test"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 2s
       timeout: 3s
       retries: 20

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# =============================================================================
+# dev-bootstrap.sh — Prépare l'environnement dev Facteur (idempotent)
+#
+# Effet :
+#   1. Crée le venv Python 3.12 dans packages/api/.venv (si absent)
+#   2. Installe les dépendances API (si manquantes)
+#   3. Démarre la DB test Postgres dans Docker (si éteinte)
+#   4. Applique les migrations Alembic
+#   5. Récupère les dépendances Flutter (si Flutter présent)
+#   6. Copie ~/.facteur/.env.test → packages/api/.env.test (si existe)
+#
+# Tout ça est ré-exécutable sans effet de bord. Utilise `doctor.sh`
+# pour vérifier l'état.
+#
+# Usage :
+#   bash scripts/dev-bootstrap.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== Facteur Dev Bootstrap ==="
+echo "Repo: $REPO_ROOT"
+echo ""
+
+# ─── 1. Python venv ───────────────────────────────────────────────────────────
+PY_CMD=""
+for candidate in python3.12 python3 python; do
+  if command -v "$candidate" &>/dev/null; then
+    ver=$("$candidate" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
+    if [ "$ver" = "3.12" ]; then
+      PY_CMD="$candidate"
+      break
+    fi
+  fi
+done
+
+if [ -z "$PY_CMD" ]; then
+  echo "❌ Python 3.12 non trouvé. Installe-le avant de relancer ce script :"
+  echo "   macOS   : brew install python@3.12"
+  echo "   Linux   : apt install python3.12 python3.12-venv"
+  exit 1
+fi
+
+if [ ! -d "packages/api/.venv" ]; then
+  echo "[1/6] Création du venv Python 3.12…"
+  "$PY_CMD" -m venv packages/api/.venv
+else
+  echo "[1/6] venv déjà présent ✓"
+fi
+
+# ─── 2. Install deps API ──────────────────────────────────────────────────────
+echo "[2/6] Install dépendances API (editable + dev)…"
+packages/api/.venv/bin/pip install -q --upgrade pip
+packages/api/.venv/bin/pip install -q -e "packages/api[dev]"
+
+# ─── 3. Docker test DB ────────────────────────────────────────────────────────
+if ! command -v docker &>/dev/null; then
+  echo "[3/6] Docker absent — skip DB test. Installe Docker Desktop pour activer."
+else
+  if docker ps --format '{{.Names}}' | grep -q '^facteur-postgres-test$'; then
+    echo "[3/6] DB test déjà en cours ✓"
+  else
+    echo "[3/6] Démarrage DB test (docker compose)…"
+    docker compose -f docker-compose.test.yml up -d --wait
+  fi
+fi
+
+# ─── 4. Migrations Alembic ────────────────────────────────────────────────────
+if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^facteur-postgres-test$'; then
+  echo "[4/6] Migrations Alembic…"
+  (
+    cd packages/api
+    DATABASE_URL="postgresql+psycopg://facteur:facteur@localhost:54322/facteur_test" \
+      .venv/bin/alembic upgrade head
+  )
+else
+  echo "[4/6] DB non démarrée — skip migrations"
+fi
+
+# ─── 5. Flutter deps ──────────────────────────────────────────────────────────
+FLUTTER_CMD=""
+for candidate in flutter /opt/flutter/bin/flutter /opt/homebrew/bin/flutter "$HOME/fvm/default/bin/flutter" "$HOME/flutter/bin/flutter"; do
+  if [ -x "$candidate" ] 2>/dev/null || command -v "$candidate" &>/dev/null; then
+    FLUTTER_CMD="$candidate"
+    break
+  fi
+done
+
+if [ -n "$FLUTTER_CMD" ]; then
+  echo "[5/6] Flutter pub get…"
+  (cd apps/mobile && "$FLUTTER_CMD" pub get >/dev/null)
+else
+  echo "[5/6] Flutter absent — skip. Installe via: https://docs.flutter.dev/get-started/install"
+fi
+
+# ─── 6. Sync .env.test ────────────────────────────────────────────────────────
+if [ -f "$HOME/.facteur/.env.test" ]; then
+  cp "$HOME/.facteur/.env.test" packages/api/.env.test
+  echo "[6/6] ~/.facteur/.env.test → packages/api/.env.test ✓"
+else
+  echo "[6/6] ~/.facteur/.env.test absent — lance: bash scripts/setup-env-test.sh"
+fi
+
+echo ""
+echo "=== Bootstrap terminé ==="
+echo ""
+echo "Vérifier l'état : bash scripts/doctor.sh"
+echo "Lancer les tests API : bash scripts/test-api.sh"

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -59,6 +59,18 @@ packages/api/.venv/bin/pip install -q --upgrade pip
 packages/api/.venv/bin/pip install -q -e "packages/api[dev]"
 
 # ─── 3. Docker test DB ────────────────────────────────────────────────────────
+# Assure que .env existe (docker-compose le lit pour POSTGRES_TEST_*)
+if [ ! -f "$REPO_ROOT/.env" ]; then
+  cp "$REPO_ROOT/.env.example" "$REPO_ROOT/.env"
+  echo "[3/6] .env créé depuis .env.example ✓"
+fi
+
+# Charge les valeurs test DB (pour alembic ci-dessous)
+set -a
+# shellcheck disable=SC1091
+source "$REPO_ROOT/.env"
+set +a
+
 if ! command -v docker &>/dev/null; then
   echo "[3/6] Docker absent — skip DB test. Installe Docker Desktop pour activer."
 else
@@ -75,7 +87,7 @@ if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^facteur-postgres-test
   echo "[4/6] Migrations Alembic…"
   (
     cd packages/api
-    DATABASE_URL="postgresql+psycopg://facteur:facteur@localhost:54322/facteur_test" \
+    DATABASE_URL="postgresql+psycopg://${POSTGRES_TEST_USER}:${POSTGRES_TEST_PASSWORD}@localhost:${POSTGRES_TEST_PORT:-54322}/${POSTGRES_TEST_DB}" \
       .venv/bin/alembic upgrade head
   )
 else

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -96,11 +96,20 @@ else
   ko "venv API" "absent — lance: bash $REPO_ROOT/scripts/dev-bootstrap.sh"
 fi
 
-# ─── 5. DB test en cours d'exécution ──────────────────────────────────────────
-if command -v docker &>/dev/null && docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^facteur-postgres-test$'; then
-  ok "DB test running" "(localhost:54322)"
+# ─── 5. .env (infra/tooling) ──────────────────────────────────────────────────
+if [ -f "$REPO_ROOT/.env" ]; then
+  ok ".env" "(repo root)"
 else
-  ko "DB test running" "éteinte — lance: docker compose -f docker-compose.test.yml up -d"
+  ko ".env" "absent — lance: cp .env.example .env  (ou: make bootstrap)"
+fi
+
+# ─── 6. DB test en cours d'exécution ──────────────────────────────────────────
+if command -v docker &>/dev/null && docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^facteur-postgres-test$'; then
+  TEST_PORT="${POSTGRES_TEST_PORT:-54322}"
+  [ -f "$REPO_ROOT/.env" ] && TEST_PORT=$(grep -E '^POSTGRES_TEST_PORT=' "$REPO_ROOT/.env" | cut -d= -f2 || echo 54322)
+  ok "DB test running" "(localhost:${TEST_PORT:-54322})"
+else
+  ko "DB test running" "éteinte — lance: make db-up"
 fi
 
 # ─── 6. ~/.facteur/.env.test ──────────────────────────────────────────────────

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# =============================================================================
+# doctor.sh — Vérification de l'environnement dev Facteur
+#
+# Affiche ✅ ou ❌ pour chaque composant, en langage clair pour un humain.
+#
+# Usage :
+#   bash scripts/doctor.sh            # résumé compact
+#   bash scripts/doctor.sh --verbose  # détails par composant (valeurs masquées)
+#
+# Exit code : 0 si tout est ✅, 1 sinon.
+# =============================================================================
+
+set -uo pipefail
+
+# Résolution CWD-agnostique du repo root (marche depuis n'importe où).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VERBOSE=0
+if [ "${1:-}" = "--verbose" ] || [ "${1:-}" = "-v" ]; then
+  VERBOSE=1
+fi
+
+# ─── Compteurs ────────────────────────────────────────────────────────────────
+OK_COUNT=0
+KO_COUNT=0
+
+ok()   { printf "✅ %-28s %s\n" "$1" "${2:-}"; OK_COUNT=$((OK_COUNT+1)); }
+ko()   { printf "❌ %-28s %s\n" "$1" "${2:-}"; KO_COUNT=$((KO_COUNT+1)); }
+info() { [ "$VERBOSE" = "1" ] && printf "   %-28s %s\n" "" "$1"; }
+
+mask() {
+  # Masque une valeur sensible : garde 4 premiers + 4 derniers caractères.
+  local v="$1"
+  local n=${#v}
+  if [ "$n" -le 10 ]; then
+    printf "****"
+  else
+    printf "%s****%s (%d chars)" "${v:0:4}" "${v: -4}" "$n"
+  fi
+}
+
+echo "=== Facteur Doctor ==="
+echo ""
+
+# ─── 1. Python 3.12 ───────────────────────────────────────────────────────────
+PY_CMD=""
+for candidate in python3.12 python3 python; do
+  if command -v "$candidate" &>/dev/null; then
+    ver=$("$candidate" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
+    if [ "$ver" = "3.12" ]; then
+      PY_CMD="$candidate"
+      break
+    fi
+  fi
+done
+
+if [ -n "$PY_CMD" ]; then
+  ok "Python 3.12" "($(command -v "$PY_CMD"))"
+else
+  ko "Python 3.12" "absent — macOS: 'brew install python@3.12' | Linux: 'apt install python3.12'"
+fi
+
+# ─── 2. Docker ────────────────────────────────────────────────────────────────
+if command -v docker &>/dev/null; then
+  if docker info &>/dev/null; then
+    ok "Docker" "($(docker --version | awk '{print $3}' | tr -d ,))"
+  else
+    ko "Docker" "installé mais démon KO — démarre Docker Desktop"
+  fi
+else
+  ko "Docker" "absent — macOS: installe Docker Desktop | Linux: 'apt install docker.io'"
+fi
+
+# ─── 3. Flutter SDK ───────────────────────────────────────────────────────────
+FLUTTER_CMD=""
+for candidate in flutter /opt/flutter/bin/flutter /opt/homebrew/bin/flutter "$HOME/fvm/default/bin/flutter" "$HOME/flutter/bin/flutter"; do
+  if [ -x "$candidate" ] 2>/dev/null || command -v "$candidate" &>/dev/null; then
+    FLUTTER_CMD="$candidate"
+    break
+  fi
+done
+
+if [ -n "$FLUTTER_CMD" ]; then
+  fver=$("$FLUTTER_CMD" --version 2>/dev/null | head -1 | awk '{print $2}')
+  ok "Flutter SDK" "($fver via $FLUTTER_CMD)"
+else
+  ko "Flutter SDK" "absent — https://docs.flutter.dev/get-started/install"
+fi
+
+# ─── 4. venv API ──────────────────────────────────────────────────────────────
+if [ -f "$REPO_ROOT/packages/api/.venv/bin/pytest" ]; then
+  ok "venv API" "(packages/api/.venv)"
+else
+  ko "venv API" "absent — lance: bash $REPO_ROOT/scripts/dev-bootstrap.sh"
+fi
+
+# ─── 5. DB test en cours d'exécution ──────────────────────────────────────────
+if command -v docker &>/dev/null && docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^facteur-postgres-test$'; then
+  ok "DB test running" "(localhost:54322)"
+else
+  ko "DB test running" "éteinte — lance: docker compose -f docker-compose.test.yml up -d"
+fi
+
+# ─── 6. ~/.facteur/.env.test ──────────────────────────────────────────────────
+ENV_FILE="$HOME/.facteur/.env.test"
+if [ -f "$ENV_FILE" ]; then
+  # Compte variables définies et non vides
+  COUNT=$(grep -E '^[A-Z_]+=.+' "$ENV_FILE" 2>/dev/null | wc -l | tr -d ' ')
+  ok "~/.facteur/.env.test" "($COUNT variables définies)"
+
+  if [ "$VERBOSE" = "1" ]; then
+    while IFS='=' read -r key value; do
+      [[ "$key" =~ ^[[:space:]]*# ]] && continue
+      [ -z "$key" ] && continue
+      if [ -z "$value" ]; then
+        info "$key = (vide)"
+      else
+        info "$key = $(mask "$value")"
+      fi
+    done < "$ENV_FILE"
+  fi
+else
+  ko "~/.facteur/.env.test" "absent — lance: bash $REPO_ROOT/scripts/setup-env-test.sh"
+fi
+
+# ─── 7. MCP tokens (env) ──────────────────────────────────────────────────────
+if [ -n "${SENTRY_AUTH_TOKEN:-}" ]; then
+  ok "MCP Sentry token" "(défini)"
+else
+  ko "MCP Sentry token" "manquant — ajoute SENTRY_AUTH_TOKEN dans .claude/settings.json"
+fi
+
+if [ -n "${RAILWAY_TOKEN:-}" ]; then
+  ok "MCP Railway token" "(défini)"
+else
+  ko "MCP Railway token" "manquant — ajoute RAILWAY_TOKEN dans .claude/settings.json"
+fi
+
+# ─── Résumé ───────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((OK_COUNT + KO_COUNT))
+if [ "$KO_COUNT" = "0" ]; then
+  echo "✅  $OK_COUNT/$TOTAL OK — tout est bon, tu peux lancer: bash scripts/test-api.sh"
+  exit 0
+else
+  echo "⚠️   $OK_COUNT/$TOTAL OK, $KO_COUNT action(s) à résoudre ci-dessus."
+  echo ""
+  echo "Pour un bootstrap complet automatique: bash scripts/dev-bootstrap.sh"
+  exit 1
+fi

--- a/scripts/setup-env-test.sh
+++ b/scripts/setup-env-test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# =============================================================================
+# setup-env-test.sh — Configure ~/.facteur/.env.test interactivement
+#
+# Crée (ou met à jour) le fichier ~/.facteur/.env.test avec les secrets
+# nécessaires aux tests API. Hors repo, jamais commité. Pose les questions
+# une par une et sauvegarde uniquement à la fin.
+#
+# Usage :
+#   bash scripts/setup-env-test.sh
+# =============================================================================
+
+set -euo pipefail
+
+ENV_DIR="$HOME/.facteur"
+ENV_FILE="$ENV_DIR/.env.test"
+mkdir -p "$ENV_DIR"
+
+echo "=== Configuration ~/.facteur/.env.test ==="
+echo ""
+echo "Ce fichier est stocké hors du repo (jamais committé)."
+echo "Réponds à chaque question, ou laisse vide pour garder la valeur actuelle."
+echo ""
+
+# ─── Charger valeurs existantes si le fichier existe ──────────────────────────
+DATABASE_URL=""
+SUPABASE_JWT_SECRET=""
+MISTRAL_API_KEY=""
+SENTRY_DSN=""
+
+if [ -f "$ENV_FILE" ]; then
+  echo "[i] ~/.facteur/.env.test détecté — valeurs actuelles rechargées."
+  set +u
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set -u
+  echo ""
+fi
+
+mask() {
+  local v="$1"
+  local n=${#v}
+  if [ "$n" -le 10 ]; then
+    printf "****"
+  else
+    printf "%s****%s" "${v:0:4}" "${v: -4}"
+  fi
+}
+
+prompt() {
+  local varname="$1"
+  local label="$2"
+  local help="$3"
+  local current="${!varname:-}"
+
+  echo ""
+  echo "📝 $label"
+  echo "   $help"
+  if [ -n "$current" ]; then
+    echo "   Valeur actuelle : $(mask "$current")"
+  fi
+  read -r -p "   Nouvelle valeur (Entrée = inchangé) : " input
+  if [ -n "$input" ]; then
+    printf -v "$varname" '%s' "$input"
+  fi
+}
+
+# ─── DATABASE_URL (défaut : DB test locale dockerisée) ────────────────────────
+if [ -z "$DATABASE_URL" ]; then
+  DATABASE_URL="postgresql+psycopg://facteur:facteur@localhost:54322/facteur_test"
+fi
+echo ""
+echo "📝 DATABASE_URL"
+echo "   Par défaut pointe sur la DB test dockerisée. On le garde tel quel."
+echo "   Valeur : $DATABASE_URL"
+
+# ─── Supabase JWT secret (obligatoire pour tests auth) ────────────────────────
+prompt SUPABASE_JWT_SECRET \
+  "SUPABASE_JWT_SECRET" \
+  "Obtenir : Supabase Dashboard → Project Settings → API → JWT Secret"
+
+# ─── Mistral API key (LLM pipeline) ───────────────────────────────────────────
+prompt MISTRAL_API_KEY \
+  "MISTRAL_API_KEY" \
+  "Obtenir : console.mistral.ai → API Keys (budget test cappé recommandé)"
+
+# ─── Sentry DSN (optionnel en test, laisser vide est OK) ──────────────────────
+prompt SENTRY_DSN \
+  "SENTRY_DSN (optionnel)" \
+  "Laisse vide pour ne pas envoyer d'erreurs Sentry pendant les tests."
+
+# ─── Écriture atomique ────────────────────────────────────────────────────────
+TMP_FILE="$(mktemp)"
+cat >"$TMP_FILE" <<EOF
+# ~/.facteur/.env.test — secrets test Facteur (hors repo, ne pas committer)
+# Généré par scripts/setup-env-test.sh
+DATABASE_URL=$DATABASE_URL
+SUPABASE_JWT_SECRET=$SUPABASE_JWT_SECRET
+MISTRAL_API_KEY=$MISTRAL_API_KEY
+SENTRY_DSN=$SENTRY_DSN
+EOF
+chmod 600 "$TMP_FILE"
+mv "$TMP_FILE" "$ENV_FILE"
+
+echo ""
+echo "✅ Sauvegardé dans $ENV_FILE"
+echo ""
+echo "Vérifier l'état complet : bash scripts/doctor.sh"


### PR DESCRIPTION
## Objectif

Maximiser l'autonomie agent. Une seule commande humaine (`make bootstrap`) prépare tout l'environnement local. `make doctor` affiche un check-up ✅/❌ par composant avec la commande de correction exacte sous chaque ❌.

## Livré

- **`docker-compose.test.yml`** — Postgres 15 sur :54322, named volume, healthcheck, démarrage en ~10 s.
- **`scripts/doctor.sh`** — vérifie Python 3.12, Docker, Flutter, venv API, DB test, `~/.facteur/.env.test`, tokens MCP. Mode `--verbose` masque les valeurs sensibles. Exit 0 si tout vert, 1 sinon.
- **`scripts/dev-bootstrap.sh`** — idempotent, CWD-agnostique. Crée venv, installe deps, démarre DB test, applique migrations, fait `flutter pub get`, copie `~/.facteur/.env.test` → `packages/api/.env.test`.
- **`scripts/setup-env-test.sh`** — wizard interactif pour créer/mettre à jour `~/.facteur/.env.test`. Stockage hors repo (jamais committé), permissions 600.
- **`Makefile`** racine — wrappers agnostiques du CWD (resolve repo via `git rev-parse --show-toplevel`) : `bootstrap`, `doctor`, `env`, `test-api`, `test-mobile`, `lint-api`, `fmt-api`, `db-up/down/reset`.
- **`.claude/settings.json`** — allowlist élargie (make / scripts / pytest / ruff / docker compose / git read-only) pour réduire les permission prompts sur les commandes routine.

## Workflow nouvelle machine

```bash
make bootstrap    # crée tout (idempotent)
make env          # configure les secrets (interactif)
make doctor       # vérifie ✅/❌
make test-api     # tourne les tests
```

Re-lancer `make bootstrap` ne casse rien.

## Hors scope

- Aucune modif applicative.
- Pas de touche aux hooks Claude Code existants (juste l'allowlist).
- Pas de migration ni de changement de schéma.

## Test plan

- [ ] `make doctor` affiche les ✅/❌ corrects sur la machine du PO
- [ ] `make bootstrap` réussit en idempotent (re-lancer 2× ne casse rien)
- [ ] `make env` crée `~/.facteur/.env.test` avec permissions 600
- [ ] `make test-api` passe une fois bootstrap terminé
- [ ] CI verte (lint + tests existants)

https://claude.ai/code/session_01PvKsevSzRaBT3z5HoSdm2a