### PR TITLE
feat(api): log endpoint/method in long_session_checkout (+ streak handler instrumentation)

### DIFF
--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -8,6 +8,10 @@ from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.pool import AsyncAdaptedQueuePool, NullPool
 
 from app.config import get_settings
+from app.middleware.request_context import (
+    current_request_method,
+    current_request_path,
+)
 
 settings = get_settings()
 
@@ -87,6 +91,24 @@ else:
 
 # Pool observability: log connections held longer than 10 seconds.
 # Helps detect session leaks that cause pool exhaustion.
+_LONG_CHECKOUT_THRESHOLD_S = 10.0
+
+
+def _maybe_log_long_checkout(connection_record) -> None:
+    checkout_time = getattr(connection_record, "_checkout_time", None)
+    if checkout_time is None:
+        return
+    duration = time.monotonic() - checkout_time
+    if duration > _LONG_CHECKOUT_THRESHOLD_S:
+        logger.warning(
+            "long_session_checkout",
+            duration_s=round(duration, 1),
+            endpoint=current_request_path.get("unknown"),
+            method=current_request_method.get("unknown"),
+        )
+    connection_record._checkout_time = None
+
+
 if _use_queue_pool:
 
     @event.listens_for(engine.sync_engine, "checkout")
@@ -95,15 +117,7 @@ if _use_queue_pool:
 
     @event.listens_for(engine.sync_engine, "checkin")
     def _on_checkin(dbapi_conn, connection_record):
-        checkout_time = getattr(connection_record, "_checkout_time", None)
-        if checkout_time:
-            duration = time.monotonic() - checkout_time
-            if duration > 10.0:
-                logger.warning(
-                    "long_session_checkout",
-                    duration_s=round(duration, 1),
-                )
-            connection_record._checkout_time = None
+        _maybe_log_long_checkout(connection_record)
 
 
 # Session factory

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -64,6 +64,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
 from app.database import close_db, get_db, init_db, text
