### PR TITLE
chore(agents): autonomie diagnostic + healthcheck robuste

### DIFF
--- a/.claude-hooks/session-start.sh
+++ b/.claude-hooks/session-start.sh
@@ -142,4 +142,25 @@ if ! command -v railway &>/dev/null \
   bash scripts/setup-cli-tools.sh 2>&1 | tail -20 || true
 fi
 
+# =============================================================================
+# Connectivité des services (secrets d'agent) — en mode fast.
+# Tous les messages commencent par [secrets] pour que l'agent scanne vite.
+# Non-bloquant : même si un service est DOWN, la session démarre.
+# =============================================================================
+if [ -f scripts/healthcheck-agent-secrets.sh ]; then
+  # N'exécute le healthcheck que si au moins un secret est présent — inutile
+  # de spammer "SKIP" partout pour des contributeurs externes qui n'ont pas
+  # accès aux secrets d'infra.
+  if [ -n "${DATABASE_URL_RO:-}${SUPABASE_ACCESS_TOKEN:-}${RAILWAY_TOKEN:-}${SENTRY_AUTH_TOKEN:-}${POSTHOG_PERSONAL_API_KEY:-}" ]; then
+    echo "[secrets] vérification connectivité (--fast)..."
+    # Préfixe chaque ligne pour scan facile par l'agent, tronque le bruit visuel.
+    bash scripts/healthcheck-agent-secrets.sh --fast 2>&1 \
+      | grep -E '\[(OK|FAIL|SKIP)\]|Résumé' \
+      | sed 's/^/[secrets] /' \
+      || true
+  else
+    echo "[secrets] aucune variable d'infra définie (normal pour contributeur sans accès)"
+  fi
+fi
+
 exit 0  # Toujours non-bloquant

--- a/.github/workflows/agent-secrets-healthcheck.yml
+++ b/.github/workflows/agent-secrets-healthcheck.yml
@@ -36,6 +36,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN:    ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           DATABASE_URL_RO:          ${{ secrets.DATABASE_URL_RO }}
           RAILWAY_TOKEN:            ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_API_TOKEN:        ${{ secrets.RAILWAY_TOKEN }}
           SENTRY_AUTH_TOKEN:        ${{ secrets.SENTRY_AUTH_TOKEN }}
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
           # Variables (identifiants publics)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,19 @@ bash docs/qa/scripts/verify_<task>.sh
 
 - [Navigation Matrix](docs/agent-brain/navigation-matrix.md) — workflows par type de tâche
 - [Safety Guardrails](docs/agent-brain/safety-guardrails.md) — guardrails + safety protocols
+- [Investigation Playbook](docs/agent-brain/investigation-playbook.md) — outils par scénario prod (bug, usage, migration, logs, sécurité)
+- [Claude Access Setup](docs/infra/claude-access-setup.md) — secrets + accès multi-services (Supabase/Railway/Sentry/PostHog)
 - [PRD](docs/prd.md) / [Architecture](docs/architecture.md) / [Front-end Spec](docs/front-end-spec.md)
 - Agents BMAD : `.bmad-core/agents/` (dev, po, architect, qa)
 - Scripts QA : `docs/qa/scripts/`
+
+### Santé des accès agents
+
+Le hook `SessionStart` lance un healthcheck `--fast` au démarrage. Scanne les lignes `[secrets]` dans les premiers messages de la session ; un `[FAIL]` doit être traité avant toute investigation prod. Healthcheck complet :
+
+```bash
+bash scripts/healthcheck-agent-secrets.sh
+```
 ## 🧪 Validation Feature via Chrome (Agent QA)
 
 Après la phase VERIFY de l'agent dev et la validation du PO (Laurin), une étape de **validation web automatisée** peut être déclenchée pour les features touchant l'UI.

