### PR TITLE
feat(api): chrono feed tuning — interest context, squared multiplier, jittered positions

### DIFF
--- a/docs/stories/core/12.feed-chrono/12.8.preferences-carousels-tuning.md
+++ b/docs/stories/core/12.feed-chrono/12.8.preferences-carousels-tuning.md
@@ -1,0 +1,198 @@
+# Story 12.8 — Tuning Préférences & Ordre Carrousels
+
+**Epic** : 12 — Feed Chronologique
+**Type** : Feature Backend
+**Branche** : `boujonlaurin-dotcom/chrono-feed-tuning`
+**Statut** : 🟡 En cours
+
+---
+
+## 👥 User Story
+
+**En tant qu'** utilisateur Facteur,
+**Je veux** que mon feed chronologique reflète plus fidèlement mes préférences (thèmes suivis, sources en priorité réduite) et que l'ordre des carrousels varie d'un jour à l'autre,
+**Afin que** mon flux soit plus pertinent et moins répétitif visuellement.
+
+---
+
+## Contexte
+
+Post Epic 12, deux retours utilisateur récurrents :
+
+- **P1** Articles hors intérêts : des sources suivies publient sur des thèmes que l'user ne suit pas. Aucun filtre positif actif en mode chrono — seuls les mutes filtrent.
+- **P2** Sources en priorité "moins" (`priority_multiplier = 0.5`) : la formule actuelle `quota = ceil(ratio × page × multiplier)` ne réduit leur présence que de moitié. L'user attend une baisse plus marquée.
+- **P3** Ordre carrousels : positions hardcodées (3, 5, 10, 15, 20) → même ordre visuel à chaque ouverture. Pas de variété ni de favoritisme métier.
+
+---
+
+## 📋 Acceptance Criteria
+
+### AC1 — Quota exposant carré (P2)
+
+- [ ] `_apply_chronological_diversification()` calcule `quota = ceil(ratio × effective_limit × multiplier²)`
+- [ ] Multiplier 0.5 → facteur ×0.25 (au lieu de ×0.5)
+- [ ] Multiplier 2.0 → facteur ×4 (au lieu de ×2)
+- [ ] Garde-fou `max(1, quota)` préservé pour toute source suivie
+
+### AC2 — Quota ÷2 si aucun match d'intérêt (P1)
+
+- [ ] Nouveau helper `_source_has_interest_match(articles_src, user_interests, user_subtopics, custom_topic_keywords) -> bool`
+- [ ] Un article matche s'il vérifie au moins UN de :
+  - `content.theme ∈ user_interests`
+  - `content.topics ∩ user_subtopics ≠ ∅`
+  - un keyword custom_topic apparaît dans `title` ou `description` (case-insensitive)
+- [ ] Si la source n'a aucun article qui matche → `quota = max(1, base_quota // 2)`
+- [ ] `get_feed()` charge `user_custom_topics` **avant** l'appel chrono et les passe à la diversification
+- [ ] Pas de requête DB supplémentaire (les 3 ensembles sont déjà chargés par `get_feed()`)
+
+### AC3 — Ordre métier des carrousels (P3)
+
+- [ ] Nouvelles positions de base : `{"favorite": 3, "new_source": 6, "gems": 9, "saved": 12, "hot": 15, "deep": 18}`
+- [ ] Le front-end reçoit ces valeurs via `position` — aucune modif Flutter requise
+
+### AC4 — Jitter déterministe (P3)
+
+- [ ] Pour chaque carrousel construit, `position_final = base + jitter` avec `jitter ∈ {-2, -1, 0, +1, +2}`
+- [ ] Seed : `md5(user_id || today_iso || carousel_type)` → jitter stable pendant 24 h
+- [ ] Users différents ↔ jitters différents (même jour, même type)
+- [ ] Dates différentes ↔ jitters différents (même user, même type)
+- [ ] Position finale `≥ 1`
+- [ ] En cas de collision entre carrousels après jitter, tie-break par ordre métier (favorite < new_source < gems < saved < hot < deep)
+
+### AC5 — Pas de régression
+
+- [ ] Mode "Pour vous" (scoring 4-piliers) inchangé
+- [ ] Digest non impacté
+- [ ] Suite `pytest` backend passe
+- [ ] Suite `flutter test` / `flutter analyze` mobile passe (aucune modif front)
+
+---
+
+## 🔧 Approche Technique
+
+### Fichiers modifiés
+
+1. `packages/api/app/services/recommendation_service.py`
+   - `_apply_chronological_diversification()` :
+     - Nouveau paramètre `interest_context: InterestContext | None = None` (namedtuple légère ou dataclass locale)
+     - Formule : `quota = ceil(ratio × effective_limit × multiplier ** 2)`
+     - Post-calcul : si `interest_context` fourni et aucun article de la source ne match → `quota = max(1, quota // 2)`
+   - `get_feed()` :
+     - Remonter le chargement de `user_custom_topics` avant l'appel chrono
+     - Construire `InterestContext(user_interests, user_subtopics, custom_topic_keywords)` et le passer
+   - `_build_carousels()` :
+     - Remplacer les positions hardcodées par lecture depuis un dict `_CAROUSEL_BASE_POSITIONS`
+     - Nouveau helper `_jitter_position(base, user_id, carousel_type, today) -> int`
+     - Appliquer `position_finale = _jitter_position(...)` à chaque insertion carrousel
+     - Résolution collision via sort stable par (position, order_métier)
+
+2. `packages/api/tests/test_feed_chronological_refresh.py` (existant) — nouveaux tests pour P1 et P2
+3. `packages/api/tests/test_feed_carousels_ordering.py` — nouveau fichier pour P3
+
+### Extraits de code
+
+```python
+# Helper matching
+def _article_matches_interests(
+    article: Content,
+    user_interests: set[str],
+    user_subtopics: set[str],
+    custom_topic_keywords: list[str],
+) -> bool:
+    if article.theme and article.theme.lower() in user_interests:
+        return True
+    if article.topics:
+        if {t.lower().strip() for t in article.topics if t} & user_subtopics:
+            return True
+    if custom_topic_keywords:
+        haystack = f"{article.title or ''} {article.description or ''}".lower()
+        for kw in custom_topic_keywords:
+            if kw and kw.lower() in haystack:
+                return True
+    return False
+
+# Quota formula (P2 + P1)
+ratio = len(articles_src) / total
+multiplier = max(0.1, source_priority_multipliers.get(source_id, 1.0))
+quota = max(1, ceil(ratio * effective_limit * multiplier ** 2))
+if interest_context is not None and not any(
+    _article_matches_interests(a, *interest_context) for a in articles_src
+):
+    quota = max(1, quota // 2)
+
+# Jitter (P3)
+def _jitter_position(base: int, user_id: UUID, carousel_type: str, today: date) -> int:
+    seed = f"{user_id}{today.isoformat()}{carousel_type}".encode()
+    jitter = int(hashlib.md5(seed).hexdigest(), 16) % 5 - 2  # {-2..+2}
+    return max(1, base + jitter)
+```
+
+---
+
+## 🧪 Vérification
+
+### Tests unitaires
+
+```bash
+cd packages/api
+pytest tests/test_feed_chronological_refresh.py tests/test_feed_carousels_ordering.py -v
+pytest -v  # suite complète
+```
+
+### Test API manuel
+
+```bash
+uvicorn app.main:app --port 8080
+# Dans un 2e terminal
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8080/api/feed?limit=20" | jq '.items[] | {title, theme}'
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8080/api/feed?limit=20" | jq '.carousels[] | {carousel_type, position}'
+```
+
+Vérifier :
+- Sources `priority_multiplier=0.5` apparaissent ≤1 fois sur 20 articles (vs 2-3 avant).
+- Articles sans match d'intérêt sont rares vs baseline.
+- Positions carrousels stables dans la journée, varient entre jours.
+
+### Régression mobile
+
+```bash
+cd apps/mobile
+flutter test
+flutter analyze
+```
+
+Ouvrir le feed chrono et vérifier visuellement que les carrousels apparaissent toujours.
+
+---
+
+## 🎯 Tâches
+
+- [x] Créer story doc 12.8 (ce fichier)
+- [x] P2 — formule `multiplier²` dans `_apply_chronological_diversification`
+- [x] P1 — `InterestContext` + helper match + halving quota
+- [x] P3 — nouvelles positions + jitter déterministe
+- [x] Tests backend nouveaux + mise à jour tests existants
+- [ ] `pytest -v` complet
+- [ ] `flutter test && flutter analyze`
+- [ ] PR vers `main`
+
+---
+
+## ⚠️ Risques & Mitigation
+
+| Risque | Mitigation |
+|--------|-----------|
+| Feed vide si user peu d'intérêts déclarés | `max(1, quota)` préservé pour toute source suivie |
+| Jitter provoque collisions position | Tie-break par ordre métier (stable sort) |
+| `multiplier²` avec valeurs = 0.5/1.0/2.0 uniquement → OK | Validation schema bloque autres valeurs |
+| Tests chrono existants cassent | Rester backward compat : `interest_context=None` → comportement P2 uniquement |
+
+---
+
+## 📚 Dépendances
+
+- Story 12.1 (backend chrono algo) — déjà mergé
+- Story 12.4 (feed carousels) — déjà mergé
+- Aucune migration Alembic requise

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -520,9 +520,7 @@ class RecommendationService:
                 if tp.slug_parent:
                     ct_slugs.add(tp.slug_parent.lower().strip())
                 if tp.keywords:
