### PR TITLE
fix(api): unblock Railway healthcheck — sentry flush async + scheduler guard

### DIFF
--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -191,13 +191,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
             # than degraded mode. The readiness probe (/api/health/ready) will
             # correctly return 503, and pool_pre_ping will reconnect when DB is back.
             sentry_sdk.capture_exception(e)
-            sentry_sdk.flush(timeout=5)
+            # sentry_sdk.flush() is synchronous — run in executor to avoid
+            # blocking the event loop (which would make Railway healthcheck time out).
+            try:
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(None, lambda: sentry_sdk.flush(timeout=5))
+            except Exception:
+                pass
     else:
         logger.warning(
             "lifespan_db_checks_skipped", reason="DATABASE_URL not set in environment"
         )
     logger.info("lifespan_starting_scheduler")
-    start_scheduler()
+    try:
+        start_scheduler()
+    except Exception as sched_exc:
+        logger.critical(
+            "lifespan_scheduler_failed", error=str(sched_exc), exc_info=True
+        )
 
     # Startup catch-up: vérifie la couverture digest (pas juste l'existence).
     # Si < 90 % des users actifs ont un digest, relance la génération.


### PR DESCRIPTION
## Problem

After the merge of PR #442, Railway's Api service deploy failed: build succeeded (31s) but all 6 healthcheck attempts on `/api/health` returned "service unavailable" → rollback.

The deploy logs showed:

```
event: lifespan_startup_db_error
error: psycopg.errors.InternalError_: DbHandler exited [SQL: select pg_catalog.version()]
hint: App will start in degraded mode. /api/health/ready will return 503.
```

## Root cause

`/api/health` is a pure liveness probe (always 200, no DB check). It should survive any DB error. But in the `except Exception` branch of the lifespan startup:

```python
sentry_sdk.capture_exception(e)
sentry_sdk.flush(timeout=5)   # ← synchronous, blocks the event loop
```

`sentry_sdk.flush()` is **synchronous** — it blocks the entire asyncio event loop for up to 5 seconds (or longer if network is slow). While blocked, uvicorn cannot process ANY incoming requests, including Railway's healthcheck. Each healthcheck connection is accepted by the socket but gets no response → Railway sees "service unavailable" and marks the attempt as failed.

Since Railway sends healthcheck probes every ~11s over a 2-minute window, and the Sentry flush can exceed 5s on a slow network, multiple consecutive attempts can fail if the event loop stays blocked.

## Fix

Two targeted changes in `app/main.py`:

1. **Run `sentry_sdk.flush()` in a thread executor** so it doesn't block the event loop. The lifespan's `yield` is reached immediately after, and uvicorn can serve healthcheck requests.

2. **Guard `start_scheduler()` in try/except** — if APScheduler fails to initialize for any reason, the uncaught exception would prevent the lifespan from reaching `yield`, causing the same healthcheck blackout.

## Scope

- 1 file changed: `packages/api/app/main.py`
- No DB schema change, no pool config change, no alembic migration
- No behavioral change in the happy path

## Test plan

- [ ] CI green (ruff check + format)
- [ ] Railway Api deploy succeeds (healthcheck passes within 2-minute window)
- [ ] `/api/health` returns 200 immediately after startup even if DB is in degraded state

https://claude.ai/code/session_01TeRUNh9V4qvNVAYbns8m9M