### PR TITLE
fix(lettres): restaurer route /lettres supprimée par #547

### DIFF
--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -31,6 +31,7 @@ import '../features/veille/screens/veille_config_screen.dart';
 import '../features/veille/screens/veille_dashboard_screen.dart';
 import '../features/veille/screens/veille_deliveries_screen.dart';
 import '../features/veille/screens/veille_delivery_detail_screen.dart';
+import '../features/lettres/screens/lettres_placeholder_screen.dart';
 import '../features/digest/screens/closure_screen.dart';
 import '../features/saved/screens/saved_screen.dart';
 import '../features/saved/screens/saved_all_screen.dart';
@@ -73,6 +74,7 @@ class RouteNames {
   static const String veilleDashboard = 'veille-dashboard';
   static const String veilleDeliveries = 'veille-deliveries';
   static const String veilleDeliveryDetail = 'veille-delivery-detail';
+  static const String lettres = 'lettres';
 }
 
 /// Chemins des routes
@@ -105,6 +107,7 @@ class RoutePaths {
   static const String veilleDashboard = '/veille/dashboard';
   static const String veilleDeliveries = '/veille/deliveries';
   static const String veilleDeliveryDetail = '/veille/deliveries/:id';
+  static const String lettres = '/lettres';
 }
 
 final routerProvider = Provider<GoRouter>((ref) {
@@ -428,6 +431,15 @@ final routerProvider = Provider<GoRouter>((ref) {
           child: VeilleDeliveryDetailScreen(
             deliveryId: state.pathParameters['id']!,
           ),
+        ),
+      ),
+
+      // Lettres du Facteur — onboarding doux. PR2 = placeholder, PR3 livre l'écran complet.
+      GoRoute(
+        path: RoutePaths.lettres,
+        name: RouteNames.lettres,
+        pageBuilder: (context, state) => const FullSwipeCupertinoPage(
+          child: LettresPlaceholderScreen(),
         ),
       ),
 

--- a/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
@@ -312,7 +312,7 @@ class _ContentShortcuts extends StatelessWidget {
           _ShortcutTile(
             icon: PhosphorIcons.chartLineUp(PhosphorIconsStyle.regular),
             label: 'Progression',
-            onTap: () => context.pushNamed(RouteNames.progress),
+            onTap: () => context.pushNamed(RouteNames.lettres),
           ),
           const _Divider(),
           _ShortcutTile(


### PR DESCRIPTION
## Problem

Cliquer sur le tile **« Progression »** dans la bottom-sheet Réglages renvoie silencieusement l'utilisateur vers `/feed` au lieu d'ouvrir l'écran « Courrier » de la Story 19.1 (Lettres du Facteur).

## Root cause

1. **PR #543** ajoute `RouteNames.lettres` + `RoutePaths.lettres` + route `GoRoute(/lettres)` → `LettresPlaceholderScreen`, et le tile « Progression » qui pointe dessus.
2. **PR #547** (feat veille E2E) **supprime par accident** dans `routes.dart` : l'import, les constantes, et le bloc `GoRoute(/lettres)` (probable mauvais rebase d'une branche antérieure à #543).
3. **Build Flutter web cassé** : `settings_sheet.dart` réfère encore `RouteNames.lettres`.
4. **PR #548** (bot Railway) fixe le build en remplaçant `RouteNames.lettres` par `RouteNames.progress`. Mais `RouteNames.progress` est marquée *« MVP: Progressions routes temporarily disabled »* et a un `redirect: → /feed` (lignes ~296-317). D'où la redirection observée.

## Fix

- Réintroduit dans `apps/mobile/lib/config/routes.dart` :
  - import `LettresPlaceholderScreen`
  - `RouteNames.lettres = 'lettres'`
  - `RoutePaths.lettres = '/lettres'`
  - `GoRoute(path: RoutePaths.lettres, …)` → `LettresPlaceholderScreen`
- Repointe le tile « Progression » sur `RouteNames.lettres` dans `settings_sheet.dart`.

## Suite

PR3 (mobile UI complète Lettres du Facteur, branche `boujonlaurin-dotcom/lettres-ui`) reste à livrer pour remplacer le placeholder « Courrier — coming soon » par les vrais écrans (cf. story 19.1).

## Test plan

- [x] `flutter analyze lib/config lib/features/settings lib/features/lettres` → 0 erreur (que des warnings préexistants `withOpacity`/`activeColor`)
- [x] `flutter test test/features/lettres/` → 14/14 verts
- [ ] Manuel : ouvrir Réglages → tap « Progression » → écran placeholder « Courrier — coming soon » s'affiche, swipe-back retourne au feed
- [ ] Web build Railway ne casse plus

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>