### PR TITLE
perf(web): quick wins Safari scroll — kIsWeb-gated

### DIFF
--- a/apps/mobile/lib/core/web/web_perf.dart
+++ b/apps/mobile/lib/core/web/web_perf.dart
@@ -1,0 +1,46 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Web-specific perf helpers. CanvasKit (forced since Flutter 3.29) is slow
+/// on Safari iOS for blur, large shadows, and continuous repaints.
+/// All helpers are no-ops on mobile so the app's visual identity stays intact
+/// on Android/iOS native builds.
+
+const bool kWebPerf = kIsWeb;
+
+/// Replaces a `BackdropFilter` by an opaque fill on web.
+/// On mobile, returns the blurred widget unchanged.
+Widget webBlurFallback({
+  required ImageFilter filter,
+  required Color fallbackColor,
+  required Widget child,
+}) {
+  if (kWebPerf) {
+    return ColoredBox(color: fallbackColor, child: child);
+  }
+  return BackdropFilter(filter: filter, child: child);
+}
+
+/// Returns a list of `BoxShadow` with reduced `blurRadius` on web
+/// (CanvasKit blur is ~quadratic; large blurs tank scroll fps on Safari).
+List<BoxShadow> webShadows(List<BoxShadow> shadows) {
+  if (!kWebPerf) return shadows;
+  return shadows
+      .map((s) => BoxShadow(
+            color: s.color,
+            offset: s.offset,
+            blurRadius: s.blurRadius / 3,
+            spreadRadius: s.spreadRadius,
+            blurStyle: s.blurStyle,
+          ))
+      .toList(growable: false);
+}
+
+/// Wraps `child` in a `RepaintBoundary` on web only.
+/// Use on items inside scrollable lists to avoid full-sliver repaints.
+Widget webRepaintBoundary({required Widget child}) {
+  if (!kWebPerf) return child;
+  return RepaintBoundary(child: child);
+}

--- a/apps/mobile/lib/features/digest/widgets/digest_welcome_modal.dart
+++ b/apps/mobile/lib/features/digest/widgets/digest_welcome_modal.dart
@@ -8,6 +8,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/theme.dart';
 import '../../../core/nudges/nudge_ids.dart';
 import '../../../core/nudges/nudge_service.dart';
+import '../../../core/web/web_perf.dart';
 
 /// Provider to track if user has seen the digest welcome
 final digestWelcomeShownProvider = StateProvider<bool>((ref) => false);
