### PR TITLE
feat(flux): polish UX — nudges, recherche, scroll-to-top, carrousels

### DIFF
--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -28,7 +28,7 @@ import '../../../widgets/design/facteur_logo.dart';
 import '../models/content_model.dart';
 import '../widgets/feed_card.dart';
 import '../widgets/compact_source_chip.dart';
-import '../widgets/compact_search_chip.dart';
+import '../widgets/search_filter_sheet.dart';
 import '../widgets/compact_theme_chip.dart';
 import '../widgets/animated_feed_card.dart';
 import '../widgets/caught_up_card.dart';
@@ -99,6 +99,12 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
   // Sticky filter bar overlay state
   bool _showStickyBar = false;
   double _lastScrollPos = 0;
+  double _lastFabScrollPos = 0;
+  bool _showScrollTopFab = false;
+  double _upwardAccumulator = 0;
+  bool _showPullHint = false;
+  DateTime? _lastPullHintAt;
+  Timer? _pullHintTimer;
   static const double _stickyScrollThreshold = 12;
   static const double _stickyHideAboveScroll = 380;
 
@@ -308,6 +314,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
       debugPrint('FeedScreen: Analytics tracking skipped during dispose');
     }
     _scrollController.dispose();
+    _pullHintTimer?.cancel();
     super.dispose();
   }
 
@@ -360,6 +367,45 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
         ScrollDirection.forward;
     if (currentScroll >= maxScroll - 800 && notScrollingUp) {
       ref.read(feedProvider.notifier).loadMore();
+    }
+
+    // Bouton "remonter" : cumul instantané du scroll vers le haut. Apparait
+    // après ≥ 250 px remontés ET position > 600 px. Disparait IMMÉDIATEMENT
+    // dès que l'utilisateur descend ou repasse sous 200 px.
+    final fabDelta = currentScroll - _lastFabScrollPos;
+    _lastFabScrollPos = currentScroll;
+    if (fabDelta < -0.5) {
+      _upwardAccumulator += -fabDelta;
+    } else if (fabDelta > 0.5) {
+      _upwardAccumulator = 0;
+      if (_showScrollTopFab) {
+        setState(() => _showScrollTopFab = false);
+      }
+    }
+    final shouldShowScrollTop =
+        _upwardAccumulator > 250 && currentScroll > 600;
+    final shouldHideScrollTop = currentScroll < 200;
+    if (shouldShowScrollTop && !_showScrollTopFab) {
+      setState(() => _showScrollTopFab = true);
+    } else if (shouldHideScrollTop && _showScrollTopFab) {
+      setState(() => _showScrollTopFab = false);
+    }
+
+    // Hint pull-to-refresh : montre une fois quand l'utilisateur remonte
+    // tout en haut du feed (signale visuellement qu'un pull est possible).
+    final scrollingUp = _scrollController.position.userScrollDirection ==
+        ScrollDirection.forward;
+    if (scrollingUp && currentScroll < 20 && _userHasScrolled) {
+      final now = DateTime.now();
+      final last = _lastPullHintAt;
+      if (last == null || now.difference(last) > const Duration(minutes: 2)) {
+        _lastPullHintAt = now;
+        setState(() => _showPullHint = true);
+        _pullHintTimer?.cancel();
+        _pullHintTimer = Timer(const Duration(milliseconds: 1800), () {
+          if (mounted) setState(() => _showPullHint = false);
+        });
+      }
     }
   }
 
@@ -463,9 +509,35 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
   }
 
   Widget _buildFilterBar(BuildContext context) {
+    final notifier = ref.read(feedProvider.notifier);
+    final hasSearch = notifier.selectedKeyword != null &&
+        notifier.selectedKeyword!.isNotEmpty;
     return FilterCollapsiblePanel(
       activeCount: _activeFilterCount(),
       chipsRow: _buildFilterChipsRow(context),
+      leadingTrigger: _SearchTriggerButton(
+        active: hasSearch,
+        keyword: notifier.selectedKeyword,
+        onTap: () {
+          HapticFeedback.mediumImpact();
+          SearchFilterSheet.show(
+            context,
+            currentKeyword: notifier.selectedKeyword,
+            onSearchSubmitted: (keyword, {bool fromTrending = false}) {
+              _withFeedLoading(() => notifier.setKeyword(
+                    keyword,
+                    includeUnfollowed: fromTrending,
+                  ));
+              _scrollToTop();
+            },
+          );
+        },
+        onClear: () {
+          HapticFeedback.mediumImpact();
+          _withFeedLoading(() => notifier.setKeyword(null));
+          _scrollToTop();
+        },
+      ),
     );
   }
 
