### PR TITLE
fix(mobile): preserve personalized notification on cold start

### DIFF
--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -299,8 +299,8 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
         'DigestNotifier: Updated notification with ${topicLabels.length} topics'
         ' (serein: $isSerein)',
       );
-    } catch (e) {
-      debugPrint('DigestNotifier: Failed to update notification: $e');
+    } catch (e, stack) {
+      debugPrint('DigestNotifier: Failed to update notification: $e\n$stack');
     }
   }
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -84,16 +84,27 @@ Future<void> main() async {
       // (peut être révoquée par une mise à jour Android ou un changement système)
       await pushNotificationService.ensureExactAlarmPermission();
 
-      final scheduled =
-          await pushNotificationService.scheduleDailyDigestNotification();
-      if (!scheduled) {
-        debugPrint(
-            'Main: WARNING — digest notification scheduling failed, retrying...');
-        // Retry après re-demande explicite de permission
-        await pushNotificationService.requestExactAlarmPermission();
-        final retryOk =
+      // Ne planifier la notification statique que si aucune n'existe déjà.
+      // Si une notification personnalisée (avec les sujets du digest) a été
+      // planifiée par DigestNotifier._updateNotificationWithTopics(), on la
+      // préserve — écraser avec le corps statique régresserait la feature.
+      final alreadyScheduled =
+          await pushNotificationService.isDigestNotificationScheduled();
+      if (!alreadyScheduled) {
+        final scheduled =
             await pushNotificationService.scheduleDailyDigestNotification();
-        debugPrint('Main: Retry result: $retryOk');
+        if (!scheduled) {
+          debugPrint(
+              'Main: WARNING — digest notification scheduling failed, retrying...');
+          // Retry après re-demande explicite de permission
+          await pushNotificationService.requestExactAlarmPermission();
+          final retryOk =
+              await pushNotificationService.scheduleDailyDigestNotification();
+          debugPrint('Main: Retry result: $retryOk');
+        }
+      } else {
+        debugPrint(
+            'Main: Digest notification already scheduled — skipping static placeholder.');
       }
 
       // Logger l'état complet pour diagnostic
@@ -205,11 +216,20 @@ Future<void> homeWidgetBackgroundCallback(Uri? uri) async {
 }
 
 /// Open a Hive box safely — if corrupted, delete and recreate it.
+///
+/// Une corruption sur la box `supabase_auth_persistence` provoque un logout
+/// silencieux (la session est perdue). On logge donc explicitement l'événement
+/// pour télémétrie.
+/// TODO(sentry): remplacer par `Sentry.captureMessage(level: error)` dès que
+/// `sentry_flutter` sera initialisé.
+/// Cf. docs/bugs/bug-android-session-forced-logouts.md.
 Future<Box<T>> _openBoxSafe<T>(String name) async {
   try {
     return await Hive.openBox<T>(name);
   } catch (e) {
     debugPrint('Main: Hive box "$name" corrupted, recreating: $e');
+    debugPrint(
+        '[AUTH_TELEMETRY] event=hive_box_corrupted box_name=$name error=$e');
     await Hive.deleteBoxFromDisk(name);
     return await Hive.openBox<T>(name);
   }


### PR DESCRIPTION
## Summary

- **Fix universel** : `main.dart` vérifie `isDigestNotificationScheduled()` avant de planifier la notification statique. Si une notification personnalisée (avec les sujets du digest) est déjà en place, elle est préservée — on évite que le cold start la remplace par le corps statique "Tes actus et décryptages du jour t'attendent".
- **Logging H2** : `_updateNotificationWithTopics()` capture maintenant le stack trace complet dans le `catch(e, stack)` pour diagnostiquer les exceptions silencieuses liées à `ref.read(sereinToggleProvider)`.

## Root cause

Depuis le commit #388 (13 avril), `_updateNotificationWithTopics()` personnalise la notification après le chargement du digest. Mais chaque cold start appelait `scheduleDailyDigestNotification()` sans corps → corps statique. Si l'app était ouverte APRÈS que la notification avait déjà été déclenchée (donc plus dans la liste `pendingNotificationRequests`), le statique gagnait.

## Test plan

- [ ] Premier lancement (pas de notification existante) → notification statique planifiée normalement
- [ ] Lancement après que le digest a été chargé → `DigestNotifier._updateNotificationWithTopics()` a planifié la personnalisée → `main.dart` logge "already scheduled — skipping" et la préserve
- [ ] Exception dans `_updateNotificationWithTopics()` → stack trace complet visible dans les logs Flutter
- [ ] Vérifier le lendemain matin que la notification affiche les sujets du digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)