### PR TITLE
fix(infra): SET LOCAL timeouts — server-side cap on idle-in-tx zombies

### DIFF
--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -146,17 +146,76 @@ async_session_maker = async_sessionmaker(
 )
 
 
+# Defaults pushed via SET LOCAL au début de CHAQUE session (helper +
+# get_db). Pourquoi SET LOCAL et pas connect_args : Supavisor en mode
+# transaction pooling ne propage PAS les options libpq startup
+# (`-c idle_in_transaction_session_timeout=...`) au backend Postgres
+# — vérifié en prod le 2026-04-28 par `SHOW idle_in_transaction_session_timeout`
+# qui renvoie `0` malgré le connect_args. SET LOCAL est une commande
+# SQL classique, donc transitée transparente par Supavisor → s'applique
+# bien à la tx en cours.
+#
+# Les valeurs : statement_timeout=30s laisse aux endpoints LLM/IO le
+# temps de respirer. idle_in_tx_timeout=10s est agressif : si une
+# coroutine est cancellée entre `execute()` et `rollback()`, Postgres
+# ferme la tx au bout de 10s même si l'app n'envoie rien. C'est ce qui
+# casse le pattern `wait_event=ClientRead` → zombie indéfini observé
+# sur le hot path /api/feed.
+_DEFAULT_STATEMENT_TIMEOUT_MS = 30_000
+_DEFAULT_IDLE_IN_TX_TIMEOUT_MS = 10_000
+
+
+async def _push_session_timeouts(
+    session: AsyncSession,
+    statement_timeout_ms: int,
+    idle_in_tx_timeout_ms: int,
+) -> None:
+    """Pousse `SET LOCAL` au début de la tx pour cap server-side.
+
+    Les `SET LOCAL` ne s'appliquent qu'à la transaction en cours →
+    n'écrasent pas les valeurs des autres sessions du pool. Best-effort :
+    si le SET échoue (DB down, pooler en panique), on laisse passer pour
+    ne pas bloquer la requête utilisateur — `handle_error` se chargera
+    de la connexion morte.
+    """
+    try:
+        await session.execute(
+            text(f"SET LOCAL statement_timeout = {statement_timeout_ms}")
+        )
+        await session.execute(
+            text(
+                f"SET LOCAL idle_in_transaction_session_timeout = {idle_in_tx_timeout_ms}"
+            )
+        )
+    except Exception as exc:
+        logger.debug(
+            "session_set_local_timeouts_failed",
+            error=str(exc),
+            exc_type=type(exc).__name__,
+        )
+
+
 @asynccontextmanager
-async def safe_async_session():
-    """Session ad-hoc avec rollback() garanti en finally.
+async def safe_async_session(
+    *,
+    statement_timeout_ms: int = _DEFAULT_STATEMENT_TIMEOUT_MS,
+    idle_in_tx_timeout_ms: int = _DEFAULT_IDLE_IN_TX_TIMEOUT_MS,
+):
+    """Session ad-hoc avec rollback() garanti + timeouts SET LOCAL.
 
     Hot fix incident 2026-04-28 (zombies `idle in transaction` côté
-    Supavisor) : tout `async with safe_async_session()` direct laisse
+    Supavisor) : tout `async with async_session_maker()` direct laisse
     une transaction implicite ouverte au retour (SQLAlchemy ne rollback
     pas automatiquement à la sortie du context si aucune exception). Le
     pooler Supabase voit alors un slot `idle in transaction`
     indéfiniment ; à 16+ zombies sur 60 slots l'app reçoit des
     connexions inutilisables.
+
+    En complément du rollback() finally — qui ne s'exécute pas si la
+    coroutine est tuée pendant un `await execute()` — on pousse aussi
+    `SET LOCAL idle_in_transaction_session_timeout` côté Postgres pour
+    que le serveur ferme la tx au bout de N secondes, indépendamment du
+    code app et du pooler.
 
     Use ce helper pour TOUS les sites qui n'utilisent pas Depends(get_db).
     Le rollback() en finally est idempotent : après commit() explicite il
