### PR TITLE
fix(widget): Space → TextView pour compat RemoteViews Samsung

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt
@@ -55,12 +55,17 @@ class FacteurWidget : AppWidgetProvider() {
                 Log.d(TAG, "onUpdate id=$appWidgetId json.len=${json?.length ?: -1}")
 
                 renderHeader(views, prefs)
+                Log.d(TAG, "header rendered id=$appWidgetId")
                 renderArticles(context, views, json)
+                Log.d(TAG, "articles rendered id=$appWidgetId")
                 wireClickIntents(context, views, appWidgetId)
+                Log.d(TAG, "intents wired id=$appWidgetId")
 
+                Log.d(TAG, "calling updateAppWidget id=$appWidgetId")
                 appWidgetManager.updateAppWidget(appWidgetId, views)
-            } catch (e: Exception) {
-                Log.e(TAG, "Widget update failed for id=$appWidgetId", e)
+                Log.d(TAG, "updateAppWidget returned id=$appWidgetId")
+            } catch (t: Throwable) {
+                Log.e(TAG, "Widget update failed for id=$appWidgetId", t)
             }
         }
     }
@@ -92,6 +97,7 @@ class FacteurWidget : AppWidgetProvider() {
         views.removeAllViews(R.id.articles_container)
 
         val articles = parseArticles(json)
+        Log.d(TAG, "parseArticles count=${articles.size}")
         if (articles.isEmpty()) {
             views.addView(
                 R.id.articles_container,
@@ -101,11 +107,10 @@ class FacteurWidget : AppWidgetProvider() {
         }
 
         for ((index, article) in articles.withIndex()) {
+            Log.d(TAG, "buildArticleRow idx=$index id=${article.id} thumb=${article.thumbnailPath.isNotBlank()} logo=${article.sourceLogoPath.isNotBlank()}")
             val row = buildArticleRow(context, article)
             views.addView(R.id.articles_container, row)
-            if (index < articles.size - 1) {
-                // Separators are baked into widget_article_row.xml.
-            }
+            Log.d(TAG, "addView ok idx=$index")
         }
     }
 

--- a/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
+++ b/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
@@ -117,7 +117,10 @@
             android:textColor="@color/facteur_accent"
             android:visibility="gone" />
 
-        <Space
+        <!-- Empty TextView used as a flexible spacer.
+             Note: <Space> is not in the RemoteViews whitelist and triggers
+             "Class not allowed to be inflated" on Samsung One UI launchers. -->
+        <TextView
             android:layout_width="0dp"
             android:layout_height="1dp"
             android:layout_weight="1" />


### PR DESCRIPTION
## Quoi

Fix du bug widget Android « Impossible d'ajouter le widget » sur launcher Samsung One UI.

- `widget_article_row.xml:120` : `<Space>` → `<TextView>` vide (spacer flexible)
- `FacteurWidget.kt` : instrumentation `Log.d` granulaire dans `onUpdate` + catch `Throwable`

## Pourquoi

`<Space>` n'est pas dans la whitelist RemoteViews d'Android. Le code Kotlin tournait correctement (`onUpdate` → `updateAppWidget returned`) mais le launcher Samsung levait silencieusement :

```
InflateException: Class not allowed to be inflated android.widget.Space
Binary XML file line #123 in com.example.facteur:layout/widget_article_row
```

Résultat utilisateur : message « Impossible d'ajouter le widget » sans aucune erreur dans Sentry (le crash est côté process launcher, pas app).

`<TextView>` vide avec `layout_weight=1` est dans la whitelist et donne le même comportement de spacer flexible. Commentaire WHY ajouté pour éviter une régression future.

## Comment ça a été vérifié

- [x] `flutter analyze` — clean (0 errors, infos pré-existantes hors diff)
- [x] `flutter test` — 505 pass, 37 échecs **tous pré-existants sur main** (vérifié via `git stash` + run sur baseline)
- [x] **Test E2E sur Samsung S24 réel** :
  - Build debug APK installé via ADB
  - Widget ajouté à l'écran d'accueil → `onUpdate id=32 json.len=1399`
  - `parseArticles count=5` → 5x `buildArticleRow` + `addView ok` → `updateAppWidget returned`
  - **Aucune erreur `AppWidgetHostView` ni `AndroidRuntime`** (avant fix : `Class not allowed to be inflated`)
- [x] /simplify passé — comment WHY ajouté sur le spacer

## Zones à risque

- **`FacteurWidget.kt`** : zone widget Android, isolée du reste de l'app. Catch élargi à `Throwable` est défensif (un onUpdate qui throw casse l'inflation côté launcher) — accepté.
- **Logs `Log.d`** : 7 calls par `onUpdate`, fires max 1× / 30 min. Aucun token / PII (widget id, json.length, article id déjà exposé via deep link). Coût perf/sécu nul.
- **Pas d'impact iOS** (widget Android-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)