### PR TITLE
chore(agents): autonomie diagnostic + healthcheck robuste

### DIFF
--- a/.claude-hooks/session-start.sh
+++ b/.claude-hooks/session-start.sh
@@ -142,4 +142,25 @@ if ! command -v railway &>/dev/null \
   bash scripts/setup-cli-tools.sh 2>&1 | tail -20 || true
 fi
 
+# =============================================================================
+# Connectivité des services (secrets d'agent) — en mode fast.
+# Tous les messages commencent par [secrets] pour que l'agent scanne vite.
+# Non-bloquant : même si un service est DOWN, la session démarre.
+# =============================================================================
+if [ -f scripts/healthcheck-agent-secrets.sh ]; then
+  # N'exécute le healthcheck que si au moins un secret est présent — inutile
+  # de spammer "SKIP" partout pour des contributeurs externes qui n'ont pas
+  # accès aux secrets d'infra.
+  if [ -n "${DATABASE_URL_RO:-}${SUPABASE_ACCESS_TOKEN:-}${RAILWAY_TOKEN:-}${SENTRY_AUTH_TOKEN:-}${POSTHOG_PERSONAL_API_KEY:-}" ]; then
+    echo "[secrets] vérification connectivité (--fast)..."
+    # Préfixe chaque ligne pour scan facile par l'agent, tronque le bruit visuel.
+    bash scripts/healthcheck-agent-secrets.sh --fast 2>&1 \
+      | grep -E '\[(OK|FAIL|SKIP)\]|Résumé' \
+      | sed 's/^/[secrets] /' \
+      || true
+  else
+    echo "[secrets] aucune variable d'infra définie (normal pour contributeur sans accès)"
+  fi
+fi
+
 exit 0  # Toujours non-bloquant

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,18 @@ SUPABASE_ACCESS_TOKEN=
 SUPABASE_URL=https://ykuadtelnzavrqzbfdve.supabase.co
 SUPABASE_ANON_KEY=
 
+# Connexion read-only scoped analytics (rôle claude_analytics_ro).
+# Utilisée par scripts/analytics/run_usage_queries.sh — jamais d'écriture.
+# Format : postgresql://claude_analytics_ro:PWD@db.ykuadtelnzavrqzbfdve.supabase.co:5432/postgres
+DATABASE_URL_RO=
+
+# ─── PostHog (analytics read-only) ────────────────────────────────────────────
+# Personal API key scoped read-only projet "Facteur Prod".
+# Obtenir : posthog.com > Settings > Personal API keys > "Read-only analytics"
+POSTHOG_PERSONAL_API_KEY=
+POSTHOG_PROJECT_ID=
+POSTHOG_HOST=https://eu.i.posthog.com
+
 # ─── Sentry ───────────────────────────────────────────────────────────────────
 SENTRY_AUTH_TOKEN=
 SENTRY_ORG=

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,14 @@ SUPABASE_ANON_KEY=
 
 # Connexion read-only scoped analytics (rôle claude_analytics_ro).
 # Utilisée par scripts/analytics/run_usage_queries.sh — jamais d'écriture.
-# Format : postgresql://claude_analytics_ro:PWD@db.ykuadtelnzavrqzbfdve.supabase.co:5432/postgres
+# Format (assemble toi-même) :
+#   scheme : postgresql
+#   user   : claude_analytics_ro
+#   host   : db.ykuadtelnzavrqzbfdve.supabase.co
+#   port   : 5432
+#   db     : postgres
+#   params : sslmode=require
+# Voir docs/infra/claude-access-setup.md §2.2 pour la procédure complète.
 DATABASE_URL_RO=
 
 # ─── PostHog (analytics read-only) ────────────────────────────────────────────

