### PR TITLE
fix(infra): hotfix idle-in-tx zombies — 3-layer defense

### DIFF
--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -1,6 +1,7 @@
 """Configuration de la base de données avec SQLAlchemy async."""
 
 import time
+from contextlib import asynccontextmanager
 
 from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -77,7 +78,17 @@ if _use_queue_pool:
             # rare où le middleware request-budget ne peut pas annuler
             # la task parce qu'elle est bloquée sur un I/O bas niveau.
             # Note libpq syntax : "-c statement_timeout=30000" (millisecondes).
-            "options": "-c statement_timeout=30000",
+            #
+            # Hot fix idle-in-tx zombies (incident 2026-04-28) :
+            # `idle_in_transaction_session_timeout=60000` → Postgres tue
+            # automatiquement toute transaction restée idle plus de 60 s.
+            # Filet de sécurité serveur indépendant du code app, au cas où
+            # un site ad-hoc oublie le rollback() en finally (cf.
+            # `safe_async_session` plus bas pour la couche app).
+            "options": (
+                "-c statement_timeout=30000 "
+                "-c idle_in_transaction_session_timeout=60000"
+            ),
         },
     )
 else:
@@ -133,6 +144,36 @@ async_session_maker = async_sessionmaker(
     autocommit=False,
     autoflush=False,
 )
+
+
+@asynccontextmanager
+async def safe_async_session():
+    """Session ad-hoc avec rollback() garanti en finally.
+
+    Hot fix incident 2026-04-28 (zombies `idle in transaction` côté
+    Supavisor) : tout `async with safe_async_session()` direct laisse
+    une transaction implicite ouverte au retour (SQLAlchemy ne rollback
+    pas automatiquement à la sortie du context si aucune exception). Le
+    pooler Supabase voit alors un slot `idle in transaction`
+    indéfiniment ; à 16+ zombies sur 60 slots l'app reçoit des
+    connexions inutilisables.
+
+    Use ce helper pour TOUS les sites qui n'utilisent pas Depends(get_db).
+    Le rollback() en finally est idempotent : après commit() explicite il
+    ne fait rien, mais protège les chemins read-only et les exceptions.
+    """
+    async with async_session_maker() as session:
+        try:
+            yield session
+        finally:
+            try:
+                await session.rollback()
+            except Exception as exc:
+                logger.debug(
+                    "session_rollback_failed_in_finally",
+                    error=str(exc),
+                    exc_type=type(exc).__name__,
+                )
 
 
 # Round 3 fix (docs/bugs/bug-infinite-load-requests.md — Sentry PYTHON-4/5/6) :
