### PR TITLE
feat(ui): simplifier l'écran d'ajout de sources

### DIFF
--- a/apps/mobile/lib/features/sources/providers/sources_providers.dart
+++ b/apps/mobile/lib/features/sources/providers/sources_providers.dart
@@ -29,7 +29,7 @@ final smartSearchProvider = FutureProvider.family<SmartSearchResponse,
 
 final trendingSourcesProvider = FutureProvider<List<Source>>((ref) async {
   final repository = ref.watch(sourcesRepositoryProvider);
-  return repository.getTrendingSources(limit: 10);
+  return repository.getTrendingSources(limit: 30);
 });
 
 final themesFollowedProvider =

--- a/apps/mobile/lib/features/sources/screens/add_source_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/add_source_screen.dart
@@ -16,7 +16,6 @@ import '../widgets/smart_search_field.dart';
 import '../widgets/source_detail_modal.dart';
 import '../widgets/source_result_card.dart';
 import '../widgets/source_result_skeleton.dart';
-import '../widgets/theme_explorer.dart';
 
 class AddSourceScreen extends ConsumerStatefulWidget {
   const AddSourceScreen({super.key});
@@ -32,12 +31,18 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
   bool _expanded = false;
   bool _sourceAdded = false;
   final Set<String> _addedSourceIds = {};
+  String? _lastAddedName;
   late final TextEditingController _searchController;
+  late final FocusNode _searchFocusNode;
+  bool _searchActive = false;
 
   @override
   void initState() {
     super.initState();
     _searchController = TextEditingController();
+    _searchFocusNode = FocusNode();
+    _searchFocusNode.addListener(_handleSearchActivity);
+    _searchController.addListener(_handleSearchActivity);
   }
 
   @override
@@ -46,8 +51,19 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
     if (query.isNotEmpty && !_sourceAdded) {
       ref.read(sourcesRepositoryProvider).logSearchAbandoned(query);
     }
+    _searchFocusNode.removeListener(_handleSearchActivity);
+    _searchController.removeListener(_handleSearchActivity);
+    _searchFocusNode.dispose();
     _searchController.dispose();
     super.dispose();
+  }
+
+  void _handleSearchActivity() {
+    final active =
+        _searchFocusNode.hasFocus || _searchController.text.isNotEmpty;
+    if (active != _searchActive) {
+      setState(() => _searchActive = active);
+    }
   }
 
   SmartSearchQuery get _searchParams => (
@@ -107,6 +123,7 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
         setState(() {
           _addedSourceIds.add(sourceId);
           _sourceAdded = true;
+          _lastAddedName = result.name;
         });
       } else {
         if (result.feedUrl.isEmpty) {
@@ -114,7 +131,10 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
           return;
         }
         await repository.addCustomSource(result.feedUrl, name: result.name);
-        setState(() => _sourceAdded = true);
+        setState(() {
+          _sourceAdded = true;
+          _lastAddedName = result.name;
+        });
       }
 
       if (!mounted) return;
@@ -137,10 +157,13 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
           isTrusted: true,
           priorityMultiplier: 2.0,
         );
-        _showSourceModal(source, recentItems: result.recentItems);
+        await _showSourceModal(source, recentItems: result.recentItems);
+        if (!mounted) return;
+        _resetForNextAdd();
       } else {
         NotificationService.showSuccess(
             'Source ajoutee ! Ses contenus apparaitront dans ton feed.');
+        _resetForNextAdd();
       }
     } catch (e) {
       if (mounted) {
@@ -196,11 +219,19 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
     }
   }
 