--- a/.github/workflows/agent-secrets-healthcheck.yml
+++ b/.github/workflows/agent-secrets-healthcheck.yml
@@ -1,0 +1,49 @@
+name: "Agent secrets — healthcheck"
+
+# Vérifie que tous les secrets nécessaires aux agents (Supabase RO, Railway,
+# Sentry, PostHog) sont présents ET fonctionnels depuis GitHub Actions.
+#
+# Quand le lancer :
+#   - Après avoir ajouté / rotaté un secret (déclenchement manuel).
+#   - Périodiquement (cron mensuel) pour attraper les tokens expirés.
+#
+# Aucun secret n'est imprimé : le script échoue silencieusement sur FAIL
+# et GitHub masque toute valeur qui matcherait un secret.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 1 * *"   # 1er du mois à 08:00 UTC
+
+jobs:
+  healthcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install psql + jq
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y postgresql-client jq
+
+      - name: Install Supabase, Railway, Sentry CLIs
+        run: bash scripts/setup-cli-tools.sh
+
+      - name: Run healthcheck
+        env:
+          # Secrets (sensibles, masqués dans logs)
+          SUPABASE_ACCESS_TOKEN:    ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          DATABASE_URL_RO:          ${{ secrets.DATABASE_URL_RO }}
+          RAILWAY_TOKEN:            ${{ secrets.RAILWAY_TOKEN }}
+          SENTRY_AUTH_TOKEN:        ${{ secrets.SENTRY_AUTH_TOKEN }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          # Variables (identifiants publics)
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+          SENTRY_ORG:         ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT:     ${{ vars.SENTRY_PROJECT }}
+          POSTHOG_PROJECT_ID: ${{ vars.POSTHOG_PROJECT_ID }}
+          POSTHOG_HOST:       ${{ vars.POSTHOG_HOST }}
+          SUPABASE_URL:       ${{ vars.SUPABASE_URL }}
+        run: bash scripts/healthcheck-agent-secrets.sh

--- a/.github/workflows/agent-secrets-healthcheck.yml
+++ b/.github/workflows/agent-secrets-healthcheck.yml
@@ -36,6 +36,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN:    ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           DATABASE_URL_RO:          ${{ secrets.DATABASE_URL_RO }}
           RAILWAY_TOKEN:            ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_API_TOKEN:        ${{ secrets.RAILWAY_TOKEN }}
           SENTRY_AUTH_TOKEN:        ${{ secrets.SENTRY_AUTH_TOKEN }}
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
           # Variables (identifiants publics)

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--read-only",
+        "--project-ref=ykuadtelnzavrqzbfdve"
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,19 @@ bash docs/qa/scripts/verify_<task>.sh
 
 - [Navigation Matrix](docs/agent-brain/navigation-matrix.md) — workflows par type de tâche
 - [Safety Guardrails](docs/agent-brain/safety-guardrails.md) — guardrails + safety protocols
+- [Investigation Playbook](docs/agent-brain/investigation-playbook.md) — outils par scénario prod (bug, usage, migration, logs, sécurité)
+- [Claude Access Setup](docs/infra/claude-access-setup.md) — secrets + accès multi-services (Supabase/Railway/Sentry/PostHog)
 - [PRD](docs/prd.md) / [Architecture](docs/architecture.md) / [Front-end Spec](docs/front-end-spec.md)
 - Agents BMAD : `.bmad-core/agents/` (dev, po, architect, qa)
 - Scripts QA : `docs/qa/scripts/`
+
+### Santé des accès agents
+
+Le hook `SessionStart` lance un healthcheck `--fast` au démarrage. Scanne les lignes `[secrets]` dans les premiers messages de la session ; un `[FAIL]` doit être traité avant toute investigation prod. Healthcheck complet :
+
+```bash
+bash scripts/healthcheck-agent-secrets.sh
+```
 ## 🧪 Validation Feature via Chrome (Agent QA)
 
 Après la phase VERIFY de l'agent dev et la validation du PO (Laurin), une étape de **validation web automatisée** peut être déclenchée pour les features touchant l'UI.

--- a/docs/agent-brain/investigation-playbook.md
+++ b/docs/agent-brain/investigation-playbook.md
@@ -1,0 +1,108 @@
+# Investigation Playbook
+
+**Quand un agent doit creuser un symptôme prod, ce doc est le point d'entrée unique.**
+Tu trouveras ici : les outils disponibles par scénario, les commandes prêtes à copier, les pièges à éviter.
+
+---
+
+## 🟢 Prérequis — est-ce que mes accès marchent ?
+
+Le hook `SessionStart` affiche automatiquement le résultat d'un healthcheck `--fast` au démarrage de la session. Scanne les lignes `[secrets]` dans les premiers messages :
+
+```
+[secrets] [OK]   connecté en tant que claude_analytics_ro
+[secrets] [OK]   API Supabase répond 200 (PAT valide)
+[secrets] [OK]   Railway GraphQL me{} OK (Account Token, user=...)
+[secrets] [OK]   API Sentry /api/0/ répond 200 (token OK)
+[secrets] [OK]   API PostHog OK (projet 129581)
+```
+
+Si tu vois des `[FAIL]`, **arrête-toi** avant d'investiguer : relance un healthcheck complet et corrige le token fautif (ou demande à l'utilisateur) :
+
+```bash
+bash scripts/healthcheck-agent-secrets.sh        # mode complet
+```
+
+Référence des secrets : [docs/infra/claude-access-setup.md](../infra/claude-access-setup.md).
+
+---
+
+## 📋 Scénarios fréquents
+
+### 1. "Un bug prod à reproduire / diagnostiquer"
+
+| Étape | Outil | Commande / MCP |
+|-------|-------|----------------|
+| Récupérer la stack trace + user impacté | Sentry API | `curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" "https://sentry.io/api/0/projects/$SENTRY_ORG/$SENTRY_PROJECT/issues/"` |
+| Reproduire l'état user côté DB | Supabase MCP (read-only) | Via l'outil `mcp__supabase__*` — ne jamais exposer `service_role` |
+| Regarder les logs du service | Railway CLI | `railway logs --service <service_id>` |
+
+**Piège** : ne pas tenter de modifier l'état user pour "tester" sans autorisation explicite. Le rôle `claude_analytics_ro` est volontairement read-only.
+
+---
+
+### 2. "Comprendre l'usage d'une feature"
+
+| Étape | Outil | Commande / MCP |
+|-------|-------|----------------|
+| Events produit (clicks, views) | PostHog API | `curl -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" "https://eu.i.posthog.com/api/projects/$POSTHOG_PROJECT_ID/events/"` |
+| Agrégats DB (streaks, rétention) | `scripts/analytics/run_usage_queries.sh` | Lance toutes les requêtes T2.* et T3.* du framework R01/R02 |
+| Nouvelle requête SQL ad-hoc | `psql "$DATABASE_URL_RO"` | Ou SQL Editor Supabase en UI |
+
+**Piège** : le pooler Supabase utilise le username `claude_analytics_ro.ykuadtelnzavrqzbfdve` (avec le point — routing pgBouncer). Si tu vois "role does not exist", c'est ce détail.
+
+---
+
+### 3. "Une migration Alembic qui a mal tourné"
+
+| Étape | Outil | Commande |
+|-------|-------|----------|
+| Identifier le head courant | Alembic local | `cd packages/api && alembic current` |
+| Vérifier qu'il n'y a qu'un head | Hook auto | `bash .claude-hooks/post-edit-alembic-heads.sh` (lancé auto) |
+| Appliquer un SQL de rattrapage | Supabase SQL Editor | Jamais `alembic upgrade` sur Railway — voir [CLAUDE.md](../../CLAUDE.md) |
+
+**Piège** : Alembic est désactivé sur Railway par design. Les migrations passent par le SQL Editor Supabase avec validation manuelle.
+
+---
+
+### 4. "Un endpoint API répond mal en prod"
+
+| Étape | Outil | Commande |
+|-------|-------|----------|
+| Status du déploiement courant | Railway CLI | `railway status --json` |
+| Logs du service | Railway CLI | `railway logs` |
+| Dernières erreurs Sentry | Sentry API | voir scénario 1 |
+| Reproduire en local | `uvicorn` | `cd packages/api && uvicorn app.main:app --port 8080` |
+
+---
+
+### 5. "Auditer la sécurité d'un accès / d'une écriture"
+
+| Question | Outil | Commande |
+|----------|-------|----------|
+| Qui peut faire quoi sur la DB ? | `psql` | `\dp schema.table` (permissions par table) |
+| Tester que `claude_analytics_ro` ne peut pas écrire | `scripts/healthcheck-agent-secrets.sh` | Mode complet (le `--fast` skip l'UPDATE probe) |
+| Vérifier un GRANT spécifique | Supabase SQL Editor | `SELECT * FROM information_schema.role_table_grants WHERE grantee='claude_analytics_ro';` |
+
+---
+
+## 🔐 Règles de sécurité (non négociables)
+
+1. **Jamais** d'écriture via `DATABASE_URL_RO`. Si tu as besoin d'écrire, demande `service_role` à l'utilisateur avec justification.
+2. **Jamais** imprimer un secret en sortie — les hooks GitHub masquent mais le script doit le faire aussi par défaut.
+3. **Toujours** utiliser le Session Pooler (port 5432 sur `*.pooler.supabase.com`), pas le endpoint direct `db.*.supabase.co` (IPv6-only).
+4. **Rotation** : si un token fuite, révoque immédiatement dans la console du service + update le secret GitHub + relance le healthcheck.
+
+---
+
+## 🧭 Outils à portée de main (aide-mémoire)
+
+| Besoin | Outil de choix | Alternative |
+|--------|----------------|-------------|
+| Query SQL read-only | `psql "$DATABASE_URL_RO"` | Supabase MCP |
+| Introspection projet Supabase | Supabase MCP (read-only) | `curl` sur api.supabase.com |
+| Logs / déploiements Railway | `railway logs` / `railway status` | API GraphQL `backboard.railway.app/graphql/v2` |
+| Issues Sentry | `sentry-cli issues list` | API `sentry.io/api/0/` |
+| Analytics événements | API PostHog | — |
+
+Pour toute commande nouvelle, **teste en mode dry-run si possible** et **commit l'ajout** dans `scripts/analytics/` ou `docs/qa/scripts/` pour que le prochain agent en bénéficie.

--- a/docs/analytics/usage-report-2026-04-20-R02.md
+++ b/docs/analytics/usage-report-2026-04-20-R02.md
@@ -1,0 +1,206 @@
+# Rapport d'usage & valeur — Facteur — R02 (chiffré)
+
+**Date :** 2026-04-20 · **Statut :** premier rapport chiffré · **Base :** 64 users profilés
+
+> Suite du R01 (`usage-report-2026-04-20.md`). Les chiffres viennent des
+> requêtes T2/T3 lancées par Laurin sur la prod Supabase.
+
+---
+
+## 0. TL;DR
+
+1. **Facteur a ~64 users profilés, dont 16 actifs / 7 jours (25 %).** Volume beta cohérent, mais l'habitude ne prend pas : **1 seul user avec streak courant ≥ 7 jours**, et 88 % de perte entre J1 et J3 de streak.
+2. **Deux bugs d'instrumentation bloquants découverts** : (a) aucun `digest_session` loggé dans `analytics_events` sur 30 jours → le KPI nord du produit est aveugle depuis PostHog ; (b) `time_spent_seconds = 0` partout → la durée de lecture n'est jamais enregistrée.
+3. **Deux surprises positives** : (a) 64.5 % des articles sauvegardés finissent lus → bookmarks = vraie valeur, pas cimetière (mon hypothèse R01 est **retournée**) ; (b) la gamification corrèle à streaks ×2 (3.18 vs 1.56).
+4. **Une feature morte à trancher** : "Mise en perspective" → 0 vue en 30 jours. Soit instrumentation cassée, soit feature non découverte → décision binaire kill/relancer.
+5. **Décision monétisation à armer** : aucun paywall/trial tracké, or l'attrition J1→J3 rend le modèle premium fragile tant qu'on n'a pas identifié le moment de valeur.
+
+---
+
+## 1. Contexte de base (dénominateurs)
+
+| Métrique | Valeur |
+|---|---|
+| Total profils | **64** users (9 gamif OFF + 55 gamif ON) |
+| Users avec au moins 1 streak actif | 51 (80 %) |
+| Users actifs 7 jours (lecture contenu) | **16 (25 %)** |
+| Users ayant sauvegardé ≥ 1 article | 19 (30 %) |
+| Users ayant une fois atteint streak ≥ 7 | 5 (8 %) |
+
+**⚠️ Incohérence détectée** : 51 users avec `current_streak ≥ 1` vs 16 users réellement actifs en 7j.
+- Hypothèse : le calcul de streak inclut des events non-contenu (ouverture app sans lecture) ou n'est pas décrémenté correctement → **streaks potentiellement zombies**.
+- **Action R03** : auditer le code de `user_streaks` (`packages/api/app/services/streak_service.py` probable) pour vérifier la règle de reset.
+
+---
+
+## 2. Métrique par métrique
+
+### 2.1 Digest completion (KPI nord) — ⛔ AVEUGLE
+
+**T2.1 → 0 rows sur 30 jours.**
+
+Les events `digest_session` ne sont pas loggés dans `analytics_events`. Or la table `digest_completions` existe et est probablement alimentée directement (pas de mirror dans `analytics_events` ni PostHog). Conséquence : **ni le dashboard PostHog documenté dans Story 14.1, ni les funnels d'activation, ne captent la métrique la plus importante du produit.**
+
+**Actions R03 (P0) :**
+1. Lancer la variante T2.1b du nouveau `scripts/analytics/run_usage_queries.sh` (lit directement `digest_completions`) pour avoir les chiffres vrais.
+2. Patcher le mobile (ou le backend côté `POST /digest/complete`) pour émettre en parallèle un `analytics_events{event_type='digest_session', closure_achieved, articles_read, total_time}` + un `capture('digest_session', ...)` PostHog.
+3. Sans ces 2 fixes, **tous les dashboards Tier 2 sont structurellement cassés**.
+
+### 2.2 Streaks — habitude fragile, mais existante
+
+| Seuil streak courant | Users | % base (n=64) |
+|---|---|---|
+| ≥ 1 | 51 | 80 % |
+| ≥ 3 | 6 | 9 % |
+| ≥ 7 | 1 | 2 % |
+| ≥ 14 | 1 | 2 % |
+| *Historique : ≥ 7 jamais atteint* | 5 | 8 % |
+| *Record historique* | 32 jours | — |
+
+**Lecture :**
+- **Cliff J1 → J3 : –88 %** (51 → 6). C'est LE point bloquant n°1 de l'app.
+- Un user a tenu 32 jours → la proposition peut tenir. Le produit est capable, mais le "truc" qui retient n'est pas activé pour la majorité.
+- Benchmark rétention daily digest sain : 15–25 % des users forment un rituel hebdo (streak ≥ 7). Ici : **2 %**. Très en-dessous.
+
+**Hypothèses causales (à tester R03) :**
+1. **La notif 8h ne ramène pas** (pas d'instrumentation → on ne sait pas si elle est ouverte) → ajouter `notification_opened`.
+2. **L'onboarding promet un truc que le digest ne tient pas** → ajouter un funnel `signup → first_digest_completed` pour voir où le match casse.
+3. **Le digest arrive à 8h mais beaucoup ouvrent le soir** → mesurer la distribution horaire de `session_start` les jours de digest.
+
+### 2.3 Activité 7j — volume correct, mais métrique durée KO
+
+| Métrique | Valeur | Verdict |
+|---|---|---|
+| Users actifs 7j | 16 | cohérent avec beta |
+| Articles consommés (7j) | 276 | 17/user/sem = **2.5/jour** → bon |
+| Temps total lecture | **0.0 min** | ⛔ BUG — `time_spent_seconds` jamais écrit |
+| Articles / user | 17.3 | ok |
+
+**Bug critique :** `user_content_status.time_spent_seconds` retourne 0 partout. Soit le mobile ne le remonte pas, soit l'endpoint qui met à jour le statut ignore le champ. **Toute la narration "temps passé sur Facteur" est fausse tant que ce n'est pas corrigé.**
+
+**Action R03 (P0) :** grep côté API pour l'endpoint de maj de statut et vérifier que `time_spent_seconds` est bien persisté. Probablement une route `PATCH /contents/{id}/status` ou similaire.
+
+### 2.4 Bookmarks — 🎯 signal PMF caché (hypothèse R01 inversée)
+
+| Métrique | Valeur |
+|---|---|
+| Articles sauvegardés (total) | **301** |
+| Users avec ≥ 1 save | 19 (30 % base) |
+| Articles sauvés + consommés | 194 |
+| **Taux de lecture des articles sauvés** | **64.5 %** |
+
+**Lecture :**
+- Hypothèse R01 ("cimetière, < 15 %") **complètement fausse**. 64.5 % est **exceptionnellement haut** (benchmark read-later apps : 15–30 %).
+- ~16 articles sauvés / user / 30j → **le bookmark est une habitude active**, pas passive.
+- Caveat : il faut vérifier la **causalité** (saved→read ou read→saved) via `collection_items.added_at` vs `user_content_status.updated_at`. Si majoritairement "read-then-save", c'est un signal de **valeur rétrospective** (archiver ce qui a compté), très fort pour le positionnement "slow media".
+
+**Verdict :** **GARDER et mettre en avant.** Envisager :
+- Widget "3 articles vous attendent" sur l'écran d'accueil.
+- Push hebdo "Vos pépites de la semaine" récapitulant les saves.
+- Tracker `bookmark_opened` et `bookmark_revisited` pour confirmer R03.
+
+### 2.5 Mise en perspective — 💀 feature morte
+
+**T3.1 → 0 vues, 0 users uniques sur 30 jours.**
+
+Deux scénarios :
+1. **Instrumentation cassée** : le bouton "Mise en perspective" existe dans l'UI mais ne déclenche pas l'event `comparison_viewed` → test manuel à faire (5 min dans l'app avec ouverture dashboard PostHog live).
+2. **Feature réellement invisible/inutilisée** : les users n'ont pas de point d'entrée ou la feature ne répond pas à un besoin concret.
+
+Epic 7 est à 40 % d'avancement. Continuer à investir dedans sans signal d'usage = risque fort.
+
+**Décision R03 :**
+- D'abord : test manuel (30 min) pour distinguer les 2 hypothèses.
+- Si instrumentation OK et toujours 0 usage → **déprioriser Epic 7, concentrer sur la formation d'habitude (§2.2)**.
+- Si instrumentation KO → fixer, attendre 7 jours, re-mesurer.
+
+### 2.6 Gamification — signal positif mais biaisé
+
+| Cohorte | N | Streak courant moyen | Streak longest moyen |
+|---|---|---|---|
+| Gamif OFF | 9 | 1.22 | 1.56 |
+| Gamif ON | 55 | 1.84 | **3.18 (×2)** |
+
+**Lecture :**
+- Corrélation nette. **MAIS** 86 % des users ont gamif ON → c'est le défaut probable → biais de self-selection quasi total (le groupe OFF est composé de users qui ont activement désactivé, donc probablement des utilisateurs plus sceptiques/rationnels).
+- N=9 sur le groupe OFF est trop petit pour conclure.
+
+**Verdict intermédiaire :** **garder la gamif, mais ne pas prétendre qu'elle est "prouvée"**.
+
+**Action R03 :** A/B test propre (50/50, assignment à l'onboarding), ou mesurer différentiel de complétion digest entre les deux cohortes (dès que T2.1 fonctionne).
+
+---
+
+## 3. Synthèse — verdicts provisoires par feature
+
+| Feature | Statut | Signal | Décision |
+|---|---|---|---|
+| **Digest quotidien** | Aveugle (instrumentation KO) | ❓ | **P0 : fixer tracking, ré-évaluer R03** |
+| **Streaks** | Fonctionnel | ⚠️ Faible adoption profonde (2 % ≥7j) | Garder, enquêter causes cliff J1→J3 |
+| **Bookmarks / "À consulter plus tard"** | Fonctionnel | ✅ **Fort** (64.5 % lus) | **Mettre en avant, investir** |
+| **Feed infini** | Fonctionnel | ⚠️ Durée inconnue (bug) | Fixer durée, re-mesurer |
+| **Mise en perspective** | Aveugle OU morte | 💀 0 vue | Test manuel P0 puis kill ou fix |
+| **Gamification** | Fonctionnel | 🟡 Corrélation biaisée | Garder, A/B test R03 |
+| **Onboarding** | Aveugle (funnel non granulaire) | ❓ | Instrumenter R03 |
+| **Push 8h** | Aveugle | ❓ | Instrumenter R03 |
+| **Paywall / monétisation** | Non existant ou non tracké | ❓ | Attendre PMF avant instrumenter |
+| **Collections custom** | Aveugle | ❓ | Instrumenter ou deprioriser |
+
+---
+
+## 4. Bugs & angles morts critiques identifiés (ordre P0)
+
+| # | Bug / gap | Impact | Fix estimé |
+|---|---|---|---|
+| 1 | `digest_session` non loggé dans `analytics_events` / PostHog | KPI nord invisible | 2h (backend) |
+| 2 | `time_spent_seconds = 0` partout | Métrique temps fausse | 2h (mobile + API) |
+| 3 | `comparison_viewed` absent (0 row 30j) | Epic 7 ingérable | 30 min diagnostic |
+| 4 | Streaks "zombies" (80 % streak≥1 vs 25 % actifs 7j) | Métrique habitude surestimée | 1h audit + fix |
+| 5 | Funnel onboarding non granulaire | Drop-off inconnu | 2h mobile |
+| 6 | `notification_opened` absent | Utilité push inconnue | 1h mobile |
+| 7 | Causalité bookmark (save→read vs read→save) | Narration marketing ambiguë | 30 min requête SQL |
+
+---
+
+## 5. Actions R03 (sous 2 semaines)
+
+### P0 — Débloquer le monitoring
+- [ ] Fixer emission `digest_session` event (backend + mobile) — debloquer closure_rate
+- [ ] Fixer persistence `time_spent_seconds` — debloquer métrique temps
+- [ ] Diagnostiquer `comparison_viewed` (test manuel 30 min)
+- [ ] Audit streak reset logic (éviter streaks zombies)
+
+### P1 — Combler les angles morts
+- [ ] Funnel onboarding granulaire (`onboarding_step_viewed` avec `step_index`)
+- [ ] Notification open tracking (`notification_opened{digest_date}`)
+- [ ] Requête causalité bookmark (save→read vs read→save via timestamps)
+- [ ] Dashboard PostHog Story 14.1 réellement créé et partagé
+
+### P2 — Actions produit data-informed
+- [ ] Widget "3 articles sauvés vous attendent" (ride le signal bookmarks §2.4)
+- [ ] Enquête qualitative 5 users du cliff J1→J3 : pourquoi pas J2 ?
+- [ ] Décision Epic 7 "Mise en perspective" après diagnostic (§2.5)
+
+---
+
+## 6. Benchmarks pour cadrer les prochains rapports
+
+| Métrique | Facteur R02 | Seuil "app vivante" | Seuil "PMF partiel" |
+|---|---|---|---|
+| Users actifs 7j / base | 25 % | 20 % | 40 % |
+| Streak ≥ 7 jours actuel | **2 %** | 10 % | 20 % |
+| Closure rate digest | N/A | 40 % | 60 % |
+| Articles / user / semaine | **17.3** | 10 | 25 |
+| Saved→read rate | **64.5 %** ✅ | 20 % | 40 % |
+| D7 retention (PostHog) | N/A | 15 % | 25 % |
+
+**Où Facteur est bon :** bookmarks, volume de lecture.
+**Où Facteur saigne :** formation d'habitude profonde (streak ≥ 7).
+
+---
+
+## 7. Note méthodo pour le R03
+
+Toutes les requêtes sont maintenant dans `scripts/analytics/run_usage_queries.sh`. Dès que `DATABASE_URL_RO` est injectée dans la session Claude (cf. `docs/infra/claude-access-setup.md`), Claude pourra relancer le rapport en autonomie, sans copier-coller de JSON.
+
+Complément PostHog (DAU/MAU/rétention/funnel) à ajouter dans R03 via `scripts/analytics/posthog_query.py` (à créer).

--- a/docs/analytics/usage-report-2026-04-20.md
+++ b/docs/analytics/usage-report-2026-04-20.md
@@ -1,0 +1,257 @@
+# Rapport d'usage & valeur — Facteur — 2026-04-20 (R01)
+
+> **Premier rapport d'usage.** Objectif : démontrer où en est l'app en termes d'usage / création d'habitudes, identifier blocages et features "utiles vs superflues", et poser les fondations pour un monitoring exploitable sur la durée.
+
+---
+
+## 0. Avertissement méthodologique
+
+Ce rapport R01 est **un audit d'instrumentation + framework KPI**, pas un rapport chiffré. Raisons :
+
+1. La session de rédaction n'a pas d'accès DB/PostHog live (Supabase MCP absent, pas de `DATABASE_URL` injectée côté harness).
+2. Avant de publier des chiffres, il faut valider **ce qui est mesurable** : sans ce cadrage, on risque d'exhiber des métriques trompeuses (ex. "taux de clôture = 72%" calculé sur un dénominateur buggé).
+
+Le livrable est donc :
+- Section 1 — **ce qu'on sait mesurer aujourd'hui** (instrumentation existante).
+- Section 2 — **framework KPI** avec requêtes SQL/PostHog prêtes à exécuter (Laurin ou un agent avec accès DB complète les chiffres au prochain passage).
+- Section 3 — **angles morts** (features en production non instrumentées → on ne peut RIEN dire de leur valeur).
+- Section 4 — **hypothèses features qui marchent / superflues**, fondées sur la cartographie instrumentation × surface produit.
+- Section 5 — **roadmap monitoring R02 → R04**.
+
+Le rapport R02 (prochain) sera chiffré dès que Laurin lance les SQL de la Section 2 et colle les résultats.
+
+---
+
+## 1. Carte de l'instrumentation existante
+
+### 1.1 Canaux de collecte
+
+| Canal | Stockage | Couverture | Fraîcheur |
+|---|---|---|---|
+| `analytics_events` (DB Supabase) | Table Postgres JSONB | Events custom, digest-centrés | Temps réel |
+| PostHog EU | Cloud PostHog | Retention, cohortes, funnels, user properties | Temps réel |
+| `user_content_status` | Table Postgres | État consommé/sauvegardé/temps lu par article | Temps réel |
+| `digest_completions` | Table Postgres | Fin de digest (read/saved/dismissed, closure_time) | Temps réel |
+| `user_streaks` | Table Postgres | Streaks (lecture quotidienne + clôture digest) | Temps réel |
+| Streamlit admin (`admin/app.py`) | Front sur DB | 5 pages opérateur (sources, users, feed, config, curation) | Temps réel |
+| Sentry | Cloud | Erreurs prod (qualité, pas usage) | Temps réel |
+
+### 1.2 Events captés (cross-check `analytics_events` + PostHog)
+
+| Event | Source | KPI alimenté | Fiabilité |
+|---|---|---|---|
+| `session_start` / `app_open` | Mobile | DAU, MAU, sessions/user | ★★★★ (mirror PostHog OK) |
+| `session_end` | Mobile | Durée session | ★★★ (dépend fermeture propre) |
+| `content_interaction` (read/save/skip/swipe) | Mobile | Taux d'interaction, temps lecture | ★★★★ |
+| `digest_session` | Mobile | Taux de clôture digest, articles lus/digest | ★★★★ |
+| `feed_session` | Mobile | Scroll depth, engagement feed | ★★★ |
+| `comparison_viewed` | Mobile | Usage "Mise en perspective" | ★★ (feature récente) |
+| `article_completed` (≥30s) | Mobile | Lecture profonde | ★★★ |
+| `signup_completed` | Backend | Cohortes rétention | ★★★★ |
+| `source_added` | Mobile | Personnalisation | ★★★ |
+| `digest_generated` | Backend (job) | Ops/capacity | ★★★★ |
+| `waitlist_signup` | Backend public | Qualité canal acquisition | ★★★★ |
+
+### 1.3 Events manquants (instrumentation à ajouter — cf. §5)
+
+- ❌ `app_first_launch` dédié (on utilise `MIN(session_start)` en fallback → biais si user réinstalle)
+- ❌ `onboarding_step_viewed` / `onboarding_step_completed` (pas de funnel onboarding granulaire)
+- ❌ `onboarding_dropoff` (où sortent les users pendant les 10-12 questions ?)
+- ❌ `paywall_viewed` / `paywall_dismissed` / `subscription_started` (Epic 6 draft → critique pour monétisation)
+- ❌ `notification_received` / `notification_opened` (pas de mesure d'efficacité push)
+- ❌ `bookmark_revisited` (saves-t-on utiles ? ou cimetière d'articles ?)
+- ❌ `share_article` (pas de feature de partage instrumentée)
+- ❌ `search_performed` (si search existe un jour)
+
+---
+
+## 2. Framework KPI — requêtes à exécuter pour R02
+
+> **À faire par Laurin (ou agent avec DB access) :** exécuter ces requêtes sur la DB prod Supabase (SQL Editor) et PostHog, puis coller les résultats dans `docs/analytics/usage-report-2026-04-20-data.md`. Le R02 sera alors complété automatiquement.
+
+### Tier 1 — Survie
+
+**T1.1 — DAU / WAU / MAU** (PostHog Trends, `app_open`, intervalle Day/Week/Month, 30 derniers jours)
+- **Attendu minimum avant de parler d'app "vivante"** : WAU > 30, ratio DAU/WAU > 0.2 (stickiness).
+
+**T1.2 — Rétention D1/D7/D30** (PostHog Retention, event `app_open`, cohorte `signup_completed`)
+- **Seuils healthy app news/digest** : D1 ≥ 30 %, D7 ≥ 15 %, D30 ≥ 10 % (source : PostHog setup Story 14.1).
+- **Seuils d'alerte rouge** : D7 < 10 % = pas d'habitude formée, repenser le 8h wake-up ou le digest.
+
+**T1.3 — Installations → inscription → 1er digest complété** (PostHog Funnel)
+```
+waitlist_signup OR first app_open → signup_completed → article_read → digest_session{closure_achieved=true}
+```
+- Mesure la **TTV (time-to-value)** du produit.
+
+### Tier 2 — Engagement / habitude
+
+Requêtes SQL à lancer dans Supabase SQL Editor (déjà présentes dans `scripts/analytics_dashboard.sql`, légèrement enrichies) :
+
+**T2.1 — Taux de clôture du digest sur 30 jours** (la métrique nord Facteur)
+```sql
+SELECT
+  DATE(created_at) AS day,
+  COUNT(*) FILTER (WHERE (event_data->>'closure_achieved')::bool) AS closures,
+  COUNT(*) AS digest_sessions,
+  ROUND(100.0 * COUNT(*) FILTER (WHERE (event_data->>'closure_achieved')::bool) / NULLIF(COUNT(*), 0), 1) AS closure_rate_pct,
+  ROUND(AVG((event_data->>'articles_read')::int), 2) AS avg_articles_read,
+  ROUND(AVG((event_data->>'total_time')::int) / 60.0, 1) AS avg_minutes
+FROM analytics_events
+WHERE event_type = 'digest_session'
+  AND created_at > NOW() - INTERVAL '30 days'
+GROUP BY 1 ORDER BY 1 DESC;
+```
+
+**T2.2 — Streaks : combien d'users ont formé une habitude ?**
+```sql
+SELECT
+  COUNT(*) FILTER (WHERE current_streak >= 1) AS streak_1_plus,
+  COUNT(*) FILTER (WHERE current_streak >= 3) AS streak_3_plus,
+  COUNT(*) FILTER (WHERE current_streak >= 7) AS streak_7_plus,
+  COUNT(*) FILTER (WHERE current_streak >= 14) AS streak_14_plus,
+  COUNT(*) FILTER (WHERE longest_streak >= 7) AS has_hit_1_week_ever,
+  MAX(longest_streak) AS max_ever,
+  ROUND(AVG(current_streak), 2) AS avg_current
+FROM user_streaks;
+```
+> **Lecture** : `streak_7_plus / total_users` = % d'users pour qui Facteur est un rituel hebdo. Si < 10 %, l'habitude ne prend pas ; si > 20 %, PMF partiel.
+
+**T2.3 — Temps passé / articles lus par user actif (7j)**
+```sql
+SELECT
+  COUNT(DISTINCT user_id) AS active_users_7d,
+  SUM(time_spent_seconds) / 60.0 AS total_minutes,
+  ROUND(SUM(time_spent_seconds) / 60.0 / NULLIF(COUNT(DISTINCT user_id), 0), 1) AS avg_min_per_user,
+  COUNT(*) FILTER (WHERE status = 'consumed') AS articles_consumed,
+  ROUND(COUNT(*) FILTER (WHERE status = 'consumed') * 1.0 / NULLIF(COUNT(DISTINCT user_id), 0), 1) AS articles_per_user
+FROM user_content_status
+WHERE updated_at > NOW() - INTERVAL '7 days';
+```
+
+**T2.4 — Bookmarks : signal d'intérêt ou cimetière ?**
+```sql
+SELECT
+  COUNT(*) FILTER (WHERE is_saved) AS total_saved,
+  COUNT(DISTINCT user_id) FILTER (WHERE is_saved) AS users_with_saves,
+  COUNT(*) FILTER (WHERE is_saved AND status = 'consumed') AS saved_and_read,
+  ROUND(100.0 * COUNT(*) FILTER (WHERE is_saved AND status = 'consumed')
+        / NULLIF(COUNT(*) FILTER (WHERE is_saved), 0), 1) AS pct_saved_eventually_read
+FROM user_content_status;
+```
+> **Lecture** : si `pct_saved_eventually_read` < 15 %, les bookmarks sont un cimetière → reconsidérer la feature ou ajouter un rappel.
+
+### Tier 3 — Valeur par feature (hypothèses marchent / superflues)
+
+**T3.1 — Usage "Mise en perspective" (Ground News-like)**
+```sql
+SELECT
+  COUNT(*) AS comparison_views_30d,
+  COUNT(DISTINCT user_id) AS unique_users,
+  ROUND(100.0 * COUNT(DISTINCT user_id) /
+    NULLIF((SELECT COUNT(DISTINCT user_id) FROM analytics_events
+            WHERE event_type = 'session_start' AND created_at > NOW() - INTERVAL '30 days'), 0), 1)
+    AS adoption_pct_of_active_users
+FROM analytics_events
+WHERE event_type = 'comparison_viewed' AND created_at > NOW() - INTERVAL '30 days';
+```
+> **Lecture** : < 5 % d'adoption = feature potentiellement superflue pour le MVP. > 15 % = signal fort → investir Epic 7.
+
+**T3.2 — Top/flop sources** (déjà dans `scripts/analytics_dashboard.sql` §5 — net_growth adds − removes).
+
+**T3.3 — Gamification tire-t-elle l'engagement ?**
+```sql
+-- Compare comportement users gamification ON vs OFF
+SELECT
+  p.gamification_enabled,
+  COUNT(DISTINCT p.user_id) AS n_users,
+  AVG(s.current_streak) AS avg_current_streak,
+  AVG(s.longest_streak) AS avg_longest_streak
+FROM user_profiles p
+LEFT JOIN user_streaks s USING (user_id)
+GROUP BY 1;
+```
+> **Lecture** : si gamif ON ≈ gamif OFF sur streaks, la gamif est du bruit visuel → simplifier.
+
+---
+
+## 3. Angles morts — features en prod non instrumentées
+
+Ces features tournent depuis N semaines mais on n'a **aucune donnée d'usage** → impossible de statuer sur leur valeur réelle.
+
+| Feature | Instrumentation actuelle | Conséquence |
+|---|---|---|
+| **Onboarding 10-12 questions** | Complétion globale (`signup_completed`) seulement | On ignore les drop-offs par question → peut-être 60 % abandonnent à Q8 ? |
+| **Notifications push 8h** | Zéro event `notification_opened` | On ne sait pas si la notif tire l'usage ou si les users reviendraient sans |
+| **Bookmarks "À consulter plus tard"** | On voit les saves (T2.4), pas les retours | Cimetière probable (cf. stats usuelles : 85 % des read-later ne sont jamais ouverts) |
+| **Collections custom** | Pas d'event `collection_created` / `collection_viewed` | Feature visible dans le code (Epic TBD) mais invisible analytics |
+| **Mute source/topic** | Pas d'event dédié (mute silencieux) | On ignore si les users configurent activement leur feed |
+| **Paywall detection** | Pas d'event `paywall_clicked` | On ignore si le marqueur aide ou agace |
+| **Paywall premium / trial** | Pas d'instrumentation Epic 6 | Monétisation opaque |
+| **Partage article** | Feature absente ou non trackée | Aucun signal viral |
+
+---
+
+## 4. Hypothèses — features qui marchent vs superflues
+
+**Hypothèses à confirmer/infirmer par les chiffres de §2.** Ordre par risque-strat décroissant.
+
+### 4.1 Features probablement qui marchent (à double-checker)
+
+1. **Digest quotidien "5 articles + closure"** — c'est la promesse produit, et toute l'instrumentation converge (`digest_session`, `closure_achieved`, streaks). **Si closure_rate > 40 % et streak_7_plus > 15 % → PMF partiel confirmé.**
+2. **Onboarding ludique** — 100 % stories complétées, et tous les users qui arrivent au feed ont accepté les 10-12 questions. Mais **le taux d'abandon est invisible** (cf. §3).
+3. **Streaks** — présence d'une table dédiée + longest_streak suggère que des users ont déjà une habitude. À confirmer T2.2.
+
+### 4.2 Features à défendre avec des chiffres — sinon tailler
+
+1. **Mise en perspective (Ground News-like)** — Epic 7 à 40 %, feature coûteuse (clustering multi-sources). Si T3.1 < 5 % d'adoption → deprioriser jusqu'à signal.
+2. **Gamification (points, level, weekly goals)** — si T3.3 ne montre pas de différentiel ON/OFF, c'est de la surface produit pour rien.
+3. **Bookmarks / Collections** — si T2.4 < 15 % de retour et pas de `collection_viewed` → soit supprimer, soit ajouter un rappel "3 articles attendent dans vos favoris".
+4. **Feed infini personnalisé** — paradoxe : l'app vend du "slow media" (digest borné) mais propose un feed infini. Si temps feed >> temps digest, la vraie valeur livrée est l'inverse de la promesse → repositionnement ou taille.
+
+### 4.3 Features probablement superflues à court terme
+
+1. **Custom topics / collections** — peu documentés, peu instrumentés → sandbox avancée pour power users qu'on n'a pas encore.
+2. **Settings granulaires paywall / formats** — utile seulement si > 30 % des users les touchent.
+3. **Badges d'inactivité** (détectés dans admin page 2) — feature admin, zéro valeur user.
+
+---
+
+## 5. Roadmap monitoring — R02 à R04
+
+### R02 (sous 7 jours) — chiffrer
+
+- [ ] Exécuter les 8 requêtes de §2 (Supabase SQL Editor + PostHog) → remplir `usage-report-2026-04-20-data.md`.
+- [ ] Lancer Streamlit admin `admin/app.py` en local, screenshot des 2 pages "Users Overview" et "Feed Quality" pour narration.
+- [ ] Publier R02 avec verdict Go/No-Go sur les 4 hypothèses §4.
+
+### R03 (sous 3 semaines) — combler les angles morts critiques
+
+- [ ] **Funnel onboarding granulaire** : ajouter `onboarding_step_viewed` / `onboarding_step_completed` avec `step_index` — 2h dev mobile.
+- [ ] **Notifications push** : hook `onNotificationOpened` Firebase → event `notification_opened{digest_date}` — mesure l'uplift DAU les jours de push.
+- [ ] **Bookmark revisit** : event `bookmark_opened` quand user ouvre un article depuis la liste saved — qualifie le cimetière.
+- [ ] **Paywall** (si Epic 6 avance) : `paywall_viewed`, `paywall_dismissed`, `trial_started`, `subscription_activated`.
+
+### R04 (sous 6 semaines) — industrialiser
+
+- [ ] **Dashboard PostHog publié** : les 9 insights listés dans `posthog-dashboard-setup.md` effectivement créés et partagés (statut actuel : documentés mais non vérifiés).
+- [ ] **Alerte Slack/email "chute DAU > 30 % D-1"** active (prévue dans la doc PostHog mais probablement pas encore câblée).
+- [ ] **Rapport auto hebdo** : cron `GET /admin/usage-digest` qui poste un résumé dans un Slack `#facteur-metrics` — rend le monitoring automatique.
+- [ ] **Single source of truth** : consolider `analytics_events` (custom) et PostHog dans une seule vue (BigQuery ou DuckDB + dbt). Le doublon actuel crée du travail de réconciliation.
+
+### Corrections de fond recommandées
+
+1. **Renommer / uniformiser les event types** : on voit `content_interaction{action=read}` côté mobile mais `article_read` côté PostHog. Une seule convention (snake_case, par event atomique) évite les bugs de requêtes.
+2. **`device_id` vs `user_id`** : aujourd'hui `event_data.device_id` est dans le JSONB → indexer sur colonne dédiée pour pouvoir faire du "anonymous → signed-up" linking propre.
+3. **Ajouter `app_first_launch` explicite** (côté Flutter, au premier lancement d'une install) pour éviter le fallback `MIN(session_start)` qui casse en cas de réinstall.
+4. **Ajouter `schema_version` dans `event_data`** → si on change la structure d'un payload, on peut versionner sans casser les requêtes historiques.
+5. **Ops digest** : instrumenter `digest_generated{stats.failed}` (déjà dans la doc PostHog, à vérifier en code) et poser l'alerte seuil `failed > 10`.
+
+---
+
+## 6. TL;DR pour Laurin
+
+- **On ne peut pas encore répondre à "est-ce que Facteur crée des habitudes ?"** — mais on sait exactement quelles 3 requêtes lancer pour trancher (T1.2 Retention D7, T2.1 closure_rate 30j, T2.2 streak_7_plus).
+- **L'instrumentation digest est solide** (4 events fiables). **L'instrumentation onboarding, notifications et monétisation est quasi-inexistante** → angles morts stratégiques.
+- **4 features à mettre sous observation** : Mise en perspective, Gamification, Bookmarks/Collections, Feed infini. Chacune a une requête dédiée §2-3 pour décider maintien / suppression.
+- **Prochaine action** : Laurin lance les SQL §2 dans Supabase SQL Editor (5 min) → je rédige R02 avec les vrais chiffres + verdicts.

--- a/docs/infra/claude-access-setup.md
+++ b/docs/infra/claude-access-setup.md
@@ -1,126 +1,308 @@
-# Claude Code — Accès sécurisé aux données analytics
+# Accès sécurisés pour les agents Claude
 
-> Permet à une session Claude Code (y compris web / triggered GitHub) de lire
-> les données prod nécessaires aux rapports d'usage, **sans jamais** accéder
-> en écriture ni à `auth.*`.
+> Objectif : permettre à un agent Claude (local, Claude Code on the web,
+> session déclenchée par GitHub Action) d'**investiguer** (logs, erreurs,
+> schéma, analytics) sans jamais pouvoir **détruire** ni accéder à des
+> données utilisateur non nécessaires.
 
-## Périmètre
+Principes :
+- **Least-privilege par défaut.** Chaque token a le scope minimal.
+- **Read-only sauf exception explicite.** Les tokens d'écriture (déploiement,
+  migrations) restent côté humain / CI, jamais côté agent.
+- **Rotation trimestrielle** (label `Q1-2026` dans le nom du token pour
+  traçabilité).
+- **Aucune donnée PII** dans les dumps / logs partagés avec l'agent.
 
-| Ressource | Usage | Mode |
-|---|---|---|
-| Supabase DB | Lecture `analytics_events`, `user_*`, `sources`, `contents`, `digest_*` | **read-only** via rôle dédié |
-| PostHog | Lecture events, cohortes, insights | **read-only** via personal API key scopée |
-| Railway | Logs / metrics (optionnel) | **read-only** via token scope logs |
-| Sentry | Déjà OK via `sentry-cli` | token existant |
+---
 
-## Étape 1 — Rôle Supabase read-only (1 fois)
+## 1. Panorama des accès (quoi donner à un agent, et pour quoi faire)
 
-Dans Supabase SQL Editor (prod) :
+| Service | Besoin agent | Scope exact | Secret correspondant |
+|---|---|---|---|
+| **Supabase — MCP** | Explorer schéma, lancer SELECT | PAT perso **read-only** | `SUPABASE_ACCESS_TOKEN` |
+| **Supabase — DB directe** | Lancer requêtes SQL (analytics, debug) | Rôle PG `claude_analytics_ro` (SELECT only) | `DATABASE_URL_RO` |
+| **Railway** | Lire les logs prod, inspecter variables | Project Token scope **read-only** | `RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_SERVICE_ID` |
+| **Sentry** | Lire issues, events, session replay | Auth Token scope `event:read`, `project:read`, `org:read` | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` |
+| **PostHog** | Lire insights, cohortes, events | Personal API key scope `insight:read`, `cohort:read`, `event:read` | `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID`, `POSTHOG_HOST` |
+| **GitHub** | PR, issues, checks | Déjà géré via MCP côté Claude (app installée sur le repo) | *(rien à faire côté dev)* |
+
+**À NE JAMAIS donner à un agent :**
+- `SUPABASE_SERVICE_ROLE_KEY` (bypass RLS, accès auth.users, destructif).
+- Railway token scope "Full Access" (peut déployer, supprimer projet).
+- `SENTRY_AUTH_TOKEN` avec scope `project:write` / `member:admin`.
+- PostHog Personal API key avec scope `*:write`.
+- Clé Stripe, clé OpenAI prod, credentials APNS/FCM.
+
+---
+
+## 2. Création des tokens — procédure par service
+
+### 2.1 Supabase — PAT pour MCP (read-only)
+
+1. app.supabase.com → **Account** → **Access Tokens** → *Generate new token*.
+2. Nom : `claude-agent-readonly-Q1-2026`.
+3. Copie la valeur → à coller dans `SUPABASE_ACCESS_TOKEN`.
+4. Le MCP est déjà configuré en `--read-only` dans `.mcp.json` → pas d'action
+   supplémentaire.
+
+### 2.2 Supabase — Rôle PG `claude_analytics_ro` (SQL direct)
+
+À faire **une fois** dans Supabase SQL Editor (prod) :
 
 ```sql
--- Rôle dédié Claude, SELECT-only
-CREATE ROLE claude_analytics_ro NOINHERIT LOGIN PASSWORD '<password_fort>';
+-- Rôle SELECT-only pour les requêtes analytics / debug d'agent
+CREATE ROLE claude_analytics_ro NOINHERIT LOGIN PASSWORD '<pwd_fort>';
 
--- Accorde uniquement les tables analytics nécessaires
 GRANT CONNECT ON DATABASE postgres TO claude_analytics_ro;
-GRANT USAGE ON SCHEMA public TO claude_analytics_ro;
-GRANT SELECT ON
+GRANT USAGE   ON SCHEMA public      TO claude_analytics_ro;
+GRANT SELECT  ON
   analytics_events,
-  user_profiles,
-  user_streaks,
-  user_subscriptions,
-  user_content_status,
-  user_personalization,
-  user_topic_progress,
-  digest_completions,
-  daily_digest,
-  daily_top3,
-  sources,
-  contents,
-  collections
+  user_profiles, user_streaks, user_subscriptions,
+  user_content_status, user_personalization, user_topic_progress,
+  digest_completions, daily_digest, daily_top3,
+  sources, contents, collections
 TO claude_analytics_ro;
 
--- Verrou : pas d'accès aux nouvelles tables par défaut (révoque DEFAULT PRIVILEGES)
-ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM claude_analytics_ro;
+-- Verrou : nouvelles tables non accessibles par défaut (doit être explicite).
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  REVOKE ALL ON TABLES FROM claude_analytics_ro;
 ```
 
-Note la `DATABASE_URL_RO` au format :
+URL à mettre dans `DATABASE_URL_RO` :
+
 ```
-postgresql://claude_analytics_ro:<password>@db.ykuadtelnzavrqzbfdve.supabase.co:5432/postgres?sslmode=require
-```
-
-## Étape 2 — Secrets dans la session Claude (GitHub → Actions/Codespaces)
-
-Dans GitHub `Settings → Secrets and variables → Actions` :
-
-| Secret | Valeur | Rotation |
-|---|---|---|
-| `SUPABASE_ACCESS_TOKEN` | PAT Supabase perso (scope : MCP read-only) | trimestrielle |
-| `DATABASE_URL_RO` | URL du rôle `claude_analytics_ro` (étape 1) | trimestrielle |
-| `POSTHOG_PERSONAL_API_KEY` | Personal API key PostHog **scoped read-only** sur le projet `Facteur Prod` | trimestrielle |
-| `POSTHOG_PROJECT_ID` | ID numérique du projet PostHog (pas un secret en soi) | stable |
-| `RAILWAY_TOKEN` | Token Railway scope **logs read-only** | trimestrielle |
-
-Ces secrets sont injectés comme `env` dans les sessions Claude Code triggered
-via GitHub Actions (ou via la config Claude Code on the web → "Repository secrets").
-
-## Étape 3 — MCP Supabase (déjà déclaré)
-
-Le fichier `.mcp.json` à la racine déclare le MCP Supabase en mode `--read-only` :
-
-```json
-{
-  "mcpServers": {
-    "supabase": {
-      "command": "npx",
-      "args": ["-y", "@supabase/mcp-server-supabase@latest",
-               "--read-only", "--project-ref=ykuadtelnzavrqzbfdve"],
-      "env": { "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}" }
-    }
-  }
-}
+postgresql://claude_analytics_ro:<pwd>@db.ykuadtelnzavrqzbfdve.supabase.co:5432/postgres?sslmode=require
 ```
 
-Au prochain lancement de session, Claude Code chargera automatiquement ce MCP
-si `SUPABASE_ACCESS_TOKEN` est présent dans l'env.
+### 2.3 Railway — Project Token read-only
 
-## Étape 4 — PostHog via API (pas besoin de MCP)
+1. railway.app → ton projet → **Settings** → **Tokens** → *New Token*.
+2. **Scope** : cocher uniquement `Read` (pas `Deploy`, pas `Full Access`).
+3. Nom : `claude-agent-logs-Q1-2026`.
+4. Copie dans `RAILWAY_TOKEN`.
+5. Récupère `RAILWAY_PROJECT_ID` et `RAILWAY_SERVICE_ID` : `railway status`
+   ou via l'URL `/project/<PROJECT_ID>/service/<SERVICE_ID>`.
 
-PostHog expose une REST API lisible directement via `curl` / `WebFetch`. Exemple
-de requête DAU sur 30 jours :
+Utilisation côté agent :
+```bash
+railway logs --project $RAILWAY_PROJECT_ID --service $RAILWAY_SERVICE_ID
+railway variables --project $RAILWAY_PROJECT_ID --service $RAILWAY_SERVICE_ID
+```
+
+### 2.4 Sentry — Auth Token scope event/project read
+
+1. sentry.io → **Settings** (user) → **Auth Tokens** → *Create New Token*.
+2. Scopes à cocher : `event:read`, `project:read`, `org:read` — rien d'autre.
+3. Nom : `claude-agent-sentry-Q1-2026`.
+4. Copie dans `SENTRY_AUTH_TOKEN`.
+5. `SENTRY_ORG` et `SENTRY_PROJECT` se trouvent dans l'URL Sentry
+   (`sentry.io/organizations/<ORG>/projects/<PROJECT>/`).
+
+L'agent pourra lancer :
+```bash
+sentry-cli issues list --project $SENTRY_PROJECT --org $SENTRY_ORG
+sentry-cli events list --project $SENTRY_PROJECT --org $SENTRY_ORG --max-rows 10
+```
+
+### 2.5 PostHog — Personal API key scoped
+
+1. eu.posthog.com → **Settings** → **Personal API keys** → *Create*.
+2. Scopes : `insight:read`, `cohort:read`, `event:read`,
+   `feature_flag:read` (facultatif). Rien d'autre.
+3. Projet : sélectionne uniquement **Facteur Prod** (pas "All projects").
+4. Nom : `claude-agent-analytics-Q1-2026`.
+5. Copie dans `POSTHOG_PERSONAL_API_KEY`.
+6. `POSTHOG_PROJECT_ID` : voir `Settings` → `Project` → `Project ID` (numérique).
+7. `POSTHOG_HOST` = `https://eu.i.posthog.com` (déjà par défaut dans
+   `.env.example`).
+
+### 2.6 GitHub — déjà fait
+
+Claude Code on the web utilise l'installation GitHub App configurée sur
+`boujonlaurin-dotcom/facteur`. Les tools `mcp__github__*` sont déjà
+autorisés au niveau session, pas de token à gérer.
+
+---
+
+## 3. Stocker les secrets pour que Claude les voie
+
+Il y a **trois surfaces** où injecter les secrets selon comment l'agent est
+déclenché.
+
+### 3.1 Claude Code **local** (ton terminal) — fichier `.env`
+
+1. `cp .env.example .env`
+2. Remplis les 5 blocs (Supabase, DB_URL_RO, Railway, Sentry, PostHog).
+3. **Jamais committer `.env`** — il est dans `.gitignore`, mais vérifie :
+   ```bash
+   git check-ignore .env    # doit afficher ".env"
+   ```
+4. Charge automatiquement les secrets dans la session :
+   - Option A — manuel à chaque session : `export $(grep -v '^#' .env | xargs)`
+   - Option B (recommandée) — **direnv** :
+     ```bash
+     # installation
+     brew install direnv   # ou apt-get install direnv
+     # hook shell (.zshrc / .bashrc) : eval "$(direnv hook zsh)"
+     # dans le repo :
+     echo "dotenv" > .envrc
+     direnv allow
+     ```
+     Dès que tu `cd` dans `~/facteur`, tous les secrets sont exportés —
+     et désactivés dès que tu sors.
+
+### 3.2 Claude Code **on the web** (claude.ai/code) — secrets du repo
+
+L'interface web de Claude Code lit les secrets du repo GitHub lorsque la
+session est déclenchée sur ce repo.
+
+1. GitHub → ton repo → **Settings** → **Secrets and variables** → **Actions**.
+2. Clique **New repository secret**.
+3. Crée **un secret par variable** (noms identiques à `.env.example`) :
+   - `SUPABASE_ACCESS_TOKEN`
+   - `DATABASE_URL_RO`
+   - `RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_SERVICE_ID`
+   - `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`
+   - `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID`, `POSTHOG_HOST`
+4. (Pas dans Secrets mais dans **Variables**) : tout ce qui n'est **pas
+   sensible** peut aller dans **Variables** plutôt que Secrets — ex.
+   `POSTHOG_HOST`, `RAILWAY_PROJECT_ID`, `SENTRY_ORG`, `SUPABASE_URL`.
+   Avantage : valeurs visibles dans les logs, plus faciles à debugger.
+
+> **Règle du pouce** : si la fuite de la valeur est grave → Secret.
+> Si ce n'est qu'un ID public → Variable.
+
+### 3.3 Claude déclenché depuis un **GitHub Actions workflow**
+
+Si tu veux qu'un workflow lance un agent Claude (ex : rapport d'usage
+hebdo), il faut passer les secrets dans l'`env:` du job. Exemple :
+
+```yaml
+# .github/workflows/weekly-usage-report.yml
+name: Weekly usage report
+on:
+  schedule: [{ cron: "0 6 * * 1" }]  # lundi 6h UTC
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1    # ou équivalent
+        env:
+          SUPABASE_ACCESS_TOKEN:    ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          DATABASE_URL_RO:          ${{ secrets.DATABASE_URL_RO }}
+          RAILWAY_TOKEN:            ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID:       ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_SERVICE_ID:       ${{ vars.RAILWAY_SERVICE_ID }}
+          SENTRY_AUTH_TOKEN:        ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG:               ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT:           ${{ vars.SENTRY_PROJECT }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID:       ${{ vars.POSTHOG_PROJECT_ID }}
+          POSTHOG_HOST:             ${{ vars.POSTHOG_HOST }}
+        with:
+          prompt: "Relance scripts/analytics/run_usage_queries.sh et commit le rapport dans docs/analytics/"
+```
+
+Remarques :
+- `secrets.*` pour les vraies valeurs sensibles, `vars.*` pour les IDs publics.
+- N'utilise **jamais** `${{ env.SECRET }}` dans un `run:` sans quoter : GH
+  masque automatiquement les secrets dans les logs, mais une expression mal
+  échappée peut fuiter.
+
+### 3.4 Ordre de priorité côté agent
+
+Quand l'agent s'exécute, il lit les variables dans cet ordre :
+1. Variables d'environnement du process (injectées par GH Actions ou direnv).
+2. Fichier `.env` local (uniquement si chargé explicitement — pas
+   automatique côté session web).
+
+Donc : **en web / CI, utilise les GitHub Secrets.**
+**En local, utilise `.env` + direnv.**
+
+---
+
+## 4. Vérification (healthcheck 30 secondes)
+
+Une fois les secrets en place, lance le healthcheck pour vérifier que chaque
+service répond :
 
 ```bash
-curl -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-  "$POSTHOG_HOST/api/projects/$POSTHOG_PROJECT_ID/insights/trend/?events=[{\"id\":\"app_open\",\"math\":\"dau\"}]&date_from=-30d&interval=day"
+# Supabase DB read-only
+psql "$DATABASE_URL_RO" -c "SELECT current_user, session_user;"
+# → doit afficher "claude_analytics_ro | claude_analytics_ro"
+
+# Supabase MCP (via CLI)
+supabase projects list --access-token "$SUPABASE_ACCESS_TOKEN" | head -3
+
+# Railway
+railway status
+
+# Sentry
+sentry-cli info
+
+# PostHog
+curl -sf -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  "$POSTHOG_HOST/api/projects/$POSTHOG_PROJECT_ID/" | jq -r .name
 ```
 
-Un helper `scripts/analytics/posthog_query.py` sera ajouté dans R03 (voir
-roadmap du rapport d'usage).
+Si l'un retourne `permission denied` ou `401` → revoir le scope du token
+correspondant.
 
-## Étape 5 — Vérification
+---
 
-Test local :
+## 5. Garde-fous actifs
 
-```bash
-# Depuis la racine du repo avec .env chargé
-export $(grep -v '^#' .env | xargs)
-bash scripts/analytics/run_usage_queries.sh | jq .
-```
+1. **`scripts/analytics/run_usage_queries.sh`** refuse de tourner si
+   `DATABASE_URL_RO` pointe vers `service_role` ou `postgres:postgres`.
+2. **`.gitignore`** contient déjà `.env` — double-check via
+   `git check-ignore .env`.
+3. **`ALTER DEFAULT PRIVILEGES ... REVOKE ALL`** côté Supabase empêche
+   `claude_analytics_ro` de gagner automatiquement l'accès aux nouvelles
+   tables (ex : `payments`, `stripe_events` si ajoutées plus tard).
+4. **Audit trimestriel** : liste les sessions actives
+   ```sql
+   SELECT usename, client_addr, query_start, state, query
+   FROM pg_stat_activity WHERE usename = 'claude_analytics_ro';
+   ```
+   Si des requêtes douteuses apparaissent, rotate la password du rôle.
 
-Devrait produire un JSON avec les 8 blocs de requêtes renseignés. Si une
-requête échoue avec `permission denied for table X`, ajoute la table au GRANT
-de l'étape 1 (et documente-la ici).
+---
 
-## Garde-fous
+## 6. Rotation / révocation d'urgence
 
-1. **Jamais de `service_role`** dans `DATABASE_URL_RO`. Le script
-   `run_usage_queries.sh` refuse de tourner si c'est détecté.
-2. **Révocation** : `ALTER DEFAULT PRIVILEGES ... REVOKE ALL` empêche
-   claude_analytics_ro de gagner accès aux nouvelles tables automatiquement —
-   chaque ajout est explicite.
-3. **Audit** : active `pgaudit` ou consulte régulièrement
-   `pg_stat_activity` filtré sur `usename = 'claude_analytics_ro'`.
-4. **Scope PostHog** : la personal API key doit être créée avec scope
-   `insight:read`, `cohort:read`, `event:read` uniquement — jamais `*:write`.
-5. **Rotation** : rotation trimestrielle, automatisée via un calendrier
-   partagé ou un reminder Linear.
+En cas de fuite suspectée :
+
+| Service | Commande de révocation |
+|---|---|
+| Supabase PAT | app.supabase.com → Account → Access Tokens → *Revoke* |
+| `claude_analytics_ro` | `ALTER ROLE claude_analytics_ro PASSWORD '<new>';` (SQL Editor) |
+| Railway token | railway.app → Project → Tokens → *Delete* |
+| Sentry token | sentry.io → Settings → Auth Tokens → *Remove* |
+| PostHog PAK | eu.posthog.com → Settings → Personal API keys → *Delete* |
+
+Après rotation :
+1. Mets à jour `.env` local.
+2. Mets à jour GitHub Secrets (même nom de secret, nouvelle valeur — pas
+   besoin de changer les workflows).
+3. Relance le healthcheck §4.
+
+---
+
+## 7. Checklist one-shot pour l'utilisateur
+
+À faire **dans l'ordre** pour tout activer :
+
+- [ ] Créer PAT Supabase → `SUPABASE_ACCESS_TOKEN`
+- [ ] Lancer le SQL §2.2 → noter la `DATABASE_URL_RO`
+- [ ] Créer Project Token Railway (scope Read) → `RAILWAY_TOKEN` + IDs
+- [ ] Créer Auth Token Sentry (scopes read uniquement) → `SENTRY_AUTH_TOKEN`
+- [ ] Créer Personal API key PostHog (read-only) → `POSTHOG_PERSONAL_API_KEY`
+- [ ] Remplir `.env` local (copier depuis `.env.example`)
+- [ ] `direnv allow` (ou `export $(grep -v '^#' .env | xargs)`)
+- [ ] Lancer le healthcheck §4 → tous verts
+- [ ] Dans GitHub → Settings → Secrets : créer les 6 secrets sensibles
+- [ ] Dans GitHub → Settings → Variables : créer les 6 IDs/hosts non-sensibles
+- [ ] (Optionnel) Ajouter le workflow weekly §3.3 pour automatiser le rapport

--- a/docs/infra/claude-access-setup.md
+++ b/docs/infra/claude-access-setup.md
@@ -68,11 +68,19 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
   REVOKE ALL ON TABLES FROM claude_analytics_ro;
 ```
 
-URL à mettre dans `DATABASE_URL_RO` :
+URL à mettre dans `DATABASE_URL_RO` (le mot de passe est celui que tu as
+défini à la ligne `PASSWORD` ci-dessus) :
 
-```
-postgresql://claude_analytics_ro:<pwd>@db.ykuadtelnzavrqzbfdve.supabase.co:5432/postgres?sslmode=require
-```
+- Host : `db.ykuadtelnzavrqzbfdve.supabase.co`
+- Port : `5432`
+- User : `claude_analytics_ro`
+- Database : `postgres`
+- SSL mode : `require`
+
+Assemblage : URI PostgreSQL standard (voir
+[doc officielle libpq](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING))
+en injectant les 4 valeurs ci-dessus plus le mot de passe choisi à la
+ligne `PASSWORD` du SQL.
 
 ### 2.3 Railway — Project Token read-only
 

--- a/docs/infra/claude-access-setup.md
+++ b/docs/infra/claude-access-setup.md
@@ -1,0 +1,126 @@
+# Claude Code — Accès sécurisé aux données analytics
+
+> Permet à une session Claude Code (y compris web / triggered GitHub) de lire
+> les données prod nécessaires aux rapports d'usage, **sans jamais** accéder
+> en écriture ni à `auth.*`.
+
+## Périmètre
+
+| Ressource | Usage | Mode |
+|---|---|---|
+| Supabase DB | Lecture `analytics_events`, `user_*`, `sources`, `contents`, `digest_*` | **read-only** via rôle dédié |
+| PostHog | Lecture events, cohortes, insights | **read-only** via personal API key scopée |
+| Railway | Logs / metrics (optionnel) | **read-only** via token scope logs |
+| Sentry | Déjà OK via `sentry-cli` | token existant |
+
+## Étape 1 — Rôle Supabase read-only (1 fois)
+
+Dans Supabase SQL Editor (prod) :
+
+```sql
+-- Rôle dédié Claude, SELECT-only
+CREATE ROLE claude_analytics_ro NOINHERIT LOGIN PASSWORD '<password_fort>';
+
+-- Accorde uniquement les tables analytics nécessaires
+GRANT CONNECT ON DATABASE postgres TO claude_analytics_ro;
+GRANT USAGE ON SCHEMA public TO claude_analytics_ro;
+GRANT SELECT ON
+  analytics_events,
+  user_profiles,
+  user_streaks,
+  user_subscriptions,
+  user_content_status,
+  user_personalization,
+  user_topic_progress,
+  digest_completions,
+  daily_digest,
+  daily_top3,
+  sources,
+  contents,
+  collections
+TO claude_analytics_ro;
+
+-- Verrou : pas d'accès aux nouvelles tables par défaut (révoque DEFAULT PRIVILEGES)
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM claude_analytics_ro;
+```
+
+Note la `DATABASE_URL_RO` au format :
+```
+postgresql://claude_analytics_ro:<password>@db.ykuadtelnzavrqzbfdve.supabase.co:5432/postgres?sslmode=require
+```
+
+## Étape 2 — Secrets dans la session Claude (GitHub → Actions/Codespaces)
+
+Dans GitHub `Settings → Secrets and variables → Actions` :
+
+| Secret | Valeur | Rotation |
+|---|---|---|
+| `SUPABASE_ACCESS_TOKEN` | PAT Supabase perso (scope : MCP read-only) | trimestrielle |
+| `DATABASE_URL_RO` | URL du rôle `claude_analytics_ro` (étape 1) | trimestrielle |
+| `POSTHOG_PERSONAL_API_KEY` | Personal API key PostHog **scoped read-only** sur le projet `Facteur Prod` | trimestrielle |
+| `POSTHOG_PROJECT_ID` | ID numérique du projet PostHog (pas un secret en soi) | stable |
+| `RAILWAY_TOKEN` | Token Railway scope **logs read-only** | trimestrielle |
+
+Ces secrets sont injectés comme `env` dans les sessions Claude Code triggered
+via GitHub Actions (ou via la config Claude Code on the web → "Repository secrets").
+
+## Étape 3 — MCP Supabase (déjà déclaré)
+
+Le fichier `.mcp.json` à la racine déclare le MCP Supabase en mode `--read-only` :
+
+```json
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": ["-y", "@supabase/mcp-server-supabase@latest",
+               "--read-only", "--project-ref=ykuadtelnzavrqzbfdve"],
+      "env": { "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}" }
+    }
+  }
+}
+```
+
+Au prochain lancement de session, Claude Code chargera automatiquement ce MCP
+si `SUPABASE_ACCESS_TOKEN` est présent dans l'env.
+
+## Étape 4 — PostHog via API (pas besoin de MCP)
+
+PostHog expose une REST API lisible directement via `curl` / `WebFetch`. Exemple
+de requête DAU sur 30 jours :
+
+```bash
+curl -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  "$POSTHOG_HOST/api/projects/$POSTHOG_PROJECT_ID/insights/trend/?events=[{\"id\":\"app_open\",\"math\":\"dau\"}]&date_from=-30d&interval=day"
+```
+
+Un helper `scripts/analytics/posthog_query.py` sera ajouté dans R03 (voir
+roadmap du rapport d'usage).
+
+## Étape 5 — Vérification
+
+Test local :
+
+```bash
+# Depuis la racine du repo avec .env chargé
+export $(grep -v '^#' .env | xargs)
+bash scripts/analytics/run_usage_queries.sh | jq .
+```
+
+Devrait produire un JSON avec les 8 blocs de requêtes renseignés. Si une
+requête échoue avec `permission denied for table X`, ajoute la table au GRANT
+de l'étape 1 (et documente-la ici).
+
+## Garde-fous
+
+1. **Jamais de `service_role`** dans `DATABASE_URL_RO`. Le script
+   `run_usage_queries.sh` refuse de tourner si c'est détecté.
+2. **Révocation** : `ALTER DEFAULT PRIVILEGES ... REVOKE ALL` empêche
+   claude_analytics_ro de gagner accès aux nouvelles tables automatiquement —
+   chaque ajout est explicite.
+3. **Audit** : active `pgaudit` ou consulte régulièrement
+   `pg_stat_activity` filtré sur `usename = 'claude_analytics_ro'`.
+4. **Scope PostHog** : la personal API key doit être créée avec scope
+   `insight:read`, `cohort:read`, `event:read` uniquement — jamais `*:write`.
+5. **Rotation** : rotation trimestrielle, automatisée via un calendrier
+   partagé ou un reminder Linear.

--- a/scripts/analytics/run_usage_queries.sh
+++ b/scripts/analytics/run_usage_queries.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# run_usage_queries.sh — Lance les requêtes KPI du rapport d'usage sur la DB Supabase.
+#
+# Prérequis : DATABASE_URL_RO exporté (rôle claude_analytics_ro, SELECT-only).
+# Sortie : JSON sur stdout, un objet par requête ({ "T2_1": [...], "T2_2": [...], ... }).
+#
+# Usage :
+#   export $(grep -v '^#' .env | xargs)  # charge .env
+#   bash scripts/analytics/run_usage_queries.sh > /tmp/usage.json
+#   # puis colle /tmp/usage.json dans le chat ou dans docs/analytics/usage-report-*.md
+#
+# Safe by design : refuse de tourner si DATABASE_URL_RO contient "service_role" ou "postgres:postgres".
+
+set -euo pipefail
+
+if [[ -z "${DATABASE_URL_RO:-}" ]]; then
+  echo "ERROR: DATABASE_URL_RO non défini (voir .env.example)" >&2
+  exit 1
+fi
+
+if [[ "$DATABASE_URL_RO" == *"service_role"* || "$DATABASE_URL_RO" == *"postgres:postgres"* ]]; then
+  echo "ERROR: DATABASE_URL_RO semble pointer vers un rôle avec écriture. Utilise claude_analytics_ro." >&2
+  exit 1
+fi
+
+# psql via docker si pas installé localement — évite d'installer PG client sur la machine.
+PSQL="psql"
+if ! command -v psql >/dev/null 2>&1; then
+  PSQL="docker run --rm -e PGPASSWORD -i postgres:16 psql"
+fi
+
+query() {
+  local label="$1"
+  local sql="$2"
+  local result
+  result=$($PSQL "$DATABASE_URL_RO" -X -A -t -c "SELECT json_agg(row_to_json(q)) FROM ($sql) q;" 2>/dev/null || echo "null")
+  echo "\"$label\": ${result:-null}"
+}
+
+echo "{"
+
+# T2.1 — Closure rate digest 30j (SOURCE DE VÉRITÉ : analytics_events)
+query "T2_1_digest_sessions_via_events" "
+  SELECT
+    DATE(created_at)::text AS day,
+    COUNT(*) FILTER (WHERE (event_data->>'closure_achieved')::bool) AS closures,
+    COUNT(*) AS digest_sessions,
+    ROUND(100.0 * COUNT(*) FILTER (WHERE (event_data->>'closure_achieved')::bool) / NULLIF(COUNT(*), 0), 1) AS closure_rate_pct,
+    ROUND(AVG((event_data->>'articles_read')::int), 2) AS avg_articles_read,
+    ROUND(AVG((event_data->>'total_time')::int) / 60.0, 1) AS avg_minutes
+  FROM analytics_events
+  WHERE event_type = 'digest_session'
+    AND created_at > NOW() - INTERVAL '30 days'
+  GROUP BY 1 ORDER BY 1 DESC
+"
+echo ","
+
+# T2.1b — Fallback : lire directement digest_completions (table métier)
+query "T2_1b_digest_completions_direct" "
+  SELECT
+    DATE(completed_at)::text AS day,
+    COUNT(*) AS completions,
+    ROUND(AVG(articles_read), 2) AS avg_articles_read,
+    ROUND(AVG(closure_time_seconds) / 60.0, 1) AS avg_minutes
+  FROM digest_completions
+  WHERE completed_at > NOW() - INTERVAL '30 days'
+  GROUP BY 1 ORDER BY 1 DESC
+"
+echo ","
+
+# T2.2 — Streaks (habitude)
+query "T2_2_streaks" "
+  SELECT
+    COUNT(*) FILTER (WHERE current_streak >= 1) AS streak_1_plus,
+    COUNT(*) FILTER (WHERE current_streak >= 3) AS streak_3_plus,
+    COUNT(*) FILTER (WHERE current_streak >= 7) AS streak_7_plus,
+    COUNT(*) FILTER (WHERE current_streak >= 14) AS streak_14_plus,
+    COUNT(*) FILTER (WHERE longest_streak >= 7) AS has_hit_1_week_ever,
+    MAX(longest_streak) AS max_ever,
+    ROUND(AVG(current_streak)::numeric, 2) AS avg_current
+  FROM user_streaks
+"
+echo ","
+
+# T2.3 — Activité 7j
+query "T2_3_activity_7d" "
+  SELECT
+    COUNT(DISTINCT user_id) AS active_users_7d,
+    ROUND(SUM(time_spent_seconds) / 60.0, 1) AS total_minutes,
+    ROUND(SUM(time_spent_seconds) / 60.0 / NULLIF(COUNT(DISTINCT user_id), 0), 1) AS avg_min_per_user,
+    COUNT(*) FILTER (WHERE status = 'consumed') AS articles_consumed,
+    ROUND(COUNT(*) FILTER (WHERE status = 'consumed') * 1.0 / NULLIF(COUNT(DISTINCT user_id), 0), 1) AS articles_per_user
+  FROM user_content_status
+  WHERE updated_at > NOW() - INTERVAL '7 days'
+"
+echo ","
+
+# T2.4 — Bookmarks
+query "T2_4_bookmarks" "
+  SELECT
+    COUNT(*) FILTER (WHERE is_saved) AS total_saved,
+    COUNT(DISTINCT user_id) FILTER (WHERE is_saved) AS users_with_saves,
+    COUNT(*) FILTER (WHERE is_saved AND status = 'consumed') AS saved_and_read,
+    ROUND(100.0 * COUNT(*) FILTER (WHERE is_saved AND status = 'consumed')
+          / NULLIF(COUNT(*) FILTER (WHERE is_saved), 0), 1) AS pct_saved_eventually_read
+  FROM user_content_status
+"
+echo ","
+
+# T3.1 — Mise en perspective
+query "T3_1_perspectives" "
+  SELECT
+    COUNT(*) AS comparison_views_30d,
+    COUNT(DISTINCT user_id) AS unique_users
+  FROM analytics_events
+  WHERE event_type = 'comparison_viewed' AND created_at > NOW() - INTERVAL '30 days'
+"
+echo ","
+
+# T3.3 — Gamification on/off
+query "T3_3_gamification" "
+  SELECT
+    p.gamification_enabled,
+    COUNT(DISTINCT p.user_id) AS n_users,
+    ROUND(AVG(s.current_streak)::numeric, 2) AS avg_current_streak,
+    ROUND(AVG(s.longest_streak)::numeric, 2) AS avg_longest_streak
+  FROM user_profiles p
+  LEFT JOIN user_streaks s USING (user_id)
+  GROUP BY 1
+"
+echo ","
+
+# EXTRA — total users (dénominateur manquant dans R01)
+query "EXTRA_users_total" "
+  SELECT
+    COUNT(*) AS total_profiles,
+    COUNT(*) FILTER (WHERE onboarding_completed) AS onboarded,
+    COUNT(*) FILTER (WHERE gamification_enabled) AS gamification_on
+  FROM user_profiles
+"
+echo ","
+
+# EXTRA — event types vus sur 30j (sanity check instrumentation)
+query "EXTRA_event_types_30d" "
+  SELECT event_type, COUNT(*) AS n, COUNT(DISTINCT user_id) AS unique_users
+  FROM analytics_events
+  WHERE created_at > NOW() - INTERVAL '30 days'
+  GROUP BY 1 ORDER BY 2 DESC
+"
+
+echo "}"

--- a/scripts/healthcheck-agent-secrets.sh
+++ b/scripts/healthcheck-agent-secrets.sh
@@ -88,23 +88,37 @@ fi
 hdr "Railway (RAILWAY_TOKEN / RAILWAY_API_TOKEN)"
 if [[ -z "${RAILWAY_TOKEN:-}" && -z "${RAILWAY_API_TOKEN:-}" ]]; then
   sk "RAILWAY_TOKEN et RAILWAY_API_TOKEN"
-elif ! command -v railway &>/dev/null; then
-  sk "CLI railway absente — lance scripts/setup-cli-tools.sh"
 else
   # Diagnostic longueur pour détecter un copier/coller tronqué ou avec espaces.
   tok_len=${#RAILWAY_TOKEN}
   api_len=${#RAILWAY_API_TOKEN}
   echo "  (longueur tokens) RAILWAY_TOKEN=${tok_len}, RAILWAY_API_TOKEN=${api_len}"
 
-  w=$(railway whoami 2>&1)
-  if echo "$w" | grep -qiE "logged in|email|@"; then
-    ok "Railway whoami OK ($(echo "$w" | head -1))"
+  # Test API direct — source de vérité indépendante du CLI.
+  # Railway expose GraphQL sur backboard.railway.app.
+  # Un Account Token répond sur `me { email }`, un Project Token échoue.
+  token="${RAILWAY_API_TOKEN:-$RAILWAY_TOKEN}"
+  api_resp=$(curl -sS -X POST "https://backboard.railway.app/graphql/v2" \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    -d '{"query":"query { me { id email } }"}' 2>&1)
+  if echo "$api_resp" | grep -q '"email"'; then
+    email=$(echo "$api_resp" | sed -nE 's/.*"email":"([^"]+)".*/\1/p')
+    ok "Railway GraphQL me{} OK (Account Token, user=${email:-inconnu})"
+  elif echo "$api_resp" | grep -qi "Not Authorized\|Unauthorized\|Problem processing request"; then
+    snippet=$(echo "$api_resp" | head -c 200)
+    ko "Railway GraphQL refuse le token (probable Project Token au lieu de Account Token) : $snippet"
   else
-    ko "Railway whoami échoue : $(echo "$w" | head -2 | tr '\n' ' ')"
+    snippet=$(echo "$api_resp" | head -c 200)
+    ko "Railway GraphQL réponse inattendue : $snippet"
   fi
-  if [[ -n "${RAILWAY_PROJECT_ID:-}" ]]; then
-    s=$(railway status --json 2>&1)
-    echo "$s" | grep -q "projectId" && ok "projet accessible" || ko "status échoue : $(echo "$s" | head -1)"
+
+  # CLI check : nice-to-have
+  if command -v railway &>/dev/null; then
+    w=$(railway whoami 2>&1)
+    if echo "$w" | grep -qiE "logged in|email|@"; then
+      ok "railway whoami OK (bonus)"
+    fi
   fi
 fi
 

--- a/scripts/healthcheck-agent-secrets.sh
+++ b/scripts/healthcheck-agent-secrets.sh
@@ -7,14 +7,19 @@
 #
 # Usage CI : appelé par .github/workflows/agent-secrets-healthcheck.yml
 #
-# Sortie :
-#   - Un bloc par service avec OK/FAIL/SKIP
-#   - Exit 0 si tous OK ou SKIP, exit 1 si un FAIL
+# Modes :
+#   (défaut)  : tous les checks, exit 1 si un FAIL
+#   --fast    : ne lance que les checks réseau rapides (skip psql UPDATE
+#               probe, skip CLI probes, skip longs timeouts). Sortie plus
+#               compacte. Conçu pour être appelé depuis le SessionStart hook.
 #
 # Jamais de secret imprimé dans la sortie.
 
 set -u
 pipefail_off=$-; set +e  # on veut continuer même si une check échoue
+
+FAST=0
+[[ "${1:-}" == "--fast" ]] && FAST=1
 
 pass=0; fail=0; skip=0
 
@@ -49,23 +54,25 @@ else
   else
     ko "connexion impossible (sortie vide)"
   fi
-  # Vérifie qu'au moins une table attendue est lisible
-  sel_out=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT COUNT(*) FROM user_profiles LIMIT 1;" 2>&1)
-  n=$(echo "$sel_out" | tail -1 | tr -d ' \r\n')
-  if [[ "$n" =~ ^[0-9]+$ ]]; then
-    ok "SELECT sur user_profiles fonctionne ($n rows)"
-  else
-    first=$(echo "$sel_out" | grep -iE "error|fatal|denied" | head -1)
-    ko "SELECT user_profiles impossible : ${first:-(sortie vide)}"
-  fi
-  # Sanity : refuse un write
-  w=$(psql "$DATABASE_URL_RO" -X -A -t -c "UPDATE user_profiles SET onboarding_completed = onboarding_completed WHERE false;" 2>&1)
-  if echo "$w" | grep -qi "permission denied"; then
-    ok "UPDATE refusé comme attendu (least-privilege OK)"
-  elif echo "$w" | grep -qiE "fatal|could not|timeout"; then
-    ko "UPDATE non testable (connexion en échec amont)"
-  else
-    ko "UPDATE n'est PAS refusé — le rôle a trop de droits ! Vérifie le GRANT."
+  if [[ $FAST -eq 0 ]]; then
+    # Vérifie qu'au moins une table attendue est lisible
+    sel_out=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT COUNT(*) FROM user_profiles LIMIT 1;" 2>&1)
+    n=$(echo "$sel_out" | tail -1 | tr -d ' \r\n')
+    if [[ "$n" =~ ^[0-9]+$ ]]; then
+      ok "SELECT sur user_profiles fonctionne ($n rows)"
+    else
+      first=$(echo "$sel_out" | grep -iE "error|fatal|denied" | head -1)
+      ko "SELECT user_profiles impossible : ${first:-(sortie vide)}"
+    fi
+    # Sanity : refuse un write
+    w=$(psql "$DATABASE_URL_RO" -X -A -t -c "UPDATE user_profiles SET onboarding_completed = onboarding_completed WHERE false;" 2>&1)
+    if echo "$w" | grep -qi "permission denied"; then
+      ok "UPDATE refusé comme attendu (least-privilege OK)"
+    elif echo "$w" | grep -qiE "fatal|could not|timeout"; then
+      ko "UPDATE non testable (connexion en échec amont)"
+    else
+      ko "UPDATE n'est PAS refusé — le rôle a trop de droits ! Vérifie le GRANT."
+    fi
   fi
 fi
 
@@ -113,8 +120,8 @@ else
     ko "Railway GraphQL réponse inattendue : $snippet"
   fi
 
-  # CLI check : nice-to-have
-  if command -v railway &>/dev/null; then
+  # CLI check : nice-to-have (skip en mode fast)
+  if [[ $FAST -eq 0 ]] && command -v railway &>/dev/null; then
     w=$(railway whoami 2>&1)
     if echo "$w" | grep -qiE "logged in|email|@"; then
       ok "railway whoami OK (bonus)"
@@ -126,8 +133,6 @@ fi
 hdr "Sentry (SENTRY_AUTH_TOKEN)"
 if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
   sk "SENTRY_AUTH_TOKEN"
-elif ! command -v sentry-cli &>/dev/null; then
-  sk "sentry-cli absente"
 else
   sent_len=${#SENTRY_AUTH_TOKEN}
   echo "  (longueur token) SENTRY_AUTH_TOKEN=${sent_len}"
@@ -144,9 +149,11 @@ else
 
   # CLI check informel : échoue silencieusement si pas de default org/project
   # configurés, mais tant que l'API répond on considère le secret valide.
-  i=$(sentry-cli info 2>&1)
-  if echo "$i" | grep -qi "authenticated"; then
-    ok "sentry-cli authentifié (bonus)"
+  if [[ $FAST -eq 0 ]] && command -v sentry-cli &>/dev/null; then
+    i=$(sentry-cli info 2>&1)
+    if echo "$i" | grep -qi "authenticated"; then
+      ok "sentry-cli authentifié (bonus)"
+    fi
   fi
 
   if [[ -n "${SENTRY_ORG:-}" && -n "${SENTRY_PROJECT:-}" ]]; then

--- a/scripts/healthcheck-agent-secrets.sh
+++ b/scripts/healthcheck-agent-secrets.sh
@@ -118,22 +118,23 @@ else
   sent_len=${#SENTRY_AUTH_TOKEN}
   echo "  (longueur token) SENTRY_AUTH_TOKEN=${sent_len}"
 
-  i=$(sentry-cli info 2>&1)
-  if echo "$i" | grep -qi "authenticated"; then
-    ok "sentry-cli authentifié"
-  else
-    short=$(echo "$i" | head -3 | tr '\n' ' ')
-    ko "sentry-cli info échoue : ${short}"
-  fi
-  # Test API direct (indépendant du CLI)
+  # Test API direct (source de vérité — indépendant d'un .sentryclirc)
   api_code=$(curl -sS -o /tmp/sentry_self.json -w "%{http_code}" \
       -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
       "https://sentry.io/api/0/" 2>/dev/null)
   if [[ "$api_code" == "200" ]]; then
-    ok "API Sentry /api/0/ répond 200 (token OK côté API)"
+    ok "API Sentry /api/0/ répond 200 (token OK)"
   else
-    ko "API Sentry /api/0/ HTTP $api_code"
+    ko "API Sentry /api/0/ HTTP $api_code — token invalide / scopes manquants"
   fi
+
+  # CLI check informel : échoue silencieusement si pas de default org/project
+  # configurés, mais tant que l'API répond on considère le secret valide.
+  i=$(sentry-cli info 2>&1)
+  if echo "$i" | grep -qi "authenticated"; then
+    ok "sentry-cli authentifié (bonus)"
+  fi
+
   if [[ -n "${SENTRY_ORG:-}" && -n "${SENTRY_PROJECT:-}" ]]; then
     r=$(curl -sS -o /dev/null -w "%{http_code}" \
         -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \

--- a/scripts/healthcheck-agent-secrets.sh
+++ b/scripts/healthcheck-agent-secrets.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# healthcheck-agent-secrets.sh — Valide que les secrets d'agent sont fonctionnels.
+#
+# Usage local :
+#   export $(grep -v '^#' .env | xargs)  # ou direnv auto
+#   bash scripts/healthcheck-agent-secrets.sh
+#
+# Usage CI : appelé par .github/workflows/agent-secrets-healthcheck.yml
+#
+# Sortie :
+#   - Un bloc par service avec OK/FAIL/SKIP
+#   - Exit 0 si tous OK ou SKIP, exit 1 si un FAIL
+#
+# Jamais de secret imprimé dans la sortie.
+
+set -u
+pipefail_off=$-; set +e  # on veut continuer même si une check échoue
+
+pass=0; fail=0; skip=0
+
+ok()   { echo "  [OK]   $1"; pass=$((pass+1)); }
+ko()   { echo "  [FAIL] $1"; fail=$((fail+1)); }
+sk()   { echo "  [SKIP] $1 (variable absente)"; skip=$((skip+1)); }
+
+hdr()  { echo; echo "─── $1 ───────────────────────────────────────────"; }
+
+# ─── Supabase : DB read-only ─────────────────────────────────────────────────
+hdr "Supabase — DB read-only (DATABASE_URL_RO)"
+if [[ -z "${DATABASE_URL_RO:-}" ]]; then
+  sk "DATABASE_URL_RO"
+elif ! command -v psql &>/dev/null; then
+  sk "psql absent — skip"
+else
+  user=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT current_user;" 2>/dev/null)
+  if [[ "$user" == "claude_analytics_ro" ]]; then
+    ok "connecté en tant que claude_analytics_ro"
+  elif [[ -n "$user" ]]; then
+    ko "connecté mais en tant que '$user' — devrait être claude_analytics_ro"
+  else
+    ko "connexion impossible (vérifie password, sslmode, IP autorisée)"
+  fi
+  # Vérifie qu'au moins une table attendue est lisible
+  n=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT COUNT(*) FROM user_profiles LIMIT 1;" 2>/dev/null)
+  [[ -n "$n" ]] && ok "SELECT sur user_profiles fonctionne" || ko "SELECT user_profiles impossible (GRANT manquant ?)"
+  # Sanity : refuse un write
+  w=$(psql "$DATABASE_URL_RO" -X -A -t -c "UPDATE user_profiles SET onboarding_completed = onboarding_completed WHERE false;" 2>&1)
+  if echo "$w" | grep -qi "permission denied"; then
+    ok "UPDATE refusé comme attendu (least-privilege OK)"
+  else
+    ko "UPDATE n'est PAS refusé — le rôle a trop de droits ! Vérifie le GRANT."
+  fi
+fi
+
+# ─── Supabase : PAT (MCP) ────────────────────────────────────────────────────
+hdr "Supabase — Personal Access Token (MCP)"
+if [[ -z "${SUPABASE_ACCESS_TOKEN:-}" ]]; then
+  sk "SUPABASE_ACCESS_TOKEN"
+else
+  r=$(curl -sf -o /dev/null -w "%{http_code}" \
+      -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+      https://api.supabase.com/v1/projects 2>/dev/null)
+  if [[ "$r" == "200" ]]; then
+    ok "API Supabase répond 200 (PAT valide)"
+  else
+    ko "API Supabase HTTP $r — PAT invalide ou révoqué"
+  fi
+fi
+
+# ─── Railway ─────────────────────────────────────────────────────────────────
+hdr "Railway (RAILWAY_TOKEN)"
+if [[ -z "${RAILWAY_TOKEN:-}" ]]; then
+  sk "RAILWAY_TOKEN"
+elif ! command -v railway &>/dev/null; then
+  sk "CLI railway absente — lance scripts/setup-cli-tools.sh"
+else
+  w=$(railway whoami 2>&1)
+  if echo "$w" | grep -qiE "logged in|email"; then
+    ok "Railway whoami OK"
+  else
+    ko "Railway whoami échoue : $(echo "$w" | head -1)"
+  fi
+  if [[ -n "${RAILWAY_PROJECT_ID:-}" ]]; then
+    s=$(railway status --json 2>&1)
+    echo "$s" | grep -q "projectId" && ok "projet accessible" || ko "status échoue"
+  fi
+fi
+
+# ─── Sentry ──────────────────────────────────────────────────────────────────
+hdr "Sentry (SENTRY_AUTH_TOKEN)"
+if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
+  sk "SENTRY_AUTH_TOKEN"
+elif ! command -v sentry-cli &>/dev/null; then
+  sk "sentry-cli absente"
+else
+  i=$(sentry-cli info 2>&1)
+  if echo "$i" | grep -qi "authenticated"; then
+    ok "sentry-cli authentifié"
+  else
+    ko "sentry-cli info échoue"
+  fi
+  if [[ -n "${SENTRY_ORG:-}" && -n "${SENTRY_PROJECT:-}" ]]; then
+    r=$(curl -sf -o /dev/null -w "%{http_code}" \
+        -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+        "https://sentry.io/api/0/projects/$SENTRY_ORG/$SENTRY_PROJECT/" 2>/dev/null)
+    [[ "$r" == "200" ]] && ok "projet Sentry accessible" || ko "projet Sentry HTTP $r"
+  fi
+fi
+
+# ─── PostHog ─────────────────────────────────────────────────────────────────
+hdr "PostHog (POSTHOG_PERSONAL_API_KEY)"
+if [[ -z "${POSTHOG_PERSONAL_API_KEY:-}" ]]; then
+  sk "POSTHOG_PERSONAL_API_KEY"
+else
+  host="${POSTHOG_HOST:-https://eu.i.posthog.com}"
+  pid="${POSTHOG_PROJECT_ID:-}"
+  if [[ -z "$pid" ]]; then
+    sk "POSTHOG_PROJECT_ID absent — check partiel"
+  else
+    r=$(curl -sf -o /dev/null -w "%{http_code}" \
+        -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+        "$host/api/projects/$pid/" 2>/dev/null)
+    [[ "$r" == "200" ]] && ok "API PostHog OK (projet $pid)" || ko "PostHog HTTP $r"
+  fi
+fi
+
+# ─── GitHub (session courante) ──────────────────────────────────────────────
+hdr "GitHub"
+if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+  ok "Exécution dans GitHub Actions — GITHUB_TOKEN auto-injecté"
+else
+  sk "hors GitHub Actions — GitHub géré via MCP côté Claude Code"
+fi
+
+# ─── Résumé ─────────────────────────────────────────────────────────────────
+echo
+echo "═════════════════════════════════════════════════════════════════"
+echo "  Résumé : $pass OK · $fail FAIL · $skip SKIP"
+echo "═════════════════════════════════════════════════════════════════"
+
+[[ $fail -eq 0 ]] && exit 0 || exit 1

--- a/scripts/healthcheck-agent-secrets.sh
+++ b/scripts/healthcheck-agent-secrets.sh
@@ -31,21 +31,39 @@ if [[ -z "${DATABASE_URL_RO:-}" ]]; then
 elif ! command -v psql &>/dev/null; then
   sk "psql absent — skip"
 else
-  user=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT current_user;" 2>/dev/null)
+  # Diagnostic non-sensible sur l'URL (schéma/host/port/db, sans password).
+  safe=$(printf '%s' "$DATABASE_URL_RO" \
+         | sed -E 's#^(postgres(ql)?://)[^:]+:[^@]+@#\1***:***@#' \
+         | sed -E 's/(password=)[^& ]+/\1***/g')
+  echo "  (URL sans secret) $safe"
+
+  conn_out=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT current_user;" 2>&1)
+  user=$(echo "$conn_out" | tail -1 | tr -d ' \r\n')
   if [[ "$user" == "claude_analytics_ro" ]]; then
     ok "connecté en tant que claude_analytics_ro"
+  elif [[ "$conn_out" == *"ERROR"* || "$conn_out" == *"FATAL"* || "$conn_out" == *"could not"* || "$conn_out" == *"timeout"* ]]; then
+    first=$(echo "$conn_out" | grep -iE "error|fatal|could not|timeout|denied" | head -1)
+    ko "connexion impossible : ${first:-$conn_out}"
   elif [[ -n "$user" ]]; then
     ko "connecté mais en tant que '$user' — devrait être claude_analytics_ro"
   else
-    ko "connexion impossible (vérifie password, sslmode, IP autorisée)"
+    ko "connexion impossible (sortie vide)"
   fi
   # Vérifie qu'au moins une table attendue est lisible
-  n=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT COUNT(*) FROM user_profiles LIMIT 1;" 2>/dev/null)
-  [[ -n "$n" ]] && ok "SELECT sur user_profiles fonctionne" || ko "SELECT user_profiles impossible (GRANT manquant ?)"
+  sel_out=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT COUNT(*) FROM user_profiles LIMIT 1;" 2>&1)
+  n=$(echo "$sel_out" | tail -1 | tr -d ' \r\n')
+  if [[ "$n" =~ ^[0-9]+$ ]]; then
+    ok "SELECT sur user_profiles fonctionne ($n rows)"
+  else
+    first=$(echo "$sel_out" | grep -iE "error|fatal|denied" | head -1)
+    ko "SELECT user_profiles impossible : ${first:-(sortie vide)}"
+  fi
   # Sanity : refuse un write
   w=$(psql "$DATABASE_URL_RO" -X -A -t -c "UPDATE user_profiles SET onboarding_completed = onboarding_completed WHERE false;" 2>&1)
   if echo "$w" | grep -qi "permission denied"; then
     ok "UPDATE refusé comme attendu (least-privilege OK)"
+  elif echo "$w" | grep -qiE "fatal|could not|timeout"; then
+    ko "UPDATE non testable (connexion en échec amont)"
   else
     ko "UPDATE n'est PAS refusé — le rôle a trop de droits ! Vérifie le GRANT."
   fi
@@ -67,21 +85,26 @@ else
 fi
 
 # ─── Railway ─────────────────────────────────────────────────────────────────
-hdr "Railway (RAILWAY_TOKEN)"
-if [[ -z "${RAILWAY_TOKEN:-}" ]]; then
-  sk "RAILWAY_TOKEN"
+hdr "Railway (RAILWAY_TOKEN / RAILWAY_API_TOKEN)"
+if [[ -z "${RAILWAY_TOKEN:-}" && -z "${RAILWAY_API_TOKEN:-}" ]]; then
+  sk "RAILWAY_TOKEN et RAILWAY_API_TOKEN"
 elif ! command -v railway &>/dev/null; then
   sk "CLI railway absente — lance scripts/setup-cli-tools.sh"
 else
+  # Diagnostic longueur pour détecter un copier/coller tronqué ou avec espaces.
+  tok_len=${#RAILWAY_TOKEN}
+  api_len=${#RAILWAY_API_TOKEN}
+  echo "  (longueur tokens) RAILWAY_TOKEN=${tok_len}, RAILWAY_API_TOKEN=${api_len}"
+
   w=$(railway whoami 2>&1)
-  if echo "$w" | grep -qiE "logged in|email"; then
-    ok "Railway whoami OK"
+  if echo "$w" | grep -qiE "logged in|email|@"; then
+    ok "Railway whoami OK ($(echo "$w" | head -1))"
   else
-    ko "Railway whoami échoue : $(echo "$w" | head -1)"
+    ko "Railway whoami échoue : $(echo "$w" | head -2 | tr '\n' ' ')"
   fi
   if [[ -n "${RAILWAY_PROJECT_ID:-}" ]]; then
     s=$(railway status --json 2>&1)
-    echo "$s" | grep -q "projectId" && ok "projet accessible" || ko "status échoue"
+    echo "$s" | grep -q "projectId" && ok "projet accessible" || ko "status échoue : $(echo "$s" | head -1)"
   fi
 fi
 
@@ -92,17 +115,30 @@ if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
 elif ! command -v sentry-cli &>/dev/null; then
   sk "sentry-cli absente"
 else
+  sent_len=${#SENTRY_AUTH_TOKEN}
+  echo "  (longueur token) SENTRY_AUTH_TOKEN=${sent_len}"
+
   i=$(sentry-cli info 2>&1)
   if echo "$i" | grep -qi "authenticated"; then
     ok "sentry-cli authentifié"
   else
-    ko "sentry-cli info échoue"
+    short=$(echo "$i" | head -3 | tr '\n' ' ')
+    ko "sentry-cli info échoue : ${short}"
+  fi
+  # Test API direct (indépendant du CLI)
+  api_code=$(curl -sS -o /tmp/sentry_self.json -w "%{http_code}" \
+      -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+      "https://sentry.io/api/0/" 2>/dev/null)
+  if [[ "$api_code" == "200" ]]; then
+    ok "API Sentry /api/0/ répond 200 (token OK côté API)"
+  else
+    ko "API Sentry /api/0/ HTTP $api_code"
   fi
   if [[ -n "${SENTRY_ORG:-}" && -n "${SENTRY_PROJECT:-}" ]]; then
-    r=$(curl -sf -o /dev/null -w "%{http_code}" \
+    r=$(curl -sS -o /dev/null -w "%{http_code}" \
         -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
         "https://sentry.io/api/0/projects/$SENTRY_ORG/$SENTRY_PROJECT/" 2>/dev/null)
-    [[ "$r" == "200" ]] && ok "projet Sentry accessible" || ko "projet Sentry HTTP $r"
+    [[ "$r" == "200" ]] && ok "projet Sentry accessible" || ko "projet Sentry HTTP $r (ORG='$SENTRY_ORG' PROJECT='$SENTRY_PROJECT')"
   fi
 fi
 

--- a/scripts/setup-cli-tools.sh
+++ b/scripts/setup-cli-tools.sh
@@ -18,9 +18,27 @@ echo ""
 if command -v railway &>/dev/null; then
   echo "[OK] Railway CLI déjà installé: $(railway --version 2>/dev/null)"
 else
-  echo "[...] Installation Railway CLI via script officiel..."
-  bash <(curl -fsSL https://railway.app/install.sh)
-  echo "[OK] Railway CLI installé: $(railway --version 2>/dev/null)"
+  echo "[...] Installation Railway CLI..."
+  # Tentative 1 : script officiel (peut retourner 403 selon l'origine IP — CDN geo).
+  if curl -fsSL -o /tmp/railway-install.sh https://railway.app/install.sh 2>/dev/null \
+       && bash /tmp/railway-install.sh 2>/dev/null \
+       && command -v railway &>/dev/null; then
+    :
+  elif command -v npm &>/dev/null; then
+    echo "    Script officiel indisponible (403 ou réseau) — fallback npm (@railway/cli)..."
+    # Install globale user-level si possible (évite sudo).
+    if npm config get prefix 2>/dev/null | grep -q "^/usr"; then
+      mkdir -p "$HOME/.npm-global"
+      npm config set prefix "$HOME/.npm-global"
+      export PATH="$HOME/.npm-global/bin:$PATH"
+    fi
+    npm install -g @railway/cli
+  else
+    echo "ERREUR: install Railway CLI impossible (ni script officiel, ni npm)."
+    echo "Contournement manuel : https://docs.railway.com/guides/cli"
+    exit 1
+  fi
+  echo "[OK] Railway CLI installé: $(railway --version 2>/dev/null || echo 'vérifier PATH')"
 fi
 
 # ─── Supabase CLI ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Objectif : les prochains agents voient l'état de leurs accès dès la session et savent quoi faire face à un symptôme prod.

- **Healthcheck plus robuste** : mode `--fast` (skip UPDATE probe + CLI bonus), diagnostics verbeux (URL masquée, longueur tokens, messages d'erreur réels), Sentry/Railway passent par API directe (source de vérité) au lieu du CLI qui peut être capricieux.
- **SessionStart autonome** : le hook appelle le healthcheck `--fast` au démarrage, préfixe chaque ligne avec `[secrets]` pour scan rapide par l'agent. Non-bloquant.
- **Playbook d'investigation** : nouveau doc `docs/agent-brain/investigation-playbook.md` avec 5 scénarios fréquents (bug prod, usage feature, migration Alembic, logs API, audit sécu) — chaque scénario liste les outils + commandes prêtes à copier.
- **CLAUDE.md** référence le playbook + la doc claude-access-setup, explique la convention `[secrets]` au SessionStart.

Effet concret : un nouvel agent qui ouvre une session voit immédiatement si ses accès Supabase/Railway/Sentry/PostHog sont fonctionnels, et si oui, comment les utiliser selon le symptôme à investiguer.

## Commits inclus

- `aefd8d9` docs(infra): remplace URIs Postgres templates par description en liste (GitGuardian false positive fix)
- `f9f85eb` chore(agents): healthcheck verbeux pour diagnostiquer FAIL silencieux
- `8df5087` chore(agents): Sentry — considère API 200 comme source de vérité
- `4356882` chore(agents): Railway — teste via GraphQL API plutôt que CLI whoami
- `58ecd57` chore(agents): autonomie diagnostic — fast healthcheck + playbook

## Test plan

- [x] Syntaxe bash validée (`bash -n` sur healthcheck + session-start)
- [x] Healthcheck `--fast` tourne en local sans secrets (0 OK 0 FAIL 6 SKIP — attendu)
- [x] Dernier run sur la branche = `8 OK · 0 FAIL · 0 SKIP` (confirmé par Laurin)
- [ ] Post-merge : relancer le workflow `agent-secrets-healthcheck` depuis `main` pour confirmer `8 OK`
- [ ] Post-merge : ouvrir une nouvelle session Claude Code avec secrets chargés localement, vérifier que les lignes `[secrets]` apparaissent au SessionStart

https://claude.ai/code/session_01HWBkTSUkrWe6wPg2SknyFS