### PR TITLE
fix(sources): écran noir au retour de «Ajouter une source»

### DIFF
--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../../shared/widgets/fab_nudge_bubble.dart';
 import '../../../shared/widgets/states/friendly_error_view.dart';
@@ -334,7 +335,7 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
           ),
           const SizedBox(width: 6),
           FloatingActionButton.extended(
-            onPressed: () => context.go('/settings/sources/add'),
+            onPressed: () => context.pushNamed(RouteNames.addSource),
             icon: Icon(PhosphorIcons.plus(PhosphorIconsStyle.bold)),
             label: const Text('Ajouter une source'),
             backgroundColor: colors.primary,


### PR DESCRIPTION
## Problème

Quitter l'écran « Ajouter une source » et revenir vers le feed provoquait un écran noir.

## Cause racine

`sources_screen.dart:337` utilisait `context.go('/settings/sources/add')` au lieu de `context.push`. Dans GoRouter, `context.go` **remplace toute la stack de navigation** — il supprimait donc le `/feed` en dessous. Au retour (pop × 3 : add-source → sources → settings sheet → feed), il ne restait rien sous les pages de settings → écran noir.

## Fix

Remplace `context.go` par `context.pushNamed(RouteNames.addSource)`, qui empile la nouvelle route **par-dessus** la stack existante (feed inclus).

**Stack incorrecte (avant)** :
```
ModalBottomSheetPage /settings
  FullSwipeCupertinoPage /settings/sources
    FullSwipeCupertinoPage /settings/sources/add
```
Pas de `/feed` en dessous.

**Stack correcte (après)** :
```
FeedScreen /feed
  ModalBottomSheetPage /settings
    FullSwipeCupertinoPage /settings/sources
      FullSwipeCupertinoPage /settings/sources/add
```

## Fichiers modifiés

- `apps/mobile/lib/features/sources/screens/sources_screen.dart` (+2 / -1)

## Test plan

- [ ] Feed → ouvrir Settings → Sources → « Ajouter une source » → X (fermer) → SourcesScreen visible (pas d'écran noir)
- [ ] Swipe back depuis « Ajouter une source » → même résultat
- [ ] Feed → Settings → Sources → Add source → fermer sheet → retour feed complet sans noir

🤖 Generated with [Claude Code](https://claude.com/claude-code)