-  void _showSourceModal(
+  void _resetForNextAdd() {
+    _searchController.clear();
+    setState(() {
+      _currentQuery = '';
+      _expanded = false;
+    });
+  }
+
+  Future<void> _showSourceModal(
     Source source, {
     List<SmartSearchRecentItem>? recentItems,
   }) {
-    showModalBottomSheet<void>(
+    return showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
@@ -257,25 +288,62 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
           icon: Icon(PhosphorIcons.x(PhosphorIconsStyle.regular)),
           onPressed: () => context.pop(),
         ),
-        title: Text(
-          'Ajouter une source',
-          style: Theme.of(context).textTheme.displaySmall,
-        ),
+        title: const Text('Ajouter une source'),
       ),
       body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.fromLTRB(
+          FacteurSpacing.space4,
+          FacteurSpacing.space2,
+          FacteurSpacing.space4,
+          FacteurSpacing.space8,
+        ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            SmartSearchField(
-              controller: _searchController,
-              onSubmit: (value) => _runSearch(value),
-              onClear: _clearSearch,
-              onSearch: () => _runSearch(),
-            ),
-            const SizedBox(height: 16),
+            if (_currentQuery.isEmpty) ...[
+              const SizedBox(height: FacteurSpacing.space6),
+              _buildSearchIntro(),
+              const SizedBox(height: FacteurSpacing.space6),
+            ],
+            _buildBreathingSearch(colors),
+            SizedBox(
+                height: _currentQuery.isEmpty
+                    ? FacteurSpacing.space8
+                    : FacteurSpacing.space4),
             _buildContent(),
           ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBreathingSearch(FacteurColors colors) {
+    final glow = _searchActive ? colors.primary.withValues(alpha: 0.18) : Colors.transparent;
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 320),
+      curve: Curves.easeOut,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        boxShadow: [
+          BoxShadow(
+            color: glow,
+            blurRadius: _searchActive ? 28 : 0,
+            spreadRadius: _searchActive ? 2 : 0,
+          ),
+        ],
+      ),
+      child: TweenAnimationBuilder<double>(
+        tween: Tween(begin: 1.0, end: _searchActive ? 1.01 : 1.0),
+        duration: const Duration(milliseconds: 320),
+        curve: Curves.easeOut,
+        builder: (context, scale, child) =>
+            Transform.scale(scale: scale, child: child),
+        child: SmartSearchField(
+          controller: _searchController,
+          focusNode: _searchFocusNode,
+          onSubmit: (value) => _runSearch(value),
+          onClear: _clearSearch,
+          onSearch: () => _runSearch(),
         ),
       ),
     );
@@ -325,28 +393,144 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
     ref.read(analyticsServiceProvider).trackAddSourceExampleTap(text);
   }
 
-  Widget _buildEmptyState() => _buildUrlRssEmptyState();
-
-  Widget _buildUrlRssEmptyState() {
+  Widget _buildEmptyState() {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _buildSourceTypesRow(),
-        const SizedBox(height: 20),
+        if (_sourceAdded) ...[
+          _buildAddedNudge(),
+          const SizedBox(height: FacteurSpacing.space6),
+        ],
         ExampleChips(onTap: _onExampleTap),
-        const SizedBox(height: 24),
-        const ThemeExplorer(),
-        const SizedBox(height: 24),
+        const SizedBox(height: FacteurSpacing.space8),
         CommunityGemsStrip(
           onSourceTap: _showSourceModal,
           onGemTap: (sourceId) {
             ref.read(analyticsServiceProvider).trackAddSourceGemTap(sourceId);
           },
         ),
-        const SizedBox(height: 24),
-        _buildInspirationHints(),
-        const SizedBox(height: 24),
       ],
+    );
+  }
+
+  Widget _buildAddedNudge() {
+    final colors = context.facteurColors;
+    final name = _lastAddedName;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        onTap: () {
+          setState(() {
+            _sourceAdded = false;
+            _lastAddedName = null;
+          });
+          _searchFocusNode.requestFocus();
+        },
+        child: Container(
+          padding: const EdgeInsets.all(FacteurSpacing.space4),
+          decoration: BoxDecoration(
+            color: colors.primary.withValues(alpha: 0.08),
+            borderRadius: BorderRadius.circular(FacteurRadius.large),
+            border: Border.all(color: colors.primary.withValues(alpha: 0.25)),
+          ),
+          child: Row(
+            children: [
+              Icon(PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                  size: 22, color: colors.primary),
+              const SizedBox(width: FacteurSpacing.space3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      name != null
+                          ? '« $name » ajoutée'
+                          : 'Source ajoutée',
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: colors.textPrimary,
+                          ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'Une autre à ajouter ?',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colors.textSecondary,
+                          ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: FacteurSpacing.space2),
+              Icon(PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
+                  size: 18, color: colors.primary),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSearchIntro() {
+    final colors = context.facteurColors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Text(
+          'Que veux-tu suivre ?',
+          textAlign: TextAlign.center,
+          style: FacteurTypography.serifTitle(colors.textPrimary)
+              .copyWith(fontSize: 28, height: 1.15),
+        ),
+        const SizedBox(height: FacteurSpacing.space2),
+        Text(
+          'Tape un nom de média ou colle son URL.\nOn l\'amène dans ton app.',
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: colors.textSecondary,
+                height: 1.45,
+              ),
+        ),
+        const SizedBox(height: FacteurSpacing.space4),
+        _buildSupportedTypesInfo(colors),
+      ],
+    );
+  }
+
+  Widget _buildSupportedTypesInfo(FacteurColors colors) {
+    const items = <({String label, int iconIndex})>[
+      (label: 'Médias', iconIndex: 0),
+      (label: 'Newsletters', iconIndex: 1),
+      (label: 'YouTube', iconIndex: 2),
+      (label: 'Reddit', iconIndex: 3),
+      (label: 'Podcasts', iconIndex: 4),
+    ];
+    return Wrap(
+      alignment: WrapAlignment.center,
+      spacing: 14,
+      runSpacing: 6,
+      children: items.map((it) {
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              _iconForContentType(it.iconIndex),
+              size: 13,
+              color: colors.textTertiary,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              it.label,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: colors.textTertiary,
+                  ),
+            ),
+          ],
+        );
+      }).toList(),
     );
   }
 
