### PR TITLE
fix(mobile): article screen spacing and perspectives section improvements

### DIFF
--- a/apps/mobile/ios/Flutter/Debug.xcconfig
+++ b/apps/mobile/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/apps/mobile/ios/Flutter/Release.xcconfig
+++ b/apps/mobile/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/apps/mobile/ios/Podfile
+++ b/apps/mobile/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/apps/mobile/lib/config/theme.dart
+++ b/apps/mobile/lib/config/theme.dart
@@ -304,6 +304,7 @@ class FacteurSpacing {
   static const double space4 = 16;
   static const double space6 = 24;
   static const double space8 = 32;
+  static const double space16 = 64;
 }
 
 class FacteurRadius {

--- a/apps/mobile/lib/core/ui/notification_service.dart
+++ b/apps/mobile/lib/core/ui/notification_service.dart
@@ -26,6 +26,7 @@ class NotificationService {
     Duration duration = const Duration(seconds: 3),
     IconData? icon,
     BuildContext? context,
+    EdgeInsets? margin,
   }) {
     final state = messengerKey.currentState;
     if (state == null) return;
@@ -79,7 +80,7 @@ class NotificationService {
         behavior: SnackBarBehavior.floating,
         elevation: 4,
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        margin: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+        margin: margin ?? const EdgeInsets.fromLTRB(16, 0, 16, 12),
         duration: duration,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -70,6 +70,9 @@ const double _kHeaderContentHeight = 50;
 /// = vertical padding (12+12) + button row height (44).
 const double _kFooterContentHeight = 82.0;
 
+/// Bottom scroll clearance so content isn't hidden behind the FAB row.
+const double _kFabBottomClearance = 120.0;
+
 class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     with TickerProviderStateMixin, WidgetsBindingObserver {
   late AnimationController _fabController;
@@ -1248,7 +1251,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             mainAxisSize: MainAxisSize.min,
             children: [
               CircularProgressIndicator(),
-              SizedBox(height: 16),
+              const SizedBox(height: FacteurSpacing.space4),
               Text('Recherche de perspectives...'),
             ],
           ),
@@ -1354,7 +1357,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             mainAxisSize: MainAxisSize.min,
             children: [
               CircularProgressIndicator(color: colors.primary),
-              const SizedBox(height: 16),
+              const SizedBox(height: FacteurSpacing.space4),
               Text(
                 'Ouverture dans votre navigateur...',
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
@@ -1404,7 +1407,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             mainAxisSize: MainAxisSize.min,
             children: [
               CircularProgressIndicator(color: colors.primary),
-              const SizedBox(height: 16),
+              const SizedBox(height: FacteurSpacing.space4),
               Text(
                 'Ouverture dans votre navigateur...',
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
@@ -1619,26 +1622,37 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       duration: const Duration(milliseconds: 200),
                       child: IgnorePointer(
                         ignoring: !show,
-                        child: FilledButton.icon(
-                          onPressed: () {
-                            HapticFeedback.lightImpact();
-                            _requestPerspectivesAnalysis();
-                          },
-                          style: FilledButton.styleFrom(
-                            backgroundColor: context.facteurColors.primary
-                                .withValues(alpha: 1.0),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(12),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.white.withValues(alpha: 0.85),
+                                blurRadius: 0,
+                              ),
+                            ],
+                          ),
+                          child: OutlinedButton.icon(
+                            onPressed: () {
+                              HapticFeedback.lightImpact();
+                              _requestPerspectivesAnalysis();
+                            },
+                            style: OutlinedButton.styleFrom(
+                              foregroundColor: context.facteurColors.primary,
+                              side: BorderSide(
+                                color: context.facteurColors.primary,
+                              ),
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.5),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
                             ),
-                          ),
-                          icon: Icon(
-                            PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
-                            size: 16,
-                            color: Colors.white,
-                          ),
-                          label: const Text(
-                            'Lancer l\'analyse Facteur',
-                            style: TextStyle(color: Colors.white),
+                            icon: Icon(
+                              PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                              size: 16,
+                            ),
+                            label: const Text('Lancer l\'analyse Facteur'),
                           ),
                         ),
                       ),
@@ -1709,7 +1723,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                               ),
                             ],
                           ),
-                          const SizedBox(height: 12),
+                          const SizedBox(height: FacteurSpacing.space3),
                         ],
                         // Perspectives FAB (articles only) — always just above other FABs
                         if (content.contentType == ContentType.article) ...[
@@ -1722,13 +1736,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 _perspectivesResponse!.perspectives.isEmpty,
                             onTap: () {
                               HapticFeedback.lightImpact();
-                              final ctx =
-                                  _perspectivesKey.currentContext;
+                              final ctx = _perspectivesKey.currentContext;
                               if (ctx != null) {
                                 Scrollable.ensureVisible(
                                   ctx,
-                                  duration: const Duration(
-                                      milliseconds: 400),
+                                  duration: const Duration(milliseconds: 400),
                                   curve: Curves.easeInOut,
                                 );
                               } else {
@@ -1736,7 +1748,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                               }
                             },
                           ),
-                          const SizedBox(height: 12),
+                          const SizedBox(height: FacteurSpacing.space3),
                         ],
                         // External link FAB — hidden for articles unless WebView is active
                         if (content.contentType != ContentType.article ||
@@ -1759,7 +1771,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                               ),
                             ),
                           ),
-                          const SizedBox(height: 12),
+                          const SizedBox(height: FacteurSpacing.space3),
                         ],
                         // 🌻 Sunflower recommendation FAB + nudge label
                         Row(
@@ -1788,8 +1800,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                           horizontal: 12, vertical: 6),
                                       decoration: BoxDecoration(
                                         color: const Color(0xFFFFF8E1),
-                                        borderRadius:
-                                            BorderRadius.circular(16),
+                                        borderRadius: BorderRadius.circular(16),
                                         boxShadow: [
                                           BoxShadow(
                                             color:
@@ -1838,7 +1849,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             ),
                           ],
                         ),
-                        const SizedBox(height: 12),
+                        const SizedBox(height: FacteurSpacing.space3),
                         // Merged Bookmark + Note FAB (long-press for collection picker)
                         GestureDetector(
                           onLongPress: () {
@@ -1879,7 +1890,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         ),
                         // Note welcome tooltip — bottom of FAB column, near the bookmark button
                         if (_showNoteWelcome) ...[
-                          const SizedBox(height: 12),
+                          const SizedBox(height: FacteurSpacing.space3),
                           NoteWelcomeTooltip(
                             onDismiss: () =>
                                 setState(() => _showNoteWelcome = false),
@@ -2096,9 +2107,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           : PhosphorIcons.bookmarkSimple(
                               PhosphorIconsStyle.regular),
                       size: 24,
-                      color: content.isSaved
-                          ? Colors.white
-                          : colors.textSecondary,
+                      color:
+                          content.isSaved ? Colors.white : colors.textSecondary,
                     ),
                     tooltip: 'Sauvegarder',
                   ),
@@ -2645,7 +2655,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           ),
           if (response.comparisonQuality == 'low')
             PerspectivesWarningBadge(colors: colors, textTheme: textTheme),
