### PR TITLE
fix(app-update): téléchargement résilient + UX flux mise à jour APK

### DIFF
--- a/apps/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/apps/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -26,6 +26,11 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin audio_session, com.ryanheise.audio_session.AudioSessionPlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new vn.hunghd.flutterdownloader.FlutterDownloaderPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin flutter_downloader, vn.hunghd.flutterdownloader.FlutterDownloaderPlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new com.pichillilorenzo.flutter_inappwebview_android.InAppWebViewFlutterPlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin flutter_inappwebview_android, com.pichillilorenzo.flutter_inappwebview_android.InAppWebViewFlutterPlugin", e);

--- a/apps/mobile/ios/Runner/GeneratedPluginRegistrant.m
+++ b/apps/mobile/ios/Runner/GeneratedPluginRegistrant.m
@@ -18,6 +18,12 @@
 @import audio_session;
 #endif
 
+#if __has_include(<flutter_downloader/FlutterDownloaderPlugin.h>)
+#import <flutter_downloader/FlutterDownloaderPlugin.h>
+#else
+@import flutter_downloader;
+#endif
+
 #if __has_include(<flutter_inappwebview_ios/InAppWebViewFlutterPlugin.h>)
 #import <flutter_inappwebview_ios/InAppWebViewFlutterPlugin.h>
 #else