@@ -164,6 +223,9 @@ async def safe_async_session():
     """
     async with async_session_maker() as session:
         try:
+            await _push_session_timeouts(
+                session, statement_timeout_ms, idle_in_tx_timeout_ms
+            )
             yield session
         finally:
             try:

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -229,7 +229,9 @@ class RecommendationService:
             return profile, sources, subtopics
 
         async def _batch_personalization():
-            async with safe_async_session() as s:
+            async with safe_async_session(
+                statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000
+            ) as s:
                 pz = await s.scalar(personalization_stmt)
                 digest = await s.scalar(digest_stmt)
                 # Epic 13: Load muted entities (defensive — tolère schema drift)
@@ -514,7 +516,9 @@ class RecommendationService:
             custom_topics_stmt = select(UserTopicProfile).where(
                 UserTopicProfile.user_id == user_id
             )
-            async with safe_async_session() as s:
+            async with safe_async_session(
+                statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000
+            ) as s:
                 user_custom_topics = list((await s.scalars(custom_topics_stmt)).all())
             self.user_custom_topics = user_custom_topics
 
@@ -629,7 +633,9 @@ class RecommendationService:
         )
 
         async def _batch_scoring_context():
-            async with safe_async_session() as s:
+            async with safe_async_session(
+                statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000
+            ) as s:
                 affinity_rows = (await s.execute(source_affinity_stmt)).all()
                 custom_rows = (await s.scalars(custom_topics_stmt)).all()
                 return self._normalize_affinity(affinity_rows), list(custom_rows)
@@ -637,7 +643,9 @@ class RecommendationService:
         async def _batch_impressions():
             if not impression_ids:
                 return {}
-            async with safe_async_session() as s:
+            async with safe_async_session(
+                statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000
+            ) as s:
                 stmt = select(
                     UserContentStatus.content_id,
                     UserContentStatus.last_impressed_at,

--- a/packages/api/tests/test_set_local_timeouts.py
+++ b/packages/api/tests/test_set_local_timeouts.py
@@ -1,0 +1,101 @@
+"""Tests pour SET LOCAL timeouts pushed dans chaque session.
+
+Suite à l'investigation 2026-04-28 : `connect_args.options="-c idle_in_tx..."`
+est ignoré par Supavisor en mode transaction pooling. Solution durable :
+pousser SET LOCAL en SQL au début de chaque tx — Supavisor transit les
+SQL commands transparente.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app import database
+
+
+@pytest.mark.asyncio
+async def test_safe_async_session_emits_set_local_default_timeouts():
+    """Default : statement_timeout=30s, idle_in_tx=10s sur chaque session."""
+    mock_session = AsyncMock()
+    fake_factory_cm = AsyncMock()
+    fake_factory_cm.__aenter__.return_value = mock_session
+    fake_factory_cm.__aexit__.return_value = None
+
+    with patch.object(database, "async_session_maker", return_value=fake_factory_cm):
+        async with database.safe_async_session() as session:
+            assert session is mock_session
+
+    # 2 SET LOCAL + (potential downstream code calls) — assert at minimum the SETs.
+    sql_calls = [
+        str(call.args[0]) for call in mock_session.execute.await_args_list
+    ]
+    assert any("SET LOCAL statement_timeout = 30000" in s for s in sql_calls), sql_calls
+    assert any(
+        "SET LOCAL idle_in_transaction_session_timeout = 10000" in s for s in sql_calls
+    ), sql_calls
+    mock_session.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_safe_async_session_accepts_custom_timeouts():
+    """Le hot path /api/feed pousse 8s/5s — défense en profondeur stricte."""
+    mock_session = AsyncMock()
+    fake_factory_cm = AsyncMock()
+    fake_factory_cm.__aenter__.return_value = mock_session
+    fake_factory_cm.__aexit__.return_value = None
+
+    with patch.object(database, "async_session_maker", return_value=fake_factory_cm):
+        async with database.safe_async_session(
+            statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000
+        ) as _:
+            pass
+
+    sql_calls = [str(c.args[0]) for c in mock_session.execute.await_args_list]
+    assert any("SET LOCAL statement_timeout = 8000" in s for s in sql_calls), sql_calls
+    assert any(
+        "SET LOCAL idle_in_transaction_session_timeout = 5000" in s for s in sql_calls
+    ), sql_calls
+
+
+@pytest.mark.asyncio
+async def test_safe_async_session_swallows_set_local_failure():
+    """Si le SET LOCAL échoue (DB down), on ne doit pas planter la requête —
+    la connexion morte sera évacuée par handle_error.
+    """
+    mock_session = AsyncMock()
+    mock_session.execute.side_effect = RuntimeError("connection lost")
+    fake_factory_cm = AsyncMock()
+    fake_factory_cm.__aenter__.return_value = mock_session
+    fake_factory_cm.__aexit__.return_value = None
+
+    with patch.object(database, "async_session_maker", return_value=fake_factory_cm):
+        async with database.safe_async_session() as session:
+            assert session is mock_session  # MUST yield, MUST NOT raise
+
+
+def test_feed_batch_sessions_use_strict_timeouts():
+    """Régression : les 4 sessions ad-hoc du hot path /api/feed doivent
+    pousser des timeouts stricts (8s/5s) — pas les défauts (30s/10s).
+    Trop laxiste = pool saturé avant que Postgres ne tue.
+    """
+    import inspect
+
+    from app.services import recommendation_service
+
+    src = inspect.getsource(recommendation_service)
+    # 4 sites attendus (cf. fix 2026-04-28) : _batch_personalization,
+    # custom_topics, _batch_scoring_context, _batch_impressions.
+    strict_call = (
+        "safe_async_session(\n"
+        "                statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000\n"
+        "            )"
+    )
+    assert src.count("statement_timeout_ms=8_000") >= 4, (
+        f"Expected ≥4 strict timeouts in feed hot path, found "
+        f"{src.count('statement_timeout_ms=8_000')}. Did you remove a feed "
+        f"batch session without keeping the strict timeout?"
+    )
+    assert strict_call in src, (
+        "Strict-timeout safe_async_session() call signature changed — update "
+        "this test or check the feed batch sessions"
+    )


