### PR TITLE
fix(mobile): hide overlays on WebView activation to unblock modals

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -649,6 +649,19 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       setState(() {
         _isWebViewActive = true;
       });
+
+      // Smart-arrival : libère l'écran pour que l'utilisateur puisse interagir
+      // avec une éventuelle modale (cookies, paywall) qui verrouille souvent
+      // body { overflow: hidden } — sans scroll, le ScrollBridge JS ne peut
+      // rien signaler, donc on doit cacher proactivement les overlays.
+      _scrollStopTimer?.cancel(); // sinon le timer hérité du scroll CTA réaffiche le footer
+      _animateHeaderTo(1.0);
+      _animateFooterTo(1.0);
+
+      // Header revient après 2 s pour permettre la navigation back.
+      Timer(const Duration(seconds: 2), () {
+        if (mounted && _isWebViewActive) _animateHeaderTo(0.0);
+      });
     }
   }
 
@@ -2002,7 +2015,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         ],
                         Expanded(
                           child: Text(
-                            'Lire sur ${content.source.name}',
+                            _ctaTapped
+                                ? 'Ouvrir via navigateur'
+                                : 'Lire sur ${content.source.name}',
                             style: textTheme.labelMedium?.copyWith(
                               fontWeight: FontWeight.w600,
                               color: colors.textPrimary,
@@ -2013,7 +2028,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         ),
                         const SizedBox(width: 4),
                         Icon(
-                          PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
+                          _ctaTapped
+                              ? PhosphorIcons.arrowUpRight(
+                                  PhosphorIconsStyle.regular)
+                              : PhosphorIcons.arrowRight(
+                                  PhosphorIconsStyle.regular),
                           size: 16,
                           color: colors.textSecondary,
                         ),
@@ -2038,8 +2057,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           _suppressPerspectivesCheck = true;
                           _atPerspectivesSection.value = false;
                           _showStickyPerspectivesHeader.value = false;
-                          if (_inAppScrollController.hasClients) {
-                            _inAppScrollController.animateTo(
+                          final ScrollController activeController =
+                              _scrollController.hasClients
+                                  ? _scrollController
+                                  : _inAppScrollController;
+                          if (activeController.hasClients) {
+                            activeController.animateTo(
                               0,
                               duration: const Duration(milliseconds: 400),
                               curve: Curves.easeInOut,
@@ -2966,8 +2989,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                               const SizedBox(height: FacteurSpacing.space4),
                             ],
                           ),
-                          footer: SizedBox(
-                              height: _kFooterContentHeight + bottomInset),
+                          footer: (_perspectivesResponse != null ||
+                                  _perspectivesLoading)
+                              ? null
+                              : SizedBox(
+                                  height:
+                                      _kFooterContentHeight + bottomInset),
                         ),
                       ),
 
@@ -2976,11 +3003,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           _perspectivesLoading) ...[
                         Container(
                           color: colors.backgroundPrimary,
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: FacteurSpacing.space4),
-                            child: Divider(color: colors.border, height: 1),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: FacteurSpacing.space4,
+                            vertical: FacteurSpacing.space6,
                           ),
+                          child: Divider(color: colors.border, height: 1),
                         ),
                         Container(
                           color: colors.backgroundPrimary,
@@ -3034,6 +3061,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                     )
                                   : const SizedBox.shrink(),
                         ),
+                        SizedBox(
+                            height: _kFooterContentHeight + bottomInset),
                       ],
 
                       // ZONE 3: Transparent spacer — only after CTA tap to enable scroll animation.

