### PR TITLE
feat(veille): pipeline LLM digest — clusters articles + why_it_matters

### DIFF
--- a/docs/stories/core/18.2.veille-backend-pipeline.md
+++ b/docs/stories/core/18.2.veille-backend-pipeline.md
@@ -1,0 +1,106 @@
+# Story 18.2 : Pipeline LLM « Ma veille » (Phase 3 / Stream A)
+
+## Status: In progress
+
+> Branche : `boujonlaurin-dotcom/veille-pipeline` — PR cible **`main`** (staging déprécié).
+
+---
+
+## Story
+
+**As a** utilisateur Facteur ayant configuré une veille (phase 2),
+**I want** que mon scanner `*/30 min` génère des `items` réels au lieu de `[]`,
+**so that** mes livraisons contiennent des clusters d'articles thématiques avec un mini-pourquoi (LLM), prêts à être consommés par le front (stream B) et notifiés par push (stream C).
+
+---
+
+## Décisions PO (réponses au plan v2)
+
+1. **Refactor pool DB** : Option **C** — split en `_phase1_mark_running` (commit + close session injectée) → builder ouvre ses propres sessions courtes via `session_maker` → `_phase3_persist` ouvre sa propre session. Zéro ambiguïté sur la connexion empruntée pendant l'appel LLM (3-5 s).
+2. **`TopicCluster.cluster_id`** : `str` (UUID4 stringifié, set dans `ImportanceDetector.build_topic_clusters` ligne 194). Utilisé tel quel dans les items.
+3. **Index GIN sur `Content.topics`** : pas de migration en V1. Le filtre `source_id IN (...) AND published_at >= since` hit déjà l'index composite `ix_contents_source_published`. ARRAY OVERLAP appliqué sur sous-ensemble. Documenté comme suivi (cf. risques).
+4. **Garde-fou clusters singletons** : si après filtrage `len(top_clusters) == 0` → on retourne `items=[]` (idempotent, scanner re-essayera au prochain tick).
+5. **Migration vl01** : déjà appliquée en prod Supabase (confirmée 2026-05-01) — pas de SQL à rejouer.
+
+---
+
+## Acceptance Criteria
+
+1. Le job `run_veille_generation_for_config` génère des `items` au format :
+   ```json
+   [
+     {
+       "cluster_id": "uuid-string",
+       "title": "string",
+       "articles": [
+         {"content_id": "uuid", "source_id": "uuid", "title": "string", "url": "string", "excerpt": "string", "published_at": "ISO8601"}
+       ],
+       "why_it_matters": "string"
+     }
+   ]
+   ```
+2. Filtrage articles : publiés ≥ `last_delivered_at` (ou 7 jours si jamais livré), `source_id IN veille_sources`, intersection `Content.topics ARRAY OVERLAP veille_topics`.
+3. Clustering via `ImportanceDetector.build_topic_clusters(contents)` (Jaccard sur titres). Filtrage : on garde les clusters dont au moins 1 article a un topic match. Top-N (default N=8) par taille décroissante (nb articles puis nb sources).
+4. **CRITIQUE pool DB** : 0 session DB tenue pendant l'appel LLM (Option C). Session injectée fermée avant appel builder. Builder ouvre ses propres sessions courtes via `safe_async_session`. `_phase3_persist` ouvre sa propre short session.
+5. LLM `why_it_matters` : 1 appel batch `EditorialLLMClient.chat_json` (mistral-large-latest, T=0.3) qui renvoie `{cluster_id: why}`. Fallback déterministe si LLM `is_ready=False` ou retour `None`.
+6. Idempotence : rejouer la génération sur la même `(config_id, target_date)` produit toujours 1 row (UPSERT `on_conflict_do_update`).
+7. Schémas Pydantic `VeilleDeliveryArticle` + `VeilleDeliveryItem` ajoutés ; `VeilleDeliveryResponse.items: list[VeilleDeliveryItem]`.
+8. Tests : `tests/test_veille_digest_builder.py` (≥ 7 tests : input loader, fetch contents avec ARRAY OVERLAP, filter clusters, top-N, LLM mocké, fallback, format items, anti-régression session pas tenue pendant LLM). Extend `tests/test_veille_generation_job.py` (items réels, idempotence, fallback). 1 test routes (format).
+9. `pytest -v` complet vert ; `ruff format --check` + `ruff check` verts.
+10. PR vers `main`.
+
+---
+
+## Plan technique
+
+### Architecture pipeline (Option C)
+
+```
+run_veille_generation_for_config(session, config_id, target_date, *, builder)
+├─ _phase1_mark_running(session, config_id, target_date) → delivery_id
+│  └─ UPSERT veille_deliveries SET state=RUNNING, attempts++
+│  └─ session.commit() + session expire (caller la ferme/réutilise vide)
+│
+├─ items = await builder.build(config_id)        ← session injectée NON utilisée
+│  └─ short session 1 : SELECT VeilleConfig + topics + sources
+│  └─ short session 2 : SELECT contents (sources × topics × since)
+│  └─ build_topic_clusters (in-memory)
+│  └─ LLM call (HORS session DB, 3-5s)
+│
+└─ _phase3_persist(session_maker, delivery_id, config_id, items, finished_at)
+   └─ short session : UPDATE delivery (items, state=SUCCEEDED) + UPDATE cfg (last_delivered_at, next_scheduled_at)
+   └─ commit
+```
+
+### Fichiers
+
+| Fichier | Action |
+|---|---|
+| `packages/api/app/services/veille/digest_builder.py` | NEW (~250 lignes) |
+| `packages/api/app/jobs/veille_generation_job.py` | EDIT (refactor Option C, injection builder) |
+| `packages/api/app/routers/veille.py` | EDIT (force_generate route — injection builder) |
+| `packages/api/app/schemas/veille.py` | EDIT (`VeilleDeliveryArticle`, `VeilleDeliveryItem`) |
+| `packages/api/tests/test_veille_digest_builder.py` | NEW (~7 tests) |
+| `packages/api/tests/test_veille_generation_job.py` | EDIT (3-4 tests) |
+| `docs/stories/core/18.2.veille-backend-pipeline.md` | NEW (cette story) |
+
+Aucune migration DB. Aucun changement de scheduler.
+
+---
+
+## Risques / suivis
+
+1. **Pool DB** — option C élimine l'ambiguïté V1. Les tests anti-régression vérifient que le builder ouvre/ferme proprement ses sessions et qu'aucune session injectée n'est touchée pendant l'appel LLM.
+2. **`Content.topics ARRAY OVERLAP`** — pas d'index GIN sur `topics` en V1. Le filtre composite `(source_id, published_at)` sélectionne d'abord, puis OVERLAP s'applique sur sous-ensemble. À mesurer en prod si latence > 1s ; si oui, créer migration `CREATE INDEX CONCURRENTLY ix_contents_topics ON contents USING gin (topics)`.
+3. **LLM batch unique** — pour 8 clusters, un seul appel Mistral. Si N grandit (multi-veilles V2), envisager batching par groupe de 5 pour rester sous le context window.
+4. **Articles peu nombreux** — si 0 cluster pertinent → `items=[]` (idempotent, re-tentative au tick suivant). Pas d'erreur.
+5. **`last_delivered_at` jamais set** — fallback `now() - 7 days` (constante `DEFAULT_LOOKBACK_DAYS`).
+
+---
+
+## Hors scope (18.3 / 18.4)
+
+- Stream B — front Flutter wiring (Dio client, écrans config/suggestions/deliveries).
+- Stream C — push notifications + deeplink détail.
+- Multi-veilles par user (V2/V3).
+- Cache LLM des `why_it_matters` par hash(contents).

