### PR TITLE
fix(onboarding): écrans questionnaire scrollables sur petit écran

### DIFF
--- a/apps/mobile/lib/features/onboarding/screens/questions/approach_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/approach_question.dart
@@ -21,54 +21,62 @@ class ApproachQuestion extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const Spacer(flex: 2),
+          Expanded(
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const SizedBox(height: FacteurSpacing.space8),
 
-          // Question
-          Text(
-            OnboardingStrings.q4Title,
-            style: Theme.of(context).textTheme.displayLarge,
-            textAlign: TextAlign.center,
-          ),
-
-          const SizedBox(height: FacteurSpacing.space8),
-
-          // Options binaires
-          IntrinsicHeight(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Expanded(
-                  child: BinarySelectionCard(
-                    emoji: '⚡', // Direct
-                    label: OnboardingStrings.q4DirectLabel,
-                    subtitle: OnboardingStrings.q4DirectSubtitle,
-                    isSelected: selectedApproach == 'direct',
-                    onTap: () {
-                      ref
-                          .read(onboardingProvider.notifier)
-                          .selectApproach('direct');
-                    },
+                  Text(
+                    OnboardingStrings.q4Title,
+                    style: Theme.of(context).textTheme.displayLarge,
+                    textAlign: TextAlign.center,
                   ),
-                ),
-                const SizedBox(width: FacteurSpacing.space3),
-                Expanded(
-                  child: BinarySelectionCard(
-                    emoji: '🔍', // Détaillé
-                    label: OnboardingStrings.q4DetailedLabel,
-                    subtitle: OnboardingStrings.q4DetailedSubtitle,
-                    isSelected: selectedApproach == 'detailed',
-                    onTap: () {
-                      ref
-                          .read(onboardingProvider.notifier)
-                          .selectApproach('detailed');
-                    },
+
+                  const SizedBox(height: FacteurSpacing.space8),
+
+                  IntrinsicHeight(
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Expanded(
+                          child: BinarySelectionCard(
+                            emoji: '⚡',
+                            label: OnboardingStrings.q4DirectLabel,
+                            subtitle: OnboardingStrings.q4DirectSubtitle,
+                            isSelected: selectedApproach == 'direct',
+                            onTap: () {
+                              ref
+                                  .read(onboardingProvider.notifier)
+                                  .selectApproach('direct');
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: FacteurSpacing.space3),
+                        Expanded(
+                          child: BinarySelectionCard(
+                            emoji: '🔍',
+                            label: OnboardingStrings.q4DetailedLabel,
+                            subtitle: OnboardingStrings.q4DetailedSubtitle,
+                            isSelected: selectedApproach == 'detailed',
+                            onTap: () {
+                              ref
+                                  .read(onboardingProvider.notifier)
+                                  .selectApproach('detailed');
+                            },
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-              ],
+
+                  const SizedBox(height: FacteurSpacing.space6),
+                ],
+              ),
             ),
           ),
-
-          const Spacer(flex: 3),
 
           DelayedContinueButton(
             visible: selectedApproach != null,

--- a/apps/mobile/lib/features/onboarding/screens/questions/article_count_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/article_count_question.dart
@@ -22,93 +22,100 @@ class ArticleCountQuestion extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const Spacer(flex: 2),
+          Expanded(
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const SizedBox(height: FacteurSpacing.space8),
 
-          Text(
-            OnboardingStrings.articleCountTitle,
-            style: Theme.of(context).textTheme.displayLarge,
-            textAlign: TextAlign.center,
-          ),
-
-          const SizedBox(height: FacteurSpacing.space3),
-
-          Text(
-            OnboardingStrings.articleCountSubtitle,
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium
-                ?.copyWith(color: colors.textSecondary),
-            textAlign: TextAlign.center,
-          ),
-
-          const SizedBox(height: FacteurSpacing.space8),
-
-          // 3 articles
-          SelectionCard(
-            emoji: '🌱',
-            label: OnboardingStrings.articleCount3Label,
-            subtitle: OnboardingStrings.articleCount3Subtitle,
-            isSelected: selectedCount == 3,
-            onTap: () {
-              ref.read(onboardingProvider.notifier).selectDailyArticleCount(3);
-            },
-          ),
-
-          const SizedBox(height: FacteurSpacing.space3),
-
-          // 5 articles (recommended)
-          Stack(
-            clipBehavior: Clip.none,
-            children: [
-              SelectionCard(
-                emoji: '🪴',
-                label: OnboardingStrings.articleCount5Label,
-                subtitle: OnboardingStrings.articleCount5Subtitle,
-                isSelected: selectedCount == 5,
-                onTap: () {
-                  ref
-                      .read(onboardingProvider.notifier)
-                      .selectDailyArticleCount(5);
-                },
-              ),
-              Positioned(
-                top: -8,
-                right: 12,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: FacteurSpacing.space2,
-                    vertical: FacteurSpacing.space1,
+                  Text(
+                    OnboardingStrings.articleCountTitle,
+                    style: Theme.of(context).textTheme.displayLarge,
+                    textAlign: TextAlign.center,
                   ),
-                  decoration: BoxDecoration(
-                    color: colors.primary,
-                    borderRadius: BorderRadius.circular(FacteurRadius.small),
+
+                  const SizedBox(height: FacteurSpacing.space3),
+
+                  Text(
+                    OnboardingStrings.articleCountSubtitle,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyMedium
+                        ?.copyWith(color: colors.textSecondary),
+                    textAlign: TextAlign.center,
                   ),
-                  child: Text(
-                    OnboardingStrings.articleCount5Recommended,
-                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: Colors.white,
-                          fontWeight: FontWeight.w600,
+
+                  const SizedBox(height: FacteurSpacing.space8),
+
+                  SelectionCard(
+                    emoji: '🌱',
+                    label: OnboardingStrings.articleCount3Label,
+                    subtitle: OnboardingStrings.articleCount3Subtitle,
+                    isSelected: selectedCount == 3,
+                    onTap: () {
+                      ref.read(onboardingProvider.notifier).selectDailyArticleCount(3);
+                    },
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space3),
+
+                  Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      SelectionCard(
+                        emoji: '🪴',
+                        label: OnboardingStrings.articleCount5Label,
+                        subtitle: OnboardingStrings.articleCount5Subtitle,
+                        isSelected: selectedCount == 5,
+                        onTap: () {
+                          ref
+                              .read(onboardingProvider.notifier)
+                              .selectDailyArticleCount(5);
+                        },
+                      ),
+                      Positioned(
+                        top: -8,
+                        right: 12,
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: FacteurSpacing.space2,
+                            vertical: FacteurSpacing.space1,
+                          ),
+                          decoration: BoxDecoration(
+                            color: colors.primary,
+                            borderRadius: BorderRadius.circular(FacteurRadius.small),
+                          ),
+                          child: Text(
+                            OnboardingStrings.articleCount5Recommended,
+                            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                          ),
                         ),
+                      ),
+                    ],
                   ),
-                ),
+
+                  const SizedBox(height: FacteurSpacing.space3),
+
+                  SelectionCard(
+                    emoji: '🌳',
+                    label: OnboardingStrings.articleCount7Label,
+                    subtitle: OnboardingStrings.articleCount7Subtitle,
+                    isSelected: selectedCount == 7,
+                    onTap: () {
+                      ref.read(onboardingProvider.notifier).selectDailyArticleCount(7);
+                    },
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space6),
+                ],
               ),
-            ],
+            ),
           ),
-
-          const SizedBox(height: FacteurSpacing.space3),
-
-          // 7 articles
-          SelectionCard(
-            emoji: '🌳',
-            label: OnboardingStrings.articleCount7Label,
-            subtitle: OnboardingStrings.articleCount7Subtitle,
-            isSelected: selectedCount == 7,
-            onTap: () {
-              ref.read(onboardingProvider.notifier).selectDailyArticleCount(7);
-            },
-          ),
-
-          const Spacer(flex: 3),
 
           DelayedContinueButton(
             visible: selectedCount != null,

--- a/apps/mobile/lib/features/onboarding/screens/questions/digest_mode_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/digest_mode_question.dart
@@ -25,127 +25,128 @@ class DigestModeQuestion extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const Spacer(flex: 2),
+          Expanded(
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const SizedBox(height: FacteurSpacing.space8),
 
-          Text(
-            '🌿 Rester serein ?',
-            style: Theme.of(context).textTheme.displayLarge,
-            textAlign: TextAlign.center,
-          ),
+                  Text(
+                    '🌿 Rester serein ?',
+                    style: Theme.of(context).textTheme.displayLarge,
+                    textAlign: TextAlign.center,
+                  ),
 
-          const SizedBox(height: FacteurSpacing.space3),
+                  const SizedBox(height: FacteurSpacing.space3),
 
-          Text.rich(
-            TextSpan(
-              style: Theme.of(context)
-                  .textTheme
-                  .bodyMedium
-                  ?.copyWith(color: colors.textSecondary),
-              children: const [
-                TextSpan(
-                    text: OnboardingStrings.digestModeSereinPart1),
-                TextSpan(
-                  text: OnboardingStrings.digestModeSereinBold1,
-                  style: TextStyle(fontWeight: FontWeight.w700),
-                ),
-                TextSpan(
-                    text: OnboardingStrings.digestModeSereinPart2),
-                TextSpan(
-                  text: OnboardingStrings.digestModeSereinBold2,
-                  style: TextStyle(fontWeight: FontWeight.w700),
-                ),
-                TextSpan(
-                    text: OnboardingStrings.digestModeSereinPart3),
-                TextSpan(
-                  text: OnboardingStrings.digestModeSereinBold3,
-                  style: TextStyle(fontWeight: FontWeight.w700),
-                ),
-                TextSpan(
-                    text: OnboardingStrings.digestModeSereinPart4),
-              ],
+                  Text.rich(
+                    TextSpan(
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyMedium
+                          ?.copyWith(color: colors.textSecondary),
+                      children: const [
+                        TextSpan(text: OnboardingStrings.digestModeSereinPart1),
+                        TextSpan(
+                          text: OnboardingStrings.digestModeSereinBold1,
+                          style: TextStyle(fontWeight: FontWeight.w700),
+                        ),
+                        TextSpan(text: OnboardingStrings.digestModeSereinPart2),
+                        TextSpan(
+                          text: OnboardingStrings.digestModeSereinBold2,
+                          style: TextStyle(fontWeight: FontWeight.w700),
+                        ),
+                        TextSpan(text: OnboardingStrings.digestModeSereinPart3),
+                        TextSpan(
+                          text: OnboardingStrings.digestModeSereinBold3,
+                          style: TextStyle(fontWeight: FontWeight.w700),
+                        ),
+                        TextSpan(text: OnboardingStrings.digestModeSereinPart4),
+                      ],
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space8),
+
+                  ElevatedButton.icon(
+                    onPressed: () {
+                      HapticFeedback.lightImpact();
+                      ref.read(onboardingProvider.notifier).selectDigestMode('serein');
+                    },
+                    icon: Icon(SereinColors.sereinIcon, size: 18),
+                    label: const Text('Oui, rester serein'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: SereinColors.sereinColor,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 24),
+                      textStyle: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(FacteurRadius.large),
+                      ),
+                    ),
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space3),
+
+                  OutlinedButton.icon(
+                    onPressed: () {
+                      HapticFeedback.lightImpact();
+                      ref
+                          .read(onboardingProvider.notifier)
+                          .selectDigestMode('pour_vous');
+                    },
+                    icon: Icon(SereinColors.normalIcon, size: 18),
+                    label: const Text('Non, tout voir'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: colors.textPrimary,
+                      padding: const EdgeInsets.symmetric(vertical: 24),
+                      textStyle: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      side: BorderSide(
+                        color: colors.textTertiary.withOpacity(0.3),
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(FacteurRadius.large),
+                      ),
+                    ),
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space2),
+
+                  TextButton(
+                    onPressed: () {
+                      HapticFeedback.selectionClick();
+                      ref
+                          .read(onboardingProvider.notifier)
+                          .markDigestMode('serein');
+                      context.pushNamed(
+                        RouteNames.myInterests,
+                        queryParameters: const {'serein': '1'},
+                      );
+                    },
+                    child: Text(
+                      OnboardingStrings.personalizeSereinCta,
+                      style: TextStyle(
+                        color: SereinColors.sereinColor,
+                        fontWeight: FontWeight.w600,
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space6),
+                ],
+              ),
             ),
-            textAlign: TextAlign.center,
           ),
-
-          const SizedBox(height: FacteurSpacing.space8),
-
-          // Primary: Oui, rester serein
-          ElevatedButton.icon(
-            onPressed: () {
-              HapticFeedback.lightImpact();
-              ref.read(onboardingProvider.notifier).selectDigestMode('serein');
-            },
-            icon: Icon(SereinColors.sereinIcon, size: 18),
-            label: const Text('Oui, rester serein'),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: SereinColors.sereinColor,
-              foregroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(vertical: 24),
-              textStyle: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-              ),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(FacteurRadius.large),
-              ),
-            ),
-          ),
-
-          const SizedBox(height: FacteurSpacing.space3),
-
-          // Secondary: Non, tout voir
-          OutlinedButton.icon(
-            onPressed: () {
-              HapticFeedback.lightImpact();
-              ref
-                  .read(onboardingProvider.notifier)
-                  .selectDigestMode('pour_vous');
-            },
-            icon: Icon(SereinColors.normalIcon, size: 18),
-            label: const Text('Non, tout voir'),
-            style: OutlinedButton.styleFrom(
-              foregroundColor: colors.textPrimary,
-              padding: const EdgeInsets.symmetric(vertical: 24),
-              textStyle: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-              ),
-              side: BorderSide(
-                color: colors.textTertiary.withOpacity(0.3),
-              ),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(FacteurRadius.large),
-              ),
-            ),
-          ),
-
-          const SizedBox(height: FacteurSpacing.space2),
-
-          // Optional: personalise the serein filter before continuing.
-          TextButton(
-            onPressed: () {
-              HapticFeedback.selectionClick();
-              // Mark the choice but stay on this question so the user returns
-              // here after configuring exclusions.
-              ref
-                  .read(onboardingProvider.notifier)
-                  .markDigestMode('serein');
-              context.pushNamed(
-                RouteNames.myInterests,
-                queryParameters: const {'serein': '1'},
-              );
-            },
-            child: Text(
-              OnboardingStrings.personalizeSereinCta,
-              style: TextStyle(
-                color: SereinColors.sereinColor,
-                fontWeight: FontWeight.w600,
-                decoration: TextDecoration.underline,
-              ),
-            ),
-          ),
-
-          const Spacer(flex: 3),
 
           DelayedContinueButton(
             visible: selectedMode != null,

--- a/apps/mobile/lib/features/onboarding/screens/questions/gamification_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/gamification_question.dart
@@ -23,70 +23,78 @@ class GamificationQuestion extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const Spacer(flex: 2),
+          Expanded(
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const SizedBox(height: FacteurSpacing.space8),
 
-          // Question
-          Text(
-            OnboardingStrings.q8Title,
-            style: Theme.of(context).textTheme.displayLarge,
-            textAlign: TextAlign.center,
-          ),
+                  Text(
+                    OnboardingStrings.q8Title,
+                    style: Theme.of(context).textTheme.displayLarge,
+                    textAlign: TextAlign.center,
+                  ),
 
-          const SizedBox(height: FacteurSpacing.space3),
+                  const SizedBox(height: FacteurSpacing.space3),
 
-          Text.rich(
-            TextSpan(
-              style: Theme.of(
-                context,
-              ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
-              children: [
-                const TextSpan(text: OnboardingStrings.q8SubtitlePart1),
-                TextSpan(
-                  text: OnboardingStrings.q8SubtitleBold1,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: colors.textSecondary,
-                        fontWeight: FontWeight.w700,
-                      ),
-                ),
-                const TextSpan(text: OnboardingStrings.q8SubtitlePart2),
-                TextSpan(
-                  text: OnboardingStrings.q8SubtitleBold2,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: colors.textSecondary,
-                        fontWeight: FontWeight.w700,
-                      ),
-                ),
-                const TextSpan(text: OnboardingStrings.q8SubtitlePart3),
-              ],
+                  Text.rich(
+                    TextSpan(
+                      style: Theme.of(
+                        context,
+                      ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
+                      children: [
+                        const TextSpan(text: OnboardingStrings.q8SubtitlePart1),
+                        TextSpan(
+                          text: OnboardingStrings.q8SubtitleBold1,
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                color: colors.textSecondary,
+                                fontWeight: FontWeight.w700,
+                              ),
+                        ),
+                        const TextSpan(text: OnboardingStrings.q8SubtitlePart2),
+                        TextSpan(
+                          text: OnboardingStrings.q8SubtitleBold2,
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                color: colors.textSecondary,
+                                fontWeight: FontWeight.w700,
+                              ),
+                        ),
+                        const TextSpan(text: OnboardingStrings.q8SubtitlePart3),
+                      ],
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space8),
+
+                  SelectionCard(
+                    emoji: '✅',
+                    label: OnboardingStrings.q8YesLabel,
+                    isSelected: gamificationEnabled == true,
+                    onTap: () {
+                      ref.read(onboardingProvider.notifier).selectGamification(true);
+                    },
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space3),
+
+                  SelectionCard(
+                    emoji: '🚫',
+                    label: OnboardingStrings.q8NoLabel,
+                    subtitle: OnboardingStrings.q8NoSubtitle,
+                    isSelected: gamificationEnabled == false,
+                    onTap: () {
+                      ref.read(onboardingProvider.notifier).selectGamification(false);
+                    },
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space6),
+                ],
+              ),
             ),
