### PR TITLE
chore(alembic): merge lf01 + sp01 heads (no-op ls01)

### DIFF
--- a/packages/api/alembic/versions/ls01_merge_lf01_sp01.py
+++ b/packages/api/alembic/versions/ls01_merge_lf01_sp01.py
@@ -1,0 +1,26 @@
+"""merge lf01 + sp01 heads
+
+Revision ID: ls01
+Revises: lf01, sp01
+Create Date: 2026-05-03 00:00:00.000000
+
+Migration de merge no-op : `lf01` (user_letter_progress) et `sp01`
+(whitelist sport) ont été appliquées indépendamment sur main, créant
+deux heads. Cette révision les unifie pour que `alembic upgrade head`
+reste déterministe.
+"""
+
+from collections.abc import Sequence
+
+revision: str = "ls01"
+down_revision: str | Sequence[str] | None = ("lf01", "sp01")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- `lf01` (user_letter_progress) et `sp01` (whitelist sport) ont été mergées sur main indépendamment → 2 heads alembic.
- Ajoute `ls01` (no-op DDL) avec `down_revision = (\"lf01\", \"sp01\")` pour réunifier en un head unique.
- Sans ce fix, le prochain `alembic upgrade head` planterait (\"Multiple head revisions\").

## SQL Supabase (à exécuter après merge)
\`\`\`sql
BEGIN;
-- Vérifier l'état avant
SELECT version_num FROM alembic_version;
-- Doit retourner 2 lignes : lf01 + sp01

-- Remplacer les 2 heads par ls01
DELETE FROM alembic_version WHERE version_num IN ('lf01', 'sp01');
INSERT INTO alembic_version (version_num) VALUES ('ls01');

-- Vérifier
SELECT version_num FROM alembic_version;
-- Doit retourner 1 ligne : ls01
COMMIT;
\`\`\`

## Test plan
- [x] `python -c "...ScriptDirectory.get_heads()"` → `['ls01']` localement
- [ ] CI green
- [ ] SQL Supabase appliqué après merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)