### PR TITLE
fix(api): expunge_all() before rollback — unbreaks /api/feed (PYTHON-2X)

### DIFF
--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -228,6 +228,30 @@ async def safe_async_session(
             )
             yield session
         finally:
+            # Ordre CRITIQUE — vu en prod 2026-04-28 (Sentry PYTHON-2X
+            # `DetachedInstanceError UserPersonalization`, 260+ events
+            # post #493) : `session.rollback()` expire tous les objets
+            # ORM persistants par défaut. Sites qui retournent un objet
+            # ORM hors du context block (ex `_batch_personalization` →
+            # `pz`, accédé ensuite via `pz.muted_sources`) tombent en
+            # DetachedInstanceError dès que rollback() s'exécute en
+            # finally → /api/feed 500 → "Petit souci !" mobile.
+            #
+            # Fix : `expunge_all()` AVANT rollback. Détache les objets
+            # de la session — ils gardent leurs attributs déjà chargés
+            # (les lazy relationships restent inaccessibles, comme avec
+            # tout objet détaché classique). rollback() opère ensuite
+            # sur une session vide d'objets persistants → pas d'expiry,
+            # mais le ROLLBACK SQL est bien envoyé pour fermer la tx
+            # côté Supavisor.
+            try:
+                session.expunge_all()
+            except Exception as exc:
+                logger.debug(
+                    "session_expunge_failed_in_finally",
+                    error=str(exc),
+                    exc_type=type(exc).__name__,
+                )
             try:
                 await session.rollback()
             except Exception as exc:

--- a/packages/api/tests/test_database_hotfix.py
+++ b/packages/api/tests/test_database_hotfix.py
@@ -83,3 +83,68 @@ async def test_safe_async_session_swallows_rollback_failure():
             assert session is mock_session
 
     mock_session.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_safe_async_session_expunges_before_rollback_no_detached_error():
+    """Régression critique 2026-04-28 PYTHON-2X (260+ events) :
+    `await session.rollback()` en finally expirait tous les objets ORM
+    persistants. Sites qui retournent un objet hors du `async with`
+    (ex `_batch_personalization` → UserPersonalization) avaient
+    `DetachedInstanceError` au prochain accès attribut → /api/feed 500.
+
+    Fix : `expunge_all()` AVANT rollback. Garantit que :
+    1. expunge_all est appelé (détache les objets, pas d'expiry par
+       rollback ensuite).
+    2. expunge_all est appelé AVANT rollback (ordre critique — l'inverse
+       expirerait avant de détacher).
+    3. rollback est toujours appelé (zombie defense intacte).
+    """
+    from unittest.mock import MagicMock
+
+    call_order: list[str] = []
+    mock_session = AsyncMock()
+    mock_session.expunge_all = MagicMock(
+        side_effect=lambda: call_order.append("expunge")
+    )
+
+    async def _track_rollback():
+        call_order.append("rollback")
+
+    mock_session.rollback = AsyncMock(side_effect=_track_rollback)
+
+    fake_factory_cm = AsyncMock()
+    fake_factory_cm.__aenter__.return_value = mock_session
+    fake_factory_cm.__aexit__.return_value = None
+
+    with patch.object(database, "async_session_maker", return_value=fake_factory_cm):
+        async with database.safe_async_session() as session:
+            assert session is mock_session
+
+    mock_session.expunge_all.assert_called_once()
+    mock_session.rollback.assert_awaited_once()
+    # Ordre : expunge AVANT rollback. Sinon rollback expire ce qui reste
+    # attaché → DetachedInstanceError à l'accès .relationship downstream.
+    assert call_order == ["expunge", "rollback"], call_order
+
+
+@pytest.mark.asyncio
+async def test_safe_async_session_swallows_expunge_failure():
+    """expunge_all() ne doit jamais bloquer le rollback derrière —
+    sinon une session corrompue empêcherait le ROLLBACK SQL d'être
+    envoyé → retour à zero des zombies.
+    """
+    from unittest.mock import MagicMock
+
+    mock_session = AsyncMock()
+    mock_session.expunge_all = MagicMock(side_effect=RuntimeError("session corrupted"))
+    fake_factory_cm = AsyncMock()
+    fake_factory_cm.__aenter__.return_value = mock_session
+    fake_factory_cm.__aexit__.return_value = None
+
+    with patch.object(database, "async_session_maker", return_value=fake_factory_cm):
+        async with database.safe_async_session() as session:
+            assert session is mock_session
+
+    # rollback DOIT être appelé même si expunge a planté.
+    mock_session.rollback.assert_awaited_once()


