### PR TITLE
feat(sources): recos équipe Facteur dans la modal source

### DIFF
--- a/apps/mobile/lib/features/sources/models/source_model.dart
+++ b/apps/mobile/lib/features/sources/models/source_model.dart
@@ -32,7 +32,8 @@ class Source {
   final int followerCount;
   final double priorityMultiplier;
   final bool hasSubscription;
-  final String? editorialNote;
+  final String? recommendedBy;
+  final String? recommendationReason;
 
   Source({
     required this.id,
@@ -58,7 +59,8 @@ class Source {
     this.followerCount = 0,
     this.priorityMultiplier = 1.0,
     this.hasSubscription = false,
-    this.editorialNote,
+    this.recommendedBy,
+    this.recommendationReason,
   });
 
   Source copyWith({
@@ -85,7 +87,8 @@ class Source {
     int? followerCount,
     double? priorityMultiplier,
     bool? hasSubscription,
-    String? editorialNote,
+    String? recommendedBy,
+    String? recommendationReason,
   }) {
     return Source(
       id: id ?? this.id,
@@ -111,7 +114,8 @@ class Source {
       followerCount: followerCount ?? this.followerCount,
       priorityMultiplier: priorityMultiplier ?? this.priorityMultiplier,
       hasSubscription: hasSubscription ?? this.hasSubscription,
-      editorialNote: editorialNote ?? this.editorialNote,
+      recommendedBy: recommendedBy ?? this.recommendedBy,
+      recommendationReason: recommendationReason ?? this.recommendationReason,
     );
   }
 
@@ -152,7 +156,8 @@ class Source {
         priorityMultiplier:
             (json['priority_multiplier'] as num?)?.toDouble() ?? 1.0,
         hasSubscription: (json['has_subscription'] as bool?) ?? false,
-        editorialNote: json['editorial_note'] as String?,
+        recommendedBy: json['recommended_by'] as String?,
+        recommendationReason: json['recommendation_reason'] as String?,
       );
     } catch (e) {
       debugPrint('Source.fromJson: [ERROR] Failed to parse: $e');

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -217,8 +217,8 @@ class SourceDetailModal extends ConsumerWidget {
               ),
             ),
           ],
-          if (displaySource.editorialNote != null &&
-              displaySource.editorialNote!.trim().isNotEmpty) ...[
+          if (displaySource.recommendedBy != null &&
+              displaySource.recommendedBy!.trim().isNotEmpty) ...[
             const SizedBox(height: 16),
             Container(
               padding: const EdgeInsets.all(16),
@@ -240,24 +240,34 @@ class SourceDetailModal extends ConsumerWidget {
                         fit: BoxFit.contain,
                       ),
                       const SizedBox(width: 8),
-                      Text(
-                        'Pourquoi on apprécie',
-                        style:
-                            Theme.of(context).textTheme.titleSmall?.copyWith(
-                                  color: colors.textPrimary,
-                                  fontWeight: FontWeight.bold,
-                                ),
+                      Expanded(
+                        child: Text(
+                          'Recommandé par ${displaySource.recommendedBy} '
+                          '— équipe Facteur',
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleSmall
+                              ?.copyWith(
+                                color: colors.textPrimary,
+                                fontWeight: FontWeight.bold,
+                              ),
+                        ),
                       ),
                     ],
                   ),
-                  const SizedBox(height: 10),
-                  Text(
-                    displaySource.editorialNote!,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: colors.textSecondary,
-                          height: 1.5,
-                        ),
-                  ),
+                  if (displaySource.recommendationReason != null &&
+                      displaySource.recommendationReason!
+                          .trim()
+                          .isNotEmpty) ...[
+                    const SizedBox(height: 10),
+                    Text(
+                      displaySource.recommendationReason!,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colors.textSecondary,
+                            height: 1.5,
+                          ),
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/packages/api/alembic/versions/tr01_pepites_team_recos.py
+++ b/packages/api/alembic/versions/tr01_pepites_team_recos.py
@@ -1,0 +1,255 @@
+"""pepites team recos: recommended_by + recommendation_reason
+
+Revision ID: tr01
+Revises: gn01, vl01
+Create Date: 2026-05-02
+
+- Remplace `sources.editorial_note` par `recommended_by` (str) +
+  `recommendation_reason` (text).
+- Réinitialise les pépites (`is_pepite_recommendation = false`) et active
+  uniquement les 15 sources recommandées par l'équipe Facteur (Laurin,
+  Anh-Dao, Django, Lucas).
+- Crée les 5 sources qui n'existaient pas encore en DB (PsykoCouac,
+  Les Lueurs, Limit, Chaleur Humaine, Le Code a changé).
+
+Aussi : merge des deux heads `gn01` + `vl01`.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "tr01"
+down_revision: str | tuple[str, ...] = ("gn01", "vl01")
+branch_labels: Sequence[str] | None = None
+depends_on: str | None = None
+
+
+# (name, type, url, feed_url, theme, recommended_by, recommendation_reason)
+NEW_SOURCES: list[tuple[str, str, str, str, str, str, str]] = [
+    (
+        "PsykoCouac",
+        "youtube",
+        "https://www.youtube.com/@PsykoCouac",
+        "https://www.youtube.com/feeds/videos.xml?channel_id=UCsE6tdKFV2oSHFyDll72rWg",
+        "society",
+        "Anh-Dao",
+        "Vulgarisation de la psychologie par un praticien. Une bonne porte "
+        "d'entrée pour développer ouverture, compréhension et bienveillance "
+        "pour soi et autrui.",
+    ),
+    (
+        "Les Lueurs",
+        "podcast",
+        "https://leslueurs.fr/",
+        "https://feeds.podcastics.com/podcastics/podcasts/rss/5697_a59f1749b640068f2d54338141e262a0.rss",
+        "society",
+        "Anh-Dao",
+        "Podcasts avec des intervenant·e·s qui apportent un peu de "
+        "philosophie et d'espoir. Une invitation à l'introspection pour "
+        "cultiver sa réflexivité.",
+    ),
+    (
+        "Limit",
+        "youtube",
+        "https://www.youtube.com/@LIMITMEDIA",
+        "https://www.youtube.com/feeds/videos.xml?channel_id=UCAbFIrKZCYdKucQYnhxWnrA",
+        "environment",
+        "Anh-Dao",
+        "Média qui aborde les limites planétaires en intégrant planchers "
+        "sociaux et plafonds de ressources. La théorie du donut au cœur "
+        "d'une vision pour une société plus robuste.",
+    ),
+    (
+        "Chaleur Humaine",
+        "podcast",
+        "https://podcasts.lemonde.fr/chaleur-humaine",
+        "https://feeds.acast.com/public/shows/68db9a016d92c33f9c2eff83",
+        "environment",
+        "Django",
+        "Le podcast climat de Nabil Wakim (Le Monde) : beaucoup d'humain, "
+        "de la légèreté, et des invité·e·s pertinent·e·s. Plein "
+        "d'apprentissages.",
+    ),
+    (
+        "Le Code a changé",
+        "podcast",
+        "https://www.radiofrance.fr/franceinter/podcasts/le-code-a-change",
+        "https://radiofrance-podcast.net/podcast09/rss_20856.xml",
+        "tech",
+        "Django",
+        "Xavier de la Porte explore le numérique comme miroir de notre "
+        "époque. Narration, introspection et entretiens permettent de "
+        "prendre de la hauteur sur notre rapport à la tech.",
+    ),
+]
+
+
+# (name LIKE pattern, recommended_by, recommendation_reason)
+EXISTING_RECOS: list[tuple[str, str, str]] = [
+    (
+        "The Conversation",
+        "Laurin",
+        "Choix de sujets très intéressants. Traitement rigoureux. Articles "
+        "longs et étayés, on en ressort avec l'impression d'avoir très bien "
+        "compris le sujet.",
+    ),
+    (
+        "Le Grand Continent",
+        "Laurin",
+        "Traitement super rigoureux et expert. Articles longs et étayés, on "
+        "en ressort avec l'impression d'avoir très bien compris le sujet.",
+    ),
+    (
+        "Cerveau & Psycho",
+        "Laurin",
+        "Choix de sujets très pertinents. Peu d'articles mais tous très "
+        "intéressants quand on s'intéresse à la psychologie et à la société.",
+    ),
+    (
+        "Next.ink",
+        "Laurin",
+        "Angles intéressants sur la Tech. Rédaction experte et indépendante, "
+        "un autre angle que les discours uniquement optimistes ou "
+        "pessimistes sur le numérique.",
+    ),
+    (
+        "Blast",
+        "Anh-Dao",
+        "Les formats de Salomé Saqué : sujets éco/sociologiques constructifs, "
+        "intervenants experts. Format long qui apporte réflexion et idées "
+        "applicables.",
+    ),
+    (
+        "Vert",
+        "Django",
+        "Média indépendant focus écologie, toujours avec une pointe d'humour, "
+        "et qui debunk les fausses infos. Actualités d'utilité publique.",
+    ),
+    (
+        "Novethic",
+        "Django",
+        "Média engagé spécialisé finance durable et économie responsable. "
+        "Propose des thèmes et angles qu'on ne trouve pas ailleurs.",
+    ),
+    (
+        "StreetPress",
+        "Django",
+        "Média indépendant qui enquête sur l'extrême droite et ses dérives "
+        "depuis des années.",
+    ),
+    (
+        "Le Réveilleur",
+        "Django",
+        "LA chaîne pour comprendre les mécaniques d'énergie et de carbone. "
+        "Exigeante, dense — exactement ce qu'on cherche sur Facteur.",
+    ),
+    (
+        "Underscore_",
+        "Lucas",
+        "Vulgarisation tech ambitieuse et indépendante. Format long et "
+        "exigeant qui prend le temps de creuser les vrais enjeux du "
+        "numérique au-delà du buzz.",
+    ),
+]
+
+
+def upgrade() -> None:
+    # 1. Schema changes
+    op.add_column(
+        "sources",
+        sa.Column("recommended_by", sa.String(length=50), nullable=True),
+    )
+    op.add_column(
+        "sources",
+        sa.Column("recommendation_reason", sa.Text(), nullable=True),
+    )
+    op.drop_column("sources", "editorial_note")
+
+    # 2. Reset pépites + clear old recommendation fields
+    op.execute(
+        "UPDATE sources SET is_pepite_recommendation = false, "
+        "recommended_by = NULL, recommendation_reason = NULL"
+    )
+
+    bind = op.get_bind()
+
+    # 3. Update existing sources (match by exact name where possible).
+    # The Conversation has 2 entries — only flag the FR one.
+    bind.execute(
+        sa.text(
+            "UPDATE sources SET is_pepite_recommendation = true, "
+            "is_active = true, recommended_by = :rb, "
+            "recommendation_reason = :rr "
+            "WHERE name = 'The Conversation' "
+            "AND feed_url = 'https://theconversation.com/fr/articles.atom'"
+        ),
+        {
+            "rb": "Laurin",
+            "rr": (
+                "Choix de sujets très intéressants. Traitement rigoureux. "
+                "Articles longs et étayés, on en ressort avec l'impression "
+                "d'avoir très bien compris le sujet."
+            ),
+        },
+    )
+
+    for name, rb, rr in EXISTING_RECOS:
+        if name == "The Conversation":
+            continue
+        where = "name ILIKE 'StreetPress%'" if name == "StreetPress" else "name = :name"
+        bind.execute(
+            sa.text(
+                "UPDATE sources SET is_pepite_recommendation = true, "
+                "is_active = true, recommended_by = :rb, "
+                f"recommendation_reason = :rr WHERE {where}"
+            ),
+            {"name": name, "rb": rb, "rr": rr},
+        )
+
+    # 4. Insert new sources (skip if already exist by feed_url).
+    for name, type_, url, feed_url, theme, rb, rr in NEW_SOURCES:
+        bind.execute(
+            sa.text(
+                "INSERT INTO sources (id, name, url, feed_url, type, theme, "
+                "is_active, is_curated, is_pepite_recommendation, "
+                "recommended_by, recommendation_reason) "
+                "VALUES (gen_random_uuid(), :name, :url, :feed_url, :type, "
+                ":theme, true, true, true, :rb, :rr) "
+                "ON CONFLICT (feed_url) DO UPDATE SET "
+                "is_active = true, is_pepite_recommendation = true, "
+                "recommended_by = EXCLUDED.recommended_by, "
+                "recommendation_reason = EXCLUDED.recommendation_reason"
+            ),
+            {
+                "name": name,
+                "url": url,
+                "feed_url": feed_url,
+                "type": type_,
+                "theme": theme,
+                "rb": rb,
+                "rr": rr,
+            },
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    # Remove inserted sources
+    for _, _, _, feed_url, *_ in NEW_SOURCES:
+        bind.execute(
+            sa.text("DELETE FROM sources WHERE feed_url = :feed_url"),
+            {"feed_url": feed_url},
+        )
+    op.execute(
+        "UPDATE sources SET is_pepite_recommendation = false, "
+        "recommended_by = NULL, recommendation_reason = NULL"
+    )
+    op.add_column(
+        "sources",
+        sa.Column("editorial_note", sa.Text(), nullable=True),
+    )
+    op.drop_column("sources", "recommendation_reason")
+    op.drop_column("sources", "recommended_by")

--- a/packages/api/app/models/source.py
+++ b/packages/api/app/models/source.py
@@ -136,8 +136,11 @@ class Source(Base):
         ARRAY(Text), nullable=True
     )
 
-    # Note éditoriale "Pourquoi on apprécie" — affichée dans la modal source.
-    editorial_note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Recommandation équipe Facteur — affichée dans la modal source ouverte.
+    # `recommended_by` : prénom du membre de l'équipe (Laurin/Anh-Dao/Django/Lucas).
+    # `recommendation_reason` : raison personnelle, ton de l'équipe.
+    recommended_by: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    recommendation_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Relations
     contents: Mapped[list["Content"]] = relationship(

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -245,7 +245,8 @@ def _source_to_response(
         score_independence=s.score_independence,
         score_rigor=s.score_rigor,
         score_ux=s.score_ux,
-        editorial_note=getattr(s, "editorial_note", None),
+        recommended_by=getattr(s, "recommended_by", None),
+        recommendation_reason=getattr(s, "recommendation_reason", None),
     )
 
 

--- a/packages/api/app/schemas/source.py
+++ b/packages/api/app/schemas/source.py
@@ -37,7 +37,8 @@ class SourceResponse(BaseModel):
     score_independence: float | None = None
     score_rigor: float | None = None
     score_ux: float | None = None
-    editorial_note: str | None = None
+    recommended_by: str | None = None
+    recommendation_reason: str | None = None
 
     class Config:
         from_attributes = True

--- a/packages/api/app/services/pepite_service.py
+++ b/packages/api/app/services/pepite_service.py
@@ -179,7 +179,8 @@ class PepiteService:
                 score_independence=s.score_independence,
                 score_rigor=s.score_rigor,
                 score_ux=s.score_ux,
-                editorial_note=getattr(s, "editorial_note", None),
+                recommended_by=getattr(s, "recommended_by", None),
+                recommendation_reason=getattr(s, "recommendation_reason", None),
             )
             for s, follower_count in selected
         ]

--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -97,7 +97,8 @@ class SourceService:
                 score_independence=s.score_independence,
                 score_rigor=s.score_rigor,
                 score_ux=s.score_ux,
-                editorial_note=getattr(s, "editorial_note", None),
+                recommended_by=getattr(s, "recommended_by", None),
+                recommendation_reason=getattr(s, "recommendation_reason", None),
             )
             for s in custom_sources
         ]
@@ -157,7 +158,8 @@ class SourceService:
                 score_independence=s.score_independence,
                 score_rigor=s.score_rigor,
                 score_ux=s.score_ux,
-                editorial_note=getattr(s, "editorial_note", None),
+                recommended_by=getattr(s, "recommended_by", None),
+                recommendation_reason=getattr(s, "recommendation_reason", None),
             )
             for s in sources
         ]
@@ -222,7 +224,8 @@ class SourceService:
                 score_independence=s.score_independence,
                 score_rigor=s.score_rigor,
                 score_ux=s.score_ux,
-                editorial_note=getattr(s, "editorial_note", None),
+                recommended_by=getattr(s, "recommended_by", None),
+                recommendation_reason=getattr(s, "recommendation_reason", None),
             )
             for s, follower_count in rows
         ]
@@ -289,7 +292,8 @@ class SourceService:
                 score_independence=s.score_independence,
                 score_rigor=s.score_rigor,
                 score_ux=s.score_ux,
-                editorial_note=getattr(s, "editorial_note", None),
+                recommended_by=getattr(s, "recommended_by", None),
+                recommendation_reason=getattr(s, "recommendation_reason", None),
             )
             for s in sources
         ]
@@ -366,7 +370,8 @@ class SourceService:
             score_independence=source.score_independence,
             score_rigor=source.score_rigor,
             score_ux=source.score_ux,
-            editorial_note=getattr(source, "editorial_note", None),
+            recommended_by=getattr(source, "recommended_by", None),
+            recommendation_reason=getattr(source, "recommendation_reason", None),
         )
 
     async def delete_custom_source(self, user_id: str, source_id: str) -> bool:
@@ -496,7 +501,8 @@ class SourceService:
             score_independence=source.score_independence,
             score_rigor=source.score_rigor,
             score_ux=source.score_ux,
-            editorial_note=getattr(source, "editorial_note", None),
+            recommended_by=getattr(source, "recommended_by", None),
+            recommendation_reason=getattr(source, "recommendation_reason", None),
         )
 
     async def update_source_subscription(
@@ -558,7 +564,8 @@ class SourceService:
             score_independence=source.score_independence,
             score_rigor=source.score_rigor,
             score_ux=source.score_ux,
-            editorial_note=getattr(source, "editorial_note", None),
+            recommended_by=getattr(source, "recommended_by", None),
+            recommendation_reason=getattr(source, "recommendation_reason", None),
         )
 
     async def untrust_source(self, user_id: str, source_id: str) -> bool:


### PR DESCRIPTION
## Quoi

- Remplace `Source.editorial_note` par `recommended_by` + `recommendation_reason` (backend + mobile).
- Met à jour la liste des "pépites" (sources recommandées par l'équipe) : 15 sources curées par Laurin, Anh-Dao, Django, Lucas.
- Crée 5 sources qui manquaient en DB : PsykoCouac, Les Lueurs, Limit, Chaleur Humaine, Le Code a changé (RSS / podcast / YouTube).
- Modal source ouverte : encart "Recommandé par {X} — équipe Facteur" + raison personnalisée, dans le même container DS.

## Pourquoi

L'ancien champ `editorial_note` ("Pourquoi on apprécie") ne portait pas l'auteur de la recommandation. La liste à jour fournie par l'équipe comporte un curateur + une raison personnelle pour chaque source — ce PR ajoute ces deux dimensions et rafraîchit complètement la liste.

## Comment ça a été vérifié

- [x] `pytest tests/services/test_pepite_service.py` — 19/19 passés
- [x] `flutter test test/features/sources/` — 49/49 passés
- [x] `ruff check` + `ruff format --check` — clean
- [x] `alembic heads` — un seul head (`tr01`, merge des 2 heads `gn01` + `vl01`)
- [x] Diff revu pour réutilisation / qualité / efficacité (pas de duplication, pas de sur-ingénierie)
- [ ] Test manuel sur device : ouvrir une carte pépite → vérifier l'encart (à valider après merge)

## Zones à risque

- **Migration Alembic `tr01`** : merge 2 heads + drop `editorial_note` + insert 5 nouvelles sources + reset des pépites. À appliquer en prod via Supabase SQL Editor (jamais sur Railway).
- **Changement breaking de schéma** : tout client mobile en cache continuera à parser `editorial_note` comme `null` (defensive parsing) → pas de crash, mais l'encart sera caché tant que la modal n'a pas reçu les nouveaux champs depuis l'API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)