### PR TITLE
fix(digest): clone editorial_v1 for new users + fail-open post-gather

### DIFF
--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -456,11 +456,32 @@ async def get_both_digests(
             leader_fut.set_result(result)
             return result
 
-        # Use the original session for the lightweight preference read
-        service = DigestService(db)
-        serein_enabled = await service._get_user_serein_enabled(user_uuid)
+        # Post-gather DB ops — the outer `db` session has been idle during the
+        # 25-30s LLM pipeline, and Supabase/PgBouncer sometimes kills idle
+        # connections in that window. We already generated both variants in
+        # their own short-lived sessions, so here we only need the preference
+        # read + community enrichment. Make them both tolerant: if `db` is
+        # dead, roll back once (forces SQLAlchemy to check out a fresh slot)
+        # and fall back to defaults rather than 500-ing a successfully
+        # generated pair of digests.
+        try:
+            service = DigestService(db)
+            serein_enabled = await service._get_user_serein_enabled(user_uuid)
+        except Exception:
+            logger.exception(
+                "digest_both_serein_enabled_lookup_failed",
+                user_id=current_user_id,
+            )
+            try:
+                await db.rollback()
+            except Exception as rb_exc:
+                logger.debug(
+                    "digest_both_post_gather_rollback_failed",
+                    error=str(rb_exc),
+                )
+            serein_enabled = False
 
-        # Enrich both variants with community carousel
+        # Enrich both variants with community carousel (already fail-open).
         if normal:
             normal = await _enrich_community_carousel(db, user_uuid, normal)
         if serein:


### PR DESCRIPTION
## Root cause — new users signed up after the 6am batch

**User report:** "j'étais sur un nouveau compte créé cette après-midi. La génération du Digest a des problèmes dans le cas précis où l'utilisateur est nouveau."

editorial_v1 is intentionally user-agnostic: the LLM pipeline produces a single `EditorialPipelineResult` per (target_date, mode), and every user who receives editorial format sees the same `items` content. The `DailyDigest` rows are still per-user though, so a user created after the 6am batch has **no row**.

Before this PR, that user fell through to on-demand generation, which:
- Re-runs the 3-5 min LLM pipeline if the in-process cache has expired or the Railway container restarted between 6am and their first load.
- Regularly exceeds the `/digest` and `/digest/both` timeouts (25-30 s).
- Regularly exceeds the mobile retry budget (~80 s of 202 polling).

Net symptom: **infinite loading spinner after onboarding** for users who sign up mid-day. `schedule_initial_digest_generation` (#422) helps when the pipeline succeeds fast, but it's a race against the client and offers no protection when the pipeline fails or the process restarts.

## Changes

### Commit 1 — `fix(digest): clone sibling user's editorial_v1 digest for new users`

The core fix. Adds `_try_clone_global_editorial_digest` in `DigestService` that queries for the most recently generated `editorial_v1` digest for the same `(target_date, is_serene)` belonging to any *other* user, and inserts a copy owned by this user.

- Only `editorial_v1` is cloned (topics_v1 / flat_v1 are per-user).
- On unique-constraint race: rollback and return the row that won the race.
- On any other failure: log, return None, fall through to the existing generation path. Always best-effort.
- New `TestCloneGlobalEditorialDigest` class (3 tests). Existing tests that exercise the yesterday-fallback / render-failure flows get a `_try_clone_global_editorial_digest=None` patch so they keep testing the path they were written for.

### Commit 2 — `fix(digest): /digest/both survives dead session after pipeline`

Defense-in-depth layer for the post-gather path: wraps the `serein_enabled` lookup in a try/except + rollback + fallback, so a Supabase-killed idle connection after the 25-30s pipeline no longer 500s a request that has both digests ready.

## Type

- [x] Bug fix (primary)
- [x] Defensive refactor (commit 2)

## Scope

- `packages/api/app/services/digest_service.py` (+129 / −1) — clone method + step 1b-before hook
- `packages/api/app/routers/digest.py` (+25 / −4) — post-gather fail-open
- `packages/api/tests/test_digest_service.py` (+230 / −3) — 3 new tests + 3 patch additions

No schema change, no migration, no pool config change.

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] `ast.parse` of all modified files — OK
- [ ] `cd packages/api && pytest tests/test_digest_service.py tests/test_digest_both_singleflight.py tests/test_digest_both_timeout.py -v` — CI to confirm. Local `pytest` unavailable (sgmllib3k build failure in sandbox).
- [ ] Post-deploy: create a new account after 6am batch → Essentiel should load instantly (cloned row) instead of spinning. Confirm `digest_cloning_global_editorial` log appears with a `source_user_id` different from the new user.
- [ ] Post-deploy: `digest_both_serein_enabled_lookup_failed` should stay rare; when it does fire, the request must still return 200 with `serein_enabled=false`.

## Out of scope

- Cross-process editorial cache (Redis-backed). The clone shortcut removes the need for it in the new-user case — batch writes a DB row for every user, new users clone from that row.
- Same clone path for `topics_v1` / `flat_v1`. These formats are per-user by design (scoring depends on followed sources) and would produce semantically wrong digests if shared.
- Proactive `pool_pre_ping` before post-gather work: would help the commit-2 scenario too, but is broader than a quick fix.

## Rollback

Each commit is self-contained and revertable:
- Revert commit 1 to disable the clone shortcut (behavior reverts to previous on-demand path).
- Revert commit 2 to restore the non-fail-open post-gather path.
