### PR TITLE
feat(letters): backend Lettres du Facteur (Story 19.1, PR1/3)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,82 +1,53 @@
-# PR — Story 18.3 « Ma veille » end-to-end (front wiring + historique + push notifs)
+# PR1 — Lettres du Facteur (backend) · Story 19.1
 
-## Why
+## Summary
 
-Phase E2E de la feature « Ma veille ». Le backend pipeline (18.1 + 18.2,
-PR #524 + #535) produit des `items[]` réels avec clusters + `why_it_matters`
-LLM. Côté front Flutter, le flow 4-steps était encore 100 % mock :
+PR1 sur 3 pour la feature « Lettres du Facteur » (soft onboarding gamifié, anti-FOMO).
 
-- `submit()` no-op à `apps/mobile/lib/features/veille/providers/veille_config_provider.dart:142` ;
-- aucun écran historique livraisons ni détail livraison ;
-- aucune notif planifiée à la livraison.
+- Nouvelle table `user_letter_progress` (Alembic `lf01`) — stocke uniquement la progression utilisateur.
+- 3 lettres en constantes Python (`app/services/letters/catalog.py`) : L0 « Bienvenue » (archivée par défaut), L1 « Tes premières sources » (4 actions auto-détectées), L2 « Ton rythme idéal » (upcoming, débloquée au classement de L1).
+- 2 endpoints :
+  - `GET /api/letters` → état complet, idempotent (init silencieux pour new user).
+  - `POST /api/letters/{letter_id}/refresh-status` → recalcule auto-détection + chaînage.
+- Auto-détection serveur des 4 actions de L1 :
+  - `define_editorial_line` → `count(user_topic_profiles)` ≥ 3.
+  - `add_5_sources` → `count(user_sources)` ≥ 5.
+  - `add_2_personal_sources` → `count(user_sources WHERE is_custom)` ≥ 2.
+  - `first_perspectives_open` → ≥1 `analytics_events` `event_type='perspectives_opened'` (event ajouté de manière non-bloquante dans `routers/contents.py:get_perspectives`).
 
-Cette PR ferme la boucle « configuration → livraison → consommation » sur
-l'app et planifie une notif locale (pas de FCM côté projet) pour rappeler
-au user que sa veille est tombée.
+## Décisions architecturales
 
-## What
-
-### Front wiring
-
-- `submit()` étape 4 → POST `/api/veille/config` (real `VeilleRepository`).
-- Suggestions topics/sources réelles à l'entrée des étapes 2 et 3 (POST
-  `/api/veille/suggestions/{topics,sources}` avec spinner bloquant +
-  fallback mock UX si erreur réseau).
-- Redirect automatique `/veille/config` → `/veille/dashboard` quand
-  `GET /api/veille/config` retourne 200 (au lieu de relancer le flow).
-- Filtrage des sources mock-only au submit (sans `apiSourceId` UUID API,
-  elles ne peuvent pas être ingérées par le backend).
-
-### Nouveaux écrans
-
-- **Dashboard** `/veille/dashboard` : thème, topics, sources, schedule,
-  countdown next_scheduled_at, boutons Modifier / Pause / Supprimer / Historique.
-- **Historique** `/veille/deliveries` : liste 20 dernières livraisons,
-  pull-to-refresh, empty state.
-- **Détail livraison** `/veille/deliveries/:id` : clusters + `why_it_matters` +
-  articles → tap ouvre InAppWebView (`launchUrl` mode `inAppBrowserView`).
-  Gère les états `running`/`pending` (loader) et `failed` (state d'erreur sympa).
-
-### Push notif locale + deeplink
-
-- `PushNotificationService.scheduleVeilleNotification(scheduledAt)` (NotifId=3,
-  channel `veille_channel`). Planifié à `next_scheduled_at + 30 min` pour
-  laisser le scanner */30 min générer la livraison avant que la notif tombe.
-- Cancel automatique sur PATCH status=paused / DELETE.
-- Mapping deeplink `io.supabase.facteur://veille/dashboard` ajouté à
-  `DeepLinkService.parse` (`WidgetDeepLinkTarget.veille`).
-
-### Architecture
-
-- Pas de modif backend (la pipeline fait déjà tout).
-- Patterns réutilisés : `digest_repository.dart` (Dio + exceptions typées),
-  `digest_provider.dart` (AsyncNotifier — simplifié load-on-enter),
-  `scheduleDailyDigestNotification` (zonedSchedule local).
-- Retries bornés (interceptor existant : 2 retries sur 5xx ≠503, 0 sur 4xx) —
-  pas de retries cascadés type stale-fallback du digest (anti-cascade pool DB).
-- Story doc : `docs/stories/core/18.3.veille-e2e.md`.
+- **FK** : `user_profiles.user_id` (cohérent avec `veille_configs`), pas `auth.users(id)`.
+- **RLS** : non activée — scoping par FastAPI auth (cohérent avec les autres tables user-scoped).
+- **Lettres = constantes** : V1 = 3 lettres en dur, rotation = redeploy. Pas de surface d'admin pour V1.
+- **Migration** : Alembic + apply manuel Supabase. **Application Supabase TODO** : `mcp__supabase__apply_migration` est en read-only mode dans cet environnement. À exécuter manuellement via Supabase SQL Editor (le SQL est dans le commit + dans `docs/stories/core/19.1.lettres-facteur.md`).
 
 ## Test plan
 
-- [x] `flutter analyze lib/features/veille` → 1 info-level lint, 0 erreur.
-- [x] `flutter test test/features/veille/models/veille_models_test.dart` →
-  15 tests verts (parsing fromJson + sérialisation toJson).
-- [x] `flutter test test/core/services/{deep_link_service,push_notification_service_copy}_test.dart`
-  → 14 tests verts (anti-régression, +2 tests pour le mapping veille deep link).
-- [x] `pytest -q` backend (anti-régression) : 838 passed, 85 errors —
-  TOUTES les errors sont `psycopg.OperationalError` (DB locale Supabase non
-  démarrée, infra), aucune cassée par cette PR.
-- [ ] `/validate-feature` (Chrome MCP, viewport 390x844) — scénarios :
-  happy path, redirect dashboard, pause/reprendre, suppression, livraison
-  failed, erreur réseau suggestions, tap notif. Cf. `.context/qa-handoff.md`.
-- [ ] Smoke API local : `uvicorn app.main:app --port 8080`, configure une
-  veille, vérifier POST /config + log `PushNotificationService: veille scheduled @ ...`,
-  POST /deliveries/generate (debug), refresh historique.
+- [x] `pytest tests/routers/test_letters_routes.py -v` — 11/11 PASSED (init, 4 détecteurs, chaînage, idempotence x2, cross-tenant, 404).
+- [x] Suite complète `pytest -v --ignore=tests/routers/test_notification_preferences.py` — 934 passed, 13 skipped.
+- [x] `ruff format --check` + `ruff check` — verts sur tous les fichiers touchés.
+- [x] `bash docs/qa/scripts/verify_letters.sh` — pytest pass + smoke routes wired.
+- [x] `alembic heads` → 1 head unique (`lf01`).
+- [ ] **Manuel post-merge** : appliquer la migration `lf01_create_user_letter_progress` sur Supabase via SQL Editor (MCP read-only en local).
 
-## Out of scope
+### Test ignoré
 
-- Multi-veilles par user (V2/V3).
-- Carte « Ma veille » sur le feed (entry point — tranché en brainstorming PO).
-- Push serveur (FCM/APNS) — pas de stockage push_token côté backend, hors V1.
-- Cache disque persistant pour livraisons (load-on-enter mémoire suffit).
-- Pagination historique > 20.
+`tests/routers/test_notification_preferences.py::test_patch_increments_refusal_count` est en échec **pré-existant** (TZ-dépendant Paris été : assertion sur string `2026-04-28T12:00:00` qui matche pas `2026-04-28T14:00:00+02:00`). Pas de lien avec cette PR — confirmé en stashant les changements.
+
+## Suite — PR2 et PR3
+
+Cette PR ne touche **pas** au mobile. Suivi dans `docs/stories/core/19.1.lettres-facteur.md`.
+
+- PR2 = data layer mobile (modèles Dart + provider + RingAvatar + ProfileAvatarButton).
+- PR3 = UI mobile (7 widgets, 2 screens, route, banner feed, /validate-feature).
+
+## Forme JSON `GET /api/letters` (pour PR2)
+
+```json
+[
+  {"id":"letter_0","num":"00","title":"Bienvenue chez Facteur","message":"...","signature":"Le Facteur","actions":[],"status":"archived","completed_actions":[],"progress":1.0,"started_at":null,"archived_at":"2026-05-02T..."},
+  {"id":"letter_1","num":"01","title":"Tes premières sources","message":"Bienvenue. Avant de t'emmener plus loin...","signature":"Le Facteur","actions":[{"id":"define_editorial_line","label":"...","help":"..."}, ...],"status":"active","completed_actions":["define_editorial_line"],"progress":0.25,"started_at":"2026-05-02T...","archived_at":null},
+  {"id":"letter_2","num":"02","title":"Ton rythme idéal","message":"...","signature":"Le Facteur","actions":[{"id":"set_frequency","label":"...","help":"..."}],"status":"upcoming","completed_actions":[],"progress":0.0,"started_at":null,"archived_at":null}
+]
+```

--- a/docs/qa/scripts/verify_letters.sh
+++ b/docs/qa/scripts/verify_letters.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# verify_letters.sh — E2E QA for the « Lettres du Facteur » feature (Story 19.1).
+#
+# Stratégie : on n'a pas de moyen simple de fabriquer un JWT Supabase valide
+# en local. On valide donc la chaîne :
+#   1. Smoke : la route est enregistrée et exige un token (401 sans auth).
+#   2. Logique : on lance la suite pytest dédiée — qui couvre les 8 cas
+#      (init, 4 détecteurs, chaînage, idempotence, cross-tenant, 404).
+#
+# Usage:
+#   ./docs/qa/scripts/verify_letters.sh [API_BASE_URL]
+#   Default: http://localhost:8080/api
+#
+# DATABASE_URL doit pointer sur la DB de test (cf conftest.py). Sur poste
+# local, par défaut :
+#   export DATABASE_URL="postgresql+psycopg://laurinboujon@localhost:5432/facteur_test?sslmode=disable"
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+API="${1:-http://localhost:8080/api}"
+PASS=0
+FAIL=0
+
+green() { printf "\033[32m✅ %s\033[0m\n" "$1"; PASS=$((PASS+1)); }
+red()   { printf "\033[31m❌ %s\033[0m\n" "$1"; FAIL=$((FAIL+1)); }
+info()  { printf "\033[34mℹ️  %s\033[0m\n" "$1"; }
+
+echo "=== Lettres du Facteur — Verification ==="
+echo "API: $API"
+echo ""
+
+# --- 1. Pytest suite (logique métier complète) ---
+info "1. Running pytest suite tests/routers/test_letters_routes.py..."
+pushd "$REPO_ROOT/packages/api" >/dev/null
+if PYTHONPATH=. pytest tests/routers/test_letters_routes.py -v -x \
+    --no-header 2>&1 | tail -20; then
+  green "All letters tests passed"
+else
+  red "Pytest suite failed"
+fi
+popd >/dev/null
+echo ""
+
+# --- 2. Smoke route enregistrée (auth required) ---
+info "2. GET /api/letters without auth → expect 401/403..."
+HTTP=$(curl -s -o /dev/null -w "%{http_code}" "$API/letters" 2>/dev/null || true)
+if [ "$HTTP" = "401" ] || [ "$HTTP" = "403" ]; then
+  green "GET /api/letters returns $HTTP (auth required, route is wired)"
+elif [ -z "$HTTP" ] || [ "$HTTP" = "000" ]; then
+  info "API not reachable at $API — skipping smoke (start with: uvicorn app.main:app --port 8080)"
+else
+  red "GET /api/letters returned unexpected $HTTP"
+fi
+echo ""
+
+# --- 3. Smoke refresh-status route ---
+info "3. POST /api/letters/letter_1/refresh-status without auth → expect 401/403..."
+HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API/letters/letter_1/refresh-status" 2>/dev/null || true)
+if [ "$HTTP" = "401" ] || [ "$HTTP" = "403" ]; then
+  green "POST /api/letters/.../refresh-status returns $HTTP"
+elif [ -z "$HTTP" ] || [ "$HTTP" = "000" ]; then
+  info "API not reachable — skipping smoke"
+else
+  red "POST refresh-status returned unexpected $HTTP"
+fi
+echo ""
+
+# --- Bilan ---
+echo "=== Résultats : $PASS pass / $FAIL fail ==="
+[ "$FAIL" -eq 0 ]

--- a/docs/stories/core/19.1.lettres-facteur.md
+++ b/docs/stories/core/19.1.lettres-facteur.md
@@ -1,0 +1,133 @@
+# Story 19.1 — Lettres du Facteur (soft onboarding gamifié)
+
+## Description
+
+Système d'onboarding doux « Lettres du Facteur ». L'utilisateur·rice reçoit progressivement des « lettres » contenant 1 à 4 actions courtes pour configurer son expérience. Quand une lettre est accomplie, elle est rangée avec un cachet ; le Facteur s'efface. Pas de stade final, pas de FOMO, pas de classement.
+
+**Principe** : « Faire de soi son propre Facteur. »
+
+**Plan global** : `/Users/laurinboujon/.claude/plans/system-instruction-you-are-working-wild-rain.md`
+**Plan PR1** : `/Users/laurinboujon/.claude/plans/system-instruction-you-are-working-warm-otter.md`
+**Design handoff** : `/Users/laurinboujon/Desktop/Facteur/Claude Design/design_handoff_lettres_facteur/`
+
+3 lettres V1 :
+- **L0** « Bienvenue » — archivée par défaut, 0 action
+- **L1** « Tes premières sources » — active par défaut, 4 actions auto-détectées
+- **L2** « Ton rythme idéal » — upcoming, débloquée quand L1 archivée
+
+---
+
+## PR1 — Backend (cette PR)
+
+Branche : `boujonlaurin-dotcom/lettres-api` → base `main`.
+
+### Tasks
+
+- [ ] Story doc créée
+- [ ] Migration Alembic `lf01_create_user_letter_progress` (down_revision = `tr01`)
+- [ ] Migration appliquée sur Supabase via `mcp__supabase__apply_migration`
+- [ ] Modèle SQLAlchemy `UserLetterProgress` + enregistrement dans `app/models/__init__.py`
+- [ ] Catalogue `app/services/letters/catalog.py` (constantes L0/L1/L2)
+- [ ] Service `app/services/letters/service.py` : `get_user_letters` + `refresh_letter_status` + 4 détecteurs
+- [ ] Tracking `perspectives_opened` ajouté dans `routers/contents.py:get_perspectives`
+- [ ] Router `app/routers/letters.py` (2 endpoints)
+- [ ] Router enregistré dans `app/main.py`
+- [ ] Tests `tests/routers/test_letters_routes.py` — 8 cas
+- [ ] Script QA `docs/qa/scripts/verify_letters.sh`
+- [ ] `pytest -v` complet vert
+- [ ] `ruff format --check` + `ruff check` verts
+- [ ] PR vers `main` ouverte
+
+### Fichiers modifiés (PR1)
+
+| Fichier | Action |
+|---|---|
+| `packages/api/alembic/versions/lf01_create_user_letter_progress.py` | CREATE |
+| `packages/api/app/models/user_letter_progress.py` | CREATE |
+| `packages/api/app/models/__init__.py` | EDIT |
+| `packages/api/app/services/letters/__init__.py` | CREATE |
+| `packages/api/app/services/letters/catalog.py` | CREATE |
+| `packages/api/app/services/letters/service.py` | CREATE |
+| `packages/api/app/routers/letters.py` | CREATE |
+| `packages/api/app/routers/contents.py` | EDIT (log perspectives_opened) |
+| `packages/api/app/main.py` | EDIT (include_router) |
+| `packages/api/tests/routers/test_letters_routes.py` | CREATE |
+| `docs/qa/scripts/verify_letters.sh` | CREATE |
+| `docs/stories/core/19.1.lettres-facteur.md` | CREATE |
+
+---
+
+## PR2 — Mobile data layer (à venir)
+
+Branche : `boujonlaurin-dotcom/lettres-data-layer`.
+
+À remplir au démarrage de PR2. Inclura : modèles Dart, repository, AsyncNotifierProvider, RingAvatar, ProfileAvatarButton réécrit, settings sheet entrée Courrier (route TODO).
+
+---
+
+## PR3 — Mobile UI (à venir)
+
+Branche : `boujonlaurin-dotcom/lettres-ui`.
+
+À remplir au démarrage de PR3. Inclura : 7 widgets, 2 screens, route `/lettres` + `/lettres/:id`, banner feed, /validate-feature.
+
+---
+
+## Décisions architecturales
+
+- **Migration** : Alembic + apply manuel Supabase (cohérent avec `vl01_create_veille_tables`). Pas d'exécution Alembic sur Railway.
+- **FK user_id** : `user_profiles.user_id` (cohérent avec veille_configs), pas `auth.users(id)`.
+- **RLS** : non activée — scoping fait par FastAPI auth (cohérent avec `veille_configs` / `user_topic_profiles`).
+- **Auto-détection action 1 (`define_editorial_line`)** : table `user_topic_profiles` (UserTopicProfile, custom topics Epic 11), seuil ≥3.
+- **Auto-détection action 2 (`add_5_sources`)** : table `user_sources`, count total ≥5 (pas de colonne `active`/`is_active` à filtrer).
+- **Auto-détection action 3 (`add_2_personal_sources`)** : `user_sources WHERE is_custom=true`, ≥2 (le mission disait `source_type='custom'` qui n'existe pas).
+- **Auto-détection action 4 (`first_perspectives_open`)** : réutilise `analytics_events` existant ; ajout d'un `log_event(event_type='perspectives_opened')` non-bloquant dans `routers/contents.py:get_perspectives`.
+- **Lettres = constantes Python** : pas de table letters/letter_actions. Rotation éditoriale = redeploy. Justifié pour V1 (3 lettres seulement).
+
+## Notes pour PR2
+
+### Forme JSON `GET /api/letters`
+
+```json
+[
+  {
+    "id": "letter_0",
+    "num": "00",
+    "title": "Bienvenue chez Facteur",
+    "message": "...",
+    "signature": "Le Facteur",
+    "actions": [],
+    "status": "archived",
+    "completed_actions": [],
+    "progress": 1.0,
+    "started_at": null,
+    "archived_at": "2026-05-02T..."
+  },
+  {
+    "id": "letter_1",
+    "num": "01",
+    "title": "Tes premières sources",
+    "message": "Bienvenue. Avant de t'emmener plus loin...",
+    "signature": "Le Facteur",
+    "actions": [
+      {"id": "define_editorial_line", "label": "...", "help": "..."},
+      ...
+    ],
+    "status": "active",
+    "completed_actions": ["define_editorial_line", "add_5_sources"],
+    "progress": 0.5,
+    "started_at": "2026-05-02T...",
+    "archived_at": null
+  },
+  ...
+]
+```
+
+### Endpoints
+
+- `GET /api/letters` → état complet, idempotent (init si pas de rows)
+- `POST /api/letters/{letter_id}/refresh-status` → re-détection + chaînage, retourne la lettre à jour
+
+### Issues rencontrées
+
+(à alimenter au fil de l'eau)

--- a/packages/api/alembic/versions/lf01_create_user_letter_progress.py
+++ b/packages/api/alembic/versions/lf01_create_user_letter_progress.py
@@ -1,0 +1,73 @@
+"""create user_letter_progress table (Lettres du Facteur)
+
+Revision ID: lf01
+Revises: tr01
+Create Date: 2026-05-02
+
+Une row par (user_id, letter_id). Les lettres elles-mêmes sont des constantes
+Python (`app/services/letters/catalog.py`) — la DB stocke uniquement la
+progression. `completed_actions` est un jsonb d'ids d'actions cochées par
+auto-détection.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "lf01"
+down_revision: str | Sequence[str] | None = "tr01"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_letter_progress",
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user_profiles.user_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("letter_id", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+        ),
+        sa.Column(
+            "completed_actions",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("user_id", "letter_id", name="pk_user_letter_progress"),
+        sa.CheckConstraint(
+            "status IN ('upcoming', 'active', 'archived')",
+            name="ck_user_letter_progress_status",
+        ),
+    )
+    op.create_index(
+        "ix_user_letter_progress_user_status",
+        "user_letter_progress",
+        ["user_id", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_user_letter_progress_user_status",
+        table_name="user_letter_progress",
+    )
+    op.drop_table("user_letter_progress")

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -83,6 +83,7 @@ from app.routers import (
     feed,
     images,
     internal,
+    letters,
     notification_preferences,
     personalization,
     progress,
@@ -468,6 +469,7 @@ app.include_router(
     tags=["WellInformed"],
 )
 app.include_router(veille.router, prefix="/api/veille", tags=["Veille"])
+app.include_router(letters.router, prefix="/api/letters", tags=["Letters"])
 
 
 @app.exception_handler(Exception)

--- a/packages/api/app/models/__init__.py
+++ b/packages/api/app/models/__init__.py
@@ -21,6 +21,7 @@ from app.models.source import Source, UserSource
 from app.models.source_search_log import SourceSearchLog
 from app.models.subscription import UserSubscription
 from app.models.user import UserInterest, UserPreference, UserProfile, UserStreak
+from app.models.user_letter_progress import UserLetterProgress
 from app.models.user_notification_preferences import UserNotificationPreferences
 from app.models.user_personalization import UserPersonalization
 from app.models.user_topic_profile import UserTopicProfile
@@ -86,6 +87,8 @@ __all__ = [
     "PerspectiveAnalysis",
     # Custom Topics (Epic 11)
     "UserTopicProfile",
+    # Lettres du Facteur (Story 19.1)
+    "UserLetterProgress",
     # Curation (Backoffice)
     "CurationAnnotation",
     # Waitlist (Landing Page)

--- a/packages/api/app/models/user_letter_progress.py
+++ b/packages/api/app/models/user_letter_progress.py
@@ -1,0 +1,66 @@
+"""Modèle UserLetterProgress — Lettres du Facteur (Story 19.1).
+
+Une row par (user_id, letter_id). Les lettres elles-mêmes sont des constantes
+Python (`app/services/letters/catalog.py`) — la DB stocke uniquement la
+progression utilisateur.
+"""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    PrimaryKeyConstraint,
+    Text,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class UserLetterProgress(Base):
+    """Progression d'un user sur une lettre du Facteur."""
+
+    __tablename__ = "user_letter_progress"
+    __table_args__ = (
+        PrimaryKeyConstraint("user_id", "letter_id", name="pk_user_letter_progress"),
+        CheckConstraint(
+            "status IN ('upcoming', 'active', 'archived')",
+            name="ck_user_letter_progress_status",
+        ),
+        Index(
+            "ix_user_letter_progress_user_status",
+            "user_id",
+            "status",
+        ),
+    )
+
+    user_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("user_profiles.user_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    letter_id: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    completed_actions: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb"), default=list
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    archived_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -743,6 +743,20 @@ async def get_perspectives(
 
     cache_key = str(content_id)
 
+    # Track perspective open (Story 19.1 — Lettres du Facteur, action 4).
+    # Non-bloquant : un échec ne doit pas casser l'endpoint. Un seul event
+    # suffit pour la détection (DETECTORS["first_perspectives_open"] LIMIT 1).
+    try:
+        from app.services.analytics_service import AnalyticsService
+
+        await AnalyticsService(db).log_event(
+            user_id=UUID(current_user_id),
+            event_type="perspectives_opened",
+            event_data={"content_id": cache_key},
+        )
+    except Exception:
+        logger.warning("perspectives_open_tracking_failed", exc_info=True)
+
     # Check cache (TTLCache handles expiration automatically)
     cached_response = _perspectives_cache.get(cache_key)
     if cached_response is not None:

--- a/packages/api/app/routers/letters.py
+++ b/packages/api/app/routers/letters.py
@@ -1,0 +1,47 @@
+"""Router /api/letters — Lettres du Facteur (Story 19.1).
+
+2 endpoints :
+- `GET /api/letters` : retourne les 3 lettres avec leur état courant (init
+  silencieux si new user).
+- `POST /api/letters/{letter_id}/refresh-status` : recalcule l'auto-détection
+  pour une lettre, archive si terminée, déverrouille la suivante.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.services.letters.catalog import LETTERS_BY_ID
+from app.services.letters.service import (
+    get_user_letters,
+    refresh_letter_status,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+@router.get("")
+async def list_letters(
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+) -> list[dict]:
+    return await get_user_letters(UUID(current_user_id), db)
+
+
+@router.post("/{letter_id}/refresh-status")
+async def refresh_status(
+    letter_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+) -> dict:
+    if letter_id not in LETTERS_BY_ID:
+        raise HTTPException(status_code=404, detail="Letter not found")
+    return await refresh_letter_status(UUID(current_user_id), letter_id, db)

--- a/packages/api/app/services/letters/catalog.py
+++ b/packages/api/app/services/letters/catalog.py
@@ -1,0 +1,75 @@
+"""Catalogue des lettres du Facteur (constantes serveur).
+
+V1 = 3 lettres en dur. Rotation éditoriale = redeploy. Les lettres ne sont
+pas en DB — la table `user_letter_progress` ne stocke que la progression
+utilisateur.
+"""
+
+LETTER_0: dict = {
+    "id": "letter_0",
+    "num": "00",
+    "title": "Bienvenue chez Facteur",
+    "default_status": "archived",
+    "actions": [],
+    "message": (
+        "Bienvenue dans Facteur. Je m'occuperai chaque jour de te déposer "
+        "ce qui mérite ton attention."
+    ),
+    "signature": "Le Facteur",
+}
+
+LETTER_1: dict = {
+    "id": "letter_1",
+    "num": "01",
+    "title": "Tes premières sources",
+    "default_status": "active",
+    "actions": [
+        {
+            "id": "define_editorial_line",
+            "label": "Définir ta ligne éditoriale",
+            "help": "3 à 5 centres d'intérêt — tech, climat, culture…",
+        },
+        {
+            "id": "add_5_sources",
+            "label": "Ajouter 5 sources à ta sélection",
+            "help": (
+                "Pioche dans la liste suggérée. Tu peux toujours en retirer plus tard."
+            ),
+        },
+        {
+            "id": "add_2_personal_sources",
+            "label": "Ajouter 2 sources personnelles",
+            "help": "Un blog, une newsletter, un site que tu lis déjà.",
+        },
+        {
+            "id": "first_perspectives_open",
+            "label": "Lancer ta première analyse de comparaison",
+            "help": "Compare deux angles sur le même sujet.",
+        },
+    ],
+    "message": (
+        "Bienvenue. Avant de t'emmener plus loin, posons les bases : "
+        "ta ligne éditoriale, les sources que tu connais, et celles que "
+        "tu veux ajouter à ta sélection."
+    ),
+    "signature": "Le Facteur",
+}
+
+LETTER_2: dict = {
+    "id": "letter_2",
+    "num": "02",
+    "title": "Ton rythme idéal",
+    "default_status": "upcoming",
+    "actions": [
+        {
+            "id": "set_frequency",
+            "label": "Choisir ta fréquence de digest",
+            "help": "Quotidien, hebdomadaire, ou à la demande.",
+        },
+    ],
+    "message": ("Maintenant que ta sélection est posée, choisissons ton rythme."),
+    "signature": "Le Facteur",
+}
+
+LETTERS_ORDER: list[dict] = [LETTER_0, LETTER_1, LETTER_2]
+LETTERS_BY_ID: dict[str, dict] = {letter["id"]: letter for letter in LETTERS_ORDER}

--- a/packages/api/app/services/letters/service.py
+++ b/packages/api/app/services/letters/service.py
@@ -1,0 +1,236 @@
+"""Service Lettres du Facteur — auto-détection actions + chaînage.
+
+`get_user_letters` est idempotent : si l'utilisateur n'a pas encore de rows,
+on initialise les 3 lettres en base puis on retourne l'état complet (en
+rafraîchissant la lettre active pour propager les actions déjà accomplies).
+
+`refresh_letter_status` recalcule les détecteurs pour une lettre donnée et,
+si elle est complète, l'archive et déverrouille la suivante.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.analytics import AnalyticsEvent
+from app.models.source import UserSource
+from app.models.user_letter_progress import UserLetterProgress
+from app.models.user_topic_profile import UserTopicProfile
+from app.services.letters.catalog import (
+    LETTERS_BY_ID,
+    LETTERS_ORDER,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+# ─── Détecteurs ────────────────────────────────────────────────────────────
+
+
+async def _detect_define_editorial_line(user_id: UUID, db: AsyncSession) -> bool:
+    """≥3 centres d'intérêt via UserTopicProfile (custom topics, Epic 11)."""
+    stmt = (
+        select(func.count())
+        .select_from(UserTopicProfile)
+        .where(UserTopicProfile.user_id == user_id)
+    )
+    return ((await db.execute(stmt)).scalar() or 0) >= 3
+
+
+async def _detect_add_5_sources(user_id: UUID, db: AsyncSession) -> bool:
+    """≥5 user_sources (toute association compte)."""
+    stmt = (
+        select(func.count())
+        .select_from(UserSource)
+        .where(UserSource.user_id == user_id)
+    )
+    return ((await db.execute(stmt)).scalar() or 0) >= 5
+
+
+async def _detect_add_2_personal_sources(user_id: UUID, db: AsyncSession) -> bool:
+    """≥2 user_sources avec is_custom=True."""
+    stmt = (
+        select(func.count())
+        .select_from(UserSource)
+        .where(UserSource.user_id == user_id, UserSource.is_custom.is_(True))
+    )
+    return ((await db.execute(stmt)).scalar() or 0) >= 2
+
+
+async def _detect_first_perspectives_open(user_id: UUID, db: AsyncSession) -> bool:
+    """Au moins un AnalyticsEvent event_type='perspectives_opened'."""
+    stmt = (
+        select(AnalyticsEvent.id)
+        .where(
+            AnalyticsEvent.user_id == user_id,
+            AnalyticsEvent.event_type == "perspectives_opened",
+        )
+        .limit(1)
+    )
+    return (await db.execute(stmt)).scalar() is not None
+
+
+DETECTORS = {
+    "define_editorial_line": _detect_define_editorial_line,
+    "add_5_sources": _detect_add_5_sources,
+    "add_2_personal_sources": _detect_add_2_personal_sources,
+    "first_perspectives_open": _detect_first_perspectives_open,
+    # `set_frequency` (L2) : à brancher quand l'UI sera prête (PR2/PR3).
+}
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _serialize(row: UserLetterProgress, catalog: dict) -> dict:
+    """Compose la réponse JSON à partir de la row DB + des constantes."""
+    actions = catalog["actions"]
+    completed = list(row.completed_actions or [])
+    progress = (
+        len([a for a in actions if a["id"] in completed]) / len(actions)
+        if actions
+        else 1.0
+    )
+    return {
+        "id": catalog["id"],
+        "num": catalog["num"],
+        "title": catalog["title"],
+        "message": catalog["message"],
+        "signature": catalog["signature"],
+        "actions": actions,
+        "status": row.status,
+        "completed_actions": completed,
+        "progress": round(progress, 4),
+        "started_at": row.started_at.isoformat() if row.started_at else None,
+        "archived_at": row.archived_at.isoformat() if row.archived_at else None,
+    }
+
+
+async def _get_rows(user_id: UUID, db: AsyncSession) -> dict[str, UserLetterProgress]:
+    stmt = select(UserLetterProgress).where(UserLetterProgress.user_id == user_id)
+    rows = (await db.execute(stmt)).scalars().all()
+    return {row.letter_id: row for row in rows}
+
+
+async def _init_progress(user_id: UUID, db: AsyncSession) -> None:
+    """Crée les 3 rows initiales pour un nouveau user."""
+    now = datetime.now(UTC)
+    for catalog in LETTERS_ORDER:
+        default_status = catalog["default_status"]
+        row = UserLetterProgress(
+            user_id=user_id,
+            letter_id=catalog["id"],
+            status=default_status,
+            completed_actions=[],
+            started_at=now if default_status == "active" else None,
+            archived_at=now if default_status == "archived" else None,
+        )
+        db.add(row)
+    await db.commit()
+
+
+def _next_upcoming(
+    rows: dict[str, UserLetterProgress], after_letter_id: str
+) -> UserLetterProgress | None:
+    """Cherche la prochaine lettre upcoming dans le dict déjà chargé."""
+    order_ids = [letter["id"] for letter in LETTERS_ORDER]
+    try:
+        idx = order_ids.index(after_letter_id)
+    except ValueError:
+        return None
+    for next_id in order_ids[idx + 1 :]:
+        candidate = rows.get(next_id)
+        if candidate is not None and candidate.status == "upcoming":
+            return candidate
+    return None
+
+
+async def _recompute_completed(
+    user_id: UUID, catalog: dict, db: AsyncSession
+) -> list[str]:
+    """Lance les détecteurs pour chaque action de la lettre."""
+    completed: list[str] = []
+    for action in catalog["actions"]:
+        detector = DETECTORS.get(action["id"])
+        if detector is None:
+            continue
+        try:
+            if await detector(user_id, db):
+                completed.append(action["id"])
+        except Exception:
+            logger.warning(
+                "letter_detector_failed",
+                user_id=str(user_id),
+                action_id=action["id"],
+                exc_info=True,
+            )
+    return completed
+
+
+# ─── API publique ──────────────────────────────────────────────────────────
+
+
+async def refresh_letter_status(
+    user_id: UUID, letter_id: str, db: AsyncSession
+) -> dict:
+    """Recalcule les actions cochées + archive si terminée + déverrouille
+    la suivante. Idempotent."""
+    catalog = LETTERS_BY_ID[letter_id]
+    rows = await _get_rows(user_id, db)
+    if letter_id not in rows:
+        # Init si jamais — peut arriver pour un user qui n'a pas appelé
+        # GET /api/letters au préalable.
+        await _init_progress(user_id, db)
+        rows = await _get_rows(user_id, db)
+    row = rows[letter_id]
+
+    # Idempotence : une lettre archivée n'est jamais re-évaluée.
+    if row.status == "archived":
+        return _serialize(row, catalog)
+
+    completed = await _recompute_completed(user_id, catalog, db)
+    action_ids = [a["id"] for a in catalog["actions"]]
+    merged = [a_id for a_id in action_ids if a_id in completed]
+    now = datetime.now(UTC)
+    if merged != list(row.completed_actions or []):
+        row.completed_actions = merged
+        row.updated_at = now
+
+    if action_ids and len(merged) == len(action_ids) and row.status == "active":
+        row.status = "archived"
+        row.archived_at = now
+        next_row = _next_upcoming(rows, letter_id)
+        if next_row is not None:
+            next_row.status = "active"
+            next_row.started_at = now
+            next_row.updated_at = now
+
+    await db.commit()
+    await db.refresh(row)
+    return _serialize(row, catalog)
+
+
+async def get_user_letters(user_id: UUID, db: AsyncSession) -> list[dict]:
+    """Retourne les 3 lettres avec leur état courant. Init si pas de rows."""
+    rows = await _get_rows(user_id, db)
+    if not rows:
+        await _init_progress(user_id, db)
+        rows = await _get_rows(user_id, db)
+
+    # Refresh la lettre active (s'il y en a une) pour propager les actions
+    # accomplies hors de l'app (ex: user a ajouté des sources sans appeler
+    # refresh-status explicitement).
+    active_id = next(
+        (lid for lid, r in rows.items() if r.status == "active"),
+        None,
+    )
+    if active_id is not None:
+        await refresh_letter_status(user_id, active_id, db)
+        rows = await _get_rows(user_id, db)
+
+    return [_serialize(rows[letter["id"]], letter) for letter in LETTERS_ORDER]

--- a/packages/api/tests/routers/test_letters_routes.py
+++ b/packages/api/tests/routers/test_letters_routes.py
@@ -1,0 +1,280 @@
+"""Tests pour le router /api/letters (Story 19.1 — Lettres du Facteur).
+
+Couvre :
+- État initial pour un new user (L0 archived, L1 active, L2 upcoming).
+- Auto-détection des 4 actions de L1.
+- Chaînage L1 → L2 quand toutes les actions sont cochées.
+- Idempotence du refresh.
+- Cross-tenant : un user ne voit pas les rows d'un autre.
+- 404 sur letter_id inconnu.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.analytics import AnalyticsEvent
+from app.models.enums import SourceType
+from app.models.source import Source, UserSource
+from app.models.user import UserProfile
+from app.models.user_letter_progress import UserLetterProgress
+from app.models.user_topic_profile import UserTopicProfile
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def auth_user(db_session):
+    user_id = uuid4()
+    profile = UserProfile(
+        user_id=user_id,
+        display_name="Letters Test User",
+        onboarding_completed=True,
+    )
+    db_session.add(profile)
+    await db_session.commit()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        yield user_id
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+def _client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+async def _add_topics(db_session, user_id: UUID, count: int) -> None:
+    for i in range(count):
+        db_session.add(
+            UserTopicProfile(
+                user_id=user_id,
+                topic_name=f"Topic {i}",
+                slug_parent="custom",
+                source_type="explicit",
+            )
+        )
+    await db_session.commit()
+
+
+async def _add_sources(db_session, user_id: UUID, total: int, custom: int) -> None:
+    """Crée `total` user_sources dont `custom` avec is_custom=True."""
+    for i in range(total):
+        src = Source(
+            id=uuid4(),
+            name=f"Source {i}",
+            url=f"https://src-{i}.example.com",
+            feed_url=f"https://src-{i}.example.com/feed-{uuid4()}.xml",
+            type=SourceType.ARTICLE,
+            theme="society",
+            is_active=True,
+        )
+        db_session.add(src)
+        await db_session.flush()
+        db_session.add(
+            UserSource(
+                user_id=user_id,
+                source_id=src.id,
+                is_custom=i < custom,
+            )
+        )
+    await db_session.commit()
+
+
+async def _add_perspectives_event(db_session, user_id: UUID) -> None:
+    db_session.add(
+        AnalyticsEvent(
+            user_id=user_id,
+            event_type="perspectives_opened",
+            event_data={"content_id": str(uuid4())},
+        )
+    )
+    await db_session.commit()
+
+
+# ─── Tests ─────────────────────────────────────────────────────────────────
+
+
+class TestInitialState:
+    async def test_new_user_returns_three_letters(self, auth_user):
+        async with _client() as ac:
+            resp = await ac.get("/api/letters")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 3
+
+        l0, l1, l2 = data
+        assert l0["id"] == "letter_0"
+        assert l0["status"] == "archived"
+        assert l0["progress"] == 1.0
+        assert l0["archived_at"] is not None
+        assert l0["actions"] == []
+
+        assert l1["id"] == "letter_1"
+        assert l1["status"] == "active"
+        assert l1["completed_actions"] == []
+        assert l1["progress"] == 0.0
+        assert l1["started_at"] is not None
+        assert len(l1["actions"]) == 4
+
+        assert l2["id"] == "letter_2"
+        assert l2["status"] == "upcoming"
+
+    async def test_get_is_idempotent(self, auth_user):
+        async with _client() as ac:
+            resp1 = await ac.get("/api/letters")
+            resp2 = await ac.get("/api/letters")
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+        # Pas de doublons en DB après un 2e GET
+        assert len(resp2.json()) == 3
+
+
+class TestAutoDetection:
+    async def test_define_editorial_line_detected(self, auth_user, db_session):
+        await _add_topics(db_session, auth_user, 3)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_1/refresh-status")
+
+        assert resp.status_code == 200
+        assert "define_editorial_line" in resp.json()["completed_actions"]
+
+    async def test_editorial_line_below_threshold_not_detected(
+        self, auth_user, db_session
+    ):
+        await _add_topics(db_session, auth_user, 2)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_1/refresh-status")
+
+        assert "define_editorial_line" not in resp.json()["completed_actions"]
+
+    async def test_sources_actions_detected(self, auth_user, db_session):
+        await _add_sources(db_session, auth_user, total=5, custom=2)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_1/refresh-status")
+
+        completed = resp.json()["completed_actions"]
+        assert "add_5_sources" in completed
+        assert "add_2_personal_sources" in completed
+
+    async def test_perspectives_event_detected(self, auth_user, db_session):
+        await _add_perspectives_event(db_session, auth_user)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_1/refresh-status")
+
+        assert "first_perspectives_open" in resp.json()["completed_actions"]
+
+
+class TestChaining:
+    async def test_l1_archived_unlocks_l2(self, auth_user, db_session):
+        await _add_topics(db_session, auth_user, 3)
+        await _add_sources(db_session, auth_user, total=5, custom=2)
+        await _add_perspectives_event(db_session, auth_user)
+
+        async with _client() as ac:
+            refresh_resp = await ac.post("/api/letters/letter_1/refresh-status")
+            list_resp = await ac.get("/api/letters")
+
+        assert refresh_resp.status_code == 200
+        l1_data = refresh_resp.json()
+        assert l1_data["status"] == "archived"
+        assert l1_data["archived_at"] is not None
+        assert l1_data["progress"] == 1.0
+
+        l0, l1, l2 = list_resp.json()
+        assert l1["status"] == "archived"
+        assert l2["status"] == "active"
+        assert l2["started_at"] is not None
+
+
+class TestIdempotence:
+    async def test_refresh_twice_same_state(self, auth_user, db_session):
+        await _add_topics(db_session, auth_user, 3)
+
+        async with _client() as ac:
+            r1 = await ac.post("/api/letters/letter_1/refresh-status")
+            r2 = await ac.post("/api/letters/letter_1/refresh-status")
+
+        assert r1.json()["completed_actions"] == r2.json()["completed_actions"]
+        assert r1.json()["status"] == r2.json()["status"]
+
+    async def test_archived_letter_not_unarchived_on_refresh(
+        self, auth_user, db_session
+    ):
+        # Archive L1 manuellement
+        await _add_topics(db_session, auth_user, 3)
+        await _add_sources(db_session, auth_user, total=5, custom=2)
+        await _add_perspectives_event(db_session, auth_user)
+
+        async with _client() as ac:
+            await ac.post("/api/letters/letter_1/refresh-status")
+            # Re-call → ne change rien
+            r2 = await ac.post("/api/letters/letter_1/refresh-status")
+
+        assert r2.json()["status"] == "archived"
+
+
+class TestCrossTenant:
+    async def test_other_user_data_not_visible(self, auth_user, db_session):
+        # Crée un autre user avec des rows
+        other_id = uuid4()
+        other_profile = UserProfile(
+            user_id=other_id,
+            display_name="Other User",
+            onboarding_completed=True,
+        )
+        db_session.add(other_profile)
+        # Ajoute des rows letter_progress pour other user
+        for letter_id, status in [
+            ("letter_0", "archived"),
+            ("letter_1", "archived"),
+            ("letter_2", "active"),
+        ]:
+            db_session.add(
+                UserLetterProgress(
+                    user_id=other_id,
+                    letter_id=letter_id,
+                    status=status,
+                    completed_actions=[],
+                    started_at=datetime.now(UTC),
+                )
+            )
+        await db_session.commit()
+
+        # Le user authentifié ne voit que ses propres rows (init pour lui)
+        async with _client() as ac:
+            resp = await ac.get("/api/letters")
+
+        data = resp.json()
+        assert len(data) == 3
+        assert data[0]["status"] == "archived"  # L0
+        assert data[1]["status"] == "active"  # L1 par défaut
+        assert data[2]["status"] == "upcoming"  # L2 par défaut
+
+
+class TestErrors:
+    async def test_unknown_letter_id_returns_404(self, auth_user):
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_xxx/refresh-status")
+        assert resp.status_code == 404


### PR DESCRIPTION
# PR1 — Lettres du Facteur (backend) · Story 19.1

## Summary

PR1 sur 3 pour la feature « Lettres du Facteur » (soft onboarding gamifié, anti-FOMO).

- Nouvelle table `user_letter_progress` (Alembic `lf01`) — stocke uniquement la progression utilisateur.
- 3 lettres en constantes Python (`app/services/letters/catalog.py`) : L0 « Bienvenue » (archivée par défaut), L1 « Tes premières sources » (4 actions auto-détectées), L2 « Ton rythme idéal » (upcoming, débloquée au classement de L1).
- 2 endpoints :
  - `GET /api/letters` → état complet, idempotent (init silencieux pour new user).
  - `POST /api/letters/{letter_id}/refresh-status` → recalcule auto-détection + chaînage.
- Auto-détection serveur des 4 actions de L1 :
  - `define_editorial_line` → `count(user_topic_profiles)` ≥ 3.
  - `add_5_sources` → `count(user_sources)` ≥ 5.
  - `add_2_personal_sources` → `count(user_sources WHERE is_custom)` ≥ 2.
  - `first_perspectives_open` → ≥1 `analytics_events` `event_type='perspectives_opened'` (event ajouté de manière non-bloquante dans `routers/contents.py:get_perspectives`).

## Décisions architecturales

- **FK** : `user_profiles.user_id` (cohérent avec `veille_configs`), pas `auth.users(id)`.
- **RLS** : non activée — scoping par FastAPI auth (cohérent avec les autres tables user-scoped).
- **Lettres = constantes** : V1 = 3 lettres en dur, rotation = redeploy. Pas de surface d'admin pour V1.
- **Migration** : Alembic + apply manuel Supabase. **Application Supabase TODO** : `mcp__supabase__apply_migration` est en read-only mode dans cet environnement. À exécuter manuellement via Supabase SQL Editor (le SQL est dans le commit + dans `docs/stories/core/19.1.lettres-facteur.md`).

## Test plan

- [x] `pytest tests/routers/test_letters_routes.py -v` — 11/11 PASSED (init, 4 détecteurs, chaînage, idempotence x2, cross-tenant, 404).
- [x] Suite complète `pytest -v --ignore=tests/routers/test_notification_preferences.py` — 934 passed, 13 skipped.
- [x] `ruff format --check` + `ruff check` — verts sur tous les fichiers touchés.
- [x] `bash docs/qa/scripts/verify_letters.sh` — pytest pass + smoke routes wired.
- [x] `alembic heads` → 1 head unique (`lf01`).
- [ ] **Manuel post-merge** : appliquer la migration `lf01_create_user_letter_progress` sur Supabase via SQL Editor (MCP read-only en local).

### Test ignoré

`tests/routers/test_notification_preferences.py::test_patch_increments_refusal_count` est en échec **pré-existant** (TZ-dépendant Paris été : assertion sur string `2026-04-28T12:00:00` qui matche pas `2026-04-28T14:00:00+02:00`). Pas de lien avec cette PR — confirmé en stashant les changements.

## Suite — PR2 et PR3

Cette PR ne touche **pas** au mobile. Suivi dans `docs/stories/core/19.1.lettres-facteur.md`.

- PR2 = data layer mobile (modèles Dart + provider + RingAvatar + ProfileAvatarButton).
- PR3 = UI mobile (7 widgets, 2 screens, route, banner feed, /validate-feature).

## Forme JSON `GET /api/letters` (pour PR2)

```json
[
  {"id":"letter_0","num":"00","title":"Bienvenue chez Facteur","message":"...","signature":"Le Facteur","actions":[],"status":"archived","completed_actions":[],"progress":1.0,"started_at":null,"archived_at":"2026-05-02T..."},
  {"id":"letter_1","num":"01","title":"Tes premières sources","message":"Bienvenue. Avant de t'emmener plus loin...","signature":"Le Facteur","actions":[{"id":"define_editorial_line","label":"...","help":"..."}, ...],"status":"active","completed_actions":["define_editorial_line"],"progress":0.25,"started_at":"2026-05-02T...","archived_at":null},
  {"id":"letter_2","num":"02","title":"Ton rythme idéal","message":"...","signature":"Le Facteur","actions":[{"id":"set_frequency","label":"...","help":"..."}],"status":"upcoming","completed_actions":[],"progress":0.0,"started_at":null,"archived_at":null}
]
```