### PR TITLE
fix(reader): unblock WebView overlay hide/show on scroll

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -779,8 +779,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     }
     // In video readers the header stays visible at all times (only native
     // fullscreen covers it, which is handled by the system).
-    // For short articles that don't need scrolling, keep header visible.
-    if (!isVideo && !_isShortArticle) {
+    // For short articles that don't need scrolling, keep header visible —
+    // EXCEPT in WebView mode where scroll comes from the JS bridge and the
+    // user expects hide-on-scroll regardless of how short the in-app stub was.
+    if (!isVideo && (!_isShortArticle || _isWebViewActive)) {
       final headerHeight =
           MediaQuery.of(context).padding.top + _kHeaderContentHeight;
       final shift = delta / headerHeight;
@@ -809,7 +811,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     });
     // Auto-hide header after 3s of inactivity (no scroll), but only if not at top
     _inactivityTimer?.cancel();
-    if (!isVideo && !_isShortArticle) {
+    if (!isVideo && (!_isShortArticle || _isWebViewActive)) {
       _inactivityTimer = Timer(const Duration(seconds: 3), () {
         if (mounted && _webScrollY > 0 && _headerOffset.value < 1.0) {
           _animateHeaderTo(1.0);
@@ -1644,8 +1646,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   if (metrics.maxScrollExtent > 0) {
                     final rawProgress =
                         metrics.pixels / metrics.maxScrollExtent;
-                    // Footer becomes permanent at end of ALL content (incl. perspectives)
-                    if (!_footerPermanent.value && rawProgress >= 0.98) {
+                    // Footer becomes permanent at end of ALL content (incl.
+                    // perspectives) for native in-app reading. Skip for
+                    // scroll-to-site (CTA tapped) where reaching the end means
+                    // revealing the WebView, not finishing reading — locking
+                    // the footer there would freeze it visible during the
+                    // entire WebView session.
+                    if (!_footerPermanent.value &&
+                        !_ctaTapped &&
+                        rawProgress >= 0.98) {
                       _footerPermanent.value = true;
                       _animateFooterTo(0.0);
                     }

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -713,20 +713,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       // Reset permanent-footer latch acquired during the CTA reveal scroll
       // so subsequent WebView scroll deltas can hide/show header & footer.
       _footerPermanent.value = false;
-      _footerOffset.value = 0.0;
 
       // Smart-arrival : libère l'écran pour que l'utilisateur puisse interagir
       // avec une éventuelle modale (cookies, paywall) qui verrouille souvent
       // body { overflow: hidden } — sans scroll, le ScrollBridge JS ne peut
       // rien signaler, donc on doit cacher proactivement les overlays.
-      _scrollStopTimer?.cancel(); // sinon le timer hérité du scroll CTA réaffiche le footer
+      // Header & footer restent cachés par défaut en mode WebView et ne
+      // réapparaissent qu'au scroll vers le haut (via _onScrollDelta).
+      _scrollStopTimer?.cancel();
+      _inactivityTimer?.cancel();
       _animateHeaderTo(1.0);
       _animateFooterTo(1.0);
-
-      // Header revient après 2 s pour permettre la navigation back.
-      Timer(const Duration(seconds: 2), () {
-        if (mounted && _isWebViewActive) _animateHeaderTo(0.0);
-      });
     }
   }
 
@@ -799,13 +796,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             (_footerOffset.value + footerShift).clamp(0.0, 1.0);
       }
     }
-    // FABs + footer reappear after 2.5s of scroll inactivity
+    // FABs + footer reappear after 2.5s of scroll inactivity.
+    // Skip the footer reappear in WebView mode — overlays must stay hidden
+    // until the user explicitly scrolls up to maximise reading space.
     _scrollStopTimer?.cancel();
     _scrollStopTimer = Timer(const Duration(milliseconds: 2000), () {
       if (mounted) {
         _fabOpacity.value = 1.0;
         _fabReappearController.forward(from: 0);
-        _animateFooterTo(0.0);
+        if (!_isWebViewActive) _animateFooterTo(0.0);
       }
     });
     // Auto-hide header after 3s of inactivity (no scroll), but only if not at top


### PR DESCRIPTION
## What

Restore proper hide-on-scroll-down / show-on-scroll-up of the header & footer in scroll-to-site WebView mode, after #500/#504 left them frozen.

## Why

Two distinct freezes were stacking:

1. The CTA reveal scroll always hits >=98% of LAYER 1's maxScrollExtent, which tripped the "user reached end of article" branch and locked \`_footerPermanent\` → footer stuck visible for the whole WebView session. Now gated by \`!_ctaTapped\`.
2. Partial-content articles have an essentially empty in-app body, so \`maxScrollExtent < 50\` flipped \`_isShortArticle = true\`. \`_onScrollDelta\` then skipped header/footer adjustments — JS-bridge scrolls inside the WebView had no effect. Now \`_isWebViewActive\` bypasses the short-article gate.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally
- [ ] Linting passes
- [x] No new Python \`List[]\` imports
- [ ] Peer Review Conductor completed

## Staging

- [x] N/A (mobile-only — needs device QA on partial AND full-content articles)