--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -1,7 +1,8 @@
 """Configuration de la base de données avec SQLAlchemy async."""
 
 import time
-from contextlib import asynccontextmanager
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 
 from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -163,6 +164,10 @@ async_session_maker = async_sessionmaker(
 # sur le hot path /api/feed.
 _DEFAULT_STATEMENT_TIMEOUT_MS = 30_000
 _DEFAULT_IDLE_IN_TX_TIMEOUT_MS = 10_000
+
+
+SessionMaker = Callable[..., AbstractAsyncContextManager[AsyncSession]]
+"""Type alias pour une factory `safe_async_session` injectable (tests)."""
 
 
 async def _push_session_timeouts(

--- a/packages/api/app/jobs/veille_generation_job.py
+++ b/packages/api/app/jobs/veille_generation_job.py
@@ -1,9 +1,7 @@
 """Génération des livraisons de veille — scanner */30 min.
 
-Pool DB : le scan est UN SELECT sur `ix_veille_configs_next_scheduled` puis
-session fermée AVANT tout traitement. Chaque config a une session dédiée
-bornée par un semaphore (incidents historiques de saturation pool, cf.
-`docs/bugs/bug-infinite-load-requests.md`).
+Invariant : aucune session DB tenue pendant l'appel LLM (3-5 s). Cf.
+incidents pool QueuePool docs/bugs/bug-infinite-load-requests.md (#363).
 """
 
 from __future__ import annotations
@@ -17,13 +15,15 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import safe_async_session
+from app.database import SessionMaker, safe_async_session
 from app.models.veille import (
     VeilleConfig,
     VeilleDelivery,
     VeilleGenerationState,
     VeilleStatus,
 )
+from app.services.editorial.llm_client import EditorialLLMClient
+from app.services.veille.digest_builder import VeilleDigestBuilder
 from app.services.veille.scheduling import compute_next_scheduled_at
 from app.utils.time import today_paris
 
@@ -61,11 +61,20 @@ async def run_veille_generation(target_date: date | None = None) -> None:
         logger.info("veille_generation_job_no_due", target_date=str(target))
         return
 
-    semaphore = asyncio.Semaphore(_CONCURRENCY_LIMIT)
-    results = await asyncio.gather(
-        *(_process_config_with_semaphore(semaphore, cid, target) for cid in config_ids),
-        return_exceptions=True,
-    )
+    llm = EditorialLLMClient()
+    builder = VeilleDigestBuilder(llm=llm, session_maker=safe_async_session)
+
+    try:
+        semaphore = asyncio.Semaphore(_CONCURRENCY_LIMIT)
+        results = await asyncio.gather(
+            *(
+                _process_config_with_semaphore(semaphore, cid, target, builder)
+                for cid in config_ids
+            ),
+            return_exceptions=True,
+        )
+    finally:
+        await llm.close()
 
     succeeded = sum(1 for r in results if r is True)
     failed = sum(1 for r in results if isinstance(r, Exception) or r is False)
@@ -83,16 +92,18 @@ async def _process_config_with_semaphore(
     semaphore: asyncio.Semaphore,
     config_id: UUID,
     target: date,
+    builder: VeilleDigestBuilder,
 ) -> bool:
-    async with semaphore, safe_async_session() as session:
+    async with semaphore:
         try:
             await run_veille_generation_for_config(
-                session, config_id, target_date=target
+                config_id,
+                target_date=target,
+                session_maker=safe_async_session,
+                builder=builder,
             )
-            await session.commit()
             return True
         except Exception as exc:
-            await session.rollback()
             logger.error(
                 "veille_generation_job_config_failed",
                 config_id=str(config_id),
@@ -102,15 +113,47 @@ async def _process_config_with_semaphore(
 
 
 async def run_veille_generation_for_config(
-    session: AsyncSession,
     config_id: UUID,
     target_date: date,
+    *,
+    session_maker: SessionMaker,
+    builder: VeilleDigestBuilder | None = None,
 ) -> VeilleDelivery:
     """Génère (ou met à jour) la livraison pour une config + date données.
 
-    Idempotent via UPSERT sur (`veille_config_id`, `target_date`). Le caller
-    assure le `commit()` (utilisé depuis le job ET depuis la route debug).
+    Pipeline 3-phase, sessions courtes — la session est commit + close
+    AVANT l'appel LLM pour que la connexion soit rendue au pool. `builder
+    is None` → `items=[]` (utilisé en tests).
     """
+    async with session_maker() as s:
+        delivery_id, _ = await _phase1_mark_running(s, config_id, target_date)
+        await s.commit()
+
+    items: list[dict] = []
+    if builder is not None:
+        items = await builder.build(config_id)
+
+    finished_at = datetime.now(UTC)
+    async with session_maker() as s:
+        delivery = await _phase3_persist(s, delivery_id, config_id, items, finished_at)
+        await s.commit()
+        await s.refresh(delivery)
+
+    logger.info(
+        "veille_generation_config_processed",
+        config_id=str(config_id),
+        target_date=str(target_date),
+        item_count=len(items),
+    )
+    return delivery
+
+
+async def _phase1_mark_running(
+    session: AsyncSession,
+    config_id: UUID,
+    target_date: date,
+) -> tuple[UUID, datetime]:
+    """UPSERT veille_deliveries en état RUNNING. Retourne (delivery_id, started_at)."""
     cfg = (
         (
             await session.execute(
@@ -124,7 +167,6 @@ async def run_veille_generation_for_config(
         raise ValueError(f"VeilleConfig introuvable: {config_id}")
 
     started_at = datetime.now(UTC)
-
     upsert_stmt = (
         pg_insert(VeilleDelivery)
         .values(
@@ -145,17 +187,30 @@ async def run_veille_generation_for_config(
         .returning(VeilleDelivery.id)
     )
     delivery_id = (await session.execute(upsert_stmt)).scalar_one()
-    delivery = await session.get(VeilleDelivery, delivery_id)
-    assert delivery is not None
+    return delivery_id, started_at
 
-    finished_at = datetime.now(UTC)
+
+async def _phase3_persist(
+    session: AsyncSession,
+    delivery_id: UUID,
+    config_id: UUID,
+    items: list[dict],
+    finished_at: datetime,
+) -> VeilleDelivery:
+    """UPDATE delivery SUCCEEDED + recalc next_scheduled_at."""
+    delivery = await session.get(VeilleDelivery, delivery_id)
+    if delivery is None:
+        raise ValueError(f"VeilleDelivery introuvable: {delivery_id}")
+
     delivery.generation_state = VeilleGenerationState.SUCCEEDED.value
-    delivery.items = []
+    delivery.items = items
     delivery.finished_at = finished_at
     delivery.generated_at = finished_at
     delivery.last_error = None
 
-    # Recalcule next_scheduled_at + last_delivered_at.
+    cfg = await session.get(VeilleConfig, config_id)
+    if cfg is None:
+        raise ValueError(f"VeilleConfig introuvable: {config_id}")
     cfg.last_delivered_at = finished_at
     cfg.next_scheduled_at = compute_next_scheduled_at(
         frequency=cfg.frequency,
@@ -167,14 +222,4 @@ async def run_veille_generation_for_config(
     )
 
     await session.flush()
-
-    logger.info(
-        "veille_generation_config_processed",
-        config_id=str(config_id),
-        target_date=str(target_date),
-        next_scheduled_at=cfg.next_scheduled_at.isoformat()
-        if cfg.next_scheduled_at
-        else None,
-    )
-
     return delivery

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -17,7 +17,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
-from app.database import get_db
+from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
 from app.jobs.veille_generation_job import run_veille_generation_for_config
 from app.models.enums import SourceType
@@ -45,7 +45,9 @@ from app.schemas.veille import (
     VeilleTopicResponse,
     VeilleTopicSuggestion,
 )
+from app.services.editorial.llm_client import EditorialLLMClient
 from app.services.source_service import SourceService
+from app.services.veille.digest_builder import VeilleDigestBuilder
 from app.services.veille.scheduling import compute_next_scheduled_at
 from app.services.veille.source_suggester import (
     SourceSuggester,
@@ -502,7 +504,6 @@ async def get_delivery(
 @router.post("/deliveries/generate", response_model=VeilleDeliveryResponse)
 async def force_generate(
     req: VeilleGenerateRequest,
-    db: AsyncSession = Depends(get_db),
     current_user_id: str = Depends(get_current_user_id),
 ):
     """Admin/debug : force la génération de la livraison du jour.
@@ -517,12 +518,25 @@ async def force_generate(
         )
 
     user_uuid = UUID(current_user_id)
-    cfg = await _get_active_config(db, user_uuid)
+    # Pas de Depends(get_db) — sinon la session resterait checked-out
+    # pendant tout l'appel LLM (3-5 s), annulant le bénéfice Option C.
+    async with safe_async_session() as s:
+        cfg = await _get_active_config(s, user_uuid)
     if cfg is None:
         raise HTTPException(status_code=404, detail="Aucune veille active à générer.")
 
     target = req.target_date or today_paris()
-    delivery = await run_veille_generation_for_config(db, cfg.id, target_date=target)
-    await db.commit()
-    await db.refresh(delivery)
+
+    llm = EditorialLLMClient()
+    try:
+        builder = VeilleDigestBuilder(llm=llm, session_maker=safe_async_session)
+        delivery = await run_veille_generation_for_config(
+            cfg.id,
+            target_date=target,
+            session_maker=safe_async_session,
+            builder=builder,
+        )
+    finally:
+        await llm.close()
+
     return VeilleDeliveryResponse.model_validate(delivery)

--- a/packages/api/app/schemas/veille.py
+++ b/packages/api/app/schemas/veille.py
@@ -166,13 +166,33 @@ class VeilleDeliveryListItem(BaseModel):
     created_at: datetime
 
 
+class VeilleDeliveryArticle(BaseModel):
+    """Article référencé dans un cluster d'une livraison veille."""
+
+    content_id: UUID
+    source_id: UUID
+    title: str
+    url: str
+    excerpt: str = ""
+    published_at: datetime
+
+
+class VeilleDeliveryItem(BaseModel):
+    """Cluster thématique exposé au front (Story 18.2)."""
+
+    cluster_id: str
+    title: str
+    articles: list[VeilleDeliveryArticle] = Field(default_factory=list)
+    why_it_matters: str = ""
+
+
 class VeilleDeliveryResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
     veille_config_id: UUID
     target_date: date
-    items: list[dict]
+    items: list[VeilleDeliveryItem] = Field(default_factory=list)
     generation_state: Literal["pending", "running", "succeeded", "failed"]
     attempts: int
     started_at: datetime | None = None

--- a/packages/api/app/services/veille/digest_builder.py
+++ b/packages/api/app/services/veille/digest_builder.py
@@ -1,0 +1,292 @@
+"""Construit la liste d'items pour une livraison de veille.
+
+Invariant : zéro session DB tenue pendant l'appel LLM. Sessions ouvertes
+via `session_maker` (typiquement `safe_async_session`) et fermées entre
+chaque phase.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import SessionMaker
+from app.models.content import Content
+from app.models.veille import VeilleConfig, VeilleSource, VeilleTopic
+from app.services.briefing.importance_detector import ImportanceDetector, TopicCluster
+from app.services.editorial.llm_client import EditorialLLMClient
+
+logger = structlog.get_logger()
+
+DEFAULT_LOOKBACK_DAYS = 7
+DEFAULT_TOP_N_CLUSTERS = 8
+DEFAULT_MAX_ARTICLES_PER_CLUSTER = 5
+DEFAULT_EXCERPT_LENGTH = 280
+_FETCH_CONTENTS_LIMIT = 500
+
+
+@dataclass
+class VeilleDigestInput:
+    config_id: UUID
+    user_topic_ids: list[str]
+    user_topic_labels: list[str]
+    user_source_ids: list[UUID]
+    last_delivered_at: datetime | None
+    theme_id: str
+    theme_label: str
+
+
+class VeilleDigestBuilder:
+    """Génère les `items` d'une livraison à partir d'une config veille."""
+
+    def __init__(
+        self,
+        llm: EditorialLLMClient,
+        session_maker: SessionMaker,
+        top_n: int = DEFAULT_TOP_N_CLUSTERS,
+        max_articles_per_cluster: int = DEFAULT_MAX_ARTICLES_PER_CLUSTER,
+        lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    ) -> None:
+        self.llm = llm
+        self.session_maker = session_maker
+        self.detector = ImportanceDetector()
+        self.top_n = top_n
+        self.max_articles_per_cluster = max_articles_per_cluster
+        self.lookback_days = lookback_days
+
+    async def build(self, config_id: UUID) -> list[dict]:
+        async with self.session_maker() as s:
+            ctx = await self._load_input(s, config_id)
+
+        if not ctx.user_source_ids or not ctx.user_topic_ids:
+            logger.info(
+                "veille_pipeline.skip_empty_config",
+                config_id=str(config_id),
+                source_count=len(ctx.user_source_ids),
+                topic_count=len(ctx.user_topic_ids),
+            )
+            return []
+
+        async with self.session_maker() as s:
+            contents = await self._fetch_contents(s, ctx)
+
+        if not contents:
+            logger.info(
+                "veille_pipeline.no_contents",
+                config_id=str(config_id),
+                since=ctx.last_delivered_at.isoformat()
+                if ctx.last_delivered_at
+                else None,
+            )
+            return []
+
+        all_clusters = self.detector.build_topic_clusters(contents)
+        relevant = self._filter_clusters_for_topics(all_clusters, ctx.user_topic_ids)
+        top_clusters = self._top_n_clusters(relevant)
+
+        if not top_clusters:
+            logger.info(
+                "veille_pipeline.no_relevant_clusters",
+                config_id=str(config_id),
+                total_clusters=len(all_clusters),
+            )
+            return []
+
+        why_map = await self._generate_why_it_matters(top_clusters, ctx)
+
+        items = self._build_items(top_clusters, why_map)
+        logger.info(
+            "veille_pipeline.items_built",
+            config_id=str(config_id),
+            item_count=len(items),
+            article_count=sum(len(it["articles"]) for it in items),
+        )
+        return items
+
+    async def _load_input(self, s: AsyncSession, config_id: UUID) -> VeilleDigestInput:
+        # Une seule AsyncSession ne peut servir qu'une requête à la fois
+        # (`InterfaceError: another operation is in progress`) — on garde
+        # les 3 SELECT séquentiels.
+        cfg = (
+            (await s.execute(select(VeilleConfig).where(VeilleConfig.id == config_id)))
+            .scalars()
+            .first()
+        )
+        if cfg is None:
+            raise ValueError(f"VeilleConfig introuvable: {config_id}")
+        topics = (
+            (
+                await s.execute(
+                    select(VeilleTopic).where(VeilleTopic.veille_config_id == config_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        sources = (
+            (
+                await s.execute(
+                    select(VeilleSource).where(
+                        VeilleSource.veille_config_id == config_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return VeilleDigestInput(
+            config_id=cfg.id,
+            user_topic_ids=[t.topic_id for t in topics],
+            user_topic_labels=[t.label for t in topics],
+            user_source_ids=[s.source_id for s in sources],
+            last_delivered_at=cfg.last_delivered_at,
+            theme_id=cfg.theme_id,
+            theme_label=cfg.theme_label,
+        )
+
+    async def _fetch_contents(
+        self, s: AsyncSession, ctx: VeilleDigestInput
+    ) -> list[Content]:
+        since = ctx.last_delivered_at or (
+            datetime.now(UTC) - timedelta(days=self.lookback_days)
+        )
+        stmt = (
+            select(Content)
+            .where(
+                Content.source_id.in_(ctx.user_source_ids),
+                Content.published_at >= since,
+                Content.topics.op("&&")(ctx.user_topic_ids),
+            )
+            .order_by(Content.published_at.desc())
+            .limit(_FETCH_CONTENTS_LIMIT)
+        )
+        return list((await s.execute(stmt)).scalars().all())
+
+    def _filter_clusters_for_topics(
+        self, clusters: list[TopicCluster], user_topic_ids: list[str]
+    ) -> list[TopicCluster]:
+        topic_set = set(user_topic_ids)
+        return [
+            c
+            for c in clusters
+            if any(
+                content.topics and topic_set.intersection(content.topics)
+                for content in c.contents
+            )
+        ]
+
+    def _top_n_clusters(self, clusters: list[TopicCluster]) -> list[TopicCluster]:
+        return sorted(
+            clusters,
+            key=lambda c: (len(c.contents), len(c.source_ids)),
+            reverse=True,
+        )[: self.top_n]
+
+    async def _generate_why_it_matters(
+        self, clusters: list[TopicCluster], ctx: VeilleDigestInput
+    ) -> dict[str, str]:
+        if not self.llm.is_ready:
+            return self._fallback_why_it_matters(clusters)
+        response = await self.llm.chat_json(
+            system=(
+                "Tu es éditeur de veille thématique pour Facteur. Pour chaque "
+                "cluster d'articles, tu rédiges UNE phrase (max 220 caractères) "
+                "expliquant en quoi ce sujet est pertinent pour un lecteur "
+                "intéressé par les topics donnés. Ton: factuel, concret, pas "
+                "de lyrisme. Réponds UNIQUEMENT en JSON: "
+                '{"clusters": {"<cluster_id>": "<why_it_matters>"}}.'
+            ),
+            user_message=self._build_prompt(clusters, ctx),
+            temperature=0.3,
+            max_tokens=1500,
+        )
+        mapping = response.get("clusters") if isinstance(response, dict) else None
+        if not isinstance(mapping, dict):
+            logger.warning(
+                "veille_pipeline.why_llm_invalid_response",
+                response_type=type(response).__name__,
+            )
+            return self._fallback_why_it_matters(clusters)
+        return {
+            c.cluster_id: (
+                str(mapping.get(c.cluster_id) or "").strip()
+                or self._fallback_for_cluster(c)
+            )
+            for c in clusters
+        }
+
+    def _fallback_why_it_matters(self, clusters: list[TopicCluster]) -> dict[str, str]:
+        return {c.cluster_id: self._fallback_for_cluster(c) for c in clusters}
+
+    def _fallback_for_cluster(self, c: TopicCluster) -> str:
+        n_articles = len(c.contents)
+        n_sources = len(c.source_ids)
+        if n_sources >= 2:
+            return f"{n_articles} articles de {n_sources} sources couvrent ce sujet."
+        return f"{n_articles} article(s) sur ce sujet."
+
+    def _build_prompt(
+        self, clusters: list[TopicCluster], ctx: VeilleDigestInput
+    ) -> str:
+        payload = {
+            "theme": ctx.theme_label,
+            "topics": ctx.user_topic_labels,
+            "clusters": [
+                {
+                    "cluster_id": c.cluster_id,
+                    "title_sample": self._derive_cluster_title(c),
+                    "n_articles": len(c.contents),
+                    "n_sources": len(c.source_ids),
+                    "sample_titles": [
+                        content.title[:160]
+                        for content in sorted(
+                            c.contents,
+                            key=lambda x: x.published_at,
+                            reverse=True,
+                        )[:3]
+                    ],
+                }
+                for c in clusters
+            ],
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+    def _build_items(
+        self, clusters: list[TopicCluster], why_map: dict[str, str]
+    ) -> list[dict]:
+        items: list[dict] = []
+        for c in clusters:
+            articles = [
+                {
+                    "content_id": str(content.id),
+                    "source_id": str(content.source_id),
+                    "title": content.title,
+                    "url": content.url,
+                    "excerpt": (content.description or "")[:DEFAULT_EXCERPT_LENGTH],
+                    "published_at": content.published_at.isoformat(),
+                }
+                for content in sorted(
+                    c.contents, key=lambda x: x.published_at, reverse=True
+                )[: self.max_articles_per_cluster]
+            ]
+            items.append(
+                {
+                    "cluster_id": c.cluster_id,
+                    "title": self._derive_cluster_title(c),
+                    "articles": articles,
+                    "why_it_matters": why_map.get(c.cluster_id, ""),
+                }
+            )
+        return items
+
+    def _derive_cluster_title(self, c: TopicCluster) -> str:
+        if not c.contents:
+            return "Cluster veille"
+        most_recent = max(c.contents, key=lambda x: x.published_at)
+        return most_recent.title[:160]

--- a/packages/api/tests/conftest.py
+++ b/packages/api/tests/conftest.py
@@ -1,5 +1,6 @@
 """Test configuration and fixtures for API tests."""
 
+from contextlib import asynccontextmanager
 from uuid import uuid4
 
 import pytest
@@ -77,6 +78,23 @@ async def db_session(create_tables):
         finally:
             await session.rollback()
             await session.close()
+
+
+@pytest.fixture
+def fake_session_maker(db_session):
+    """Yield la session de test à chaque ouverture.
+
+    Pour les composants qui prennent un `session_maker` (factory de sessions
+    courtes ad-hoc, type `safe_async_session`). Singleton de test : tous les
+    `async with` retournent la même `db_session` pour persister sur la base
+    de test. À utiliser pour tester le pattern Option C sans pool réel.
+    """
+
+    @asynccontextmanager
+    async def _maker():
+        yield db_session
+
+    return _maker
 
 
 @pytest_asyncio.fixture

--- a/packages/api/tests/test_veille_digest_builder.py
+++ b/packages/api/tests/test_veille_digest_builder.py
@@ -1,0 +1,431 @@
+"""Tests pour `VeilleDigestBuilder` (Story 18.2 / Phase 3 / Stream A).
+
+Couvre :
+- chargement contexte (config + topics + sources)
+- fetch contents avec filtre source_id × published_at × ARRAY OVERLAP topics
+- filtrage clusters pertinents + top-N
+- LLM mocké (réponse OK / réponse None / pas ready)
+- format items
+- anti-régression : ZÉRO session DB tenue pendant l'appel LLM
+"""
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from app.models.content import Content
+from app.models.enums import ContentType, SourceType
+from app.models.source import Source
+from app.models.user import UserProfile
+from app.models.veille import (
+    VeilleConfig,
+    VeilleFrequency,
+    VeilleSource,
+    VeilleSourceKind,
+    VeilleStatus,
+    VeilleTopic,
+    VeilleTopicKind,
+)
+from app.services.veille.digest_builder import VeilleDigestBuilder
+
+
+@pytest_asyncio.fixture
+async def test_user(db_session):
+    user_id = uuid4()
+    db_session.add(
+        UserProfile(
+            user_id=user_id,
+            display_name="Builder User",
+            onboarding_completed=True,
+        )
+    )
+    await db_session.commit()
+    return user_id
+
+
+@pytest_asyncio.fixture
+async def test_sources(db_session):
+    sources = [
+        Source(
+            id=uuid4(),
+            name=f"Source {i}",
+            url=f"https://s{i}.example.com",
+            feed_url=f"https://s{i}.example.com/feed-{uuid4()}.xml",
+            type=SourceType.ARTICLE,
+            theme="education",
+            is_active=True,
+            is_curated=True,
+        )
+        for i in range(3)
+    ]
+    for s in sources:
+        db_session.add(s)
+    await db_session.commit()
+    return sources
+
+
+@pytest_asyncio.fixture
+async def veille_config(db_session, test_user, test_sources):
+    """Config avec 2 topics et les 3 sources."""
+    cfg = VeilleConfig(
+        id=uuid4(),
+        user_id=test_user,
+        theme_id="education",
+        theme_label="Éducation",
+        frequency=VeilleFrequency.WEEKLY,
+        day_of_week=0,
+        delivery_hour=7,
+        timezone="Europe/Paris",
+        status=VeilleStatus.ACTIVE,
+    )
+    db_session.add(cfg)
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            VeilleTopic(
+                veille_config_id=cfg.id,
+                topic_id="t-eval",
+                label="Évaluation",
+                kind=VeilleTopicKind.PRESET,
+            ),
+            VeilleTopic(
+                veille_config_id=cfg.id,
+                topic_id="sub-dys",
+                label="Dys",
+                kind=VeilleTopicKind.PRESET,
+            ),
+        ]
+    )
+    db_session.add_all(
+        [
+            VeilleSource(
+                veille_config_id=cfg.id,
+                source_id=s.id,
+                kind=VeilleSourceKind.FOLLOWED,
+            )
+            for s in test_sources
+        ]
+    )
+    await db_session.commit()
+    await db_session.refresh(cfg)
+    return cfg
+
+
+def _make_content(
+    *,
+    source_id,
+    title: str,
+    topics: list[str],
+    published_at: datetime | None = None,
+    description: str = "Lorem ipsum",
+):
+    return Content(
+        id=uuid4(),
+        source_id=source_id,
+        title=title,
+        url=f"https://example.com/{uuid4()}",
+        description=description,
+        published_at=published_at or datetime.now(UTC),
+        content_type=ContentType.ARTICLE,
+        guid=f"guid-{uuid4()}",
+        topics=topics,
+    )
+
+
+@pytest_asyncio.fixture
+async def matching_contents(db_session, test_sources):
+    """Articles répartis sur 3 sources, plusieurs avec titre proche (cluster)."""
+    base = datetime.now(UTC) - timedelta(hours=2)
+    items = [
+        _make_content(
+            source_id=test_sources[0].id,
+            title="Réforme évaluation collège annoncée",
+            topics=["t-eval"],
+            published_at=base + timedelta(minutes=10),
+        ),
+        _make_content(
+            source_id=test_sources[1].id,
+            title="Réforme évaluation collège : détails",
+            topics=["t-eval"],
+            published_at=base + timedelta(minutes=20),
+        ),
+        _make_content(
+            source_id=test_sources[2].id,
+            title="Évaluation au collège, ce qui change",
+            topics=["t-eval"],
+            published_at=base + timedelta(minutes=30),
+        ),
+        _make_content(
+            source_id=test_sources[0].id,
+            title="Dyslexie : étude longitudinale relayée",
+            topics=["sub-dys"],
+            published_at=base + timedelta(minutes=40),
+        ),
+        _make_content(
+            source_id=test_sources[1].id,
+            title="Hors topic — sport scolaire revisited",
+            topics=["t-sport"],
+            published_at=base + timedelta(minutes=50),
+        ),
+    ]
+    for c in items:
+        db_session.add(c)
+    await db_session.commit()
+    return items
+
+
+def _make_llm_mock(*, ready: bool = True, response=None):
+    llm = MagicMock()
+    llm.is_ready = ready
+    llm.chat_json = AsyncMock(return_value=response)
+    return llm
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+
+class TestLoadInput:
+    async def test_loads_topics_and_sources(
+        self, db_session, veille_config, fake_session_maker
+    ):
+        builder = VeilleDigestBuilder(
+            llm=_make_llm_mock(ready=False), session_maker=fake_session_maker
+        )
+        async with fake_session_maker() as s:
+            ctx = await builder._load_input(s, veille_config.id)
+
+        assert ctx.config_id == veille_config.id
+        assert set(ctx.user_topic_ids) == {"t-eval", "sub-dys"}
+        assert len(ctx.user_source_ids) == 3
+        assert ctx.theme_label == "Éducation"
+
+    async def test_raises_when_config_missing(self, db_session, fake_session_maker):
+        builder = VeilleDigestBuilder(
+            llm=_make_llm_mock(ready=False), session_maker=fake_session_maker
+        )
+        async with fake_session_maker() as s:
+            with pytest.raises(ValueError, match="introuvable"):
+                await builder._load_input(s, uuid4())
+
+
+class TestBuild:
+    async def test_returns_empty_when_no_sources(
+        self, db_session, test_user, fake_session_maker
+    ):
+        cfg = VeilleConfig(
+            id=uuid4(),
+            user_id=test_user,
+            theme_id="education",
+            theme_label="Éducation",
+            frequency=VeilleFrequency.WEEKLY,
+            day_of_week=0,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            status=VeilleStatus.ACTIVE,
+        )
+        db_session.add(cfg)
+        await db_session.flush()
+        db_session.add(
+            VeilleTopic(
+                veille_config_id=cfg.id,
+                topic_id="t-eval",
+                label="Eval",
+                kind=VeilleTopicKind.PRESET,
+            )
+        )
+        await db_session.commit()
+
+        builder = VeilleDigestBuilder(
+            llm=_make_llm_mock(ready=False), session_maker=fake_session_maker
+        )
+        items = await builder.build(cfg.id)
+        assert items == []
+
+    async def test_returns_empty_when_no_matching_contents(
+        self, db_session, veille_config, fake_session_maker
+    ):
+        # Aucun article inséré → fetch_contents retourne []
+        builder = VeilleDigestBuilder(
+            llm=_make_llm_mock(ready=False), session_maker=fake_session_maker
+        )
+        items = await builder.build(veille_config.id)
+        assert items == []
+
+    async def test_filters_by_topic_overlap(
+        self,
+        db_session,
+        veille_config,
+        matching_contents,
+        fake_session_maker,
+    ):
+        """L'article tagué `t-sport` ne doit pas remonter."""
+        builder = VeilleDigestBuilder(
+            llm=_make_llm_mock(ready=False),
+            session_maker=fake_session_maker,
+            top_n=10,
+        )
+        items = await builder.build(veille_config.id)
+
+        all_titles = [a["title"] for it in items for a in it["articles"]]
+        assert all("sport scolaire" not in t for t in all_titles)
+        assert any("Réforme évaluation" in t for t in all_titles)
+
+    async def test_top_n_caps_clusters(
+        self,
+        db_session,
+        veille_config,
+        matching_contents,
+        fake_session_maker,
+    ):
+        builder = VeilleDigestBuilder(
+            llm=_make_llm_mock(ready=False),
+            session_maker=fake_session_maker,
+            top_n=1,
+        )
+        items = await builder.build(veille_config.id)
+        assert len(items) == 1
+
+    async def test_item_format(
+        self,
+        db_session,
+        veille_config,
+        matching_contents,
+        fake_session_maker,
+    ):
+        builder = VeilleDigestBuilder(
+            llm=_make_llm_mock(ready=False),
+            session_maker=fake_session_maker,
+        )
+        items = await builder.build(veille_config.id)
+        assert items, "Expected at least one item"
+        for it in items:
+            assert isinstance(it["cluster_id"], str)
+            assert isinstance(it["title"], str) and it["title"]
+            assert isinstance(it["why_it_matters"], str)
+            assert isinstance(it["articles"], list)
+            for a in it["articles"]:
+                assert {
+                    "content_id",
+                    "source_id",
+                    "title",
+                    "url",
+                    "excerpt",
+                    "published_at",
+                } <= set(a)
+
+
+class TestWhyItMatters:
+    async def test_uses_llm_response_when_ready(
+        self,
+        db_session,
+        veille_config,
+        matching_contents,
+        fake_session_maker,
+    ):
+        # Fake LLM renvoyant un mapping arbitraire ; on vérifie que le builder
+        # consomme bien le mapping.
+        captured: dict[str, str] = {}
+
+        async def _chat_json_side_effect(**kwargs):
+            # On fabrique une réponse en lisant les cluster_ids du prompt.
+            import json as _json
+
+            payload = _json.loads(kwargs["user_message"])
+            mapping = {c["cluster_id"]: "LLM-WHY" for c in payload["clusters"]}
+            captured.update(mapping)
+            return {"clusters": mapping}
+
+        llm = MagicMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(side_effect=_chat_json_side_effect)
+
+        builder = VeilleDigestBuilder(llm=llm, session_maker=fake_session_maker)
+        items = await builder.build(veille_config.id)
+        assert items
+        assert all(it["why_it_matters"] == "LLM-WHY" for it in items)
+        llm.chat_json.assert_awaited_once()
+
+    async def test_fallback_when_llm_not_ready(
+        self,
+        db_session,
+        veille_config,
+        matching_contents,
+        fake_session_maker,
+    ):
+        builder = VeilleDigestBuilder(
+            llm=_make_llm_mock(ready=False),
+            session_maker=fake_session_maker,
+        )
+        items = await builder.build(veille_config.id)
+        assert items
+        for it in items:
+            assert it["why_it_matters"]
+            assert (
+                "article" in it["why_it_matters"].lower()
+                or "sources" in it["why_it_matters"].lower()
+            )
+
+    async def test_fallback_when_llm_returns_none(
+        self,
+        db_session,
+        veille_config,
+        matching_contents,
+        fake_session_maker,
+    ):
+        llm = _make_llm_mock(ready=True, response=None)
+        builder = VeilleDigestBuilder(llm=llm, session_maker=fake_session_maker)
+        items = await builder.build(veille_config.id)
+        assert items
+        for it in items:
+            assert it["why_it_matters"]
+
+
+class TestPoolDbSafety:
+    """Anti-régression : ZÉRO session DB tenue pendant le LLM call."""
+
+    async def test_no_session_open_during_llm_call(
+        self,
+        db_session,
+        veille_config,
+        matching_contents,
+    ):
+        active_count = {"value": 0, "max": 0}
+        active_during_llm: list[int] = []
+
+        @asynccontextmanager
+        async def _tracking_maker():
+            active_count["value"] += 1
+            active_count["max"] = max(active_count["max"], active_count["value"])
+            try:
+                yield db_session
+            finally:
+                active_count["value"] -= 1
+
+        async def _chat_json_capture(**kwargs):
+            active_during_llm.append(active_count["value"])
+            import json as _json
+
+            payload = _json.loads(kwargs["user_message"])
+            return {"clusters": {c["cluster_id"]: "ok" for c in payload["clusters"]}}
+
+        llm = MagicMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(side_effect=_chat_json_capture)
+
+        builder = VeilleDigestBuilder(llm=llm, session_maker=_tracking_maker)
+        items = await builder.build(veille_config.id)
+
+        assert items
+        assert active_during_llm, "LLM was not invoked"
+        assert active_during_llm == [0], (
+            f"DB session was held during LLM call: {active_during_llm}"
+        )
+        # Sessions sont ouvertes séquentiellement (jamais 2 en même temps).
+        assert active_count["max"] == 1
+        # Toutes les sessions ont été fermées proprement.
+        assert active_count["value"] == 0

--- a/packages/api/tests/test_veille_generation_job.py
+++ b/packages/api/tests/test_veille_generation_job.py
@@ -1,14 +1,13 @@
-"""Tests pour le job de génération veille (Story 18.1).
+"""Tests pour le job de génération veille (Stories 18.1 + 18.2).
 
-Note : le job lui-même utilise `safe_async_session` qui ouvre ses propres
-sessions ; on ne peut pas mocker ça facilement. On teste donc la sous-
-fonction `run_veille_generation_for_config` qui prend une session en
-paramètre, et un test d'intégration léger pour `run_veille_generation`
-(sans connexion réelle au pool — on patche `safe_async_session`).
+Pipeline Option C : `run_veille_generation_for_config` ouvre ses propres
+sessions courtes via `session_maker`. Les tests injectent un fake maker
+qui yield la `db_session` du fixture pour persister sur la base de test.
 """
 
+from contextlib import asynccontextmanager
 from datetime import UTC, date, datetime
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
@@ -66,13 +65,14 @@ async def active_config(db_session, test_user):
 
 class TestProcessConfig:
     async def test_creates_succeeded_delivery_with_empty_items(
-        self, db_session, active_config
+        self, db_session, active_config, fake_session_maker
     ):
         target = date(2026, 5, 4)
         result = await run_veille_generation_for_config(
-            db_session, active_config.id, target_date=target
+            active_config.id,
+            target_date=target,
+            session_maker=fake_session_maker,
         )
-        await db_session.commit()
 
         assert result.veille_config_id == active_config.id
         assert result.target_date == target
@@ -84,78 +84,101 @@ class TestProcessConfig:
         assert result.generated_at is not None
 
     async def test_recomputes_next_scheduled_at(
-        self, db_session, active_config
+        self, db_session, active_config, fake_session_maker
     ):
         prev_next = active_config.next_scheduled_at
         target = date(2026, 5, 4)
         await run_veille_generation_for_config(
-            db_session, active_config.id, target_date=target
+            active_config.id,
+            target_date=target,
+            session_maker=fake_session_maker,
         )
-        await db_session.commit()
         await db_session.refresh(active_config)
 
         assert active_config.last_delivered_at is not None
         assert active_config.next_scheduled_at != prev_next
-        # weekly + lundi (dow=0) → +7 jours par rapport à last_delivered.
         diff_days = (
             active_config.next_scheduled_at - active_config.last_delivered_at
         ).days
-        assert diff_days >= 6  # au moins une semaine d'écart
+        assert diff_days >= 6
 
-    async def test_idempotent_upsert(self, db_session, active_config):
-        """Rejouer le même (config_id, target_date) → 1 seule row, attempts incrémenté."""
+    async def test_idempotent_upsert(
+        self, db_session, active_config, fake_session_maker
+    ):
+        """Rejouer (config_id, target_date) → 1 row, attempts incrémenté."""
         target = date(2026, 5, 4)
 
         first = await run_veille_generation_for_config(
-            db_session, active_config.id, target_date=target
+            active_config.id,
+            target_date=target,
+            session_maker=fake_session_maker,
         )
-        await db_session.commit()
         assert first.attempts == 1
 
         second = await run_veille_generation_for_config(
-            db_session, active_config.id, target_date=target
+            active_config.id,
+            target_date=target,
+            session_maker=fake_session_maker,
         )
-        await db_session.commit()
-        await db_session.refresh(second)
 
-        # Même row.
         assert second.id == first.id
-
-        # 1 seule row pour ce (config, date).
         all_rows = (
-            await db_session.execute(
-                select(VeilleDelivery).where(
-                    VeilleDelivery.veille_config_id == active_config.id,
-                    VeilleDelivery.target_date == target,
+            (
+                await db_session.execute(
+                    select(VeilleDelivery).where(
+                        VeilleDelivery.veille_config_id == active_config.id,
+                        VeilleDelivery.target_date == target,
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         assert len(list(all_rows)) == 1
         assert second.attempts == 2
 
-    async def test_raises_when_config_missing(self, db_session):
+    async def test_raises_when_config_missing(self, db_session, fake_session_maker):
         with pytest.raises(ValueError, match="introuvable"):
             await run_veille_generation_for_config(
-                db_session, uuid4(), target_date=date(2026, 5, 4)
+                uuid4(),
+                target_date=date(2026, 5, 4),
+                session_maker=fake_session_maker,
             )
+
+    async def test_persists_items_from_builder(
+        self, db_session, active_config, fake_session_maker
+    ):
+        """Avec un builder qui retourne des items → ils sont persistés."""
+        items = [
+            {
+                "cluster_id": "abc-123",
+                "title": "Sujet test",
+                "articles": [],
+                "why_it_matters": "Important.",
+            }
+        ]
+        builder = AsyncMock()
+        builder.build = AsyncMock(return_value=items)
+
+        result = await run_veille_generation_for_config(
+            active_config.id,
+            target_date=date(2026, 5, 4),
+            session_maker=fake_session_maker,
+            builder=builder,
+        )
+
+        assert result.items == items
+        assert result.generation_state == VeilleGenerationState.SUCCEEDED
+        builder.build.assert_awaited_once_with(active_config.id)
 
 
 class TestRunVeilleGenerationScanner:
     async def test_no_due_configs_logs_and_returns(self, db_session):
         """Si aucune config n'est due → pas de delivery créée."""
-        # On patche `safe_async_session` pour qu'il yield notre db_session,
-        # afin que le scanner SELECT s'exécute sur la fixture (pas sur le
-        # vrai pool). Le scanner utilise ALSO `safe_async_session` dans le
-        # bloc per-config — comme il n'y a pas de config due, ce bloc n'est
-        # jamais atteint.
-        from contextlib import asynccontextmanager
 
         @asynccontextmanager
         async def _fake_session():
             yield db_session
 
-        with patch(
-            "app.jobs.veille_generation_job.safe_async_session", _fake_session
-        ):
+        with patch("app.jobs.veille_generation_job.safe_async_session", _fake_session):
             await run_veille_generation(target_date=date(2026, 5, 4))
-        # Pas d'exception → OK.


### PR DESCRIPTION
## Quoi

Phase 3 / Stream A de la Story 18.2 « Ma veille » : le scanner `*/30 min`
génère désormais des `items` réels au lieu de `[]`, sous forme de clusters
thématiques d'articles + un mini `why_it_matters` LLM (Mistral).

- Nouveau service `VeilleDigestBuilder` : `Content.topics ARRAY OVERLAP`
  sur `(source_id, published_at)` → clustering Jaccard via
  `ImportanceDetector.build_topic_clusters` → 1 appel batch
  `EditorialLLMClient.chat_json` pour les `why_it_matters` → fallback
  déterministe si `MISTRAL_API_KEY` absent.
- `run_veille_generation_for_config` refactoré en 3 phases (Option C) :
  Phase 1 (UPSERT RUNNING) + Phase 3 (UPDATE SUCCEEDED) ouvrent leurs
  propres sessions courtes ; le builder ouvre les siennes en interne.
  **Aucune connexion DB n'est retenue pendant les 3-5 s de l'appel LLM**
  (pattern post-incident #363 — saturation pool QueuePool).
- Route `POST /api/veille/deliveries/generate` : drop du `Depends(get_db)`
  qui aurait gardé la session checked-out pendant tout le LLM call.
- Schémas Pydantic `VeilleDeliveryArticle` + `VeilleDeliveryItem` pour
  contractualiser le format côté front (Stream B 18.3).
- Type alias `SessionMaker` mutualisé dans `app/database.py` ; fixture
  `fake_session_maker` mutualisée dans `tests/conftest.py`.

## Pourquoi

Phase 2 (PR #524) avait livré le scanner avec un placeholder `items=[]`.
Cette PR remplace le placeholder par la pipeline réelle, prête à être
consommée par les Streams B (front wiring) et C (push notifs) — sans
nouvelle migration DB et sans modifier le scheduler.

## Comment ça a été vérifié

- [x] `pytest -v` complet : 926 passed, 13 skipped, **1 fail
  pré-existant non lié** (`test_patch_increments_refusal_count` — bug TZ
  reproduit sur arbre vierge, hors scope veille).
- [x] Tests veille ciblés : 17 verts (`test_veille_digest_builder.py`
  avec un test d'anti-régression vérifiant que la session DB n'est jamais
  ouverte pendant le LLM call ; `test_veille_generation_job.py`).
- [x] `ruff format --check` + `ruff check` : clean.
- [x] Revue agentique reuse + qualité + efficacité passée — fixes
  appliqués (route force_generate, asserts → ValueError, type alias
  mutualisé, fixture mutualisée, flatten LLM guards).

## Zones à risque

- **Pool DB** (transversal, historique d'incidents). Le test
  `test_no_session_open_during_llm_call` verrouille l'invariant.
- **`Content.topics` ARRAY OVERLAP** sans index GIN dédié. Le filtre
  composite `(source_id, published_at)` réduit déjà le sous-ensemble ;
  à mesurer en prod, et créer une migration GIN si > 1 s.
- **Alembic 2 heads** (`gn01` + `vl01`) — pré-existant, introduit par
  la PR #524 qui a oublié de chaîner `down_revision` sur `gn01`. Cette
  PR n'ajoute pas de migration ; à corriger dans une PR maintenance
  séparée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)