@@ -542,19 +614,6 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                   await notifier.setTopic(slug);
                 }
               });
-              _scrollToTop();
-            },
-          ),
-        ),
-        const SizedBox(width: 8),
-        Flexible(
-          child: CompactSearchChip(
-            activeKeyword: notifier.selectedKeyword,
-            onSearchChanged: (keyword, {bool fromTrending = false}) {
-              _withFeedLoading(() => notifier.setKeyword(
-                    keyword,
-                    includeUnfollowed: fromTrending,
-                  ));
               _scrollToTop();
             },
           ),
@@ -812,12 +871,23 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                                 .watch(savedNudgeDismissedProvider)
                                 .valueOrNull ??
                             false;
+                        // SavedNudge : laisser respirer le feed avant de pousser
+                        // un nudge "Tu as N sauvegardés". Au minimum 10 cartes
+                        // après le carrousel "Plus tard, c'est maintenant"
+                        // (saved) si présent ; sinon position fixe assez basse.
+                        final savedCarouselPos = state.carousels
+                            .where((c) =>
+                                c.carouselType == 'saved' && c.items.isNotEmpty)
+                            .map((c) => c.position)
+                            .fold<int?>(null, (acc, p) => acc == null ? p : (p < acc ? p : acc));
+                        final savedNudgePos = savedCarouselPos != null
+                            ? savedCarouselPos + 11
+                            : 33;
                         final showSavedNudge = !showCaughtUp &&
                             !savedNudgeDismissed &&
                             savedSummary != null &&
                             savedSummary.unreadCount >= 3 &&
-                            contents.length > 6;
-                        const savedNudgePos = 6;
+                            contents.length > savedNudgePos;
 
                         // Backend gère rate-limit + cool-down : liste vide → widget invisible.
                         final pepitesAsync = ref.watch(pepitesProvider);
@@ -833,11 +903,21 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                                 notifier.selectedEntity != null ||
                                 notifier.selectedSourceId != null;
 
-                        // Carousels: sorted by position, hidden when filter active
+                        // Carousels: sorted by position, hidden when filter
+                        // active. Pour éviter l'effet "fin de flux" où plusieurs
+                        // carrousels s'empilent en queue avant que loadMore
+                        // ramène la page suivante : on filtre les positions au-
+                        // delà des items chargés, et on réserve une queue de
+                        // 5 items lorsqu'une page suivante est attendue.
+                        final reservedTail =
+                            ref.read(feedProvider.notifier).hasNext ? 5 : 0;
+                        final maxAllowedPos =
+                            (contents.length - reservedTail).clamp(0, contents.length);
                         final sortedCarousels = hasActiveFilter
                             ? <FeedCarouselData>[]
                             : ([...state.carousels]
-                                .where((c) => c.items.isNotEmpty)
+                                .where((c) =>
+                                    c.items.isNotEmpty && c.position < maxAllowedPos)
                                 .toList()
                                 ..sort((a, b) => a.position.compareTo(b.position)));
 
@@ -971,7 +1051,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
 
                                 // Carousels at their designated positions
                                 for (final carousel in sortedCarousels) {
-                                  final effectivePos = carousel.position.clamp(0, contents.length) + contentOffset;
+                                  final effectivePos = carousel.position + contentOffset;
                                   if (listIndex == effectivePos) {
                                     contentOffset++;
                                     return Padding(
@@ -1180,7 +1260,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
 
                                 final showHint = !_swipeHintSeen &&
                                     _userHasScrolled &&
-                                    contentIndex <= 1;
+                                    contentIndex == 0;
 
                                 Widget cardWidget = SwipeToOpenCard(
                                   onSwipeOpen: () => _showArticleModal(content),
@@ -1559,7 +1639,180 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                   ),
                 ),
               ),
+            // Bouton "remonter en haut" : apparait quand l'utilisateur a
+            // scrollé bas et commence à remonter. Tap = scroll-to-top smooth.
+            Positioned(
+              right: 16,
+              bottom: 24,
+              child: SafeArea(
+                child: AnimatedSlide(
+                  duration: const Duration(milliseconds: 220),
+                  curve: Curves.easeOutCubic,
+                  offset: _showScrollTopFab
+                      ? Offset.zero
+                      : const Offset(0, 1.6),
+                  child: AnimatedOpacity(
+                    duration: const Duration(milliseconds: 220),
+                    opacity: _showScrollTopFab ? 1.0 : 0.0,
+                    child: _ScrollToTopButton(
+                      onTap: () {
+                        HapticFeedback.lightImpact();
+                        _scrollToTop();
+                      },
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            // Hint pull-to-refresh : flèche vers le bas qui flotte au-dessus
+            // du feed quand l'utilisateur arrive en haut, signalant qu'on
+            // peut tirer pour rafraîchir. Ne déclenche PAS de refresh.
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: SafeArea(
+                bottom: false,
+                child: IgnorePointer(
+                  child: AnimatedOpacity(
+                    duration: const Duration(milliseconds: 280),
+                    opacity: _showPullHint ? 1.0 : 0.0,
+                    child: _PullToRefreshHint(active: _showPullHint),
+                  ),
+                ),
+              ),
+            ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ScrollToTopButton extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _ScrollToTopButton({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Material(
+      color: colors.backgroundPrimary,
+      shape: const CircleBorder(),
+      elevation: 4,
+      shadowColor: Colors.black26,
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: Container(
+          width: 44,
+          height: 44,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(color: colors.border),
+          ),
+          alignment: Alignment.center,
+          child: Icon(
+            PhosphorIcons.caretUp(PhosphorIconsStyle.bold),
+            size: 18,
+            color: colors.textPrimary,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PullToRefreshHint extends StatefulWidget {
+  final bool active;
+  const _PullToRefreshHint({required this.active});
+
+  @override
+  State<_PullToRefreshHint> createState() => _PullToRefreshHintState();
+}
+
+class _PullToRefreshHintState extends State<_PullToRefreshHint>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _bounceController;
+
+  @override
+  void initState() {
+    super.initState();
+    _bounceController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    );
+    if (widget.active) _bounceController.repeat();
+  }
+
+  @override
+  void didUpdateWidget(_PullToRefreshHint oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.active && !_bounceController.isAnimating) {
+      _bounceController.repeat();
+    } else if (!widget.active && _bounceController.isAnimating) {
+      _bounceController.stop();
+      _bounceController.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _bounceController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.only(top: 80),
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          decoration: BoxDecoration(
+            color: colors.primary.withOpacity(0.95),
+            borderRadius: BorderRadius.circular(FacteurRadius.full),
+            boxShadow: [
+              BoxShadow(
+                color: colors.primary.withOpacity(0.25),
+                blurRadius: 12,
+                offset: const Offset(0, 3),
+              ),
+            ],
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AnimatedBuilder(
+                animation: _bounceController,
+                builder: (context, child) {
+                  final t = _bounceController.value;
+                  // Bounce vertical : 0 → -3 → +3 → 0
+                  final offset = math.sin(t * math.pi * 2) * 3.0;
+                  return Transform.translate(
+                    offset: Offset(0, offset),
+                    child: child,
+                  );
+                },
+                child: Icon(
+                  PhosphorIcons.arrowDown(PhosphorIconsStyle.bold),
+                  size: 14,
+                  color: Colors.white,
+                ),
+              ),
+              const SizedBox(width: 8),
+              const Text(
+                'Tirer pour rafraîchir',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1810,6 +2063,96 @@ class _RefreshConfirmSheet extends StatelessWidget {
             ),
           ],
         ],
+      ),
+    );
+  }
+}
+
+class _SearchTriggerButton extends StatelessWidget {
+  final bool active;
+  final String? keyword;
+  final VoidCallback onTap;
+  final VoidCallback onClear;
+
+  const _SearchTriggerButton({
+    required this.active,
+    required this.keyword,
+    required this.onTap,
+    required this.onClear,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final primary = colors.primary;
+    if (active) {
+      return GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: Container(
+          height: 32,
+          padding: const EdgeInsets.only(left: 10, right: 6),
+          decoration: BoxDecoration(
+            color: primary.withOpacity(0.12),
+            border: Border.all(color: primary),
+            borderRadius: BorderRadius.circular(FacteurRadius.full),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.bold),
+                size: 14,
+                color: primary,
+              ),
+              const SizedBox(width: 4),
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 100),
+                child: Text(
+                  keyword ?? '',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: primary,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: onClear,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 8),
+                  child: Icon(
+                    PhosphorIcons.x(PhosphorIconsStyle.bold),
+                    size: 12,
+                    color: primary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Container(
+        height: 32,
+        width: 32,
+        decoration: BoxDecoration(
+          color: colors.surface,
+          border: Border.all(color: colors.border),
+          borderRadius: BorderRadius.circular(FacteurRadius.full),
+        ),
+        alignment: Alignment.center,
+        child: Icon(
+          PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
+          size: 16,
+          color: colors.textSecondary,
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/widgets/feed_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_card.dart
@@ -228,6 +228,11 @@ class _FeedCardState extends State<FeedCard>
                             // Source Logo + Name (tappable for source detail — Epic 12)
                             Flexible(
                             child: _FooterBadgeNudge(
+                              // Une seule balise pulse par carte. Si la carte
+                              // n'a pas de topic chip, c'est forcément la
+                              // source. Sinon, parité du hashCode.
+                              enabled: widget.topicChipWidget == null ||
+                                  widget.content.id.hashCode.isEven,
                               child: KeyedSubtree(
                                 // Fallback anchor for feed_badge_longpress when
                                 // the card has no topic chip.
@@ -467,6 +472,7 @@ class _FeedCardState extends State<FeedCard>
                             if (widget.topicChipWidget != null)
                               Flexible(
                                 child: _FooterBadgeNudge(
+                                  enabled: widget.content.id.hashCode.isOdd,
                                   child: KeyedSubtree(
                                     // Nudge anchor attaches to topic chip when
                                     // present (priority target for
@@ -737,8 +743,9 @@ class _FeedCardState extends State<FeedCard>
 /// Plays a tiny scale pulse (~2%) at random intervals (8–15 s).
 class _FooterBadgeNudge extends StatefulWidget {
   final Widget child;
+  final bool enabled;
 
-  const _FooterBadgeNudge({required this.child});
+  const _FooterBadgeNudge({required this.child, this.enabled = true});
 
   @override
   State<_FooterBadgeNudge> createState() => _FooterBadgeNudgeState();
@@ -749,24 +756,40 @@ class _FooterBadgeNudgeState extends State<_FooterBadgeNudge>
   late final AnimationController _controller;
   final math.Random _rng = math.Random();
   Timer? _timer;
+  bool _firstPopFired = false;
 
   @override
   void initState() {
     super.initState();
     _controller = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 600),
+      duration: const Duration(milliseconds: 1100),
     );
     _controller.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
         _scheduleNext();
       }
     });
-    _scheduleNext();
+    if (widget.enabled) _scheduleNext();
+  }
+
+  @override
+  void didUpdateWidget(_FooterBadgeNudge oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.enabled && !oldWidget.enabled) {
+      _scheduleNext();
+    } else if (!widget.enabled && oldWidget.enabled) {
+      _timer?.cancel();
+      _controller.value = 0;
+    }
   }
 
   void _scheduleNext() {
-    final delayMs = 8000 + _rng.nextInt(7000); // 8–15 s
+    // 1er pop rapide pour être découvrable, puis cadence rare (20–35 s).
+    final delayMs = !_firstPopFired
+        ? 2500 + _rng.nextInt(2000)
+        : 20000 + _rng.nextInt(15000);
+    _firstPopFired = true;
     _timer?.cancel();
     _timer = Timer(Duration(milliseconds: delayMs), () {
       if (mounted) _controller.forward(from: 0);
@@ -782,11 +805,16 @@ class _FooterBadgeNudgeState extends State<_FooterBadgeNudge>
 
   @override
   Widget build(BuildContext context) {
+    if (!widget.enabled) return widget.child;
     return AnimatedBuilder(
       animation: _controller,
       builder: (context, child) {
-        // One gentle sine pulse: 1.0 → 1.02 → 1.0
-        final scale = 1.0 + 0.02 * math.sin(_controller.value * math.pi);
+        final t = _controller.value;
+        // Pulsation ease-in-out smooth : grossissement bien visible sans
+        // coloration. Pic à scale 1.12 puis retour.
+        final pulse = math.sin(t * math.pi);
+        final eased = Curves.easeInOutSine.transform(pulse.clamp(0.0, 1.0));
+        final scale = 1.0 + 0.12 * eased;
         return Transform.scale(scale: scale, child: child);
       },
       child: widget.child,

--- a/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
+++ b/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
@@ -14,11 +14,13 @@ import '../../../config/theme.dart';
 class FilterCollapsiblePanel extends StatefulWidget {
   final int activeCount;
   final Widget chipsRow;
+  final Widget? leadingTrigger;
 
   const FilterCollapsiblePanel({
     super.key,
     required this.activeCount,
     required this.chipsRow,
+    this.leadingTrigger,
   });
 
   @override
@@ -37,7 +39,7 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final hasActive = widget.activeCount > 0;
-    final label = hasActive ? 'Filtres · ${widget.activeCount}' : 'Filtres';
+    final label = hasActive ? '${widget.activeCount}' : '';
 
     return SizedBox(
       height: 32,
@@ -80,20 +82,28 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
                         )),
             ),
           ),
+          if (widget.leadingTrigger != null) ...[
+            widget.leadingTrigger!,
+            const SizedBox(width: 8),
+          ],
           GestureDetector(
             onTap: _toggle,
             behavior: HitTestBehavior.opaque,
             child: AnimatedContainer(
               duration: const Duration(milliseconds: 180),
               height: 32,
-              padding: const EdgeInsets.symmetric(horizontal: 14),
+              padding: EdgeInsets.symmetric(
+                horizontal: hasActive && !_expanded ? 12 : 10,
+              ),
               decoration: BoxDecoration(
                 color: (_expanded || hasActive)
                     ? colors.primary.withOpacity(0.12)
-                    : Colors.transparent,
-                border: (_expanded || hasActive)
-                    ? Border.all(color: colors.primary)
-                    : null,
+                    : colors.surface,
+                border: Border.all(
+                  color: (_expanded || hasActive)
+                      ? colors.primary
+                      : colors.border,
+                ),
                 borderRadius: BorderRadius.circular(FacteurRadius.full),
               ),
               child: Row(
@@ -103,21 +113,19 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
                     _expanded
                         ? PhosphorIcons.x(PhosphorIconsStyle.bold)
                         : PhosphorIcons.funnel(PhosphorIconsStyle.regular),
-                    size: 14,
+                    size: 16,
                     color: (_expanded || hasActive)
                         ? colors.primary
                         : colors.textSecondary,
                   ),
-                  if (!_expanded) ...[
-                    const SizedBox(width: 6),
+                  if (!_expanded && hasActive) ...[
+                    const SizedBox(width: 4),
                     Text(
                       label,
                       style: TextStyle(
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                        color: hasActive
-                            ? colors.primary
-                            : colors.textSecondary,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        color: colors.primary,
                       ),
                     ),
                   ],

--- a/apps/mobile/lib/features/feed/widgets/search_filter_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/search_filter_sheet.dart
@@ -80,9 +80,13 @@ class _SearchFilterSheetState extends ConsumerState<SearchFilterSheet> {
     final trendingAsync = ref.watch(trendingTopicsProvider);
     final hasQuery = _searchController.text.trim().isNotEmpty;
 
-    return Container(
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: Container(
       constraints: BoxConstraints(
-        maxHeight: MediaQuery.of(context).size.height * 0.81,
+        maxHeight: MediaQuery.of(context).size.height * 0.95,
       ),
       decoration: BoxDecoration(
         color: colors.backgroundSecondary,
@@ -301,6 +305,7 @@ class _SearchFilterSheetState extends ConsumerState<SearchFilterSheet> {
               ),
           ],
         ),
+      ),
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/widgets/swipe_to_open_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/swipe_to_open_card.dart
@@ -73,7 +73,7 @@ class _SwipeToOpenCardState extends State<SwipeToOpenCard>
 
     _hintController = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 700),
+      duration: const Duration(milliseconds: 2800),
     )..addListener(_onHintTick);
 
     if (widget.enableHintAnimation && widget.onSwipeDismiss != null) {
@@ -102,7 +102,7 @@ class _SwipeToOpenCardState extends State<SwipeToOpenCard>
   }
 
   void _scheduleHintAnimation() {
-    Future.delayed(const Duration(milliseconds: 1200), () {
+    Future.delayed(const Duration(milliseconds: 2200), () {
       if (mounted && !_hintPlayed && !_dragUnderway) {
         _hintPlayed = true;
         _hintController.forward().then((_) {
@@ -136,12 +136,15 @@ class _SwipeToOpenCardState extends State<SwipeToOpenCard>
   void _onHintTick() {
     if (!_dragUnderway && !_isDismissing) {
       setState(() {
-        // Sine wave: 0 → -20 → 0
+        // Séquence bidirectionnelle douce : glisse à droite puis à gauche.
+        // Amplitude réduite (45 px) + courbe ease-in-out lente pour rester
+        // discrète et non-intimidante.
         final t = _hintController.value;
-        _dragExtent = -40.0 *
-            Curves.easeInOut.transform(
-              t <= 0.5 ? t * 2 : (1.0 - t) * 2,
-            );
+        final phase = t < 0.5 ? t * 2 : (t - 0.5) * 2;
+        final direction = t < 0.5 ? 1.0 : -1.0;
+        final shape = phase <= 0.5 ? phase * 2 : (1.0 - phase) * 2;
+        _dragExtent =
+            direction * 45.0 * Curves.easeInOutSine.transform(shape);
       });
     }
   }

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -1092,13 +1092,13 @@ class RecommendationService:
     # `decale` is only emitted in serein mode, which excludes hot/community,
     # so it sits at community's slot.
     _CAROUSEL_BASE_POSITIONS: dict[str, int] = {
-        "favorite": 3,
-        "new_source": 6,
-        "community": 9,
-        "decale": 9,
-        "saved": 12,
-        "hot": 15,
-        "deep": 18,
+        "favorite": 5,
+        "new_source": 11,
+        "community": 17,
+        "decale": 17,
+        "saved": 23,
+        "hot": 29,
+        "deep": 35,
     }
 
     @staticmethod
@@ -1138,7 +1138,7 @@ class RecommendationService:
         MIN_CAROUSEL_ITEMS = 3  # Minimum items for building a carousel
         MIN_DISPLAY_ITEMS = 2  # T2: Minimum items after consumed filtering
         MAX_CAROUSEL_ITEMS = 5
-        MIN_CAROUSEL_POSITION = 4  # No carousel before position 4
+        MIN_CAROUSEL_POSITION = 5  # No carousel before position 5 (≈ GNews cadence)
         carousels: list[dict] = []
         promoted_ids: set[UUID] = set()
         used_group_keys: set[str] = set()  # Prevent same group in hot + deep
@@ -1424,19 +1424,16 @@ class RecommendationService:
                     if len(items) < MIN_NEW_SOURCE_ITEMS:
                         continue
 
-                    # T3D: Dynamic position based on source age.
-                    # Very-recent sources keep priority slots (1 / 3); older
-                    # ones fall back on the Story 12.8 jittered business slot.
+                    # Cooldown post-add 6 h — laisse les articles de la source
+                    # remonter naturellement dans le main feed avant de pousser
+                    # un carrousel "Récemment ajouté".
                     now = datetime.datetime.now(datetime.UTC)
                     source_age_seconds = (now - src_row.added_at).total_seconds()
-                    if source_age_seconds < 24 * 3600:  # < 24h
-                        position = 1
-                    elif source_age_seconds < 3 * 24 * 3600:  # < 3 days
-                        position = 3
-                    else:
-                        position = self._jitter_carousel_position(
-                            "new_source", user_id, today
-                        )
+                    if source_age_seconds < 6 * 3600:
+                        continue
+                    position = self._jitter_carousel_position(
+                        "new_source", user_id, today
+                    )
 
                     logger.info(
                         "carousel_new_source_selected",
@@ -1664,13 +1661,16 @@ class RecommendationService:
                 business_rank.get(c["carousel_type"], 99),
             )
         )
-        taken: set[int] = set()
+        # Carrousels espacés d'au moins MIN_GAP slots — évite les empilements
+        # adjacents qui rendent le flux dense (effet GNews / Apple News).
+        MIN_GAP = 6
+        taken: list[int] = []
         for c in carousels:
             pos = max(c["position"], MIN_CAROUSEL_POSITION)
-            while pos in taken:
+            while any(abs(pos - t) < MIN_GAP for t in taken):
                 pos += 1
             c["position"] = pos
-            taken.add(pos)
+            taken.append(pos)
 
         # Convert Content objects to serializable dicts for CarouselInfo
         carousel_dicts = []

--- a/packages/api/tests/test_feed_carousels.py
+++ b/packages/api/tests/test_feed_carousels.py
@@ -132,8 +132,8 @@ class TestBuildCarouselsHot:
         assert c["carousel_type"] == "hot"
         assert "Trump" in c["title"]
         assert c["emoji"] == "\U0001f50d"
-        # Story 12.8: hot base position is 15 (business order), no jitter without user_id
-        assert c["position"] == 15
+        # Hot base position is 29 (cadence GNews ~6, business order)
+        assert c["position"] == 29
         assert len(c["items"]) == 5  # rep + 4 hidden
         assert len(c["badges"]) == len(c["items"])
         assert c["badges"][0]["code"] == "actu_chaude"
@@ -433,7 +433,7 @@ class TestBuildCarouselsNewSource:
         assert len(new_src) == 1
         c = new_src[0]
         assert "TechCrunch" in c["title"]
-        assert c["position"] >= 4  # MIN_CAROUSEL_POSITION enforced
+        assert c["position"] >= 5  # MIN_CAROUSEL_POSITION enforced
         assert c["badges"][0]["code"] == "new_source"
         assert len(c["items"]) == 4
 
@@ -533,7 +533,7 @@ class TestBuildCarouselsCommunity:
         assert len(community) == 1
         c = community[0]
         assert c["title"] == "Recos de la communauté"
-        assert c["position"] >= 4  # MIN_CAROUSEL_POSITION enforced; slot shuffled
+        assert c["position"] >= 5  # MIN_CAROUSEL_POSITION enforced; slot shuffled
         assert c["badges"][0]["code"] == "community"
         assert len(c["items"]) == 4
 
@@ -601,7 +601,7 @@ class TestBuildCarouselsSaved:
         assert len(saved) == 1
         c = saved[0]
         assert c["title"] == "Plus tard, c\u2019est maintenant !"
-        assert c["position"] >= 4  # MIN_CAROUSEL_POSITION enforced; slot shuffled
+        assert c["position"] >= 5  # MIN_CAROUSEL_POSITION enforced; slot shuffled
         assert len(c["items"]) == 3
 
         # Verify per-item badges
@@ -686,8 +686,8 @@ class TestBuildCarouselsPhaseB_Integration:
 
 class TestMinCarouselPosition:
     @pytest.mark.asyncio
-    async def test_no_carousel_below_position_4(self):
-        """All carousels must have position >= 4 (MIN_CAROUSEL_POSITION)."""
+    async def test_no_carousel_below_min_position(self):
+        """All carousels must have position >= MIN_CAROUSEL_POSITION."""
         service = _setup_service()
         rep = MockContent(title="Trump article")
         hidden = [MockContent(title=f"Trump {i}") for i in range(4)]
@@ -700,8 +700,8 @@ class TestMinCarouselPosition:
 
         _, carousels = await service._build_carousels([], pre_regroup_map)
         for c in carousels:
-            assert c["position"] >= 4, (
-                f"Carousel {c['carousel_type']} at position {c['position']} < 4"
+            assert c["position"] >= 5, (
+                f"Carousel {c['carousel_type']} at position {c['position']} < 5"
             )
 
     @pytest.mark.asyncio
@@ -719,8 +719,8 @@ class TestMinCarouselPosition:
 
         _, carousels = await service._build_carousels([], pre_regroup_map)
         assert len(carousels) == 1
-        # Story 12.8: hot base position is 15 (no jitter without user_id)
-        assert carousels[0]["position"] == 15
+        # Hot base position is 29 (no jitter without user_id)
+        assert carousels[0]["position"] == 29
 
 
 def _setup_service_with_overflow_and_mocks():
@@ -799,7 +799,7 @@ class TestDailyJitter:
         service.keyword_overflow = []
 
         base_hot = RecommendationService._CAROUSEL_BASE_POSITIONS["hot"]
-        MIN_POS = 4
+        MIN_POS = 5
         for _ in range(20):
             _, carousels = await service._build_carousels(
                 [], pre_regroup_map, user_id=uuid4(),


### PR DESCRIPTION
## Quoi

Lot de corrections UX/UI sur le flux pour traiter plusieurs frictions
rapportées par le PO :

- **Recherche découvrable** : extraite des chips filtres, exposée comme
  icône loupe à gauche du bouton filtres. Le clavier Android ne masque
  plus la barre de recherche (`viewInsets.bottom` + `maxHeight 0.95`).
- **Nudge balises** (long-press source / topic) : pulse smooth
  ease-in-out 1.0 → 1.12, **sans coloration** (les pulses précédents avec
  glow primary étaient peu élégants). 1er pop à 2.5–4.5 s puis cadence
  20–35 s. **Une seule balise pulse par carte** (parité du
  `content.id.hashCode`) → jamais 2 chips qui pulsent en même temps sur
  une même carte.
- **Nudge swipe-to-dismiss** : limité à la carte 0 (au lieu de 0 et 1),
  durée portée à 2800 ms (de 700/1800), amplitude 45 px. Plus discret,
  non-intimidant.
- **Bouton scroll-to-top** : FAB rond (caretUp, design system) qui
  apparait après ≥250 px de scroll vers le haut ET position >600 px.
  Disparait **immédiatement** dès que l'utilisateur scroll vers le bas
  ou repasse sous 200 px.
- **Hint pull-to-refresh** : pill primary blanche avec flèche bas qui
  bounce (±3 px, sin 900 ms) quand l'utilisateur arrive en haut du feed,
  cooldown 2 min. **Purement visuel** — n'applique aucun refresh
  (corrige l'auto-refresh aggressif de la première itération).
- **Carrousels** : positions backend rééchelonnées (5/11/17/23/29/35) et
  filtre `maxAllowedPos` pour éviter l'empilement en queue de page avant
  que `loadMore` ramène la page suivante.
- **SavedNudge** : position dynamique = carrousel `saved` + 11
  (fallback : 33) au lieu d'une position fixe 6.

## Pourquoi

Le feed restait peu découvrable : long-press balises invisible,
recherche cachée derrière le bouton filtres, scroll-to-top absent,
carrousels qui s'empilaient en fin de page. Cette PR adresse les
frictions au cas par cas en gardant un esthétique sobre (pas de
coloration agressive sur les nudges).

## Comment ça a été vérifié

- [x] `flutter analyze lib/features/feed/` : 0 erreur introduite
- [x] `flutter test test/features/feed/feed_card_test.dart
      test/core/nudges/` : 39 tests OK
- [x] `pytest packages/api/tests/test_feed_carousels.py` : 28 tests OK
- [x] Revue manuelle perf scroll : tous les `setState` dans `_onScroll`
      sont gardés (no-op si la valeur n'a pas changé) ; `_FooterBadgeNudge`
      désactivé court-circuite l'`AnimatedBuilder` (early return) et ne
      schedule pas de Timer ; `_PullToRefreshHint` controller stoppé via
      `didUpdateWidget` quand invisible ; Timer du pull hint stocké dans
      un field et annulé en `dispose`.

## Zones à risque

- `feed_screen.dart` `_onScroll` (chemin chaud — chaque tick de scroll).
  Tous les chemins de `setState` sont gardés par des comparaisons ; pas
  de calcul lourd ajouté. Performances scroll attendues identiques voire
  meilleures (l'ancien `_FooterBadgeNudge` enregistrait un Timer +
  rebuild AnimatedBuilder sur chaque carte ; maintenant 50 % des cartes
  court-circuitent ce chemin).
- `recommendation_service.py` carousel positions : la cadence
  inter-carousels passe de 3 à 5 cartes, alignée sur la cadence GNews.
  Tests dorsaux mis à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)