### PR TITLE
fix(onboarding): save robuste — fallback dégradé + re-sync auto

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'config/theme.dart';
 import 'config/routes.dart';
 import 'features/feed/providers/feed_preload_provider.dart';
+import 'features/onboarding/providers/onboarding_sync_provider.dart';
 import 'features/settings/providers/theme_provider.dart';
 
 import 'core/ui/notification_service.dart';
@@ -22,6 +23,10 @@ class FacteurApp extends ConsumerWidget {
     // watches auth state and kicks off `feedProvider.future` in the
     // background so the Feed tab renders instantly on first tap.
     ref.watch(feedPreloadProvider);
+
+    // Active la re-sync automatique de l'onboarding quand la session devient
+    // authentifiée (best-effort, silencieux) — voir onboarding_sync_provider.dart.
+    ref.watch(onboardingSyncProvider);
 
     return MaterialApp.router(
       title: 'Facteur',

--- a/apps/mobile/lib/core/api/user_api_service.dart
+++ b/apps/mobile/lib/core/api/user_api_service.dart
@@ -76,19 +76,26 @@ class UserApiService {
     return UserProfile.fromJson(data);
   }
 
-  /// Formate les réponses pour l'API (camelCase → snake_case)
+  /// Formate les réponses pour l'API (camelCase → snake_case).
+  ///
+  /// Défense en profondeur : applique des défauts neutres si l'état mobile
+  /// est incomplet (reprise partielle, bug de navigation). Évite un 422
+  /// Pydantic côté backend qui détruirait la progression utilisateur.
   Map<String, dynamic> _formatAnswersForApi(OnboardingAnswers answers) {
+    final objective = (answers.objectives?.isNotEmpty ?? false)
+        ? answers.objectives!.join(',')
+        : 'culture';
     return {
-      'objective': answers.objectives?.join(','),
+      'objective': objective,
       'age_range': answers.ageRange,
       'gender': answers.gender,
-      'approach': answers.approach,
+      'approach': answers.approach ?? 'detailed',
       'perspective': answers.perspective,
-      'response_style': answers.responseStyle,
+      'response_style': answers.responseStyle ?? 'nuanced',
       'content_recency': answers.contentRecency ?? 'recent',
-      'gamification_enabled': answers.gamificationEnabled,
-      'weekly_goal': answers.dailyArticleCount,
-      'digest_mode': answers.digestMode,
+      'gamification_enabled': answers.gamificationEnabled ?? true,
+      'weekly_goal': answers.dailyArticleCount ?? 5,
+      'digest_mode': answers.digestMode ?? 'pour_vous',
       'themes': answers.themes,
       'subtopics': answers.subtopics,
       'preferred_sources': answers.preferredSources,

--- a/apps/mobile/lib/features/onboarding/providers/conclusion_notifier.dart
+++ b/apps/mobile/lib/features/onboarding/providers/conclusion_notifier.dart
@@ -64,8 +64,10 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
       _apiCompleted = true;
       _checkCompletion();
     } catch (e) {
-      // Tous les retries ont échoué → montrer l'erreur
+      // Tous les retries ont échoué → sauvegarder localement pour re-sync
+      // automatique au prochain lancement, puis afficher le fallback.
       _minAnimationTimer?.cancel();
+      await _saveProfileLocallyDegraded();
       state = ConclusionError(e.toString());
     }
   }
@@ -199,20 +201,9 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
     await startConclusion();
   }
 
-  /// Mode dégradé : continuer sans sauvegarder
-  Future<void> continueAnyway() async {
-    // Marquer comme complété localement uniquement (mode dégradé)
-    await _saveProfileLocallyDegraded();
-
-    // Marquer l'onboarding comme finalisé
-    _ref.read(onboardingProvider.notifier).finalizeOnboarding();
-
-    state = const ConclusionSuccess();
-
-    debugPrint('Mode dégradé activé : onboarding complété localement uniquement');
-  }
-
-  /// Sauvegarde en mode dégradé (local uniquement)
+  /// Sauvegarde en mode dégradé (local uniquement).
+  /// Appelée automatiquement quand tous les retries API échouent — pose le flag
+  /// `pending_sync` que le bootstrap re-traitera au prochain lancement authentifié.
   Future<void> _saveProfileLocallyDegraded() async {
     try {
       final answers = _ref.read(onboardingProvider).answers;

--- a/apps/mobile/lib/features/onboarding/providers/onboarding_provider.dart
+++ b/apps/mobile/lib/features/onboarding/providers/onboarding_provider.dart
@@ -174,12 +174,18 @@ class OnboardingState {
   final bool isTransitioning;
   final bool showReaction;
 
+  /// Thèmes personnalisés dont la sauvegarde API a échoué pendant Subtopics.
+  /// Affiché en fin de parcours pour informer l'utilisateur qu'il pourra
+  /// les ré-ajouter depuis Mes Intérêts.
+  final List<String> failedCustomTopics;
+
   const OnboardingState({
     this.currentSection = OnboardingSection.overview,
     this.currentQuestionIndex = 0,
     this.answers = const OnboardingAnswers(),
     this.isTransitioning = false,
     this.showReaction = false,
+    this.failedCustomTopics = const [],
   });
 
   /// Nombre total de questions dans la Section 1
@@ -240,6 +246,7 @@ class OnboardingState {
     OnboardingAnswers? answers,
     bool? isTransitioning,
     bool? showReaction,
+    List<String>? failedCustomTopics,
   }) {
     return OnboardingState(
       currentSection: currentSection ?? this.currentSection,
@@ -247,6 +254,7 @@ class OnboardingState {
       answers: answers ?? this.answers,
       isTransitioning: isTransitioning ?? this.isTransitioning,
       showReaction: showReaction ?? this.showReaction,
+      failedCustomTopics: failedCustomTopics ?? this.failedCustomTopics,
     );
   }
 }
@@ -624,6 +632,20 @@ class OnboardingNotifier extends StateNotifier<OnboardingState> {
     // Cette méthode est appelée avant la transition vers l'animation finale
     // Les données seront envoyées à l'API dans l'écran d'animation
     _saveAnswers();
+  }
+
+  /// Enregistre les noms des thèmes personnalisés dont la création API a échoué
+  /// pendant Subtopics. Non-bloquant — affiché en résumé après la conclusion.
+  void recordFailedCustomTopics(List<String> names) {
+    if (names.isEmpty) return;
+    state = state.copyWith(
+      failedCustomTopics: [...state.failedCustomTopics, ...names],
+    );
+  }
+
+  /// Reset la liste des échecs (après affichage du résumé post-onboarding).
+  void clearFailedCustomTopics() {
+    state = state.copyWith(failedCustomTopics: const []);
   }
 
   /// BYPASS TEMPORAIRE POUR TEST (A supprimer plus tard)

--- a/apps/mobile/lib/features/onboarding/providers/onboarding_sync_provider.dart
+++ b/apps/mobile/lib/features/onboarding/providers/onboarding_sync_provider.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../../core/api/providers.dart';
+import '../../../core/auth/auth_state.dart';
+import 'onboarding_provider.dart';
+
+/// Re-sync onboarding answers saved locally when the previous attempt failed.
+///
+/// Le notifier `ConclusionNotifier` pose `pending_sync = true` + `answers_backup`
+/// dans la box Hive `user_profile` quand tous les retries API échouent. Ce
+/// provider observe l'auth et, à chaque passage à l'état authentifié, tente
+/// silencieusement un renvoi best-effort. Succès → flags nettoyés. Échec →
+/// on réessaiera au prochain lancement.
+class OnboardingSyncNotifier extends StateNotifier<void> {
+  OnboardingSyncNotifier(this._ref) : super(null) {
+    _ref.listen<AuthState>(authStateProvider, (previous, next) {
+      final wasAuthenticated = previous?.isAuthenticated ?? false;
+      if (!wasAuthenticated && next.isAuthenticated) {
+        _attemptResync();
+      }
+    }, fireImmediately: true);
+  }
+
+  final Ref _ref;
+  bool _inFlight = false;
+
+  static const _boxName = 'user_profile';
+  static const _pendingSyncKey = 'pending_sync';
+  static const _answersBackupKey = 'answers_backup';
+
+  Future<void> _attemptResync() async {
+    if (_inFlight) return;
+    _inFlight = true;
+    try {
+      final box = await Hive.openBox(_boxName);
+      final pending = box.get(_pendingSyncKey) as bool? ?? false;
+      if (!pending) return;
+
+      final rawBackup = box.get(_answersBackupKey);
+      if (rawBackup == null) {
+        await box.put(_pendingSyncKey, false);
+        return;
+      }
+
+      final answers = OnboardingAnswers.fromJson(
+        Map<String, dynamic>.from(rawBackup as Map),
+      );
+
+      debugPrint(
+        '[ONBOARDING_TELEMETRY] event=resync_start pending=true',
+      );
+
+      final userService = _ref.read(userApiServiceProvider);
+      final result = await userService.saveOnboarding(answers);
+
+      if (result.success) {
+        await box.put(_pendingSyncKey, false);
+        await box.delete(_answersBackupKey);
+        if (result.profile != null) {
+          await box.put('profile', result.profile!.toJson());
+          await box.put('onboarding_completed', true);
+        }
+        // Resync a écrit le profil côté serveur : forcer la relecture par
+        // `authStateProvider` pour que `needsOnboarding` ne reste pas bloqué
+        // à `true` (décision prise par `_checkOnboardingStatus` lancé avant
+        // que le resync ne termine).
+        await _ref
+            .read(authStateProvider.notifier)
+            .refreshOnboardingStatus();
+        debugPrint('[ONBOARDING_TELEMETRY] event=resync_success');
+      } else {
+        debugPrint(
+          '[ONBOARDING_TELEMETRY] event=resync_failed '
+          'error_type=${result.errorType} message=${result.errorMessage}',
+        );
+      }
+    } catch (e) {
+      debugPrint('[ONBOARDING_TELEMETRY] event=resync_exception error=$e');
+    } finally {
+      _inFlight = false;
+    }
+  }
+}
+
+/// Provider à watcher depuis `FacteurApp` pour activer la re-sync automatique.
+final onboardingSyncProvider =
+    StateNotifierProvider<OnboardingSyncNotifier, void>(
+  (ref) => OnboardingSyncNotifier(ref),
+);

--- a/apps/mobile/lib/features/onboarding/screens/conclusion_animation_screen.dart
+++ b/apps/mobile/lib/features/onboarding/screens/conclusion_animation_screen.dart
@@ -5,6 +5,8 @@ import 'package:go_router/go_router.dart';
 import '../../../config/theme.dart';
 import '../../../config/routes.dart';
 import '../../../core/auth/auth_state.dart';
+import '../../../shared/strings/loader_error_strings.dart';
+import '../../../shared/widgets/states/laurin_fallback_view.dart';
 import '../providers/conclusion_notifier.dart';
 import '../providers/onboarding_provider.dart';
 import '../widgets/animated_message_text.dart';
@@ -53,7 +55,12 @@ class _ConclusionAnimationScreenState
           ConclusionLoading() => const _LoadingView(),
           ConclusionSuccess() =>
             const _LoadingView(), // Garde l'animation pendant la transition
-          ConclusionError(:final message) => _ErrorView(errorMessage: message),
+          ConclusionError() => LaurinFallbackView(
+              title: OnboardingFallbackStrings.title,
+              subtitle: OnboardingFallbackStrings.subtitle,
+              onRetry: () =>
+                  ref.read(conclusionNotifierProvider.notifier).retry(),
+            ),
         },
       ),
     );