-          const SizedBox(height: 10),
+          const SizedBox(height: FacteurSpacing.space2),
           PerspectivesBiasBar(
             colors: colors,
             mergedDistribution: merged,
@@ -2680,10 +2690,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     final widths = [1.0, 1.0, 0.92, 1.0, 0.85, 1.0, 0.95, 0.6];
     return _ShimmerSkeleton(
       children: [
-        const SizedBox(height: 16),
+        const SizedBox(height: FacteurSpacing.space4),
         for (final w in widths)
           Padding(
-            padding: const EdgeInsets.only(bottom: 12),
+            padding: const EdgeInsets.only(bottom: FacteurSpacing.space3),
             child: FractionallySizedBox(
               alignment: Alignment.centerLeft,
               widthFactor: w,
@@ -2870,16 +2880,14 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           color: colors.backgroundPrimary,
                           child: _perspectivesLoading &&
                                   _perspectivesResponse == null
-                              ? const Center(
-                                  child: CircularProgressIndicator())
+                              ? const Center(child: CircularProgressIndicator())
                               : _perspectivesResponse != null
                                   ? PerspectivesInlineSection(
                                       key: _perspectivesKey,
                                       perspectives: _perspectivesResponse!
                                           .perspectives
                                           .map(
-                                            (PerspectiveData p) =>
-                                                Perspective(
+                                            (PerspectiveData p) => Perspective(
                                               title: p.title,
                                               url: p.url,
                                               sourceName: p.sourceName,
@@ -2889,28 +2897,21 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                             ),
                                           )
                                           .toList(),
-                                      biasDistribution:
-                                          _perspectivesResponse!
-                                              .biasDistribution,
-                                      keywords:
-                                          _perspectivesResponse!.keywords,
-                                      sourceBiasStance:
-                                          _perspectivesResponse!
-                                              .sourceBiasStance,
-                                      sourceName:
-                                          _content?.source.name ?? '',
+                                      biasDistribution: _perspectivesResponse!
+                                          .biasDistribution,
+                                      keywords: _perspectivesResponse!.keywords,
+                                      sourceBiasStance: _perspectivesResponse!
+                                          .sourceBiasStance,
+                                      sourceName: _content?.source.name ?? '',
                                       contentId: widget.contentId,
-                                      comparisonQuality:
-                                          _perspectivesResponse!
-                                              .comparisonQuality,
+                                      comparisonQuality: _perspectivesResponse!
+                                          .comparisonQuality,
                                       externalSelectedSegments:
                                           _perspectivesSelectedSegments,
-                                      onSegmentTap:
-                                          _onPerspectivesSegmentTap,
+                                      onSegmentTap: _onPerspectivesSegmentTap,
                                       onClearSegments: () {
                                         setState(() =>
-                                            _perspectivesSelectedSegments =
-                                                {});
+                                            _perspectivesSelectedSegments = {});
                                         WidgetsBinding.instance
                                             .addPostFrameCallback((_) {
                                           if (mounted) {
@@ -2918,10 +2919,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                           }
                                         });
                                       },
-                                      analysisState:
-                                          _perspectivesAnalysisState,
-                                      analysisText:
-                                          _perspectivesAnalysisText,
+                                      analysisState: _perspectivesAnalysisState,
+                                      analysisText: _perspectivesAnalysisText,
                                       onRequestAnalysis:
                                           _requestPerspectivesAnalysis,
                                       analysisZoneKey: _analysisZoneKey,
@@ -3140,7 +3139,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     ],
 
                     // Bottom spacing for FABs
-                    const SizedBox(height: 120),
+                    const SizedBox(height: _kFabBottomClearance),
                   ],
                 ),
               ),
@@ -3341,11 +3340,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             key: _scrollViewKey,
             controller: _inAppScrollController,
             child: Column(
-              spacing: 16,
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 // ── Header clearance ──────────────────────────────────────
                 SizedBox(height: headerHeight),
+                const SizedBox(height: FacteurSpacing.space2),
 
                 // ── Top section: thumbnail → chips → title → reading time ─
                 Padding(
@@ -3415,12 +3414,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   ),
                 ),
 
+                const SizedBox(height: FacteurSpacing.space4),
+
                 // ── Divider: header / article ─────────────────────────────
                 Padding(
                   padding: const EdgeInsets.symmetric(
                       horizontal: FacteurSpacing.space4),
                   child: Divider(color: colors.border, height: 1),
                 ),
+                const SizedBox(height: FacteurSpacing.space4),
 
                 // ── Article section ────────────────────────────────────────
                 // Zero-height marker at the end lets _measureArticleExtent()
@@ -3435,11 +3437,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
                 // ── Perspectives section ───────────────────────────────────
                 if (_perspectivesResponse != null || _perspectivesLoading) ...[
+                  const SizedBox(height: FacteurSpacing.space4),
                   Padding(
                     padding: const EdgeInsets.symmetric(
                         horizontal: FacteurSpacing.space4),
                     child: Divider(color: colors.border, height: 1),
                   ),
+                  const SizedBox(height: FacteurSpacing.space4),
                   if (_perspectivesLoading && _perspectivesResponse == null)
                     const Center(child: CircularProgressIndicator())
                   else if (_perspectivesResponse != null)
@@ -3480,6 +3484,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 ],
 
                 // ── Footer clearance ───────────────────────────────────────
+                const SizedBox(height: FacteurSpacing.space4),
                 SizedBox(
                   height: _kFooterContentHeight +
                       MediaQuery.of(context).viewPadding.bottom,

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -99,6 +99,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   bool _footerPermanent =
       false; // true once user reaches end of displayed content
   final ValueNotifier<bool> _atPerspectivesSection = ValueNotifier(false);
+  bool _suppressPerspectivesCheck = false;
   bool _showNoteWelcome = false;
   bool _linkCopiedFab = false;
   bool _linkCopiedHeader = false;
@@ -566,6 +567,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   /// is visible in the viewport. Called from the scroll notification handler.
   /// Uses ValueNotifier to avoid triggering a full setState during scroll.
   void _checkAtPerspectivesSection() {
+    if (_suppressPerspectivesCheck) return;
     final ctx = _perspectivesKey.currentContext;
     if (ctx == null) return;
     final perspBox = ctx.findRenderObject() as RenderBox?;
@@ -1997,6 +1999,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         style: iconButtonStyle,
                         onPressed: () {
                           HapticFeedback.lightImpact();
+                          _suppressPerspectivesCheck = true;
                           _atPerspectivesSection.value = false;
                           if (_inAppScrollController.hasClients) {
                             _inAppScrollController.animateTo(
@@ -2005,11 +2008,33 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                               curve: Curves.easeInOut,
                             );
                           }
+                          Future.delayed(const Duration(milliseconds: 450), () {
+                            if (mounted) _suppressPerspectivesCheck = false;
+                          });
                         },
-                        icon: Icon(
-                          PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
-                          size: 24,
-                          color: colors.textSecondary,
+                        icon: SizedBox(
+                          width: 28,
+                          height: 28,
+                          child: Stack(
+                            children: [
+                              Center(
+                                child: Icon(
+                                  PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
+                                  size: 24,
+                                  color: colors.textSecondary,
+                                ),
+                              ),
+                              Positioned(
+                                right: 0,
+                                bottom: 0,
+                                child: Icon(
+                                  PhosphorIcons.arrowUp(PhosphorIconsStyle.bold),
+                                  size: 8,
+                                  color: colors.textSecondary,
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     );
@@ -2019,6 +2044,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     iconColor: colors.textSecondary,
                     onTap: () {
                       HapticFeedback.lightImpact();
+                      _suppressPerspectivesCheck = true;
                       _atPerspectivesSection.value = true;
                       final ctx = _perspectivesKey.currentContext;
                       if (ctx != null) {
@@ -2030,6 +2056,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       } else {
                         _showPerspectives(context);
                       }
+                      Future.delayed(const Duration(milliseconds: 450), () {
+                        if (mounted) _suppressPerspectivesCheck = false;
+                      });
                     },
                   );
                 },
@@ -3642,14 +3671,33 @@ class _WinkingEyeButtonState extends State<_WinkingEyeButton>
           style: widget.style,
           onPressed: widget.onTap,
           tooltip: 'Autres points de vue',
-          icon: Transform.scale(
-            scaleY: _scaleY.value,
-            child: Icon(
-              isWinking
-                  ? PhosphorIcons.eyeClosed(PhosphorIconsStyle.regular)
-                  : PhosphorIcons.eye(PhosphorIconsStyle.regular),
-              size: 22,
-              color: widget.iconColor,
+          icon: SizedBox(
+            width: 28,
+            height: 28,
+            child: Stack(
+              children: [
+                Center(
+                  child: Transform.scale(
+                    scaleY: _scaleY.value,
+                    child: Icon(
+                      isWinking
+                          ? PhosphorIcons.eyeClosed(PhosphorIconsStyle.regular)
+                          : PhosphorIcons.eye(PhosphorIconsStyle.regular),
+                      size: 22,
+                      color: widget.iconColor,
+                    ),
+                  ),
+                ),
+                Positioned(
+                  right: 0,
+                  bottom: 0,
+                  child: Icon(
+                    PhosphorIcons.arrowDown(PhosphorIconsStyle.bold),
+                    size: 8,
+                    color: widget.iconColor,
+                  ),
+                ),
+              ],
             ),
           ),
         );

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -2679,7 +2679,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
               const SizedBox(width: 12),
               Expanded(
                 child: Text(
-                  'Voir tous les points de vue',
+                  'Voir d\'autres points de vue',
                   style: textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                     color: colors.textPrimary,

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -2053,11 +2053,36 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                               Positioned(
                                 right: 0,
                                 bottom: 0,
-                                child: Icon(
-                                  PhosphorIcons.arrowUp(
-                                      PhosphorIconsStyle.bold),
-                                  size: 8,
-                                  color: colors.textSecondary,
+                                child: Stack(
+                                  children: [
+                                    Text(
+                                      String.fromCharCode(PhosphorIcons.arrowUp(
+                                              PhosphorIconsStyle.bold)
+                                          .codePoint),
+                                      style: TextStyle(
+                                        fontFamily: PhosphorIcons.arrowUp(
+                                                PhosphorIconsStyle.bold)
+                                            .fontFamily,
+                                        package: PhosphorIcons.arrowUp(
+                                                PhosphorIconsStyle.bold)
+                                            .fontPackage,
+                                        fontSize: 8,
+                                        height: 1.0,
+                                        foreground: Paint()
+                                          ..style = PaintingStyle.stroke
+                                          ..strokeWidth = 4.0
+                                          ..strokeJoin = StrokeJoin.round
+                                          ..strokeCap = StrokeCap.round
+                                          ..color = colors.backgroundPrimary,
+                                      ),
+                                    ),
+                                    Icon(
+                                      PhosphorIcons.arrowUp(
+                                          PhosphorIconsStyle.bold),
+                                      size: 8,
+                                      color: colors.textSecondary.withValues(alpha: 0.5),
+                                    ),
+                                  ],
                                 ),
                               ),
                             ],
@@ -2145,7 +2170,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   onPressed: _toggleLike,
                   icon: SunflowerIcon(
                     isActive: content.isLiked,
-                    size: 24,
+                    size: 20,
                     inactiveColor: colors.textSecondary,
                   ),
                   tooltip: 'Recommander',
@@ -3747,10 +3772,35 @@ class _WinkingEyeButtonState extends State<_WinkingEyeButton>
                 Positioned(
                   right: 0,
                   bottom: 0,
-                  child: Icon(
-                    PhosphorIcons.arrowDown(PhosphorIconsStyle.bold),
-                    size: 8,
-                    color: widget.iconColor,
+                  child: Stack(
+                    children: [
+                      Text(
+                        String.fromCharCode(
+                            PhosphorIcons.arrowDown(PhosphorIconsStyle.bold)
+                                .codePoint),
+                        style: TextStyle(
+                          fontFamily:
+                              PhosphorIcons.arrowDown(PhosphorIconsStyle.bold)
+                                  .fontFamily,
+                          package:
+                              PhosphorIcons.arrowDown(PhosphorIconsStyle.bold)
+                                  .fontPackage,
+                          fontSize: 8,
+                          height: 1.0,
+                          foreground: Paint()
+                            ..style = PaintingStyle.stroke
+                            ..strokeWidth = 4.0
+                            ..strokeJoin = StrokeJoin.round
+                            ..strokeCap = StrokeCap.round
+                            ..color = context.facteurColors.backgroundPrimary,
+                        ),
+                      ),
+                      Icon(
+                        PhosphorIcons.arrowDown(PhosphorIconsStyle.bold),
+                        size: 8,
+                        color: widget.iconColor.withValues(alpha: 0.5),
+                      ),
+                    ],
                   ),
                 ),
               ],

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -2039,27 +2039,34 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       ),
                     );
                   }
+                  final perspectivesEmpty = !_perspectivesLoading &&
+                      _perspectivesResponse != null &&
+                      _perspectivesResponse!.perspectives.isEmpty;
                   return _WinkingEyeButton(
                     style: iconButtonStyle,
-                    iconColor: colors.textSecondary,
-                    onTap: () {
-                      HapticFeedback.lightImpact();
-                      _suppressPerspectivesCheck = true;
-                      _atPerspectivesSection.value = true;
-                      final ctx = _perspectivesKey.currentContext;
-                      if (ctx != null) {
-                        Scrollable.ensureVisible(
-                          ctx,
-                          duration: const Duration(milliseconds: 400),
-                          curve: Curves.easeInOut,
-                        );
-                      } else {
-                        _showPerspectives(context);
-                      }
-                      Future.delayed(const Duration(milliseconds: 450), () {
-                        if (mounted) _suppressPerspectivesCheck = false;
-                      });
-                    },
+                    iconColor: perspectivesEmpty
+                        ? colors.textSecondary.withValues(alpha: 0.35)
+                        : colors.textSecondary,
+                    onTap: perspectivesEmpty
+                        ? null
+                        : () {
+                            HapticFeedback.lightImpact();
+                            _suppressPerspectivesCheck = true;
+                            _atPerspectivesSection.value = true;
+                            final ctx = _perspectivesKey.currentContext;
+                            if (ctx != null) {
+                              Scrollable.ensureVisible(
+                                ctx,
+                                duration: const Duration(milliseconds: 400),
+                                curve: Curves.easeInOut,
+                              );
+                            } else {
+                              _showPerspectives(context);
+                            }
+                            Future.delayed(const Duration(milliseconds: 450), () {
+                              if (mounted) _suppressPerspectivesCheck = false;
+                            });
+                          },
                   );
                 },
               ),
@@ -3594,7 +3601,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
 /// Eye button that winks periodically (scaleY close → open) to hint at perspectives.
 class _WinkingEyeButton extends StatefulWidget {
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
   final ButtonStyle? style;
   final Color iconColor;
 
@@ -3650,7 +3657,7 @@ class _WinkingEyeButtonState extends State<_WinkingEyeButton>
     final delayMs = (baseMs * multiplier).round();
     _timer?.cancel();
     _timer = Timer(Duration(milliseconds: delayMs), () {
-      if (mounted) _controller.forward(from: 0);
+      if (mounted && widget.onTap != null) _controller.forward(from: 0);
     });
   }
 
@@ -3667,26 +3674,33 @@ class _WinkingEyeButtonState extends State<_WinkingEyeButton>
       animation: _scaleY,
       builder: (context, _) {
         final isWinking = _scaleY.value < 0.5;
+        final disabled = widget.onTap == null;
         return IconButton(
           style: widget.style,
           onPressed: widget.onTap,
-          tooltip: 'Autres points de vue',
+          tooltip: disabled ? 'Pas d\'autres points de vue' : 'Autres points de vue',
           icon: SizedBox(
             width: 28,
             height: 28,
             child: Stack(
               children: [
                 Center(
-                  child: Transform.scale(
-                    scaleY: _scaleY.value,
-                    child: Icon(
-                      isWinking
-                          ? PhosphorIcons.eyeClosed(PhosphorIconsStyle.regular)
-                          : PhosphorIcons.eye(PhosphorIconsStyle.regular),
-                      size: 22,
-                      color: widget.iconColor,
-                    ),
-                  ),
+                  child: disabled
+                      ? Icon(
+                          PhosphorIcons.eyeClosed(PhosphorIconsStyle.regular),
+                          size: 22,
+                          color: widget.iconColor,
+                        )
+                      : Transform.scale(
+                          scaleY: _scaleY.value,
+                          child: Icon(
+                            isWinking
+                                ? PhosphorIcons.eyeClosed(PhosphorIconsStyle.regular)
+                                : PhosphorIcons.eye(PhosphorIconsStyle.regular),
+                            size: 22,
+                            color: widget.iconColor,
+                          ),
+                        ),
                 ),
                 Positioned(
                   right: 0,

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -2661,7 +2661,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           bottom: BorderSide(color: colors.border, width: 1),
         ),
       ),
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
@@ -2685,34 +2685,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   ),
                 ),
               ),
-              // "Tout afficher" clear button when a filter is active
-              if (selected.isNotEmpty)
-                GestureDetector(
-                  onTap: () {
-                    setState(() => _perspectivesSelectedSegments = {});
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      if (mounted) _checkAtPerspectivesSection();
-                    });
-                  },
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        'Tout afficher',
-                        style: textTheme.labelSmall?.copyWith(
-                          color: colors.primary,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      const SizedBox(width: 4),
-                      Icon(
-                        PhosphorIcons.x(PhosphorIconsStyle.bold),
-                        size: 12,
-                        color: colors.primary,
-                      ),
-                    ],
-                  ),
-                ),
             ],
           ),
           if (response.comparisonQuality == 'low')
@@ -2725,6 +2697,43 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             sourceName: _content?.source.name ?? '',
             selectedSegments: selected,
             onSegmentTap: _onPerspectivesSegmentTap,
+          ),
+          SizedBox(
+            height: selected.isNotEmpty ? 28 : 4,
+            child: selected.isNotEmpty
+                ? Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Align(
+                      alignment: Alignment.topRight,
+                      child: GestureDetector(
+                        onTap: () {
+                          setState(() => _perspectivesSelectedSegments = {});
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            if (mounted) _checkAtPerspectivesSection();
+                          });
+                        },
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              'Tout afficher',
+                              style: textTheme.labelSmall?.copyWith(
+                                color: colors.primary,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            Icon(
+                              PhosphorIcons.x(PhosphorIconsStyle.bold),
+                              size: 12,
+                              color: colors.primary,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  )
+                : null,
           ),
         ],
       ),

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -118,6 +118,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   final GlobalKey _articleKey = GlobalKey();
   final GlobalKey _bridgeKey = GlobalKey();
   final GlobalKey _perspectivesKey = GlobalKey();
