### PR TITLE
feat(infra): real auto-restart safety net — /api/health/ready healthcheck + pool watchdog

### DIFF
--- a/.github/workflows/pool-saturation-watchdog.yml
+++ b/.github/workflows/pool-saturation-watchdog.yml
@@ -1,0 +1,120 @@
+name: Pool saturation watchdog
+
+# v1 = mode dry-run. Si saturation confirmée (2 probes à 30 s d'intervalle,
+# usage_pct > 90 ou status=saturated), on n'effectue PAS le redeploy Railway :
+# on ouvre une issue GitHub. Après 24 h sans faux positif, une PR de suivi
+# remplacera la branche dry-run par la mutation `serviceInstanceRedeploy`.
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+    inputs:
+      force_saturated_for_test:
+        description: "Simuler une saturation pour tester la branche dry-run"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: pool-watchdog
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      API_URL: ${{ vars.API_URL }}
+      RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+      FORCE_SATURATED: ${{ github.event.inputs.force_saturated_for_test }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Probe pool & confirm saturation
+        run: |
+          set -euo pipefail
+
+          if [ -z "${API_URL:-}" ]; then
+            echo "::error::vars.API_URL non configuré"
+            exit 1
+          fi
+
+          if [ "${FORCE_SATURATED:-false}" = "true" ]; then
+            METRICS='{"status":"saturated","usage_pct":99,"size":50,"checked_out":50,"overflow":0,"_simulated":true}'
+            METRICS2="$METRICS"
+            echo "::warning::Mode test forcé — saturation simulée"
+          else
+            METRICS=$(curl -fsS --max-time 10 "$API_URL/api/health/pool")
+          fi
+          echo "Probe #1: $METRICS"
+
+          STATUS=$(echo "$METRICS" | jq -r '.status // "unknown"')
+          USAGE=$(echo "$METRICS" | jq -r '.usage_pct // 0')
+
+          HIGH=0
+          if [ "$STATUS" = "saturated" ]; then HIGH=1; fi
+          if [ "$(echo "$USAGE > 90" | bc -l)" = "1" ]; then HIGH=1; fi
+
+          if [ "$HIGH" != "1" ]; then
+            echo "Pool OK (status=$STATUS, usage=${USAGE}%)"
+            exit 0
+          fi
+
+          echo "Pression élevée (status=$STATUS, usage=${USAGE}%) — 2e probe dans 30 s..."
+          sleep 30
+
+          if [ "${FORCE_SATURATED:-false}" != "true" ]; then
+            METRICS2=$(curl -fsS --max-time 10 "$API_URL/api/health/pool")
+          fi
+          echo "Probe #2: $METRICS2"
+
+          STATUS2=$(echo "$METRICS2" | jq -r '.status // "unknown"')
+          USAGE2=$(echo "$METRICS2" | jq -r '.usage_pct // 0')
+
+          CONFIRMED=0
+          if [ "$STATUS2" = "saturated" ]; then CONFIRMED=1; fi
+          if [ "$(echo "$USAGE2 > 90" | bc -l)" = "1" ]; then CONFIRMED=1; fi
+
+          if [ "$CONFIRMED" != "1" ]; then
+            echo "Pression retombée (status=$STATUS2, usage=${USAGE2}%) — pas d'action."
+            exit 0
+          fi
+
+          echo "WOULD REDEPLOY — saturation confirmée (status=$STATUS2, usage=${USAGE2}%)"
+
+          # Vérifie que les secrets/vars Railway sont prêts pour la PR #2
+          # (on n'appelle pas l'API en v1 dry-run).
+          for v in RAILWAY_API_TOKEN RAILWAY_SERVICE_ID RAILWAY_ENVIRONMENT_ID; do
+            if [ -z "${!v:-}" ]; then
+              echo "::warning::$v non configuré — bloquera l'activation en PR #2"
+            fi
+          done
+
+          BODY=$(printf '%s\n' \
+            "Pool saturation confirmée par 2 probes consécutives." \
+            "" \
+            "**Probe #1** (\`/api/health/pool\`):" \
+            '```json' \
+            "$METRICS" \
+            '```' \
+            "" \
+            "**Probe #2** (+30 s):" \
+            '```json' \
+            "$METRICS2" \
+            '```' \
+            "" \
+            "- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            "- Mode: **dry-run** — aucun redeploy effectué." \
+            "" \
+            "Investiguer la cause (leak ? pic de trafic ?) avant d'activer le mode actif (PR de suivi).")
+
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "[watchdog] pool saturation confirmée — would redeploy" \
+            --body "$BODY" \
+            --label "infra,watchdog" || \
+              echo "::warning::gh issue create a échoué (labels manquants ?)"

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "DOCKERFILE"
 dockerfilePath = "packages/api/Dockerfile"
 
 [deploy]
-healthcheckPath = "/api/health"
+healthcheckPath = "/api/health/ready"
 healthcheckTimeout = 120
 restartPolicyType = "ALWAYS"
 restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Contexte

Avant #465, `_scheduled_restart` redémarrait proactivement le worker en cas de pression pool. Cette logique a été supprimée. La PR #479 a ajouté `restartPolicyType=ALWAYS` + `restartPolicyMaxRetries=10` pour compenser, **mais cette policy ne se déclenche que si le healthcheck Railway échoue**. Or `healthcheckPath = /api/health` (liveness pure) renvoie toujours 200, même DB injoignable / pool saturé.

→ **Aucun redéploiement automatique réel depuis #465.** Ce PR ré-arme le filet de sécurité en deux volets indissociables.

## Changements

### 1. `railway.toml` — healthcheck DB-aware
`healthcheckPath` : `/api/health` → `/api/health/ready` (renvoie 503 si `SELECT 1` échoue). Réarme `restartPolicyType=ALWAYS` côté Railway.

### 2. `.github/workflows/pool-saturation-watchdog.yml` — watchdog dry-run
- Cron `*/5`, double probe à 30 s sur `/api/health/pool`.
- Seuil : `status=saturated` ou `usage_pct>90`.
- **Mode dry-run v1** : `WOULD REDEPLOY` + `gh issue create` (pas de mutation Railway).
- Input `workflow_dispatch.force_saturated_for_test` pour valider la branche dry-run.

## Vars / secrets GH (déjà configurés)

- `vars.API_URL` = `https://facteur-production.up.railway.app`
- `vars.RAILWAY_SERVICE_ID`, `vars.RAILWAY_ENVIRONMENT_ID`
- `secrets.RAILWAY_TOKEN` (vérifié présent, inutilisé en v1 dry-run)

## Plan de déploiement

1. Merge → Railway redéploie avec le nouveau healthcheck. **Surveiller** dashboard Railway pendant 10 min : healthcheck doit rester vert.
2. `gh workflow run pool-saturation-watchdog.yml` manuel → vérifier que le run lit `/api/health/pool` et n'ouvre pas d'issue (status=ok).
3. `gh workflow run pool-saturation-watchdog.yml -f force_saturated_for_test=true` → vérifier qu'une issue `[watchdog]` est ouverte.
4. **Soak 24 h** : aucune issue `[watchdog]` ne doit s'ouvrir sur prod stable.
5. **PR de suivi** (hors scope) : retirer le dry-run et activer `serviceInstanceRedeploy`.

## Risques

- Boucle de redeploy si pool saturé en permanence → mitigé par dry-run 24 h (PR #1) + déploiement après hand-offs #1/#2/#3 (pool 50 stable).
- Token Railway compromis = privilèges redeploy → scope minimal au moment d'activer (PR de suivi).
- Lifespan FastAPI (`init_db` fail-soft) ne bloque pas `/ready` au boot, `healthcheckTimeout=120` couvre largement.

## Test plan

- [ ] CI verte
- [ ] Déploiement Railway : healthcheck `/api/health/ready` reste vert ≥ 10 min
- [ ] `gh workflow run pool-saturation-watchdog.yml` → run vert, pas d'issue
- [ ] `gh workflow run ... -f force_saturated_for_test=true` → issue `[watchdog]` créée
- [ ] Aucune issue `[watchdog]` ouverte pendant 24 h post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)