### PR TITLE
feat(api)+fix(mobile): less sport in digest + perspectives title truncation

### DIFF
--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -515,45 +515,47 @@ class _PerspectiveCard extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Title area
-            Padding(
-              padding: const EdgeInsets.fromLTRB(12, 12, 12, 8),
-              child: IntrinsicHeight(
-                child: Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  // Bias indicator
-                  Container(
+            Stack(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(28, 12, 12, 8),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          perspective.title.replaceAll(RegExp(r'\s*[-–|]\s*[^-–|]+$'), '').trim(),
+                          style: textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w500,
+                            color: colors.textPrimary,
+                            fontSize: (textTheme.bodyMedium?.fontSize ?? 14) + 1,
+                          ),
+                          maxLines: 4,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Icon(
+                        PhosphorIcons.arrowSquareOut(PhosphorIconsStyle.regular),
+                        size: 16,
+                        color: colors.textTertiary,
+                      ),
+                    ],
+                  ),
+                ),
+                Positioned(
+                  left: 12,
+                  top: 12,
+                  bottom: 8,
+                  child: Container(
                     width: 4,
                     decoration: BoxDecoration(
                       color: perspective.getBiasColor(colors),
                       borderRadius: BorderRadius.circular(2),
                     ),
                   ),
-                  const SizedBox(width: 12),
-                  // Title
-                  Expanded(
-                    child: Text(
-                      perspective.title.replaceAll(RegExp(r'\s*[-–|]\s*[^-–|]+$'), '').trim(),
-                      style: textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w500,
-                        color: colors.textPrimary,
-                        fontSize: (textTheme.bodyMedium?.fontSize ?? 14) + 1,
-                      ),
-                      maxLines: 4,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                  Align(
-                    alignment: Alignment.topCenter,
-                    child: Icon(
-                      PhosphorIcons.arrowSquareOut(PhosphorIconsStyle.regular),
-                      size: 16,
-                      color: colors.textTertiary,
-                    ),
-                  ),
-                ],
-              ),
-              ),
+                ),
+              ],
             ),
 
             // Footer — source info, tappable if source found in DB