+  final GlobalKey _firstPerspectiveCardKey = GlobalKey();
   bool _isWebViewActive = false;
   bool _ctaTapped = false;
   double _bridgeEndOffset = 0;
@@ -575,7 +576,22 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
     final perspScreenY = perspBox.localToGlobal(Offset.zero).dy;
     final screenHeight = MediaQuery.of(context).size.height;
-    final reached = perspScreenY < screenHeight * 0.85;
+
+    // Show button once the user has scrolled past the first card.
+    bool reached;
+    final firstCardCtx = _firstPerspectiveCardKey.currentContext;
+    if (firstCardCtx != null) {
+      final firstCardBox = firstCardCtx.findRenderObject() as RenderBox?;
+      if (firstCardBox != null && firstCardBox.hasSize) {
+        final firstCardBottomY = firstCardBox.localToGlobal(Offset.zero).dy +
+            firstCardBox.size.height;
+        reached = firstCardBottomY < screenHeight * 0.9;
+      } else {
+        reached = perspScreenY < screenHeight * 0.85;
+      }
+    } else {
+      reached = perspScreenY < screenHeight * 0.85;
+    }
 
     if (reached != _atPerspectivesSection.value) {
       _atPerspectivesSection.value = reached;
@@ -1624,42 +1640,50 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             PerspectivesAnalysisState.idle &&
                         _perspectivesResponse != null &&
                         _perspectivesResponse!.perspectives.isNotEmpty;
-                    return AnimatedOpacity(
-                      opacity: show ? 1.0 : 0.0,
+                    return AnimatedScale(
+                      scale: show ? 1.0 : 0.9,
                       duration: const Duration(milliseconds: 200),
-                      child: IgnorePointer(
-                        ignoring: !show,
-                        child: DecoratedBox(
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(12),
-                            boxShadow: [
-                              BoxShadow(
-                                color: Colors.white.withValues(alpha: 0.85),
-                                blurRadius: 0,
+                      curve: Curves.easeOut,
+                      child: AnimatedOpacity(
+                        opacity: show ? 1.0 : 0.0,
+                        duration: const Duration(milliseconds: 200),
+                        child: IgnorePointer(
+                          ignoring: !show,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(12),
+                              color: context.facteurColors.surfaceElevated
+                                  .withValues(alpha: 0.95),
+                              border: Border.all(
+                                color: context.facteurColors.border,
                               ),
-                            ],
-                          ),
-                          child: OutlinedButton.icon(
-                            onPressed: () {
-                              HapticFeedback.lightImpact();
-                              _requestPerspectivesAnalysis();
-                            },
-                            style: OutlinedButton.styleFrom(
-                              foregroundColor: context.facteurColors.primary,
-                              side: BorderSide(
-                                color: context.facteurColors.primary,
-                              ),
-                              backgroundColor:
-                                  Colors.white.withValues(alpha: 0.5),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12),
-                              ),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withValues(alpha: 0.08),
+                                  blurRadius: 16,
+                                  offset: const Offset(0, 4),
+                                ),
+                              ],
                             ),
-                            icon: Icon(
-                              PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
-                              size: 16,
+                            child: OutlinedButton.icon(
+                              onPressed: () {
+                                HapticFeedback.lightImpact();
+                                _requestPerspectivesAnalysis();
+                              },
+                              style: OutlinedButton.styleFrom(
+                                foregroundColor: context.facteurColors.primary,
+                                side: BorderSide.none,
+                                backgroundColor: Colors.transparent,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                              ),
+                              icon: Icon(
+                                PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                                size: 16,
+                              ),
+                              label: const Text('Lancer l\'analyse Facteur'),
                             ),
-                            label: const Text('Lancer l\'analyse Facteur'),
                           ),
                         ),
                       ),
@@ -2019,7 +2043,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             children: [
                               Center(
                                 child: Icon(
-                                  PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
+                                  PhosphorIcons.newspaper(
+                                      PhosphorIconsStyle.regular),
                                   size: 24,
                                   color: colors.textSecondary,
                                 ),
@@ -2028,7 +2053,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 right: 0,
                                 bottom: 0,
                                 child: Icon(
-                                  PhosphorIcons.arrowUp(PhosphorIconsStyle.bold),
+                                  PhosphorIcons.arrowUp(
+                                      PhosphorIconsStyle.bold),
                                   size: 8,
                                   color: colors.textSecondary,
                                 ),
@@ -2063,7 +2089,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             } else {
                               _showPerspectives(context);
                             }
-                            Future.delayed(const Duration(milliseconds: 450), () {
+                            Future.delayed(const Duration(milliseconds: 450),
+                                () {
                               if (mounted) _suppressPerspectivesCheck = false;
                             });
                           },
@@ -2845,7 +2872,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                         decoration: BoxDecoration(
                                           color: colors.warning
                                               .withValues(alpha: 0.12),
-                                          borderRadius: BorderRadius.circular(8),
+                                          borderRadius:
+                                              BorderRadius.circular(8),
                                         ),
                                         child: Text(
                                           'Aperçu — contenu partiel',
@@ -2955,6 +2983,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                       onRequestAnalysis:
                                           _requestPerspectivesAnalysis,
                                       analysisZoneKey: _analysisZoneKey,
+                                      firstCardKey: _firstPerspectiveCardKey,
                                     )
                                   : const SizedBox.shrink(),
                         ),
@@ -3506,6 +3535,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       analysisText: _perspectivesAnalysisText,
                       onRequestAnalysis: _requestPerspectivesAnalysis,
                       analysisZoneKey: _analysisZoneKey,
+                      firstCardKey: _firstPerspectiveCardKey,
                     ),
                 ],
 
@@ -3678,7 +3708,8 @@ class _WinkingEyeButtonState extends State<_WinkingEyeButton>
         return IconButton(
           style: widget.style,
           onPressed: widget.onTap,
-          tooltip: disabled ? 'Pas d\'autres points de vue' : 'Autres points de vue',
+          tooltip:
+              disabled ? 'Pas d\'autres points de vue' : 'Autres points de vue',
           icon: SizedBox(
             width: 28,
             height: 28,
@@ -3695,7 +3726,8 @@ class _WinkingEyeButtonState extends State<_WinkingEyeButton>
                           scaleY: _scaleY.value,
                           child: Icon(
                             isWinking
-                                ? PhosphorIcons.eyeClosed(PhosphorIconsStyle.regular)
+                                ? PhosphorIcons.eyeClosed(
+                                    PhosphorIconsStyle.regular)
                                 : PhosphorIcons.eye(PhosphorIconsStyle.regular),
                             size: 22,
                             color: widget.iconColor,

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -2025,6 +2025,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           HapticFeedback.lightImpact();
                           _suppressPerspectivesCheck = true;
                           _atPerspectivesSection.value = false;
+                          _showStickyPerspectivesHeader.value = false;
                           if (_inAppScrollController.hasClients) {
                             _inAppScrollController.animateTo(
                               0,

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -890,6 +890,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           newLiked
               ? 'Ajouté à Mes contenus recommandés 🌻'
               : 'Retiré de Mes contenus recommandés 🌻',
+          margin: const EdgeInsets.fromLTRB(16, 0, 16, 94),
         );
         // Refresh collections to update liked collection counts
         ref.invalidate(collectionsProvider);
@@ -1773,81 +1774,30 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           ),
                           const SizedBox(height: FacteurSpacing.space3),
                         ],
-                        // 🌻 Sunflower recommendation FAB + nudge label
-                        Row(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            // Animated "Recommander ?" nudge label
-                            AnimatedSwitcher(
-                              duration: const Duration(milliseconds: 300),
-                              transitionBuilder: (child, animation) =>
-                                  FadeTransition(
-                                opacity: animation,
-                                child: SlideTransition(
-                                  position: Tween<Offset>(
-                                    begin: const Offset(0.3, 0),
-                                    end: Offset.zero,
-                                  ).animate(animation),
-                                  child: child,
-                                ),
-                              ),
-                              child: _showSunflowerNudge
-                                  ? Container(
-                                      key: const ValueKey('nudge_visible'),
-                                      margin: const EdgeInsets.only(right: 10),
-                                      padding: const EdgeInsets.symmetric(
-                                          horizontal: 12, vertical: 6),
-                                      decoration: BoxDecoration(
-                                        color: const Color(0xFFFFF8E1),
-                                        borderRadius: BorderRadius.circular(16),
-                                        boxShadow: [
-                                          BoxShadow(
-                                            color:
-                                                Colors.black.withOpacity(0.1),
-                                            blurRadius: 8,
-                                            offset: const Offset(0, 2),
-                                          ),
-                                        ],
-                                      ),
-                                      child: const Text(
-                                        'Recommander ? 🌻',
-                                        style: TextStyle(
-                                          fontSize: 13,
-                                          fontWeight: FontWeight.w600,
-                                          color: Color(0xFF795548),
-                                        ),
-                                      ),
-                                    )
-                                  : const SizedBox.shrink(
-                                      key: ValueKey('nudge_hidden'),
-                                    ),
-                            ),
-                            ScaleTransition(
-                              scale: _likeScaleAnimation,
-                              child: SizedBox(
-                                width: 50,
-                                height: 50,
-                                child: FloatingActionButton(
-                                  onPressed: _toggleLike,
-                                  backgroundColor: content.isLiked
-                                      ? colors.primary
-                                      : Colors.white,
-                                  foregroundColor: content.isLiked
-                                      ? Colors.white
-                                      : colors.textPrimary,
-                                  elevation: content.isLiked ? 4 : 2,
-                                  heroTag: 'sunflower_fab',
-                                  tooltip: 'Recommander',
-                                  child: SunflowerIcon(
-                                    isActive: content.isLiked,
-                                    size: 25,
-                                    inactiveColor: colors.textPrimary,
-                                  ),
-                                ),
+                        // 🌻 Sunflower recommendation FAB
+                        ScaleTransition(
+                          scale: _likeScaleAnimation,
+                          child: SizedBox(
+                            width: 50,
+                            height: 50,
+                            child: FloatingActionButton(
+                              onPressed: _toggleLike,
+                              backgroundColor: content.isLiked
+                                  ? colors.primary
+                                  : Colors.white,
+                              foregroundColor: content.isLiked
+                                  ? Colors.white
+                                  : colors.textPrimary,
+                              elevation: content.isLiked ? 4 : 2,
+                              heroTag: 'sunflower_fab',
+                              tooltip: 'Recommander',
+                              child: SunflowerIcon(
+                                isActive: content.isLiked,
+                                size: 25,
+                                inactiveColor: colors.textPrimary,
                               ),
                             ),
-                          ],
+                          ),
                         ),
                         const SizedBox(height: FacteurSpacing.space3),
                         // Merged Bookmark + Note FAB (long-press for collection picker)
@@ -2146,7 +2096,57 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         offset: Offset(0, offset * (_kFooterContentHeight + bottomInset + 8)),
         child: child,
       ),
-      child: footerContent,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(right: 16, bottom: 8),
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 300),
+              transitionBuilder: (child, animation) => FadeTransition(
+                opacity: animation,
+                child: SlideTransition(
+                  position: Tween<Offset>(
+                    begin: const Offset(0, 0.3),
+                    end: Offset.zero,
+                  ).animate(animation),
+                  child: child,
+                ),
+              ),
+              child: _showSunflowerNudge
+                  ? Container(
+                      key: const ValueKey('nudge_visible'),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 6),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFFFF8E1).withValues(alpha: 0.5),
+                        borderRadius: BorderRadius.circular(16),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: 0.1),
+                            blurRadius: 8,
+                            offset: const Offset(0, 2),
+                          ),
+                        ],
+                      ),
+                      child: const Text(
+                        'Recommander ? 🌻',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: Color(0xFF795548),
+                        ),
+                      ),
+                    )
+                  : const SizedBox.shrink(
+                      key: ValueKey('nudge_hidden'),
+                    ),
+            ),
+          ),
+          footerContent,
+        ],
+      ),
     );
   }
 