@@ -63,8 +70,36 @@ class _ConclusionAnimationScreenState
     // Marquer l'onboarding comme terminé dans l'auth state
     await ref.read(authStateProvider.notifier).setOnboardingCompleted();
 
+    // Capture la liste des customs échoués AVANT clearSavedData pour pouvoir
+    // afficher le résumé utilisateur ("tu pourras les réajouter").
+    final failedCustomTopics =
+        List<String>.from(ref.read(onboardingProvider).failedCustomTopics);
+
     // Effacer les données locales temporaires
     ref.read(onboardingProvider.notifier).clearSavedData();
+    ref.read(onboardingProvider.notifier).clearFailedCustomTopics();
+
+    if (mounted && failedCustomTopics.isNotEmpty) {
+      // Dialog bloquant au lieu d'une SnackBar : les bottom sheets suivants
+      // (thème, notifications) poseraient un barrier qui masquerait la
+      // SnackBar. Le dialog garantit que l'utilisateur voit l'info.
+      await showDialog<void>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          content: Text(
+            OnboardingFallbackStrings.failedCustomTopicsMessage(
+              failedCustomTopics,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    }
 
     // Proposer le choix du thème avant de naviguer
     if (mounted) {
@@ -111,103 +146,3 @@ class _LoadingView extends StatelessWidget {
   }
 }
 
-/// Vue d'erreur avec options de retry
-class _ErrorView extends ConsumerWidget {
-  final String errorMessage;
-
-  const _ErrorView({required this.errorMessage});
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = context.facteurColors;
-
-    return Padding(
-      padding: const EdgeInsets.all(FacteurSpacing.space6),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Spacer(flex: 2),
-
-          // Emoji d'erreur
-          const Text('⚠️', style: TextStyle(fontSize: 64)),
-
-          const SizedBox(height: FacteurSpacing.space6),
-
-          // Titre
-          Text(
-            'Oups, un problème est survenu',
-            style: Theme.of(context).textTheme.displayMedium,
-            textAlign: TextAlign.center,
-          ),
-
-          const SizedBox(height: FacteurSpacing.space4),
-
-          // Message d'erreur
-          Text(
-            'Impossible de sauvegarder ton profil',
-            style: Theme.of(
-              context,
-            ).textTheme.bodyLarge?.copyWith(color: colors.textSecondary),
-            textAlign: TextAlign.center,
-          ),
-
-          if (errorMessage.isNotEmpty) ...[
-            const SizedBox(height: FacteurSpacing.space3),
-            Container(
-              padding: const EdgeInsets.all(FacteurSpacing.space3),
-              decoration: BoxDecoration(
-                color: colors.surface,
-                borderRadius: BorderRadius.circular(FacteurRadius.small),
-              ),
-              child: Text(
-                errorMessage,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodySmall?.copyWith(color: colors.textTertiary),
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ],
-
-          const Spacer(flex: 3),
-
-          // Bouton réessayer
-          SizedBox(
-            width: double.infinity,
-            child: ElevatedButton(
-              onPressed: () {
-                ref.read(conclusionNotifierProvider.notifier).retry();
-              },
-              style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-                backgroundColor: colors.primary,
-              ),
-              child: const Text(
-                'Réessayer',
-                style: TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
-              ),
-            ),
-          ),
-
-          const SizedBox(height: FacteurSpacing.space3),
-
-          // Bouton continuer quand même
-          TextButton(
-            onPressed: () {
-              ref.read(conclusionNotifierProvider.notifier).continueAnyway();
-            },
-            child: Text(
-              'Continuer quand même',
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: colors.textSecondary,
-                    decoration: TextDecoration.underline,
-                  ),
-            ),
-          ),
-
-          const SizedBox(height: FacteurSpacing.space4),
-        ],
-      ),
-    );
-  }
-}

