### PR TITLE
feat(instrumentation): Sprint 1 — time_spent, digest completion, PostHog

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -71,6 +71,8 @@ jobs:
             --dart-define="SUPABASE_URL=${{ secrets.SUPABASE_URL }}" \
             --dart-define="SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" \
             --dart-define="REVENUECAT_IOS_KEY=${{ secrets.REVENUECAT_IOS_KEY }}" \
+            --dart-define="POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" \
+            --dart-define="POSTHOG_HOST=${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}" \
             --dart-define="APP_RELEASE_TAG=${{ steps.version.outputs.version }}"
 
       - name: Upload APK as artifact

--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -52,6 +52,8 @@ jobs:
             --dart-define="SUPABASE_URL=${{ secrets.SUPABASE_URL }}" \
             --dart-define="SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" \
             --dart-define="REVENUECAT_IOS_KEY=${{ secrets.REVENUECAT_IOS_KEY }}" \
+            --dart-define="POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" \
+            --dart-define="POSTHOG_HOST=${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}" \
             --dart-define="APP_RELEASE_TAG=${{ steps.version.outputs.version }}"
 
       - name: Create unsigned IPA from xcarchive

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -38,7 +38,9 @@ jobs:
             --dart-define="API_BASE_URL=${{ github.event.inputs.api_base_url || vars.API_BASE_URL || 'https://facteur-production.up.railway.app/api' }}" \
             --dart-define="SUPABASE_URL=${{ secrets.SUPABASE_URL }}" \
             --dart-define="SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" \
-            --dart-define="REVENUECAT_IOS_KEY=${{ secrets.REVENUECAT_IOS_KEY }}"
+            --dart-define="REVENUECAT_IOS_KEY=${{ secrets.REVENUECAT_IOS_KEY }}" \
+            --dart-define="POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" \
+            --dart-define="POSTHOG_HOST=${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}"
 
       - name: Copy Documentation to Build
         run: |

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -1059,16 +1059,23 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       if (_content != null) {
         final duration = DateTime.now().difference(_startTime).inSeconds;
 
+        final supabase = Supabase.instance.client;
+        final apiClient = ApiClient(supabase);
+        final repository = FeedRepository(apiClient);
+
         // Persist reading progress via status endpoint
         if (progressPct > 0) {
-          final supabase = Supabase.instance.client;
-          final apiClient = ApiClient(supabase);
-          final repository = FeedRepository(apiClient);
           repository.updateContentStatusWithProgress(
             _content!.id,
             progressPct,
           );
         }
+
+        // Accumulate reading time on user_content_status for recommendation signal.
+        repository.updateContentStatusWithTimeSpent(
+          _content!.id,
+          duration,
+        );
 
         // Track article read duration
         ref.read(analyticsServiceProvider).trackArticleRead(

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -40,6 +40,12 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
   /// fresh content generated in the background.
   Timer? _staleFallbackRefetchTimer;
 
+  /// Per-item reading timer: records the timestamp at which each digest item
+  /// was first opened (action `read`). Read again when the user performs a
+  /// follow-up action (save, like, dismiss) to compute `time_spent_seconds`
+  /// for the analytics event. Capped at 1800s per item.
+  final DigestItemReadingTimers _readingTimers = DigestItemReadingTimers();
+
   /// Number of consecutive stale-fallback refetch attempts that still came
   /// back stale. Capped by [_staleFallbackMaxAttempts] so a broken backend
   /// can't cause an indefinite polling loop on the mobile client.
@@ -380,6 +386,12 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
       return;
     }
 
+    // Start the per-item reading timer on first open so follow-up actions
+    // (save/like/dismiss) can report an accurate time_spent_seconds.
+    if (action == 'read') {
+      _readingTimers.start(contentId);
+    }
+
     // Optimistic update — apply to flat items
     final updatedItems = currentDigest.items.map((item) {
       if (item.contentId == contentId) {
@@ -705,6 +717,8 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
         return;
     }
 
+    final timeSpentSeconds = _readingTimers.consume(item.contentId, action);
+
     try {
       ref.read(analyticsServiceProvider).trackContentInteraction(
             action: analyticsAction,
@@ -713,7 +727,7 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
             sourceId: item.source?.id ?? '',
             topics: item.topics,
             position: position,
-            timeSpentSeconds: 0,
+            timeSpentSeconds: timeSpentSeconds,
           );
     } catch (e) {
       // Fail silently — analytics should never block user actions
@@ -870,5 +884,29 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
     } else {
       _sereinDigest = updated;
     }
+  }
+}
+
+/// Tracks the per-item reading timer so digest follow-up actions
+/// (save/like/dismiss) can report an accurate `time_spent_seconds` to the
+/// analytics pipeline. Start on first `read`, consume on subsequent action.
+/// `read` itself is the open event and always reports 0 — the article viewer
+/// captures the actual reading duration.
+class DigestItemReadingTimers {
+  final Map<String, DateTime> _openedAt = {};
+
+  static const int maxSeconds = 1800;
+
+  void start(String contentId, {DateTime? now}) {
+    _openedAt[contentId] = now ?? DateTime.now();
+  }
+
+  int consume(String contentId, String action, {DateTime? now}) {
+    if (action == 'read') return 0;
+    final openedAt = _openedAt.remove(contentId);
+    if (openedAt == null) return 0;
+    final elapsed = (now ?? DateTime.now()).difference(openedAt).inSeconds;
+    if (elapsed <= 0) return 0;
+    return elapsed > maxSeconds ? maxSeconds : elapsed;
   }
 }

--- a/apps/mobile/lib/features/feed/repositories/feed_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/feed_repository.dart
@@ -833,6 +833,23 @@ class FeedRepository {
     }
   }
 
