### PR TITLE
fix(nudges): drop welcomeTourSeen state guard (blocks all PR2 v1 users)

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -31,7 +31,6 @@ import '../widgets/article_reader_widget.dart';
 import '../widgets/audio_player_widget.dart';
 import '../widgets/youtube_player_widget.dart';
 import '../widgets/note_input_sheet.dart';
-import '../../../core/auth/auth_state.dart';
 import '../../../core/nudges/nudge_coordinator.dart';
 import '../../../core/nudges/nudge_counters.dart';
 import '../../../core/nudges/nudge_ids.dart';
@@ -324,19 +323,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       }
     });
 
-    // All feature nudges are gated on welcome_tour being seen — we don't want
-    // them surfacing during (or piggybacking on) the onboarding tour flow.
-    if (ref.read(authStateProvider).welcomeTourSeen) {
-      // First-time save+notes nudge, routed via NudgeCoordinator (respects
-      // kill switch + queue + legacy `has_seen_note_welcome` key).
-      _requestSaveNotesNudge();
+    // First-time save+notes nudge — gating is enforced by the coordinator's
+    // prereq on welcome_tour (device-scoped key, legacy fallback honored).
+    // The article screen can't be reached during the tour (overlay blocks
+    // taps), so no extra "tour active" guard needed here.
+    _requestSaveNotesNudge();
 
-      // Persist article open count for triggers (read_on_site 4th article,
-      // feed_preview_longpress ≥2 articles opened).
-      NudgeCounters.increment(NudgeCounters.articleOpenCount).then((count) {
-        if (mounted) _articleOpenCount = count;
-      });
-    }
+    // Persist article open count for triggers (read_on_site 4th article,
+    // feed_preview_longpress ≥2 articles opened).
+    NudgeCounters.increment(NudgeCounters.articleOpenCount).then((count) {
+      if (mounted) _articleOpenCount = count;
+    });
 
     // 🌻 Nudge: record article open and start 30s timer
     NudgeTracker.recordArticleOpen();
@@ -1103,7 +1100,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
   void _maybeTriggerPerspectivesCta() {
     if (_perspectivesCtaTriggered) return;
-    if (!ref.read(authStateProvider).welcomeTourSeen) return;
     final response = _perspectivesResponse;
     if (response == null) return;
     if (response.perspectives.isEmpty || !response.shouldDisplay) return;

--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -15,11 +15,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../../config/theme.dart';
 import '../../../config/topic_labels.dart';
 import '../../../config/routes.dart';
-import '../../../core/auth/auth_state.dart';
 import '../../../core/nudges/nudge_coordinator.dart';
 import '../../../core/nudges/nudge_counters.dart';
 import '../../../core/nudges/nudge_ids.dart';
 import '../../../core/nudges/widgets/feed_nudge_anchors.dart';
+import '../../welcome_tour/controllers/welcome_tour_controller.dart';
 import '../../../core/providers/analytics_provider.dart';
 import '../../../core/providers/navigation_providers.dart';
 import '../providers/feed_provider.dart';
@@ -154,10 +154,12 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
   }
 
   Future<void> _recordFeedOpenAndMaybeNudge() async {
-    // Gate everything on welcome_tour having been seen. During the tour the
-    // shell navigates to /feed to show step 2, triggering this initState —
-    // we don't want that to count as a "natural" feed visit.
-    if (!ref.read(authStateProvider).welcomeTourSeen) return;
+    // The shell navigates to /feed during welcome_tour step 2 — don't count
+    // that as a "natural" visit and don't request a spotlight that would
+    // overlap the tour overlay. Whether the tour has been seen at all is
+    // already enforced by the registry prerequisite (read device-scoped, so
+    // PR2 v1 legacy users who never re-saw the user-scoped tour still pass).
+    if (ref.read(welcomeTourControllerProvider).active) return;
     final opens = await NudgeCounters.increment(NudgeCounters.feedOpenCount);
     final taps = await NudgeCounters.get(NudgeCounters.feedCardTapCount);
     if (!mounted) return;
@@ -180,7 +182,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
   }
 
   Future<void> _onFeedCardTapped() async {
-    if (!ref.read(authStateProvider).welcomeTourSeen) return;
+    if (ref.read(welcomeTourControllerProvider).active) return;
     await NudgeCounters.increment(NudgeCounters.feedCardTapCount);
   }
 