### PR DESCRIPTION
## TL;DR

**260+ Sentry events PYTHON-2X \`DetachedInstanceError UserPersonalization\` depuis 07:39 UTC** = la vraie cause du feed cassé en mobile (\"Petit souci !\"), pas les zombies. Premier event 5 min après le déploiement de #493. C'est moi qui ai cassé la prod en pensant la sauver.

## Cause

PR #493 a ajouté \`await session.rollback()\` en finally dans \`safe_async_session\` pour la zombie defense. Mais en SQLAlchemy 2.x, \`rollback()\` **expire par défaut tous les attributs des objets ORM persistants** — comportement standard, pas configurable au niveau sessionmaker (\`expire_on_commit=False\` ne couvre que le commit ; pas de kwarg \`expire_on_rollback\`, vérifié dans le source SQLAlchemy 2.0.25).

Conséquence sur le pattern courant dans \`recommendation_service\` :

\`\`\`python
async def _batch_personalization():
    async with safe_async_session() as s:
        pz = await s.scalar(personalization_stmt)  # pz attaché à s
        return pz
        # finally: await s.rollback() → expire pz (encore attaché)
        # __aexit__: close() → détache pz, mais déjà expiré
# pz.muted_sources → DetachedInstanceError (refresh sur session fermée)
\`\`\`

Stack trace Sentry confirme : \`feed.py:get_personalized_feed:167\` → \`_compute_feed:235\` → \`recommendation_service.py:get_feed:353\` (= accès \`personalization.muted_sources\`) → SQLAlchemy \`_load_expired\` → DetachedInstanceError.

## Fix — one-liner conceptuel, ordre critique

\`session.expunge_all()\` AVANT \`session.rollback()\` dans le finally.

\`expunge_all()\` détache tous les objets de la session — ils gardent leurs attributs déjà chargés (les lazy relationships restent inaccessibles, comme avec n'importe quel objet détaché). \`rollback()\` opère ensuite sur une session vide d'objets persistants → pas d'expiry, mais le ROLLBACK SQL est bien envoyé pour fermer la tx côté Supavisor.

Les deux étapes wrappées en try/except indépendants : si expunge plante (session corrompue), on tente quand même rollback pour ne pas régresser la zombie defense.

## Tests

- \`test_safe_async_session_expunges_before_rollback_no_detached_error\` — vérifie l'ordre \`expunge → rollback\` (l'inverse expirerait avant de détacher → DetachedInstanceError)
- \`test_safe_async_session_swallows_expunge_failure\` — si expunge plante, rollback toujours appelé

## Test plan

- [x] \`pytest tests/test_database_hotfix.py tests/test_set_local_timeouts.py\` → 10 passed (dont 2 nouveaux ordering)
- [x] \`pytest -q\` (suite complète) → 744 passed
- [x] \`ruff format --check\` + \`ruff check\` → clean
- [ ] **Post-deploy critique** : Sentry PYTHON-2X / 2Y doit cesser immédiatement
- [ ] Post-deploy : /api/feed reprend du service, plus de \"Petit souci !\" mobile
- [ ] Post-deploy : zombies idle-in-tx restent à 0 (rollback toujours appelé, defense intacte)

## Mea culpa

J'ai passé toute la matinée à empiler des couches infra (#493, #494) en croyant que les zombies étaient la cause. C'était un symptôme. La vraie cause était **le rollback() que j'ai ajouté** qui cassait l'ORM downstream via expiry. Sentry me criait dessus avec PYTHON-2X dès 07:39, j'ai ignoré. Mes excuses pour le bruit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)