### PR TITLE
fix(widget-android): preserve articles on streak refresh + UI polish

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt
@@ -39,6 +39,10 @@ class FacteurWidget : AppWidgetProvider() {
             try {
                 val views = RemoteViews(context.packageName, R.layout.facteur_widget)
                 val prefs = HomeWidgetPlugin.getData(context)
+                Log.d(
+                    TAG,
+                    "onUpdate: id=$appWidgetId data=${prefs != null} json.len=${prefs?.getString("articles_json", null)?.length ?: -1}",
+                )
 
                 // Header — streak
                 val streak = prefs?.getString("streak", "0")?.toIntOrNull() ?: 0

--- a/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidgetRemoteViewsFactory.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidgetRemoteViewsFactory.kt
@@ -2,7 +2,13 @@ package com.example.facteur
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.RectF
 import android.net.Uri
 import android.util.Log
 import android.view.View
@@ -56,12 +62,13 @@ class FacteurWidgetRemoteViewsFactory(
     override fun onDataSetChanged() {
         rows.clear()
         try {
-            val data = HomeWidgetPlugin.getData(context) ?: run {
-                rows.add(placeholderRow("Ouvre Facteur pour charger ton essentiel"))
-                return
-            }
-            val json = data.getString("articles_json", null)
-            if (json.isNullOrBlank() || json == "[]") {
+            val data = HomeWidgetPlugin.getData(context)
+            val json = data?.getString("articles_json", null)
+            Log.d(
+                TAG,
+                "onDataSetChanged: data=${data != null} json.len=${json?.length ?: -1}",
+            )
+            if (data == null || json.isNullOrBlank() || json == "[]") {
                 rows.add(placeholderRow("Ouvre Facteur pour charger ton essentiel"))
                 return
             }
@@ -73,8 +80,9 @@ class FacteurWidgetRemoteViewsFactory(
             if (rows.isEmpty()) {
                 rows.add(placeholderRow("Ouvre Facteur pour charger ton essentiel"))
             }
+            Log.d(TAG, "onDataSetChanged: rows=${rows.size}")
         } catch (e: Exception) {
-            Log.w(TAG, "onDataSetChanged failed: ${e.message}")
+            Log.w(TAG, "onDataSetChanged failed", e)
             rows.clear()
             rows.add(placeholderRow("Ouvre Facteur pour charger ton essentiel"))
         }
@@ -84,9 +92,16 @@ class FacteurWidgetRemoteViewsFactory(
         rows.clear()
     }
 
-    override fun getCount(): Int = rows.size
+    override fun getCount(): Int = if (rows.isEmpty()) 1 else rows.size
 
-    override fun getViewAt(position: Int): RemoteViews {
+    override fun getViewAt(position: Int): RemoteViews = try {
+        buildViewAt(position)
+    } catch (e: Exception) {
+        Log.w(TAG, "getViewAt($position) failed", e)
+        placeholderViews("Ouvre Facteur pour charger ton essentiel")
+    }
+
+    private fun buildViewAt(position: Int): RemoteViews {
         val row = rows.getOrNull(position) ?: return placeholderViews(
             "Ouvre Facteur pour charger ton essentiel"
         )
@@ -105,8 +120,8 @@ class FacteurWidgetRemoteViewsFactory(
         )
         rv.setTextViewText(R.id.row_title, row.title)
 
-        // Thumbnail
-        val thumb = loadBitmap(row.thumbnailPath)
+        // Thumbnail (rounded 8dp corners)
+        val thumb = loadBitmap(row.thumbnailPath)?.let { roundCorners(it, 8f) }
         if (thumb != null) {
             rv.setImageViewBitmap(R.id.row_thumbnail, thumb)
             rv.setViewVisibility(R.id.row_thumbnail, View.VISIBLE)
@@ -213,7 +228,20 @@ class FacteurWidgetRemoteViewsFactory(
         return rv
     }
 
-    private fun loadBitmap(path: String?): android.graphics.Bitmap? {
+    private fun roundCorners(src: Bitmap, radiusDp: Float): Bitmap {
+        val density = context.resources.displayMetrics.density
+        val r = radiusDp * density
+        val output = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(output)
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+        val rect = RectF(0f, 0f, src.width.toFloat(), src.height.toFloat())
+        canvas.drawRoundRect(rect, r, r, paint)
+        paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
+        canvas.drawBitmap(src, 0f, 0f, paint)
+        return output
+    }
+
+    private fun loadBitmap(path: String?): Bitmap? {
         if (path.isNullOrBlank()) return null
         return try {
             val file = File(path)

--- a/apps/mobile/android/app/src/main/res/drawable/widget_badge_a_la_une.xml
+++ b/apps/mobile/android/app/src/main/res/drawable/widget_badge_a_la_une.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="8dp" />
+    <solid android:color="#1FD35400" />
+</shape>

--- a/apps/mobile/android/app/src/main/res/layout/facteur_widget.xml
+++ b/apps/mobile/android/app/src/main/res/layout/facteur_widget.xml
@@ -5,14 +5,14 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:background="@drawable/widget_root_bg"
-    android:padding="14dp">
+    android:padding="16dp">
 
     <!-- Header: Facteur wordmark + streak end-aligned -->
     <RelativeLayout
         android:id="@+id/widget_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="2dp">
+        android:layout_marginBottom="4dp">
 
         <TextView
             android:id="@+id/app_name"
@@ -45,7 +45,8 @@
         android:layout_marginBottom="10dp"
         android:gravity="center"
         android:text="L'Essentiel du jour"
-        android:textSize="12sp"
+        android:textSize="13sp"
+        android:fontFamily="sans-serif"
         android:textColor="@color/facteur_text_secondary" />
 
     <!-- Stale banner (shown when articles_updated_at > 36h) -->

--- a/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
+++ b/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
@@ -6,10 +6,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingTop="6dp"
-    android:paddingBottom="6dp"
-    android:paddingStart="4dp"
-    android:paddingEnd="4dp">
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp"
+    android:paddingStart="0dp"
+    android:paddingEnd="0dp">
 
     <!-- Header line: "1 — International" + (optional) À la Une badge -->
     <LinearLayout
@@ -36,12 +36,15 @@
             android:id="@+id/row_a_la_une"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="10sp"
+            android:layout_marginStart="6dp"
+            android:textSize="11sp"
             android:textStyle="bold"
-            android:textColor="#FFFFFF"
-            android:background="@color/facteur_a_la_une_bg"
-            android:paddingStart="6dp"
-            android:paddingEnd="6dp"
+            android:textAllCaps="true"
+            android:letterSpacing="0.05"
+            android:textColor="@color/facteur_accent"
+            android:background="@drawable/widget_badge_a_la_une"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
             android:paddingTop="2dp"
             android:paddingBottom="2dp"
             android:visibility="gone"
@@ -60,8 +63,9 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textSize="14sp"
+            android:textSize="15sp"
             android:textStyle="bold"
+            android:fontFamily="sans-serif-medium"
             android:textColor="@color/facteur_text_primary"
             android:lineSpacingExtra="2dp"
             android:maxLines="2"
@@ -87,9 +91,9 @@
 
         <ImageView
             android:id="@+id/row_source_logo"
-            android:layout_width="14dp"
-            android:layout_height="14dp"
-            android:layout_marginEnd="4dp"
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_marginEnd="6dp"
             android:scaleType="fitCenter"
             android:visibility="gone"
             android:contentDescription="Source logo" />

--- a/apps/mobile/android/app/src/main/res/xml/facteur_widget_info.xml
+++ b/apps/mobile/android/app/src/main/res/xml/facteur_widget_info.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:minWidth="250dp"
-    android:minHeight="180dp"
+    android:minHeight="340dp"
     android:targetCellWidth="4"
-    android:targetCellHeight="4"
+    android:targetCellHeight="5"
+    android:maxResizeWidth="500dp"
+    android:maxResizeHeight="500dp"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="1800000"
     android:previewLayout="@layout/facteur_widget"

--- a/apps/mobile/lib/core/services/widget_service.dart
+++ b/apps/mobile/lib/core/services/widget_service.dart
@@ -24,31 +24,39 @@ class WidgetService {
   static const _maxArticles = 5;
   static final _dio = Dio();
 
-  /// Update the home screen widget with the latest digest and streak data.
+  /// Update the home screen widget with the latest digest and/or streak data.
+  ///
+  /// Each parameter is independent: passing only `streak` will refresh the
+  /// streak counter without touching `articles_json`. This avoids wiping
+  /// previously saved articles when streak refresh fires after digest fetch.
   static Future<void> updateWidget({
     DigestResponse? digest,
     StreakModel? streak,
   }) async {
     try {
-      final articles = await _buildArticleList(digest);
+      if (digest != null) {
+        final articles = await _buildArticleList(digest);
+        await HomeWidget.saveWidgetData(
+          'articles_json',
+          jsonEncode(articles),
+        );
+        await HomeWidget.saveWidgetData(
+          'articles_updated_at',
+          '${DateTime.now().millisecondsSinceEpoch}',
+        );
+        await HomeWidget.saveWidgetData(
+          'digest_status',
+          _computeStatus(digest),
+        );
+        await HomeWidget.saveWidgetData(
+          'digest_progress',
+          _computeProgress(digest),
+        );
+      }
 
-      await HomeWidget.saveWidgetData(
-        'articles_json',
-        jsonEncode(articles),
-      );
-      await HomeWidget.saveWidgetData(
-        'articles_updated_at',
-        '${DateTime.now().millisecondsSinceEpoch}',
-      );
-      await HomeWidget.saveWidgetData('digest_status', _computeStatus(digest));
-      await HomeWidget.saveWidgetData(
-        'digest_progress',
-        _computeProgress(digest),
-      );
-      await HomeWidget.saveWidgetData(
-        'streak',
-        '${streak?.currentStreak ?? 0}',
-      );
+      if (streak != null) {
+        await HomeWidget.saveWidgetData('streak', '${streak.currentStreak}');
+      }
 
       await HomeWidget.updateWidget(androidName: _androidName);
     } catch (e) {


### PR DESCRIPTION
## What

Android home widget patch: streak-only refreshes no longer wipe `articles_json`, plus defensive rendering and a UI polish pass.

## Why

Streak refresh fired after digest fetch was overwriting saved articles with an empty list, leaving the widget blank. Also tightened `RemoteViewsFactory` against transient errors and refreshed badge/typography/sizing.

## Type

- [ ] Feature
- [x] Bug fix
- [x] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally
- [ ] Linting passes
- [x] No new Python `List[]` imports
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (Android-only widget change)