### PR TITLE
fix(infra): bump DB pool 20→50 + restore stdout observability for pool signals

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,40 +1,39 @@
-# PR #465 — fix(infra): crashs serveur matinaux — restart policy ALWAYS + retrait mitigation SIGTERM
+# PR — bump DB pool 20→50 + restore stdout observability
 
-## Quoi
+## Why
+Prod (Railway, Supabase Pooler partagé 60 conn) sature dès ~6 requêtes feed concurrentes :
+- `pool_size=10 + max_overflow=10 = 20` → toute requête au-delà attend `pool_timeout=30s` puis timeout.
+- Sentry IDs : QueuePool TimeoutError (cf. `queue.QueuePool` dans Sentry, `db_pool_pressure_high`).
 
-Railway était configuré en `restartPolicyType: ON_FAILURE`. Le job cron `_scheduled_restart` émettait un SIGTERM 3×/jour (01h/09h/17h Paris) comme mitigation temporaire d'une fuite de sessions SQLAlchemy — uvicorn drainait proprement (exit 0) → Railway ne relançait pas → l'app était down jusqu'au restart manuel. Ce PR passe Railway en `ALWAYS` et retire le job SIGTERM devenu obsolète.
+En parallèle, les listeners d'observabilité existants (`long_session_checkout` `database.py`, `db_pool_pressure_high` `main.py`) émettent bien des `structlog.warning(...)` mais **n'apparaissent jamais dans Railway logs des 7 derniers jours** (audit). Avant de poser un kill-switch GH Action ou tout monitoring externe, il faut s'assurer que le pipeline stdout fonctionne.
 
-## Pourquoi
+## What
 
-`_scheduled_restart` était une mitigation P0 documentée dans `bug-infinite-load-requests.md` avec la note explicite « À retirer dès que les fixes P1/P2 sont déployés et validés ≥ 48h ». Ces fixes (sessions scoped, RSS timeout, pool isolation) sont en prod. La mitigation avait survécu à sa raison d'être et causait 3 pannes manuelles/jour.
+### `packages/api/app/database.py`
+- Capacité prod consolidée dans `PROD_POOL_KWARGS` (importable depuis tests).
+- `pool_size=25`, `max_overflow=25` → 50 conns max → ~16 requêtes feed concurrentes.
+- `pool_timeout=30 → 10s` : un slot bloqué cède vite au lieu de masquer la saturation.
+- Marge : 60 (Supabase) - 50 (app) = 10 conns pour le scheduler in-process.
+- `pool_recycle=180`, `pool_pre_ping=True` inchangés.
 
-## Fichiers modifiés
+### `packages/api/app/main.py`
+- Boot probe `logger.warning("startup_logger_check", level="warning_emitted")` juste après `structlog.configure`. Si absent du 1er log post-deploy → pipeline stdout cassé, on sait avant de chercher pourquoi `db_pool_pressure_high` ne sort pas. Confirme aussi que `LoggingIntegration` Sentry (filtre `logging.ERROR`) ne capture pas les warnings structlog.
+- `/api/health/pool` : `logger.info("pool_metrics_probed", **metrics)` avant return — base pour mesurer la fréquence de ping du futur kill-switch GH Action.
 
-- **Config** : `railway.json` — `ON_FAILURE` → `ALWAYS` + `restartPolicyMaxRetries: 10`
-- **Backend** : `packages/api/app/workers/scheduler.py` — retrait de `_scheduled_restart()`, son `add_job` (01h/09h/17h), et les imports `os`/`signal`
-- **Tests** : `packages/api/tests/workers/test_scheduler.py` — 2 tests qui vérifiaient l'existence du job remplacés par un test de garde qui vérifie son absence (`test_scheduled_restart_job_is_not_registered`)
-- **Docs** : `docs/bugs/bug-server-crashes.md` — nouveau bug doc (diagnostic + plan Phase 2 si nécessaire)
+### `packages/api/tests/test_health_pool.py`
+- `test_prod_pool_kwargs_capacity` lock 25/25/10/180 — toute modif future déclenche revue.
 
