### PR TITLE
fix(infra): hotfix incident 2026-04-28 — revert pool params + explicit rollback + revert healthcheck

### DIFF
--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -41,9 +41,9 @@ _use_queue_pool = _is_railway or _is_supabase
 # Exposé pour les tests : capacité prod et fail-fast timeout. Toute modif ici
 # impacte la pression sur le Supabase Pooler (60 conn partagées).
 PROD_POOL_KWARGS = {
-    "pool_size": 25,
-    "max_overflow": 25,
-    "pool_timeout": 10,
+    "pool_size": 10,
+    "max_overflow": 10,
+    "pool_timeout": 30,
     "pool_recycle": 180,
 }
 
@@ -59,11 +59,11 @@ if _use_queue_pool:
         pool_pre_ping=True,
         # Use AsyncAdaptedQueuePool for proper connection management
         poolclass=AsyncAdaptedQueuePool,
-        # Supabase Pooler 60 connection limit shared. App: 25+25=50 max →
-        # ~16 concurrent feed requests (~3 conns/req). Margin 10 left for the
-        # in-process scheduler. pool_timeout=10s : fail fast for visibility
-        # instead of 30s silent stalls. pool_recycle=180s : Supabase PgBouncer
-        # idle timeout is ~5 min, recycle before that.
+        # Supabase Pooler 60 connection limit shared. App: 10+10=20 max →
+        # laisse de la marge pour le scheduler in-process et autres clients.
+        # pool_timeout=30s : tolère un pic court sans 503 cascade (le revert du
+        # 10s post-incident 2026-04-28 — voir hotfix associé). pool_recycle=180s :
+        # Supabase PgBouncer idle timeout ~5 min, recycle avant.
         **PROD_POOL_KWARGS,
         # Connect args for PgBouncer compatibility
         connect_args={

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -230,11 +230,16 @@ class RecommendationService:
 
         async def _batch_personalization():
             async with async_session_maker() as s:
-                pz = await s.scalar(personalization_stmt)
-                digest = await s.scalar(digest_stmt)
-                # Epic 13: Load muted entities (defensive — tolère schema drift)
-                muted_entities = await _load_muted_entities_safe(s, user_id)
-                return pz, digest, muted_entities
+                try:
+                    pz = await s.scalar(personalization_stmt)
+                    digest = await s.scalar(digest_stmt)
+                    # Epic 13: Load muted entities (defensive — tolère schema drift)
+                    muted_entities = await _load_muted_entities_safe(s, user_id)
+                    return pz, digest, muted_entities
+                finally:
+                    # Hotfix 2026-04-28 : libère la transaction Postgres-side
+                    # même sur close() implicite — sinon "idle in transaction".
+                    await s.rollback()
 
         # gather() préserve le parallélisme : self.session et la short
         # session de _batch_personalization sont des sessions distinctes,
@@ -515,7 +520,12 @@ class RecommendationService:
                 UserTopicProfile.user_id == user_id
             )
             async with async_session_maker() as s:
-                user_custom_topics = list((await s.scalars(custom_topics_stmt)).all())
+                try:
+                    user_custom_topics = list(
+                        (await s.scalars(custom_topics_stmt)).all()
+                    )
+                finally:
+                    await s.rollback()  # hotfix 2026-04-28 idle-in-tx
             self.user_custom_topics = user_custom_topics
 
             ct_slugs: set[str] = set()
@@ -630,28 +640,34 @@ class RecommendationService:
 
         async def _batch_scoring_context():
             async with async_session_maker() as s:
-                affinity_rows = (await s.execute(source_affinity_stmt)).all()
-                custom_rows = (await s.scalars(custom_topics_stmt)).all()
-                return self._normalize_affinity(affinity_rows), list(custom_rows)
+                try:
+                    affinity_rows = (await s.execute(source_affinity_stmt)).all()
+                    custom_rows = (await s.scalars(custom_topics_stmt)).all()
+                    return self._normalize_affinity(affinity_rows), list(custom_rows)
+                finally:
+                    await s.rollback()  # hotfix 2026-04-28 idle-in-tx
 
         async def _batch_impressions():
             if not impression_ids:
                 return {}
             async with async_session_maker() as s:
