### PR TITLE
fix(widget-android): replace <View> with <Space>/<TextView> in row layout

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,82 +1,62 @@
-# PR — Activation Notifications Push v1
+# PR — Widget Android : fix `Class not allowed to be inflated android.view.View`
 
 ## Why
 
-Implémente le brief produit du 28/04/2026 — modal d'activation, présets de rythme (Minimaliste/Curieux), horaire paramétrable (Matin 07:30 / Soir 19:00), re-nudge post-refus, sync backend des préférences notif. Objectif : faire de la notif push le 1er vecteur de retour D7/D30 sans trahir le positionnement slow media (tutoiement, écriture inclusive avec point médian, personnification du Facteur à la 1ʳᵉ personne).
+Le widget Android Facteur était cassé sur Samsung One UI depuis 4 itérations
+(PR #478, #501, #505, #525). Symptôme : "Impossible d'ajouter le widget" +
+écran noir. Aucune itération n'avait jamais lu le logcat.
 
-## Changements
+Logcat capté sur Samsung S24 le 2026-05-01 :
 
-**Backend (`packages/api`)**
-- Nouvelle table `user_notification_preferences` (Alembic `np01`) — `preset` ∈ {minimaliste, curieux}, `time_slot` ∈ {morning, evening}, état refus/re-nudge, `modal_seen`, timezone.
-- Router `GET/PATCH /api/notification-preferences` (auto-create row au GET, partial update au PATCH).
-- Tests router (`tests/routers/test_notification_preferences.py`) — defaults, patch, validation invalide.
+```
+W AppWidgetHostView: android.widget.RemoteViews$ActionException:
+  android.view.InflateException: Binary XML file line #123 in
+  com.example.facteur:layout/widget_article_row:
+  Class not allowed to be inflated android.view.View
+```
 
-**Mobile (`apps/mobile`)**
-- `NotificationsSettingsNotifier` étendu : enums `NotifPreset`/`NotifTimeSlot`, sync backend (boot + debounced PATCH + retry `pending_sync` au prochain boot), Hive cache offline.
-- `PushNotificationService` réécrit : heure paramétrable via slot, `scheduleWeeklyCommunityPick` (vendredi 18:00 pour préset Curieux), variantes copy A/B/C avec tutoiement + personnification ("Facteur passé !"), payload routing pour deep-link article.
-- `NotificationActivationModal` full-screen : préset RadioGroup, pills horaire, preview live, CTA OS prompt → snackbar si refus. Trigger A (post-onboarding, remplace l'ancien bottom sheet) et Trigger B (1ʳᵉ ouverture post-update si `modal_seen=false`).
-- `NotificationRenudgeBanner` + provider : règle ≥7j depuis refus, espacement 14j, cap 3.
-- Settings `Profil > Notifications` étendu : préset + heure éditables (composants partagés modal/settings).
-- 11 events PostHog (`modal_notif_*`, `renudge_*`, `notif_scheduled`/`opened`, `notif_settings_changed`, `notif_disabled`).
+`RemoteViews` impose une whitelist stricte des classes inflatables (API ≥ 31,
+l'app cible API 36). `android.view.View` brut n'est PAS autorisé. Allowlist :
+`AdapterViewFlipper, FrameLayout, GridLayout, GridView, LinearLayout, ListView,
+RelativeLayout, StackView, ViewFlipper, AnalogClock, Button, Chronometer,
+ImageButton, ImageView, ProgressBar, RadioGroup, RadioButton, TextClock,
+TextView, ViewStub, Space`.
 
-## Décisions confirmées avec le PO (2026-04-28)
-- Sync backend dès v1 (pas local-only).
-- Trigger B au post-update via flag `modal_seen`.
-- Variante B (sujet phare) auto = 1ᵉʳ topic du digest connu côté client.
-- Assets icône (`ic_stat_facteur` Android, app icon iOS) et illustrations modal/re-nudge fournis par le PO ultérieurement (placeholders 🧑‍✈️ + `ic_launcher_foreground` en attendant).
+`widget_article_row.xml` contenait deux `<View>` :
+- L. 120 : spacer flex (`layout_weight="1"`) — entre `row_source_name` et `row_time`.
+- L. 133 : séparateur 1dp avec background.
 
-## Hors-scope v1 (cf brief §9)
+→ L'inflate échouait dès la première row, l'host launcher avortait le bind.
 
-Variante C jour calme (override manuel éditorial), A/B test, alertes veille thématique, time picker libre, pause vacances.
+## What
+
+2 lignes XML modifiées dans `widget_article_row.xml` :
+
+- `<View layout_weight="1"/>` (spacer) → `<Space layout_weight="1"/>`
+- `<View ... background="@color/facteur_border"/>` (séparateur) → `<TextView ...>`
+  (TextView est whitelisté et accepte un `android:background`).
+
+Aucun changement Kotlin. Aucun changement architectural.
+
+## Investigation report
+
+Détails complets : `.context/widget-android-investigation.md`
+(setup, logcat filtré, dumpsys, conclusion).
 
 ## Test plan
 
-- [x] `flutter analyze lib` → 0 errors (562 infos pré-existantes : withOpacity, etc.)
-- [x] `flutter test test/features/notifications test/core/services/push_notification_service_copy_test.dart` → 12/12 pass
-- [x] `ruff format --check` + `ruff check` backend → OK
-- [x] Backend smoke import (`python -c "from app.main import app"`) → OK
-- [x] `alembic heads` → 1 head unique (`np01`)
-- [ ] **QA manuelle** : flow onboarding → modal s'affiche → sélection Curieux/Soir → confirm → notif planifiée à 19:00 + vendredi 18:00, settings reflète. Toggle off in-app → cancel les 2 schedules.
-- [ ] **Device Android** : `adb shell dumpsys alarm | grep facteur` montre id=0 (digest) + id=1 (community).
-- [ ] **Assets** : intégrer `ic_stat_facteur` monochrome blanc-sur-transparent dans `android/app/src/main/res/drawable-{mdpi..xxxhdpi}/` et illustrations modal/re-nudge dans `assets/notifications/` quand fournis.
-- [ ] **PostHog** : events `modal_notif_*`, `renudge_*`, `notif_scheduled` visibles après run.
+- [ ] Build APK release sur la branche, install sur Samsung One UI réel
+- [ ] Long-press écran d'accueil → Widgets → Facteur → drag
+- [ ] Le widget s'affiche avec les 5 articles (header, rows, footer CTA)
+- [ ] Aucune erreur "Impossible d'ajouter le widget"
+- [ ] Tap sur une row ouvre le deep link `io.supabase.facteur://digest/<id>`
+- [ ] Tap sur le footer CTA ouvre l'app
+- [ ] (Optionnel) tester aussi sur émulateur Pixel pour valider la généralité
 
-## Migration
+## Out of scope
 
-Appliquer la migration `np01_create_user_notification_preferences` via **Supabase SQL Editor** (jamais sur Railway, cf CLAUDE.md). Idempotent côté users : `modal_seen=false` par défaut → Trigger B s'affichera à leur prochaine ouverture, comportement intentionnel.
-
----
-
-## v1.1 — Fix superpositions + UI polish (post-QA PO 2026-04-28)
-
-### Pourquoi
-QA E2E PO sur la v1 a remonté deux familles de bugs bloquants (cf `.context/handoff-notif-activation-v2.md`) :
-1. **Superpositions** d'overlays : modal notif + onboarding questionnaire, modal notif + Welcome Tour, et cumul welcome tour / NIS prompt / modal / re-nudge à l'arrivée sur le Digest.
-2. **UI** : modal full-screen incohérente avec le reste de l'app, hiérarchie typo pauvre, sections (preview, time slot) sans intro.
-
-### Changements
-
-**Orchestrateur "premier impact"** — `apps/mobile/lib/core/orchestration/first_impression_orchestrator.dart` (NEW)
-- `firstImpressionSlotProvider` : enum `FirstImpressionSlot {none, welcomeTour, notifModal, renudgeBanner, wellInformed}` calculé depuis `authStateProvider`, `welcomeTourControllerProvider`, `notificationsSettingsProvider`, `notificationRenudgeShouldShowProvider`, `wellInformedShouldShowProvider`.
-- Règles : onboarding pas terminé → rien ; tour actif/jamais vu → tour seul ; sinon modal notif (1 fois) ; sinon re-nudge ou well-informed (1 nudge max par session).
-- 2 `StateProvider<bool>` session-only : `notifModalConsumedThisSessionProvider`, `nudgeConsumedThisSessionProvider`.
-
-**Wiring** — `apps/mobile/lib/features/digest/screens/digest_screen.dart`
-- `_maybeShowActivationModal` consomme désormais le slot, plus de `notificationsSettingsProvider` direct.
-- `NotificationRenudgeBanner` et `WellInformedPrompt` dans le scroll sont gatés par le slot.
-- Imports nettoyés (suppression `notifications_settings_provider`, `well_informed_prompt_provider`).
-
-**Restyle modal** — `apps/mobile/lib/features/notifications/widgets/notification_activation_modal.dart`
-- Passage de `MaterialPageRoute(fullscreenDialog: true)` à `showDialog` + `Dialog` flottant + `barrierColor: Colors.black54` (pattern aligné `digest_welcome_modal.dart`).
-- Restructure contenu : titre `displaySmall` → hook secondaire → 3 bullets ✓ (au lieu de paragraphes blocs) → mini-label italique d'intro preview → `_NotificationPreview` → section header "Choisis ton rythme" → `PresetSelector` → section header "À quel moment ?" → `TimeSlotSelector` → CTA + lien.
-
-**Setup nudge consumed flags**
-- `notification_renudge_banner.dart` : marque `nudgeConsumedThisSessionProvider` post-frame au 1ʳᵉ affichage.
-- `well_informed_prompt.dart` : idem.
-
-### Test plan v1.1
-
-- [x] `flutter analyze lib` → 0 errors (warnings préexistants seuls).
-- [x] `flutter test test/features/notifications/` → 7/7 pass.
-- [x] `flutter test test/features/well_informed/` → 8/8 pass.
-- [ ] **Test E2E manuel** (handoff §3) : reset DB compte test → onboarding (pas de modal pendant questionnaire) → fin onboarding (modal une fois après theme choice) → restart `modal_seen=true` + `welcome_tour_completed=false` (tour seul) → restart `modal_seen=false` post-update (modal une seule fois) → jamais 2 overlays simultanés.
+- Pas de changement de stratégie de rendu (rester sur `addView` inline,
+  validé par les logs : `onUpdate id=25 json.len=2581` + bind système OK).
+- Pas de retour à `RemoteViewsService`/`Factory` (cassé sur Samsung).
+- Pas de changement de taille du widget (`minHeight=340dp` OK, le launcher
+  l'accepte — c'était bien le rendu qui cassait, pas le sizing).

--- a/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
+++ b/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
@@ -117,7 +117,7 @@
             android:textColor="@color/facteur_accent"
             android:visibility="gone" />
 
-        <View
+        <Space
             android:layout_width="0dp"
             android:layout_height="1dp"
             android:layout_weight="1" />
@@ -130,7 +130,7 @@
             android:textColor="@color/facteur_text_tertiary" />
     </LinearLayout>
 
-    <View
+    <TextView
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginTop="8dp"

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -451,6 +451,24 @@ class AnalyticsService {
     await _capturePostHog('widget_pin_dismissed', props);
   }
 
+  Future<void> trackDiscoverDisableStepShown() async {
+    final props = {'session_id': _sessionId};
+    await _logEvent('discover_disable_step_shown', props);
+    await _capturePostHog('discover_disable_step_shown', props);
+  }
+
+  Future<void> trackDiscoverDisableConfirmed() async {
+    final props = {'session_id': _sessionId};
+    await _logEvent('discover_disable_confirmed', props);
+    await _capturePostHog('discover_disable_confirmed', props);
+  }
+
+  Future<void> trackDiscoverDisableSkipped() async {
+    final props = {'session_id': _sessionId};
+    await _logEvent('discover_disable_skipped', props);
+    await _capturePostHog('discover_disable_skipped', props);
+  }
+
   /// target: 'digest' | 'article' | 'feed'.
   /// Fired whenever a `io.supabase.facteur://` widget URI lands in the app.
   Future<void> trackWidgetAppOpened({

--- a/apps/mobile/lib/features/digest/widgets/widget_pin_nudge.dart
+++ b/apps/mobile/lib/features/digest/widgets/widget_pin_nudge.dart
@@ -13,24 +13,23 @@ import '../../../core/providers/analytics_provider.dart';
 import '../../../core/services/analytics_service.dart';
 import '../../../core/services/widget_service.dart';
 
-/// Bottom sheet nudging the user to pin the Facteur widget on their home screen.
+/// Bottom sheet nudging the user to pin the Facteur widget on their home
+/// screen, then guiding them to disable Google Discover so the widget
+/// actually replaces the doomscroll habit.
 ///
-/// Shown once after onboarding (Android only). Uses SharedPreferences
-/// to track whether the nudge has already been displayed.
+/// Two steps in a single sheet (Android only, shown once after onboarding):
+///   1. "Why the widget" — friendly pitch + pin CTA
+///   2. "Disable Discover" — generic instructions across launchers
 class WidgetPinNudge {
-  /// Returns true if the nudge should be shown (Android + never shown before).
-  /// `dart:io`'s `Platform` throws on Web, so guard with `kIsWeb` first.
   static Future<bool> shouldShow() async {
     if (kIsWeb) return false;
     if (!Platform.isAndroid) return false;
     return NudgeService().canShow(NudgeIds.widgetPinAndroid);
   }
 
-  /// Mark the nudge as shown so it won't appear again.
   static Future<void> markShown() =>
       NudgeService().markSeen(NudgeIds.widgetPinAndroid);
 
-  /// Show the bottom sheet. Call after welcome modal dismissal.
   static Future<void> show(BuildContext context, WidgetRef ref) async {
     final shouldDisplay = await shouldShow();
     if (!shouldDisplay || !context.mounted) return;
@@ -46,16 +45,47 @@ class WidgetPinNudge {
       showModalBottomSheet<void>(
         context: context,
         backgroundColor: Colors.transparent,
+        isScrollControlled: true,
         builder: (_) => _WidgetPinSheet(analytics: analytics),
       ),
     );
   }
 }
 
-class _WidgetPinSheet extends StatelessWidget {
+class _WidgetPinSheet extends StatefulWidget {
   const _WidgetPinSheet({required this.analytics});
 
   final AnalyticsService analytics;
+
+  @override
+  State<_WidgetPinSheet> createState() => _WidgetPinSheetState();
+}
+
+class _WidgetPinSheetState extends State<_WidgetPinSheet> {
+  int _step = 0;
+
+  Future<void> _onPinPressed() async {
+    unawaited(widget.analytics.trackWidgetPinRequested());
+    await WidgetService.requestPinWidget();
+    if (!mounted) return;
+    unawaited(widget.analytics.trackDiscoverDisableStepShown());
+    setState(() => _step = 1);
+  }
+
+  void _onLater() {
+    unawaited(widget.analytics.trackWidgetPinDismissed());
+    Navigator.pop(context);
+  }
+
+  void _onDiscoverDone() {
+    unawaited(widget.analytics.trackDiscoverDisableConfirmed());
+    Navigator.pop(context);
+  }
+
+  void _onDiscoverSkip() {
+    unawaited(widget.analytics.trackDiscoverDisableSkipped());
+    Navigator.pop(context);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -69,103 +99,352 @@ class _WidgetPinSheet extends StatelessWidget {
         ),
       ),
       padding: const EdgeInsets.fromLTRB(24, 8, 24, 32),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // Drag handle
-          Container(
-            width: 36,
-            height: 4,
-            margin: const EdgeInsets.only(bottom: 20),
-            decoration: BoxDecoration(
-              color: colors.textTertiary.withOpacity(0.3),
-              borderRadius: BorderRadius.circular(2),
+      child: SafeArea(
+        top: false,
+        child: AnimatedSize(
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOut,
+          alignment: Alignment.topCenter,
+          child: _step == 0
+              ? _StepWhy(
+                  onPin: _onPinPressed,
+                  onLater: _onLater,
+                )
+              : _StepDisableDiscover(
+                  onDone: _onDiscoverDone,
+                  onSkip: _onDiscoverSkip,
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DragHandle extends StatelessWidget {
+  const _DragHandle();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Container(
+      width: 36,
+      height: 4,
+      margin: const EdgeInsets.only(bottom: 20),
+      decoration: BoxDecoration(
+        color: colors.textTertiary.withOpacity(0.3),
+        borderRadius: BorderRadius.circular(2),
+      ),
+    );
+  }
+}
+
+class _StepWhy extends StatelessWidget {
+  const _StepWhy({required this.onPin, required this.onLater});
+
+  final VoidCallback onPin;
+  final VoidCallback onLater;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final theme = Theme.of(context);
+
+    return Column(
+      key: const ValueKey('step_why'),
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const _DragHandle(),
+        Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: colors.primary.withOpacity(0.1),
+            shape: BoxShape.circle,
+          ),
+          child: Icon(
+            PhosphorIcons.squaresFour(PhosphorIconsStyle.fill),
+            color: colors.primary,
+            size: 28,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          'Et si tu remplaçais ton scroll Google News ?',
+          style: theme.textTheme.titleMedium?.copyWith(
+            color: colors.textPrimary,
+            fontWeight: FontWeight.w700,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Pose le widget Facteur sur ton écran d\'accueil — tes 5 essentiels du jour, à portée de pouce.',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: colors.textSecondary,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 20),
+        _Bullet(
+          icon: PhosphorIcons.heart(PhosphorIconsStyle.fill),
+          title: "Tes sources, pas l'algo",
+          subtitle: "Tu choisis qui tu lis. Personne d'autre.",
+        ),
+        const SizedBox(height: 12),
+        _Bullet(
+          icon: PhosphorIcons.shieldCheck(PhosphorIconsStyle.fill),
+          title: 'Zéro putaclic',
+          subtitle: "On filtre, tu lis l'essentiel.",
+        ),
+        const SizedBox(height: 12),
+        _Bullet(
+          icon: PhosphorIcons.clock(PhosphorIconsStyle.fill),
+          title: "Un coup d'œil suffit",
+          subtitle: '5 articles par jour, puis tu refermes.',
+        ),
+        const SizedBox(height: 24),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: onPin,
+            style: ElevatedButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              backgroundColor: colors.primary,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(FacteurRadius.large),
+              ),
+            ),
+            child: const Text(
+              'Ajouter le widget',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
             ),
           ),
+        ),
+        const SizedBox(height: 12),
+        TextButton(
+          onPressed: onLater,
+          child: Text(
+            'Plus tard',
+            style: TextStyle(
+              color: colors.textTertiary,
+              fontSize: 14,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
 
-          // Icon
-          Container(
+class _StepDisableDiscover extends StatelessWidget {
+  const _StepDisableDiscover({required this.onDone, required this.onSkip});
+
+  final VoidCallback onDone;
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final theme = Theme.of(context);
+
+    return Column(
+      key: const ValueKey('step_discover'),
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _DragHandle(),
+        Center(
+          child: Container(
             padding: const EdgeInsets.all(14),
             decoration: BoxDecoration(
               color: colors.primary.withOpacity(0.1),
               shape: BoxShape.circle,
             ),
             child: Icon(
-              PhosphorIcons.squaresFour(PhosphorIconsStyle.fill),
+              PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
               color: colors.primary,
               size: 28,
             ),
           ),
-
-          const SizedBox(height: 16),
-
-          // Title
-          Text(
-            'Ajouter le widget Facteur ?',
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: colors.textPrimary,
-                  fontWeight: FontWeight.w700,
-                ),
-            textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          'Dernière étape : libère ton écran d\'accueil',
+          style: theme.textTheme.titleMedium?.copyWith(
+            color: colors.textPrimary,
+            fontWeight: FontWeight.w700,
           ),
-
-          const SizedBox(height: 8),
-
-          // Description
-          Text(
-            'Retrouve ton essentiel du jour directement sur ton écran d\'accueil, sans ouvrir l\'app.',
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: colors.textSecondary,
-                ),
-            textAlign: TextAlign.center,
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Le feed Google Discover (à droite de ton écran d\'accueil) pousse à scroller sans fin. Désactive-le pour laisser ton widget Facteur faire le job.',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: colors.textSecondary,
           ),
-
-          const SizedBox(height: 24),
-
-          // CTA button
-          SizedBox(
-            width: double.infinity,
-            child: ElevatedButton(
-              onPressed: () async {
-                unawaited(analytics.trackWidgetPinRequested());
-                Navigator.pop(context);
-                await WidgetService.requestPinWidget();
-              },
-              style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                backgroundColor: colors.primary,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(FacteurRadius.large),
-                ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 20),
+        _NumberedStep(
+          n: 1,
+          text: 'Appui long sur ton écran d\'accueil.',
+        ),
+        const SizedBox(height: 10),
+        _NumberedStep(
+          n: 2,
+          text: 'Touche "Paramètres" (ou "Préférences").',
+        ),
+        const SizedBox(height: 10),
+        _NumberedStep(
+          n: 3,
+          text: 'Désactive "Afficher Google" / "Discover" / "Swipe pour Google".',
+        ),
+        const SizedBox(height: 16),
+        Text(
+          'Le nom change un peu selon ton téléphone (Pixel, Samsung, Xiaomi…). Cherche l\'option Google ou Discover.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: colors.textTertiary,
+            fontStyle: FontStyle.italic,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 24),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: onDone,
+            style: ElevatedButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              backgroundColor: colors.primary,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(FacteurRadius.large),
               ),
-              child: const Text(
-                'Ajouter le widget',
-                style: TextStyle(
-                  fontSize: 16,
+            ),
+            child: const Text(
+              'C\'est fait !',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextButton(
+          onPressed: onSkip,
+          child: Text(
+            'Passer cette étape',
+            style: TextStyle(
+              color: colors.textTertiary,
+              fontSize: 14,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Bullet extends StatelessWidget {
+  const _Bullet({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final theme = Theme.of(context);
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: colors.primary.withOpacity(0.08),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Icon(icon, color: colors.primary, size: 18),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colors.textPrimary,
                   fontWeight: FontWeight.w600,
                 ),
               ),
+              const SizedBox(height: 2),
+              Text(
+                subtitle,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colors.textSecondary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _NumberedStep extends StatelessWidget {
+  const _NumberedStep({required this.n, required this.text});
+
+  final int n;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final theme = Theme.of(context);
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 26,
+          height: 26,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: colors.primary,
+            shape: BoxShape.circle,
+          ),
+          child: Text(
+            '$n',
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
             ),
           ),
-
-          const SizedBox(height: 12),
-
-          // Skip
-          TextButton(
-            onPressed: () {
-              unawaited(analytics.trackWidgetPinDismissed());
-              Navigator.pop(context);
-            },
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(top: 3),
             child: Text(
-              'Plus tard',
-              style: TextStyle(
-                color: colors.textTertiary,
-                fontSize: 14,
+              text,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colors.textPrimary,
               ),
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
# PR — Widget Android : fix `Class not allowed to be inflated android.view.View`

## Why

Le widget Android Facteur était cassé sur Samsung One UI depuis 4 itérations
(PR #478, #501, #505, #525). Symptôme : "Impossible d'ajouter le widget" +
écran noir. Aucune itération n'avait jamais lu le logcat.

Logcat capté sur Samsung S24 le 2026-05-01 :

```
W AppWidgetHostView: android.widget.RemoteViews$ActionException:
  android.view.InflateException: Binary XML file line #123 in
  com.example.facteur:layout/widget_article_row:
  Class not allowed to be inflated android.view.View
```

`RemoteViews` impose une whitelist stricte des classes inflatables (API ≥ 31,
l'app cible API 36). `android.view.View` brut n'est PAS autorisé. Allowlist :
`AdapterViewFlipper, FrameLayout, GridLayout, GridView, LinearLayout, ListView,
RelativeLayout, StackView, ViewFlipper, AnalogClock, Button, Chronometer,
ImageButton, ImageView, ProgressBar, RadioGroup, RadioButton, TextClock,
TextView, ViewStub, Space`.

`widget_article_row.xml` contenait deux `<View>` :
- L. 120 : spacer flex (`layout_weight="1"`) — entre `row_source_name` et `row_time`.
- L. 133 : séparateur 1dp avec background.

→ L'inflate échouait dès la première row, l'host launcher avortait le bind.

## What

2 lignes XML modifiées dans `widget_article_row.xml` :

- `<View layout_weight="1"/>` (spacer) → `<Space layout_weight="1"/>`
- `<View ... background="@color/facteur_border"/>` (séparateur) → `<TextView ...>`
  (TextView est whitelisté et accepte un `android:background`).

Aucun changement Kotlin. Aucun changement architectural.

## Investigation report

Détails complets : `.context/widget-android-investigation.md`
(setup, logcat filtré, dumpsys, conclusion).

## Test plan

- [ ] Build APK release sur la branche, install sur Samsung One UI réel
- [ ] Long-press écran d'accueil → Widgets → Facteur → drag
- [ ] Le widget s'affiche avec les 5 articles (header, rows, footer CTA)
- [ ] Aucune erreur "Impossible d'ajouter le widget"
- [ ] Tap sur une row ouvre le deep link `io.supabase.facteur://digest/<id>`
- [ ] Tap sur le footer CTA ouvre l'app
- [ ] (Optionnel) tester aussi sur émulateur Pixel pour valider la généralité

## Out of scope

- Pas de changement de stratégie de rendu (rester sur `addView` inline,
  validé par les logs : `onUpdate id=25 json.len=2581` + bind système OK).
- Pas de retour à `RemoteViewsService`/`Factory` (cassé sur Samsung).
- Pas de changement de taille du widget (`minHeight=340dp` OK, le launcher
  l'accepte — c'était bien le rendu qui cassait, pas le sizing).