### PR TITLE
fix(flux): "Flux continu" filter + update in settings + back nav + profile avatar

### DIFF
--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -53,7 +53,6 @@ import '../widgets/feed_carousel.dart';
 import '../widgets/profile_avatar_button.dart';
 import '../../gamification/widgets/streak_indicator.dart';
 import '../../app_update/providers/app_update_provider.dart';
-import '../../app_update/widgets/update_button.dart';
 import '../../app_update/widgets/update_modal.dart';
 import '../../../core/orchestration/first_impression_orchestrator.dart';
 import '../../notifications/widgets/notification_activation_modal.dart';
@@ -654,30 +653,46 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                           alignment: Alignment.center,
                           children: [
                             const FacteurLogo(size: 22, showIcon: false),
-                            Align(
-                              alignment: Alignment.centerLeft,
-                              child: const StreakIndicator(),
-                            ),
-                            Align(
-                              alignment: Alignment.centerLeft,
-                              child: ProfileAvatarButton(
-                                onTap: () =>
-                                    context.push(RoutePaths.settings),
-                              ),
-                            ),
                             const Align(
+                              alignment: Alignment.centerLeft,
+                              child: StreakIndicator(),
+                            ),
+                            Align(
                               alignment: Alignment.centerRight,
-                              child: Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  const UpdateButton(),
-                                  const SizedBox(width: 8),
-                                  ProfileAvatarButton(
-                                    onTap: () =>
-                                        context.push(RoutePaths.settings),
-                                  ),
-                                ],
-                              ),
+                              child: Consumer(builder: (context, ref, _) {
+                                final hasUpdate = ref
+                                        .watch(appUpdateProvider)
+                                        .valueOrNull
+                                        ?.updateAvailable ==
+                                    true;
+                                final settingsButton = ProfileAvatarButton(
+                                  onTap: () =>
+                                      context.push(RoutePaths.settings),
+                                );
+                                if (!hasUpdate) return settingsButton;
+                                return Stack(
+                                  clipBehavior: Clip.none,
+                                  children: [
+                                    settingsButton,
+                                    Positioned(
+                                      top: -2,
+                                      right: -2,
+                                      child: Container(
+                                        width: 12,
+                                        height: 12,
+                                        decoration: BoxDecoration(
+                                          color: colors.error,
+                                          shape: BoxShape.circle,
+                                          border: Border.all(
+                                            color: colors.backgroundPrimary,
+                                            width: 2,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                );
+                              }),
                             ),
                           ],
                         ),

--- a/apps/mobile/lib/features/feed/widgets/compact_source_chip.dart
+++ b/apps/mobile/lib/features/feed/widgets/compact_source_chip.dart
@@ -29,24 +29,6 @@ class CompactSourceChip extends StatelessWidget {
 
   bool get _isActive => selectedSourceId != null;
 
-  /// Top 3 favorites sorted: real logo first, then hasSubscription, then priorityMultiplier desc.
-  List<Source> get _topSources {
-    final sorted = [...followedSources];
-    sorted.sort((a, b) {
-      // 1. Prefer sources with a real logo image
-      final aHasLogo = a.logoUrl != null && a.logoUrl!.isNotEmpty;
-      final bHasLogo = b.logoUrl != null && b.logoUrl!.isNotEmpty;
-      if (aHasLogo != bHasLogo) return bHasLogo ? 1 : -1;
-      // 2. Then hasSubscription
-      if (a.hasSubscription != b.hasSubscription) {
-        return b.hasSubscription ? 1 : -1;
-      }
-      // 3. Then priorityMultiplier desc
-      return b.priorityMultiplier.compareTo(a.priorityMultiplier);
-    });
-    return sorted.take(3).toList();
-  }
-
   @override
   Widget build(BuildContext context) {
     return AnimatedSwitcher(
@@ -103,7 +85,6 @@ class _InactiveChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final muted = colors.textSecondary;
 
     return GestureDetector(
       onTap: onTap,
@@ -118,56 +99,19 @@ class _InactiveChip extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (topSources.isEmpty) ...[
-              Text(
-                'Sources',
-                style: TextStyle(
-                    fontSize: 12,
-                    color: colors.textPrimary,
-                    fontWeight: FontWeight.w500),
+            Text(
+              'Mes sources',
+              style: TextStyle(
+                fontSize: 12,
+                color: colors.textPrimary,
+                fontWeight: FontWeight.w500,
               ),
-              const SizedBox(width: 4),
-            ] else ...[
-              // Avatar stack — overlap adapts to screen width
-              Builder(builder: (context) {
-                final screenW = MediaQuery.of(context).size.width;
-                // step ranges from 13 (small, ~320px) to 16 (large, ≥430px)
-                final step = (screenW / 35).clamp(13.0, 16.0);
-                final stackW = 18.0 + (topSources.length - 1) * step;
-                return Opacity(
-                  opacity: 0.65,
-                  child: SizedBox(
-                    width: stackW,
-                    height: 18,
-                    child: Stack(
-                      clipBehavior: Clip.none,
-                      children: [
-                        for (int i = 0; i < topSources.length; i++)
-                          Positioned(
-                            left: i * step,
-                            child: _SourceAvatar(
-                              source: topSources[i],
-                              size: 18,
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
-                );
-              }),
-              const SizedBox(width: 6),
-              if (remainingCount > 0) ...[
-                Text(
-                  '+$remainingCount',
-                  style: TextStyle(fontSize: 11, color: muted),
-                ),
-                const SizedBox(width: 2),
-              ],
-            ],
+            ),
+            const SizedBox(width: 4),
             Icon(
               PhosphorIcons.caretDown(PhosphorIconsStyle.bold),
               size: 10,
-              color: muted,
+              color: colors.textSecondary,
             ),
           ],
         ),

--- a/apps/mobile/lib/features/feed/widgets/compact_theme_chip.dart
+++ b/apps/mobile/lib/features/feed/widgets/compact_theme_chip.dart
@@ -95,7 +95,7 @@ class _InactiveChip extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
-              'Thèmes',
+              'Mes thèmes',
               style: TextStyle(
                   fontSize: 12,
                   color: colors.textPrimary,

--- a/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
@@ -116,6 +116,7 @@ class _CarouselCard extends StatelessWidget {
   final int articleCount;
   final DateTime targetDate;
   final VoidCallback onTap;
+  final double avatarOpacity;
 
   const _CarouselCard({
     required this.backgroundColor,

--- a/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
+++ b/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
@@ -4,11 +4,13 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
 
-/// "Filtrer" button + inline expand panel.
+/// Filter row with the trigger button on the RIGHT.
 ///
-/// Collapsed: a pill button labelled "Filtres" (with active count when ≥1
-/// filter is set). Expanded: the [chipsRow] is rendered below the button
-/// using AnimatedSize.
+/// - Collapsed + no active filter: "Flux continu" label + thin grey rule fills
+///   the left side ; "Filtres" pill sits on the right.
+/// - Collapsed + active filter(s): empty space on the left ; pill shows count.
+/// - Expanded: pills slide in to the left ; the trigger morphs into a pill of
+///   the same shape with an × icon (primary, "selected" look).
 class FilterCollapsiblePanel extends StatefulWidget {
   final int activeCount;
   final Widget chipsRow;
@@ -37,22 +39,59 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
     final hasActive = widget.activeCount > 0;
     final label = hasActive ? 'Filtres · ${widget.activeCount}' : 'Filtres';
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Align(
-          alignment: Alignment.centerLeft,
-          child: GestureDetector(
+    return SizedBox(
+      height: 32,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 200),
+              transitionBuilder: (child, anim) =>
+                  FadeTransition(opacity: anim, child: child),
+              child: _expanded
+                  ? Padding(
+                      key: const ValueKey('chips'),
+                      padding: const EdgeInsets.only(right: 8),
+                      child: widget.chipsRow,
+                    )
+                  : (hasActive
+                      ? const SizedBox.shrink(key: ValueKey('idle'))
+                      : Padding(
+                          key: const ValueKey('flux-continu'),
+                          padding: const EdgeInsets.only(right: 12),
+                          child: Row(
+                            children: [
+                              Text(
+                                'FLUX CONTINU',
+                                style: FacteurTypography.stamp(
+                                        colors.textTertiary)
+                                    .copyWith(letterSpacing: 1.2),
+                              ),
+                              const SizedBox(width: 10),
+                              Expanded(
+                                child: Container(
+                                  height: 1,
+                                  color: colors.border.withOpacity(0.5),
+                                ),
+                              ),
+                            ],
+                          ),
+                        )),
+            ),
+          ),
+          GestureDetector(
             onTap: _toggle,
             behavior: HitTestBehavior.opaque,
-            child: Container(
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 180),
               height: 32,
               padding: const EdgeInsets.symmetric(horizontal: 14),
               decoration: BoxDecoration(
-                color: hasActive
+                color: (_expanded || hasActive)
                     ? colors.primary.withOpacity(0.12)
                     : Colors.transparent,
-                border: hasActive
+                border: (_expanded || hasActive)
                     ? Border.all(color: colors.primary)
                     : null,
                 borderRadius: BorderRadius.circular(FacteurRadius.full),
@@ -61,50 +100,33 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Icon(
-                    PhosphorIcons.funnel(PhosphorIconsStyle.regular),
+                    _expanded
+                        ? PhosphorIcons.x(PhosphorIconsStyle.bold)
+                        : PhosphorIcons.funnel(PhosphorIconsStyle.regular),
                     size: 14,
-                    color: hasActive ? colors.primary : colors.textSecondary,
+                    color: (_expanded || hasActive)
+                        ? colors.primary
+                        : colors.textSecondary,
                   ),
-                  const SizedBox(width: 6),
-                  Text(
-                    label,
-                    style: TextStyle(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                      color: hasActive
-                          ? colors.primary
-                          : colors.textSecondary,
+                  if (!_expanded) ...[
+                    const SizedBox(width: 6),
+                    Text(
+                      label,
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: hasActive
+                            ? colors.primary
+                            : colors.textSecondary,
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: 6),
-                  AnimatedRotation(
-                    turns: _expanded ? 0.5 : 0,
-                    duration: const Duration(milliseconds: 220),
-                    child: Icon(
-                      PhosphorIcons.caretDown(PhosphorIconsStyle.bold),
-                      size: 11,
-                      color: hasActive
-                          ? colors.primary
-                          : colors.textSecondary,
-                    ),
-                  ),
+                  ],
                 ],
               ),
             ),
           ),
-        ),
-        AnimatedSize(
-          duration: const Duration(milliseconds: 220),
-          curve: Curves.easeOutCubic,
-          alignment: Alignment.topLeft,
-          child: _expanded
-              ? Padding(
-                  padding: const EdgeInsets.only(top: 10),
-                  child: widget.chipsRow,
-                )
-              : const SizedBox(width: double.infinity),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/saved/screens/saved_screen.dart
+++ b/apps/mobile/lib/features/saved/screens/saved_screen.dart
@@ -46,6 +46,13 @@ class _SavedScreenState extends ConsumerState<SavedScreen> {
     return Scaffold(
       backgroundColor: colors.backgroundPrimary,
       appBar: AppBar(
+        leading: Navigator.of(context).canPop()
+            ? IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: () => context.pop(),
+              )
+            : null,
+        automaticallyImplyLeading: false,
         title: const Text('Mes sauvegardes'),
         backgroundColor: colors.backgroundPrimary,
         elevation: 0,

--- a/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
@@ -6,8 +6,9 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/routes.dart';
 import '../../../config/serein_colors.dart';
 import '../../../config/theme.dart';
+import '../../app_update/providers/app_update_provider.dart';
+import '../../app_update/widgets/update_bottom_sheet.dart';
 import '../../digest/providers/serein_toggle_provider.dart';
-import '../../feed/widgets/profile_avatar_button.dart';
 import '../providers/user_profile_provider.dart';
 import 'feedback_modal.dart';
 
@@ -72,11 +73,12 @@ class SettingsSheet extends ConsumerWidget {
                     FacteurSpacing.space4,
                     FacteurSpacing.space8,
                   ),
-                  child: Column(
+                  child: const Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: const [
+                    children: [
                       _ProfileBlock(),
                       SizedBox(height: FacteurSpacing.space4),
+                      _UpdateAvailableTile(),
                       _SereinSwitchTile(),
                       SizedBox(height: FacteurSpacing.space4),
                       _ContentShortcuts(),
@@ -106,7 +108,24 @@ class _ProfileBlock extends ConsumerWidget {
         padding: const EdgeInsets.all(FacteurSpacing.space4),
         child: Row(
           children: [
-            const ProfileAvatarButton.display(size: 48),
+            Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: colors.primary.withOpacity(0.10),
+                border: Border.all(
+                  color: colors.primary.withOpacity(0.25),
+                  width: 1,
+                ),
+              ),
+              alignment: Alignment.center,
+              child: Icon(
+                PhosphorIcons.userCircle(PhosphorIconsStyle.duotone),
+                size: 30,
+                color: colors.primary,
+              ),
+            ),
             const SizedBox(width: FacteurSpacing.space4),
             Expanded(
               child: Consumer(builder: (context, ref, _) {
@@ -141,6 +160,76 @@ class _ProfileBlock extends ConsumerWidget {
               size: 18,
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UpdateAvailableTile extends ConsumerWidget {
+  const _UpdateAvailableTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final info = ref.watch(appUpdateProvider).valueOrNull;
+    if (info == null || !info.updateAvailable) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.only(bottom: FacteurSpacing.space4),
+      child: _SheetCard(
+        onTap: () => UpdateBottomSheet.show(context, info: info),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: FacteurSpacing.space4,
+            vertical: FacteurSpacing.space4,
+          ),
+          child: Row(
+            children: [
+              Icon(
+                PhosphorIcons.arrowCircleDown(PhosphorIconsStyle.regular),
+                color: colors.primary,
+                size: 22,
+              ),
+              const SizedBox(width: FacteurSpacing.space3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Mise à jour disponible',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: colors.primary,
+                          ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      info.name.isNotEmpty ? info.name : info.latestTag,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colors.textSecondary,
+                          ),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                width: 10,
+                height: 10,
+                decoration: BoxDecoration(
+                  color: colors.error,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: FacteurSpacing.space2),
+              Icon(
+                PhosphorIcons.caretRight(PhosphorIconsStyle.regular),
+                color: colors.primary.withOpacity(0.6),
+                size: 18,
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -241,7 +330,7 @@ class _ContentShortcuts extends StatelessWidget {
           _ShortcutTile(
             icon: PhosphorIcons.bookmarkSimple(PhosphorIconsStyle.regular),
             label: 'Sauvegardés',
-            onTap: () => context.go(RoutePaths.saved),
+            onTap: () => context.pushNamed(RouteNames.saved),
           ),
         ],
       ),


### PR DESCRIPTION
## What

- **Filter row** restored on the feed: stamp "FLUX CONTINU" + grey inline rule on the left, pill **Filtres** on the right that morphs to × when expanded (`filter_collapsible_panel.dart`).
- **App update** removed from the feed header; gear now shows a red dot when an update is available and a "Mise à jour disponible" tile appears in the Réglages sheet (modal at launch is unchanged).
- **Réglages → Sauvegardés** back navigation fixed: switched from `context.go` to `pushNamed` and added a conditional back arrow in `SavedScreen`.
- **Polish**: "Mes sources" / "Mes thèmes" text-only inactive chips, elegant `userCircle` avatar in the profile block, removed the duplicated gear overlapping the streak, and fixed two pre-existing compile errors inherited from main (`compact_source_chip`, `digest_entry_card`).

## Why

Recent merges lost the "Flux continu" design and the header update button (gated Android-only, invisible on web/iOS). Going from Réglages to Sauvegardés stranded users with no way back to the feed.

## Type

- [x] Bug fix

## Checklist

- [x] `flutter analyze` clean (no new errors; fixes 8 pre-existing errors)
- [x] No backend changes
- [ ] Peer Review Conductor

## Staging

- [ ] N/A — frontend-only, manual QA via `/validate-feature` recommended