@@ -273,7 +314,7 @@ async def get_db() -> AsyncSession:
     originale du handler. Sinon Starlette/Sentry capturent une cascade confuse
     de PendingRollbackError au lieu de la vraie cause.
     """
-    async with async_session_maker() as session:
+    async with safe_async_session() as session:
         try:
             yield session
             await session.commit()

--- a/packages/api/app/dependencies.py
+++ b/packages/api/app/dependencies.py
@@ -60,7 +60,7 @@ async def _check_email_confirmed_with_retry(
     from sqlalchemy.exc import OperationalError
     from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
-    from app.database import async_session_maker
+    from app.database import safe_async_session
 
     global _email_confirmed_cache
 
@@ -78,7 +78,7 @@ async def _check_email_confirmed_with_retry(
     for attempt in range(max_retries):
         try:
             # Use asyncio.wait_for to add timeout to the entire session operation
-            async with async_session_maker() as session:
+            async with safe_async_session() as session:
                 # Execute query with shorter timeout to avoid holding connections
                 result = await asyncio.wait_for(
                     session.execute(

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -23,7 +23,7 @@ import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import async_session_maker
+from app.database import safe_async_session
 from app.models.daily_digest import DailyDigest
 from app.models.user import UserProfile
 from app.services.digest_generation_state_service import (
@@ -169,7 +169,7 @@ class DigestGenerationJob:
                 # courtes pendant les 3-5 min de LLM ; évite d'agripper la
                 # session batch pour toute la durée. Cf. bug-infinite-load-requests.md P1.
                 pipeline = EditorialPipelineService(
-                    session, session_maker=async_session_maker
+                    session, session_maker=safe_async_session
                 )
                 if pipeline.llm.is_ready and user_ids:
                     global_candidates = await self._get_global_candidates(session)
@@ -422,7 +422,7 @@ class DigestGenerationJob:
 
         async def process_with_limit(user_id: UUID) -> None:
             # Open a fresh session per user so errors don't poison peers
-            async with semaphore, async_session_maker() as user_session:
+            async with semaphore, safe_async_session() as user_session:
                 try:
                     await self._generate_digest_for_user(
                         user_session,
@@ -447,7 +447,7 @@ class DigestGenerationJob:
                     # variants as failed in a fresh session so rollback
                     # doesn't erase the observability row.
                     try:
-                        async with async_session_maker() as state_session:
+                        async with safe_async_session() as state_session:
                             for is_ser in (False, True):
                                 await state_mark_failed(
                                     state_session,
@@ -470,7 +470,7 @@ class DigestGenerationJob:
         async def _missing_pairs() -> list[tuple[UUID, bool]]:
             """Return (user_id, is_serene) pairs missing from daily_digest."""
             expected = {(uid, is_ser) for uid in user_ids for is_ser in (False, True)}
-            async with async_session_maker() as ro_session:
+            async with safe_async_session() as ro_session:
                 result = await ro_session.execute(
                     select(DailyDigest.user_id, DailyDigest.is_serene).where(
                         DailyDigest.target_date == target_date,
@@ -619,9 +619,7 @@ class DigestGenerationJob:
                     # session_maker propagé → pipeline LLM utilisera des
                     # sessions courtes et commit()ra user_session avant LLM
                     # pour libérer la connexion au pool.
-                    selector = DigestSelector(
-                        session, session_maker=async_session_maker
-                    )
+                    selector = DigestSelector(session, session_maker=safe_async_session)
                     digest_items = await selector.select_for_user(
                         user_id=user_id,
                         limit=user_target,
@@ -723,7 +721,7 @@ class DigestGenerationJob:
                     # so this user's main session can continue with the
                     # other variant cleanly.
                     try:
-                        async with async_session_maker() as variant_state_session:
+                        async with safe_async_session() as variant_state_session:
                             await state_mark_failed(
                                 variant_state_session,
                                 user_id,
@@ -796,7 +794,7 @@ async def run_digest_generation(
     mark_generation_started()
 
     # Obtenir une session depuis le contexte
-    async with async_session_maker() as session:
+    async with safe_async_session() as session:
         try:
             result = await job.run(session, target_date)
             await session.commit()
@@ -837,7 +835,7 @@ async def generate_digest_for_user(
     if target_date is None:
         target_date = today_paris()
 
-    async with async_session_maker() as session:
+    async with safe_async_session() as session:
         try:
             # Vérifier l'existant
             if not force:
@@ -867,7 +865,7 @@ async def generate_digest_for_user(
             # Générer — session_maker pour que la pipeline LLM (si format
             # éditorial activé) ouvre des sessions courtes et n'agrippe pas
             # la session de regen. Cf. bug-infinite-load-requests.md (P1).
-            selector = DigestSelector(session, session_maker=async_session_maker)
+            selector = DigestSelector(session, session_maker=safe_async_session)
             digest_items = await selector.select_for_user(
                 user_id=user_id,
                 limit=DiversityConstraints.TARGET_DIGEST_SIZE,

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -278,14 +278,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
                     from sqlalchemy import func
                     from sqlalchemy import select as sa_select
 
-                    from app.database import async_session_maker
+                    from app.database import safe_async_session
                     from app.jobs.digest_generation_job import run_digest_generation
                     from app.models.daily_digest import DailyDigest
                     from app.models.user import UserProfile
 
                     await asyncio.sleep(60)
 
-                    async with async_session_maker() as session:
+                    async with safe_async_session() as session:
                         today = datetime.now(ZoneInfo("Europe/Paris")).date()
 
                         total_users = await session.scalar(

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import async_session_maker, get_db
+from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
 from app.models.content import Content
 from app.models.enums import ContentType
@@ -108,7 +108,7 @@ async def get_content_detail(
                     )
 
                 # Persist enrichment via a short-lived session.
-                async with async_session_maker() as write_session:
+                async with safe_async_session() as write_session:
                     stmt = select(Content).where(Content.id == content_id)
                     db_content = await write_session.scalar(stmt)
                     if db_content:
@@ -137,7 +137,7 @@ async def get_content_detail(
                 # Courte session dédiée — n'emprunte pas `db` qui est déjà
                 # committée (connexion rendue au pool).
                 try:
-                    async with async_session_maker() as fallback_session:
+                    async with safe_async_session() as fallback_session:
                         stmt = select(Content).where(Content.id == content_id)
                         db_content = await fallback_session.scalar(stmt)
                         if db_content:

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import async_session_maker, get_db
+from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
 from app.models.daily_digest import DailyDigest
 from app.schemas.digest import (
@@ -451,7 +451,7 @@ async def generate_digest(
     # Cf. bug-infinite-load-requests.md (P1) — la pipeline éditoriale doit
     # pouvoir ouvrir ses propres sessions courtes hors de la session FastAPI
     # pour libérer la connexion au pool pendant 3-5 min de travail LLM.
-    service = DigestService(db, session_maker=async_session_maker)
+    service = DigestService(db, session_maker=safe_async_session)
     user_uuid = UUID(current_user_id)
 
     # Round 2 fix (item 4) : wait_for sur la génération — même motif que

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -12,7 +12,7 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import async_session_maker, get_db
+from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
 from app.models.failed_source_attempt import FailedSourceAttempt
 from app.models.source import Source
@@ -63,7 +63,7 @@ async def _log_failed_source_attempt(
     # rollback-on-BaseException (database.py:257) which would otherwise erase
     # the insert.
     try:
-        async with async_session_maker() as session:
+        async with safe_async_session() as session:
             session.add(
                 FailedSourceAttempt(
                     user_id=UUID(user_id),

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -111,7 +111,7 @@ def _schedule_background_regen(
 
     async def _regen() -> None:
         # Local import to avoid circulars
-        from app.database import async_session_maker
+        from app.database import safe_async_session
         from app.services.digest_generation_state_service import (
             mark_failed as _state_mark_failed,
         )
@@ -133,7 +133,7 @@ def _schedule_background_regen(
             return
 
         try:
-            async with async_session_maker() as bg_session:
+            async with safe_async_session() as bg_session:
                 bg_svc = DigestService(bg_session)
                 try:
                     # Check if a modern-format digest already exists.
@@ -179,7 +179,7 @@ def _schedule_background_regen(
                     # Record the failure in a fresh session so rollback
                     # doesn't wipe the observability row.
                     try:
-                        async with async_session_maker() as err_session:
+                        async with safe_async_session() as err_session:
                             await _state_mark_failed(
                                 err_session,
                                 user_id,

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -196,7 +196,7 @@ class RecommendationService:
 
         from sqlalchemy.orm import joinedload
 
-        from app.database import async_session_maker
+        from app.database import safe_async_session
         from app.models.daily_digest import DailyDigest
         from app.models.user_personalization import UserPersonalization
 
@@ -229,7 +229,7 @@ class RecommendationService:
             return profile, sources, subtopics
 
         async def _batch_personalization():
-            async with async_session_maker() as s:
+            async with safe_async_session() as s:
                 pz = await s.scalar(personalization_stmt)
                 digest = await s.scalar(digest_stmt)
                 # Epic 13: Load muted entities (defensive — tolère schema drift)
@@ -514,7 +514,7 @@ class RecommendationService:
             custom_topics_stmt = select(UserTopicProfile).where(
                 UserTopicProfile.user_id == user_id
             )
-            async with async_session_maker() as s:
+            async with safe_async_session() as s:
                 user_custom_topics = list((await s.scalars(custom_topics_stmt)).all())
             self.user_custom_topics = user_custom_topics
 
@@ -629,7 +629,7 @@ class RecommendationService:
         )
 
         async def _batch_scoring_context():
-            async with async_session_maker() as s:
+            async with safe_async_session() as s:
                 affinity_rows = (await s.execute(source_affinity_stmt)).all()
                 custom_rows = (await s.scalars(custom_topics_stmt)).all()
                 return self._normalize_affinity(affinity_rows), list(custom_rows)
@@ -637,7 +637,7 @@ class RecommendationService:
         async def _batch_impressions():
             if not impression_ids:
                 return {}
-            async with async_session_maker() as s:
+            async with safe_async_session() as s:
                 stmt = select(
                     UserContentStatus.content_id,
                     UserContentStatus.last_impressed_at,

--- a/packages/api/app/services/search/cache.py
+++ b/packages/api/app/services/search/cache.py
@@ -10,7 +10,7 @@ import structlog
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import async_session_maker
+from app.database import safe_async_session
 
 logger = structlog.get_logger()
 
@@ -84,7 +84,7 @@ async def search_cache_set(
     expires = now + timedelta(hours=CACHE_TTL_HOURS)
 
     try:
-        async with async_session_maker() as session:
+        async with safe_async_session() as session:
             await session.execute(
                 text(
                     "INSERT INTO source_search_cache "

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -13,7 +13,7 @@ from sqlalchemy import func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
-from app.database import async_session_maker
+from app.database import safe_async_session
 from app.models.enums import SourceType
 from app.models.host_feed_resolution import HostFeedResolution
 from app.models.source import Source
@@ -147,7 +147,7 @@ async def _record_search_log(
         for r in results[:5]
     ]
     try:
-        async with async_session_maker() as session:
+        async with safe_async_session() as session:
             session.add(
                 SourceSearchLog(
                     user_id=UUID(user_id),
@@ -175,7 +175,7 @@ async def mark_search_abandoned(user_id: str, query: str) -> None:
     """Flag the most recent matching search log as abandoned."""
     normalized = normalize_query(query)
     try:
-        async with async_session_maker() as session:
+        async with safe_async_session() as session:
             await session.execute(
                 text(
                     """
