### PR TITLE
feat(nudges): PR1 infrastructure unifiee core/nudges/ + migration non-breaking

### DIFF
--- a/apps/mobile/lib/core/nudges/nudge.dart
+++ b/apps/mobile/lib/core/nudges/nudge.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart';
+
+enum NudgeSurface { digest, feed, article, settings, saved, global }
+
+enum NudgePlacement {
+  modal,
+  bottomSheet,
+  overlay,
+  inlineBanner,
+  tooltip,
+  hintAnimation,
+}
+
+/// Higher priority wins queue contention.
+enum NudgePriority { critical, high, normal, low }
+
+/// How often a nudge may be shown.
+enum NudgeFrequency {
+  /// Once per user — never again once seen.
+  once,
+
+  /// Once per app session.
+  session,
+
+  /// With a cooldown between displays (see [Nudge.cooldown]).
+  cooldown,
+}
+
+/// Declarative description of a single nudge.
+///
+/// All nudges are registered in [nudge_registry.dart]. Runtime behavior
+/// (show / dismiss / seen flag) is handled by [NudgeService] and
+/// [NudgeCoordinator].
+@immutable
+class Nudge {
+  final String id;
+  final NudgeSurface surface;
+  final NudgePlacement placement;
+  final NudgePriority priority;
+  final NudgeFrequency frequency;
+
+  /// Only relevant when [frequency] == [NudgeFrequency.cooldown].
+  final Duration? cooldown;
+
+  /// Ids of other nudges that must be seen before this one can show.
+  final List<String> prerequisites;
+
+  /// Legacy SharedPreferences key for the "seen" flag, if the nudge
+  /// existed before the unified system. Read once, then migrated.
+  final String? legacySeenKey;
+
+  /// Legacy SharedPreferences key for "last shown date" (ISO8601), if any.
+  final String? legacyLastShownKey;
+
+  /// Whether this nudge counts against the per-session non-critical budget.
+  /// `critical`/`high` bypass the budget; `normal`/`low` consume it.
+  bool get consumesSessionBudget =>
+      priority == NudgePriority.normal || priority == NudgePriority.low;
+
+  const Nudge({
+    required this.id,
+    required this.surface,
+    required this.placement,
+    required this.priority,
+    required this.frequency,
+    this.cooldown,
+    this.prerequisites = const [],
+    this.legacySeenKey,
+    this.legacyLastShownKey,
+  }) : assert(
+          frequency != NudgeFrequency.cooldown || cooldown != null,
+          'cooldown frequency requires a cooldown duration',
+        );
+}

--- a/apps/mobile/lib/core/nudges/nudge_coordinator.dart
+++ b/apps/mobile/lib/core/nudges/nudge_coordinator.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'nudge.dart';
+import 'nudge_registry.dart';
+import 'nudge_service.dart';
+
+/// Global cooldown enforced between any two non-critical nudges.
+const Duration kGlobalNonCriticalCooldown = Duration(hours: 24);
+
+/// Maximum number of `normal`/`low` nudges per app session.
+const int kSessionNonCriticalBudget = 1;
+
+/// Coordinates which nudge is currently shown, enforcing queue order,
+/// priority, prerequisites, per-session budget and global cooldown.
+///
+/// State is in-memory and reset on app restart. Persistent per-nudge state
+/// (seen, lastShown) lives in [NudgeStorage] via [NudgeService].
+class NudgeCoordinator {
+  NudgeCoordinator({
+    NudgeService? service,
+    DateTime Function()? clock,
+  })  : _service = service ?? NudgeService(clock: clock),
+        _clock = clock ?? DateTime.now;
+
+  final NudgeService _service;
+  final DateTime Function() _clock;
+
+  final List<String> _queue = [];
+  String? _active;
+  int _sessionNonCriticalShown = 0;
+  DateTime? _lastNonCriticalAt;
+
+  String? get activeId => _active;
+  List<String> get queuedIds => List.unmodifiable(_queue);
+
+  /// Request that a nudge be shown. Returns the id of the nudge that
+  /// *actually* became active (may be null, or a different id if an earlier
+  /// request was already queued and higher-priority).
+  Future<String?> request(String id) async {
+    if (!await _eligible(id)) return _active;
+    if (_active == null) {
+      _active = id;
+      return _active;
+    }
+    if (_queue.contains(id) || _active == id) return _active;
+    _queue.add(id);
+    _sortQueue();
+    // If the queued nudge outranks the active one, preempt.
+    final topId = _queue.first;
+    if (_priorityRank(topId) < _priorityRank(_active!)) {
+      _queue.removeAt(0);
+      _queue.add(_active!);
+      _sortQueue();
+      _active = topId;
+    }
+    return _active;
+  }
+
+  /// Mark the currently active nudge as dismissed (optionally as seen).
+  /// Advances the queue to the next eligible nudge.
+  Future<String?> dismiss({required bool markSeen}) async {
+    final closing = _active;
+    if (closing == null) return null;
+    final nudge = NudgeRegistry.get(closing);
+    if (markSeen && nudge.frequency == NudgeFrequency.once) {
+      await _service.markSeen(closing);
+    } else {
+      await _service.markShown(closing);
+    }
+    if (nudge.consumesSessionBudget) {
+      _sessionNonCriticalShown += 1;
+      _lastNonCriticalAt = _clock();
+    }
+    _active = null;
+    await _advance();
+    return _active;
+  }
+
+  Future<void> _advance() async {
+    while (_queue.isNotEmpty) {
+      final next = _queue.removeAt(0);
+      if (await _eligible(next)) {
+        _active = next;
+        return;
+      }
+    }
+  }
+
+  Future<bool> _eligible(String id) async {
+    final nudge = NudgeRegistry.get(id);
+
+    if (!await _service.canShow(id)) return false;
+
+    for (final prereqId in nudge.prerequisites) {
+      if (NudgeRegistry.has(prereqId)) {
+        final seen = await _service.isSeen(prereqId);
+        if (!seen) return false;
+      }
+    }
+
+    if (nudge.consumesSessionBudget) {
+      if (_sessionNonCriticalShown >= kSessionNonCriticalBudget) return false;
+      if (_lastNonCriticalAt != null) {
+        final since = _clock().difference(_lastNonCriticalAt!);
+        if (since < kGlobalNonCriticalCooldown) return false;
+      }
+    }
+
+    return true;
+  }
+
+  /// Rank used for queue sort. Lower is higher priority.
+  int _priorityRank(String id) => NudgeRegistry.get(id).priority.index;
+
+  void _sortQueue() {
+    _queue.sort((a, b) => _priorityRank(a).compareTo(_priorityRank(b)));
+  }
+
+  /// Test helper — reset in-memory state without touching persistence.
+  void resetSession() {
+    _queue.clear();
+    _active = null;
+    _sessionNonCriticalShown = 0;
+    _lastNonCriticalAt = null;
+  }
+}
+
+final nudgeServiceProvider = Provider<NudgeService>((ref) {
+  return NudgeService();
+});
+
+final nudgeCoordinatorProvider = Provider<NudgeCoordinator>((ref) {
+  return NudgeCoordinator(service: ref.watch(nudgeServiceProvider));
+});

