### PR TITLE
feat(web): proxy d'images backend — fix canvas taint Safari/CanvasKit

### DIFF
--- a/apps/mobile/lib/widgets/design/facteur_image.dart
+++ b/apps/mobile/lib/widgets/design/facteur_image.dart
@@ -2,8 +2,17 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 
-/// Cross-platform network image: uses native <img> tag on web (CORS-exempt),
-/// CachedNetworkImage on mobile (disk caching).
+import '../../config/constants.dart';
+
+/// Cross-platform network image.
+///
+/// On mobile (Android/iOS native) → `CachedNetworkImage` (disk cache).
+/// On web → `Image.network` via le proxy backend `/api/images/proxy?url=...`.
+/// Pourquoi le proxy : depuis Flutter 3.29 le rendu Web est forcé en CanvasKit,
+/// qui dessine les images sur `<canvas>`. Toute image cross-origin sans en-tête
+/// `Access-Control-Allow-Origin` produit un canvas taint → `errorBuilder`. Le
+/// proxy re-sert l'image avec CORS + cache long. Le chemin mobile est
+/// strictement inchangé pour éviter toute divergence app vs web.
 class FacteurImage extends StatelessWidget {
   final String imageUrl;
   final double? width;
@@ -22,11 +31,19 @@ class FacteurImage extends StatelessWidget {
     this.errorWidget,
   });
 
