### PR TITLE
refine(mobile): digest + feed visual polish

### DIFF
--- a/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
+++ b/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
@@ -61,18 +61,17 @@ class TopicChip extends StatelessWidget {
           () => showArticleSheet(context, content,
               initialSection: ArticleSheetSection.topic),
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
         decoration: BoxDecoration(
-          color: isFollowed
-              ? Color.lerp(colors.backgroundSecondary, Colors.black, 0.008)!
-              : Color.lerp(colors.backgroundSecondary, Colors.black, 0.003)!,
+          color: Color.lerp(colors.backgroundSecondary, Colors.black, 0.005)!,
           borderRadius: BorderRadius.circular(8),
         ),
         child: Text(
           topicLabel,
           style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                color: colors.textTertiary,
+                color: colors.textSecondary,
                 fontWeight: FontWeight.w500,
+                fontSize: 11,
               ),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -10,6 +10,7 @@ import '../../../core/providers/analytics_provider.dart';
 import '../../../core/services/push_notification_service.dart';
 import '../../../core/services/widget_service.dart';
 import '../../../core/ui/notification_service.dart';
+import '../../onboarding/providers/onboarding_provider.dart';
 import '../models/digest_models.dart';
 import '../repositories/digest_repository.dart';
 import 'serein_toggle_provider.dart';
@@ -650,12 +651,25 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
     return processedCount / tc;
   }
 
-  /// Check if all units are processed and trigger completion.
+  /// Daily goal = what the UI displays in the progress bar. Matches the
+  /// `min(totalCount, onboarding.dailyArticleCount)` formula used in
+  /// digest_screen. Completion fires when the user hits this goal, even if
+  /// extras (pépite / coup de cœur) are still unprocessed.
+  int get goalCount {
+    final tc = totalCount;
+    if (tc == 0) return 0;
+    final userPref =
+        ref.read(onboardingProvider).answers.dailyArticleCount ?? 5;
+    return tc < userPref ? tc : userPref;
+  }
+
+  /// Check if the daily goal is reached and trigger completion.
   void _checkAndHandleCompletion() {
     final digest = state.value;
     if (digest == null || digest.isCompleted) return;
 
-    if (processedCount >= totalCount) {
+    final goal = goalCount;
+    if (goal > 0 && processedCount >= goal) {
       completeDigest();
     }
   }

--- a/apps/mobile/lib/features/digest/screens/closure_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/closure_screen.dart
@@ -199,10 +199,17 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
     }
   }
 
-  void _navigateToFeed() {
-    // Replace current route (don't allow back to closure)
-    context.go(RoutePaths.feed);
+  /// Works both as a pushed route and as a modal: pop the current overlay
+  /// first (dialog or closure route), then redirect so the user can't
+  /// back-navigate to the closure view.
+  void _goAndDismiss(String path) {
+    if (Navigator.of(context).canPop()) {
+      Navigator.of(context).pop();
+    }
+    context.go(path);
   }
+
+  void _navigateToFeed() => _goAndDismiss(RoutePaths.feed);
 
   void _onExplorerPlusPressed() {
     _navigateToFeed();
@@ -338,7 +345,7 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
               return Padding(
                 padding: const EdgeInsets.only(top: FacteurSpacing.space3),
                 child: GestureDetector(
-                  onTap: () => context.go(RoutePaths.saved),
+                  onTap: () => _goAndDismiss(RoutePaths.saved),
                   child: Container(
                     margin: const EdgeInsets.symmetric(horizontal: 32),
                     padding: const EdgeInsets.symmetric(

--- a/apps/mobile/lib/features/digest/screens/digest_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/digest_screen.dart
@@ -38,6 +38,7 @@ import '../widgets/digest_briefing_section.dart';
 import '../widgets/digest_personalization_sheet.dart';
 import '../widgets/digest_welcome_modal.dart';
 import '../widgets/widget_pin_nudge.dart';
+import 'closure_screen.dart';
 import '../../saved/widgets/collection_picker_sheet.dart';
 import '../../saved/providers/collections_provider.dart';
 import '../../../core/ui/notification_service.dart';
@@ -171,8 +172,38 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
     });
   }
 
+  /// Show the closure screen as a modal (slides up from bottom) instead of
+  /// pushing a route, so the digest stays in place behind it.
+  void _showClosureModal(String digestId) {
+    showGeneralDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: 'Fermer',
+      barrierColor: Colors.black.withOpacity(0.35),
+      transitionDuration: const Duration(milliseconds: 320),
+      pageBuilder: (_, __, ___) => ClosureScreen(digestId: digestId),
+      transitionBuilder: (_, animation, __, child) {
+        final curved =
+            CurvedAnimation(parent: animation, curve: Curves.easeOutCubic);
+        return SlideTransition(
+          position: Tween<Offset>(
+            begin: const Offset(0, 1),
+            end: Offset.zero,
+          ).animate(curved),
+          child: child,
+        );
+      },
+    );
+  }
+
   void _openArticle(DigestItem item) async {
     HapticFeedback.mediumImpact();
+
+    // Mark as read on tap, before navigation — gives immediate feedback on
+    // the progress micro-bars without waiting for the user to pop back.
+    if (!item.isRead && !item.isDismissed) {
+      ref.read(digestProvider.notifier).applyAction(item.contentId, 'read');
+    }
 
     // Premium source → open in external browser for authenticated access
     final sources = ref.read(userSourcesProvider).valueOrNull ?? [];
@@ -182,9 +213,6 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
       final uri = Uri.tryParse(item.url);
       if (uri != null) {
         await launchUrl(uri, mode: LaunchMode.externalApplication);
-        if (!item.isRead && !item.isDismissed) {
-          ref.read(digestProvider.notifier).applyAction(item.contentId, 'read');
-        }
         return;
       }
     }
@@ -204,11 +232,6 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
               noteText: updated.noteText,
             );
       }