-                stmt = select(
-                    UserContentStatus.content_id,
-                    UserContentStatus.last_impressed_at,
-                    UserContentStatus.manually_impressed,
-                ).where(
-                    UserContentStatus.user_id == user_id,
-                    UserContentStatus.content_id.in_(impression_ids),
-                    UserContentStatus.last_impressed_at.isnot(None),
-                )
-                rows = (await s.execute(stmt)).all()
-                return {
-                    row.content_id: (row.last_impressed_at, row.manually_impressed)
-                    for row in rows
-                }
+                try:
+                    stmt = select(
+                        UserContentStatus.content_id,
+                        UserContentStatus.last_impressed_at,
+                        UserContentStatus.manually_impressed,
+                    ).where(
+                        UserContentStatus.user_id == user_id,
+                        UserContentStatus.content_id.in_(impression_ids),
+                        UserContentStatus.last_impressed_at.isnot(None),
+                    )
+                    rows = (await s.execute(stmt)).all()
+                    return {
+                        row.content_id: (row.last_impressed_at, row.manually_impressed)
+                        for row in rows
+                    }
+                finally:
+                    await s.rollback()  # hotfix 2026-04-28 idle-in-tx
 
         (
             (source_affinity_scores, user_custom_topics),

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -755,25 +755,28 @@ class SmartSourceSearchService:
 
         try:
             async with async_session_maker() as session:
-                row = await session.execute(
-                    select(HostFeedResolution).where(
-                        HostFeedResolution.host == key,
-                        HostFeedResolution.expires_at > datetime.now(UTC),
+                try:
+                    row = await session.execute(
+                        select(HostFeedResolution).where(
+                            HostFeedResolution.host == key,
+                            HostFeedResolution.expires_at > datetime.now(UTC),
+                        )
                     )
-                )
-                cached = row.scalar_one_or_none()
-                if cached is not None:
-                    if cached.feed_url:
-                        return {
-                            "feed_url": cached.feed_url,
-                            "name": cached.title,
-                            "type": cached.type,
-                            "favicon_url": cached.logo_url,
-                            "description": cached.description,
-                            "recent_items": [],
-                        }
-                    # Negative cache hit — host known to have no feed.
-                    return None
+                    cached = row.scalar_one_or_none()
+                    if cached is not None:
+                        if cached.feed_url:
+                            return {
+                                "feed_url": cached.feed_url,
+                                "name": cached.title,
+                                "type": cached.type,
+                                "favicon_url": cached.logo_url,
+                                "description": cached.description,
+                                "recent_items": [],
+                            }
+                        # Negative cache hit — host known to have no feed.
+                        return None
+                finally:
+                    await session.rollback()  # hotfix 2026-04-28 idle-in-tx
         except Exception as exc:
             logger.debug("host_feed_cache.lookup_failed", host=key, error=str(exc))
 

--- a/packages/api/tests/test_health_pool.py
+++ b/packages/api/tests/test_health_pool.py
@@ -35,14 +35,16 @@ async def test_pool_endpoint_returns_metrics():
 
 
 def test_prod_pool_kwargs_capacity():
-    """Locks the production pool capacity at 25+25=50 with fail-fast timeout.
+    """Locks the production pool capacity at 10+10=20 with 30s timeout.
 
-    Supabase Pooler is 60 conns shared — bumping these without leaving
-    headroom for the in-process scheduler will starve other clients.
+    Revert post-incident 2026-04-28 : le bump 25/25/10s a déclenché un
+    thundering herd au pic matinal (pool_timeout=10s + retries Dio mobile).
+    Supabase Pooler partage 60 conns — on garde 20 max app + marge scheduler
+    et autres clients.
     """
     from app.database import PROD_POOL_KWARGS
 
-    assert PROD_POOL_KWARGS["pool_size"] == 25
-    assert PROD_POOL_KWARGS["max_overflow"] == 25
-    assert PROD_POOL_KWARGS["pool_timeout"] == 10
+    assert PROD_POOL_KWARGS["pool_size"] == 10
+    assert PROD_POOL_KWARGS["max_overflow"] == 10
+    assert PROD_POOL_KWARGS["pool_timeout"] == 30
     assert PROD_POOL_KWARGS["pool_recycle"] == 180

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,10 @@ builder = "DOCKERFILE"
 dockerfilePath = "packages/api/Dockerfile"
 
 [deploy]
-healthcheckPath = "/api/health/ready"
+# TEMP : revert to liveness probe pendant qu'on scelle les fuites idle-in-tx.
+# Issue suivi : ré-armer /api/health/ready quand pg_stat_activity reste propre 24h.
+# Voir incident 2026-04-28 + PR #490.
+healthcheckPath = "/api/health"
 healthcheckTimeout = 120
 restartPolicyType = "ALWAYS"
 restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Incident

Ce matin **2026-04-28 06:39-06:57 UTC** : pool DB saturé en cascade.
- Sentry : `QueuePool size=25 overflow=25 timeout=10.00 reached` à 06:39:31
- Burst de 9× `DbHandler exited (psycopg)` sur 06:39-06:57
- Articles + feed KO côté mobile

## Cause racine (combo 3 facteurs introduits par #488/#490)

1. **#488** a bumpé pool 10/10/30s → 25/25/10s. `pool_timeout=10s` + retries Dio mobile ×4 = thundering herd au pic matinal.
2. **Sessions ad-hoc** `async with async_session_maker() as s:` (read-only, parallèles via `asyncio.gather`) dans les hot paths feed/digest n'émettent pas de `rollback()` explicite avant `close()` → 16 connexions `idle in transaction` côté Supabase Pooler depuis 22 min à 1h56.
3. **#490** healthcheck `/api/health/ready` : pool saturé → 503 → restart pod → zombies Pooler pas évincés à temps → cascade `DbHandler exited`.

## Changements

### A — Revert params pool (`packages/api/app/database.py`)
Restaure pré-#488 : `pool_size=10`, `max_overflow=10`, `pool_timeout=30s`. Capacité 20 (10+10). Garde `pool_recycle=180`, `pool_pre_ping=True`, listeners `long_session_checkout`/`_invalidate_on_supabase_kill`. Tests `test_health_pool.py` mis à jour.

### B — Rollback explicite sur sessions ad-hoc read-only
Pattern :
```python
async with async_session_maker() as s:
    try:
        ...
    finally:
        await s.rollback()  # libère la transaction Postgres-side
```
Sites patchés (read-only sans commit/rollback dans le code existant) :
- `recommendation_service.py` : `_batch_personalization`, custom_topics load (~ligne 517), `_batch_scoring_context`, `_batch_impressions`.
- `smart_source_search.py` : `_resolve_host_feed` cache lookup.

Sites laissés intacts car déjà couverts par commit/rollback explicite : `digest_service.py` (bg_session/err_session avec commit + rollback dans except), `sources._log_failed_source_attempt`, `smart_source_search.mark_search_abandoned` + `_cache_feed_meta`, `cache.set`.

### C — Healthcheck Railway TEMPORAIRE (`railway.toml`)
`healthcheckPath = "/api/health"` (liveness) au lieu de `/api/health/ready`. Commentaire explicite : reverter quand `pg_stat_activity` reste propre 24h. `restartPolicyType = "ALWAYS"` et `restartPolicyMaxRetries = 10` inchangés.

## Test plan

- [x] `pytest tests/test_health_pool.py` (assertions pool params)
- [x] `pytest tests/test_digest_service.py tests/test_digest_readonly_hotpath.py tests/services/ tests/recommendation/` : 157 passed
- [x] `pytest -q` suite complète : 770 passed (errors restants = tests requérant Supabase local non démarré, pré-existants — pas une régression)
- [x] `ruff format --check packages/api/app` : 167 files already formatted
- [x] `ruff check packages/api/app` : All checks passed

## Suivi

- [ ] Créer issue GitHub : `Re-arm /api/health/ready healthcheck (suite hotfix 2026-04-28)` — ré-armer une fois `pg_stat_activity` propre 24h + 0 `DbHandler exited` Sentry sur 24h.
- [ ] Surveiller Railway logs + Sentry 30 min post-deploy (`db_pool_pressure_high`, `long_session_checkout`, `DbHandler exited`).
- [ ] Vérifier via Supabase MCP : `SELECT count(*) FROM pg_stat_activity WHERE state='idle in transaction'` → <5 dans 5 min post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)