### PR TITLE
feat(feed): Pépites carousel — sources curées recommandées (Story 13.2)

### DIFF
--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -58,6 +58,7 @@ import '../widgets/interest_filter_sheet.dart';
 import '../../digest/providers/serein_toggle_provider.dart';
 import '../../digest/widgets/serein_toggle_chip.dart';
 import '../../sources/providers/sources_providers.dart';
+import '../../sources/widgets/pepites_carousel.dart';
 import '../../progress/widgets/progression_card.dart';
 import '../../../shared/widgets/loaders/loading_view.dart';
 import '../../../shared/widgets/mode_accent.dart';
@@ -678,6 +679,13 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                             contents.length > 6;
                         const savedNudgePos = 6;
 
+                        // Backend gère rate-limit + cool-down : liste vide → widget invisible.
+                        final pepitesAsync = ref.watch(pepitesProvider);
+                        final pepitesList = pepitesAsync.valueOrNull ?? const [];
+                        final showPepitesCarousel = pepitesList.isNotEmpty &&
+                            contents.length > 3;
+                        const pepitesCarouselPos = 3;
+
                         // Empty state when a filter is active but no results
                         final hasActiveFilter =
                             notifier.selectedTheme != null ||
@@ -697,7 +705,10 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                         // trailing (loader ou spacer). CaughtUp et SavedNudge sont
                         // mutuellement exclusifs → intercalatedCount ≤ 1.
                         final int intercalatedCount =
-                            (showCaughtUp ? 1 : 0) + (showSavedNudge ? 1 : 0) + sortedCarousels.length;
+                            (showCaughtUp ? 1 : 0) +
+                            (showSavedNudge ? 1 : 0) +
+                            (showPepitesCarousel ? 1 : 0) +
+                            sortedCarousels.length;
                         final int effectiveChildCount =
                             contents.isEmpty ? 1 : contents.length + intercalatedCount + 1;
 
@@ -784,6 +795,21 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                                 // Compter la CaughtUpCard si elle est passée (pour le décalage)
                                 if (showCaughtUp && listIndex > caughtUpPos) {
                                   contentOffset++;
+                                }
+
+                                if (showPepitesCarousel) {
+                                  final pepitesEffectivePos =
+                                      pepitesCarouselPos + contentOffset;
+                                  if (listIndex == pepitesEffectivePos) {
+                                    return const Padding(
+                                      key: ValueKey('pepites_carousel'),
+                                      padding: EdgeInsets.only(bottom: 16),
+                                      child: PepitesCarousel(),
+                                    );
+                                  }
+                                  if (listIndex > pepitesEffectivePos) {
+                                    contentOffset++;
+                                  }
                                 }
 
                                 // Saved Nudge at position 6

--- a/apps/mobile/lib/features/sources/providers/sources_providers.dart
+++ b/apps/mobile/lib/features/sources/providers/sources_providers.dart
@@ -49,6 +49,41 @@ final userSourcesProvider =
   return UserSourcesNotifier();
 });
 