--- a/apps/mobile/lib/features/feed/widgets/source_adjust_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/source_adjust_sheet.dart
@@ -5,7 +5,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
-import '../../../core/auth/auth_state.dart';
 import '../../../core/nudges/nudge_coordinator.dart';
 import '../../../core/nudges/nudge_ids.dart';
 import '../../../core/nudges/widgets/nudge_inline_banner.dart';
@@ -63,10 +62,9 @@ class _SourceAdjustSheetState extends ConsumerState<SourceAdjustSheet> {
   }
 
   Future<void> _requestExplainerNudge() async {
-    // Gate on welcome_tour: never surface catalogue nudges while the tour
-    // hasn't finished. The coordinator also enforces this via prerequisites,
-    // but this early-return avoids a wasted roundtrip for the common case.
-    if (!ref.read(authStateProvider).welcomeTourSeen) return;
+    // welcome_tour gating is handled by the coordinator's prereq (device-
+    // scoped key, legacy fallback honored). This sheet can't be opened
+    // during the tour (overlay blocks the source long-press).
     final coordinator = ref.read(nudgeCoordinatorProvider);
     final active =
         await coordinator.request(NudgeIds.prioritySliderExplainer);


### PR DESCRIPTION
## Diagnostic

PR3 (#472) a introduit un garde \`if (!authStateProvider.welcomeTourSeen) return;\` dans \`feed_screen\`, \`content_detail_screen\` et \`source_adjust_sheet\`. Ce garde lit la clé **user-scoped** \`nudge.welcome_tour.seen.<userId>\` qui n'est écrite QUE par les users qui ont complété le tour POST PR2 v2 (la version user-scoped déployée le 2026-04-24).

Tous les users qui avaient complété le tour AVANT (PR2 v1, device-scoped seulement) ont \`welcomeTourSeen=false\` même s'ils ont vu et fini le tour. Le early-return court-circuite tous les triggers.

**Évidence PostHog (7 jours)** :
- \`article_read\` : 34 events
- \`digest_session\` : 2 events
- \`nudge_shown\` / \`nudge_dismissed\` : **0 events**

Or \`article_save_notes\` devrait fire à la 1ʳᵉ ouverture d'article — son absence prouve que le early-return tape.

## Fix

- \`feed_screen\` : remplace le garde par \`welcomeTourControllerProvider.active\` (in-memory, précis : ne bloque que pendant que le tour est en cours, pour éviter la superposition de spotlights pendant l'étape 2 qui navigue vers \`/feed\`).
- \`content_detail_screen\` + \`source_adjust_sheet\` : suppression du garde. Ces UIs ne sont pas atteignables pendant le tour (overlay bloque les taps), donc aucun risque de superposition.

Le gating "user n'a jamais vu le tour" reste assuré par la prereq dans le registry (\`prerequisites: [welcomeTour]\`) que le coordinator évalue via \`isSeen()\` sur la clé **device-scoped** avec fallback legacy — tous les users qui ont complété le tour (v1 OU v2) passent.

## Test plan

- [ ] Build Android, ouvrir 1 article sur un compte ayant fini le tour PR2 v1 → \`article_save_notes\` doit s'afficher.
- [ ] PostHog : vérifier que \`nudge_shown\` commence à arriver dans les heures suivant le déploiement.
- [ ] Tour en cours (compte test sans tour vu) : naviguer manuellement à \`/feed\` étape 2 ne doit pas déclencher de spotlight \`feed_badge_longpress\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)