+  /// Fire-and-forget: accumulate time spent on an article.
+  /// Backend accumulates across sessions (see ContentService.update_content_status).
+  /// Cap client-side at 1800s to guard against forgotten background tabs.
+  Future<void> updateContentStatusWithTimeSpent(
+      String contentId, int timeSpentSeconds) async {
+    if (timeSpentSeconds <= 0) return;
+    final capped = timeSpentSeconds > 1800 ? 1800 : timeSpentSeconds;
+    try {
+      await _apiClient.dio.post<void>(
+        'contents/$contentId/status',
+        data: {'time_spent_seconds': capped},
+      );
+    } catch (e) {
+      print('FeedRepository: [ERROR] updateContentStatusWithTimeSpent: $e');
+    }
+  }
+
   Future<void> updateContentStatus(
       String contentId, ContentStatus status) async {
     try {

--- a/apps/mobile/lib/features/feed/widgets/article_viewer_modal.dart
+++ b/apps/mobile/lib/features/feed/widgets/article_viewer_modal.dart
@@ -115,6 +115,10 @@ class _ArticleViewerModalState extends ConsumerState<ArticleViewerModal> {
           widget.content.source.id,
           duration,
         );
+    // Accumulate reading time on user_content_status for recommendation signal.
+    ref
+        .read(feedRepositoryProvider)
+        .updateContentStatusWithTimeSpent(widget.content.id, duration);
     super.dispose();
   }
 

--- a/apps/mobile/test/features/digest/digest_item_reading_timers_test.dart
+++ b/apps/mobile/test/features/digest/digest_item_reading_timers_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/digest/providers/digest_provider.dart';
+
+/// Sprint 1.2 — per-item timer for digest content_interaction events.
+/// Ensures follow-up actions (save/like/dismiss) report a non-zero
+/// `time_spent_seconds` while the open event (`read`) stays at 0.
+void main() {
+  group('DigestItemReadingTimers', () {
+    test('consume returns elapsed seconds for follow-up actions', () {
+      final timers = DigestItemReadingTimers();
+      final opened = DateTime(2026, 4, 24, 10, 0, 0);
+      timers.start('article-1', now: opened);
+
+      final saved = timers.consume(
+        'article-1',
+        'save',
+        now: opened.add(const Duration(seconds: 42)),
+      );
+      expect(saved, 42);
+    });
+
+    test('read itself always reports 0s (open event, not duration)', () {
+      final timers = DigestItemReadingTimers();
+      timers.start(
+        'article-1',
+        now: DateTime(2026, 4, 24, 10, 0, 0),
+      );
+      final duration = timers.consume(
+        'article-1',
+        'read',
+        now: DateTime(2026, 4, 24, 10, 5, 0),
+      );
+      expect(duration, 0);
+    });
+
+    test('caps at 1800 seconds (30 min)', () {
+      final timers = DigestItemReadingTimers();
+      final opened = DateTime(2026, 4, 24, 10, 0, 0);
+      timers.start('article-2', now: opened);
+
+      final duration = timers.consume(
+        'article-2',
+        'save',
+        now: opened.add(const Duration(hours: 3)),
+      );
+      expect(duration, DigestItemReadingTimers.maxSeconds);
+    });
+
+    test('returns 0 when no prior read action was recorded', () {
+      final timers = DigestItemReadingTimers();
+      final duration = timers.consume('article-3', 'save');
+      expect(duration, 0);
+    });
+
+    test('consume clears the timer to avoid double-counting', () {
+      final timers = DigestItemReadingTimers();
+      final opened = DateTime(2026, 4, 24, 10, 0, 0);
+      timers.start('article-4', now: opened);
+
+      final first = timers.consume(
+        'article-4',
+        'save',
+        now: opened.add(const Duration(seconds: 30)),
+      );
+      final second = timers.consume(
+        'article-4',
+        'like',
+        now: opened.add(const Duration(seconds: 60)),
+      );
+
+      expect(first, 30);
+      expect(second, 0, reason: 'Timer must be consumed only once.');
+    });
+
+    test('clamps negative elapsed (clock skew) to 0', () {
+      final timers = DigestItemReadingTimers();
+      final opened = DateTime(2026, 4, 24, 10, 0, 0);
+      timers.start('article-5', now: opened);
+
+      final duration = timers.consume(
+        'article-5',
+        'save',
+        now: opened.subtract(const Duration(seconds: 5)),
+      );
+      expect(duration, 0);
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/feed_repository_time_spent_test.dart
+++ b/apps/mobile/test/features/feed/feed_repository_time_spent_test.dart
@@ -1,0 +1,96 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:facteur/core/api/api_client.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart';
+
+/// Sprint 1.1 — PATCH `time_spent_seconds` on `user_content_status`.
+/// Ensures the mobile repository POSTs the accumulated reading duration
+/// (capped at 1800s) to `/contents/{id}/status` so the recommendation
+/// feedback loop receives the signal.
+class _MockApiClient extends Mock implements ApiClient {}
+
+class _MockDio extends Mock implements Dio {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(RequestOptions(path: ''));
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  Response<void> _ok() => Response<void>(
+        requestOptions: RequestOptions(path: 'contents/x/status'),
+        statusCode: 200,
+      );
+
+  test('posts time_spent_seconds payload to /contents/{id}/status', () async {
+    final api = _MockApiClient();
+    final dio = _MockDio();
+    when(() => api.dio).thenReturn(dio);
+
+    Map<String, dynamic>? capturedData;
+    String? capturedPath;
+    when(() => dio.post<void>(any(), data: any(named: 'data'))).thenAnswer(
+      (invocation) async {
+        capturedPath = invocation.positionalArguments.first as String;
+        capturedData =
+            invocation.namedArguments[#data] as Map<String, dynamic>?;
+        return _ok();
+      },
+    );
+
+    final repo = FeedRepository(api);
+    await repo.updateContentStatusWithTimeSpent('article-1', 42);
+
+    expect(capturedPath, 'contents/article-1/status');
+    expect(capturedData, {'time_spent_seconds': 42});
+  });
+
+  test('caps the payload at 1800 seconds (30 min)', () async {
+    final api = _MockApiClient();
+    final dio = _MockDio();
+    when(() => api.dio).thenReturn(dio);
+
+    Map<String, dynamic>? capturedData;
+    when(() => dio.post<void>(any(), data: any(named: 'data'))).thenAnswer(
+      (invocation) async {
+        capturedData =
+            invocation.namedArguments[#data] as Map<String, dynamic>?;
+        return _ok();
+      },
+    );
+
+    final repo = FeedRepository(api);
+    await repo.updateContentStatusWithTimeSpent('article-2', 7200);
+
+    expect(capturedData?['time_spent_seconds'], 1800);
+  });
+
+  test('skips the network call when duration is zero or negative', () async {
+    final api = _MockApiClient();
+    final dio = _MockDio();
+    when(() => api.dio).thenReturn(dio);
+
+    final repo = FeedRepository(api);
+    await repo.updateContentStatusWithTimeSpent('article-3', 0);
+    await repo.updateContentStatusWithTimeSpent('article-3', -5);
+
+    verifyNever(() => dio.post<void>(any(), data: any(named: 'data')));
+  });
+
+  test('swallows Dio errors (fire-and-forget)', () async {
+    final api = _MockApiClient();
+    final dio = _MockDio();
+    when(() => api.dio).thenReturn(dio);
+    when(() => dio.post<void>(any(), data: any(named: 'data'))).thenThrow(
+      DioException(requestOptions: RequestOptions(path: 'x')),
+    );
+
+    final repo = FeedRepository(api);
+    await expectLater(
+      repo.updateContentStatusWithTimeSpent('article-4', 30),
+      completes,
+    );
+  });
+}

--- a/packages/api/app/services/content_service.py
+++ b/packages/api/app/services/content_service.py
@@ -106,6 +106,12 @@ class ContentService:
             conflict_set["reading_progress"] = func.greatest(
                 UserContentStatus.reading_progress, update_data.reading_progress
             )
+        # time_spent_seconds accumulates across sessions instead of being overwritten.
+        if update_data.time_spent_seconds is not None:
+            conflict_set["time_spent_seconds"] = (
+                func.coalesce(UserContentStatus.time_spent_seconds, 0)
+                + update_data.time_spent_seconds
+            )
 
         # Upsert statement
         stmt = (
@@ -140,6 +146,16 @@ class ContentService:
 
             await self._adjust_subtopic_weights(
                 user_id, content_id, ScoringWeights.READ_TOPIC_BOOST
+            )
+
+            # Implicit digest completion: if ≥80% of today's digest is now
+            # consumed, insert a digest_completions row (idempotent). This
+            # backstops the closure_screen explicit path when users never
+            # reach the "terminer mon digest" CTA.
+            from app.services.digest_service import DigestService
+
+            await DigestService(self.session).maybe_record_implicit_completion(
+                user_id, content_id
             )
 
         return updated_status

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -1286,9 +1286,7 @@ class DigestService:
                         )
                     )
                 )
-                consumed_count = (
-                    await self.session.execute(count_stmt)
-                ).scalar_one()
+                consumed_count = (await self.session.execute(count_stmt)).scalar_one()
 
                 if consumed_count / len(content_ids) < threshold:
                     continue

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -24,7 +24,7 @@ from uuid import UUID, uuid4
 
 import structlog
 import yaml
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -1195,20 +1195,36 @@ class DigestService:
         # Get action stats from content statuses
         stats = await self._get_digest_action_stats(user_id, digest)
 
-        # Create completion record
-        completion = DigestCompletion(
-            id=uuid4(),
-            user_id=user_id,
-            target_date=digest.target_date,
-            completed_at=datetime.utcnow(),
-            articles_read=stats["read"],
-            articles_saved=stats["saved"],
-            articles_dismissed=stats["dismissed"],
-            closure_time_seconds=closure_time_seconds,
+        # Upsert completion record. The implicit path
+        # (`maybe_record_implicit_completion`) may have already inserted a
+        # minimal row once the user crossed the 80% threshold — in that case
+        # we enrich it here with the full stats from the explicit flow.
+        completed_at = datetime.utcnow()
+        upsert_stmt = (
+            pg_insert(DigestCompletion)
+            .values(
+                user_id=user_id,
+                target_date=digest.target_date,
+                completed_at=completed_at,
+                articles_read=stats["read"],
+                articles_saved=stats["saved"],
+                articles_dismissed=stats["dismissed"],
+                closure_time_seconds=closure_time_seconds,
+            )
+            .on_conflict_do_update(
+                index_elements=["user_id", "target_date"],
+                set_={
+                    "completed_at": completed_at,
+                    "articles_read": stats["read"],
+                    "articles_saved": stats["saved"],
+                    "articles_dismissed": stats["dismissed"],
+                    "closure_time_seconds": closure_time_seconds,
+                },
+            )
         )
-        self.session.add(completion)
+        await self.session.execute(upsert_stmt)
 
-        # Update closure streak
+        # Update closure streak (idempotent same-day via last_closure_date).
         streak_update = await self._update_closure_streak(user_id)
 
         await self.session.flush()
@@ -1216,7 +1232,7 @@ class DigestService:
         return {
             "success": True,
             "digest_id": digest_id,
-            "completed_at": completion.completed_at,
+            "completed_at": completed_at,
             "articles_read": stats["read"],
             "articles_saved": stats["saved"],
             "articles_dismissed": stats["dismissed"],
@@ -1224,6 +1240,98 @@ class DigestService:
             "closure_streak": streak_update["current"],
             "streak_message": streak_update.get("message"),
         }
+
+    async def maybe_record_implicit_completion(
+        self,
+        user_id: UUID,
+        content_id: UUID,
+        threshold: float = 0.8,
+    ) -> bool:
+        """Record a digest_completions row implicitly when the user has
+        consumed ≥`threshold` of today's digest items.
+
+        Mirrors the closure_screen POST `/digest/{id}/complete` path so that
+        users who never reach the explicit "terminer mon digest" CTA still
+        appear in the engagement funnel. Idempotent via the UNIQUE constraint
+        on (user_id, target_date) → `ON CONFLICT DO NOTHING`.
+
+        Returns True when a completion was attempted (threshold met), False
+        otherwise. Callers can treat any exception as non-fatal — the helper
+        swallows errors so it never blocks the main content-status flow.
+        """
+        try:
+            today = today_paris()
+            stmt = select(DailyDigest).where(
+                and_(
+                    DailyDigest.user_id == user_id,
+                    DailyDigest.target_date == today,
+                )
+            )
+            result = await self.session.execute(stmt)
+            digests = list(result.scalars().all())
+
+            for digest in digests:
+                content_ids = self._extract_digest_content_ids(digest)
+                if not content_ids or content_id not in content_ids:
+                    continue
+
+                count_stmt = (
+                    select(func.count())
+                    .select_from(UserContentStatus)
+                    .where(
+                        and_(
+                            UserContentStatus.user_id == user_id,
+                            UserContentStatus.content_id.in_(content_ids),
+                            UserContentStatus.status == ContentStatus.CONSUMED,
+                        )
+                    )
+                )
+                consumed_count = (
+                    await self.session.execute(count_stmt)
+                ).scalar_one()
+
+                if consumed_count / len(content_ids) < threshold:
+                    continue
+
+                insert_stmt = (
+                    pg_insert(DigestCompletion)
+                    .values(
+                        user_id=user_id,
+                        target_date=digest.target_date,
+                        completed_at=datetime.utcnow(),
+                        articles_read=consumed_count,
+                    )
+                    .on_conflict_do_nothing(
+                        index_elements=["user_id", "target_date"],
+                    )
+                    .returning(DigestCompletion.id)
+                )
+                inserted_id = (
+                    await self.session.execute(insert_stmt)
+                ).scalar_one_or_none()
+                logger.info(
+                    "digest_completion_implicit",
+                    user_id=str(user_id),
+                    target_date=str(digest.target_date),
+                    consumed_count=consumed_count,
+                    total=len(content_ids),
+                    inserted=inserted_id is not None,
+                )
+                # Keep the closure streak in sync when we actually inserted a
+                # new row — `_update_closure_streak` is itself same-day
+                # idempotent, but skipping the call when we no-opped on
+                # conflict avoids an unnecessary UserStreak read/write.
+                if inserted_id is not None:
+                    await self._update_closure_streak(user_id)
+                return True
+        except Exception as exc:  # noqa: BLE001 — never break the caller
+            logger.warning(
+                "digest_completion_implicit_failed",
+                user_id=str(user_id),
+                content_id=str(content_id),
+                error=str(exc),
+            )
+        return False
 
     async def _get_existing_digest(
         self, user_id: UUID, target_date: date, is_serene: bool = False
@@ -2594,19 +2702,23 @@ class DigestService:
             source_id=str(content.source_id),
         )
 
-    async def _get_digest_action_stats(
-        self, user_id: UUID, digest: DailyDigest
-    ) -> dict[str, int]:
-        """Count actions taken on digest items."""
-        # Handle both flat and topics_v1 formats
+    @staticmethod
+    def _extract_digest_content_ids(digest: DailyDigest) -> list[UUID]:
+        """Return the flat list of content UUIDs in a digest, regardless of
+        storage format (`flat_v1` list vs `topics_v1`/`editorial_v1` dict)."""
         if isinstance(digest.items, dict) and digest.items.get("format") == "topics_v1":
-            content_ids = [
+            return [
                 UUID(a["content_id"])
                 for t in digest.items["topics"]
                 for a in t["articles"]
             ]
-        else:
-            content_ids = [UUID(item["content_id"]) for item in digest.items]
+        return [UUID(item["content_id"]) for item in digest.items]
+
+    async def _get_digest_action_stats(
+        self, user_id: UUID, digest: DailyDigest
+    ) -> dict[str, int]:
+        """Count actions taken on digest items."""
+        content_ids = self._extract_digest_content_ids(digest)
 
         # Get all statuses for these content items
         stmt = select(UserContentStatus).where(

--- a/packages/api/scripts/backfill_digest_completions.py
+++ b/packages/api/scripts/backfill_digest_completions.py
@@ -1,0 +1,165 @@
+"""Rejoue la règle implicite `digest_completion ≥ 80% consumed` sur les
+`daily_digest` des N derniers jours.
+
+Plan engagement & PMF — Sprint 1.3. Avant le déploiement, la table
+`digest_completions` est vide pour la majorité des users actifs parce que le
+path explicite (closure_screen POST /digest/{id}/complete) n'a jamais été
+atteint (app backgroundée, network drop, etc.). Ce script backfille en
+INSERT idempotent (ON CONFLICT DO NOTHING) pour que la métrique "digest
+completions per user-day" reflète la réalité.
+
+Idempotent : relançable sans effet de bord grâce à l'UNIQUE (user_id,
+target_date).
+
+Usage:
+    cd packages/api && source venv/bin/activate
+    python scripts/backfill_digest_completions.py --days 30 [--threshold 0.8] [--dry-run]
+"""
+
+from dotenv import load_dotenv
+from pathlib import Path
+
+# Load .env BEFORE any app imports
+load_dotenv(Path(__file__).parent.parent / ".env", override=True)
+
+import argparse
+import asyncio
+import os
+import sys
+from datetime import datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+# Add parent directory for app imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.models.content import UserContentStatus
+from app.models.daily_digest import DailyDigest
+from app.models.digest_completion import DigestCompletion
+from app.models.enums import ContentStatus
+from app.services.digest_service import DigestService
+from app.utils.time import today_paris
+
+
+async def backfill(days: int, threshold: float, dry_run: bool) -> None:
+    from app.database import async_session_maker, init_db
+
+    print(f"Initializing database connection... (days={days}, threshold={threshold}, dry_run={dry_run})")
+    await init_db()
+
+    cutoff = today_paris() - timedelta(days=days)
+
+    async with async_session_maker() as session:
+        stmt = (
+            select(DailyDigest)
+            .where(DailyDigest.target_date >= cutoff)
+            .order_by(DailyDigest.target_date.desc())
+        )
+        result = await session.execute(stmt)
+        digests = list(result.scalars().all())
+        print(f"Found {len(digests)} daily_digest rows in the window.")
+
+        inserted = 0
+        skipped_threshold = 0
+        skipped_existing = 0
+        errors = 0
+
+        for digest in digests:
+            try:
+                content_ids = DigestService._extract_digest_content_ids(digest)
+                if not content_ids:
+                    continue
+
+                count_stmt = (
+                    select(func.count())
+                    .select_from(UserContentStatus)
+                    .where(
+                        and_(
+                            UserContentStatus.user_id == digest.user_id,
+                            UserContentStatus.content_id.in_(content_ids),
+                            UserContentStatus.status == ContentStatus.CONSUMED,
+                        )
+                    )
+                )
+                consumed_count = (await session.execute(count_stmt)).scalar_one()
+
+                if consumed_count / len(content_ids) < threshold:
+                    skipped_threshold += 1
+                    continue
+
+                # Check for existing row (for stats only — INSERT is idempotent)
+                existing_stmt = select(DigestCompletion).where(
+                    and_(
+                        DigestCompletion.user_id == digest.user_id,
+                        DigestCompletion.target_date == digest.target_date,
+                    )
+                )
+                existing = (await session.execute(existing_stmt)).scalar_one_or_none()
+                if existing is not None:
+                    skipped_existing += 1
+                    continue
+
+                if dry_run:
+                    inserted += 1
+                    continue
+
+                insert_stmt = (
+                    pg_insert(DigestCompletion)
+                    .values(
+                        user_id=digest.user_id,
+                        target_date=digest.target_date,
+                        completed_at=datetime.utcnow(),
+                        articles_read=consumed_count,
+                    )
+                    .on_conflict_do_nothing(
+                        index_elements=["user_id", "target_date"],
+                    )
+                )
+                await session.execute(insert_stmt)
+                inserted += 1
+            except Exception as exc:  # noqa: BLE001
+                errors += 1
+                print(
+                    f"[error] user={digest.user_id} date={digest.target_date}: {exc}"
+                )
+
+        if not dry_run:
+            await session.commit()
+
+        print(
+            f"Done. inserted={inserted} "
+            f"skipped_threshold={skipped_threshold} "
+            f"skipped_existing={skipped_existing} "
+            f"errors={errors} "
+            f"dry_run={dry_run}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="How many days back to replay (default: 30).",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.8,
+        help="Fraction of consumed items that triggers a completion (default: 0.8).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute stats without writing any row.",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(backfill(args.days, args.threshold, args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/tests/test_digest_completion_implicit.py
+++ b/packages/api/tests/test_digest_completion_implicit.py
@@ -1,0 +1,281 @@
+"""Tests pour DigestService.maybe_record_implicit_completion.
+
+Plan engagement & PMF — Sprint 1.3. Règle implicite : quand un user a consumed
+≥ 80 % des items du daily_digest du jour, on INSERT idempotemment une row dans
+`digest_completions` (contrainte UNIQUE sur user_id+target_date).
+
+Les tests mockent la session SQLAlchemy et inspectent :
+- l'existence (ou non) d'un appel `execute(insert stmt)` sur DigestCompletion
+- le bypass quand le seuil n'est pas atteint
+- le bypass quand le content_id n'appartient pas au digest
+- la tolérance aux exceptions (jamais fatal pour le caller)
+"""
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.dialects.postgresql import Insert as PgInsert
+
+from app.models.daily_digest import DailyDigest
+from app.models.digest_completion import DigestCompletion
+from app.services.digest_service import DigestService
+
+
+def _make_digest(user_id: UUID, content_ids: list[UUID]) -> DailyDigest:
+    digest = DailyDigest()
+    digest.user_id = user_id
+    digest.target_date = date(2026, 4, 24)
+    digest.items = [{"content_id": str(cid)} for cid in content_ids]
+    digest.is_serene = False
+    digest.format_version = "flat_v1"
+    return digest
+
+
+def _mock_session_with(
+    digest: DailyDigest | None,
+    consumed_count: int,
+    inserted_id: UUID | None = None,
+):
+    """Return an AsyncMock session where:
+    - first execute() resolves to a list containing `digest` (or empty)
+    - second execute() resolves to the consumed count (or unused)
+    - third execute() is the insert statement we assert on; its
+      `scalar_one_or_none()` returns `inserted_id` (None => ON CONFLICT no-op)
+    """
+    session = AsyncMock()
+
+    digest_result = MagicMock()
+    digest_result.scalars.return_value.all.return_value = [digest] if digest else []
+
+    count_result = MagicMock()
+    count_result.scalar_one.return_value = consumed_count
+
+    insert_result = MagicMock()
+    insert_result.scalar_one_or_none.return_value = inserted_id
+
+    session.execute = AsyncMock(
+        side_effect=[digest_result, count_result, insert_result]
+    )
+    return session
+
+
+@pytest.fixture
+def user_id() -> UUID:
+    return uuid4()
+
+
+@pytest.fixture
+def service_with_mocks():
+    def _build(session):
+        with (
+            patch("app.services.digest_service.DigestSelector"),
+            patch("app.services.digest_service.StreakService"),
+        ):
+            return DigestService(session)
+
+    return _build
+
+
+@pytest.mark.asyncio
+async def test_inserts_completion_when_threshold_reached(
+    service_with_mocks, user_id
+):
+    content_ids = [uuid4() for _ in range(5)]
+    digest = _make_digest(user_id, content_ids)
+    # 4 / 5 = 80% → triggers
+    session = _mock_session_with(digest, consumed_count=4)
+    service = service_with_mocks(session)
+
+    with patch(
+        "app.services.digest_service.today_paris",
+        return_value=date(2026, 4, 24),
+    ):
+        recorded = await service.maybe_record_implicit_completion(
+            user_id, content_ids[0]
+        )
+
+    assert recorded is True
+    # Third execute call should be the pg_insert on DigestCompletion
+    assert session.execute.await_count == 3
+    insert_stmt = session.execute.await_args_list[2].args[0]
+    assert isinstance(insert_stmt, PgInsert)
+    assert insert_stmt.table.name == DigestCompletion.__tablename__
+
+
+@pytest.mark.asyncio
+async def test_skips_when_below_threshold(service_with_mocks, user_id):
+    content_ids = [uuid4() for _ in range(5)]
+    digest = _make_digest(user_id, content_ids)
+    # 3 / 5 = 60% → below 80%
+    session = _mock_session_with(digest, consumed_count=3)
+    service = service_with_mocks(session)
+
+    with patch(
+        "app.services.digest_service.today_paris",
+        return_value=date(2026, 4, 24),
+    ):
+        recorded = await service.maybe_record_implicit_completion(
+            user_id, content_ids[0]
+        )
+
+    assert recorded is False
+    # Only the digest select + count query should have run — no insert.
+    assert session.execute.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_skips_when_content_not_in_digest(service_with_mocks, user_id):
+    digest_content_ids = [uuid4() for _ in range(5)]
+    digest = _make_digest(user_id, digest_content_ids)
+    session = _mock_session_with(digest, consumed_count=99)
+    service = service_with_mocks(session)
+
+    foreign_content_id = uuid4()
+
+    with patch(
+        "app.services.digest_service.today_paris",
+        return_value=date(2026, 4, 24),
+    ):
+        recorded = await service.maybe_record_implicit_completion(
+            user_id, foreign_content_id
+        )
+
+    assert recorded is False
+    # Only the digest select should have fired — content skip short-circuits.
+    assert session.execute.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_no_digest_today_returns_false(service_with_mocks, user_id):
+    session = _mock_session_with(None, consumed_count=0)
+    service = service_with_mocks(session)
+
+    with patch(
+        "app.services.digest_service.today_paris",
+        return_value=date(2026, 4, 24),
+    ):
+        recorded = await service.maybe_record_implicit_completion(
+            user_id, uuid4()
+        )
+
+    assert recorded is False
+
+
+@pytest.mark.asyncio
+async def test_swallows_exceptions(service_with_mocks, user_id):
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=RuntimeError("db offline"))
+    service = service_with_mocks(session)
+
+    # Must never raise — caller (update_content_status) relies on this.
+    recorded = await service.maybe_record_implicit_completion(
+        user_id, uuid4()
+    )
+    assert recorded is False
+
+
+@pytest.mark.asyncio
+async def test_insert_uses_on_conflict_do_nothing(
+    service_with_mocks, user_id
+):
+    """The INSERT must be idempotent via ON CONFLICT DO NOTHING on the
+    (user_id, target_date) UNIQUE — otherwise the explicit completion path
+    and the implicit path would race and one would raise IntegrityError."""
+    content_ids = [uuid4() for _ in range(5)]
+    digest = _make_digest(user_id, content_ids)
+    session = _mock_session_with(digest, consumed_count=5)
+    service = service_with_mocks(session)
+
+    with patch(
+        "app.services.digest_service.today_paris",
+        return_value=date(2026, 4, 24),
+    ):
+        await service.maybe_record_implicit_completion(user_id, content_ids[0])
+
+    insert_stmt = session.execute.await_args_list[2].args[0]
+    # Compile to inspect the ON CONFLICT clause.
+    from sqlalchemy.dialects import postgresql
+
+    compiled_sql = str(
+        insert_stmt.compile(dialect=postgresql.dialect())
+    ).lower()
+    assert "on conflict" in compiled_sql
+    assert "do nothing" in compiled_sql
+
+
+@pytest.mark.asyncio
+async def test_updates_closure_streak_on_successful_insert(
+    service_with_mocks, user_id
+):
+    """When the implicit INSERT actually writes a new row, the closure streak
+    must be incremented so users who never tap `terminer` still see their
+    streak tick. Conflict no-ops should skip the streak update."""
+    content_ids = [uuid4() for _ in range(5)]
+    digest = _make_digest(user_id, content_ids)
+    session = _mock_session_with(
+        digest, consumed_count=5, inserted_id=uuid4()
+    )
+    service = service_with_mocks(session)
+    service._update_closure_streak = AsyncMock(return_value={"current": 1})
+
+    with patch(
+        "app.services.digest_service.today_paris",
+        return_value=date(2026, 4, 24),
+    ):
+        await service.maybe_record_implicit_completion(user_id, content_ids[0])
+
+    service._update_closure_streak.assert_awaited_once_with(user_id)
+
+
+@pytest.mark.asyncio
+async def test_skips_closure_streak_on_conflict(service_with_mocks, user_id):
+    """ON CONFLICT no-op (row already existed via explicit path) must NOT
+    bump the streak a second time."""
+    content_ids = [uuid4() for _ in range(5)]
+    digest = _make_digest(user_id, content_ids)
+    session = _mock_session_with(digest, consumed_count=5, inserted_id=None)
+    service = service_with_mocks(session)
+    service._update_closure_streak = AsyncMock()
+
+    with patch(
+        "app.services.digest_service.today_paris",
+        return_value=date(2026, 4, 24),
+    ):
+        await service.maybe_record_implicit_completion(user_id, content_ids[0])
+
+    service._update_closure_streak.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_supports_topics_v1_format(service_with_mocks, user_id):
+    """Digest stored in `topics_v1` dict format should also be parsed."""
+    content_ids = [uuid4() for _ in range(5)]
+    digest = DailyDigest()
+    digest.user_id = user_id
+    digest.target_date = date(2026, 4, 24)
+    digest.items = {
+        "format": "topics_v1",
+        "topics": [
+            {
+                "topic_id": "t1",
+                "articles": [{"content_id": str(cid)} for cid in content_ids],
+            }
+        ],
+    }
+    digest.is_serene = False
+    digest.format_version = "topics_v1"
+
+    session = _mock_session_with(digest, consumed_count=5)
+    service = service_with_mocks(session)
+
+    with patch(
+        "app.services.digest_service.today_paris",
+        return_value=date(2026, 4, 24),
+    ):
+        recorded = await service.maybe_record_implicit_completion(
+            user_id, content_ids[0]
+        )
+
+    assert recorded is True

--- a/packages/api/tests/test_digest_service.py
+++ b/packages/api/tests/test_digest_service.py
@@ -267,8 +267,18 @@ class TestCompleteDigest:
             await service.complete_digest(digest_id=uuid4(), user_id=uuid4())
 
     @pytest.mark.asyncio
-    async def test_complete_adds_completion_record(self, service, mock_session):
-        """Completing a digest adds a DigestCompletion to the session."""
+    async def test_complete_upserts_completion_record(self, service, mock_session):
+        """Completing a digest issues an idempotent pg_insert on digest_completions.
+
+        The upsert path tolerates a pre-existing row from the implicit
+        threshold writer (`maybe_record_implicit_completion`) — the explicit
+        flow then enriches it with articles_saved / dismissed / closure_time.
+        """
+        from sqlalchemy.dialects import postgresql
+        from sqlalchemy.dialects.postgresql import Insert as PgInsert
+
+        from app.models.digest_completion import DigestCompletion
+
         digest_id = uuid4()
         user_id = uuid4()
 
@@ -300,14 +310,23 @@ class TestCompleteDigest:
                 digest_id=digest_id, user_id=user_id, closure_time_seconds=60
             )
 
-        # Verify session.add was called with a DigestCompletion instance
-        mock_session.add.assert_called_once()
-        added_obj = mock_session.add.call_args[0][0]
-        from app.models.digest_completion import DigestCompletion
+        # No ORM add: the upsert is dispatched via session.execute.
+        mock_session.add.assert_not_called()
 
-        assert isinstance(added_obj, DigestCompletion)
-        assert added_obj.user_id == user_id
-        assert added_obj.target_date == date.today()
+        executed_stmts = [c.args[0] for c in mock_session.execute.await_args_list]
+        upserts = [
+            s
+            for s in executed_stmts
+            if isinstance(s, PgInsert)
+            and s.table.name == DigestCompletion.__tablename__
+        ]
+        assert len(upserts) == 1
+
+        compiled = str(
+            upserts[0].compile(dialect=postgresql.dialect())
+        ).lower()
+        assert "on conflict" in compiled
+        assert "do update" in compiled
 
 
 # ─── Tests: get_or_create_digest fallback J-1 ────────────────────────────────

--- a/packages/api/tests/test_time_spent_accumulation.py
+++ b/packages/api/tests/test_time_spent_accumulation.py
@@ -1,0 +1,149 @@
+"""Test l'accumulation de `time_spent_seconds` sur `user_content_status`.
+
+Plan engagement & PMF — Sprint 1.1. Le service ne doit plus écraser la valeur
+existante : le conflict_set doit utiliser `coalesce(existing, 0) + new` pour
+que les sessions successives s'additionnent (pré-requis du feedback loop
+interest weights).
+
+Sprint 1.3. Vérifie aussi que la règle implicite `digest_completions` est
+bien câblée dans la branche CONSUMED.
+
+Pas de DB requise : on inspecte le SQL compilé du statement upsert.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from app.models.content import UserContentStatus
+from app.models.enums import ContentStatus
+from app.schemas.content import ContentStatusUpdate
+from app.services.content_service import ContentService
+
+
+def _captured_stmt(session_mock):
+    """Retrieve the compiled UPSERT passed to `session.scalars`."""
+    assert session_mock.scalars.call_args is not None
+    stmt = session_mock.scalars.call_args.args[0]
+    return str(stmt.compile(dialect=postgresql.dialect()))
+
+
+@pytest.mark.asyncio
+async def test_time_spent_uses_accumulation_expression_in_conflict_set():
+    session = AsyncMock()
+    mock_status = UserContentStatus(
+        user_id=uuid4(), content_id=uuid4(), time_spent_seconds=60
+    )
+    result = MagicMock()
+    result.one.return_value = mock_status
+    session.scalars.return_value = result
+
+    service = ContentService(session)
+    await service.update_content_status(
+        user_id=uuid4(),
+        content_id=uuid4(),
+        update_data=ContentStatusUpdate(time_spent_seconds=30),
+    )
+
+    sql = _captured_stmt(session).lower()
+    # The ON CONFLICT DO UPDATE must reference the existing row value,
+    # not overwrite it with a plain parameter.
+    assert "on conflict" in sql
+    assert "coalesce" in sql
+    assert "user_content_status.time_spent_seconds" in sql
+
+
+@pytest.mark.asyncio
+async def test_time_spent_absent_does_not_emit_time_spent_in_conflict_set():
+    """Update sans time_spent (ex: juste reading_progress) ne doit pas toucher
+    `time_spent_seconds` dans le SET clause — sinon on le reset à 0."""
+    session = AsyncMock()
+    mock_status = UserContentStatus(
+        user_id=uuid4(), content_id=uuid4(), time_spent_seconds=60
+    )
+    result = MagicMock()
+    result.one.return_value = mock_status
+    session.scalars.return_value = result
+
+    service = ContentService(session)
+    await service.update_content_status(
+        user_id=uuid4(),
+        content_id=uuid4(),
+        update_data=ContentStatusUpdate(reading_progress=50),
+    )
+
+    sql = _captured_stmt(session).lower()
+    # When time_spent_seconds is not provided, it must NOT appear in the SET.
+    # We assert the value column is never on the left side of a `=` in the SET list.
+    # The upsert SQL contains columns only in VALUES and SET — none of these
+    # references should mention `time_spent_seconds = …` for this call.
+    assert "time_spent_seconds =" not in sql
+    assert "time_spent_seconds=" not in sql
+
+
+@pytest.mark.asyncio
+async def test_consumed_status_triggers_implicit_digest_completion():
+    """When status becomes CONSUMED, update_content_status must invoke
+    DigestService.maybe_record_implicit_completion so the engagement funnel
+    catches users who never tap "terminer mon digest"."""
+    session = AsyncMock()
+    mock_status = UserContentStatus(user_id=uuid4(), content_id=uuid4())
+    result = MagicMock()
+    result.one.return_value = mock_status
+    session.scalars.return_value = result
+    session.get = AsyncMock(return_value=None)  # skip interest/subtopic paths
+
+    user_id = uuid4()
+    content_id = uuid4()
+
+    with (
+        patch(
+            "app.services.content_service.StreakService"
+        ) as streak_cls,
+        patch(
+            "app.services.digest_service.DigestService"
+        ) as digest_cls,
+    ):
+        streak_cls.return_value.increment_consumption = AsyncMock()
+        digest_instance = digest_cls.return_value
+        digest_instance.maybe_record_implicit_completion = AsyncMock(
+            return_value=True
+        )
+
+        service = ContentService(session)
+        await service.update_content_status(
+            user_id=user_id,
+            content_id=content_id,
+            update_data=ContentStatusUpdate(status=ContentStatus.CONSUMED),
+        )
+
+        digest_instance.maybe_record_implicit_completion.assert_awaited_once_with(
+            user_id, content_id
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_consumed_status_skips_implicit_completion():
+    """Only CONSUMED should trigger the digest_completion hook — SEEN/UNSEEN
+    must not fire it (avoids spurious inserts when a user merely scrolls past
+    a card)."""
+    session = AsyncMock()
+    mock_status = UserContentStatus(user_id=uuid4(), content_id=uuid4())
+    result = MagicMock()
+    result.one.return_value = mock_status
+    session.scalars.return_value = result
+    session.get = AsyncMock(return_value=None)
+
+    with patch(
+        "app.services.digest_service.DigestService"
+    ) as digest_cls:
+        service = ContentService(session)
+        await service.update_content_status(
+            user_id=uuid4(),
+            content_id=uuid4(),
+            update_data=ContentStatusUpdate(status=ContentStatus.SEEN),
+        )
+
+        digest_cls.assert_not_called()


### PR DESCRIPTION
## What

Sprint 1 of the engagement & PMF instrumentation plan: wire the missing writes so `user_content_status.time_spent_seconds`, `digest_completions`, and PostHog actually fill up in prod.

## Why

Audit showed the tables/PostHog have been silent since 20 Feb — infra existed but reads/writes were not connected end-to-end. Without these signals we can't compute PMF metrics (activation, retention, Sean Ellis).

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)