-                    ct_keywords.extend(
-                        kw.lower().strip() for kw in tp.keywords if kw
-                    )
+                    ct_keywords.extend(kw.lower().strip() for kw in tp.keywords if kw)
             interest_context = InterestContext(
                 user_interests={s.lower().strip() for s in user_interests if s},
                 user_subtopics={s.lower().strip() for s in user_subtopics if s}

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -1,8 +1,10 @@
 import asyncio
 import datetime
+import hashlib
 import re
 import time
 import unicodedata
+from dataclasses import dataclass, field
 from uuid import UUID
 
 import structlog
@@ -16,6 +18,42 @@ from app.models.source import Source, UserSource
 from app.models.user import UserProfile, UserSubtopic
 
 logger = structlog.get_logger()
+
+
+@dataclass
+class InterestContext:
+    """User interest signals used to weight chronological quotas.
+
+    Chrono mode has no scoring; these sets are consulted to halve the quota
+    of sources whose candidates don't match anything the user follows.
+    """
+
+    user_interests: set[str] = field(default_factory=set)
+    user_subtopics: set[str] = field(default_factory=set)
+    custom_topic_keywords: list[str] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return not (
+            self.user_interests or self.user_subtopics or self.custom_topic_keywords
+        )
+
+
+def _article_matches_interests(
+    article: Content, interest_context: InterestContext
+) -> bool:
+    theme = getattr(article, "theme", None)
+    if theme and theme.lower().strip() in interest_context.user_interests:
+        return True
+    if article.topics and interest_context.user_subtopics:
+        article_topics = {t.lower().strip() for t in article.topics if t}
+        if article_topics & interest_context.user_subtopics:
+            return True
+    if interest_context.custom_topic_keywords:
+        haystack = f"{article.title or ''} {article.description or ''}".lower()
+        for kw in interest_context.custom_topic_keywords:
+            if kw and kw in haystack:
+                return True
+    return False
 
 
 async def _load_muted_entities_safe(session, user_id: UUID) -> set[str]:
@@ -465,19 +503,8 @@ class RecommendationService:
                 mode="chronological",
             )
 