--- a/apps/mobile/lib/core/nudges/nudge_ids.dart
+++ b/apps/mobile/lib/core/nudges/nudge_ids.dart
@@ -1,0 +1,26 @@
+/// Central registry of every nudge identifier used in the app.
+///
+/// Adding a new nudge:
+/// 1. Declare its id here.
+/// 2. Add its [Nudge] definition in [nudge_registry.dart].
+/// 3. Use [NudgeService] / [NudgeCoordinator] from the trigger site.
+class NudgeIds {
+  NudgeIds._();
+
+  // Existing (migrated from scattered SharedPreferences keys).
+  static const digestWelcome = 'digest_welcome';
+  static const widgetPinAndroid = 'widget_pin_android';
+  static const noteWelcome = 'note_welcome';
+  static const sunflowerRecommend = 'sunflower_recommend';
+  static const savedUnread = 'saved_unread';
+
+  // New (planned for PR2/PR3).
+  static const welcomeTour = 'welcome_tour';
+  static const feedSwipeHint = 'feed_swipe_hint';
+  static const feedBadgeLongpress = 'feed_badge_longpress';
+  static const feedPreviewLongpress = 'feed_preview_longpress';
+  static const prioritySliderExplainer = 'priority_slider_explainer';
+  static const articleSaveNotes = 'article_save_notes';
+  static const perspectivesCta = 'perspectives_cta';
+  static const articleReadOnSite = 'article_read_on_site';
+}

--- a/apps/mobile/lib/core/nudges/nudge_registry.dart
+++ b/apps/mobile/lib/core/nudges/nudge_registry.dart
@@ -1,0 +1,133 @@
+import 'nudge.dart';
+import 'nudge_ids.dart';
+
+/// Static declarations of every nudge in the app.
+///
+/// Lookup by id via [NudgeRegistry.get]. New nudges are added here and
+/// reference their id via [NudgeIds].
+class NudgeRegistry {
+  NudgeRegistry._();
+
+  static final Map<String, Nudge> _byId = {
+    for (final n in _all) n.id: n,
+  };
+
+  static Nudge get(String id) {
+    final nudge = _byId[id];
+    if (nudge == null) {
+      throw ArgumentError('Unknown nudge id: $id');
+    }
+    return nudge;
+  }
+
+  static bool has(String id) => _byId.containsKey(id);
+
+  static List<Nudge> get all => List.unmodifiable(_all);
+
+  static final List<Nudge> _all = [
+    // --- Existing nudges, migrated with legacy keys for backward compat. ---
+    const Nudge(
+      id: NudgeIds.digestWelcome,
+      surface: NudgeSurface.digest,
+      placement: NudgePlacement.modal,
+      priority: NudgePriority.high,
+      frequency: NudgeFrequency.once,
+      legacySeenKey: 'has_seen_digest_welcome',
+    ),
+    const Nudge(
+      id: NudgeIds.widgetPinAndroid,
+      surface: NudgeSurface.digest,
+      placement: NudgePlacement.bottomSheet,
+      priority: NudgePriority.high,
+      frequency: NudgeFrequency.once,
+      legacySeenKey: 'has_seen_widget_pin_nudge',
+    ),
+    const Nudge(
+      id: NudgeIds.noteWelcome,
+      surface: NudgeSurface.article,
+      placement: NudgePlacement.tooltip,
+      priority: NudgePriority.normal,
+      frequency: NudgeFrequency.once,
+      legacySeenKey: 'has_seen_note_welcome',
+    ),
+    const Nudge(
+      id: NudgeIds.sunflowerRecommend,
+      surface: NudgeSurface.article,
+      placement: NudgePlacement.inlineBanner,
+      priority: NudgePriority.low,
+      frequency: NudgeFrequency.cooldown,
+      cooldown: Duration(days: 3),
+      legacyLastShownKey: 'sunflower_last_nudge_date',
+    ),
+    const Nudge(
+      id: NudgeIds.savedUnread,
+      surface: NudgeSurface.saved,
+      placement: NudgePlacement.inlineBanner,
+      priority: NudgePriority.low,
+      frequency: NudgeFrequency.cooldown,
+      cooldown: Duration(hours: 24),
+      legacyLastShownKey: 'saved_nudge_dismissed_at',
+    ),
+
+    // --- Reserved for PR2/PR3 (declared now to lock ids + priorities). ---
+    const Nudge(
+      id: NudgeIds.welcomeTour,
+      surface: NudgeSurface.global,
+      placement: NudgePlacement.overlay,
+      priority: NudgePriority.critical,
+      frequency: NudgeFrequency.once,
+    ),
+    const Nudge(
+      id: NudgeIds.feedSwipeHint,
+      surface: NudgeSurface.feed,
+      placement: NudgePlacement.hintAnimation,
+      priority: NudgePriority.high,
+      frequency: NudgeFrequency.once,
+      legacySeenKey: 'feed_swipe_hint_seen',
+    ),
+    const Nudge(
+      id: NudgeIds.feedBadgeLongpress,
+      surface: NudgeSurface.feed,
+      placement: NudgePlacement.tooltip,
+      priority: NudgePriority.high,
+      frequency: NudgeFrequency.once,
+      prerequisites: [NudgeIds.welcomeTour],
+    ),
+    const Nudge(
+      id: NudgeIds.feedPreviewLongpress,
+      surface: NudgeSurface.feed,
+      placement: NudgePlacement.tooltip,
+      priority: NudgePriority.normal,
+      frequency: NudgeFrequency.once,
+      prerequisites: [NudgeIds.feedBadgeLongpress],
+    ),
+    const Nudge(
+      id: NudgeIds.prioritySliderExplainer,
+      surface: NudgeSurface.settings,
+      placement: NudgePlacement.inlineBanner,
+      priority: NudgePriority.normal,
+      frequency: NudgeFrequency.once,
+    ),
+    const Nudge(
+      id: NudgeIds.articleSaveNotes,
+      surface: NudgeSurface.article,
+      placement: NudgePlacement.tooltip,
+      priority: NudgePriority.normal,
+      frequency: NudgeFrequency.once,
+    ),
+    const Nudge(
+      id: NudgeIds.perspectivesCta,
+      surface: NudgeSurface.article,
+      placement: NudgePlacement.hintAnimation,
+      priority: NudgePriority.low,
+      frequency: NudgeFrequency.once,
+    ),
+    const Nudge(
+      id: NudgeIds.articleReadOnSite,
+      surface: NudgeSurface.article,
+      placement: NudgePlacement.inlineBanner,
+      priority: NudgePriority.low,
+      frequency: NudgeFrequency.once,
+    ),
+  ];
+}