+/// Pépites — sources curées poussées dans le feed.
+/// Liste vide si aucun trigger actif, rate-limit, ou cool-down côté backend.
+final pepitesProvider =
+    AsyncNotifierProvider<PepitesNotifier, List<Source>>(() {
+  return PepitesNotifier();
+});
+
+class PepitesNotifier extends AsyncNotifier<List<Source>> {
+  @override
+  Future<List<Source>> build() async {
+    final repository = ref.watch(sourcesRepositoryProvider);
+    return repository.getPepites();
+  }
+
+  /// Dismiss le carousel côté backend + vide l'état local.
+  Future<void> dismiss() async {
+    final repository = ref.read(sourcesRepositoryProvider);
+    state = const AsyncValue.data([]);
+    try {
+      await repository.dismissPepiteCarousel();
+    } catch (e, stack) {
+      // ignore: avoid_print
+      print('PepitesNotifier: [ERROR] dismiss failed: $e\n$stack');
+    }
+  }
+
+  /// Retire localement une source (après follow) sans refetch.
+  void removeLocal(String sourceId) {
+    if (!state.hasValue) return;
+    state = AsyncValue.data(
+      state.value!.where((s) => s.id != sourceId).toList(),
+    );
+  }
+}
+
 class UserSourcesNotifier extends AsyncNotifier<List<Source>> {
   @override
   Future<List<Source>> build() async {

--- a/apps/mobile/lib/features/sources/repositories/sources_repository.dart
+++ b/apps/mobile/lib/features/sources/repositories/sources_repository.dart
@@ -203,6 +203,36 @@ class SourcesRepository {
     }
   }
 
+  Future<List<Source>> getPepites({int limit = 4}) async {
+    try {
+      final response = await _apiClient.dio
+          .get<dynamic>('sources/pepites', queryParameters: {'limit': limit});
+      if (response.statusCode == 200) {
+        final data = response.data;
+        if (data is List) {
+          return data
+              .map((json) => Source.fromJson(json as Map<String, dynamic>))
+              .toList();
+        }
+      }
+      return [];
+    } catch (e) {
+      // ignore: avoid_print
+      print('SourcesRepository: [ERROR] getPepites: $e');
+      return [];
+    }
+  }
+
+  Future<void> dismissPepiteCarousel() async {
+    try {
+      await _apiClient.dio.post<dynamic>('sources/pepites/dismiss');
+    } catch (e) {
+      // ignore: avoid_print
+      print('SourcesRepository: [ERROR] dismissPepiteCarousel: $e');
+      rethrow;
+    }
+  }
+
   Future<ThemeSourcesResponse> getSourcesByTheme(String slug) async {
     try {
       final response =

--- a/apps/mobile/lib/features/sources/widgets/pepite_card.dart
+++ b/apps/mobile/lib/features/sources/widgets/pepite_card.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../models/source_model.dart';
+
+/// Carte "Pépite" affichée dans le carousel de recommandation de sources.
+/// Logo central, nom, validation sociale, bouton "Suivre" explicite.
+class PepiteCard extends StatelessWidget {
+  final Source source;
+  final VoidCallback onFollow;
+  final VoidCallback onTap;
+  final bool isFollowing;
+
+  const PepiteCard({
+    super.key,
+    required this.source,
+    required this.onFollow,
+    required this.onTap,
+    this.isFollowing = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Container(
+        width: 170,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(FacteurRadius.medium),
+          border: Border.all(color: colors.border),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            _buildLogo(colors),
+            const SizedBox(height: 10),
+            Text(
+              source.name,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              _socialProof(),
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: colors.textSecondary,
+                    fontSize: 11,
+                  ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              height: 32,
+              child: ElevatedButton(
+                onPressed: isFollowing ? null : onFollow,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: colors.primary,
+                  foregroundColor: colors.textPrimary,
+                  disabledBackgroundColor: colors.primary.withValues(alpha: 0.5),
+                  elevation: 0,
+                  padding: EdgeInsets.zero,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(FacteurRadius.small),
+                  ),
+                ),
+                child: Text(
+                  isFollowing ? '…' : 'Suivre',
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _socialProof() {
+    final n = source.followerCount;
+    if (n <= 0) return 'Source de confiance';
+    final lecteurs = n > 1 ? 'lecteurs' : 'lecteur';
+    return 'Source de confiance\nde $n $lecteurs';
+  }
+
+  Widget _buildLogo(FacteurColors colors) {
+    if (source.logoUrl != null && source.logoUrl!.isNotEmpty) {
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(FacteurRadius.small),
+        child: Image.network(
+          source.logoUrl!,
+          width: 48,
+          height: 48,
+          fit: BoxFit.cover,
+          errorBuilder: (_, __, ___) => _buildLogoFallback(colors),
+        ),
+      );
+    }
+    return _buildLogoFallback(colors);
+  }
+
+  Widget _buildLogoFallback(FacteurColors colors) {
+    return Container(
+      width: 48,
+      height: 48,
+      decoration: BoxDecoration(
+        color: colors.backgroundSecondary,
+        borderRadius: BorderRadius.circular(FacteurRadius.small),
+      ),
+      child: Icon(
+        PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
+        size: 22,
+        color: colors.primary,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/sources/widgets/pepite_preview_sheet.dart
+++ b/apps/mobile/lib/features/sources/widgets/pepite_preview_sheet.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../../../shared/widgets/buttons/primary_button.dart';
+import '../models/source_model.dart';
+
+/// Bottom sheet déclenchée au tap sur une PepiteCard (hors bouton "Suivre").
+/// Affiche plus de contexte sur la source et expose un CTA "Suivre" explicite.
+class PepitePreviewSheet extends StatelessWidget {
+  final Source source;
+  final VoidCallback onFollow;
+
+  const PepitePreviewSheet({
+    super.key,
+    required this.source,
+    required this.onFollow,
+  });
+
+  static Future<void> show(
+    BuildContext context, {
+    required Source source,
+    required VoidCallback onFollow,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => PepitePreviewSheet(
+        source: source,
+        onFollow: () {
+          Navigator.of(ctx).pop();
+          onFollow();
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      padding: EdgeInsets.only(
+        left: FacteurSpacing.space4,
+        right: FacteurSpacing.space4,
+        top: FacteurSpacing.space3,
+        bottom: MediaQuery.of(context).viewInsets.bottom + FacteurSpacing.space6,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: colors.border,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          Row(
+            children: [
+              _buildLogo(colors),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      source.name,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      source.getThemeLabel(),
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color: colors.primary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          if (source.followerCount > 0)
+            Row(
+              children: [
+                Icon(
+                  PhosphorIcons.users(PhosphorIconsStyle.regular),
+                  size: 14,
+                  color: colors.textSecondary,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  'Source de confiance de ${source.followerCount} '
+                  '${source.followerCount > 1 ? "lecteurs" : "lecteur"}',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colors.textSecondary,
+                      ),
+                ),
+              ],
+            ),
+          if (source.description != null &&
+              source.description!.trim().isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Text(
+              source.description!,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: colors.textSecondary,
+                    height: 1.4,
+                  ),
+            ),
+          ],
+          const SizedBox(height: 24),
+          PrimaryButton(
+            label: 'Suivre cette source',
+            icon: PhosphorIcons.plus(PhosphorIconsStyle.bold),
+            onPressed: onFollow,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLogo(FacteurColors colors) {
+    if (source.logoUrl != null && source.logoUrl!.isNotEmpty) {
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(FacteurRadius.medium),
+        child: Image.network(
+          source.logoUrl!,
+          width: 56,
+          height: 56,
+          fit: BoxFit.cover,
+          errorBuilder: (_, __, ___) => _buildLogoFallback(colors),
+        ),
+      );
+    }
+    return _buildLogoFallback(colors);
+  }
+
+  Widget _buildLogoFallback(FacteurColors colors) {
+    return Container(
+      width: 56,
+      height: 56,
+      decoration: BoxDecoration(
+        color: colors.backgroundSecondary,
+        borderRadius: BorderRadius.circular(FacteurRadius.medium),
+      ),
+      child: Icon(
+        PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
+        size: 26,
+        color: colors.primary,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/sources/widgets/pepites_carousel.dart
+++ b/apps/mobile/lib/features/sources/widgets/pepites_carousel.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../models/source_model.dart';
+import '../providers/sources_providers.dart';
+import 'pepite_card.dart';
+import 'pepite_preview_sheet.dart';
+
+/// Carousel de recommandations de sources curées ("Pépites"), affiché dans
+/// le feed pour aider à découvrir des sources de qualité. Visibilité gérée
+/// côté backend (rate-limit + cool-down) : liste vide → SizedBox.shrink.
+class PepitesCarousel extends ConsumerWidget {
+  const PepitesCarousel({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final asyncPepites = ref.watch(pepitesProvider);
+
+    return asyncPepites.when(
+      data: (sources) {
+        if (sources.isEmpty) return const SizedBox.shrink();
+        return _buildCarousel(context, ref, colors, sources);
+      },
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+    );
+  }
+
+  Widget _buildCarousel(
+    BuildContext context,
+    WidgetRef ref,
+    FacteurColors colors,
+    List<Source> sources,
+  ) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 14),
+      decoration: BoxDecoration(
+        color: colors.backgroundSecondary,
+        borderRadius: BorderRadius.circular(FacteurRadius.medium),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 14),
+            child: Row(
+              children: [
+                Icon(
+                  PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                  size: 16,
+                  color: colors.primary,
+                ),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    'Des sources à découvrir',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                  ),
+                ),
+                _DismissButton(
+                  onPressed: () =>
+                      ref.read(pepitesProvider.notifier).dismiss(),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+          SizedBox(
+            height: 200,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 14),
+              itemCount: sources.length,
+              separatorBuilder: (_, __) => const SizedBox(width: 10),
+              itemBuilder: (_, index) {
+                final source = sources[index];
+                return PepiteCard(
+                  source: source,
+                  onFollow: () => _onFollow(context, ref, source),
+                  onTap: () => _onTap(context, ref, source),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _onFollow(
+    BuildContext context,
+    WidgetRef ref,
+    Source source,
+  ) async {
+    ref.read(pepitesProvider.notifier).removeLocal(source.id);
+    try {
+      await ref.read(sourcesRepositoryProvider).trustSource(source.id);
+      ref.invalidate(userSourcesProvider);
+    } catch (_) {
+      // silent : retry au prochain refresh
+    }
+  }
+
+  void _onTap(BuildContext context, WidgetRef ref, Source source) {
+    PepitePreviewSheet.show(
+      context,
+      source: source,
+      onFollow: () => _onFollow(context, ref, source),
+    );
+  }
+}
+
+class _DismissButton extends StatelessWidget {
+  final VoidCallback onPressed;
+
+  const _DismissButton({required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Semantics(
+      label: 'Masquer les recommandations',
+      button: true,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(20),
+        child: Padding(
+          padding: const EdgeInsets.all(6),
+          child: Icon(
+            PhosphorIcons.x(PhosphorIconsStyle.bold),
+            size: 16,
+            color: colors.textSecondary,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/sources/widgets/pepite_card_test.dart
+++ b/apps/mobile/test/features/sources/widgets/pepite_card_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/widgets/pepite_card.dart';
+
+void main() {
+  group('PepiteCard', () {
+    Source mk({int followers = 42, String? logo}) => Source(
+          id: 'src-1',
+          name: 'Le Grand Continent',
+          type: SourceType.article,
+          theme: 'international',
+          logoUrl: logo,
+          followerCount: followers,
+        );
+
+    Widget wrap(Widget child) => ProviderScope(
+          child: MaterialApp(
+            theme: FacteurTheme.lightTheme,
+            home: Scaffold(body: Center(child: child)),
+          ),
+        );
+
+    testWidgets('renders source name and social proof', (tester) async {
+      await tester.pumpWidget(wrap(PepiteCard(
+        source: mk(followers: 340),
+        onFollow: () {},
+        onTap: () {},
+      )));
+
+      expect(find.text('Le Grand Continent'), findsOneWidget);
+      expect(find.textContaining('Source de confiance'), findsOneWidget);
+      expect(find.textContaining('340'), findsOneWidget);
+      expect(find.text('Suivre'), findsOneWidget);
+    });
+
+    testWidgets('omits follower count when 0', (tester) async {
+      await tester.pumpWidget(wrap(PepiteCard(
+        source: mk(followers: 0),
+        onFollow: () {},
+        onTap: () {},
+      )));
+
+      expect(find.text('Source de confiance'), findsOneWidget);
+      expect(find.textContaining('lecteur'), findsNothing);
+    });
+
+    testWidgets('Suivre button fires onFollow', (tester) async {
+      var followTapped = false;
+      var cardTapped = false;
+
+      await tester.pumpWidget(wrap(PepiteCard(
+        source: mk(),
+        onFollow: () => followTapped = true,
+        onTap: () => cardTapped = true,
+      )));
+
+      await tester.tap(find.text('Suivre'));
+      await tester.pump();
+
+      expect(followTapped, isTrue);
+      expect(cardTapped, isFalse);
+    });
+
+    testWidgets('tapping body (not button) fires onTap', (tester) async {
+      var followTapped = false;
+      var cardTapped = false;
+
+      await tester.pumpWidget(wrap(PepiteCard(
+        source: mk(),
+        onFollow: () => followTapped = true,
+        onTap: () => cardTapped = true,
+      )));
+
+      await tester.tap(find.text('Le Grand Continent'));
+      await tester.pump();
+
+      expect(cardTapped, isTrue);
+      expect(followTapped, isFalse);
+    });
+
+    testWidgets('disables Suivre while isFollowing', (tester) async {
+      await tester.pumpWidget(wrap(PepiteCard(
+        source: mk(),
+        onFollow: () {},
+        onTap: () {},
+        isFollowing: true,
+      )));
+
+      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      expect(button.onPressed, isNull);
+    });
+  });
+}

--- a/apps/mobile/test/features/sources/widgets/pepites_carousel_test.dart
+++ b/apps/mobile/test/features/sources/widgets/pepites_carousel_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/providers/sources_providers.dart';
+import 'package:facteur/features/sources/widgets/pepites_carousel.dart';
+
+class _FakePepitesNotifier extends PepitesNotifier {
+  _FakePepitesNotifier(this._initial);
+  final List<Source> _initial;
+  int dismissCalls = 0;
+
+  @override
+  Future<List<Source>> build() async => _initial;
+
+  @override
+  Future<void> dismiss() async {
+    dismissCalls++;
+    state = const AsyncValue.data([]);
+  }
+}
+
+void main() {
+  group('PepitesCarousel', () {
+    final mockSources = [
+      Source(
+        id: '1',
+        name: 'Le Grand Continent',
+        type: SourceType.article,
+        theme: 'international',
+        followerCount: 340,
+      ),
+      Source(
+        id: '2',
+        name: 'Next.ink',
+        type: SourceType.article,
+        theme: 'tech',
+        followerCount: 128,
+      ),
+    ];
+
+    Widget wrap({required List<Source> sources, _FakePepitesNotifier? notifier}) {
+      final fake = notifier ?? _FakePepitesNotifier(sources);
+      return ProviderScope(
+        overrides: [
+          pepitesProvider.overrideWith(() => fake),
+        ],
+        child: MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: const Scaffold(body: PepitesCarousel()),
+        ),
+      );
+    }
+
+    testWidgets('renders title and source cards when data loaded',
+        (tester) async {
+      await tester.pumpWidget(wrap(sources: mockSources));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Des sources à découvrir'), findsOneWidget);
+      expect(find.text('Le Grand Continent'), findsOneWidget);
+      expect(find.text('Next.ink'), findsOneWidget);
+    });
+
+    testWidgets('renders nothing when list is empty', (tester) async {
+      await tester.pumpWidget(wrap(sources: const []));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Des sources à découvrir'), findsNothing);
+    });
+
+    testWidgets('dismiss button calls notifier.dismiss', (tester) async {
+      final fake = _FakePepitesNotifier(mockSources);
+      await tester.pumpWidget(wrap(sources: mockSources, notifier: fake));
+      await tester.pumpAndSettle();
+
+      final dismiss = find.bySemanticsLabel('Masquer les recommandations');
+      expect(dismiss, findsOneWidget);
+
+      await tester.tap(dismiss);
+      await tester.pumpAndSettle();
+
+      expect(fake.dismissCalls, 1);
+      expect(find.text('Le Grand Continent'), findsNothing);
+    });
+  });
+}

--- a/docs/qa/scripts/seed_feed_pepites.sql
+++ b/docs/qa/scripts/seed_feed_pepites.sql
@@ -1,0 +1,66 @@
+-- Story 13.2 — Feed Pépites Carousel
+--
+-- A exécuter dans Supabase SQL Editor (prod + staging).
+--
+-- 1. Applique la migration Alembic (`pr01_feed_pepites_carousel`) manuellement
+--    si Alembic n'a pas été run : ajoute les 2 colonnes sur `sources` et les 2
+--    timestamps sur `user_personalization`. Idempotent.
+-- 2. Seed initial : flag les sources à pousser dans le carousel.
+--
+-- Pour retirer une source du carousel plus tard :
+--   UPDATE sources SET is_pepite_recommendation = FALSE WHERE name = '…';
+-- Pour en ajouter une :
+--   UPDATE sources SET is_pepite_recommendation = TRUE,
+--          pepite_for_themes = ARRAY['tech']
+--   WHERE name = '…';
+
+BEGIN;
+
+-- 1. Migration (idempotent). À skipper si Alembic a déjà joué pr01.
+ALTER TABLE sources
+  ADD COLUMN IF NOT EXISTS is_pepite_recommendation BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE sources
+  ADD COLUMN IF NOT EXISTS pepite_for_themes TEXT[];
+
+CREATE INDEX IF NOT EXISTS ix_sources_is_pepite_recommendation
+  ON sources (is_pepite_recommendation);
+
+ALTER TABLE user_personalization
+  ADD COLUMN IF NOT EXISTS pepite_carousel_dismissed_at TIMESTAMPTZ;
+
+ALTER TABLE user_personalization
+  ADD COLUMN IF NOT EXISTS pepite_carousel_last_shown_at TIMESTAMPTZ;
+
+-- 2. Seed initial — curation manuelle (liste à finaliser par Laurin).
+-- Les `pepite_for_themes` sont utilisés pour prioriser l'affichage aux users
+-- dont les thèmes suivis matchent. Sans match, les sources restent éligibles
+-- mais passent après les matchs.
+
+UPDATE sources
+   SET is_pepite_recommendation = TRUE,
+       pepite_for_themes = ARRAY['geopolitics', 'international']
+ WHERE name ILIKE '%grand continent%';
+
+UPDATE sources
+   SET is_pepite_recommendation = TRUE,
+       pepite_for_themes = ARRAY['tech']
+ WHERE name ILIKE 'next.ink' OR name ILIKE 'next inpact%';
+
+UPDATE sources
+   SET is_pepite_recommendation = TRUE,
+       pepite_for_themes = ARRAY['society', 'science']
+ WHERE name ILIKE 'the conversation%';
+
+UPDATE sources
+   SET is_pepite_recommendation = TRUE,
+       pepite_for_themes = ARRAY['environment']
+ WHERE name ILIKE 'ethic et tac%';
+
+-- Vérification :
+SELECT id, name, theme, pepite_for_themes
+  FROM sources
+ WHERE is_pepite_recommendation = TRUE
+ ORDER BY name;
+
+COMMIT;

--- a/docs/stories/core/13.2.feed-pepites-carousel.story.md
+++ b/docs/stories/core/13.2.feed-pepites-carousel.story.md
@@ -1,0 +1,163 @@
+# Story 13.2: Carousel "Pépites" dans le feed — recommandation de sources curées
+
+## Status: Ready for Review
+
+## Change Log
+
+- **2026-04-21** — Rate-limit adaptatif par palier de sources suivies (Option A) + suppression du trigger d'inactivité. Tous les utilisateurs sont désormais éligibles, avec une fréquence d'affichage inversement proportionnelle au nombre de sources suivies (`<20` → 24h, `20–50` → 7j, `>50` → 14j). Motivation : sur les comptes investis (>50 sources), l'ancien trigger retournait toujours False ; la feature était invisible malgré le curatage manuel. Fichiers touchés : `pepite_service.py`, `test_pepite_service.py`, cette story. Pas de changement mobile.
+
+## Story
+
+**As a** utilisateur Facteur qui suit peu de sources (souvent < 20) ou qui n'en a pas ajouté depuis plus d'une semaine,
+**I want** découvrir, directement dans le feed, des sources à haute rigueur journalistique curées manuellement par l'équipe, avec une validation sociale claire,
+**so that** mon feed s'enrichit vers du contenu de qualité en un tap, sans avoir à chercher activement, et respectant le rythme "moment de fermeture" de l'app.
+
+## Context
+
+### Problème produit
+- Beaucoup de comptes ont un feed pauvre par manque de sources suivies.
+- Ils passent à côté de sources excellentes (Le Grand Continent, Next.ink, The Conversation, Ethic et Tac…).
+- Aucune mécanique n'existe actuellement pour pousser ces sources au bon moment dans l'UX.
+
+### Solution
+- Un mini-carousel horizontal **"Des sources à découvrir"** intercalé dans le feed à la position 3.
+- Sélection **curée manuellement** par Laurin via 2 champs sur `sources` (flag + thèmes associés), maintenue directement via SQL Supabase.
+- **Tous les utilisateurs sont éligibles** — la fréquence d'affichage varie inversement avec l'investissement dans l'app (rate-limit adaptatif par palier de sources suivies).
+- Validation sociale affichée : "Source de confiance de {N} lecteurs" (calculée dynamiquement).
+- Tap sur la card → preview source existante (`SourcePreviewCard`). Follow = bouton explicite (intentionnel).
+- Dismiss carousel-level (pas par source en v1) : cool-down 7j avant réapparition.
+- **Rate-limit adaptatif** : `<20 sources` → 1×/24h, `20–50 sources` → 1×/7j, `>50 sources` → 1×/14j.
+
+## Acceptance Criteria
+
+1. ✅ 2 nouvelles colonnes sur `sources` : `is_pepite_recommendation` (bool NOT NULL default false, indexée), `pepite_for_themes` (text[] nullable).
+2. ✅ 2 nouvelles colonnes sur `user_personalization` : `pepite_carousel_dismissed_at` (timestamptz nullable), `pepite_carousel_last_shown_at` (timestamptz nullable).
+3. ✅ Endpoint `GET /sources/pepites?limit=4` retourne jusqu'à 4 `SourceResponse` quand le rate-limit adaptatif (selon palier de sources suivies) et le cool-down le permettent. Liste vide sinon (réponse 200 `[]`).
+4. ✅ L'endpoint exclut les sources déjà suivies (`UserSource`) et les sources mutées (`UserPersonalization.muted_sources`).
+5. ✅ Priorisation : sources dont `pepite_for_themes` ∩ thèmes suivis du user est non-vide d'abord, puis les autres.
+6. ✅ Le champ `follower_count` est calculé au vol (pattern `func.count(UserSource.user_id)`) et renvoyé dans la réponse.
+7. ✅ Un appel réussi met à jour `pepite_carousel_last_shown_at`.
+8. ✅ Endpoint `POST /sources/pepites/dismiss` → 204. Met à jour `pepite_carousel_dismissed_at = now()`.
+9. ✅ Mobile : widget `PepitesCarousel` + `PepiteCard` implémentés, style visuellement distinct des carousels de contenu (pas de thumbnail d'article, logo source central, fond différencié).
+10. ✅ Intégration dans `feed_screen.dart` à la position 3, sans régresser les interstitiels existants (`CaughtUpCard`, `SavedNudge`, `FeedCarousel`).
+11. ✅ Tap sur la card (hors bouton "Suivre") → `SourcePreviewCard` ouverte (bottom sheet existant).
+12. ✅ Bouton "Suivre" explicite → `toggleTrust()` optimiste + retire la card du carousel.
+13. ✅ Tap ✕ → dismiss carousel + `dismissPepiteCarousel()` appelé.
+14. ✅ Tests backend (service + endpoints) et mobile (widgets + intégration) verts. `flutter analyze` clean.
+
+## Plan technique
+
+### Data model
+
+#### Migration Alembic (`pr01_feed_pepites_carousel.py`, down_revision = `sr01_add_serein_exclusion`)
+```python
+op.add_column("sources", sa.Column("is_pepite_recommendation", sa.Boolean(), nullable=False, server_default="false"))
+op.add_column("sources", sa.Column("pepite_for_themes", sa.ARRAY(sa.Text()), nullable=True))
+op.create_index("ix_sources_is_pepite_recommendation", "sources", ["is_pepite_recommendation"])
+
+op.add_column("user_personalization", sa.Column("pepite_carousel_dismissed_at", sa.DateTime(timezone=True), nullable=True))
+op.add_column("user_personalization", sa.Column("pepite_carousel_last_shown_at", sa.DateTime(timezone=True), nullable=True))
+```
+
+Application en prod via **Supabase SQL Editor** (règle du projet — pas d'alembic upgrade sur Railway).
+
+### Backend
+
+**Models** (`app/models/source.py`, `app/models/user_personalization.py`)
+- Ajouter les 4 champs correspondants.
+
+**Service** (`app/services/pepite_service.py` — nouveau)
+- `should_show_pepite_carousel(user_id) -> bool`
+  - Short-circuit si `pepite_carousel_dismissed_at > now - 7 days` (cool-down)
+  - Sinon, fetch `source_count` puis applique rate-limit adaptatif :
+    - `< 20` sources → 24h
+    - `20–50` sources → 7j
+    - `> 50` sources → 14j
+- `get_pepites_for_user(user_id, limit=4) -> list[SourceResponse]`
+  - `should_show_pepite_carousel` gate
+  - SELECT sources WHERE `is_pepite_recommendation AND is_active AND id NOT IN (user_sources) AND id NOT IN (muted_sources)`
+  - Compute `follower_count` per candidate
+  - Prioritize by theme match (`pepite_for_themes ∩ user_interests`) — then by follower_count DESC
+  - LIMIT `limit`
+  - Update `pepite_carousel_last_shown_at = now()` (commit if non-empty result)
+- `dismiss_pepite_carousel(user_id) -> None`
+  - UPSERT `user_personalization.pepite_carousel_dismissed_at = now()`
+
+**Routes** (`app/routers/sources.py` — ajouter)
+- `GET /sources/pepites?limit=4` → `list[SourceResponse]`
+- `POST /sources/pepites/dismiss` → 204
+
+### Mobile
+
+**Repository** (`features/sources/repositories/sources_repository.dart`)
+- `Future<List<Source>> getPepites({int limit = 4})`
+- `Future<void> dismissPepiteCarousel()`
+
+**Provider** (`features/sources/providers/sources_providers.dart`)
+- `pepitesProvider` (FutureProvider `AsyncValue<List<Source>>`)
+- Dismiss notifier qui invalide le provider après dismiss
+
+**Widgets** (nouveaux)
+- `features/sources/widgets/pepites_carousel.dart` — header + liste horizontale + bouton ✕
+- `features/sources/widgets/pepite_card.dart` — logo / nom / "Source de confiance de N lecteurs" / CTA Suivre
+
+**Intégration** (`features/feed/screens/feed_screen.dart`)
+- Ajouter à la position 3 dans le `SliverChildBuilderDelegate`
+- Ajuster `effectiveChildCount`
+
+### Tests
+
+**Backend** (`tests/services/test_pepite_service.py`, `tests/routers/test_sources_pepites.py`)
+- Paliers de rate-limit (`_rate_limit_hours`) : < 20 → 24h, 20–50 → 7j, > 50 → 14j
+- Rate-limit bloque dans chaque palier selon la fenêtre correspondante
+- Dismiss récent (< 7j) court-circuite sans query source_count
+- Autorisé quand aucune personalization OU window dépassée
+- Exclusion sources déjà suivies
+- Exclusion sources mutées
+- Priorisation par thème
+- Endpoint POST dismiss persiste le timestamp
+
+**Mobile** (`test/features/sources/widgets/*_test.dart`)
+- `PepiteCard` : rendu logo/nom/follower_count, tap "Suivre", tap card → preview
+- `PepitesCarousel` : rendu, état vide, dismiss ✕
+- `feed_screen` : carousel présent à pos 3 quand pépites non-vide, absent sinon
+
+### Seeding (post-déploiement, via Supabase SQL Editor)
+
+Script fourni séparément pour que Laurin active la liste finale :
+```sql
+UPDATE sources SET is_pepite_recommendation = TRUE, pepite_for_themes = ARRAY['international']
+  WHERE name = 'Le Grand Continent';
+UPDATE sources SET is_pepite_recommendation = TRUE, pepite_for_themes = ARRAY['tech']
+  WHERE name = 'Next.ink';
+-- etc.
+```
+
+## Files impactés
+
+### Backend
+- `packages/api/alembic/versions/pr01_feed_pepites_carousel.py` (nouveau)
+- `packages/api/app/models/source.py` (modifié)
+- `packages/api/app/models/user_personalization.py` (modifié)
+- `packages/api/app/services/pepite_service.py` (nouveau)
+- `packages/api/app/routers/sources.py` (modifié)
+- `packages/api/tests/services/test_pepite_service.py` (nouveau)
+- `packages/api/tests/routers/test_sources_pepites.py` (nouveau)
+
+### Mobile
+- `apps/mobile/lib/features/sources/widgets/pepites_carousel.dart` (nouveau)
+- `apps/mobile/lib/features/sources/widgets/pepite_card.dart` (nouveau)
+- `apps/mobile/lib/features/sources/repositories/sources_repository.dart` (modifié)
+- `apps/mobile/lib/features/sources/providers/sources_providers.dart` (modifié)
+- `apps/mobile/lib/features/feed/screens/feed_screen.dart` (modifié)
+- `apps/mobile/test/features/sources/widgets/pepite_card_test.dart` (nouveau)
+- `apps/mobile/test/features/sources/widgets/pepites_carousel_test.dart` (nouveau)
+
+### Docs
+- `docs/stories/core/13.2.feed-pepites-carousel.story.md` (ce fichier)
+
+## Out of scope v1 (à réévaluer)
+- Dismiss par source (v1 = dismiss carousel entier uniquement)
+- Scoring algorithmique qualité × popularité × pertinence
+- Fallback "end-of-feed" si pas de pépites éligibles
+- A/B test de la position (fixe à pos 3 en v1)

--- a/packages/api/alembic/versions/pr01_feed_pepites_carousel.py
+++ b/packages/api/alembic/versions/pr01_feed_pepites_carousel.py
@@ -1,0 +1,69 @@
+"""feed pepites carousel (Story 13.2)
+
+Revision ID: pr01
+Revises: np01
+Create Date: 2026-04-21
+
+Adds:
+- sources.is_pepite_recommendation (bool, indexed) — flag de curation manuelle
+- sources.pepite_for_themes (text[]) — thèmes associés pour priorisation
+- user_personalization.pepite_carousel_dismissed_at (timestamptz) — cool-down dismiss
+- user_personalization.pepite_carousel_last_shown_at (timestamptz) — rate-limit 1/jour
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "pr01"
+down_revision: str = "np01"
+branch_labels: Sequence[str] | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sources",
+        sa.Column(
+            "is_pepite_recommendation",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "sources",
+        sa.Column("pepite_for_themes", sa.ARRAY(sa.Text()), nullable=True),
+    )
+    op.create_index(
+        "ix_sources_is_pepite_recommendation",
+        "sources",
+        ["is_pepite_recommendation"],
+    )
+
+    op.add_column(
+        "user_personalization",
+        sa.Column(
+            "pepite_carousel_dismissed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "user_personalization",
+        sa.Column(
+            "pepite_carousel_last_shown_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_personalization", "pepite_carousel_last_shown_at")
+    op.drop_column("user_personalization", "pepite_carousel_dismissed_at")
+    op.drop_index("ix_sources_is_pepite_recommendation", table_name="sources")
+    op.drop_column("sources", "pepite_for_themes")
+    op.drop_column("sources", "is_pepite_recommendation")

--- a/packages/api/app/models/source.py
+++ b/packages/api/app/models/source.py
@@ -128,6 +128,14 @@ class Source(Base):
         Boolean, default=False, server_default="false"
     )
 
+    # Story 13.2 — "Pépites" carousel : curation manuelle (flag + thèmes associés)
+    is_pepite_recommendation: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", index=True
+    )
+    pepite_for_themes: Mapped[list[str] | None] = mapped_column(
+        ARRAY(Text), nullable=True
+    )
+
     # Relations
     contents: Mapped[list["Content"]] = relationship(
         "Content", back_populates="source", cascade="all, delete-orphan"

--- a/packages/api/app/models/user_personalization.py
+++ b/packages/api/app/models/user_personalization.py
@@ -47,6 +47,14 @@ class UserPersonalization(Base):
         Boolean, default=True, server_default="true"
     )
 
+    # Story 13.2 — Carousel "Pépites" : rate-limit et cool-down dismiss
+    pepite_carousel_dismissed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    pepite_carousel_last_shown_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow
     )

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -37,6 +37,7 @@ from app.schemas.source import (
     UpdateSourceWeightRequest,
 )
 from app.services.feed_cache import FEED_CACHE
+from app.services.pepite_service import PepiteService
 from app.services.search.smart_source_search import (
     SmartSourceSearchService,
     mark_search_abandoned,
@@ -171,6 +172,36 @@ async def get_trending_sources(
     service = SourceService(db)
     sources = await service.get_trending_sources(user_id=user_id, limit=limit)
     return sources
+
+
+@router.get("/pepites", response_model=list[SourceResponse])
+async def get_pepites(
+    limit: int = 4,
+    user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> list[SourceResponse]:
+    """Carousel "Pépites" — sources curées à pousser dans le feed.
+
+    Liste vide si l'utilisateur ne remplit pas les conditions
+    (rate-limité ou dismiss récent).
+    """
+    service = PepiteService(db)
+    sources = await service.get_pepites_for_user(user_id, limit=limit)
+    if sources:
+        await db.commit()
+    return sources
+
+
+@router.post("/pepites/dismiss", status_code=status.HTTP_204_NO_CONTENT)
+async def dismiss_pepites_carousel(
+    user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Dismiss le carousel "Pépites" — cool-down 7j avant réapparition."""
+    service = PepiteService(db)
+    await service.dismiss_pepite_carousel(user_id)
+    await db.commit()
+    return None
 
 
 THEME_LABELS = {

--- a/packages/api/app/services/pepite_service.py
+++ b/packages/api/app/services/pepite_service.py
@@ -1,0 +1,212 @@
+"""Service "Pépites" — recommandations curées de sources dans le feed.
+
+Critères d'affichage :
+- Rate-limit adaptatif par palier de sources suivies :
+    - < 20 sources : max 1×/24h
+    - 20–50 sources : max 1×/7 jours
+    - > 50 sources : max 1×/14 jours
+- AND cool-down : si dismissé récemment, attendre 7j
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.source import Source, UserSource
+from app.models.user import UserInterest
+from app.models.user_personalization import UserPersonalization
+from app.schemas.source import SourceResponse
+
+logger = structlog.get_logger()
+
+LOW_SOURCES_THRESHOLD = 20
+HIGH_SOURCES_THRESHOLD = 50
+DISMISS_COOL_DOWN_DAYS = 7
+RATE_LIMIT_HOURS_LOW = 24
+RATE_LIMIT_HOURS_MEDIUM = 24 * 7
+RATE_LIMIT_HOURS_HIGH = 24 * 14
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _as_utc(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
+class PepiteService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def _load_personalization(
+        self, user_uuid: UUID
+    ) -> UserPersonalization | None:
+        return await self.db.scalar(
+            select(UserPersonalization).where(UserPersonalization.user_id == user_uuid)
+        )
+
+    async def _source_count(self, user_uuid: UUID) -> int:
+        result = await self.db.execute(
+            select(func.count(UserSource.id)).where(UserSource.user_id == user_uuid)
+        )
+        return result.scalar() or 0
+
+    @staticmethod
+    def _rate_limit_hours(source_count: int) -> int:
+        if source_count < LOW_SOURCES_THRESHOLD:
+            return RATE_LIMIT_HOURS_LOW
+        if source_count < HIGH_SOURCES_THRESHOLD:
+            return RATE_LIMIT_HOURS_MEDIUM
+        return RATE_LIMIT_HOURS_HIGH
+
+    @staticmethod
+    def _rate_limited(
+        personalization: UserPersonalization | None, source_count: int
+    ) -> bool:
+        if (
+            personalization is None
+            or personalization.pepite_carousel_last_shown_at is None
+        ):
+            return False
+        last_shown = _as_utc(personalization.pepite_carousel_last_shown_at)
+        hours = PepiteService._rate_limit_hours(source_count)
+        return last_shown > _now() - timedelta(hours=hours)
+
+    @staticmethod
+    def _in_cool_down(personalization: UserPersonalization | None) -> bool:
+        if (
+            personalization is None
+            or personalization.pepite_carousel_dismissed_at is None
+        ):
+            return False
+        dismissed_at = _as_utc(personalization.pepite_carousel_dismissed_at)
+        return dismissed_at > _now() - timedelta(days=DISMISS_COOL_DOWN_DAYS)
+
+    async def _is_eligible(
+        self, user_uuid: UUID, personalization: UserPersonalization | None
+    ) -> bool:
+        if self._in_cool_down(personalization):
+            return False
+        source_count = await self._source_count(user_uuid)
+        return not self._rate_limited(personalization, source_count)
+
+    async def should_show_pepite_carousel(self, user_id: str) -> bool:
+        user_uuid = UUID(user_id)
+        personalization = await self._load_personalization(user_uuid)
+        return await self._is_eligible(user_uuid, personalization)
+
+    async def _user_interest_slugs(self, user_uuid: UUID) -> set[str]:
+        result = await self.db.execute(
+            select(UserInterest.interest_slug).where(UserInterest.user_id == user_uuid)
+        )
+        return {row[0] for row in result.all()}
+
+    async def _user_followed_source_ids(self, user_uuid: UUID) -> set[UUID]:
+        result = await self.db.execute(
+            select(UserSource.source_id).where(UserSource.user_id == user_uuid)
+        )
+        return set(result.scalars().all())
+
+    async def _ensure_personalization(
+        self, user_uuid: UUID, personalization: UserPersonalization | None
+    ) -> UserPersonalization:
+        if personalization is not None:
+            return personalization
+        created = UserPersonalization(user_id=user_uuid)
+        self.db.add(created)
+        return created
+
+    async def get_pepites_for_user(
+        self, user_id: str, limit: int = 4
+    ) -> list[SourceResponse]:
+        """Retourne jusqu'à `limit` sources pépites pour l'utilisateur.
+
+        Liste vide si aucun trigger actif, rate-limit, ou cool-down.
+        """
+        user_uuid = UUID(user_id)
+        personalization = await self._load_personalization(user_uuid)
+
+        if not await self._is_eligible(user_uuid, personalization):
+            return []
+
+        followed_ids = await self._user_followed_source_ids(user_uuid)
+        interest_slugs = await self._user_interest_slugs(user_uuid)
+
+        muted_ids: set[UUID] = (
+            set(personalization.muted_sources)
+            if personalization and personalization.muted_sources
+            else set()
+        )
+        excluded_ids = followed_ids | muted_ids
+
+        count_col = func.count(UserSource.user_id).label("follower_count")
+        query = (
+            select(Source, count_col)
+            .outerjoin(UserSource, UserSource.source_id == Source.id)
+            .where(Source.is_pepite_recommendation)
+            .where(Source.is_active)
+            .group_by(Source.id)
+        )
+        if excluded_ids:
+            query = query.where(Source.id.notin_(excluded_ids))
+
+        result = await self.db.execute(query)
+        rows = result.all()
+
+        def _match_score(source: Source) -> int:
+            if not source.pepite_for_themes or not interest_slugs:
+                return 0
+            return len(set(source.pepite_for_themes) & interest_slugs)
+
+        rows.sort(
+            key=lambda row: (_match_score(row[0]), row[1] or 0),
+            reverse=True,
+        )
+
+        selected = rows[:limit]
+        if not selected:
+            return []
+
+        personalization = await self._ensure_personalization(user_uuid, personalization)
+        personalization.pepite_carousel_last_shown_at = _now()
+        await self.db.flush()
+
+        return [
+            SourceResponse(
+                id=s.id,
+                name=s.name,
+                url=s.url,
+                type=s.type,
+                theme=s.theme,
+                description=s.description,
+                logo_url=s.logo_url,
+                is_curated=s.is_curated,
+                is_custom=not s.is_curated,
+                is_trusted=False,
+                is_muted=False,
+                content_count=0,
+                follower_count=follower_count or 0,
+                bias_stance=getattr(s.bias_stance, "value", "unknown"),
+                reliability_score=getattr(s.reliability_score, "value", "unknown"),
+                bias_origin=getattr(s.bias_origin, "value", "unknown"),
+                secondary_themes=s.secondary_themes,
+                granular_topics=s.granular_topics,
+                source_tier=s.source_tier or "mainstream",
+                score_independence=s.score_independence,
+                score_rigor=s.score_rigor,
+                score_ux=s.score_ux,
+            )
+            for s, follower_count in selected
+        ]
+
+    async def dismiss_pepite_carousel(self, user_id: str) -> None:
+        user_uuid = UUID(user_id)
+        personalization = await self._load_personalization(user_uuid)
+        personalization = await self._ensure_personalization(user_uuid, personalization)
+        personalization.pepite_carousel_dismissed_at = _now()
+        await self.db.flush()
+        logger.info("pepite_carousel_dismissed", user_id=user_id)

--- a/packages/api/tests/services/test_pepite_service.py
+++ b/packages/api/tests/services/test_pepite_service.py
@@ -1,0 +1,407 @@
+"""Tests for PepiteService (Story 13.2 — Feed Pepites Carousel).
+
+Mock-based tests (no DB required) covering:
+- Adaptive rate-limit by followed-source palier
+- Cool-down predicate (dismiss)
+- Selection logic (exclusion, theme priority, touch last_shown)
+- Dismiss
+"""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.models.enums import SourceType
+from app.services.pepite_service import (
+    DISMISS_COOL_DOWN_DAYS,
+    HIGH_SOURCES_THRESHOLD,
+    LOW_SOURCES_THRESHOLD,
+    RATE_LIMIT_HOURS_HIGH,
+    RATE_LIMIT_HOURS_LOW,
+    RATE_LIMIT_HOURS_MEDIUM,
+    PepiteService,
+)
+
+
+def _now():
+    return datetime.now(UTC)
+
+
+def _mk_source(
+    *,
+    name="Src",
+    theme="tech",
+    is_curated=True,
+    pepite_for_themes=None,
+    source_id=None,
+):
+    return SimpleNamespace(
+        id=source_id or uuid4(),
+        name=name,
+        url=f"https://{name.lower().replace(' ', '')}.example.com",
+        type=SourceType.ARTICLE,
+        theme=theme,
+        description=None,
+        logo_url=None,
+        is_curated=is_curated,
+        is_active=True,
+        is_pepite_recommendation=True,
+        pepite_for_themes=pepite_for_themes,
+        bias_stance=SimpleNamespace(value="unknown"),
+        reliability_score=SimpleNamespace(value="unknown"),
+        bias_origin=SimpleNamespace(value="unknown"),
+        secondary_themes=None,
+        granular_topics=None,
+        source_tier="mainstream",
+        score_independence=None,
+        score_rigor=None,
+        score_ux=None,
+    )
+
+
+class TestRateLimitHours:
+    """Adaptive rate-limit window per followed-source palier."""
+
+    def test_low_palier_24h(self):
+        assert PepiteService._rate_limit_hours(0) == RATE_LIMIT_HOURS_LOW
+        assert (
+            PepiteService._rate_limit_hours(LOW_SOURCES_THRESHOLD - 1)
+            == RATE_LIMIT_HOURS_LOW
+        )
+
+    def test_medium_palier_7d(self):
+        assert (
+            PepiteService._rate_limit_hours(LOW_SOURCES_THRESHOLD)
+            == RATE_LIMIT_HOURS_MEDIUM
+        )
+        assert (
+            PepiteService._rate_limit_hours(HIGH_SOURCES_THRESHOLD - 1)
+            == RATE_LIMIT_HOURS_MEDIUM
+        )
+
+    def test_high_palier_14d(self):
+        assert (
+            PepiteService._rate_limit_hours(HIGH_SOURCES_THRESHOLD)
+            == RATE_LIMIT_HOURS_HIGH
+        )
+        assert (
+            PepiteService._rate_limit_hours(HIGH_SOURCES_THRESHOLD * 10)
+            == RATE_LIMIT_HOURS_HIGH
+        )
+
+
+class TestRateLimitPredicate:
+    def test_not_rate_limited_when_personalization_none(self):
+        assert PepiteService._rate_limited(None, source_count=0) is False
+
+    def test_not_rate_limited_when_last_shown_none(self):
+        perso = SimpleNamespace(pepite_carousel_last_shown_at=None)
+        assert PepiteService._rate_limited(perso, source_count=5) is False
+
+    def test_rate_limited_recent_low_palier(self):
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=_now() - timedelta(hours=1),
+        )
+        assert PepiteService._rate_limited(perso, source_count=5) is True
+
+    def test_not_rate_limited_past_24h_low_palier(self):
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=_now()
+            - timedelta(hours=RATE_LIMIT_HOURS_LOW + 1),
+        )
+        assert PepiteService._rate_limited(perso, source_count=5) is False
+
+    def test_handles_naive_datetime(self):
+        naive = datetime.utcnow() - timedelta(hours=1)
+        perso = SimpleNamespace(pepite_carousel_last_shown_at=naive)
+        assert PepiteService._rate_limited(perso, source_count=5) is True
+
+    def test_medium_palier_blocks_for_7_days(self):
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=_now() - timedelta(days=6),
+        )
+        # 20 sources → 7d window → still blocked at 6d
+        assert PepiteService._rate_limited(perso, source_count=30) is True
+        # But <20 sources → 24h window → not blocked at 6d
+        assert PepiteService._rate_limited(perso, source_count=5) is False
+
+    def test_high_palier_blocks_for_14_days(self):
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=_now() - timedelta(days=10),
+        )
+        # 100 sources → 14d window → still blocked at 10d
+        assert PepiteService._rate_limited(perso, source_count=100) is True
+        # 30 sources → 7d window → not blocked at 10d
+        assert PepiteService._rate_limited(perso, source_count=30) is False
+
+
+class TestCoolDownPredicate:
+    def test_not_in_cool_down_when_personalization_none(self):
+        assert PepiteService._in_cool_down(None) is False
+
+    def test_not_in_cool_down_when_dismissed_none(self):
+        perso = SimpleNamespace(pepite_carousel_dismissed_at=None)
+        assert PepiteService._in_cool_down(perso) is False
+
+    def test_in_cool_down_when_recently_dismissed(self):
+        perso = SimpleNamespace(
+            pepite_carousel_dismissed_at=_now() - timedelta(days=1),
+        )
+        assert PepiteService._in_cool_down(perso) is True
+
+    def test_cool_down_expires(self):
+        perso = SimpleNamespace(
+            pepite_carousel_dismissed_at=_now()
+            - timedelta(days=DISMISS_COOL_DOWN_DAYS + 1),
+        )
+        assert PepiteService._in_cool_down(perso) is False
+
+
+class TestShouldShow:
+    @pytest.mark.asyncio
+    async def test_blocked_by_cool_down_short_circuits_without_count_query(self):
+        session = AsyncMock()
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=None,
+            pepite_carousel_dismissed_at=_now() - timedelta(days=1),
+        )
+        session.scalar = AsyncMock(return_value=perso)
+        session.execute = AsyncMock()
+
+        service = PepiteService(session)
+        assert await service.should_show_pepite_carousel(str(uuid4())) is False
+        session.execute.assert_not_called()  # cool-down short-circuits
+
+    @pytest.mark.asyncio
+    async def test_blocked_by_rate_limit_low_palier(self):
+        session = AsyncMock()
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=_now() - timedelta(hours=1),
+            pepite_carousel_dismissed_at=None,
+        )
+        session.scalar = AsyncMock(return_value=perso)
+        count_result = MagicMock()
+        count_result.scalar.return_value = 5
+        session.execute = AsyncMock(return_value=count_result)
+
+        service = PepiteService(session)
+        assert await service.should_show_pepite_carousel(str(uuid4())) is False
+
+    @pytest.mark.asyncio
+    async def test_blocked_by_rate_limit_high_palier_after_10_days(self):
+        """Compte avec 60 sources → rate-limit 14j. Last shown 10j ago → bloqué."""
+        session = AsyncMock()
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=_now() - timedelta(days=10),
+            pepite_carousel_dismissed_at=None,
+        )
+        session.scalar = AsyncMock(return_value=perso)
+        count_result = MagicMock()
+        count_result.scalar.return_value = 60
+        session.execute = AsyncMock(return_value=count_result)
+
+        service = PepiteService(session)
+        assert await service.should_show_pepite_carousel(str(uuid4())) is False
+
+    @pytest.mark.asyncio
+    async def test_allows_when_no_personalization_and_any_source_count(self):
+        session = AsyncMock()
+        session.scalar = AsyncMock(return_value=None)
+        count_result = MagicMock()
+        count_result.scalar.return_value = 100
+        session.execute = AsyncMock(return_value=count_result)
+
+        service = PepiteService(session)
+        assert await service.should_show_pepite_carousel(str(uuid4())) is True
+
+    @pytest.mark.asyncio
+    async def test_allows_when_past_rate_limit_window_for_palier(self):
+        """Compte 30 sources → 7j window. Last shown 8j ago → autorisé."""
+        session = AsyncMock()
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=_now() - timedelta(days=8),
+            pepite_carousel_dismissed_at=None,
+        )
+        session.scalar = AsyncMock(return_value=perso)
+        count_result = MagicMock()
+        count_result.scalar.return_value = 30
+        session.execute = AsyncMock(return_value=count_result)
+
+        service = PepiteService(session)
+        assert await service.should_show_pepite_carousel(str(uuid4())) is True
+
+
+class TestSelection:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_rate_limited(self):
+        """Rate-limited → empty."""
+        session = AsyncMock()
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=_now() - timedelta(hours=1),
+            pepite_carousel_dismissed_at=None,
+        )
+        session.scalar = AsyncMock(return_value=perso)
+        count_result = MagicMock()
+        count_result.scalar.return_value = 5  # low palier → 24h window
+        session.execute = AsyncMock(return_value=count_result)
+
+        service = PepiteService(session)
+        results = await service.get_pepites_for_user(str(uuid4()))
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_excludes_followed_and_muted(self):
+        session = AsyncMock()
+        user_id = uuid4()
+
+        followed_id = uuid4()
+        muted_id = uuid4()
+        visible = _mk_source(name="Visible", theme="tech")
+
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=None,
+            pepite_carousel_dismissed_at=None,
+            muted_sources=[muted_id],
+        )
+        session.scalar = AsyncMock(return_value=perso)
+
+        # execute() call order:
+        # 1. _source_count (should_show_pepite_carousel)
+        # 2. followed IDs
+        # 3. interest slugs
+        # 4. candidate query
+        count_result = MagicMock()
+        count_result.scalar.return_value = 5
+        followed_result = MagicMock()
+        followed_result.scalars.return_value.all.return_value = [followed_id]
+        interests_result = MagicMock()
+        interests_result.all.return_value = []
+        sources_result = MagicMock()
+        sources_result.all.return_value = [(visible, 3)]
+
+        session.execute = AsyncMock(
+            side_effect=[
+                count_result,
+                followed_result,
+                interests_result,
+                sources_result,
+            ]
+        )
+
+        service = PepiteService(session)
+        results = await service.get_pepites_for_user(str(user_id))
+        assert len(results) == 1
+        assert results[0].name == "Visible"
+        assert results[0].follower_count == 3
+
+    @pytest.mark.asyncio
+    async def test_prioritizes_theme_match(self):
+        session = AsyncMock()
+        match = _mk_source(name="Match", theme="tech", pepite_for_themes=["tech"])
+        no_match = _mk_source(
+            name="NoMatch", theme="international", pepite_for_themes=["international"]
+        )
+
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=None,
+            pepite_carousel_dismissed_at=None,
+            muted_sources=[],
+        )
+        session.scalar = AsyncMock(return_value=perso)
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 5
+        followed_result = MagicMock()
+        followed_result.scalars.return_value.all.return_value = []
+        interests_result = MagicMock()
+        interests_result.all.return_value = [("tech",)]
+        # Return no_match FIRST in raw SQL result — should be reordered by sort
+        sources_result = MagicMock()
+        sources_result.all.return_value = [(no_match, 10), (match, 1)]
+
+        session.execute = AsyncMock(
+            side_effect=[
+                count_result,
+                followed_result,
+                interests_result,
+                sources_result,
+            ]
+        )
+
+        service = PepiteService(session)
+        results = await service.get_pepites_for_user(str(uuid4()), limit=2)
+        assert [r.name for r in results] == ["Match", "NoMatch"]
+
+    @pytest.mark.asyncio
+    async def test_touches_last_shown_on_non_empty_result(self):
+        session = AsyncMock()
+        src = _mk_source(name="One")
+
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=None,
+            pepite_carousel_dismissed_at=None,
+            muted_sources=[],
+        )
+        session.scalar = AsyncMock(return_value=perso)
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+        followed_result = MagicMock()
+        followed_result.scalars.return_value.all.return_value = []
+        interests_result = MagicMock()
+        interests_result.all.return_value = []
+        sources_result = MagicMock()
+        sources_result.all.return_value = [(src, 0)]
+
+        session.execute = AsyncMock(
+            side_effect=[
+                count_result,
+                followed_result,
+                interests_result,
+                sources_result,
+            ]
+        )
+
+        service = PepiteService(session)
+        results = await service.get_pepites_for_user(str(uuid4()))
+        assert results
+        assert perso.pepite_carousel_last_shown_at is not None
+        session.flush.assert_awaited()
+
+
+class TestDismiss:
+    @pytest.mark.asyncio
+    async def test_dismiss_creates_personalization_when_missing(self):
+        session = AsyncMock()
+        session.scalar = AsyncMock(return_value=None)
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+
+        service = PepiteService(session)
+        await service.dismiss_pepite_carousel(str(uuid4()))
+
+        session.add.assert_called_once()
+        created = session.add.call_args.args[0]
+        assert created.pepite_carousel_dismissed_at is not None
+        session.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dismiss_updates_existing_personalization(self):
+        session = AsyncMock()
+        old_ts = _now() - timedelta(days=30)
+        perso = SimpleNamespace(pepite_carousel_dismissed_at=old_ts)
+        session.scalar = AsyncMock(return_value=perso)
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+
+        service = PepiteService(session)
+        await service.dismiss_pepite_carousel(str(uuid4()))
+
+        session.add.assert_not_called()
+        assert perso.pepite_carousel_dismissed_at > old_ts
+        session.flush.assert_awaited_once()


### PR DESCRIPTION
## Summary

Carousel **"Des sources à découvrir"** intercalé en position 3 du feed mobile pour pousser des sources curées manuellement (`Le Grand Continent`, `Courrier International`, `Usbek & Rica`, …) aux utilisateurs au bon moment.

- **Backend** : nouveau `PepiteService` + endpoints `GET /sources/pepites` & `POST /sources/pepites/dismiss`. Migration `pr01` ajoute 2 colonnes sur `sources` (flag + thèmes) et 2 timestamps sur `user_personalization`.
- **Mobile** : widgets `PepiteCard`, `PepitesCarousel`, `PepitePreviewSheet`. Provider Riverpod avec dismiss optimiste et retrait local post-follow.
- **Visibilité gatée** : rate-limit adaptatif par palier (24h <20 sources / 7j 20-50 / 14j >50) + cool-down 7j si dismiss.
- **Priorisation** : sources dont `pepite_for_themes` matche les thèmes suivis du user en tête, puis follower_count.

## Migration & seed

⚠️ **Migration déjà appliquée en prod** via Supabase SQL Editor (règle projet — pas d'`alembic upgrade` sur Railway). Le fichier Alembic `pr01_feed_pepites_carousel.py` est uniquement source-of-truth pour les environnements locaux.

Seed initial appliqué (10 sources curées : Courrier International, Numerama Décryptages, Le Canard Enchaîné, Vert, Cerveau & Psycho, Usbek & Rica, Socialter, ScienceEtonnante, Monsieur Phi, Monsieur Bidouille). Script reproductible : `docs/qa/scripts/seed_feed_pepites.sql`.

## Tests

- Backend : 25/25 PASS (`pytest tests/services/test_pepite_service.py`) — paliers, cool-down, exclusion followed/muted, priorisation thèmes, dismiss.
- Mobile : 8/8 PASS (`flutter test test/features/sources/widgets/pepite*_test.dart`) — rendu, état vide, dismiss.
- Lint : `ruff check` + `ruff format` clean ; `flutter analyze` sans erreurs.

## Test plan

- [ ] CI verte
- [ ] Après merge + déploiement Railway : ouvrir le feed sur un compte test → vérifier apparition du carousel
- [ ] Tap sur card → preview sheet → bouton "Suivre" → la source disparaît du carousel et apparaît dans My Sources
- [ ] Tap ✕ → carousel masqué + cool-down 7j enregistré (`user_personalization.pepite_carousel_dismissed_at`)
- [ ] Vérifier que les exclusions fonctionnent : un user qui suit déjà toutes les pépites → liste vide

## Suite (hors scope, branches séparées)

- Affinement de la fréquence d'apparition (paliers à itérer après data réelle)
- Refonte du design de la carte
- Maintenance : nettoyage des sources curées avec RSS cassé (Alternatives Économiques, Libération, Les Échos, Mécaniques du Complot, Le Collimateur, Brut, Transfert, Le Point, Guerres de Business — 236 followers cumulés)

🤖 Generated with [Claude Code](https://claude.com/claude-code)