--- a/docs/maintenance/maintenance-less-sport-in-digest.md
+++ b/docs/maintenance/maintenance-less-sport-in-digest.md
@@ -1,0 +1,83 @@
+# Maintenance — Pénalité Sport dans le scoring du digest
+
+> **Branche** : `boujonlaurin-dotcom/less-sport`
+> **Date** : 2026-04-20
+> **Type** : Maintenance (calibration algo digest — réduction articles Sport)
+
+---
+
+## Contexte
+
+Le digest quotidien (5-7 articles, **identique pour tous les utilisateurs**, modes `pour_vous` et `serein`) donne trop de place aux articles de type Sport par rapport à l'intention produit.
+
+### État existant (avant)
+
+Il existe déjà une dépriorisation au niveau des **clusters éditoriaux** :
+- `editorial/pipeline.py:147` appelle `cap_low_priority_clusters(..., max_sport=1)`
+- Résultat : au plus 1 cluster Sport parmi les topics du jour
+
+**Gap identifié** : aucune pénalité n'est appliquée au scoring des **articles individuels** dans `digest_selector._score_candidates()`. Conséquence :
+- Un article Sport avec bonus source suivie + topic user + très récent peut toujours remonter au top
+- Le cap cluster filtre les *topics*, pas la pondération finale des articles
+
+### Intention produit
+
+Réduire mécaniquement la probabilité de sélection d'un article Sport, **sans exclusion dure**. Un Sport vraiment pertinent (source suivie + topic ciblé + très récent) peut encore passer.
+
+### Scope
+
+**IN-SCOPE** : `digest_selector._score_candidates()` — les deux modes (`pour_vous` et `serein`).
+
+**OUT-OF-SCOPE** :
+- Le feed chronologique (pas de changement)
+- Le cap cluster éditorial (conservé tel quel, complémentaire)
+- La classification ML des thèmes/topics (inchangée)
+
+## Implémentation
+
+### 1. Détection Sport unifiée
+
+Nouveau helper `is_sport_content(content)` dans `packages/api/app/services/recommendation/filter_presets.py`, symétrique à `is_sport_cluster` existant. Détecte un article Sport via :
+1. `content.theme ∈ LOW_PRIORITY_SPORT_THEMES` (= `{"sport","sports"}`)
+2. `"sport" ∈ content.topics`
+3. Titre/description matche un `LOW_PRIORITY_SPORT_KEYWORDS` (liste existante : football, rugby, tennis, PSG, Ligue 1, etc.)
+
+Réutilise les constantes déjà définies (lignes 377-408 de `filter_presets.py`).
+
+### 2. Constante de pénalité
+
+Nouvelle constante dans `scoring_config.py` :
+```python
+DIGEST_SPORT_PENALTY = -40.0
+```
+Valeur alignée sur `MUTED_THEME_MALUS` (-40). Un Sport avec theme match (+50) + source suivie (+35) + recency récent (+25) = +110 pts bruts peut encore battre un neutre moyen (~60-80 pts).
+
+### 3. Application dans le scoring
+
+Dans `digest_selector._score_candidates()`, juste après `final_score = base_score + recency_bonus` :
+- Si `is_sport_content(content)` → `final_score += DIGEST_SPORT_PENALTY`
+- Breakdown enrichi avec label "Sport (priorité réduite)" pour transparence algorithmique
+
+### 4. Tests
+
+- `tests/test_low_priority_cap.py` → classe `TestIsSportContent` (5 cas)
+- `tests/test_digest_selector.py` → `test_sport_article_gets_penalty` (article Sport vs neutre)
+
+## Fichiers modifiés
+
+- `packages/api/app/services/recommendation/filter_presets.py`
+- `packages/api/app/services/recommendation/scoring_config.py`
+- `packages/api/app/services/digest_selector.py`
+- `packages/api/tests/test_low_priority_cap.py`
+- `packages/api/tests/test_digest_selector.py`
+
+Pas de migration DB, pas de changement front mobile, pas de changement d'API.
+
+## Vérification
+
+```bash
+cd packages/api && pytest tests/test_low_priority_cap.py tests/test_digest_selector.py -v
+cd packages/api && pytest -v
+```
+
+Manuel : `GET /api/digest/today` pour un user test → vérifier ≤ 1 article Sport dans les 5-7 et breakdown "Sport (priorité réduite)" pour articles Sport.

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -40,7 +40,10 @@ from app.models.source import Source, UserSource
 from app.models.user import UserProfile, UserSubtopic
 from app.schemas.digest import DigestScoreBreakdown
 from app.services.briefing.importance_detector import ImportanceDetector
-from app.services.recommendation.filter_presets import apply_serein_filter
+from app.services.recommendation.filter_presets import (
+    apply_serein_filter,
+    is_sport_content,
+)
 from app.services.recommendation.scoring_config import ScoringWeights
 from app.services.recommendation.scoring_engine import ScoringContext
 from app.services.recommendation_service import RecommendationService
@@ -1013,6 +1016,17 @@ class DigestSelector:
                     recency_bonus = 0.0
 
                 final_score = base_score + recency_bonus
+
+                # Sport penalty (applied to both pour_vous and serein modes)
+                if is_sport_content(content):
+                    final_score += ScoringWeights.DIGEST_SPORT_PENALTY
+                    breakdown.append(
+                        DigestScoreBreakdown(
+                            label="Sport (priorité réduite)",
+                            points=ScoringWeights.DIGEST_SPORT_PENALTY,
+                            is_positive=False,
+                        )
+                    )
 
                 # Capture CoreLayer contributions
                 # Theme match (3-tier: content.theme > source.theme > secondary)

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -440,6 +440,18 @@ def is_sport_cluster(cluster: TopicCluster) -> bool:
     return _match_ratio(cluster, LOW_PRIORITY_SPORT_KEYWORDS) > 0.5
 
 
+def is_sport_content(content: Content) -> bool:
+    """Article individuel de type Sport (theme, topics ou keywords titre/desc)."""
+    if content.theme and content.theme.lower() in LOW_PRIORITY_SPORT_THEMES:
+        return True
+    if content.topics and any(
+        isinstance(t, str) and t.lower() == "sport" for t in content.topics
+    ):
+        return True
+    text = f"{content.title or ''} {content.description or ''}".lower()
+    return any(kw in text for kw in LOW_PRIORITY_SPORT_KEYWORDS)
+
+
 def is_faits_divers_cluster(cluster: TopicCluster) -> bool:
     """Cluster dominé par les faits divers (>50% titres matchent)."""
     return _match_ratio(cluster, LOW_PRIORITY_FAITS_DIVERS_KEYWORDS) > 0.5

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -126,6 +126,13 @@ class ScoringWeights:
     # plutôt que domination d'une seule.
     DIGEST_DIVERSITY_DIVISOR = 2
 