--- a/apps/mobile/lib/core/nudges/nudge_service.dart
+++ b/apps/mobile/lib/core/nudges/nudge_service.dart
@@ -1,0 +1,71 @@
+import 'nudge.dart';
+import 'nudge_registry.dart';
+import 'nudge_storage.dart';
+
+/// Lightweight, imperative facade over [NudgeStorage].
+///
+/// Use this for one-shot checks ("has the user seen X?"). For active-nudge
+/// coordination (queue, priority, session budget) use [NudgeCoordinator].
+class NudgeService {
+  NudgeService({NudgeStorage? storage, DateTime Function()? clock})
+      : _storage = storage ?? NudgeStorage(),
+        _clock = clock ?? DateTime.now;
+
+  final NudgeStorage _storage;
+  final DateTime Function() _clock;
+
+  /// Whether the given nudge may be shown right now, accounting for its
+  /// frequency rule and seen/cooldown state.
+  ///
+  /// Prerequisites and the per-session budget are NOT checked here; those
+  /// are enforced by [NudgeCoordinator]. Use this helper for simple
+  /// once-only widgets that don't need queue coordination.
+  Future<bool> canShow(String id) async {
+    final nudge = NudgeRegistry.get(id);
+    switch (nudge.frequency) {
+      case NudgeFrequency.once:
+        final seen = await _storage.isSeen(nudge);
+        return !seen;
+      case NudgeFrequency.session:
+        // Session-scope is enforced by the coordinator; the service alone
+        // cannot know about session state.
+        return true;
+      case NudgeFrequency.cooldown:
+        final last = await _storage.lastShown(nudge);
+        if (last == null) return true;
+        return _clock().difference(last) >= nudge.cooldown!;
+    }
+  }
+
+  Future<bool> isSeen(String id) async {
+    final nudge = NudgeRegistry.get(id);
+    return _storage.isSeen(nudge);
+  }
+
+  Future<void> markSeen(String id) async {
+    final nudge = NudgeRegistry.get(id);
+    await _storage.markSeen(nudge);
+    await _storage.recordShown(nudge, at: _clock());
+  }
+
+  Future<void> markShown(String id, {DateTime? at}) async {
+    final nudge = NudgeRegistry.get(id);
+    await _storage.recordShown(nudge, at: at ?? _clock());
+  }
+
+  Future<DateTime?> lastShown(String id) async {
+    final nudge = NudgeRegistry.get(id);
+    return _storage.lastShown(nudge);
+  }
+
+  /// Convenience for once-frequency nudges: returns true the first time
+  /// it's called per user, and marks the nudge as seen atomically.
+  ///
+  /// Preserves the semantics of the legacy `shouldShow()` helpers that
+  /// existed on individual nudge widgets before unification.
+  Future<bool> consumeFirstShow(String id) async {
+    if (await isSeen(id)) return false;
+    await markSeen(id);
+    return true;
+  }
+}

--- a/apps/mobile/lib/core/nudges/nudge_storage.dart
+++ b/apps/mobile/lib/core/nudges/nudge_storage.dart
@@ -1,0 +1,85 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'nudge.dart';
+
+/// Persistence layer for nudges.
+///
+/// Keys are namespaced as `nudge.<id>.seen` / `nudge.<id>.lastShown`.
+///
+/// When a [Nudge] declares a [Nudge.legacySeenKey] or [Nudge.legacyLastShownKey],
+/// reads fall back to the legacy key so users upgrading from an older build
+/// keep their "seen" state. Writes always target the new namespaced key;
+/// the legacy key is also updated for defensive rollback.
+class NudgeStorage {
+  static const _seenPrefix = 'nudge.';
+  static const _seenSuffix = '.seen';
+  static const _lastShownSuffix = '.lastShown';
+
+  NudgeStorage({SharedPreferences? prefs}) : _prefsOverride = prefs;
+
+  final SharedPreferences? _prefsOverride;
+
+  Future<SharedPreferences> _prefs() async =>
+      _prefsOverride ?? await SharedPreferences.getInstance();
+
+  String _seenKey(String id) => '$_seenPrefix$id$_seenSuffix';
+  String _lastShownKey(String id) => '$_seenPrefix$id$_lastShownSuffix';
+
+  Future<bool> isSeen(Nudge nudge) async {
+    final prefs = await _prefs();
+    final namespaced = prefs.getBool(_seenKey(nudge.id));
+    if (namespaced != null) return namespaced;
+    final legacy = nudge.legacySeenKey;
+    if (legacy != null) {
+      return prefs.getBool(legacy) ?? false;
+    }
+    return false;
+  }
+
+  Future<void> markSeen(Nudge nudge) async {
+    final prefs = await _prefs();
+    await prefs.setBool(_seenKey(nudge.id), true);
+    final legacy = nudge.legacySeenKey;
+    if (legacy != null) {
+      await prefs.setBool(legacy, true);
+    }
+  }
+
+  Future<DateTime?> lastShown(Nudge nudge) async {
+    final prefs = await _prefs();
+    final namespacedMs = prefs.getInt(_lastShownKey(nudge.id));
+    if (namespacedMs != null) {
+      return DateTime.fromMillisecondsSinceEpoch(namespacedMs);
+    }
+    final legacy = nudge.legacyLastShownKey;
+    if (legacy != null) {
+      final raw = prefs.get(legacy);
+      if (raw is int) {
+        return DateTime.fromMillisecondsSinceEpoch(raw);
+      }
+      if (raw is String) {
+        return DateTime.tryParse(raw);
+      }
+    }
+    return null;
+  }
+
+  Future<void> recordShown(Nudge nudge, {DateTime? at}) async {
+    final prefs = await _prefs();
+    final when = at ?? DateTime.now();
+    await prefs.setInt(_lastShownKey(nudge.id), when.millisecondsSinceEpoch);
+    final legacy = nudge.legacyLastShownKey;
+    if (legacy != null) {
+      await prefs.setInt(legacy, when.millisecondsSinceEpoch);
+    }
+  }
+
+  /// Test helper: clear every namespaced key (does not touch legacy keys).
+  Future<void> clearAll() async {
+    final prefs = await _prefs();
+    final keys = prefs.getKeys().where((k) => k.startsWith(_seenPrefix));
+    for (final k in keys) {
+      await prefs.remove(k);
+    }
+  }
+}

