### PR TITLE
fix(mobile): dart2js field promotion — unblock Railway web build

### DIFF
--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -257,11 +257,12 @@ class AnalyticsService {
     String event,
     Map<String, dynamic> rawProps,
   ) async {
-    if (_posthog == null || !_posthog.isEnabled) return;
+    final ph = _posthog;
+    if (ph == null || !ph.isEnabled) return;
     final cleanProps = <String, Object>{};
     rawProps.forEach((key, value) {
       if (value != null) cleanProps[key] = value as Object;
     });
-    await _posthog.capture(event: event, properties: cleanProps);
+    await ph.capture(event: event, properties: cleanProps);
   }
 }


### PR DESCRIPTION
## Problème

Le build Flutter web Railway échoue depuis le merge du PR #434 (PostHog).

**Erreur exacte** (surfacée via les logs Railway complets) :

```
lib/core/services/analytics_service.dart:260:39:
Error: Property 'isEnabled' cannot be accessed on 'PostHogService?' because it is potentially null.
    if (_posthog == null || !_posthog.isEnabled) return;
                                      ^^^^^^^^^
Info: '_posthog' couldn't be promoted because field promotion is only available in Dart 3.2 and above.
  final PostHogService? _posthog;

lib/core/services/analytics_service.dart:265:20:
Error: Method 'capture' cannot be called on 'PostHogService?' because it is potentially null.
    await _posthog.capture(event: event, properties: cleanProps);
```

## Cause racine

`dart2js` (Dart 3.10.7, Flutter 3.38.6 — la version du Dockerfile) ne fait **pas** de field promotion sur les champs de classe, même `final`, même après un null-check dans une condition `||`. En VM (mobile natif) la promotion fonctionne — c'est une divergence dart2js vs VM.

## Fix

1 fichier, 3 lignes changées dans `analytics_service.dart::_capturePostHog` :

**Avant**
```dart
if (_posthog == null || !_posthog.isEnabled) return;
await _posthog.capture(event: event, properties: cleanProps);
```

**Après**
```dart
final ph = _posthog;               // copie locale → promotable par dart2js
if (ph == null || !ph.isEnabled) return;
await ph.capture(event: event, properties: cleanProps);
```

Aucune autre modification — 0 impact fonctionnel. La logique est identique.

## Scope

- Aucune modif backend.
- Aucune migration DB.
- Aucun changement de comportement.

## Test plan

- [ ] CI verte (lint + flutter analyze)
- [ ] Railway redéploie et build Flutter web passe (la raison du PR)
- [ ] Mobile iOS/Android inchangé (same logic, local var only)

https://claude.ai/code/session_01PvKsevSzRaBT3z5HoSdm2a