### PR TITLE
feat(veille): E2E front wiring + dashboard + historique + push notifs (18.3)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,62 +1,82 @@
-# PR — Widget Android : fix `Class not allowed to be inflated android.view.View`
+# PR — Story 18.3 « Ma veille » end-to-end (front wiring + historique + push notifs)
 
 ## Why
 
-Le widget Android Facteur était cassé sur Samsung One UI depuis 4 itérations
-(PR #478, #501, #505, #525). Symptôme : "Impossible d'ajouter le widget" +
-écran noir. Aucune itération n'avait jamais lu le logcat.
+Phase E2E de la feature « Ma veille ». Le backend pipeline (18.1 + 18.2,
+PR #524 + #535) produit des `items[]` réels avec clusters + `why_it_matters`
+LLM. Côté front Flutter, le flow 4-steps était encore 100 % mock :
 
-Logcat capté sur Samsung S24 le 2026-05-01 :
+- `submit()` no-op à `apps/mobile/lib/features/veille/providers/veille_config_provider.dart:142` ;
+- aucun écran historique livraisons ni détail livraison ;
+- aucune notif planifiée à la livraison.
 
-```
-W AppWidgetHostView: android.widget.RemoteViews$ActionException:
-  android.view.InflateException: Binary XML file line #123 in
-  com.example.facteur:layout/widget_article_row:
-  Class not allowed to be inflated android.view.View
-```
-
-`RemoteViews` impose une whitelist stricte des classes inflatables (API ≥ 31,
-l'app cible API 36). `android.view.View` brut n'est PAS autorisé. Allowlist :
-`AdapterViewFlipper, FrameLayout, GridLayout, GridView, LinearLayout, ListView,
-RelativeLayout, StackView, ViewFlipper, AnalogClock, Button, Chronometer,
-ImageButton, ImageView, ProgressBar, RadioGroup, RadioButton, TextClock,
-TextView, ViewStub, Space`.
-
-`widget_article_row.xml` contenait deux `<View>` :
-- L. 120 : spacer flex (`layout_weight="1"`) — entre `row_source_name` et `row_time`.
-- L. 133 : séparateur 1dp avec background.
-
-→ L'inflate échouait dès la première row, l'host launcher avortait le bind.
+Cette PR ferme la boucle « configuration → livraison → consommation » sur
+l'app et planifie une notif locale (pas de FCM côté projet) pour rappeler
+au user que sa veille est tombée.
 
 ## What
 
-2 lignes XML modifiées dans `widget_article_row.xml` :
+### Front wiring
 
-- `<View layout_weight="1"/>` (spacer) → `<Space layout_weight="1"/>`
-- `<View ... background="@color/facteur_border"/>` (séparateur) → `<TextView ...>`
-  (TextView est whitelisté et accepte un `android:background`).
+- `submit()` étape 4 → POST `/api/veille/config` (real `VeilleRepository`).
+- Suggestions topics/sources réelles à l'entrée des étapes 2 et 3 (POST
+  `/api/veille/suggestions/{topics,sources}` avec spinner bloquant +
+  fallback mock UX si erreur réseau).
+- Redirect automatique `/veille/config` → `/veille/dashboard` quand
+  `GET /api/veille/config` retourne 200 (au lieu de relancer le flow).
+- Filtrage des sources mock-only au submit (sans `apiSourceId` UUID API,
+  elles ne peuvent pas être ingérées par le backend).
 
-Aucun changement Kotlin. Aucun changement architectural.
+### Nouveaux écrans
 
-## Investigation report
+- **Dashboard** `/veille/dashboard` : thème, topics, sources, schedule,
+  countdown next_scheduled_at, boutons Modifier / Pause / Supprimer / Historique.
+- **Historique** `/veille/deliveries` : liste 20 dernières livraisons,
+  pull-to-refresh, empty state.
+- **Détail livraison** `/veille/deliveries/:id` : clusters + `why_it_matters` +
+  articles → tap ouvre InAppWebView (`launchUrl` mode `inAppBrowserView`).
+  Gère les états `running`/`pending` (loader) et `failed` (state d'erreur sympa).
 
-Détails complets : `.context/widget-android-investigation.md`
-(setup, logcat filtré, dumpsys, conclusion).
+### Push notif locale + deeplink
+
+- `PushNotificationService.scheduleVeilleNotification(scheduledAt)` (NotifId=3,
+  channel `veille_channel`). Planifié à `next_scheduled_at + 30 min` pour
+  laisser le scanner */30 min générer la livraison avant que la notif tombe.
+- Cancel automatique sur PATCH status=paused / DELETE.
+- Mapping deeplink `io.supabase.facteur://veille/dashboard` ajouté à
+  `DeepLinkService.parse` (`WidgetDeepLinkTarget.veille`).
+
+### Architecture
+
+- Pas de modif backend (la pipeline fait déjà tout).
+- Patterns réutilisés : `digest_repository.dart` (Dio + exceptions typées),
+  `digest_provider.dart` (AsyncNotifier — simplifié load-on-enter),
+  `scheduleDailyDigestNotification` (zonedSchedule local).
+- Retries bornés (interceptor existant : 2 retries sur 5xx ≠503, 0 sur 4xx) —
+  pas de retries cascadés type stale-fallback du digest (anti-cascade pool DB).
+- Story doc : `docs/stories/core/18.3.veille-e2e.md`.
 
 ## Test plan
 
-- [ ] Build APK release sur la branche, install sur Samsung One UI réel
-- [ ] Long-press écran d'accueil → Widgets → Facteur → drag
-- [ ] Le widget s'affiche avec les 5 articles (header, rows, footer CTA)
-- [ ] Aucune erreur "Impossible d'ajouter le widget"
-- [ ] Tap sur une row ouvre le deep link `io.supabase.facteur://digest/<id>`
-- [ ] Tap sur le footer CTA ouvre l'app
-- [ ] (Optionnel) tester aussi sur émulateur Pixel pour valider la généralité
+- [x] `flutter analyze lib/features/veille` → 1 info-level lint, 0 erreur.
+- [x] `flutter test test/features/veille/models/veille_models_test.dart` →
+  15 tests verts (parsing fromJson + sérialisation toJson).
+- [x] `flutter test test/core/services/{deep_link_service,push_notification_service_copy}_test.dart`
+  → 14 tests verts (anti-régression, +2 tests pour le mapping veille deep link).
+- [x] `pytest -q` backend (anti-régression) : 838 passed, 85 errors —
+  TOUTES les errors sont `psycopg.OperationalError` (DB locale Supabase non
+  démarrée, infra), aucune cassée par cette PR.
+- [ ] `/validate-feature` (Chrome MCP, viewport 390x844) — scénarios :
+  happy path, redirect dashboard, pause/reprendre, suppression, livraison
+  failed, erreur réseau suggestions, tap notif. Cf. `.context/qa-handoff.md`.
+- [ ] Smoke API local : `uvicorn app.main:app --port 8080`, configure une
+  veille, vérifier POST /config + log `PushNotificationService: veille scheduled @ ...`,
+  POST /deliveries/generate (debug), refresh historique.
 
 ## Out of scope
 
-- Pas de changement de stratégie de rendu (rester sur `addView` inline,
-  validé par les logs : `onUpdate id=25 json.len=2581` + bind système OK).
-- Pas de retour à `RemoteViewsService`/`Factory` (cassé sur Samsung).
-- Pas de changement de taille du widget (`minHeight=340dp` OK, le launcher
-  l'accepte — c'était bien le rendu qui cassait, pas le sizing).
+- Multi-veilles par user (V2/V3).
+- Carte « Ma veille » sur le feed (entry point — tranché en brainstorming PO).
+- Push serveur (FCM/APNS) — pas de stockage push_token côté backend, hors V1.
+- Cache disque persistant pour livraisons (load-on-enter mémoire suffit).
+- Pagination historique > 20.

--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,14 +1,19 @@
-# QA Handoff — « Bonnes nouvelles du jour » : mobile + push notification
+# QA Handoff — Story 18.3 « Ma veille » end-to-end
+
+> Rempli par l'agent dev en fin de développement, après validation du PO.
+> Sert d'input à `/validate-feature`.
 
 ## Feature développée
 
-Repositionnement mobile du digest serein de « Lecture apaisée » → « Bonnes
-nouvelles du jour ». Ajoute (1) un renommage end-to-end de la pill, des
-titres et de la copy interests ; (2) un badge « À LA UNE · N sources » sur
-le sujet rang 1 multi-sources ; (3) un canal de notification push local
-dédié, opt-in indépendant du push principal (modal d'activation + écran
-profil > notifications), avec règle stricte d'absence de couplage entre
-les deux opt-ins.
+Câblage end-to-end du flow « Ma veille » sur l'app mobile :
+- Wiring du submit étape 4 → POST `/api/veille/config` (suppression du no-op).
+- Suggestions topics/sources réelles (POST `/api/veille/suggestions/{topics,sources}`) à l'entrée des étapes 2 et 3 (au lieu du mock).
+- Nouvel écran « Ma veille déjà configurée » (dashboard) — affiché si `GET /api/veille/config` = 200 ; redirige automatiquement depuis `/veille/config` au lieu de relancer le flow 4-steps.
+- Nouvel écran historique livraisons (`/veille/deliveries`) — liste 20 dernières.
+- Nouvel écran détail livraison (`/veille/deliveries/:id`) — clusters + `why_it_matters` + articles cliquables (InAppWebView).
+- Notif locale planifiée côté front au submit (`flutter_local_notifications`, NotifId=3, à `next_scheduled_at + 30 min`), deeplink `io.supabase.facteur://veille/dashboard`.
+
+Aucune modif backend (pipeline déjà livrée en 18.1/18.2).
 
 ## PR associée
 
@@ -18,150 +23,146 @@ les deux opt-ins.
 
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| Feed (carte d'entrée digest) | `/feed` | Modifié — pill + titre carte serein |
-| Digest (hero) | `/digest` | Modifié — pill + titre adaptés au mode |
-| Digest (sujets) | `/digest` | Modifié — badge « À LA UNE · N sources » |
-| Mes Intérêts (mode serein) | `/interests` | Modifié — copy renommée |
-| Modal d'activation notif | n/a (overlay) | Modifié — section indépendante « Bonnes nouvelles » |
-| Profil > Notifications | `/profile/notifications` | Modifié — toggle Bonnes nouvelles + horaire |
+| Flow Veille — Étape 1 (thème) | `/veille/config` | Modifié — redirect dashboard si config existe |
+| Flow Veille — Étape 2 (suggestions topics) | `/veille/config` | Modifié — POST `/suggestions/topics` au mount |
+| Flow Veille — Étape 3 (sources) | `/veille/config` | Modifié — POST `/suggestions/sources` au mount |
+| Flow Veille — Étape 4 (fréquence + submit) | `/veille/config` | Modifié — POST `/config` réel + planif notif locale |
+| Dashboard « Ma veille déjà configurée » | `/veille/dashboard` | **Nouveau** |
+| Historique livraisons | `/veille/deliveries` | **Nouveau** |
+| Détail livraison | `/veille/deliveries/:id` | **Nouveau** |
 
 ## Scénarios de test
 
-### Scénario 1 : Renommage carte feed (happy path)
-**Parcours** :
-1. Aller sur `/feed`
-2. Observer la 2e carte d'entrée digest
-**Résultat attendu** :
-- Pill `BONNES NOUVELLES` (couleur serein verte conservée)
-- Titre `Les bonnes nouvelles du jour`
-- Tap → ouvre `/digest` en mode serein
+### Scénario 1 : Happy path — première config & livraison
 
-### Scénario 2 : Renommage hero digest serein
 **Parcours** :
-1. Tap la carte « Bonnes nouvelles » depuis le feed
-2. Observer le hero du digest
-**Résultat attendu** :
-- Pill `BONNES NOUVELLES` (au lieu de `L'ESSENTIEL`)
-- Titre `Les bonnes nouvelles du jour`
-- Si on bascule vers le mode normal (toggle serein OFF) : pill et titre
-  reviennent à `L'ESSENTIEL` + `L'essentiel du jour`.
+1. Auth dans l'app. Aucune veille configurée.
+2. Naviguer vers `/veille/config` (depuis settings ou route directe).
+3. Étape 1 : choisir thème « IA & éducation ».
+4. Étape 2 : observer le spinner pendant 1-3s, puis suggestions LLM affichées (différentes du mock figé). Sélectionner 3 topics.
+5. Étape 3 : spinner puis sources `followed` + `niche` réelles. Sélectionner 4 sources.
+6. Étape 4 : fréquence weekly · lundi · 7h. Tap « Configurer ma veille ».
+7. Vérifier : POST `/api/veille/config` → 200 dans logs uvicorn.
+8. Vérifier : redirection vers `/veille/dashboard` (pas le SnackBar mock).
+9. Vérifier (Android Studio Logcat ou debug print) : `PushNotificationService: scheduled veilleDelivery for <next_scheduled_at + 30min>`.
+10. (debug local) `POST /api/veille/deliveries/generate` → 200 succeeded.
+11. Re-ouvrir l'app → dashboard → bouton « Historique » → liste 1 livraison.
+12. Tap livraison → détail → 1+ cluster avec titre + `why_it_matters` + articles.
+13. Tap article → InAppWebView s'ouvre.
 
-### Scénario 3 : Badge « À LA UNE · N sources » (rang 1 multi-sources)
-**Parcours** :
-1. Ouvrir le digest avec un sujet rang 1 ayant `is_une=true` et
-   `source_count >= 2`
-2. Observer la zone des badges sous le titre du sujet
 **Résultat attendu** :
-- Badge terracotta `À LA UNE · 4 sources` (count = `source_count` API,
-  pas `articles.length`)
-- Couleur clairement distincte de la pill `BONNES NOUVELLES` (verte)
-  et de la pill `L'ESSENTIEL` (orange/primary)
+- Aucune erreur réseau ni 4xx visible dans les logs.
+- La notif locale est bien planifiée (vérifiable via Logcat ou `flutter logs`).
+- Le dashboard affiche le thème, topics, sources, fréquence et un countdown vers `next_scheduled_at`.
+- Le détail livraison montre des clusters réels (ou fallback déterministe si `MISTRAL_API_KEY` absent localement, sans badge visible).
 
-### Scénario 4 : Badge absent quand single-source
-**Parcours** :
-1. Ouvrir un digest dont le rang 1 a `is_une=true` mais `source_count=1`
-2. Observer
-**Résultat attendu** :
-- Aucun badge « À LA UNE » affiché — le sujet rang 1 est rendu comme un
-  sujet ordinaire.
+### Scénario 2 : Veille déjà configurée — redirect dashboard
 
-### Scénario 5 : Modal d'activation — opt-in indépendant (CRITIQUE)
 **Parcours** :
-1. Première ouverture de l'app (état: `modal_seen=false`)
-2. Modal d'activation s'affiche
-3. **Sans toucher au toggle Bonnes nouvelles**, choisir préset + horaire
-   du push principal, taper `Activer ton Facteur`
-4. Aller dans Profil > Notifications
-**Résultat attendu** :
-- Push principal activé (préset + horaire enregistrés)
-- Toggle « Bonnes nouvelles du jour » reste **OFF** dans Profil
-- AUCUNE notification Bonnes nouvelles planifiée
+1. Avoir une veille active (cf. Scénario 1).
+2. Tap depuis settings le bouton « Configurer ma veille » (ou navigate manuel `/veille/config`).
+3. Observer.
 
-### Scénario 6 : Modal — opt-in Bonnes nouvelles
-**Parcours** :
-1. Réinitialiser, ouvrir la modal
-2. Activer le switch « 🌱 Bonnes nouvelles du jour », choisir un horaire
-   (par défaut soir)
-3. Taper `Activer ton Facteur`
 **Résultat attendu** :
-- Les 2 canaux sont activés (digest principal + bonnes nouvelles)
-- L'horaire bonnes nouvelles est indépendant de l'horaire principal
+- L'utilisateur voit le dashboard `/veille/dashboard`, pas le flow 4-steps (Step1).
+- Si l'utilisateur tap « Modifier ma veille » sur le dashboard → flow 4-steps relancé avec le state preset (thème, topics, sources cochés).
 
-### Scénario 7 : Profil > Notifications — découvrabilité
-**Parcours** :
-1. Utilisateur a activé uniquement le push principal au scénario 5
-2. Quelques jours plus tard, va dans Profil > Notifications
-3. Observer
-**Résultat attendu** :
-- Section « 🌱 Bonnes nouvelles du jour » visible avec son toggle
-  (même si le push principal est ON)
-- Tap toggle → demande de permission OS si nécessaire, puis
-  `TimeSlotSelector` apparaît
+### Scénario 3 : Pause & Reprendre
 
-### Scénario 8 : Désactivation Bonnes nouvelles
 **Parcours** :
-1. Bonnes nouvelles activées avec horaire `evening`
-2. Profil > Notifications → toggle Bonnes nouvelles OFF
-**Résultat attendu** :
-- Notification Bonnes nouvelles annulée
-- Push principal et community pick non impactés
+1. Dashboard avec veille active.
+2. Tap « Mettre en pause ».
+3. Observer.
 
-### Scénario 9 : Copy mes intérêts (mode serein)
-**Parcours** :
-1. Activer le mode serein
-2. Aller sur Mes Intérêts
 **Résultat attendu** :
-- Titre `Vos bonnes nouvelles` (au lieu de `Votre mode serein`)
-- Sous-titre `Choisissez ce qui reste dans vos bonnes nouvelles…`
-  (sans mention « bulle apaisée »)
+- PATCH `/api/veille/config` → 200, `status="paused"`.
+- Le bouton devient « Reprendre ».
+- Le countdown disparaît (ou affiche « En pause »).
+- La notif locale précédemment planifiée est cancelled (vérifiable via debug print).
+- Tap « Reprendre » → PATCH status="active" + reschedule notif.
+
+### Scénario 4 : Suppression
+
+**Parcours** :
+1. Dashboard avec veille active.
+2. Tap « Supprimer ma veille » → confirm dialog → confirmer.
+3. Observer.
+
+**Résultat attendu** :
+- DELETE `/api/veille/config` → 204.
+- L'utilisateur est redirigé vers `/feed` (ou la route de fallback).
+- Re-ouvrir `/veille/config` → flow 4-steps de nouveau (état GET /config = 404).
+- Notif locale cancelled.
+
+### Scénario 5 : Détail livraison failed
+
+**Parcours** :
+1. Forcer une livraison `failed` (peut nécessiter un seed DB côté QA — alternative : mocker côté UI test).
+2. Ouvrir l'historique → tap la livraison.
+
+**Résultat attendu** :
+- Le détail affiche un état d'erreur sympa (« La livraison a échoué — le scanner réessaiera bientôt »).
+- Pas de crash, pas d'erreur dans les logs front.
+
+### Scénario 6 : Erreur réseau pendant suggestions
+
+**Parcours** :
+1. Étape 2 (suggestions topics) : couper le wifi.
+2. Re-tenter le mount (back puis re-forward).
+
+**Résultat attendu** :
+- Toast `« Suggestions indisponibles, conserve ta sélection »`.
+- La grille reste fonctionnelle avec mock data (pas de crash).
+- Bouton « Réessayer » disponible.
+
+### Scénario 7 : Tap notification locale
+
+**Parcours** :
+1. Avoir une veille active avec notif schedulée.
+2. (Debug Android) déclencher la notif manuellement OU avancer la date système.
+3. Tap la notif depuis l'écran de verrouillage.
+
+**Résultat attendu** :
+- L'app s'ouvre sur `/veille/dashboard` (deeplink `io.supabase.facteur://veille/dashboard`).
+- Si `target_date` du jour a une livraison `succeeded`, le bouton « Historique » l'affiche en haut.
 
 ## Critères d'acceptation
 
-- [ ] Toutes occurrences `LECTURE APAISÉE` / `Une lecture apaisée` ont
-      disparu de l'UI mobile (sauf comments internes ou la copy filter
-      bar « Rester serein » du feed, hors scope).
-- [ ] Pill `BONNES NOUVELLES` rendue dans la carte feed et dans le hero
-      digest mode serein.
-- [ ] `DigestTopic.sourceCount` lit la valeur API `source_count` (pas
-      `articles.length`).
-- [ ] Badge « À LA UNE · N sources » affiché si et seulement si
-      `topic.isUne == true && topic.sourceCount >= 2`.
-- [ ] Toggle « Bonnes nouvelles » présent dans la modal d'activation +
-      l'écran Profil > Notifications.
-- [ ] Activer le push principal n'active jamais le canal Bonnes
-      nouvelles (et inversement).
-- [ ] `flutter test` sur les fichiers touchés passe : digest_entry_card,
-      a_la_une_badge, push_notification_service_copy.
-- [ ] `flutter analyze` ne crée pas de NOUVEAU error / warning par
-      rapport à la baseline (info-level OK).
+- [ ] Submit étape 4 fait un vrai POST `/api/veille/config` (plus de SnackBar mock).
+- [ ] Étapes 2 et 3 appellent les endpoints suggestions avec spinner bloquant.
+- [ ] Toute config existante (GET 200) déclenche un redirect vers `/veille/dashboard` au lieu du flow.
+- [ ] Dashboard rend thème, topics, sources, fréquence, countdown.
+- [ ] Boutons dashboard (Modifier/Pause/Supprimer/Voir historique) tous fonctionnels.
+- [ ] Historique liste 20 livraisons max, empty state si 0.
+- [ ] Détail livraison rend les clusters avec `why_it_matters` + articles.
+- [ ] Tap article ouvre InAppWebView (pas le navigateur externe).
+- [ ] Notif locale planifiée au submit, cancellée au pause/delete, re-schedulée au PATCH frequency.
+- [ ] Deeplink `io.supabase.facteur://veille/dashboard` mappé.
+- [ ] `flutter test` vert sur les fichiers touchés/créés.
+- [ ] `flutter analyze` ne crée pas de NOUVEAU error/warning.
 
 ## Zones de risque
 
-1. **Modèle `DigestTopic.sourceCount` : changement de getter → champ
-   API.** Tous les endroits qui construisaient un `DigestTopic` dans des
-   tests sans passer `sourceCount` recevront `0` par défaut (au lieu de
-   `articles.length`). Vérifier qu'aucun test fixture ne dépend
-   implicitement de l'ancien comportement.
-2. **Couplage opt-in (CRITIQUE).** Toute régression qui pré-coche le
-   toggle Bonnes nouvelles automatiquement (par ex. en lisant
-   `serein_enabled` du provider) viole la règle. Ne PAS modifier
-   `_GoodNewsSection` pour qu'elle écoute autre chose que son propre
-   état.
-3. **Push notification permission.** Sur Android, `setGoodNewsEnabled`
-   re-demande la permission OS. Si le user a déjà accordé pour le push
-   principal, le système devrait répondre immédiatement sans re-prompt.
-   À vérifier sur device réel.
-4. **Persistance Hive.** Les nouvelles clés `notif_good_news_enabled`
-   et `notif_good_news_time_slot` n'existent pas pour les users
-   existants — fallback `false` / `evening` côté `_loadFromHive`.
-5. **Backend non touché** — l'API expose déjà `is_une` + `source_count`
-   sur `DigestTopic`. Si l'un des deux disparaît côté pipeline (par ex.
-   refactor), le badge ne s'affichera jamais.
+1. **UUIDs vs slugs mock** — le mock `veille_mock_data.dart` utilise des slugs (`s-lm`, `t-eval`) qui n'existent pas en DB. Le wiring API n'envoie QUE les UUIDs renvoyés par les endpoints suggestions. Vérifier qu'AUCUNE source mock-only (sans `apiSourceId`) ne fuit dans le POST /config (sinon 400 ou faux source ingéré).
+2. **Notif locale & timezone** — utiliser `tz.TZDateTime.from(when, tz.local)` (pattern `scheduleDailyDigestNotification`). Sinon DST Paris peut décaler la notif d'1h.
+3. **Retries cascadés** — la règle « max 1 sur 5xx, 0 sur 4xx » est CRITIQUE. Pas de retry cascadé type `digest_provider._loadBothDigests` (mémoire `bug-infinite-load-requests` : pool DB déjà saturé en prod).
+4. **Mistral KO côté backend** — `why_it_matters` reçoit alors un fallback déterministe (« 4 articles de 2 sources couvrent ce sujet »). À considérer comme valide, pas un état d'erreur. Pas de badge.
+5. **Multi-device** — la notif est purement locale. Si l'utilisateur configure depuis device A, device B ne recevra pas la notif. Documenté hors scope V1.
+6. **`generation_state == "running"`** — au moment où la notif tombe, le scanner peut encore tourner. Le détail doit gérer ce cas (afficher un loader « génération en cours, refresh dans X s »).
+7. **InAppWebView** — vérifier qu'on réutilise le même helper que le digest (`Grep "InAppWebView"` côté `features/digest/` ou `features/feed/`). Sinon implémenter un fallback `url_launcher` propre.
 
 ## Dépendances
 
-- Endpoint API : `GET /api/digest/both` (ne change pas — déjà expose
-  `is_une` + `source_count` sur les topics serein).
+- Endpoints API (déjà livrés en 18.1/18.2) :
+  - `GET /api/veille/config`
+  - `POST /api/veille/config`
+  - `PATCH /api/veille/config`
+  - `DELETE /api/veille/config`
+  - `POST /api/veille/suggestions/topics`
+  - `POST /api/veille/suggestions/sources`
+  - `GET /api/veille/deliveries?limit=20`
+  - `GET /api/veille/deliveries/{id}`
+  - `POST /api/veille/deliveries/generate` (debug, dev only)
 - Pas de migration backend.
-- Pas de sender FCM/APNS (push 100% local via
-  `flutter_local_notifications`).
+- Pas de FCM/APNS (push 100% local via `flutter_local_notifications`).
+- Scanner backend `*/30 min` (déjà schedulé via APScheduler).

--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -28,6 +28,9 @@ import '../features/progress/screens/quiz_screen.dart';
 import '../features/subscription/screens/paywall_screen.dart';
 import '../features/digest/screens/digest_screen.dart';
 import '../features/veille/screens/veille_config_screen.dart';
+import '../features/veille/screens/veille_dashboard_screen.dart';
+import '../features/veille/screens/veille_deliveries_screen.dart';
+import '../features/veille/screens/veille_delivery_detail_screen.dart';
 import '../features/digest/screens/closure_screen.dart';
 import '../features/saved/screens/saved_screen.dart';
 import '../features/saved/screens/saved_all_screen.dart';
@@ -67,6 +70,9 @@ class RouteNames {
   static const String topicExplorer = 'topic-explorer';
   static const String themeSources = 'theme-sources';
   static const String veilleConfig = 'veille-config';
+  static const String veilleDashboard = 'veille-dashboard';
+  static const String veilleDeliveries = 'veille-deliveries';
+  static const String veilleDeliveryDetail = 'veille-delivery-detail';
 }
 
 /// Chemins des routes
@@ -96,6 +102,9 @@ class RoutePaths {
   static const String paywall = '/paywall';
   static const String emailConfirmation = '/email-confirmation';
   static const String veilleConfig = '/veille/config';
+  static const String veilleDashboard = '/veille/dashboard';
+  static const String veilleDeliveries = '/veille/deliveries';
+  static const String veilleDeliveryDetail = '/veille/deliveries/:id';
 }
 
 final routerProvider = Provider<GoRouter>((ref) {
@@ -392,6 +401,35 @@ final routerProvider = Provider<GoRouter>((ref) {
         name: RouteNames.veilleConfig,
         pageBuilder: (context, state) => const FullSwipeCupertinoPage(
           child: VeilleConfigScreen(),
+        ),
+      ),
+
+      // Veille Dashboard — vue de la config existante (édit/pause/delete).
+      GoRoute(
+        path: RoutePaths.veilleDashboard,
+        name: RouteNames.veilleDashboard,
+        pageBuilder: (context, state) => const FullSwipeCupertinoPage(
+          child: VeilleDashboardScreen(),
+        ),
+      ),
+
+      // Veille Deliveries — historique des livraisons.
+      GoRoute(
+        path: RoutePaths.veilleDeliveries,
+        name: RouteNames.veilleDeliveries,
+        pageBuilder: (context, state) => const FullSwipeCupertinoPage(
+          child: VeilleDeliveriesScreen(),
+        ),
+      ),
+
+      // Veille Delivery Detail — clusters + articles.
+      GoRoute(
+        path: RoutePaths.veilleDeliveryDetail,
+        name: RouteNames.veilleDeliveryDetail,
+        pageBuilder: (context, state) => FullSwipeCupertinoPage(
+          child: VeilleDeliveryDetailScreen(
+            deliveryId: state.pathParameters['id']!,
+          ),
         ),
       ),
 

--- a/apps/mobile/lib/core/services/deep_link_service.dart
+++ b/apps/mobile/lib/core/services/deep_link_service.dart
@@ -15,6 +15,7 @@ import 'analytics_service.dart';
 /// - `io.supabase.facteur://digest/<contentId>?pos=<n>&topicId=<id>`
 ///   → `/feed/content/<contentId>` (article reader)
 /// - `io.supabase.facteur://feed` → `/feed`
+/// - `io.supabase.facteur://veille/dashboard` → `/veille/dashboard`
 ///
 /// `io.supabase.facteur://login-callback` is intentionally ignored — Supabase
 /// SDK intercepts it before it reaches us. Anything else falls through to
@@ -180,6 +181,10 @@ class DeepLinkService {
         _analytics?.trackWidgetAppOpened(target: 'feed');
         router.go(action.route!);
         return;
+      case WidgetDeepLinkTarget.veille:
+        _analytics?.trackWidgetAppOpened(target: 'veille');
+        router.go(action.route!);
+        return;
       case WidgetDeepLinkTarget.ignored:
       case WidgetDeepLinkTarget.unhandled:
         debugPrint('DeepLinkService: unhandled uri=$uri');
@@ -207,6 +212,18 @@ class DeepLinkService {
         (host.isEmpty && segments.isNotEmpty && segments.first == 'digest');
     final isFeed = host == 'feed' ||
         (host.isEmpty && segments.isNotEmpty && segments.first == 'feed');
+    final isVeille = host == 'veille' ||
+        (host.isEmpty && segments.isNotEmpty && segments.first == 'veille');
+
+    if (isVeille) {
+      // `io.supabase.facteur://veille/dashboard` → `/veille/dashboard`.
+      // Toute autre cible veille (deliveries, …) inconnue tombe en fallback
+      // sur le dashboard plutôt que l'errorBuilder GoRouter.
+      return const WidgetDeepLinkAction(
+        target: WidgetDeepLinkTarget.veille,
+        route: RoutePaths.veilleDashboard,
+      );
+    }
 
     if (isDigest) {
       final articleId = _extractArticleIdFrom(host, segments);
@@ -253,7 +270,7 @@ class DeepLinkService {
   }
 }
 
-enum WidgetDeepLinkTarget { digest, article, feed, ignored, unhandled }
+enum WidgetDeepLinkTarget { digest, article, feed, veille, ignored, unhandled }
 
 class WidgetDeepLinkAction {
   final WidgetDeepLinkTarget target;

--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -20,6 +20,7 @@ class _NotifIds {
   static const dailyDigest = 0;
   static const weeklyCommunityPick = 1;
   static const dailyGoodNews = 2;
+  static const veilleDelivery = 3;
 }
 
 /// Service de notifications push locales (FCM non utilisé en v1).
@@ -143,6 +144,11 @@ class PushNotificationService {
   static const String goodNewsTitle = '🌱 Vos bonnes nouvelles du jour';
   static const String goodNewsBody =
       "Une dose d'espoir, sélectionnée avec soin.";
+
+  /// Livraison « Ma veille » — notif locale planifiée à `next_scheduled_at + 30 min`.
+  static const String veilleTitle = 'Ta veille est arrivée';
+  static const String veilleBody =
+      "Découvre les sujets phares de ta période, sélectionnés pour toi.";
 
   /// Construit le triplet (title, body, bigText) selon la variante.
   ///
@@ -373,6 +379,77 @@ class PushNotificationService {
 
   Future<bool> isGoodNewsNotificationScheduled() =>
       _isScheduled(_NotifIds.dailyGoodNews);
+
+  /// Planifie la notification locale « Ma veille » pour [scheduledAt].
+  ///
+  /// Le caller doit ajouter une marge (≈30 min) à `next_scheduled_at` reçu du
+  /// backend pour laisser le scanner `*/30 min` générer la livraison avant
+  /// que la notif ne tombe.
+  ///
+  /// Retourne `true` si la notif a bien été enregistrée auprès du système, ou
+  /// `false` si la date est dans le passé (évite le crash sur Android, qui
+  /// refuse de planifier dans le passé).
+  Future<bool> scheduleVeilleNotification({
+    required DateTime scheduledAt,
+  }) async {
+    final tzScheduled = tz.TZDateTime.from(scheduledAt, tz.local);
+    if (!tzScheduled.isAfter(tz.TZDateTime.now(tz.local))) {
+      debugPrint(
+        'PushNotificationService: skip veille schedule — past date $scheduledAt',
+      );
+      return false;
+    }
+
+    final androidPlugin = _plugin.resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin>();
+    final canUseExact =
+        (await androidPlugin?.canScheduleExactNotifications()) ?? true;
+    final scheduleMode = canUseExact
+        ? AndroidScheduleMode.alarmClock
+        : AndroidScheduleMode.inexactAllowWhileIdle;
+
+    final androidDetails = AndroidNotificationDetails(
+      'veille_channel',
+      'Ma veille',
+      channelDescription:
+          'Notification quand ta veille personnalisée est prête.',
+      importance: Importance.high,
+      priority: Priority.high,
+      icon: '@drawable/ic_stat_facteur',
+      color: const Color(0xFFD35400),
+      styleInformation: const BigTextStyleInformation(
+        veilleBody,
+        contentTitle: veilleTitle,
+      ),
+    );
+    const iosDetails = DarwinNotificationDetails();
+
+    await _plugin.zonedSchedule(
+      id: _NotifIds.veilleDelivery,
+      title: veilleTitle,
+      body: veilleBody,
+      scheduledDate: tzScheduled,
+      notificationDetails: NotificationDetails(
+        android: androidDetails,
+        iOS: iosDetails,
+      ),
+      androidScheduleMode: scheduleMode,
+      payload: 'route:/veille/dashboard',
+    );
+
+    debugPrint(
+      'PushNotificationService: veille scheduled @ $tzScheduled',
+    );
+
+    return _isScheduled(_NotifIds.veilleDelivery);
+  }
+
+  Future<void> cancelVeilleNotification() async {
+    await _plugin.cancel(id: _NotifIds.veilleDelivery);
+  }
+
+  Future<bool> isVeilleNotificationScheduled() =>
+      _isScheduled(_NotifIds.veilleDelivery);
 
   Future<bool> _isScheduled(int id) async {
     final pending = await _plugin.pendingNotificationRequests();

--- a/apps/mobile/lib/features/veille/models/veille_config_dto.dart
+++ b/apps/mobile/lib/features/veille/models/veille_config_dto.dart
@@ -1,0 +1,294 @@
+import 'package:flutter/foundation.dart';
+
+/// DTOs miroir de `packages/api/app/schemas/veille.py` (réponses + bodies).
+
+@immutable
+class VeilleTopicDto {
+  final String id;
+  final String topicId;
+  final String label;
+  final String kind;
+  final String? reason;
+  final int position;
+
+  const VeilleTopicDto({
+    required this.id,
+    required this.topicId,
+    required this.label,
+    required this.kind,
+    required this.reason,
+    required this.position,
+  });
+
+  factory VeilleTopicDto.fromJson(Map<String, dynamic> json) {
+    return VeilleTopicDto(
+      id: json['id'] as String,
+      topicId: json['topic_id'] as String,
+      label: json['label'] as String,
+      kind: json['kind'] as String,
+      reason: json['reason'] as String?,
+      position: (json['position'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+@immutable
+class VeilleSourceLiteDto {
+  final String id;
+  final String name;
+  final String url;
+  final String feedUrl;
+  final String theme;
+  final String type;
+  final bool isCurated;
+  final String? logoUrl;
+
+  const VeilleSourceLiteDto({
+    required this.id,
+    required this.name,
+    required this.url,
+    required this.feedUrl,
+    required this.theme,
+    required this.type,
+    required this.isCurated,
+    required this.logoUrl,
+  });
+
+  factory VeilleSourceLiteDto.fromJson(Map<String, dynamic> json) {
+    return VeilleSourceLiteDto(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      url: json['url'] as String,
+      feedUrl: json['feed_url'] as String,
+      theme: json['theme'] as String,
+      type: json['type'] as String,
+      isCurated: json['is_curated'] as bool? ?? false,
+      logoUrl: json['logo_url'] as String?,
+    );
+  }
+}
+
+@immutable
+class VeilleSourceDto {
+  final String id;
+  final VeilleSourceLiteDto source;
+  final String kind;
+  final String? why;
+  final int position;
+
+  const VeilleSourceDto({
+    required this.id,
+    required this.source,
+    required this.kind,
+    required this.why,
+    required this.position,
+  });
+
+  factory VeilleSourceDto.fromJson(Map<String, dynamic> json) {
+    return VeilleSourceDto(
+      id: json['id'] as String,
+      source:
+          VeilleSourceLiteDto.fromJson(json['source'] as Map<String, dynamic>),
+      kind: json['kind'] as String,
+      why: json['why'] as String?,
+      position: (json['position'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+@immutable
+class VeilleConfigDto {
+  final String id;
+  final String userId;
+  final String themeId;
+  final String themeLabel;
+  final String frequency;
+  final int? dayOfWeek;
+  final int deliveryHour;
+  final String timezone;
+  final String status;
+  final DateTime? lastDeliveredAt;
+  final DateTime? nextScheduledAt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final List<VeilleTopicDto> topics;
+  final List<VeilleSourceDto> sources;
+
+  const VeilleConfigDto({
+    required this.id,
+    required this.userId,
+    required this.themeId,
+    required this.themeLabel,
+    required this.frequency,
+    required this.dayOfWeek,
+    required this.deliveryHour,
+    required this.timezone,
+    required this.status,
+    required this.lastDeliveredAt,
+    required this.nextScheduledAt,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.topics,
+    required this.sources,
+  });
+
+  factory VeilleConfigDto.fromJson(Map<String, dynamic> json) {
+    return VeilleConfigDto(
+      id: json['id'] as String,
+      userId: json['user_id'] as String,
+      themeId: json['theme_id'] as String,
+      themeLabel: json['theme_label'] as String,
+      frequency: json['frequency'] as String,
+      dayOfWeek: (json['day_of_week'] as num?)?.toInt(),
+      deliveryHour: (json['delivery_hour'] as num?)?.toInt() ?? 7,
+      timezone: (json['timezone'] as String?) ?? 'Europe/Paris',
+      status: json['status'] as String,
+      lastDeliveredAt: json['last_delivered_at'] != null
+          ? DateTime.parse(json['last_delivered_at'] as String)
+          : null,
+      nextScheduledAt: json['next_scheduled_at'] != null
+          ? DateTime.parse(json['next_scheduled_at'] as String)
+          : null,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
+      topics: ((json['topics'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleTopicDto.fromJson)
+          .toList(),
+      sources: ((json['sources'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleSourceDto.fromJson)
+          .toList(),
+    );
+  }
+}
+
+// ─── Bodies (POST/PATCH) ──────────────────────────────────────────────────
+
+@immutable
+class VeilleTopicSelectionRequest {
+  final String topicId;
+  final String label;
+  final String kind;
+  final String? reason;
+  final int position;
+
+  const VeilleTopicSelectionRequest({
+    required this.topicId,
+    required this.label,
+    required this.kind,
+    this.reason,
+    this.position = 0,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'topic_id': topicId,
+        'label': label,
+        'kind': kind,
+        if (reason != null) 'reason': reason,
+        'position': position,
+      };
+}
+
+@immutable
+class VeilleNicheCandidateRequest {
+  final String name;
+  final String url;
+  final String? why;
+
+  const VeilleNicheCandidateRequest({
+    required this.name,
+    required this.url,
+    this.why,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'url': url,
+        if (why != null) 'why': why,
+      };
+}
+
+@immutable
+class VeilleSourceSelectionRequest {
+  final String kind;
+  final String? sourceId;
+  final VeilleNicheCandidateRequest? nicheCandidate;
+  final String? why;
+  final int position;
+
+  const VeilleSourceSelectionRequest({
+    required this.kind,
+    this.sourceId,
+    this.nicheCandidate,
+    this.why,
+    this.position = 0,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'kind': kind,
+        if (sourceId != null) 'source_id': sourceId,
+        if (nicheCandidate != null) 'niche_candidate': nicheCandidate!.toJson(),
+        if (why != null) 'why': why,
+        'position': position,
+      };
+}
+
+@immutable
+class VeilleConfigUpsertRequest {
+  final String themeId;
+  final String themeLabel;
+  final List<VeilleTopicSelectionRequest> topics;
+  final List<VeilleSourceSelectionRequest> sourceSelections;
+  final String frequency;
+  final int? dayOfWeek;
+  final int deliveryHour;
+  final String timezone;
+
+  const VeilleConfigUpsertRequest({
+    required this.themeId,
+    required this.themeLabel,
+    required this.topics,
+    required this.sourceSelections,
+    required this.frequency,
+    required this.dayOfWeek,
+    this.deliveryHour = 7,
+    this.timezone = 'Europe/Paris',
+  });
+
+  Map<String, dynamic> toJson() => {
+        'theme_id': themeId,
+        'theme_label': themeLabel,
+        'topics': topics.map((t) => t.toJson()).toList(),
+        'source_selections': sourceSelections.map((s) => s.toJson()).toList(),
+        'frequency': frequency,
+        if (dayOfWeek != null) 'day_of_week': dayOfWeek,
+        'delivery_hour': deliveryHour,
+        'timezone': timezone,
+      };
+}
+
+@immutable
+class VeilleConfigPatchRequest {
+  final String? frequency;
+  final int? dayOfWeek;
+  final int? deliveryHour;
+  final String? timezone;
+  final String? status;
+
+  const VeilleConfigPatchRequest({
+    this.frequency,
+    this.dayOfWeek,
+    this.deliveryHour,
+    this.timezone,
+    this.status,
+  });
+
+  Map<String, dynamic> toJson() => {
+        if (frequency != null) 'frequency': frequency,
+        if (dayOfWeek != null) 'day_of_week': dayOfWeek,
+        if (deliveryHour != null) 'delivery_hour': deliveryHour,
+        if (timezone != null) 'timezone': timezone,
+        if (status != null) 'status': status,
+      };
+}

--- a/apps/mobile/lib/features/veille/models/veille_delivery.dart
+++ b/apps/mobile/lib/features/veille/models/veille_delivery.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class VeilleDeliveryArticle {
+  final String contentId;
+  final String sourceId;
+  final String title;
+  final String url;
+  final String excerpt;
+  final DateTime publishedAt;
+
+  const VeilleDeliveryArticle({
+    required this.contentId,
+    required this.sourceId,
+    required this.title,
+    required this.url,
+    required this.excerpt,
+    required this.publishedAt,
+  });
+
+  factory VeilleDeliveryArticle.fromJson(Map<String, dynamic> json) {
+    return VeilleDeliveryArticle(
+      contentId: json['content_id'] as String,
+      sourceId: json['source_id'] as String,
+      title: json['title'] as String,
+      url: json['url'] as String,
+      excerpt: (json['excerpt'] as String?) ?? '',
+      publishedAt: DateTime.parse(json['published_at'] as String),
+    );
+  }
+}
+
+@immutable
+class VeilleDeliveryItem {
+  final String clusterId;
+  final String title;
+  final List<VeilleDeliveryArticle> articles;
+  final String whyItMatters;
+
+  const VeilleDeliveryItem({
+    required this.clusterId,
+    required this.title,
+    required this.articles,
+    required this.whyItMatters,
+  });
+
+  factory VeilleDeliveryItem.fromJson(Map<String, dynamic> json) {
+    final raw = (json['articles'] as List?) ?? const [];
+    return VeilleDeliveryItem(
+      clusterId: json['cluster_id'] as String,
+      title: (json['title'] as String?) ?? '',
+      articles: raw
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleDeliveryArticle.fromJson)
+          .toList(),
+      whyItMatters: (json['why_it_matters'] as String?) ?? '',
+    );
+  }
+}
+
+enum VeilleGenerationState { pending, running, succeeded, failed }
+
+VeilleGenerationState veilleGenerationStateFrom(String value) {
+  return VeilleGenerationState.values.firstWhere(
+    (s) => s.name == value,
+    orElse: () => VeilleGenerationState.pending,
+  );
+}
+
+@immutable
+class VeilleDeliveryListItem {
+  final String id;
+  final String veilleConfigId;
+  final DateTime targetDate;
+  final VeilleGenerationState generationState;
+  final int itemCount;
+  final DateTime? generatedAt;
+  final DateTime createdAt;
+
+  const VeilleDeliveryListItem({
+    required this.id,
+    required this.veilleConfigId,
+    required this.targetDate,
+    required this.generationState,
+    required this.itemCount,
+    required this.generatedAt,
+    required this.createdAt,
+  });
+
+  factory VeilleDeliveryListItem.fromJson(Map<String, dynamic> json) {
+    return VeilleDeliveryListItem(
+      id: json['id'] as String,
+      veilleConfigId: json['veille_config_id'] as String,
+      targetDate: DateTime.parse(json['target_date'] as String),
+      generationState:
+          veilleGenerationStateFrom(json['generation_state'] as String),
+      itemCount: (json['item_count'] as num?)?.toInt() ?? 0,
+      generatedAt: json['generated_at'] != null
+          ? DateTime.parse(json['generated_at'] as String)
+          : null,
+      createdAt: DateTime.parse(json['created_at'] as String),
+    );
+  }
+}
+
+@immutable
+class VeilleDeliveryResponse {
+  final String id;
+  final String veilleConfigId;
+  final DateTime targetDate;
+  final List<VeilleDeliveryItem> items;
+  final VeilleGenerationState generationState;
+  final int attempts;
+  final DateTime? startedAt;
+  final DateTime? finishedAt;
+  final String? lastError;
+  final int version;
+  final DateTime? generatedAt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  const VeilleDeliveryResponse({
+    required this.id,
+    required this.veilleConfigId,
+    required this.targetDate,
+    required this.items,
+    required this.generationState,
+    required this.attempts,
+    required this.startedAt,
+    required this.finishedAt,
+    required this.lastError,
+    required this.version,
+    required this.generatedAt,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory VeilleDeliveryResponse.fromJson(Map<String, dynamic> json) {
+    final rawItems = (json['items'] as List?) ?? const [];
+    return VeilleDeliveryResponse(
+      id: json['id'] as String,
+      veilleConfigId: json['veille_config_id'] as String,
+      targetDate: DateTime.parse(json['target_date'] as String),
+      items: rawItems
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleDeliveryItem.fromJson)
+          .toList(),
+      generationState:
+          veilleGenerationStateFrom(json['generation_state'] as String),
+      attempts: (json['attempts'] as num?)?.toInt() ?? 0,
+      startedAt: json['started_at'] != null
+          ? DateTime.parse(json['started_at'] as String)
+          : null,
+      finishedAt: json['finished_at'] != null
+          ? DateTime.parse(json['finished_at'] as String)
+          : null,
+      lastError: json['last_error'] as String?,
+      version: (json['version'] as num?)?.toInt() ?? 1,
+      generatedAt: json['generated_at'] != null
+          ? DateTime.parse(json['generated_at'] as String)
+          : null,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
+    );
+  }
+}

--- a/apps/mobile/lib/features/veille/models/veille_suggestion.dart
+++ b/apps/mobile/lib/features/veille/models/veille_suggestion.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class VeilleTopicSuggestion {
+  final String topicId;
+  final String label;
+  final String? reason;
+
+  const VeilleTopicSuggestion({
+    required this.topicId,
+    required this.label,
+    this.reason,
+  });
+
+  factory VeilleTopicSuggestion.fromJson(Map<String, dynamic> json) {
+    return VeilleTopicSuggestion(
+      topicId: json['topic_id'] as String,
+      label: json['label'] as String,
+      reason: json['reason'] as String?,
+    );
+  }
+}
+
+@immutable
+class VeilleSourceSuggestion {
+  final String sourceId;
+  final String name;
+  final String url;
+  final String feedUrl;
+  final String theme;
+  final String? why;
+
+  const VeilleSourceSuggestion({
+    required this.sourceId,
+    required this.name,
+    required this.url,
+    required this.feedUrl,
+    required this.theme,
+    this.why,
+  });
+
+  factory VeilleSourceSuggestion.fromJson(Map<String, dynamic> json) {
+    return VeilleSourceSuggestion(
+      sourceId: json['source_id'] as String,
+      name: json['name'] as String,
+      url: json['url'] as String,
+      feedUrl: json['feed_url'] as String,
+      theme: json['theme'] as String,
+      why: json['why'] as String?,
+    );
+  }
+}
+
+@immutable
+class VeilleSourceSuggestionsResponse {
+  final List<VeilleSourceSuggestion> followed;
+  final List<VeilleSourceSuggestion> niche;
+
+  const VeilleSourceSuggestionsResponse({
+    required this.followed,
+    required this.niche,
+  });
+
+  factory VeilleSourceSuggestionsResponse.fromJson(Map<String, dynamic> json) {
+    return VeilleSourceSuggestionsResponse(
+      followed: ((json['followed'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleSourceSuggestion.fromJson)
+          .toList(),
+      niche: ((json['niche'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleSourceSuggestion.fromJson)
+          .toList(),
+    );
+  }
+}

--- a/apps/mobile/lib/features/veille/providers/veille_active_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_active_config_provider.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/veille_config_dto.dart';
+import 'veille_repository_provider.dart';
+
+/// AsyncNotifier load-on-enter pour la config veille active de l'utilisateur.
+///
+/// `null` → pas de veille configurée (404). Un DTO → veille active. Une erreur
+/// → propagée à l'UI (pas de retry agressif, anti-cascade pool DB).
+///
+/// Pas de cache disque : refresh = invalidation provider via `ref.invalidate`.
+class VeilleActiveConfigNotifier extends AsyncNotifier<VeilleConfigDto?> {
+  @override
+  Future<VeilleConfigDto?> build() async {
+    final repo = ref.read(veilleRepositoryProvider);
+    return repo.getConfig();
+  }
+
+  /// Met à jour la config locale après un PATCH/POST réussi pour éviter un
+  /// round-trip réseau supplémentaire. Le caller passe le DTO frais renvoyé
+  /// par le backend.
+  void hydrateFromServer(VeilleConfigDto? cfg) {
+    state = AsyncData(cfg);
+  }
+}
+
+final veilleActiveConfigProvider = AsyncNotifierProvider<
+    VeilleActiveConfigNotifier, VeilleConfigDto?>(
+  VeilleActiveConfigNotifier.new,
+);

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -3,8 +3,37 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/services/push_notification_service.dart';
 import '../data/veille_mock_data.dart';
 import '../models/veille_config.dart';
+import '../models/veille_config_dto.dart';
+import '../models/veille_suggestion.dart';
+import '../repositories/veille_repository.dart';
+import 'veille_active_config_provider.dart';
+import 'veille_repository_provider.dart';
+
+/// Métadonnées attachées à une source dans le state du flow. Permet de
+/// distinguer les sources catalogue (UUID API) des sources mock-only ; au
+/// submit on filtre les mock-only et on envoie un `source_id` (UUID) ou un
+/// `niche_candidate{name, url}` selon ce qui est dispo.
+@immutable
+class VeilleSourceMeta {
+  final String slug;
+  final String name;
+  final String kind; // "followed" | "niche"
+  final String? apiSourceId; // UUID si la source vient du catalogue
+  final String? url;
+  final String? why;
+
+  const VeilleSourceMeta({
+    required this.slug,
+    required this.name,
+    required this.kind,
+    this.apiSourceId,
+    this.url,
+    this.why,
+  });
+}
 
 /// État du flow de configuration de la veille (4 étapes).
 ///
@@ -23,6 +52,18 @@ class VeilleConfigState {
   final VeilleFrequency frequency;
   final VeilleDay day;
 
+  /// Mapping slug → label pour topics (mock défauts + override API).
+  final Map<String, String> topicLabels;
+
+  /// Mapping slug → metadata pour sources (mock défauts + override API).
+  final Map<String, VeilleSourceMeta> sourcesMeta;
+
+  /// Submit en cours — empêche les double-tap.
+  final bool isSubmitting;
+
+  /// Dernier message d'erreur API. UI le pop dans un Snackbar puis le clear.
+  final String? lastError;
+
   const VeilleConfigState({
     required this.step,
     required this.loadingFrom,
@@ -33,18 +74,26 @@ class VeilleConfigState {
     required this.nicheSources,
     required this.frequency,
     required this.day,
+    required this.topicLabels,
+    required this.sourcesMeta,
+    required this.isSubmitting,
+    required this.lastError,
   });
 
-  factory VeilleConfigState.initial() => const VeilleConfigState(
+  factory VeilleConfigState.initial() => VeilleConfigState(
         step: 1,
         loadingFrom: null,
         selectedTheme: null,
-        selectedTopics: <String>{},
+        selectedTopics: VeilleMockData.defaultTopics,
         selectedSuggestions: VeilleMockData.defaultSuggestions,
         followedSources: VeilleMockData.defaultFollowedSources,
         nicheSources: VeilleMockData.defaultNicheSources,
         frequency: VeilleFrequency.weekly,
         day: VeilleDay.mon,
+        topicLabels: _initialTopicLabels(),
+        sourcesMeta: const {},
+        isSubmitting: false,
+        lastError: null,
       );
 
   bool get isLoading => loadingFrom != null;
@@ -64,6 +113,10 @@ class VeilleConfigState {
     Set<String>? nicheSources,
     VeilleFrequency? frequency,
     VeilleDay? day,
+    Map<String, String>? topicLabels,
+    Map<String, VeilleSourceMeta>? sourcesMeta,
+    bool? isSubmitting,
+    Object? lastError = _Sentinel.value,
   }) =>
       VeilleConfigState(
         step: step ?? this.step,
@@ -79,26 +132,40 @@ class VeilleConfigState {
         nicheSources: nicheSources ?? this.nicheSources,
         frequency: frequency ?? this.frequency,
         day: day ?? this.day,
+        topicLabels: topicLabels ?? this.topicLabels,
+        sourcesMeta: sourcesMeta ?? this.sourcesMeta,
+        isSubmitting: isSubmitting ?? this.isSubmitting,
+        lastError:
+            lastError == _Sentinel.value ? this.lastError : lastError as String?,
       );
+
+  static Map<String, String> _initialTopicLabels() {
+    final out = <String, String>{};
+    for (final t in VeilleMockData.presetTopics) {
+      out[t.id] = t.label;
+    }
+    for (final t in VeilleMockData.suggestedTopics) {
+      out[t.id] = t.label;
+    }
+    return out;
+  }
+
 }
 
 enum _Sentinel { value }
 
 class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
-  VeilleConfigNotifier() : super(VeilleConfigState.initial());
+  VeilleConfigNotifier(this._ref) : super(VeilleConfigState.initial());
+
+  final Ref _ref;
 
   static const Duration _loadingDuration = Duration(milliseconds: 2500);
+  static const Duration _veilleNotificationLeadTime = Duration(minutes: 30);
 
   Timer? _loadingTimer;
 
   void selectTheme(String id) {
-    final shouldSeedTopics =
-        state.selectedTheme == null && state.selectedTopics.isEmpty;
-    state = state.copyWith(
-      selectedTheme: id,
-      selectedTopics:
-          shouldSeedTopics ? VeilleMockData.defaultTopics : null,
-    );
+    state = state.copyWith(selectedTheme: id);
   }
 
   void toggleTopic(String id) =>
@@ -138,15 +205,212 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     state = state.copyWith(step: state.step - 1);
   }
 
-  /// Sortie de la 4e étape — pour l'instant pas d'appel API.
+  /// Hydrate l'état avec des suggestions topics venues de l'API (étape 2).
+  /// Le mapping slug → label est mis à jour ; les sélections existantes ne
+  /// sont pas touchées.
+  void applyTopicSuggestions(List<VeilleTopicSuggestion> apiTopics) {
+    if (apiTopics.isEmpty) return;
+    final next = Map<String, String>.from(state.topicLabels);
+    for (final t in apiTopics) {
+      next[t.topicId] = t.label;
+    }
+    state = state.copyWith(topicLabels: next);
+  }
+
+  /// Hydrate l'état avec des suggestions sources venues de l'API (étape 3).
+  ///
+  /// Les sources API alimentent toujours `sourcesMeta`. Pour les sélections
+  /// par défaut, on ne pré-coche que lors de la 1ère hydratation API (quand
+  /// aucune sélection user ne référence un UUID API). Une invalidation ulté-
+  /// rieure (« Proposer plus de sources ») ne doit pas wipe les choix user.
+  void applySourceSuggestions(VeilleSourceSuggestionsResponse apiSources) {
+    final nextMeta = Map<String, VeilleSourceMeta>.from(state.sourcesMeta);
+
+    for (final s in apiSources.followed) {
+      nextMeta[s.sourceId] = VeilleSourceMeta(
+        slug: s.sourceId,
+        name: s.name,
+        kind: 'followed',
+        apiSourceId: s.sourceId,
+        url: s.url,
+        why: s.why,
+      );
+    }
+    for (final s in apiSources.niche) {
+      nextMeta[s.sourceId] = VeilleSourceMeta(
+        slug: s.sourceId,
+        name: s.name,
+        kind: 'niche',
+        apiSourceId: s.sourceId,
+        url: s.url,
+        why: s.why,
+      );
+    }
+
+    final hasUserApiSelection = state.followedSources
+            .any((slug) => state.sourcesMeta[slug]?.apiSourceId != null) ||
+        state.nicheSources
+            .any((slug) => state.sourcesMeta[slug]?.apiSourceId != null);
+
+    if (hasUserApiSelection) {
+      state = state.copyWith(sourcesMeta: nextMeta);
+      return;
+    }
+
+    state = state.copyWith(
+      sourcesMeta: nextMeta,
+      followedSources: apiSources.followed.map((s) => s.sourceId).toSet(),
+      nicheSources: apiSources.niche.map((s) => s.sourceId).toSet(),
+    );
+  }
+
+  /// Sortie de la 4e étape — POST /api/veille/config + planification de la
+  /// notif locale à `next_scheduled_at + 30 min`.
+  ///
+  /// Les sources mock-only (sans `apiSourceId`) sont filtrées : seules les
+  /// sources catalogue (UUID API) sont envoyées, sinon le backend rejette.
   Future<void> submit() async {
-    // TODO(veille): brancher POST /veille/config quand backend dispo.
+    if (state.isSubmitting) return;
+    state = state.copyWith(isSubmitting: true, lastError: null);
+
+    try {
+      final body = _buildUpsertRequest(state);
+      final repo = _ref.read(veilleRepositoryProvider);
+      final cfg = await repo.upsertConfig(body);
+
+      // Best-effort — un échec de planification ne doit pas bloquer la
+      // soumission. La notif locale est rejouée à l'open.
+      try {
+        if (cfg.nextScheduledAt != null) {
+          final scheduledAt =
+              cfg.nextScheduledAt!.add(_veilleNotificationLeadTime);
+          await PushNotificationService()
+              .scheduleVeilleNotification(scheduledAt: scheduledAt);
+        }
+      } catch (e) {
+        debugPrint('VeilleConfigNotifier: schedule notif failed: $e');
+      }
+
+      _ref
+          .read(veilleActiveConfigProvider.notifier)
+          .hydrateFromServer(cfg);
+      state = state.copyWith(isSubmitting: false);
+    } on VeilleApiException catch (e) {
+      state = state.copyWith(
+        isSubmitting: false,
+        lastError: e.message,
+      );
+      rethrow;
+    } catch (e) {
+      state = state.copyWith(
+        isSubmitting: false,
+        lastError: e.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  void clearError() => state = state.copyWith(lastError: null);
+
+  /// Réinitialise le flow (utilisé après suppression / pour repartir d'une
+  /// nouvelle config depuis le dashboard).
+  void reset() {
+    _loadingTimer?.cancel();
+    state = VeilleConfigState.initial();
   }
 
   Set<String> _toggle(Set<String> set, String id) {
     final next = Set<String>.from(set);
     if (!next.add(id)) next.remove(id);
     return next;
+  }
+
+  VeilleConfigUpsertRequest _buildUpsertRequest(VeilleConfigState s) {
+    final themeId = s.selectedTheme ?? VeilleMockData.defaultTheme;
+    final themeLabel = VeilleMockData.themes
+            .firstWhere(
+              (t) => t.id == themeId,
+              orElse: () => VeilleMockData.themes.first,
+            )
+            .label;
+
+    final topics = <VeilleTopicSelectionRequest>[];
+    var pos = 0;
+    for (final slug in s.selectedTopics) {
+      topics.add(
+        VeilleTopicSelectionRequest(
+          topicId: slug,
+          label: s.topicLabels[slug] ?? slug,
+          kind: 'preset',
+          position: pos++,
+        ),
+      );
+    }
+    for (final slug in s.selectedSuggestions) {
+      topics.add(
+        VeilleTopicSelectionRequest(
+          topicId: slug,
+          label: s.topicLabels[slug] ?? slug,
+          kind: 'suggested',
+          position: pos++,
+        ),
+      );
+    }
+
+    final sourceSelections = <VeilleSourceSelectionRequest>[];
+    var spos = 0;
+    for (final slug in s.followedSources) {
+      final meta = s.sourcesMeta[slug];
+      if (meta?.apiSourceId == null) continue; // mock-only — drop
+      sourceSelections.add(
+        VeilleSourceSelectionRequest(
+          kind: 'followed',
+          sourceId: meta!.apiSourceId,
+          why: meta.why,
+          position: spos++,
+        ),
+      );
+    }
+    for (final slug in s.nicheSources) {
+      final meta = s.sourcesMeta[slug];
+      if (meta?.apiSourceId == null) continue;
+      sourceSelections.add(
+        VeilleSourceSelectionRequest(
+          kind: 'niche',
+          sourceId: meta!.apiSourceId,
+          why: meta.why,
+          position: spos++,
+        ),
+      );
+    }
+
+    return VeilleConfigUpsertRequest(
+      themeId: themeId,
+      themeLabel: themeLabel,
+      topics: topics,
+      sourceSelections: sourceSelections,
+      frequency: _frequencyToWire(s.frequency),
+      dayOfWeek: _dayToWire(s.day, s.frequency),
+    );
+  }
+
+  static String _frequencyToWire(VeilleFrequency f) => switch (f) {
+        VeilleFrequency.weekly => 'weekly',
+        VeilleFrequency.biweekly => 'biweekly',
+        VeilleFrequency.monthly => 'monthly',
+      };
+
+  static int? _dayToWire(VeilleDay d, VeilleFrequency f) {
+    if (f == VeilleFrequency.monthly) return null;
+    return switch (d) {
+      VeilleDay.mon => 0,
+      VeilleDay.tue => 1,
+      VeilleDay.wed => 2,
+      VeilleDay.thu => 3,
+      VeilleDay.fri => 4,
+      VeilleDay.sat => 5,
+      VeilleDay.sun => 6,
+    };
   }
 
   @override
@@ -158,5 +422,5 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
 
 final veilleConfigProvider =
     StateNotifierProvider.autoDispose<VeilleConfigNotifier, VeilleConfigState>(
-  (ref) => VeilleConfigNotifier(),
+  (ref) => VeilleConfigNotifier(ref),
 );

--- a/apps/mobile/lib/features/veille/providers/veille_deliveries_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_deliveries_provider.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/veille_delivery.dart';
+import 'veille_repository_provider.dart';
+
+/// AsyncNotifier load-on-enter pour la liste des livraisons (limit=20).
+///
+/// Refresh = `ref.invalidate(veilleDeliveriesProvider)` (pull-to-refresh côté
+/// UI). Pas de cache disque, pas de stale-fallback.
+class VeilleDeliveriesNotifier
+    extends AsyncNotifier<List<VeilleDeliveryListItem>> {
+  @override
+  Future<List<VeilleDeliveryListItem>> build() async {
+    final repo = ref.read(veilleRepositoryProvider);
+    return repo.listDeliveries();
+  }
+}
+
+final veilleDeliveriesProvider = AsyncNotifierProvider<
+    VeilleDeliveriesNotifier, List<VeilleDeliveryListItem>>(
+  VeilleDeliveriesNotifier.new,
+);
+
+/// Détail d'une livraison particulière. AutoDispose family : la mémoire est
+/// libérée dès qu'on quitte l'écran de détail.
+final veilleDeliveryProvider = FutureProvider.autoDispose
+    .family<VeilleDeliveryResponse, String>(
+  (ref, deliveryId) async {
+    final repo = ref.read(veilleRepositoryProvider);
+    return repo.getDelivery(deliveryId);
+  },
+);

--- a/apps/mobile/lib/features/veille/providers/veille_repository_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_repository_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/providers.dart';
+import '../repositories/veille_repository.dart';
+
+final veilleRepositoryProvider = Provider<VeilleRepository>((ref) {
+  final apiClient = ref.watch(apiClientProvider);
+  return VeilleRepository(apiClient);
+});

--- a/apps/mobile/lib/features/veille/providers/veille_suggestions_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_suggestions_provider.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/veille_suggestion.dart';
+import 'veille_repository_provider.dart';
+
+/// Param du FutureProvider topics — `theme_id`, `theme_label`, et la liste
+/// `selected_topic_ids` (utilisée par le LLM pour exclure ce qui est déjà
+/// dans la sélection user).
+@immutable
+class VeilleTopicsSuggestionParams {
+  final String themeId;
+  final String themeLabel;
+  final List<String> selectedTopicIds;
+
+  const VeilleTopicsSuggestionParams({
+    required this.themeId,
+    required this.themeLabel,
+    required this.selectedTopicIds,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is VeilleTopicsSuggestionParams &&
+        other.themeId == themeId &&
+        other.themeLabel == themeLabel &&
+        _listEquals(other.selectedTopicIds, selectedTopicIds);
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(themeId, themeLabel, Object.hashAll(selectedTopicIds));
+
+  static bool _listEquals(List<String> a, List<String> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}
+
+@immutable
+class VeilleSourcesSuggestionParams {
+  final String themeId;
+  final List<String> topicLabels;
+
+  const VeilleSourcesSuggestionParams({
+    required this.themeId,
+    required this.topicLabels,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is VeilleSourcesSuggestionParams &&
+        other.themeId == themeId &&
+        VeilleTopicsSuggestionParams._listEquals(
+          other.topicLabels,
+          topicLabels,
+        );
+  }
+
+  @override
+  int get hashCode => Object.hash(themeId, Object.hashAll(topicLabels));
+}
+
+/// Suggestions topics LLM appelées au mount de l'étape 2. AutoDispose pour
+/// libérer la mémoire dès que l'utilisateur quitte l'écran.
+final veilleTopicSuggestionsProvider = FutureProvider.autoDispose
+    .family<List<VeilleTopicSuggestion>, VeilleTopicsSuggestionParams>(
+  (ref, params) async {
+    final repo = ref.read(veilleRepositoryProvider);
+    return repo.suggestTopics(
+      themeId: params.themeId,
+      themeLabel: params.themeLabel,
+      selectedTopicIds: params.selectedTopicIds,
+    );
+  },
+);
+
+/// Suggestions sources LLM appelées au mount de l'étape 3.
+final veilleSourceSuggestionsProvider = FutureProvider.autoDispose
+    .family<VeilleSourceSuggestionsResponse, VeilleSourcesSuggestionParams>(
+  (ref, params) async {
+    final repo = ref.read(veilleRepositoryProvider);
+    return repo.suggestSources(
+      themeId: params.themeId,
+      topicLabels: params.topicLabels,
+    );
+  },
+);

--- a/apps/mobile/lib/features/veille/repositories/veille_repository.dart
+++ b/apps/mobile/lib/features/veille/repositories/veille_repository.dart
@@ -1,0 +1,174 @@
+import 'package:dio/dio.dart';
+
+import '../../../core/api/api_client.dart';
+import '../models/veille_config_dto.dart';
+import '../models/veille_delivery.dart';
+import '../models/veille_suggestion.dart';
+
+/// Levée quand `GET /api/veille/config` renvoie 404 — pas de veille active
+/// pour cet utilisateur. Le caller distingue cet état du reste pour
+/// rediriger vers le flow de configuration au lieu de remonter une erreur.
+class VeilleConfigNotFoundException implements Exception {
+  const VeilleConfigNotFoundException();
+  @override
+  String toString() => 'VeilleConfigNotFoundException';
+}
+
+/// Erreur générique des endpoints `/api/veille/*` (4xx ou 5xx). Les retries
+/// sur 5xx ≠503 sont déjà gérés par `RetryInterceptor` au niveau Dio
+/// (`core/api/retry_interceptor.dart`). Au niveau caller, on ne re-tente
+/// jamais — on remonte cette exception.
+class VeilleApiException implements Exception {
+  final int? statusCode;
+  final String message;
+  const VeilleApiException(this.message, {this.statusCode});
+  @override
+  String toString() =>
+      'VeilleApiException(status: $statusCode, message: $message)';
+}
+
+class VeilleRepository {
+  final ApiClient _apiClient;
+
+  VeilleRepository(this._apiClient);
+
+  Dio get _dio => _apiClient.dio;
+
+  // ─── Config ────────────────────────────────────────────────────────────
+
+  /// `GET /api/veille/config` → DTO si 200, `null` si 404 (pas de veille
+  /// active). Toute autre erreur → `VeilleApiException`.
+  Future<VeilleConfigDto?> getConfig() async {
+    try {
+      final response = await _dio.get<dynamic>('veille/config');
+      final data = response.data as Map<String, dynamic>;
+      return VeilleConfigDto.fromJson(data);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        return null;
+      }
+      throw _wrap(e);
+    }
+  }
+
+  Future<VeilleConfigDto> upsertConfig(VeilleConfigUpsertRequest body) async {
+    try {
+      final response =
+          await _dio.post<dynamic>('veille/config', data: body.toJson());
+      return VeilleConfigDto.fromJson(response.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      throw _wrap(e);
+    }
+  }
+
+  Future<VeilleConfigDto> patchConfig(VeilleConfigPatchRequest body) async {
+    try {
+      final response =
+          await _dio.patch<dynamic>('veille/config', data: body.toJson());
+      return VeilleConfigDto.fromJson(response.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        throw const VeilleConfigNotFoundException();
+      }
+      throw _wrap(e);
+    }
+  }
+
+  Future<void> deleteConfig() async {
+    try {
+      await _dio.delete<dynamic>('veille/config');
+    } on DioException catch (e) {
+      throw _wrap(e);
+    }
+  }
+
+  // ─── Suggestions ───────────────────────────────────────────────────────
+
+  Future<List<VeilleTopicSuggestion>> suggestTopics({
+    required String themeId,
+    required String themeLabel,
+    List<String> selectedTopicIds = const [],
+    List<String> excludeTopicIds = const [],
+  }) async {
+    try {
+      final response = await _dio.post<dynamic>(
+        'veille/suggestions/topics',
+        data: {
+          'theme_id': themeId,
+          'theme_label': themeLabel,
+          'selected_topic_ids': selectedTopicIds,
+          'exclude_topic_ids': excludeTopicIds,
+        },
+      );
+      final raw = response.data as List<dynamic>;
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleTopicSuggestion.fromJson)
+          .toList();
+    } on DioException catch (e) {
+      throw _wrap(e);
+    }
+  }
+
+  Future<VeilleSourceSuggestionsResponse> suggestSources({
+    required String themeId,
+    List<String> topicLabels = const [],
+    List<String> excludeSourceIds = const [],
+  }) async {
+    try {
+      final response = await _dio.post<dynamic>(
+        'veille/suggestions/sources',
+        data: {
+          'theme_id': themeId,
+          'topic_labels': topicLabels,
+          'exclude_source_ids': excludeSourceIds,
+        },
+      );
+      return VeilleSourceSuggestionsResponse.fromJson(
+        response.data as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw _wrap(e);
+    }
+  }
+
+  // ─── Deliveries ────────────────────────────────────────────────────────
+
+  Future<List<VeilleDeliveryListItem>> listDeliveries({int limit = 20}) async {
+    try {
+      final response = await _dio.get<dynamic>(
+        'veille/deliveries',
+        queryParameters: {'limit': limit},
+      );
+      final raw = response.data as List<dynamic>;
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleDeliveryListItem.fromJson)
+          .toList();
+    } on DioException catch (e) {
+      throw _wrap(e);
+    }
+  }
+
+  Future<VeilleDeliveryResponse> getDelivery(String id) async {
+    try {
+      final response = await _dio.get<dynamic>('veille/deliveries/$id');
+      return VeilleDeliveryResponse.fromJson(
+        response.data as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw _wrap(e);
+    }
+  }
+
+  VeilleApiException _wrap(DioException e) {
+    final code = e.response?.statusCode;
+    final detail = e.response?.data is Map
+        ? (e.response?.data as Map)['detail']?.toString()
+        : null;
+    return VeilleApiException(
+      detail ?? e.message ?? 'erreur réseau',
+      statusCode: code,
+    );
+  }
+}

--- a/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
@@ -3,7 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../data/veille_mock_data.dart';
+import '../../models/veille_config.dart';
+import '../../models/veille_suggestion.dart';
 import '../../providers/veille_config_provider.dart';
+import '../../providers/veille_suggestions_provider.dart';
 import '../../widgets/veille_widgets.dart';
 
 class Step2SuggestionsScreen extends ConsumerWidget {
@@ -14,6 +17,44 @@ class Step2SuggestionsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(veilleConfigProvider);
     final notifier = ref.read(veilleConfigProvider.notifier);
+
+    final themeId = state.selectedTheme;
+    final themeLabel = themeId == null
+        ? null
+        : VeilleMockData.themes
+            .firstWhere(
+              (t) => t.id == themeId,
+              orElse: () => VeilleMockData.themes.first,
+            )
+            .label;
+
+    final params = (themeId != null && themeLabel != null)
+        ? VeilleTopicsSuggestionParams(
+            themeId: themeId,
+            themeLabel: themeLabel,
+            selectedTopicIds: state.selectedTopics.toList()..sort(),
+          )
+        : null;
+
+    final asyncSuggestions = params == null
+        ? const AsyncValue<List<VeilleTopicSuggestion>>.data([])
+        : ref.watch(veilleTopicSuggestionsProvider(params));
+
+    // Hydrate les labels du state UNE fois par nouvelle réponse — ref.listen
+    // ne re-tire pas à chaque rebuild (contrairement à whenData inline qui
+    // boucle sur la mutation du state).
+    if (params != null) {
+      ref.listen<AsyncValue<List<VeilleTopicSuggestion>>>(
+        veilleTopicSuggestionsProvider(params),
+        (_, next) {
+          next.whenData((items) {
+            if (items.isNotEmpty) {
+              notifier.applyTopicSuggestions(items);
+            }
+          });
+        },
+      );
+    }
 
     return Column(
       children: [
@@ -34,35 +75,46 @@ class Step2SuggestionsScreen extends ConsumerWidget {
                   'Et ces angles auxquels tu n\'aurais peut-être pas pensé ?',
                 ),
                 const SizedBox(height: 22),
-                Column(
-                  children: [
-                    for (int i = 0;
-                        i < VeilleMockData.suggestedTopics.length;
-                        i++) ...[
-                      if (i > 0) const SizedBox(height: 6),
-                      SuggestionRow(
-                        label: VeilleMockData.suggestedTopics[i].label,
-                        reason: VeilleMockData.suggestedTopics[i].reason,
-                        selected: state.selectedSuggestions.contains(
-                          VeilleMockData.suggestedTopics[i].id,
-                        ),
-                        onTap: () => notifier.toggleSuggestion(
-                          VeilleMockData.suggestedTopics[i].id,
-                        ),
-                      ),
-                    ],
-                  ],
+                asyncSuggestions.when(
+                  loading: () => const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 24),
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                  error: (_, __) => _MockFallback(state: state, notifier: notifier),
+                  data: (apiItems) {
+                    final items = apiItems.isNotEmpty
+                        ? apiItems
+                            .map((s) => VeilleTopic(
+                                  id: s.topicId,
+                                  label: s.label,
+                                  reason: s.reason ?? '',
+                                ))
+                            .toList()
+                        : VeilleMockData.suggestedTopics;
+                    return Column(
+                      children: [
+                        for (int i = 0; i < items.length; i++) ...[
+                          if (i > 0) const SizedBox(height: 6),
+                          SuggestionRow(
+                            label: items[i].label,
+                            reason: items[i].reason,
+                            selected: state.selectedSuggestions
+                                .contains(items[i].id),
+                            onTap: () => notifier.toggleSuggestion(items[i].id),
+                          ),
+                        ],
+                      ],
+                    );
+                  },
                 ),
                 const SizedBox(height: 16),
                 GhostLink(
                   label: 'Proposer d\'autres angles',
                   icon: PhosphorIcons.arrowsClockwise(),
                   onTap: () {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('Bientôt — le facteur prépare d\'autres angles.'),
-                      ),
-                    );
+                    if (params != null) {
+                      ref.invalidate(veilleTopicSuggestionsProvider(params));
+                    }
                   },
                 ),
               ],
@@ -80,6 +132,42 @@ class Step2SuggestionsScreen extends ConsumerWidget {
             onPressed: notifier.goNext,
           ),
         ),
+      ],
+    );
+  }
+}
+
+class _MockFallback extends StatelessWidget {
+  final VeilleConfigState state;
+  final VeilleConfigNotifier notifier;
+  const _MockFallback({required this.state, required this.notifier});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(bottom: 12),
+          child: Text(
+            'Suggestions indisponibles, conserve ta sélection.',
+            style: TextStyle(fontSize: 12, color: Color(0xFF8B7E63)),
+          ),
+        ),
+        for (int i = 0;
+            i < VeilleMockData.suggestedTopics.length;
+            i++) ...[
+          if (i > 0) const SizedBox(height: 6),
+          SuggestionRow(
+            label: VeilleMockData.suggestedTopics[i].label,
+            reason: VeilleMockData.suggestedTopics[i].reason,
+            selected: state.selectedSuggestions.contains(
+              VeilleMockData.suggestedTopics[i].id,
+            ),
+            onTap: () => notifier.toggleSuggestion(
+              VeilleMockData.suggestedTopics[i].id,
+            ),
+          ),
+        ],
       ],
     );
   }

--- a/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
@@ -3,7 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../data/veille_mock_data.dart';
+import '../../models/veille_config.dart';
+import '../../models/veille_suggestion.dart';
 import '../../providers/veille_config_provider.dart';
+import '../../providers/veille_suggestions_provider.dart';
 import '../../widgets/veille_source_card.dart';
 import '../../widgets/veille_widgets.dart';
 
@@ -15,6 +18,40 @@ class Step3SourcesScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(veilleConfigProvider);
     final notifier = ref.read(veilleConfigProvider.notifier);
+
+    final themeId = state.selectedTheme;
+    final topicLabels = <String>[
+      ...state.selectedTopics.map((id) => state.topicLabels[id] ?? id),
+      ...state.selectedSuggestions.map((id) => state.topicLabels[id] ?? id),
+    ];
+
+    final params = themeId == null
+        ? null
+        : VeilleSourcesSuggestionParams(
+            themeId: themeId,
+            topicLabels: topicLabels,
+          );
+
+    final asyncSuggestions = params == null
+        ? const AsyncValue<VeilleSourceSuggestionsResponse>.data(
+            VeilleSourceSuggestionsResponse(followed: [], niche: []),
+          )
+        : ref.watch(veilleSourceSuggestionsProvider(params));
+
+    // Hydrate les sources via ref.listen pour éviter une boucle infinie
+    // (apply → state change → rebuild → re-apply).
+    if (params != null) {
+      ref.listen<AsyncValue<VeilleSourceSuggestionsResponse>>(
+        veilleSourceSuggestionsProvider(params),
+        (_, next) {
+          next.whenData((apiResp) {
+            if (apiResp.followed.isNotEmpty || apiResp.niche.isNotEmpty) {
+              notifier.applySourceSuggestions(apiResp);
+            }
+          });
+        },
+      );
+    }
 
     return Column(
       children: [
@@ -35,61 +72,27 @@ class Step3SourcesScreen extends ConsumerWidget {
                   'Les sources qui couvriront le mieux tes angles',
                 ),
                 const SizedBox(height: 24),
-                const VeilleBlockLabel('Tes sources de confiance'),
-                Column(
-                  children: [
-                    for (int i = 0;
-                        i < VeilleMockData.followedSources.length;
-                        i++) ...[
-                      if (i > 0) const SizedBox(height: 6),
-                      VeilleSourceCard(
-                        source: VeilleMockData.followedSources[i],
-                        inVeille: state.followedSources.contains(
-                          VeilleMockData.followedSources[i].id,
-                        ),
-                        isNiche: false,
-                        onToggle: () => notifier.toggleFollowedSource(
-                          VeilleMockData.followedSources[i].id,
-                        ),
-                      ),
-                    ],
-                  ],
-                ),
-                const SizedBox(height: 24),
-                const VeilleBlockLabel(
-                  'Sources niches recommandées par le facteur',
-                ),
-                Column(
-                  children: [
-                    for (int i = 0;
-                        i < VeilleMockData.nicheSources.length;
-                        i++) ...[
-                      if (i > 0) const SizedBox(height: 6),
-                      VeilleSourceCard(
-                        source: VeilleMockData.nicheSources[i],
-                        inVeille: state.nicheSources.contains(
-                          VeilleMockData.nicheSources[i].id,
-                        ),
-                        isNiche: true,
-                        onToggle: () => notifier.toggleNicheSource(
-                          VeilleMockData.nicheSources[i].id,
-                        ),
-                      ),
-                    ],
-                  ],
+                asyncSuggestions.when(
+                  loading: () => const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 24),
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                  error: (_, __) =>
+                      _MockSourcesFallback(state: state, notifier: notifier),
+                  data: (resp) => _ApiSourceLists(
+                    resp: resp,
+                    state: state,
+                    notifier: notifier,
+                  ),
                 ),
                 const SizedBox(height: 16),
                 GhostLink(
                   label: 'Proposer plus de sources',
                   icon: PhosphorIcons.arrowsClockwise(),
                   onTap: () {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text(
-                          'Bientôt — le facteur cherche d\'autres sources niches.',
-                        ),
-                      ),
-                    );
+                    if (params != null) {
+                      ref.invalidate(veilleSourceSuggestionsProvider(params));
+                    }
                   },
                 ),
               ],
@@ -107,6 +110,133 @@ class Step3SourcesScreen extends ConsumerWidget {
             onPressed: notifier.goNext,
           ),
         ),
+      ],
+    );
+  }
+}
+
+class _ApiSourceLists extends StatelessWidget {
+  final VeilleSourceSuggestionsResponse resp;
+  final VeilleConfigState state;
+  final VeilleConfigNotifier notifier;
+
+  const _ApiSourceLists({
+    required this.resp,
+    required this.state,
+    required this.notifier,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (resp.followed.isEmpty && resp.niche.isEmpty) {
+      return _MockSourcesFallback(state: state, notifier: notifier);
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (resp.followed.isNotEmpty) ...[
+          const VeilleBlockLabel('Tes sources de confiance'),
+          for (int i = 0; i < resp.followed.length; i++) ...[
+            if (i > 0) const SizedBox(height: 6),
+            VeilleSourceCard(
+              source: _toUiSource(resp.followed[i]),
+              inVeille: state.followedSources.contains(resp.followed[i].sourceId),
+              isNiche: false,
+              onToggle: () =>
+                  notifier.toggleFollowedSource(resp.followed[i].sourceId),
+            ),
+          ],
+          const SizedBox(height: 24),
+        ],
+        if (resp.niche.isNotEmpty) ...[
+          const VeilleBlockLabel(
+            'Sources niches recommandées par le facteur',
+          ),
+          for (int i = 0; i < resp.niche.length; i++) ...[
+            if (i > 0) const SizedBox(height: 6),
+            VeilleSourceCard(
+              source: _toUiSource(resp.niche[i]),
+              inVeille: state.nicheSources.contains(resp.niche[i].sourceId),
+              isNiche: true,
+              onToggle: () =>
+                  notifier.toggleNicheSource(resp.niche[i].sourceId),
+            ),
+          ],
+        ],
+      ],
+    );
+  }
+
+  static VeilleSource _toUiSource(VeilleSourceSuggestion s) {
+    final letter = s.name.isNotEmpty ? s.name[0].toUpperCase() : '?';
+    return VeilleSource(
+      id: s.sourceId,
+      letter: letter,
+      name: s.name,
+      meta: 'Source suggérée',
+      why: s.why,
+      logoUrl: 'https://www.google.com/s2/favicons?sz=128&domain=${_domain(s.url)}',
+    );
+  }
+
+  static String _domain(String url) {
+    final uri = Uri.tryParse(url);
+    return uri?.host ?? url;
+  }
+}
+
+class _MockSourcesFallback extends StatelessWidget {
+  final VeilleConfigState state;
+  final VeilleConfigNotifier notifier;
+  const _MockSourcesFallback({required this.state, required this.notifier});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(bottom: 12),
+          child: Text(
+            'Suggestions indisponibles, conserve ta sélection.',
+            style: TextStyle(fontSize: 12, color: Color(0xFF8B7E63)),
+          ),
+        ),
+        const VeilleBlockLabel('Tes sources de confiance'),
+        for (int i = 0;
+            i < VeilleMockData.followedSources.length;
+            i++) ...[
+          if (i > 0) const SizedBox(height: 6),
+          VeilleSourceCard(
+            source: VeilleMockData.followedSources[i],
+            inVeille: state.followedSources.contains(
+              VeilleMockData.followedSources[i].id,
+            ),
+            isNiche: false,
+            onToggle: () => notifier.toggleFollowedSource(
+              VeilleMockData.followedSources[i].id,
+            ),
+          ),
+        ],
+        const SizedBox(height: 24),
+        const VeilleBlockLabel(
+          'Sources niches recommandées par le facteur',
+        ),
+        for (int i = 0;
+            i < VeilleMockData.nicheSources.length;
+            i++) ...[
+          if (i > 0) const SizedBox(height: 6),
+          VeilleSourceCard(
+            source: VeilleMockData.nicheSources[i],
+            inVeille: state.nicheSources.contains(
+              VeilleMockData.nicheSources[i].id,
+            ),
+            isNiche: true,
+            onToggle: () => notifier.toggleNicheSource(
+              VeilleMockData.nicheSources[i].id,
+            ),
+          ),
+        ],
       ],
     );
   }

--- a/apps/mobile/lib/features/veille/screens/steps/step4_frequency_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step4_frequency_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
@@ -90,12 +92,10 @@ class Step4FrequencyScreen extends ConsumerWidget {
             border: Border(top: BorderSide(color: Color(0xFFE6E1D6))),
           ),
           child: VeilleCtaButton(
-            label: 'Lancer ma veille',
+            label: state.isSubmitting ? 'Envoi en cours…' : 'Lancer ma veille',
             leadingIcon: PhosphorIcons.check(),
-            onPressed: () async {
-              await notifier.submit();
-              await onSubmit();
-            },
+            onPressed:
+                state.isSubmitting ? null : () => unawaited(onSubmit()),
           ),
         ),
       ],

--- a/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
@@ -2,8 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../config/routes.dart';
 import '../../../config/theme.dart';
+import '../providers/veille_active_config_provider.dart';
 import '../providers/veille_config_provider.dart';
+import '../repositories/veille_repository.dart';
 import 'steps/step1_theme_screen.dart';
 import 'steps/step2_suggestions_screen.dart';
 import 'steps/step3_sources_screen.dart';
@@ -11,31 +14,62 @@ import 'steps/step4_frequency_screen.dart';
 import 'transitions/flow_loading_screen.dart';
 
 /// Host du flow de configuration de la veille.
-/// Switch entre les 4 écrans + écran de loading IA entre étapes.
+///
+/// - Si l'utilisateur a déjà une config active (`GET /api/veille/config` =
+///   200), redirect vers `/veille/dashboard` au lieu de relancer le flow.
+/// - Si 404 (pas de veille), affiche le flow 4-steps normal.
+/// - Si erreur API, affiche le flow normal et laisse le user tenter de
+///   créer une veille (l'erreur sera relevée au submit).
 class VeilleConfigScreen extends ConsumerWidget {
   const VeilleConfigScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(veilleConfigProvider);
+    final notifier = ref.read(veilleConfigProvider.notifier);
+    final activeConfig = ref.watch(veilleActiveConfigProvider);
+
+    // Si une config est déjà active, le user n'a rien à reconfigurer →
+    // redirect vers le dashboard. context.go est idempotent, donc même si le
+    // postFrameCallback se ré-arme à chaque rebuild, GoRouter dédupe.
+    if (activeConfig.valueOrNull != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (context.mounted) context.go(RoutePaths.veilleDashboard);
+      });
+    }
 
     void close() {
       if (context.canPop()) {
         context.pop();
       } else {
-        context.go('/feed');
+        context.go(RoutePaths.feed);
       }
     }
 
     Future<void> handleSubmit() async {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(
-            'Veille configurée — première livraison bientôt en preview.',
+      try {
+        await notifier.submit();
+        if (!context.mounted) return;
+        context.go(RoutePaths.veilleDashboard);
+      } on VeilleApiException catch (e) {
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Impossible d\'enregistrer ta veille (${e.statusCode ?? '?'}). Réessaie.',
+            ),
           ),
-        ),
-      );
-      close();
+        );
+      } catch (_) {
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Erreur réseau. Vérifie ta connexion et réessaie.',
+            ),
+          ),
+        );
+      }
     }
 
     Widget body;

--- a/apps/mobile/lib/features/veille/screens/veille_dashboard_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_dashboard_screen.dart
@@ -1,0 +1,502 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/routes.dart';
+import '../../../core/services/push_notification_service.dart';
+import '../models/veille_config_dto.dart';
+import '../providers/veille_active_config_provider.dart';
+import '../providers/veille_repository_provider.dart';
+import '../repositories/veille_repository.dart';
+
+class VeilleDashboardScreen extends ConsumerWidget {
+  const VeilleDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncConfig = ref.watch(veilleActiveConfigProvider);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF2E8D5),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFFF2E8D5),
+        elevation: 0,
+        title: Text(
+          'Ma veille',
+          style: GoogleFonts.dmSans(
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+            color: const Color(0xFF2A2419),
+          ),
+        ),
+        leading: IconButton(
+          icon: Icon(PhosphorIcons.x(), color: const Color(0xFF2A2419)),
+          onPressed: () {
+            if (context.canPop()) {
+              context.pop();
+            } else {
+              context.go(RoutePaths.feed);
+            }
+          },
+        ),
+      ),
+      body: asyncConfig.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _ErrorView(
+          message: e.toString(),
+          onRetry: () => ref.invalidate(veilleActiveConfigProvider),
+        ),
+        data: (cfg) {
+          if (cfg == null) {
+            // L'utilisateur n'a plus de veille (peut arriver après DELETE).
+            // On le redirige vers le flow de configuration.
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (context.mounted) context.go(RoutePaths.veilleConfig);
+            });
+            return const SizedBox.shrink();
+          }
+          return _DashboardBody(cfg: cfg);
+        },
+      ),
+    );
+  }
+}
+
+class _DashboardBody extends ConsumerWidget {
+  final VeilleConfigDto cfg;
+  const _DashboardBody({required this.cfg});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isPaused = cfg.status == 'paused';
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+      children: [
+        Text(
+          cfg.themeLabel,
+          style: GoogleFonts.dmSans(
+            fontSize: 22,
+            fontWeight: FontWeight.w700,
+            color: const Color(0xFF2A2419),
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          isPaused ? 'En pause' : _scheduleHuman(cfg),
+          style: GoogleFonts.dmSans(
+            fontSize: 13,
+            color: const Color(0xFF8B7E63),
+          ),
+        ),
+        const SizedBox(height: 24),
+        _SectionLabel(label: 'Tes angles (${cfg.topics.length})'),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 6,
+          runSpacing: 6,
+          children: cfg.topics
+              .map((t) => _Chip(label: t.label))
+              .toList(growable: false),
+        ),
+        const SizedBox(height: 24),
+        _SectionLabel(label: 'Tes sources (${cfg.sources.length})'),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 6,
+          runSpacing: 6,
+          children: cfg.sources
+              .map((s) => _Chip(label: s.source.name))
+              .toList(growable: false),
+        ),
+        if (!isPaused && cfg.nextScheduledAt != null) ...[
+          const SizedBox(height: 24),
+          Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: const Color(0xFFE6E1D6)),
+            ),
+            child: Row(
+              children: [
+                Icon(PhosphorIcons.calendar(),
+                    size: 18, color: const Color(0xFF8B7E63)),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Prochaine livraison',
+                        style: GoogleFonts.dmSans(
+                          fontSize: 12,
+                          color: const Color(0xFF8B7E63),
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        _formatNextScheduled(cfg.nextScheduledAt!),
+                        style: GoogleFonts.dmSans(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                          color: const Color(0xFF2A2419),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+        const SizedBox(height: 24),
+        _PrimaryButton(
+          icon: PhosphorIcons.envelope(),
+          label: 'Voir l\'historique',
+          onTap: () => context.pushNamed(RouteNames.veilleDeliveries),
+        ),
+        const SizedBox(height: 10),
+        _SecondaryButton(
+          icon: PhosphorIcons.pencilSimple(),
+          label: 'Modifier ma veille',
+          onTap: () => context.go(RoutePaths.veilleConfig),
+        ),
+        const SizedBox(height: 10),
+        _SecondaryButton(
+          icon: isPaused ? PhosphorIcons.play() : PhosphorIcons.pause(),
+          label: isPaused ? 'Reprendre' : 'Mettre en pause',
+          onTap: () => _togglePause(context, ref, cfg),
+        ),
+        const SizedBox(height: 10),
+        _DangerButton(
+          icon: PhosphorIcons.trash(),
+          label: 'Supprimer ma veille',
+          onTap: () => _confirmDelete(context, ref),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _togglePause(
+    BuildContext context,
+    WidgetRef ref,
+    VeilleConfigDto cfg,
+  ) async {
+    final repo = ref.read(veilleRepositoryProvider);
+    final nextStatus = cfg.status == 'paused' ? 'active' : 'paused';
+    try {
+      final updated = await repo.patchConfig(
+        VeilleConfigPatchRequest(status: nextStatus),
+      );
+      ref
+          .read(veilleActiveConfigProvider.notifier)
+          .hydrateFromServer(updated);
+
+      // Reschedule / cancel local notif selon l'état.
+      final pushService = PushNotificationService();
+      if (nextStatus == 'paused') {
+        await pushService.cancelVeilleNotification();
+      } else if (updated.nextScheduledAt != null) {
+        await pushService.scheduleVeilleNotification(
+          scheduledAt: updated.nextScheduledAt!.add(const Duration(minutes: 30)),
+        );
+      }
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            nextStatus == 'paused' ? 'Veille mise en pause' : 'Veille reprise',
+          ),
+        ),
+      );
+    } on VeilleApiException catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Erreur (${e.statusCode ?? '?'}). Réessaie.')),
+      );
+    }
+  }
+
+  Future<void> _confirmDelete(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Supprimer ma veille ?'),
+        content: const Text(
+          'Cette action est définitive. L\'historique des livraisons sera conservé.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Annuler'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: TextButton.styleFrom(foregroundColor: const Color(0xFFB73B3B)),
+            child: const Text('Supprimer'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    final repo = ref.read(veilleRepositoryProvider);
+    try {
+      await repo.deleteConfig();
+      await PushNotificationService().cancelVeilleNotification();
+      ref
+          .read(veilleActiveConfigProvider.notifier)
+          .hydrateFromServer(null);
+      if (!context.mounted) return;
+      context.go(RoutePaths.feed);
+    } on VeilleApiException catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Erreur (${e.statusCode ?? '?'}). Réessaie.')),
+      );
+    }
+  }
+
+  static String _scheduleHuman(VeilleConfigDto cfg) {
+    final freq = switch (cfg.frequency) {
+      'weekly' => 'chaque semaine',
+      'biweekly' => 'toutes les 2 semaines',
+      'monthly' => 'chaque mois',
+      _ => cfg.frequency,
+    };
+    final dayLabel = cfg.dayOfWeek == null ? null : _dayLabel(cfg.dayOfWeek!);
+    if (dayLabel == null) {
+      return '$freq · ${cfg.deliveryHour}h';
+    }
+    return '$freq · $dayLabel · ${cfg.deliveryHour}h';
+  }
+
+  static String _dayLabel(int dow) {
+    const labels = [
+      'lundi',
+      'mardi',
+      'mercredi',
+      'jeudi',
+      'vendredi',
+      'samedi',
+      'dimanche'
+    ];
+    if (dow < 0 || dow >= labels.length) return '';
+    return labels[dow];
+  }
+
+  static String _formatNextScheduled(DateTime d) {
+    final local = d.toLocal();
+    const months = [
+      'janv.',
+      'févr.',
+      'mars',
+      'avr.',
+      'mai',
+      'juin',
+      'juill.',
+      'août',
+      'sept.',
+      'oct.',
+      'nov.',
+      'déc.',
+    ];
+    final m = months[local.month - 1];
+    final hh = local.hour.toString().padLeft(2, '0');
+    final mm = local.minute.toString().padLeft(2, '0');
+    return '${local.day} $m ${local.year} · $hh:$mm';
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String label;
+  const _SectionLabel({required this.label});
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      label,
+      style: GoogleFonts.dmSans(
+        fontSize: 12,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.4,
+        color: const Color(0xFF8B7E63),
+      ),
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  final String label;
+  const _Chip({required this.label});
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: const Color(0xFFE6E1D6)),
+      ),
+      child: Text(
+        label,
+        style: GoogleFonts.dmSans(
+          fontSize: 12,
+          color: const Color(0xFF2A2419),
+        ),
+      ),
+    );
+  }
+}
+
+class _PrimaryButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  const _PrimaryButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 50,
+      child: Material(
+        color: const Color(0xFF2A2419),
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Center(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, color: Colors.white, size: 18),
+                const SizedBox(width: 8),
+                Text(
+                  label,
+                  style: GoogleFonts.dmSans(
+                    color: Colors.white,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SecondaryButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  const _SecondaryButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 48,
+      child: Material(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: const Color(0xFFE6E1D6)),
+            ),
+            child: Center(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(icon, size: 18, color: const Color(0xFF2A2419)),
+                  const SizedBox(width: 8),
+                  Text(
+                    label,
+                    style: GoogleFonts.dmSans(
+                      color: const Color(0xFF2A2419),
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DangerButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  const _DangerButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+  @override
+  Widget build(BuildContext context) {
+    return TextButton.icon(
+      onPressed: onTap,
+      icon: Icon(icon, color: const Color(0xFFB73B3B), size: 16),
+      label: Text(
+        label,
+        style: GoogleFonts.dmSans(
+          color: const Color(0xFFB73B3B),
+          fontSize: 13,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+  const _ErrorView({required this.message, required this.onRetry});
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(PhosphorIcons.cloudSlash(), size: 32, color: const Color(0xFFB67C2E)),
+            const SizedBox(height: 12),
+            Text(
+              'Impossible de charger ta veille.',
+              style: GoogleFonts.dmSans(
+                fontSize: 14,
+                color: const Color(0xFF2A2419),
+              ),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(onPressed: onRetry, child: const Text('Réessayer')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/veille/screens/veille_deliveries_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_deliveries_screen.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/routes.dart';
+import '../models/veille_delivery.dart';
+import '../providers/veille_deliveries_provider.dart';
+
+class VeilleDeliveriesScreen extends ConsumerWidget {
+  const VeilleDeliveriesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncDeliveries = ref.watch(veilleDeliveriesProvider);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF2E8D5),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFFF2E8D5),
+        elevation: 0,
+        title: Text(
+          'Historique de ma veille',
+          style: GoogleFonts.dmSans(
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+            color: const Color(0xFF2A2419),
+          ),
+        ),
+        iconTheme: const IconThemeData(color: Color(0xFF2A2419)),
+      ),
+      body: RefreshIndicator(
+        onRefresh: () async => ref.invalidate(veilleDeliveriesProvider),
+        child: asyncDeliveries.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => _ErrorView(
+            message: e.toString(),
+            onRetry: () => ref.invalidate(veilleDeliveriesProvider),
+          ),
+          data: (list) {
+            if (list.isEmpty) {
+              return const _EmptyView();
+            }
+            return ListView.separated(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+              itemCount: list.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 10),
+              itemBuilder: (context, i) => _DeliveryListCard(
+                delivery: list[i],
+                onTap: () {
+                  context.pushNamed(
+                    RouteNames.veilleDeliveryDetail,
+                    pathParameters: {'id': list[i].id},
+                  );
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _DeliveryListCard extends StatelessWidget {
+  final VeilleDeliveryListItem delivery;
+  final VoidCallback onTap;
+
+  const _DeliveryListCard({required this.delivery, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: const Color(0xFFE6E1D6)),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      _formatTargetDate(delivery.targetDate),
+                      style: GoogleFonts.dmSans(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
+                        color: const Color(0xFF2A2419),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      _subtitle(delivery),
+                      style: GoogleFonts.dmSans(
+                        fontSize: 12,
+                        color: const Color(0xFF8B7E63),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                PhosphorIcons.caretRight(),
+                size: 16,
+                color: const Color(0xFF8B7E63),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _subtitle(VeilleDeliveryListItem d) {
+    switch (d.generationState) {
+      case VeilleGenerationState.succeeded:
+        return '${d.itemCount} sujet${d.itemCount > 1 ? 's' : ''}';
+      case VeilleGenerationState.running:
+      case VeilleGenerationState.pending:
+        return 'Génération en cours…';
+      case VeilleGenerationState.failed:
+        return 'Échec — réessai automatique';
+    }
+  }
+
+  static String _formatTargetDate(DateTime d) {
+    const months = [
+      'janv.',
+      'févr.',
+      'mars',
+      'avr.',
+      'mai',
+      'juin',
+      'juill.',
+      'août',
+      'sept.',
+      'oct.',
+      'nov.',
+      'déc.',
+    ];
+    return '${d.day} ${months[d.month - 1]} ${d.year}';
+  }
+}
+
+class _EmptyView extends StatelessWidget {
+  const _EmptyView();
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      // ListView pour permettre le pull-to-refresh même quand vide.
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 80, 24, 24),
+          child: Column(
+            children: [
+              Icon(
+                PhosphorIcons.envelope(),
+                size: 36,
+                color: const Color(0xFFB67C2E),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Aucune livraison pour le moment.',
+                textAlign: TextAlign.center,
+                style: GoogleFonts.dmSans(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: const Color(0xFF2A2419),
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                'Ta première livraison arrivera à la prochaine date programmée.',
+                textAlign: TextAlign.center,
+                style: GoogleFonts.dmSans(
+                  fontSize: 12,
+                  color: const Color(0xFF8B7E63),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+  const _ErrorView({required this.message, required this.onRetry});
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 80, 24, 24),
+          child: Column(
+            children: [
+              Icon(PhosphorIcons.cloudSlash(), size: 32, color: const Color(0xFFB67C2E)),
+              const SizedBox(height: 12),
+              Text(
+                'Impossible de charger l\'historique.',
+                style: GoogleFonts.dmSans(
+                  fontSize: 14,
+                  color: const Color(0xFF2A2419),
+                ),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(onPressed: onRetry, child: const Text('Réessayer')),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/features/veille/screens/veille_delivery_detail_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_delivery_detail_screen.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../models/veille_delivery.dart';
+import '../providers/veille_deliveries_provider.dart';
+import '../widgets/veille_cluster_card.dart';
+
+class VeilleDeliveryDetailScreen extends ConsumerWidget {
+  final String deliveryId;
+  const VeilleDeliveryDetailScreen({super.key, required this.deliveryId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncDelivery = ref.watch(veilleDeliveryProvider(deliveryId));
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF2E8D5),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFFF2E8D5),
+        elevation: 0,
+        title: asyncDelivery.maybeWhen(
+          data: (d) => Text(
+            _formatTargetDate(d.targetDate),
+            style: GoogleFonts.dmSans(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: const Color(0xFF2A2419),
+            ),
+          ),
+          orElse: () => Text(
+            'Livraison',
+            style: GoogleFonts.dmSans(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: const Color(0xFF2A2419),
+            ),
+          ),
+        ),
+        iconTheme: const IconThemeData(color: Color(0xFF2A2419)),
+      ),
+      body: asyncDelivery.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _ErrorState(
+          message: e.toString(),
+          onRetry: () => ref.invalidate(veilleDeliveryProvider(deliveryId)),
+        ),
+        data: (delivery) => _DeliveryBody(
+          delivery: delivery,
+          onArticleTap: (a) => _openArticle(context, a.url),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openArticle(BuildContext context, String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    try {
+      await launchUrl(uri, mode: LaunchMode.inAppBrowserView);
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Impossible d\'ouvrir l\'article: $e')),
+        );
+      }
+    }
+  }
+
+  String _formatTargetDate(DateTime d) {
+    const months = [
+      'janv.',
+      'févr.',
+      'mars',
+      'avr.',
+      'mai',
+      'juin',
+      'juill.',
+      'août',
+      'sept.',
+      'oct.',
+      'nov.',
+      'déc.',
+    ];
+    final m = months[d.month - 1];
+    return '${d.day} $m ${d.year}';
+  }
+}
+
+class _DeliveryBody extends StatelessWidget {
+  final VeilleDeliveryResponse delivery;
+  final void Function(VeilleDeliveryArticle) onArticleTap;
+  const _DeliveryBody({
+    required this.delivery,
+    required this.onArticleTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (delivery.generationState == VeilleGenerationState.failed) {
+      return _DeliveryFailedView(lastError: delivery.lastError);
+    }
+    if (delivery.generationState == VeilleGenerationState.running ||
+        delivery.generationState == VeilleGenerationState.pending) {
+      return const _DeliveryPendingView();
+    }
+    if (delivery.items.isEmpty) {
+      return const _DeliveryEmptyView();
+    }
+    return ListView.builder(
+      padding: const EdgeInsets.only(top: 8, bottom: 24),
+      itemCount: delivery.items.length,
+      itemBuilder: (context, i) => VeilleClusterCard(
+        item: delivery.items[i],
+        onArticleTap: onArticleTap,
+      ),
+    );
+  }
+}
+
+class _DeliveryPendingView extends StatelessWidget {
+  const _DeliveryPendingView();
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CircularProgressIndicator(),
+            const SizedBox(height: 16),
+            Text(
+              'Génération en cours…',
+              style: GoogleFonts.dmSans(
+                fontSize: 14,
+                color: const Color(0xFF8B7E63),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DeliveryFailedView extends StatelessWidget {
+  final String? lastError;
+  const _DeliveryFailedView({this.lastError});
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              PhosphorIcons.warningCircle(),
+              size: 36,
+              color: const Color(0xFFB67C2E),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'La livraison a échoué',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.dmSans(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: const Color(0xFF2A2419),
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'Le scanner réessaiera bientôt — pas besoin de relancer la veille.',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.dmSans(
+                fontSize: 13,
+                color: const Color(0xFF8B7E63),
+              ),
+            ),
+            if (lastError != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                lastError!,
+                style: GoogleFonts.dmSans(
+                  fontSize: 11,
+                  color: const Color(0xFFAFA38B),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DeliveryEmptyView extends StatelessWidget {
+  const _DeliveryEmptyView();
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          'Pas de cluster pour cette livraison.',
+          textAlign: TextAlign.center,
+          style: GoogleFonts.dmSans(
+            fontSize: 14,
+            color: const Color(0xFF8B7E63),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+  const _ErrorState({required this.message, required this.onRetry});
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(PhosphorIcons.cloudSlash(), size: 32, color: const Color(0xFFB67C2E)),
+            const SizedBox(height: 12),
+            Text(
+              'Erreur réseau',
+              style: GoogleFonts.dmSans(
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                color: const Color(0xFF2A2419),
+              ),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(onPressed: onRetry, child: const Text('Réessayer')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/veille/widgets/veille_cluster_card.dart
+++ b/apps/mobile/lib/features/veille/widgets/veille_cluster_card.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../models/veille_delivery.dart';
+
+/// Carte représentant un cluster d'articles dans la livraison de veille.
+class VeilleClusterCard extends StatelessWidget {
+  final VeilleDeliveryItem item;
+  final void Function(VeilleDeliveryArticle) onArticleTap;
+
+  const VeilleClusterCard({
+    super.key,
+    required this.item,
+    required this.onArticleTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0xFFE6E1D6)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            item.title,
+            style: GoogleFonts.dmSans(
+              fontSize: 17,
+              fontWeight: FontWeight.w700,
+              color: const Color(0xFF2A2419),
+            ),
+          ),
+          if (item.whyItMatters.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: const Color(0xFFF5EFE0),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    PhosphorIcons.lightbulb(),
+                    size: 14,
+                    color: const Color(0xFF8B7E63),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      item.whyItMatters,
+                      style: GoogleFonts.dmSans(
+                        fontSize: 13,
+                        height: 1.4,
+                        color: const Color(0xFF5C5240),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+          const SizedBox(height: 14),
+          for (var i = 0; i < item.articles.length; i++) ...[
+            if (i > 0) const Divider(height: 18, color: Color(0xFFEFE9DA)),
+            _ArticleRow(
+              article: item.articles[i],
+              onTap: () => onArticleTap(item.articles[i]),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ArticleRow extends StatelessWidget {
+  final VeilleDeliveryArticle article;
+  final VoidCallback onTap;
+
+  const _ArticleRow({required this.article, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              article.title,
+              style: GoogleFonts.dmSans(
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                color: const Color(0xFF2A2419),
+              ),
+            ),
+            if (article.excerpt.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(
+                article.excerpt,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: GoogleFonts.dmSans(
+                  fontSize: 12,
+                  height: 1.4,
+                  color: const Color(0xFF8B7E63),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/core/services/deep_link_service_test.dart
+++ b/apps/mobile/test/core/services/deep_link_service_test.dart
@@ -33,6 +33,22 @@ void main() {
       expect(action.topicId, 'international');
     });
 
+    test('veille/dashboard → veille target', () {
+      final action = DeepLinkService.parse(
+        Uri.parse('io.supabase.facteur://veille/dashboard'),
+      );
+      expect(action.target, WidgetDeepLinkTarget.veille);
+      expect(action.route, '/veille/dashboard');
+    });
+
+    test('veille bare host → veille target (fallback dashboard)', () {
+      final action = DeepLinkService.parse(
+        Uri.parse('io.supabase.facteur://veille'),
+      );
+      expect(action.target, WidgetDeepLinkTarget.veille);
+      expect(action.route, '/veille/dashboard');
+    });
+
     test('feed host → feed target', () {
       final action = DeepLinkService.parse(
         Uri.parse('io.supabase.facteur://feed'),

--- a/apps/mobile/test/features/veille/models/veille_models_test.dart
+++ b/apps/mobile/test/features/veille/models/veille_models_test.dart
@@ -1,0 +1,331 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/veille/models/veille_config_dto.dart';
+import 'package:facteur/features/veille/models/veille_delivery.dart';
+import 'package:facteur/features/veille/models/veille_suggestion.dart';
+
+void main() {
+  group('VeilleDeliveryArticle.fromJson', () {
+    test('parses required fields', () {
+      final article = VeilleDeliveryArticle.fromJson({
+        'content_id': 'c1',
+        'source_id': 's1',
+        'title': 'Titre',
+        'url': 'https://example.test/a',
+        'excerpt': 'Résumé',
+        'published_at': '2026-05-01T07:00:00Z',
+      });
+
+      expect(article.contentId, 'c1');
+      expect(article.sourceId, 's1');
+      expect(article.title, 'Titre');
+      expect(article.url, 'https://example.test/a');
+      expect(article.excerpt, 'Résumé');
+      expect(article.publishedAt.toUtc().hour, 7);
+    });
+
+    test('defaults excerpt to empty string when missing', () {
+      final article = VeilleDeliveryArticle.fromJson({
+        'content_id': 'c1',
+        'source_id': 's1',
+        'title': 'Titre',
+        'url': 'https://example.test/a',
+        'published_at': '2026-05-01T07:00:00Z',
+      });
+
+      expect(article.excerpt, '');
+    });
+  });
+
+  group('VeilleDeliveryItem.fromJson', () {
+    test('parses cluster + articles + why_it_matters', () {
+      final item = VeilleDeliveryItem.fromJson({
+        'cluster_id': 'cl1',
+        'title': 'IA & écoles',
+        'why_it_matters': 'Sujet structurant.',
+        'articles': [
+          {
+            'content_id': 'c1',
+            'source_id': 's1',
+            'title': 'A1',
+            'url': 'https://example.test/a1',
+            'excerpt': 'e1',
+            'published_at': '2026-05-01T07:00:00Z',
+          },
+        ],
+      });
+
+      expect(item.clusterId, 'cl1');
+      expect(item.title, 'IA & écoles');
+      expect(item.whyItMatters, 'Sujet structurant.');
+      expect(item.articles, hasLength(1));
+      expect(item.articles.first.contentId, 'c1');
+    });
+
+    test('handles empty articles list', () {
+      final item = VeilleDeliveryItem.fromJson({
+        'cluster_id': 'cl1',
+        'title': 't',
+        'why_it_matters': '',
+        'articles': <dynamic>[],
+      });
+      expect(item.articles, isEmpty);
+    });
+  });
+
+  group('VeilleDeliveryListItem.fromJson', () {
+    test('parses target_date as DateTime + state enum', () {
+      final item = VeilleDeliveryListItem.fromJson({
+        'id': 'd1',
+        'veille_config_id': 'vc1',
+        'target_date': '2026-05-02',
+        'generation_state': 'succeeded',
+        'item_count': 5,
+        'generated_at': '2026-05-02T07:30:00Z',
+        'created_at': '2026-05-02T07:00:00Z',
+      });
+
+      expect(item.id, 'd1');
+      expect(item.veilleConfigId, 'vc1');
+      expect(item.generationState, VeilleGenerationState.succeeded);
+      expect(item.itemCount, 5);
+      expect(item.generatedAt, isNotNull);
+    });
+
+    test('null generated_at when missing', () {
+      final item = VeilleDeliveryListItem.fromJson({
+        'id': 'd1',
+        'veille_config_id': 'vc1',
+        'target_date': '2026-05-02',
+        'generation_state': 'pending',
+        'item_count': 0,
+        'created_at': '2026-05-02T07:00:00Z',
+      });
+      expect(item.generatedAt, isNull);
+      expect(item.generationState, VeilleGenerationState.pending);
+    });
+  });
+
+  group('VeilleDeliveryResponse.fromJson', () {
+    test('parses full response with items', () {
+      final delivery = VeilleDeliveryResponse.fromJson({
+        'id': 'd1',
+        'veille_config_id': 'vc1',
+        'target_date': '2026-05-02',
+        'items': [
+          {
+            'cluster_id': 'cl1',
+            'title': 'titre',
+            'why_it_matters': 'why',
+            'articles': <dynamic>[],
+          },
+        ],
+        'generation_state': 'succeeded',
+        'attempts': 1,
+        'started_at': '2026-05-02T07:00:00Z',
+        'finished_at': '2026-05-02T07:30:00Z',
+        'last_error': null,
+        'version': 1,
+        'generated_at': '2026-05-02T07:30:00Z',
+        'created_at': '2026-05-02T07:00:00Z',
+        'updated_at': '2026-05-02T07:30:00Z',
+      });
+
+      expect(delivery.items, hasLength(1));
+      expect(delivery.generationState, VeilleGenerationState.succeeded);
+    });
+
+    test('handles failed state with last_error', () {
+      final delivery = VeilleDeliveryResponse.fromJson({
+        'id': 'd1',
+        'veille_config_id': 'vc1',
+        'target_date': '2026-05-02',
+        'items': <dynamic>[],
+        'generation_state': 'failed',
+        'attempts': 3,
+        'started_at': '2026-05-02T07:00:00Z',
+        'finished_at': null,
+        'last_error': 'LLM timeout',
+        'version': 1,
+        'generated_at': null,
+        'created_at': '2026-05-02T07:00:00Z',
+        'updated_at': '2026-05-02T07:00:00Z',
+      });
+
+      expect(delivery.generationState, VeilleGenerationState.failed);
+      expect(delivery.lastError, 'LLM timeout');
+      expect(delivery.items, isEmpty);
+    });
+  });
+
+  group('VeilleTopicSuggestion.fromJson', () {
+    test('parses with optional reason', () {
+      final s = VeilleTopicSuggestion.fromJson({
+        'topic_id': 't-eval',
+        'label': 'Évaluation',
+        'reason': 'présent dans 8 lectures',
+      });
+      expect(s.topicId, 't-eval');
+      expect(s.label, 'Évaluation');
+      expect(s.reason, 'présent dans 8 lectures');
+    });
+
+    test('null reason when missing', () {
+      final s = VeilleTopicSuggestion.fromJson({
+        'topic_id': 't1',
+        'label': 'X',
+      });
+      expect(s.reason, isNull);
+    });
+  });
+
+  group('VeilleSourceSuggestionsResponse.fromJson', () {
+    test('parses both followed and niche lists', () {
+      final r = VeilleSourceSuggestionsResponse.fromJson({
+        'followed': [
+          {
+            'source_id': 's1',
+            'name': 'Le Monde',
+            'url': 'https://lemonde.fr',
+            'feed_url': 'https://lemonde.fr/rss',
+            'theme': 'edu',
+            'why': null,
+          },
+        ],
+        'niche': [
+          {
+            'source_id': 's2',
+            'name': 'EdSurge',
+            'url': 'https://edsurge.com',
+            'feed_url': 'https://edsurge.com/rss',
+            'theme': 'edu',
+            'why': 'innovations US',
+          },
+        ],
+      });
+      expect(r.followed, hasLength(1));
+      expect(r.niche, hasLength(1));
+      expect(r.niche.first.why, 'innovations US');
+    });
+  });
+
+  group('VeilleConfigDto.fromJson', () {
+    test('hydrates topics + sources', () {
+      final cfg = VeilleConfigDto.fromJson({
+        'id': 'vc1',
+        'user_id': 'u1',
+        'theme_id': 'edu',
+        'theme_label': 'Éducation',
+        'frequency': 'weekly',
+        'day_of_week': 0,
+        'delivery_hour': 7,
+        'timezone': 'Europe/Paris',
+        'status': 'active',
+        'last_delivered_at': null,
+        'next_scheduled_at': '2026-05-09T05:00:00Z',
+        'created_at': '2026-05-02T07:00:00Z',
+        'updated_at': '2026-05-02T07:00:00Z',
+        'topics': [
+          {
+            'id': 't-row-1',
+            'topic_id': 't-eval',
+            'label': 'Évaluation',
+            'kind': 'preset',
+            'reason': null,
+            'position': 0,
+          },
+        ],
+        'sources': [
+          {
+            'id': 'vs1',
+            'kind': 'followed',
+            'why': null,
+            'position': 0,
+            'source': {
+              'id': 's1',
+              'name': 'Le Monde',
+              'url': 'https://lemonde.fr',
+              'feed_url': 'https://lemonde.fr/rss',
+              'theme': 'edu',
+              'type': 'article',
+              'is_curated': true,
+              'logo_url': null,
+            },
+          },
+        ],
+      });
+
+      expect(cfg.id, 'vc1');
+      expect(cfg.frequency, 'weekly');
+      expect(cfg.dayOfWeek, 0);
+      expect(cfg.topics, hasLength(1));
+      expect(cfg.topics.first.label, 'Évaluation');
+      expect(cfg.sources, hasLength(1));
+      expect(cfg.sources.first.source.name, 'Le Monde');
+    });
+  });
+
+  group('VeilleConfigUpsertRequest.toJson', () {
+    test('serializes minimal weekly config', () {
+      final body = VeilleConfigUpsertRequest(
+        themeId: 'edu',
+        themeLabel: 'Éducation',
+        topics: const [
+          VeilleTopicSelectionRequest(
+            topicId: 't-eval',
+            label: 'Évaluation',
+            kind: 'preset',
+          ),
+        ],
+        sourceSelections: const [
+          VeilleSourceSelectionRequest(
+            kind: 'followed',
+            sourceId: 's1',
+            position: 0,
+          ),
+        ],
+        frequency: 'weekly',
+        dayOfWeek: 0,
+      );
+
+      final json = body.toJson();
+      expect(json['theme_id'], 'edu');
+      expect(json['frequency'], 'weekly');
+      expect(json['day_of_week'], 0);
+      expect((json['topics'] as List).first['kind'], 'preset');
+      expect((json['source_selections'] as List).first['source_id'], 's1');
+    });
+
+    test('serializes niche candidate when no source_id', () {
+      final body = VeilleConfigUpsertRequest(
+        themeId: 'edu',
+        themeLabel: 'Éducation',
+        topics: const [],
+        sourceSelections: const [
+          VeilleSourceSelectionRequest(
+            kind: 'niche',
+            nicheCandidate: VeilleNicheCandidateRequest(
+              name: 'New niche',
+              url: 'https://niche.test',
+            ),
+          ),
+        ],
+        frequency: 'monthly',
+        dayOfWeek: null,
+      );
+      final json = body.toJson();
+      final selections = json['source_selections'] as List;
+      expect(selections.first['niche_candidate'], isNotNull);
+      expect(selections.first.containsKey('source_id'), isFalse);
+      expect(json.containsKey('day_of_week'), isFalse);
+    });
+  });
+
+  group('VeilleConfigPatchRequest.toJson', () {
+    test('omits null fields entirely', () {
+      final body = VeilleConfigPatchRequest(status: 'paused');
+      final json = body.toJson();
+      expect(json, {'status': 'paused'});
+    });
+  });
+}

--- a/docs/stories/core/18.3.veille-e2e.md
+++ b/docs/stories/core/18.3.veille-e2e.md
@@ -1,0 +1,490 @@
+# Story 18.3 : « Ma veille » end-to-end (front wiring + historique + push notifs)
+
+## Status: Plan rédigé — en attente GO PO
+
+> Branche : `boujonlaurin-dotcom/veille-e2e` — PR cible **`main`** (staging déprécié, hook bloque).
+
+---
+
+## Story
+
+**As a** utilisateur Facteur ayant un compte actif,
+**I want** configurer ma veille via le flow 4 étapes (vraies suggestions LLM, soumission persistée), retrouver ma config depuis un dashboard dédié, lire l'historique de mes livraisons et le détail (clusters + `why_it_matters` + articles cliquables), et recevoir une notif locale quand une livraison tombe,
+**so that** la phase E2E ferme la boucle « configuration → livraison → consommation » sur l'app sans aucun mock résiduel côté contrat API.
+
+---
+
+## Context
+
+### Phases précédentes (déjà mergées)
+
+- **18.1** (PR #524) — Foundations backend : tables Postgres, CRUD `/api/veille/config`, suggestions LLM topics/sources, scheduler `*/30 min`. `items=[]` par défaut.
+- **18.2** (PR #535) — Pipeline LLM : `VeilleDigestBuilder` produit des `items[]` réels (clusters + `why_it_matters` Mistral, fallback déterministe), session DB jamais tenue pendant l'appel LLM (Option C). 9 endpoints `/api/veille/*` opérationnels.
+
+### Phase 18.3 (cette story)
+
+Front Flutter `apps/mobile/lib/features/veille/` est encore 100 % mock :
+- `veille_config_provider.dart:142` → `submit()` no-op (TODO explicite).
+- `veille_config_screen.dart:30` → `handleSubmit()` SnackBar puis pop.
+- Aucun écran historique ni détail livraison.
+- Aucune notif planifiée à la livraison.
+
+L'app utilise `flutter_local_notifications` (pas FCM), et le backend ne stocke aucun push token. Le push « livraison » se fait donc via une notif **locale** planifiée côté front au submit (pattern `scheduleDailyDigestNotification` réutilisé).
+
+### Hors scope
+
+- Multi-veilles par user (V2/V3).
+- Carte « Ma veille » sur le feed/accueil (entry point — non sélectionné en brainstorming).
+- Push serveur via FCM/APNS (gros chantier, justifié seulement quand multi-device).
+
+---
+
+## Décisions PO (réponses au brainstorming AskUserQuestion)
+
+| # | Sujet | Arbitrage |
+|---|---|---|
+| 1 | Découpage | Story unique 18.3 monolithique (wiring + historique + détail + push, 1 PR) |
+| 2 | Périmètre écrans | « Ma veille déjà configurée » (dashboard) + Historique livraisons + Détail livraison. Pas de carte feed dans cette phase. |
+| 3 | Push notif | Notif locale planifiée côté front au submit (pattern `scheduleDailyDigestNotification`) |
+| 4a | Cache front | Cache mémoire « load on enter » simple (pas de stale-fallback ni retries cascadés) |
+| 4b | Retries | Max 1 sur 5xx, 0 sur 4xx (anti-cascade pool DB) |
+| 4c | Suggestions topics/sources | Appel API à l'entrée d'écran, bloquant (spinner) |
+| 4d | `veille_mock_data.dart` | **Conservé** (sert aux défauts state initial du provider, jamais envoyé au backend) |
+| 4e | Tap article dans détail | InAppWebView (cohérence digest) |
+
+---
+
+## Acceptance Criteria
+
+1. **Submit étape 4 → POST /api/veille/config** : crée/met à jour la config + topics + sources. Body conforme `VeilleConfigUpsert` (cf. `packages/api/app/schemas/veille.py:99`). Réponse 200 → state succès.
+2. **Suggestions API à l'entrée** : `step2_suggestions_screen.dart` appelle `POST /api/veille/suggestions/topics` au mount (spinner pendant la requête), `step3_sources_screen.dart` idem avec `/suggestions/sources`. Erreur réseau → toast + bouton retry, mock data en fallback visuel temporaire.
+3. **Écran « Ma veille déjà configurée »** : si `GET /api/veille/config` retourne 200, l'utilisateur ouvrant `/veille/config` est redirigé vers `/veille/dashboard` au lieu de relancer le flow. Si 404 → flow normal.
+4. **Dashboard** : affiche thème, topics, sources, fréquence, prochain `next_scheduled_at` (countdown). Boutons : « Voir l'historique », « Modifier » (relance flow preset state), « Mettre en pause » (PATCH status=paused), « Supprimer » (DELETE → 204).
+5. **Historique** : `GET /api/veille/deliveries?limit=20` ; ListView 1 carte/livraison (date, nb items, état). Empty state si 0 livraison.
+6. **Détail livraison** : `GET /api/veille/deliveries/{id}` ; rend chaque cluster en carte (titre, `why_it_matters`, articles). Tap article → InAppWebView (helper réutilisé du digest). Gère `generation_state == "failed"` (message d'erreur sympa).
+7. **Notif locale** : au POST /config réussi, planifie une notif locale (NotifId=3) à `next_scheduled_at + 30 min` (laisse le scanner */30 min générer). PATCH status=paused / DELETE → cancel notif. Re-PATCH frequency → cancel + reschedule.
+8. **Deeplink** : `io.supabase.facteur://veille/dashboard` mappé dans `deep_link_service.dart` → ouvre dashboard. Tap notif → deeplink.
+9. **Retries bornés** : `VeilleRepository` propage 4xx sans retry, 5xx avec max 1 retry (anti-cascade pool DB).
+10. **Cache « load on enter »** : pas de cache disque, pas de stale-fallback. Refresh manuel via pull-to-refresh + invalidation au push (provider invalidation).
+11. **Tests verts** : `flutter test` (5 fichiers touchés/créés), `flutter analyze` (pas de nouveau warning), `pytest -v` (anti-régression backend, pas de modif Python).
+12. **`/validate-feature` (Chrome MCP, viewport 390x844)** : 5 scénarios passent (cf. QA handoff).
+13. **PR vers `main`** (`--base main` obligatoire).
+
+---
+
+## Plan technique
+
+### Architecture front (vue d'ensemble)
+
+```
+features/veille/
+├── data/
+│   └── veille_mock_data.dart                 (CONSERVÉ — défauts state initial)
+├── models/
+│   ├── veille_config.dart                    (EDIT — `apiSourceId: String?` sur VeilleSource)
+│   ├── veille_delivery.dart                  (NEW — miroir Pydantic)
+│   └── veille_suggestion.dart                (NEW — DTOs suggestions)
+├── repositories/
+│   └── veille_repository.dart                (NEW — 9 méthodes Dio)
+├── providers/
+│   ├── veille_repository_provider.dart       (NEW)
+│   ├── veille_config_provider.dart           (EDIT — submit() POST /config + planif notif)
+│   ├── veille_active_config_provider.dart    (NEW — GET /config, hydrate dashboard)
+│   ├── veille_suggestions_provider.dart      (NEW — POST /suggestions/topics + /sources)
+│   ├── veille_deliveries_provider.dart       (NEW — GET /deliveries)
+│   └── veille_delivery_provider.dart         (NEW — GET /deliveries/:id)
+├── screens/
+│   ├── veille_config_screen.dart             (EDIT — handleSubmit propage erreur)
+│   ├── veille_dashboard_screen.dart          (NEW)
+│   ├── veille_deliveries_screen.dart         (NEW)
+│   ├── veille_delivery_detail_screen.dart    (NEW)
+│   └── steps/
+│       ├── step2_suggestions_screen.dart     (EDIT — POST /suggestions/topics au mount)
+│       └── step3_sources_screen.dart         (EDIT — POST /suggestions/sources au mount)
+└── widgets/
+    └── veille_cluster_card.dart              (NEW — carte cluster détail)
+
+core/services/push_notification_service.dart  (EDIT — scheduleVeilleNotification, NotifId=3)
+core/services/deep_link_service.dart          (EDIT — mapping veille/dashboard)
+config/routes.dart                            (EDIT — 3 nouvelles routes hors ShellRoute)
+```
+
+### 1. `VeilleRepository` (NEW, ~200 lignes)
+
+`apps/mobile/lib/features/veille/repositories/veille_repository.dart`. Pattern strict de `digest_repository.dart` (Dio + exceptions typées + 4xx propagé).
+
+```dart
+class VeilleRepository {
+  final ApiClient _apiClient;
+  VeilleRepository(this._apiClient);
+
+  Future<VeilleConfigResponse?> getConfig();        // 200 / null si 404
+  Future<VeilleConfigResponse> upsertConfig(VeilleConfigUpsertRequest body);
+  Future<VeilleConfigResponse> patchConfig({...});
+  Future<void> deleteConfig();                      // 204
+  Future<List<VeilleTopicSuggestion>> suggestTopics({...});
+  Future<VeilleSourceSuggestionsResponse> suggestSources({...});
+  Future<List<VeilleDeliveryListItem>> listDeliveries({int limit = 20});
+  Future<VeilleDeliveryResponse> getDelivery(String id);
+}
+
+class VeilleConfigNotFoundException implements Exception { ... }
+class VeilleApiException implements Exception { ... }
+```
+
+Retries : implémentés au niveau du provider (max 1 sur 5xx via `try/catch + retry once`), pas au repo. 4xx → exception immédiate.
+
+### 2. Models Dart
+
+#### `models/veille_delivery.dart` (NEW)
+
+Miroir de `packages/api/app/schemas/veille.py` :
+
+```dart
+class VeilleDeliveryArticle  { String contentId, sourceId, title, url, excerpt; DateTime publishedAt; }
+class VeilleDeliveryItem     { String clusterId, title, whyItMatters; List<VeilleDeliveryArticle> articles; }
+class VeilleDeliveryResponse { String id, veilleConfigId; DateTime targetDate, generatedAt?; List<VeilleDeliveryItem> items; String generationState; ... }
+class VeilleDeliveryListItem { String id, veilleConfigId, generationState; DateTime targetDate, generatedAt?, createdAt; int itemCount; }
+```
+
+`fromJson` / `toJson` via `freezed` ? Si la convention du projet est `freezed`, l'utiliser. Sinon constructeur manuel + `fromJson`.
+
+#### `models/veille_suggestion.dart` (NEW)
+
+```dart
+class VeilleTopicSuggestion       { String topicId, label, reason?; }
+class VeilleSourceSuggestion      { String sourceId, name, url, feedUrl, theme, why?; }
+class VeilleSourceSuggestionsResponse { List<VeilleSourceSuggestion> followed, niche; }
+```
+
+#### `models/veille_config.dart` (EDIT)
+
+`VeilleSource` reçoit un champ `apiSourceId: String?` (UUID stringifié). Quand non-null → sérialise `kind="followed"|"niche"` + `source_id`. Quand null + URL fournie → `kind="niche"` + `niche_candidate{name, url, why?}`. Le mock garde `apiSourceId=null` (jamais envoyé).
+
+### 3. `VeilleConfigNotifier.submit()` (EDIT, ligne 142)
+
+```dart
+Future<void> submit() async {
+  if (_isSubmitting) return;
+  _isSubmitting = true;
+  try {
+    final repo = _ref.read(veilleRepositoryProvider);
+    final body = _buildUpsertRequest(state);   // mappe state → VeilleConfigUpsertRequest
+    final cfg = await repo.upsertConfig(body);
+    await _scheduleVeilleLocalNotification(cfg);
+    // invalidation provider pour rafraîchir le dashboard à la prochaine ouverture
+    _ref.invalidate(veilleActiveConfigProvider);
+  } finally {
+    _isSubmitting = false;
+  }
+}
+```
+
+`_buildUpsertRequest` mappe :
+- `theme_id`, `theme_label` (depuis `VeilleMockData.themes` ou état flow)
+- `topics: [...selectedTopics, ...selectedSuggestions].map((id) → VeilleTopicSelection(topic_id=id, label=lookup(id), kind=preset|suggested))`
+- `source_selections: [...followedSources.map(kind=followed)..., ...nicheSources.map(kind=niche)...]` — `apiSourceId` non-null requis pour les sources de l'API ; les sources mock-only sont filtrées (édition impossible tant qu'on n'a pas leur UUID API).
+
+Erreurs API → propagées (rethrow). Le screen catch et affiche un Snackbar.
+
+### 4. `veille_config_screen.dart` `handleSubmit()` (EDIT, ligne 30)
+
+```dart
+Future<void> handleSubmit() async {
+  try {
+    await ref.read(veilleConfigProvider.notifier).submit();
+    if (!context.mounted) return;
+    context.go(RoutePaths.veilleDashboard);
+  } on VeilleApiException {
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Impossible d\'enregistrer ta veille. Réessaie.')),
+    );
+  }
+}
+```
+
+### 5. Push notif
+
+#### `core/services/push_notification_service.dart` (EDIT)
+
+```dart
+class _NotifIds {
+  static const dailyDigest = 0;
+  static const weeklyCommunityPick = 1;
+  static const dailyGoodNews = 2;
+  static const veilleDelivery = 3;   // NEW
+}
+
+Future<void> scheduleVeilleNotification({
+  required DateTime when,
+  required String veilleConfigId,
+}) async {
+  await _plugin.zonedSchedule(
+    _NotifIds.veilleDelivery,
+    'Ta veille est arrivée',
+    'Découvre les sujets phares de la semaine.',
+    tz.TZDateTime.from(when, tz.local),
+    NotificationDetails(...),
+    payload: 'io.supabase.facteur://veille/dashboard',
+    androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+    uiLocalNotificationDateInterpretation: ...,
+  );
+}
+
+Future<void> cancelVeilleNotification() => _plugin.cancel(_NotifIds.veilleDelivery);
+```
+
+#### `core/services/deep_link_service.dart` (EDIT)
+
+Ajouter dans `_handleUri` :
+```dart
+case 'veille':
+  if (segments.firstOrNull == 'dashboard') {
+    return _go(RoutePaths.veilleDashboard);
+  }
+```
+
+### 6. Écrans
+
+#### `veille_dashboard_screen.dart` (NEW)
+
+Layout :
+```
+┌─────────────────────────────────────┐
+│ ← AppBar  « Ma veille »             │
+├─────────────────────────────────────┤
+│ [Header thème + chips topics]       │
+│ [Sources sélectionnées]             │
+│ [Schedule : weekly · lundi · 7h]    │
+│ [Countdown « Prochaine livraison »] │
+│                                     │
+│ [Bouton] Voir l'historique          │
+│ [Bouton] Modifier ma veille         │
+│ [Bouton secondaire] Mettre en pause │
+│ [Bouton danger] Supprimer ma veille │
+└─────────────────────────────────────┘
+```
+
+Hydraté par `veilleActiveConfigProvider` (AsyncValue). Loading → spinner, error → retry button, data null → redirect /veille/config (état impossible normalement).
+
+#### `veille_deliveries_screen.dart` (NEW)
+
+```
+┌─────────────────────────────────────┐
+│ ← AppBar  « Historique »            │
+├─────────────────────────────────────┤
+│ [Card] 02 mai 2026  · 8 sujets     │
+│ [Card] 25 avr 2026  · 7 sujets     │
+│ ...                                 │
+│ (empty state si 0 livraison)        │
+└─────────────────────────────────────┘
+```
+
+Hydraté par `veilleDeliveriesProvider`. Pull-to-refresh = invalidation provider.
+
+#### `veille_delivery_detail_screen.dart` (NEW)
+
+```
+┌─────────────────────────────────────┐
+│ ← AppBar  « 02 mai 2026 »           │
+├─────────────────────────────────────┤
+│ ┌─ VeilleClusterCard ─────────────┐ │
+│ │ Titre cluster                   │ │
+│ │ ┌─ Why it matters ────────────┐ │ │
+│ │ └─────────────────────────────┘ │ │
+│ │ • article 1 (source · excerpt) │ │
+│ │ • article 2                    │ │
+│ └─────────────────────────────────┘ │
+│ ...                                 │
+└─────────────────────────────────────┘
+```
+
+Hydraté par `veilleDeliveryProvider(id)`. Tap article → InAppWebView (helper réutilisé du digest).
+
+État `failed` → Card d'erreur sympa (« La livraison a échoué — le scanner réessaiera bientôt »).
+
+### 7. Routing (`apps/mobile/lib/config/routes.dart`)
+
+```dart
+class RoutePaths {
+  // ...
+  static const String veilleDashboard      = '/veille/dashboard';
+  static const String veilleDeliveries     = '/veille/deliveries';
+  static const String veilleDeliveryDetail = '/veille/deliveries/:id';
+}
+
+// Dans le shell GoRoute hors ShellRoute :
+GoRoute(
+  path: RoutePaths.veilleDashboard,
+  pageBuilder: (c, s) => FullSwipeCupertinoPage(child: VeilleDashboardScreen()),
+),
+GoRoute(
+  path: RoutePaths.veilleDeliveries,
+  pageBuilder: (c, s) => FullSwipeCupertinoPage(child: VeilleDeliveriesScreen()),
+),
+GoRoute(
+  path: RoutePaths.veilleDeliveryDetail,
+  pageBuilder: (c, s) => FullSwipeCupertinoPage(
+    child: VeilleDeliveryDetailScreen(deliveryId: s.pathParameters['id']!),
+  ),
+),
+```
+
+Logique d'entrée : `step1_theme_screen.dart` peut consulter `veilleActiveConfigProvider` au mount et rediriger si config existe. Alternative : redirect côté router dans `redirect:` (plus propre — à valider).
+
+### 8. Suggestions API
+
+`step2_suggestions_screen.dart` (EDIT) :
+- au mount, si `selectedTheme != null`, appel `POST /suggestions/topics` (`theme_id`, `theme_label`, `selected_topic_ids` = topics déjà sélectionnés).
+- spinner pendant la requête (50% opacity sur la grille).
+- au retour, hydrate la liste affichée à la place du mock.
+- erreur réseau → toast `« Suggestions indisponibles, conserve ta sélection »` + garde mock.
+
+`step3_sources_screen.dart` (EDIT) : pareil avec `POST /suggestions/sources` (topic_labels lookup-és depuis topics sélectionnés).
+
+---
+
+## Tasks / Subtasks
+
+### Phase A — Repository + models
+- [ ] `models/veille_delivery.dart` (NEW)
+- [ ] `models/veille_suggestion.dart` (NEW)
+- [ ] `models/veille_config.dart` EDIT (apiSourceId)
+- [ ] `repositories/veille_repository.dart` (NEW, 9 méthodes)
+- [ ] `providers/veille_repository_provider.dart` (NEW)
+- [ ] Tests `test/features/veille/repositories/veille_repository_test.dart` (9 tests via MockDio)
+
+### Phase B — Providers
+- [ ] `providers/veille_active_config_provider.dart` (NEW, AsyncNotifier load-on-enter)
+- [ ] `providers/veille_suggestions_provider.dart` (NEW, FutureProvider.family)
+- [ ] `providers/veille_deliveries_provider.dart` (NEW, AsyncNotifier list)
+- [ ] `providers/veille_delivery_provider.dart` (NEW, AsyncNotifier.family by id)
+- [ ] EDIT `providers/veille_config_provider.dart` : implémenter `submit()` réel + `_buildUpsertRequest`
+- [ ] Tests : `veille_config_provider_test.dart` (submit OK, 5xx 1 retry, 4xx no retry, schedule notif appelé), `veille_active_config_provider_test.dart` (200 / 404), `veille_deliveries_provider_test.dart`
+
+### Phase C — Push notif + deeplink
+- [ ] `core/services/push_notification_service.dart` EDIT — `scheduleVeilleNotification` + `cancelVeilleNotification` + NotifId=3
+- [ ] `core/services/deep_link_service.dart` EDIT — mapping `veille/dashboard`
+- [ ] Test : `push_notification_service_test.dart` (schedule veille notif → cancel)
+
+### Phase D — Routes + écrans
+- [ ] `config/routes.dart` EDIT — 3 routes new
+- [ ] `screens/veille_dashboard_screen.dart` (NEW)
+- [ ] `screens/veille_deliveries_screen.dart` (NEW)
+- [ ] `screens/veille_delivery_detail_screen.dart` (NEW)
+- [ ] `widgets/veille_cluster_card.dart` (NEW)
+- [ ] EDIT `screens/veille_config_screen.dart` — `handleSubmit` propage erreur API
+- [ ] EDIT `screens/steps/step2_suggestions_screen.dart` + `step3_sources_screen.dart` — appel suggestions API
+- [ ] Tests : `veille_dashboard_screen_test.dart` (render + interactions pause/delete/edit), `veille_deliveries_screen_test.dart`, `veille_delivery_detail_screen_test.dart`
+
+### Phase E — Verify + PR
+- [ ] `flutter test` veille suite : vert
+- [ ] `flutter test` suite complète : vert (anticipation hook `stop-verify-tests.sh`)
+- [ ] `flutter analyze` : aucun nouveau warning
+- [ ] `pytest -v` (anti-régression Python) : vert
+- [ ] `/validate-feature` (Chrome MCP) : 5 scénarios verts (rapport dans `.context/validate-feature-report.md`)
+- [ ] `/go` → SIMPLIFY → PR vers `main`
+
+---
+
+## Réutilisations explicites (NE PAS RÉINVENTER)
+
+| Helper | Localisation | Usage |
+|---|---|---|
+| `ApiClient` + `apiClientProvider` | `core/api/api_client.dart`, `core/api/providers.dart` | DI Dio dans `VeilleRepository` |
+| `DigestRepository` (pattern Dio + exceptions) | `features/digest/repositories/digest_repository.dart` | Modèle stylistique pour `VeilleRepository` |
+| `digestRepositoryProvider` (pattern) | `features/digest/providers/digest_provider.dart:18-21` | `veilleRepositoryProvider` |
+| AsyncNotifier load-on-enter (simplifié) | `features/digest/providers/digest_provider.dart` | `veilleActiveConfigProvider`, `veilleDeliveriesProvider` |
+| `PushNotificationService.zonedSchedule` | `core/services/push_notification_service.dart` (`scheduleDailyDigestNotification`) | `scheduleVeilleNotification` |
+| `DeepLinkService` mapping | `core/services/deep_link_service.dart` | Ajout `veille/dashboard` |
+| InAppWebView article | helper feed/digest existant (à localiser via `Grep "InAppWebView"`) | Tap article détail livraison |
+| `SourceLogoAvatar` + `SourceDetailModal` | `features/sources/widgets/source_detail_modal.dart` (déjà importé dans veille) | Dashboard + détail livraison |
+
+---
+
+## Fichiers (création / modification)
+
+### Mobile
+
+| Fichier | Action |
+|---|---|
+| `apps/mobile/lib/features/veille/models/veille_config.dart` | EDIT |
+| `apps/mobile/lib/features/veille/models/veille_delivery.dart` | NEW |
+| `apps/mobile/lib/features/veille/models/veille_suggestion.dart` | NEW |
+| `apps/mobile/lib/features/veille/repositories/veille_repository.dart` | NEW |
+| `apps/mobile/lib/features/veille/providers/veille_repository_provider.dart` | NEW |
+| `apps/mobile/lib/features/veille/providers/veille_config_provider.dart` | EDIT |
+| `apps/mobile/lib/features/veille/providers/veille_active_config_provider.dart` | NEW |
+| `apps/mobile/lib/features/veille/providers/veille_suggestions_provider.dart` | NEW |
+| `apps/mobile/lib/features/veille/providers/veille_deliveries_provider.dart` | NEW |
+| `apps/mobile/lib/features/veille/providers/veille_delivery_provider.dart` | NEW |
+| `apps/mobile/lib/features/veille/screens/veille_config_screen.dart` | EDIT |
+| `apps/mobile/lib/features/veille/screens/veille_dashboard_screen.dart` | NEW |
+| `apps/mobile/lib/features/veille/screens/veille_deliveries_screen.dart` | NEW |
+| `apps/mobile/lib/features/veille/screens/veille_delivery_detail_screen.dart` | NEW |
+| `apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart` | EDIT |
+| `apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart` | EDIT |
+| `apps/mobile/lib/features/veille/widgets/veille_cluster_card.dart` | NEW |
+| `apps/mobile/lib/core/services/push_notification_service.dart` | EDIT |
+| `apps/mobile/lib/core/services/deep_link_service.dart` | EDIT |
+| `apps/mobile/lib/config/routes.dart` | EDIT |
+| `apps/mobile/test/features/veille/repositories/veille_repository_test.dart` | NEW |
+| `apps/mobile/test/features/veille/providers/veille_config_provider_test.dart` | NEW |
+| `apps/mobile/test/features/veille/providers/veille_active_config_provider_test.dart` | NEW |
+| `apps/mobile/test/features/veille/providers/veille_deliveries_provider_test.dart` | NEW |
+| `apps/mobile/test/features/veille/screens/veille_dashboard_screen_test.dart` | NEW |
+| `.context/qa-handoff.md` | EDIT (ré-écrit pour 18.3) |
+
+### Backend
+
+Aucune modif. Anti-régression `pytest -v` seulement.
+
+---
+
+## Vérification end-to-end
+
+```bash
+# Backend (anti-régression)
+cd packages/api && pytest -v
+
+# Mobile (suite + analyze)
+cd apps/mobile && flutter test
+cd apps/mobile && flutter analyze
+
+# E2E manuel
+# 1. uvicorn app.main:app --port 8080
+# 2. Auth dans l'app
+# 3. Configurer une veille (4 étapes), submit
+# 4. Vérifier : POST /api/veille/config 200 (logs uvicorn)
+# 5. Vérifier : notif locale schedulée (debug print PushNotificationService)
+# 6. Re-ouvrir /veille/config → redirect dashboard
+# 7. Bouton « Historique » → liste (vide tant que pas de livraison)
+# 8. POST /api/veille/deliveries/generate (debug, only !prod) → relance scanner
+# 9. Refresh historique → 1 livraison succeeded
+# 10. Tap → détail → vérifier clusters + why_it_matters + tap article ouvre InAppWebView
+
+# /validate-feature obligatoire (feature 100% UI mobile, cf. CLAUDE.md)
+```
+
+---
+
+## Risques / suivis
+
+1. **Pool DB** (mémoire `bug-infinite-load-requests`) — règle « max 1 retry sur 5xx, 0 sur 4xx » appliquée DANS `VeilleRepository`. Pas de retry cascadé type `digest_provider._loadBothDigests` — overkill ici, et amplifierait la pression sur le pool si les configs partent en cascade.
+2. **UUIDs vs slugs mock** — le mock `veille_mock_data.dart` utilise des slugs (`s-lm`, `t-eval`). Strategy : le wiring API n'utilise QUE les UUIDs renvoyés par les endpoints suggestions. Le mock reste local, jamais envoyé. Impact : la « modification » du flow depuis le dashboard repart d'une config hydratée par GET /config (UUIDs réels), pas du mock.
+3. **Notif locale + `next_scheduled_at`** — schedule à `next + 30 min` pour laisser le scanner générer. Si user PATCH frequency → cancel + reschedule. Si user DELETE → cancel. Risque résiduel : si scanner échoue, la notif tombe quand même → l'utilisateur ouvre l'app → détail = `failed` → message d'erreur (non-bloquant).
+4. **Mistral KO** — backend renvoie `why_it_matters` fallback déterministes. Front les affiche tels quels, sans badge spécial (Q4 silencieux).
+5. **Memory `feedback_design_before_impl`** — le dashboard et l'historique seront livrés avec un design « starting point » (cf. wireframes ci-dessus). PO ajustera en exec UI si besoin.
+6. **Pas de FCM** — push purement local. Multi-device incoherence acceptée pour V1 (l'utilisateur reçoit la notif sur le device sur lequel il a configuré la veille). Migration FCM hors scope.
+
+---
+
+## Hors scope (V2 / V3)
+
+- Multi-veilles par user (V2/V3 — table conçue extensible).
+- Carte d'entrée « Ma veille » sur le feed.
+- Push serveur via FCM/APNS (justifié seulement quand multi-device).
+- Cache disque persistant pour livraisons (load-on-enter mémoire suffit en V1).
+- Pagination historique > 20.
+- Webhooks Supabase Realtime.


### PR DESCRIPTION
# PR — Story 18.3 « Ma veille » end-to-end (front wiring + historique + push notifs)

## Why

Phase E2E de la feature « Ma veille ». Le backend pipeline (18.1 + 18.2,
PR #524 + #535) produit des `items[]` réels avec clusters + `why_it_matters`
LLM. Côté front Flutter, le flow 4-steps était encore 100 % mock :

- `submit()` no-op à `apps/mobile/lib/features/veille/providers/veille_config_provider.dart:142` ;
- aucun écran historique livraisons ni détail livraison ;
- aucune notif planifiée à la livraison.

Cette PR ferme la boucle « configuration → livraison → consommation » sur
l'app et planifie une notif locale (pas de FCM côté projet) pour rappeler
au user que sa veille est tombée.

## What

### Front wiring

- `submit()` étape 4 → POST `/api/veille/config` (real `VeilleRepository`).
- Suggestions topics/sources réelles à l'entrée des étapes 2 et 3 (POST
  `/api/veille/suggestions/{topics,sources}` avec spinner bloquant +
  fallback mock UX si erreur réseau).
- Redirect automatique `/veille/config` → `/veille/dashboard` quand
  `GET /api/veille/config` retourne 200 (au lieu de relancer le flow).
- Filtrage des sources mock-only au submit (sans `apiSourceId` UUID API,
  elles ne peuvent pas être ingérées par le backend).

### Nouveaux écrans

- **Dashboard** `/veille/dashboard` : thème, topics, sources, schedule,
  countdown next_scheduled_at, boutons Modifier / Pause / Supprimer / Historique.
- **Historique** `/veille/deliveries` : liste 20 dernières livraisons,
  pull-to-refresh, empty state.
- **Détail livraison** `/veille/deliveries/:id` : clusters + `why_it_matters` +
  articles → tap ouvre InAppWebView (`launchUrl` mode `inAppBrowserView`).
  Gère les états `running`/`pending` (loader) et `failed` (state d'erreur sympa).

### Push notif locale + deeplink

- `PushNotificationService.scheduleVeilleNotification(scheduledAt)` (NotifId=3,
  channel `veille_channel`). Planifié à `next_scheduled_at + 30 min` pour
  laisser le scanner */30 min générer la livraison avant que la notif tombe.
- Cancel automatique sur PATCH status=paused / DELETE.
- Mapping deeplink `io.supabase.facteur://veille/dashboard` ajouté à
  `DeepLinkService.parse` (`WidgetDeepLinkTarget.veille`).

### Architecture

- Pas de modif backend (la pipeline fait déjà tout).
- Patterns réutilisés : `digest_repository.dart` (Dio + exceptions typées),
  `digest_provider.dart` (AsyncNotifier — simplifié load-on-enter),
  `scheduleDailyDigestNotification` (zonedSchedule local).
- Retries bornés (interceptor existant : 2 retries sur 5xx ≠503, 0 sur 4xx) —
  pas de retries cascadés type stale-fallback du digest (anti-cascade pool DB).
- Story doc : `docs/stories/core/18.3.veille-e2e.md`.

## Test plan

- [x] `flutter analyze lib/features/veille` → 1 info-level lint, 0 erreur.
- [x] `flutter test test/features/veille/models/veille_models_test.dart` →
  15 tests verts (parsing fromJson + sérialisation toJson).
- [x] `flutter test test/core/services/{deep_link_service,push_notification_service_copy}_test.dart`
  → 14 tests verts (anti-régression, +2 tests pour le mapping veille deep link).
- [x] `pytest -q` backend (anti-régression) : 838 passed, 85 errors —
  TOUTES les errors sont `psycopg.OperationalError` (DB locale Supabase non
  démarrée, infra), aucune cassée par cette PR.
- [ ] `/validate-feature` (Chrome MCP, viewport 390x844) — scénarios :
  happy path, redirect dashboard, pause/reprendre, suppression, livraison
  failed, erreur réseau suggestions, tap notif. Cf. `.context/qa-handoff.md`.
- [ ] Smoke API local : `uvicorn app.main:app --port 8080`, configure une
  veille, vérifier POST /config + log `PushNotificationService: veille scheduled @ ...`,
  POST /deliveries/generate (debug), refresh historique.

## Out of scope

- Multi-veilles par user (V2/V3).
- Carte « Ma veille » sur le feed (entry point — tranché en brainstorming PO).
- Push serveur (FCM/APNS) — pas de stockage push_token côté backend, hors V1.
- Cache disque persistant pour livraisons (load-on-enter mémoire suffit).
- Pagination historique > 20.