### PR TITLE
feat(digest): refonte UI Bonnes nouvelles + condense hero + tap plus rapide

### DIFF
--- a/apps/mobile/lib/features/digest/screens/digest_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/digest_screen.dart
@@ -97,12 +97,6 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
   void _openArticle(DigestItem item) async {
     HapticFeedback.mediumImpact();
 
-    // Mark as read on tap, before navigation — gives immediate feedback on
-    // the progress micro-bars without waiting for the user to pop back.
-    if (!item.isRead && !item.isDismissed) {
-      ref.read(digestProvider.notifier).applyAction(item.contentId, 'read');
-    }
-
     // Premium source → open in external browser for authenticated access
     final sources = ref.read(userSourcesProvider).valueOrNull ?? [];
     final isPremium = item.source?.id != null &&
@@ -115,10 +109,20 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
       }
     }
 
-    // Navigate to article detail
+    // Navigate first so the Cupertino transition starts immediately. The
+    // mark-as-read state mutation (which rebuilds the digest tree) is deferred
+    // to a microtask so it doesn't compete with the push for the next frame.
     final content = _convertToContent(item);
-    final updated = await context
+    final pushFuture = context
         .push<Content?>('/feed/content/${item.contentId}', extra: content);
+
+    if (!item.isRead && !item.isDismissed) {
+      Future.microtask(() {
+        ref.read(digestProvider.notifier).applyAction(item.contentId, 'read');
+      });
+    }
+
+    final updated = await pushFuture;
 
     // Sync bookmark + note state back to digest
     if (updated != null) {
@@ -354,9 +358,11 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
                   // Header : back rond + titre majuscules
                   SliverToBoxAdapter(
                     child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: FacteurSpacing.space4,
-                        vertical: FacteurSpacing.space2,
+                      padding: const EdgeInsets.fromLTRB(
+                        FacteurSpacing.space4,
+                        4,
+                        FacteurSpacing.space4,
+                        4,
                       ),
                       child: Row(
                         children: [

--- a/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
@@ -163,25 +163,30 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
       height: 1.45,
       color: colors.textSecondary,
     );
-    // En serein éditorial, les dots sont rendus après QuoteBlock
-    // (cf. _buildEditorialLayout) — on les omet du haut.
-    final showDotsAtTop = widget.dailyGoal > 0 &&
-        !(widget.isSerein && widget.usesEditorial && _usesTopics);
+    final showDotsAtTop = widget.dailyGoal > 0;
+    final showQuoteAtTop = widget.isSerein &&
+        widget.usesEditorial &&
+        _usesTopics &&
+        widget.digest?.quote != null;
 
     return Padding(
-      padding: const EdgeInsets.only(top: 12, bottom: 8),
+      padding: const EdgeInsets.only(top: 8, bottom: 8),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (!widget.isSerein)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(14, 4, 14, 0),
-              child: Text(
-                "L'Essentiel est une synthèse des sujets les plus couverts en France aujourd'hui. Facteur compare les points de vues, et t'amène vers des articles pour t'aider à prendre du recul sur l'actualité.",
-                style: introTextStyle,
-              ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(14, 4, 14, 0),
+            child: Text(
+              widget.isSerein
+                  ? "Chaque matin, nous analysons l'actu pour en sortir les quelques nouvelles qui nous redonnent (un petit peu) foi en l'humanité et en l'avenir. Bonne lecture !"
+                  : "L'Essentiel est une synthèse des sujets les plus couverts en France aujourd'hui. Facteur compare les points de vues, et t'amène vers des articles pour t'aider à prendre du recul sur l'actualité.",
+              style: introTextStyle,
             ),
-          if (!widget.isSerein) const SizedBox(height: 16),
+          ),
+          const SizedBox(height: 16),
+          // Quote block (serein editorial only) — rendered above the counter
+          // so the gap counter→first-card matches Essentiel exactly (16px).
+          if (showQuoteAtTop) QuoteBlock(quote: widget.digest!.quote!),
           // Compact progress counter (after description, before topics)
           if (showDotsAtTop) ...[
             Padding(
@@ -287,22 +292,8 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
     final isSerene = widget.isSerein;
     final sections = <Widget>[];
 
-    // Quote block first in serein mode — sets the tone for the reading.
-    // The dots gauge then sits between the quote and the first topic so the
-    // reader sees: citation → progression → topics.
-    if (isSerene && widget.digest?.quote != null) {
-      sections.add(QuoteBlock(quote: widget.digest!.quote!));
-      if (widget.dailyGoal > 0) {
-        sections.add(const SizedBox(height: 4));
-        sections.add(
-          Padding(
-            padding: const EdgeInsets.only(left: 14),
-            child: _buildCompactCounter(context.facteurColors),
-          ),
-        );
-        sections.add(const SizedBox(height: 16));
-      }
-    }
+    // Quote + counter for serein mode are rendered above this widget (in
+    // build()) so the spacing counter→first-topic matches Essentiel exactly.
 
     // Topics with intro text, editorial DigestCards, and transition text
     for (int i = 0; i < widget.topics!.length; i++) {

--- a/apps/mobile/lib/features/digest/widgets/digest_hero.dart
+++ b/apps/mobile/lib/features/digest/widgets/digest_hero.dart
@@ -26,7 +26,7 @@ class DigestHero extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return SizedBox(
-      height: 170,
+      height: 140,
       child: Stack(
         clipBehavior: Clip.hardEdge,
         children: [
@@ -38,14 +38,14 @@ class DigestHero extends StatelessWidget {
                 isSerein
                     ? 'assets/notifications/facteur_goodnews.png'
                     : 'assets/notifications/facteur_avatar.png',
-                height: 140,
+                height: 110,
                 fit: BoxFit.contain,
               ),
             ),
           ),
           // Pill identifiant le mode actif, en haut à gauche.
           Positioned(
-            top: 16,
+            top: 10,
             left: 16,
             child: isSerein
                 ? BonnesNouvellesPill(isDark: isDark)
@@ -54,8 +54,8 @@ class DigestHero extends StatelessWidget {
           // Titre + caption en bas à gauche.
           Positioned(
             left: 16,
-            right: 140,
-            bottom: 18,
+            right: 130,
+            bottom: 10,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
@@ -65,11 +65,11 @@ class DigestHero extends StatelessWidget {
                       ? 'Les bonnes nouvelles'
                       : "L'essentiel du jour",
                   style: FacteurTypography.serifTitle(colors.textPrimary)
-                      .copyWith(fontSize: 32, height: 1.1),
+                      .copyWith(fontSize: 28, height: 1.1),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                 ),
-                const SizedBox(height: 14),
+                const SizedBox(height: 8),
                 Text(
                   '$articleCount articles · ${formatDigestDate(targetDate)}',
                   style:

--- a/apps/mobile/lib/features/digest/widgets/quote_block.dart
+++ b/apps/mobile/lib/features/digest/widgets/quote_block.dart
@@ -18,7 +18,7 @@ class QuoteBlock extends StatelessWidget {
     final separatorColor = colors.primary.withOpacity(isDark ? 0.45 : 0.38);
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 6, 16, 14),
+      padding: const EdgeInsets.fromLTRB(16, 6, 16, 8),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -78,7 +78,7 @@ class QuoteBlock extends StatelessWidget {
               color: colors.textSecondary.withOpacity(0.65),
             ),
           ),
-          const SizedBox(height: 14),
+          const SizedBox(height: 8),
           // Bottom separator
           Center(
             child: Container(

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -92,8 +92,7 @@ class _TopicSectionState extends ConsumerState<TopicSection>
   PageController? _expandedPageController;
   int _expandedPage = 0;
 
-  bool get _effectiveExpanded =>
-      _isExpanded || (widget.editorialMode && widget.isSerene);
+  bool get _effectiveExpanded => _isExpanded;
 
   /// Content IDs whose images failed to load (detected at runtime).
   final Set<String> _collapsedImages = {};
@@ -948,7 +947,7 @@ class _TopicSectionState extends ConsumerState<TopicSection>
                   color: colors.success,
                 ),
               ),
-            if (_isExpanded && !widget.isSerene)
+            if (_isExpanded)
               GestureDetector(
                 onTap: () => setState(() => _isExpanded = false),
                 behavior: HitTestBehavior.opaque,


### PR DESCRIPTION
## What

Refonte de la page « Bonnes nouvelles » + condensation du haut des deux pages digest + ouverture plus rapide au tap d'une carte.

- **Bonnes nouvelles** : previews compactes cliquables (comme Essentiel) en supprimant l'auto-expand serein dans `TopicSection` ; bouton de repli (caret) désormais visible en serein. Texte d'intro éditorial ajouté. Quote + progression bar sortis du `ListView.separated` pour que le gap progression → 1ère carte soit exactement 16px (identique Essentiel) au lieu des ~38px générés par les séparateurs.
- **Hero (les 2 pages)** : hauteur 170→140, illustration 110px, titre 28px, paddings recadrés ; header `Revenir au flux` vertical 8→4.
- **UX tap carrousel** : `_openArticle` push la route avant `applyAction('read')`, ce dernier déféré via `Future.microtask` → la transition Cupertino démarre sans rebuild concurrent du tree digest.

## Why

Les bonnes nouvelles n'avaient plus le format « preview cliquable » de l'Essentiel et perdaient en lisibilité. Le haut des deux pages mangeait trop d'espace. Au tap d'une carte, le rebuild synchrone de l'arbre digest causait 1-2s de latence perçue avant l'ouverture.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`) — N/A (front only)
- [x] Linting passes (`flutter analyze` sur les fichiers touchés : aucune nouvelle erreur)
- [x] No new Python `List[]` imports — N/A
- [x] If touching auth/DB: read Safety Guardrails — N/A
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (front only, rollback = revert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)