--- a/docs/agent-brain/investigation-playbook.md
+++ b/docs/agent-brain/investigation-playbook.md
@@ -1,0 +1,108 @@
+# Investigation Playbook
+
+**Quand un agent doit creuser un symptôme prod, ce doc est le point d'entrée unique.**
+Tu trouveras ici : les outils disponibles par scénario, les commandes prêtes à copier, les pièges à éviter.
+
+---
+
+## 🟢 Prérequis — est-ce que mes accès marchent ?
+
+Le hook `SessionStart` affiche automatiquement le résultat d'un healthcheck `--fast` au démarrage de la session. Scanne les lignes `[secrets]` dans les premiers messages :
+
+```
+[secrets] [OK]   connecté en tant que claude_analytics_ro
+[secrets] [OK]   API Supabase répond 200 (PAT valide)
+[secrets] [OK]   Railway GraphQL me{} OK (Account Token, user=...)
+[secrets] [OK]   API Sentry /api/0/ répond 200 (token OK)
+[secrets] [OK]   API PostHog OK (projet 129581)
+```
+
+Si tu vois des `[FAIL]`, **arrête-toi** avant d'investiguer : relance un healthcheck complet et corrige le token fautif (ou demande à l'utilisateur) :
+
+```bash
+bash scripts/healthcheck-agent-secrets.sh        # mode complet
+```
+
+Référence des secrets : [docs/infra/claude-access-setup.md](../infra/claude-access-setup.md).
+
+---
+
+## 📋 Scénarios fréquents
+
+### 1. "Un bug prod à reproduire / diagnostiquer"
+
+| Étape | Outil | Commande / MCP |
+|-------|-------|----------------|
+| Récupérer la stack trace + user impacté | Sentry API | `curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" "https://sentry.io/api/0/projects/$SENTRY_ORG/$SENTRY_PROJECT/issues/"` |
+| Reproduire l'état user côté DB | Supabase MCP (read-only) | Via l'outil `mcp__supabase__*` — ne jamais exposer `service_role` |
+| Regarder les logs du service | Railway CLI | `railway logs --service <service_id>` |
+
+**Piège** : ne pas tenter de modifier l'état user pour "tester" sans autorisation explicite. Le rôle `claude_analytics_ro` est volontairement read-only.
+
+---
+
+### 2. "Comprendre l'usage d'une feature"
+
+| Étape | Outil | Commande / MCP |
+|-------|-------|----------------|
+| Events produit (clicks, views) | PostHog API | `curl -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" "https://eu.i.posthog.com/api/projects/$POSTHOG_PROJECT_ID/events/"` |
+| Agrégats DB (streaks, rétention) | `scripts/analytics/run_usage_queries.sh` | Lance toutes les requêtes T2.* et T3.* du framework R01/R02 |
+| Nouvelle requête SQL ad-hoc | `psql "$DATABASE_URL_RO"` | Ou SQL Editor Supabase en UI |
+
+**Piège** : le pooler Supabase utilise le username `claude_analytics_ro.ykuadtelnzavrqzbfdve` (avec le point — routing pgBouncer). Si tu vois "role does not exist", c'est ce détail.
+
+---
+
+### 3. "Une migration Alembic qui a mal tourné"
+
+| Étape | Outil | Commande |
+|-------|-------|----------|
+| Identifier le head courant | Alembic local | `cd packages/api && alembic current` |
+| Vérifier qu'il n'y a qu'un head | Hook auto | `bash .claude-hooks/post-edit-alembic-heads.sh` (lancé auto) |
+| Appliquer un SQL de rattrapage | Supabase SQL Editor | Jamais `alembic upgrade` sur Railway — voir [CLAUDE.md](../../CLAUDE.md) |
+
+**Piège** : Alembic est désactivé sur Railway par design. Les migrations passent par le SQL Editor Supabase avec validation manuelle.
+
+---
+
+### 4. "Un endpoint API répond mal en prod"
+
+| Étape | Outil | Commande |
+|-------|-------|----------|
+| Status du déploiement courant | Railway CLI | `railway status --json` |
+| Logs du service | Railway CLI | `railway logs` |
+| Dernières erreurs Sentry | Sentry API | voir scénario 1 |
+| Reproduire en local | `uvicorn` | `cd packages/api && uvicorn app.main:app --port 8080` |
+
+---
+
+### 5. "Auditer la sécurité d'un accès / d'une écriture"
+
+| Question | Outil | Commande |
+|----------|-------|----------|
+| Qui peut faire quoi sur la DB ? | `psql` | `\dp schema.table` (permissions par table) |
+| Tester que `claude_analytics_ro` ne peut pas écrire | `scripts/healthcheck-agent-secrets.sh` | Mode complet (le `--fast` skip l'UPDATE probe) |
+| Vérifier un GRANT spécifique | Supabase SQL Editor | `SELECT * FROM information_schema.role_table_grants WHERE grantee='claude_analytics_ro';` |
+
+---
+
+## 🔐 Règles de sécurité (non négociables)
+
+1. **Jamais** d'écriture via `DATABASE_URL_RO`. Si tu as besoin d'écrire, demande `service_role` à l'utilisateur avec justification.
+2. **Jamais** imprimer un secret en sortie — les hooks GitHub masquent mais le script doit le faire aussi par défaut.
+3. **Toujours** utiliser le Session Pooler (port 5432 sur `*.pooler.supabase.com`), pas le endpoint direct `db.*.supabase.co` (IPv6-only).
+4. **Rotation** : si un token fuite, révoque immédiatement dans la console du service + update le secret GitHub + relance le healthcheck.
+
+---
+
+## 🧭 Outils à portée de main (aide-mémoire)
+
+| Besoin | Outil de choix | Alternative |
+|--------|----------------|-------------|
+| Query SQL read-only | `psql "$DATABASE_URL_RO"` | Supabase MCP |
+| Introspection projet Supabase | Supabase MCP (read-only) | `curl` sur api.supabase.com |
+| Logs / déploiements Railway | `railway logs` / `railway status` | API GraphQL `backboard.railway.app/graphql/v2` |
+| Issues Sentry | `sentry-cli issues list` | API `sentry.io/api/0/` |
+| Analytics événements | API PostHog | — |
+
+Pour toute commande nouvelle, **teste en mode dry-run si possible** et **commit l'ajout** dans `scripts/analytics/` ou `docs/qa/scripts/` pour que le prochain agent en bénéficie.

--- a/scripts/healthcheck-agent-secrets.sh
+++ b/scripts/healthcheck-agent-secrets.sh
@@ -7,14 +7,19 @@
 #
 # Usage CI : appelé par .github/workflows/agent-secrets-healthcheck.yml
 #
-# Sortie :
-#   - Un bloc par service avec OK/FAIL/SKIP
-#   - Exit 0 si tous OK ou SKIP, exit 1 si un FAIL
+# Modes :
+#   (défaut)  : tous les checks, exit 1 si un FAIL
+#   --fast    : ne lance que les checks réseau rapides (skip psql UPDATE
+#               probe, skip CLI probes, skip longs timeouts). Sortie plus
+#               compacte. Conçu pour être appelé depuis le SessionStart hook.
 #
 # Jamais de secret imprimé dans la sortie.
 
 set -u
 pipefail_off=$-; set +e  # on veut continuer même si une check échoue
+
+FAST=0
+[[ "${1:-}" == "--fast" ]] && FAST=1
 
 pass=0; fail=0; skip=0
 
@@ -31,23 +36,43 @@ if [[ -z "${DATABASE_URL_RO:-}" ]]; then
 elif ! command -v psql &>/dev/null; then
   sk "psql absent — skip"
 else
-  user=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT current_user;" 2>/dev/null)
+  # Diagnostic non-sensible sur l'URL (schéma/host/port/db, sans password).
+  safe=$(printf '%s' "$DATABASE_URL_RO" \
+         | sed -E 's#^(postgres(ql)?://)[^:]+:[^@]+@#\1***:***@#' \
+         | sed -E 's/(password=)[^& ]+/\1***/g')
+  echo "  (URL sans secret) $safe"
+
+  conn_out=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT current_user;" 2>&1)
+  user=$(echo "$conn_out" | tail -1 | tr -d ' \r\n')
   if [[ "$user" == "claude_analytics_ro" ]]; then
     ok "connecté en tant que claude_analytics_ro"
+  elif [[ "$conn_out" == *"ERROR"* || "$conn_out" == *"FATAL"* || "$conn_out" == *"could not"* || "$conn_out" == *"timeout"* ]]; then
+    first=$(echo "$conn_out" | grep -iE "error|fatal|could not|timeout|denied" | head -1)
+    ko "connexion impossible : ${first:-$conn_out}"
   elif [[ -n "$user" ]]; then
     ko "connecté mais en tant que '$user' — devrait être claude_analytics_ro"
   else
-    ko "connexion impossible (vérifie password, sslmode, IP autorisée)"
+    ko "connexion impossible (sortie vide)"
   fi
-  # Vérifie qu'au moins une table attendue est lisible
-  n=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT COUNT(*) FROM user_profiles LIMIT 1;" 2>/dev/null)
-  [[ -n "$n" ]] && ok "SELECT sur user_profiles fonctionne" || ko "SELECT user_profiles impossible (GRANT manquant ?)"
-  # Sanity : refuse un write
-  w=$(psql "$DATABASE_URL_RO" -X -A -t -c "UPDATE user_profiles SET onboarding_completed = onboarding_completed WHERE false;" 2>&1)
-  if echo "$w" | grep -qi "permission denied"; then
-    ok "UPDATE refusé comme attendu (least-privilege OK)"
-  else
-    ko "UPDATE n'est PAS refusé — le rôle a trop de droits ! Vérifie le GRANT."
+  if [[ $FAST -eq 0 ]]; then
+    # Vérifie qu'au moins une table attendue est lisible
+    sel_out=$(psql "$DATABASE_URL_RO" -X -A -t -c "SELECT COUNT(*) FROM user_profiles LIMIT 1;" 2>&1)
+    n=$(echo "$sel_out" | tail -1 | tr -d ' \r\n')
+    if [[ "$n" =~ ^[0-9]+$ ]]; then
+      ok "SELECT sur user_profiles fonctionne ($n rows)"
+    else
+      first=$(echo "$sel_out" | grep -iE "error|fatal|denied" | head -1)
+      ko "SELECT user_profiles impossible : ${first:-(sortie vide)}"
+    fi
+    # Sanity : refuse un write
+    w=$(psql "$DATABASE_URL_RO" -X -A -t -c "UPDATE user_profiles SET onboarding_completed = onboarding_completed WHERE false;" 2>&1)
+    if echo "$w" | grep -qi "permission denied"; then
+      ok "UPDATE refusé comme attendu (least-privilege OK)"
+    elif echo "$w" | grep -qiE "fatal|could not|timeout"; then
+      ko "UPDATE non testable (connexion en échec amont)"
+    else
+      ko "UPDATE n'est PAS refusé — le rôle a trop de droits ! Vérifie le GRANT."
+    fi
   fi
 fi
 
@@ -67,21 +92,40 @@ else
 fi
 
 # ─── Railway ─────────────────────────────────────────────────────────────────
-hdr "Railway (RAILWAY_TOKEN)"
-if [[ -z "${RAILWAY_TOKEN:-}" ]]; then
-  sk "RAILWAY_TOKEN"
-elif ! command -v railway &>/dev/null; then
-  sk "CLI railway absente — lance scripts/setup-cli-tools.sh"
+hdr "Railway (RAILWAY_TOKEN / RAILWAY_API_TOKEN)"
+if [[ -z "${RAILWAY_TOKEN:-}" && -z "${RAILWAY_API_TOKEN:-}" ]]; then
+  sk "RAILWAY_TOKEN et RAILWAY_API_TOKEN"
 else
-  w=$(railway whoami 2>&1)
-  if echo "$w" | grep -qiE "logged in|email"; then
-    ok "Railway whoami OK"
+  # Diagnostic longueur pour détecter un copier/coller tronqué ou avec espaces.
+  tok_len=${#RAILWAY_TOKEN}
+  api_len=${#RAILWAY_API_TOKEN}
+  echo "  (longueur tokens) RAILWAY_TOKEN=${tok_len}, RAILWAY_API_TOKEN=${api_len}"
+
+  # Test API direct — source de vérité indépendante du CLI.
+  # Railway expose GraphQL sur backboard.railway.app.
+  # Un Account Token répond sur `me { email }`, un Project Token échoue.
+  token="${RAILWAY_API_TOKEN:-$RAILWAY_TOKEN}"
+  api_resp=$(curl -sS -X POST "https://backboard.railway.app/graphql/v2" \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    -d '{"query":"query { me { id email } }"}' 2>&1)
+  if echo "$api_resp" | grep -q '"email"'; then
+    email=$(echo "$api_resp" | sed -nE 's/.*"email":"([^"]+)".*/\1/p')
+    ok "Railway GraphQL me{} OK (Account Token, user=${email:-inconnu})"
+  elif echo "$api_resp" | grep -qi "Not Authorized\|Unauthorized\|Problem processing request"; then
+    snippet=$(echo "$api_resp" | head -c 200)
+    ko "Railway GraphQL refuse le token (probable Project Token au lieu de Account Token) : $snippet"
   else
-    ko "Railway whoami échoue : $(echo "$w" | head -1)"
+    snippet=$(echo "$api_resp" | head -c 200)
+    ko "Railway GraphQL réponse inattendue : $snippet"
   fi
-  if [[ -n "${RAILWAY_PROJECT_ID:-}" ]]; then
-    s=$(railway status --json 2>&1)
-    echo "$s" | grep -q "projectId" && ok "projet accessible" || ko "status échoue"
+
+  # CLI check : nice-to-have (skip en mode fast)
+  if [[ $FAST -eq 0 ]] && command -v railway &>/dev/null; then
+    w=$(railway whoami 2>&1)
+    if echo "$w" | grep -qiE "logged in|email|@"; then
+      ok "railway whoami OK (bonus)"
+    fi
   fi
 fi
 
@@ -89,20 +133,34 @@ fi
 hdr "Sentry (SENTRY_AUTH_TOKEN)"
 if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
   sk "SENTRY_AUTH_TOKEN"
-elif ! command -v sentry-cli &>/dev/null; then
-  sk "sentry-cli absente"
 else
-  i=$(sentry-cli info 2>&1)
-  if echo "$i" | grep -qi "authenticated"; then
-    ok "sentry-cli authentifié"
+  sent_len=${#SENTRY_AUTH_TOKEN}
+  echo "  (longueur token) SENTRY_AUTH_TOKEN=${sent_len}"
+
+  # Test API direct (source de vérité — indépendant d'un .sentryclirc)
+  api_code=$(curl -sS -o /tmp/sentry_self.json -w "%{http_code}" \
+      -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+      "https://sentry.io/api/0/" 2>/dev/null)
+  if [[ "$api_code" == "200" ]]; then
+    ok "API Sentry /api/0/ répond 200 (token OK)"
   else
-    ko "sentry-cli info échoue"
+    ko "API Sentry /api/0/ HTTP $api_code — token invalide / scopes manquants"
   fi
+
+  # CLI check informel : échoue silencieusement si pas de default org/project
+  # configurés, mais tant que l'API répond on considère le secret valide.
+  if [[ $FAST -eq 0 ]] && command -v sentry-cli &>/dev/null; then
+    i=$(sentry-cli info 2>&1)
+    if echo "$i" | grep -qi "authenticated"; then
+      ok "sentry-cli authentifié (bonus)"
+    fi
+  fi
+
   if [[ -n "${SENTRY_ORG:-}" && -n "${SENTRY_PROJECT:-}" ]]; then
-    r=$(curl -sf -o /dev/null -w "%{http_code}" \
+    r=$(curl -sS -o /dev/null -w "%{http_code}" \
         -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
         "https://sentry.io/api/0/projects/$SENTRY_ORG/$SENTRY_PROJECT/" 2>/dev/null)
-    [[ "$r" == "200" ]] && ok "projet Sentry accessible" || ko "projet Sentry HTTP $r"
+    [[ "$r" == "200" ]] && ok "projet Sentry accessible" || ko "projet Sentry HTTP $r (ORG='$SENTRY_ORG' PROJECT='$SENTRY_PROJECT')"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Objectif : les prochains agents voient l'état de leurs accès dès la session et savent quoi faire face à un symptôme prod.

- **Healthcheck plus robuste** : mode `--fast` (skip UPDATE probe + CLI bonus). Diagnostics verbeux (URL masquée, longueur tokens, messages d'erreur réels). Railway test via GraphQL API (`backboard.railway.app/graphql/v2 me{}`), Sentry via API directe (`sentry.io/api/0/`) — plus fiable que les CLI qui peuvent être capricieux.
- **Workflow GH Actions** : injecte le token Railway sous `RAILWAY_API_TOKEN` aussi (certaines commandes CLI préfèrent ce nom).
- **SessionStart autonome** : le hook appelle le healthcheck `--fast` au démarrage si au moins une variable d'infra est présente, préfixe chaque ligne avec `[secrets]` pour scan rapide par l'agent. Non-bloquant.
- **Playbook d'investigation** : nouveau doc `docs/agent-brain/investigation-playbook.md` avec 5 scénarios fréquents (bug prod, usage feature, migration Alembic, logs API, audit sécu) — chaque scénario liste les outils + commandes prêtes à copier.
- **CLAUDE.md** référence le playbook + la doc claude-access-setup, explique la convention `[secrets]` au SessionStart.

Effet concret : un nouvel agent qui ouvre une session voit immédiatement si ses accès Supabase/Railway/Sentry/PostHog sont fonctionnels, et si oui, comment les utiliser selon le symptôme à investiguer.

**Remplace #459** (historique obsolète à cause du squash merge de #454 — cette PR part d'une branche fraîche depuis `main`).

## Test plan

- [x] Syntaxe bash validée (`bash -n` sur healthcheck + session-start)
- [x] Healthcheck `--fast` OK en local sans secrets (tous SKIP — attendu)
- [x] Dernier workflow run avec les changements = `8 OK · 0 FAIL · 0 SKIP` (confirmé par Laurin sur PR #459 avant fermeture)
- [ ] Post-merge : relancer le workflow `agent-secrets-healthcheck` depuis `main` pour confirmer
- [ ] Post-merge : ouvrir une nouvelle session Claude Code avec secrets chargés localement, vérifier les lignes `[secrets]` au SessionStart

https://claude.ai/code/session_01HWBkTSUkrWe6wPg2SknyFS