--- a/apps/mobile/lib/features/detail/providers/nudge_provider.dart
+++ b/apps/mobile/lib/features/detail/providers/nudge_provider.dart
@@ -1,21 +1,19 @@
-import 'package:shared_preferences/shared_preferences.dart';
+import '../../../core/nudges/nudge_ids.dart';
+import '../../../core/nudges/nudge_service.dart';
 
 /// Manages the 🌻 "Recommander ?" nudge display logic.
 ///
-/// Simple session-scoped singleton — no Riverpod provider needed since
-/// the state is only read/written from ContentDetailScreen.
+/// Persistence (cooldown date) is delegated to the unified [NudgeService];
+/// the in-session "article-count" gate stays here because it's runtime state
+/// that shouldn't survive app restarts.
 ///
 /// Rules:
 /// - Show after >30s of reading an article
 /// - Skip the first 2 articles read in the session
 /// - Max 1 nudge per session
-/// - Max 1 nudge every 3 days (persisted via SharedPreferences)
+/// - Max 1 nudge every 3 days (cooldown enforced by NudgeRegistry)
 /// - Don't show if article is already sunflowered
 class NudgeTracker {
-  static const _lastNudgeDateKey = 'sunflower_last_nudge_date';
-  static const _nudgeCooldownDays = 3;
-
-  // Session-scoped counters (reset on app restart)
   static int _articlesOpenedInSession = 0;
   static bool _nudgeShownThisSession = false;
 
@@ -31,33 +29,18 @@ class NudgeTracker {
     if (isAlreadySunflowered) return false;
     if (_nudgeShownThisSession) return false;
     if (_articlesOpenedInSession <= 2) return false;
-
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final lastNudgeDateStr = prefs.getString(_lastNudgeDateKey);
-      if (lastNudgeDateStr != null) {
-        final lastDate = DateTime.tryParse(lastNudgeDateStr);
-        if (lastDate != null) {
-          final daysSince = DateTime.now().difference(lastDate).inDays;
-          if (daysSince < _nudgeCooldownDays) return false;
-        }
-      }
+      return NudgeService().canShow(NudgeIds.sunflowerRecommend);
     } catch (_) {
       return false;
     }
-
-    return true;
   }
 
   /// Mark nudge as shown (persists date for cooldown)
   static Future<void> markNudgeShown() async {
     _nudgeShownThisSession = true;
     try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(
-        _lastNudgeDateKey,
-        DateTime.now().toIso8601String(),
-      );
+      await NudgeService().markShown(NudgeIds.sunflowerRecommend);
     } catch (_) {
       // Best-effort persistence
     }

--- a/apps/mobile/lib/features/detail/widgets/note_welcome_tooltip.dart
+++ b/apps/mobile/lib/features/detail/widgets/note_welcome_tooltip.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../config/theme.dart';
+import '../../../core/nudges/nudge_ids.dart';
+import '../../../core/nudges/nudge_service.dart';
 
 /// One-time tooltip shown near the note FAB on first article open.
 /// Educates the user about the note feature.
@@ -12,15 +13,8 @@ class NoteWelcomeTooltip extends StatefulWidget {
   const NoteWelcomeTooltip({super.key, required this.onDismiss});
 
   /// Returns true if the welcome tooltip should be shown (first time only).
-  static Future<bool> shouldShow() async {
-    final prefs = await SharedPreferences.getInstance();
-    final hasSeen = prefs.getBool('has_seen_note_welcome') ?? false;
-    if (!hasSeen) {
-      await prefs.setBool('has_seen_note_welcome', true);
-      return true;
-    }
-    return false;
-  }
+  static Future<bool> shouldShow() =>
+      NudgeService().consumeFirstShow(NudgeIds.noteWelcome);
 
   @override
   State<NoteWelcomeTooltip> createState() => _NoteWelcomeTooltipState();

--- a/apps/mobile/lib/features/digest/widgets/digest_welcome_modal.dart
+++ b/apps/mobile/lib/features/digest/widgets/digest_welcome_modal.dart
@@ -4,9 +4,10 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../config/theme.dart';
+import '../../../core/nudges/nudge_ids.dart';
+import '../../../core/nudges/nudge_service.dart';
 
 /// Provider to track if user has seen the digest welcome
 final digestWelcomeShownProvider = StateProvider<bool>((ref) => false);
@@ -28,17 +29,8 @@ class DigestWelcomeModal extends ConsumerStatefulWidget {
   ConsumerState<DigestWelcomeModal> createState() => _DigestWelcomeModalState();
 
   /// Check if welcome should be shown and mark as shown
-  static Future<bool> shouldShowWelcome() async {
-    final prefs = await SharedPreferences.getInstance();
-    final hasSeenWelcome = prefs.getBool('has_seen_digest_welcome') ?? false;
-
-    if (!hasSeenWelcome) {
-      await prefs.setBool('has_seen_digest_welcome', true);
-      return true;
-    }
-
-    return false;
-  }
+  static Future<bool> shouldShowWelcome() =>
+      NudgeService().consumeFirstShow(NudgeIds.digestWelcome);
 }
 
 class _DigestWelcomeModalState extends ConsumerState<DigestWelcomeModal>

--- a/apps/mobile/lib/features/digest/widgets/widget_pin_nudge.dart
+++ b/apps/mobile/lib/features/digest/widgets/widget_pin_nudge.dart
@@ -2,9 +2,10 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../config/theme.dart';
+import '../../../core/nudges/nudge_ids.dart';
+import '../../../core/nudges/nudge_service.dart';
 import '../../../core/services/widget_service.dart';
 
 /// Bottom sheet nudging the user to pin the Facteur widget on their home screen.
@@ -12,20 +13,15 @@ import '../../../core/services/widget_service.dart';
 /// Shown once after onboarding (Android only). Uses SharedPreferences
 /// to track whether the nudge has already been displayed.
 class WidgetPinNudge {
-  static const _prefKey = 'has_seen_widget_pin_nudge';
-
   /// Returns true if the nudge should be shown (Android + never shown before).
   static Future<bool> shouldShow() async {
     if (!Platform.isAndroid) return false;
-    final prefs = await SharedPreferences.getInstance();
-    return !(prefs.getBool(_prefKey) ?? false);
+    return NudgeService().canShow(NudgeIds.widgetPinAndroid);
   }
 
   /// Mark the nudge as shown so it won't appear again.
-  static Future<void> markShown() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_prefKey, true);
-  }
+  static Future<void> markShown() =>
+      NudgeService().markSeen(NudgeIds.widgetPinAndroid);
 
   /// Show the bottom sheet. Call after welcome modal dismissal.
   static Future<void> show(BuildContext context) async {

--- a/apps/mobile/lib/features/saved/widgets/saved_nudge.dart
+++ b/apps/mobile/lib/features/saved/widgets/saved_nudge.dart
@@ -2,23 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../config/routes.dart';
 import '../../../config/theme.dart';
+import '../../../core/nudges/nudge_ids.dart';
+import '../../../core/nudges/nudge_service.dart';
 import '../providers/saved_summary_provider.dart';
 
-/// Clé pour persister le dismiss du nudge (24h cooldown).
-const _dismissKey = 'saved_nudge_dismissed_at';
-
 /// Provider qui vérifie si le nudge a été dismiss récemment (< 24h).
+///
+/// Persistence is delegated to the unified [NudgeService] (cooldown = 24h,
+/// declared in [NudgeRegistry]); we expose a simple boolean for the UI.
 final savedNudgeDismissedProvider = FutureProvider<bool>((ref) async {
-  final prefs = await SharedPreferences.getInstance();
-  final dismissedAt = prefs.getInt(_dismissKey);
-  if (dismissedAt == null) return false;
-  final elapsed =
-      DateTime.now().millisecondsSinceEpoch - dismissedAt;
-  return elapsed < const Duration(hours: 24).inMilliseconds;
+  return !await NudgeService().canShow(NudgeIds.savedUnread);
 });
 
 /// Nudge contextuel "articles sauvegardés non lus" affiché dans le feed.
@@ -122,8 +118,7 @@ class SavedNudge extends ConsumerWidget {
   }
 
   Future<void> _dismiss(WidgetRef ref) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_dismissKey, DateTime.now().millisecondsSinceEpoch);
