### PR TITLE
hotfix(api): singleflight per user on /digest/both (P0)

### DIFF
--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -380,7 +380,7 @@ async def get_both_digests(
                 asyncio.shield(leader_fut),
                 timeout=DIGEST_BOTH_FOLLOWER_TIMEOUT_S,
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise HTTPException(
                 status_code=503,
                 detail="digest_generation_timeout",

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -58,6 +58,16 @@ DIGEST_BOTH_GATHER_TIMEOUT_S = 30.0
 DIGEST_SINGLE_TIMEOUT_S = 30.0
 DIGEST_GENERATE_TIMEOUT_S = 60.0  # force=True peut prendre plus
 
+# Singleflight per user_uuid for /digest/both. Hotfix P0 2026-04-20: mobile
+# spammait 4 requêtes concurrentes → chacune ouvrait 2 sessions DB (gather) →
+# pool saturé en boucle. Les followers rejoignent le future du leader au lieu
+# de relancer leur propre gather.
+# Follower timeout > DIGEST_BOTH_GATHER_TIMEOUT_S + marge pour laisser le
+# leader propager son 503 avant que le follower raise lui-même.
+_digest_both_inflight: dict[UUID, asyncio.Future] = {}
+_digest_both_inflight_lock = asyncio.Lock()
+DIGEST_BOTH_FOLLOWER_TIMEOUT_S = 35.0
+
 
 class ActionRequest(BaseModel):
     """Simple action request body model."""
@@ -349,86 +359,126 @@ async def get_both_digests(
                 },
             )
 
-    # Generate both variants in parallel with separate DB sessions
-    # to avoid SQLAlchemy session conflicts and halve on-demand latency.
-    #
-    # BUG FIX (bug-infinite-load-requests.md) — each variant is bounded by
-    # DIGEST_BOTH_VARIANT_TIMEOUT_S; the whole gather is bounded by
-    # DIGEST_BOTH_GATHER_TIMEOUT_S. Without these, a slow upstream (Mistral
-    # LLM, Google News RSS, Supabase) hangs the request forever, holds 2 DB
-    # sessions, and rapidly exhausts the pool — making *every* other endpoint
-    # appear to "load indefinitely".
-    async def _gen_variant(is_serene: bool) -> DigestResponse | None:
-        async with async_session_maker() as session:
-            svc = DigestService(session, session_maker=async_session_maker)
+    # Singleflight per user_uuid: si une requête est déjà en vol pour ce user,
+    # les suivantes attendent son résultat au lieu de spawner leurs propres
+    # sessions DB. Protège le pool sous rafale mobile (4 requêtes concurrentes
+    # × 2 sessions gather = 8 slots par user sans dédup).
+    async with _digest_both_inflight_lock:
+        inflight_fut = _digest_both_inflight.get(user_uuid)
+        if inflight_fut is not None and not inflight_fut.done():
+            leader_fut: asyncio.Future = inflight_fut
+            leader_role = False
+        else:
+            leader_fut = asyncio.get_event_loop().create_future()
+            _digest_both_inflight[user_uuid] = leader_fut
+            leader_role = True
+
+    if not leader_role:
+        logger.info("digest_both_singleflight_join", user_id=current_user_id)
+        try:
             return await asyncio.wait_for(
-                svc.get_or_create_digest(user_uuid, target_date, is_serene=is_serene),
-                timeout=DIGEST_BOTH_VARIANT_TIMEOUT_S,
+                asyncio.shield(leader_fut),
+                timeout=DIGEST_BOTH_FOLLOWER_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            raise HTTPException(
+                status_code=503,
+                detail="digest_generation_timeout",
             )
 
     try:
-        normal, serein = await asyncio.wait_for(
-            asyncio.gather(
-                _gen_variant(False),
-                _gen_variant(True),
-            ),
-            timeout=DIGEST_BOTH_GATHER_TIMEOUT_S,
-        )
-    except TimeoutError:
-        logger.warning(
-            "digest_both_timeout",
-            user_id=current_user_id,
-            variant_timeout_s=DIGEST_BOTH_VARIANT_TIMEOUT_S,
-            gather_timeout_s=DIGEST_BOTH_GATHER_TIMEOUT_S,
-            hint="Upstream hang detected — sessions released to protect pool.",
-        )
-        raise HTTPException(
-            status_code=503,
-            detail="digest_generation_timeout",
-        )
+        # Generate both variants in parallel with separate DB sessions
+        # to avoid SQLAlchemy session conflicts and halve on-demand latency.
+        #
+        # BUG FIX (bug-infinite-load-requests.md) — each variant is bounded by
+        # DIGEST_BOTH_VARIANT_TIMEOUT_S; the whole gather is bounded by
+        # DIGEST_BOTH_GATHER_TIMEOUT_S. Without these, a slow upstream (Mistral
+        # LLM, Google News RSS, Supabase) hangs the request forever, holds 2 DB
+        # sessions, and rapidly exhausts the pool — making *every* other endpoint
+        # appear to "load indefinitely".
+        async def _gen_variant(is_serene: bool) -> DigestResponse | None:
+            async with async_session_maker() as session:
+                svc = DigestService(session, session_maker=async_session_maker)
+                return await asyncio.wait_for(
+                    svc.get_or_create_digest(
+                        user_uuid, target_date, is_serene=is_serene
+                    ),
+                    timeout=DIGEST_BOTH_VARIANT_TIMEOUT_S,
+                )
 
-    # If either variant is missing, don't return a 200 with null fields (the
-    # mobile client mishandles null variants as a permanent failure). Schedule
-    # regen for the specific missing variant(s) and ask the client to retry
-    # on the same 202 contract as the batch-running branch. Both-None and
-    # partial-None converge on the same response so the mobile side stays
-    # on a single polling contract.
-    if normal is None or serein is None:
-        effective_date = target_date or today_paris()
-        logger.warning(
-            "digest_both_returned_none_scheduled_regen",
-            user_id=current_user_id,
-            target_date=str(effective_date),
-            normal_missing=normal is None,
-            serein_missing=serein is None,
+        try:
+            normal, serein = await asyncio.wait_for(
+                asyncio.gather(
+                    _gen_variant(False),
+                    _gen_variant(True),
+                ),
+                timeout=DIGEST_BOTH_GATHER_TIMEOUT_S,
+            )
+        except TimeoutError:
+            logger.warning(
+                "digest_both_timeout",
+                user_id=current_user_id,
+                variant_timeout_s=DIGEST_BOTH_VARIANT_TIMEOUT_S,
+                gather_timeout_s=DIGEST_BOTH_GATHER_TIMEOUT_S,
+                hint="Upstream hang detected — sessions released to protect pool.",
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="digest_generation_timeout",
+            )
+
+        # If either variant is missing, don't return a 200 with null fields (the
+        # mobile client mishandles null variants as a permanent failure). Schedule
+        # regen for the specific missing variant(s) and ask the client to retry
+        # on the same 202 contract as the batch-running branch. Both-None and
+        # partial-None converge on the same response so the mobile side stays
+        # on a single polling contract.
+        if normal is None or serein is None:
+            effective_date = target_date or today_paris()
+            logger.warning(
+                "digest_both_returned_none_scheduled_regen",
+                user_id=current_user_id,
+                target_date=str(effective_date),
+                normal_missing=normal is None,
+                serein_missing=serein is None,
+            )
+            if normal is None:
+                schedule_digest_regen(user_uuid, effective_date, is_serene=False)
+            if serein is None:
+                schedule_digest_regen(user_uuid, effective_date, is_serene=True)
+            result: DualDigestResponse | JSONResponse = JSONResponse(
+                status_code=202,
+                content={
+                    "status": "preparing",
+                    "message": "Votre briefing est en cours de préparation...",
+                },
+            )
+            leader_fut.set_result(result)
+            return result
+
+        # Use the original session for the lightweight preference read
+        service = DigestService(db)
+        serein_enabled = await service._get_user_serein_enabled(user_uuid)
+
+        # Enrich both variants with community carousel
+        if normal:
+            normal = await _enrich_community_carousel(db, user_uuid, normal)
+        if serein:
+            serein = await _enrich_community_carousel(db, user_uuid, serein)
+
+        result = DualDigestResponse(
+            normal=normal,
+            serein=serein,
+            serein_enabled=serein_enabled,
         )
-        if normal is None:
-            schedule_digest_regen(user_uuid, effective_date, is_serene=False)
-        if serein is None:
-            schedule_digest_regen(user_uuid, effective_date, is_serene=True)
-        return JSONResponse(
-            status_code=202,
-            content={
-                "status": "preparing",
-                "message": "Votre briefing est en cours de préparation...",
-            },
-        )
-
-    # Use the original session for the lightweight preference read
-    service = DigestService(db)
-    serein_enabled = await service._get_user_serein_enabled(user_uuid)
-
-    # Enrich both variants with community carousel
-    if normal:
-        normal = await _enrich_community_carousel(db, user_uuid, normal)
-    if serein:
-        serein = await _enrich_community_carousel(db, user_uuid, serein)
-
-    return DualDigestResponse(
-        normal=normal,
-        serein=serein,
-        serein_enabled=serein_enabled,
-    )
+        leader_fut.set_result(result)
+        return result
+    except BaseException as exc:
+        if not leader_fut.done():
+            leader_fut.set_exception(exc)
+        raise
+    finally:
+        _digest_both_inflight.pop(user_uuid, None)
 
 
 @router.post("/{digest_id}/action", response_model=DigestActionResponse)

--- a/packages/api/tests/test_digest_both_singleflight.py
+++ b/packages/api/tests/test_digest_both_singleflight.py
@@ -1,0 +1,161 @@
+"""Regression tests for /digest/both singleflight dedup (hotfix P0 2026-04-20).
+
+Without singleflight, a mobile client firing N concurrent /digest/both requests
+for the same user would spawn N × 2 DB sessions via `asyncio.gather`, rapidly
+saturating the pool. These tests lock in:
+
+1. Same-user concurrent requests → only 1 leader runs the gather, followers
+   share its result.
+2. Different-user requests proceed in parallel (no false serialization).
+3. If the leader fails (HTTPException), followers receive the same exception.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers import digest as digest_router
+
+
+class _FakeDB:
+    """Minimal AsyncSession stand-in — the handler only calls `.scalar()` on it
+    when `is_generation_running()` returns True (we stub that False here)."""
+
+    async def scalar(self, *args, **kwargs):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_inflight():
+    """Ensure a clean _inflight dict between tests."""
+    digest_router._digest_both_inflight.clear()
+    yield
+    digest_router._digest_both_inflight.clear()
+
+
+async def _call(user_uuid):
+    return await digest_router.get_both_digests(
+        target_date=None,
+        db=_FakeDB(),
+        current_user_id=str(user_uuid),
+    )
+
+
+@pytest.mark.asyncio
+async def test_singleflight_same_user_dedupes_gather():
+    """5 concurrent requests for the same user_uuid → `get_or_create_digest`
+    is called only 2 times (1 leader × 2 variants), not 10."""
+
+    user_uuid = uuid4()
+    call_count = 0
+    release = asyncio.Event()
+
+    async def _slow_variant(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        # Block until the followers have had a chance to arrive and join.
+        await release.wait()
+        return None  # None → handler returns 202, no DigestResponse needed
+
+    with (
+        patch.object(digest_router, "is_generation_running", return_value=False),
+        patch.object(
+            digest_router.DigestService,
+            "get_or_create_digest",
+            new=AsyncMock(side_effect=_slow_variant),
+        ),
+        patch.object(digest_router, "schedule_digest_regen"),
+    ):
+        # Fire 5 concurrent calls; let the event loop schedule them all before
+        # releasing the leader so followers hit the singleflight lock first.
+        tasks = [asyncio.create_task(_call(user_uuid)) for _ in range(5)]
+        await asyncio.sleep(0.05)
+        release.set()
+        results = await asyncio.gather(*tasks)
+
+    # Leader runs gather once → 2 variant calls (normal + serene). Followers
+    # share the leader's future without re-entering _gen_variant.
+    assert call_count == 2, (
+        f"Expected 2 get_or_create_digest calls (1 leader × 2 variants), "
+        f"got {call_count} — singleflight failed to dedupe."
+    )
+    # All 5 requests return the same response (JSONResponse 202).
+    assert len(results) == 5
+    assert all(r is results[0] for r in results[1:]), (
+        "All followers should receive the exact same response object as the leader."
+    )
+
+
+@pytest.mark.asyncio
+async def test_singleflight_different_users_run_in_parallel():
+    """2 different user_uuids → 2 gathers run concurrently (no false serialization)."""
+
+    user_a = uuid4()
+    user_b = uuid4()
+    variant_delay = 0.2
+
+    async def _slow_variant(*_args, **_kwargs):
+        await asyncio.sleep(variant_delay)
+        return None
+
+    with (
+        patch.object(digest_router, "is_generation_running", return_value=False),
+        patch.object(
+            digest_router.DigestService,
+            "get_or_create_digest",
+            new=AsyncMock(side_effect=_slow_variant),
+        ),
+        patch.object(digest_router, "schedule_digest_regen"),
+    ):
+        t0 = time.monotonic()
+        await asyncio.gather(_call(user_a), _call(user_b))
+        elapsed = time.monotonic() - t0
+
+    # If parallel: elapsed ≈ variant_delay. If serialized: ≈ 2 × variant_delay.
+    # Generous margin — we only care that the second user is not blocked
+    # behind the first.
+    assert elapsed < variant_delay * 1.6, (
+        f"Expected parallel execution (≈{variant_delay}s), got {elapsed:.3f}s — "
+        f"different users should not serialize on the singleflight lock."
+    )
+
+
+@pytest.mark.asyncio
+async def test_singleflight_leader_error_propagates_to_followers():
+    """Leader raises HTTPException → all followers raise the same exception."""
+
+    user_uuid = uuid4()
+    release = asyncio.Event()
+
+    async def _fail_after_wait(*_args, **_kwargs):
+        await release.wait()
+        raise HTTPException(status_code=503, detail="leader_failed")
+
+    with (
+        patch.object(digest_router, "is_generation_running", return_value=False),
+        patch.object(
+            digest_router.DigestService,
+            "get_or_create_digest",
+            new=AsyncMock(side_effect=_fail_after_wait),
+        ),
+        patch.object(digest_router, "schedule_digest_regen"),
+    ):
+        tasks = [asyncio.create_task(_call(user_uuid)) for _ in range(5)]
+        await asyncio.sleep(0.05)
+        release.set()
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    # All 5 must raise HTTPException(503). Leader raises from its own handler;
+    # followers raise the same exception propagated via the shared future.
+    assert len(results) == 5
+    for idx, r in enumerate(results):
+        assert isinstance(r, HTTPException), (
+            f"Request {idx} should have raised HTTPException, got {type(r).__name__}: {r}"
+        )
+        assert r.status_code == 503, (
+            f"Request {idx}: expected status 503, got {r.status_code}"
+        )


### PR DESCRIPTION
## P0 — Pool DB saturé par rafale mobile sur /api/digest/both

### Incident
2026-04-20 09:53 UTC : pool DB à 100%, boucle de 503 `digest_generation_timeout` sur `/api/digest/both`.

### Root cause
Le handler `get_both_digests` (`packages/api/app/routers/digest.py`) spawn **2 sessions DB** via `asyncio.gather` pour générer les variantes normal + serene. Le mobile envoie **4 requêtes concurrentes** pour le même `user_uuid` → **8 slots DB par user**. Quelques users concurrents suffisent à saturer le pool, ce qui déclenche le `wait_for` de 30 s sur toutes les requêtes et produit la boucle de 503.

### Fix
Singleflight per `user_uuid` : si une requête est déjà en vol pour un user, les suivantes attendent son résultat partagé via un `asyncio.Future` au lieu de spawner leur propre gather.

- `_digest_both_inflight: dict[UUID, asyncio.Future]` + `asyncio.Lock` au niveau module
- Followers utilisent `asyncio.shield` + `wait_for(35s)` pour recevoir le résultat du leader
- Leader `set_result` / `set_exception` sur le future, cleanup dans `finally`
- Log `digest_both_singleflight_join` pour observer la dédup en prod
- Le lock reste court (lookup + create_future) → pas de fausse sérialisation cross-user

### Tests
- `test_singleflight_same_user_dedupes_gather` : 5 requêtes concurrentes même user → 2 appels `get_or_create_digest` (pas 10)
- `test_singleflight_different_users_run_in_parallel` : 2 users distincts → exécution parallèle confirmée (wall-clock)
- `test_singleflight_leader_error_propagates_to_followers` : leader raise `HTTPException(503)` → les 5 followers reçoivent la même exception
- Régression `test_digest_both_hanging_variant_returns_503_timeout` reste verte
- 92 tests digest-liés passent sans régression

### Hors scope
- Pas de modif des params pool (interdit par l'incident)
- Pas de cache inter-requêtes (seulement inflight-join)
- Le cas batch-running early-202 reste hors singleflight (pas de gather, pas d'ouverture de session)

## Test plan
- [x] `pytest tests/test_digest_both_singleflight.py tests/test_digest_both_timeout.py -v` → 4/4 passed
- [x] `pytest -k digest` → 92/92 passed
- [ ] Post-deploy : `curl /api/health/pool` retourne `usage_pct < 30%` en ≤ 2 min
- [ ] Post-deploy : `railway logs | grep digest_both_singleflight_join` apparaît
- [ ] Post-deploy : plus de 503 `digest_generation_timeout` sur `/api/digest/both`

🤖 Generated with [Claude Code](https://claude.com/claude-code)