### PR TITLE
feat(feed): trigger conditionnel carte « Tu es à jour »

### DIFF
--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -85,7 +85,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
   bool _showWelcome = false;
   bool _activationModalShown = false;
   bool _caughtUpDismissed = false;
-  static const int _caughtUpThreshold = 8;
+  static const int _caughtUpMinScrolled = 15;
   final ScrollController _scrollController = ScrollController();
   double _maxScrollPercent = 0.0;
   final int _itemsViewed = 0;
@@ -710,10 +710,37 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                         final streakAsync = ref.watch(streakProvider);
                         final dailyCount =
                             streakAsync.valueOrNull?.weeklyCount ?? 0;
-                        final showCaughtUp = dailyCount >= _caughtUpThreshold &&
-                            !_caughtUpDismissed;
-                        // Position de la carte "Tu es à jour" après 8 articles
-                        const caughtUpPos = 8;
+                        final isSerein =
+                            ref.watch(sereinToggleProvider).enabled;
+
+                        bool showCaughtUp;
+                        int caughtUpPos;
+                        if (_caughtUpDismissed) {
+                          showCaughtUp = false;
+                          caughtUpPos = -1;
+                        } else if (isSerein) {
+                          showCaughtUp =
+                              dailyCount >= _caughtUpMinScrolled &&
+                                  contents.length > _caughtUpMinScrolled;
+                          caughtUpPos = _caughtUpMinScrolled;
+                        } else {
+                          final now = DateTime.now();
+                          final firstOldIdx = contents.indexWhere(
+                            (c) =>
+                                now.difference(c.publishedAt) >
+                                const Duration(hours: 24),
+                          );
+                          if (firstOldIdx >= 0 &&
+                              contents.length >= _caughtUpMinScrolled) {
+                            caughtUpPos = firstOldIdx < _caughtUpMinScrolled
+                                ? _caughtUpMinScrolled
+                                : firstOldIdx;
+                            showCaughtUp = contents.length > caughtUpPos;
+                          } else {
+                            showCaughtUp = false;
+                            caughtUpPos = -1;
+                          }
+                        }
 
                         // Saved nudge: show at position 6 if user has 3+ unread saves
                         final savedSummary =


### PR DESCRIPTION
## What

Modifie l'apparition de `CaughtUpCard` dans le feed (`apps/mobile/lib/features/feed/screens/feed_screen.dart`) :
- **Mode chronologique** : la carte n'apparaît que si un article >24h est atteint **et** que l'utilisateur a scrollé ≥ 15 articles. Position = `max(15, indexOfFirstArticle>24h)`.
- **Mode serein** : comportement actuel basé sur `dailyCount` conservé, mais position déplacée de 8 → 15.

## Why

Éviter d'afficher prématurément « Tu es à jour » alors que des articles récents restent à découvrir, et ne déclencher le signal de fermeture qu'au moment où le contenu devient véritablement « ancien ».

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`flutter analyze` — aucun nouvel issue)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (mobile-only UI tweak)