-            # Phase 1: Chronological diversification with expanded pool for Phase 2
-            # Request more articles than limit so Phase 2 has room to compress neutrals
-            phase1_limit = limit * 3
-            result, source_overflow = self._apply_chronological_diversification(
-                candidates, source_priority_multipliers, phase1_limit, offset
-            )
-            self.source_overflow = source_overflow
-            await self._hydrate_user_status(result, user_id, followed_source_ids)
-
-            # Source interleaving: avoid consecutive articles from same source
-            result = self._apply_source_interleaving(result)
-
-            # Load custom topics for cluster building (reuse by caller)
+            # Story 12.8: load custom topics BEFORE diversification so we can
+            # build an InterestContext (halve quotas of sources with zero match).
             from app.models.user_topic_profile import UserTopicProfile
 
             custom_topics_stmt = select(UserTopicProfile).where(
@@ -486,6 +513,38 @@ class RecommendationService:
             async with async_session_maker() as s:
                 user_custom_topics = list((await s.scalars(custom_topics_stmt)).all())
             self.user_custom_topics = user_custom_topics
+
+            ct_slugs: set[str] = set()
+            ct_keywords: list[str] = []
+            for tp in user_custom_topics:
+                if tp.slug_parent:
+                    ct_slugs.add(tp.slug_parent.lower().strip())
+                if tp.keywords:
+                    ct_keywords.extend(
+                        kw.lower().strip() for kw in tp.keywords if kw
+                    )
+            interest_context = InterestContext(
+                user_interests={s.lower().strip() for s in user_interests if s},
+                user_subtopics={s.lower().strip() for s in user_subtopics if s}
+                | ct_slugs,
+                custom_topic_keywords=ct_keywords,
+            )
+
+            # Phase 1: Chronological diversification with expanded pool for Phase 2
+            # Request more articles than limit so Phase 2 has room to compress neutrals
+            phase1_limit = limit * 3
+            result, source_overflow = self._apply_chronological_diversification(
+                candidates,
+                source_priority_multipliers,
+                phase1_limit,
+                offset,
+                interest_context=interest_context,
+            )
+            self.source_overflow = source_overflow
+            await self._hydrate_user_status(result, user_id, followed_source_ids)
+
+            # Source interleaving: avoid consecutive articles from same source
+            result = self._apply_source_interleaving(result)
 
             # Snapshot all articles before regroupement removes hidden ones
             pre_regroup_map = {a.id: a for a in result}
@@ -761,16 +820,20 @@ class RecommendationService:
         source_priority_multipliers: dict[UUID, float],
         limit: int,
         offset: int,
+        interest_context: InterestContext | None = None,
     ) -> tuple[list[Content], dict[UUID, int]]:
         """
         Epic 12: Algorithme "Ratio Normalisé" — chronological feed with source diversification.
 
         Pipeline:
         1. Group by source, compute relative frequency
-        2. Compute quota per source: ceil(frequency × (offset+limit) × priority_multiplier), min 1
-        3. Keep the N most recent articles per source (up to quota)
-        4. Sort all retained articles by published_at DESC
-        5. Paginate with offset (quotas cover offset+limit so slice is never empty)
+        2. Compute quota per source: ceil(frequency × (offset+limit) × priority_multiplier²), min 1
+           - Story 12.8: squared multiplier so "moins" (0.5) ↦ ×0.25 and "plus" (2.0) ↦ ×4.
+        3. Story 12.8: halve the quota for sources whose candidates don't match any
+           user interest (theme / subtopic / custom topic keyword).
+        4. Keep the N most recent articles per source (up to quota)
+        5. Sort all retained articles by published_at DESC
+        6. Paginate with offset (quotas cover offset+limit so slice is never empty)
         """
         from math import ceil
 
@@ -785,12 +848,20 @@ class RecommendationService:
         total = len(candidates)
         effective_limit = offset + limit  # Cover all pages up to current request
 
-        # PASS 2: Compute quotas with user multipliers
+        apply_interest_halving = (
+            interest_context is not None and not interest_context.is_empty()
+        )
+
+        # PASS 2: Compute quotas with user multipliers (squared) and interest halving
         quotas: dict[UUID, int] = {}
         for source_id, articles_src in by_source.items():
             ratio = len(articles_src) / total
             multiplier = max(0.1, source_priority_multipliers.get(source_id, 1.0))
-            quota = max(1, ceil(ratio * effective_limit * multiplier))
+            quota = max(1, ceil(ratio * effective_limit * (multiplier**2)))
+            if apply_interest_halving and not any(
+                _article_matches_interests(a, interest_context) for a in articles_src
+            ):
+                quota = max(1, quota // 2)
             quotas[source_id] = quota
 
         logger.debug(
@@ -801,12 +872,13 @@ class RecommendationService:
             },
         )
 