@@ -3594,11 +3594,13 @@ class _WinkingEyeButtonState extends State<_WinkingEyeButton>
   late final AnimationController _controller;
   late final Animation<double> _scaleY;
   final math.Random _rng = math.Random();
+  final Stopwatch _timeOnScreen = Stopwatch();
   Timer? _timer;
 
   @override
   void initState() {
     super.initState();
+    _timeOnScreen.start();
     _controller = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 320),
@@ -3622,7 +3624,11 @@ class _WinkingEyeButtonState extends State<_WinkingEyeButton>
   }
 
   void _scheduleNext() {
-    final delayMs = 4000 + _rng.nextInt(11000); // 4–15 s
+    final elapsed = _timeOnScreen.elapsed.inSeconds;
+    // Multiplier grows from 1× at t=0 to 3× at t=60s, then stays at 3×.
+    final multiplier = (3.0 * (elapsed.clamp(0, 60) / 60.0)).clamp(1.0, 3.0);
+    final baseMs = 2000 + _rng.nextInt(3001); // 2–5 s
+    final delayMs = (baseMs * multiplier).round();
     _timer?.cancel();
     _timer = Timer(Duration(milliseconds: delayMs), () {
       if (mounted) _controller.forward(from: 0);

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -1904,8 +1904,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     const iconButtonStyle = ButtonStyle(
       tapTargetSize: MaterialTapTargetSize.shrinkWrap,
       visualDensity: VisualDensity.compact,
-      padding: WidgetStatePropertyAll(EdgeInsets.all(12)),
-      minimumSize: WidgetStatePropertyAll(Size(56, 56)),
+      padding: WidgetStatePropertyAll(EdgeInsets.all(8)),
+      minimumSize: WidgetStatePropertyAll(Size(44, 44)),
       shape: WidgetStatePropertyAll(CircleBorder()),
     );
 

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -64,7 +64,8 @@ class ContentDetailScreen extends ConsumerStatefulWidget {
 }
 
 /// Height of the header content area (below the status bar).
-const double _kHeaderContentHeight = 50;
+/// = top padding (16) + icon row (~34) + bottom padding (8).
+const double _kHeaderContentHeight = 58;
 
 /// Height of the footer content area (above the safe-area bottom inset).
 /// = vertical padding (12+12) + button row height (44).
@@ -2160,9 +2161,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       child: SafeArea(
         bottom: false,
         child: Container(
-          padding: const EdgeInsets.symmetric(
-            horizontal: FacteurSpacing.space2,
-            vertical: FacteurSpacing.space2,
+          padding: const EdgeInsets.only(
+            top: FacteurSpacing.space4,
+            bottom: FacteurSpacing.space2,
+            left: FacteurSpacing.space2,
+            right: FacteurSpacing.space2,
           ),
           child: Padding(
             padding:
@@ -3344,7 +3347,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
               children: [
                 // ── Header clearance ──────────────────────────────────────
                 SizedBox(height: headerHeight),
-                const SizedBox(height: FacteurSpacing.space2),
 
                 // ── Top section: thumbnail → chips → title → reading time ─
                 Padding(

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -3533,7 +3533,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         horizontal: FacteurSpacing.space4),
                     child: Divider(color: colors.border, height: 1),
                   ),
-                  const SizedBox(height: FacteurSpacing.space4),
+                  const SizedBox(height: FacteurSpacing.space8),
                   if (_perspectivesLoading && _perspectivesResponse == null)
                     const Center(child: CircularProgressIndicator())
                   else if (_perspectivesResponse != null)

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -2409,7 +2409,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
     // Dense layout: 4 tags max across macro-theme + topic + entities.
     // Remaining entities are grouped into a "+X" overflow chip.
-    const maxTotalVisible = 4;
+    const maxTotalVisible = 6;
 
     final hasMacroTheme = content.topics.isNotEmpty &&
         getTopicMacroTheme(content.topics.first) != null;
@@ -2804,20 +2804,16 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 const SizedBox(height: FacteurSpacing.space3),
                               ],
                               if (content.entities.isNotEmpty || isPartial) ...[
-                                Wrap(
-                                  spacing: 6,
-                                  runSpacing: 4,
-                                  crossAxisAlignment: WrapCrossAlignment.center,
+                                _FadeScrollRow(
                                   children: [
                                     if (isPartial)
                                       Container(
                                         padding: const EdgeInsets.symmetric(
-                                            horizontal: 10, vertical: 4),
+                                            horizontal: 8, vertical: 4),
                                         decoration: BoxDecoration(
                                           color: colors.warning
                                               .withValues(alpha: 0.12),
-                                          borderRadius: BorderRadius.circular(
-                                              FacteurRadius.pill),
+                                          borderRadius: BorderRadius.circular(8),
                                         ),
                                         child: Text(
                                           'Aperçu — contenu partiel',
@@ -3366,19 +3362,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           ),
                         ),
                       if (content.entities.isNotEmpty || isPartial)
-                        Wrap(
-                          spacing: 6,
-                          runSpacing: 4,
-                          crossAxisAlignment: WrapCrossAlignment.center,
+                        _FadeScrollRow(
                           children: [
                             if (isPartial)
                               Container(
                                 padding: const EdgeInsets.symmetric(
-                                    horizontal: 10, vertical: 4),
+                                    horizontal: 8, vertical: 4),
                                 decoration: BoxDecoration(
                                   color: colors.warning.withValues(alpha: 0.12),
-                                  borderRadius:
-                                      BorderRadius.circular(FacteurRadius.pill),
+                                  borderRadius: BorderRadius.circular(8),
                                 ),
                                 child: Text(
                                   'Aperçu — contenu partiel',
@@ -3771,6 +3763,85 @@ class _ShimmerSkeletonState extends State<_ShimmerSkeleton>
         crossAxisAlignment: CrossAxisAlignment.stretch,
         mainAxisSize: MainAxisSize.min,
         children: widget.children,
+      ),
+    );
+  }
+}
+
+class _FadeScrollRow extends StatefulWidget {
+  final List<Widget> children;
+
+  const _FadeScrollRow({required this.children});
+
+  @override
+  State<_FadeScrollRow> createState() => _FadeScrollRowState();
+}
+
+class _FadeScrollRowState extends State<_FadeScrollRow> {
+  final _controller = ScrollController();
+  bool _atStart = true;
+  bool _atEnd = false;
+  bool _pointerDown = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_onScroll);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _onScroll());
+  }
+
+  void _onScroll() {
+    if (!_controller.hasClients) return;
+    final pos = _controller.position;
+    final atStart = pos.pixels <= 0;
+    final atEnd = pos.pixels >= pos.maxScrollExtent;
+    if (atStart != _atStart || atEnd != _atEnd) {
+      setState(() {
+        _atStart = atStart;
+        _atEnd = atEnd;
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: _atStart || !_pointerDown,
+      child: Listener(
+        onPointerDown: (_) => setState(() => _pointerDown = true),
+        onPointerUp: (_) => setState(() => _pointerDown = false),
+        onPointerCancel: (_) => setState(() => _pointerDown = false),
+        child: ShaderMask(
+          shaderCallback: (bounds) => LinearGradient(
+            begin: Alignment.centerLeft,
+            end: Alignment.centerRight,
+            colors: [
+              _atStart ? Colors.white : Colors.transparent,
+              Colors.white,
+              Colors.white,
+              _atEnd ? Colors.white : Colors.transparent,
+            ],
+            stops: const [0.0, 0.12, 0.82, 1.0],
+          ).createShader(bounds),
+          blendMode: BlendMode.dstIn,
+          child: NotificationListener<ScrollNotification>(
+            onNotification: (_) => true,
+            child: SingleChildScrollView(
+              controller: _controller,
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                spacing: 6,
+                children: widget.children,
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -64,8 +64,12 @@ class ContentDetailScreen extends ConsumerStatefulWidget {
 }
 
 /// Height of the header content area (below the status bar).
-/// = top padding (16) + icon row (~34) + bottom padding (8).
-const double _kHeaderContentHeight = 58;
+/// = top padding (16) + icon row (~36) + bottom padding (8) + 2px safety margin.
+const double _kHeaderContentHeight = 62;
+
+/// Visual bottom of the header for overlay anchoring (progress bar, sticky headers).
+/// Slightly less than the true bottom to guarantee 1px overlap and eliminate rounding gaps.
+const double _kHeaderVisualBottom = 59;
 
 /// Height of the footer content area (above the safe-area bottom inset).
 /// = vertical padding (12+12) + button row height (44).
@@ -1537,7 +1541,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 builder: (context, offset, _) {
                   final statusBarHeight = MediaQuery.of(context).padding.top;
                   final topWhenHeaderVisible =
-                      statusBarHeight + _kHeaderContentHeight;
+                      statusBarHeight + _kHeaderVisualBottom;
                   final topWhenHeaderHidden = statusBarHeight;
                   final top = topWhenHeaderVisible -
                       offset * (topWhenHeaderVisible - topWhenHeaderHidden);
@@ -1563,10 +1567,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     builder: (context, offset, _) {
                       final statusBarHeight =
                           MediaQuery.of(context).padding.top;
-                      // Sits immediately below the reading progress bar (+2px).
                       final topWhenHeaderVisible =
-                          statusBarHeight + _kHeaderContentHeight + 2.0;
-                      final topWhenHeaderHidden = statusBarHeight + 2.0;
+                          statusBarHeight + _kHeaderVisualBottom;
+                      final topWhenHeaderHidden = statusBarHeight;
                       final top = topWhenHeaderVisible -
                           offset * (topWhenHeaderVisible - topWhenHeaderHidden);
                       return Positioned(
@@ -2594,13 +2597,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         border: Border(
           bottom: BorderSide(color: colors.border, width: 1),
         ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.1),
-            blurRadius: 4,
-            offset: const Offset(0, 2),
-          ),
-        ],
       ),
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
       child: Column(

--- a/apps/mobile/lib/features/detail/widgets/article_entities_sheet.dart
+++ b/apps/mobile/lib/features/detail/widgets/article_entities_sheet.dart
@@ -91,7 +91,7 @@ class ArticleEntitiesSheet extends ConsumerWidget {
                     mutedTopics.contains(entity.text.toLowerCase());
 
                 return Padding(
-                  padding: const EdgeInsets.only(bottom: 12),
+                  padding: const EdgeInsets.only(bottom: FacteurSpacing.space3),
                   child: Row(
                     children: [
                       // Entity name
@@ -110,7 +110,7 @@ class ArticleEntitiesSheet extends ConsumerWidget {
                                 overflow: TextOverflow.ellipsis,
                               ),
                               if (entity.label.isNotEmpty) ...[
-                                const SizedBox(height: 2),
+                                const SizedBox(height: FacteurSpacing.space1),
                                 Container(
                                   padding: const EdgeInsets.symmetric(
                                     horizontal: 6,

--- a/apps/mobile/lib/features/detail/widgets/article_reader_widget.dart
+++ b/apps/mobile/lib/features/detail/widgets/article_reader_widget.dart
@@ -73,7 +73,7 @@ class ArticleReaderWidget extends StatelessWidget {
               'h2': Style(
                 fontSize: FontSize(20),
                 fontWeight: FontWeight.w600,
-                margin: Margins.only(bottom: 12, top: 20),
+                margin: Margins.only(bottom: 12, top: 24),
                 color: colors.textPrimary,
               ),
               'h3': Style(
@@ -145,7 +145,7 @@ class ArticleReaderWidget extends StatelessWidget {
             },
           ),
           if (footer != null) ...[
-            const SizedBox(height: 32),
+            const SizedBox(height: FacteurSpacing.space8),
             footer!,
           ],
         ],

--- a/apps/mobile/lib/features/detail/widgets/note_input_sheet.dart
+++ b/apps/mobile/lib/features/detail/widgets/note_input_sheet.dart
@@ -197,7 +197,7 @@ class _NoteInputSheetState extends State<NoteInputSheet> {
                 ),
               ),
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: FacteurSpacing.space4),
 
             // Header: title + delete button
             Row(
@@ -241,7 +241,7 @@ class _NoteInputSheetState extends State<NoteInputSheet> {
                 ],
               ],
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: FacteurSpacing.space3),
 
             // Text field
             TextField(
@@ -270,7 +270,7 @@ class _NoteInputSheetState extends State<NoteInputSheet> {
                 counterText: '',
               ),
             ),
-            const SizedBox(height: 8),
+            const SizedBox(height: FacteurSpacing.space2),
 
             // Character count + auto-save hint
             Row(

--- a/apps/mobile/lib/features/detail/widgets/note_welcome_tooltip.dart
+++ b/apps/mobile/lib/features/detail/widgets/note_welcome_tooltip.dart
@@ -74,8 +74,8 @@ class _NoteWelcomeTooltipState extends State<NoteWelcomeTooltip>
         child: FadeTransition(
           opacity: _opacity,
           child: Container(
-            margin: const EdgeInsets.only(bottom: 12),
-            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            margin: const EdgeInsets.only(bottom: FacteurSpacing.space3),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: FacteurSpacing.space2),
             decoration: BoxDecoration(
               color: colors.surfaceElevated,
               borderRadius: BorderRadius.circular(12),

--- a/apps/mobile/lib/features/detail/widgets/youtube_player_widget.dart
+++ b/apps/mobile/lib/features/detail/widgets/youtube_player_widget.dart
@@ -324,9 +324,9 @@ class _YouTubePlayerWidgetState extends State<YouTubePlayerWidget> {
               ),
             ),
           if (widget.footer != null) ...[
-            const SizedBox(height: 32),
+            const SizedBox(height: FacteurSpacing.space8),
             widget.footer!,
-            const SizedBox(height: 64),
+            const SizedBox(height: FacteurSpacing.space16),
           ],
         ],
       ),

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -136,7 +136,8 @@ class PerspectivesBottomSheet extends ConsumerStatefulWidget {
       _PerspectivesBottomSheetState();
 }
 
-class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomSheet> {
+class _PerspectivesBottomSheetState
+    extends ConsumerState<PerspectivesBottomSheet> {
   PerspectivesAnalysisState _analysisState = PerspectivesAnalysisState.idle;
   String? _analysisText;
   Set<String> _selectedSegments = {};
@@ -154,15 +155,18 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
 
   List<Perspective> get _sortedPerspectives {
     final sorted = [...widget.perspectives];
-    sorted.sort((a, b) =>
-        _groupOrder.indexOf(a.biasGroup).compareTo(_groupOrder.indexOf(b.biasGroup)));
+    sorted.sort((a, b) => _groupOrder
+        .indexOf(a.biasGroup)
+        .compareTo(_groupOrder.indexOf(b.biasGroup)));
     return sorted;
   }
 
   List<Perspective> get _filteredPerspectives {
     final sorted = _sortedPerspectives;
     if (_selectedSegments.isEmpty) return sorted;
-    return sorted.where((p) => _selectedSegments.contains(p.biasGroup)).toList();
+    return sorted
+        .where((p) => _selectedSegments.contains(p.biasGroup))
+        .toList();
   }
 
   void _onSegmentTapInternal(String key) {
@@ -194,8 +198,9 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
 
       setState(() {
         _analysisText = result;
-        _analysisState =
-            result != null ? PerspectivesAnalysisState.done : PerspectivesAnalysisState.error;
+        _analysisState = result != null
+            ? PerspectivesAnalysisState.done
+            : PerspectivesAnalysisState.error;
       });
     } catch (e) {
       if (!mounted) return;
@@ -210,7 +215,8 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
     final filtered = _filteredPerspectives;
 
     return Container(
-      constraints: BoxConstraints(maxHeight: MediaQuery.of(context).size.height * 0.92),
+      constraints:
+          BoxConstraints(maxHeight: MediaQuery.of(context).size.height * 0.92),
       decoration: BoxDecoration(
         color: colors.backgroundPrimary,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
@@ -259,21 +265,26 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
                                   style: textTheme.titleMedium?.copyWith(
                                     fontWeight: FontWeight.bold,
                                     color: colors.textPrimary,
-                                    fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
+                                    fontSize:
+                                        (textTheme.titleMedium?.fontSize ??
+                                                16) +
+                                            1,
                                   ),
                                 ),
                               ),
                               IconButton(
                                 padding: EdgeInsets.zero,
                                 visualDensity: VisualDensity.compact,
-                                icon: Icon(PhosphorIcons.x(PhosphorIconsStyle.bold)),
+                                icon: Icon(
+                                    PhosphorIcons.x(PhosphorIconsStyle.bold)),
                                 onPressed: () => Navigator.pop(context),
                                 color: colors.textSecondary,
                               ),
                             ],
                           ),
                           if (widget.comparisonQuality == 'low')
-                            PerspectivesWarningBadge(colors: colors, textTheme: textTheme),
+                            PerspectivesWarningBadge(
+                                colors: colors, textTheme: textTheme),
                           const SizedBox(height: 16),
                           PerspectivesBiasBar(
                             colors: colors,
@@ -289,20 +300,23 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
                                 ? Align(
                                     alignment: Alignment.centerRight,
                                     child: GestureDetector(
-                                      onTap: () => setState(() => _selectedSegments = {}),
+                                      onTap: () => setState(
+                                          () => _selectedSegments = {}),
                                       child: Row(
                                         mainAxisSize: MainAxisSize.min,
                                         children: [
                                           Text(
                                             'Tout afficher',
-                                            style: textTheme.labelSmall?.copyWith(
+                                            style:
+                                                textTheme.labelSmall?.copyWith(
                                               color: colors.primary,
                                               fontWeight: FontWeight.w600,
                                             ),
                                           ),
                                           const SizedBox(width: 4),
                                           Icon(
-                                            PhosphorIcons.x(PhosphorIconsStyle.bold),
+                                            PhosphorIcons.x(
+                                                PhosphorIconsStyle.bold),
                                             size: 12,
                                             color: colors.primary,
                                           ),
@@ -316,15 +330,12 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
                         ],
                       ),
                     ),
-                    if (filtered.isEmpty)
-                      PerspectivesEmptyState(colors: colors, textTheme: textTheme)
-                    else
-                      ...filtered.map(
-                        (p) => Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
-                          child: _PerspectiveCard(perspective: p),
-                        ),
+                    ...filtered.map(
+                      (p) => Padding(
+                        padding: const EdgeInsets.only(bottom: 8),
+                        child: _PerspectiveCard(perspective: p),
                       ),
+                    ),
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
                       child: PerspectivesAnalysisZone(
@@ -353,14 +364,16 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
                               style: textTheme.titleMedium?.copyWith(
                                 fontWeight: FontWeight.bold,
                                 color: colors.textPrimary,
-                                fontSize: (textTheme.titleMedium?.fontSize ?? 16) + 1,
+                                fontSize:
+                                    (textTheme.titleMedium?.fontSize ?? 16) + 1,
                               ),
                             ),
                           ),
                           IconButton(
                             padding: EdgeInsets.zero,
                             visualDensity: VisualDensity.compact,
-                            icon: Icon(PhosphorIcons.x(PhosphorIconsStyle.bold)),
+                            icon:
+                                Icon(PhosphorIcons.x(PhosphorIconsStyle.bold)),
                             onPressed: () => Navigator.pop(context),
                             color: colors.textSecondary,
                           ),
@@ -368,7 +381,8 @@ class _PerspectivesBottomSheetState extends ConsumerState<PerspectivesBottomShee
                       ),
                     ),
                     const SizedBox(height: 16),
-                    PerspectivesEmptyState(colors: colors, textTheme: textTheme),
+                    PerspectivesEmptyState(
+                        colors: colors, textTheme: textTheme),
                   ],
                 ],
               ),
@@ -524,11 +538,14 @@ class _PerspectiveCard extends ConsumerWidget {
                     children: [
                       Expanded(
                         child: Text(
-                          perspective.title.replaceAll(RegExp(r'\s*[-–|]\s*[^-–|]+$'), '').trim(),
+                          perspective.title
+                              .replaceAll(RegExp(r'\s*[-–|]\s*[^-–|]+$'), '')
+                              .trim(),
                           style: textTheme.bodyMedium?.copyWith(
                             fontWeight: FontWeight.w500,
                             color: colors.textPrimary,
-                            fontSize: (textTheme.bodyMedium?.fontSize ?? 14) + 1,
+                            fontSize:
+                                (textTheme.bodyMedium?.fontSize ?? 14) + 1,
                           ),
                           maxLines: 4,
                           overflow: TextOverflow.ellipsis,
@@ -536,7 +553,8 @@ class _PerspectiveCard extends ConsumerWidget {
                       ),
                       const SizedBox(width: 8),
                       Icon(
-                        PhosphorIcons.arrowSquareOut(PhosphorIconsStyle.regular),
+                        PhosphorIcons.arrowSquareOut(
+                            PhosphorIconsStyle.regular),
                         size: 16,
                         color: colors.textTertiary,
                       ),
@@ -622,7 +640,8 @@ class _PerspectiveCard extends ConsumerWidget {
                         style: textTheme.labelMedium?.copyWith(
                           color: colors.textPrimary,
                           fontWeight: FontWeight.w600,
-                          fontSize: (textTheme.labelMedium?.fontSize ?? 12) - 0.5,
+                          fontSize:
+                              (textTheme.labelMedium?.fontSize ?? 12) - 0.5,
                         ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
@@ -670,7 +689,6 @@ class _PerspectiveCard extends ConsumerWidget {
     );
   }
 }
-
 
 class PerspectivesWarningBadge extends StatelessWidget {
   final FacteurColors colors;
@@ -721,7 +739,7 @@ class PerspectivesEmptyState extends StatelessWidget {
     return SizedBox(
       width: double.infinity,
       child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 32),
+        padding: EdgeInsets.zero,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -730,19 +748,27 @@ class PerspectivesEmptyState extends StatelessWidget {
               size: 48,
               color: colors.textSecondary.withValues(alpha: 0.5),
             ),
-            const SizedBox(height: 16),
-            Text(
-              'Sujet peu couvert',
-              style: textTheme.titleSmall?.copyWith(
-                color: colors.textSecondary,
-                fontWeight: FontWeight.w600,
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                'Sujet peu couvert',
+                style: textTheme.titleSmall?.copyWith(
+                  color: colors.textSecondary,
+                  fontWeight: FontWeight.w600,
+                ),
+                textAlign: TextAlign.center,
               ),
             ),
             const SizedBox(height: 8),
-            Text(
-              'Ce sujet est peu couvert par les médias.\nEssaie la comparaison sur un autre article !',
-              style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
-              textAlign: TextAlign.center,
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                "Ce sujet n'a pas encore été repris par d'autres médias.",
+                style:
+                    textTheme.bodySmall?.copyWith(color: colors.textTertiary),
+                textAlign: TextAlign.center,
+              ),
             ),
           ],
         ),
@@ -799,7 +825,8 @@ class PerspectivesBiasBar extends StatelessWidget {
           children: List.generate(segments.length, (i) {
             final seg = segments[i];
             final count = mergedDistribution[seg.$1] ?? 0;
-            final isActive = selectedSegments.isEmpty || selectedSegments.contains(seg.$1);
+            final isActive =
+                selectedSegments.isEmpty || selectedSegments.contains(seg.$1);
             return Expanded(
               flex: flexValues[i],
               child: GestureDetector(
@@ -811,9 +838,11 @@ class PerspectivesBiasBar extends StatelessWidget {
                     children: [
                       Center(
                         child: Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 6, vertical: 2),
                           decoration: BoxDecoration(
-                            color: seg.$3.withValues(alpha: count > 0 ? 0.15 : 0.05),
+                            color: seg.$3
+                                .withValues(alpha: count > 0 ? 0.15 : 0.05),
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: FittedBox(
@@ -839,7 +868,9 @@ class PerspectivesBiasBar extends StatelessWidget {
                         decoration: BoxDecoration(
                           color: count > 0
                               ? seg.$3.withValues(
-                                  alpha: count == 1 ? 0.55 : (count == 2 ? 0.8 : 1.0))
+                                  alpha: count == 1
+                                      ? 0.55
+                                      : (count == 2 ? 0.8 : 1.0))
                               : seg.$3.withValues(alpha: 0.25),
                           borderRadius: BorderRadius.circular(6),
                           border: count > 0
@@ -870,7 +901,8 @@ class PerspectivesBiasBar extends StatelessWidget {
 
               final markerX = constraints.maxWidth * offsetFraction;
               final sourceColor = segments[sourceIndex].$3;
-              final displayName = sourceName.isNotEmpty ? sourceName : segments[sourceIndex].$2;
+              final displayName =
+                  sourceName.isNotEmpty ? sourceName : segments[sourceIndex].$2;
 
               return SizedBox(
                 height: 28,
@@ -882,11 +914,13 @@ class PerspectivesBiasBar extends StatelessWidget {
                       top: 0,
                       child: CustomPaint(
                         size: const Size(14, 8),
-                        painter: PerspectivesTrianglePainter(color: sourceColor),
+                        painter:
+                            PerspectivesTrianglePainter(color: sourceColor),
                       ),
                     ),
                     Positioned(
-                      left: (markerX - 50).clamp(0.0, constraints.maxWidth - 100),
+                      left:
+                          (markerX - 50).clamp(0.0, constraints.maxWidth - 100),
                       top: 10,
                       child: SizedBox(
                         width: 100,
@@ -933,7 +967,8 @@ class PerspectivesAnalysisZone extends StatefulWidget {
   });
 
   @override
-  State<PerspectivesAnalysisZone> createState() => PerspectivesAnalysisZoneState();
+  State<PerspectivesAnalysisZone> createState() =>
+      PerspectivesAnalysisZoneState();
 }
 
 class PerspectivesAnalysisZoneState extends State<PerspectivesAnalysisZone> {
@@ -944,7 +979,7 @@ class PerspectivesAnalysisZoneState extends State<PerspectivesAnalysisZone> {
     if (widget.state == PerspectivesAnalysisState.idle) {
       return _buildAnalysisCta();
     }
-    
+
     return AnimatedSize(
       key: widget.zoneKey,
       duration: const Duration(milliseconds: 300),
@@ -976,7 +1011,8 @@ class PerspectivesAnalysisZoneState extends State<PerspectivesAnalysisZone> {
         ),
         style: OutlinedButton.styleFrom(
           side: BorderSide(color: widget.colors.primary.withValues(alpha: 0.4)),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
           padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 20),
         ),
       ),
@@ -1013,13 +1049,15 @@ class PerspectivesAnalysisZoneState extends State<PerspectivesAnalysisZone> {
       decoration: BoxDecoration(
         color: widget.colors.primary.withValues(alpha: 0.05),
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: widget.colors.primary.withValues(alpha: 0.15)),
+        border:
+            Border.all(color: widget.colors.primary.withValues(alpha: 0.15)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           GestureDetector(
-            onTap: () => setState(() => _isAnalysisExpanded = !_isAnalysisExpanded),
+            onTap: () =>
+                setState(() => _isAnalysisExpanded = !_isAnalysisExpanded),
             behavior: HitTestBehavior.opaque,
             child: Row(
               children: [
@@ -1160,7 +1198,8 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
       _PerspectivesInlineSectionState();
 }
 
-class _PerspectivesInlineSectionState extends ConsumerState<PerspectivesInlineSection> {
+class _PerspectivesInlineSectionState
+    extends ConsumerState<PerspectivesInlineSection> {
   Set<String> _selectedSegments = {};
 
   Set<String> get _effectiveSegments =>
@@ -1179,15 +1218,18 @@ class _PerspectivesInlineSectionState extends ConsumerState<PerspectivesInlineSe
 
   List<Perspective> get _sortedPerspectives {
     final sorted = [...widget.perspectives];
-    sorted.sort((a, b) =>
-        _groupOrder.indexOf(a.biasGroup).compareTo(_groupOrder.indexOf(b.biasGroup)));
+    sorted.sort((a, b) => _groupOrder
+        .indexOf(a.biasGroup)
+        .compareTo(_groupOrder.indexOf(b.biasGroup)));
     return sorted;
   }
 
   List<Perspective> get _filteredPerspectives {
     final sorted = _sortedPerspectives;
     if (_effectiveSegments.isEmpty) return sorted;
-    return sorted.where((p) => _effectiveSegments.contains(p.biasGroup)).toList();
+    return sorted
+        .where((p) => _effectiveSegments.contains(p.biasGroup))
+        .toList();
   }
 
   void _onSegmentTapInternal(String key) {
@@ -1253,7 +1295,8 @@ class _PerspectivesInlineSectionState extends ConsumerState<PerspectivesInlineSe
                   ],
                 ),
                 if (widget.comparisonQuality == 'low')
-                  PerspectivesWarningBadge(colors: colors, textTheme: textTheme),
+                  PerspectivesWarningBadge(
+                      colors: colors, textTheme: textTheme),
                 const SizedBox(height: 16),
                 PerspectivesBiasBar(
                   colors: colors,
@@ -1302,15 +1345,12 @@ class _PerspectivesInlineSectionState extends ConsumerState<PerspectivesInlineSe
               ],
             ),
           ),
-          if (filtered.isEmpty)
-            PerspectivesEmptyState(colors: colors, textTheme: textTheme)
-          else
-            ...filtered.map(
-              (p) => Padding(
-                padding: const EdgeInsets.only(bottom: 8),
-                child: _PerspectiveCard(perspective: p),
-              ),
+          ...filtered.map(
+            (p) => Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: _PerspectiveCard(perspective: p),
             ),
+          ),
           if (widget.analysisState != PerspectivesAnalysisState.idle)
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -261,7 +261,7 @@ class _PerspectivesBottomSheetState
                               const SizedBox(width: 12),
                               Expanded(
                                 child: Text(
-                                  'Voir tous les points de vue',
+                                  'Voir d\'autres points de vue',
                                   style: textTheme.titleMedium?.copyWith(
                                     fontWeight: FontWeight.bold,
                                     color: colors.textPrimary,
@@ -360,7 +360,7 @@ class _PerspectivesBottomSheetState
                           const SizedBox(width: 12),
                           Expanded(
                             child: Text(
-                              'Voir tous les points de vue',
+                              'Voir d\'autres points de vue',
                               style: textTheme.titleMedium?.copyWith(
                                 fontWeight: FontWeight.bold,
                                 color: colors.textPrimary,
@@ -1289,7 +1289,7 @@ class _PerspectivesInlineSectionState
                     const SizedBox(width: 12),
                     Expanded(
                       child: Text(
-                        'Voir tous les points de vue',
+                        'Voir d\'autres points de vue',
                         style: textTheme.titleMedium?.copyWith(
                           fontWeight: FontWeight.bold,
                           color: colors.textPrimary,
@@ -1356,11 +1356,11 @@ class _PerspectivesInlineSectionState
               child: _PerspectiveCard(perspective: filtered.first),
             ),
           ...filtered.skip(1).map(
-            (p) => Padding(
-              padding: const EdgeInsets.only(bottom: 8),
-              child: _PerspectiveCard(perspective: p),
-            ),
-          ),
+                (p) => Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: _PerspectiveCard(perspective: p),
+                ),
+              ),
           if (widget.comparisonQuality == 'low')
             Padding(
               padding: const EdgeInsets.only(top: 4, bottom: 8),
@@ -1397,7 +1397,7 @@ class _PerspectivesInlineSectionState
                 const SizedBox(width: 12),
                 Expanded(
                   child: Text(
-                    'Voir tous les points de vue',
+                    'Voir d\'autres points de vue',
                     style: textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.bold,
                       color: colors.textPrimary,

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1175,6 +1175,10 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
   /// Key attached to the analysis result zone so the parent can scroll to it.
   final Key? analysisZoneKey;
 
+  /// Key attached to the first perspective card so the parent can detect
+  /// when the user has scrolled past it.
+  final Key? firstCardKey;
+
   const PerspectivesInlineSection({
     super.key,
     required this.perspectives,
@@ -1191,6 +1195,7 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
     this.analysisText,
     this.onRequestAnalysis,
     this.analysisZoneKey,
+    this.firstCardKey,
   });
 
   @override
@@ -1344,7 +1349,13 @@ class _PerspectivesInlineSectionState
               ],
             ),
           ),
-          ...filtered.map(
+          if (filtered.isNotEmpty)
+            Padding(
+              key: widget.firstCardKey,
+              padding: const EdgeInsets.only(bottom: 8),
+              child: _PerspectiveCard(perspective: filtered.first),
+            ),
+          ...filtered.skip(1).map(
             (p) => Padding(
               padding: const EdgeInsets.only(bottom: 8),
               child: _PerspectiveCard(perspective: p),

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1294,9 +1294,6 @@ class _PerspectivesInlineSectionState
                     ),
                   ],
                 ),
-                if (widget.comparisonQuality == 'low')
-                  PerspectivesWarningBadge(
-                      colors: colors, textTheme: textTheme),
                 const SizedBox(height: 16),
                 PerspectivesBiasBar(
                   colors: colors,
@@ -1307,41 +1304,43 @@ class _PerspectivesInlineSectionState
                   onSegmentTap: _handleSegmentTap,
                 ),
                 SizedBox(
-                  height: 20,
+                  height: _effectiveSegments.isNotEmpty ? 28 : 4,
                   child: _effectiveSegments.isNotEmpty
-                      ? Align(
-                          alignment: Alignment.centerRight,
-                          child: GestureDetector(
-                            onTap: () {
-                              if (widget.onClearSegments != null) {
-                                widget.onClearSegments!();
-                              } else {
-                                setState(() => _selectedSegments = {});
-                              }
-                            },
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Text(
-                                  'Tout afficher',
-                                  style: textTheme.labelSmall?.copyWith(
-                                    color: colors.primary,
-                                    fontWeight: FontWeight.w600,
+                      ? Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: Align(
+                            alignment: Alignment.topRight,
+                            child: GestureDetector(
+                              onTap: () {
+                                if (widget.onClearSegments != null) {
+                                  widget.onClearSegments!();
+                                } else {
+                                  setState(() => _selectedSegments = {});
+                                }
+                              },
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Text(
+                                    'Tout afficher',
+                                    style: textTheme.labelSmall?.copyWith(
+                                      color: colors.primary,
+                                      fontWeight: FontWeight.w600,
+                                    ),
                                   ),
-                                ),
-                                const SizedBox(width: 4),
-                                Icon(
-                                  PhosphorIcons.x(PhosphorIconsStyle.bold),
-                                  size: 12,
-                                  color: colors.primary,
-                                ),
-                              ],
+                                  const SizedBox(width: 4),
+                                  Icon(
+                                    PhosphorIcons.x(PhosphorIconsStyle.bold),
+                                    size: 12,
+                                    color: colors.primary,
+                                  ),
+                                ],
+                              ),
                             ),
                           ),
                         )
                       : null,
                 ),
-                const SizedBox(height: 8),
               ],
             ),
           ),
@@ -1351,6 +1350,14 @@ class _PerspectivesInlineSectionState
               child: _PerspectiveCard(perspective: p),
             ),
           ),
+          if (widget.comparisonQuality == 'low')
+            Padding(
+              padding: const EdgeInsets.only(top: 4, bottom: 8),
+              child: Center(
+                child: PerspectivesWarningBadge(
+                    colors: colors, textTheme: textTheme),
+              ),
+            ),
           if (widget.analysisState != PerspectivesAnalysisState.idle)
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),

--- a/apps/mobile/lib/features/feed/widgets/perspectives_loading_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_loading_sheet.dart
@@ -51,7 +51,7 @@ class PerspectivesLoadingSheet extends StatelessWidget {
                 const SizedBox(width: 12),
                 Expanded(
                   child: Text(
-                    'Voir tous les points de vue',
+                    'Voir d\'autres points de vue',
                     style: textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.bold,
                       color: colors.textPrimary,

--- a/apps/mobile/lib/widgets/sunflower_icon.dart
+++ b/apps/mobile/lib/widgets/sunflower_icon.dart
@@ -44,7 +44,7 @@ class SunflowerIcon extends StatelessWidget {
         );
       },
       child: Text(
-        '🌻',
+        isActive ? '🌻' : '🌱',
         key: ValueKey('sunflower_${isActive ? 'active' : 'inactive'}'),
         style: TextStyle(
           fontSize: size,

--- a/apps/mobile/macos/Flutter/Flutter-Debug.xcconfig
+++ b/apps/mobile/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/apps/mobile/macos/Flutter/Flutter-Release.xcconfig
+++ b/apps/mobile/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/apps/mobile/macos/Podfile
+++ b/apps/mobile/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end


### PR DESCRIPTION
## What

Refactors the article detail screen layout and spacing, and improves the perspectives bottom sheet — including sticky bias bar behavior, analysis button timing, chip placement, and section title copy. Also restores missing iOS and macOS Podfiles and updates xcconfig CocoaPods includes.

## Why

Several visual inconsistencies and UX issues in the article detail screen and perspectives section were identified post-MVP, including misaligned components, premature analysis button triggers, and broken CocoaPods build config.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [x] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)