### PR TITLE
feat(ui): refresh Mes sources / Mes intérêts / Mes sauvegardes

### DIFF
--- a/apps/mobile/lib/features/custom_topics/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/custom_topics/screens/my_interests_screen.dart
@@ -3,11 +3,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../config/routes.dart';
+import '../../../config/serein_colors.dart';
 import '../../../config/theme.dart';
 import '../../../config/topic_labels.dart';
+import '../../../shared/widgets/fab_nudge_bubble.dart';
 import '../../../shared/widgets/states/friendly_error_view.dart';
 import '../../digest/providers/serein_toggle_provider.dart';
-import '../../digest/widgets/serein_toggle_chip.dart';
 import '../../feed/repositories/personalization_repository.dart';
 import '../models/topic_models.dart';
 import '../providers/custom_topics_provider.dart';
@@ -91,29 +92,28 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
         backgroundColor: colors.backgroundPrimary,
         elevation: 0,
         titleTextStyle: textTheme.displaySmall,
-        bottom: const PreferredSize(
-          preferredSize: Size.fromHeight(40),
-          child: Padding(
-            padding: EdgeInsets.only(
-              right: FacteurSpacing.space3,
-              bottom: FacteurSpacing.space2,
-            ),
-            child: Align(
-              alignment: Alignment.centerRight,
-              child: SereinToggleChip(),
+      ),
+      floatingActionButton: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const Flexible(
+            child: FabNudgeBubble(
+              text: 'Suivez n\'importe quel sujet pour le faire ressortir dans votre flux !',
             ),
           ),
-        ),
-      ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => EntityAddSheet.show(context),
-        backgroundColor: const Color(0xFFE07A5F),
-        foregroundColor: Colors.white,
-        icon: const Icon(Icons.add, size: 20),
-        label: const Text(
-          'Sujet personnalisé',
-          style: TextStyle(fontWeight: FontWeight.w600),
-        ),
+          const SizedBox(width: 6),
+          FloatingActionButton.extended(
+            onPressed: () => EntityAddSheet.show(context),
+            backgroundColor: const Color(0xFFE07A5F),
+            foregroundColor: Colors.white,
+            icon: const Icon(Icons.add, size: 20),
+            label: const Text(
+              'Sujet personnalisé',
+              style: TextStyle(fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
       ),
       body: topicsAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
@@ -245,6 +245,21 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
                         ),
                       ),
                     ],
+                  ),
+                ),
+
+                // Mode Serein toggle (DS aligned with Réglages sheet)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(
+                    FacteurSpacing.space4,
+                    0,
+                    FacteurSpacing.space4,
+                    FacteurSpacing.space3,
+                  ),
+                  child: _SereinToggleTile(
+                    enabled: sereinMode,
+                    onChanged: () =>
+                        ref.read(sereinToggleProvider.notifier).toggle(),
                   ),
                 ),
 
@@ -472,3 +487,79 @@ class _ContentTypesSection extends ConsumerWidget {
   }
 }
 
