### PR TITLE
fix(ui): cartes sources/intérêts plus compactes + nudges FAB auto-dismiss

### DIFF
--- a/apps/mobile/lib/features/custom_topics/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/custom_topics/screens/my_interests_screen.dart
@@ -99,7 +99,8 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
         children: [
           const Flexible(
             child: FabNudgeBubble(
-              text: 'Suivez n\'importe quel sujet pour le faire ressortir dans votre flux !',
+              text: 'Suivez vos sujets pour les booster',
+              dismissKey: 'nudge_custom_topic_v1',
             ),
           ),
           const SizedBox(width: 6),

--- a/apps/mobile/lib/features/custom_topics/widgets/theme_section.dart
+++ b/apps/mobile/lib/features/custom_topics/widgets/theme_section.dart
@@ -136,8 +136,8 @@ class ThemeSection extends ConsumerWidget {
           child: ExpansionTile(
             initiallyExpanded: false,
             tilePadding: const EdgeInsets.symmetric(
-              horizontal: FacteurSpacing.space4,
-              vertical: FacteurSpacing.space3,
+              horizontal: FacteurSpacing.space3,
+              vertical: FacteurSpacing.space2,
             ),
             childrenPadding: const EdgeInsets.only(
               bottom: FacteurSpacing.space3,
@@ -453,11 +453,11 @@ class _ThemeHeader extends ConsumerWidget {
 
     final titleText = Expanded(
       child: Text(
-        '${getMacroThemeEmoji(themeLabel)}  $themeLabel',
+        '${getMacroThemeEmoji(themeLabel)} $themeLabel',
         style: textTheme.titleMedium?.copyWith(
           color: colors.textPrimary,
           fontWeight: FontWeight.w700,
-          fontSize: 17,
+          fontSize: 15,
         ),
       ),
     );
@@ -560,7 +560,7 @@ class _ThemeHeader extends ConsumerWidget {
             );
           },
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
+            padding: const EdgeInsets.symmetric(horizontal: 4),
             child: Icon(
               PhosphorIcons.minusCircle(PhosphorIconsStyle.regular),
               size: 16,

--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -103,8 +103,7 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
       appBar: _isSearching
           ? AppBar(
               leading: IconButton(
-                icon: Icon(
-                    PhosphorIcons.arrowLeft(PhosphorIconsStyle.regular)),
+                icon: Icon(PhosphorIcons.arrowLeft(PhosphorIconsStyle.regular)),
                 onPressed: _exitSearch,
               ),
               title: TextField(
@@ -121,8 +120,7 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
               actions: [
                 if (_searchQuery.isNotEmpty)
                   IconButton(
-                    icon: Icon(
-                        PhosphorIcons.x(PhosphorIconsStyle.regular)),
+                    icon: Icon(PhosphorIcons.x(PhosphorIconsStyle.regular)),
                     onPressed: () {
                       _searchController.clear();
                     },
@@ -140,8 +138,8 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                 Stack(
                   children: [
                     IconButton(
-                      icon: Icon(PhosphorIcons.funnel(
-                          PhosphorIconsStyle.regular)),
+                      icon: Icon(
+                          PhosphorIcons.funnel(PhosphorIconsStyle.regular)),
                       onPressed: () => _showFilterSheet(colors),
                     ),
                     if (_hasActiveFilter)
@@ -165,165 +163,163 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
         onRefresh: () => ref.refresh(userSourcesProvider.future),
         color: colors.primary,
         child: sourcesAsync.when(
-        loading: () => _scrollableCenter(
-          const Center(child: CircularProgressIndicator()),
-        ),
-        error: (err, stack) => _scrollableCenter(
-          _consecutiveErrorCount >= 2
-              ? LaurinFallbackView(
-                  onRetry: () {
-                    setState(() => _consecutiveErrorCount = 0);
-                    ref.invalidate(userSourcesProvider);
-                  },
-                )
-              : FriendlyErrorView(
-                  error: err,
-                  onRetry: () => ref.invalidate(userSourcesProvider),
-                ),
-        ),
-        data: (sources) {
-          // Sort alphabetically
-          var allSources = sources.toList()
-            ..sort(
-                (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
-
-          // Apply search filter
-          if (_searchQuery.isNotEmpty) {
-            allSources = allSources
-                .where((s) =>
-                    s.name.toLowerCase().contains(_searchQuery.toLowerCase()))
-                .toList();
-          }
-
-          if (allSources.isEmpty && _searchQuery.isEmpty) {
-            return _scrollableCenter(
-              Text(
-                'Aucune source disponible',
-                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: colors.textSecondary,
-                    ),
-              ),
-            );
-          }
-
-          // Apply theme + type filters for display
-          var filteredSources = allSources.toList();
-          if (_selectedTheme != null) {
-            filteredSources = filteredSources
-                .where((s) => s.theme?.toLowerCase() == _selectedTheme)
-                .toList();
-          }
-          if (_selectedType != null) {
-            filteredSources = filteredSources
-                .where((s) => s.type == _selectedType)
-                .toList();
-          }
-          // Split into 4 groups: premium, custom (non-muted), curated (non-muted), muted
-          final premiumSources = filteredSources
-              .where((s) => s.hasSubscription && !s.isMuted)
-              .toList();
-          final customSources = filteredSources
-              .where((s) => s.isCustom && !s.isMuted)
-              .toList();
-          final curatedSources = filteredSources
-              .where((s) => s.isCurated && !s.isMuted)
-              .toList();
-          final mutedSources =
-              filteredSources.where((s) => s.isMuted).toList();
-
-          final noResults = filteredSources.isEmpty && _hasActiveFilter;
-
-          if (noResults) {
-            return _scrollableCenter(
-              Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    PhosphorIcons.funnel(PhosphorIconsStyle.regular),
-                    size: 40,
-                    color: colors.textTertiary,
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    'Aucune source pour ces filtres',
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyMedium
-                        ?.copyWith(color: colors.textSecondary),
-                  ),
-                  const SizedBox(height: 8),
-                  TextButton(
-                    onPressed: () {
-                      setState(() {
-                        _selectedTheme = null;
-                        _selectedType = null;
-                      });
+          loading: () => _scrollableCenter(
+            const Center(child: CircularProgressIndicator()),
+          ),
+          error: (err, stack) => _scrollableCenter(
+            _consecutiveErrorCount >= 2
+                ? LaurinFallbackView(
+                    onRetry: () {
+                      setState(() => _consecutiveErrorCount = 0);
+                      ref.invalidate(userSourcesProvider);
                     },
-                    child: const Text('Réinitialiser les filtres'),
+                  )
+                : FriendlyErrorView(
+                    error: err,
+                    onRetry: () => ref.invalidate(userSourcesProvider),
                   ),
-                  ...mutedSources
-                      .map((source) => _buildSourceItem(source)),
-                ],
-              ),
-            );
-          }
+          ),
+          data: (sources) {
+            // Sort alphabetically
+            var allSources = sources.toList()
+              ..sort((a, b) =>
+                  a.name.toLowerCase().compareTo(b.name.toLowerCase()));
 
-          return ListView(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-            physics: const AlwaysScrollableScrollPhysics(),
-            children: [
-              _IntroBlock(colors: colors),
-              const SizedBox(height: 16),
-              if (premiumSources.isNotEmpty)
-                _buildCollapsibleSection(
-                  title: 'Mes abonnements Premium',
-                  count: premiumSources.length,
-                  isExpanded: _premiumExpanded,
-                  onToggle: () => setState(
-                      () => _premiumExpanded = !_premiumExpanded),
-                  sources: premiumSources,
-                  colors: colors,
-                  icon: PhosphorIcons.star(PhosphorIconsStyle.fill),
+            // Apply search filter
+            if (_searchQuery.isNotEmpty) {
+              allSources = allSources
+                  .where((s) =>
+                      s.name.toLowerCase().contains(_searchQuery.toLowerCase()))
+                  .toList();
+            }
+
+            if (allSources.isEmpty && _searchQuery.isEmpty) {
+              return _scrollableCenter(
+                Text(
+                  'Aucune source disponible',
+                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        color: colors.textSecondary,
+                      ),
                 ),
-              const _HidePaidToggleCard(),
-              const SizedBox(height: 8),
-              if (customSources.isNotEmpty)
-                _buildCollapsibleSection(
-                  title: 'Mes sources personnalisees',
-                  count: customSources.length,
-                  isExpanded: _customExpanded,
-                  onToggle: () => setState(
-                      () => _customExpanded = !_customExpanded),
-                  sources: customSources,
-                  colors: colors,
+              );
+            }
+
+            // Apply theme + type filters for display
+            var filteredSources = allSources.toList();
+            if (_selectedTheme != null) {
+              filteredSources = filteredSources
+                  .where((s) => s.theme?.toLowerCase() == _selectedTheme)
+                  .toList();
+            }
+            if (_selectedType != null) {
+              filteredSources = filteredSources
+                  .where((s) => s.type == _selectedType)
+                  .toList();
+            }
+            // Split into 4 groups: premium, custom (non-muted), curated (non-muted), muted
+            final premiumSources = filteredSources
+                .where((s) => s.hasSubscription && !s.isMuted)
+                .toList();
+            final customSources =
+                filteredSources.where((s) => s.isCustom && !s.isMuted).toList();
+            final curatedSources = filteredSources
+                .where((s) => s.isCurated && !s.isMuted)
+                .toList();
+            final mutedSources =
+                filteredSources.where((s) => s.isMuted).toList();
+
+            final noResults = filteredSources.isEmpty && _hasActiveFilter;
+
+            if (noResults) {
+              return _scrollableCenter(
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      PhosphorIcons.funnel(PhosphorIconsStyle.regular),
+                      size: 40,
+                      color: colors.textTertiary,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      'Aucune source pour ces filtres',
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyMedium
+                          ?.copyWith(color: colors.textSecondary),
+                    ),
+                    const SizedBox(height: 8),
+                    TextButton(
+                      onPressed: () {
+                        setState(() {
+                          _selectedTheme = null;
+                          _selectedType = null;
+                        });
+                      },
+                      child: const Text('Réinitialiser les filtres'),
+                    ),
+                    ...mutedSources.map((source) => _buildSourceItem(source)),
+                  ],
                 ),
-              if (curatedSources.isNotEmpty)
-                _buildCollapsibleSection(
-                  title: 'Sources suggerees',
-                  count: curatedSources.length,
-                  isExpanded: _curatedExpanded,
-                  onToggle: () => setState(
-                      () => _curatedExpanded = !_curatedExpanded),
-                  sources: curatedSources,
-                  colors: colors,
-                ),
-              if (mutedSources.isNotEmpty) ...[
+              );
+            }
+
+            return ListView(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                _IntroBlock(colors: colors),
+                const SizedBox(height: 16),
+                if (premiumSources.isNotEmpty)
+                  _buildCollapsibleSection(
+                    title: 'Mes abonnements Premium',
+                    count: premiumSources.length,
+                    isExpanded: _premiumExpanded,
+                    onToggle: () =>
+                        setState(() => _premiumExpanded = !_premiumExpanded),
+                    sources: premiumSources,
+                    colors: colors,
+                    icon: PhosphorIcons.star(PhosphorIconsStyle.fill),
+                  ),
+                const _HidePaidToggleCard(),
                 const SizedBox(height: 8),
-                _buildCollapsibleSection(
-                  title: 'Sources masquees',
-                  count: mutedSources.length,
-                  isExpanded: _mutedExpanded,
-                  onToggle: () => setState(
-                      () => _mutedExpanded = !_mutedExpanded),
-                  sources: mutedSources,
-                  colors: colors,
-                  icon: PhosphorIcons.eyeSlash(PhosphorIconsStyle.bold),
-                  isMuted: true,
-                ),
+                if (customSources.isNotEmpty)
+                  _buildCollapsibleSection(
+                    title: 'Mes sources personnalisees',
+                    count: customSources.length,
+                    isExpanded: _customExpanded,
+                    onToggle: () =>
+                        setState(() => _customExpanded = !_customExpanded),
+                    sources: customSources,
+                    colors: colors,
+                  ),
+                if (curatedSources.isNotEmpty)
+                  _buildCollapsibleSection(
+                    title: 'Sources suggerees',
+                    count: curatedSources.length,
+                    isExpanded: _curatedExpanded,
+                    onToggle: () =>
+                        setState(() => _curatedExpanded = !_curatedExpanded),
+                    sources: curatedSources,
+                    colors: colors,
+                  ),
+                if (mutedSources.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  _buildCollapsibleSection(
+                    title: 'Sources masquees',
+                    count: mutedSources.length,
+                    isExpanded: _mutedExpanded,
+                    onToggle: () =>
+                        setState(() => _mutedExpanded = !_mutedExpanded),
+                    sources: mutedSources,
+                    colors: colors,
+                    icon: PhosphorIcons.eyeSlash(PhosphorIconsStyle.bold),
+                    isMuted: true,
+                  ),
+                ],
               ],
-            ],
-          );
-        },
+            );
+          },
         ),
       ),
       floatingActionButton: Row(
@@ -332,7 +328,8 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
         children: [
           const Flexible(
             child: FabNudgeBubble(
-              text: 'Ajoute n\'importe quelle source (média, newsletter, vidéos…)',
+              text: 'Ajoute média, newsletter, vidéo…',
+              dismissKey: 'nudge_add_source_v1',
             ),
           ),
           const SizedBox(width: 6),
@@ -455,7 +452,8 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
         ),
         AnimatedCrossFade(
           firstChild: Column(
-            children: sources.map((source) => _buildSourceItem(source)).toList(),
+            children:
+                sources.map((source) => _buildSourceItem(source)).toList(),
           ),
           secondChild: const SizedBox.shrink(),
           crossFadeState:
@@ -709,7 +707,7 @@ class _IntroBlock extends StatelessWidget {
           ),
           const SizedBox(height: 6),
           Text(
-            'Choisissez les sources qui comptent pour vous : réglez leur fréquence d\'apparition de 1 (occasionnellement) à 3 (ne rien rater), masquez celles qui ne vous parlent pas, et ajoutez de nouvelles sources pour enrichir votre flux.',
+            'Réglez les fréquences d\'apparitions de vos sources de 1 (occasionnellement) à 3 (tout voir), masquez celles qui ne vous parlent pas, et ajoutez plus de sources pour enrichir votre flux.',
             style: textTheme.bodySmall?.copyWith(
               color: colors.textSecondary,
               height: 1.45,
@@ -737,9 +735,8 @@ class _HidePaidToggleCard extends ConsumerWidget {
         color: colors.surface,
         borderRadius: borderRadius,
         child: InkWell(
-          onTap: () => ref
-              .read(hidePaidContentProvider.notifier)
-              .toggle(!hidePaid),
+          onTap: () =>
+              ref.read(hidePaidContentProvider.notifier).toggle(!hidePaid),
           borderRadius: borderRadius,
           child: Container(
             decoration: BoxDecoration(

--- a/apps/mobile/lib/features/sources/widgets/source_list_item.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_list_item.dart
@@ -66,8 +66,8 @@ class SourceListItem extends StatelessWidget {
         opacity: isMuted ? 0.5 : 1.0,
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 150),
-          margin: const EdgeInsets.only(bottom: 14),
-          padding: const EdgeInsets.all(18),
+          margin: const EdgeInsets.only(bottom: 10),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
           decoration: BoxDecoration(
             color: isMuted
                 ? colors.surface
@@ -87,10 +87,10 @@ class SourceListItem extends StatelessWidget {
             children: [
               SourceLogoAvatar(
                 source: source,
-                size: 60,
-                radius: 12,
+                size: 48,
+                radius: 10,
               ),
-              const SizedBox(width: 14),
+              const SizedBox(width: 10),
 
               // Info
               Expanded(
@@ -152,7 +152,7 @@ class SourceListItem extends StatelessWidget {
 
               // Priority slider for trusted, non-muted sources
               if (!isMuted && isTrusted && onWeightChanged != null) ...[
-                const SizedBox(width: 8),
+                const SizedBox(width: 6),
                 PrioritySlider(
                   key: ValueKey(source.priorityMultiplier),
                   currentMultiplier: source.priorityMultiplier,

--- a/apps/mobile/lib/shared/widgets/fab_nudge_bubble.dart
+++ b/apps/mobile/lib/shared/widgets/fab_nudge_bubble.dart
@@ -1,62 +1,129 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../config/theme.dart';
 
 /// Petite bulle "nudge" affichée à gauche d'un FAB pour inviter à l'action.
 /// Speech-bubble avec petit triangle pointant vers la droite (le FAB).
-class FabNudgeBubble extends StatelessWidget {
+///
+/// Quand [dismissKey] est fourni, la bulle se masque automatiquement après
+/// [autoDismissAfter] (fade-out) et persiste l'état dans SharedPreferences :
+/// elle ne réapparaît plus une fois auto-dismissée.
+class FabNudgeBubble extends StatefulWidget {
   final String text;
   final double maxWidth;
+  final String? dismissKey;
+  final Duration autoDismissAfter;
 
   const FabNudgeBubble({
     super.key,
     required this.text,
-    this.maxWidth = 200,
+    this.maxWidth = 160,
+    this.dismissKey,
+    this.autoDismissAfter = const Duration(seconds: 7),
   });
 
   @override
+  State<FabNudgeBubble> createState() => _FabNudgeBubbleState();
+}
+
+class _FabNudgeBubbleState extends State<FabNudgeBubble> {
+  bool _visible = true;
+  bool _checked = false;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.dismissKey != null) {
+      _checkDismissed();
+    } else {
+      _checked = true;
+      _scheduleDismiss();
+    }
+  }
+
+  Future<void> _checkDismissed() async {
+    final prefs = await SharedPreferences.getInstance();
+    final dismissed = prefs.getBool(widget.dismissKey!) ?? false;
+    if (!mounted) return;
+    setState(() {
+      _checked = true;
+      _visible = !dismissed;
+    });
+    if (_visible) _scheduleDismiss();
+  }
+
+  void _scheduleDismiss() {
+    _timer = Timer(widget.autoDismissAfter, () async {
+      if (!mounted) return;
+      setState(() => _visible = false);
+      if (widget.dismissKey != null) {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setBool(widget.dismissKey!, true);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    if (!_checked) return const SizedBox.shrink();
     final colors = context.facteurColors;
-    return ConstrainedBox(
-      constraints: BoxConstraints(maxWidth: maxWidth),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Flexible(
-            child: Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: FacteurSpacing.space3,
-                vertical: FacteurSpacing.space2,
-              ),
-              decoration: BoxDecoration(
-                color: colors.surface,
-                borderRadius: BorderRadius.circular(FacteurRadius.medium),
-                border: Border.all(color: colors.border),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withOpacity(0.06),
-                    blurRadius: 8,
-                    offset: const Offset(0, 2),
+    return IgnorePointer(
+      ignoring: !_visible,
+      child: AnimatedOpacity(
+        opacity: _visible ? 1.0 : 0.0,
+        duration: const Duration(milliseconds: 200),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: widget.maxWidth),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: FacteurSpacing.space3,
+                    vertical: FacteurSpacing.space2,
                   ),
-                ],
+                  decoration: BoxDecoration(
+                    color: colors.surface,
+                    borderRadius: BorderRadius.circular(FacteurRadius.medium),
+                    border: Border.all(color: colors.border),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.06),
+                        blurRadius: 8,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                  child: Text(
+                    widget.text,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: colors.textSecondary,
+                          height: 1.25,
+                        ),
+                  ),
+                ),
               ),
-              child: Text(
-                text,
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: colors.textSecondary,
-                      height: 1.25,
-                    ),
+              CustomPaint(
+                size: const Size(8, 12),
+                painter: _BubbleTailPainter(
+                  fill: colors.surface,
+                  border: colors.border,
+                ),
               ),
-            ),
+            ],
           ),
-          CustomPaint(
-            size: const Size(8, 12),
-            painter: _BubbleTailPainter(
-              fill: colors.surface,
-              border: colors.border,
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## What

- `SourceListItem` : padding 18→14h/12v, margin 14→10, avatar 60→48, gaps réduits.
- `ThemeSection` : tilePadding compact, fontSize titre thème 17→15, padding minus-icon 8→4.
- `FabNudgeBubble` : converti en `StatefulWidget` avec auto-dismiss après 7 s (fade-out 200 ms) + persistance `SharedPreferences` via `dismissKey`. `maxWidth` 200→160. Textes raccourcis sur Sources et Mes Intérêts.

## Why

Tests E2E sur petit Android (PR #530) : titres tronqués (\"Au Microb'…\", \"Environn\\nement\") et nudges FAB qui débordent à gauche de l'écran sans jamais disparaître. Cette PR libère la zone titre sans toucher aux curseurs (cliquabilité préservée) et fait disparaître les nudges après 7 s, durablement.

## Type

- [x] Bug fix

## Checklist

- [ ] Tests pass locally
- [ ] Linting passes
- [x] No new Python `List[]` imports (N/A — Flutter only)
- [x] If touching auth/DB: read Safety Guardrails (N/A)
- [ ] Peer Review Conductor completed

## Staging

- [x] N/A (UI mobile only)