-## Zones à risque
+## Risques & mitigations
+- **Saturation Supabase Pooler** : 50 conns app + éventuels workers pourraient frôler 60. Marge 10 explicite ; si plusieurs réplicas Railway → revoir avant scale horizontal.
+- **pool_timeout=10s** : plus agressif. Si symptôme "tout charge à l'infini" disparaît au profit de 5xx visibles → succès attendu (visibilité).
 
-- **Retrait de la mitigation pool** : si P1/P2 n'est pas aussi stable qu'estimé, le pool peut re-saturer sans garde-fou. Signal clair : Sentry `QueuePool limit reached` → revert.
-- **`ALWAYS` policy** : Railway relancera sur tout exit 0, y compris un futur shutdown intentionnel mal câblé. Borné par `maxRetries: 10`.
+## Critères d'acceptation
+- [x] `pytest -v tests/test_health_pool.py` vert (2/2)
+- [ ] Au boot prod : `db_pool_config pool_type=AsyncAdaptedQueuePool` + `startup_logger_check` visibles dans `railway logs`
+- [ ] `curl /api/health/pool` retourne `size=25`
+- [ ] 50 requêtes parallèles → 0 timeout pool
 
-## Points d'attention pour le reviewer
-
-1. **Hypothèse P1/P2 stable** : l'investigation est basée sur l'analyse statique du code (pas d'accès live à Sentry/Railway logs dans cette session). On pose que les fixes pool tiennent, mais le monitoring post-deploy est critique.
-2. **`ALWAYS` ne couvre pas les hangs** : si le process reste vivant mais figé (pool saturé sans crash), Railway ne redémarre toujours pas — ce cas nécessiterait un monitor externe ou un liveness check DB. Documenté en Phase 2 du bug doc.
-3. **Tests non exécutés localement** : pas de venv dans ce workspace. Validation AST OK, pytest à confirmer en CI.
-
-## Ce qui N'A PAS changé (mais pourrait sembler affecté)
-
-- **`_digest_watchdog`** (7h30 Paris) : non touché.
-- **`bug-infinite-load-requests.md`** : les références à `_scheduled_restart` qu'il contient sont historiques, pas du code actif.
-- **Pool config** (`database.py:43-44`) : `pool_size=10, max_overflow=10` (total 20 conns) inchangé — Phase 2 adressera si contention résiduelle.
-
-## Comment tester
-
-1. **Après deploy** — logs Railway au prochain créneau 09h00 Paris : ne plus voir `scheduled_restart_initiated`. Container doit rester up.
-2. **Logs startup** : chercher le log `Scheduler started` avec le champ `jobs=["rss_sync", "daily_top3", "daily_digest", "digest_watchdog", "storage_cleanup"]`. Plus de `scheduled_restart_cron`.
-3. **Stabilité 48h** : zéro restart manuel requis. Si Sentry `QueuePool limit reached` → `git revert 7144c98f`.
-4. **CI** : `cd packages/api && pytest tests/workers/test_scheduler.py -v` — notamment `test_scheduled_restart_job_is_not_registered`.
+## Pas inclus
+- Pas de migration Alembic.
+- Pas de changement mobile.
+- Kill-switch GH Action séparé (hand-off #3).

--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -38,6 +38,15 @@ _is_railway = "railway" in (settings.database_url or "").lower()
 _is_supabase = "supabase" in (settings.database_url or "").lower()
 _use_queue_pool = _is_railway or _is_supabase
 
+# Exposé pour les tests : capacité prod et fail-fast timeout. Toute modif ici
+# impacte la pression sur le Supabase Pooler (60 conn partagées).
+PROD_POOL_KWARGS = {
+    "pool_size": 25,
+    "max_overflow": 25,
+    "pool_timeout": 10,
+    "pool_recycle": 180,
+}
+
 if _use_queue_pool:
     # Railway/Supabase: Use AsyncAdaptedQueuePool for proper connection pooling
     # This handles connection drops better than NullPool
@@ -50,16 +59,12 @@ if _use_queue_pool:
         pool_pre_ping=True,
         # Use AsyncAdaptedQueuePool for proper connection management
         poolclass=AsyncAdaptedQueuePool,
-        # Pool size optimized for Supabase PgBouncer (60 connection limit shared)
-        # Feed endpoint uses ~3 connections per request (2 batched parallel sessions + 1 main)
-        # pool_size=10 + max_overflow=10 = 20 max → supports ~6 concurrent feed requests
-        pool_size=10,
-        max_overflow=10,
-        # Connection timeout - increased to prevent pool exhaustion
-        pool_timeout=30,
-        # Recycle connections frequently to prevent Supabase from killing them
-        # Supabase PgBouncer idle timeout is ~5 minutes, recycle at 3 minutes
-        pool_recycle=180,
+        # Supabase Pooler 60 connection limit shared. App: 25+25=50 max →
+        # ~16 concurrent feed requests (~3 conns/req). Margin 10 left for the
+        # in-process scheduler. pool_timeout=10s : fail fast for visibility
+        # instead of 30s silent stalls. pool_recycle=180s : Supabase PgBouncer
+        # idle timeout is ~5 min, recycle before that.
+        **PROD_POOL_KWARGS,
         # Connect args for PgBouncer compatibility
         connect_args={
             "prepare_threshold": None,  # Disable prepared statements for PgBouncer transaction mode

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -48,6 +48,11 @@ structlog.configure(
     logger_factory=structlog.PrintLoggerFactory(),
 )
 logger = structlog.get_logger()
+# Boot probe : confirme en prod que les warnings structlog atteignent stdout
+# JSON (Railway logs / Sentry). Si absent du 1er log post-deploy, le pipeline
+# est cassé et les signaux pool (long_session_checkout, db_pool_pressure_high)
+# ne remontent pas non plus.
+logger.warning("startup_logger_check", level="warning_emitted")
 
 db_url = os.environ.get("DATABASE_URL")
 logger.info(
@@ -552,6 +557,7 @@ async def pool_metrics() -> dict[str, Any]:
                 usage_pct=round(usage_pct * 100, 1),
             )
 
+    logger.info("pool_metrics_probed", **metrics)
     return metrics
 
 

--- a/packages/api/tests/test_health_pool.py
+++ b/packages/api/tests/test_health_pool.py
@@ -32,3 +32,17 @@ async def test_pool_endpoint_returns_metrics():
     # Usage pct is only computed when size is known (QueuePool); in tests we
     # use NullPool which has no size, so it may be None.
     assert body.get("size") is None or isinstance(body["size"], int)
+
+
+def test_prod_pool_kwargs_capacity():
+    """Locks the production pool capacity at 25+25=50 with fail-fast timeout.
+
+    Supabase Pooler is 60 conns shared — bumping these without leaving
+    headroom for the in-process scheduler will starve other clients.
+    """
+    from app.database import PROD_POOL_KWARGS
+
+    assert PROD_POOL_KWARGS["pool_size"] == 25
+    assert PROD_POOL_KWARGS["max_overflow"] == 25
+    assert PROD_POOL_KWARGS["pool_timeout"] == 10
+    assert PROD_POOL_KWARGS["pool_recycle"] == 180


### PR DESCRIPTION
## What
- `database.py` : capacité prod consolidée dans `PROD_POOL_KWARGS` — `pool_size=25`, `max_overflow=25` (50 conns max → ~16 feed concurrents), `pool_timeout=30→10s` pour fail-fast au lieu de stalls silencieux.
- `main.py` : boot probe `startup_logger_check` (warning) après `structlog.configure` + `pool_metrics_probed` (info) sur `/api/health/pool` — vérifie que les warnings structlog (`long_session_checkout`, `db_pool_pressure_high`) atteignent bien Railway stdout / Sentry.
- `test_health_pool.py` : test lock 25/25/10/180.

## Why
Prod sature dès ~6 requêtes feed concurrentes (pool 10+10=20). Marge : Supabase Pooler 60 conns - 50 app = 10 pour le scheduler in-process. Et les warnings d'observabilité existants n'apparaissent **jamais** dans Railway logs des 7 derniers jours (audit) — boot probe pour valider le pipeline avant de poser un kill-switch externe.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass locally (`pytest -v tests/test_health_pool.py` → 2/2)
- [x] Linting passes (`ruff check` + `ruff format --check`)
- [x] No new `List[]` imports
- [x] Touche DB pool — Safety Guardrails consultés

## Staging
- [ ] N/A — sera déployé directement sur main, vérifier `startup_logger_check` + `db_pool_config size=25` dans `railway logs` post-deploy.