### PR TITLE
fix(nav): polish carte Essentiel — perforations + alignement titre/meta

### DIFF
--- a/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
@@ -138,7 +138,12 @@ class _DigestCard extends StatelessWidget {
 class _PerforationDots extends StatelessWidget {
   final Color color;
   static const double _dotSize = 3;
-  static const double _spacing = 10;
+  static const double _spacing = 6;
+  // Fraction de la hauteur disponible utilisée par la colonne de dots :
+  // une perforation plus courte ancrée vers le bas réduit l'espace mort
+  // dans la moitié haute de la carte, l'espacement visuel inter-dots reste
+  // identique (_spacing px).
+  static const double _fillFraction = 0.55;
 
   const _PerforationDots({required this.color});
 
@@ -148,13 +153,16 @@ class _PerforationDots extends StatelessWidget {
       builder: (context, constraints) {
         final height = constraints.maxHeight;
         final unit = _dotSize + _spacing;
-        final count = height <= 0 ? 0 : ((height + _spacing) / unit).floor();
-        return SizedBox(
-          height: height,
+        final maxCount =
+            height <= 0 ? 0 : ((height + _spacing) / unit).floor();
+        final count = (maxCount * _fillFraction).round();
+        return Align(
+          alignment: Alignment.bottomCenter,
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            mainAxisSize: MainAxisSize.min,
             children: [
-              for (int i = 0; i < count; i++)
+              for (int i = 0; i < count; i++) ...[
+                if (i > 0) const SizedBox(height: _spacing),
                 Container(
                   width: _dotSize,
                   height: _dotSize,
@@ -163,6 +171,7 @@ class _PerforationDots extends StatelessWidget {
                     shape: BoxShape.circle,
                   ),
                 ),
+              ],
             ],
           ),
         );

--- a/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
@@ -99,32 +99,30 @@ class _DigestCard extends StatelessWidget {
             left: 28,
             child: EssentielPill(colors: colors, isDark: isDark),
           ),
-          // Titre + caption ancrés juste sous le pill (haut-gauche).
+          // Titre serif ancré juste sous le pill (haut-gauche).
           Positioned(
             left: 28,
             right: 120,
             top: 52,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  "L'essentiel du jour",
-                  style: FacteurTypography.serifTitle(colors.textPrimary)
-                      .copyWith(fontSize: 24, height: 1.15),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  '$articleCount articles · ${formatDigestDate(targetDate)}',
-                  style:
-                      FacteurTypography.stamp(colors.textTertiary).copyWith(
-                    fontSize: 11,
-                    letterSpacing: 1.2,
-                  ),
-                ),
-              ],
+            child: Text(
+              "L'essentiel du jour",
+              style: FacteurTypography.serifTitle(colors.textPrimary)
+                  .copyWith(fontSize: 24, height: 1.15),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          // Meta (articles · date) ancrée en bas à gauche.
+          Positioned(
+            left: 28,
+            right: 120,
+            bottom: 16,
+            child: Text(
+              '$articleCount articles · ${formatDigestDate(targetDate)}',
+              style: FacteurTypography.stamp(colors.textTertiary).copyWith(
+                fontSize: 11,
+                letterSpacing: 1.2,
+              ),
             ),
           ),
         ],

--- a/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
@@ -138,7 +138,7 @@ class _DigestCard extends StatelessWidget {
 class _PerforationDots extends StatelessWidget {
   final Color color;
   static const double _dotSize = 3;
-  static const double _spacing = 6;
+  static const double _spacing = 10;
 
   const _PerforationDots({required this.color});
 

--- a/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
@@ -99,11 +99,11 @@ class _DigestCard extends StatelessWidget {
             left: 28,
             child: EssentielPill(colors: colors, isDark: isDark),
           ),
-          // Titre + caption en bas à gauche.
+          // Titre + caption ancrés juste sous le pill (haut-gauche).
           Positioned(
             left: 28,
             right: 120,
-            bottom: 16,
+            top: 52,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
@@ -139,11 +139,6 @@ class _PerforationDots extends StatelessWidget {
   final Color color;
   static const double _dotSize = 3;
   static const double _spacing = 6;
-  // Fraction de la hauteur disponible utilisée par la colonne de dots :
-  // une perforation plus courte ancrée vers le bas réduit l'espace mort
-  // dans la moitié haute de la carte, l'espacement visuel inter-dots reste
-  // identique (_spacing px).
-  static const double _fillFraction = 0.55;
 
   const _PerforationDots({required this.color});
 
@@ -153,16 +148,13 @@ class _PerforationDots extends StatelessWidget {
       builder: (context, constraints) {
         final height = constraints.maxHeight;
         final unit = _dotSize + _spacing;
-        final maxCount =
-            height <= 0 ? 0 : ((height + _spacing) / unit).floor();
-        final count = (maxCount * _fillFraction).round();
-        return Align(
-          alignment: Alignment.bottomCenter,
+        final count = height <= 0 ? 0 : ((height + _spacing) / unit).floor();
+        return SizedBox(
+          height: height,
           child: Column(
-            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              for (int i = 0; i < count; i++) ...[
-                if (i > 0) const SizedBox(height: _spacing),
+              for (int i = 0; i < count; i++)
                 Container(
                   width: _dotSize,
                   height: _dotSize,
@@ -171,7 +163,6 @@ class _PerforationDots extends StatelessWidget {
                     shape: BoxShape.circle,
                   ),
                 ),
-              ],
             ],
           ),
         );


### PR DESCRIPTION
## Summary
- Titre serif (« L'essentiel du jour ») ré-ancré juste sous le pill (top:52) → fini le grand vide entre la balise et le titre.
- Meta (« N articles · DD MMM ») ré-ancrée en bas (bottom:16) → bloc texte qui aère naturellement la moitié haute et reste lisible près de la base.
- Perforations restaurées sur toute la hauteur (spaceBetween, spacing 6) après itérations sur la densité.

PR de polish pure de la preview card du feed (1 fichier, +20/-22). Le gros du Story 17.2 (transition 250 ms, hero plein-page, header back+titre, UpdateButton migré) est déjà sur main via la squash de #512.

## Test plan
- [x] `flutter analyze lib/features/feed/widgets/digest_entry_card.dart` → 0 error.
- [x] `flutter test test/features/feed/widgets/digest_entry_card_test.dart` → 2/2 passent.
- [ ] Vérification visuelle Chrome 390x844 : pill + titre serrés en haut, meta collée en bas, perforations sur toute la hauteur, avatar facteur bottom-right intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)