### PR TITLE
fix(digest): clone editorial_v1 digest for new users (no more 3-5 min on-demand LLM)

### DIFF
--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -13,6 +13,7 @@ Safe reuse patterns:
 """
 
 import asyncio
+import contextlib
 import hashlib
 import random
 import time
@@ -480,6 +481,32 @@ class DigestService:
         # is a dead-end: the user sees yesterday's digest all day even when
         # the batch never reran for them.
         if not force_regenerate:
+            # 1b-before: Fast path for new users — editorial_v1 is globally
+            # shared (same `items` JSONB for every user who gets editorial
+            # format), so a user who signs up after the 6am batch can reuse
+            # the digest that was already generated for any other user
+            # today. Without this, new users hit the full on-demand LLM
+            # pipeline (3-5 min), which exceeds both the /digest timeouts
+            # and the mobile retry budget — the classic "spinner forever
+            # after onboarding" symptom.
+            if expected_version == "editorial_v1":
+                cloned = await self._try_clone_global_editorial_digest(
+                    user_id=user_id,
+                    target_date=target_date,
+                    is_serene=is_serene,
+                )
+                if cloned is not None:
+                    try:
+                        return await self._build_digest_response(cloned, user_id)
+                    except Exception:
+                        logger.exception(
+                            "digest_cloned_editorial_render_failed",
+                            user_id=str(user_id),
+                            cloned_from_generated_at=str(cloned.generated_at),
+                        )
+                        # Fall through to real generation — the clone was a
+                        # best-effort shortcut, never a blocker.
+
             yesterday = target_date - timedelta(days=1)
             yesterday_digest = await self._get_existing_digest(
                 user_id, yesterday, is_serene=is_serene
@@ -1211,6 +1238,108 @@ class DigestService:
         )
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
+
+    async def _try_clone_global_editorial_digest(
+        self,
+        user_id: UUID,
+        target_date: date,
+        is_serene: bool,
+    ) -> DailyDigest | None:
+        """Clone any other user's editorial_v1 digest for the same date+variant.
+
+        editorial_v1 is intentionally user-agnostic: the `items` JSONB is
+        produced once per (date, mode) by the editorial pipeline and is
+        identical for every user who receives editorial format. This method
+        copies an existing row to a new row for `user_id` so new users
+        signing up after the 6am batch get the digest instantly, without
+        running the LLM pipeline on-demand (which regularly exceeds the
+        /digest timeouts + mobile retry budget).
+
+        Returns:
+            The cloned `DailyDigest` (already flushed to the session) on
+            success, or `None` if no source digest exists, the clone insert
+            raced with another writer, or any other error occurred. This is
+            always a best-effort shortcut — callers fall through to real
+            generation on None.
+        """
+        try:
+            src_stmt = (
+                select(DailyDigest)
+                .where(
+                    and_(
+                        DailyDigest.user_id != user_id,
+                        DailyDigest.target_date == target_date,
+                        DailyDigest.is_serene == is_serene,
+                        DailyDigest.format_version == "editorial_v1",
+                    )
+                )
+                .order_by(DailyDigest.generated_at.desc())
+                .limit(1)
+            )
+            source = (await self.session.execute(src_stmt)).scalar_one_or_none()
+        except Exception:
+            logger.exception(
+                "digest_clone_source_lookup_failed",
+                user_id=str(user_id),
+                target_date=str(target_date),
+                is_serene=is_serene,
+            )
+            return None
+
+        if source is None:
+            return None
+
+        logger.info(
+            "digest_cloning_global_editorial",
+            user_id=str(user_id),
+            target_date=str(target_date),
+            is_serene=is_serene,
+            source_user_id=str(source.user_id),
+            source_generated_at=str(source.generated_at),
+        )
+
+        cloned = DailyDigest(
+            id=uuid4(),
+            user_id=user_id,
+            target_date=target_date,
+            items=source.items,
+            mode=source.mode or ("serein" if is_serene else "pour_vous"),
+            is_serene=is_serene,
+            format_version="editorial_v1",
+            generated_at=source.generated_at,
+        )
+        self.session.add(cloned)
+        try:
+            await self.session.flush()
+        except IntegrityError:
+            # Race: another request inserted a row for this (user, date,
+            # is_serene) between the `_get_existing_digest` check at step 1
+            # and this flush. Rollback the clone and let the caller serve
+            # the freshly-committed row on the retry path.
+            await self.session.rollback()
+            logger.warning(
+                "digest_clone_insert_race_condition",
+                user_id=str(user_id),
+                target_date=str(target_date),
+                is_serene=is_serene,
+            )
+            existing = await self._get_existing_digest(
+                user_id, target_date, is_serene=is_serene
+            )
+            return existing
+        except Exception:
+            # Any other error — log and fall through to generation.
+            logger.exception(
+                "digest_clone_flush_failed",
+                user_id=str(user_id),
+                target_date=str(target_date),
+                is_serene=is_serene,
+            )
+            with contextlib.suppress(Exception):
+                await self.session.rollback()
+            return None
+
+        return cloned
 
     async def _create_digest_record(
         self,

--- a/packages/api/tests/test_digest_service.py
+++ b/packages/api/tests/test_digest_service.py
@@ -349,8 +349,18 @@ class TestFallbackYesterday:
             ),
             patch.object(service, "_build_digest_response", mock_build),
             patch.object(
-                service, "_get_user_digest_format",
-                new_callable=AsyncMock, return_value="editorial",
+                service,
+                "_get_user_digest_format",
+                new_callable=AsyncMock,
+                return_value="editorial",
+            ),
+            # No sibling editorial_v1 digest to clone — forces the yesterday
+            # fallback path we want to test.
+            patch.object(
+                service,
+                "_try_clone_global_editorial_digest",
+                new_callable=AsyncMock,
+                return_value=None,
             ),
         ):
             mock_user_svc_cls.return_value.get_or_create_profile = AsyncMock()
@@ -466,12 +476,24 @@ class TestFallbackYesterday:
                 service, "_get_existing_digest", side_effect=fake_get_existing
             ),
             patch.object(
-                service, "_build_digest_response",
-                new_callable=AsyncMock, return_value=response,
+                service,
+                "_build_digest_response",
+                new_callable=AsyncMock,
+                return_value=response,
             ),
             patch.object(
-                service, "_get_user_digest_format",
-                new_callable=AsyncMock, return_value="editorial",
+                service,
+                "_get_user_digest_format",
+                new_callable=AsyncMock,
+                return_value="editorial",
+            ),
+            # No sibling editorial_v1 digest to clone — forces the yesterday
+            # fallback path so the stale-flag + bg-regen assertions apply.
+            patch.object(
+                service,
+                "_try_clone_global_editorial_digest",
+                new_callable=AsyncMock,
+                return_value=None,
             ),
             patch(
                 "app.services.digest_service._schedule_background_regen"
@@ -595,16 +617,30 @@ class TestDeferredStaleFormatDeletion:
                 service, "_get_existing_digest", side_effect=fake_get_existing
             ),
             patch.object(
-                service, "_get_user_digest_format",
-                new_callable=AsyncMock, return_value="editorial",
+                service,
+                "_get_user_digest_format",
+                new_callable=AsyncMock,
+                return_value="editorial",
             ),
             patch.object(
-                service, "_get_emergency_candidates",
-                new_callable=AsyncMock, return_value=[],
+                service,
+                "_get_emergency_candidates",
+                new_callable=AsyncMock,
+                return_value=[],
             ),
             patch.object(
-                service, "_build_digest_response",
-                new_callable=AsyncMock, return_value=response,
+                service,
+                "_build_digest_response",
+                new_callable=AsyncMock,
+                return_value=response,
+            ),
+            # No sibling editorial_v1 digest to clone — exercises the
+            # stale-format last-resort fallback we want to test.
+            patch.object(
+                service,
+                "_try_clone_global_editorial_digest",
+                new_callable=AsyncMock,
+                return_value=None,
             ),
         ):
             mock_user_svc_cls.return_value.get_or_create_profile = AsyncMock()
@@ -707,6 +743,14 @@ class TestRenderFailureFallback:
                 return_value=[],
             ),
             patch.object(service, "_build_digest_response", side_effect=fake_build),
+            # No sibling editorial_v1 digest to clone — the render-failure
+            # flow under test must reach the selector via the regen path.
+            patch.object(
+                service,
+                "_try_clone_global_editorial_digest",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             mock_user_svc_cls.return_value.get_or_create_profile = AsyncMock()
             result = await service.get_or_create_digest(
@@ -724,8 +768,10 @@ class TestRenderFailureFallback:
         # (An exact "was/wasn't deleted" assertion depends on whether
         # generation also failed here; the key regression is the absence
         # of a re-raise, checked by reaching this line.)
-        assert result is None or result is fresh_response or hasattr(
-            result, "is_stale_fallback"
+        assert (
+            result is None
+            or result is fresh_response
+            or hasattr(result, "is_stale_fallback")
         )
 
     @pytest.mark.asyncio
@@ -787,3 +833,162 @@ class TestRenderFailureFallback:
         # pre-emptively wiping the only digest the user has.
         for call in mock_session.delete.call_args_list:
             assert call.args[0] is not corrupted
+
+
+# ─── Tests: editorial_v1 clone-from-sibling fast path for new users ───────────
+
+
+class TestCloneGlobalEditorialDigest:
+    """editorial_v1 is user-agnostic — new users should reuse a sibling's digest.
+
+    Without this fast path, a user who signs up after the 6am batch hits a
+    full on-demand LLM pipeline (3-5 min). That regularly exceeds the
+    `/digest` timeouts + mobile retry budget and surfaces as an infinite
+    loading spinner after onboarding.
+    """
+
+    @pytest.mark.asyncio
+    async def test_clone_invoked_when_editorial_format_and_no_user_digest(
+        self, service, mock_session
+    ):
+        """editorial format + no today/yesterday digest → clone path is tried."""
+        user_id = uuid4()
+        today = date.today()
+
+        cloned_digest = Mock()
+        cloned_digest.id = uuid4()
+        cloned_digest.target_date = today
+        cloned_digest.format_version = "editorial_v1"
+        cloned_digest.user_id = user_id
+
+        mock_response = Mock()
+        mock_clone = AsyncMock(return_value=cloned_digest)
+
+        with (
+            patch("app.services.user_service.UserService") as mock_user_svc_cls,
+            patch.object(
+                service,
+                "_get_existing_digest",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                service,
+                "_get_user_digest_format",
+                new_callable=AsyncMock,
+                return_value="editorial",
+            ),
+            patch.object(service, "_try_clone_global_editorial_digest", new=mock_clone),
+            patch.object(
+                service,
+                "_build_digest_response",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+        ):
+            mock_user_svc_cls.return_value.get_or_create_profile = AsyncMock()
+            result = await service.get_or_create_digest(
+                user_id=user_id, target_date=today
+            )
+
+        assert result is mock_response
+        mock_clone.assert_awaited_once_with(
+            user_id=user_id, target_date=today, is_serene=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_clone_not_invoked_for_non_editorial_format(
+        self, service, mock_session
+    ):
+        """topics format → the clone shortcut must NOT run (topics_v1 is per-user)."""
+        user_id = uuid4()
+        today = date.today()
+
+        service.selector = Mock()
+        service.selector.select_for_user = AsyncMock(return_value=[])
+
+        _prefs_result = Mock()
+        _prefs_result.scalar_one_or_none = Mock(return_value=None)
+        _prefs_result.all = Mock(return_value=[])
+        mock_session.execute.return_value = _prefs_result
+
+        mock_clone = AsyncMock(return_value=None)
+
+        with (
+            patch("app.services.user_service.UserService") as mock_user_svc_cls,
+            patch.object(
+                service,
+                "_get_existing_digest",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                service,
+                "_get_user_digest_format",
+                new_callable=AsyncMock,
+                return_value="topics",
+            ),
+            patch.object(service, "_try_clone_global_editorial_digest", new=mock_clone),
+            patch.object(
+                service,
+                "_get_emergency_candidates",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch.object(service, "_build_digest_response", new_callable=AsyncMock),
+        ):
+            mock_user_svc_cls.return_value.get_or_create_profile = AsyncMock()
+            with contextlib.suppress(Exception):
+                await service.get_or_create_digest(user_id=user_id, target_date=today)
+
+        mock_clone.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_clone_failure_falls_through_to_generation(
+        self, service, mock_session
+    ):
+        """If clone returns None, the rest of the pipeline must still run."""
+        user_id = uuid4()
+        today = date.today()
+
+        service.selector = Mock()
+        service.selector.select_for_user = AsyncMock(return_value=[])
+
+        _prefs_result = Mock()
+        _prefs_result.scalar_one_or_none = Mock(return_value=None)
+        _prefs_result.all = Mock(return_value=[])
+        mock_session.execute.return_value = _prefs_result
+
+        with (
+            patch("app.services.user_service.UserService") as mock_user_svc_cls,
+            patch.object(
+                service,
+                "_get_existing_digest",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                service,
+                "_get_user_digest_format",
+                new_callable=AsyncMock,
+                return_value="editorial",
+            ),
+            patch.object(
+                service,
+                "_try_clone_global_editorial_digest",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                service,
+                "_get_emergency_candidates",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch.object(service, "_build_digest_response", new_callable=AsyncMock),
+        ):
+            mock_user_svc_cls.return_value.get_or_create_profile = AsyncMock()
+            with contextlib.suppress(Exception):
+                await service.get_or_create_digest(user_id=user_id, target_date=today)
+
+        service.selector.select_for_user.assert_awaited()


### PR DESCRIPTION
## Root cause

User report: "j'étais sur un nouveau compte créé cette après-midi. La génération du Digest a des problèmes dans le cas précis où l'utilisateur est nouveau."

editorial_v1 is intentionally user-agnostic — the LLM pipeline produces a single `EditorialPipelineResult` per `(target_date, mode)` and every user receiving editorial format sees the same `items` content. But `DailyDigest` rows are still per-user, so a user created after the 6am batch has **no row at all**.

Previously, that user fell through to on-demand generation, which:
- Re-runs the 3-5 min LLM pipeline if the in-process cache has expired or Railway restarted between 6am and their first load.
- Exceeds the `/digest` and `/digest/both` timeouts (25-30 s).
- Exceeds the mobile retry budget (~80 s of 202 polling).

Net symptom: **infinite loading spinner after onboarding** for users who sign up mid-day. `schedule_initial_digest_generation` (#422) helps when the pipeline succeeds fast but is a race against the client.

## Fix

New method `DigestService._try_clone_global_editorial_digest` in `get_or_create_digest`:

1. When `expected_version == "editorial_v1"` and the user has no digest for today
2. Query the most recently generated `editorial_v1` row for the same `(target_date, is_serene)` belonging to any *other* user
3. Insert a copy owned by this user (same `items`, `mode`, `generated_at`)
4. Return it — `_build_digest_response` does the rest

- **Only `editorial_v1`** is cloned. `topics_v1` and `flat_v1` are genuinely per-user (scoring driven by followed sources) and cloning across users would be wrong.
- **Race condition** on unique constraint `(user_id, target_date, is_serene)`: rollback and return the row that won the race.
- **Any other failure**: log, return None, fall through to the existing on-demand generation path. This is always a best-effort shortcut, never a blocker.

## Type

- [x] Bug fix

## Scope

- `packages/api/app/services/digest_service.py` (+129) — new method + step 1b-before hook
- `packages/api/tests/test_digest_service.py` (+230 / −3) — 3 new tests + 3 patch additions in existing tests

No schema change, no migration, no pool config change.

## Tests

New `TestCloneGlobalEditorialDigest` class:
- Clone invoked when format=editorial and user has no digest
- Clone NOT invoked when format=topics (per-user)
- Clone returning None falls through to the existing generation path

Existing tests that exercise the yesterday-fallback / render-failure flows on editorial format get a `_try_clone_global_editorial_digest=None` patch so they keep testing their path.

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] `ast.parse` of modified files — OK
- [ ] `cd packages/api && pytest tests/test_digest_service.py -v` — CI to confirm
- [ ] Post-deploy: create a new account after the 6am batch → Essentiel loads instantly. Confirm `digest_cloning_global_editorial` log appears with `source_user_id` different from the new user.

## Relation to PR #456

PR #456 contains both this clone commit AND a defensive `/digest/both` post-gather fail-open. This new PR extracts just the clone fix (the actual root cause for the new-user bug) into its own reviewable change. #456 can be closed, rebased onto this, or left as a separate defensive PR — your call.

## Rollback

Single commit, self-contained. Revert `c2a1b2c` to restore the previous on-demand path for new users.