-        # PASS 2b: Diversity cap — no source gets more than 4× min_quota (× its multiplier)
+        # PASS 2b: Diversity cap — no source gets more than MAX_SOURCE_RATIO × min_quota
+        # (scaled by the same squared multiplier we use in PASS 2).
         MAX_SOURCE_RATIO = 8
         min_quota = min(quotas.values())
         for source_id in quotas:
             multiplier = max(0.1, source_priority_multipliers.get(source_id, 1.0))
-            cap = max(1, ceil(MAX_SOURCE_RATIO * min_quota * multiplier))
+            cap = max(1, ceil(MAX_SOURCE_RATIO * min_quota * (multiplier**2)))
             quotas[source_id] = min(quotas[source_id], cap)
 
         # PASS 2c: Normalize quotas so total ≈ limit (prevent overflow
@@ -1005,6 +1077,38 @@ class RecommendationService:
                 updated[source_id] = count
         self.source_overflow = updated
 
+    # Story 12.8: business-ordered base positions for carousel types
+    # (favorite > new_source > community > saved > hot > deep).
+    # `decale` is only emitted in serein mode, which excludes hot/community,
+    # so it sits at community's slot.
+    _CAROUSEL_BASE_POSITIONS: dict[str, int] = {
+        "favorite": 3,
+        "new_source": 6,
+        "community": 9,
+        "decale": 9,
+        "saved": 12,
+        "hot": 15,
+        "deep": 18,
+    }
+
+    @staticmethod
+    def _jitter_carousel_position(
+        carousel_type: str,
+        user_id: UUID | None,
+        today: datetime.date,
+    ) -> int:
+        """Return base position ± 2, seeded by (user_id, today, carousel_type).
+
+        Story 12.8: deterministic daily jitter so the feed visually varies across
+        days but stays stable within a single day's reloads.
+        """
+        base = RecommendationService._CAROUSEL_BASE_POSITIONS.get(carousel_type, 15)
+        if user_id is None:
+            return base
+        seed = f"{user_id}|{today.isoformat()}|{carousel_type}".encode()
+        jitter = int(hashlib.md5(seed).hexdigest(), 16) % 5 - 2  # {-2,-1,0,+1,+2}
+        return max(1, base + jitter)
+
     async def _build_carousels(
         self,
         result: list[Content],
@@ -1017,12 +1121,10 @@ class RecommendationService:
         Promote overflow groups to horizontal carousels.
 
         Phase A: up to 3 carousels from entity/keyword overflow (hot/favorite/deep).
-        Phase B: up to 3 DB-driven carousels (new_source/gems/saved).
+        Phase B: up to 3 DB-driven carousels (new_source/community/saved).
 
         Returns: (filtered_result, carousel_dicts)
         """
-        import random as _random
-
         MIN_CAROUSEL_ITEMS = 3  # Minimum items for building a carousel
         MIN_DISPLAY_ITEMS = 2  # T2: Minimum items after consumed filtering
         MAX_CAROUSEL_ITEMS = 5
@@ -1030,6 +1132,7 @@ class RecommendationService:
         carousels: list[dict] = []
         promoted_ids: set[UUID] = set()
         used_group_keys: set[str] = set()  # Prevent same group in hot + deep
+        today = datetime.date.today()
 
         # T2: Fetch consumed content IDs to exclude from carousels
         consumed_ids: set[UUID] = set()
@@ -1083,7 +1186,9 @@ class RecommendationService:
                             "carousel_type": "hot",
                             "title": f"Actu chaude : {display_name}",
                             "emoji": "\U0001f50d",
-                            "position": 5,
+                            "position": self._jitter_carousel_position(
+                                "hot", user_id, today
+                            ),
                             "items": hot_articles,
                             "badges": badges,
                         }
@@ -1127,7 +1232,9 @@ class RecommendationService:
                     "carousel_type": "favorite",
                     "title": f"Focus sur {topic_name}",
                     "emoji": "\U0001f3af",
-                    "position": 10,
+                    "position": self._jitter_carousel_position(
+                        "favorite", user_id, today
+                    ),
                     "items": items,
                     "badges": [badge] * len(items),
                 }
@@ -1181,7 +1288,9 @@ class RecommendationService:
                             "carousel_type": "deep",
                             "title": "Ouvrir ses horizons",
                             "emoji": "\U0001f30d",
-                            "position": 15,
+                            "position": self._jitter_carousel_position(
+                                "deep", user_id, today
+                            ),
                             "items": items,
                             "badges": badges,
                         }
@@ -1227,7 +1336,9 @@ class RecommendationService:
                         "carousel_type": "decale",
                         "title": "L'actu décalée",
                         "emoji": "\U0001f604",
-                        "position": 12,
+                        "position": self._jitter_carousel_position(
+                            "decale", user_id, today
+                        ),
                         "items": decale_articles,
                         "badges": badges,
                     }
@@ -1303,7 +1414,9 @@ class RecommendationService:
                     if len(items) < MIN_NEW_SOURCE_ITEMS:
                         continue
 
-                    # T3D: Dynamic position based on source age
+                    # T3D: Dynamic position based on source age.
+                    # Very-recent sources keep priority slots (1 / 3); older
+                    # ones fall back on the Story 12.8 jittered business slot.
                     now = datetime.datetime.now(datetime.UTC)
                     source_age_seconds = (now - src_row.added_at).total_seconds()
                     if source_age_seconds < 24 * 3600:  # < 24h
@@ -1311,7 +1424,9 @@ class RecommendationService:
                     elif source_age_seconds < 3 * 24 * 3600:  # < 3 days
                         position = 3
                     else:
-                        position = 20
+                        position = self._jitter_carousel_position(
+                            "new_source", user_id, today
+                        )
 
                     logger.info(
                         "carousel_new_source_selected",
@@ -1431,7 +1546,9 @@ class RecommendationService:
                             "carousel_type": "community",
                             "title": "Recos de la communauté",
                             "emoji": "\U0001f33b",
-                            "position": 15,
+                            "position": self._jitter_carousel_position(
+                                "community", user_id, today
+                            ),
                             "items": items,
                             "badges": badges,
                         }
@@ -1504,7 +1621,9 @@ class RecommendationService:
                             "carousel_type": "saved",
                             "title": "Plus tard, c\u2019est maintenant !",
                             "emoji": "\U0001f4cc",
-                            "position": 20,
+                            "position": self._jitter_carousel_position(
+                                "saved", user_id, today
+                            ),
                             "items": items,
                             "badges": badges,
                         }
@@ -1516,22 +1635,32 @@ class RecommendationService:
         if promoted_ids:
             result = [a for a in result if a.id not in promoted_ids]
 
-        # --- Daily slot shuffle (B2) ---
-        # Assign carousels to shuffled slot positions for variety.
-        # Slots define position ranges; each day the carousel-to-slot mapping changes.
-        # Deterministic per user+day so pull-to-refresh stays stable.
-        CAROUSEL_SLOTS = [(4, 6), (8, 11), (14, 17)]
-        if daily_seed is not None and len(carousels) > 0:
-            rng = _random.Random(daily_seed)
-            # Build slot assignments: shuffle slot order, assign to carousels
-            slot_indices = list(range(len(CAROUSEL_SLOTS)))
-            rng.shuffle(slot_indices)
-            for i, c in enumerate(carousels):
-                if i < len(slot_indices):
-                    slot_min, slot_max = CAROUSEL_SLOTS[slot_indices[i]]
-                    c["position"] = rng.randint(slot_min, slot_max)
-                # Carousels beyond slot count keep their original position
-        # --- End daily slot shuffle ---
+        # Story 12.8 — Collision resolver: if two carousels land on the same
+        # position after jitter, bump later ones (in business order) so each
+        # carousel occupies a unique slot. Business order is derived from the
+        # base position map; earlier base = higher priority.
+        business_rank = {
+            t: i
+            for i, t in enumerate(
+                sorted(
+                    self._CAROUSEL_BASE_POSITIONS,
+                    key=self._CAROUSEL_BASE_POSITIONS.get,
+                )
+            )
+        }
+        carousels.sort(
+            key=lambda c: (
+                c["position"],
+                business_rank.get(c["carousel_type"], 99),
+            )
+        )
+        taken: set[int] = set()
+        for c in carousels:
+            pos = max(c["position"], MIN_CAROUSEL_POSITION)
+            while pos in taken:
+                pos += 1
+            c["position"] = pos
+            taken.add(pos)
 
         # Convert Content objects to serializable dicts for CarouselInfo
         carousel_dicts = []

--- a/packages/api/tests/test_feed_carousels.py
+++ b/packages/api/tests/test_feed_carousels.py
@@ -132,7 +132,8 @@ class TestBuildCarouselsHot:
         assert c["carousel_type"] == "hot"
         assert "Trump" in c["title"]
         assert c["emoji"] == "\U0001f50d"
-        assert c["position"] == 5
+        # Story 12.8: hot base position is 15 (business order), no jitter without user_id
+        assert c["position"] == 15
         assert len(c["items"]) == 5  # rep + 4 hidden
         assert len(c["badges"]) == len(c["items"])
         assert c["badges"][0]["code"] == "actu_chaude"
@@ -705,7 +706,7 @@ class TestMinCarouselPosition:
 
     @pytest.mark.asyncio
     async def test_hot_position_unchanged_without_user_id(self):
-        """Without user_id, hot carousel keeps its original position (5 >= 4)."""
+        """Without user_id, hot carousel falls back to its business-order base."""
         service = _setup_service()
         rep = MockContent(title="Trump article")
         hidden = [MockContent(title=f"Trump {i}") for i in range(4)]
@@ -718,7 +719,8 @@ class TestMinCarouselPosition:
 
         _, carousels = await service._build_carousels([], pre_regroup_map)
         assert len(carousels) == 1
-        assert carousels[0]["position"] == 5  # No shuffle, 5 >= MIN(4)
+        # Story 12.8: hot base position is 15 (no jitter without user_id)
+        assert carousels[0]["position"] == 15
 
 
 def _setup_service_with_overflow_and_mocks():
@@ -730,9 +732,11 @@ def _setup_service_with_overflow_and_mocks():
     return service
 
 
-class TestDailySlotShuffle:
+class TestDailyJitter:
+    """Story 12.8: deterministic daily jitter around business-order base."""
+
     @pytest.mark.asyncio
-    async def test_shuffle_deterministic_same_day(self):
+    async def test_jitter_deterministic_same_day(self):
         """Same user_id + same day → same positions on repeated calls."""
         service = _setup_service_with_overflow_and_mocks()
         user_id = uuid4()
@@ -757,7 +761,7 @@ class TestDailySlotShuffle:
         assert pos1 == pos2
 
     @pytest.mark.asyncio
-    async def test_shuffle_varies_across_users(self):
+    async def test_jitter_varies_across_users(self):
         """Different user_ids on the same day may get different positions."""
         service = _setup_service_with_overflow_and_mocks()
         rep = MockContent(title="Trump article")
@@ -769,7 +773,6 @@ class TestDailySlotShuffle:
         ]
         service.keyword_overflow = []
 
-        # Run for many different user_ids — at least some should differ
         positions = set()
         for _ in range(20):
             _, carousels = await service._build_carousels(
@@ -778,12 +781,13 @@ class TestDailySlotShuffle:
             if carousels:
                 positions.add(carousels[0]["position"])
 
-        # With 20 random user_ids and slots [4-6], we expect multiple distinct positions
         assert len(positions) > 1, "Positions should vary across different users"
 
     @pytest.mark.asyncio
-    async def test_all_shuffled_positions_within_slot_ranges(self):
-        """Shuffled positions must fall within defined slot ranges."""
+    async def test_jitter_stays_within_base_plus_minus_2(self):
+        """Jittered positions stay within base ±2 of the business-order slot."""
+        from app.services.recommendation_service import RecommendationService
+
         service = _setup_service_with_overflow_and_mocks()
         rep = MockContent(title="Trump article")
         hidden = [MockContent(title=f"Trump {i}") for i in range(4)]
@@ -794,16 +798,18 @@ class TestDailySlotShuffle:
         ]
         service.keyword_overflow = []
 
-        VALID_RANGES = [(4, 6), (8, 11), (14, 17)]
+        base_hot = RecommendationService._CAROUSEL_BASE_POSITIONS["hot"]
+        MIN_POS = 4
         for _ in range(20):
             _, carousels = await service._build_carousels(
                 [], pre_regroup_map, user_id=uuid4(),
             )
             for c in carousels:
                 pos = c["position"]
-                in_any_range = any(lo <= pos <= hi for lo, hi in VALID_RANGES)
-                assert in_any_range, (
-                    f"Position {pos} not in any valid slot range {VALID_RANGES}"
+                # Only one carousel here → no collisions. Jitter is ±2 around
+                # the base, clamped to MIN_CAROUSEL_POSITION.
+                assert max(MIN_POS, base_hot - 2) <= pos <= base_hot + 2, (
+                    f"Hot position {pos} outside jitter band for base {base_hot}"
                 )
 
 

--- a/packages/api/tests/test_feed_carousels_ordering.py
+++ b/packages/api/tests/test_feed_carousels_ordering.py
@@ -1,0 +1,133 @@
+"""Story 12.8 — Tests ordre métier + jitter déterministe des carrousels.
+
+Vérifie :
+- Les positions de base suivent le nouvel ordre métier (favorite > new_source > community > saved > hot > deep).
+- `_jitter_carousel_position()` est stable pour un couple (user_id, date, type) donné.
+- Le jitter varie entre utilisateurs différents sur la même date.
+- Le jitter varie entre dates différentes pour le même utilisateur.
+- Le jitter reste dans la fenêtre ±2 autour de la base.
+- Les positions finales sont toujours ≥ 1.
+"""
+
+from __future__ import annotations
+
+import datetime
+from uuid import uuid4
+
+from app.services.recommendation_service import RecommendationService
+
+
+class TestCarouselBaseOrder:
+    def test_business_order_is_favorite_first_deep_last(self):
+        """Ordre métier validé avec l'utilisateur :
+        favorite > new_source > community > saved > hot > deep."""
+        bp = RecommendationService._CAROUSEL_BASE_POSITIONS
+        assert bp["favorite"] < bp["new_source"]
+        assert bp["new_source"] < bp["community"]
+        assert bp["community"] < bp["saved"]
+        assert bp["saved"] < bp["hot"]
+        assert bp["hot"] < bp["deep"]
+
+    def test_decale_shares_community_slot_since_mutually_exclusive(self):
+        """`decale` n'apparaît qu'en mode serein (qui exclut `community` et `hot`),
+        donc il peut partager le slot de `community` sans collision réelle."""
+        bp = RecommendationService._CAROUSEL_BASE_POSITIONS
+        assert bp["decale"] == bp["community"]
+
+
+class TestJitterDeterminism:
+    def test_jitter_stable_for_same_user_same_day(self):
+        user_id = uuid4()
+        today = datetime.date(2026, 4, 19)
+        pos_a = RecommendationService._jitter_carousel_position("hot", user_id, today)
+        pos_b = RecommendationService._jitter_carousel_position("hot", user_id, today)
+        assert pos_a == pos_b
+
+    def test_jitter_varies_across_users_same_day(self):
+        today = datetime.date(2026, 4, 19)
+        positions = {
+            RecommendationService._jitter_carousel_position("hot", uuid4(), today)
+            for _ in range(30)
+        }
+        assert len(positions) > 1, "Jitter should vary across users"
+
+    def test_jitter_varies_across_dates_same_user(self):
+        user_id = uuid4()
+        positions = {
+            RecommendationService._jitter_carousel_position(
+                "hot",
+                user_id,
+                datetime.date(2026, 4, 1) + datetime.timedelta(days=d),
+            )
+            for d in range(30)
+        }
+        assert len(positions) > 1, "Jitter should vary across dates"
+
+    def test_jitter_varies_across_carousel_types(self):
+        """Même user + date, différents types → différents jitters."""
+        user_id = uuid4()
+        today = datetime.date(2026, 4, 19)
+        jitters = {
+            RecommendationService._jitter_carousel_position(t, user_id, today)
+            - RecommendationService._CAROUSEL_BASE_POSITIONS[t]
+            for t in ("favorite", "new_source", "community", "saved", "hot", "deep")
+        }
+        # Not all 6 will be distinct, but at least 2 different jitter values expected
+        assert len(jitters) >= 2
+
+
+class TestJitterBounds:
+    def test_jitter_stays_within_plus_minus_2_of_base(self):
+        """Sur 200 tirages, tout écart au base doit être dans {-2, -1, 0, 1, 2}."""
+        today = datetime.date(2026, 4, 19)
+        base = RecommendationService._CAROUSEL_BASE_POSITIONS["favorite"]
+        for _ in range(200):
+            pos = RecommendationService._jitter_carousel_position(
+                "favorite", uuid4(), today
+            )
+            delta = pos - base
+            assert -2 <= delta <= 2, f"Jitter delta {delta} out of bounds"
+
+    def test_position_never_below_one(self):
+        """Même si base=3 et jitter=-2, la position finale ≥ 1 (et non 0/-1)."""
+        today = datetime.date(2026, 4, 19)
+        for _ in range(200):
+            pos = RecommendationService._jitter_carousel_position(
+                "favorite", uuid4(), today
+            )
+            assert pos >= 1
+
+    def test_no_user_id_returns_raw_base(self):
+        """Sans user_id, pas de seed → on renvoie la base brute."""
+        today = datetime.date(2026, 4, 19)
+        for carousel_type, base in (
+            RecommendationService._CAROUSEL_BASE_POSITIONS.items()
+        ):
+            pos = RecommendationService._jitter_carousel_position(
+                carousel_type, None, today
+            )
+            assert pos == base
+
+    def test_unknown_carousel_type_falls_back_to_default(self):
+        """Type inconnu → base par défaut (15) ± jitter, toujours ≥ 1."""
+        today = datetime.date(2026, 4, 19)
+        pos = RecommendationService._jitter_carousel_position(
+            "mystery_carousel_type", uuid4(), today
+        )
+        assert 13 <= pos <= 17
+
+
+class TestJitterDistribution:
+    def test_jitter_uses_full_range(self):
+        """Sur beaucoup de users, tous les jitters {-2..+2} doivent apparaître."""
+        today = datetime.date(2026, 4, 19)
+        base = RecommendationService._CAROUSEL_BASE_POSITIONS["hot"]
+        observed = set()
+        for _ in range(500):
+            pos = RecommendationService._jitter_carousel_position(
+                "hot", uuid4(), today
+            )
+            observed.add(pos - base)
+        assert observed == {-2, -1, 0, 1, 2}, (
+            f"Expected full jitter range, got {observed}"
+        )

--- a/packages/api/tests/test_feed_chronological_refresh.py
+++ b/packages/api/tests/test_feed_chronological_refresh.py
@@ -191,3 +191,207 @@ class TestChronologicalRefreshFilter:
         candidate_ids = {c.id for c in candidates}
         assert target.id not in candidate_ids
         assert other.id in candidate_ids
+
+
+# ---------------------------------------------------------------------------
+# Story 12.8 — Tests P1/P2 : formule multiplier² + halving quota sans intérêt
+# ---------------------------------------------------------------------------
+
+
+def _fake_article(source_id, *, theme=None, topics=None, title="", description=""):
+    """Build a lightweight Content-like object for diversification tests.
+
+    `_apply_chronological_diversification` and `_article_matches_interests`
+    only touch `source_id`, `published_at`, `theme`, `topics`, `title`,
+    `description` — we avoid full DB fixtures to keep these tests fast.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id=uuid4(),
+        source_id=source_id,
+        published_at=datetime.now(UTC),
+        theme=theme,
+        topics=topics or [],
+        title=title,
+        description=description,
+    )
+
+
+class TestChronoMultiplierSquared:
+    """P2 — la formule quota utilise `multiplier²` (pas `multiplier`)."""
+
+    def test_multiplier_half_yields_quarter_quota(self):
+        from app.services.recommendation_service import RecommendationService
+
+        src_a = uuid4()  # priority 1.0
+        src_b = uuid4()  # priority 0.5 → multiplier² = 0.25
+        candidates = [_fake_article(src_a) for _ in range(40)] + [
+            _fake_article(src_b) for _ in range(40)
+        ]
+        multipliers = {src_a: 1.0, src_b: 0.5}
+
+        retained, _ = RecommendationService._apply_chronological_diversification(
+            candidates,
+            multipliers,
+            limit=20,
+            offset=0,
+        )
+        counts = {src_a: 0, src_b: 0}
+        for a in retained:
+            counts[a.source_id] += 1
+
+        assert counts[src_b] < counts[src_a]
+        assert counts[src_b] <= 4
+
+    def test_multiplier_two_yields_four_times_quota(self):
+        from app.services.recommendation_service import RecommendationService
+
+        src_a = uuid4()  # priority 1.0
+        src_b = uuid4()  # priority 2.0 → multiplier² = 4
+        candidates = [_fake_article(src_a) for _ in range(40)] + [
+            _fake_article(src_b) for _ in range(40)
+        ]
+        multipliers = {src_a: 1.0, src_b: 2.0}
+
+        retained, _ = RecommendationService._apply_chronological_diversification(
+            candidates,
+            multipliers,
+            limit=20,
+            offset=0,
+        )
+        counts = {src_a: 0, src_b: 0}
+        for a in retained:
+            counts[a.source_id] += 1
+
+        assert counts[src_b] > counts[src_a]
+
+
+class TestChronoInterestHalving:
+    """P1 — quota ÷2 si la source n'a aucun article qui matche les intérêts."""
+
+    def test_source_without_interest_match_is_halved(self):
+        from app.services.recommendation_service import (
+            InterestContext,
+            RecommendationService,
+        )
+
+        src_match = uuid4()
+        src_no_match = uuid4()
+        candidates = [
+            _fake_article(src_match, theme="tech") for _ in range(40)
+        ] + [_fake_article(src_no_match, theme="sports") for _ in range(40)]
+        multipliers = {src_match: 1.0, src_no_match: 1.0}
+        interest_ctx = InterestContext(
+            user_interests={"tech"},
+            user_subtopics=set(),
+            custom_topic_keywords=[],
+        )
+
+        retained, _ = RecommendationService._apply_chronological_diversification(
+            candidates,
+            multipliers,
+            limit=20,
+            offset=0,
+            interest_context=interest_ctx,
+        )
+        counts = {src_match: 0, src_no_match: 0}
+        for a in retained:
+            counts[a.source_id] += 1
+
+        assert counts[src_no_match] < counts[src_match]
+
+    def test_any_single_match_keeps_full_quota(self):
+        """Un seul article qui matche suffit à éviter le halving."""
+        from app.services.recommendation_service import (
+            InterestContext,
+            RecommendationService,
+        )
+
+        src_a = uuid4()
+        src_b = uuid4()
+        candidates_a = [_fake_article(src_a, theme="tech") for _ in range(40)]
+        candidates_b = [_fake_article(src_b, theme="sports") for _ in range(39)] + [
+            _fake_article(src_b, theme="tech")
+        ]
+        multipliers = {src_a: 1.0, src_b: 1.0}
+        interest_ctx = InterestContext(
+            user_interests={"tech"},
+            user_subtopics=set(),
+            custom_topic_keywords=[],
+        )
+
+        retained, _ = RecommendationService._apply_chronological_diversification(
+            candidates_a + candidates_b,
+            multipliers,
+            limit=20,
+            offset=0,
+            interest_context=interest_ctx,
+        )
+        counts = {src_a: 0, src_b: 0}
+        for a in retained:
+            counts[a.source_id] += 1
+
+        assert counts[src_b] >= counts[src_a] - 2
+
+    def test_empty_interest_context_disables_halving(self):
+        """Sans intérêts déclarés → backward-compat (P2 seul)."""
+        from app.services.recommendation_service import (
+            InterestContext,
+            RecommendationService,
+        )
+
+        src_a = uuid4()
+        src_b = uuid4()
+        candidates = [_fake_article(src_a) for _ in range(40)] + [
+            _fake_article(src_b) for _ in range(40)
+        ]
+        multipliers = {src_a: 1.0, src_b: 1.0}
+        empty_ctx = InterestContext()
+        assert empty_ctx.is_empty()
+
+        retained, _ = RecommendationService._apply_chronological_diversification(
+            candidates,
+            multipliers,
+            limit=20,
+            offset=0,
+            interest_context=empty_ctx,
+        )
+        counts = {src_a: 0, src_b: 0}
+        for a in retained:
+            counts[a.source_id] += 1
+
+        assert abs(counts[src_a] - counts[src_b]) <= 1
+
+    def test_subtopic_match_via_topics(self):
+        from app.services.recommendation_service import (
+            InterestContext,
+            _article_matches_interests,
+        )
+
+        article = _fake_article(uuid4(), theme="other", topics=["startups", "ai"])
+        ctx = InterestContext(
+            user_interests=set(),
+            user_subtopics={"ai"},
+            custom_topic_keywords=[],
+        )
+        assert _article_matches_interests(article, ctx) is True
+
+    def test_custom_topic_keyword_match(self):
+        from app.services.recommendation_service import (
+            InterestContext,
+            _article_matches_interests,
+        )
+
+        article = _fake_article(
+            uuid4(),
+            theme="other",
+            title="Mistral AI lève un tour de série C",
+            description="Une startup française…",
+        )
+        ctx = InterestContext(
+            user_interests=set(),
+            user_subtopics=set(),
+            custom_topic_keywords=["mistral ai"],
+        )
+        assert _article_matches_interests(article, ctx) is True


