### PR TITLE
Fix digest perspective undercount & same-day deep article selection

### DIFF
--- a/docs/bugs/bug-digest-pas-de-recul-same-event.md
+++ b/docs/bugs/bug-digest-pas-de-recul-same-event.md
@@ -3,7 +3,7 @@
 **Date** : 2026-04-22
 **Branche** : `claude/fix-digest-viewpoints-9QcL6`
 **Sévérité** : P1 — décrédibilise la promesse "Pas de recul / Prendre du recul"
-**Statut** : Plan à valider
+**Statut** : Plan validé — Axes 1 et 3 implémentés dans ce PR, Axe 2 reporté (voir §6)
 
 ---
 
@@ -38,30 +38,22 @@ La cause **A** suffit à bloquer ~90 % des cas observés : si on impose qu'un "p
 
 ---
 
-## 3. Plan d'implémentation (proposé)
+## 3. Plan d'implémentation — scope retenu pour ce PR
 
-Trois axes, livrables indépendants, priorités dans l'ordre (A seul résout la plupart des cas).
+Axes 1 + 3 implémentés dans ce PR. Axe 2 reporté (voir §6).
 
-### Axe 1 — Time-gate dans le pool deep (fix A)
+### Axe 1 — Time-gate dans le pool deep (fix A) — ✅ DANS CE PR
 
 `editorial/deep_matcher.py::_load_deep_articles` :
 
-- Ajouter un paramètre `min_age_hours` (par défaut dans `EditorialConfig.pipeline.deep_min_age_hours = 24`).
-- Requête : `Content.published_at <= now - min_age_hours`.
+- Ajouter un paramètre de configuration `deep_min_age_hours` (défaut **24 h**, valeur sûre choisie pour capital confiance utilisateurs).
+- Requête : `Content.published_at <= now - deep_min_age_hours`.
 - Exposer la valeur dans `config/editorial_config.yaml` pour réglage opérateur.
 - Garder la limite haute à 3000 sans filtre d'ancienneté supérieure (des analyses de fond peuvent être pertinentes plusieurs mois après).
 
-Trade-off : on perd la fenêtre "décryptage du jour même" d'une source deep qui publie très vite après un évènement. C'est acceptable et conforme à la promesse produit ("prendre du recul" ≠ "autre dépêche sur le même évènement").
+Trade-off assumé : on perd la fenêtre "décryptage du jour même" d'une source deep qui publierait très vite après un évènement. Conforme à la promesse produit ("prendre du recul" ≠ "autre dépêche sur le même évènement").
 
-### Axe 2 — Rejet des quasi-doublons (fix C)
-
-`editorial/deep_matcher.py::_prefilter` :
-
-- Après scoring, **exclure** tout candidat dont le Jaccard de titre (pas label+angle, uniquement `article.title` vs les titres du `cluster.contents`) dépasse `DEEP_TITLE_SIMILARITY_MAX = 0.6`.
-- Fournir `cluster_titles` via `match_for_topics` (en sus de `cluster_entities`).
-- Logger `deep_matcher.near_duplicate_rejected` pour surveillance.
-
-### Axe 3 — Renforcement du prompt LLM (fix D)
+### Axe 3 — Renforcement du prompt LLM (fix D) — ✅ DANS CE PR
 
 `config/editorial_prompts.yaml::deep_matching.system` : ajouter une règle de rejet explicite :
 
@@ -71,26 +63,37 @@ Trade-off : on perd la fenêtre "décryptage du jour même" d'une source deep qu
 
 Pas de changement de température / modèle.
 
-### Axe 4 (optionnel, à discuter) — Signal de type "analyse" côté source
-
-Marquer un sous-ensemble de flux comme `source_subtier = "analysis"` (ex : "La Croix — Analyses", "The Conversation", "Alternatives Économiques"). Restreindre le pool deep à ce sous-ensemble **si** `subtier == "analysis"` est disponible, sinon fallback sur `source_tier == "deep"`.
-
-Hors scope du présent fix — demande une migration DB + audit des sources. Seulement mentionné pour mémoire.
-
 ---
 
 ## 4. Fichiers modifiés (pour référence)
 
-- `packages/api/app/services/editorial/deep_matcher.py` (Axes 1 + 2)
-- `packages/api/app/services/editorial/config.py` + `config/editorial_config.yaml` (Axe 1 — param `deep_min_age_hours`)
-- `config/editorial_prompts.yaml` (Axe 3)
-- Tests : `packages/api/tests/editorial/test_deep_matcher.py` — cas time-gate, cas near-duplicate, cas LLM rejette correctement.
+- `packages/api/app/services/editorial/deep_matcher.py` (Axe 1 — time-gate)
+- `packages/api/app/services/editorial/config.py` (Axe 1 — nouveau champ `deep_min_age_hours`)
+- `packages/api/config/editorial_config.yaml` (Axe 1 — valeur par défaut)
+- `packages/api/config/editorial_prompts.yaml` (Axe 3 — prompt deep_matching)
+- `packages/api/tests/editorial/test_deep_matcher.py` (couverture time-gate)
 
 ---
 
-## 5. Questions à valider
+## 5. Décisions actées
 