@@ -125,6 +131,7 @@
 + (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {
   [AppLinksIosPlugin registerWithRegistrar:[registry registrarForPlugin:@"AppLinksIosPlugin"]];
   [AudioSessionPlugin registerWithRegistrar:[registry registrarForPlugin:@"AudioSessionPlugin"]];
+  [FlutterDownloaderPlugin registerWithRegistrar:[registry registrarForPlugin:@"FlutterDownloaderPlugin"]];
   [InAppWebViewFlutterPlugin registerWithRegistrar:[registry registrarForPlugin:@"InAppWebViewFlutterPlugin"]];
   [FlutterLocalNotificationsPlugin registerWithRegistrar:[registry registrarForPlugin:@"FlutterLocalNotificationsPlugin"]];
   [FlutterSecureStorageDarwinPlugin registerWithRegistrar:[registry registrarForPlugin:@"FlutterSecureStorageDarwinPlugin"]];

--- a/apps/mobile/lib/features/app_update/services/app_update_service.dart
+++ b/apps/mobile/lib/features/app_update/services/app_update_service.dart
@@ -1,59 +1,180 @@
-import 'package:dio/dio.dart';
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:ui';
+
+import 'package:flutter_downloader/flutter_downloader.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../../core/api/api_client.dart';
 
-/// Thrown when Android refuses to install the APK (e.g. signature mismatch).
-class AppUpdateInstallException implements Exception {
-  final String message;
+/// Snapshot of the current update download.
+class UpdateProgress {
+  final String taskId;
+  final DownloadTaskStatus status;
+  final int progress; // 0-100
+  final String? errorMessage;
   final bool isIncompatible;
-  AppUpdateInstallException({required this.message, this.isIncompatible = false});
 
-  @override
-  String toString() => 'AppUpdateInstallException: $message';
+  const UpdateProgress({
+    required this.taskId,
+    required this.status,
+    required this.progress,
+    this.errorMessage,
+    this.isIncompatible = false,
+  });
 }
 
-/// Handles APK download and installation trigger.
+const _kPortName = 'facteur_app_update_port';
+const _kHiveTaskId = 'update_task_id';
+const _kHiveFilePath = 'update_file_path';
+const _kApkFileName = 'facteur-update.apk';
+
+/// Singleton managing the APK download lifecycle via Android DownloadManager.
+///
+/// Survives app backgrounding because flutter_downloader uses a system service.
+/// The widget reconnects to an in-flight task at rebuild via [resumeIfActive].
 class AppUpdateService {
-  final ApiClient _apiClient;
+  AppUpdateService._();
+  static final AppUpdateService instance = AppUpdateService._();
 
-  AppUpdateService(this._apiClient);
+  final StreamController<UpdateProgress> _controller =
+      StreamController<UpdateProgress>.broadcast();
+  Stream<UpdateProgress> get progressStream => _controller.stream;
 
-  /// Download the latest APK and trigger Android install.
-  ///
-  /// [onProgress] receives (received, total) bytes for progress display.
-  /// Throws on failure.
-  Future<void> downloadAndInstall({
-    required void Function(int received, int total) onProgress,
-  }) async {
-    // 1. Get temporary download URL from backend
-    final urlResponse = await _apiClient.get('app/update/download-url');
+  ReceivePort? _port;
+  String? _currentTaskId;
+  String? _currentFilePath;
+  bool _installTriggered = false;
+
+  void _bind() {
+    if (_port != null) return;
+    _port = ReceivePort();
+    IsolateNameServer.registerPortWithName(_port!.sendPort, _kPortName);
+    _port!.listen((dynamic data) {
+      final list = data as List<dynamic>;
+      final id = list[0] as String;
+      final status = DownloadTaskStatus.fromInt(list[1] as int);
+      final progress = list[2] as int;
+      _controller.add(UpdateProgress(
+        taskId: id,
+        status: status,
+        progress: progress,
+      ));
+      if (id == _currentTaskId && status == DownloadTaskStatus.complete) {
+        unawaited(_triggerInstall());
+      }
+    });
+    FlutterDownloader.registerCallback(downloadCallback);
+  }
+
+  /// Starts a fresh APK download. Returns the new [UpdateProgress] (enqueued).
+  Future<UpdateProgress> startUpdate(ApiClient apiClient) async {
+    _bind();
+    _installTriggered = false;
+
+    final urlResponse = await apiClient.get('app/update/download-url');
     final downloadUrl = (urlResponse as Map<String, dynamic>)['url'] as String;
 
-    // 2. Get temp directory for download
     final dir = await getTemporaryDirectory();
-    final filePath = '${dir.path}/facteur-update.apk';
+    final filePath = '${dir.path}/$_kApkFileName';
+    final stale = File(filePath);
+    try {
+      if (stale.existsSync()) stale.deleteSync();
+    } catch (_) {/* best-effort */}
 
-    // 3. Download APK with progress using a clean Dio (no auth interceptors)
-    final downloadDio = Dio(BaseOptions(
-      connectTimeout: const Duration(seconds: 30),
-      receiveTimeout: const Duration(minutes: 5),
-    ));
-
-    await downloadDio.download(
-      downloadUrl,
-      filePath,
-      onReceiveProgress: onProgress,
+    final taskId = await FlutterDownloader.enqueue(
+      url: downloadUrl,
+      savedDir: dir.path,
+      fileName: _kApkFileName,
+      showNotification: true,
+      openFileFromNotification: false,
+      saveInPublicStorage: false,
     );
+    if (taskId == null) {
+      throw Exception('Impossible de démarrer le téléchargement');
+    }
 
-    // 4. Trigger Android install intent
+    _currentTaskId = taskId;
+    _currentFilePath = filePath;
+    final box = Hive.box<dynamic>('settings');
+    await box.put(_kHiveTaskId, taskId);
+    await box.put(_kHiveFilePath, filePath);
+
+    return UpdateProgress(
+      taskId: taskId,
+      status: DownloadTaskStatus.enqueued,
+      progress: 0,
+    );
+  }
+
+  /// Reconnects to an existing in-flight task, if any. Returns null when
+  /// nothing is active.
+  Future<UpdateProgress?> resumeIfActive() async {
+    final box = Hive.box<dynamic>('settings');
+    final taskId = box.get(_kHiveTaskId) as String?;
+    final filePath = box.get(_kHiveFilePath) as String?;
+    if (taskId == null) return null;
+
+    final tasks = await FlutterDownloader.loadTasksWithRawQuery(
+      query: "SELECT * FROM task WHERE task_id='$taskId'",
+    );
+    if (tasks == null || tasks.isEmpty) {
+      await _clearPersistedTask();
+      return null;
+    }
+    final t = tasks.first;
+    _currentTaskId = taskId;
+    _currentFilePath = filePath;
+    _bind();
+
+    if (t.status == DownloadTaskStatus.complete) {
+      // Download finished while app was killed — kick off install now.
+      unawaited(_triggerInstall());
+    } else if (t.status == DownloadTaskStatus.failed ||
+        t.status == DownloadTaskStatus.canceled) {
+      await _clearPersistedTask();
+    }
+
+    return UpdateProgress(
+      taskId: taskId,
+      status: t.status,
+      progress: t.progress,
+    );
+  }
+
+  Future<void> _triggerInstall() async {
+    if (_installTriggered) return;
+    _installTriggered = true;
+    final filePath = _currentFilePath;
+    if (filePath == null) return;
     final result = await OpenFilex.open(filePath);
     if (result.type != ResultType.done) {
-      throw AppUpdateInstallException(
-        message: result.message,
+      _controller.add(UpdateProgress(
+        taskId: _currentTaskId ?? '',
+        status: DownloadTaskStatus.failed,
+        progress: 100,
+        errorMessage: result.message,
         isIncompatible: true,
-      );
+      ));
     }
+    unawaited(_clearPersistedTask());
   }
+
+  Future<void> _clearPersistedTask() async {
+    try {
+      final box = Hive.box<dynamic>('settings');
+      await box.delete(_kHiveTaskId);
+      await box.delete(_kHiveFilePath);
+    } catch (_) {/* box might not be open in tests */}
+  }
+}
+
+/// Top-level callback invoked by flutter_downloader on a background isolate.
+@pragma('vm:entry-point')
+void downloadCallback(String id, int status, int progress) {
+  final send = IsolateNameServer.lookupPortByName(_kPortName);
+  send?.send(<dynamic>[id, status, progress]);
 }

--- a/apps/mobile/lib/features/app_update/widgets/update_bottom_sheet.dart
+++ b/apps/mobile/lib/features/app_update/widgets/update_bottom_sheet.dart
@@ -1,15 +1,21 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_downloader/flutter_downloader.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
 import '../../../core/api/providers.dart';
 import '../providers/app_update_provider.dart';
 import '../services/app_update_service.dart';
-import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 enum _UpdateState { idle, downloading, done, error, incompatible }
 
 /// Bottom sheet showing update details and download progress.
+///
+/// The sheet is **non-dismissible by tap/drag** (faux-clic protection during
+/// download). A close button is provided in safe states (idle/error/done).
 class UpdateBottomSheet extends ConsumerStatefulWidget {
   final AppUpdateInfo info;
 
@@ -20,6 +26,8 @@ class UpdateBottomSheet extends ConsumerStatefulWidget {
       context: context,
       backgroundColor: Colors.transparent,
       isScrollControlled: true,
+      isDismissible: false,
+      enableDrag: false,
       useSafeArea: true,
       builder: (_) => UpdateBottomSheet(info: info),
     );
@@ -33,122 +41,216 @@ class _UpdateBottomSheetState extends ConsumerState<UpdateBottomSheet> {
   _UpdateState _state = _UpdateState.idle;
   double _progress = 0;
   String? _errorMessage;
+  StreamSubscription<UpdateProgress>? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _maybeResume();
+  }
+
+  Future<void> _maybeResume() async {
+    final active = await AppUpdateService.instance.resumeIfActive();
+    if (!mounted || active == null) return;
+    _listen();
+    _applyProgress(active);
+  }
+
+  void _listen() {
+    _sub?.cancel();
+    _sub = AppUpdateService.instance.progressStream.listen(_applyProgress);
+  }
+
+  void _applyProgress(UpdateProgress p) {
+    if (!mounted) return;
+    setState(() {
+      switch (p.status) {
+        case DownloadTaskStatus.enqueued:
+        case DownloadTaskStatus.running:
+        case DownloadTaskStatus.paused:
+          _state = _UpdateState.downloading;
+          _progress = (p.progress.clamp(0, 100)) / 100.0;
+          break;
+        case DownloadTaskStatus.complete:
+          _state = _UpdateState.done;
+          _progress = 1.0;
+          // Auto-close after Android installer prompt opens.
+          Future.delayed(const Duration(seconds: 2), () {
+            if (mounted && _state == _UpdateState.done) {
+              Navigator.of(context).maybePop();
+            }
+          });
+          break;
+        case DownloadTaskStatus.failed:
+          _state = p.isIncompatible
+              ? _UpdateState.incompatible
+              : _UpdateState.error;
+          _errorMessage = p.errorMessage ??
+              'Le téléchargement a échoué. Vérifiez votre connexion.';
+          break;
+        case DownloadTaskStatus.canceled:
+          _state = _UpdateState.error;
+          _errorMessage = 'Téléchargement annulé.';
+          break;
+        case DownloadTaskStatus.undefined:
+          break;
+      }
+    });
+  }
 
   Future<void> _startUpdate() async {
     setState(() {
       _state = _UpdateState.downloading;
       _progress = 0;
     });
+    _listen();
 
     try {
       final apiClient = ref.read(apiClientProvider);
-      final service = AppUpdateService(apiClient);
-
-      await service.downloadAndInstall(
-        onProgress: (received, total) {
-          if (total > 0 && mounted) {
-            setState(() => _progress = received / total);
-          }
-        },
-      );
-
-      if (mounted) {
-        setState(() => _state = _UpdateState.done);
-        // Close sheet after a short delay since Android installer is opening
-        Future.delayed(const Duration(seconds: 1), () {
-          if (mounted) Navigator.of(context).pop();
-        });
-      }
-    } on AppUpdateInstallException catch (e) {
-      // ignore: avoid_print
-      print('AppUpdate: install failed: $e');
-      if (mounted) {
-        setState(() {
-          _state = e.isIncompatible
-              ? _UpdateState.incompatible
-              : _UpdateState.error;
-          _errorMessage = e.message;
-        });
-      }
+      await AppUpdateService.instance.startUpdate(apiClient);
     } catch (e) {
       // ignore: avoid_print
       print('AppUpdate: download failed: $e');
       if (mounted) {
         setState(() {
           _state = _UpdateState.error;
-          _errorMessage = 'Le telechargement a echoue. Verifiez votre connexion.';
+          _errorMessage =
+              'Le téléchargement a échoué. Vérifiez votre connexion.';
         });
       }
     }
   }
 
   @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  bool get _canClose =>
+      _state != _UpdateState.downloading && _state != _UpdateState.done;
+
+  @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
 
-    return Container(
-      decoration: BoxDecoration(
-        color: colors.backgroundSecondary,
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
-      ),
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Drag handle
-              Center(
-                child: Container(
-                  width: 40,
-                  height: 4,
-                  margin: const EdgeInsets.only(top: 12, bottom: 20),
-                  decoration: BoxDecoration(
-                    color: colors.textTertiary.withOpacity(0.3),
-                    borderRadius: BorderRadius.circular(2),
+    return PopScope(
+      canPop: _canClose,
+      child: Container(
+        decoration: BoxDecoration(
+          color: colors.backgroundSecondary,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Drag handle + close button row
+                Padding(
+                  padding: const EdgeInsets.only(top: 8, bottom: 8),
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      Container(
+                        width: 40,
+                        height: 4,
+                        decoration: BoxDecoration(
+                          color: colors.textTertiary.withOpacity(0.3),
+                          borderRadius: BorderRadius.circular(2),
+                        ),
+                      ),
+                      if (_canClose)
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: IconButton(
+                            icon: Icon(
+                              Icons.close,
+                              color: colors.textSecondary,
+                              size: 22,
+                            ),
+                            onPressed: () => Navigator.of(context).maybePop(),
+                            tooltip: 'Fermer',
+                          ),
+                        ),
+                    ],
                   ),
                 ),
-              ),
+                const SizedBox(height: 8),
 
-              // Title
-              Text(
-                'Mise a jour disponible',
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.w700,
-                    ),
-              ),
-              const SizedBox(height: 4),
-
-              // Release name
-              Text(
-                widget.info.name.isNotEmpty
-                    ? widget.info.name
-                    : widget.info.latestTag,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: colors.textSecondary,
-                    ),
-              ),
-
-              // APK size
-              if (widget.info.apkSize != null) ...[
-                const SizedBox(height: 2),
+                // Title
                 Text(
-                  widget.info.formattedSize,
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: colors.textTertiary,
+                  'Mise à jour disponible',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
                       ),
                 ),
+                const SizedBox(height: 4),
+
+                // Release name
+                Text(
+                  widget.info.name.isNotEmpty
+                      ? widget.info.name
+                      : widget.info.latestTag,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: colors.textSecondary,
+                      ),
+                ),
+
+                if (widget.info.apkSize != null) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    widget.info.formattedSize,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: colors.textTertiary,
+                        ),
+                  ),
+                ],
+
+                const SizedBox(height: 20),
+
+                // Action area
+                _buildActionArea(context, colors),
               ],
-
-              const SizedBox(height: 20),
-
-              // Action area
-              _buildActionArea(context, colors),
-            ],
+            ),
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildAndroidPermInfo(FacteurColors colors, {required bool compact}) {
+    final text = compact
+        ? 'Android peut vous demander d\'autoriser l\'installation à la fin du téléchargement — c\'est normal, cliquez sur Autoriser puis revenez ici.'
+        : 'Android va vous demander d\'autoriser l\'installation depuis cette app. Cliquez sur Autoriser dans les paramètres qui s\'ouvrent — la mise à jour reprendra ensuite.';
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.primary.withOpacity(0.08),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            PhosphorIcons.info(PhosphorIconsStyle.fill),
+            color: colors.primary,
+            size: 18,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              text,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colors.textSecondary,
+                    height: 1.4,
+                  ),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -156,29 +258,34 @@ class _UpdateBottomSheetState extends ConsumerState<UpdateBottomSheet> {
   Widget _buildActionArea(BuildContext context, FacteurColors colors) {
     switch (_state) {
       case _UpdateState.idle:
-        return SizedBox(
-          width: double.infinity,
-          child: FilledButton(
-            onPressed: _startUpdate,
-            style: FilledButton.styleFrom(
-              backgroundColor: colors.primary,
-              foregroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(vertical: 14),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _buildAndroidPermInfo(colors, compact: false),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: _startUpdate,
+              style: FilledButton.styleFrom(
+                backgroundColor: colors.primary,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
               ),
+              child: const Text('Mettre à jour'),
             ),
-            child: const Text('Mettre a jour'),
-          ),
+          ],
         );
 
       case _UpdateState.downloading:
         return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             ClipRRect(
               borderRadius: BorderRadius.circular(4),
               child: LinearProgressIndicator(
-                value: _progress,
+                value: _progress > 0 ? _progress : null,
                 backgroundColor: colors.surface,
                 valueColor: AlwaysStoppedAnimation(colors.primary),
                 minHeight: 6,
@@ -186,11 +293,15 @@ class _UpdateBottomSheetState extends ConsumerState<UpdateBottomSheet> {
             ),
             const SizedBox(height: 8),
             Text(
-              'Telechargement... ${(_progress * 100).toInt()}%',
+              _progress > 0
+                  ? 'Téléchargement... ${(_progress * 100).toInt()}%'
+                  : 'Téléchargement en cours...',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: colors.textSecondary,
                   ),
             ),
+            const SizedBox(height: 16),
+            _buildAndroidPermInfo(colors, compact: true),
           ],
         );
 
@@ -228,10 +339,10 @@ class _UpdateBottomSheetState extends ConsumerState<UpdateBottomSheet> {
             ),
             const SizedBox(height: 8),
             Text(
-              'Cette mise a jour n\'est pas compatible avec la version installee.\n\n'
-              'Desinstallez l\'app depuis les Parametres Android, '
-              'puis reinstallez-la depuis le lien de telechargement.\n\n'
-              'Vos donnees sont sauvegardees sur le serveur, rien ne sera perdu.',
+              'Cette mise à jour n\'est pas compatible avec la version installée.\n\n'
+              'Désinstallez l\'app depuis les Paramètres Android, '
+              'puis réinstallez-la depuis le lien de téléchargement.\n\n'
+              'Vos données sont sauvegardées sur le serveur, rien ne sera perdu.',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: colors.textSecondary,
                     height: 1.4,
@@ -245,7 +356,7 @@ class _UpdateBottomSheetState extends ConsumerState<UpdateBottomSheet> {
         return Column(
           children: [
             Text(
-              _errorMessage ?? 'Erreur lors du telechargement',
+              _errorMessage ?? 'Erreur lors du téléchargement',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: colors.error,
                   ),
@@ -263,7 +374,7 @@ class _UpdateBottomSheetState extends ConsumerState<UpdateBottomSheet> {
                     borderRadius: BorderRadius.circular(12),
                   ),
                 ),
-                child: const Text('Reessayer'),
+                child: const Text('Réessayer'),
               ),
             ),
           ],

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:home_widget/home_widget.dart';
+import 'package:flutter_downloader/flutter_downloader.dart';
 
 import 'app.dart';
 import 'config/constants.dart';
@@ -69,6 +70,14 @@ Future<void> _bootstrap() async {
 
   // Initialiser Hive (storage local)
   await Hive.initFlutter();
+
+  // Initialiser flutter_downloader (Android DownloadManager) pour la mise
+  // à jour APK : permet au téléchargement de continuer en arrière-plan.
+  try {
+    await FlutterDownloader.initialize(debug: false, ignoreSsl: false);
+  } catch (e) {
+    debugPrint('Main: FlutterDownloader init failed (non-critical): $e');
+  }
 
   // Pré-ouvrir les boxes et vérifier leur contenu
   // Try-catch avec fallback : si un box est corrompu, on le recrée vide

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -390,6 +390,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
+  flutter_downloader:
+    dependency: "direct main"
+    description:
+      name: flutter_downloader
+      sha256: "93a9ddbd561f8a3f5483b4189453fba145a0a1014a88143c96a966296b78a118"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.12.0"
   flutter_html:
     dependency: "direct main"
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -87,6 +87,7 @@ dependencies:
   package_info_plus: ^8.0.0
   path_provider: ^2.1.2
   open_filex: ^4.5.0
+  flutter_downloader: ^1.11.8
   flutter_inappwebview: ^6.1.5
 
 dev_dependencies:


### PR DESCRIPTION
## Quoi

Trois fixes UX sur le flux de mise à jour APK Android (modal "Mettre à jour") :

1. **Préavis Android** — Encart info dans le bottom sheet expliquant que Android va demander d'autoriser l'installation, dans les états idle (texte long) et downloading (rappel court). Évite la confusion quand les Paramètres s'ouvrent.
2. **Téléchargement résilient au background** — Migration de `Dio.download` (in-process, killed au background) vers `flutter_downloader` (Android DownloadManager). Le DL continue si l'app passe en arrière-plan ou si l'écran s'éteint. Le `taskId` est persisté dans la box Hive `settings` ; au rebuild du sheet, `resumeIfActive()` reconnecte à la tâche en cours et reprend la barre depuis sa progression actuelle.
3. **Bottom sheet non-dismissible** — `isDismissible: false`, `enableDrag: false`, `PopScope(canPop: …)` pour bloquer back/swipe pendant le download. Bouton croix explicite ajouté en haut, visible uniquement dans les états sûrs (idle/error/incompatible). Plus de faux-clic qui annule le DL.

## Pourquoi

Bugs UX remontés : utilisateurs qui pensent que la maj s'annule quand Android ouvre les Paramètres ; downloads qui repartent à 0% après un lock écran ; faux-clics hors modal qui annulent le DL.

## Comment ça a été vérifié

- [x] `flutter analyze` sur le module : 0 erreur (warnings `withOpacity` pré-existants, pattern projet)
- [x] `flutter test` : aucune nouvelle régression (37 échecs identiques à `main`, pré-existants)
- [ ] **À tester sur device Android réel** (Playwright/web ne peut pas tester un flux APK natif) :
  - Encart "Android va demander…" visible en idle
  - Lock écran 30s pendant DL → reprise sans redémarrage
  - Tap hors sheet / swipe down / back pendant DL → sheet reste ouvert
  - Fin DL → installateur Android s'ouvre

## Zones à risque

- `main.dart` — ajout `FlutterDownloader.initialize()` (try/catch non-bloquant).
- `app_update_service.dart` — réécriture complète (singleton + IsolateNameServer + Hive).
- `update_bottom_sheet.dart` — refonte de la gestion d'état (Stream + initState resume).
- Aucun changement backend, aucune migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)