@@ -97,10 +98,11 @@ class _DigestWelcomeModalState extends ConsumerState<DigestWelcomeModal>
       onTap: _dismiss,
       child: FadeTransition(
         opacity: _backdropAnimation,
-        child: BackdropFilter(
+        child: webBlurFallback(
           filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+          fallbackColor: Colors.black.withOpacity(0.7),
           child: Container(
-            color: Colors.black.withOpacity(0.55),
+            color: kWebPerf ? null : Colors.black.withOpacity(0.55),
             child: Center(
               child: GestureDetector(
                 onTap: () {}, // Prevent tap through

--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -15,6 +15,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../../config/theme.dart';
 import '../../../config/topic_labels.dart';
 import '../../../config/routes.dart';
+import '../../../core/web/web_perf.dart';
 import '../../../core/nudges/nudge_coordinator.dart';
 import '../../../core/nudges/nudge_counters.dart';
 import '../../../core/nudges/nudge_ids.dart';
@@ -1325,11 +1326,15 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                     duration: const Duration(milliseconds: 180),
                     curve: Curves.easeOut,
                     child: ClipRect(
-                      child: BackdropFilter(
+                      child: webBlurFallback(
                         filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+                        fallbackColor: colors.backgroundPrimary
+                            .withValues(alpha: 0.96),
                         child: Container(
-                          color: colors.backgroundPrimary
-                              .withValues(alpha: 0.88),
+                          color: kWebPerf
+                              ? null
+                              : colors.backgroundPrimary
+                                  .withValues(alpha: 0.88),
                           padding: EdgeInsets.fromLTRB(
                             16,
                             MediaQuery.of(context).padding.top + 10,

--- a/apps/mobile/lib/shared/widgets/loaders/facteur_loader.dart
+++ b/apps/mobile/lib/shared/widgets/loaders/facteur_loader.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 
@@ -20,6 +21,26 @@ class FacteurLoader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tint = color ?? context.facteurColors.primary;
+    if (kIsWeb) {
+      // Lottie repaints every frame — kills Safari iOS scroll/idle perf.
+      // Static spinner is enough for the temporary web build.
+      final dim = width < height ? width : height;
+      final stroke = (dim / 14).clamp(2.0, 4.0).toDouble();
+      return SizedBox(
+        width: width,
+        height: height,
+        child: Center(
+          child: SizedBox(
+            width: dim * 0.5,
+            height: dim * 0.5,
+            child: CircularProgressIndicator(
+              strokeWidth: stroke,
+              valueColor: AlwaysStoppedAnimation<Color>(tint),
+            ),
+          ),
+        ),
+      );
+    }
     return SizedBox(
       width: width,
       height: height,

--- a/apps/mobile/lib/widgets/design/facteur_card.dart
+++ b/apps/mobile/lib/widgets/design/facteur_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:facteur/config/theme.dart';
+import 'package:facteur/core/web/web_perf.dart';
 
 class FacteurCard extends StatefulWidget {
   final Widget child;
@@ -81,25 +82,26 @@ class _FacteurCardState extends State<FacteurCard>
     final cardColor = widget.backgroundColor ?? context.facteurColors.surface;
 
     final Widget cardContent = Container(
-      clipBehavior: Clip.antiAlias,
+      // Clip.antiAlias is expensive under CanvasKit on Safari — use hardEdge on web.
+      clipBehavior: kWebPerf ? Clip.hardEdge : Clip.antiAlias,
       decoration: BoxDecoration(
         color: cardColor,
         borderRadius:
             BorderRadius.circular(widget.borderRadius ?? FacteurRadius.medium),
-        boxShadow: widget.boxShadow ?? [
+        boxShadow: webShadows(widget.boxShadow ?? [
           BoxShadow(
             color: Colors.black.withOpacity(0.1),
             blurRadius: 4,
             offset: const Offset(0, 2),
           ),
-        ],
+        ]),
       ),
       padding: widget.padding ?? const EdgeInsets.all(FacteurSpacing.space4),
       child: widget.child,
     );
 
     if (widget.onTap == null && widget.onLongPressStart == null) {
-      return cardContent;
+      return webRepaintBoundary(child: cardContent);
     }
 
     return GestureDetector(
@@ -120,9 +122,11 @@ class _FacteurCardState extends State<FacteurCard>
           : null,
       onLongPressMoveUpdate: widget.onLongPressMoveUpdate,
       onLongPressEnd: widget.onLongPressEnd,
-      child: ScaleTransition(
-        scale: _scaleAnimation,
-        child: cardContent,
+      child: webRepaintBoundary(
+        child: ScaleTransition(
+          scale: _scaleAnimation,
+          child: cardContent,
+        ),
       ),
     );
   }

--- a/apps/mobile/web/index.html
+++ b/apps/mobile/web/index.html
@@ -45,8 +45,6 @@
     /* Prevent browser native pull-to-refresh so Flutter's RefreshIndicator works */
     html, body { overscroll-behavior-y: contain; }
   </style>
-  <!-- Use HTML renderer to avoid CORS issues with external images (CanvasKit blocks cross-origin images) -->
-  <script>window.flutterWebRenderer = "html";</script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
## What

Quick wins de fluidité pour la version web Safari, tous gardés derrière `kIsWeb` — la version mobile (Android/iOS app) reste **strictement intacte**.

- Nouveau helper `apps/mobile/lib/core/web/web_perf.dart` : `webBlurFallback`, `webShadows` (blur ÷3), `webRepaintBoundary`, `kWebPerf`.
- `BackdropFilter` σ=18 (sticky filter bar feed) et σ=6 (digest welcome modal) → `ColoredBox` opaque sur web (CanvasKit blur tue le scroll Safari).
- `FacteurCard` (utilisé partout) : `RepaintBoundary` web-only + `Clip.hardEdge` au lieu de `antiAlias` + ombres atténuées sur web.
- `FacteurLoader` : Lottie → `CircularProgressIndicator` natif sur web (Lottie repaint chaque frame).
- `web/index.html` : suppression de `window.flutterWebRenderer = "html"` (API retirée depuis Flutter 3.29, dead code en 3.38.6).

## Why

Régression récente de fluidité signalée par les utilisateurs web (Safari iOS surtout) : scroll laggy sur digest et feed. Diagnostic : le combo CanvasKit (forcé depuis Flutter 3.29) + `BackdropFilter` σ=18 + Lottie + ClipRRect.antiAlias + ombres lourdes sur des centaines de cartes = 5–10 fps. La version web restant temporaire (avant l'app iOS native), on patche chirurgicalement web-only sans toucher au design mobile.

## Type

- [ ] Feature
- [ ] Bug fix
- [x] Maintenance / Refactor

## Checklist

- [x] `flutter analyze` propre sur les fichiers touchés (warnings pré-existants seulement)
- [x] `flutter test` passe sur `test/widgets/` + `test/shared/` (12/12)
- [x] Aucun changement runtime sur mobile (tous les helpers retournent l'AST original si `!kIsWeb`)
- [ ] Smoke test Safari iOS sur build deployed après merge (à faire)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (web build via GitHub Pages workflow `build-web.yml` sur push `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)