@@ -461,51 +645,6 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
 
   // ─── Shared Widgets ────────────────────────────────────────────
 
-  Widget _buildHelpCard({
-    required String title,
-    String? description,
-  }) {
-    final colors = context.facteurColors;
-
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: colors.surface,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: colors.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(PhosphorIcons.lightbulb(PhosphorIconsStyle.regular),
-                  size: 18, color: colors.primary),
-              const SizedBox(width: 8),
-              Text(
-                title,
-                style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      color: colors.textPrimary,
-                    ),
-              ),
-            ],
-          ),
-          if (description != null) ...[
-            const SizedBox(height: 10),
-            Text(
-              description,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: colors.textSecondary,
-                    height: 1.4,
-                  ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
   static const _contentTypeOptions =
       <({String label, String apiValue, int iconIndex})>[
     (label: 'Médias', apiValue: 'article', iconIndex: 0),
@@ -565,170 +704,4 @@ class _AddSourceScreenState extends ConsumerState<AddSourceScreen> {
     );
   }
 
-  Widget _buildSourceTypesRow() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'Ajoutez n\'importe quelle source à Facteur !',
-          style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                color: context.facteurColors.textPrimary,
-                fontWeight: FontWeight.w600,
-              ),
-        ),
-        const SizedBox(height: 10),
-        _buildFilterChips(),
-      ],
-    );
-  }
-
-  Widget _buildInspirationHints() {
-    final colors = context.facteurColors;
-    const hints = <String>[
-      'Une newsletter qui s\'accumule dans la boîte mail',
-      'Une chaîne YouTube recommandée par un proche',
-      'Un compte Instagram ou LinkedIn d\'expert',
-      'Un subreddit qui revient souvent dans les conversations',
-    ];
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: colors.surface,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: colors.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(PhosphorIcons.lightbulb(PhosphorIconsStyle.fill),
-                  size: 18, color: colors.primary),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  'Quelques conseils',
-                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: colors.textPrimary,
-                      ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          ...hints.map((hint) => Padding(
-                padding: const EdgeInsets.only(bottom: 6),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.only(top: 7),
-                      child: Container(
-                        width: 4,
-                        height: 4,
-                        decoration: BoxDecoration(
-                          color: colors.textTertiary,
-                          shape: BoxShape.circle,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Text(
-                        hint,
-                        style:
-                            Theme.of(context).textTheme.bodySmall?.copyWith(
-                                  color: colors.textSecondary,
-                                  height: 1.4,
-                                ),
-                      ),
-                    ),
-                  ],
-                ),
-              )),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSourceListTile(Source source) {
-    final colors = context.facteurColors;
-    return Container(
-      margin: const EdgeInsets.only(bottom: 12),
-      decoration: BoxDecoration(
-        color: colors.surface,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: colors.border),
-      ),
-      child: ListTile(
-        contentPadding: const EdgeInsets.all(12),
-        leading: source.logoUrl != null
-            ? Container(
-                width: 48,
-                height: 48,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(8),
-                  image: DecorationImage(
-                    image: NetworkImage(source.logoUrl!),
-                    fit: BoxFit.cover,
-                  ),
-                ),
-              )
-            : Container(
-                width: 48,
-                height: 48,
-                decoration: BoxDecoration(
-                  color: colors.backgroundSecondary,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Icon(
-                    PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
-                    color: colors.primary),
-              ),
-        title: Text(source.name,
-            style: Theme.of(context).textTheme.titleSmall,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-                source.description?.isNotEmpty == true
-                    ? source.description!
-                    : source.getThemeLabel(),
-                style: Theme.of(context)
-                    .textTheme
-                    .bodySmall
-                    ?.copyWith(color: colors.textSecondary),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis),
-            if (source.followerCount > 0) ...[
-              const SizedBox(height: 4),
-              Row(
-                children: [
-                  Icon(PhosphorIcons.users(PhosphorIconsStyle.regular),
-                      size: 11, color: colors.textTertiary),
-                  const SizedBox(width: 3),
-                  Text(
-                    '${source.followerCount} ${source.followerCount == 1 ? 'lecteur' : 'lecteurs'}',
-                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: colors.textTertiary,
-                          fontSize: 11,
-                        ),
-                  ),
-                ],
-              ),
-            ],
-          ],
-        ),
-        trailing: source.isTrusted
-            ? Icon(PhosphorIcons.checkCircle(PhosphorIconsStyle.fill),
-                color: colors.success)
-            : Icon(PhosphorIcons.caretRight(PhosphorIconsStyle.regular),
-                color: colors.textTertiary),
-        onTap: () => _showSourceModal(source),
-      ),
-    );
-  }
 }

