### PR TITLE
hotfix(app-update): disable default WorkManagerInitializer (boot crash)

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET"/>
     <!-- Required for flutter_local_notifications scheduled notifications -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
@@ -76,6 +77,22 @@
             <meta-data
                 android:name="vn.hunghd.flutterdownloader.MAX_CONCURRENT_TASKS"
                 android:value="1" />
+        </provider>
+
+        <!-- Désactive le WorkManagerInitializer par défaut d'androidx.startup :
+             flutter_downloader initialise lui-même WorkManager via son
+             FlutterDownloaderInitializer ci-dessus. Sans ce remove, les deux
+             tentent l'init au démarrage et lèvent IllegalStateException
+             "WorkManager is already initialized" → crash systématique au boot. -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
         </provider>
 
         <!-- Required for flutter_local_notifications scheduled notifications -->


### PR DESCRIPTION
## Hotfix critique — l'app crash au lancement sur main

PR #540 a ajouté \`FlutterDownloaderInitializer\` (ContentProvider qui init WorkManager avec une config custom) mais sans désactiver le \`WorkManagerInitializer\` par défaut d'\`androidx.startup\`. Au boot, les deux tentent d'initialiser WorkManager → le second throw \`IllegalStateException(\"WorkManager is already initialized\")\` → process killed avant \`MainActivity.onCreate\`.

**Toute install fraîche depuis le merge de #540 crash systématiquement** (\"Une erreur s'est produite\").

## Stack capturée (logcat device Samsung Android 14, com.example.facteur)

\`\`\`
java.lang.RuntimeException: Unable to get provider
  androidx.startup.InitializationProvider:
  androidx.startup.StartupException:
  java.lang.IllegalStateException: WorkManager is already initialized.
  Did you try to initialize it manually without disabling
  WorkManagerInitializer?
    at androidx.work.impl.WorkManagerImpl.initialize(WorkManagerImpl.java:196)
    at androidx.work.WorkManagerInitializer.create(WorkManagerInitializer.java:39)
    at androidx.startup.AppInitializer.doInitialize(AppInitializer.java:180)
\`\`\`

## Fix

Override de \`InitializationProvider\` avec \`tools:node=\"merge\"\` + \`tools:node=\"remove\"\` sur la meta \`WorkManagerInitializer\`, comme documenté dans le README de flutter_downloader. \`FlutterDownloaderInitializer\` reste le seul chemin d'init de WorkManager.

## Comment ça a été vérifié

- [x] Stack trace identifiée à 100% sur device réel (logcat fourni)
- [x] Conforme à la doc officielle flutter_downloader \`README.md > Configuration\`
- [ ] Build APK + install fresh sur device — **à valider par Laurin** dès que le CI a produit l'APK
- [ ] Vérifier flow update APK toujours fonctionnel (téléchargement % visible, install ok)

## Zones à risque

- \`AndroidManifest.xml\` — config bas niveau, impacte init de **tous** les composants WorkManager (rappel : flutter_local_notifications utilise aussi WorkManager indirectement). À surveiller post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)