@@ -754,7 +754,7 @@ class SmartSourceSearchService:
             return await self._try_detect_feed(url)
 
         try:
-            async with async_session_maker() as session:
+            async with safe_async_session() as session:
                 row = await session.execute(
                     select(HostFeedResolution).where(
                         HostFeedResolution.host == key,
@@ -790,7 +790,7 @@ class SmartSourceSearchService:
         now = datetime.now(UTC)
         expires = now + timedelta(days=ttl_days)
         try:
-            async with async_session_maker() as session:
+            async with safe_async_session() as session:
                 await session.execute(
                     text(
                         """

--- a/packages/api/app/workers/rss_sync.py
+++ b/packages/api/app/workers/rss_sync.py
@@ -2,7 +2,7 @@
 
 import structlog
 
-from app.database import async_session_maker
+from app.database import safe_async_session
 from app.services.sync_service import SyncService
 
 logger = structlog.get_logger()
@@ -16,8 +16,8 @@ async def sync_all_sources() -> dict:
     """
     logger.info("Executing periodic RSS sync job")
 
-    async with async_session_maker() as session:
-        service = SyncService(session, session_maker=async_session_maker)
+    async with safe_async_session() as session:
+        service = SyncService(session, session_maker=safe_async_session)
         try:
             return await service.sync_all_sources()
         finally:
@@ -41,8 +41,8 @@ async def sync_source(source_id: str) -> bool:
     """
     logger.info("Executing manual RSS sync for source", source_id=source_id)
 
-    async with async_session_maker() as session:
-        service = SyncService(session, session_maker=async_session_maker)
+    async with safe_async_session() as session:
+        service = SyncService(session, session_maker=safe_async_session)
         try:
             # Récupérer la source
             from uuid import UUID

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -34,13 +34,13 @@ async def _digest_watchdog() -> None:
     """
     from sqlalchemy import func, select
 
-    from app.database import async_session_maker
+    from app.database import safe_async_session
     from app.models.daily_digest import DailyDigest
     from app.models.user import UserProfile
     from app.utils.time import today_paris
 
     try:
-        async with async_session_maker() as session:
+        async with safe_async_session() as session:
             try:
                 today = today_paris()
 
@@ -97,6 +97,55 @@ async def _digest_watchdog() -> None:
 
     except Exception:
         logger.exception("digest_watchdog_failed")
+
+
+async def _zombie_session_sweeper() -> None:
+    """Defensive belt : kill les sessions Supavisor `idle in transaction` > 5 min.
+
+    Hot fix incident 2026-04-28. Le timeout Postgres
+    `idle_in_transaction_session_timeout=60000ms` (cf. database.py
+    connect_args) devrait déjà couvrir, mais ce sweeper sert de
+    monitoring + filet de secours si une connexion contourne le SET
+    (ex: pooler config drift, connexion ouverte avant un hot reload).
+
+    Log :
+    - `zombie_session_sweeper_clean` (debug) : aucun zombie détecté.
+    - `zombie_session_sweeper_killed` (warning) : zombies tués →
+      investigate, c'est qu'un `safe_async_session` est manqué quelque part.
+    """
+    from sqlalchemy import text
+
+    from app.database import safe_async_session
+
+    try:
+        async with safe_async_session() as session:
+            result = await session.execute(
+                text(
+                    """
+                    SELECT
+                        pg_terminate_backend(pid) AS terminated,
+                        pid,
+                        EXTRACT(EPOCH FROM (now() - state_change))::int AS idle_seconds
+                    FROM pg_stat_activity
+                    WHERE state = 'idle in transaction'
+                      AND application_name = 'Supavisor'
+                      AND state_change < now() - interval '5 minutes'
+                      AND pid <> pg_backend_pid()
+                    """
+                )
+            )
+            killed = result.fetchall()
+            if killed:
+                logger.warning(
+                    "zombie_session_sweeper_killed",
+                    count=len(killed),
+                    pids=[r[1] for r in killed],
+                    max_idle_s=max(r[2] for r in killed),
+                )
+            else:
+                logger.debug("zombie_session_sweeper_clean")
+    except Exception:
+        logger.exception("zombie_session_sweeper_failed")
 
 
 def start_scheduler() -> None:
@@ -156,6 +205,17 @@ def start_scheduler() -> None:
         replace_existing=True,
     )
 
+    # Zombie session sweeper — kill Supavisor sessions stuck in
+    # `idle in transaction` > 5 min (filet de sécurité par-dessus le
+    # timeout Postgres + le rollback() en finally de safe_async_session).
+    scheduler.add_job(
+        _zombie_session_sweeper,
+        trigger=IntervalTrigger(minutes=5),
+        id="zombie_session_sweeper",
+        name="Zombie session sweeper (idle in tx > 5min)",
+        replace_existing=True,
+    )
+
     scheduler.start()
     logger.info(
         "Scheduler started",
@@ -165,6 +225,7 @@ def start_scheduler() -> None:
             "daily_digest",
             "digest_watchdog",
             "storage_cleanup",
+            "zombie_session_sweeper",
         ],
         rss_interval_minutes=settings.rss_sync_interval_minutes,
         digest_cron="06:00 Europe/Paris",

--- a/packages/api/app/workers/storage_cleanup.py
+++ b/packages/api/app/workers/storage_cleanup.py
@@ -7,7 +7,7 @@ import structlog
 from sqlalchemy import delete, func, select
 
 from app.config import get_settings
-from app.database import async_session_maker
+from app.database import safe_async_session
 from app.models.content import Content, UserContentStatus
 from app.models.daily_digest import DailyDigest
 from app.models.source import Source
@@ -59,7 +59,7 @@ async def cleanup_old_articles() -> dict:
         cutoff_date=cutoff_date.isoformat(),
     )
 
-    async with async_session_maker() as session:
+    async with safe_async_session() as session:
         try:
             # Subquery: articles bookmarkés (à préserver)
             bookmarked_subquery = select(UserContentStatus.content_id).where(

--- a/packages/api/app/workers/top3_job.py
+++ b/packages/api/app/workers/top3_job.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import structlog
 from sqlalchemy import select
 
-from app.database import async_session_maker
+from app.database import safe_async_session
 from app.models.user import UserProfile
 from app.services.briefing_service import BriefingService
 
@@ -31,7 +31,7 @@ async def generate_daily_top3_job(trigger_manual: bool = False):
         # contribuait à saturer le pool Supabase (connexions check-outées
         # sans rollback propre).
         # 1. Global context : session courte dédiée.
-        async with async_session_maker() as ctx_session:
+        async with safe_async_session() as ctx_session:
             try:
                 briefing_service_ctx = BriefingService(ctx_session)
                 logger.info("daily_top3_building_context")
@@ -72,7 +72,7 @@ async def generate_daily_top3_job(trigger_manual: bool = False):
 
         for user_id in user_ids:
             try:
-                async with async_session_maker() as user_session:
+                async with safe_async_session() as user_session:
                     try:
                         briefing_service = BriefingService(user_session)
                         await briefing_service.generate_briefing_for_user(

--- a/packages/api/tests/routers/test_sources_failed_attempt_logging.py
+++ b/packages/api/tests/routers/test_sources_failed_attempt_logging.py
@@ -7,7 +7,7 @@ HTTPException raised right after the `db.add(attempt)` — every
 FailedSourceAttempt insert in the previous implementation was
 silently discarded.
 
-The fix uses its own short-lived session via `async_session_maker`
+The fix uses its own short-lived session via `safe_async_session`
 so the commit survives the handler's HTTPException.
 """
 
@@ -33,7 +33,7 @@ async def test_log_failed_source_attempt_uses_fresh_session_and_commits():
 
     mock_session_maker = MagicMock(return_value=mock_cm)
 
-    with patch.object(sources_mod, "async_session_maker", mock_session_maker):
+    with patch.object(sources_mod, "safe_async_session", mock_session_maker):
         await sources_mod._log_failed_source_attempt(
             user_id=str(uuid4()),
             input_text="https://example.com/",
@@ -55,7 +55,7 @@ async def test_log_failed_source_attempt_swallows_errors():
 
     broken_session_maker = MagicMock(side_effect=RuntimeError("DB down"))
 
-    with patch.object(sources_mod, "async_session_maker", broken_session_maker):
+    with patch.object(sources_mod, "safe_async_session", broken_session_maker):
         # Must not raise
         await sources_mod._log_failed_source_attempt(
             user_id=str(uuid4()),
@@ -85,7 +85,7 @@ async def test_log_failed_source_attempt_truncates_long_inputs():
     mock_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch.object(
-        sources_mod, "async_session_maker", MagicMock(return_value=mock_cm)
+        sources_mod, "safe_async_session", MagicMock(return_value=mock_cm)
     ):
         await sources_mod._log_failed_source_attempt(
             user_id=str(uuid4()),

--- a/packages/api/tests/test_database_hotfix.py
+++ b/packages/api/tests/test_database_hotfix.py
@@ -1,0 +1,85 @@
+"""Tests pour le hot fix idle-in-tx zombies (incident 2026-04-28).
+
+Couvre les 2 couches centralisées :
+- Layer A : `safe_async_session` rollback() en finally même sur happy path.
+- Layer B : connect_args contient `idle_in_transaction_session_timeout=60000`
+  (filet Postgres-side).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app import database
+
+
+def test_connect_args_includes_idle_in_tx_timeout():
+    """Régression : tout nouveau commit qui touche `connect_args` doit
+    préserver le timeout côté Postgres. Sans ce SET, un site qui
+    oublie le rollback() laisse des zombies indéfiniment dans
+    Supavisor (cf. incident 2026-04-28).
+    """
+    import inspect
+
+    src = inspect.getsource(database)
+    assert "idle_in_transaction_session_timeout=60000" in src, (
+        "connect_args must SET idle_in_transaction_session_timeout=60000 "
+        "to prevent Supavisor zombies (incident 2026-04-28)"
+    )
+    assert "statement_timeout=30000" in src, "must keep statement_timeout"
+
+
+@pytest.mark.asyncio
+async def test_safe_async_session_rolls_back_on_happy_path():
+    """Le pattern central : même sans exception, `safe_async_session`
+    appelle rollback() en finally pour fermer toute tx implicite côté
+    Supavisor. Sans ça, un SELECT read-only laisse le slot
+    `idle in transaction`.
+    """
+    mock_session = AsyncMock()
+    fake_factory_cm = AsyncMock()
+    fake_factory_cm.__aenter__.return_value = mock_session
+    fake_factory_cm.__aexit__.return_value = None
+
+    with patch.object(database, "async_session_maker", return_value=fake_factory_cm):
+        async with database.safe_async_session() as session:
+            assert session is mock_session
+            # No exception, no explicit commit — exactly the read-only pattern.
+
+    mock_session.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_safe_async_session_rolls_back_on_exception():
+    """L'exception ne masque pas le rollback() — défense en profondeur."""
+    mock_session = AsyncMock()
+    fake_factory_cm = AsyncMock()
+    fake_factory_cm.__aenter__.return_value = mock_session
+    fake_factory_cm.__aexit__.return_value = None
+
+    with patch.object(database, "async_session_maker", return_value=fake_factory_cm):
+        with pytest.raises(RuntimeError):
+            async with database.safe_async_session() as session:
+                assert session is mock_session
+                raise RuntimeError("simulated handler crash")
+
+    mock_session.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_safe_async_session_swallows_rollback_failure():
+    """Si rollback() lui-même échoue (connexion morte), on log et
+    on ne masque pas la sortie normale du context — sinon une simple
+    déco DB tuerait toute la requête.
+    """
+    mock_session = AsyncMock()
+    mock_session.rollback.side_effect = RuntimeError("connection already gone")
+    fake_factory_cm = AsyncMock()
+    fake_factory_cm.__aenter__.return_value = mock_session
+    fake_factory_cm.__aexit__.return_value = None
+
+    with patch.object(database, "async_session_maker", return_value=fake_factory_cm):
+        async with database.safe_async_session() as session:
+            assert session is mock_session
+
+    mock_session.rollback.assert_awaited_once()

--- a/packages/api/tests/test_storage_cleanup.py
+++ b/packages/api/tests/test_storage_cleanup.py
@@ -53,7 +53,7 @@ async def test_cleanup_deletes_old_articles():
     mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session_maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.workers.storage_cleanup.async_session_maker", mock_session_maker), \
+    with patch("app.workers.storage_cleanup.safe_async_session", mock_session_maker), \
          patch("app.workers.storage_cleanup.settings") as mock_settings:
         mock_settings.rss_retention_days = 20
 
@@ -89,7 +89,7 @@ async def test_cleanup_skips_when_no_old_articles():
     mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session_maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.workers.storage_cleanup.async_session_maker", mock_session_maker), \
+    with patch("app.workers.storage_cleanup.safe_async_session", mock_session_maker), \
          patch("app.workers.storage_cleanup.settings") as mock_settings:
         mock_settings.rss_retention_days = 20
 
@@ -130,7 +130,7 @@ async def test_cleanup_rollback_on_error():
     mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session_maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.workers.storage_cleanup.async_session_maker", mock_session_maker), \
+    with patch("app.workers.storage_cleanup.safe_async_session", mock_session_maker), \
          patch("app.workers.storage_cleanup.settings") as mock_settings:
         mock_settings.rss_retention_days = 14
 
@@ -155,7 +155,7 @@ async def test_cleanup_respects_custom_retention_days():
     mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session_maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.workers.storage_cleanup.async_session_maker", mock_session_maker), \
+    with patch("app.workers.storage_cleanup.safe_async_session", mock_session_maker), \
          patch("app.workers.storage_cleanup.settings") as mock_settings:
         mock_settings.rss_retention_days = 7
 
@@ -193,7 +193,7 @@ async def test_cleanup_logs_statistics():
     mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session_maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.workers.storage_cleanup.async_session_maker", mock_session_maker), \
+    with patch("app.workers.storage_cleanup.safe_async_session", mock_session_maker), \
          patch("app.workers.storage_cleanup.settings") as mock_settings, \
          patch("app.workers.storage_cleanup.logger") as mock_logger:
         mock_settings.rss_retention_days = 20
@@ -236,7 +236,7 @@ async def test_cleanup_preserves_bookmarked_articles():
     mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session_maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.workers.storage_cleanup.async_session_maker", mock_session_maker), \
+    with patch("app.workers.storage_cleanup.safe_async_session", mock_session_maker), \
          patch("app.workers.storage_cleanup.settings") as mock_settings:
         mock_settings.rss_retention_days = 20
 
@@ -291,7 +291,7 @@ async def test_cleanup_preserves_digest_referenced_content():
         "app.workers.storage_cleanup._collect_referenced_content_ids",
         new=AsyncMock(return_value={referenced_id}),
     ), patch(
-        "app.workers.storage_cleanup.async_session_maker", mock_session_maker
+        "app.workers.storage_cleanup.safe_async_session", mock_session_maker
     ), patch("app.workers.storage_cleanup.settings") as mock_settings:
         mock_settings.rss_retention_days = 20
 
@@ -344,7 +344,7 @@ async def test_cleanup_skip_path_reports_preserved_digest_refs():
         "app.workers.storage_cleanup._collect_referenced_content_ids",
         new=AsyncMock(return_value={referenced_id}),
     ), patch(
-        "app.workers.storage_cleanup.async_session_maker", mock_session_maker
+        "app.workers.storage_cleanup.safe_async_session", mock_session_maker
     ), patch("app.workers.storage_cleanup.settings") as mock_settings:
         mock_settings.rss_retention_days = 20
 

--- a/packages/api/tests/workers/test_rss_sync.py
+++ b/packages/api/tests/workers/test_rss_sync.py
@@ -6,7 +6,7 @@ import pytest
 
 
 def _make_session_cm():
-    """Build a mock async_session_maker() that tracks rollback/commit on the
+    """Build a mock safe_async_session() that tracks rollback/commit on the
     session yielded to the worker.
     """
     session = AsyncMock()
@@ -32,7 +32,7 @@ async def test_sync_all_sources_releases_outer_session():
     maker, session = _make_session_cm()
 
     with patch(
-        "app.workers.rss_sync.async_session_maker", maker
+        "app.workers.rss_sync.safe_async_session", maker
     ), patch("app.workers.rss_sync.SyncService") as MockService:
         instance = MockService.return_value
         instance.sync_all_sources = AsyncMock(
@@ -59,7 +59,7 @@ async def test_sync_source_releases_outer_session_on_not_found():
     session.execute = AsyncMock(return_value=exec_result)
 
     with patch(
-        "app.workers.rss_sync.async_session_maker", maker
+        "app.workers.rss_sync.safe_async_session", maker
     ), patch("app.workers.rss_sync.SyncService") as MockService:
         instance = MockService.return_value
         instance.process_source = AsyncMock()

--- a/packages/api/tests/workers/test_scheduler.py
+++ b/packages/api/tests/workers/test_scheduler.py
@@ -281,7 +281,7 @@ class TestDigestWatchdogCoverage:
 
         with (
             patch(
-                "app.database.async_session_maker",
+                "app.database.safe_async_session",
                 side_effect=lambda: fake_sm(),
             ),
             patch(
@@ -309,7 +309,7 @@ class TestDigestWatchdogCoverage:
 
         with (
             patch(
-                "app.database.async_session_maker",
+                "app.database.safe_async_session",
                 side_effect=lambda: fake_sm(),
             ),
             patch(
@@ -335,7 +335,7 @@ class TestDigestWatchdogCoverage:
 
         with (
             patch(
-                "app.database.async_session_maker",
+                "app.database.safe_async_session",
                 side_effect=lambda: fake_sm(),
             ),
             patch(

--- a/packages/api/tests/workers/test_zombie_session_sweeper.py
+++ b/packages/api/tests/workers/test_zombie_session_sweeper.py
@@ -1,0 +1,113 @@
+"""Tests pour le zombie_session_sweeper (Layer C du hot fix 2026-04-28).
+
+Le sweeper est exécuté toutes les 5 min par APScheduler. Il sert de
+filet de sécurité par-dessus :
+- Layer A (rollback() en finally dans `safe_async_session`)
+- Layer B (`idle_in_transaction_session_timeout=60000` côté Postgres)
+
+Si jamais une couche est contournée (config drift Supavisor, code
+externe, etc.), le sweeper rattrape la fuite avant que les zombies ne
+saturent les 60 slots du pooler.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.workers.scheduler import _zombie_session_sweeper
+
+
+def _make_session_maker(execute_result=None, execute_side_effect=None):
+    mock_session = AsyncMock()
+    if execute_side_effect is not None:
+        mock_session.execute = AsyncMock(side_effect=execute_side_effect)
+    else:
+        mock_session.execute = AsyncMock(return_value=execute_result)
+
+    @asynccontextmanager
+    async def fake_sm():
+        yield mock_session
+
+    return fake_sm, mock_session
+
+
+@pytest.mark.asyncio
+async def test_sweeper_kills_zombies_and_logs_warning():
+    """Si pg_stat_activity remonte des zombies, log warning + count."""
+    fake_rows = [
+        (True, 12345, 360),
+        (True, 12346, 420),
+    ]
+    fake_result = MagicMock()
+    fake_result.fetchall = MagicMock(return_value=fake_rows)
+    fake_sm, mock_session = _make_session_maker(execute_result=fake_result)
+
+    with (
+        patch("app.database.safe_async_session", side_effect=lambda: fake_sm()),
+        patch("app.workers.scheduler.logger") as mock_logger,
+    ):
+        await _zombie_session_sweeper()
+
+    # SQL bien envoyé
+    assert mock_session.execute.await_count == 1
+    sql = str(mock_session.execute.await_args.args[0])
+    assert "pg_terminate_backend" in sql
+    assert "idle in transaction" in sql
+    assert "Supavisor" in sql
+
+    # Logged warning avec les bons pids
+    mock_logger.warning.assert_called_once()
+    name, kwargs = mock_logger.warning.call_args[0][0], mock_logger.warning.call_args[1]
+    assert name == "zombie_session_sweeper_killed"
+    assert kwargs["count"] == 2
+    assert kwargs["pids"] == [12345, 12346]
+    assert kwargs["max_idle_s"] == 420
+
+
+@pytest.mark.asyncio
+async def test_sweeper_logs_clean_when_no_zombies():
+    """Aucun zombie détecté = log debug, pas de warning."""
+    fake_result = MagicMock()
+    fake_result.fetchall = MagicMock(return_value=[])
+    fake_sm, _ = _make_session_maker(execute_result=fake_result)
+
+    with (
+        patch("app.database.safe_async_session", side_effect=lambda: fake_sm()),
+        patch("app.workers.scheduler.logger") as mock_logger,
+    ):
+        await _zombie_session_sweeper()
+
+    mock_logger.warning.assert_not_called()
+    mock_logger.debug.assert_called_once_with("zombie_session_sweeper_clean")
+
+
+@pytest.mark.asyncio
+async def test_sweeper_swallows_exceptions():
+    """Une erreur DB ne doit jamais crasher le scheduler — sinon le
+    sweeper s'arrête et c'est précisément lui qui devrait sauver l'app.
+    """
+    fake_sm, _ = _make_session_maker(execute_side_effect=RuntimeError("db down"))
+
+    with (
+        patch("app.database.safe_async_session", side_effect=lambda: fake_sm()),
+        patch("app.workers.scheduler.logger") as mock_logger,
+    ):
+        await _zombie_session_sweeper()  # MUST NOT raise
+
+    mock_logger.exception.assert_called_once_with("zombie_session_sweeper_failed")
+
+
+@pytest.mark.asyncio
+async def test_sweeper_registered_in_scheduler():
+    """Le job doit être dans la définition de start_scheduler avec
+    un interval de 5 min.
+    """
+    import inspect
+
+    from app.workers import scheduler as scheduler_mod
+
+    src = inspect.getsource(scheduler_mod.start_scheduler)
+    assert "_zombie_session_sweeper" in src
+    assert 'id="zombie_session_sweeper"' in src
+    assert "IntervalTrigger(minutes=5)" in src


### PR DESCRIPTION
## Incident

**2026-04-28 matin** — 16 sessions Supavisor `idle in transaction` saturent 16/60 slots du pooler partagé. L'app reçoit des connexions zombifiées :
- `DbHandler exited` (Sentry, 06:39–07:12 UTC)
- `PendingRollbackError` (07:01)
- `/api/health/ready` timeout

Résolu manuellement par kill SQL des PIDs concernés (Laurin, ~07:15 UTC). Cette PR pose le hot fix permanent.

## Cause racine

Tout `async with async_session_maker() as s:` ad-hoc laisse une transaction implicite ouverte au sortie : SQLAlchemy ne rollback **pas** automatiquement quand on quitte le context sans exception. Côté Supavisor, le slot reste `idle in transaction` indéfiniment (`wait_event=ClientRead`). À 16+ zombies sur 60 slots, le pool donne des connexions inutilisables aux nouveaux callers.

`get_db()` était correct. Mais 27 sites ad-hoc (jobs, workers, services, routers ne passant pas par `Depends`) étaient vulnérables.

## Changements — défense en profondeur, 3 couches indépendantes

### Layer A — code app : `safe_async_session` (database.py)

Helper `@asynccontextmanager` qui **garantit `rollback()` en finally**. Migration des **27 sites ad-hoc** + **4 factory params** (`session_maker=`) propagés aux services internes (`DigestSelector`, `EditorialPipelineService`, `SyncService`, etc.).

`rollback()` après `commit()` est un no-op — donc safe par défaut sur les chemins read-only ET protège les chemins d'écriture si une exception shunt le `commit()`.

> Choix d'archi : helper centralisé plutôt que 27 try/finally manuels — strictement équivalent fonctionnellement, beaucoup moins de surface de risque, testable en un seul endroit.

### Layer B — Postgres-side : `idle_in_transaction_session_timeout=60000`

Poussé via `connect_args.options` dans `database.py`. Postgres tue automatiquement toute tx restée idle > 60 s, sans dépendre du code app. Pas de migration Alembic — paramètre runtime via libpq options (`-c idle_in_transaction_session_timeout=60000`).

### Layer C — watchdog app : `zombie_session_sweeper`

Nouveau job APScheduler (workers/scheduler.py), `IntervalTrigger(minutes=5)`. Kill via `pg_terminate_backend` les sessions Supavisor `idle in transaction` > 5 min. Logged :
- `zombie_session_sweeper_clean` (debug) → sain
- `zombie_session_sweeper_killed` (warning, count + pids + max_idle_s) → un site safe_async_session est manqué quelque part, à investiguer

### Tests

- `tests/test_database_hotfix.py` (4 tests) : `rollback()` appelé en finally (happy path, exception, rollback fail), régression `connect_args` contient bien `idle_in_transaction_session_timeout=60000`.
- `tests/workers/test_zombie_session_sweeper.py` (4 tests) : kill + log warning, log debug si clean, swallow exceptions, registered in `start_scheduler`.
- Mises à jour des 4 fichiers de tests existants qui patchaient `async_session_maker` → patch désormais `safe_async_session` (mêmes assertions, symbole renommé).

## Test plan

- [x] `pytest tests/test_database_hotfix.py tests/workers/ tests/test_storage_cleanup.py tests/routers/test_sources_failed_attempt_logging.py` → 33 passed
- [x] `pytest -q` (suite complète) → 778 passed, 13 skipped, 34 errors **tous dus à local Postgres :54322 absent** (env, sans rapport)
- [x] `ruff format --check packages/api/app` → clean
- [x] `ruff check packages/api/app` → All checks passed
- [ ] Post-deploy : `psql … -c "SHOW idle_in_transaction_session_timeout;"` doit dire `60000ms`
- [ ] Post-deploy : Sentry silencieux sur `DbHandler exited` + `PendingRollbackError` pendant 30 min
- [ ] Post-deploy : logs Railway montrent `zombie_session_sweeper_clean` toutes les 5 min

## Pas de migration Alembic

Aucune. La config `idle_in_transaction_session_timeout` est passée via `connect_args` au runtime, pas en SQL persisté. Pas de touche Supabase Editor nécessaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)