--- a/apps/mobile/lib/features/sources/widgets/community_gems_strip.dart
+++ b/apps/mobile/lib/features/sources/widgets/community_gems_strip.dart
@@ -6,7 +6,7 @@ import '../../../config/theme.dart';
 import '../models/source_model.dart';
 import '../providers/sources_providers.dart';
 
-class CommunityGemsStrip extends ConsumerWidget {
+class CommunityGemsStrip extends ConsumerStatefulWidget {
   final void Function(Source source) onSourceTap;
   final void Function(String sourceId)? onGemTap;
 
@@ -17,125 +17,196 @@ class CommunityGemsStrip extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = context.facteurColors;
-    final trendingAsync = ref.watch(trendingSourcesProvider);
+  ConsumerState<CommunityGemsStrip> createState() => _CommunityGemsStripState();
+}
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Icon(PhosphorIcons.fire(PhosphorIconsStyle.regular),
-                size: 18, color: colors.primary),
-            const SizedBox(width: 6),
-            Text(
-              'Pepites de la communaute',
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-          ],
-        ),
-        const SizedBox(height: 12),
-        trendingAsync.when(
-          data: (sources) {
-            if (sources.isEmpty) {
-              return Text(
-                'Aucune pepite pour le moment.',
-                style: Theme.of(context)
-                    .textTheme
-                    .bodySmall
-                    ?.copyWith(color: colors.textTertiary),
-              );
-            }
-            return SizedBox(
-              height: 88,
-              child: ListView.separated(
-                scrollDirection: Axis.horizontal,
-                itemCount: sources.length,
-                separatorBuilder: (_, __) => const SizedBox(width: 10),
-                itemBuilder: (context, index) =>
-                    _buildGemItem(context, sources[index]),
-              ),
-            );
-          },
-          loading: () => SizedBox(
-            height: 88,
-            child: ListView.separated(
-              scrollDirection: Axis.horizontal,
-              itemCount: 4,
-              separatorBuilder: (_, __) => const SizedBox(width: 10),
-              itemBuilder: (_, __) => _buildPlaceholder(context),
-            ),
+class _CommunityGemsStripState extends ConsumerState<CommunityGemsStrip> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _buildHeader(context, colors),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOut,
+            alignment: Alignment.topCenter,
+            child: _expanded
+                ? _buildExpanded(context, colors)
+                : const SizedBox.shrink(),
           ),
-          error: (_, __) => const SizedBox.shrink(),
-        ),
-      ],
+        ],
+      ),
     );
   }
 
