### PR TITLE
fix(reader): truncated perspective titles + raw HTML tags in reader

### DIFF
--- a/apps/mobile/lib/core/utils/html_utils.dart
+++ b/apps/mobile/lib/core/utils/html_utils.dart
@@ -4,26 +4,60 @@
 /// dans les cards feed/digest et le reader in-app.
 library;
 
+/// Décode les entités HTML (named + numériques decimal/hex), en bouclant
+/// pour gérer le multi-encodage (ex: `&amp;lt;` → `&lt;` → `<`).
+///
+/// Robuste face aux flux RSS où les entités peuvent être encodées 1, 2 ou
+/// 3 fois selon les pipelines. Limite la boucle à 3 passes.
+String decodeHtmlEntities(String input) {
+  var text = input;
+  for (var pass = 0; pass < 3; pass++) {
+    final before = text;
+    // Numeric entities (decimal & hex) — handles any code point.
+    text = text.replaceAllMapped(
+      RegExp(r'&#(x[0-9a-fA-F]+|[0-9]+);'),
+      (m) {
+        final raw = m.group(1)!;
+        final code = raw.startsWith('x') || raw.startsWith('X')
+            ? int.tryParse(raw.substring(1), radix: 16)
+            : int.tryParse(raw);
+        if (code == null || code < 0 || code > 0x10FFFF) return m.group(0)!;
+        return String.fromCharCode(code);
+      },
+    );
+    // Named entities. `&amp;` must come last so pre-existing `&amp;lt;`
+    // becomes `&lt;` and gets fully decoded on the next pass.
+    text = text
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&apos;', "'")
+        .replaceAll('&nbsp;', ' ')
+        .replaceAll('&laquo;', '«')
+        .replaceAll('&raquo;', '»')
+        .replaceAll('&hellip;', '…')
+        .replaceAll('&mdash;', '—')
+        .replaceAll('&ndash;', '–')
+        .replaceAll('&lsquo;', '‘')
+        .replaceAll('&rsquo;', '’')
+        .replaceAll('&ldquo;', '“')
+        .replaceAll('&rdquo;', '”')
+        .replaceAll('&amp;', '&');
+    if (text == before) break;
+  }
+  return text;
+}
+
 /// Supprime les balises HTML et décode les entités HTML courantes.
 ///
 /// Utilisé pour nettoyer les descriptions RSS qui peuvent contenir
 /// du HTML brut avant affichage dans les cards et previews.
 String stripHtml(String html) {
+  // Decode entities first so encoded `&lt;p&gt;` becomes `<p>` and is then
+  // stripped by the tag regex below.
+  var text = decodeHtmlEntities(html);
   // Remove HTML tags
-  var text = html.replaceAll(RegExp(r'<[^>]+>'), '');
-  // Decode common HTML entities
-  text = text
-      .replaceAll('&amp;', '&')
-      .replaceAll('&lt;', '<')
-      .replaceAll('&gt;', '>')
-      .replaceAll('&quot;', '"')
-      .replaceAll('&#39;', "'")
-      .replaceAll('&apos;', "'")
-      .replaceAll('&nbsp;', ' ')
-      .replaceAll('&#8217;', '\u2019')
-      .replaceAll('&#8216;', '\u2018')
-      .replaceAll('&#8220;', '\u201C')
-      .replaceAll('&#8221;', '\u201D');
+  text = text.replaceAll(RegExp(r'<[^>]+>'), '');
   // Collapse multiple whitespace/newlines into single space
   text = text.replaceAll(RegExp(r'\s+'), ' ').trim();
   return text;
@@ -31,20 +65,15 @@ String stripHtml(String html) {
 
 /// Nettoie le HTML d'un article pour le reader in-app.
 ///
-/// - Décode les entités HTML (gère le double encodage RSS)
+/// - Décode les entités HTML (gère le double/triple encodage RSS, named +
+///   numérique)
 /// - Supprime les images et figures (affichées séparément en hero)
 /// - Supprime les paragraphes et divs vides
 /// - Préserve les balises sémantiques (p, h1-h6, blockquote, ul, etc.)
 String sanitizeArticleHtml(String html) {
-  var content = html;
-  // Decode HTML entities (handles double-encoded RSS content)
-  content = content
-      .replaceAll('&amp;', '&')
-      .replaceAll('&lt;', '<')
-      .replaceAll('&gt;', '>')
-      .replaceAll('&quot;', '"')
-      .replaceAll('&#39;', "'")
-      .replaceAll('&apos;', "'");
+  // Decode HTML entities (handles single, double or triple-encoded RSS
+  // content, including named and numeric entities).
+  var content = decodeHtmlEntities(html);
   // Strip figure elements (includes figcaption) — order matters
   content = content.replaceAll(
       RegExp(r'<figure[^>]*>.*?</figure>', dotAll: true), '');
@@ -119,7 +148,7 @@ final _truncationPatterns = [
   RegExp(r'Lire la suite', caseSensitive: false),
   RegExp(r'Read more', caseSensitive: false),
   RegExp(r'Continue reading', caseSensitive: false),
-  RegExp(r"L['']article .+ est apparu en premier sur", caseSensitive: false),
+  RegExp(r"L['’]article .+ est apparu en premier sur", caseSensitive: false),
   RegExp(r'Cet article .+ est publié sur', caseSensitive: false),
   RegExp(r'The post .+ appeared first on', caseSensitive: false),
 ];

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -588,7 +588,7 @@ class _PerspectiveCard extends ConsumerWidget {
                       Expanded(
                         child: Text(
                           perspective.title
-                              .replaceAll(RegExp(r'\s*[-–|]\s*[^-–|]+$'), '')
+                              .replaceAll(RegExp(r'\s+[-–|]\s+[^-–|]+$'), '')
                               .trim(),
                           style: textTheme.bodyMedium?.copyWith(
                             fontWeight: FontWeight.w500,


### PR DESCRIPTION
## What

- **Perspectives — titres tronqués** : le regex qui retire le suffixe source (ex: \" - Le Monde\") matchait aussi les tirets internes, transformant \"L'ex-directeur du FBI\" en \"L'ex\". Le regex exige désormais des espaces autour du séparateur (`\s+[-–|]\s+`).
- **Reader — balises HTML brutes** : nouvelle fonction `decodeHtmlEntities()` qui gère les entités named + numériques (decimal & hex), avec boucle multi-passes pour décoder le multi-encodage RSS (`&amp;lt;p&amp;gt;` → `<p>`). `stripHtml` et `sanitizeArticleHtml` l'utilisent en première étape.

## Why

Deux bugs visuels signalés sur la même session : titres coupés au tiret dans la modale de comparaison, et balises `<p>`/`<h2>`/`<a>` rendues comme texte brut dans le reader pour certains articles dont le flux RSS est doublement encodé.

## Type

- [x] Bug fix

## Checklist

- [x] `flutter analyze` passe sur les fichiers modifiés
- [ ] Tests pass locally
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed