### PR TITLE
chore(lint): ruff-format scheduler.py (CI lint hotfix from #479)

### DIFF
--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -91,7 +91,9 @@ async def _digest_watchdog() -> None:
                 try:
                     await session.rollback()
                 except Exception:
-                    logger.warning("digest_watchdog outer rollback failed", exc_info=True)
+                    logger.warning(
+                        "digest_watchdog outer rollback failed", exc_info=True
+                    )
 
     except Exception:
         logger.exception("digest_watchdog_failed")


### PR DESCRIPTION
## Summary

- Hotfix : la PR #479 a été mergée alors que le check CI `lint` (ruff format --check) avait échoué — une seule ligne (`logger.warning` dans `_digest_watchdog`) dépasse la limite 88 char après le wrapping try/except du F3 audit sweep.
- Reformatage automatique via `ruff format` : split sur 3 lignes. Aucun changement de comportement.
- Cause de l'incident : ma vérif locale pré-merge n'a couvert que `ruff check` (linter), pas `ruff format --check` (formatter). À ajouter au runbook agent.

## Test plan

- [x] `ruff format --check app/` → 163 files already formatted
- [x] `ruff check app/workers/scheduler.py` → All checks passed
- [x] `pytest tests/workers/test_scheduler.py` → 12 passed
- [ ] CI lint passe sur cette PR avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)