-1. **Axe 1** : valeur par défaut de `deep_min_age_hours` — 24 h (sûr mais filtre aussi les décryptages rapides légitimes) ou 12 h (moins restrictif) ?
-2. **Axe 2** : seuil `DEEP_TITLE_SIMILARITY_MAX` — 0.6 (strict) ou 0.5 (très strict) ? Un seuil trop bas peut rejeter de vraies analyses qui réutilisent des mots-clés du sujet.
-3. **Axe 4** : d'accord pour l'écarter de ce fix (demande un chantier dédié) ?
-4. **Périmètre PR** : Axes 1 + 3 suffisent-ils pour ce tour, Axe 2 en PR suivant ? Ou tout en un seul PR ?
+- **`deep_min_age_hours = 24`** choisi (vs 12 h) : priorité capital confiance utilisateurs. On préfère moins de "Pas de recul" affichés mais de qualité irréprochable.
+- **1 seul PR combiné** avec Bug #1 Axe 2 (cf. `bug-digest-perspective-undercount.md`).
+
+---
+
+## 6. Reporté au post-merge (follow-up)
+
+### Follow-up PR (après merge des deux PR en parallèle — la nôtre et celle "Post-filtre de cohérence sujet + masquage UI" de l'agent parallèle)
+
+- **Axe 2 — Rejet Jaccard des quasi-doublons** (`deep_matcher.py::_prefilter`) :
+  - Exclure les candidats dont le Jaccard de titre vs les titres du `cluster.contents` dépasse `DEEP_TITLE_SIMILARITY_MAX = 0.6`.
+  - Réutiliser `services/text_similarity.py` (extrait par la PR in-reader) pour ne pas dupliquer Jaccard/normalize_title.
+  - Harmoniser avec les constantes `PERSPECTIVE_*` pour cohérence digest ↔ in-reader.
+  - À évaluer après observabilité : si le time-gate 24 h + prompt strict suffisent en prod (taux de quasi-doublons proche de zéro), l'Axe 2 peut rester optionnel.
+
+- **Axe 4 — Signal `source_subtier = "analysis"`** (hors scope long terme) :
+  - Marquer un sous-ensemble de flux comme "analyse pure" (La Croix — Analyses, The Conversation, Alternatives Économiques, etc.).
+  - Migration DB + audit des sources requis. Chantier dédié, pas prioritaire tant que Axes 1 + 3 donnent satisfaction.
+
+- **Surveillance post-merge** : observer `deep_matcher.llm_rejections` (taux de rejet doit augmenter avec le prompt durci) et ajouter un log `deep_matcher.time_gate_excluded` pour mesurer combien de candidats sont écartés par la règle d'ancienneté.

--- a/docs/bugs/bug-digest-pas-de-recul-same-event.md
+++ b/docs/bugs/bug-digest-pas-de-recul-same-event.md
@@ -1,0 +1,96 @@
+﻿# Bug — "Prendre du recul" sélectionne une actu du jour, pas une analyse de fond
+
+**Date** : 2026-04-22
+**Branche** : `claude/fix-digest-viewpoints-9QcL6`
+**Sévérité** : P1 — décrédibilise la promesse "Pas de recul / Prendre du recul"
+**Statut** : Plan à valider
+
+---
+
+## 1. Reproduction (capture 3)
+
+Digest du 2026-04-22, sujet #4 "Société" — _Le Texas autorisé à imposer l'affichage des Dix commandements dans les éco…_ (France Info, 4 h).
+
+- Bloc "Prendre du recul" : _"États-Unis : le Texas autorisé à imposer l'affichage des Dix co…"_ (La Croix — Analyses).
+- Les deux titres couvrent **le même évènement, au même moment, avec le même cadrage**. La Croix n'apporte ici aucune mise en perspective systémique/structurelle/historique — c'est une dépêche parallèle.
+- Critères attendus du bloc (cf. prompt `deep_matching`) : "éclairage systémique, structurel ou historique", "complémentarité avec l'actualité chaude (perspective différente)". Pas respecté.
+
+---
+
+## 2. Flux actuel & points de friction
+
+`editorial/deep_matcher.py::match_for_topics` :
+
+1. `_load_deep_articles` : tous les contenus des sources `source_tier = "deep"` non payants, triés par `published_at desc`, **cap 3000**, **aucun filtre temporel**.
+2. `_prefilter` : Jaccard entre tokens (`topic.label + topic.deep_angle`) et (`article.title + topics + description[:200]`), seuil `deep_jaccard_threshold = 0.08`, bonus entités +0.15 max.
+3. `_llm_evaluate` : le LLM choisit un index ou renvoie `null`.
+
+### Causes racines
+
+| # | Cause | Détail |
+|---|-------|--------|
+| A | **Pas de time-gate** dans `_load_deep_articles`. Un article "deep" publié 30 min après l'actu principale reste éligible. | Le candidat La Croix du matin 2026-04-22 est aligné temporellement sur la France Info → ce n'est structurellement pas un "pas de recul". |
+| B | Au sein d'une source `source_tier = "deep"`, tous les flux sont agrégés sans distinction : un feed "La Croix — Analyses" peut contenir à la fois des décryptages et des reprises de dépêches. Le tier source ne garantit pas la nature du contenu. | Le mot-clé "Analyses" dans le nom de la rubrique n'est jamais lu. |
+| C | Le pré-filtre Jaccard récompense la **similarité lexicale brute** : un article quasi-doublon du titre de l'actu obtient un score très haut et remonte en tête de candidats. Le LLM se contente de valider ce top-1 (biais d'ancrage + `deep_angle` générique produit par `curation`). | Sur un sujet "Texas Dix commandements", les 6-8 mots-clés du titre se retrouvent quasi identiques des deux côtés → Jaccard ≥ 0.5, arbitre LLM peu sollicité. |
+| D | Le prompt `deep_matching.system` ne dit pas explicitement : *"REFUSE si le candidat est la même dépêche que l'actu, même publiée par une source deep."* | Cas de rejet manquant. |
+
+La cause **A** suffit à bloquer ~90 % des cas observés : si on impose qu'un "pas de recul" ait au moins `N` heures de recul sur les articles chauds, cet article-ci est automatiquement exclu.
+
+---
+
+## 3. Plan d'implémentation (proposé)
+
+Trois axes, livrables indépendants, priorités dans l'ordre (A seul résout la plupart des cas).
+
+### Axe 1 — Time-gate dans le pool deep (fix A)
+
+`editorial/deep_matcher.py::_load_deep_articles` :
+
+- Ajouter un paramètre `min_age_hours` (par défaut dans `EditorialConfig.pipeline.deep_min_age_hours = 24`).
+- Requête : `Content.published_at <= now - min_age_hours`.
+- Exposer la valeur dans `config/editorial_config.yaml` pour réglage opérateur.
+- Garder la limite haute à 3000 sans filtre d'ancienneté supérieure (des analyses de fond peuvent être pertinentes plusieurs mois après).
+
+Trade-off : on perd la fenêtre "décryptage du jour même" d'une source deep qui publie très vite après un évènement. C'est acceptable et conforme à la promesse produit ("prendre du recul" ≠ "autre dépêche sur le même évènement").
+
+### Axe 2 — Rejet des quasi-doublons (fix C)
+
+`editorial/deep_matcher.py::_prefilter` :
+
+- Après scoring, **exclure** tout candidat dont le Jaccard de titre (pas label+angle, uniquement `article.title` vs les titres du `cluster.contents`) dépasse `DEEP_TITLE_SIMILARITY_MAX = 0.6`.
+- Fournir `cluster_titles` via `match_for_topics` (en sus de `cluster_entities`).
+- Logger `deep_matcher.near_duplicate_rejected` pour surveillance.
+
+### Axe 3 — Renforcement du prompt LLM (fix D)
+
+`config/editorial_prompts.yaml::deep_matching.system` : ajouter une règle de rejet explicite :
+
+> REFUSE (`selected_index: null`) si :
+> - Le candidat est **une actualité du même évènement** (même fait, même jour, mêmes protagonistes, même cadrage), même publiée par une source de fond.
+> - Le candidat n'apporte **aucun éclairage supplémentaire** au-delà du compte-rendu factuel — il doit proposer une mise en contexte historique, structurelle, comparatiste ou analytique.
+
+Pas de changement de température / modèle.
+
+### Axe 4 (optionnel, à discuter) — Signal de type "analyse" côté source
+
+Marquer un sous-ensemble de flux comme `source_subtier = "analysis"` (ex : "La Croix — Analyses", "The Conversation", "Alternatives Économiques"). Restreindre le pool deep à ce sous-ensemble **si** `subtier == "analysis"` est disponible, sinon fallback sur `source_tier == "deep"`.
+
+Hors scope du présent fix — demande une migration DB + audit des sources. Seulement mentionné pour mémoire.
+
+---
+
+## 4. Fichiers modifiés (pour référence)
+
+- `packages/api/app/services/editorial/deep_matcher.py` (Axes 1 + 2)
+- `packages/api/app/services/editorial/config.py` + `config/editorial_config.yaml` (Axe 1 — param `deep_min_age_hours`)
+- `config/editorial_prompts.yaml` (Axe 3)
+- Tests : `packages/api/tests/editorial/test_deep_matcher.py` — cas time-gate, cas near-duplicate, cas LLM rejette correctement.
+
+---
+
+## 5. Questions à valider
+
+1. **Axe 1** : valeur par défaut de `deep_min_age_hours` — 24 h (sûr mais filtre aussi les décryptages rapides légitimes) ou 12 h (moins restrictif) ?
+2. **Axe 2** : seuil `DEEP_TITLE_SIMILARITY_MAX` — 0.6 (strict) ou 0.5 (très strict) ? Un seuil trop bas peut rejeter de vraies analyses qui réutilisent des mots-clés du sujet.
+3. **Axe 4** : d'accord pour l'écarter de ce fix (demande un chantier dédié) ?
+4. **Périmètre PR** : Axes 1 + 3 suffisent-ils pour ce tour, Axe 2 en PR suivant ? Ou tout en un seul PR ?