--- a/docs/bugs/bug-webview-overlays-block-modals.md
+++ b/docs/bugs/bug-webview-overlays-block-modals.md
@@ -1,0 +1,62 @@
+# Bug: WebView reader — overlays bloquent les modales (cookies, paywalls)
+
+## Statut
+- [ ] En cours d'investigation
+- [x] En cours de correction
+- [ ] Corrigé (date: YYYY-MM-DD)
+
+## Sévérité
+🔴 Critique — interface inutilisable sur les sites avec cookie-wall (Contexte, La Croix, etc.)
+
+## Description
+
+Dans le reader (mode "scroll-to-site"), une fois que l'utilisateur tape « Lire sur [Source] », la WebView s'active et charge le site original. Les overlays Flutter (header en haut, footer en bas) restent visibles et **couvrent la modale de cookies / paywall** qui apparaît au chargement. Quand cette modale verrouille le scroll du `body` (`overflow: hidden`, courant sur les CMP), aucun événement scroll n'arrive au JS bridge → impossible de cacher les overlays par geste.
+
+Résultat : impossible d'accepter les cookies, impossible de naviguer dans la modale.
+
+## Étapes de reproduction
+1. Ouvrir l'app, se rendre sur un article d'un site avec cookie-wall (ex : Contexte, La Croix)
+2. Lire le contenu in-app jusqu'à voir le bouton « Lire sur [Source] » au footer
+3. Taper « Lire sur [Source] » → la WebView s'active
+4. **Constat** : la modale cookies apparaît, mais le footer Flutter couvre les boutons « Accepter / Refuser »
+5. Tenter de scroller pour cacher le footer → ne fonctionne pas (modale lock body scroll)
+
+## Cause racine
+
+Dans `apps/mobile/lib/features/detail/screens/content_detail_screen.dart` :
+
+1. `_footerOffset` est initialisé à `0.0` (visible) — ligne 161.
+2. À l'activation de la WebView (`_onScrollToSite`, ligne 648), aucune action n'est prise pour masquer les overlays.
+3. Le `_scrollStopTimer` armé pendant l'animation CTA `_scrollController.animateTo(maxScrollExtent)` ré-affiche le footer 2 s plus tard (`_onScrollDelta`, ligne 726-732).
+4. Le JS bridge `ScrollBridge` n'observe que les événements `scroll` du document — quand le body est `overflow:hidden`, il n'en reçoit jamais.
+
+## Solution
+
+UX validée :
+- À l'activation WebView : masquer **immédiatement** header + footer (vue maximale → modale visible en entier).
+- Après **2 s** : header réapparaît automatiquement (pour permettre le retour).
+- Footer reste caché jusqu'à scroll-up explicite (puis comportement reader standard).
+
+Implémentation : modification unique dans `_onScrollToSite` (ligne ~648) :
+
+```dart
+if (shouldActivate && !_isWebViewActive) {
+  setState(() => _isWebViewActive = true);
+
+  _scrollStopTimer?.cancel(); // annule le timer hérité du scroll CTA
+  _animateHeaderTo(1.0);
+  _animateFooterTo(1.0);
+
+  Timer(const Duration(seconds: 2), () {
+    if (mounted && _isWebViewActive) _animateHeaderTo(0.0);
+  });
+}
+```
+
+## Fichiers concernés
+- `apps/mobile/lib/features/detail/screens/content_detail_screen.dart`
+
+## Notes
+- Décision UX : pas de tap-to-toggle JS bridge, pas de détection heuristique de modale — l'approche timing suffit.
+- Comportement post-arrivée identique au reader d'article (scroll-down cache, scroll-up réaffiche, etc.).
+- Screenshots : modale cookies Contexte + La Croix bloquée par footer (joints à la PR).


### PR DESCRIPTION
## What

Hide header/footer overlays immediately when WebView activates, then show header again after 2s. Improves CTA button feedback: text changes to "Ouvrir via navigateur" and icon to arrowUpRight after tap. Fixes scroll-to-top to prefer main scroll controller, and removes footer during perspectives load.

## Why

WebView overlays (cookies, paywalls) were blocked by Flutter header/footer, making sites unusable. When modals lock body scroll (`overflow: hidden`), the JS scroll bridge never fires, so overlays couldn't be hidden by gesture.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally
- [x] Linting passes
- [x] No new Python `List[]` imports
- [x] No auth/DB changes
- [x] Code review completed