### PR TITLE
feat(veille): backend foundations — config + suggestions LLM + scanner */30min

### DIFF
--- a/docs/qa/sql/vl01_create_veille_tables.sql
+++ b/docs/qa/sql/vl01_create_veille_tables.sql
@@ -1,0 +1,121 @@
+-- ============================================================================
+-- vl01_create_veille_tables.sql
+-- ============================================================================
+-- Export SQL pour application manuelle dans Supabase SQL Editor (prod).
+-- Équivalent à `alembic upgrade en01:vl01` (cf. alembic/versions/vl01_create_veille_tables.py).
+--
+-- Convention repo : Alembic tourne en local. En prod, le SQL est exécuté
+-- manuellement dans Supabase SQL Editor (jamais d'Alembic sur Railway,
+-- cf. CLAUDE.md "Contraintes Techniques").
+--
+-- 4 tables Epic 18 « Ma veille » (phase 2 backend) :
+--   - veille_configs    : 1 active par user (partial UNIQUE), thème + cadence
+--   - veille_topics     : topics rattachés (preset/suggested/custom)
+--   - veille_sources    : sources rattachées (followed/niche), FK RESTRICT
+--   - veille_deliveries : livraisons périodiques (squelette V1, items=[])
+--
+-- Pré-requis : extension `pgcrypto` activée pour `gen_random_uuid()`.
+-- ============================================================================
+
+-- Pré-requis : extension pour gen_random_uuid()
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ─── 1. veille_configs ───────────────────────────────────────────────────────
+CREATE TABLE veille_configs (
+    id UUID DEFAULT gen_random_uuid() NOT NULL,
+    user_id UUID NOT NULL,
+    theme_id VARCHAR(50) NOT NULL,
+    theme_label VARCHAR(120) NOT NULL,
+    frequency VARCHAR(20) NOT NULL,
+    day_of_week SMALLINT,
+    delivery_hour SMALLINT DEFAULT 7 NOT NULL,
+    timezone TEXT DEFAULT 'Europe/Paris' NOT NULL,
+    status VARCHAR(20) DEFAULT 'active' NOT NULL,
+    last_delivered_at TIMESTAMP WITH TIME ZONE,
+    next_scheduled_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY(user_id) REFERENCES user_profiles (user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX ix_veille_configs_next_scheduled
+    ON veille_configs (next_scheduled_at)
+    WHERE status = 'active';
+
+CREATE INDEX ix_veille_configs_user_id
+    ON veille_configs (user_id);
+
+-- Partial UNIQUE : 1 seule config ACTIVE par user (V1).
+CREATE UNIQUE INDEX uq_veille_configs_user_active
+    ON veille_configs (user_id)
+    WHERE status = 'active';
+
+
+-- ─── 2. veille_topics ────────────────────────────────────────────────────────
+CREATE TABLE veille_topics (
+    id UUID DEFAULT gen_random_uuid() NOT NULL,
+    veille_config_id UUID NOT NULL,
+    topic_id VARCHAR(80) NOT NULL,
+    label VARCHAR(200) NOT NULL,
+    kind VARCHAR(20) NOT NULL,
+    reason TEXT,
+    position SMALLINT DEFAULT 0 NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_veille_topics_config_topic UNIQUE (veille_config_id, topic_id),
+    FOREIGN KEY(veille_config_id) REFERENCES veille_configs (id) ON DELETE CASCADE
+);
+
+
+-- ─── 3. veille_sources ───────────────────────────────────────────────────────
+CREATE TABLE veille_sources (
+    id UUID DEFAULT gen_random_uuid() NOT NULL,
+    veille_config_id UUID NOT NULL,
+    source_id UUID NOT NULL,
+    kind VARCHAR(20) NOT NULL,
+    why TEXT,
+    position SMALLINT DEFAULT 0 NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_veille_sources_config_source UNIQUE (veille_config_id, source_id),
+    FOREIGN KEY(veille_config_id) REFERENCES veille_configs (id) ON DELETE CASCADE,
+    FOREIGN KEY(source_id) REFERENCES sources (id) ON DELETE RESTRICT
+);
+
+CREATE INDEX ix_veille_sources_source_id
+    ON veille_sources (source_id);
+
+
+-- ─── 4. veille_deliveries ────────────────────────────────────────────────────
+CREATE TABLE veille_deliveries (
+    id UUID DEFAULT gen_random_uuid() NOT NULL,
+    veille_config_id UUID NOT NULL,
+    target_date DATE NOT NULL,
+    items JSONB DEFAULT '[]'::jsonb NOT NULL,
+    generation_state VARCHAR(20) DEFAULT 'pending' NOT NULL,
+    attempts SMALLINT DEFAULT 0 NOT NULL,
+    started_at TIMESTAMP WITH TIME ZONE,
+    finished_at TIMESTAMP WITH TIME ZONE,
+    last_error TEXT,
+    version SMALLINT DEFAULT 1 NOT NULL,
+    generated_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_veille_deliveries_config_target UNIQUE (veille_config_id, target_date),
+    FOREIGN KEY(veille_config_id) REFERENCES veille_configs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX ix_veille_deliveries_target_date
+    ON veille_deliveries (target_date);
+
+CREATE INDEX ix_veille_deliveries_state
+    ON veille_deliveries (generation_state);
+
+
+-- ============================================================================
+-- Vérification post-migration
+-- ============================================================================
+-- SELECT tablename FROM pg_tables WHERE tablename LIKE 'veille_%' ORDER BY 1;
+-- Attendu : 4 lignes (veille_configs / veille_deliveries / veille_sources / veille_topics)

--- a/docs/stories/core/18.1.veille-backend-foundations.md
+++ b/docs/stories/core/18.1.veille-backend-foundations.md
@@ -1,0 +1,315 @@
+# Story 18.1 : Fondations backend « Ma veille » (Phase 2)
+
+## Status: Implementation Complete — En attente review
+
+## Story
+
+**As a** utilisateur Facteur ayant configuré une veille en local (phase 1, Riverpod + `VeilleMockData`),
+**I want** que ma configuration de veille soit persistée côté serveur et qu'un scanner planifié déclenche une livraison périodique (squelette pour l'instant),
+**so that** la phase 3 puisse remplacer la mock data par des appels réels et brancher la pipeline éditoriale de génération sans toucher au front.
+
+## Context
+
+### Phase 1 (déjà faite, parallèle)
+
+Branche `boujonlaurin-dotcom/brainstorm-design` — flow « Ma veille » UI Flutter 100 % local : Riverpod + `VeilleMockData`, `submit()` no-op. Le contrat JSON cible est aligné sur les modèles Dart `VeilleTheme`, `VeilleTopic`, `VeilleSource`, `VeilleFrequency`, `VeilleDay`.
+
+### Phase 2 (cette story)
+
+Plomberie backend FastAPI + Postgres/Supabase : modèles DB, endpoints CRUD, services LLM pour suggestions topics/sources, scheduler `*/30 min` + squelette d'un job de livraison qui marque les rows en `succeeded` avec `items=[]`. **Pas de génération réelle** — c'est la phase 3.
+
+### Phase 3 (hors scope)
+
+Génération réelle des items (clustering articles → curation → writing) via réutilisation `EditorialPipelineService`, notifications push, branchement front↔back, multi-veilles par user.
+
+### Réponses du PO aux 4 questions de cadrage
+
+1. **LLM** : Mistral (réutiliser `EditorialLLMClient` + clé `MISTRAL_API_KEY` déjà en place).
+2. **Cardinalité** : 1 veille active par user en V1. `UniqueConstraint(user_id) WHERE status='active'` (partial unique). Table designée extensible (PK `id` distincte du `user_id`).
+3. **Source niche absente du catalogue** : **ingérer dans `sources` à la volée** (pas un simple `external_slug` snapshot). Réutiliser `SourceService.detect_source` + flux `add_custom_source` existants.
+4. **Cadence scanner** : contrainte critique **« risque de saturation des pools de connexions »** — historique d'incidents en prod (cf. `docs/bugs/bug-infinite-load-requests.md` + récent `fix: batch parallel DB sessions to prevent QueuePool exhaustion (#363)`). Tout le design doit minimiser le temps d'occupation d'une connexion DB. Cadence retenue : **`*/30 min`** + scan ultra-léger (1 SELECT indexé) + une session courte par config + libération de la connexion AVANT chaque appel LLM (pattern `session_maker=safe_async_session`).
+
+## Acceptance Criteria
+
+1. ✅ Migration Alembic `vl01_create_veille_tables.py` (down_revision=`en01`) crée 4 tables : `veille_configs`, `veille_topics`, `veille_sources`, `veille_deliveries`. `alembic heads` retourne 1 head.
+2. ✅ Export SQL équivalent dans `docs/qa/sql/vl01_create_veille_tables.sql` pour application manuelle Supabase prod.
+3. ✅ Endpoints `/api/veille/config` (GET/POST/PATCH/DELETE) fonctionnels avec auth JWT, idempotents.
+4. ✅ Endpoints `/api/veille/suggestions/topics` et `/api/veille/suggestions/sources` retournent des suggestions LLM (Mistral) avec fallback déterministe si `MISTRAL_API_KEY` absent.
+5. ✅ Endpoint `/api/veille/deliveries` (liste + détail) retourne le squelette `items=[]`.
+6. ✅ Endpoint debug `POST /api/veille/deliveries/generate` guard via setting (off en prod).
+7. ✅ Job `run_veille_generation` planifié `*/30 min` (Europe/Paris) via APScheduler, semaphore=5, idempotent (UPSERT `on_conflict_do_update`), max_instances=1.
+8. ✅ **Aucune session DB ouverte pendant un appel LLM** (session courte → commit → libère → LLM → nouvelle session courte pour persister).
+9. ✅ `compute_next_scheduled_at` : fonction pure, testée à 100 % (weekly/biweekly/monthly + DST Paris + jamais livré).
+10. ✅ Source niche : si non présente dans le catalogue → ingestion à la volée via `SourceService.detect_source` + création row `Source` avec `is_curated=False`, `is_active=True` (sans `UserSource`).
+11. ✅ Tests verts : `pytest -v` (5 nouveaux fichiers `tests/test_veille_*.py`), `ruff format --check`, `ruff check`.
+12. ✅ Smoke API local OK : `POST /api/veille/config` → 200 ; `GET /api/veille/config` → 200 ; suggestions → 200 ; scheduler logue `veille_generation` au démarrage uvicorn.
+13. ✅ PR ouverte vers **`main`** (`--base main` obligatoire, hook `pre-bash-no-staging.sh`).
+
+## Garde-fous pool DB (point critique transversal)
+
+> **Lentille de lecture de toutes les autres sections** : chaque interaction DB doit la respecter.
+
+- **Helper unique** : `safe_async_session` (cf. `app/database.py:199`) avec rollback garanti + `SET LOCAL statement_timeout=30s` + `idle_in_transaction_session_timeout=10s`. Aucun `async with async_session_maker()` direct.
+- **Pas de session ouverte pendant un appel LLM** : pattern `session_maker=safe_async_session` propagé au job — comme `DigestSelector` / `EditorialPipelineService` (`app/jobs/digest_generation_job.py:172`). Session courte → SELECT/UPSERT → `commit()` → libère → LLM 3-5 s → nouvelle session courte → persiste.
+- **Scanner */30 min** : un seul `SELECT id, user_id, frequency, day_of_week, delivery_hour, last_delivered_at FROM veille_configs WHERE status='active' AND next_scheduled_at <= now()` indexé sur `next_scheduled_at`. Session du scanner libérée immédiatement après ce SELECT.
+- **Per-config processing** : session dédiée par config via `safe_async_session`, semaphore `asyncio.Semaphore(5)` (vs 10 du digest — la veille tourne plus rarement).
+- **Idempotence** : UPSERT `veille_deliveries` via `pg_insert(...).on_conflict_do_update(index_elements=["veille_config_id","target_date"])`. Rejouer un scan ne crée pas de doublons.
+- **Jamais de `safe_async_session` imbriqué** : un site ouvre UNE session ; les sites appelés reçoivent la session via paramètre.
+
+## Plan technique
+
+### 1. Schéma DB — `alembic/versions/vl01_create_veille_tables.py`
+
+`down_revision = "en01"` (head courant vérifié — seule migration sans descendant).
+
+#### `veille_configs`
+- `id UUID PK default gen_random_uuid()`
+- `user_id UUID NOT NULL` — FK `user_profiles.user_id` ondelete CASCADE (pattern `user_topic_profiles`)
+- `theme_id String(50) NOT NULL` — slug du thème (taxonomie existante, soft string)
+- `theme_label String(120) NOT NULL` — snapshot pour audit
+- `frequency Enum('weekly','biweekly','monthly') NOT NULL`
+- `day_of_week SmallInt NULL` (0–6, lundi=0 ; nullable si `monthly`)
+- `delivery_hour SmallInt NOT NULL default 7` (0–23)
+- `timezone Text NOT NULL default 'Europe/Paris'`
+- `status Enum('active','paused','archived') NOT NULL default 'active'`
+- `last_delivered_at TimestampTZ NULL`
+- `next_scheduled_at TimestampTZ NULL` — recalculé à chaque livraison
+- `created_at`, `updated_at` (server_default `now()`)
+- Indexes : `ix_veille_configs_next_scheduled (next_scheduled_at) WHERE status='active'`, `ix_veille_configs_user_id (user_id)`
+- Contraintes : `uq_veille_configs_user_active UNIQUE(user_id) WHERE status='active'` (partial)
+
+#### `veille_topics`
+- `id UUID PK`, `veille_config_id UUID FK ondelete CASCADE`
+- `topic_id String(80) NOT NULL` — id stable (`t-eval`, `sub-dys`, …)
+- `label String(200) NOT NULL`
+- `kind Enum('preset','suggested','custom') NOT NULL`
+- `reason Text NULL` — mini-pourquoi affiché
+- `position SmallInt NOT NULL default 0`
+- `created_at`
+- `UniqueConstraint(veille_config_id, topic_id)`
+
+#### `veille_sources`
+- `id UUID PK`, `veille_config_id UUID FK ondelete CASCADE`
+- `source_id UUID FK sources(id) ondelete RESTRICT NOT NULL` — toute source en catalogue (ingestion à la volée si besoin)
+- `kind Enum('followed','niche') NOT NULL`
+- `why Text NULL` — justification IA pour les niches
+- `position SmallInt NOT NULL default 0`
+- `created_at`
+- `UniqueConstraint(veille_config_id, source_id)`
+- Index : `ix_veille_sources_source_id (source_id)`
+
+#### `veille_deliveries`
+- `id UUID PK`, `veille_config_id UUID FK ondelete CASCADE`
+- `target_date Date NOT NULL`
+- `items JSONB NOT NULL default '[]'` — squelette `[{cluster_id,title,articles:[{content_id,source_id,...}],why_it_matters}]` — **vide en V1**
+- `generation_state Enum('pending','running','succeeded','failed') NOT NULL default 'pending'`
+- `attempts SmallInt NOT NULL default 0`
+- `started_at TimestampTZ NULL`, `finished_at TimestampTZ NULL`
+- `last_error Text NULL`
+- `version SmallInt NOT NULL default 1`
+- `generated_at TimestampTZ NULL`
+- `created_at`, `updated_at`
+- `UniqueConstraint(veille_config_id, target_date)`
+- Indexes : `ix_veille_deliveries_target_date (target_date)`, `ix_veille_deliveries_state (generation_state)`
+
+> Pas de table `veille_generation_state` séparée — pour V1 les colonnes embarquées suffisent (digest a une table séparée parce qu'il a 2 variantes/jour ; nous n'en avons qu'une).
+
+#### Export SQL Supabase
+Fichier `docs/qa/sql/vl01_create_veille_tables.sql` (CREATE TABLE + indexes complets) parallèle à la migration Alembic, à appliquer manuellement dans Supabase SQL Editor (jamais d'exécution Alembic sur Railway, cf. CLAUDE.md).
+
+### 2. Services métier
+
+#### `app/services/veille/scheduling.py` — fonction pure
+```python
+def compute_next_scheduled_at(
+    frequency: VeilleFrequency,
+    day_of_week: int | None,
+    delivery_hour: int,
+    timezone: str,
+    last_delivered_at: datetime | None,
+    now: datetime,
+) -> datetime: ...
+```
+Pas de side-effect, pas de DB. Testée à 100 %.
+
+#### `app/services/veille/topic_suggester.py`
+- Singleton via `get_topic_suggester()` (pattern `TopicEnrichmentService` cf. `app/services/ml/topic_enrichment_service.py:412`).
+- `async def suggest_topics(theme_id, theme_label, selected_topic_ids: list[str], excluded_topic_ids: list[str] = []) -> list[TopicSuggestion]`
+- Réutilise `EditorialLLMClient.chat_json()` (mistral-large-latest, temperature=0.3).
+- Pydantic `LLMSuggestedTopic` parser strict ; en cas d'échec → fallback 5 topics génériques liés au thème.
+- Cache court 10 min via `cachetools.TTLCache` in-process (clé = hash de `theme_id + sorted(selected_topic_ids)`).
+- **Aucune session DB ouverte** dans ce service.
+
+#### `app/services/veille/source_suggester.py`
+- `async def suggest_sources(theme_id, topic_labels: list[str], excluded_source_ids: list[UUID]) -> SourceSuggestions(followed=[], niche=[])`
+- Pour `followed` : SELECT léger sur `user_sources` JOIN `sources` filtré par thème.
+- Pour `niche` : LLM propose 6–8 candidats (`name + url + best-effort feed_url`). Pour chacun :
+  - Hydratation via `SourceService.detect_source(url)` (`app/services/source_service.py:580`).
+  - Si feed_url déjà en catalogue → renvoie son `id`.
+  - Sinon **ingestion** : créer une row `Source` avec `is_curated=False`, `is_active=True` (pas de `UserSource` car ce n'est pas un follow).
+- Si `MISTRAL_API_KEY` absent → fallback déterministe : SELECT sources `is_curated=true AND theme=theme_id AND id NOT IN excluded` LIMIT 5.
+- L'ingestion utilise une session passée en paramètre (pas d'ouverture interne).
+
+### 3. API endpoints (`app/routers/veille.py`, préfixe `/api/veille`)
+
+Toutes les routes : `Depends(get_current_user_id)` → str → `UUID(current_user_id)` (pattern existant). Toutes utilisent `Depends(get_db)`.
+
+| Méthode | Route | Description |
+|---|---|---|
+| GET | `/config` | `VeilleConfigResponse \| 404` (config + topics + sources hydratés) |
+| POST | `/config` | Upsert idempotent. Body `VeilleConfigUpsert`. Calcule `next_scheduled_at`. Si `niche_candidate` sans source_id → ingestion catalogue. Renvoie la config finale. |
+| PATCH | `/config` | Patch partiel (frequency / day_of_week / delivery_hour / status). Recalcule `next_scheduled_at` si change. |
+| DELETE | `/config` | Soft delete (`status='archived'`, garde l'historique deliveries). |
+| POST | `/suggestions/topics` | `{theme_id, selected_topic_ids[], exclude_topic_ids[]?}` → `[VeilleTopicSuggestion×5]` |
+| POST | `/suggestions/sources` | `{theme_id, topic_labels[], exclude_source_ids[]?, known_followed_source_ids[]?}` → `{followed:[], niche:[]}` |
+| GET | `/deliveries?limit=20&before=ISO8601` | Liste paginée |
+| GET | `/deliveries/{id}` | Détail (items vides en V1) |
+| POST | `/deliveries/generate` | Force-génère `target_date=today`. **Admin/debug** : guard `settings.allow_admin_force_generate` (off en prod). |
+
+Schémas Pydantic dans `app/schemas/veille.py` — convention `from_attributes=True`, `model_config` partout.
+
+### 4. Scheduler / job de livraison
+
+#### `app/jobs/veille_generation_job.py`
+Pattern adapté de `digest_generation_job.py` mais **sans la lourdeur LLM** (V1 ne génère pas de contenu) :
+
+```python
+async def run_veille_generation(target_date=None):
+    """Pour chaque veille_config active dont next_scheduled_at <= now()."""
+    async with safe_async_session() as scan_session:
+        configs_due = await scan_session.execute(
+            select(VeilleConfig).where(
+                VeilleConfig.status == "active",
+                VeilleConfig.next_scheduled_at <= datetime.now(UTC),
+            ).limit(500)  # garde-fou
+        )
+        configs = list(configs_due.scalars().all())
+    # Session FERMÉE ici avant tout traitement.
+
+    semaphore = asyncio.Semaphore(5)
+    async def process(cfg_id, user_id, frequency, dow, hour, last_delivered):
+        async with semaphore, safe_async_session() as s:
+            # 1. UPSERT veille_deliveries en "running"
+            # 2. (V1) items=[] succeeded — phase 3 ajoutera la pipeline LLM ici
+            # 3. UPDATE veille_configs SET last_delivered_at=now(),
+            #    next_scheduled_at=compute_next_scheduled_at(...)
+            # 4. commit (libère la connexion)
+    await asyncio.gather(*(process(*c) for c in configs), return_exceptions=True)
+```
+
+- État `running → succeeded` immédiat en V1.
+- `failed` réservé aux erreurs DB / sérialisation.
+- Logging structuré (`structlog`) : `veille_generation_job_started/_completed/_config_processed`.
+
+#### `app/workers/scheduler.py` — ajout
+```python
+scheduler.add_job(
+    run_veille_generation,
+    trigger=CronTrigger(minute="*/30", timezone=_PARIS_TZ),
+    id="veille_generation",
+    name="Veille Generation Scanner",
+    replace_existing=True,
+    misfire_grace_time=900,  # 15 min — moins critique que digest
+    coalesce=True,
+    max_instances=1,
+)
+```
+Ajouter `"veille_generation"` à la liste loguée par `start_scheduler()`.
+
+## Tasks / Subtasks
+
+### Phase A — DB schema ✅
+- [x] Créer modèles SQLAlchemy `app/models/veille.py` (4 modèles + 5 enums)
+- [x] Importer dans `app/models/__init__.py` (Base.metadata)
+- [x] Migration Alembic `alembic/versions/vl01_create_veille_tables.py` (down_revision=`en01`)
+- [x] Export SQL `docs/qa/sql/vl01_create_veille_tables.sql`
+- [x] `alembic upgrade head` local OK + `alembic heads` = 1 (`vl01`) + downgrade -1 OK
+- [x] Tests `tests/test_veille_models.py` (9 tests : CRUD, partial UNIQUE, cascade)
+
+### Phase B — Services métier ✅
+- [x] `app/services/veille/__init__.py` + `scheduling.py` (fonction pure)
+- [x] Tests `tests/test_veille_scheduling.py` (16 tests : weekly/biweekly/monthly + DST Paris + jamais livré + validation)
+- [x] `app/services/veille/topic_suggester.py` (singleton + LLM Mistral + cache TTL 10 min + fallback déterministe)
+- [x] Tests `tests/test_veille_topic_suggester.py` (9 tests : LLM success, fallback variants, cache LRU)
+- [x] `app/services/veille/source_suggester.py` (followed SELECT + niche LLM + ingestion à la volée)
+- [x] Tests `tests/test_veille_source_ingestion.py` (5 tests : mock detect_source, réutilisation feed_url, fallback)
+
+### Phase C — API ✅
+- [x] Schémas Pydantic `app/schemas/veille.py`
+- [x] Router `app/routers/veille.py` (9 endpoints)
+- [x] Inclure dans `app/main.py` : `include_router(veille.router, prefix="/api/veille", tags=["Veille"])`
+- [x] Tests `tests/routers/test_veille_routes.py` (10 tests : 200/404/upsert/401/LLM mocké)
+
+### Phase D — Job + scheduler ✅
+- [x] `app/jobs/veille_generation_job.py` — `run_veille_generation` (scanner) + `run_veille_generation_for_config` (exposed pour debug + tests)
+- [x] `app/workers/scheduler.py` : add_job `veille_generation` (`*/30 min` Paris, `max_instances=1`, `misfire_grace_time=900`)
+- [x] Tests `tests/test_veille_generation_job.py` (5 tests : transitions état + idempotence UPSERT + recalc + scanner avec mock safe_async_session)
+
+### Phase E — Verify + PR ✅
+- [x] `pytest -v` veille suite : **54/54 verts**
+- [x] `pytest -v` suite complète : 904 passed, 1 pre-existing TZ failure (`test_patch_increments_refusal_count` — sans rapport)
+- [x] `ruff format --check` + `ruff check` verts
+- [x] Smoke API local : 9 endpoints `/api/veille/*` enregistrés
+- [x] Lancement uvicorn confirme `veille_generation` dans la liste de jobs
+- [ ] `/go` → SIMPLIFY → PR vers `main`
+
+## Réutilisations explicites (NE PAS RÉINVENTER)
+
+| Helper | Localisation | Usage |
+|---|---|---|
+| `EditorialLLMClient.chat_json()` | `app/services/editorial/llm_client.py:52` | Appel Mistral + retries + JSON parsing |
+| `safe_async_session` | `app/database.py:199` | Session courte avec rollback garanti |
+| `get_current_user_id` | `app/dependencies.py:180` | Auth JWT |
+| `SourceService.detect_source` | `app/services/source_service.py:580` | Hydratation source |
+| `SourceService.add_custom_source` | `app/services/source_service.py:297` | Création row Source |
+| `pg_insert(...).on_conflict_do_update` | `app/services/digest_generation_state_service.py` | Upserts atomiques |
+| `_get_or_create` | `app/routers/notification_preferences.py` | Auto-create idempotent |
+| `pytest_asyncio` + `db_session` + `test_user` | `tests/conftest.py` + `tests/test_custom_topics.py` | Fixtures |
+
+## Fichiers (création / modification)
+
+| Fichier | Action |
+|---|---|
+| `packages/api/alembic/versions/vl01_create_veille_tables.py` | NEW |
+| `docs/qa/sql/vl01_create_veille_tables.sql` | NEW (export Supabase) |
+| `packages/api/app/models/veille.py` | NEW (4 modèles) |
+| `packages/api/app/models/__init__.py` | EDIT (importer veille pour Base.metadata) |
+| `packages/api/app/schemas/veille.py` | NEW |
+| `packages/api/app/routers/veille.py` | NEW |
+| `packages/api/app/main.py` | EDIT (include_router veille) |
+| `packages/api/app/services/veille/__init__.py` | NEW |
+| `packages/api/app/services/veille/scheduling.py` | NEW (pure) |
+| `packages/api/app/services/veille/topic_suggester.py` | NEW |
+| `packages/api/app/services/veille/source_suggester.py` | NEW |
+| `packages/api/app/jobs/veille_generation_job.py` | NEW |
+| `packages/api/app/workers/scheduler.py` | EDIT (add_job veille) |
+| `packages/api/tests/test_veille_*.py` | NEW (5 fichiers) |
+
+## Vérification end-to-end
+
+1. **Tests unitaires** : `cd packages/api && pytest -v tests/test_veille_*.py` → vert.
+2. **Suite complète** : `cd packages/api && pytest -v` → vert (anticipation hook `stop-verify-tests.sh`).
+3. **Lint** : `ruff format --check .` + `ruff check .` → vert (CI vérifie les deux, cf. memory `feedback_python_ruff_format_check.md`).
+4. **Alembic** : `alembic upgrade head` local OK, `alembic heads` = 1, `alembic downgrade -1` OK.
+5. **Scheduler** : `uvicorn app.main:app --reload` → log `Scheduler started ... jobs=[..., 'veille_generation']`.
+6. **Smoke API** (curl + JWT test user) :
+   - `POST /api/veille/config` (body minimal) → 200, row insérée.
+   - `GET /api/veille/config` → 200, structure attendue.
+   - `POST /api/veille/suggestions/topics` (LLM mocké en test, vrai en local si `MISTRAL_API_KEY` set) → 200, 5 items.
+7. **`/go`** en fin de tâche → VERIFY → SIMPLIFY → PR vers `main`.
+
+## Hors scope (phase 3)
+
+- Génération réelle des items (clustering articles → curation → writing) — réutilisera `EditorialPipelineService`.
+- Notifications push à la livraison.
+- Branchement front ↔ backend (le repo Veille mobile vit sur `boujonlaurin-dotcom/brainstorm-design`).
+- Édition multi-veilles par user (V2).
+- Webhooks Supabase Realtime.
+
+## Risques / points d'attention
+
+1. **Pool DB** — point critique transversal. Toute déviation du pattern `safe_async_session` doit être justifiée.
+2. **Migration prod** — n'oublie pas de générer le SQL parallèle pour Supabase (cf. CLAUDE.md « jamais d'exécution Alembic sur Railway »).
+3. **Singleton + cache TTL** — `cachetools.TTLCache` est in-process : si on scale horizontalement plus tard, prévoir Redis. OK pour V1.
+4. **Ingestion source à la volée** — la création de `Source` sans `UserSource` doit être bien isolée pour ne pas polluer le catalogue curé. `is_curated=False` est le marqueur.
+5. **Story doc front phase 1** — n'existe pas dans cette branche (vit sur `brainstorm-design`). Le contrat JSON est documenté ici à partir des modèles Dart annoncés.

--- a/packages/api/alembic/versions/vl01_create_veille_tables.py
+++ b/packages/api/alembic/versions/vl01_create_veille_tables.py
@@ -1,0 +1,271 @@
+"""create veille tables
+
+Revision ID: vl01
+Revises: en01
+Create Date: 2026-05-01
+
+4 tables pour la feature « Ma veille » : configs (1 active par user via partial
+UNIQUE WHERE status='active'), topics, sources (FK RESTRICT vers sources —
+ingestion à la volée pour les niches absentes du catalogue), deliveries
+(idempotent via UNIQUE (veille_config_id, target_date)).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "vl01"
+down_revision: str | Sequence[str] | None = "en01"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 1. veille_configs
+    op.create_table(
+        "veille_configs",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user_profiles.user_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("theme_id", sa.String(length=50), nullable=False),
+        sa.Column("theme_label", sa.String(length=120), nullable=False),
+        sa.Column("frequency", sa.String(length=20), nullable=False),
+        sa.Column("day_of_week", sa.SmallInteger(), nullable=True),
+        sa.Column(
+            "delivery_hour",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default=sa.text("7"),
+        ),
+        sa.Column(
+            "timezone",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'Europe/Paris'"),
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'active'"),
+        ),
+        sa.Column("last_delivered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("next_scheduled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_veille_configs_next_scheduled",
+        "veille_configs",
+        ["next_scheduled_at"],
+        postgresql_where=sa.text("status = 'active'"),
+    )
+    op.create_index(
+        "ix_veille_configs_user_id",
+        "veille_configs",
+        ["user_id"],
+    )
+    op.create_index(
+        "uq_veille_configs_user_active",
+        "veille_configs",
+        ["user_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'active'"),
+    )
+
+    # 2. veille_topics
+    op.create_table(
+        "veille_topics",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "veille_config_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("veille_configs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("topic_id", sa.String(length=80), nullable=False),
+        sa.Column("label", sa.String(length=200), nullable=False),
+        sa.Column("kind", sa.String(length=20), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column(
+            "position",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "veille_config_id",
+            "topic_id",
+            name="uq_veille_topics_config_topic",
+        ),
+    )
+
+    # 3. veille_sources
+    op.create_table(
+        "veille_sources",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "veille_config_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("veille_configs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "source_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("sources.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.String(length=20), nullable=False),
+        sa.Column("why", sa.Text(), nullable=True),
+        sa.Column(
+            "position",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "veille_config_id",
+            "source_id",
+            name="uq_veille_sources_config_source",
+        ),
+    )
+    op.create_index(
+        "ix_veille_sources_source_id",
+        "veille_sources",
+        ["source_id"],
+    )
+
+    # 4. veille_deliveries
+    op.create_table(
+        "veille_deliveries",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "veille_config_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("veille_configs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("target_date", sa.Date(), nullable=False),
+        sa.Column(
+            "items",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "generation_state",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column(
+            "attempts",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column(
+            "version",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column("generated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "veille_config_id",
+            "target_date",
+            name="uq_veille_deliveries_config_target",
+        ),
+    )
+    op.create_index(
+        "ix_veille_deliveries_target_date",
+        "veille_deliveries",
+        ["target_date"],
+    )
+    op.create_index(
+        "ix_veille_deliveries_state",
+        "veille_deliveries",
+        ["generation_state"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_veille_deliveries_state", table_name="veille_deliveries")
+    op.drop_index("ix_veille_deliveries_target_date", table_name="veille_deliveries")
+    op.drop_table("veille_deliveries")
+
+    op.drop_index("ix_veille_sources_source_id", table_name="veille_sources")
+    op.drop_table("veille_sources")
+
+    op.drop_table("veille_topics")
+
+    op.drop_index("uq_veille_configs_user_active", table_name="veille_configs")
+    op.drop_index("ix_veille_configs_user_id", table_name="veille_configs")
+    op.drop_index("ix_veille_configs_next_scheduled", table_name="veille_configs")
+    op.drop_table("veille_configs")

--- a/packages/api/app/jobs/veille_generation_job.py
+++ b/packages/api/app/jobs/veille_generation_job.py
@@ -1,0 +1,180 @@
+"""Génération des livraisons de veille — scanner */30 min.
+
+Pool DB : le scan est UN SELECT sur `ix_veille_configs_next_scheduled` puis
+session fermée AVANT tout traitement. Chaque config a une session dédiée
+bornée par un semaphore (incidents historiques de saturation pool, cf.
+`docs/bugs/bug-infinite-load-requests.md`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, date, datetime
+from uuid import UUID
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import safe_async_session
+from app.models.veille import (
+    VeilleConfig,
+    VeilleDelivery,
+    VeilleGenerationState,
+    VeilleStatus,
+)
+from app.services.veille.scheduling import compute_next_scheduled_at
+from app.utils.time import today_paris
+
+logger = structlog.get_logger()
+
+_CONCURRENCY_LIMIT = 5
+_SCAN_LIMIT = 500
+
+
+async def run_veille_generation(target_date: date | None = None) -> None:
+    """Scanner périodique : génère les livraisons des configs `due`."""
+    target = target_date or today_paris()
+    started_at = datetime.now(UTC)
+
+    logger.info("veille_generation_job_started", target_date=str(target))
+
+    async with safe_async_session() as scan_session:
+        configs_due = (
+            (
+                await scan_session.execute(
+                    select(VeilleConfig)
+                    .where(
+                        VeilleConfig.status == VeilleStatus.ACTIVE.value,
+                        VeilleConfig.next_scheduled_at <= started_at,
+                    )
+                    .limit(_SCAN_LIMIT)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        config_ids = [c.id for c in configs_due]
+
+    if not config_ids:
+        logger.info("veille_generation_job_no_due", target_date=str(target))
+        return
+
+    semaphore = asyncio.Semaphore(_CONCURRENCY_LIMIT)
+    results = await asyncio.gather(
+        *(_process_config_with_semaphore(semaphore, cid, target) for cid in config_ids),
+        return_exceptions=True,
+    )
+
+    succeeded = sum(1 for r in results if r is True)
+    failed = sum(1 for r in results if isinstance(r, Exception) or r is False)
+
+    logger.info(
+        "veille_generation_job_completed",
+        target_date=str(target),
+        configs_processed=len(config_ids),
+        succeeded=succeeded,
+        failed=failed,
+    )
+
+
+async def _process_config_with_semaphore(
+    semaphore: asyncio.Semaphore,
+    config_id: UUID,
+    target: date,
+) -> bool:
+    async with semaphore, safe_async_session() as session:
+        try:
+            await run_veille_generation_for_config(
+                session, config_id, target_date=target
+            )
+            await session.commit()
+            return True
+        except Exception as exc:
+            await session.rollback()
+            logger.error(
+                "veille_generation_job_config_failed",
+                config_id=str(config_id),
+                error=str(exc),
+            )
+            return False
+
+
+async def run_veille_generation_for_config(
+    session: AsyncSession,
+    config_id: UUID,
+    target_date: date,
+) -> VeilleDelivery:
+    """Génère (ou met à jour) la livraison pour une config + date données.
+
+    Idempotent via UPSERT sur (`veille_config_id`, `target_date`). Le caller
+    assure le `commit()` (utilisé depuis le job ET depuis la route debug).
+    """
+    cfg = (
+        (
+            await session.execute(
+                select(VeilleConfig).where(VeilleConfig.id == config_id)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if cfg is None:
+        raise ValueError(f"VeilleConfig introuvable: {config_id}")
+
+    started_at = datetime.now(UTC)
+
+    upsert_stmt = (
+        pg_insert(VeilleDelivery)
+        .values(
+            veille_config_id=config_id,
+            target_date=target_date,
+            generation_state=VeilleGenerationState.RUNNING.value,
+            attempts=1,
+            started_at=started_at,
+        )
+        .on_conflict_do_update(
+            index_elements=["veille_config_id", "target_date"],
+            set_={
+                "generation_state": VeilleGenerationState.RUNNING.value,
+                "started_at": started_at,
+                "attempts": VeilleDelivery.attempts + 1,
+            },
+        )
+        .returning(VeilleDelivery.id)
+    )
+    delivery_id = (await session.execute(upsert_stmt)).scalar_one()
+    delivery = await session.get(VeilleDelivery, delivery_id)
+    assert delivery is not None
+
+    finished_at = datetime.now(UTC)
+    delivery.generation_state = VeilleGenerationState.SUCCEEDED.value
+    delivery.items = []
+    delivery.finished_at = finished_at
+    delivery.generated_at = finished_at
+    delivery.last_error = None
+
+    # Recalcule next_scheduled_at + last_delivered_at.
+    cfg.last_delivered_at = finished_at
+    cfg.next_scheduled_at = compute_next_scheduled_at(
+        frequency=cfg.frequency,
+        day_of_week=cfg.day_of_week,
+        delivery_hour=cfg.delivery_hour,
+        timezone=cfg.timezone,
+        last_delivered_at=cfg.last_delivered_at,
+        now=finished_at,
+    )
+
+    await session.flush()
+
+    logger.info(
+        "veille_generation_config_processed",
+        config_id=str(config_id),
+        target_date=str(target_date),
+        next_scheduled_at=cfg.next_scheduled_at.isoformat()
+        if cfg.next_scheduled_at
+        else None,
+    )
+
+    return delivery

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -90,6 +90,7 @@ from app.routers import (
     streaks,
     subscription,
     users,
+    veille,
     waitlist,
     webhooks,
     well_informed,
@@ -466,6 +467,7 @@ app.include_router(
     prefix="/api/well-informed",
     tags=["WellInformed"],
 )
+app.include_router(veille.router, prefix="/api/veille", tags=["Veille"])
 
 
 @app.exception_handler(Exception)

--- a/packages/api/app/models/__init__.py
+++ b/packages/api/app/models/__init__.py
@@ -24,6 +24,17 @@ from app.models.user import UserInterest, UserPreference, UserProfile, UserStrea
 from app.models.user_notification_preferences import UserNotificationPreferences
 from app.models.user_personalization import UserPersonalization
 from app.models.user_topic_profile import UserTopicProfile
+from app.models.veille import (
+    VeilleConfig,
+    VeilleDelivery,
+    VeilleFrequency,
+    VeilleGenerationState,
+    VeilleSource,
+    VeilleSourceKind,
+    VeilleStatus,
+    VeilleTopic,
+    VeilleTopicKind,
+)
 from app.models.waitlist import WaitlistEntry
 from app.models.waitlist_survey import WaitlistSurveyResponse
 from app.models.well_informed_rating import UserWellInformedRating
@@ -86,4 +97,14 @@ __all__ = [
     "UserEntityPreference",
     # Self-reported "well-informed" score (Story 14.3)
     "UserWellInformedRating",
+    # Ma veille (Epic 18)
+    "VeilleConfig",
+    "VeilleTopic",
+    "VeilleSource",
+    "VeilleDelivery",
+    "VeilleFrequency",
+    "VeilleStatus",
+    "VeilleTopicKind",
+    "VeilleSourceKind",
+    "VeilleGenerationState",
 ]

--- a/packages/api/app/models/veille.py
+++ b/packages/api/app/models/veille.py
@@ -1,0 +1,239 @@
+"""Modèles SQLAlchemy pour « Ma veille »."""
+
+from datetime import date, datetime
+from enum import StrEnum
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    SmallInteger,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class VeilleFrequency(StrEnum):
+    """Cadence de livraison d'une veille."""
+
+    WEEKLY = "weekly"
+    BIWEEKLY = "biweekly"
+    MONTHLY = "monthly"
+
+
+class VeilleStatus(StrEnum):
+    """Statut d'une config veille."""
+
+    ACTIVE = "active"
+    PAUSED = "paused"
+    ARCHIVED = "archived"
+
+
+class VeilleTopicKind(StrEnum):
+    """Origine d'un topic rattaché à une veille."""
+
+    PRESET = "preset"
+    SUGGESTED = "suggested"
+    CUSTOM = "custom"
+
+
+class VeilleSourceKind(StrEnum):
+    """Origine d'une source rattachée à une veille."""
+
+    FOLLOWED = "followed"
+    NICHE = "niche"
+
+
+class VeilleGenerationState(StrEnum):
+    """État de génération d'une livraison."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class VeilleConfig(Base):
+    """Config de veille d'un user — partial UNIQUE garantit 1 ACTIVE par user."""
+
+    __tablename__ = "veille_configs"
+    __table_args__ = (
+        Index(
+            "ix_veille_configs_next_scheduled",
+            "next_scheduled_at",
+            postgresql_where=text("status = 'active'"),
+        ),
+        Index("ix_veille_configs_user_id", "user_id"),
+        Index(
+            "uq_veille_configs_user_active",
+            "user_id",
+            unique=True,
+            postgresql_where=text("status = 'active'"),
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("user_profiles.user_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    theme_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    theme_label: Mapped[str] = mapped_column(String(120), nullable=False)
+    frequency: Mapped[str] = mapped_column(String(20), nullable=False)
+    day_of_week: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    delivery_hour: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default=text("7")
+    )
+    timezone: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'Europe/Paris'")
+    )
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=text("'active'")
+    )
+    last_delivered_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    next_scheduled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+        onupdate=text("now()"),
+    )
+
+
+class VeilleTopic(Base):
+    """Topic rattaché à une veille_config."""
+
+    __tablename__ = "veille_topics"
+    __table_args__ = (
+        UniqueConstraint(
+            "veille_config_id", "topic_id", name="uq_veille_topics_config_topic"
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    veille_config_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("veille_configs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    topic_id: Mapped[str] = mapped_column(String(80), nullable=False)
+    label: Mapped[str] = mapped_column(String(200), nullable=False)
+    kind: Mapped[str] = mapped_column(String(20), nullable=False)
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    position: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default=text("0")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+
+class VeilleSource(Base):
+    """Source rattachée à une veille_config (toutes sont en catalogue)."""
+
+    __tablename__ = "veille_sources"
+    __table_args__ = (
+        UniqueConstraint(
+            "veille_config_id", "source_id", name="uq_veille_sources_config_source"
+        ),
+        Index("ix_veille_sources_source_id", "source_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    veille_config_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("veille_configs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    source_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("sources.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    kind: Mapped[str] = mapped_column(String(20), nullable=False)
+    why: Mapped[str | None] = mapped_column(Text, nullable=True)
+    position: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default=text("0")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+
+class VeilleDelivery(Base):
+    """Livraison périodique de veille."""
+
+    __tablename__ = "veille_deliveries"
+    __table_args__ = (
+        UniqueConstraint(
+            "veille_config_id",
+            "target_date",
+            name="uq_veille_deliveries_config_target",
+        ),
+        Index("ix_veille_deliveries_target_date", "target_date"),
+        Index("ix_veille_deliveries_state", "generation_state"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    veille_config_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("veille_configs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_date: Mapped[date] = mapped_column(Date, nullable=False)
+    items: Mapped[list[dict]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    generation_state: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=text("'pending'")
+    )
+    attempts: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default=text("0")
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    version: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default=text("1")
+    )
+    generated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+        onupdate=text("now()"),
+    )

--- a/packages/api/app/routers/__init__.py
+++ b/packages/api/app/routers/__init__.py
@@ -17,6 +17,7 @@ from app.routers import (
     streaks,
     subscription,
     users,
+    veille,
     webhooks,
 )
 
@@ -37,5 +38,6 @@ __all__ = [
     "streaks",
     "subscription",
     "users",
+    "veille",
     "webhooks",
 ]

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -1,0 +1,528 @@
+"""Router /api/veille — CRUD config, suggestions LLM, livraisons.
+
+Pool DB : 1 session par requête via `Depends(get_db)`. Les /suggestions
+appellent le LLM mais restent bornées à la durée d'une requête utilisateur
+(vs le scanner background, cf. `veille_generation_job` qui doit libérer la
+session avant le LLM).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.jobs.veille_generation_job import run_veille_generation_for_config
+from app.models.enums import SourceType
+from app.models.source import Source
+from app.models.veille import (
+    VeilleConfig,
+    VeilleDelivery,
+    VeilleSource,
+    VeilleStatus,
+    VeilleTopic,
+)
+from app.schemas.veille import (
+    VeilleConfigPatch,
+    VeilleConfigResponse,
+    VeilleConfigUpsert,
+    VeilleDeliveryListItem,
+    VeilleDeliveryResponse,
+    VeilleGenerateRequest,
+    VeilleSourceLite,
+    VeilleSourceResponse,
+    VeilleSourceSuggestion,
+    VeilleSourceSuggestionsResponse,
+    VeilleSuggestSourcesRequest,
+    VeilleSuggestTopicsRequest,
+    VeilleTopicResponse,
+    VeilleTopicSuggestion,
+)
+from app.services.source_service import SourceService
+from app.services.veille.scheduling import compute_next_scheduled_at
+from app.services.veille.source_suggester import (
+    SourceSuggester,
+    get_source_suggester,
+)
+from app.services.veille.topic_suggester import (
+    TopicSuggester,
+    get_topic_suggester,
+)
+from app.utils.time import today_paris
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+async def _get_active_config(db: AsyncSession, user_id: UUID) -> VeilleConfig | None:
+    stmt = select(VeilleConfig).where(
+        VeilleConfig.user_id == user_id,
+        VeilleConfig.status == VeilleStatus.ACTIVE.value,
+    )
+    return (await db.execute(stmt)).scalars().first()
+
+
+async def _hydrate_response(
+    db: AsyncSession, cfg: VeilleConfig
+) -> VeilleConfigResponse:
+    """Charge topics + sources (avec hydratation Source) pour la réponse."""
+    topics_rows = (
+        (
+            await db.execute(
+                select(VeilleTopic)
+                .where(VeilleTopic.veille_config_id == cfg.id)
+                .order_by(VeilleTopic.position, VeilleTopic.created_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    sources_rows = (
+        (
+            await db.execute(
+                select(VeilleSource)
+                .where(VeilleSource.veille_config_id == cfg.id)
+                .order_by(VeilleSource.position, VeilleSource.created_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    source_ids = [vs.source_id for vs in sources_rows]
+    sources_by_id: dict[UUID, Source] = {}
+    if source_ids:
+        for src in (
+            (await db.execute(select(Source).where(Source.id.in_(source_ids))))
+            .scalars()
+            .all()
+        ):
+            sources_by_id[src.id] = src
+
+    return VeilleConfigResponse(
+        id=cfg.id,
+        user_id=cfg.user_id,
+        theme_id=cfg.theme_id,
+        theme_label=cfg.theme_label,
+        frequency=cfg.frequency,  # type: ignore[arg-type]
+        day_of_week=cfg.day_of_week,
+        delivery_hour=cfg.delivery_hour,
+        timezone=cfg.timezone,
+        status=cfg.status,  # type: ignore[arg-type]
+        last_delivered_at=cfg.last_delivered_at,
+        next_scheduled_at=cfg.next_scheduled_at,
+        created_at=cfg.created_at,
+        updated_at=cfg.updated_at,
+        topics=[
+            VeilleTopicResponse(
+                id=t.id,
+                topic_id=t.topic_id,
+                label=t.label,
+                kind=t.kind,  # type: ignore[arg-type]
+                reason=t.reason,
+                position=t.position,
+            )
+            for t in topics_rows
+        ],
+        sources=[
+            VeilleSourceResponse(
+                id=vs.id,
+                source=VeilleSourceLite.model_validate(sources_by_id[vs.source_id]),
+                kind=vs.kind,  # type: ignore[arg-type]
+                why=vs.why,
+                position=vs.position,
+            )
+            for vs in sources_rows
+            if vs.source_id in sources_by_id
+        ],
+    )
+
+
+async def _resolve_source_id(
+    db: AsyncSession,
+    selection,
+    theme_id: str,
+) -> UUID:
+    """Renvoie un source_id existant ou ingère le candidat niche."""
+    if selection.source_id is not None:
+        return selection.source_id
+    if selection.niche_candidate is None:
+        raise HTTPException(
+            status_code=400,
+            detail="source_selection: source_id ou niche_candidate requis.",
+        )
+
+    cand = selection.niche_candidate
+    source_service = SourceService(db)
+    detected = await source_service.detect_source(cand.url)
+
+    existing = (
+        (await db.execute(select(Source).where(Source.feed_url == detected.feed_url)))
+        .scalars()
+        .first()
+    )
+    if existing is not None:
+        return existing.id
+
+    try:
+        source_type = SourceType(detected.detected_type)
+    except ValueError:
+        source_type = SourceType.ARTICLE
+
+    new_source = Source(
+        id=uuid4(),
+        name=cand.name or detected.name,
+        url=cand.url,
+        feed_url=detected.feed_url,
+        type=source_type,
+        theme=theme_id,
+        description=detected.description,
+        logo_url=detected.logo_url,
+        is_curated=False,
+        is_active=True,
+    )
+    db.add(new_source)
+    await db.flush()
+    logger.info(
+        "veille.source_ingested",
+        source_id=str(new_source.id),
+        feed_url=new_source.feed_url,
+    )
+    return new_source.id
+
+
+# ─── Endpoints config ────────────────────────────────────────────────────────
+
+
+@router.get("/config", response_model=VeilleConfigResponse)
+async def get_config(
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    user_uuid = UUID(current_user_id)
+    cfg = await _get_active_config(db, user_uuid)
+    if cfg is None:
+        raise HTTPException(
+            status_code=404, detail="Aucune veille active pour cet utilisateur."
+        )
+    return await _hydrate_response(db, cfg)
+
+
+@router.post("/config", response_model=VeilleConfigResponse)
+async def upsert_config(
+    body: VeilleConfigUpsert,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    user_uuid = UUID(current_user_id)
+
+    cfg = await _get_active_config(db, user_uuid)
+    now = datetime.now(UTC)
+
+    if cfg is None:
+        cfg = VeilleConfig(
+            id=uuid4(),
+            user_id=user_uuid,
+            theme_id=body.theme_id,
+            theme_label=body.theme_label,
+            frequency=body.frequency,
+            day_of_week=body.day_of_week,
+            delivery_hour=body.delivery_hour,
+            timezone=body.timezone,
+            status=VeilleStatus.ACTIVE.value,
+        )
+        db.add(cfg)
+        await db.flush()
+    else:
+        cfg.theme_id = body.theme_id
+        cfg.theme_label = body.theme_label
+        cfg.frequency = body.frequency
+        cfg.day_of_week = body.day_of_week
+        cfg.delivery_hour = body.delivery_hour
+        cfg.timezone = body.timezone
+
+    # Replace topics + sources atomically.
+    await db.execute(delete(VeilleTopic).where(VeilleTopic.veille_config_id == cfg.id))
+    await db.execute(
+        delete(VeilleSource).where(VeilleSource.veille_config_id == cfg.id)
+    )
+
+    for idx, t in enumerate(body.topics):
+        db.add(
+            VeilleTopic(
+                veille_config_id=cfg.id,
+                topic_id=t.topic_id,
+                label=t.label,
+                kind=t.kind,
+                reason=t.reason,
+                position=idx,
+            )
+        )
+
+    seen_source_ids: set[UUID] = set()
+    for idx, sel in enumerate(body.source_selections):
+        source_id = await _resolve_source_id(db, sel, body.theme_id)
+        if source_id in seen_source_ids:
+            continue
+        seen_source_ids.add(source_id)
+        db.add(
+            VeilleSource(
+                veille_config_id=cfg.id,
+                source_id=source_id,
+                kind=sel.kind,
+                why=sel.why,
+                position=idx,
+            )
+        )
+
+    cfg.next_scheduled_at = compute_next_scheduled_at(
+        frequency=cfg.frequency,
+        day_of_week=cfg.day_of_week,
+        delivery_hour=cfg.delivery_hour,
+        timezone=cfg.timezone,
+        last_delivered_at=cfg.last_delivered_at,
+        now=now,
+    )
+
+    await db.commit()
+    await db.refresh(cfg)
+    return await _hydrate_response(db, cfg)
+
+
+@router.patch("/config", response_model=VeilleConfigResponse)
+async def patch_config(
+    patch: VeilleConfigPatch,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    user_uuid = UUID(current_user_id)
+    cfg = await _get_active_config(db, user_uuid)
+    if cfg is None:
+        raise HTTPException(
+            status_code=404, detail="Aucune veille active pour cet utilisateur."
+        )
+
+    updates = patch.model_dump(exclude_unset=True)
+    if not updates:
+        return await _hydrate_response(db, cfg)
+
+    schedule_dirty = bool(
+        {"frequency", "day_of_week", "delivery_hour", "timezone"} & updates.keys()
+    )
+
+    for field, value in updates.items():
+        setattr(cfg, field, value)
+
+    if schedule_dirty:
+        cfg.next_scheduled_at = compute_next_scheduled_at(
+            frequency=cfg.frequency,
+            day_of_week=cfg.day_of_week,
+            delivery_hour=cfg.delivery_hour,
+            timezone=cfg.timezone,
+            last_delivered_at=cfg.last_delivered_at,
+            now=datetime.now(UTC),
+        )
+
+    await db.commit()
+    await db.refresh(cfg)
+    return await _hydrate_response(db, cfg)
+
+
+@router.delete("/config", status_code=204)
+async def delete_config(
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    user_uuid = UUID(current_user_id)
+    cfg = await _get_active_config(db, user_uuid)
+    if cfg is None:
+        # Idempotent : pas d'erreur si déjà supprimé.
+        return None
+    cfg.status = VeilleStatus.ARCHIVED.value
+    await db.commit()
+    return None
+
+
+# ─── Endpoints suggestions ───────────────────────────────────────────────────
+
+
+@router.post(
+    "/suggestions/topics",
+    response_model=list[VeilleTopicSuggestion],
+)
+async def suggest_topics(
+    req: VeilleSuggestTopicsRequest,
+    suggester: TopicSuggester = Depends(get_topic_suggester),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    UUID(current_user_id)  # validate JWT subject
+    items = await suggester.suggest_topics(
+        theme_id=req.theme_id,
+        theme_label=req.theme_label,
+        selected_topic_ids=req.selected_topic_ids,
+        excluded_topic_ids=req.exclude_topic_ids,
+    )
+    return [
+        VeilleTopicSuggestion(topic_id=it.topic_id, label=it.label, reason=it.reason)
+        for it in items
+    ]
+
+
+@router.post(
+    "/suggestions/sources",
+    response_model=VeilleSourceSuggestionsResponse,
+)
+async def suggest_sources(
+    req: VeilleSuggestSourcesRequest,
+    db: AsyncSession = Depends(get_db),
+    suggester: SourceSuggester = Depends(get_source_suggester),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    user_uuid = UUID(current_user_id)
+    result = await suggester.suggest_sources(
+        session=db,
+        user_id=user_uuid,
+        theme_id=req.theme_id,
+        topic_labels=req.topic_labels,
+        excluded_source_ids=req.exclude_source_ids,
+    )
+    await db.commit()  # persiste les éventuelles ingestions niche
+
+    return VeilleSourceSuggestionsResponse(
+        followed=[
+            VeilleSourceSuggestion(
+                source_id=it.source_id,
+                name=it.name,
+                url=it.url,
+                feed_url=it.feed_url,
+                theme=it.theme,
+                why=it.why,
+            )
+            for it in result.followed
+        ],
+        niche=[
+            VeilleSourceSuggestion(
+                source_id=it.source_id,
+                name=it.name,
+                url=it.url,
+                feed_url=it.feed_url,
+                theme=it.theme,
+                why=it.why,
+            )
+            for it in result.niche
+        ],
+    )
+
+
+# ─── Endpoints deliveries ────────────────────────────────────────────────────
+
+
+@router.get("/deliveries", response_model=list[VeilleDeliveryListItem])
+async def list_deliveries(
+    limit: int = Query(20, ge=1, le=100),
+    before: datetime | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    user_uuid = UUID(current_user_id)
+    cfg = await _get_active_config(db, user_uuid)
+    if cfg is None:
+        return []
+
+    stmt = (
+        select(VeilleDelivery)
+        .where(VeilleDelivery.veille_config_id == cfg.id)
+        .order_by(VeilleDelivery.target_date.desc())
+        .limit(limit)
+    )
+    if before is not None:
+        stmt = stmt.where(VeilleDelivery.created_at < before)
+
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        VeilleDeliveryListItem(
+            id=r.id,
+            veille_config_id=r.veille_config_id,
+            target_date=r.target_date,
+            generation_state=r.generation_state,  # type: ignore[arg-type]
+            item_count=len(r.items or []),
+            generated_at=r.generated_at,
+            created_at=r.created_at,
+        )
+        for r in rows
+    ]
+
+
+@router.get("/deliveries/{delivery_id}", response_model=VeilleDeliveryResponse)
+async def get_delivery(
+    delivery_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    user_uuid = UUID(current_user_id)
+    delivery = (
+        (
+            await db.execute(
+                select(VeilleDelivery).where(VeilleDelivery.id == delivery_id)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if delivery is None:
+        raise HTTPException(404, "Livraison introuvable.")
+
+    cfg = (
+        (
+            await db.execute(
+                select(VeilleConfig).where(VeilleConfig.id == delivery.veille_config_id)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if cfg is None or cfg.user_id != user_uuid:
+        raise HTTPException(404, "Livraison introuvable.")
+
+    return VeilleDeliveryResponse.model_validate(delivery)
+
+
+@router.post("/deliveries/generate", response_model=VeilleDeliveryResponse)
+async def force_generate(
+    req: VeilleGenerateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Admin/debug : force la génération de la livraison du jour.
+
+    Désactivé en production sauf si la config explicite l'autorise.
+    """
+    settings = get_settings()
+    if settings.environment == "production":
+        raise HTTPException(
+            status_code=403,
+            detail="Endpoint debug désactivé en production.",
+        )
+
+    user_uuid = UUID(current_user_id)
+    cfg = await _get_active_config(db, user_uuid)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail="Aucune veille active à générer.")
+
+    target = req.target_date or today_paris()
+    delivery = await run_veille_generation_for_config(db, cfg.id, target_date=target)
+    await db.commit()
+    await db.refresh(delivery)
+    return VeilleDeliveryResponse.model_validate(delivery)

--- a/packages/api/app/schemas/veille.py
+++ b/packages/api/app/schemas/veille.py
@@ -1,0 +1,190 @@
+"""Schémas Pydantic pour « Ma veille »."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# ─── Sub-objects ─────────────────────────────────────────────────────────────
+
+
+class VeilleTopicResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    topic_id: str
+    label: str
+    kind: Literal["preset", "suggested", "custom"]
+    reason: str | None = None
+    position: int = 0
+
+
+class VeilleSourceLite(BaseModel):
+    """Source hydratée embarquée dans une veille."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    url: str
+    feed_url: str
+    theme: str
+    type: str
+    is_curated: bool
+    logo_url: str | None = None
+
+
+class VeilleSourceResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    source: VeilleSourceLite
+    kind: Literal["followed", "niche"]
+    why: str | None = None
+    position: int = 0
+
+
+# ─── Config (GET / POST / PATCH) ─────────────────────────────────────────────
+
+
+class VeilleConfigResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    user_id: UUID
+    theme_id: str
+    theme_label: str
+    frequency: Literal["weekly", "biweekly", "monthly"]
+    day_of_week: int | None = None
+    delivery_hour: int = 7
+    timezone: str = "Europe/Paris"
+    status: Literal["active", "paused", "archived"]
+    last_delivered_at: datetime | None = None
+    next_scheduled_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+    topics: list[VeilleTopicResponse] = []
+    sources: list[VeilleSourceResponse] = []
+
+
+class VeilleTopicSelection(BaseModel):
+    topic_id: str = Field(min_length=1, max_length=80)
+    label: str = Field(min_length=1, max_length=200)
+    kind: Literal["preset", "suggested", "custom"]
+    reason: str | None = Field(default=None, max_length=500)
+    position: int = Field(default=0, ge=0)
+
+
+class VeilleNicheCandidate(BaseModel):
+    """Niche absente du catalogue → ingestion à la volée."""
+
+    name: str = Field(min_length=1, max_length=200)
+    url: str = Field(min_length=4, max_length=2048)
+    why: str | None = Field(default=None, max_length=500)
+
+
+class VeilleSourceSelection(BaseModel):
+    """Soit un source_id existant, soit un candidat niche à ingérer."""
+
+    kind: Literal["followed", "niche"]
+    source_id: UUID | None = None
+    niche_candidate: VeilleNicheCandidate | None = None
+    why: str | None = Field(default=None, max_length=500)
+    position: int = Field(default=0, ge=0)
+
+
+class VeilleConfigUpsert(BaseModel):
+    theme_id: str = Field(min_length=1, max_length=50)
+    theme_label: str = Field(min_length=1, max_length=120)
+    topics: list[VeilleTopicSelection] = Field(default_factory=list)
+    source_selections: list[VeilleSourceSelection] = Field(default_factory=list)
+    frequency: Literal["weekly", "biweekly", "monthly"]
+    day_of_week: int | None = Field(default=None, ge=0, le=6)
+    delivery_hour: int = Field(default=7, ge=0, le=23)
+    timezone: str = Field(default="Europe/Paris", max_length=64)
+
+
+class VeilleConfigPatch(BaseModel):
+    frequency: Literal["weekly", "biweekly", "monthly"] | None = None
+    day_of_week: int | None = Field(default=None, ge=0, le=6)
+    delivery_hour: int | None = Field(default=None, ge=0, le=23)
+    timezone: str | None = Field(default=None, max_length=64)
+    status: Literal["active", "paused", "archived"] | None = None
+
+
+# ─── Suggestions ─────────────────────────────────────────────────────────────
+
+
+class VeilleTopicSuggestion(BaseModel):
+    topic_id: str
+    label: str
+    reason: str | None = None
+
+
+class VeilleSuggestTopicsRequest(BaseModel):
+    theme_id: str = Field(min_length=1, max_length=50)
+    theme_label: str = Field(min_length=1, max_length=120)
+    selected_topic_ids: list[str] = Field(default_factory=list)
+    exclude_topic_ids: list[str] = Field(default_factory=list)
+
+
+class VeilleSourceSuggestion(BaseModel):
+    source_id: UUID
+    name: str
+    url: str
+    feed_url: str
+    theme: str
+    why: str | None = None
+
+
+class VeilleSourceSuggestionsResponse(BaseModel):
+    followed: list[VeilleSourceSuggestion]
+    niche: list[VeilleSourceSuggestion]
+
+
+class VeilleSuggestSourcesRequest(BaseModel):
+    theme_id: str = Field(min_length=1, max_length=50)
+    topic_labels: list[str] = Field(default_factory=list)
+    exclude_source_ids: list[UUID] = Field(default_factory=list)
+
+
+# ─── Deliveries ──────────────────────────────────────────────────────────────
+
+
+class VeilleDeliveryListItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    veille_config_id: UUID
+    target_date: date
+    generation_state: Literal["pending", "running", "succeeded", "failed"]
+    item_count: int = 0
+    generated_at: datetime | None = None
+    created_at: datetime
+
+
+class VeilleDeliveryResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    veille_config_id: UUID
+    target_date: date
+    items: list[dict]
+    generation_state: Literal["pending", "running", "succeeded", "failed"]
+    attempts: int
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    last_error: str | None = None
+    version: int
+    generated_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class VeilleGenerateRequest(BaseModel):
+    """Force une génération pour la config courante au target_date=today."""
+
+    target_date: date | None = None

--- a/packages/api/app/services/veille/__init__.py
+++ b/packages/api/app/services/veille/__init__.py
@@ -1,0 +1,1 @@
+"""Services pour la feature « Ma veille »."""

--- a/packages/api/app/services/veille/scheduling.py
+++ b/packages/api/app/services/veille/scheduling.py
@@ -1,0 +1,148 @@
+"""Prochain `next_scheduled_at` d'une veille — fonction pure (no DB, no I/O).
+
+Cadences :
+- weekly / biweekly : prochain `day_of_week` à `delivery_hour` (heure locale).
+- monthly           : le 1er du mois à `delivery_hour` (`day_of_week` ignoré).
+
+Les datetimes d'entrée doivent être timezone-aware ; le retour est UTC.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from app.models.veille import VeilleFrequency
+
+
+def compute_next_scheduled_at(
+    frequency: VeilleFrequency | str,
+    day_of_week: int | None,
+    delivery_hour: int,
+    timezone: str,
+    last_delivered_at: datetime | None,
+    now: datetime,
+) -> datetime:
+    """Calcule le prochain horaire de livraison d'une veille (UTC).
+
+    Args:
+        frequency: 'weekly' | 'biweekly' | 'monthly'.
+        day_of_week: 0–6 (lundi=0). Requis pour weekly/biweekly, ignoré pour monthly.
+        delivery_hour: 0–23 (heure locale dans `timezone`).
+        timezone: ex. 'Europe/Paris'. Utilisé pour le calcul jour/heure.
+        last_delivered_at: datetime aware de la dernière livraison réussie,
+            ou None si jamais livrée.
+        now: datetime aware (référence "maintenant").
+
+    Returns:
+        datetime aware en UTC du prochain horaire de livraison.
+
+    Raises:
+        ValueError: si la fréquence est inconnue, ou si day_of_week est requis
+            mais absent (weekly/biweekly), ou si delivery_hour hors [0,23].
+    """
+    if not 0 <= delivery_hour <= 23:
+        raise ValueError(f"delivery_hour hors [0,23]: {delivery_hour}")
+
+    freq = frequency.value if isinstance(frequency, VeilleFrequency) else str(frequency)
+    tz = ZoneInfo(timezone)
+
+    # On travaille en heure locale, on retourne en UTC.
+    now_local = now.astimezone(tz)
+    last_local = last_delivered_at.astimezone(tz) if last_delivered_at else None
+
+    if freq == VeilleFrequency.MONTHLY.value:
+        target_local = _next_monthly(now_local, last_local, delivery_hour, tz)
+    elif freq in (
+        VeilleFrequency.WEEKLY.value,
+        VeilleFrequency.BIWEEKLY.value,
+    ):
+        if day_of_week is None or not 0 <= day_of_week <= 6:
+            raise ValueError(f"day_of_week (0–6) requis pour {freq}: {day_of_week!r}")
+        step_days = 7 if freq == VeilleFrequency.WEEKLY.value else 14
+        target_local = _next_weekly_or_biweekly(
+            now_local, last_local, day_of_week, delivery_hour, step_days, tz
+        )
+    else:
+        raise ValueError(f"Fréquence inconnue: {freq!r}")
+
+    return target_local.astimezone(UTC)
+
+
+def _next_weekly_or_biweekly(
+    now_local: datetime,
+    last_local: datetime | None,
+    day_of_week: int,
+    delivery_hour: int,
+    step_days: int,
+    tz: ZoneInfo,
+) -> datetime:
+    """Prochaine occurrence weekly ou biweekly en heure locale."""
+    if last_local is None:
+        # Jamais livré : prochain `day_of_week` à `delivery_hour` ≥ now.
+        candidate = _snap_to_dow(now_local.date(), day_of_week, delivery_hour, tz)
+        if candidate <= now_local:
+            candidate = candidate + timedelta(days=7)
+        return candidate
+
+    # Déjà livré : last + step, snappé au day_of_week à delivery_hour, et
+    # au moins après now_local (en cas de retard du job).
+    candidate_date = (last_local + timedelta(days=step_days)).date()
+    candidate = _snap_to_dow(candidate_date, day_of_week, delivery_hour, tz)
+    while candidate <= now_local:
+        candidate = candidate + timedelta(days=step_days)
+    return candidate
+
+
+def _next_monthly(
+    now_local: datetime,
+    last_local: datetime | None,
+    delivery_hour: int,
+    tz: ZoneInfo,
+) -> datetime:
+    """Prochain 1er du mois à `delivery_hour` en heure locale."""
+    base = last_local or now_local
+    year, month = base.year, base.month
+    if last_local is None:
+        # Si on n'a jamais livré et qu'on est avant le 1er à delivery_hour
+        # ce mois-ci, on tire ce mois-ci ; sinon on passe au mois suivant.
+        candidate = datetime.combine(
+            base.date().replace(day=1), time(hour=delivery_hour), tzinfo=tz
+        )
+        if candidate > now_local:
+            return candidate
+
+    # Avancer au mois suivant.
+    if month == 12:
+        year, month = year + 1, 1
+    else:
+        month += 1
+    candidate = datetime.combine(
+        base.date().replace(year=year, month=month, day=1),
+        time(hour=delivery_hour),
+        tzinfo=tz,
+    )
+    while candidate <= now_local:
+        if month == 12:
+            year, month = year + 1, 1
+        else:
+            month += 1
+        candidate = datetime.combine(
+            base.date().replace(year=year, month=month, day=1),
+            time(hour=delivery_hour),
+            tzinfo=tz,
+        )
+    return candidate
+
+
+def _snap_to_dow(
+    base_date,
+    target_dow: int,
+    hour: int,
+    tz: ZoneInfo,
+) -> datetime:
+    """Retourne le datetime aware au prochain `target_dow` ≥ `base_date` à `hour`."""
+    current_dow = base_date.weekday()
+    delta = (target_dow - current_dow) % 7
+    target = base_date + timedelta(days=delta)
+    return datetime.combine(target, time(hour=hour), tzinfo=tz)

--- a/packages/api/app/services/veille/source_suggester.py
+++ b/packages/api/app/services/veille/source_suggester.py
@@ -1,0 +1,284 @@
+"""Suggestion de sources pour une veille : `followed` + `niche` (avec ingestion).
+
+- `followed` : sources suivies par l'user, filtrées par thème.
+- `niche`    : sources proposées par LLM, hydratées via `SourceService.detect_source` ;
+  ingérées à la volée si absentes du catalogue (`is_curated=False`, sans `UserSource`).
+
+Pool DB : la session est passée en paramètre — pas de réouverture interne.
+Sans `MISTRAL_API_KEY`, fallback déterministe sur sources curées du même thème.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import structlog
+from pydantic import BaseModel, Field, ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.enums import SourceType
+from app.models.source import Source, UserSource
+from app.services.editorial.llm_client import EditorialLLMClient
+from app.services.source_service import SourceService
+
+logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class SourceSuggestionItem:
+    source_id: UUID
+    name: str
+    url: str
+    feed_url: str
+    theme: str
+    why: str | None
+
+
+@dataclass(frozen=True)
+class SourceSuggestions:
+    followed: list[SourceSuggestionItem]
+    niche: list[SourceSuggestionItem]
+
+
+class _LLMNicheCandidate(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+    url: str = Field(min_length=4, max_length=2048)
+    why: str | None = Field(default=None, max_length=300)
+
+
+_NICHE_SYSTEM_PROMPT = """Tu es un expert en curation média francophone. Tu connais les sources de niche, indépendantes, et spécialisées sur des thématiques pointues.
+
+Tâche : pour un thème + des topics donnés, propose 6 à 8 sources de niche pertinentes (médias indé, newsletters, blogs spécialisés, podcasts, magazines).
+
+Format JSON strict :
+{"sources": [{"name": "<nom>", "url": "<url racine>", "why": "<1 phrase max>"}, ...]}
+
+Contraintes :
+- 6 à 8 sources max.
+- url : URL racine ou page d'accueil (pas un article spécifique).
+- why : pourquoi cette source est intéressante pour ce thème (1 phrase).
+- Diversifie : médias indé, perspectives variées, formats variés.
+- Évite les médias mainstream (Le Monde, Le Figaro, etc.).
+- Réponds UNIQUEMENT avec le JSON."""
+
+
+class SourceSuggester:
+    """Suggère des sources `followed` + `niche` pour une veille."""
+
+    def __init__(self, llm: EditorialLLMClient | None = None) -> None:
+        self._llm = llm or EditorialLLMClient()
+
+    async def suggest_sources(
+        self,
+        session: AsyncSession,
+        user_id: UUID,
+        theme_id: str,
+        topic_labels: list[str],
+        excluded_source_ids: list[UUID] | None = None,
+    ) -> SourceSuggestions:
+        """Renvoie sources `followed` + `niche` pour la veille en cours.
+
+        Args:
+            session: AsyncSession ouverte (caller-managed).
+            user_id: UUID du user (pour requêter `user_sources`).
+            theme_id: slug du thème.
+            topic_labels: labels des topics retenus (pour aider le LLM).
+            excluded_source_ids: sources à exclure (déjà rattachées, refusées).
+
+        Returns:
+            `SourceSuggestions(followed=..., niche=...)`.
+        """
+        excluded = set(excluded_source_ids or [])
+
+        followed = await self._followed(session, user_id, theme_id, excluded)
+        niche = await self._niche(session, theme_id, topic_labels, excluded)
+
+        return SourceSuggestions(followed=followed, niche=niche)
+
+    async def _followed(
+        self,
+        session: AsyncSession,
+        user_id: UUID,
+        theme_id: str,
+        excluded: set[UUID],
+    ) -> list[SourceSuggestionItem]:
+        """Sources déjà trustées par l'user, filtrées par thème + exclusions."""
+        stmt = (
+            select(Source)
+            .join(UserSource, UserSource.source_id == Source.id)
+            .where(
+                UserSource.user_id == user_id,
+                Source.theme == theme_id,
+                Source.is_active.is_(True),
+            )
+        )
+        result = await session.execute(stmt)
+        rows = list(result.scalars().all())
+        return [
+            SourceSuggestionItem(
+                source_id=s.id,
+                name=s.name,
+                url=s.url,
+                feed_url=s.feed_url,
+                theme=s.theme,
+                why=None,
+            )
+            for s in rows
+            if s.id not in excluded
+        ]
+
+    async def _niche(
+        self,
+        session: AsyncSession,
+        theme_id: str,
+        topic_labels: list[str],
+        excluded: set[UUID],
+    ) -> list[SourceSuggestionItem]:
+        if not self._llm.is_ready:
+            return await self._fallback_niche(session, theme_id, excluded)
+
+        user_message = (
+            f"Thème : {theme_id}\n"
+            f"Topics retenus : {', '.join(topic_labels) if topic_labels else '(aucun)'}\n\n"
+            f"Propose 6 à 8 sources de niche pour ce thème."
+        )
+        raw = await self._llm.chat_json(
+            system=_NICHE_SYSTEM_PROMPT,
+            user_message=user_message,
+            model="mistral-large-latest",
+            temperature=0.4,
+            max_tokens=1200,
+        )
+        candidates = self._parse_niche(raw)
+        if not candidates:
+            return await self._fallback_niche(session, theme_id, excluded)
+
+        items: list[SourceSuggestionItem] = []
+        source_service = SourceService(session)
+        for cand in candidates:
+            try:
+                hydrated = await self._hydrate_or_ingest(
+                    session, source_service, cand, theme_id
+                )
+            except Exception as exc:
+                logger.warning(
+                    "source_suggester.hydrate_failed",
+                    name=cand.name,
+                    url=cand.url,
+                    error=str(exc),
+                )
+                continue
+            if hydrated.id in excluded:
+                continue
+            items.append(
+                SourceSuggestionItem(
+                    source_id=hydrated.id,
+                    name=hydrated.name,
+                    url=hydrated.url,
+                    feed_url=hydrated.feed_url,
+                    theme=hydrated.theme,
+                    why=cand.why,
+                )
+            )
+
+        return items
+
+    async def _hydrate_or_ingest(
+        self,
+        session: AsyncSession,
+        source_service: SourceService,
+        cand: _LLMNicheCandidate,
+        theme_id: str,
+    ) -> Source:
+        """Ingest la source à la volée si absente du catalogue."""
+        detected = await source_service.detect_source(cand.url)
+
+        existing_stmt = select(Source).where(Source.feed_url == detected.feed_url)
+        existing = (await session.execute(existing_stmt)).scalars().first()
+        if existing:
+            return existing
+
+        try:
+            source_type = SourceType(detected.detected_type)
+        except ValueError:
+            source_type = SourceType.ARTICLE
+
+        new_source = Source(
+            id=uuid4(),
+            name=cand.name or detected.name,
+            url=cand.url,
+            feed_url=detected.feed_url,
+            type=source_type,
+            theme=theme_id,
+            description=detected.description,
+            logo_url=detected.logo_url,
+            is_curated=False,
+            is_active=True,
+        )
+        session.add(new_source)
+        await session.flush()
+        logger.info(
+            "source_suggester.source_ingested",
+            source_id=str(new_source.id),
+            name=new_source.name,
+            theme=theme_id,
+        )
+        return new_source
+
+    async def _fallback_niche(
+        self,
+        session: AsyncSession,
+        theme_id: str,
+        excluded: set[UUID],
+    ) -> list[SourceSuggestionItem]:
+        """Sans LLM : 5 sources curées du même thème non exclues."""
+        stmt = (
+            select(Source)
+            .where(
+                Source.is_curated.is_(True),
+                Source.is_active.is_(True),
+                Source.theme == theme_id,
+            )
+            .limit(5)
+        )
+        if excluded:
+            stmt = stmt.where(Source.id.notin_(excluded))
+        result = await session.execute(stmt)
+        return [
+            SourceSuggestionItem(
+                source_id=s.id,
+                name=s.name,
+                url=s.url,
+                feed_url=s.feed_url,
+                theme=s.theme,
+                why=None,
+            )
+            for s in result.scalars().all()
+        ]
+
+    @staticmethod
+    def _parse_niche(raw: dict | list | None) -> list[_LLMNicheCandidate]:
+        if not isinstance(raw, dict):
+            return []
+        items = raw.get("sources")
+        if not isinstance(items, list):
+            return []
+        out: list[_LLMNicheCandidate] = []
+        for it in items:
+            try:
+                out.append(_LLMNicheCandidate.model_validate(it))
+            except ValidationError as exc:
+                logger.debug("source_suggester.skip_invalid", error=str(exc))
+        return out
+
+
+_source_suggester: SourceSuggester | None = None
+
+
+def get_source_suggester() -> SourceSuggester:
+    global _source_suggester
+    if _source_suggester is None:
+        _source_suggester = SourceSuggester()
+    return _source_suggester

--- a/packages/api/app/services/veille/topic_suggester.py
+++ b/packages/api/app/services/veille/topic_suggester.py
@@ -1,0 +1,200 @@
+"""Suggestion de topics liés à un thème via LLM Mistral, avec cache TTL + fallback.
+
+Pool DB : ce service n'ouvre AUCUNE session — le caller fournit ce qu'il faut.
+Cache in-process (`cachetools.TTLCache`) — à migrer Redis si scale horizontal.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+import structlog
+from cachetools import TTLCache
+from pydantic import BaseModel, Field, ValidationError
+
+from app.services.editorial.llm_client import EditorialLLMClient
+
+logger = structlog.get_logger()
+
+_DEFAULT_CACHE_SIZE = 256
+_DEFAULT_CACHE_TTL_SECONDS = 600  # 10 min
+_SUGGESTIONS_PER_CALL = 5
+
+
+@dataclass(frozen=True)
+class TopicSuggestion:
+    topic_id: str
+    label: str
+    reason: str | None
+
+
+class _LLMSuggestedTopic(BaseModel):
+    """Schéma strict du JSON retourné par le LLM."""
+
+    topic_id: str = Field(min_length=1, max_length=80)
+    label: str = Field(min_length=1, max_length=200)
+    reason: str | None = Field(default=None, max_length=300)
+
+
+_SYSTEM_PROMPT = """Tu es un expert en curation éditoriale francophone, spécialisé en veille thématique.
+
+Tâche : pour un thème donné et une liste de topics déjà sélectionnés par l'utilisateur, propose 5 topics SUPPLÉMENTAIRES pertinents, NON redondants avec ceux déjà choisis ni avec ceux à exclure.
+
+Format JSON strict :
+{"topics": [{"topic_id": "<slug-kebab-case>", "label": "<nom court fr>", "reason": "<1 phrase max sur le pourquoi>"}, ...]}
+
+Contraintes :
+- Exactement 5 topics.
+- topic_id : slug en kebab-case, max 80 caractères, stable (ex: "evaluations-scolaires").
+- label : nom court français max 60 caractères (ex: "Évaluations scolaires").
+- reason : 1 phrase max 200 caractères qui explique l'intérêt pour le thème — peut être null.
+- Topics ciblés, ni trop génériques ni trop pointus.
+- Respecte la diversité : couvre plusieurs angles du thème.
+- Réponds UNIQUEMENT avec le JSON, rien d'autre."""
+
+
+def _fallback_topics(theme_label: str) -> list[TopicSuggestion]:
+    """5 topics génériques de secours quand le LLM est indisponible."""
+    return [
+        TopicSuggestion(
+            topic_id="actualite-generale",
+            label=f"Actualité {theme_label}",
+            reason=f"Suit l'actualité courante autour de {theme_label}",
+        ),
+        TopicSuggestion(
+            topic_id="analyses-de-fond",
+            label="Analyses de fond",
+            reason="Articles long format et tribunes d'experts",
+        ),
+        TopicSuggestion(
+            topic_id="recherche-etudes",
+            label="Recherche et études",
+            reason="Études récentes et travaux de recherche",
+        ),
+        TopicSuggestion(
+            topic_id="debats-controverses",
+            label="Débats et controverses",
+            reason="Sujets clivants et arguments contradictoires",
+        ),
+        TopicSuggestion(
+            topic_id="initiatives-pratiques",
+            label="Initiatives et bonnes pratiques",
+            reason="Retours d'expérience concrets et solutions testées",
+        ),
+    ]
+
+
+class TopicSuggester:
+    """Suggère des topics liés à un thème via LLM, avec cache + fallback."""
+
+    def __init__(
+        self,
+        llm: EditorialLLMClient | None = None,
+        cache_size: int = _DEFAULT_CACHE_SIZE,
+        cache_ttl: int = _DEFAULT_CACHE_TTL_SECONDS,
+    ) -> None:
+        self._llm = llm or EditorialLLMClient()
+        self._cache: TTLCache[str, list[TopicSuggestion]] = TTLCache(
+            maxsize=cache_size, ttl=cache_ttl
+        )
+
+    @staticmethod
+    def _cache_key(theme_id: str, selected: list[str], excluded: list[str]) -> str:
+        payload = (
+            f"{theme_id}|{','.join(sorted(selected))}|{','.join(sorted(excluded))}"
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    async def suggest_topics(
+        self,
+        theme_id: str,
+        theme_label: str,
+        selected_topic_ids: list[str],
+        excluded_topic_ids: list[str] | None = None,
+    ) -> list[TopicSuggestion]:
+        """Renvoie 5 suggestions de topics pour `theme_id`.
+
+        Args:
+            theme_id: slug du thème (ex: 'education').
+            theme_label: label affichable (ex: 'Éducation').
+            selected_topic_ids: topics déjà choisis (à éviter).
+            excluded_topic_ids: topics à exclure (ex: refusés précédemment).
+
+        Returns:
+            Exactement 5 `TopicSuggestion`. Fallback déterministe si LLM KO.
+        """
+        excluded = excluded_topic_ids or []
+        cache_key = self._cache_key(theme_id, selected_topic_ids, excluded)
+        if cached := self._cache.get(cache_key):
+            return cached
+
+        if not self._llm.is_ready:
+            logger.warning(
+                "topic_suggester.llm_unavailable",
+                theme_id=theme_id,
+                using="fallback",
+            )
+            result = _fallback_topics(theme_label)
+            self._cache[cache_key] = result
+            return result
+
+        user_message = (
+            f"Thème : {theme_label} (slug: {theme_id})\n"
+            f"Topics déjà sélectionnés : "
+            f"{', '.join(selected_topic_ids) if selected_topic_ids else '(aucun)'}\n"
+            f"Topics à exclure : "
+            f"{', '.join(excluded) if excluded else '(aucun)'}\n\n"
+            f"Propose 5 topics supplémentaires."
+        )
+
+        raw = await self._llm.chat_json(
+            system=_SYSTEM_PROMPT,
+            user_message=user_message,
+            model="mistral-large-latest",
+            temperature=0.3,
+            max_tokens=800,
+        )
+
+        suggestions = self._parse(raw)
+        if suggestions is None or len(suggestions) != _SUGGESTIONS_PER_CALL:
+            logger.warning(
+                "topic_suggester.parse_failed",
+                theme_id=theme_id,
+                using="fallback",
+            )
+            suggestions = _fallback_topics(theme_label)
+
+        self._cache[cache_key] = suggestions
+        return suggestions
+
+    @staticmethod
+    def _parse(raw: dict | list | None) -> list[TopicSuggestion] | None:
+        if not isinstance(raw, dict):
+            return None
+        items = raw.get("topics")
+        if not isinstance(items, list):
+            return None
+        try:
+            parsed = [_LLMSuggestedTopic.model_validate(it) for it in items]
+        except ValidationError as exc:
+            logger.warning("topic_suggester.validation_error", error=str(exc))
+            return None
+        return [
+            TopicSuggestion(
+                topic_id=p.topic_id,
+                label=p.label,
+                reason=p.reason,
+            )
+            for p in parsed
+        ]
+
+
+_topic_suggester: TopicSuggester | None = None
+
+
+def get_topic_suggester() -> TopicSuggester:
+    global _topic_suggester
+    if _topic_suggester is None:
+        _topic_suggester = TopicSuggester()
+    return _topic_suggester

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -8,6 +8,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from app.config import get_settings
 from app.jobs.digest_generation_job import run_digest_generation
+from app.jobs.veille_generation_job import run_veille_generation
 from app.workers.rss_sync import sync_all_sources
 from app.workers.storage_cleanup import cleanup_old_articles
 from app.workers.top3_job import generate_daily_top3_job
@@ -222,6 +223,22 @@ def start_scheduler() -> None:
         replace_existing=True,
     )
 
+    # Veille generation scanner — */30 min Paris.
+    # Scan ultra-léger (1 SELECT indexé sur next_scheduled_at) puis traitement
+    # par config avec session courte. Concurrence bornée à 5 (vs 10 du digest)
+    # car la veille tourne moins souvent → on peut être plus prudent côté
+    # pool DB (cf. bug-infinite-load-requests.md).
+    scheduler.add_job(
+        run_veille_generation,
+        trigger=CronTrigger(minute="*/30", timezone=_PARIS_TZ),
+        id="veille_generation",
+        name="Veille Generation Scanner",
+        replace_existing=True,
+        misfire_grace_time=900,
+        coalesce=True,
+        max_instances=1,
+    )
+
     scheduler.start()
     logger.info(
         "Scheduler started",
@@ -232,6 +249,7 @@ def start_scheduler() -> None:
             "digest_watchdog",
             "storage_cleanup",
             "zombie_session_sweeper",
+            "veille_generation",
         ],
         rss_interval_minutes=settings.rss_sync_interval_minutes,
         digest_cron="06:00 Europe/Paris",

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -1,0 +1,327 @@
+"""Tests pour le router /api/veille (Story 18.1).
+
+Couvre les endpoints CRUD config + suggestions + deliveries avec auth mockée.
+LLM Mistral mocké via AsyncMock sur les singletons des suggesters.
+"""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.enums import SourceType
+from app.models.source import Source
+from app.models.user import UserProfile
+from app.services.veille.source_suggester import (
+    SourceSuggester,
+    SourceSuggestionItem,
+    SourceSuggestions,
+)
+from app.services.veille.topic_suggester import TopicSuggester, TopicSuggestion
+
+
+@pytest_asyncio.fixture
+async def auth_user(db_session):
+    user_id = uuid4()
+    profile = UserProfile(
+        user_id=user_id,
+        display_name="Veille Route User",
+        onboarding_completed=True,
+    )
+    db_session.add(profile)
+    await db_session.commit()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        yield user_id
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def curated_education_source(db_session):
+    src = Source(
+        id=uuid4(),
+        name="Café Pédago",
+        url="https://cafe.example.com",
+        feed_url=f"https://cafe.example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="education",
+        is_active=True,
+        is_curated=True,
+    )
+    db_session.add(src)
+    await db_session.commit()
+    return src
+
+
+def _client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+class TestConfigCRUD:
+    async def test_get_404_when_no_config(self, auth_user):
+        async with _client() as ac:
+            resp = await ac.get("/api/veille/config")
+        assert resp.status_code == 404
+
+    async def test_post_creates_config(
+        self, auth_user, curated_education_source
+    ):
+        body = {
+            "theme_id": "education",
+            "theme_label": "Éducation",
+            "topics": [
+                {
+                    "topic_id": "t-eval",
+                    "label": "Évaluations",
+                    "kind": "preset",
+                    "reason": None,
+                    "position": 0,
+                }
+            ],
+            "source_selections": [
+                {
+                    "kind": "followed",
+                    "source_id": str(curated_education_source.id),
+                    "position": 0,
+                }
+            ],
+            "frequency": "weekly",
+            "day_of_week": 0,
+            "delivery_hour": 7,
+            "timezone": "Europe/Paris",
+        }
+        async with _client() as ac:
+            resp = await ac.post("/api/veille/config", json=body)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["theme_id"] == "education"
+        assert data["frequency"] == "weekly"
+        assert data["status"] == "active"
+        assert len(data["topics"]) == 1
+        assert data["topics"][0]["topic_id"] == "t-eval"
+        assert len(data["sources"]) == 1
+        assert data["sources"][0]["source"]["name"] == "Café Pédago"
+        assert data["next_scheduled_at"] is not None
+
+    async def test_post_upsert_replaces_topics(
+        self, auth_user, curated_education_source
+    ):
+        base_body = {
+            "theme_id": "education",
+            "theme_label": "Éducation",
+            "topics": [
+                {
+                    "topic_id": "t-eval",
+                    "label": "Évaluations",
+                    "kind": "preset",
+                }
+            ],
+            "source_selections": [
+                {
+                    "kind": "followed",
+                    "source_id": str(curated_education_source.id),
+                }
+            ],
+            "frequency": "weekly",
+            "day_of_week": 0,
+            "delivery_hour": 7,
+        }
+        async with _client() as ac:
+            await ac.post("/api/veille/config", json=base_body)
+
+            updated = {
+                **base_body,
+                "topics": [
+                    {
+                        "topic_id": "t-neuro",
+                        "label": "Neurosciences",
+                        "kind": "suggested",
+                        "reason": "Pertinent",
+                    }
+                ],
+            }
+            resp = await ac.post("/api/veille/config", json=updated)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["topics"]) == 1
+        assert data["topics"][0]["topic_id"] == "t-neuro"
+
+    async def test_patch_updates_frequency(
+        self, auth_user, curated_education_source
+    ):
+        async with _client() as ac:
+            await ac.post(
+                "/api/veille/config",
+                json={
+                    "theme_id": "education",
+                    "theme_label": "Éducation",
+                    "topics": [],
+                    "source_selections": [
+                        {
+                            "kind": "followed",
+                            "source_id": str(curated_education_source.id),
+                        }
+                    ],
+                    "frequency": "weekly",
+                    "day_of_week": 0,
+                    "delivery_hour": 7,
+                },
+            )
+
+            resp = await ac.patch(
+                "/api/veille/config",
+                json={"frequency": "monthly", "day_of_week": None},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["frequency"] == "monthly"
+
+    async def test_delete_archives(
+        self, auth_user, curated_education_source
+    ):
+        async with _client() as ac:
+            await ac.post(
+                "/api/veille/config",
+                json={
+                    "theme_id": "education",
+                    "theme_label": "Éducation",
+                    "topics": [],
+                    "source_selections": [
+                        {
+                            "kind": "followed",
+                            "source_id": str(curated_education_source.id),
+                        }
+                    ],
+                    "frequency": "weekly",
+                    "day_of_week": 0,
+                    "delivery_hour": 7,
+                },
+            )
+
+            resp = await ac.delete("/api/veille/config")
+            assert resp.status_code == 204
+
+            after = await ac.get("/api/veille/config")
+            assert after.status_code == 404
+
+    async def test_delete_idempotent(self, auth_user):
+        async with _client() as ac:
+            resp = await ac.delete("/api/veille/config")
+        # Pas d'erreur même sans config (idempotent).
+        assert resp.status_code == 204
+
+
+class TestSuggestions:
+    async def test_topics_returns_5(self, auth_user):
+        from app.services.veille import topic_suggester as ts_module
+
+        original = ts_module._topic_suggester
+        mock_llm = AsyncMock()
+        mock_llm.is_ready = True
+        mock_llm.chat_json = AsyncMock(
+            return_value={
+                "topics": [
+                    {"topic_id": f"t{i}", "label": f"T{i}", "reason": None}
+                    for i in range(5)
+                ]
+            }
+        )
+        ts_module._topic_suggester = TopicSuggester(llm=mock_llm)
+        try:
+            async with _client() as ac:
+                resp = await ac.post(
+                    "/api/veille/suggestions/topics",
+                    json={
+                        "theme_id": "education",
+                        "theme_label": "Éducation",
+                        "selected_topic_ids": ["t-eval"],
+                    },
+                )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data) == 5
+            assert data[0]["topic_id"] == "t0"
+        finally:
+            ts_module._topic_suggester = original
+
+    async def test_sources_followed_and_niche(
+        self, auth_user, curated_education_source
+    ):
+        from app.services.veille import source_suggester as ss_module
+
+        original = ss_module._source_suggester
+
+        class StubSuggester(SourceSuggester):
+            async def suggest_sources(  # type: ignore[override]
+                self, session, user_id, theme_id, topic_labels,
+                excluded_source_ids=None,
+            ):
+                return SourceSuggestions(
+                    followed=[
+                        SourceSuggestionItem(
+                            source_id=curated_education_source.id,
+                            name=curated_education_source.name,
+                            url=curated_education_source.url,
+                            feed_url=curated_education_source.feed_url,
+                            theme="education",
+                            why=None,
+                        )
+                    ],
+                    niche=[],
+                )
+
+        ss_module._source_suggester = StubSuggester()
+        try:
+            async with _client() as ac:
+                resp = await ac.post(
+                    "/api/veille/suggestions/sources",
+                    json={
+                        "theme_id": "education",
+                        "topic_labels": ["evaluations"],
+                        "exclude_source_ids": [],
+                    },
+                )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["followed"]) == 1
+            assert data["followed"][0]["name"] == "Café Pédago"
+            assert data["niche"] == []
+        finally:
+            ss_module._source_suggester = original
+
+
+class TestDeliveries:
+    async def test_list_empty_when_no_config(self, auth_user):
+        async with _client() as ac:
+            resp = await ac.get("/api/veille/deliveries")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestAuth:
+    async def test_get_config_requires_auth(self, db_session):
+        # Pas de auth_user fixture → pas d'override get_current_user_id.
+        # FastAPI lèvera 401/403 (selon implementation auth).
+        async with _client() as ac:
+            resp = await ac.get("/api/veille/config")
+        # 401 (Unauthorized) ou 403 (Forbidden) — on accepte les deux.
+        assert resp.status_code in (401, 403)

--- a/packages/api/tests/test_veille_generation_job.py
+++ b/packages/api/tests/test_veille_generation_job.py
@@ -1,0 +1,161 @@
+"""Tests pour le job de génération veille (Story 18.1).
+
+Note : le job lui-même utilise `safe_async_session` qui ouvre ses propres
+sessions ; on ne peut pas mocker ça facilement. On teste donc la sous-
+fonction `run_veille_generation_for_config` qui prend une session en
+paramètre, et un test d'intégration léger pour `run_veille_generation`
+(sans connexion réelle au pool — on patche `safe_async_session`).
+"""
+
+from datetime import UTC, date, datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.jobs.veille_generation_job import (
+    run_veille_generation,
+    run_veille_generation_for_config,
+)
+from app.models.user import UserProfile
+from app.models.veille import (
+    VeilleConfig,
+    VeilleDelivery,
+    VeilleFrequency,
+    VeilleGenerationState,
+    VeilleStatus,
+)
+
+
+@pytest_asyncio.fixture
+async def test_user(db_session):
+    user_id = uuid4()
+    db_session.add(
+        UserProfile(
+            user_id=user_id,
+            display_name="Job Test User",
+            onboarding_completed=True,
+        )
+    )
+    await db_session.commit()
+    return user_id
+
+
+@pytest_asyncio.fixture
+async def active_config(db_session, test_user):
+    """Config active dont next_scheduled_at est ≤ now (donc due)."""
+    cfg = VeilleConfig(
+        id=uuid4(),
+        user_id=test_user,
+        theme_id="education",
+        theme_label="Éducation",
+        frequency=VeilleFrequency.WEEKLY,
+        day_of_week=0,
+        delivery_hour=7,
+        timezone="Europe/Paris",
+        status=VeilleStatus.ACTIVE,
+        next_scheduled_at=datetime(2026, 5, 1, 0, 0, tzinfo=UTC),
+    )
+    db_session.add(cfg)
+    await db_session.commit()
+    await db_session.refresh(cfg)
+    return cfg
+
+
+class TestProcessConfig:
+    async def test_creates_succeeded_delivery_with_empty_items(
+        self, db_session, active_config
+    ):
+        target = date(2026, 5, 4)
+        result = await run_veille_generation_for_config(
+            db_session, active_config.id, target_date=target
+        )
+        await db_session.commit()
+
+        assert result.veille_config_id == active_config.id
+        assert result.target_date == target
+        assert result.generation_state == VeilleGenerationState.SUCCEEDED
+        assert result.items == []
+        assert result.attempts == 1
+        assert result.started_at is not None
+        assert result.finished_at is not None
+        assert result.generated_at is not None
+
+    async def test_recomputes_next_scheduled_at(
+        self, db_session, active_config
+    ):
+        prev_next = active_config.next_scheduled_at
+        target = date(2026, 5, 4)
+        await run_veille_generation_for_config(
+            db_session, active_config.id, target_date=target
+        )
+        await db_session.commit()
+        await db_session.refresh(active_config)
+
+        assert active_config.last_delivered_at is not None
+        assert active_config.next_scheduled_at != prev_next
+        # weekly + lundi (dow=0) → +7 jours par rapport à last_delivered.
+        diff_days = (
+            active_config.next_scheduled_at - active_config.last_delivered_at
+        ).days
+        assert diff_days >= 6  # au moins une semaine d'écart
+
+    async def test_idempotent_upsert(self, db_session, active_config):
+        """Rejouer le même (config_id, target_date) → 1 seule row, attempts incrémenté."""
+        target = date(2026, 5, 4)
+
+        first = await run_veille_generation_for_config(
+            db_session, active_config.id, target_date=target
+        )
+        await db_session.commit()
+        assert first.attempts == 1
+
+        second = await run_veille_generation_for_config(
+            db_session, active_config.id, target_date=target
+        )
+        await db_session.commit()
+        await db_session.refresh(second)
+
+        # Même row.
+        assert second.id == first.id
+
+        # 1 seule row pour ce (config, date).
+        all_rows = (
+            await db_session.execute(
+                select(VeilleDelivery).where(
+                    VeilleDelivery.veille_config_id == active_config.id,
+                    VeilleDelivery.target_date == target,
+                )
+            )
+        ).scalars().all()
+        assert len(list(all_rows)) == 1
+        assert second.attempts == 2
+
+    async def test_raises_when_config_missing(self, db_session):
+        with pytest.raises(ValueError, match="introuvable"):
+            await run_veille_generation_for_config(
+                db_session, uuid4(), target_date=date(2026, 5, 4)
+            )
+
+
+class TestRunVeilleGenerationScanner:
+    async def test_no_due_configs_logs_and_returns(self, db_session):
+        """Si aucune config n'est due → pas de delivery créée."""
+        # On patche `safe_async_session` pour qu'il yield notre db_session,
+        # afin que le scanner SELECT s'exécute sur la fixture (pas sur le
+        # vrai pool). Le scanner utilise ALSO `safe_async_session` dans le
+        # bloc per-config — comme il n'y a pas de config due, ce bloc n'est
+        # jamais atteint.
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _fake_session():
+            yield db_session
+
+        with patch(
+            "app.jobs.veille_generation_job.safe_async_session", _fake_session
+        ):
+            await run_veille_generation(target_date=date(2026, 5, 4))
+        # Pas d'exception → OK.

--- a/packages/api/tests/test_veille_models.py
+++ b/packages/api/tests/test_veille_models.py
@@ -1,0 +1,343 @@
+"""Tests pour les modèles SQLAlchemy de « Ma veille » (Story 18.1).
+
+Couvre :
+- CRUD basique sur les 4 tables (config / topics / sources / deliveries).
+- Partial UNIQUE constraint `uq_veille_configs_user_active` (1 active par user).
+- Cascade ondelete CASCADE depuis veille_configs vers topics/sources/deliveries.
+"""
+
+from datetime import UTC, date, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.models.enums import SourceType
+from app.models.source import Source
+from app.models.user import UserProfile
+from app.models.veille import (
+    VeilleConfig,
+    VeilleDelivery,
+    VeilleFrequency,
+    VeilleGenerationState,
+    VeilleSource,
+    VeilleSourceKind,
+    VeilleStatus,
+    VeilleTopic,
+    VeilleTopicKind,
+)
+
+
+@pytest_asyncio.fixture
+async def test_user(db_session):
+    user_id = uuid4()
+    profile = UserProfile(
+        user_id=user_id,
+        display_name="Veille Test User",
+        onboarding_completed=True,
+    )
+    db_session.add(profile)
+    await db_session.commit()
+    return profile
+
+
+@pytest_asyncio.fixture
+async def test_source(db_session):
+    source = Source(
+        id=uuid4(),
+        name="Edu Daily",
+        url="https://edu.example.com",
+        feed_url=f"https://edu.example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="education",
+        is_active=True,
+        is_curated=True,
+    )
+    db_session.add(source)
+    await db_session.commit()
+    return source
+
+
+class TestVeilleConfigCRUD:
+    @pytest.mark.asyncio
+    async def test_create_minimal_config(self, db_session, test_user):
+        cfg = VeilleConfig(
+            user_id=test_user.user_id,
+            theme_id="education",
+            theme_label="Éducation",
+            frequency=VeilleFrequency.WEEKLY,
+            day_of_week=0,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            status=VeilleStatus.ACTIVE,
+        )
+        db_session.add(cfg)
+        await db_session.commit()
+        await db_session.refresh(cfg)
+
+        assert cfg.id is not None
+        assert cfg.user_id == test_user.user_id
+        assert cfg.theme_id == "education"
+        assert cfg.frequency == VeilleFrequency.WEEKLY
+        assert cfg.status == VeilleStatus.ACTIVE
+        assert cfg.last_delivered_at is None
+        assert cfg.next_scheduled_at is None
+        assert cfg.created_at is not None
+
+    @pytest.mark.asyncio
+    async def test_partial_unique_one_active_per_user(
+        self, db_session, test_user
+    ):
+        """Le partial UNIQUE empêche 2 configs ACTIVE pour le même user,
+        mais autorise 1 active + N archived."""
+        user_id = test_user.user_id
+        active = VeilleConfig(
+            user_id=user_id,
+            theme_id="education",
+            theme_label="Éducation",
+            frequency=VeilleFrequency.WEEKLY,
+            delivery_hour=7,
+            status=VeilleStatus.ACTIVE,
+        )
+        db_session.add(active)
+        await db_session.commit()
+
+        # Une 2e ACTIVE doit casser la contrainte partial UNIQUE.
+        dupe = VeilleConfig(
+            user_id=user_id,
+            theme_id="health",
+            theme_label="Santé",
+            frequency=VeilleFrequency.MONTHLY,
+            delivery_hour=8,
+            status=VeilleStatus.ACTIVE,
+        )
+        db_session.add(dupe)
+        with pytest.raises(IntegrityError):
+            await db_session.commit()
+        await db_session.rollback()
+
+        # Une ARCHIVED en plus de l'ACTIVE doit passer.
+        archived = VeilleConfig(
+            user_id=user_id,
+            theme_id="health",
+            theme_label="Santé",
+            frequency=VeilleFrequency.MONTHLY,
+            delivery_hour=8,
+            status=VeilleStatus.ARCHIVED,
+        )
+        db_session.add(archived)
+        await db_session.commit()
+        await db_session.refresh(archived)
+        assert archived.status == VeilleStatus.ARCHIVED
+
+
+class TestVeilleTopicAndSource:
+    @pytest_asyncio.fixture
+    async def cfg(self, db_session, test_user):
+        c = VeilleConfig(
+            user_id=test_user.user_id,
+            theme_id="education",
+            theme_label="Éducation",
+            frequency=VeilleFrequency.WEEKLY,
+            delivery_hour=7,
+            status=VeilleStatus.ACTIVE,
+        )
+        db_session.add(c)
+        await db_session.commit()
+        await db_session.refresh(c)
+        return c
+
+    @pytest.mark.asyncio
+    async def test_attach_topics(self, db_session, cfg):
+        topics = [
+            VeilleTopic(
+                veille_config_id=cfg.id,
+                topic_id="t-eval",
+                label="Évaluations",
+                kind=VeilleTopicKind.PRESET,
+                position=0,
+            ),
+            VeilleTopic(
+                veille_config_id=cfg.id,
+                topic_id="sub-dys",
+                label="Dys (TDA/H, dyslexie)",
+                kind=VeilleTopicKind.SUGGESTED,
+                reason="Pertinent vu tes lectures",
+                position=1,
+            ),
+        ]
+        db_session.add_all(topics)
+        await db_session.commit()
+
+        result = await db_session.execute(
+            select(VeilleTopic).where(VeilleTopic.veille_config_id == cfg.id)
+        )
+        rows = list(result.scalars().all())
+        assert len(rows) == 2
+        assert {r.topic_id for r in rows} == {"t-eval", "sub-dys"}
+
+    @pytest.mark.asyncio
+    async def test_topic_unique_per_config(self, db_session, cfg):
+        db_session.add(
+            VeilleTopic(
+                veille_config_id=cfg.id,
+                topic_id="t-eval",
+                label="Évaluations",
+                kind=VeilleTopicKind.PRESET,
+            )
+        )
+        await db_session.commit()
+
+        db_session.add(
+            VeilleTopic(
+                veille_config_id=cfg.id,
+                topic_id="t-eval",
+                label="Évaluations bis",
+                kind=VeilleTopicKind.PRESET,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await db_session.commit()
+        await db_session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_attach_source(self, db_session, cfg, test_source):
+        link = VeilleSource(
+            veille_config_id=cfg.id,
+            source_id=test_source.id,
+            kind=VeilleSourceKind.FOLLOWED,
+            position=0,
+        )
+        db_session.add(link)
+        await db_session.commit()
+        await db_session.refresh(link)
+        assert link.kind == VeilleSourceKind.FOLLOWED
+
+
+class TestVeilleDelivery:
+    @pytest_asyncio.fixture
+    async def cfg(self, db_session, test_user):
+        c = VeilleConfig(
+            user_id=test_user.user_id,
+            theme_id="education",
+            theme_label="Éducation",
+            frequency=VeilleFrequency.WEEKLY,
+            delivery_hour=7,
+            status=VeilleStatus.ACTIVE,
+        )
+        db_session.add(c)
+        await db_session.commit()
+        await db_session.refresh(c)
+        return c
+
+    @pytest.mark.asyncio
+    async def test_create_delivery_default_state(self, db_session, cfg):
+        delivery = VeilleDelivery(
+            veille_config_id=cfg.id,
+            target_date=date.today(),
+        )
+        db_session.add(delivery)
+        await db_session.commit()
+        await db_session.refresh(delivery)
+
+        assert delivery.generation_state == VeilleGenerationState.PENDING
+        assert delivery.items == []
+        assert delivery.attempts == 0
+        assert delivery.version == 1
+
+    @pytest.mark.asyncio
+    async def test_unique_per_config_date(self, db_session, cfg):
+        target = date.today()
+        db_session.add(
+            VeilleDelivery(veille_config_id=cfg.id, target_date=target)
+        )
+        await db_session.commit()
+
+        db_session.add(
+            VeilleDelivery(veille_config_id=cfg.id, target_date=target)
+        )
+        with pytest.raises(IntegrityError):
+            await db_session.commit()
+        await db_session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_state_transitions(self, db_session, cfg):
+        delivery = VeilleDelivery(
+            veille_config_id=cfg.id,
+            target_date=date.today(),
+        )
+        db_session.add(delivery)
+        await db_session.commit()
+
+        delivery.generation_state = VeilleGenerationState.RUNNING
+        delivery.started_at = datetime.now(UTC)
+        await db_session.commit()
+        await db_session.refresh(delivery)
+        assert delivery.generation_state == VeilleGenerationState.RUNNING
+
+        delivery.generation_state = VeilleGenerationState.SUCCEEDED
+        delivery.finished_at = datetime.now(UTC)
+        await db_session.commit()
+        await db_session.refresh(delivery)
+        assert delivery.generation_state == VeilleGenerationState.SUCCEEDED
+
+
+class TestCascade:
+    @pytest.mark.asyncio
+    async def test_delete_config_cascades_children(
+        self, db_session, test_user, test_source
+    ):
+        cfg = VeilleConfig(
+            user_id=test_user.user_id,
+            theme_id="education",
+            theme_label="Éducation",
+            frequency=VeilleFrequency.WEEKLY,
+            delivery_hour=7,
+            status=VeilleStatus.ACTIVE,
+        )
+        db_session.add(cfg)
+        await db_session.commit()
+        await db_session.refresh(cfg)
+
+        cfg_id = cfg.id
+
+        db_session.add_all(
+            [
+                VeilleTopic(
+                    veille_config_id=cfg_id,
+                    topic_id="t-eval",
+                    label="Évaluations",
+                    kind=VeilleTopicKind.PRESET,
+                ),
+                VeilleSource(
+                    veille_config_id=cfg_id,
+                    source_id=test_source.id,
+                    kind=VeilleSourceKind.FOLLOWED,
+                ),
+                VeilleDelivery(
+                    veille_config_id=cfg_id,
+                    target_date=date.today() - timedelta(days=1),
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        await db_session.delete(cfg)
+        await db_session.commit()
+
+        topics = await db_session.execute(
+            select(VeilleTopic).where(VeilleTopic.veille_config_id == cfg_id)
+        )
+        sources = await db_session.execute(
+            select(VeilleSource).where(VeilleSource.veille_config_id == cfg_id)
+        )
+        deliveries = await db_session.execute(
+            select(VeilleDelivery).where(
+                VeilleDelivery.veille_config_id == cfg_id
+            )
+        )
+        assert list(topics.scalars().all()) == []
+        assert list(sources.scalars().all()) == []
+        assert list(deliveries.scalars().all()) == []

--- a/packages/api/tests/test_veille_scheduling.py
+++ b/packages/api/tests/test_veille_scheduling.py
@@ -1,0 +1,246 @@
+"""Tests pour `compute_next_scheduled_at` (Story 18.1).
+
+Fonction pure, pas de DB. Couvre :
+- weekly / biweekly / monthly, jamais livré + déjà livré.
+- DST Paris (passage heure d'été) : l'heure locale 7:00 reste 7:00.
+- Validation des entrées (frequency / day_of_week / delivery_hour).
+"""
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.models.veille import VeilleFrequency
+from app.services.veille.scheduling import compute_next_scheduled_at
+
+PARIS = ZoneInfo("Europe/Paris")
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+def _paris(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=PARIS)
+
+
+class TestWeeklyNeverDelivered:
+    def test_today_before_delivery_hour(self):
+        # Lundi 2026-05-04 06:00 UTC = 08:00 Paris (avant 7? Non, après).
+        # Tirons un cas net : Lundi 2026-05-04 03:00 Paris, livre à 07:00 Lundi.
+        now = _paris(2026, 5, 4, 3)  # lundi 03:00 Paris
+        result = compute_next_scheduled_at(
+            VeilleFrequency.WEEKLY,
+            day_of_week=0,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=None,
+            now=now,
+        )
+        assert result.astimezone(PARIS) == _paris(2026, 5, 4, 7)
+
+    def test_today_after_delivery_hour(self):
+        # Lundi 2026-05-04 09:00 Paris : la livraison de 7h est passée → semaine prochaine.
+        now = _paris(2026, 5, 4, 9)
+        result = compute_next_scheduled_at(
+            VeilleFrequency.WEEKLY,
+            day_of_week=0,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=None,
+            now=now,
+        )
+        assert result.astimezone(PARIS) == _paris(2026, 5, 11, 7)
+
+    def test_not_on_day_of_week(self):
+        # Mercredi 2026-05-06, on veut le prochain lundi (= 2026-05-11).
+        now = _paris(2026, 5, 6, 10)
+        result = compute_next_scheduled_at(
+            VeilleFrequency.WEEKLY,
+            day_of_week=0,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=None,
+            now=now,
+        )
+        assert result.astimezone(PARIS) == _paris(2026, 5, 11, 7)
+
+
+class TestWeeklyAlreadyDelivered:
+    def test_plus_seven_days(self):
+        # Livré lundi 2026-05-04 07:00 Paris → prochain lundi 2026-05-11 07:00.
+        last = _paris(2026, 5, 4, 7)
+        now = _paris(2026, 5, 4, 8)
+        result = compute_next_scheduled_at(
+            VeilleFrequency.WEEKLY,
+            day_of_week=0,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=last,
+            now=now,
+        )
+        assert result.astimezone(PARIS) == _paris(2026, 5, 11, 7)
+
+    def test_skip_if_now_past_candidate(self):
+        # Livré lundi 2026-05-04, mais le scanner a 1 mois de retard
+        # (now = 2026-06-08 = lundi). Le prochain doit être ≥ now.
+        last = _paris(2026, 5, 4, 7)
+        now = _paris(2026, 6, 8, 9)  # lundi 09:00, après 7:00
+        result = compute_next_scheduled_at(
+            VeilleFrequency.WEEKLY,
+            day_of_week=0,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=last,
+            now=now,
+        )
+        assert result.astimezone(PARIS) == _paris(2026, 6, 15, 7)
+
+
+class TestBiweekly:
+    def test_plus_fourteen_days(self):
+        last = _paris(2026, 5, 4, 7)
+        now = _paris(2026, 5, 4, 8)
+        result = compute_next_scheduled_at(
+            VeilleFrequency.BIWEEKLY,
+            day_of_week=0,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=last,
+            now=now,
+        )
+        assert result.astimezone(PARIS) == _paris(2026, 5, 18, 7)
+
+
+class TestMonthly:
+    def test_never_delivered_before_first(self):
+        # 2026-05-01 03:00 Paris (avant 7h le 1er) → tire le 1er à 7h.
+        now = _paris(2026, 5, 1, 3)
+        result = compute_next_scheduled_at(
+            VeilleFrequency.MONTHLY,
+            day_of_week=None,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=None,
+            now=now,
+        )
+        assert result.astimezone(PARIS) == _paris(2026, 5, 1, 7)
+
+    def test_never_delivered_after_first(self):
+        # 2026-05-15 → tire le 1er juin à 7h.
+        now = _paris(2026, 5, 15, 12)
+        result = compute_next_scheduled_at(
+            VeilleFrequency.MONTHLY,
+            day_of_week=None,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=None,
+            now=now,
+        )
+        assert result.astimezone(PARIS) == _paris(2026, 6, 1, 7)
+
+    def test_already_delivered(self):
+        last = _paris(2026, 5, 1, 7)
+        now = _paris(2026, 5, 2, 10)
+        result = compute_next_scheduled_at(
+            VeilleFrequency.MONTHLY,
+            day_of_week=None,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=last,
+            now=now,
+        )
+        assert result.astimezone(PARIS) == _paris(2026, 6, 1, 7)
+
+    def test_year_rollover(self):
+        # Livré 2026-12-01 → prochain 2027-01-01.
+        last = _paris(2026, 12, 1, 7)
+        now = _paris(2026, 12, 1, 8)
+        result = compute_next_scheduled_at(
+            VeilleFrequency.MONTHLY,
+            day_of_week=None,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=last,
+            now=now,
+        )
+        assert result.astimezone(PARIS) == _paris(2027, 1, 1, 7)
+
+
+class TestDST:
+    def test_paris_spring_forward_keeps_local_seven(self):
+        # Le 30 mars 2025 le passage à l'heure d'été : 02:00 → 03:00.
+        # On veut que la livraison hebdo à 07:00 Paris reste 07:00 Paris,
+        # même si l'offset UTC change (UTC+1 → UTC+2).
+        last = _paris(2025, 3, 24, 7)  # lundi 24 mars (UTC+1)
+        now = _paris(2025, 3, 24, 8)
+        result = compute_next_scheduled_at(
+            VeilleFrequency.WEEKLY,
+            day_of_week=0,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=last,
+            now=now,
+        )
+        # Lundi 31 mars à 07:00 Paris = 05:00 UTC (UTC+2 en été).
+        assert result.astimezone(PARIS) == _paris(2025, 3, 31, 7)
+        assert result == _utc(2025, 3, 31, 5)
+
+
+class TestValidation:
+    def test_invalid_frequency_raises(self):
+        with pytest.raises(ValueError, match="Fréquence inconnue"):
+            compute_next_scheduled_at(
+                "yearly",
+                day_of_week=0,
+                delivery_hour=7,
+                timezone="Europe/Paris",
+                last_delivered_at=None,
+                now=_paris(2026, 5, 1),
+            )
+
+    def test_missing_dow_for_weekly_raises(self):
+        with pytest.raises(ValueError, match="day_of_week"):
+            compute_next_scheduled_at(
+                VeilleFrequency.WEEKLY,
+                day_of_week=None,
+                delivery_hour=7,
+                timezone="Europe/Paris",
+                last_delivered_at=None,
+                now=_paris(2026, 5, 1),
+            )
+
+    def test_invalid_dow_raises(self):
+        with pytest.raises(ValueError, match="day_of_week"):
+            compute_next_scheduled_at(
+                VeilleFrequency.WEEKLY,
+                day_of_week=9,
+                delivery_hour=7,
+                timezone="Europe/Paris",
+                last_delivered_at=None,
+                now=_paris(2026, 5, 1),
+            )
+
+    def test_invalid_hour_raises(self):
+        with pytest.raises(ValueError, match="delivery_hour"):
+            compute_next_scheduled_at(
+                VeilleFrequency.WEEKLY,
+                day_of_week=0,
+                delivery_hour=25,
+                timezone="Europe/Paris",
+                last_delivered_at=None,
+                now=_paris(2026, 5, 1),
+            )
+
+    def test_monthly_ignores_dow(self):
+        # Pas d'erreur même si day_of_week=None pour monthly.
+        result = compute_next_scheduled_at(
+            VeilleFrequency.MONTHLY,
+            day_of_week=None,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            last_delivered_at=None,
+            now=_paris(2026, 5, 15, 12),
+        )
+        assert result.astimezone(PARIS) == _paris(2026, 6, 1, 7)

--- a/packages/api/tests/test_veille_source_ingestion.py
+++ b/packages/api/tests/test_veille_source_ingestion.py
@@ -1,0 +1,285 @@
+"""Tests pour SourceSuggester (Story 18.1) — ingestion à la volée des niches.
+
+Mocke `SourceService.detect_source` (pas d'appel HTTP réel) + `EditorialLLMClient.chat_json`.
+Couvre :
+- Followed : SELECT user_sources filtré par thème.
+- Niche : ingestion d'une nouvelle source si feed_url absent du catalogue.
+- Niche : réutilisation de la row existante si feed_url déjà connu.
+- Fallback déterministe sans `MISTRAL_API_KEY`.
+"""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.enums import SourceType
+from app.models.source import Source, UserSource
+from app.models.user import UserProfile
+from app.services.veille.source_suggester import SourceSuggester
+
+
+@pytest_asyncio.fixture
+async def test_user(db_session):
+    user_id = uuid4()
+    profile = UserProfile(
+        user_id=user_id,
+        display_name="Veille User",
+        onboarding_completed=True,
+    )
+    db_session.add(profile)
+    await db_session.commit()
+    return profile
+
+
+@pytest_asyncio.fixture
+async def followed_source(db_session, test_user):
+    src = Source(
+        id=uuid4(),
+        name="Le café pédago",
+        url="https://cafepedago.example.com",
+        feed_url=f"https://cafepedago.example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="education",
+        is_active=True,
+        is_curated=True,
+    )
+    db_session.add(src)
+    db_session.add(
+        UserSource(
+            id=uuid4(),
+            user_id=test_user.user_id,
+            source_id=src.id,
+        )
+    )
+    await db_session.commit()
+    return src
+
+
+@pytest_asyncio.fixture
+async def offtheme_followed_source(db_session, test_user):
+    """Source suivie mais sur un autre thème — ne doit PAS apparaître."""
+    src = Source(
+        id=uuid4(),
+        name="Tech Daily",
+        url="https://techdaily.example.com",
+        feed_url=f"https://techdaily.example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="tech",
+        is_active=True,
+        is_curated=True,
+    )
+    db_session.add(src)
+    db_session.add(
+        UserSource(
+            id=uuid4(),
+            user_id=test_user.user_id,
+            source_id=src.id,
+        )
+    )
+    await db_session.commit()
+    return src
+
+
+def _detect_response(name: str, feed_url: str, source_type: str = "article"):
+    """Simule un SourceDetectResponse minimal."""
+    from app.schemas.source import SourceDetectResponse
+
+    return SourceDetectResponse(
+        source_id=None,
+        detected_type=source_type,
+        feed_url=feed_url,
+        name=name,
+        description=f"{name} — média indé",
+        logo_url=None,
+        theme="education",
+        preview={"item_count": 0, "latest_titles": []},
+        bias_stance="unknown",
+        reliability_score="unknown",
+        bias_origin="unknown",
+    )
+
+
+class TestFollowed:
+    async def test_returns_only_theme_matching(
+        self,
+        db_session,
+        test_user,
+        followed_source,
+        offtheme_followed_source,
+    ):
+        llm = AsyncMock()
+        llm.is_ready = False  # niche → fallback (vide ici car pas de curated)
+        suggester = SourceSuggester(llm=llm)
+
+        result = await suggester.suggest_sources(
+            session=db_session,
+            user_id=test_user.user_id,
+            theme_id="education",
+            topic_labels=["evaluations"],
+        )
+
+        followed_ids = [s.source_id for s in result.followed]
+        assert followed_source.id in followed_ids
+        assert offtheme_followed_source.id not in followed_ids
+
+    async def test_excludes_specified(
+        self, db_session, test_user, followed_source
+    ):
+        llm = AsyncMock()
+        llm.is_ready = False
+        suggester = SourceSuggester(llm=llm)
+
+        result = await suggester.suggest_sources(
+            session=db_session,
+            user_id=test_user.user_id,
+            theme_id="education",
+            topic_labels=[],
+            excluded_source_ids=[followed_source.id],
+        )
+
+        assert result.followed == []
+
+
+class TestNicheIngestion:
+    async def test_ingest_new_source(self, db_session, test_user):
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value={
+                "sources": [
+                    {
+                        "name": "Mediapart Education",
+                        "url": "https://mediapart-edu.example.com",
+                        "why": "Investigation sur les politiques éducatives",
+                    }
+                ]
+            }
+        )
+        suggester = SourceSuggester(llm=llm)
+
+        new_feed = "https://mediapart-edu.example.com/feed.xml"
+
+        with patch(
+            "app.services.veille.source_suggester.SourceService.detect_source",
+            new=AsyncMock(
+                return_value=_detect_response(
+                    "Mediapart Education", new_feed
+                )
+            ),
+        ):
+            result = await suggester.suggest_sources(
+                session=db_session,
+                user_id=test_user.user_id,
+                theme_id="education",
+                topic_labels=["politiques"],
+            )
+
+        assert len(result.niche) == 1
+        assert result.niche[0].feed_url == new_feed
+
+        # Source row créée avec is_curated=False.
+        ingested = (
+            await db_session.execute(
+                select(Source).where(Source.feed_url == new_feed)
+            )
+        ).scalars().first()
+        assert ingested is not None
+        assert ingested.is_curated is False
+        assert ingested.is_active is True
+        assert ingested.theme == "education"
+
+        # Pas de UserSource créée (c'est une niche, pas un follow).
+        link = (
+            await db_session.execute(
+                select(UserSource).where(
+                    UserSource.user_id == test_user.user_id,
+                    UserSource.source_id == ingested.id,
+                )
+            )
+        ).scalars().first()
+        assert link is None
+
+    async def test_reuse_existing_source(
+        self, db_session, test_user, followed_source
+    ):
+        """Si le feed_url existe déjà → on renvoie la row existante (pas de doublon)."""
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value={
+                "sources": [
+                    {
+                        "name": followed_source.name,
+                        "url": followed_source.url,
+                        "why": "Spécialisé éducation",
+                    }
+                ]
+            }
+        )
+        suggester = SourceSuggester(llm=llm)
+
+        with patch(
+            "app.services.veille.source_suggester.SourceService.detect_source",
+            new=AsyncMock(
+                return_value=_detect_response(
+                    followed_source.name, followed_source.feed_url
+                )
+            ),
+        ):
+            result = await suggester.suggest_sources(
+                session=db_session,
+                user_id=test_user.user_id,
+                theme_id="education",
+                topic_labels=[],
+            )
+
+        # La niche ne doit PAS dupliquer la source.
+        # Note : la source existante est aussi `followed` ici → dans la vraie
+        # vie le caller passe `excluded_source_ids` avec les followed pour
+        # éviter le doublon ; le service fait confiance à cette liste.
+        # On vérifie ici qu'AUCUNE nouvelle row Source n'a été créée.
+        all_with_feed = (
+            await db_session.execute(
+                select(Source).where(Source.feed_url == followed_source.feed_url)
+            )
+        ).scalars().all()
+        assert len(list(all_with_feed)) == 1
+        # Et que la niche pointe sur la row existante.
+        assert result.niche[0].source_id == followed_source.id
+
+
+class TestFallback:
+    async def test_no_llm_returns_curated_same_theme(
+        self, db_session, test_user
+    ):
+        # Crée 6 sources curées thème education ; le fallback en renvoie 5 max.
+        for i in range(6):
+            db_session.add(
+                Source(
+                    id=uuid4(),
+                    name=f"Edu Source {i}",
+                    url=f"https://edu{i}.example.com",
+                    feed_url=f"https://edu{i}.example.com/feed-{uuid4()}.xml",
+                    type=SourceType.ARTICLE,
+                    theme="education",
+                    is_active=True,
+                    is_curated=True,
+                )
+            )
+        await db_session.commit()
+
+        llm = AsyncMock()
+        llm.is_ready = False
+        suggester = SourceSuggester(llm=llm)
+
+        result = await suggester.suggest_sources(
+            session=db_session,
+            user_id=test_user.user_id,
+            theme_id="education",
+            topic_labels=[],
+        )
+
+        assert len(result.niche) == 5

--- a/packages/api/tests/test_veille_topic_suggester.py
+++ b/packages/api/tests/test_veille_topic_suggester.py
@@ -1,0 +1,245 @@
+"""Tests pour TopicSuggester (Story 18.1).
+
+LLM mocké via `AsyncMock` sur `EditorialLLMClient.chat_json`.
+Couvre : succès LLM, parsing strict, fallback déterministe, cache TTL.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.veille.topic_suggester import (
+    TopicSuggester,
+    _fallback_topics,
+)
+
+
+def _llm_response(topics: list[dict]) -> dict:
+    return {"topics": topics}
+
+
+class TestSuggestTopics:
+    async def test_llm_success(self):
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {
+                        "topic_id": "evaluations",
+                        "label": "Évaluations",
+                        "reason": "Suit les réformes",
+                    },
+                    {
+                        "topic_id": "neuroscience",
+                        "label": "Neurosciences",
+                        "reason": None,
+                    },
+                    {
+                        "topic_id": "dys",
+                        "label": "Dys (TDA/H)",
+                        "reason": "Très demandé",
+                    },
+                    {
+                        "topic_id": "numerique",
+                        "label": "Numérique éducatif",
+                        "reason": None,
+                    },
+                    {
+                        "topic_id": "lecture",
+                        "label": "Lecture",
+                        "reason": None,
+                    },
+                ]
+            )
+        )
+        suggester = TopicSuggester(llm=llm)
+
+        result = await suggester.suggest_topics(
+            theme_id="education",
+            theme_label="Éducation",
+            selected_topic_ids=["t-eval"],
+        )
+
+        assert len(result) == 5
+        assert result[0].topic_id == "evaluations"
+        assert result[2].label == "Dys (TDA/H)"
+        assert llm.chat_json.await_count == 1
+
+    async def test_fallback_when_llm_not_ready(self):
+        llm = AsyncMock()
+        llm.is_ready = False
+        suggester = TopicSuggester(llm=llm)
+
+        result = await suggester.suggest_topics(
+            theme_id="education",
+            theme_label="Éducation",
+            selected_topic_ids=[],
+        )
+
+        assert result == _fallback_topics("Éducation")
+        # No LLM call.
+        assert llm.chat_json.await_count == 0
+
+    async def test_fallback_on_llm_returning_none(self):
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(return_value=None)
+        suggester = TopicSuggester(llm=llm)
+
+        result = await suggester.suggest_topics(
+            theme_id="education",
+            theme_label="Éducation",
+            selected_topic_ids=[],
+        )
+
+        assert result == _fallback_topics("Éducation")
+
+    async def test_fallback_on_invalid_payload(self):
+        llm = AsyncMock()
+        llm.is_ready = True
+        # Pas de clé "topics".
+        llm.chat_json = AsyncMock(return_value={"oops": []})
+        suggester = TopicSuggester(llm=llm)
+
+        result = await suggester.suggest_topics(
+            theme_id="education",
+            theme_label="Éducation",
+            selected_topic_ids=[],
+        )
+
+        assert result == _fallback_topics("Éducation")
+
+    async def test_fallback_on_wrong_count(self):
+        llm = AsyncMock()
+        llm.is_ready = True
+        # 3 topics au lieu de 5 → fallback.
+        llm.chat_json = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {"topic_id": "a", "label": "A", "reason": None},
+                    {"topic_id": "b", "label": "B", "reason": None},
+                    {"topic_id": "c", "label": "C", "reason": None},
+                ]
+            )
+        )
+        suggester = TopicSuggester(llm=llm)
+
+        result = await suggester.suggest_topics(
+            theme_id="education",
+            theme_label="Éducation",
+            selected_topic_ids=[],
+        )
+
+        assert result == _fallback_topics("Éducation")
+
+    async def test_fallback_on_validation_error(self):
+        llm = AsyncMock()
+        llm.is_ready = True
+        # topic_id vide invalide selon le schéma Pydantic (min_length=1).
+        llm.chat_json = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {"topic_id": "", "label": "X", "reason": None},
+                    {"topic_id": "a", "label": "A", "reason": None},
+                    {"topic_id": "b", "label": "B", "reason": None},
+                    {"topic_id": "c", "label": "C", "reason": None},
+                    {"topic_id": "d", "label": "D", "reason": None},
+                ]
+            )
+        )
+        suggester = TopicSuggester(llm=llm)
+
+        result = await suggester.suggest_topics(
+            theme_id="education",
+            theme_label="Éducation",
+            selected_topic_ids=[],
+        )
+
+        assert result == _fallback_topics("Éducation")
+
+
+class TestCacheTTL:
+    async def test_cache_hits_skip_llm(self):
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {"topic_id": "x", "label": "X", "reason": None},
+                    {"topic_id": "y", "label": "Y", "reason": None},
+                    {"topic_id": "z", "label": "Z", "reason": None},
+                    {"topic_id": "u", "label": "U", "reason": None},
+                    {"topic_id": "v", "label": "V", "reason": None},
+                ]
+            )
+        )
+        suggester = TopicSuggester(llm=llm)
+
+        first = await suggester.suggest_topics(
+            theme_id="education",
+            theme_label="Éducation",
+            selected_topic_ids=["a", "b"],
+        )
+        second = await suggester.suggest_topics(
+            theme_id="education",
+            theme_label="Éducation",
+            selected_topic_ids=["b", "a"],  # ordre différent → même clé (sorted)
+        )
+        assert first == second
+        assert llm.chat_json.await_count == 1  # cache hit le 2e
+
+    async def test_different_excluded_misses_cache(self):
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {"topic_id": "x", "label": "X", "reason": None},
+                    {"topic_id": "y", "label": "Y", "reason": None},
+                    {"topic_id": "z", "label": "Z", "reason": None},
+                    {"topic_id": "u", "label": "U", "reason": None},
+                    {"topic_id": "v", "label": "V", "reason": None},
+                ]
+            )
+        )
+        suggester = TopicSuggester(llm=llm)
+
+        await suggester.suggest_topics(
+            theme_id="education",
+            theme_label="Éducation",
+            selected_topic_ids=["a"],
+            excluded_topic_ids=[],
+        )
+        await suggester.suggest_topics(
+            theme_id="education",
+            theme_label="Éducation",
+            selected_topic_ids=["a"],
+            excluded_topic_ids=["banned"],
+        )
+        assert llm.chat_json.await_count == 2  # clés différentes
+
+    async def test_cache_size_limit(self):
+        """Le cache LRU évince les entrées quand on dépasse maxsize."""
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {"topic_id": "x", "label": "X", "reason": None},
+                    {"topic_id": "y", "label": "Y", "reason": None},
+                    {"topic_id": "z", "label": "Z", "reason": None},
+                    {"topic_id": "u", "label": "U", "reason": None},
+                    {"topic_id": "v", "label": "V", "reason": None},
+                ]
+            )
+        )
+        suggester = TopicSuggester(llm=llm, cache_size=2, cache_ttl=600)
+
+        # 3 thèmes différents → le 1er est évincé.
+        await suggester.suggest_topics("t1", "T1", [])
+        await suggester.suggest_topics("t2", "T2", [])
+        await suggester.suggest_topics("t3", "T3", [])
+        # Le t1 est évincé : nouvel appel LLM attendu.
+        await suggester.suggest_topics("t1", "T1", [])
+        assert llm.chat_json.await_count == 4


### PR DESCRIPTION
# PR — Veille backend foundations (Epic 18 phase 2)

## Summary

Pose la plomberie backend de la feature « Ma veille » (Epic 18 — phase 2 sur 3).
Permet à la phase 3 de remplacer la mock data Flutter par des appels réels et
de brancher la pipeline éditoriale de génération.

- **DB** : 4 tables (`veille_configs` partial UNIQUE WHERE status='active',
  `veille_topics`, `veille_sources` FK RESTRICT, `veille_deliveries`
  UPSERT-idempotent). Migration Alembic `vl01` + export SQL
  `docs/qa/sql/vl01_*.sql` pour Supabase prod.
- **API** : 9 endpoints `/api/veille/*` (CRUD config, suggestions
  topics+sources via Mistral avec cache TTL + fallback déterministe,
  deliveries).
- **Job** : scanner `*/30 min` Paris (`semaphore=5`, `max_instances=1`,
  `misfire_grace_time=900`), session courte AVANT tout traitement, recalc
  `next_scheduled_at`. V1 stocke `items=[]` ; phase 3 branchera la pipeline
  LLM en propageant `session_maker=safe_async_session`.

**Pool DB** (point critique transversal) : aucune session ouverte pendant un
appel LLM, pattern `safe_async_session` partout, scan ultra-léger sur l'index
partial `ix_veille_configs_next_scheduled` (cf.
`docs/bugs/bug-infinite-load-requests.md`, fix #363).

## Story

- `docs/stories/core/18.1.veille-backend-foundations.md` (status :
  Implementation Complete).

## Test plan

- [x] `pytest tests/test_veille_*.py tests/routers/test_veille_routes.py` →
      **54/54 verts** (modèles, scheduling pure DST Paris, suggesters LLM
      mocké + cache LRU + fallback, ingestion source à la volée, routes auth
      + CRUD + suggestions, job idempotence + scanner).
- [x] `pytest` complet → 904 passed (1 pre-existing TZ-only failure
      `test_patch_increments_refusal_count` sans rapport).
- [x] `ruff format --check` + `ruff check app/` → verts.
- [x] `alembic upgrade head` local OK ; `alembic heads` = 1 (`vl01`) ;
      `alembic downgrade -1` OK.
- [x] Smoke local : 9 endpoints `/api/veille/*` enregistrés ; scheduler logue
      `'veille_generation'` au démarrage uvicorn.
- [ ] **Prod migration** : appliquer
      `docs/qa/sql/vl01_create_veille_tables.sql` manuellement dans Supabase
      SQL Editor avant merge (jamais d'Alembic sur Railway, cf. CLAUDE.md).

## Hors scope (phase 3)

- Génération réelle des items (clustering → curation → writing) via
  `EditorialPipelineService`.
- Notifications push à la livraison.
- Branchement front ↔ backend (le repo Veille mobile vit sur
  `boujonlaurin-dotcom/brainstorm-design`).
- Édition multi-veilles par user (V2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)