### PR TITLE
feat(mobile): adaptive title/description for image-less article cards

### DIFF
--- a/apps/mobile/lib/features/custom_topics/screens/topic_explorer_screen.dart
+++ b/apps/mobile/lib/features/custom_topics/screens/topic_explorer_screen.dart
@@ -261,6 +261,7 @@ class TopicExplorerScreen extends ConsumerWidget {
                         ),
                         child: FeedCard(
                           content: article,
+                          titleMaxLines: 5,
                           onTap: () {
                             // Navigate to article detail
                             Navigator.of(context).pushNamed(

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -10,6 +10,7 @@ import '../../custom_topics/widgets/topic_chip.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/providers/feed_provider.dart';
 import '../../feed/repositories/feed_repository.dart';
+import '../../feed/utils/article_title_layout.dart';
 import '../../feed/widgets/dismiss_banner.dart';
 import '../../feed/widgets/feed_card.dart';
 import '../../feed/widgets/initial_circle.dart';
@@ -158,27 +159,31 @@ class _TopicSectionState extends ConsumerState<TopicSection>
   double _estimateCardHeight(DigestItem article, double cardWidth) {
     final hasImage = _imageWillRender(article);
 
-    // Title: fontSize 20, lineHeight 1.2, max lines = digest title budget.
-    // Estimate line count from title length vs available width.
-    // Average char width ≈ 10px at fontSize 20 → chars per line ≈ cardWidth / 10.
-    final charsPerLine = (cardWidth - _bodyPadding) / 10;
-    final titleLines = (article.title.length / charsPerLine)
-        .round()
-        .clamp(1, _digestTitleMaxLines);
-    final titleHeight = titleLines * 20.0 * 1.2;
+    final titleLines = ArticleTitleLayout.estimateTitleLines(
+      title: article.title,
+      availableWidth: cardWidth - _bodyPadding,
+      hasImage: hasImage,
+    );
+    final titleHeight = titleLines * ArticleTitleLayout.titleLineHeight;
 
     double bodyHeight = _bodyPadding + titleHeight + _spacer + _metaRowHeight;
 
-    // Description only shown when no image (alwaysShowDescription: !imageVisible)
     if (!hasImage) {
       final desc = article.description ?? '';
       if (desc.isNotEmpty) {
-        final descCharsPerLine = (cardWidth - _bodyPadding) / 8;
-        final descLines =
-            (desc.length / descCharsPerLine).round().clamp(1, 4);
-        // descriptionFontSize: 15, lineHeight: 1.3
-        final descHeight = descLines * 15.0 * 1.3;
-        bodyHeight += _spacer + descHeight;
+        final descMax = ArticleTitleLayout.descriptionMaxLinesForCarousel(
+          estimatedTitleLines: titleLines,
+          hasImage: false,
+          hasDescription: true,
+        );
+        final descLines = ArticleTitleLayout.estimateDescriptionLines(
+          description: desc,
+          availableWidth: cardWidth - _bodyPadding,
+          maxLines: descMax,
+        );
+        if (descLines > 0) {
+          bodyHeight += _spacer + descLines * ArticleTitleLayout.descLineHeight;
+        }
       }
     }
 

--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -947,6 +947,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                                     isConsumed: isConsumed,
                                     child: FeedCard(
                                       content: content,
+                                      titleMaxLines: 5,
                                       onTap: () => _showArticleModal(content),
                                       onLongPressStart: (_) =>
                                           ArticlePreviewOverlay.show(

--- a/apps/mobile/lib/features/feed/utils/article_title_layout.dart
+++ b/apps/mobile/lib/features/feed/utils/article_title_layout.dart
@@ -1,0 +1,63 @@
+/// Decides how many lines of title and description should be shown on an
+/// article preview card.
+///
+/// When a card has no image, we allow the title to grow up to 5 lines and
+/// shrink the description progressively so the overall card height stays
+/// close to a card that shows an image (title 3 lines + no description).
+class ArticleTitleLayout {
+  static const double titleLineHeight = 20.0 * 1.2;
+  static const double descLineHeight = 15.0 * 1.3;
+
+  static const double _titleCharPx = 10.0;
+  static const double _descCharPx = 8.0;
+
+  static int titleMaxLines({required bool hasImage}) => hasImage ? 3 : 5;
+
+  static int estimateTitleLines({
+    required String title,
+    required double availableWidth,
+    required bool hasImage,
+  }) {
+    if (title.trim().isEmpty) return 1;
+    final perLine =
+        (availableWidth / _titleCharPx).clamp(1.0, double.infinity);
+    final lines = (title.length / perLine).ceil();
+    return lines.clamp(1, titleMaxLines(hasImage: hasImage));
+  }
+
+  /// Standard feed card: 3→2L, 4→1L, 5→0L. Hidden when image is present.
+  static int descriptionMaxLines({
+    required int estimatedTitleLines,
+    required bool hasImage,
+    required bool hasDescription,
+  }) {
+    if (hasImage || !hasDescription) return 0;
+    if (estimatedTitleLines <= 3) return 2;
+    if (estimatedTitleLines == 4) return 1;
+    return 0;
+  }
+
+  /// Carousel variant (`alwaysShowDescription = !imageVisible`): 3→4L, 4→2L, 5→1L.
+  static int descriptionMaxLinesForCarousel({
+    required int estimatedTitleLines,
+    required bool hasImage,
+    required bool hasDescription,
+  }) {
+    if (hasImage || !hasDescription) return 0;
+    if (estimatedTitleLines <= 3) return 4;
+    if (estimatedTitleLines == 4) return 2;
+    return 1;
+  }
+
+  static int estimateDescriptionLines({
+    required String description,
+    required double availableWidth,
+    required int maxLines,
+  }) {
+    if (maxLines <= 0 || description.trim().isEmpty) return 0;
+    final perLine =
+        (availableWidth / _descCharPx).clamp(1.0, double.infinity);
+    final lines = (description.length / perLine).ceil();
+    return lines.clamp(1, maxLines);
+  }
+}

--- a/apps/mobile/lib/features/feed/widgets/briefing_section.dart
+++ b/apps/mobile/lib/features/feed/widgets/briefing_section.dart
@@ -227,6 +227,7 @@ class BriefingSection extends StatelessWidget {
           opacity: item.isConsumed ? 0.6 : 1.0,
           child: FeedCard(
             content: item.content,
+            titleMaxLines: 5,
             onTap: () => onItemTap(item),
           ),
         ),

--- a/apps/mobile/lib/features/feed/widgets/feed_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_card.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/core/utils/html_utils.dart';
 import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/feed/utils/article_title_layout.dart';
 import 'package:facteur/features/feed/widgets/reading_badge.dart';
 import 'package:facteur/widgets/design/facteur_card.dart';
 import 'package:facteur/widgets/design/facteur_image.dart';
@@ -533,13 +534,10 @@ class _FeedCardState extends State<FeedCard>
       BuildContext context, FacteurColors colors, TextTheme textTheme) {
     final hasDescription =
         widget.content.description != null && widget.content.description!.isNotEmpty;
-    final showDescription = widget.alwaysShowDescription
-        ? hasDescription
-        : widget.expandContent
-            ? hasDescription
-            : ((widget.content.thumbnailUrl == null ||
-                    widget.content.thumbnailUrl!.isEmpty) &&
-                hasDescription);
+    final hasImage = widget.content.thumbnailUrl != null &&
+        widget.content.thumbnailUrl!.isNotEmpty;
+    final effectiveTitleMaxLines =
+        hasImage ? math.min(3, widget.titleMaxLines) : widget.titleMaxLines;
 
     final bodyContent = Padding(
       padding: const EdgeInsets.symmetric(
@@ -550,30 +548,66 @@ class _FeedCardState extends State<FeedCard>
         mainAxisSize: widget.expandContent ? MainAxisSize.max : MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Titre
-          Text(
-            widget.content.title,
-            style: textTheme.displaySmall?.copyWith(
-              fontSize: 20,
-              fontWeight: FontWeight.w700,
-              height: 1.2,
-            ),
-            maxLines: widget.expandContent ? null : widget.titleMaxLines,
-            overflow: widget.expandContent ? null : TextOverflow.ellipsis,
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final estimatedTitleLines = ArticleTitleLayout.estimateTitleLines(
+                title: widget.content.title,
+                availableWidth: constraints.maxWidth,
+                hasImage: hasImage,
+              );
+              final int descMaxLines;
+              if (widget.expandContent) {
+                descMaxLines = 8;
+              } else if (widget.alwaysShowDescription) {
+                descMaxLines = ArticleTitleLayout.descriptionMaxLinesForCarousel(
+                  estimatedTitleLines: estimatedTitleLines,
+                  hasImage: hasImage,
+                  hasDescription: hasDescription,
+                );
+              } else {
+                descMaxLines = ArticleTitleLayout.descriptionMaxLines(
+                  estimatedTitleLines: estimatedTitleLines,
+                  hasImage: hasImage,
+                  hasDescription: hasDescription,
+                );
+              }
+              final showDescription = widget.expandContent
+                  ? hasDescription
+                  : descMaxLines > 0;
+
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    widget.content.title,
+                    style: textTheme.displaySmall?.copyWith(
+                      fontSize: 20,
+                      fontWeight: FontWeight.w700,
+                      height: 1.2,
+                    ),
+                    maxLines:
+                        widget.expandContent ? null : effectiveTitleMaxLines,
+                    overflow:
+                        widget.expandContent ? null : TextOverflow.ellipsis,
+                  ),
+                  if (showDescription) ...[
+                    const SizedBox(height: FacteurSpacing.space2),
+                    Text(
+                      stripHtml(widget.content.description!),
+                      style: textTheme.bodySmall?.copyWith(
+                        color: colors.textSecondary.withOpacity(0.85),
+                        height: 1.3,
+                        fontSize: widget.descriptionFontSize,
+                      ),
+                      maxLines:
+                          widget.expandContent ? 8 : descMaxLines,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ],
+              );
+            },
           ),
-          if (showDescription) ...[
-            const SizedBox(height: FacteurSpacing.space2),
-            Text(
-              stripHtml(widget.content.description!),
-              style: textTheme.bodySmall?.copyWith(
-                color: colors.textSecondary.withOpacity(0.85),
-                height: 1.3,
-                fontSize: widget.descriptionFontSize,
-              ),
-              maxLines: widget.expandContent ? 8 : widget.alwaysShowDescription ? 4 : 2,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
           const SizedBox(height: FacteurSpacing.space2),
           // Métadonnées (Type • Durée)
           Row(

--- a/apps/mobile/lib/features/feed/widgets/feed_carousel.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_carousel.dart
@@ -5,6 +5,7 @@ import '../../../config/theme.dart';
 import '../../../widgets/design/facteur_thumbnail.dart';
 import '../../digest/widgets/editorial_badge.dart';
 import '../models/content_model.dart';
+import '../utils/article_title_layout.dart';
 import 'feed_card.dart';
 
 /// Horizontal carousel intercalated in the feed.
@@ -104,19 +105,31 @@ class _FeedCarouselState extends State<FeedCarousel> {
   double _estimateCardHeight(Content article, double cardWidth) {
     final hasImage = _imageWillRender(article);
 
-    final charsPerLine = (cardWidth - _bodyPadding) / 10;
-    final titleLines = (article.title.length / charsPerLine).ceil().clamp(1, 3);
-    final titleHeight = titleLines * 20.0 * 1.2;
+    final titleLines = ArticleTitleLayout.estimateTitleLines(
+      title: article.title,
+      availableWidth: cardWidth - _bodyPadding,
+      hasImage: hasImage,
+    );
+    final titleHeight = titleLines * ArticleTitleLayout.titleLineHeight;
 
     double bodyHeight = _bodyPadding + titleHeight + _spacer + _metaRowHeight;
 
     if (!hasImage) {
       final desc = article.description ?? '';
       if (desc.isNotEmpty) {
-        final descCharsPerLine = (cardWidth - _bodyPadding) / 8;
-        final descLines = (desc.length / descCharsPerLine).ceil().clamp(1, 4);
-        final descHeight = descLines * 15.0 * 1.3;
-        bodyHeight += _spacer + descHeight;
+        final descMax = ArticleTitleLayout.descriptionMaxLinesForCarousel(
+          estimatedTitleLines: titleLines,
+          hasImage: false,
+          hasDescription: true,
+        );
+        final descLines = ArticleTitleLayout.estimateDescriptionLines(
+          description: desc,
+          availableWidth: cardWidth - _bodyPadding,
+          maxLines: descMax,
+        );
+        if (descLines > 0) {
+          bodyHeight += _spacer + descLines * ArticleTitleLayout.descLineHeight;
+        }
       }
     }
 
@@ -228,6 +241,7 @@ class _FeedCarouselState extends State<FeedCarousel> {
           content: article,
           alwaysShowDescription: !imageVisible,
           descriptionFontSize: 15,
+          titleMaxLines: 5,
           onImageError: () => _onImageError(article.id),
           onTap: () => widget.onArticleTap(article),
           // T1: Full card feature parity
@@ -326,6 +340,7 @@ class _FeedCarouselState extends State<FeedCarousel> {
       content: article,
       alwaysShowDescription: !imageVisible,
       descriptionFontSize: 15,
+      titleMaxLines: 5,
       onImageError: () => _onImageError(article.id),
       onTap: () => widget.onArticleTap(article),
       // T1: Full card feature parity

--- a/apps/mobile/lib/features/saved/screens/collection_detail_screen.dart
+++ b/apps/mobile/lib/features/saved/screens/collection_detail_screen.dart
@@ -218,6 +218,7 @@ class _CollectionDetailScreenState
                             padding: const EdgeInsets.only(bottom: 16),
                             child: FeedCard(
                               content: content,
+                              titleMaxLines: 5,
                               isSaved: content.isSaved,
                               isLiked: content.isLiked,
                               onTap: () => context.pushNamed(

--- a/apps/mobile/lib/features/saved/screens/saved_all_screen.dart
+++ b/apps/mobile/lib/features/saved/screens/saved_all_screen.dart
@@ -169,6 +169,7 @@ class _SavedAllScreenState extends ConsumerState<SavedAllScreen> {
                                 padding: const EdgeInsets.only(bottom: 16),
                                 child: FeedCard(
                                   content: content,
+                                  titleMaxLines: 5,
                                   isSaved: true,
                                   isLiked: content.isLiked,
                                   onSourceTap: () {

--- a/apps/mobile/lib/features/saved/screens/saved_screen.dart
+++ b/apps/mobile/lib/features/saved/screens/saved_screen.dart
@@ -337,6 +337,7 @@ class _WeeklyNotesSection extends ConsumerWidget {
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               child: FeedCard(
                 content: article,
+                titleMaxLines: 5,
                 isSaved: article.isSaved,
                 isLiked: article.isLiked,
                 onTap: () => context.pushNamed(
@@ -410,6 +411,7 @@ class _RecentSavedSection extends ConsumerWidget {
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               child: FeedCard(
                 content: article,
+                titleMaxLines: 5,
                 isSaved: article.isSaved,
                 isLiked: article.isLiked,
                 onTap: () => context.pushNamed(

--- a/apps/mobile/test/features/feed/utils/article_title_layout_test.dart
+++ b/apps/mobile/test/features/feed/utils/article_title_layout_test.dart
@@ -1,0 +1,201 @@
+import 'package:facteur/features/feed/utils/article_title_layout.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ArticleTitleLayout.titleMaxLines', () {
+    test('returns 3 with image', () {
+      expect(ArticleTitleLayout.titleMaxLines(hasImage: true), 3);
+    });
+    test('returns 5 without image', () {
+      expect(ArticleTitleLayout.titleMaxLines(hasImage: false), 5);
+    });
+  });
+
+  group('ArticleTitleLayout.estimateTitleLines', () {
+    test('empty title returns 1', () {
+      final lines = ArticleTitleLayout.estimateTitleLines(
+        title: '',
+        availableWidth: 300,
+        hasImage: false,
+      );
+      expect(lines, 1);
+    });
+
+    test('whitespace-only title returns 1', () {
+      final lines = ArticleTitleLayout.estimateTitleLines(
+        title: '   ',
+        availableWidth: 300,
+        hasImage: false,
+      );
+      expect(lines, 1);
+    });
+
+    test('short title fits in 1 line', () {
+      final lines = ArticleTitleLayout.estimateTitleLines(
+        title: 'Short title',
+        availableWidth: 300,
+        hasImage: false,
+      );
+      expect(lines, 1);
+    });
+
+    test('long title clamps to 3 lines when image is present', () {
+      final lines = ArticleTitleLayout.estimateTitleLines(
+        title: 'x' * 500,
+        availableWidth: 300,
+        hasImage: true,
+      );
+      expect(lines, 3);
+    });
+
+    test('long title clamps to 5 lines when image is absent', () {
+      final lines = ArticleTitleLayout.estimateTitleLines(
+        title: 'x' * 500,
+        availableWidth: 300,
+        hasImage: false,
+      );
+      expect(lines, 5);
+    });
+  });
+
+  group('ArticleTitleLayout.descriptionMaxLines (feed)', () {
+    test('hidden when image is present', () {
+      expect(
+        ArticleTitleLayout.descriptionMaxLines(
+          estimatedTitleLines: 2,
+          hasImage: true,
+          hasDescription: true,
+        ),
+        0,
+      );
+    });
+
+    test('hidden when description is empty', () {
+      expect(
+        ArticleTitleLayout.descriptionMaxLines(
+          estimatedTitleLines: 2,
+          hasImage: false,
+          hasDescription: false,
+        ),
+        0,
+      );
+    });
+
+    test('title <=3 lines -> 2 desc lines', () {
+      for (final t in [1, 2, 3]) {
+        expect(
+          ArticleTitleLayout.descriptionMaxLines(
+            estimatedTitleLines: t,
+            hasImage: false,
+            hasDescription: true,
+          ),
+          2,
+        );
+      }
+    });
+
+    test('title 4 lines -> 1 desc line', () {
+      expect(
+        ArticleTitleLayout.descriptionMaxLines(
+          estimatedTitleLines: 4,
+          hasImage: false,
+          hasDescription: true,
+        ),
+        1,
+      );
+    });
+
+    test('title 5 lines -> 0 desc line', () {
+      expect(
+        ArticleTitleLayout.descriptionMaxLines(
+          estimatedTitleLines: 5,
+          hasImage: false,
+          hasDescription: true,
+        ),
+        0,
+      );
+    });
+  });
+
+  group('ArticleTitleLayout.descriptionMaxLinesForCarousel', () {
+    test('hidden when image is present', () {
+      expect(
+        ArticleTitleLayout.descriptionMaxLinesForCarousel(
+          estimatedTitleLines: 2,
+          hasImage: true,
+          hasDescription: true,
+        ),
+        0,
+      );
+    });
+
+    test('title <=3 lines -> 4 desc lines (current carousel default)', () {
+      expect(
+        ArticleTitleLayout.descriptionMaxLinesForCarousel(
+          estimatedTitleLines: 3,
+          hasImage: false,
+          hasDescription: true,
+        ),
+        4,
+      );
+    });
+
+    test('title 4 lines -> 2 desc lines', () {
+      expect(
+        ArticleTitleLayout.descriptionMaxLinesForCarousel(
+          estimatedTitleLines: 4,
+          hasImage: false,
+          hasDescription: true,
+        ),
+        2,
+      );
+    });
+
+    test('title 5 lines -> 1 desc line (keeps card height close to standard)',
+        () {
+      expect(
+        ArticleTitleLayout.descriptionMaxLinesForCarousel(
+          estimatedTitleLines: 5,
+          hasImage: false,
+          hasDescription: true,
+        ),
+        1,
+      );
+    });
+  });
+
+  group('ArticleTitleLayout.estimateDescriptionLines', () {
+    test('returns 0 when maxLines is 0', () {
+      expect(
+        ArticleTitleLayout.estimateDescriptionLines(
+          description: 'some description',
+          availableWidth: 300,
+          maxLines: 0,
+        ),
+        0,
+      );
+    });
+
+    test('returns 0 when description is empty', () {
+      expect(
+        ArticleTitleLayout.estimateDescriptionLines(
+          description: '',
+          availableWidth: 300,
+          maxLines: 4,
+        ),
+        0,
+      );
+    });
+
+    test('clamps to maxLines for very long description', () {
+      expect(
+        ArticleTitleLayout.estimateDescriptionLines(
+          description: 'x' * 1000,
+          availableWidth: 300,
+          maxLines: 4,
+        ),
+        4,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Sans image, le titre s'étend jusqu'à 5 lignes et la description rétrécit/disparaît pour garder une hauteur de carte proche du standard.
- Avec image, le titre reste plafonné à 3 lignes et la description est masquée (comportement inchangé).
- Wire-up du helper `ArticleTitleLayout` (déjà écrit + testé) dans `FeedCard` via un `LayoutBuilder` + estimation des lignes ; mise à jour des deux estimateurs de hauteur PageView (`topic_section`, `feed_carousel`) pour rester alignés.

## Changes
- `FeedCard` : `titleMaxLines` devient le plafond *sans image* ; cap implicite à `min(3, titleMaxLines)` quand une image est présente.
- Description adaptative — rule feed : `≤3→2L, 4→1L, 5→0L` ; rule carousel : `≤3→4L, 4→2L, 5→1L`.
- 9 sites d'appel feed-side passent désormais `titleMaxLines: 5` : feed principal, saved (x4), topic_explorer, briefing_section, feed_carousel (x2).
- Sites d'appel digest (coup_de_coeur, pepite, actu_decalee, digest_briefing, topic_section) passent déjà `titleMaxLines: 5` — pas de changement.
- `expandContent` (article preview overlay) : branche dédiée, comportement inchangé.

## Risk to flag
**Cartes digest avec image : cap de 5 → 3 lignes.** Aujourd'hui `titleMaxLines: 5` agissait comme plafond dur, donc un titre ultra-long avec image pouvait s'afficher sur 4–5 lignes. Avec la nouvelle sémantique, ces cas-là rendent 3 lignes + ellipsis. C'est intentionnel (règle « 5 lignes seulement sans image ») mais à valider visuellement sur quelques digests réels.

## Dependencies
Le helper `article_title_layout.dart` apparaît aussi dans la PR ouverte #440 (commit cherry-pické). Si #440 merge avant celle-ci, rebase trivial : les fichiers sont identiques.

## Test plan
- [x] `flutter test test/features/feed/utils/article_title_layout_test.dart` → 19 / 19
- [x] `flutter test test/features/feed/feed_card_test.dart` → 3 / 3
- [x] `flutter test` (suite complète) → 337 pass / 37 fail (aucun nouveau ; failures pré-existantes hors scope)
- [x] `flutter analyze` → aucun nouveau warning sur les fichiers touchés
- [ ] QA visuel à exécuter : feed sans image (titre 4-5L), feed avec image (3L), digest topic_section carousel (hauteur OK), long-press preview (inchangé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)