-  Widget _buildGemItem(BuildContext context, Source source) {
-    final colors = context.facteurColors;
-
-    return GestureDetector(
-      onTap: () {
-        onGemTap?.call(source.id);
-        onSourceTap(source);
-      },
-      child: Container(
-        width: 140,
-        padding: const EdgeInsets.all(10),
-        decoration: BoxDecoration(
-          color: colors.surface,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: colors.border),
+  Widget _buildHeader(BuildContext context, FacteurColors colors) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () => setState(() => _expanded = !_expanded),
+        child: Padding(
+          padding: const EdgeInsets.all(14),
+          child: Row(
+            children: [
+              Icon(PhosphorIcons.fire(PhosphorIconsStyle.regular),
+                  size: 20, color: colors.primary),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Pépites de la communauté',
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: colors.textPrimary,
+                          ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'Les sources favorites de la communauté Facteur',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colors.textTertiary,
+                          ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              AnimatedRotation(
+                turns: _expanded ? 0.5 : 0,
+                duration: const Duration(milliseconds: 200),
+                child: Icon(
+                  PhosphorIcons.caretDown(PhosphorIconsStyle.regular),
+                  size: 18,
+                  color: colors.textTertiary,
+                ),
+              ),
+            ],
+          ),
         ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+      ),
+    );
+  }
+
+  Widget _buildExpanded(BuildContext context, FacteurColors colors) {
+    final trendingAsync = ref.watch(trendingSourcesProvider);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(14, 0, 14, 14),
+      child: trendingAsync.when(
+        data: (sources) {
+          if (sources.isEmpty) {
+            return Text(
+              'Aucune pépite pour le moment.',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: colors.textTertiary),
+            );
+          }
+          return Column(
+            children: [
+              Divider(height: 1, color: colors.border),
+              const SizedBox(height: 8),
+              ...sources.map((s) => _buildGemTile(context, colors, s)),
+            ],
+          );
+        },
+        loading: () => const Padding(
+          padding: EdgeInsets.symmetric(vertical: 16),
+          child: Center(
+            child: SizedBox(
+              width: 22,
+              height: 22,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+        ),
+        error: (_, __) => Text(
+          'Impossible de charger les pépites.',
+          style: Theme.of(context)
+              .textTheme
+              .bodySmall
+              ?.copyWith(color: colors.textTertiary),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGemTile(
+      BuildContext context, FacteurColors colors, Source source) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: () {
+        widget.onGemTap?.call(source.id);
+        widget.onSourceTap(source);
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+        child: Row(
           children: [
-            Row(
-              children: [
-                _buildLogo(source, colors),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
+            _buildLogo(source, colors),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
                     source.name,
-                    style: Theme.of(context)
-                        .textTheme
-                        .labelMedium
-                        ?.copyWith(fontWeight: FontWeight.w600),
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: colors.textPrimary,
+                        ),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-                ),
-              ],
-            ),
-            const Spacer(),
-            Text(
-              source.getThemeLabel(),
-              style: Theme.of(context)
-                  .textTheme
-                  .labelSmall
-                  ?.copyWith(color: colors.textTertiary),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-            if (source.followerCount > 0) ...[
-              const SizedBox(height: 2),
-              Row(
-                children: [
-                  Icon(PhosphorIcons.users(PhosphorIconsStyle.regular),
-                      size: 10, color: colors.textTertiary),
-                  const SizedBox(width: 3),
-                  Text(
-                    '${source.followerCount}',
-                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: colors.textTertiary,
-                          fontSize: 10,
+                  const SizedBox(height: 2),
+                  Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          source.getThemeLabel(),
+                          style: Theme.of(context)
+                              .textTheme
+                              .labelSmall
+                              ?.copyWith(color: colors.textTertiary),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
+                      ),
+                      if (source.followerCount > 0) ...[
+                        const SizedBox(width: 8),
+                        Icon(PhosphorIcons.users(PhosphorIconsStyle.regular),
+                            size: 11, color: colors.textTertiary),
+                        const SizedBox(width: 3),
+                        Text(
+                          '${source.followerCount}',
+                          style: Theme.of(context)
+                              .textTheme
+                              .labelSmall
+                              ?.copyWith(color: colors.textTertiary),
+                        ),
+                      ],
+                    ],
                   ),
                 ],
               ),
-            ],
+            ),
+            const SizedBox(width: 8),
+            Icon(PhosphorIcons.caretRight(PhosphorIconsStyle.regular),
+                size: 16, color: colors.textTertiary),
           ],
         ),
       ),
@@ -145,11 +216,11 @@ class CommunityGemsStrip extends ConsumerWidget {
   Widget _buildLogo(Source source, FacteurColors colors) {
     if (source.logoUrl != null) {
       return ClipRRect(
-        borderRadius: BorderRadius.circular(6),
+        borderRadius: BorderRadius.circular(8),
         child: Image.network(
           source.logoUrl!,
-          width: 32,
-          height: 32,
+          width: 36,
+          height: 36,
           fit: BoxFit.cover,
           errorBuilder: (_, __, ___) => _buildLogoFallback(colors),
         ),
@@ -160,62 +231,14 @@ class CommunityGemsStrip extends ConsumerWidget {
 
   Widget _buildLogoFallback(FacteurColors colors) {
     return Container(
-      width: 32,
-      height: 32,
+      width: 36,
+      height: 36,
       decoration: BoxDecoration(
         color: colors.backgroundSecondary,
-        borderRadius: BorderRadius.circular(6),
+        borderRadius: BorderRadius.circular(8),
       ),
       child: Icon(PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
-          size: 16, color: colors.primary),
-    );
-  }
-
-  Widget _buildPlaceholder(BuildContext context) {
-    final colors = context.facteurColors;
-    return Container(
-      width: 140,
-      padding: const EdgeInsets.all(10),
-      decoration: BoxDecoration(
-        color: colors.surface,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: colors.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Container(
-                width: 32,
-                height: 32,
-                decoration: BoxDecoration(
-                  color: colors.backgroundSecondary,
-                  borderRadius: BorderRadius.circular(6),
-                ),
-              ),
-              const SizedBox(width: 8),
-              Container(
-                width: 60,
-                height: 12,
-                decoration: BoxDecoration(
-                  color: colors.backgroundSecondary,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-              ),
-            ],
-          ),
-          const Spacer(),
-          Container(
-            width: 50,
-            height: 10,
-            decoration: BoxDecoration(
-              color: colors.backgroundSecondary,
-              borderRadius: BorderRadius.circular(4),
-            ),
-          ),
-        ],
-      ),
+          size: 18, color: colors.primary),
     );
   }
 }

--- a/apps/mobile/lib/features/sources/widgets/smart_search_field.dart
+++ b/apps/mobile/lib/features/sources/widgets/smart_search_field.dart
@@ -16,6 +16,7 @@ class SmartSearchField extends StatelessWidget {
   final VoidCallback onClear;
   final VoidCallback? onSearch;
   final bool enabled;
+  final FocusNode? focusNode;
 
   const SmartSearchField({
     super.key,
@@ -24,6 +25,7 @@ class SmartSearchField extends StatelessWidget {
     required this.onClear,
     this.onSearch,
     this.enabled = true,
+    this.focusNode,
   });
 
   @override
@@ -32,10 +34,11 @@ class SmartSearchField extends StatelessWidget {
 
     return TextField(
       controller: controller,
+      focusNode: focusNode,
       decoration: InputDecoration(
-        hintText: 'Rechercher une source...',
-        prefixIcon: Icon(
-            PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular)),
+        hintText: 'Une URL, un nom de média...',
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 18, vertical: 18),
         suffixIcon: ValueListenableBuilder<TextEditingValue>(
           valueListenable: controller,
           builder: (_, value, __) {

--- a/apps/mobile/test/features/sources/widgets/community_gems_strip_test.dart
+++ b/apps/mobile/test/features/sources/widgets/community_gems_strip_test.dart
@@ -14,24 +14,38 @@ void main() {
       Source(id: '3', name: 'r/france', type: SourceType.reddit),
     ];
 
-    testWidgets('renders sources horizontally when data loaded',
-        (tester) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            trendingSourcesProvider.overrideWith((_) async => mockSources),
-          ],
-          child: MaterialApp(
-            theme: FacteurTheme.lightTheme,
-            home: Scaffold(
-              body: CommunityGemsStrip(
-                onSourceTap: (_) {},
-              ),
+    Widget buildHarness(List<Source> sources, {void Function(Source)? onTap, void Function(String)? onGem}) {
+      return ProviderScope(
+        overrides: [
+          trendingSourcesProvider.overrideWith((_) async => sources),
+        ],
+        child: MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: Scaffold(
+            body: CommunityGemsStrip(
+              onSourceTap: onTap ?? (_) {},
+              onGemTap: onGem,
             ),
           ),
         ),
       );
+    }
 
+    testWidgets('header is visible and section is collapsed by default',
+        (tester) async {
+      await tester.pumpWidget(buildHarness(mockSources));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Pépites de la communauté'), findsOneWidget);
+      expect(find.text('Le Monde'), findsNothing);
+    });
+
+    testWidgets('expands and renders all sources when header tapped',
+        (tester) async {
+      await tester.pumpWidget(buildHarness(mockSources));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Pépites de la communauté'));
       await tester.pumpAndSettle();
 
       expect(find.text('Le Monde'), findsOneWidget);
@@ -39,70 +53,29 @@ void main() {
       expect(find.text('r/france'), findsOneWidget);
     });
 
-    testWidgets('displays section title', (tester) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            trendingSourcesProvider.overrideWith((_) async => mockSources),
-          ],
-          child: MaterialApp(
-            theme: FacteurTheme.lightTheme,
-            home: Scaffold(
-              body: CommunityGemsStrip(
-                onSourceTap: (_) {},
-              ),
-            ),
-          ),
-        ),
-      );
-
-      expect(find.text('Pepites de la communaute'), findsOneWidget);
-    });
-
-    testWidgets('shows empty message when no sources', (tester) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            trendingSourcesProvider
-                .overrideWith((_) async => <Source>[]),
-          ],
-          child: MaterialApp(
-            theme: FacteurTheme.lightTheme,
-            home: Scaffold(
-              body: CommunityGemsStrip(
-                onSourceTap: (_) {},
-              ),
-            ),
-          ),
-        ),
-      );
-
+    testWidgets('shows empty message when expanded with no sources',
+        (tester) async {
+      await tester.pumpWidget(buildHarness(<Source>[]));
       await tester.pumpAndSettle();
 
-      expect(find.text('Aucune pepite pour le moment.'), findsOneWidget);
+      await tester.tap(find.text('Pépites de la communauté'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Aucune pépite pour le moment.'), findsOneWidget);
     });
 
-    testWidgets('fires callbacks on tap', (tester) async {
+    testWidgets('fires callbacks on gem tap', (tester) async {
       Source? tappedSource;
       String? tappedGemId;
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            trendingSourcesProvider.overrideWith((_) async => mockSources),
-          ],
-          child: MaterialApp(
-            theme: FacteurTheme.lightTheme,
-            home: Scaffold(
-              body: CommunityGemsStrip(
-                onSourceTap: (s) => tappedSource = s,
-                onGemTap: (id) => tappedGemId = id,
-              ),
-            ),
-          ),
-        ),
-      );
+      await tester.pumpWidget(buildHarness(
+        mockSources,
+        onTap: (s) => tappedSource = s,
+        onGem: (id) => tappedGemId = id,
+      ));
+      await tester.pumpAndSettle();
 
+      await tester.tap(find.text('Pépites de la communauté'));
       await tester.pumpAndSettle();
 
       await tester.tap(find.text('Le Monde'));

--- a/apps/mobile/test/features/sources/widgets/smart_search_field_test.dart
+++ b/apps/mobile/test/features/sources/widgets/smart_search_field_test.dart
@@ -36,7 +36,7 @@ void main() {
       ));
 
       expect(find.byType(TextField), findsOneWidget);
-      expect(find.text('Rechercher une source...'), findsOneWidget);
+      expect(find.text('Une URL, un nom de média...'), findsOneWidget);
     });
 
     testWidgets('does NOT fire onSubmit while typing (no debounce)',


### PR DESCRIPTION
## What

Refonte de l'écran *Ajouter une source* pour une expérience plus apaisée et alignée DS : barre de recherche centrale (loupe préfixe en doublon supprimée, halo de respiration au focus), titre serif + sous-titre court, ligne info des types supportés, Pépites de la communauté repensées en section collapsible donnant accès à toutes les pépites (au lieu d'un strip horizontal limité), nudge « Une autre à ajouter ? » après ajout pour encourager l'enchaînement.

## Why

L'état vide accumulait trop de blocs (ThemeExplorer, conseils, filter chips inutiles avant recherche), noyant le geste central. Les pépites n'avaient pas de vraie place. Après un ajout, l'utilisateur était sorti du flux, ce qui décourageait l'ajout multiple.

## Type

- [x] Feature

## Checklist

- [x] flutter analyze clean sur les fichiers touchés
- [x] flutter test (community_gems_strip, smart_search_field) ✅
- [ ] Peer Review Conductor

## Staging

- [ ] N/A (mobile UI uniquement)