### PR DESCRIPTION
## Pourquoi #493 n'a pas tenu

Investigation post-merge (08:00 UTC) sur la DB live : \`SHOW idle_in_transaction_session_timeout\` renvoie **\`0\`** — le \`connect_args.options\` poussé hier est ignoré. **Supavisor en mode transaction pooling ne propage pas les options libpq startup au backend Postgres.**

Conséquence : Layer B inactif, Layer A (\`rollback()\` finally) interrompu par la cancellation asyncio sur \`await execute()\`, Layer C arrive trop tard. Les 3 couches de #493 traitaient un symptôme.

**Smoking gun live :** 8 sessions \`idle in transaction\`, oldest 156s, toutes \`wait_event=ClientRead\` sur la query feed. Postgres attend que l'app lise les lignes — la coroutine a été tuée. Self-perpétuant : chaque /api/feed cancellé crée un zombie. Killer manuellement ne débloque pas le feed.

## Fix : SET LOCAL — la voie systémique

\`SET LOCAL\` est une **commande SQL classique** (pas une option libpq startup), donc Supavisor la passe transparente au backend. C'est la seule voie fiable derrière un pooler transaction-mode.

### Système-wide (défauts modérés)

\`safe_async_session()\` pousse en début de tx :
- \`SET LOCAL statement_timeout = 30000\` (30s)
- \`SET LOCAL idle_in_transaction_session_timeout = 10000\` (10s)

Tous les sites qui passent par le helper en bénéficient (jobs, workers, services, **et \`get_db()\` qui wrappe \`safe_async_session\` → tous les handlers FastAPI**).

### Hot path /api/feed (strict)

Les 4 sessions ad-hoc dans \`recommendation_service\` (\`_batch_personalization\`, custom_topics, \`_batch_scoring_context\`, \`_batch_impressions\`) passent en :
- \`statement_timeout = 8s\`
- \`idle_in_transaction_session_timeout = 5s\`

Postgres tue la tx en 5s **quoi qu'il arrive côté app** — finit le pattern ClientRead-stuck à la racine.

## Pourquoi ça casse vraiment la boucle

| Garantie | Avant #493 | Après #493 | Après cette PR |
|---|---|---|---|
| Indépendant de la cancellation asyncio | ❌ | ❌ (rollback finally interrompu) | ✅ Postgres impose son timer |
| Indépendant de Supavisor pooler | ❌ | ❌ (startup options strippées) | ✅ SET LOCAL = SQL, transitée |
| Garanti dans les 10s | ❌ | ❌ (sweeper 5+5 min) | ✅ 5-10s server-side |

## Test plan

- [x] \`pytest tests/test_set_local_timeouts.py tests/test_database_hotfix.py tests/workers/ tests/test_storage_cleanup.py tests/routers/test_sources_failed_attempt_logging.py\` → 37 passed
- [x] \`pytest -q\` → 742 passed (34 erreurs env-dépendantes :54322 ignorées, identiques pré-fix)
- [x] \`ruff format --check\` + \`ruff check\` → clean
- [ ] **Post-deploy critique** : \`SHOW idle_in_transaction_session_timeout\` dans une session app doit dire \`10000ms\` (ou \`5000ms\` sur la session feed). Si toujours \`0\`, le SET LOCAL n'a pas été émis — investiguer.
- [ ] Post-deploy : \`SELECT count(*) FROM pg_stat_activity WHERE state='idle in transaction' AND state_change < now() - interval '15 seconds';\` doit rester à 0
- [ ] Post-deploy : /api/feed reprend une latence p95 < 2s

## Décisions explicites

**Pas d'eager-fetch refactor.** Le diagnostic initial proposait de matérialiser tous les \`scalars().all()\` pour éviter les curseurs lazy. Mais avec psycopg buffered (le défaut), \`await session.scalars(stmt)\` matérialise déjà côté serveur — la "lazy" pattern n'est pas réellement lazy. Le SET LOCAL adresse la vraie cause (cancellation pendant l'await) sans toucher au business code.

**Pas de touche à get_db.** Il wrappe déjà \`safe_async_session\` → bénéficie automatiquement.

**Suite logique (Option 2 du brief)** : refactor recommendation_service pour 1-2 sessions/req max, à faire en PR séparée cette semaine. Cette PR-ci stabilise la prod immédiatement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)