+  /// Sur web, route l'URL via le proxy backend pour contourner le canvas
+  /// taint CanvasKit. No-op si l'URL pointe déjà vers notre API.
+  static String _resolveWebUrl(String url) {
+    final base = ApiConstants.baseUrl;
+    if (url.startsWith(base)) return url;
+    return '${base}images/proxy?url=${Uri.encodeComponent(url)}';
+  }
+
   @override
   Widget build(BuildContext context) {
     if (kIsWeb) {
       return Image.network(
-        imageUrl,
+        _resolveWebUrl(imageUrl),
         width: width,
         height: height,
         fit: fit,

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -76,6 +76,7 @@ from app.routers import (
     custom_topics,
     digest,
     feed,
+    images,
     internal,
     personalization,
     progress,
@@ -383,6 +384,7 @@ app.include_router(users.router, prefix="/api/users", tags=["Users"])
 app.include_router(feed.router, prefix="/api/feed", tags=["Feed"])
 app.include_router(digest.router, prefix="/api/digest", tags=["Digest"])
 app.include_router(contents.router, prefix="/api/contents", tags=["Contents"])
+app.include_router(images.router, prefix="/api/images", tags=["Images"])
 app.include_router(sources.router, prefix="/api/sources", tags=["Sources"])
 app.include_router(
     subscription.router, prefix="/api/subscription", tags=["Subscription"]

--- a/packages/api/app/routers/images.py
+++ b/packages/api/app/routers/images.py
@@ -1,0 +1,68 @@
+"""Proxy d'images pour la version Web (Safari/CanvasKit).
+
+Sous CanvasKit, Flutter dessine les images dans un <canvas>. Toute image
+cross-origin sans en-tête `Access-Control-Allow-Origin` produit un canvas
+taint → l'`Image.network` tombe en `errorBuilder` et la vignette se
+collapse pour le reste de la session (cf. facteur_thumbnail.dart). Ce
+proxy re-sert l'image avec les en-têtes CORS et un cache CDN agressif.
+
+Mobile (Android/iOS natifs) ne passe PAS par ce chemin — voir
+`apps/mobile/lib/widgets/design/facteur_image.dart` qui ne réécrit l'URL
+que si `kIsWeb`.
+"""
+
+from urllib.parse import urlparse
+
+import httpx
+import structlog
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import Response
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+_TIMEOUT_S = 5.0
+_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+_CACHE_HEADERS = {
+    "Cache-Control": "public, max-age=604800, immutable",
+    "Access-Control-Allow-Origin": "*",
+}
+
+
+@router.get("/proxy")
+async def proxy_image(url: str = Query(..., min_length=8, max_length=2048)) -> Response:
+    """Fetch an external image and re-serve it with CORS + cache headers.
+
+    Returns 404 on any upstream failure so the Flutter `errorBuilder`
+    collapses the thumbnail cleanly (same UX as a real broken image).
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise HTTPException(status_code=400, detail="invalid_url")
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=_TIMEOUT_S,
+            follow_redirects=True,
+            max_redirects=3,
+        ) as client:
+            resp = await client.get(url)
+    except (httpx.HTTPError, httpx.InvalidURL):
+        raise HTTPException(status_code=404, detail="upstream_unreachable") from None
+
+    if resp.status_code != 200:
+        raise HTTPException(status_code=404, detail="upstream_status")
+
+    content_type = resp.headers.get("content-type", "").split(";")[0].strip().lower()
+    if not content_type.startswith("image/"):
+        raise HTTPException(status_code=415, detail="not_an_image")
+
+    body = resp.content
+    if len(body) > _MAX_BYTES:
+        raise HTTPException(status_code=413, detail="image_too_large")
+
+    return Response(
+        content=body,
+        media_type=content_type,
+        headers=_CACHE_HEADERS,
+    )

--- a/packages/api/tests/routers/test_images_proxy.py
+++ b/packages/api/tests/routers/test_images_proxy.py
@@ -1,0 +1,95 @@
+"""Tests for the web image proxy endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+def _mock_response(status_code: int, content: bytes, content_type: str) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = content
+    resp.headers = {"content-type": content_type}
+    return resp
+
+
+def _patched_client(get_return=None, get_side_effect=None):
+    """Patches httpx.AsyncClient inside the router module."""
+    mock_client_instance = MagicMock()
+    mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+    mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+    if get_side_effect is not None:
+        mock_client_instance.get = AsyncMock(side_effect=get_side_effect)
+    else:
+        mock_client_instance.get = AsyncMock(return_value=get_return)
+    return patch(
+        "app.routers.images.httpx.AsyncClient",
+        return_value=mock_client_instance,
+    )
+
+
+@pytest.mark.asyncio
+async def test_proxy_happy_path_returns_image_with_cors_and_cache():
+    fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+    with _patched_client(get_return=_mock_response(200, fake_png, "image/png")):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(
+                "/api/images/proxy",
+                params={"url": "https://cdn.example.com/a.png"},
+            )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("image/png")
+    assert resp.headers["access-control-allow-origin"] == "*"
+    assert "max-age=604800" in resp.headers["cache-control"]
+    assert resp.content == fake_png
+
+
+@pytest.mark.asyncio
+async def test_proxy_rejects_non_https_scheme():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(
+            "/api/images/proxy", params={"url": "http://insecure.example/a.png"}
+        )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_proxy_returns_404_when_upstream_unreachable():
+    with _patched_client(get_side_effect=httpx.ConnectError("boom")):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(
+                "/api/images/proxy",
+                params={"url": "https://cdn.example.com/a.png"},
+            )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_proxy_returns_415_when_content_type_not_image():
+    with _patched_client(get_return=_mock_response(200, b"<html></html>", "text/html")):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(
+                "/api/images/proxy",
+                params={"url": "https://cdn.example.com/page"},
+            )
+    assert resp.status_code == 415
+
+
+@pytest.mark.asyncio
+async def test_proxy_returns_404_when_upstream_not_200():
+    with _patched_client(get_return=_mock_response(404, b"", "image/png")):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(
+                "/api/images/proxy",
+                params={"url": "https://cdn.example.com/missing.png"},
+            )
+    assert resp.status_code == 404


### PR DESCRIPTION
## What

Nouveau `GET /api/images/proxy?url=…` qui re-sert les images externes avec `Access-Control-Allow-Origin: *` + `Cache-Control: max-age=604800, immutable`. `FacteurImage` route les URLs via ce proxy **uniquement** sur Web (`kIsWeb`) ; mobile (`CachedNetworkImage`) inchangé.

## Why

Depuis Flutter 3.29 le rendu Web est forcé en CanvasKit qui dessine les images dans un `<canvas>`. Toute image cross-origin sans en-tête CORS provoque un canvas taint → `errorBuilder` → l'URL est cachée dans `_failedUrls` (facteur_thumbnail.dart) et la vignette se collapse pour la session. Symptôme : ~80 % des previews d'articles masquées et 100 % des favicons de sources invisibles sur Safari iOS. Le proxy contourne ça côté serveur sans toucher au chemin natif (zéro drift app/web, zéro régression perf APK, optimisations PR #486 préservées).

## Type

- [x] Bug fix

## Checklist

- [x] Tests pass locally (`pytest -v tests/routers/test_images_proxy.py` — 5/5)
- [x] Linting passes (`ruff check` + `ruff format --check`)
- [x] No new Python `List[]` imports
- [ ] If touching auth/DB: read Safety Guardrails (N/A)
- [ ] Peer Review Conductor completed

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed (vérifier sur Safari iOS : previews + favicons s'affichent, console DevTools sans erreur CORS)