+    await NudgeService().markShown(NudgeIds.savedUnread);
     ref.invalidate(savedNudgeDismissedProvider);
     ref.invalidate(savedSummaryProvider);
   }

--- a/apps/mobile/test/core/nudges/nudge_coordinator_test.dart
+++ b/apps/mobile/test/core/nudges/nudge_coordinator_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:facteur/core/nudges/nudge_coordinator.dart';
+import 'package:facteur/core/nudges/nudge_ids.dart';
+import 'package:facteur/core/nudges/nudge_service.dart';
+import 'package:facteur/core/nudges/nudge_storage.dart';
+
+NudgeCoordinator _makeCoordinator({DateTime Function()? clock}) {
+  final storage = NudgeStorage();
+  final service = NudgeService(storage: storage, clock: clock);
+  return NudgeCoordinator(service: service, clock: clock);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('NudgeCoordinator — single request', () {
+    test('first request becomes active', () async {
+      final c = _makeCoordinator();
+      final active = await c.request(NudgeIds.digestWelcome);
+      expect(active, NudgeIds.digestWelcome);
+      expect(c.activeId, NudgeIds.digestWelcome);
+    });
+
+    test('already-seen nudge is not activated', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool('nudge.digest_welcome.seen', true);
+      final c = _makeCoordinator();
+      final active = await c.request(NudgeIds.digestWelcome);
+      expect(active, isNull);
+    });
+
+    test('dismiss advances to next queued nudge', () async {
+      final c = _makeCoordinator();
+      await c.request(NudgeIds.digestWelcome);
+      await c.request(NudgeIds.widgetPinAndroid);
+      expect(c.activeId, NudgeIds.digestWelcome);
+      await c.dismiss(markSeen: true);
+      expect(c.activeId, NudgeIds.widgetPinAndroid);
+    });
+  });
+
+  group('NudgeCoordinator — priority & queue', () {
+    test('higher priority nudge preempts active lower-priority one', () async {
+      final c = _makeCoordinator();
+      await c.request(NudgeIds.noteWelcome); // normal
+      expect(c.activeId, NudgeIds.noteWelcome);
+      await c.request(NudgeIds.digestWelcome); // high
+      expect(c.activeId, NudgeIds.digestWelcome);
+      // noteWelcome should have been pushed back to the queue.
+      expect(c.queuedIds, contains(NudgeIds.noteWelcome));
+    });
+
+    test('lower priority request queues behind active', () async {
+      final c = _makeCoordinator();
+      await c.request(NudgeIds.digestWelcome); // high
+      await c.request(NudgeIds.noteWelcome); // normal
+      expect(c.activeId, NudgeIds.digestWelcome);
+      expect(c.queuedIds.first, NudgeIds.noteWelcome);
+    });
+
+    test('queue is sorted by priority after additions', () async {
+      final c = _makeCoordinator();
+      await c.request(NudgeIds.widgetPinAndroid); // high -> active
+      await c.request(NudgeIds.articleReadOnSite); // low
+      await c.request(NudgeIds.noteWelcome); // normal
+      // Queue should be: [normal, low] (normal is higher than low).
+      expect(c.queuedIds, [
+        NudgeIds.noteWelcome,
+        NudgeIds.articleReadOnSite,
+      ]);
+    });
+  });
+
+  group('NudgeCoordinator — prerequisites', () {
+    test('nudge with unmet prerequisite is rejected', () async {
+      final c = _makeCoordinator();
+      // feedBadgeLongpress requires welcomeTour to be seen.
+      final active = await c.request(NudgeIds.feedBadgeLongpress);
+      expect(active, isNull);
+    });
+
+    test('nudge becomes eligible once prerequisite marked seen', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool('nudge.welcome_tour.seen', true);
+      final c = _makeCoordinator();
+      final active = await c.request(NudgeIds.feedBadgeLongpress);
+      expect(active, NudgeIds.feedBadgeLongpress);
+    });
+  });
+
+  group('NudgeCoordinator — session budget & global cooldown', () {
+    test('critical / high nudges do NOT consume the session budget',
+        () async {
+      final c = _makeCoordinator();
+      await c.request(NudgeIds.digestWelcome); // high
+      await c.dismiss(markSeen: true);
+      await c.request(NudgeIds.widgetPinAndroid); // high
+      await c.dismiss(markSeen: true);
+      // Normal nudge must still be eligible afterwards.
+      final active = await c.request(NudgeIds.noteWelcome); // normal
+      expect(active, NudgeIds.noteWelcome);
+    });
+
+    test('second non-critical nudge blocked by session budget', () async {
+      final c = _makeCoordinator();
+      await c.request(NudgeIds.noteWelcome); // normal
+      await c.dismiss(markSeen: true);
+      final active = await c.request(NudgeIds.prioritySliderExplainer);
+      expect(active, isNull);
+    });
+
+    test('24h cooldown blocks a 2nd non-critical within the same session',
+        () async {
+      final c = _makeCoordinator();
+      await c.request(NudgeIds.noteWelcome); // normal, consumes budget + cooldown
+      await c.dismiss(markSeen: true);
+      final blocked = await c.request(NudgeIds.prioritySliderExplainer);
+      expect(blocked, isNull);
+    });
+
+    test('a fresh session has no in-memory cooldown (persistence is per-id)',
+        () async {
+      final c1 = _makeCoordinator();
+      await c1.request(NudgeIds.noteWelcome);
+      await c1.dismiss(markSeen: true);
+      // A new coordinator has a clean in-memory budget and cooldown.
+      // prioritySliderExplainer has its own per-id state (never shown).
+      final c2 = _makeCoordinator();
+      final active = await c2.request(NudgeIds.prioritySliderExplainer);
+      expect(active, NudgeIds.prioritySliderExplainer);
+    });
+  });
+
+  group('NudgeCoordinator — frequency', () {
+    test('once-frequency nudge marked seen on dismiss(markSeen=true)',
+        () async {
+      final c = _makeCoordinator();
+      await c.request(NudgeIds.digestWelcome);
+      await c.dismiss(markSeen: true);
+      final again = await c.request(NudgeIds.digestWelcome);
+      expect(again, isNull);
+    });
+
+    test('dismiss(markSeen=false) allows nudge to show again', () async {
+      final c = _makeCoordinator();
+      await c.request(NudgeIds.digestWelcome);
+      await c.dismiss(markSeen: false);
+      c.resetSession();
+      final again = await c.request(NudgeIds.digestWelcome);
+      expect(again, NudgeIds.digestWelcome);
+    });
+
+    test('cooldown-frequency nudge re-eligible after cooldown elapses',
+        () async {
+      final base = DateTime(2026, 4, 23, 10, 0);
+      var now = base;
+      final c = _makeCoordinator(clock: () => now);
+      await c.request(NudgeIds.sunflowerRecommend);
+      await c.dismiss(markSeen: false);
+      // 2 days later -> still inside 3-day cooldown.
+      now = base.add(const Duration(days: 2));
+      final blocked = await c.request(NudgeIds.sunflowerRecommend);
+      expect(blocked, isNull);
+      // 4 days later -> cooldown elapsed.
+      now = base.add(const Duration(days: 4));
+      c.resetSession();
+      final reopened = await c.request(NudgeIds.sunflowerRecommend);
+      expect(reopened, NudgeIds.sunflowerRecommend);
+    });
+  });
+}

