### PR TITLE
fix(sources): release DB session before LLM/HTTP in smart-search (#485 pattern)

### DIFF
--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -1,5 +1,6 @@
 """Routes sources."""
 
+import contextlib
 import time
 from collections import defaultdict
 from urllib.parse import urlparse
@@ -229,7 +230,19 @@ async def smart_search(
             detail="Too many requests (max 10/minute)",
         )
 
-    service = SmartSourceSearchService(db)
+    async def _release_db() -> None:
+        # Hand the request-scoped session back to the pool before the service
+        # enters its slow external phase (LLM/Brave/GoogleNews). FastAPI's
+        # `get_db` dependency wraps `close()` in a finally — calling it here
+        # is safe because AsyncSession.close() is idempotent.
+        try:
+            await db.commit()
+        except Exception:
+            with contextlib.suppress(Exception):
+                await db.rollback()
+        await db.close()
+
+    service = SmartSourceSearchService(db, on_phase1_done=_release_db)
     try:
         result = await service.search(
             data.query,

--- a/packages/api/app/services/search/cache.py
+++ b/packages/api/app/services/search/cache.py
@@ -10,6 +10,8 @@ import structlog
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import async_session_maker
+
 logger = structlog.get_logger()
 
 CACHE_TTL_HOURS = 24
@@ -41,63 +43,69 @@ def hash_query(
     ).hexdigest()
 
 
-class SearchCache:
-    """Postgres cache for smart search results (24h TTL)."""
+async def search_cache_get(
+    session: AsyncSession,
+    query: str,
+    content_type: str | None = None,
+    expand: bool = False,
+) -> dict | None:
+    """Look up cached result via the caller's session. Returns None if miss/expired."""
+    query_hash = hash_query(query, content_type, expand)
+    now = datetime.now(UTC)
 
-    def __init__(self, db: AsyncSession) -> None:
-        self.db = db
+    result = await session.execute(
+        text(
+            "SELECT payload FROM source_search_cache "
+            "WHERE query_hash = :hash AND expires_at > :now"
+        ),
+        {"hash": query_hash, "now": now},
+    )
+    row = result.fetchone()
+    if row:
+        logger.info("search_cache.hit", query_hash=query_hash[:12])
+        return row[0] if isinstance(row[0], dict) else json.loads(row[0])
+    return None
 
-    async def get(
-        self,
-        query: str,
-        content_type: str | None = None,
-        expand: bool = False,
-    ) -> dict | None:
-        """Look up cached result. Returns None if miss or expired."""
-        query_hash = hash_query(query, content_type, expand)
-        now = datetime.now(UTC)
 
-        result = await self.db.execute(
-            text(
-                "SELECT payload FROM source_search_cache "
-                "WHERE query_hash = :hash AND expires_at > :now"
-            ),
-            {"hash": query_hash, "now": now},
-        )
-        row = result.fetchone()
-        if row:
-            logger.info("search_cache.hit", query_hash=query_hash[:12])
-            return row[0] if isinstance(row[0], dict) else json.loads(row[0])
-        return None
+async def search_cache_set(
+    query: str,
+    payload: dict,
+    content_type: str | None = None,
+    expand: bool = False,
+) -> None:
+    """Insert or update cache entry with 24h TTL using a short-lived session.
 
-    async def set(
-        self,
-        query: str,
-        payload: dict,
-        content_type: str | None = None,
-        expand: bool = False,
-    ) -> None:
-        """Insert or update cache entry with 24h TTL."""
-        query_hash = hash_query(query, content_type, expand)
-        raw = _build_cache_key(query, content_type, expand)
-        now = datetime.now(UTC)
-        expires = now + timedelta(hours=CACHE_TTL_HOURS)
+    The smart-search hot path releases its injected DB session before slow
+    external HTTP calls; the cache write happens after, so we can't reuse it.
+    """
+    query_hash = hash_query(query, content_type, expand)
+    raw = _build_cache_key(query, content_type, expand)
+    now = datetime.now(UTC)
+    expires = now + timedelta(hours=CACHE_TTL_HOURS)
 
-        await self.db.execute(
-            text(
-                "INSERT INTO source_search_cache "
-                "(query_hash, query_raw, payload, created_at, expires_at) "
-                "VALUES (:hash, :raw, :payload, :now, :expires) "
-                "ON CONFLICT (query_hash) DO UPDATE SET "
-                "payload = :payload, created_at = :now, expires_at = :expires"
-            ),
-            {
-                "hash": query_hash,
-                "raw": raw,
-                "payload": json.dumps(payload),
-                "now": now,
-                "expires": expires,
-            },
-        )
-        await self.db.flush()
+    try:
+        async with async_session_maker() as session:
+            await session.execute(
+                text(
+                    "INSERT INTO source_search_cache "
+                    "(query_hash, query_raw, payload, created_at, expires_at) "
+                    "VALUES (:hash, :raw, :payload, :now, :expires) "
+                    "ON CONFLICT (query_hash) DO UPDATE SET "
+                    "payload = :payload, created_at = :now, expires_at = :expires"
+                ),
+                {
+                    "hash": query_hash,
+                    "raw": raw,
+                    "payload": json.dumps(payload),
+                    "now": now,
+                    "expires": expires,
+                },
+            )
+            await session.commit()
         logger.info("search_cache.set", query_hash=query_hash[:12])
+    except Exception as exc:
+        logger.warning(
+            "search_cache.set_failed",
+            error=str(exc),
+            exc_type=type(exc).__name__,
+        )

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -3,6 +3,7 @@
 import asyncio
 import re
 import time
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 from uuid import UUID
@@ -19,7 +20,11 @@ from app.models.source import Source
 from app.models.source_search_log import SourceSearchLog
 from app.models.user import UserInterest
 from app.services.rss_parser import RSSParser
-from app.services.search.cache import SearchCache, normalize_query
+from app.services.search.cache import (
+    normalize_query,
+    search_cache_get,
+    search_cache_set,
+)
 from app.services.search.providers.brave import BraveSearchProvider
 from app.services.search.providers.denylist import (
     is_listicle_host,
@@ -268,13 +273,39 @@ def _compute_score(
 class SmartSourceSearchService:
     """Orchestrates the multi-layer smart search pipeline."""
 
-    def __init__(self, db: AsyncSession) -> None:
+    def __init__(
+        self,
+        db: AsyncSession,
+        on_phase1_done: Callable[[], Awaitable[None]] | None = None,
+    ) -> None:
         self.db = db
-        self.cache = SearchCache(db)
+        self._on_phase1_done = on_phase1_done
+        self._session_released = False
         self.rss_parser = RSSParser()
         self.brave = BraveSearchProvider()
         self.reddit = RedditSearchProvider()
         self.google_news = GoogleNewsProvider()
+
+    async def _release_session(self) -> None:
+        """Release the request-scoped DB session before slow externals.
+
+        Mirrors the digest hot-path pattern (PR #485): the injected session
+        is held only for the short phase-1 reads (cache lookup, catalog ILIKE,
+        user_themes), then handed back to the pool before LLM/HTTP work so it
+        doesn't sit idle for ~30s.
+        """
+        if self._session_released:
+            return
+        self._session_released = True
+        if self._on_phase1_done is not None:
+            try:
+                await self._on_phase1_done()
+            except Exception as exc:
+                logger.warning(
+                    "smart_search.release_session_failed",
+                    error=str(exc),
+                    exc_type=type(exc).__name__,
+                )
 
     async def close(self) -> None:
         await self.rss_parser.close()
@@ -317,8 +348,9 @@ class SmartSourceSearchService:
             }
 
         # Cache check (keyed by query + content_type + expand)
-        cached = await self.cache.get(query, content_type, expand)
+        cached = await search_cache_get(self.db, query, content_type, expand)
         if cached:
+            await self._release_session()
             elapsed = int((time.monotonic() - start) * 1000)
             cached["cache_hit"] = True
             cached["latency_ms"] = elapsed
@@ -385,6 +417,10 @@ class SmartSourceSearchService:
                     content_type=content_type,
                     expand=expand,
                 )
+
+        # All phase-1 reads done — release the injected session before any
+        # slow external HTTP call (LLM/Brave/GoogleNews). Mirrors PR #485.
+        await self._release_session()
 
         # (b) YouTube API — if signal and type allows
         if content_type in (None, "youtube") and (
@@ -1129,6 +1165,9 @@ class SmartSourceSearchService:
         dropped here — the user added this guard explicitly because returning
         article-style results without feeds is the bug we're fixing.
         """
+        # Idempotent: ensures phase-1 short-circuit paths also release the
+        # injected session before the cache write + log insert.
+        await self._release_session()
         results = [r for r in results if r.get("feed_url")]
         # Drop the internal `_similarity` debug field before serializing.
         for r in results:
@@ -1147,10 +1186,9 @@ class SmartSourceSearchService:
             "latency_ms": elapsed,
         }
 
-        try:
-            await self.cache.set(normalized, response, content_type, expand)
-        except Exception as e:
-            logger.warning("smart_search.cache_set_failed", error=str(e))
+        # search_cache_set opens its own short-lived session — never reuses
+        # the request-scoped one (which has been released by now).
+        await search_cache_set(normalized, response, content_type, expand)
 
         await _record_search_log(
             user_id=user_id,

--- a/packages/api/tests/services/search/test_smart_source_search_session.py
+++ b/packages/api/tests/services/search/test_smart_source_search_session.py
@@ -1,0 +1,256 @@
+"""Session-lifecycle tests for SmartSourceSearchService.
+
+These verify the "release DB session before slow externals" pattern (mirrors
+PR #485 on the digest hot path). The injected request-scoped session must be
+handed back to the pool BEFORE any LLM/HTTP layer runs, otherwise the pool
+saturates under burst load (3× QueuePool TimeoutError on 2026-04-27).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services.search.smart_source_search import SmartSourceSearchService
+
+
+class _FakeSession:
+    """Minimal AsyncSession stand-in tracking close() vs other ops ordering."""
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.closed = False
+
+    async def execute(self, *args, **kwargs):
+        self.events.append("execute")
+
+        class _R:
+            def fetchone(self_inner):
+                return None
+
+            def fetchall(self_inner):
+                return []
+
+        return _R()
+
+    async def commit(self) -> None:
+        self.events.append("commit")
+
+    async def rollback(self) -> None:
+        self.events.append("rollback")
+
+    async def close(self) -> None:
+        self.events.append("close")
+        self.closed = True
+
+
+def _make_service(db: _FakeSession, *, on_phase1_done=None) -> SmartSourceSearchService:
+    return SmartSourceSearchService(db, on_phase1_done=on_phase1_done)
+
+
+@pytest.mark.asyncio
+async def test_release_session_calls_hook_once():
+    db = _FakeSession()
+    calls = {"n": 0}
+
+    async def hook() -> None:
+        calls["n"] += 1
+        await db.close()
+
+    svc = _make_service(db, on_phase1_done=hook)
+    await svc._release_session()
+    await svc._release_session()  # idempotent
+    assert calls["n"] == 1
+    assert db.closed is True
+
+
+@pytest.mark.asyncio
+async def test_release_session_no_hook_safe():
+    db = _FakeSession()
+    svc = _make_service(db, on_phase1_done=None)
+    await svc._release_session()  # must not raise
+    assert svc._session_released is True
+
+
+@pytest.mark.asyncio
+async def test_search_releases_before_externals():
+    """When phase 2 runs, the injected session must already be closed."""
+    db = _FakeSession()
+    user_id = str(uuid4())
+
+    closed_when_brave_called: list[bool] = []
+
+    async def fake_brave(self, query, user_themes):
+        closed_when_brave_called.append(db.closed)
+        return []
+
+    async def hook() -> None:
+        await db.close()
+
+    svc = _make_service(db, on_phase1_done=hook)
+
+    # Stub all expensive paths so we exercise the orchestrator only.
+    with (
+        patch.object(
+            SmartSourceSearchService,
+            "_get_user_themes",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_catalog",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_brave",
+            new=fake_brave,
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_google_news",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_mistral",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "app.services.search.smart_source_search.search_cache_get",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search.search_cache_set",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search._record_search_log",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        # The brave provider readiness check looks at self.brave.is_ready;
+        # swap in a stub that reports ready so the layer runs in expand mode.
+        svc.brave = SimpleNamespace(is_ready=True)  # type: ignore[assignment]
+        await svc.search(
+            "test-query-no-match",
+            user_id,
+            content_type=None,
+            expand=True,  # forces external pipeline
+        )
+
+    # Brave was called → assert session was closed by then.
+    assert closed_when_brave_called, "brave layer never ran"
+    assert all(closed_when_brave_called), (
+        "DB session was still open when phase-2 externals started — "
+        "release-before-externals contract violated"
+    )
+
+
+@pytest.mark.asyncio
+async def test_short_circuit_path_also_releases():
+    """Strong-catalog short-circuit must also release before _finalize side-effects."""
+    db = _FakeSession()
+    user_id = str(uuid4())
+
+    strong_match = {
+        "name": "stratechery",
+        "url": "https://stratechery.com",
+        "feed_url": "https://stratechery.com/feed",
+        "type": "article",
+        "in_catalog": True,
+        "is_curated": True,
+        "score": 0.9,
+        "source_layer": "catalog",
+        "_similarity": 1.0,
+    }
+
+    released = {"flag": False}
+
+    async def hook() -> None:
+        released["flag"] = True
+        await db.close()
+
+    svc = _make_service(db, on_phase1_done=hook)
+
+    with (
+        patch.object(
+            SmartSourceSearchService,
+            "_get_user_themes",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_catalog",
+            new=AsyncMock(return_value=[strong_match]),
+        ),
+        patch(
+            "app.services.search.smart_source_search.search_cache_get",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search.search_cache_set",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search._record_search_log",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await svc.search("stratechery", user_id, content_type=None, expand=False)
+
+    assert released["flag"] is True
+    assert db.closed is True
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_releases_session():
+    db = _FakeSession()
+    user_id = str(uuid4())
+
+    released = {"flag": False}
+
+    async def hook() -> None:
+        released["flag"] = True
+        await db.close()
+
+    svc = _make_service(db, on_phase1_done=hook)
+
+    cached_payload = {
+        "query_normalized": "x",
+        "results": [],
+        "cache_hit": False,
+        "layers_called": ["catalog"],
+        "latency_ms": 0,
+    }
+
+    with (
+        patch(
+            "app.services.search.smart_source_search.search_cache_get",
+            new=AsyncMock(return_value=cached_payload),
+        ),
+        patch(
+            "app.services.search.smart_source_search._record_search_log",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        out = await svc.search("x", user_id, content_type=None, expand=False)
+
+    assert out["cache_hit"] is True
+    assert released["flag"] is True
+
+
+@pytest.mark.asyncio
+async def test_double_close_is_safe():
+    db = _FakeSession()
+
+    async def hook() -> None:
+        await db.close()
+        await db.close()  # idempotent on real AsyncSession too
+
+    svc = _make_service(db, on_phase1_done=hook)
+    await svc._release_session()
+    assert db.events.count("close") == 2


### PR DESCRIPTION
## What

Refactor `POST /api/sources/smart-search` to release its injected DB session before slow external HTTP work (Mistral / Brave / GoogleNews), mirroring PR #485 on the digest hot path. The session is used only for phase-1 reads (cache lookup, catalog ILIKE, user_themes); the cache write in `_finalize` now uses an ad-hoc session via `async_session_maker()`.

## Why

On 2026-04-27 ~17:46 UTC Sentry recorded 3× `QueuePool TimeoutError`, all on `smart-search` — the handler held one pool slot for ~30s of pure I/O. With pool 50 (PR #488) this became visible; the fix removes the long checkout entirely.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`pytest tests/services/search/` → 70 passed; full suite 763 passed, 44 pre-existing DB-setup errors unrelated)
- [x] Linting passes (`ruff check` + `ruff format --check`)
- [x] No new Python `List[]` imports
- [x] Touches DB session lifecycle — release pattern mirrors PR #485, `AsyncSession.close()` is idempotent so `get_db`'s `finally` stays safe
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed (burst load with `hey -n 20 -c 20` to confirm `/api/health/pool` checked_out < 30 % and 0× `long_session_checkout`)
- [ ] N/A