+    # --- DIGEST LOW-PRIORITY (Sport) ---
+
+    # Pénalité appliquée aux articles Sport dans le scoring du digest (2 modes).
+    # Alignée sur MUTED_THEME_MALUS (-40) : un Sport fort (source suivie + topic
+    # ciblé + très récent) peut encore dépasser le seuil — pas d'exclusion dure.
+    DIGEST_SPORT_PENALTY = -40.0
+
     # --- DIGEST TRENDING/IMPORTANCE (Pour vous hybride) ---
 
     # Bonus pour article trending (couvert par ≥3 sources distinctes).

--- a/packages/api/tests/test_digest_selector.py
+++ b/packages/api/tests/test_digest_selector.py
@@ -822,3 +822,102 @@ class TestGenerateReasonTrending:
 
         reason = selector._generate_reason(content, defaultdict(int), defaultdict(int), breakdown)
         assert reason == "Thème : AI"
+
+
+# ─── Tests: Sport penalty in _score_candidates ───────────────────────────────
+
+
+class TestScoreCandidatesSportPenalty:
+    """Pénalité Sport appliquée dans le scoring du digest (2 modes)."""
+
+    @pytest.fixture
+    def context(self):
+        return DigestContext(
+            user_id=uuid4(),
+            user_profile=Mock(),
+            user_interests={"tech", "science"},
+            user_interest_weights={"tech": 1.0, "science": 1.0},
+            followed_source_ids=set(),
+            custom_source_ids=set(),
+            user_prefs={},
+            user_subtopics=set(),
+            user_subtopic_weights={},
+            muted_sources=set(),
+            muted_themes=set(),
+            muted_topics=set(),
+            muted_content_types=set(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_sport_article_gets_penalty(self, selector, context):
+        """Article Sport perd DIGEST_SPORT_PENALTY points vs article neutre équivalent."""
+        from app.services.recommendation.scoring_config import ScoringWeights
+
+        sport_src = make_source(name="Sport Source", theme="sport")
+        tech_src = make_source(name="Tech Source", theme="tech")
+        now = datetime.now(timezone.utc)
+        sport_content = make_content(source=sport_src, theme="sport", published_at=now)
+        tech_content = make_content(source=tech_src, theme="tech", published_at=now)
+
+        selector.rec_service = Mock()
+        selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
+        selector.rec_service.scoring_engine = Mock()
+        selector.rec_service.scoring_engine.compute_score = Mock(return_value=100.0)
+
+        scored = await selector._score_candidates(
+            [sport_content, tech_content], context, mode="pour_vous"
+        )
+
+        by_id = {c.id: (s, bd) for c, s, bd in scored}
+        sport_score, sport_breakdown = by_id[sport_content.id]
+        tech_score, _ = by_id[tech_content.id]
+
+        assert tech_score - sport_score == pytest.approx(
+            abs(ScoringWeights.DIGEST_SPORT_PENALTY)
+        )
+        labels = [b.label for b in sport_breakdown]
+        assert "Sport (priorité réduite)" in labels
+
+    @pytest.mark.asyncio
+    async def test_sport_penalty_applies_in_serein_mode(self, selector, context):
+        """La pénalité Sport s'applique aussi en mode serein."""
+        from app.services.recommendation.scoring_config import ScoringWeights
+
+        sport_src = make_source(name="Sport Source", theme="sport")
+        now = datetime.now(timezone.utc)
+        sport_content = make_content(source=sport_src, theme="sport", published_at=now)
+
+        selector.rec_service = Mock()
+        selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
+        selector.rec_service.scoring_engine = Mock()
+        selector.rec_service.scoring_engine.compute_score = Mock(return_value=100.0)
+
+        scored = await selector._score_candidates(
+            [sport_content], context, mode="serein"
+        )
+
+        _, _, breakdown = scored[0]
+        sport_entry = next(
+            (b for b in breakdown if b.label == "Sport (priorité réduite)"), None
+        )
+        assert sport_entry is not None
+        assert sport_entry.points == ScoringWeights.DIGEST_SPORT_PENALTY
+
+    @pytest.mark.asyncio
+    async def test_sport_detected_via_topics(self, selector, context):
+        """Article non-sport en theme mais avec 'sport' dans topics est pénalisé."""
+        src = make_source(name="Mixed Source", theme="tech")
+        now = datetime.now(timezone.utc)
+        content = make_content(
+            source=src, theme="tech", topics=["sport", "football"], published_at=now
+        )
+
+        selector.rec_service = Mock()
+        selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
+        selector.rec_service.scoring_engine = Mock()
+        selector.rec_service.scoring_engine.compute_score = Mock(return_value=100.0)
+
+        scored = await selector._score_candidates([content], context, mode="pour_vous")
+        _, _, breakdown = scored[0]
+        labels = [b.label for b in breakdown]
+        assert "Sport (priorité réduite)" in labels

--- a/packages/api/tests/test_low_priority_cap.py
+++ b/packages/api/tests/test_low_priority_cap.py
@@ -19,6 +19,7 @@ from app.services.recommendation.filter_presets import (
     cap_low_priority_clusters,
     is_faits_divers_cluster,
     is_sport_cluster,
+    is_sport_content,
 )
 
 
@@ -26,6 +27,8 @@ from app.services.recommendation.filter_presets import (
 class _FakeContent:
     title: str | None = None
     description: str | None = None
+    theme: str | None = None
+    topics: list[str] | None = None
 
 
 @dataclass
@@ -82,6 +85,37 @@ class TestIsSportCluster:
             ],
         )
         assert not is_sport_cluster(cluster)
+
+
+class TestIsSportContent:
+    def test_theme_sport_is_sport(self):
+        c = _FakeContent(theme="sport", title="Actu diverse")
+        assert is_sport_content(c)
+
+    def test_theme_sports_plural_is_sport(self):
+        c = _FakeContent(theme="sports", title="x")
+        assert is_sport_content(c)
+
+    def test_topic_sport_in_array_is_sport(self):
+        c = _FakeContent(theme="tech", topics=["ai", "sport"], title="x")
+        assert is_sport_content(c)
+
+    def test_keyword_in_title_is_sport(self):
+        c = _FakeContent(theme="tech", title="PSG bat l'OM 3-1 en Ligue 1")
+        assert is_sport_content(c)
+
+    def test_neutral_content_is_not_sport(self):
+        c = _FakeContent(
+            theme="tech",
+            topics=["ai", "startups"],
+            title="IA générative en entreprise",
+            description="Analyse des tendances",
+        )
+        assert not is_sport_content(c)
+
+    def test_none_fields_not_sport(self):
+        c = _FakeContent(theme=None, topics=None, title=None, description=None)
+        assert not is_sport_content(c)
 
 
 class TestIsFaitsDiversCluster:


### PR DESCRIPTION
## What

- **API** — Ajoute une pénalité de -40 pts sur les articles Sport dans le scoring du digest (`_score_candidates`, modes `pour_vous` + `serein`) via un nouveau helper `is_sport_content()` (détection theme/topics/keywords titre+desc).
- **Mobile** — Fixe le tronquage sévère du titre dans les cartes de perspectives (`_PerspectiveCard`) en remplaçant `IntrinsicHeight + Row(stretch) + Expanded(Text)` par un `Stack` avec bias bar `Positioned` — pattern plus robuste qui évite la mesure intrinsèque instable.

## Why

- **API** — Comble le gap entre le cap cluster (`max_sport=1`) et le scoring des articles individuels : un Sport avec bonus source suivie + topic ciblé + très récent pouvait encore remonter au top. Pénalité non-bloquante (alignée sur `MUTED_THEME_MALUS`) pour garder la porte ouverte aux Sport vraiment pertinents.
- **Mobile** — Sur la vue perspectives, le premier article s'affichait parfois tronqué à 2 mots alors que `maxLines: 4` était configuré. Le pattern `IntrinsicHeight + Expanded(Text multilignes)` est un anti-pattern Flutter qui produit des largeurs calculées instables.

## Type

- [x] Feature (API — sport penalty)
- [x] Bug fix (mobile — perspectives card)
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (5 tests ajoutés dans `test_digest_selector.py` + `test_low_priority_cap.py`)
- [x] `flutter analyze` OK sur le fichier modifié
- [x] No new Python `List[]` imports
- [ ] If touching auth/DB: read Safety Guardrails (N/A)
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)