### PR TITLE
chore(observability): expand Sentry RSS noise filter (~5k events / 14j eliminated)

### DIFF
--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -117,16 +117,44 @@ def _get_alembic_head() -> str:
         return "unknown"
 
 
-# Drop trafilatura HTTP noise (not 200 / download error) saturating Sentry quota.
+# Drop predictable RSS fetch noise saturating Sentry quota (sources rate-limit
+# our crawler — expected, not actionable). Metric preserved via Railway log.
+_RSS_NOISE_LOGGERS = (
+    "trafilatura",
+    "feedparser",
+    "app.workers.rss_sync",
+    "app.services.rss_parser",
+)
+_RSS_NOISE_PATTERNS = (
+    "not a 200 response",
+    "download error",
+    "403 client error",
+    "404 client error",
+    "read timed out",
+    "connection reset",
+)
+
+
+def _extract_event_message(event: dict) -> str:
+    msg = (event.get("logentry") or {}).get("message") or event.get("message") or ""
+    for exc in (event.get("exception") or {}).get("values") or []:
+        val = exc.get("value") or ""
+        if val:
+            msg = f"{msg} {val}"
+    return msg
+
+
 def _sentry_before_send(event: dict, hint: dict) -> dict | None:
     logger_name = event.get("logger") or ""
-    if not logger_name.startswith("trafilatura"):
+    if not logger_name.startswith(_RSS_NOISE_LOGGERS):
         return event
-    message = (
-        event.get("logentry", {}).get("message", "") or event.get("message", "") or ""
-    )
-    message_lower = message.lower()
-    if "not a 200 response" in message_lower or "download error:" in message_lower:
+    message_lower = _extract_event_message(event).lower()
+    if any(pat in message_lower for pat in _RSS_NOISE_PATTERNS):
+        logger.info(
+            "rss_fetch_dropped_from_sentry",
+            sentry_logger=logger_name,
+            reason_excerpt=message_lower[:200],
+        )
         return None
     return event
 

--- a/packages/api/tests/test_sentry_filter.py
+++ b/packages/api/tests/test_sentry_filter.py
@@ -1,0 +1,49 @@
+"""Sentry before_send filter — drops predictable RSS fetch noise."""
+
+from app.main import _sentry_before_send
+
+
+def _logentry(logger_name: str, message: str) -> dict:
+    return {"logger": logger_name, "logentry": {"message": message}}
+
+
+def _exc_event(logger_name: str, exc_value: str) -> dict:
+    return {
+        "logger": logger_name,
+        "exception": {"values": [{"type": "Exception", "value": exc_value}]},
+    }
+
+
+def test_drops_trafilatura_download_error():
+    event = _logentry("trafilatura.downloads", "download error: cerveauetpsycho.fr/foo")
+    assert _sentry_before_send(event, {}) is None
+
+
+def test_drops_feedparser_not_200():
+    event = _logentry("feedparser", "not a 200 response: 403 for https://tldr.tech/x")
+    assert _sentry_before_send(event, {}) is None
+
+
+def test_drops_rss_sync_read_timeout_in_exception():
+    event = _exc_event("app.workers.rss_sync", "HTTPSConnectionPool: Read timed out")
+    assert _sentry_before_send(event, {}) is None
+
+
+def test_drops_rss_parser_404():
+    event = _logentry("app.services.rss_parser", "404 Client Error: Not Found")
+    assert _sentry_before_send(event, {}) is None
+
+
+def test_keeps_digest_queuepool_error():
+    event = _logentry("app.routers.digest", "QueuePool limit of size 50 overflow")
+    assert _sentry_before_send(event, {}) is event
+
+
+def test_keeps_validation_error():
+    event = _exc_event("app.services.digest_service", "ValidationError: bad payload")
+    assert _sentry_before_send(event, {}) is event
+
+
+def test_keeps_trafilatura_unrelated_message():
+    event = _logentry("trafilatura.core", "extracted main content successfully")
+    assert _sentry_before_send(event, {}) is event


### PR DESCRIPTION
## Summary

Sentry burns ~5 000 events / 14d on predictable RSS fetch failures that drown real bugs (MissingGreenlet, QueuePool, PendingRollbackError). Top offenders:

- `download error: cerveauetpsycho.fr/...` (trafilatura) — **3 602 events**
- `not a 200 response: 403 for https://tldr.tech/...` — **1 434 events**

These are expected — sources rate-limit our crawler. Not actionable. The existing filter (`packages/api/app/main.py`) only catches `trafilatura` logger with two patterns; this PR widens it.

## Changes

- `_sentry_before_send` now matches loggers in (`trafilatura`, `feedparser`, `app.workers.rss_sync`, `app.services.rss_parser`) against patterns `not a 200 response`, `download error`, `403/404 client error`, `read timed out`, `connection reset`.
- Reads exception `value` in addition to `logentry.message` so wrapped HTTP errors are caught.
- Drops emit a `rss_fetch_dropped_from_sentry` INFO log → metric stays observable in Railway, only Sentry quota is freed.
- 7 unit tests in `tests/test_sentry_filter.py` covering both drop and keep paths.

## Test plan

- [x] `pytest -v tests/test_sentry_filter.py` (7 passed)
- [x] `ruff format --check` + `ruff check` clean
- [ ] Post-deploy: grep Railway logs for `rss_fetch_dropped_from_sentry` (should appear within minutes)
- [ ] Post-deploy +1h: Sentry RSS-noise issues plateau in event count

🤖 Generated with [Claude Code](https://claude.com/claude-code)