-    }
-
-    // Mark as read when returning from article (only if not already read)
-    if (!item.isRead && !item.isDismissed) {
-      ref.read(digestProvider.notifier).applyAction(item.contentId, 'read');
     }
   }
 
@@ -348,14 +371,15 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
 
     debugPrint('DigestScreen: digestAsync state = ${digestAsync.toString()}');
 
-    // Navigate to closure screen when digest is completed
+    // Open closure modal when digest completes. Rendered as a modal (not a
+    // route push) so the digest screen stays in place underneath; users
+    // dismiss via swipe-down or the in-modal CTAs.
     ref.listen(digestProvider, (previous, next) {
       next.whenData((digest) {
         if (digest != null &&
             digest.isCompleted &&
             previous?.value?.isCompleted != true) {
-          // Navigate to closure screen on completion
-          context.push('/digest/closure', extra: digest.digestId);
+          _showClosureModal(digest.digestId);
         }
       });
     });
@@ -394,7 +418,7 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
                     child: Padding(
                       padding: EdgeInsets.symmetric(
                         horizontal: FacteurSpacing.space6,
-                        vertical: FacteurSpacing.space3,
+                        vertical: FacteurSpacing.space2,
                       ),
                       child: Stack(
                         alignment: Alignment.center,

--- a/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
@@ -226,7 +226,7 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       itemCount: visibleItems.length,
-      separatorBuilder: (context, index) => const SizedBox(height: 5),
+      separatorBuilder: (context, index) => const SizedBox(height: 2),
       itemBuilder: (context, index) {
         final item = visibleItems[index];
         return _buildRankedCard(context, item, index + 1);
@@ -270,15 +270,6 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Text(
-          '$processed/$denominator',
-          style: TextStyle(
-            color: color,
-            fontSize: 11,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        const SizedBox(width: 5),
         ...List.generate(denominator, (i) {
           final isDone = i < processed;
           return Container(
@@ -426,37 +417,34 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
     final labelColor = isDark
         ? const Color(0x80FFFFFF) // white 50%
         : const Color(0x802C1E10); // dark brown 50%
-    final dotColor = isDark
-        ? const Color(0x33FFFFFF) // white 20%
-        : const Color(0x332C1E10); // dark brown 20%
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         // Rank label above the card
         Padding(
-          padding: const EdgeInsets.only(left: 4, bottom: 6),
+          padding: const EdgeInsets.only(left: 4, bottom: 4),
           child: Row(
             children: [
               Text(
-                'N\u00B0$rank',
+                rank.toString().padLeft(2, '0'),
                 style: TextStyle(
                   color: colors.primary.withOpacity(0.6),
-                  fontWeight: FontWeight.w900,
+                  fontWeight: FontWeight.w700,
                   fontSize: 12,
-                  letterSpacing: 1.0,
+                  letterSpacing: 0.5,
                 ),
               ),
-              const SizedBox(width: 8),
-              Container(
-                width: 4,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: dotColor,
-                  shape: BoxShape.circle,
+              const SizedBox(width: 6),
+              Text(
+                '\u2014',
+                style: TextStyle(
+                  color: labelColor,
+                  fontWeight: FontWeight.w500,
+                  fontSize: 12,
                 ),
               ),
-              const SizedBox(width: 8),
+              const SizedBox(width: 6),
               Expanded(
                 child: Text(
                   _simplifyReason(item.reason),
@@ -502,6 +490,7 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
               content: _convertToContent(item),
               descriptionFontSize: 15,
               titleMaxLines: 5,
+              denseLayout: true,
               onTap: () => widget.onItemTap(item),
               onSourceTap: widget.onSourceTap != null && item.source?.id != null
                   ? () => widget.onSourceTap!(item.source!.id!)

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -10,6 +10,7 @@ import '../../custom_topics/widgets/topic_chip.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/providers/feed_provider.dart';
 import '../../feed/repositories/feed_repository.dart';
+import '../providers/digest_provider.dart';
 import '../../feed/utils/article_title_layout.dart';
 import '../../feed/widgets/dismiss_banner.dart';
 import '../../feed/widgets/feed_card.dart';
@@ -127,8 +128,8 @@ class _TopicSectionState extends ConsumerState<TopicSection>
   /// Footer height: border (1) + padding (4×2) + icon row (~28) = ~37
   static const double _footerHeight = 57.0;
 
-  /// Body padding top + bottom (FacteurSpacing.space3 × 2 = 24)
-  static const double _bodyPadding = 24.0;
+  /// Body padding top + bottom (denseLayout: 10 × 2 = 20)
+  static const double _bodyPadding = 20.0;
 
   /// Meta row: type icon + duration text
   static const double _metaRowHeight = 20.0;
@@ -187,7 +188,7 @@ class _TopicSectionState extends ConsumerState<TopicSection>
       }
     }
 
-    final imageHeight = hasImage ? cardWidth / (16 / 9) : 0.0;
+    final imageHeight = hasImage ? cardWidth / (3 / 2) : 0.0;
     // Badge chip above card (only outside editorial mode).
     // Estimation volontairement serrée ; tout écart résiduel est
     // absorbé par Align(center) dans _buildPageView (moitié/moitié).
@@ -345,7 +346,17 @@ class _TopicSectionState extends ConsumerState<TopicSection>
     final isHero = topic.isUne && hasImage;
 
     return GestureDetector(
-      onTap: () => setState(() => _isExpanded = true),
+      onTap: () {
+        // Tap on compact preview = "reading" the article in the user's model.
+        // Mark as read immediately so the progress bar reflects the action,
+        // then expand. Avoid re-firing when already read/dismissed.
+        if (!article.isRead && !article.isDismissed) {
+          ref
+              .read(digestProvider.notifier)
+              .applyAction(article.contentId, 'read');
+        }
+        setState(() => _isExpanded = true);
+      },
       child: Container(
         margin: const EdgeInsets.symmetric(horizontal: 4),
         decoration: BoxDecoration(
@@ -1062,6 +1073,7 @@ class _TopicSectionState extends ConsumerState<TopicSection>
             alwaysShowDescription: !imageVisible,
             descriptionFontSize: 15,
             titleMaxLines: _digestTitleMaxLines,
+            denseLayout: true,
             onImageError: () => _onImageError(article.contentId),
             onTap: () => widget.onArticleTap(article),
             onSourceTap: widget.onSourceTap != null && article.source?.id != null
@@ -1107,6 +1119,7 @@ class _TopicSectionState extends ConsumerState<TopicSection>
           alwaysShowDescription: !imageVisible,
           descriptionFontSize: 15,
           titleMaxLines: _digestTitleMaxLines,
+          denseLayout: true,
           onImageError: () => _onImageError(article.contentId),
           onTap: () => widget.onArticleTap(article),
           onSourceTap: widget.onSourceTap != null && article.source?.id != null

--- a/apps/mobile/lib/features/feed/widgets/compact_theme_chip.dart
+++ b/apps/mobile/lib/features/feed/widgets/compact_theme_chip.dart
@@ -29,31 +29,6 @@ class CompactThemeChip extends StatelessWidget {
 
   bool get _isActive => selectedSlug != null;
 
-  /// Top 3 macro-theme emojis, deduplicated by macro-theme,
-  /// sorted by highest priorityMultiplier in each group.
-  List<String> get _topEmojis {
-    // Group by macro-theme, keep best priorityMultiplier per group
-    final macroThemeBest = <String, double>{};
-    for (final topic in followedTopics) {
-      final macro = getTopicMacroTheme(topic.slugParent ?? '');
-      if (macro == null) continue;
-      final current = macroThemeBest[macro] ?? 0.0;
-      if (topic.priorityMultiplier > current) {
-        macroThemeBest[macro] = topic.priorityMultiplier;
-      }
-    }
-
-    // Sort by priorityMultiplier desc
-    final sorted = macroThemeBest.entries.toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
-
-    return sorted
-        .take(3)
-        .map((e) => getMacroThemeEmoji(e.key))
-        .where((e) => e.isNotEmpty)
-        .toList();
-  }
-
   int get _totalFollowedThemes {
     final macros = <String>{};
     for (final topic in followedTopics) {
@@ -61,23 +36,6 @@ class CompactThemeChip extends StatelessWidget {
       if (macro != null) macros.add(macro);
     }
     return macros.length;
-  }
-
-  /// Emoji for the currently selected filter.
-  String get _activeEmoji {
-    if (selectedIsTheme && selectedSlug != null) {
-      // Theme slug → find the macro-theme label via macroThemeToApiSlug reverse
-      final macroLabel = macroThemeToApiSlug.entries
-          .where((e) => e.value == selectedSlug)
-          .firstOrNull
-          ?.key;
-      if (macroLabel != null) return getMacroThemeEmoji(macroLabel);
-    }
-    if (selectedSlug != null) {
-      final macro = getTopicMacroTheme(selectedSlug!);
-      if (macro != null) return getMacroThemeEmoji(macro);
-    }
-    return '';
   }
 
   @override
@@ -95,7 +53,6 @@ class CompactThemeChip extends StatelessWidget {
       child: _isActive
           ? _ActiveChip(
               key: ValueKey('theme_active_$selectedSlug'),
-              emoji: _activeEmoji,
               name: selectedName ?? 'Thème',
               onClear: () {
                 HapticFeedback.mediumImpact();
@@ -109,9 +66,7 @@ class CompactThemeChip extends StatelessWidget {
             )
           : _InactiveChip(
               key: const ValueKey('theme_inactive'),
-              emojis: _topEmojis,
-              remainingCount:
-                  _totalFollowedThemes > 3 ? _totalFollowedThemes - 3 : 0,
+              totalCount: _totalFollowedThemes,
               onTap: () {
                 HapticFeedback.mediumImpact();
                 _openSheet(context);
@@ -132,14 +87,12 @@ class CompactThemeChip extends StatelessWidget {
 }
 
 class _InactiveChip extends StatelessWidget {
-  final List<String> emojis;
-  final int remainingCount;
+  final int totalCount;
   final VoidCallback onTap;
 
   const _InactiveChip({
     super.key,
-    required this.emojis,
-    required this.remainingCount,
+    required this.totalCount,
     required this.onTap,
   });
 
@@ -156,7 +109,7 @@ class _InactiveChip extends StatelessWidget {
       onTap: onTap,
       child: Container(
         height: 28,
-        padding: const EdgeInsets.symmetric(horizontal: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 10),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(16),
           color: trackColor,
@@ -164,30 +117,19 @@ class _InactiveChip extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (emojis.isEmpty) ...[
-              Text(
-                'Thèmes',
-                style: TextStyle(
-                    fontSize: 11, color: muted, fontWeight: FontWeight.w500),
-              ),
-              const SizedBox(width: 2),
-            ] else ...[
-              Opacity(
-                opacity: 0.65,
-                child: Text(
-                  emojis.join(''),
-                  style: const TextStyle(fontSize: 14, letterSpacing: 1),
-                ),
-              ),
+            Text(
+              'Mes thèmes',
+              style: TextStyle(
+                  fontSize: 11, color: muted, fontWeight: FontWeight.w500),
+            ),
+            if (totalCount > 0) ...[
               const SizedBox(width: 4),
-              if (remainingCount > 0) ...[
-                Text(
-                  '+$remainingCount',
-                  style: TextStyle(fontSize: 11, color: muted),
-                ),
-                const SizedBox(width: 2),
-              ],
+              Text(
+                '· $totalCount',
+                style: TextStyle(fontSize: 11, color: muted),
+              ),
             ],
+            const SizedBox(width: 4),
             Icon(
               PhosphorIcons.caretDown(PhosphorIconsStyle.bold),
               size: 10,
@@ -201,14 +143,12 @@ class _InactiveChip extends StatelessWidget {
 }
 
 class _ActiveChip extends StatelessWidget {
-  final String emoji;
   final String name;
   final VoidCallback onClear;
   final VoidCallback onTap;
 
   const _ActiveChip({
     super.key,
-    required this.emoji,
     required this.name,
     required this.onClear,
     required this.onTap,
@@ -222,7 +162,7 @@ class _ActiveChip extends StatelessWidget {
       onTap: onTap,
       child: Container(
         height: 28,
-        padding: const EdgeInsets.symmetric(horizontal: 8),
+        padding: const EdgeInsets.only(left: 10),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(16),
           color: primary.withOpacity(0.12),
@@ -230,9 +170,6 @@ class _ActiveChip extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (emoji.isNotEmpty)
-              Text(emoji, style: const TextStyle(fontSize: 14)),
-            const SizedBox(width: 4),
             Flexible(
               child: Text(
                 name,

--- a/apps/mobile/lib/features/feed/widgets/feed_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_card.dart
@@ -49,6 +49,7 @@ class FeedCard extends StatefulWidget {
   /// tight, scannable layout. Digest singleton cards override to 5 so
   /// long titles can breathe on the "closure" moment of the app.
   final int titleMaxLines;
+  final bool denseLayout;
 
   const FeedCard({
     super.key,
@@ -81,6 +82,7 @@ class FeedCard extends StatefulWidget {
     this.onImageError,
     this.descriptionFontSize,
     this.titleMaxLines = 3,
+    this.denseLayout = false,
   });
 
   @override
@@ -196,11 +198,11 @@ class _FeedCardState extends State<FeedCard>
                 // 3. Footer (Source + Actions) — outside tap area
                 Container(
                   decoration: BoxDecoration(
-                    color: colors.backgroundSecondary.withOpacity(0.5),
+                    color: colors.backgroundSecondary.withOpacity(0.3),
                     border: Border(
                       top: BorderSide(
-                        color: colors.textSecondary.withOpacity(0.1),
-                        width: 1,
+                        color: colors.textSecondary.withOpacity(0.05),
+                        width: 0.5,
                       ),
                     ),
                   ),
@@ -222,9 +224,9 @@ class _FeedCardState extends State<FeedCard>
                               behavior: HitTestBehavior.opaque,
                               child: Container(
                                 padding: const EdgeInsets.symmetric(
-                                    horizontal: 5, vertical: 2),
+                                    horizontal: 6, vertical: 3),
                                 decoration: BoxDecoration(
-                                  color: Color.lerp(colors.backgroundSecondary, Colors.black, 0.003)!,
+                                  color: Color.lerp(colors.backgroundSecondary, Colors.black, 0.005)!,
                                   borderRadius: BorderRadius.circular(8),
                                 ),
                                 child: Row(
@@ -252,8 +254,8 @@ class _FeedCardState extends State<FeedCard>
                                       child: Text(
                                         widget.content.source.name,
                                         style: textTheme.labelSmall?.copyWith(
-                                          color: colors.textPrimary,
-                                          fontWeight: FontWeight.w600,
+                                          color: colors.textSecondary,
+                                          fontWeight: FontWeight.w500,
                                           fontSize: 11,
                                         ),
                                         maxLines: 1,
@@ -540,9 +542,9 @@ class _FeedCardState extends State<FeedCard>
         hasImage ? math.min(3, widget.titleMaxLines) : widget.titleMaxLines;
 
     final bodyContent = Padding(
-      padding: const EdgeInsets.symmetric(
+      padding: EdgeInsets.symmetric(
         horizontal: FacteurSpacing.space3,
-        vertical: FacteurSpacing.space3,
+        vertical: widget.denseLayout ? FacteurSpacing.space2 : FacteurSpacing.space3,
       ),
       child: Column(
         mainAxisSize: widget.expandContent ? MainAxisSize.max : MainAxisSize.min,


### PR DESCRIPTION
## What

Bundled visual refinement pass on the Digest and Feed screens.

**Digest** — tighter ranked card spacing, simpler rank label (`N°1` → `01 — reason`), removed redundant fraction counter, minor typography/spacing polish on closure + digest_screen + topic_section.

**Feed** — unified source ↔ topic badge style (same padding/weight/color), softened footer so it no longer competes with the article title (source name `w600 textPrimary` → `w500 textSecondary`), replaced theme chip emojis with a `Mes thèmes · N` CTA text label (emojis were semantically ambiguous vs branded source logos).

## Why

Users flagged both screens as visually busy with insufficient focus on the article/story itself. Pure design fine-tuning — no feature or structural change.

## Type

- [ ] Feature
- [ ] Bug fix
- [x] Maintenance / Refactor

## Checklist

- [x] `flutter analyze` clean on modified files (pre-existing `withOpacity` info warnings only)
- [x] Mobile test suite: no regressions (17 failing tests pre-exist on branch, confirmed by baseline)
- [x] No backend/auth/DB touched
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (mobile UI polish only)