--- a/docs/bugs/bug-digest-perspective-undercount.md
+++ b/docs/bugs/bug-digest-perspective-undercount.md
@@ -1,0 +1,91 @@
+﻿# Bug — Perspectives manquantes sur des sujets multi-sources du digest
+
+**Date** : 2026-04-22
+**Branche** : `claude/fix-digest-viewpoints-9QcL6`
+**Sévérité** : P1 — dégrade la promesse produit ("comparaison de points de vue")
+**Statut** : Plan à valider
+
+---
+
+## 1. Reproduction (capture 1)
+
+Digest du 2026-04-22, sujet #2 "Société" — _Fuite ANTS : près de 12 millions de comptes concernés_ (Frandroid, 32 min).
+
+- La carte n'affiche **qu'un seul logo** + "· 32 min" : pas de "+N", pas de `DivergenceAnalysisBlock` ("Voir tous les points de vue", barre Gauche/Centre/Droite).
+- Pourtant, en ouvrant le même article et en déroulant "Voir tous les points de vue" (capture 2), la bottom-sheet liste **plusieurs sources** à biais connu (Mediapart, franceinfo, …) sur le même évènement, avec une vraie barre `Gauche · Centre · Droite`.
+
+Autrement dit : **la donnée existe côté DB / Google News, mais la pipeline ne l'a pas incorporée dans `perspective_count` / `perspective_articles` du sujet**, donc le mobile masque le bloc d'analyse de biais.
+
+---
+
+## 2. Flux actuel & points de friction
+
+`editorial/pipeline.py::_process_perspectives` enchaîne :
+
+1. Cluster Jaccard (seuil `0.4`) → `cluster.contents` (articles de **notre DB** sur les 48 h, pool plafonné à **200**).
+2. `build_cluster_perspectives(cluster.contents)` — 1 Perspective par `source_id` unique.
+3. Augmentation Google News (`get_perspectives_hybrid`) — limitée à `max_results=10`, dépend d'un index Google News au moment T.
+4. Merge → filtre `bias_stance != "unknown"` → `perspective_count`, `perspective_articles`, `bias_distribution`.
+5. `analyze_divergences` appelé **uniquement si `len(merged_perspectives) >= 3`**.
+
+### Causes racines probables (cumulatives, pas exclusives)
+
+| # | Cause | Impact observé |
+|---|-------|----------------|
+| A | Seuil Jaccard **0.4** sur titres normalisés : deux titres qui décrivent le même évènement avec un cadrage différent (Frandroid "Fuite ANTS" vs Mediapart "Fuite de données à l'ANTS") peuvent basculer en clusters séparés → le sujet sélectionné hérite d'un cluster singleton. | Cluster sous-dimensionné (1 source), la bottom-sheet live ramasse ensuite la vraie couverture via Google News, d'où l'écart. |
+| B | Génération à 08 h Paris = **snapshot figé** : les sources qui publient après 08 h ou ne sont pas encore indexées par Google News à 08 h ne rentrent jamais dans `perspective_articles`. Le store JSONB ne se ré-enrichit pas. | Pour les breaking news matinales, `perspective_count` reste collé à 1-2 tandis que la bottom-sheet live explose à 8-10. |
+| C | Pool `_get_global_candidates` limité à **200** articles en 48 h : si le volume RSS dépasse 200, des articles frais peuvent être écartés (ORDER BY `published_at desc` joue en notre faveur mais ne couvre pas les retards d'ingestion). | Cluster partiel à la génération, symptôme indifférenciable de (A). |
+| D | `bias_stance` DB/map incomplet sur certaines sources tech (ex : `frandroid.com` absent de `DOMAIN_BIAS_MAP`, bias DB = `unknown`) → la source du sujet elle-même est filtrée hors de `known_perspectives`, `perspective_count` = 0 même quand le cluster a 1-2 sources. | Carte sans barre de biais alors que le cluster n'est pas vide. |
+
+La cause **A** explique le mieux le cas "Fuite ANTS" (les autres sources étaient bien publiées avant 08 h mais avec un autre cadrage). **D** explique pourquoi `perspective_count` peut tomber à 0 même avec un cluster non vide.
+
+---
+
+## 3. Plan d'implémentation (proposé)
+
+Trois axes indépendants, livrables séparément si besoin.
+
+### Axe 1 — Boost clustering via entités nommées (fix A)
+
+`briefing/importance_detector.py::build_topic_clusters` : ajouter un **matching par entités nommées** en complément du Jaccard de titres.
+
+- Pour chaque article, récupérer les entités `PERSON`/`ORG`/`EVENT` (déjà stockées dans `Content.entities`).
+- Règle de fusion additive : si deux clusters partagent ≥ 2 entités nommées ET que leur Jaccard titre ≥ 0.25 (seuil dégradé), alors fusionner.
+- Conserver le seuil par défaut `0.4` pour la voie "titre seul" (pas de régression sur les sujets sans entités).
+
+Pas de changement de `TOPIC_CLUSTER_MAX_TOKENS`.
+
+### Axe 2 — Filet de sécurité `perspective_count` (fix D)
+
+`editorial/pipeline.py::_process_perspectives` :
+
+- Si `known_perspectives` finit vide **mais** `cluster.source_ids` a ≥ 1 élément, garder au moins la source représentative dans `perspective_articles` (avec `bias_stance = "unknown"`) et fixer `perspective_count = len(cluster.source_ids)`. La barre de biais reste masquée côté mobile quand `bias_distribution` est toute à 0, mais le `DivergenceAnalysisBlock` s'affiche si `divergence_analysis` ou `bias_highlights` est non-nul.
+- Alternative moins invasive : baisser le plancher `analyze_divergences` de `>= 3` à `>= 2` pour récupérer les cas "Frandroid + 1 autre". Permet au moins d'afficher un texte de contexte.
+
+À arbitrer ensemble (voir section 5).
+
+### Axe 3 — Re-enrichissement paresseux côté endpoint (fix B)
+
+`routers/contents.py::_load_stored_perspectives_for_representative` : si `len(stored) < 3`, **ignorer le snapshot** et basculer sur le live path (`get_perspectives_hybrid` + merge cluster). Le coût LLM reste nul (l'analyse de divergence n'est pas refaite ici), on consomme uniquement un appel Google News déjà caché en amont par le TTLCache `_perspectives_cache` (2 h).
+
+Cela rend la bottom-sheet cohérente avec ce que l'utilisateur voit **au moment où il clique**, sans refaire la digest. Effet secondaire : le count affiché dans la bottom-sheet peut dépasser le count de la card — assumé, le header card reste le snapshot du matin.
+
+Pool `_get_global_candidates` (cause C) : on ne touche pas dans ce PR, sauf si le volume RSS explose (à surveiller via logs `topic_clustering_complete.total_contents`).
+
+---
+
+## 4. Fichiers modifiés (pour référence)
+
+- `packages/api/app/services/briefing/importance_detector.py` (Axe 1)
+- `packages/api/app/services/editorial/pipeline.py` (Axe 2)
+- `packages/api/app/routers/contents.py` (Axe 3)
+- Tests : `packages/api/tests/briefing/test_importance_detector.py`, `tests/editorial/test_pipeline.py`, `tests/contents/test_perspectives_endpoint.py`
+
+---
+
+## 5. Questions à valider
+
+1. **Axe 1** : ok pour élargir les fusions via entités (peut augmenter légèrement le taux de faux positifs sur des sujets qui partagent "Macron" mais pas l'évènement) ?
+2. **Axe 2** : préférence "garder la source seule avec bias unknown" ou "baisser plancher analyse à ≥ 2" ? Impact UX différent.
+3. **Axe 3** : ok pour laisser la bottom-sheet diverger du header card quand la couverture évolue entre 08 h et la lecture ?
+4. **Périmètre** : 3 axes dans 1 PR, ou séparer Axe 1 (clustering) des Axes 2/3 (affichage) ?

--- a/docs/bugs/bug-digest-perspective-undercount.md
+++ b/docs/bugs/bug-digest-perspective-undercount.md
@@ -3,7 +3,7 @@
 **Date** : 2026-04-22
 **Branche** : `claude/fix-digest-viewpoints-9QcL6`
 **Sévérité** : P1 — dégrade la promesse produit ("comparaison de points de vue")
-**Statut** : Plan à valider
+**Statut** : Plan validé — scope réduit pour éviter conflit avec la PR in-reader en parallèle (voir §6)
 
 ---
 
@@ -41,51 +41,54 @@ La cause **A** explique le mieux le cas "Fuite ANTS" (les autres sources étaien
 
 ---
 
-## 3. Plan d'implémentation (proposé)
+## 3. Plan d'implémentation — scope retenu pour ce PR
 
-Trois axes indépendants, livrables séparément si besoin.
+**Un seul axe est implémenté dans ce PR** : Axe 2 (filet de sécurité). Les Axes 1 et 3 sont reportés (voir §6).
 
-### Axe 1 — Boost clustering via entités nommées (fix A)
-
-`briefing/importance_detector.py::build_topic_clusters` : ajouter un **matching par entités nommées** en complément du Jaccard de titres.
-
-- Pour chaque article, récupérer les entités `PERSON`/`ORG`/`EVENT` (déjà stockées dans `Content.entities`).
-- Règle de fusion additive : si deux clusters partagent ≥ 2 entités nommées ET que leur Jaccard titre ≥ 0.25 (seuil dégradé), alors fusionner.
-- Conserver le seuil par défaut `0.4` pour la voie "titre seul" (pas de régression sur les sujets sans entités).
-
-Pas de changement de `TOPIC_CLUSTER_MAX_TOKENS`.
-
-### Axe 2 — Filet de sécurité `perspective_count` (fix D)
+### Axe 2 — Filet de sécurité `perspective_count` (fix D) — ✅ DANS CE PR
 
 `editorial/pipeline.py::_process_perspectives` :
 
-- Si `known_perspectives` finit vide **mais** `cluster.source_ids` a ≥ 1 élément, garder au moins la source représentative dans `perspective_articles` (avec `bias_stance = "unknown"`) et fixer `perspective_count = len(cluster.source_ids)`. La barre de biais reste masquée côté mobile quand `bias_distribution` est toute à 0, mais le `DivergenceAnalysisBlock` s'affiche si `divergence_analysis` ou `bias_highlights` est non-nul.
-- Alternative moins invasive : baisser le plancher `analyze_divergences` de `>= 3` à `>= 2` pour récupérer les cas "Frandroid + 1 autre". Permet au moins d'afficher un texte de contexte.
+- Si `known_perspectives` finit vide **mais** `cluster.source_ids` a ≥ 1 élément, garder au moins la source représentative dans `perspective_articles` (avec `bias_stance = "unknown"`) et fixer `perspective_count = len(cluster.source_ids)`.
+- `divergence_analysis` reste `None` (le plancher `>= 3 merged_perspectives` est maintenu — pas de texte LLM quand on n'a pas la matière).
+- Côté mobile, `DivergenceAnalysisBlock` reste masqué tant que `divergence_analysis` est `null`, mais le compteur de sources du footer card reflète correctement le cluster réel au lieu de tomber à 1 quand la source principale est `bias = unknown`.
 
-À arbitrer ensemble (voir section 5).
-
-### Axe 3 — Re-enrichissement paresseux côté endpoint (fix B)
-
-`routers/contents.py::_load_stored_perspectives_for_representative` : si `len(stored) < 3`, **ignorer le snapshot** et basculer sur le live path (`get_perspectives_hybrid` + merge cluster). Le coût LLM reste nul (l'analyse de divergence n'est pas refaite ici), on consomme uniquement un appel Google News déjà caché en amont par le TTLCache `_perspectives_cache` (2 h).
-
-Cela rend la bottom-sheet cohérente avec ce que l'utilisateur voit **au moment où il clique**, sans refaire la digest. Effet secondaire : le count affiché dans la bottom-sheet peut dépasser le count de la card — assumé, le header card reste le snapshot du matin.
-
-Pool `_get_global_candidates` (cause C) : on ne touche pas dans ce PR, sauf si le volume RSS explose (à surveiller via logs `topic_clustering_complete.total_contents`).
+Choix motivé : option "honnête" (on ne ment pas sur le nombre de sources) plutôt que de forcer une analyse de biais sur un échantillon de 2.
 
 ---
 
-## 4. Fichiers modifiés (pour référence)
+## 4. Fichiers modifiés dans ce PR
 
-- `packages/api/app/services/briefing/importance_detector.py` (Axe 1)
 - `packages/api/app/services/editorial/pipeline.py` (Axe 2)
-- `packages/api/app/routers/contents.py` (Axe 3)
-- Tests : `packages/api/tests/briefing/test_importance_detector.py`, `tests/editorial/test_pipeline.py`, `tests/contents/test_perspectives_endpoint.py`
+- `packages/api/tests/editorial/test_pipeline.py` (couverture filet de sécurité)
 
 ---
 
-## 5. Questions à valider
+## 5. Décisions actées
 
-1. **Axe 1** : ok pour élargir les fusions via entités (peut augmenter légèrement le taux de faux positifs sur des sujets qui partagent "Macron" mais pas l'évènement) ?
-2. **Axe 2** : préférence "garder la source seule avec bias unknown" ou "baisser plancher analyse à ≥ 2" ? Impact UX différent.
-3. **Axe 3** : ok pour laisser la bottom-sheet diverger du header card quand la couverture évolue entre 08 h et la lecture ?
-4. **Périmètre** : 3 axes dans 1 PR, ou séparer Axe 1 (clustering) des Axes 2/3 (affichage) ?
+- **Option retenue pour Axe 2** : garder la source du cluster avec `bias_stance = "unknown"` quand aucun biais n'est connu. Pas de bascule du plancher `analyze_divergences` à `>= 2` (l'analyse LLM reste réservée aux sujets avec ≥ 3 sources à biais connu).
+- **1 seul PR combiné** avec Bug #2 (cf. `bug-digest-pas-de-recul-same-event.md`).
+
+---
+
+## 6. Reporté au post-merge (follow-up)
+
+Ces deux axes sont volontairement écartés de ce PR pour éviter une dette de maintenance avec la PR **"Post-filtre de cohérence sujet + masquage UI"** (agent parallèle) qui :
+- Extrait `normalize_title` + `jaccard_similarity` dans `services/text_similarity.py`.
+- Ajoute un post-filtre `is_topically_coherent` dans `perspective_service.get_perspectives_hybrid`.
+- Introduit `should_display` et constantes `PERSPECTIVE_TITLE_JACCARD_MIN=0.30`, `PERSPECTIVE_MIN_VALID_RESULTS=2`, `PERSPECTIVE_MIN_BIAS_GROUPS=2`.
+- Touche `routers/contents.py:626-638` (en conflit direct avec notre Axe 3).
+
+### Follow-up PR (après merge des deux PR)
+
+- **Axe 1 — Boost clustering via entités nommées** (`briefing/importance_detector.py::build_topic_clusters`) :
+  - Réutiliser `services/text_similarity.py` (extrait par l'autre PR) au lieu de ré-implémenter Jaccard/normalize_title.
+  - Harmoniser les constantes de seuil avec `PERSPECTIVE_TITLE_JACCARD_MIN` pour que clustering digest et post-filtre in-reader parlent le même langage.
+  - Règle : fusion additive si ≥ 2 entités `PERSON`/`ORG`/`EVENT` partagées ET Jaccard titre ≥ 0.25.
+  - Garde le seuil 0.4 sur la voie "titre seul" pour ne pas régresser sur les sujets sans entités.
+
+- **Axe 3 — Re-enrichissement paresseux côté endpoint** (`routers/contents.py::_load_stored_perspectives_for_representative`) :
+  - Réévaluer après merge : si le post-filtre + `should_display` de l'autre PR gèrent déjà correctement l'UX (bottom-sheet vide proprement quand couverture insuffisante), l'Axe 3 devient largement redondant.
+  - Décision à trancher à ce moment-là : garder uniquement la bascule live quand `len(stored) < 3`, **ou** supprimer complètement (si `should_display` suffit).
+
+- **Surveillance post-merge** : log `topic_clustering_complete.total_contents` et `editorial_pipeline.perspectives_composition` pour identifier si le pool `_get_global_candidates = 200` est devenu trop étroit. Si oui, ticket dédié pour passer à 500.

--- a/packages/api/app/services/editorial/config.py
+++ b/packages/api/app/services/editorial/config.py
@@ -22,6 +22,12 @@ class PipelineConfig:
     deep_required: bool = False
     actu_max_age_hours: int = 24
     deep_jaccard_threshold: float = 0.10
+    # Minimum age (hours) for an article to be eligible as a "Pas de recul"
+    # candidate. Enforces that a deep-tier article published on the same
+    # morning as the hot news is excluded — "prendre du recul" should mean
+    # stepping back, not another same-day dispatch from a deep source.
+    # See docs/bugs/bug-digest-pas-de-recul-same-event.md.
+    deep_min_age_hours: int = 24
 
 
 @dataclass(frozen=True)

--- a/packages/api/app/services/editorial/deep_matcher.py
+++ b/packages/api/app/services/editorial/deep_matcher.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
 
 import structlog
 from sqlalchemy import select
@@ -89,7 +90,11 @@ class DeepMatcher:
             logger.warning("deep_matcher.no_deep_articles")
             return {t.topic_id: None for t in selected_topics}
 
-        logger.info("deep_matcher.pool_loaded", count=len(deep_articles))
+        logger.info(
+            "deep_matcher.pool_loaded",
+            count=len(deep_articles),
+            min_age_hours=self._config.pipeline.deep_min_age_hours,
+        )
 
         # Skip topics flagged as having no meaningful deep angle — we refuse
         # to force a "Pas de recul" on purely eventful / people / faits-divers
@@ -206,12 +211,18 @@ class DeepMatcher:
         return fallback_matches
 
     async def _load_deep_articles(self) -> list[Content]:
-        """Load all articles from deep sources (no time limit).
+        """Load deep-tier articles older than ``deep_min_age_hours``.
 
         Ouvre une session courte dédiée : la requête dure <1s et les
         objets Content restent utilisables hors session (expire_on_commit=False,
         selectinload sur `source`). Cf. bug-infinite-load-requests.md (P1).
+
+        Le filtre d'ancienneté minimale exclut les dépêches du même matin,
+        qui, même publiées par une source deep, ne constituent pas un vrai
+        "pas de recul". Cf. bug-digest-pas-de-recul-same-event.md.
         """
+        min_age_hours = max(self._config.pipeline.deep_min_age_hours, 0)
+        max_published_at = datetime.now(UTC) - timedelta(hours=min_age_hours)
         stmt = (
             select(Content)
             .join(Content.source)
@@ -219,6 +230,7 @@ class DeepMatcher:
             .where(
                 Source.source_tier == "deep",
                 Content.is_paid.is_(False),
+                Content.published_at <= max_published_at,
             )
             .order_by(Content.published_at.desc())
             .limit(3000)  # Safety cap

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -408,15 +408,46 @@ class EditorialPipelineService:
             known_perspectives = [
                 p for p in merged_perspectives if p.bias_stance != "unknown"
             ]
-            subject.perspective_count = len(known_perspectives)
-            subject.bias_distribution = compute_bias_distribution(known_perspectives)
-            subject.bias_highlights = compute_bias_highlights(subject.bias_distribution)
+
+            # Safety net: if every merged perspective has an unknown bias
+            # (source not in DOMAIN_BIAS_MAP nor resolvable via DB), fall
+            # back to counting the cluster sources themselves. Otherwise
+            # the card footer would show a single logo even when the digest
+            # actually grouped several outlets together. The bias
+            # distribution stays all-zero so the spectrum bar and divergence
+            # analysis remain hidden — we only lift the raw source counter.
+            # Cf. docs/bugs/bug-digest-perspective-undercount.md (Axe 2).
+            if not known_perspectives and cluster_perspectives:
+                subject.perspective_count = len(cluster_perspectives)
+                subject.bias_distribution = compute_bias_distribution([])
+                subject.bias_highlights = None
+                logger.info(
+                    "editorial_pipeline.perspective_count_safety_net",
+                    topic_id=subject.topic_id,
+                    cluster_sources=len(cluster_perspectives),
+                )
+            else:
+                subject.perspective_count = len(known_perspectives)
+                subject.bias_distribution = compute_bias_distribution(
+                    known_perspectives
+                )
+                subject.bias_highlights = compute_bias_highlights(
+                    subject.bias_distribution
+                )
 
             # Persist the full known-bias merged list so the
             # /contents/{id}/perspectives endpoint can return the exact same
             # snapshot — otherwise the bottom sheet re-runs Google News at
             # call time and shows different media than the CTA logos that
             # come from this pipeline run.
+            # When the safety net above kicked in (no known bias), persist
+            # the cluster perspectives as-is (bias_stance=unknown) so the
+            # endpoint doesn't bail out to the live path — it already has
+            # the full cluster list to return, and the mobile footer logos
+            # stay coherent with the digest-time cluster.
+            snapshot_perspectives = (
+                known_perspectives if known_perspectives else cluster_perspectives
+            )
             subject.perspective_articles = [
                 {
                     "title": p.title,
@@ -427,7 +458,7 @@ class EditorialPipelineService:
                     "published_at": p.published_at,
                     "description": p.description,
                 }
-                for p in known_perspectives
+                for p in snapshot_perspectives
             ]
 
             # Axe C — observability: log the composition so we can verify in
@@ -445,10 +476,14 @@ class EditorialPipelineService:
 
             # Build perspective_sources — max 6, deduplicated by domain.
             # Use known_perspectives so the CTA logos match the bottom sheet
-            # (which also filters out unknown bias).
+            # (which also filters out unknown bias). When the safety net
+            # above fell back to cluster sources (no known bias), feed the
+            # same list here so the footer renders logos for each outlet
+            # in the cluster, consistent with perspective_count.
+            sources_pool = known_perspectives or cluster_perspectives
             seen_domains: set[str] = set()
             unique_perspectives = []
-            for p in known_perspectives:
+            for p in sources_pool:
                 if p.source_domain not in seen_domains:
                     seen_domains.add(p.source_domain)
                     unique_perspectives.append(p)

--- a/packages/api/config/editorial_config.yaml
+++ b/packages/api/config/editorial_config.yaml
@@ -12,6 +12,11 @@ pipeline:
   # strict et sans override déterministe, on préfère un pool réduit de
   # candidats pertinents plutôt qu'une liste longue polluée.
   deep_jaccard_threshold: 0.08
+  # Ancienneté minimale d'un article "deep" pour être éligible comme
+  # "Pas de recul". 24 h garantit qu'une dépêche du même matin (même si
+  # publiée par une source deep) ne sera pas promue en mise en perspective.
+  # Cf. docs/bugs/bug-digest-pas-de-recul-same-event.md.
+  deep_min_age_hours: 24
 
 cost:
   max_llm_calls_per_batch: 10   # Safety cap LLM calls

--- a/packages/api/config/editorial_prompts.yaml
+++ b/packages/api/config/editorial_prompts.yaml
@@ -49,8 +49,17 @@ deep_matching:
     - Aucun candidat ne partage au moins une entite nommee (personne,
       organisation, pays, concept) ou un champ lexical structurel avec
       le sujet.
+    - Le candidat est une **actualite du meme evenement** : meme fait,
+      meme jour, memes protagonistes, meme cadrage factuel — meme s'il
+      est publie par une source de fond. Un "pas de recul" n'est PAS
+      une autre depeche qui reprend les memes elements, c'est une mise
+      en perspective qui ajoute un eclairage historique, structurel,
+      comparatiste ou analytique.
+    - Le candidat n'apporte **aucun eclairage supplementaire** au-dela
+      du compte-rendu factuel deja couvert par l'actualite chaude.
     - Tu hesites. En cas de doute, renvoie `null`. Mieux vaut pas de
-      "pas de recul" qu'un article hors-sujet qui decredibilise le digest.
+      "pas de recul" qu'un article hors-sujet ou redondant qui
+      decredibilise le digest.
 
     Criteres si tu choisis (cumulatifs) :
     - Pertinence systemique (PAS evenementiel — on cherche de l'analyse)

--- a/packages/api/tests/editorial/test_deep_matcher.py
+++ b/packages/api/tests/editorial/test_deep_matcher.py
@@ -77,6 +77,69 @@ class TestLoadDeepArticles:
         session.execute.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_time_gate_filters_recent_articles(self):
+        """Time-gate: deep articles younger than deep_min_age_hours are
+        excluded from the pool. Guards against same-day "dispatch masquerading
+        as pas de recul" — cf. bug-digest-pas-de-recul-same-event.md.
+        """
+        session = _mock_session_with_articles([])
+        llm = MagicMock()
+        llm.is_ready = False
+
+        config = EditorialConfig(
+            pipeline=PipelineConfig(deep_min_age_hours=24),
+            deep_matching_prompt=PromptConfig(system=""),
+        )
+        matcher = DeepMatcher(session, llm, config)
+        before = datetime.now(UTC)
+        await matcher._load_deep_articles()
+        after = datetime.now(UTC)
+
+        stmt = session.execute.await_args.args[0]
+        sql_text = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "published_at <=" in sql_text.lower()
+
+        # Introspect the bound parameter to confirm the cutoff is ~24h in the past
+        from datetime import timedelta
+
+        params = stmt.compile().params
+        cutoff_value = None
+        for v in params.values():
+            if isinstance(v, datetime):
+                cutoff_value = v
+                break
+        assert cutoff_value is not None, "expected a datetime param (published_at cutoff)"
+        expected_min = before - timedelta(hours=24)
+        expected_max = after - timedelta(hours=24)
+        assert expected_min <= cutoff_value <= expected_max
+
+    @pytest.mark.asyncio
+    async def test_time_gate_disabled_when_zero_hours(self):
+        """deep_min_age_hours=0 effectively disables the gate (cutoff = now)."""
+        session = _mock_session_with_articles([])
+        llm = MagicMock()
+        llm.is_ready = False
+
+        config = EditorialConfig(
+            pipeline=PipelineConfig(deep_min_age_hours=0),
+            deep_matching_prompt=PromptConfig(system=""),
+        )
+        matcher = DeepMatcher(session, llm, config)
+        before = datetime.now(UTC)
+        await matcher._load_deep_articles()
+
+        stmt = session.execute.await_args.args[0]
+        params = stmt.compile().params
+        cutoff_value = next(v for v in params.values() if isinstance(v, datetime))
+        # Cutoff should be very close to "now" (within a second)
+        assert (cutoff_value - before).total_seconds() < 1.5
+
+    def test_default_deep_min_age_hours_is_24(self):
+        """Default config value — documents the chosen safe threshold."""
+        config = PipelineConfig()
+        assert config.deep_min_age_hours == 24
+
+    @pytest.mark.asyncio
     async def test_uses_session_maker_and_does_not_touch_injected_session(self):
         """P1 fix — when session_maker is provided, each DB op opens a
         short-lived session. The injected `session` must NOT be used, so

--- a/packages/api/tests/editorial/test_pipeline.py
+++ b/packages/api/tests/editorial/test_pipeline.py
@@ -450,3 +450,106 @@ class TestPerspectiveCountAlignment:
 
         # Pivot = most recent content of the cluster.
         assert subject.representative_content_id == newer.id
+
+    @pytest.mark.asyncio
+    async def test_safety_net_counts_cluster_sources_when_all_bias_unknown(
+        self, mock_dependencies
+    ):
+        """Safety net (Axe 2, bug-digest-perspective-undercount):
+        when every merged perspective has bias_stance="unknown" but the
+        cluster actually grouped several outlets, ``perspective_count``
+        must fall back to the cluster source count instead of collapsing
+        to 0. bias_distribution stays all-zero so the spectrum bar and
+        LLM analysis remain hidden (we don't fake a bias signal).
+        """
+        from app.services.editorial.pipeline import EditorialPipelineService
+
+        # Two cluster articles, different outlets, both with bias unknown.
+        outlet_a_id = uuid4()
+        outlet_b_id = uuid4()
+        article_a = _make_content_mock(title="outlet A")
+        article_a.source_id = outlet_a_id
+        article_a.source.url = "https://www.outlet-a.fr/"
+        article_a.url = "https://www.outlet-a.fr/story"
+        article_a.published_at = datetime(2026, 4, 22, 6, tzinfo=UTC)
+
+        article_b = _make_content_mock(title="outlet B")
+        article_b.source_id = outlet_b_id
+        article_b.source.url = "https://www.outlet-b.fr/"
+        article_b.url = "https://www.outlet-b.fr/story"
+        article_b.published_at = datetime(2026, 4, 22, 7, tzinfo=UTC)
+
+        cluster = _make_cluster_mock(
+            cluster_id="c1",
+            label="Breaking news",
+            contents=[article_a, article_b],
+            source_ids={outlet_a_id, outlet_b_id},
+        )
+
+        # Every resolved bias is unknown (neither outlet in DOMAIN_BIAS_MAP,
+        # no DB match). Also pass through Google News articles unknown.
+        mock_dependencies["perspective"].resolve_bias = AsyncMock(return_value="unknown")
+        mock_dependencies["perspective"].get_perspectives_hybrid = AsyncMock(
+            return_value=([], [])
+        )
+        # Explicit cluster perspectives — 2 outlets, both bias=unknown.
+        # Without this override, MagicMock returns a non-awaitable sentinel
+        # and the pipeline's try/except swallows it as [], which would
+        # short-circuit the safety net we want to exercise.
+        mock_dependencies["perspective"].build_cluster_perspectives = AsyncMock(
+            return_value=[
+                _StubPerspective("unknown", "Outlet A", "outlet-a.fr"),
+                _StubPerspective("unknown", "Outlet B", "outlet-b.fr"),
+            ]
+        )
+
+        session = AsyncMock()
+        session.execute = AsyncMock(
+            return_value=MagicMock(all=MagicMock(return_value=[]))
+        )
+        svc = EditorialPipelineService(session)
+
+        with patch(
+            "app.services.editorial.pipeline.ImportanceDetector"
+        ) as mock_detector_cls:
+            mock_detector = MagicMock()
+            mock_detector.build_topic_clusters.return_value = [cluster]
+            mock_detector_cls.return_value = mock_detector
+
+            mock_dependencies["curation"].select_a_la_une.return_value = SelectedTopic(
+                topic_id="c1",
+                label="Breaking news",
+                selection_reason="Traité par 2 sources",
+                deep_angle="D",
+                source_count=2,
+            )
+            mock_dependencies["curation"].select_topics.return_value = []
+            mock_dependencies["deep"].match_for_topics.return_value = {"c1": None}
+            mock_dependencies["actu"].match_global.side_effect = (
+                lambda subjects, clusters, excluded_source_ids=None, excluded_content_ids=None: subjects
+            )
+
+            result = await svc.compute_global_context([article_a, article_b])
+
+        assert result is not None
+        subject = result.subjects[0]
+
+        # Safety net: count reflects the 2 cluster outlets, not 0.
+        assert subject.perspective_count == 2
+        # No known bias → distribution all zero (spectrum bar hidden mobile-side).
+        assert subject.bias_distribution == {
+            "left": 0,
+            "center-left": 0,
+            "center": 0,
+            "center-right": 0,
+            "right": 0,
+        }
+        assert subject.bias_highlights is None
+        # Stored snapshot must still carry the cluster outlets so
+        # /contents/{id}/perspectives can return them instead of bailing
+        # to the live path.
+        assert subject.perspective_articles is not None
+        assert len(subject.perspective_articles) == 2
+        # Footer logos — one per outlet, matching the count.
+        assert subject.perspective_sources is not None
+        assert len(subject.perspective_sources) == 2


### PR DESCRIPTION
## What

Fixes two P1 bugs affecting the digest editorial pipeline:

1. **Perspective undercount (Axe 2)**: When all merged perspectives have unknown bias (sources not in `DOMAIN_BIAS_MAP`), fall back to counting cluster sources instead of collapsing to 0. Preserves cluster perspectives in the snapshot so the footer logos and source count remain coherent.

2. **Same-day deep article selection (Axe 1 & 3)**:
   - **Axe 1**: Add time-gate filter (`deep_min_age_hours`, default 24h) to exclude deep-tier articles published too recently. Prevents same-morning dispatches from being promoted as "Pas de recul" analysis.
   - **Axe 3**: Strengthen LLM prompt to explicitly reject same-event articles and require genuine analytical perspective beyond factual recap.

## Why

**Bug #1 (perspective-undercount)**: Digest subjects with multi-source clusters were showing only 1 logo in the footer card even when the cluster contained 2+ outlets, because `perspective_count` was filtered to only known-bias sources. When all sources had unknown bias, the count dropped to 0, hiding the actual coverage breadth.

**Bug #2 (same-day deep)**: The "Prendre du recul" block was selecting articles from the same morning that merely repeated the hot news with different wording, rather than providing genuine historical/structural analysis. This undermined the product promise of "stepping back."

## Changes

### Core Logic
- `editorial/pipeline.py`: Safety net in `_process_perspectives` — when `known_perspectives` is empty but `cluster_perspectives` exists, use cluster source count and persist cluster perspectives in snapshot.
- `editorial/deep_matcher.py`: Add `_load_deep_articles` time-gate using `deep_min_age_hours` config parameter.
- `editorial/config.py`: New `PipelineConfig.deep_min_age_hours` field (default 24).
- `editorial_config.yaml`: Expose `deep_min_age_hours: 24` for operator tuning.
- `editorial_prompts.yaml`: Strengthen `deep_matching.system` prompt with explicit rejection rules for same-event articles.

### Tests
- `test_pipeline.py`: New test `test_safety_net_counts_cluster_sources_when_all_bias_unknown` validates the perspective undercount fix.
- `test_deep_matcher.py`: Three new tests for time-gate behavior (`test_time_gate_filters_recent_articles`, `test_time_gate_disabled_when_zero_hours`, `test_default_deep_min_age_hours_is_24`).

### Documentation
- Added `docs/bugs/bug-digest-perspective-undercount.md` (root cause analysis, implementation plan, follow-up axes).
- Added `docs/bugs/bug-digest-pas-de-recul-same-event.md` (root cause analysis, implementation plan, follow-up axes).

## Type

- [x] Bug fix

## Checklist

- [x] Tests pass locally (new unit tests added and passing)
- [x] Linting passes
- [x] No new `List[]` imports (uses `list[]`)
- [x] Config and prompt changes documented in bug docs
- [x] N/A (no auth/DB schema changes)

## Staging

- [ ] N/A (logic changes require staging validation; config-only aspects can be deployed independently)

## Notes

- **Axe 2 (perspective undercount)** is fully implemented in this PR.
- **Axes 1 & 3 (deep article time-gate & prompt)** are fully implemented in this PR.
- **Follow-up work** (Axes 2 & 4 for deep matching, Axes 1 & 3 for clustering) documented in bug docs for post-merge PRs to avoid conflicts with parallel in-reader work.
- Trade-off: 24h minimum age means same-day deep analysis is excluded, but this aligns with product promise and user trust.

https://claude.ai/code/session_01QwjrbS3GqMdUzbD3C68ruP