### PR TITLE
fix(notif-android): MessagingStyle + silhouette + bullets multi-actus

### DIFF
--- a/apps/mobile/android/app/src/main/res/drawable/ic_stat_facteur.xml
+++ b/apps/mobile/android/app/src/main/res/drawable/ic_stat_facteur.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,6.5 L12,12.5 L21,6.5 L21,17.5 C21,18.0523 20.5523,18.5 20,18.5 L4,18.5 C3.4477,18.5 3,18.0523 3,17.5 Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M4,5.5 L20,5.5 C20.3,5.5 20.57,5.633 20.75,5.844 L12,11.7 L3.25,5.844 C3.43,5.633 3.7,5.5 4,5.5 Z" />
+</vector>

--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -53,10 +53,10 @@ class PushNotificationService {
       tz.setLocalLocation(tz.getLocation('Europe/Paris'));
     }
 
-    // Small icon: ic_launcher_foreground a été remplacé par un asset
-    // blanc/alpha dans PR #428 — c'est l'asset correct pour la status bar.
+    // Small icon: silhouette monochrome dédiée — Android exige un asset
+    // blanc/alpha pour la status bar (sinon bloc coloré mal dimensionné).
     const androidSettings =
-        AndroidInitializationSettings('@drawable/ic_launcher_foreground');
+        AndroidInitializationSettings('@drawable/ic_stat_facteur');
 
     const iosSettings = DarwinInitializationSettings(
       requestAlertPermission: true,
@@ -121,44 +121,55 @@ class PushNotificationService {
 
   // --- Copy variants -------------------------------------------------------
 
+  /// Nom affiché comme expéditeur dans la notif Android (MessagingStyle).
+  static const String senderName = 'Ton facteur';
+
   /// Variante A — défaut, sans teaser éditorial.
-  static const String defaultTitle = 'Le facteur est passé !';
+  static const String defaultTitle = 'Le facteur est là';
   static const String defaultBody = "Ton récap du jour t'attend quand tu veux.";
 
   /// Variante C — déclenchée manuellement par l'éditorial (hors v1).
-  static const String calmTitle = 'Le facteur est passé !';
+  static const String calmTitle = 'Le facteur est là';
   static const String calmBody =
       "Rien d'important dans l'actu aujourd'hui. Belle journée !";
 
   /// Pépite communauté hebdo (vendredi 18:00, préset Curieux).
-  static const String communityTitle = 'Le facteur est passé !';
+  static const String communityTitle = 'Le facteur est là';
   static const String communityBody =
       "Les Fact·eur·isses adorent cet article. Jette-y un œil quand tu as 2 min !";
 
-  /// Construit le couple (title, body) selon la variante.
+  /// Construit le triplet (title, body, bigText) selon la variante.
   ///
-  /// - [variantB] requiert [teaser] (titre du sujet phare). Tronqué à 60c
-  ///   pour respecter le brief §6.1.
-  static ({String title, String body}) buildCopy({
+  /// - [variantB] requiert au moins un teaser dans [teasers]. Le premier
+  ///   teaser est utilisé pour le body collapsed (tronqué à 60c, brief §6.1) ;
+  ///   l'ensemble (max 3) est rendu en bullets dans le bigText Android.
+  static ({String title, String body, String bigText}) buildCopy({
     required NotifVariant variant,
-    String? teaser,
+    List<String>? teasers,
   }) {
     switch (variant) {
       case NotifVariant.variantA:
-        return (title: defaultTitle, body: defaultBody);
+        return (title: defaultTitle, body: defaultBody, bigText: defaultBody);
       case NotifVariant.variantB:
-        if (teaser == null || teaser.trim().isEmpty) {
-          return (title: defaultTitle, body: defaultBody);
+        final cleaned = (teasers ?? const <String>[])
+            .map((t) => t.trim())
+            .where((t) => t.isNotEmpty)
+            .take(3)
+            .toList();
+        if (cleaned.isEmpty) {
+          return (title: defaultTitle, body: defaultBody, bigText: defaultBody);
         }
-        final trimmed = teaser.trim();
+        final first = cleaned.first;
         final clipped =
-            trimmed.length > 60 ? '${trimmed.substring(0, 57)}…' : trimmed;
+            first.length > 60 ? '${first.substring(0, 57)}…' : first;
+        final bullets = cleaned.map((t) => '• $t').join('\n');
         return (
-          title: 'Je suis passé.',
+          title: defaultTitle,
           body: 'À la une : $clipped',
+          bigText: bullets,
         );
       case NotifVariant.variantC:
-        return (title: calmTitle, body: calmBody);
+        return (title: calmTitle, body: calmBody, bigText: calmBody);
     }
   }
 
@@ -171,11 +182,11 @@ class PushNotificationService {
   Future<bool> scheduleDailyDigestNotification({
     NotifTimeSlot timeSlot = NotifTimeSlot.morning,
     NotifVariant variant = NotifVariant.variantA,
-    String? teaser,
+    List<String>? teasers,
   }) async {
     final time = _timeOfDayFor(timeSlot);
     final scheduledDate = _nextInstanceOf(time);
-    final copy = buildCopy(variant: variant, teaser: teaser);
+    final copy = buildCopy(variant: variant, teasers: teasers);
 
     final androidPlugin = _plugin.resolvePlatformSpecificImplementation<
         AndroidFlutterLocalNotificationsPlugin>();
@@ -185,17 +196,27 @@ class PushNotificationService {
         ? AndroidScheduleMode.alarmClock
         : AndroidScheduleMode.inexactAllowWhileIdle;
 
+    const sender = Person(
+      name: senderName,
+      key: 'facteur',
+      important: true,
+      icon: DrawableResourceAndroidIcon('facteur_avatar'),
+    );
     final androidDetails = AndroidNotificationDetails(
       'digest_channel',
       'Digest quotidien',
       channelDescription: 'Notification quotidienne quand ton récap est prêt',
       importance: Importance.high,
       priority: Priority.high,
-      icon: '@drawable/ic_launcher_foreground',
-      largeIcon: const DrawableResourceAndroidBitmap('facteur_avatar'),
-      styleInformation: BigTextStyleInformation(
-        copy.body,
-        contentTitle: copy.title,
+      icon: '@drawable/ic_stat_facteur',
+      color: const Color(0xFFD35400),
+      styleInformation: MessagingStyleInformation(
+        const Person(name: 'Toi'),
+        conversationTitle: copy.title,
+        groupConversation: false,
+        messages: [
+          Message(copy.bigText, DateTime.now(), sender),
+        ],
       ),
     );
     const iosDetails = DarwinNotificationDetails();
@@ -246,7 +267,8 @@ class PushNotificationService {
       channelDescription: 'Recommandation hebdomadaire des Fact·eur·isses',
       importance: Importance.high,
       priority: Priority.high,
-      icon: '@drawable/ic_launcher_foreground',
+      icon: '@drawable/ic_stat_facteur',
+      color: const Color(0xFFD35400),
       largeIcon: const DrawableResourceAndroidBitmap('facteur_avatar'),
       styleInformation: BigTextStyleInformation(
         communityBody,

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -289,20 +289,22 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
       if (digest == null) return;
 
       final isSerein = ref.read(sereinToggleProvider).enabled;
-      final firstTopic = digest.topics
-          .map((t) => t.label)
-          .firstWhere((l) => l.isNotEmpty, orElse: () => '');
+      final topTopics = digest.topics
+          .map((t) => t.label.trim())
+          .where((l) => l.isNotEmpty)
+          .take(3)
+          .toList();
 
       // Variante C (jour calme) hors v1 — Serein + variante A pour rester
       // cohérent avec le brief §6.1 (variante C = override manuel uniquement).
-      final variant = (!isSerein && firstTopic.isNotEmpty)
+      final variant = (!isSerein && topTopics.isNotEmpty)
           ? NotifVariant.variantB
           : NotifVariant.variantA;
 
       await PushNotificationService().scheduleDailyDigestNotification(
         timeSlot: settings.timeSlot,
         variant: variant,
-        teaser: variant == NotifVariant.variantB ? firstTopic : null,
+        teasers: variant == NotifVariant.variantB ? topTopics : null,
       );
       debugPrint(
         'DigestNotifier: Re-scheduled (variant: $variant, slot: ${settings.timeSlot})',

--- a/apps/mobile/test/core/services/push_notification_service_copy_test.dart
+++ b/apps/mobile/test/core/services/push_notification_service_copy_test.dart
@@ -7,34 +7,44 @@ void main() {
       final copy = PushNotificationService.buildCopy(
         variant: NotifVariant.variantA,
       );
-      expect(copy.title, 'Le facteur est passé !');
+      expect(copy.title, 'Le facteur est là');
       expect(copy.body, "Ton récap du jour t'attend quand tu veux.");
+      expect(copy.bigText, copy.body);
     });
 
-    test('variant B with teaser uses tutoiement + personnification', () {
+    test('variant B with teasers uses tutoiement + personnification', () {
       final copy = PushNotificationService.buildCopy(
         variant: NotifVariant.variantB,
-        teaser: 'Trump',
+        teasers: ['Trump'],
       );
-      expect(copy.title, 'Je suis passé.');
+      expect(copy.title, 'Le facteur est là');
       expect(copy.body, 'À la une : Trump');
+      expect(copy.bigText, '• Trump');
     });
 
-    test('variant B without teaser falls back to A', () {
+    test('variant B with multiple teasers renders bullet bigText (max 3)', () {
       final copy = PushNotificationService.buildCopy(
         variant: NotifVariant.variantB,
-        teaser: '',
+        teasers: ['Trump', 'Climat', 'Marseille', 'Quatrième'],
       );
-      expect(copy.title, 'Le facteur est passé !');
+      expect(copy.body, 'À la une : Trump');
+      expect(copy.bigText, '• Trump\n• Climat\n• Marseille');
     });
 
-    test('variant B truncates teaser longer than 60 chars', () {
+    test('variant B without teasers falls back to A', () {
+      final copy = PushNotificationService.buildCopy(
+        variant: NotifVariant.variantB,
+        teasers: const [],
+      );
+      expect(copy.title, 'Le facteur est là');
+    });
+
+    test('variant B truncates first teaser longer than 60 chars', () {
       final teaser = 'A' * 80;
       final copy = PushNotificationService.buildCopy(
         variant: NotifVariant.variantB,
-        teaser: teaser,
+        teasers: [teaser],
       );
-      // body = "À la une : <57 chars>…"
       expect(copy.body.length, lessThanOrEqualTo('À la une : '.length + 58));
       expect(copy.body, endsWith('…'));
     });
@@ -43,7 +53,7 @@ void main() {
       final copy = PushNotificationService.buildCopy(
         variant: NotifVariant.variantC,
       );
-      expect(copy.title, 'Le facteur est passé !');
+      expect(copy.title, 'Le facteur est là');
       expect(copy.body, contains("Belle journée"));
     });
   });


### PR DESCRIPTION
## What

Refonte de la notification Android quotidienne du digest :

- Petite icône silhouette monochrome dédiée (`ic_stat_facteur.xml`) teintée Ocre Rouge pour la status bar.
- Passage en `MessagingStyleInformation` : l'avatar postman s'affiche en grand à gauche, la silhouette enveloppe en mini badge superposé (pattern WhatsApp/Messenger), expéditeur **Ton facteur**.
- `buildCopy` accepte désormais une liste de teasers (top 3 topics) rendue en bullets `• …` dans la zone message ; `digest_provider` passe les 3 premiers topics du digest.
- Titre unifié sur **« Le facteur est là »** (variantes A/B/C + community).

## Why

Sur Android, l'ancienne notif affichait : un bloc coloré mal dimensionné dans la status bar (small icon = PNG couleur), un seul topic visible, et une juxtaposition confuse logo + avatar. Le rendu désormais respecte les guidelines Android et l'identité Facteur.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`flutter test test/core/services/push_notification_service_copy_test.dart` 6/6)
- [x] Linting passes (`flutter analyze` — pas de nouvelle issue)
- [ ] No new Python `List[]` imports — N/A (mobile only)
- [ ] If touching auth/DB: read Safety Guardrails — N/A
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (mobile only — vérification device requise au prochain build Android)