-            textAlign: TextAlign.center,
           ),
-
-          const SizedBox(height: FacteurSpacing.space8),
-
-          // Options
-          SelectionCard(
-            emoji: '✅', // Oui
-            label: OnboardingStrings.q8YesLabel,
-            isSelected: gamificationEnabled == true,
-            onTap: () {
-              ref.read(onboardingProvider.notifier).selectGamification(true);
-            },
-          ),
-
-          const SizedBox(height: FacteurSpacing.space3),
-
-          SelectionCard(
-            emoji: '🚫', // Non
-            label: OnboardingStrings.q8NoLabel,
-            subtitle: OnboardingStrings.q8NoSubtitle,
-            isSelected: gamificationEnabled == false,
-            onTap: () {
-              ref.read(onboardingProvider.notifier).selectGamification(false);
-            },
-          ),
-
-          const Spacer(flex: 3),
 
           DelayedContinueButton(
             visible: gamificationEnabled != null,

--- a/apps/mobile/lib/features/onboarding/screens/questions/objective_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/objective_question.dart
@@ -51,59 +51,66 @@ class _ObjectiveQuestionState extends ConsumerState<ObjectiveQuestion> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const Spacer(flex: 2),
+          Expanded(
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const SizedBox(height: FacteurSpacing.space8),
 
-          // Question
-          Text(
-            OnboardingStrings.q1Title,
-            style: Theme.of(context).textTheme.displayLarge,
-            textAlign: TextAlign.center,
+                  Text(
+                    OnboardingStrings.q1Title,
+                    style: Theme.of(context).textTheme.displayLarge,
+                    textAlign: TextAlign.center,
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space3),
+
+                  Text(
+                    OnboardingStrings.q1Subtitle,
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
+                    textAlign: TextAlign.center,
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space6),
+
+                  SelectionCard(
+                    emoji: '🔊',
+                    label: OnboardingStrings.q1NoiseLabel,
+                    subtitle: OnboardingStrings.q1NoiseSubtitle,
+                    isSelected: _selectedObjectives.contains('noise'),
+                    onTap: () => _toggle('noise'),
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space3),
+
+                  SelectionCard(
+                    emoji: '⚖️',
+                    label: OnboardingStrings.q1BiasLabel,
+                    subtitle: OnboardingStrings.q1BiasSubtitle,
+                    isSelected: _selectedObjectives.contains('bias'),
+                    onTap: () => _toggle('bias'),
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space3),
+
+                  SelectionCard(
+                    emoji: '👎',
+                    label: OnboardingStrings.q1AnxietyLabel,
+                    subtitle: OnboardingStrings.q1AnxietySubtitle,
+                    isSelected: _selectedObjectives.contains('anxiety'),
+                    onTap: () => _toggle('anxiety'),
+                  ),
+
+                  const SizedBox(height: FacteurSpacing.space6),
+                ],
+              ),
+            ),
           ),
 
