### PR TITLE
fix(app-update): wire flutter_downloader providers in AndroidManifest

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -57,6 +57,27 @@
                 android:resource="@xml/facteur_widget_info" />
         </receiver>
 
+        <!-- flutter_downloader : provider FileProvider pour partager l'APK
+             téléchargé avec l'installeur Android, et init custom pour limiter
+             à 1 tâche concurrente (téléchargement APK uniquement). -->
+        <provider
+            android:name="vn.hunghd.flutterdownloader.DownloadedFileProvider"
+            android:authorities="${applicationId}.flutter_downloader.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
+        <provider
+            android:name="vn.hunghd.flutterdownloader.FlutterDownloaderInitializer"
+            android:authorities="${applicationId}.flutter-downloader-init"
+            android:exported="false">
+            <meta-data
+                android:name="vn.hunghd.flutterdownloader.MAX_CONCURRENT_TASKS"
+                android:value="1" />
+        </provider>
+
         <!-- Required for flutter_local_notifications scheduled notifications -->
         <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
         <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">

--- a/apps/mobile/android/app/src/main/res/xml/provider_paths.xml
+++ b/apps/mobile/android/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+    <files-path name="files" path="."/>
+    <cache-path name="cache" path="."/>
+</paths>


### PR DESCRIPTION
## Quoi

Ajoute les providers Android requis par \`flutter_downloader\` dans \`AndroidManifest.xml\` + le fichier \`res/xml/provider_paths.xml\` correspondant.

## Pourquoi

Depuis #529, la mise à jour APK reste bloquée sur un loader indéfini à l'étape \"téléchargement\" puis échoue. Cause : la migration \`Dio.download → flutter_downloader\` n'a pas inclus la config Android obligatoire du plugin.

Sans les providers \`DownloadedFileProvider\` (FileProvider pour partager l'APK avec l'installeur Android) et \`FlutterDownloaderInitializer\` (init de la base SQLite + WorkManager), \`FlutterDownloader.enqueue()\` retourne un \`taskId\` mais le \`DownloadWorker\` n'est jamais déclenché → aucun callback de progression → le bottom sheet stagne sur l'état \`enqueued\` → la notif d'échec finit par tomber.

## Comment ça a été vérifié

- [x] \`flutter analyze\` clean (653 \`info\` pré-existants, 0 error/warning)
- [x] \`flutter test\` : 478 OK / 37 KO **pré-existants** (vérifié en stashant le diff — mêmes 37 échecs sans mon changement, normal car la modif est XML-only Android)
- [ ] Test device réel : \`flutter clean && flutter build apk && flutter install\` — déclencher la mise à jour, vérifier que la barre de progression affiche des % et débouche sur l'invite d'installation Android (à valider par Laurin)

## Zones à risque

- \`apps/mobile/android/app/src/main/AndroidManifest.xml\` — config plugin Android, impacte uniquement le flux update APK
- Aucun changement Dart/iOS/backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)