--- a/apps/mobile/lib/features/onboarding/screens/questions/subtopics_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/subtopics_question.dart
@@ -110,41 +110,59 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
   }
 
   Future<void> _continue() async {
-    // Collect custom topics + entities to save via API BEFORE navigating
+    // Collect custom topics + entities to save via API BEFORE navigating.
+    // Non-bloquant : les échecs sont loggués et résumés en fin d'onboarding,
+    // jamais opposés à la progression utilisateur.
     final notifier = ref.read(customTopicsProvider.notifier);
-    final futures = <Future<dynamic>>[];
+    final attempts = <_TopicAttempt>[];
 
     for (final entry in _customTopics.entries) {
       for (final topicName in entry.value) {
-        futures.add(
-          notifier
+        attempts.add(_TopicAttempt(
+          name: topicName,
+          future: notifier
               .followTopic(topicName, slugParent: entry.key)
-              .catchError((_) => null),
-        );
+              .then<Object?>((v) => v)
+              .catchError((Object e, StackTrace st) {
+            debugPrint(
+              '[ONBOARDING_TELEMETRY] event=custom_topic_failed '
+              'name="$topicName" theme=${entry.key} error=$e',
+            );
+            return null;
+          }),
+        ));
       }
     }
     for (final entityName in _selectedEntities) {
-      futures.add(
-        notifier.followTopic(entityName).catchError((_) => null),
-      );
+      attempts.add(_TopicAttempt(
+        name: entityName,
+        future: notifier
+            .followTopic(entityName)
+            .then<Object?>((v) => v)
+            .catchError((Object e, StackTrace st) {
+          debugPrint(
+            '[ONBOARDING_TELEMETRY] event=custom_entity_failed '
+            'name="$entityName" error=$e',
+          );
+          return null;
+        }),
+      ));
     }
 
-    if (futures.isNotEmpty) {
+    if (attempts.isNotEmpty) {
       setState(() => _saving = true);
-      final results = await Future.wait(futures);
-      final failed = results.where((r) => r == null).length;
+      final results = await Future.wait(attempts.map((a) => a.future));
+      final failedNames = <String>[
+        for (var i = 0; i < attempts.length; i++)
+          if (results[i] == null) attempts[i].name,
+      ];
 
-      if (mounted && failed > 0) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              failed == results.length
-                  ? 'Impossible de sauvegarder les sujets personnalisés'
-                  : '$failed sujet(s) n\'ont pas pu être sauvegardés',
-            ),
-            duration: const Duration(seconds: 3),
-          ),
-        );
+      if (failedNames.isNotEmpty) {
+        // Stocke dans l'état — la bottom sheet de synthèse s'affichera
+        // après la conclusion, à la place du snackbar éphémère.
+        ref
+            .read(onboardingProvider.notifier)
+            .recordFailedCustomTopics(failedNames);
       }
     }
 