### PR DESCRIPTION
## What

Introduces three tuning improvements to chronological feed diversification and carousel positioning to address user-reported visual repetitiveness and weak prioritization of user interests.

## Why

Users reported three issues in chrono mode:
- **P1**: No positive interest filtering (only mutes). Chronological mode doesn't boost sources matching user themes/subtopics.
- **P2**: Multiplier 0.5 halves quotas rather than gradually de-emphasizing sources. Effect is too strong.
- **P3**: Hardcoded carousel positions produce identical visual ordering on every load, reducing perceived freshness.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Changes

**Backend (recommendation_service.py)**:
- New `InterestContext` dataclass + `_article_matches_interests()` helper to track/evaluate user interests (themes, subtopics, custom-topic keywords)
- Interest-based quota halving: sources with zero matching candidates get `quota = max(1, quota // 2)` for gentle de-emphasis
- Squared multiplier: priority factors now square before quota computation (0.5 → ×0.25, 2.0 → ×4) for stronger effect progression
- Deterministic daily jitter: carousel base positions now vary ±2 per user+day via `md5(user_id|date|type)` seed, creating visual variety within daily consistency
- Collision resolver: ensures unique carousel positions by business rank (favorite > new_source > community > saved > hot > deep)

**Tests**:
- Updated `test_feed_carousels.py` to reflect new business-rank ordering and jitter bounds
- Added `test_feed_chronological_refresh.py` (+204 lines): tests for squared multiplier and interest-halving behavior
- Added `test_feed_carousels_ordering.py` (+133 lines): comprehensive carousel jitter determinism, bounds, and distribution tests

**Documentation**:
- Added Story 12.8 (`docs/stories/core/12.feed-chrono/12.8.preferences-carousels-tuning.md`): design decisions, tuning values, checklist

All changes backward-compatible (`interest_context=None` disables halving). No Alembic migrations required.

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)