### PR TITLE
feat(sources): perf + filters + expand for custom source search

### DIFF
--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,112 +1,101 @@
-# QA Handoff — Onboarding Q9b : carrousel pour l'affinage des thèmes
+# QA Handoff — Perf & UX de "Ajout de source custom"
+
+> Feature branch : `boujonlaurin-dotcom/add-source-perf`
+> Bug doc : `docs/bugs/bug-add-source-search-perf.md`
 
 ## Feature développée
 
-L'écran d'affinage des centres d'intérêt (`Q9b — Affine tes centres d'intérêt`) ne défile plus verticalement. Les thèmes sélectionnés à Q9 sont désormais présentés sous forme de carrousel horizontal (un thème par page, swipe latéral). Un sticky header animé affiche le thème courant au-dessus du carrousel ; des dots indicateurs colorés à la couleur du thème courant indiquent la progression. Le bouton "Continue" reste actif dès le départ ; un modal de confirmation apparaît si l'utilisateur tente de continuer sans avoir parcouru tous les thèmes.
-
-## PR associée
-
-À créer après validation QA.
+Trois correctifs groupés sur l'écran d'ajout de source custom :
+1. **Perf** : short-circuit agressif du pipeline de recherche quand le nom matche fort en DB (catalog seul → <500 ms attendus).
+2. **Filtres** : les 5 badges (Médias, Newsletters, YouTube, Reddit, Podcasts) deviennent des `ChoiceChip`s cliquables. Sélection = filtre par type côté backend + skip des layers externes non pertinents.
+3. **Élargir la recherche** : bouton qui apparaît sous les résultats quand seul le catalog a répondu → relance le pipeline complet (`expand: true`).
+4. **Skeleton** : messages plus lents (800 ms/dot, ~4.8 s/message) et plus variés (6 messages) pour une sensation moins "fake".
 
 ## Écrans impactés
 
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| Onboarding Q9b — Affine tes centres d'intérêt | Onboarding section 3, step 1 (après Q9 themes) | Modifié |
+| Ajouter une source | `/sources/add` | Modifié |
 
 ## Scénarios de test
 
-### Scénario 1 : Happy path multi-thèmes
+### Scénario 1 : Recherche rapide d'une source curated (happy path perf)
 **Parcours** :
-1. Démarrer un nouvel onboarding (ou réinitialiser)
-2. Avancer jusqu'à Q9 et sélectionner 4 thèmes (ex. tech, international, science, culture)
-3. Continuer vers Q9b
+1. Ouvrir "Ajouter une source".
+2. Taper "Mediapart" dans le champ de recherche et valider.
 
 **Résultat attendu** :
-- Le sticky header affiche l'emoji + label du premier thème (couleur primaire du thème).
-- 4 dots apparaissent sous le header ; le 1er est actif (forme allongée 24×10), les 3 autres sont inactifs (10×10).
-- La carte du thème courant occupe la majorité de l'espace ; un léger peek de la carte suivante est visible à droite (viewportFraction 0.92).
-- Swipe vers la gauche → navigation vers le 2ᵉ thème : le sticky header s'anime (fade + slide), les dots avancent, la couleur active du dot passe à celle du nouveau thème.
+- Les résultats s'affichent en moins de 500 ms.
+- La source "Mediapart" est dans les résultats.
+- Un bouton **"Élargir la recherche"** apparaît en bas des résultats.
+- Sous le bouton, le texte « Cherche aussi sur YouTube, Reddit et le web. » est visible.
 
-### Scénario 2 : Persistance des sélections au swipe
+### Scénario 2 : Élargir la recherche
 **Parcours** :
-1. Sur Q9b avec 3+ thèmes
-2. Sur le thème 1, cocher 2 subtopics et 1 entité populaire
-3. Swipe vers le thème 2, cocher 1 subtopic
-4. Swipe retour vers le thème 1
-
-**Résultat attendu** : les 2 subtopics + l'entité du thème 1 sont toujours cochés.
-
-### Scénario 3 : Couleur dynamique des dots
-**Parcours** : sélectionner ≥ 3 thèmes de couleurs différentes, swipe entre eux.
-
-**Résultat attendu** : à chaque page, le dot actif prend la couleur du thème courant (ex. bleu pour tech, vert pour environnement, etc.).
-
-### Scénario 4 : Mono-thème (pas de carrousel)
-**Parcours** : à Q9, ne sélectionner qu'1 seul thème, continuer.
+1. Après le scénario 1, taper le bouton "Élargir la recherche".
 
 **Résultat attendu** :
-- Pas de sticky header au-dessus.
-- Pas de dots indicateurs.
-- La carte unique du thème s'affiche directement, avec son header interne (emoji + label) en haut de la carte (comportement legacy préservé).
-- Tap Continue → pas de modal, navigation directe vers Q10.
+- Le skeleton réapparaît brièvement.
+- De nouveaux résultats externes s'ajoutent (YouTube / Brave / GoogleNews).
+- Le bouton "Élargir la recherche" disparaît après cette relance.
 
-### Scénario 5 : Custom topic + clavier
+### Scénario 3 : Filtrer par YouTube
 **Parcours** :
-1. Sur Q9b, sur n'importe quel thème, tap "ajouter un sujet"
-2. Le clavier apparaît, le TextField se met en focus
-3. Saisir un nom et soumettre
-
-**Résultat attendu** : le TextField reste visible (le SingleChildScrollView interne à la page absorbe le décalage du clavier). Le custom chip apparaît dans la liste au-dessus du CTA.
-
-### Scénario 6 : Continue sans tout parcourir → modal
-**Parcours** :
-1. Sélectionner 4 thèmes à Q9
-2. Sur Q9b, ne swiper que jusqu'au 2ᵉ thème (visited = {0, 1})
-3. Tap Continue
+1. Clear la recherche précédente.
+2. Sélectionner la chip **YouTube**.
+3. Taper "fireship" et valider.
 
 **Résultat attendu** :
-- Modal `AlertDialog` apparaît avec titre "Êtes-vous sûr ?" et contenu "Vous pourrez toujours définir vos intérêts plus tard dans 'Mes intérêts'."
-- 2 actions : "Voir les autres thèmes" (referme sans naviguer) et "Continuer" (procède à la sauvegarde + navigation Q10).
-- Tester les 2 actions.
+- Seuls des résultats de type YouTube remontent.
+- La latence doit être réduite (Brave/Google/Mistral sont skippés).
 
-### Scénario 7 : Continue après tout parcourir → pas de modal
-**Parcours** : sélectionner 4 thèmes, swiper jusqu'au dernier (indice 3, visited = {0, 1, 2, 3}), tap Continue.
+### Scénario 4 : Médias et Newsletters = même filtre
+**Parcours** :
+1. Taper "substack" et valider.
+2. Sélectionner chip **Médias** → noter les résultats.
+3. Sélectionner chip **Newsletters** → noter les résultats.
 
-**Résultat attendu** : pas de modal, navigation directe vers Q10. Les sélections (subtopics + entities + customs des 4 thèmes) sont sauvegardées en backend.
+**Résultat attendu** :
+- Les deux filtres donnent exactement les mêmes résultats (tous deux mappent sur `type=article`).
+- Chaque chip est visuellement sélectionnée distinctement (on voit laquelle est active).
 
-### Scénario 8 : Restart onboarding
-**Parcours** : compléter Q9b une fois, revenir à Q9b via reset partiel.
+### Scénario 5 : Skeleton crédible (messages rotating)
+**Parcours** :
+1. Taper une requête qui va vraiment prendre plusieurs secondes (ex. "xyzzyq1234" qui force tous les layers).
+2. Observer le skeleton pendant >10 s.
 
-**Résultat attendu** : les sélections précédentes sont restaurées (chips cochés sur les bons thèmes), la page initiale est 0 (premier thème).
+**Résultat attendu** :
+- Les dots animent toutes les 800 ms.
+- Les messages changent toutes les ~4.8 s (pas toutes les 1.5 s comme avant).
+- Les 6 messages suivants défilent : "Exploration du catalogue", "Analyse de votre recherche", "Interrogation des plateformes", "Scan du web", "Recoupement des sources", "Préparation des suggestions".
+
+### Scénario 6 : Filtre persiste après clear
+**Parcours** :
+1. Sélectionner chip "Reddit".
+2. Taper "r/france", valider.
+3. Cliquer sur le bouton clear du champ de recherche.
+
+**Résultat attendu** :
+- Le champ est vide.
+- La chip "Reddit" reste sélectionnée (volontaire : le filtre persiste pour la prochaine recherche).
 
 ## Critères d'acceptation
 
-- [ ] Carrousel horizontal swipeable entre thèmes (≥ 2 thèmes sélectionnés)
-- [ ] Sticky header animé au-dessus du carrousel reflétant le thème courant
-- [ ] Dots indicateurs colorés à la couleur du thème courant
-- [ ] Bouton Continue actif dès le départ
-- [ ] Modal de confirmation uniquement si pas tous les thèmes parcourus
-- [ ] Cas mono-thème : rendu direct sans carrousel ni modal
-- [ ] Sélections persistantes lors des changements de page
-- [ ] Custom topic + keyboard fonctionnent dans une page de carrousel
-- [ ] Aucune régression sur la sauvegarde des subtopics/entities/customs
+- [ ] Recherche d'une source curated <500 ms (vs 2-5 s avant).
+- [ ] Bouton "Élargir la recherche" visible uniquement si `layers_called == ["catalog"]`.
+- [ ] Les 5 chips sont cliquables et mutuellement exclusives.
+- [ ] Médias et Newsletters filtrent tous deux sur `article`.
+- [ ] Skeleton affiche 6 messages uniques avec rotation lente (~4.8 s/message).
+- [ ] Aucune régression sur l'ajout effectif d'une source (flow `trustSource` / `addCustomSource`).
 
 ## Zones de risque
 
-- **Hauteur dynamique** : les cards de "tech" ou "international" peuvent être plus hautes que l'écran (beaucoup de subtopics + entités). Vérifier que le `SingleChildScrollView` interne à la page absorbe correctement le débordement vertical.
-- **Keyboard + PageView** : sur certains devices, le clavier qui s'ouvre dans une page de carrousel peut perturber le scroll. Vérifier que le TextField reste visible et que le scroll-into-view fonctionne.
-- **Animation du sticky header** : à valider visuellement — fade + slide de 0.2 vertical sur 250ms. Si trop sec ou trop lent, ajuster.
-- **Couleurs des thèmes** : 9 thèmes ont chacun leur couleur (cf. `AvailableThemes.all`). Vérifier que toutes les couleurs sont lisibles en tant que dot actif sur le fond standard.
+- **Changement de family key du `smartSearchProvider`** : de `String` vers un record `({String query, String? contentType, bool expand})`. Vérifier qu'il n'y a pas d'erreur Riverpod au runtime (refresh, invalidate).
+- **Cache backend** : la clé inclut désormais `content_type` + `expand`. Les anciennes entrées en DB sont orphelines mais ne causent pas d'erreur — elles expirent en 24 h.
+- **Short-circuit agressif** : surveiller qu'un match "substring seulement" (ex. "le" dans "lenny") ne déclenche PAS le short-circuit (tests unitaires couverts).
 
 ## Dépendances
 
-- API `/topics/follow` (via `customTopicsProvider.followTopic`) — inchangé.
-- Provider `popularEntitiesProvider(themeSlug)` — inchangé.
-- `OnboardingAnswers.subtopics` (state via Riverpod) — inchangé.
-
-Aucun endpoint backend modifié, aucune migration DB.
-
-## Fichiers modifiés
-
-- `apps/mobile/lib/features/onboarding/screens/questions/subtopics_question.dart` (seul fichier modifié pour cette feature)
+- Endpoint modifié : `POST /sources/smart-search` — nouveaux params optionnels `content_type` (article/youtube/reddit/podcast) et `expand` (bool).
+- Réponse schema inchangée — `layers_called` reste le signal principal côté client.
+- Table `source_search_cache` — aucune migration nécessaire, seule la clé de hash change.

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -222,6 +222,17 @@ class AnalyticsService {
     await _logEvent('add_source_gem_tap', {'source_id': sourceId});
   }
 
+  Future<void> trackAddSourceContentTypeFilter(String contentType) async {
+    await _logEvent(
+      'add_source_content_type_filter',
+      {'content_type': contentType},
+    );
+  }
+
+  Future<void> trackAddSourceExpand(String query) async {
+    await _logEvent('add_source_expand', {'query': query});
+  }
+
   Future<void> trackAppFirstLaunch() async {
     final prefs = await SharedPreferences.getInstance();
     if (prefs.getBool('has_launched_before') == true) return;

--- a/apps/mobile/lib/features/sources/providers/sources_providers.dart
+++ b/apps/mobile/lib/features/sources/providers/sources_providers.dart
@@ -11,12 +11,20 @@ final sourcesRepositoryProvider = Provider<SourcesRepository>((ref) {
   return SourcesRepository(ApiClient(Supabase.instance.client));
 });
 
-final smartSearchProvider =
-    FutureProvider.family<List<SmartSearchResult>, String>((ref, query) async {
-  if (query.trim().isEmpty) return [];
+typedef SmartSearchQuery = ({String query, String? contentType, bool expand});
+
+final smartSearchProvider = FutureProvider.family<SmartSearchResponse,
+    SmartSearchQuery>((ref, params) async {
+  final trimmed = params.query.trim();
+  if (trimmed.isEmpty) {
+    return const SmartSearchResponse(queryNormalized: '', results: []);
+  }
   final repository = ref.watch(sourcesRepositoryProvider);
-  final response = await repository.smartSearch(query.trim());
-  return response.results;
+  return repository.smartSearch(
+    trimmed,
+    contentType: params.contentType,
+    expand: params.expand,
+  );
 });
 
 final trendingSourcesProvider = FutureProvider<List<Source>>((ref) async {

--- a/apps/mobile/lib/features/sources/repositories/sources_repository.dart
+++ b/apps/mobile/lib/features/sources/repositories/sources_repository.dart
@@ -146,11 +146,19 @@ class SourcesRepository {
     }
   }
 
-  Future<SmartSearchResponse> smartSearch(String query) async {
+  Future<SmartSearchResponse> smartSearch(
+    String query, {
+    String? contentType,
+    bool expand = false,
+  }) async {
     try {
       final response = await _apiClient.dio.post<Map<String, dynamic>>(
         'sources/smart-search',
-        data: {'query': query},
+        data: {
+          'query': query,
+          if (contentType != null) 'content_type': contentType,
+          if (expand) 'expand': true,
+        },
       );
       if (response.statusCode == 200 && response.data != null) {
         return SmartSearchResponse.fromJson(response.data!);

--- a/apps/mobile/lib/features/sources/repositories/sources_repository.dart
+++ b/apps/mobile/lib/features/sources/repositories/sources_repository.dart
@@ -192,6 +192,17 @@ class SourcesRepository {
     }
   }
 
+  Future<void> logSearchAbandoned(String query) async {
+    try {
+      await _apiClient.dio.post<dynamic>(
+        'sources/search-abandoned',
+        data: {'query': query},
+      );
+    } catch (_) {
+      // fire-and-forget
+    }
+  }
+
   Future<ThemeSourcesResponse> getSourcesByTheme(String slug) async {
     try {
       final response =

--- a/apps/mobile/lib/features/sources/screens/add_source_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/add_source_screen.dart
@@ -30,6 +30,7 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
   String? _selectedContentType;
   String? _selectedLabel;
   bool _expanded = false;
+  bool _sourceAdded = false;
   final Set<String> _addedSourceIds = {};
   late final TextEditingController _searchController;
 
@@ -41,6 +42,10 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
 
   @override
   void dispose() {
+    final query = _currentQuery.trim();
+    if (query.isNotEmpty && !_sourceAdded) {
+      ref.read(sourcesRepositoryProvider).logSearchAbandoned(query);
+    }
     _searchController.dispose();
     super.dispose();
   }
@@ -99,13 +104,17 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
 
       if (hasCatalogId) {
         await repository.trustSource(sourceId);
-        setState(() => _addedSourceIds.add(sourceId));
+        setState(() {
+          _addedSourceIds.add(sourceId);
+          _sourceAdded = true;
+        });
       } else {
         if (result.feedUrl.isEmpty) {
           NotificationService.showError('URL du flux introuvable');
           return;
         }
         await repository.addCustomSource(result.feedUrl, name: result.name);
+        setState(() => _sourceAdded = true);
       }
 
       if (!mounted) return;

--- a/apps/mobile/lib/features/sources/screens/add_source_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/add_source_screen.dart
@@ -27,6 +27,9 @@ class AddSourceScreen extends ConsumerStatefulWidget {
 
 class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
   String _currentQuery = '';
+  String? _selectedContentType;
+  String? _selectedLabel;
+  bool _expanded = false;
   final Set<String> _addedSourceIds = {};
   late final TextEditingController _searchController;
 
@@ -42,6 +45,12 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
     super.dispose();
   }
 
+  SmartSearchQuery get _searchParams => (
+        query: _currentQuery,
+        contentType: _selectedContentType,
+        expand: _expanded,
+      );
+
   // ─── Smart Search Actions ──────────────────────────────────────
 
   void _runSearch([String? query]) {
@@ -50,12 +59,35 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
     if (_searchController.text != value) {
       _searchController.text = value;
     }
-    setState(() => _currentQuery = value);
+    setState(() {
+      _currentQuery = value;
+      _expanded = false;
+    });
   }
 
   void _clearSearch() {
     _searchController.clear();
-    setState(() => _currentQuery = '');
+    setState(() {
+      _currentQuery = '';
+      _expanded = false;
+    });
+  }
+
+  void _onContentTypeToggle(String? value) {
+    setState(() {
+      _selectedContentType = value;
+      _expanded = false;
+    });
+    if (value != null) {
+      ref
+          .read(analyticsServiceProvider)
+          .trackAddSourceContentTypeFilter(value);
+    }
+  }
+
+  void _expandSearch() {
+    setState(() => _expanded = true);
+    ref.read(analyticsServiceProvider).trackAddSourceExpand(_currentQuery);
   }
 
   Future<void> _addSource(SmartSearchResult result) async {
@@ -245,15 +277,25 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
       return _buildEmptyState();
     }
 
-    final searchAsync = ref.watch(smartSearchProvider(_currentQuery));
+    final searchAsync = ref.watch(smartSearchProvider(_searchParams));
 
-    return searchAsync.when(
-      loading: () => const SourceResultSkeleton(),
-      error: (error, _) => _buildErrorState(),
-      data: (results) {
-        if (results.isEmpty) return _buildNoResults();
-        return _buildResults(results);
-      },
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _buildFilterChips(),
+        const SizedBox(height: 12),
+        searchAsync.when(
+          loading: () => const SourceResultSkeleton(),
+          error: (error, _) => _buildErrorState(),
+          data: (response) {
+            if (response.results.isEmpty) return _buildNoResults();
+            final canExpand = !_expanded &&
+                response.layersCalled.length == 1 &&
+                response.layersCalled.first == 'catalog';
+            return _buildResults(response.results, canExpand: canExpand);
+          },
+        ),
+      ],
     );
   }
 
@@ -288,7 +330,11 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
     );
   }
 
-  Widget _buildResults(List<SmartSearchResult> results) {
+  Widget _buildResults(
+    List<SmartSearchResult> results, {
+    bool canExpand = false,
+  }) {
+    final colors = context.facteurColors;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -303,6 +349,26 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
               onAdd: () => _addSource(result),
               onPreview: () => _previewSource(result),
             )),
+        if (canExpand) ...[
+          const SizedBox(height: 8),
+          OutlinedButton.icon(
+            onPressed: _expandSearch,
+            icon: Icon(
+              PhosphorIcons.arrowsOutSimple(PhosphorIconsStyle.regular),
+              size: 16,
+              color: colors.primary,
+            ),
+            label: const Text('Élargir la recherche'),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Cherche aussi sur YouTube, Reddit et le web.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: colors.textTertiary,
+                ),
+            textAlign: TextAlign.center,
+          ),
+        ],
       ],
     );
   }
@@ -358,7 +424,7 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
             const SizedBox(height: 12),
             OutlinedButton(
               onPressed: () =>
-                  ref.invalidate(smartSearchProvider(_currentQuery)),
+                  ref.invalidate(smartSearchProvider(_searchParams)),
               child: const Text('Reessayer'),
             ),
           ],
@@ -414,15 +480,66 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
     );
   }
 
-  Widget _buildSourceTypesRow() {
+  static const _contentTypeOptions =
+      <({String label, String apiValue, int iconIndex})>[
+    (label: 'Médias', apiValue: 'article', iconIndex: 0),
+    (label: 'Newsletters', apiValue: 'article', iconIndex: 1),
+    (label: 'YouTube', apiValue: 'youtube', iconIndex: 2),
+    (label: 'Reddit', apiValue: 'reddit', iconIndex: 3),
+    (label: 'Podcasts', apiValue: 'podcast', iconIndex: 4),
+  ];
+
+  IconData _iconForContentType(int idx) {
+    switch (idx) {
+      case 0:
+        return PhosphorIcons.newspaper(PhosphorIconsStyle.fill);
+      case 1:
+        return PhosphorIcons.envelope(PhosphorIconsStyle.fill);
+      case 2:
+        return PhosphorIcons.youtubeLogo(PhosphorIconsStyle.fill);
+      case 3:
+        return PhosphorIcons.redditLogo(PhosphorIconsStyle.fill);
+      case 4:
+        return PhosphorIcons.microphone(PhosphorIconsStyle.fill);
+      default:
+        return PhosphorIcons.newspaper(PhosphorIconsStyle.fill);
+    }
+  }
+
+  Widget _buildFilterChips() {
     final colors = context.facteurColors;
-    final types = <(IconData, String)>[
-      (PhosphorIcons.newspaper(PhosphorIconsStyle.fill), 'Médias'),
-      (PhosphorIcons.envelope(PhosphorIconsStyle.fill), 'Newsletters'),
-      (PhosphorIcons.youtubeLogo(PhosphorIconsStyle.fill), 'YouTube'),
-      (PhosphorIcons.redditLogo(PhosphorIconsStyle.fill), 'Reddit'),
-      (PhosphorIcons.microphone(PhosphorIconsStyle.fill), 'Podcasts'),
-    ];
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: _contentTypeOptions.map((t) {
+        // "Médias" et "Newsletters" mappent tous les deux sur `article` —
+        // on différencie par `_selectedLabel` pour éviter la confusion.
+        final isSelected =
+            _selectedContentType == t.apiValue && _selectedLabel == t.label;
+        return ChoiceChip(
+          label: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                _iconForContentType(t.iconIndex),
+                size: 14,
+                color: isSelected ? colors.primary : colors.textSecondary,
+              ),
+              const SizedBox(width: 5),
+              Text(t.label),
+            ],
+          ),
+          selected: isSelected,
+          onSelected: (selected) {
+            setState(() => _selectedLabel = selected ? t.label : null);
+            _onContentTypeToggle(selected ? t.apiValue : null);
+          },
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildSourceTypesRow() {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -434,25 +551,7 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
               ),
         ),
         const SizedBox(height: 10),
-        Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: types
-              .map((t) => Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(t.$1, size: 14, color: colors.textSecondary),
-                      const SizedBox(width: 5),
-                      Text(
-                        t.$2,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: colors.textSecondary,
-                            ),
-                      ),
-                    ],
-                  ))
-              .toList(),
-        ),
+        _buildFilterChips(),
       ],
     );
   }

--- a/apps/mobile/lib/features/sources/widgets/source_result_skeleton.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_result_skeleton.dart
@@ -22,11 +22,19 @@ class _SourceResultSkeletonState extends State<SourceResultSkeleton>
   late final Timer _dotTimer;
 
   static const _messages = [
-    'En train de parcourir le web',
-    'Recherche en cours',
-    'Analyse des sources',
+    'Exploration du catalogue',
+    'Analyse de votre recherche',
+    'Interrogation des plateformes',
+    'Scan du web',
+    'Recoupement des sources',
+    'Préparation des suggestions',
   ];
   int _messageIndex = 0;
+  int _tick = 0;
+
+  // Rotation: un dot par 800ms, message change tous les 6 ticks (~4.8s).
+  // Assez lent pour que l'utilisateur lise, assez rapide pour rester vivant.
+  static const _ticksPerMessage = 6;
 
   @override
   void initState() {
@@ -37,11 +45,12 @@ class _SourceResultSkeletonState extends State<SourceResultSkeleton>
     )..repeat(reverse: true);
     _opacity = Tween<double>(begin: 0.3, end: 0.7).animate(_controller);
 
-    _dotTimer = Timer.periodic(const Duration(milliseconds: 500), (_) {
+    _dotTimer = Timer.periodic(const Duration(milliseconds: 800), (_) {
       if (!mounted) return;
       setState(() {
         _dotCount = (_dotCount % 3) + 1;
-        if (_dotCount == 1) {
+        _tick += 1;
+        if (_tick % _ticksPerMessage == 0) {
           _messageIndex = (_messageIndex + 1) % _messages.length;
         }
       });

--- a/docs/bugs/bug-add-source-search-perf.md
+++ b/docs/bugs/bug-add-source-search-perf.md
@@ -1,0 +1,93 @@
+# Bug : Perf & UX de "Ajout de source custom"
+
+**Date** : 2026-04-21
+**Statut** : En cours
+**Impact** : Élevé — friction majeure sur le flux d'onboarding/ajout de sources
+
+---
+
+## Symptômes
+
+1. **[Critique] Recherche lente même pour une source déjà en DB.** Une recherche "Mediapart" (source curated) prend 2–5 s alors qu'un seul appel DB devrait suffire. Les utilisateurs perçoivent la fonctionnalité comme cassée.
+2. **Badges types décoratifs.** Les 5 badges affichés sous la recherche (Médias, Newsletters, YouTube, Reddit, Podcasts) ne sont pas cliquables — l'utilisateur ne peut pas affiner sa recherche.
+3. **Loading messages "fake".** Les 3 messages défilent toutes les 1.5 s, donnant l'impression d'une animation canned qui ne reflète pas un vrai travail en cours.
+
+---
+
+## Cause racine
+
+### Problème 1
+`SmartSourceSearchService.search()` (`packages/api/app/services/search/smart_source_search.py:118`) exécute un pipeline cascadant :
+
+```
+cache → catalog (ILIKE) → YouTube API → Reddit → Brave → Google News → Mistral
+```
+
+Le short-circuit après catalog n'est déclenché que si `curated_count >= 3` (`MIN_RESULTS_FOR_SHORTCIRCUIT = 3`). Pour une requête qui matche 1–2 sources curated (cas le plus courant : on cherche *une* source précise), le pipeline continue à travers tous les layers externes, ajoutant ~2–5 s de latence sans bénéfice.
+
+### Problème 2
+`_buildSourceTypesRow()` dans `apps/mobile/lib/features/sources/screens/add_source_screen.dart:417` rend les badges comme de simples `Icon + Text`, sans `onTap`. Le backend ne supporte pas non plus de filtre par `content_type`.
+
+### Problème 3
+`source_result_skeleton.dart:40` utilise un `Timer.periodic(Duration(milliseconds: 500))` qui change les dots toutes les 500 ms et le message tous les 3 dots (1.5 s). Avec seulement 3 messages, le cycle complet fait 4.5 s — si la requête prend 3 s, l'utilisateur voit 2 messages se succéder rapidement puis le premier revenir, ce qui brise l'illusion.
+
+---
+
+## Résolution
+
+### Backend
+
+**Short-circuit agressif + gating par type + mode expand.**
+
+- Nouveau prédicat `_is_strong_catalog_match(result, normalized)` : match nom exact / préfixe / word-boundary.
+- Si catalog retourne ≥1 strong match ET `expand=False` → `_finalize()` immédiat.
+- Nouveau param `content_type: Literal["article","youtube","reddit","podcast"] | None = None` :
+  - Filtre le catalog (`Source.type == content_type`).
+  - Skip les layers non pertinents (ex. `content_type="youtube"` → skip Brave/GoogleNews/Mistral).
+  - "Médias" et "Newsletters" mappent tous les deux sur `article` côté mobile (pas d'heuristique domaine pour l'instant).
+- Nouveau param `expand: bool = False` : ignore le short-circuit catalog, force le pipeline complet. Respecte toujours `content_type`.
+- Cache key élargie (inclut `content_type` + `expand`) pour éviter les collisions.
+
+### Mobile
+
+- Badges convertis en `ChoiceChip`s single-select (`_selectedContentType`).
+- Nouveau bouton "Élargir la recherche" affiché sous les résultats quand `layers_called == ["catalog"]` ET `_expanded == false`. Tap → relance la recherche avec `expand: true`.
+- Skeleton : timer 500 ms → 800 ms, message change tous les 6 ticks (~4.8 s), 6 messages variés au lieu de 3.
+
+---
+
+## Fichiers impactés
+
+**Backend**
+- `packages/api/app/schemas/source.py`
+- `packages/api/app/services/search/smart_source_search.py`
+- `packages/api/app/services/search/cache.py`
+- `packages/api/app/routers/sources.py`
+- `packages/api/tests/services/search/test_smart_source_search.py`
+
+**Mobile**
+- `apps/mobile/lib/features/sources/repositories/sources_repository.dart`
+- `apps/mobile/lib/features/sources/providers/sources_providers.dart`
+- `apps/mobile/lib/features/sources/screens/add_source_screen.dart`
+- `apps/mobile/lib/features/sources/widgets/source_result_skeleton.dart`
+
+---
+
+## Vérification
+
+**Unitaire :** `pytest -v packages/api/tests/services/search/test_smart_source_search.py`, `flutter test`, `flutter analyze`.
+
+**Manuel (QA Chrome, viewport 390×844) :**
+1. "Mediapart" → résultats <500 ms, bouton "Élargir" visible.
+2. Tap "Élargir" → nouveaux résultats externes, bouton disparaît.
+3. Chip "YouTube" + "fireship" → seul YouTube layer appelé, latence réduite.
+4. "Médias" puis "Newsletters" → mêmes résultats (ARTICLE).
+5. "xyzzyq" → pipeline complet, 6 messages du skeleton observables, rotation ~4.8 s.
+
+---
+
+## Trade-offs
+
+- **Short-circuit agressif** peut masquer une meilleure source externe → mitigé par le bouton "Élargir".
+- **Cache key élargie** multiplie les entrées ×10 max → acceptable (TTL 24 h).
+- **Streaming SSE** écarté : le bouton "Élargir" donne un équivalent sans nouvelle infra.

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -183,7 +183,12 @@ async def smart_search(
 
     service = SmartSourceSearchService(db)
     try:
-        result = await service.search(data.query, user_id)
+        result = await service.search(
+            data.query,
+            user_id,
+            content_type=data.content_type,
+            expand=data.expand,
+        )
 
         if result.get("error") == "rate_limit_exceeded":
             raise HTTPException(

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -16,6 +16,7 @@ from app.models.failed_source_attempt import FailedSourceAttempt
 from app.models.source import Source
 from app.models.user import UserInterest
 from app.schemas.source import (
+    SearchAbandonedRequest,
     SmartSearchRecentItem,
     SmartSearchRequest,
     SmartSearchResponse,
@@ -48,7 +49,7 @@ async def _log_failed_source_attempt(
     input_text: str,
     input_type: str,
     endpoint: str,
-    error_message: str,
+    error_message: str | None = None,
 ) -> None:
     # Uses its own session so the commit survives the HTTPException that the
     # caller is about to raise. The request-scoped `get_db` dependency does
@@ -62,7 +63,7 @@ async def _log_failed_source_attempt(
                     input_text=input_text[:500],
                     input_type=input_type,
                     endpoint=endpoint,
-                    error_message=error_message[:1000],
+                    error_message=error_message[:1000] if error_message else None,
                 )
             )
             await session.commit()
@@ -223,6 +224,20 @@ async def smart_search(
         )
     finally:
         await service.close()
+
+
+@router.post("/search-abandoned", status_code=204)
+async def log_search_abandoned(
+    data: SearchAbandonedRequest,
+    user_id: str = Depends(get_current_user_id),
+) -> None:
+    """Enregistre une recherche sans ajout de source (signal mobile)."""
+    await _log_failed_source_attempt(
+        user_id=user_id,
+        input_text=data.query,
+        input_type="keyword",
+        endpoint="smart-search",
+    )
 
 
 @router.get("/by-theme/{slug}", response_model=ThemeSourcesResponse)

--- a/packages/api/app/schemas/source.py
+++ b/packages/api/app/schemas/source.py
@@ -1,10 +1,13 @@
 """Schemas source."""
 
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
 
 from app.models.enums import SourceType
+
+ContentTypeFilter = Literal["article", "youtube", "reddit", "podcast"]
 
 
 class SourceResponse(BaseModel):
@@ -111,6 +114,8 @@ class SmartSearchRequest(BaseModel):
     """Requête de recherche intelligente."""
 
     query: str = Field(..., min_length=1, max_length=500)
+    content_type: ContentTypeFilter | None = None
+    expand: bool = False
 
 
 class SmartSearchRecentItem(BaseModel):

--- a/packages/api/app/schemas/source.py
+++ b/packages/api/app/schemas/source.py
@@ -152,6 +152,12 @@ class SmartSearchResponse(BaseModel):
     latency_ms: int = 0
 
 
+class SearchAbandonedRequest(BaseModel):
+    """Signal d'abandon de recherche sans ajout de source."""
+
+    query: str = Field(..., min_length=1, max_length=500)
+
+
 class ThemeSourceGroup(BaseModel):
     """Groupe de sources par catégorie dans un thème."""
 

--- a/packages/api/app/services/search/cache.py
+++ b/packages/api/app/services/search/cache.py
@@ -19,9 +19,7 @@ def normalize_query(query: str) -> str:
     return re.sub(r"\s+", " ", query.strip().lower())
 
 
-def _build_cache_key(
-    query: str, content_type: str | None, expand: bool
-) -> str:
+def _build_cache_key(query: str, content_type: str | None, expand: bool) -> str:
     normalized = normalize_query(query)
     return f"{normalized}|ct={content_type or '-'}|x={'1' if expand else '0'}"
 

--- a/packages/api/app/services/search/cache.py
+++ b/packages/api/app/services/search/cache.py
@@ -19,10 +19,20 @@ def normalize_query(query: str) -> str:
     return re.sub(r"\s+", " ", query.strip().lower())
 
 
-def hash_query(query: str) -> str:
-    """SHA-256 hash of normalized query."""
+def _build_cache_key(
+    query: str, content_type: str | None, expand: bool
+) -> str:
     normalized = normalize_query(query)
-    return hashlib.sha256(normalized.encode()).hexdigest()
+    return f"{normalized}|ct={content_type or '-'}|x={'1' if expand else '0'}"
+
+
+def hash_query(
+    query: str, content_type: str | None = None, expand: bool = False
+) -> str:
+    """SHA-256 hash of (normalized query, content_type, expand mode)."""
+    return hashlib.sha256(
+        _build_cache_key(query, content_type, expand).encode()
+    ).hexdigest()
 
 
 class SearchCache:
@@ -31,9 +41,14 @@ class SearchCache:
     def __init__(self, db: AsyncSession) -> None:
         self.db = db
 
-    async def get(self, query: str) -> dict | None:
+    async def get(
+        self,
+        query: str,
+        content_type: str | None = None,
+        expand: bool = False,
+    ) -> dict | None:
         """Look up cached result. Returns None if miss or expired."""
-        query_hash = hash_query(query)
+        query_hash = hash_query(query, content_type, expand)
         now = datetime.now(UTC)
 
         result = await self.db.execute(
@@ -49,10 +64,16 @@ class SearchCache:
             return row[0] if isinstance(row[0], dict) else json.loads(row[0])
         return None
 
-    async def set(self, query: str, payload: dict) -> None:
+    async def set(
+        self,
+        query: str,
+        payload: dict,
+        content_type: str | None = None,
+        expand: bool = False,
+    ) -> None:
         """Insert or update cache entry with 24h TTL."""
-        query_hash = hash_query(query)
-        normalized = normalize_query(query)
+        query_hash = hash_query(query, content_type, expand)
+        raw = _build_cache_key(query, content_type, expand)
         now = datetime.now(UTC)
         expires = now + timedelta(hours=CACHE_TTL_HOURS)
 
@@ -66,7 +87,7 @@ class SearchCache:
             ),
             {
                 "hash": query_hash,
-                "raw": normalized,
+                "raw": raw,
                 "payload": json.dumps(payload),
                 "now": now,
                 "expires": expires,

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
+from app.models.enums import SourceType
 from app.models.source import Source
 from app.models.user import UserInterest
 from app.services.rss_parser import RSSParser
@@ -30,6 +31,25 @@ _user_daily_reset_date: str = ""
 
 USER_DAILY_LIMIT = 30
 MIN_RESULTS_FOR_SHORTCIRCUIT = 3
+
+
+def _is_strong_catalog_match(result: dict, normalized_query: str) -> bool:
+    """Return True when a catalog hit clearly matches the query.
+
+    Match conditions: exact name, prefix on a word boundary, or word-boundary
+    match inside the name. Substring-only matches (e.g. "le" in "ouest-france")
+    do NOT qualify — they would trigger false short-circuits.
+    """
+    if not normalized_query:
+        return False
+    name_norm = normalize_query(result.get("name", ""))
+    if not name_norm:
+        return False
+    if name_norm == normalized_query:
+        return True
+    if name_norm.startswith(normalized_query + " "):
+        return True
+    return re.search(rf"\b{re.escape(normalized_query)}\b", name_norm) is not None
 
 
 def _check_user_rate_limit(user_id: str) -> bool:
@@ -115,8 +135,21 @@ class SmartSourceSearchService:
     async def close(self) -> None:
         await self.rss_parser.close()
 
-    async def search(self, query: str, user_id: str) -> dict:
-        """Execute the full smart search pipeline.
+    async def search(
+        self,
+        query: str,
+        user_id: str,
+        content_type: str | None = None,
+        expand: bool = False,
+    ) -> dict:
+        """Execute the smart search pipeline.
+
+        - ``content_type``: optional filter ("article" / "youtube" / "reddit" /
+          "podcast"). When set, the catalog is filtered by ``Source.type`` and
+          layers that don't produce that type are skipped (huge latency win
+          for type-scoped searches).
+        - ``expand``: when True, bypass the catalog short-circuit so the full
+          external pipeline runs (used by the "Élargir la recherche" action).
 
         Returns a dict matching SmartSearchResponse schema.
         """
@@ -139,8 +172,8 @@ class SmartSourceSearchService:
                 "error": "rate_limit_exceeded",
             }
 
-        # Cache check
-        cached = await self.cache.get(query)
+        # Cache check (keyed by query + content_type + expand)
+        cached = await self.cache.get(query, content_type, expand)
         if cached:
             elapsed = int((time.monotonic() - start) * 1000)
             cached["cache_hit"] = True
@@ -150,23 +183,39 @@ class SmartSourceSearchService:
         query_type = _classify_query(query)
         user_themes = await self._get_user_themes(user_id)
 
-        # (a) Catalog ILIKE
-        catalog_results = await self._search_catalog(normalized, user_themes)
+        # (a) Catalog ILIKE (optionally filtered by type)
+        catalog_results = await self._search_catalog(
+            normalized, user_themes, content_type
+        )
         for r in catalog_results:
             if r["url"] not in seen_urls:
                 seen_urls.add(r["url"])
                 results.append(r)
         layers_called.append("catalog")
 
-        # Short-circuit on curated catalog
-        curated_count = sum(1 for r in results if r.get("is_curated"))
-        if curated_count >= MIN_RESULTS_FOR_SHORTCIRCUIT:
+        # Aggressive short-circuit: strong name match in catalog.
+        # Users can still escape with `expand=True` ("Élargir la recherche").
+        if not expand and any(
+            _is_strong_catalog_match(r, normalized) for r in results
+        ):
             return await self._finalize(
-                normalized, results, layers_called, start, False
+                normalized, results, layers_called, start, False,
+                content_type=content_type, expand=expand,
             )
 
-        # (b) YouTube API — if signal
-        if query_type == "youtube_handle" or "youtube" in normalized:
+        # Secondary guard: enough curated matches.
+        if not expand:
+            curated_count = sum(1 for r in results if r.get("is_curated"))
+            if curated_count >= MIN_RESULTS_FOR_SHORTCIRCUIT:
+                return await self._finalize(
+                    normalized, results, layers_called, start, False,
+                    content_type=content_type, expand=expand,
+                )
+
+        # (b) YouTube API — if signal and type allows
+        if content_type in (None, "youtube") and (
+            query_type == "youtube_handle" or "youtube" in normalized
+        ):
             yt_results = await self._search_youtube(query, user_themes)
             for r in yt_results:
                 if r["url"] not in seen_urls:
@@ -174,8 +223,12 @@ class SmartSourceSearchService:
                     results.append(r)
             layers_called.append("youtube")
 
-        # (c) Reddit JSON — if signal
-        if query_type == "reddit_sub" or "reddit" in normalized or "r/" in normalized:
+        # (c) Reddit JSON — if signal and type allows
+        if content_type in (None, "reddit") and (
+            query_type == "reddit_sub"
+            or "reddit" in normalized
+            or "r/" in normalized
+        ):
             reddit_results = await self._search_reddit(query, user_themes)
             for r in reddit_results:
                 if r["url"] not in seen_urls:
@@ -183,9 +236,13 @@ class SmartSourceSearchService:
                     results.append(r)
             layers_called.append("reddit")
 
-        # (d) Brave Search
+        # (d) Brave Search — articles/podcasts only
         settings = get_settings()
-        if self.brave.is_ready and _brave_calls_month < settings.brave_monthly_cap:
+        if (
+            content_type in (None, "article", "podcast")
+            and self.brave.is_ready
+            and _brave_calls_month < settings.brave_monthly_cap
+        ):
             brave_results = await self._search_brave(normalized, user_themes)
             _brave_calls_month += 1
             for r in brave_results:
@@ -201,27 +258,33 @@ class SmartSourceSearchService:
                     cap=settings.brave_monthly_cap,
                 )
 
-        # Short-circuit if enough results
-        if len(results) >= MIN_RESULTS_FOR_SHORTCIRCUIT:
+        # Short-circuit if enough results (only when not explicitly expanding)
+        if not expand and len(results) >= MIN_RESULTS_FOR_SHORTCIRCUIT:
             return await self._finalize(
-                normalized, results, layers_called, start, False
+                normalized, results, layers_called, start, False,
+                content_type=content_type, expand=expand,
             )
 
-        # (e) Google News RSS
-        gnews_results = await self._search_google_news(normalized, user_themes)
-        for r in gnews_results:
-            if r["url"] not in seen_urls:
-                seen_urls.add(r["url"])
-                results.append(r)
-        layers_called.append("google_news")
+        # (e) Google News RSS — articles/podcasts only
+        if content_type in (None, "article", "podcast"):
+            gnews_results = await self._search_google_news(normalized, user_themes)
+            for r in gnews_results:
+                if r["url"] not in seen_urls:
+                    seen_urls.add(r["url"])
+                    results.append(r)
+            layers_called.append("google_news")
 
-        if len(results) >= MIN_RESULTS_FOR_SHORTCIRCUIT:
-            return await self._finalize(
-                normalized, results, layers_called, start, False
-            )
+            if not expand and len(results) >= MIN_RESULTS_FOR_SHORTCIRCUIT:
+                return await self._finalize(
+                    normalized, results, layers_called, start, False,
+                    content_type=content_type, expand=expand,
+                )
 
-        # (f) Mistral fallback
-        if _mistral_calls_month < settings.mistral_monthly_cap:
+        # (f) Mistral fallback — catch-all, skipped when a type filter is set
+        if (
+            content_type is None
+            and _mistral_calls_month < settings.mistral_monthly_cap
+        ):
             mistral_results = await self._search_mistral(normalized, user_themes)
             _mistral_calls_month += 1
             for r in mistral_results:
@@ -230,12 +293,20 @@ class SmartSourceSearchService:
                     results.append(r)
             layers_called.append("mistral")
 
-        return await self._finalize(normalized, results, layers_called, start, False)
+        return await self._finalize(
+            normalized, results, layers_called, start, False,
+            content_type=content_type, expand=expand,
+        )
 
     # ─── Layer implementations ────────────────────────────────────
 
-    async def _search_catalog(self, query: str, user_themes: list[str]) -> list[dict]:
-        """Search catalog via ILIKE on name and url."""
+    async def _search_catalog(
+        self,
+        query: str,
+        user_themes: list[str],
+        content_type: str | None = None,
+    ) -> list[dict]:
+        """Search catalog via ILIKE on name and url, optionally filtered by type."""
         pattern = f"%{query}%"
         stmt = (
             select(Source)
@@ -244,6 +315,8 @@ class SmartSourceSearchService:
             .order_by(Source.is_curated.desc())
             .limit(10)
         )
+        if content_type:
+            stmt = stmt.where(Source.type == SourceType(content_type))
         result = await self.db.execute(stmt)
         sources = result.scalars().all()
 
@@ -522,6 +595,8 @@ class SmartSourceSearchService:
         layers_called: list[str],
         start: float,
         cache_hit: bool,
+        content_type: str | None = None,
+        expand: bool = False,
     ) -> dict:
         """Sort, trim, cache, and return response."""
         # Sort by score descending
@@ -538,9 +613,9 @@ class SmartSourceSearchService:
             "latency_ms": elapsed,
         }
 
-        # Cache the result
+        # Cache the result (keyed by query + content_type + expand)
         try:
-            await self.cache.set(normalized, response)
+            await self.cache.set(normalized, response, content_type, expand)
         except Exception as e:
             logger.warning("smart_search.cache_set_failed", error=str(e))
 

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -195,12 +195,15 @@ class SmartSourceSearchService:
 
         # Aggressive short-circuit: strong name match in catalog.
         # Users can still escape with `expand=True` ("Élargir la recherche").
-        if not expand and any(
-            _is_strong_catalog_match(r, normalized) for r in results
-        ):
+        if not expand and any(_is_strong_catalog_match(r, normalized) for r in results):
             return await self._finalize(
-                normalized, results, layers_called, start, False,
-                content_type=content_type, expand=expand,
+                normalized,
+                results,
+                layers_called,
+                start,
+                False,
+                content_type=content_type,
+                expand=expand,
             )
 
         # Secondary guard: enough curated matches.
@@ -208,8 +211,13 @@ class SmartSourceSearchService:
             curated_count = sum(1 for r in results if r.get("is_curated"))
             if curated_count >= MIN_RESULTS_FOR_SHORTCIRCUIT:
                 return await self._finalize(
-                    normalized, results, layers_called, start, False,
-                    content_type=content_type, expand=expand,
+                    normalized,
+                    results,
+                    layers_called,
+                    start,
+                    False,
+                    content_type=content_type,
+                    expand=expand,
                 )
 
         # (b) YouTube API — if signal and type allows
@@ -225,9 +233,7 @@ class SmartSourceSearchService:
 
         # (c) Reddit JSON — if signal and type allows
         if content_type in (None, "reddit") and (
-            query_type == "reddit_sub"
-            or "reddit" in normalized
-            or "r/" in normalized
+            query_type == "reddit_sub" or "reddit" in normalized or "r/" in normalized
         ):
             reddit_results = await self._search_reddit(query, user_themes)
             for r in reddit_results:
@@ -261,8 +267,13 @@ class SmartSourceSearchService:
         # Short-circuit if enough results (only when not explicitly expanding)
         if not expand and len(results) >= MIN_RESULTS_FOR_SHORTCIRCUIT:
             return await self._finalize(
-                normalized, results, layers_called, start, False,
-                content_type=content_type, expand=expand,
+                normalized,
+                results,
+                layers_called,
+                start,
+                False,
+                content_type=content_type,
+                expand=expand,
             )
 
         # (e) Google News RSS — articles/podcasts only
@@ -276,15 +287,17 @@ class SmartSourceSearchService:
 
             if not expand and len(results) >= MIN_RESULTS_FOR_SHORTCIRCUIT:
                 return await self._finalize(
-                    normalized, results, layers_called, start, False,
-                    content_type=content_type, expand=expand,
+                    normalized,
+                    results,
+                    layers_called,
+                    start,
+                    False,
+                    content_type=content_type,
+                    expand=expand,
                 )
 
         # (f) Mistral fallback — catch-all, skipped when a type filter is set
-        if (
-            content_type is None
-            and _mistral_calls_month < settings.mistral_monthly_cap
-        ):
+        if content_type is None and _mistral_calls_month < settings.mistral_monthly_cap:
             mistral_results = await self._search_mistral(normalized, user_themes)
             _mistral_calls_month += 1
             for r in mistral_results:
@@ -294,8 +307,13 @@ class SmartSourceSearchService:
             layers_called.append("mistral")
 
         return await self._finalize(
-            normalized, results, layers_called, start, False,
-            content_type=content_type, expand=expand,
+            normalized,
+            results,
+            layers_called,
+            start,
+            False,
+            content_type=content_type,
+            expand=expand,
         )
 
     # ─── Layer implementations ────────────────────────────────────

--- a/packages/api/tests/services/search/test_smart_source_search.py
+++ b/packages/api/tests/services/search/test_smart_source_search.py
@@ -5,6 +5,7 @@ import pytest
 from app.services.search.smart_source_search import (
     _classify_query,
     _compute_score,
+    _is_strong_catalog_match,
 )
 from app.services.search.cache import hash_query, normalize_query
 
@@ -154,3 +155,55 @@ class TestDedup:
         assert len(results) == 2
         assert results[0]["name"] == "A"
         assert results[1]["name"] == "C"
+
+
+# ─── Strong match predicate ──────────────────────────────────────
+
+
+class TestStrongCatalogMatch:
+    def test_exact_name(self):
+        assert _is_strong_catalog_match({"name": "Mediapart"}, "mediapart") is True
+
+    def test_case_insensitive_via_normalization(self):
+        assert _is_strong_catalog_match({"name": "MEDIAPART"}, "mediapart") is True
+
+    def test_prefix_with_trailing_word(self):
+        assert (
+            _is_strong_catalog_match(
+                {"name": "Le Monde diplomatique"}, "le monde"
+            )
+            is True
+        )
+
+    def test_word_boundary_middle(self):
+        assert (
+            _is_strong_catalog_match({"name": "Chaîne YouTube Arte"}, "arte")
+            is True
+        )
+
+    def test_substring_only_rejected(self):
+        # "le" is a substring of "lenny" but not a word — must not match.
+        assert _is_strong_catalog_match({"name": "Lenny Newsletter"}, "le") is False
+
+    def test_empty_query(self):
+        assert _is_strong_catalog_match({"name": "Mediapart"}, "") is False
+
+    def test_missing_name(self):
+        assert _is_strong_catalog_match({}, "mediapart") is False
+
+
+# ─── Cache key differentiation ──────────────────────────────────
+
+
+class TestCacheKeyDifferentiation:
+    def test_content_type_changes_hash(self):
+        assert hash_query("mediapart") != hash_query("mediapart", "article")
+
+    def test_expand_changes_hash(self):
+        assert hash_query("mediapart") != hash_query("mediapart", None, True)
+
+    def test_content_type_values_differ(self):
+        assert hash_query("fireship", "youtube") != hash_query("fireship", "article")
+
+    def test_same_params_same_hash(self):
+        assert hash_query("x", "youtube", True) == hash_query("x", "youtube", True)


### PR DESCRIPTION
## Summary

- **Perf** : short-circuit agressif du pipeline quand le nom matche fort en DB → recherche curated en <500 ms (vs 2-5 s).
- **Filtres** : les 5 badges (Médias, Newsletters, YouTube, Reddit, Podcasts) deviennent des `ChoiceChip`s qui filtrent par type côté backend et skippent les layers externes non pertinents.
- **Élargir** : bouton affiché quand seul le catalog a répondu → relance le pipeline complet (`expand: true`).
- **Skeleton** : 6 messages au lieu de 3, dots 500ms → 800ms, rotation ~4.8 s/message (vs 1.5 s) — sensation moins fake.

## Changements principaux

**Backend**
- `SmartSearchRequest` : nouveaux params `content_type` + `expand`
- Nouveau prédicat `_is_strong_catalog_match` (exact / préfixe / word-boundary, rejette substring seul)
- Gating des layers externes selon `content_type` ; `expand=True` force le pipeline complet
- Clé de cache SHA-256 intègre `content_type` + `expand`

**Mobile**
- `smartSearchProvider` family key : `String` → `({String query, String? contentType, bool expand})`
- `AddSourceScreen` : ChoiceChips cliquables, état `_expanded`, bouton "Élargir la recherche"
- Analytics : `trackAddSourceContentTypeFilter`, `trackAddSourceExpand`

## Test plan

- [ ] Backend tests : `cd packages/api && PYTHONPATH=. .venv/bin/pytest -v tests/services/search/test_smart_source_search.py` (42 OK attendu, inclus `TestStrongCatalogMatch` + `TestCacheKeyDifferentiation`)
- [ ] Mobile tests : `cd apps/mobile && flutter test test/features/sources/` (51 sources tests OK)
- [ ] `flutter analyze` clean
- [ ] QA Chrome via `/validate-feature` — 6 scénarios décrits dans `.context/qa-handoff.md`
- [ ] Perf smoke : `curl -X POST /sources/smart-search -d '{"query":"mediapart"}'` → `layers_called == ["catalog"]` et `latency_ms < 500`
- [ ] Non-régression : `-d '{"query":"mediapart","expand":true}'` → pipeline complet

🤖 Generated with [Claude Code](https://claude.com/claude-code)