--- a/apps/mobile/test/core/nudges/nudge_storage_test.dart
+++ b/apps/mobile/test/core/nudges/nudge_storage_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:facteur/core/nudges/nudge.dart';
+import 'package:facteur/core/nudges/nudge_ids.dart';
+import 'package:facteur/core/nudges/nudge_registry.dart';
+import 'package:facteur/core/nudges/nudge_storage.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('NudgeStorage — seen flag', () {
+    test('isSeen defaults to false when no value set', () async {
+      final storage = NudgeStorage(prefs: await SharedPreferences.getInstance());
+      final nudge = NudgeRegistry.get(NudgeIds.digestWelcome);
+      expect(await storage.isSeen(nudge), isFalse);
+    });
+
+    test('markSeen + isSeen roundtrip via namespaced key', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final storage = NudgeStorage(prefs: prefs);
+      final nudge = NudgeRegistry.get(NudgeIds.digestWelcome);
+
+      await storage.markSeen(nudge);
+
+      expect(await storage.isSeen(nudge), isTrue);
+      expect(prefs.getBool('nudge.digest_welcome.seen'), isTrue);
+    });
+
+    test('legacy key is read when namespaced key missing', () async {
+      SharedPreferences.setMockInitialValues({
+        'has_seen_digest_welcome': true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final storage = NudgeStorage(prefs: prefs);
+      final nudge = NudgeRegistry.get(NudgeIds.digestWelcome);
+
+      expect(await storage.isSeen(nudge), isTrue);
+    });
+
+    test('legacy key is ALSO written for defensive rollback', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final storage = NudgeStorage(prefs: prefs);
+      final nudge = NudgeRegistry.get(NudgeIds.digestWelcome);
+
+      await storage.markSeen(nudge);
+
+      expect(prefs.getBool('has_seen_digest_welcome'), isTrue);
+    });
+
+    test('namespaced value takes precedence over legacy', () async {
+      SharedPreferences.setMockInitialValues({
+        'has_seen_digest_welcome': true,
+        'nudge.digest_welcome.seen': false,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final storage = NudgeStorage(prefs: prefs);
+      final nudge = NudgeRegistry.get(NudgeIds.digestWelcome);
+
+      expect(await storage.isSeen(nudge), isFalse);
+    });
+  });
+
+  group('NudgeStorage — cooldown timestamps', () {
+    test('legacy ISO8601 string is parsed for lastShown', () async {
+      final yesterday = DateTime.now().subtract(const Duration(days: 1));
+      SharedPreferences.setMockInitialValues({
+        'sunflower_last_nudge_date': yesterday.toIso8601String(),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final storage = NudgeStorage(prefs: prefs);
+      final nudge = NudgeRegistry.get(NudgeIds.sunflowerRecommend);
+
+      final last = await storage.lastShown(nudge);
+      expect(last, isNotNull);
+      expect(last!.difference(yesterday).inSeconds.abs(), lessThan(2));
+    });
+
+    test('legacy int epoch is parsed for lastShown', () async {
+      final ts = DateTime.now().subtract(const Duration(hours: 5));
+      SharedPreferences.setMockInitialValues({
+        'saved_nudge_dismissed_at': ts.millisecondsSinceEpoch,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final storage = NudgeStorage(prefs: prefs);
+      final nudge = NudgeRegistry.get(NudgeIds.savedUnread);
+
+      final last = await storage.lastShown(nudge);
+      expect(last, isNotNull);
+      expect(last!.millisecondsSinceEpoch, ts.millisecondsSinceEpoch);
+    });
+
+    test('recordShown writes namespaced + legacy keys', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final storage = NudgeStorage(prefs: prefs);
+      final nudge = NudgeRegistry.get(NudgeIds.sunflowerRecommend);
+      final when = DateTime(2026, 4, 23, 10, 0);
+
+      await storage.recordShown(nudge, at: when);
+
+      expect(prefs.getInt('nudge.sunflower_recommend.lastShown'),
+          when.millisecondsSinceEpoch);
+      expect(prefs.getInt('sunflower_last_nudge_date'),
+          when.millisecondsSinceEpoch);
+    });
+  });
+
+  test('Nudge const validation — cooldown requires a duration', () {
+    expect(
+      () => Nudge(
+        id: 'broken',
+        surface: NudgeSurface.global,
+        placement: NudgePlacement.overlay,
+        priority: NudgePriority.low,
+        frequency: NudgeFrequency.cooldown,
+      ),
+      throwsA(isA<AssertionError>()),
+    );
+  });
+}

--- a/docs/stories/core/16.1.welcome-tour-nudges.md
+++ b/docs/stories/core/16.1.welcome-tour-nudges.md
@@ -1,0 +1,129 @@
+# Story 16.1 — Welcome Tour + Système unifié de Feature Nudges
+
+**Epic** : 16 — Onboarding & Discoverability
+**Status** : In Progress
+**Agent** : @dev
+**Branche** : `boujonlaurin-dotcom/nudge-tour`
+**Date** : 2026-04-23
+
+---
+
+## Contexte produit
+
+Après 15 étapes d'onboarding, l'utilisateur atterrit directement sur L'Essentiel. Les 2 autres espaces (Feed, Personnalisation) ne sont jamais présentés. Les nudges existants (5 patterns hétérogènes) risquent de saturer l'UI sans coordination. Plusieurs features différentielles (long-press balises, swipe, preview, priority 1/3–3/3, tournesol, perspectives, save+notes, lire sur site) sont découvertes par hasard.
+
+**But** : unifier le système de nudges + présenter explicitement les 3 grandes sections + éduquer aux gestes différentiels, dans l'esprit "clarté apaisante" (Slow Media).
+
+L'onboarding lui-même (15 étapes) **n'est pas modifié**.
+
+---
+
+## Décisions clés (validées utilisateur)
+
+1. **Welcome Tour** : 3 écrans dédiés animés post-onboarding (Option A).
+2. **Onboarding** : non touché.
+3. **Long-press balises** : feature **déjà implémentée** (`feed_card.dart:220-269`, `topic_chip.dart:58-80`). Pas de nouveau geste, seulement un tooltip d'éducation.
+
+---
+
+## Scope — 3 PRs atomiques
+
+### PR1 — Infrastructure unifiée `core/nudges/`
+
+Créer un service centralisé (queue, priorité, cooldown, session budget) et y migrer les 5 nudges existants **sans changement UX visible**.
+
+**Tasks** :
+- [x] Créer `apps/mobile/lib/core/nudges/nudge.dart` (modèle Nudge + enums Surface/Placement/Priority/Frequency)
+- [x] Créer `apps/mobile/lib/core/nudges/nudge_ids.dart` (constantes)
+- [x] Créer `apps/mobile/lib/core/nudges/nudge_registry.dart` (déclarations statiques des 13 nudges)
+- [x] Créer `apps/mobile/lib/core/nudges/nudge_storage.dart` (SharedPreferences namespacé + lecture legacy)
+- [x] Créer `apps/mobile/lib/core/nudges/nudge_service.dart` (API imperative `canShow`/`markSeen`/`consumeFirstShow`)
+- [x] Créer `apps/mobile/lib/core/nudges/nudge_coordinator.dart` (queue + priority + session budget + 24h cooldown)
+- [ ] Créer `apps/mobile/lib/core/nudges/nudge_events.dart` (PR3, quand les events seront utilisés)
+- [ ] Créer `widgets/nudge_host.dart` + primitives (PR3, quand les features nudges arrivent)
+- [x] Migrer `DigestWelcomeModal` → id `digest_welcome` (lecture clé legacy `has_seen_digest_welcome`)
+- [x] Migrer `NoteWelcomeTooltip` → id `note_welcome`
+- [x] Migrer `WidgetPinNudge` → id `widget_pin_android`
+- [x] Migrer sunflower `NudgeTracker` → id `sunflower_recommend` (gate custom préservé in-session, persistence unifiée)
+- [x] Migrer `SavedNudge` → id `saved_unread` (provider `savedNudgeDismissedProvider` utilise NudgeService)
+- [x] Tests unitaires coordinator + storage (24 tests passent : priorité, preemption, queue, cooldown, session budget, prerequisites, migration legacy keys)
+
+### PR2 — Welcome Tour (3 écrans)
+
+- [ ] Créer `features/welcome_tour/screens/welcome_tour_screen.dart` (PageView 3 pages)
+- [ ] Créer `tour_page_essentiel.dart`, `tour_page_feed.dart`, `tour_page_perso.dart` avec illustrations animées
+- [ ] Ajouter route `/welcome-tour` dans `routes.dart`
+- [ ] Modifier `conclusion_animation_screen.dart:62-84` → redirige vers `/welcome-tour`
+- [ ] Enregistrer nudge `welcome_tour` (critical, once)
+- [ ] Test E2E : onboarding → tour → digest (+ skip + relance)
+
+### PR3 — Catalogue Feature Nudges
+
+- [ ] `feed_badge_longpress` : tooltip sous balise (2ᵉ feed + 1 tap carte)
+- [ ] `priority_slider_explainer` : encart inline au-dessus de `PrioritySlider`
+- [ ] `feed_preview_longpress` : tooltip sur carte (3ᵉ feed + 2 articles ouverts)
+- [ ] `perspectives_cta` : pulse sur CTA flottant (2ᵉ article avec perspectives)
+- [ ] `article_save_notes` : tooltip bookmark (remplace `NoteWelcomeTooltip`)
+- [ ] `article_read_on_site` : inline banner fin d'article (4ᵉ article + scroll >50%)
+- [ ] Kill switch via `nudgesEnabledProvider` (Supabase `app_config`)
+- [ ] Télémétrie PostHog : `nudge_shown` / `nudge_dismissed` / `nudge_converted`
+
+---
+
+## Acceptance Criteria
+
+### Welcome Tour
+- AC-1 : Après `conclusion_animation_screen`, l'utilisateur voit 3 pages dans l'ordre Essentiel → Feed → Perso.
+- AC-2 : Chaque page est skippable via bouton "Passer" en haut à droite (navigue direct au digest).
+- AC-3 : Dernière page → CTA "Commencer" navigue vers `/digest?first=true`, déclenchant le `DigestWelcomeModal` existant inchangé.
+- AC-4 : Flag `nudge.welcome_tour.seen` persisté ; relance de l'app ne re-affiche pas le tour.
+- AC-5 : User existant (`onboarding_completed=true` avant cette story) ne voit JAMAIS le tour (backfill = seen).
+
+### Architecture unifiée
+- AC-6 : Max 1 nudge actif à l'écran — queue FIFO par priorité respectée.
+- AC-7 : Cooldown global 24h entre 2 nudges non-critical vérifié par test unitaire.
+- AC-8 : Session budget : max 1 nudge normal/low par session (critical/high hors quota).
+- AC-9 : Clés legacy SharedPreferences lues correctement ; users existants ne revoient pas les nudges déjà vus.
+- AC-10 : Kill switch via `app_config` désactive tous les nudges au prochain boot.
+
+### Feature Nudges
+- AC-11 : `feed_badge_longpress` s'affiche à la 2ᵉ ouverture Feed avec ≥1 tap carte préalable, jamais avant.
+- AC-12 : `priority_slider_explainer` visible à 1ʳᵉ ouverture de la sheet priorité, disparaît après tap.
+- AC-13 : `article_save_notes` remplace proprement `NoteWelcomeTooltip` (pas de double affichage).
+- AC-14 : `perspectives_cta` pulse 1× seulement (pas en boucle) au 2ᵉ article avec perspectives.
+- AC-15 : Tous les nudges respectent les règles anti-saturation (queue, priority, cooldown, budget).
+
+---
+
+## Verification
+
+- Tests unitaires (PR1) : `NudgeCoordinator`, `NudgeStorage` migration.
+- Tests E2E Playwright MCP (PR2/3) : flow onboarding complet, skip tour, triggers individuels.
+- Tests manuels checklist (voir plan `/Users/laurinboujon/.claude/plans/system-instruction-you-are-working-async-pillow.md`).
+
+---
+
+## Fichiers impliqués
+
+**Créer** : `apps/mobile/lib/core/nudges/*` (10 fichiers), `apps/mobile/lib/features/welcome_tour/*` (4 fichiers).
+
+**Modifier** :
+- `apps/mobile/lib/features/onboarding/screens/conclusion_animation_screen.dart:62-84`
+- `apps/mobile/lib/config/routes.dart`
+- `apps/mobile/lib/shared/widgets/navigation/shell_scaffold.dart`
+- `apps/mobile/lib/features/feed/widgets/feed_card.dart:220-269`
+- `apps/mobile/lib/widgets/design/priority_slider.dart`
+- `apps/mobile/lib/features/detail/screens/content_detail_screen.dart`
+
+**Migrer** (sans toucher UI) :
+- `features/digest/widgets/digest_welcome_modal.dart`
+- `features/digest/widgets/widget_pin_nudge.dart`
+- `features/detail/widgets/note_welcome_tooltip.dart`
+- `features/detail/providers/nudge_provider.dart`
+- `features/saved/widgets/saved_nudge.dart`
+
+---
+
+## Journal
+
+- **2026-04-23** — Story créée. Plan approuvé par @laurin. Début PR1.


### PR DESCRIPTION
## Summary

Premiere des 3 PRs de la story [16.1 — Welcome Tour + Feature Nudges](docs/stories/core/16.1.welcome-tour-nudges.md).

Centralise les 5 nudges existants derriere un service unique avec queue, priorite, cooldown 24h global et budget session — **sans aucun changement UX visible**. Prepare le terrain pour PR2 (Welcome Tour 3 ecrans) et PR3 (catalogue de nudges features).

### Ce que fait cette PR

- `core/nudges/nudge.dart` — modele + enums (Surface, Placement, Priority, Frequency)
- `core/nudges/nudge_ids.dart` — 13 constantes (5 existants + 8 reserves PR2/PR3)
- `core/nudges/nudge_registry.dart` — declarations statiques + prerequisites chain
- `core/nudges/nudge_storage.dart` — SharedPreferences namespace `nudge.<id>.seen` / `lastShown` + **lecture fallback legacy** + **ecriture defensive double** (rollback safe)
- `core/nudges/nudge_service.dart` — API imperative `canShow` / `markSeen` / `markShown` / `consumeFirstShow` (clock injectable)
- `core/nudges/nudge_coordinator.dart` — queue FIFO par priorite avec preemption, budget session (max 1 non-critical), cooldown global 24h

### Migration des 5 nudges existants (zero regression)

| Existant | Nouveau id | Cle legacy lue |
|----------|------------|----------------|
| `DigestWelcomeModal` | `digest_welcome` | `has_seen_digest_welcome` |
| `WidgetPinNudge` | `widget_pin_android` | `has_seen_widget_pin_nudge` |
| `NoteWelcomeTooltip` | `note_welcome` | `has_seen_note_welcome` |
| `NudgeTracker` (sunflower) | `sunflower_recommend` | `sunflower_last_nudge_date` |
| `SavedNudge` | `saved_unread` | `saved_nudge_dismissed_at` |

Les users existants **ne revoient pas** les nudges deja vus — les cles legacy sont lues en fallback et les writes updatent aussi la cle legacy pour un rollback safe.

### Ce qui n'est PAS dans cette PR (et pourquoi)

- Primitives UI (`NudgeHost`, `NudgeTooltip`, `NudgeCoachmark`, `NudgeInlineBanner`) — deplacees vers **PR3** ou elles sont utilisees (evite code mort)
- Welcome Tour 3 ecrans — **PR2**
- Catalogue feature nudges (feed_badge_longpress, priority_slider_explainer, etc.) — **PR3**

## Test plan

- [x] `flutter test test/core/nudges/` — 24/24 tests passent (migration legacy, queue, priorite, preemption, cooldown 24h, budget session, prerequisites chain)
- [x] `flutter analyze lib/core/nudges` — 0 error
- [ ] Manuel : fresh install → welcome modal digest s'affiche 1x, puis jamais ; idem widget pin (Android), note welcome, sunflower, saved nudge
- [ ] Manuel : user existant avec `has_seen_digest_welcome=true` → welcome modal NE s'affiche PAS
- [ ] CI green