@@ -539,6 +557,12 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
       ),
     );
   }
+}
+
+class _TopicAttempt {
+  final String name;
+  final Future<Object?> future;
+  const _TopicAttempt({required this.name, required this.future});
 }
 
 class _EntityChip extends StatelessWidget {

--- a/apps/mobile/lib/shared/strings/loader_error_strings.dart
+++ b/apps/mobile/lib/shared/strings/loader_error_strings.dart
@@ -69,3 +69,20 @@ class LaurinFallbackStrings {
 
   static const String mailSubject = 'Facteur — petit souci de chargement';
 }
+
+/// Messages spécifiques au fallback de fin d'onboarding.
+class OnboardingFallbackStrings {
+  OnboardingFallbackStrings._();
+
+  static const String title = 'On n\'a pas pu enregistrer vos réponses.';
+  static const String subtitle =
+      'L\'équipe travaille à corriger ça. Vous pourrez refaire le questionnaire plus tard — rien n\'est perdu.';
+
+  /// Résumé affiché en SnackBar quand certains thèmes personnalisés ont échoué.
+  static String failedCustomTopicsMessage(List<String> names) {
+    if (names.isEmpty) return '';
+    final preview = names.take(3).join(', ');
+    final extra = names.length > 3 ? ' et ${names.length - 3} autre(s)' : '';
+    return 'Certains sujets personnalisés n\'ont pas pu être sauvés ($preview$extra). Tu pourras les réajouter depuis Mes Intérêts.';
+  }
+}

--- a/apps/mobile/lib/shared/widgets/states/laurin_fallback_view.dart
+++ b/apps/mobile/lib/shared/widgets/states/laurin_fallback_view.dart
@@ -11,10 +11,20 @@ import '../buttons/secondary_button.dart';
 
 /// Fallback affiché après plusieurs échecs consécutifs : message rassurant et
 /// option de prévenir Laurin (mail / WhatsApp + presse-papier).
+///
+/// [title] / [subtitle] permettent d'adapter le message selon le contexte
+/// (digest, onboarding, etc.) sans dupliquer le widget.
 class LaurinFallbackView extends StatelessWidget {
   final VoidCallback onRetry;
+  final String? title;
+  final String? subtitle;
 
-  const LaurinFallbackView({super.key, required this.onRetry});
+  const LaurinFallbackView({
+    super.key,
+    required this.onRetry,
+    this.title,
+    this.subtitle,
+  });
 
   Future<void> _copyToClipboard(BuildContext context) async {
     await Clipboard.setData(
@@ -77,13 +87,13 @@ class LaurinFallbackView extends StatelessWidget {
               ),
               const SizedBox(height: FacteurSpacing.space4),
               Text(
-                LaurinFallbackStrings.title,
+                title ?? LaurinFallbackStrings.title,
                 textAlign: TextAlign.center,
                 style: FacteurTypography.displayMedium(colors.textPrimary),
               ),
               const SizedBox(height: FacteurSpacing.space2),
               Text(
-                LaurinFallbackStrings.subtitle,
+                subtitle ?? LaurinFallbackStrings.subtitle,
                 textAlign: TextAlign.center,
                 style: FacteurTypography.bodyMedium(colors.textSecondary),
               ),

--- a/packages/api/app/schemas/user.py
+++ b/packages/api/app/schemas/user.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class UserProfileCreate(BaseModel):
@@ -59,21 +59,29 @@ class UserInterestResponse(BaseModel):
 
 
 class OnboardingAnswers(BaseModel):
-    """Réponses du questionnaire d'onboarding."""
+    """Réponses du questionnaire d'onboarding.
+
+    Tolérant aux nulls: un client qui envoie un état partiel (ex. bug mobile
+    ou reprise d'onboarding interrompue) ne doit pas subir un 422 bloquant.
+    Les défauts appliqués ici permettent au service de toujours persister
+    quelque chose — les préférences à None sont ensuite skippées en base.
+    """
 
     # Section 1 - Overview
-    objective: str = Field(..., description="Objectif : learn, culture, professional")
+    objective: str | None = Field(
+        None, description="Objectif : learn, culture, professional"
+    )
     age_range: str | None = Field(
         None, description="Tranche d'âge (removed in onboarding v3)"
     )
     gender: str | None = None
-    approach: str = Field(..., description="direct ou detailed")
+    approach: str | None = Field(None, description="direct ou detailed")
 
     # Section 2 - App Preferences
     perspective: str | None = Field(
         None, description="big_picture ou detail_oriented (removed in onboarding v3)"
     )
-    response_style: str = Field(..., description="decisive ou nuanced")
+    response_style: str | None = Field(None, description="decisive ou nuanced")
     content_recency: str | None = Field(
         None, description="recent ou evergreen (deprecated)"
     )
@@ -84,6 +92,11 @@ class OnboardingAnswers(BaseModel):
     digest_mode: str | None = Field(
         "pour_vous", description="pour_vous, serein, perspective"
     )
+
+    @field_validator("gamification_enabled", mode="before")
+    @classmethod
+    def _default_gamification(cls, v: bool | None) -> bool:
+        return True if v is None else v
 
     # Section 3 - Source Preferences
     preferred_sources: list[str] | None = Field(


### PR DESCRIPTION
## What

Rend la finalisation de l'onboarding résiliente aux échecs API : fallback local dégradé avec re-sync automatique au prochain passage authentifié, backend tolérant aux nulls, et synthèse utilisateur via dialog bloquant pour les customs échoués.

## Why

Quand l'API de sauvegarde échouait en fin d'onboarding, l'utilisateur perdait sa progression (aucun flux de récupération fiable, option "continuer quand même" destructrice). Les customs échoués en Subtopics étaient signalés via une SnackBar masquée par les bottom sheets suivants.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Changements clés

- `onboardingSyncProvider` (nouveau) : re-sync best-effort sur transition vers authentifié, refresh de `needsOnboarding` après succès pour débloquer le router.
- `ConclusionNotifier` : suppression du chemin "continuer quand même" ; après échec des retries, sauvegarde locale + `pending_sync=true` + `answers_backup`, puis `LaurinFallbackView` avec retry.
- `Subtopics` : échecs customs non-bloquants, accumulés dans l'état et affichés via un `AlertDialog` bloquant après la conclusion.
- Backend `OnboardingAnswers` : `objective`/`approach`/`response_style` passent optionnels, validator `gamification_enabled` (None→True) — évite les 422 qui détruisaient la progression.

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [x] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)