+
+/// Mode Serein toggle, styled like the tile in the Réglages sheet.
+class _SereinToggleTile extends StatelessWidget {
+  final bool enabled;
+  final VoidCallback onChanged;
+
+  const _SereinToggleTile({required this.enabled, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final borderRadius = BorderRadius.circular(FacteurRadius.large);
+    return Material(
+      color: colors.surface,
+      borderRadius: borderRadius,
+      child: InkWell(
+        onTap: onChanged,
+        borderRadius: borderRadius,
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: borderRadius,
+            border: Border.all(color: colors.surfaceElevated),
+          ),
+          padding: const EdgeInsets.symmetric(
+            horizontal: FacteurSpacing.space4,
+            vertical: FacteurSpacing.space3,
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: SereinColors.sereinColor.withOpacity(0.12),
+                ),
+                alignment: Alignment.center,
+                child: Icon(
+                  SereinColors.sereinIcon,
+                  color: SereinColors.sereinColor,
+                  size: 18,
+                ),
+              ),
+              const SizedBox(width: FacteurSpacing.space3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Mode Serein',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'Une lecture plus calme, sans urgence',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colors.textSecondary,
+                          ),
+                    ),
+                  ],
+                ),
+              ),
+              Switch.adaptive(
+                value: enabled,
+                activeColor: SereinColors.sereinColor,
+                onChanged: (_) => onChanged(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/custom_topics/widgets/theme_section.dart
+++ b/apps/mobile/lib/features/custom_topics/widgets/theme_section.dart
@@ -137,7 +137,7 @@ class ThemeSection extends ConsumerWidget {
             initiallyExpanded: false,
             tilePadding: const EdgeInsets.symmetric(
               horizontal: FacteurSpacing.space4,
-              vertical: FacteurSpacing.space1,
+              vertical: FacteurSpacing.space3,
             ),
             childrenPadding: const EdgeInsets.only(
               bottom: FacteurSpacing.space3,
@@ -453,11 +453,11 @@ class _ThemeHeader extends ConsumerWidget {
 
     final titleText = Expanded(
       child: Text(
-        '${getMacroThemeEmoji(themeLabel)} ${themeLabel.toUpperCase()}',
-        style: textTheme.labelSmall?.copyWith(
-          color: colors.textTertiary,
-          letterSpacing: 1.5,
-          fontWeight: FontWeight.w600,
+        '${getMacroThemeEmoji(themeLabel)}  $themeLabel',
+        style: textTheme.titleMedium?.copyWith(
+          color: colors.textPrimary,
+          fontWeight: FontWeight.w700,
+          fontSize: 17,
         ),
       ),
     );

--- a/apps/mobile/lib/features/saved/screens/saved_screen.dart
+++ b/apps/mobile/lib/features/saved/screens/saved_screen.dart
@@ -7,18 +7,12 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../../core/ui/notification_service.dart';
-import '../../../widgets/article_preview_modal.dart';
 import '../../feed/models/content_model.dart';
-import '../../feed/providers/feed_provider.dart';
-import '../../custom_topics/widgets/topic_chip.dart';
-import '../../feed/widgets/feed_card.dart';
 import '../models/collection_model.dart';
 import '../providers/collections_provider.dart';
 import '../providers/saved_feed_provider.dart';
 import '../providers/weekly_notes_provider.dart';
 import '../widgets/collection_dialogs.dart';
-import '../widgets/collection_grid_cell.dart';
-import '../widgets/collection_picker_sheet.dart';
 
 class SavedScreen extends ConsumerStatefulWidget {
   const SavedScreen({super.key});
@@ -155,55 +149,58 @@ class _SavedScreenState extends ConsumerState<SavedScreen> {
     final totalSaved = allSaved.length;
     final readCount =
         allSaved.where((c) => c.status == ContentStatus.consumed).length;
-    final thumbnails = allSaved.take(4).map((c) => c.thumbnailUrl).toList();
 
     if (totalSaved == 0 && collections.isEmpty) {
       return SliverFillRemaining(child: _EmptyState(colors: colors));
     }
 
-    // "Tous les articles" + user collections + "Nouvelle collection"
-    final itemCount = 1 + collections.length + 1;
-
     return SliverPadding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
-      sliver: SliverGrid(
-        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 2,
-          mainAxisSpacing: 12,
-          crossAxisSpacing: 12,
-          childAspectRatio: 0.75,
-        ),
-        delegate: SliverChildBuilderDelegate(
-          (_, index) {
-            // Index 0: "Tous les articles"
-            if (index == 0) {
-              return AllArticlesGridCell(
+      sliver: SliverToBoxAdapter(
+        child: Container(
+          decoration: BoxDecoration(
+            color: colors.surface,
+            borderRadius: BorderRadius.circular(FacteurRadius.large),
+            border: Border.all(color: colors.surfaceElevated),
+          ),
+          child: Column(
+            children: [
+              _CollectionListTile(
+                icon: PhosphorIcons.bookmarksSimple(PhosphorIconsStyle.fill),
+                iconColor: colors.primary,
+                title: 'Tous les articles',
                 totalCount: totalSaved,
-                readCount: readCount,
-                thumbnails: thumbnails,
+                unreadCount: totalSaved - readCount,
+                colors: colors,
                 onTap: () => context.pushNamed('saved-all'),
-              );
-            }
-
-            // Last item: "Nouvelle collection"
-            if (index == itemCount - 1) {
-              return NewCollectionCell(
-                onTap: () => _createCollection(),
-              );
-            }
-
-            // User collections
-            final collection = collections[index - 1];
-            return CollectionGridCell(
-              collection: collection,
-              onTap: () => context.pushNamed(
-                'collection-detail',
-                pathParameters: {'id': collection.id},
               ),
-              onLongPress: () => _showCollectionMenu(collection),
-            );
-          },
-          childCount: itemCount,
+              for (final c in collections) ...[
+                _Divider(colors: colors),
+                _CollectionListTile(
+                  icon: c.isLikedCollection
+                      ? PhosphorIcons.heart(PhosphorIconsStyle.fill)
+                      : PhosphorIcons.folderSimple(PhosphorIconsStyle.fill),
+                  iconColor: c.isLikedCollection
+                      ? colors.error
+                      : colors.textSecondary,
+                  title: c.name,
+                  totalCount: c.itemCount,
+                  unreadCount: c.itemCount - c.readCount,
+                  colors: colors,
+                  onTap: () => context.pushNamed(
+                    'collection-detail',
+                    pathParameters: {'id': c.id},
+                  ),
+                  onLongPress: () => _showCollectionMenu(c),
+                ),
+              ],
+              _Divider(colors: colors),
+              _NewCollectionTile(
+                colors: colors,
+                onTap: _createCollection,
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -308,77 +305,17 @@ class _WeeklyNotesSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const SizedBox(height: 8),
-        Divider(
-          color: colors.border.withOpacity(0.3),
-          height: 1,
-          indent: 16,
-          endIndent: 16,
-        ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-          child: Row(
-            children: [
-              Icon(
-                PhosphorIcons.pencilLine(PhosphorIconsStyle.fill),
-                size: 16,
-                color: colors.primary,
-              ),
-              const SizedBox(width: 6),
-              Text(
-                'Tes pensées de la semaine',
-                style: TextStyle(
-                  color: colors.textSecondary,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                  letterSpacing: 0.5,
-                ),
-              ),
-            ],
-          ),
-        ),
-        ...articles.map((article) => Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              child: FeedCard(
-                content: article,
-                titleMaxLines: 5,
-                isSaved: article.isSaved,
-                isLiked: article.isLiked,
-                onTap: () => context.pushNamed(
-                  RouteNames.contentDetail,
-                  pathParameters: {'id': article.id},
-                  extra: article,
-                ),
-                onSourceTap: () {
-                  ref.read(feedProvider.notifier).setSource(article.source.id);
-                  context.goNamed(RouteNames.feed);
-                },
-                onSourceLongPress: () =>
-                    TopicChip.showArticleSheet(context, article,
-                        initialSection: ArticleSheetSection.source),
-                onLongPressStart: (_) =>
-                    ArticlePreviewOverlay.show(context, article),
-                onLongPressMoveUpdate: (details) =>
-                    ArticlePreviewOverlay.updateScroll(
-                        details.localOffsetFromOrigin.dy),
-                onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
-                onSave: () {
-                  onToggleSave(article);
-                  HapticFeedback.mediumImpact();
-                },
-                onSaveLongPress: () =>
-                    CollectionPickerSheet.show(context, article.id),
-              ),
-            )),
-      ],
+    return _SavedListBlock(
+      titleIcon: PhosphorIcons.pencilLine(PhosphorIconsStyle.fill),
+      title: 'Tes pensées de la semaine',
+      articles: articles,
+      colors: colors,
+      onToggleSave: onToggleSave,
     );
   }
 }
 
-/// Section "Récemment sauvegardés" avec des FeedCards complètes.
+/// Section "Récemment sauvegardés" — liste compacte sans images.
 class _RecentSavedSection extends ConsumerWidget {
   final List<Content> articles;
   final FacteurColors colors;
@@ -392,62 +329,166 @@ class _RecentSavedSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    return _SavedListBlock(
+      title: 'Récents',
+      articles: articles,
+      colors: colors,
+      onToggleSave: onToggleSave,
+    );
+  }
+}
+
+/// Card-wrapped list of saved articles (no thumbnails), aligned with the
+/// Réglages design system.
+class _SavedListBlock extends StatelessWidget {
+  final String title;
+  final IconData? titleIcon;
+  final List<Content> articles;
+  final FacteurColors colors;
+  final ValueChanged<Content> onToggleSave;
+
+  const _SavedListBlock({
+    required this.title,
+    this.titleIcon,
+    required this.articles,
+    required this.colors,
+    required this.onToggleSave,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const SizedBox(height: 8),
-        Divider(
-          color: colors.border.withOpacity(0.3),
-          height: 1,
-          indent: 16,
-          endIndent: 16,
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
+          child: Row(
+            children: [
+              if (titleIcon != null) ...[
+                Icon(titleIcon, size: 16, color: colors.primary),
+                const SizedBox(width: 6),
+              ],
+              Text(
+                title,
+                style: TextStyle(
+                  color: colors.textSecondary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0.5,
+                ),
+              ),
+            ],
+          ),
         ),
         Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-          child: Text(
-            'Récents',
-            style: TextStyle(
-              color: colors.textSecondary,
-              fontSize: 13,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0.5,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Container(
+            decoration: BoxDecoration(
+              color: colors.surface,
+              borderRadius: BorderRadius.circular(FacteurRadius.large),
+              border: Border.all(color: colors.surfaceElevated),
+            ),
+            child: Column(
+              children: [
+                for (var i = 0; i < articles.length; i++) ...[
+                  if (i > 0)
+                    Divider(
+                      height: 1,
+                      thickness: 1,
+                      color: colors.surfaceElevated,
+                      indent: 16,
+                      endIndent: 16,
+                    ),
+                  _SavedListTile(
+                    article: articles[i],
+                    colors: colors,
+                    onToggleSave: () {
+                      onToggleSave(articles[i]);
+                      HapticFeedback.mediumImpact();
+                    },
+                  ),
+                ],
+              ],
             ),
           ),
         ),
-        ...articles.map((article) => Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              child: FeedCard(
-                content: article,
-                titleMaxLines: 5,
-                isSaved: article.isSaved,
-                isLiked: article.isLiked,
-                onTap: () => context.pushNamed(
-                  RouteNames.contentDetail,
-                  pathParameters: {'id': article.id},
-                  extra: article,
-                ),
-                onSourceTap: () {
-                  ref.read(feedProvider.notifier).setSource(article.source.id);
-                  context.goNamed(RouteNames.feed);
-                },
-                onSourceLongPress: () =>
-                    TopicChip.showArticleSheet(context, article,
-                        initialSection: ArticleSheetSection.source),
-                onLongPressStart: (_) =>
-                    ArticlePreviewOverlay.show(context, article),
-                onLongPressMoveUpdate: (details) =>
-                    ArticlePreviewOverlay.updateScroll(
-                        details.localOffsetFromOrigin.dy),
-                onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
-                onSave: () {
-                  onToggleSave(article);
-                  HapticFeedback.mediumImpact();
-                },
-                onSaveLongPress: () =>
-                    CollectionPickerSheet.show(context, article.id),
-              ),
-            )),
       ],
+    );
+  }
+}
+
+class _SavedListTile extends StatelessWidget {
+  final Content article;
+  final FacteurColors colors;
+  final VoidCallback onToggleSave;
+
+  const _SavedListTile({
+    required this.article,
+    required this.colors,
+    required this.onToggleSave,
+  });
+
+  String _relativeDate(DateTime d) {
+    final diff = DateTime.now().difference(d);
+    if (diff.inDays >= 7) return '${(diff.inDays / 7).floor()}sem';
+    if (diff.inDays >= 1) return '${diff.inDays}j';
+    if (diff.inHours >= 1) return '${diff.inHours}h';
+    if (diff.inMinutes >= 1) return '${diff.inMinutes}m';
+    return 'À l\'instant';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return InkWell(
+      onTap: () => context.pushNamed(
+        RouteNames.contentDetail,
+        pathParameters: {'id': article.id},
+        extra: article,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    article.title,
+                    style: textTheme.bodyLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      height: 1.25,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${article.source.name} · ${_relativeDate(article.publishedAt)}',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colors.textSecondary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              onPressed: onToggleSave,
+              icon: Icon(
+                article.isSaved
+                    ? PhosphorIcons.bookmarkSimple(PhosphorIconsStyle.fill)
+                    : PhosphorIcons.bookmarkSimple(PhosphorIconsStyle.regular),
+                size: 20,
+                color: article.isSaved ? colors.primary : colors.textTertiary,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -489,6 +530,165 @@ class _EmptyState extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Ligne de liste pour une collection : icône, titre, compteurs.
+class _CollectionListTile extends StatelessWidget {
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final int totalCount;
+  final int unreadCount;
+  final FacteurColors colors;
+  final VoidCallback onTap;
+  final VoidCallback? onLongPress;
+
+  const _CollectionListTile({
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.totalCount,
+    required this.unreadCount,
+    required this.colors,
+    required this.onTap,
+    this.onLongPress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final showUnread = unreadCount > 0 && totalCount > 0;
+    return InkWell(
+      onTap: onTap,
+      onLongPress: onLongPress,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: FacteurSpacing.space4,
+          vertical: FacteurSpacing.space3,
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: iconColor.withOpacity(0.10),
+              ),
+              alignment: Alignment.center,
+              child: Icon(icon, color: iconColor, size: 18),
+            ),
+            const SizedBox(width: FacteurSpacing.space3),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: textTheme.bodyLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    totalCount == 0
+                        ? 'Vide'
+                        : '$totalCount ${totalCount == 1 ? 'article' : 'articles'}',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colors.textSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (showUnread)
+              Padding(
+                padding: const EdgeInsets.only(right: FacteurSpacing.space2),
+                child: Text(
+                  '$unreadCount non lu${unreadCount > 1 ? 's' : ''}',
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colors.textTertiary,
+                    fontSize: 11,
+                  ),
+                ),
+              ),
+            Icon(
+              PhosphorIcons.caretRight(PhosphorIconsStyle.regular),
+              color: colors.textTertiary,
+              size: 16,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NewCollectionTile extends StatelessWidget {
+  final FacteurColors colors;
+  final VoidCallback onTap;
+
+  const _NewCollectionTile({required this.colors, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: FacteurSpacing.space4,
+          vertical: FacteurSpacing.space3,
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: colors.primary.withOpacity(0.10),
+              ),
+              alignment: Alignment.center,
+              child: Icon(
+                PhosphorIcons.plus(PhosphorIconsStyle.bold),
+                color: colors.primary,
+                size: 16,
+              ),
+            ),
+            const SizedBox(width: FacteurSpacing.space3),
+            Expanded(
+              child: Text(
+                'Nouvelle collection',
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colors.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Divider extends StatelessWidget {
+  final FacteurColors colors;
+  const _Divider({required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    return Divider(
+      height: 1,
+      thickness: 1,
+      color: colors.surfaceElevated,
+      indent: 16,
+      endIndent: 16,
     );
   }
 }

--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
+import '../../../shared/widgets/fab_nudge_bubble.dart';
 import '../../../shared/widgets/states/friendly_error_view.dart';
 import '../../../shared/widgets/states/laurin_fallback_view.dart';
 
@@ -271,6 +272,8 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
             padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
             physics: const AlwaysScrollableScrollPhysics(),
             children: [
+              _IntroBlock(colors: colors),
+              const SizedBox(height: 16),
               if (premiumSources.isNotEmpty)
                 _buildCollapsibleSection(
                   title: 'Mes abonnements Premium',
@@ -282,6 +285,8 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                   colors: colors,
                   icon: PhosphorIcons.star(PhosphorIconsStyle.fill),
                 ),
+              const _HidePaidToggleCard(),
+              const SizedBox(height: 8),
               if (customSources.isNotEmpty)
                 _buildCollapsibleSection(
                   title: 'Mes sources personnalisees',
@@ -321,12 +326,24 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
         },
         ),
       ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => context.go('/settings/sources/add'),
-        icon: Icon(PhosphorIcons.plus(PhosphorIconsStyle.bold)),
-        label: const Text('Ajouter une source'),
-        backgroundColor: colors.primary,
-        foregroundColor: colors.surface,
+      floatingActionButton: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const Flexible(
+            child: FabNudgeBubble(
+              text: 'Ajoute n\'importe quelle source (média, newsletter, vidéos…)',
+            ),
+          ),
+          const SizedBox(width: 6),
+          FloatingActionButton.extended(
+            onPressed: () => context.go('/settings/sources/add'),
+            icon: Icon(PhosphorIcons.plus(PhosphorIconsStyle.bold)),
+            label: const Text('Ajouter une source'),
+            backgroundColor: colors.primary,
+            foregroundColor: colors.surface,
+          ),
+        ],
       ),
     );
   }
@@ -507,7 +524,6 @@ class _FilterSheetContent extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final hidePaid = ref.watch(hidePaidContentProvider);
     final colors = context.facteurColors;
 
     return Container(
@@ -560,53 +576,6 @@ class _FilterSheetContent extends ConsumerWidget {
             ),
 
             const SizedBox(height: 8),
-
-            // Paid content toggle
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
-              child: Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-                decoration: BoxDecoration(
-                  color: colors.surface,
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: colors.border),
-                ),
-                child: Row(
-                  children: [
-                    Icon(
-                      PhosphorIcons.lock(PhosphorIconsStyle.regular),
-                      size: 18,
-                      color: colors.textSecondary,
-                    ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Text(
-                        'Masquer les articles payants',
-                        style:
-                            Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                  color: colors.textPrimary,
-                                ),
-                      ),
-                    ),
-                    SizedBox(
-                      height: 28,
-                      child: Switch.adaptive(
-                        value: hidePaid,
-                        onChanged: (value) {
-                          ref
-                              .read(hidePaidContentProvider.notifier)
-                              .toggle(value);
-                        },
-                        activeTrackColor: colors.primary,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-
-            const SizedBox(height: 20),
 
             // Theme section
             Padding(
@@ -708,6 +677,127 @@ class _FilterSheetContent extends ConsumerWidget {
 
             const SizedBox(height: 24),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Intro block ─────────────────────────────────────────────
+
+class _IntroBlock extends StatelessWidget {
+  final FacteurColors colors;
+  const _IntroBlock({required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Container(
+      padding: const EdgeInsets.all(FacteurSpacing.space4),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        border: Border.all(color: colors.surfaceElevated),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Vos sources de confiance',
+            style: FacteurTypography.serifTitle(colors.textPrimary)
+                .copyWith(fontSize: 20, height: 1.2),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Choisissez les sources qui comptent pour vous : réglez leur fréquence d\'apparition de 1 (occasionnellement) à 3 (ne rien rater), masquez celles qui ne vous parlent pas, et ajoutez de nouvelles sources pour enrichir votre flux.',
+            style: textTheme.bodySmall?.copyWith(
+              color: colors.textSecondary,
+              height: 1.45,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─── Hide paid toggle card ──────────────────────────────────
+
+class _HidePaidToggleCard extends ConsumerWidget {
+  const _HidePaidToggleCard();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final hidePaid = ref.watch(hidePaidContentProvider);
+    final borderRadius = BorderRadius.circular(FacteurRadius.large);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 14),
+      child: Material(
+        color: colors.surface,
+        borderRadius: borderRadius,
+        child: InkWell(
+          onTap: () => ref
+              .read(hidePaidContentProvider.notifier)
+              .toggle(!hidePaid),
+          borderRadius: borderRadius,
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: borderRadius,
+              border: Border.all(color: colors.surfaceElevated),
+            ),
+            padding: const EdgeInsets.symmetric(
+              horizontal: FacteurSpacing.space4,
+              vertical: FacteurSpacing.space3,
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: colors.primary.withOpacity(0.10),
+                  ),
+                  alignment: Alignment.center,
+                  child: Icon(
+                    PhosphorIcons.lock(PhosphorIconsStyle.regular),
+                    color: colors.primary,
+                    size: 18,
+                  ),
+                ),
+                const SizedBox(width: FacteurSpacing.space3),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Masquer les articles payants',
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyMedium
+                            ?.copyWith(fontWeight: FontWeight.w600),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        'Cache les articles derrière un paywall.',
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodySmall
+                            ?.copyWith(color: colors.textSecondary),
+                      ),
+                    ],
+                  ),
+                ),
+                Switch.adaptive(
+                  value: hidePaid,
+                  activeColor: colors.primary,
+                  onChanged: (v) =>
+                      ref.read(hidePaidContentProvider.notifier).toggle(v),
+                ),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/apps/mobile/lib/features/sources/widgets/source_list_item.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_list_item.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/theme.dart';
-import '../../../widgets/design/facteur_image.dart';
 import '../../../widgets/design/facteur_stamp.dart';
 import '../../../widgets/design/priority_slider.dart';
 import '../models/source_model.dart';
 import 'source_detail_modal.dart';
+import 'source_logo_avatar.dart';
 
 class SourceListItem extends StatelessWidget {
   final Source source;
@@ -66,8 +66,8 @@ class SourceListItem extends StatelessWidget {
         opacity: isMuted ? 0.5 : 1.0,
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 150),
-          margin: const EdgeInsets.only(bottom: 12),
-          padding: const EdgeInsets.all(12),
+          margin: const EdgeInsets.only(bottom: 14),
+          padding: const EdgeInsets.all(18),
           decoration: BoxDecoration(
             color: isMuted
                 ? colors.surface
@@ -85,35 +85,12 @@ class SourceListItem extends StatelessWidget {
           ),
           child: Row(
             children: [
-              // Logo or Placeholder
-              Container(
-                width: 40,
-                height: 40,
-                decoration: BoxDecoration(
-                  color: colors.backgroundSecondary,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                clipBehavior: Clip.antiAlias,
-                child: source.logoUrl != null && source.logoUrl!.isNotEmpty
-                    ? FacteurImage(
-                        imageUrl: source.logoUrl!,
-                        fit: BoxFit.cover,
-                        placeholder: (context) => Center(
-                          child: SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: colors.secondary.withOpacity(0.3),
-                            ),
-                          ),
-                        ),
-                        errorWidget: (context) =>
-                            Icon(_typeIcon, color: colors.secondary, size: 20),
-                      )
-                    : Icon(_typeIcon, color: colors.secondary, size: 20),
+              SourceLogoAvatar(
+                source: source,
+                size: 60,
+                radius: 12,
               ),
-              const SizedBox(width: 12),
+              const SizedBox(width: 14),
 
               // Info
               Expanded(
@@ -126,8 +103,9 @@ class SourceListItem extends StatelessWidget {
                           child: Text(
                             source.name,
                             style:
-                                Theme.of(context).textTheme.labelLarge?.copyWith(
+                                Theme.of(context).textTheme.bodyLarge?.copyWith(
                                       color: colors.textPrimary,
+                                      fontWeight: FontWeight.w600,
                                     ),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
@@ -147,13 +125,27 @@ class SourceListItem extends StatelessWidget {
                         ],
                       ],
                     ),
-                    if (source.theme != null)
-                      Text(
-                        source.getThemeLabel(),
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: colors.textTertiary,
+                    if (source.theme != null) ...[
+                      const SizedBox(height: 2),
+                      Row(
+                        children: [
+                          Icon(_typeIcon,
+                              color: colors.textTertiary, size: 13),
+                          const SizedBox(width: 5),
+                          Flexible(
+                            child: Text(
+                              source.getThemeLabel(),
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.copyWith(color: colors.textTertiary),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
                             ),
+                          ),
+                        ],
                       ),
+                    ],
                   ],
                 ),
               ),

--- a/apps/mobile/lib/shared/widgets/fab_nudge_bubble.dart
+++ b/apps/mobile/lib/shared/widgets/fab_nudge_bubble.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+import '../../config/theme.dart';
+
+/// Petite bulle "nudge" affichée à gauche d'un FAB pour inviter à l'action.
+/// Speech-bubble avec petit triangle pointant vers la droite (le FAB).
+class FabNudgeBubble extends StatelessWidget {
+  final String text;
+  final double maxWidth;
+
+  const FabNudgeBubble({
+    super.key,
+    required this.text,
+    this.maxWidth = 200,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: maxWidth),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: FacteurSpacing.space3,
+                vertical: FacteurSpacing.space2,
+              ),
+              decoration: BoxDecoration(
+                color: colors.surface,
+                borderRadius: BorderRadius.circular(FacteurRadius.medium),
+                border: Border.all(color: colors.border),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.06),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: Text(
+                text,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: colors.textSecondary,
+                      height: 1.25,
+                    ),
+              ),
+            ),
+          ),
+          CustomPaint(
+            size: const Size(8, 12),
+            painter: _BubbleTailPainter(
+              fill: colors.surface,
+              border: colors.border,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BubbleTailPainter extends CustomPainter {
+  final Color fill;
+  final Color border;
+
+  _BubbleTailPainter({required this.fill, required this.border});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final path = Path()
+      ..moveTo(0, 0)
+      ..lineTo(size.width, size.height / 2)
+      ..lineTo(0, size.height)
+      ..close();
+    canvas.drawPath(path, Paint()..color = fill);
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = border
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _BubbleTailPainter oldDelegate) =>
+      oldDelegate.fill != fill || oldDelegate.border != border;
+}


### PR DESCRIPTION
## What

UI refresh of the three settings-shortcut pages to align with the Réglages sheet design system, plus engagement nudges next to the FABs.

- **Mes sources** : intro DS-aligned, cartes ×1.5 (avatar 60px avec fallback initiales), toggle "Masquer articles payants" sorti des filtres et placé en carte sous "Mes abonnements", nudge FAB ("Ajoute n'importe quelle source…").
- **Mes intérêts** : `SereinToggleChip` remplacé par tile Switch.adaptive (style Réglages) sous l'intro ; titres de thèmes agrandis (titleMedium 17 w700) ; nudge FAB ("Suivez n'importe quel sujet…").
- **Mes sauvegardes** : grille de collections (mosaïques thumbnails) remplacée par carte liste DS (icône cerclée, titre, total articles, badge discret "X non lus") ; articles "Pensées de la semaine" et "Récents" rendus en liste compacte sans images.
- Nouveau widget partagé `FabNudgeBubble` (bulle speech avec petit triangle).

## Why

Rendre ces pages plus belles, plus engageantes, et cohérentes avec le DS introduit en PR #516 (sheet Réglages).

## Type

- [x] Feature

## Checklist

- [ ] Tests pass locally
- [x] Linting passes (`flutter analyze` clean — info-only deprecations préexistantes)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A