### PR TITLE
fix(reader): keep WebView header/footer hidden by default + on scroll

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -713,20 +713,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       // Reset permanent-footer latch acquired during the CTA reveal scroll
       // so subsequent WebView scroll deltas can hide/show header & footer.
       _footerPermanent.value = false;
-      _footerOffset.value = 0.0;
 
       // Smart-arrival : libère l'écran pour que l'utilisateur puisse interagir
       // avec une éventuelle modale (cookies, paywall) qui verrouille souvent
       // body { overflow: hidden } — sans scroll, le ScrollBridge JS ne peut
       // rien signaler, donc on doit cacher proactivement les overlays.
-      _scrollStopTimer?.cancel(); // sinon le timer hérité du scroll CTA réaffiche le footer
+      // Header & footer restent cachés par défaut en mode WebView et ne
+      // réapparaissent qu'au scroll vers le haut (via _onScrollDelta).
+      _scrollStopTimer?.cancel();
+      _inactivityTimer?.cancel();
       _animateHeaderTo(1.0);
       _animateFooterTo(1.0);
-
-      // Header revient après 2 s pour permettre la navigation back.
-      Timer(const Duration(seconds: 2), () {
-        if (mounted && _isWebViewActive) _animateHeaderTo(0.0);
-      });
     }
   }
 
@@ -799,13 +796,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             (_footerOffset.value + footerShift).clamp(0.0, 1.0);
       }
     }
-    // FABs + footer reappear after 2.5s of scroll inactivity
+    // FABs + footer reappear after 2.5s of scroll inactivity.
+    // Skip the footer reappear in WebView mode — overlays must stay hidden
+    // until the user explicitly scrolls up to maximise reading space.
     _scrollStopTimer?.cancel();
     _scrollStopTimer = Timer(const Duration(milliseconds: 2000), () {
       if (mounted) {
         _fabOpacity.value = 1.0;
         _fabReappearController.forward(from: 0);
-        _animateFooterTo(0.0);
+        if (!_isWebViewActive) _animateFooterTo(0.0);
       }
     });
     // Auto-hide header after 3s of inactivity (no scroll), but only if not at top


### PR DESCRIPTION
## What

In scroll-to-site WebView mode, hide the header and footer on arrival and keep them hidden while scrolling — they only reappear when the user scrolls up.

## Why

After PR #500 the WebView still re-showed the header 2s after activation and re-showed the footer 2s after every scroll stop, eating reading space. The user wants the overlays out of the way by default in WebView, like the native Facteur reader.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (mobile-only — needs device QA)