-          const SizedBox(height: FacteurSpacing.space3),
-
-          Text(
-            OnboardingStrings.q1Subtitle,
-            style: Theme.of(
-              context,
-            ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
-            textAlign: TextAlign.center,
-          ),
-
-          const SizedBox(height: FacteurSpacing.space6),
-
-          // Options
-          SelectionCard(
-            emoji: '🔊',
-            label: OnboardingStrings.q1NoiseLabel,
-            subtitle: OnboardingStrings.q1NoiseSubtitle,
-            isSelected: _selectedObjectives.contains('noise'),
-            onTap: () => _toggle('noise'),
-          ),
-
-          const SizedBox(height: FacteurSpacing.space3),
-
-          SelectionCard(
-            emoji: '⚖️',
-            label: OnboardingStrings.q1BiasLabel,
-            subtitle: OnboardingStrings.q1BiasSubtitle,
-            isSelected: _selectedObjectives.contains('bias'),
-            onTap: () => _toggle('bias'),
-          ),
-
-          const SizedBox(height: FacteurSpacing.space3),
-
-          SelectionCard(
-            emoji: '👎',
-            label: OnboardingStrings.q1AnxietyLabel,
-            subtitle: OnboardingStrings.q1AnxietySubtitle,
-            isSelected: _selectedObjectives.contains('anxiety'),
-            onTap: () => _toggle('anxiety'),
-          ),
-
-          const Spacer(flex: 3),
-
-          // Continue button (disabled if empty)
           ElevatedButton(
             onPressed: _selectedObjectives.isEmpty
                 ? null

--- a/apps/mobile/lib/features/onboarding/screens/questions/response_style_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/response_style_question.dart
@@ -21,53 +21,62 @@ class ResponseStyleQuestion extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const Spacer(flex: 2),
+          Expanded(
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const SizedBox(height: FacteurSpacing.space8),
 
-          // Question
-          Text(
-            OnboardingStrings.q6Title,
-            style: Theme.of(context).textTheme.displayLarge,
-            textAlign: TextAlign.center,
-          ),
-
-          const SizedBox(height: FacteurSpacing.space8),
-
-          IntrinsicHeight(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Expanded(
-                  child: BinarySelectionCard(
-                    emoji: '⚔️', // Tranché
-                    label: OnboardingStrings.q6DecisiveLabel,
-                    subtitle: OnboardingStrings.q6DecisiveSubtitle,
-                    isSelected: selectedStyle == 'decisive',
-                    onTap: () {
-                      ref
-                          .read(onboardingProvider.notifier)
-                          .selectResponseStyle('decisive');
-                    },
+                  Text(
+                    OnboardingStrings.q6Title,
+                    style: Theme.of(context).textTheme.displayLarge,
+                    textAlign: TextAlign.center,
                   ),
-                ),
-                const SizedBox(width: FacteurSpacing.space3),
-                Expanded(
-                  child: BinarySelectionCard(
-                    emoji: '⚖️', // Nuancé
-                    label: OnboardingStrings.q6NuancedLabel,
-                    subtitle: OnboardingStrings.q6NuancedSubtitle,
-                    isSelected: selectedStyle == 'nuanced',
-                    onTap: () {
-                      ref
-                          .read(onboardingProvider.notifier)
-                          .selectResponseStyle('nuanced');
-                    },
+
+                  const SizedBox(height: FacteurSpacing.space8),
+
+                  IntrinsicHeight(
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Expanded(
+                          child: BinarySelectionCard(
+                            emoji: '⚔️',
+                            label: OnboardingStrings.q6DecisiveLabel,
+                            subtitle: OnboardingStrings.q6DecisiveSubtitle,
+                            isSelected: selectedStyle == 'decisive',
+                            onTap: () {
+                              ref
+                                  .read(onboardingProvider.notifier)
+                                  .selectResponseStyle('decisive');
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: FacteurSpacing.space3),
+                        Expanded(
+                          child: BinarySelectionCard(
+                            emoji: '⚖️',
+                            label: OnboardingStrings.q6NuancedLabel,
+                            subtitle: OnboardingStrings.q6NuancedSubtitle,
+                            isSelected: selectedStyle == 'nuanced',
+                            onTap: () {
+                              ref
+                                  .read(onboardingProvider.notifier)
+                                  .selectResponseStyle('nuanced');
+                            },
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-              ],
+
+                  const SizedBox(height: FacteurSpacing.space6),
+                ],
+              ),
             ),
           ),
-
-          const Spacer(flex: 3),
 
           DelayedContinueButton(
             visible: selectedStyle != null,


### PR DESCRIPTION
## What

Rend les 6 écrans du questionnaire d'onboarding scrollables. Le pattern `Column` + `Spacer` est remplacé par `Expanded(child: SingleChildScrollView(...))` pour le contenu, avec le bouton CTA épinglé en bas hors du scroll.

## Why

Sur iPhone SE (375×667), les `Spacer` empêchaient la visibilité du bouton CTA, rendant impossible la validation d'une réponse et la progression dans l'onboarding.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)