+from app.middleware.request_context import RequestContextMiddleware
 from app.routers import (
     admin_cohorts,
     analytics,
@@ -345,6 +346,11 @@ app = FastAPI(
     redirect_slashes=False,
 )
 
+
+# RequestContextMiddleware : pose le path/method de la requête courante dans des
+# ContextVar consommés par les listeners SQLAlchemy (long_session_checkout).
+# Ajouté avant CORS pour que CORS reste le middleware outermost (latest-added).
+app.add_middleware(RequestContextMiddleware)
 
 # Configuration CORS - MUST be added AFTER the @middleware decorator to execute FIRST
 # Note: allow_credentials=True is incompatible with allow_origins=["*"]

--- a/packages/api/app/middleware/request_context.py
+++ b/packages/api/app/middleware/request_context.py
@@ -1,0 +1,21 @@
+"""Expose métadonnées de la requête courante aux listeners (checkin pool, etc.)."""
+
+from contextvars import ContextVar
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+current_request_path: ContextVar[str] = ContextVar("current_request_path")
+current_request_method: ContextVar[str] = ContextVar("current_request_method")
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        path_token = current_request_path.set(request.url.path)
+        method_token = current_request_method.set(request.method)
+        try:
+            return await call_next(request)
+        finally:
+            current_request_path.reset(path_token)
+            current_request_method.reset(method_token)

--- a/packages/api/app/routers/streaks.py
+++ b/packages/api/app/routers/streaks.py
@@ -1,5 +1,8 @@
 """Routes streak et progression."""
 
+import time
+
+import structlog
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -9,6 +12,7 @@ from app.schemas.streak import StreakResponse
 from app.services.streak_service import StreakService
 
 router = APIRouter()
+_perf_logger = structlog.get_logger("streak_perf")
 
 
 @router.get("", response_model=StreakResponse)
@@ -17,7 +21,13 @@ async def get_streak(
     db: AsyncSession = Depends(get_db),
 ) -> StreakResponse:
     """Récupérer le streak et la progression."""
+    t0 = time.monotonic()
     service = StreakService(db)
     streak = await service.get_streak(user_id)
+    _perf_logger.info(
+        "streak_handler_duration",
+        duration_ms=round((time.monotonic() - t0) * 1000, 2),
+        user_id=user_id,
+    )
 
     return streak

--- a/packages/api/app/routers/users.py
+++ b/packages/api/app/routers/users.py
@@ -1,9 +1,11 @@
 """Routes utilisateur."""
 
 import logging
+import time
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
+import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import func
@@ -11,6 +13,7 @@ from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
+_perf_logger = structlog.get_logger("streak_perf")
 
 from app.database import get_db
 from app.dependencies import get_current_user_id
@@ -245,8 +248,15 @@ async def get_streak(
     db: AsyncSession = Depends(get_db),
 ) -> StreakResponse:
     """Récupérer le streak actuel."""
+    t0 = time.monotonic()
     service = StreakService(db)
-    return await service.get_streak(user_id)
+    result = await service.get_streak(user_id)
+    _perf_logger.info(
+        "streak_handler_duration",
+        duration_ms=round((time.monotonic() - t0) * 1000, 2),
+        user_id=user_id,
+    )
+    return result
 
 
 class PreferenceUpdateRequest(BaseModel):

--- a/packages/api/tests/test_long_session_checkout_log.py
+++ b/packages/api/tests/test_long_session_checkout_log.py
@@ -1,0 +1,78 @@
+"""Unit tests for the long_session_checkout log enrichment."""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from app import database
+from app.database import _maybe_log_long_checkout
+from app.middleware.request_context import (
+    current_request_method,
+    current_request_path,
+)
+
+
+def _make_record(age_seconds: float | None) -> SimpleNamespace:
+    """Build a connection_record stub with the given checkout age."""
+    checkout_time = None if age_seconds is None else time.monotonic() - age_seconds
+    return SimpleNamespace(_checkout_time=checkout_time)
+
+
+def test_long_checkout_log_includes_endpoint_and_method(monkeypatch):
+    """Happy path: endpoint and method from ContextVar propagate to the log."""
+    mock_logger = MagicMock()
+    monkeypatch.setattr(database, "logger", mock_logger)
+
+    path_token = current_request_path.set("/api/feed/chrono")
+    method_token = current_request_method.set("GET")
+    try:
+        record = _make_record(age_seconds=15.0)
+        _maybe_log_long_checkout(record)
+    finally:
+        current_request_path.reset(path_token)
+        current_request_method.reset(method_token)
+
+    assert mock_logger.warning.call_count == 1
+    args, kwargs = mock_logger.warning.call_args
+    assert args == ("long_session_checkout",)
+    assert kwargs["endpoint"] == "/api/feed/chrono"
+    assert kwargs["method"] == "GET"
+    assert kwargs["duration_s"] >= 15.0
+    assert record._checkout_time is None
+
+
+def test_long_checkout_log_defaults_to_unknown_when_context_missing(monkeypatch):
+    """Checkin fired outside an HTTP cycle (e.g. scheduler) falls back to 'unknown'."""
+    mock_logger = MagicMock()
+    monkeypatch.setattr(database, "logger", mock_logger)
+
+    record = _make_record(age_seconds=12.0)
+    _maybe_log_long_checkout(record)
+
+    mock_logger.warning.assert_called_once()
+    kwargs = mock_logger.warning.call_args.kwargs
+    assert kwargs["endpoint"] == "unknown"
+    assert kwargs["method"] == "unknown"
+
+
+def test_short_checkout_does_not_log(monkeypatch):
+    """Duration under threshold must not emit the warning."""
+    mock_logger = MagicMock()
+    monkeypatch.setattr(database, "logger", mock_logger)
+
+    record = _make_record(age_seconds=1.0)
+    _maybe_log_long_checkout(record)
+
+    mock_logger.warning.assert_not_called()
+    assert record._checkout_time is None
+
+
+def test_missing_checkout_time_is_noop(monkeypatch):
+    """Absence of _checkout_time attribute must not log or raise."""
+    mock_logger = MagicMock()
+    monkeypatch.setattr(database, "logger", mock_logger)
+
+    record = _make_record(age_seconds=None)
+    _maybe_log_long_checkout(record)
+
+    mock_logger.warning.assert_not_called()

--- a/packages/api/tests/test_streak_handler_scope.py
+++ b/packages/api/tests/test_streak_handler_scope.py
@@ -1,0 +1,175 @@
+"""Tests for streak handler session scope and instrumentation (perf-watch 2026-04-20).
+
+The /api/users/streak handler was reported holding its DB session ~60 s on a
+trivial SELECT (Sentry "dbhandler exited" signature). Static analysis showed
+the scope contains only DB awaits (no HTTP / sleep), so the fix is to
+instrument `streak_handler_duration` and lock the contract: session released
+promptly, log event emitted on every call.
+"""
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.schemas.streak import StreakResponse
+
+
+def _canned_streak_response() -> StreakResponse:
+    return StreakResponse(
+        current_streak=3,
+        longest_streak=5,
+        last_activity_date=date(2026, 4, 19),
+        weekly_count=2,
+        weekly_goal=10,
+        weekly_progress=0.2,
+    )
+
+
+def _build_fake_session() -> MagicMock:
+    """A MagicMock session with async commit/rollback/close spies."""
+    fake = MagicMock()
+    fake.commit = AsyncMock()
+    fake.rollback = AsyncMock()
+    fake.close = AsyncMock()
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_users_streak_emits_duration_event():
+    """Handler must emit `streak_handler_duration` with duration_ms and user_id."""
+    fake_user_id = str(uuid4())
+    fake_session = _build_fake_session()
+
+    async def _fake_user():
+        return fake_user_id
+
+    async def _fake_db():
+        try:
+            yield fake_session
+            await fake_session.commit()
+        finally:
+            await fake_session.close()
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+
+    try:
+        with (
+            patch("app.routers.users.StreakService") as MockService,
+            patch("app.routers.users._perf_logger") as mock_logger,
+        ):
+            instance = MockService.return_value
+            instance.get_streak = AsyncMock(return_value=_canned_streak_response())
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                resp = await ac.get("/api/users/streak")
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["current_streak"] == 3
+    assert body["weekly_goal"] == 10
+
+    # Exactly one structured log event with the expected shape.
+    assert mock_logger.info.call_count == 1
+    call = mock_logger.info.call_args
+    assert call.args == ("streak_handler_duration",)
+    kwargs = call.kwargs
+    assert kwargs["user_id"] == fake_user_id
+    assert isinstance(kwargs["duration_ms"], (int, float))
+    assert kwargs["duration_ms"] >= 0
+    # Regression guard: no unexpected external await inflating the scope.
+    assert kwargs["duration_ms"] < 1000
+
+
+@pytest.mark.asyncio
+async def test_users_streak_session_released_after_handler():
+    """Handler must not hold the session: commit + close called once each."""
+    fake_user_id = str(uuid4())
+    fake_session = _build_fake_session()
+
+    async def _fake_user():
+        return fake_user_id
+
+    async def _fake_db():
+        try:
+            yield fake_session
+            await fake_session.commit()
+        finally:
+            await fake_session.close()
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+
+    try:
+        with patch("app.routers.users.StreakService") as MockService:
+            instance = MockService.return_value
+            instance.get_streak = AsyncMock(return_value=_canned_streak_response())
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                resp = await ac.get("/api/users/streak")
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    fake_session.commit.assert_awaited_once()
+    fake_session.close.assert_awaited_once()
+    fake_session.rollback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streaks_root_emits_duration_event():
+    """The duplicate /api/streaks handler must emit the same instrumentation."""
+    fake_user_id = str(uuid4())
+    fake_session = _build_fake_session()
+
+    async def _fake_user():
+        return fake_user_id
+
+    async def _fake_db():
+        try:
+            yield fake_session
+            await fake_session.commit()
+        finally:
+            await fake_session.close()
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+
+    try:
+        with (
+            patch("app.routers.streaks.StreakService") as MockService,
+            patch("app.routers.streaks._perf_logger") as mock_logger,
+        ):
+            instance = MockService.return_value
+            instance.get_streak = AsyncMock(return_value=_canned_streak_response())
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                resp = await ac.get("/api/streaks")
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert mock_logger.info.call_count == 1
+    call = mock_logger.info.call_args
+    assert call.args == ("streak_handler_duration",)
+    kwargs = call.kwargs
+    assert kwargs["user_id"] == fake_user_id
+    assert isinstance(kwargs["duration_ms"], (int, float))
+    assert kwargs["duration_ms"] >= 0
+    assert kwargs["duration_ms"] < 1000
+    fake_session.commit.assert_awaited_once()
+    fake_session.close.assert_awaited_once()


### PR DESCRIPTION
## Summary

Bundled PR from perf-watch 2026-04-20 work :

- **feat(api)** — Enrichit le log `long_session_checkout` avec `endpoint=` et `method=` via un `RequestContextMiddleware` léger qui pose le path/method de la requête courante dans des `ContextVar`. Sans ça, les bursts pool (ex. 07:40 UTC avec 6× `duration_s≈60`) sont impossibles à attribuer à un endpoint précis — Sentry est saturé donc les logs Railway sont notre seule source.
- **fix(api)** — Instrumente `/api/users/streak` et `/api/streaks` avec un event `streak_handler_duration` (duration_ms + user_id) pour distinguer une régression handler d'un problème pool/PgBouncer lorsqu'un SELECT trivial tient la session ~60 s.

## Changes

### `long_session_checkout` enrichment (`b5b7007e`)
- `packages/api/app/middleware/request_context.py` — nouveau : `ContextVar` + `RequestContextMiddleware` (BaseHTTPMiddleware).
- `packages/api/app/main.py` — branche le middleware **avant** CORS pour que CORS reste outermost.
- `packages/api/app/database.py` — extrait `_maybe_log_long_checkout` (testable), lit `current_request_path.get(\"unknown\")` / `current_request_method.get(\"unknown\")` et les injecte au `logger.warning`.
- `packages/api/tests/test_long_session_checkout_log.py` — 4 tests : happy path, fallback scheduler, sous-seuil no-op, `_checkout_time=None` no-op.

### Streak handler instrumentation (`150198af`)
- `packages/api/app/routers/{streaks,users}.py` — event `streak_handler_duration`.
- `packages/api/tests/test_streak_handler_scope.py` — contrat commit/close + duration_ms < 1000 ms.

## Constraints

- Python 3.12, types natifs.
- **Aucun changement aux params pool** (`pool_size`, `max_overflow`, `pool_timeout`, `pool_recycle` inchangés).

## Test plan

- [x] \`pytest tests/test_long_session_checkout_log.py\` — 4 passed
- [ ] CI green
- [ ] Post-deploy : \`railway logs --service WEB | grep long_session_checkout\` affiche bien \`endpoint=...\` et \`method=...\`
- [ ] Prochain burst pool : endpoint fautif identifiable → priorisation F2/F3 possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)