### PR TITLE
feat(veille): personalization V1 (PR A) — fondations DB + presets endpoint

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,82 +1,61 @@
-# PR — Story 18.3 « Ma veille » end-to-end (front wiring + historique + push notifs)
+# PR — Veille V1 personalization (PR A : fondations DB + presets)
 
 ## Summary
 
-Phase E2E de la feature « Ma veille ». Le backend pipeline (18.1 + 18.2,
-PR #524 + #535) produit des `items[]` réels avec clusters + `why_it_matters`
-LLM. Côté front Flutter, le flow 4-steps était encore 100 % mock :
-
-- `submit()` no-op à `apps/mobile/lib/features/veille/providers/veille_config_provider.dart:142` ;
-- aucun écran historique livraisons ni détail livraison ;
-- aucune notif planifiée à la livraison.
-
-Cette PR ferme la boucle « configuration → livraison → consommation » sur
-l'app et planifie une notif locale (pas de FCM côté projet) pour rappeler
-au user que sa veille est tombée.
+Première brique de la refonte V1 « Ma veille ». Pose les colonnes DB pour
+capturer purpose / editorial_brief / preset_id (PR B câblera la persistance via
+le router `/config`) et expose un endpoint public `GET /api/veille/presets`
+qui alimente la nouvelle section « Inspirations » du Step 1 + le nouvel écran
+Step 1.5 « preset preview » côté mobile.
 
 ## What
 
-### Front wiring
+### Backend
 
-- `submit()` étape 4 → POST `/api/veille/config` (real `VeilleRepository`).
-- Suggestions topics/sources réelles à l'entrée des étapes 2 et 3 (POST
-  `/api/veille/suggestions/{topics,sources}` avec spinner bloquant +
-  fallback mock UX si erreur réseau).
-- Redirect automatique `/veille/config` → `/veille/dashboard` quand
-  `GET /api/veille/config` retourne 200 (au lieu de relancer le flow).
-- Filtrage des sources mock-only au submit (sans `apiSourceId` UUID API,
-  elles ne peuvent pas être ingérées par le backend).
+- **Migration `vp01`** (heads `ls01` → `vp01`) :
+  - 4 colonnes nullables sur `veille_configs` (`purpose`, `purpose_other`,
+    `editorial_brief`, `preset_id`).
+  - `notif_veille_enabled BOOLEAN NOT NULL DEFAULT false` sur
+    `user_notification_preferences` (toggle pour la modal opt-in PR C).
+- **`GET /api/veille/presets`** (public, no-auth) — retourne les presets V1
+  avec leurs sources curées (résolution runtime via
+  `Source.theme + is_curated + is_active`, ordre `name`, limite 6).
+- Données : `app/data/veille_presets.py`.
+- Schemas : `VeillePresetResponse` + adjacents.
 
-### Nouveaux écrans
+### Mobile
 
-- **Dashboard** `/veille/dashboard` : thème, topics, sources, schedule,
-  countdown next_scheduled_at, boutons Modifier / Pause / Supprimer / Historique.
-- **Historique** `/veille/deliveries` : liste 20 dernières livraisons,
-  pull-to-refresh, empty state.
-- **Détail livraison** `/veille/deliveries/:id` : clusters + `why_it_matters` +
-  articles → tap ouvre InAppWebView (`launchUrl` mode `inAppBrowserView`).
-  Gère les états `running`/`pending` (loader) et `failed` (state d'erreur sympa).
+- Nouvel écran `step1_5_preset_preview_screen.dart` (preview du preset entre
+  Step 1 thème et Step 2 topics).
+- `veille_presets_provider.dart` (Async list provider, GET `/presets`).
+- Step 1 thème enrichi : section « Inspirations » avec preset cards.
+- `veille_config_provider.dart` étendu (purpose, editorialBrief, presetId).
+- Modèles + serializers `VeilleConfig` étendus.
+- Tests : presets model/provider + screens
+  (`step1_5_preset_preview_screen_test.dart`) + widgets
+  (`preset_card_test.dart`).
 
-### Push notif locale + deeplink
+## How ça a été vérifié
 
-- `PushNotificationService.scheduleVeilleNotification(scheduledAt)` (NotifId=3,
-  channel `veille_channel`). Planifié à `next_scheduled_at + 30 min` pour
-  laisser le scanner */30 min générer la livraison avant que la notif tombe.
-- Cancel automatique sur PATCH status=paused / DELETE.
-- Mapping deeplink `io.supabase.facteur://veille/dashboard` ajouté à
-  `DeepLinkService.parse` (`WidgetDeepLinkTarget.veille`).
+- [ ] `pytest -v` (backend complet, incl. `test_veille_presets` +
+      `test_veille_personalization_columns`)
+- [ ] `ruff format --check && ruff check` (lint Python)
+- [ ] `alembic heads` → 1 head (`vp01`) ; `alembic upgrade head` OK local
+- [ ] `flutter test && flutter analyze`
+- [ ] `curl GET /api/veille/presets` → 200 sans auth, body non vide
+- [ ] Playwright MCP : Step 1 → preset card → Step 1.5 preview → Step 2
+- [ ] `/simplify` passé
 
-### Architecture
+## Hors scope (PR B / PR C)
 
-- Pas de modif backend (la pipeline fait déjà tout).
-- Patterns réutilisés : `digest_repository.dart` (Dio + exceptions typées),
-  `digest_provider.dart` (AsyncNotifier — simplifié load-on-enter),
-  `scheduleDailyDigestNotification` (zonedSchedule local).
-- Retries bornés (interceptor existant : 2 retries sur 5xx ≠503, 0 sur 4xx) —
-  pas de retries cascadés type stale-fallback du digest (anti-cascade pool DB).
-- Story doc : `docs/stories/core/18.3.veille-e2e.md`.
+- PR B : câblage persistance des champs `purpose / editorial_brief / preset_id`
+  dans POST `/api/veille/config` (router).
+- PR C : modal opt-in notif veille (toggle `notif_veille_enabled`).
 
-## Hors scope (PR3)
+## Zones à risque
 
-- [x] `flutter analyze lib/features/veille` → 1 info-level lint, 0 erreur.
-- [x] `flutter test test/features/veille/models/veille_models_test.dart` →
-  15 tests verts (parsing fromJson + sérialisation toJson).
-- [x] `flutter test test/core/services/{deep_link_service,push_notification_service_copy}_test.dart`
-  → 14 tests verts (anti-régression, +2 tests pour le mapping veille deep link).
-- [x] `pytest -q` backend (anti-régression) : 838 passed, 85 errors —
-  TOUTES les errors sont `psycopg.OperationalError` (DB locale Supabase non
-  démarrée, infra), aucune cassée par cette PR.
-- [ ] `/validate-feature` (Chrome MCP, viewport 390x844) — scénarios :
-  happy path, redirect dashboard, pause/reprendre, suppression, livraison
-  failed, erreur réseau suggestions, tap notif. Cf. `.context/qa-handoff.md`.
-- [ ] Smoke API local : `uvicorn app.main:app --port 8080`, configure une
-  veille, vérifier POST /config + log `PushNotificationService: veille scheduled @ ...`,
-  POST /deliveries/generate (debug), refresh historique.
-
-## Out of scope
-
-- Multi-veilles par user (V2/V3).
-- Carte « Ma veille » sur le feed (entry point — tranché en brainstorming PO).
-- Push serveur (FCM/APNS) — pas de stockage push_token côté backend, hors V1.
-- Cache disque persistant pour livraisons (load-on-enter mémoire suffit).
-- Pagination historique > 20.
+- **Migration** : ajout colonnes nullable + 1 NOT NULL avec
+  `server_default('false')` → safe sur table existante, compatible rolling
+  deploy. Pas d'index ajouté.
+- **Endpoint `/presets` no-auth** : OK (lecture seule, pas de PII, pas de
+  rate-limit dédié — la donnée est statique côté serveur).

--- a/apps/mobile/lib/features/veille/models/veille_config.dart
+++ b/apps/mobile/lib/features/veille/models/veille_config.dart
@@ -71,6 +71,76 @@ class VeilleSource {
   }
 }
 
+@immutable
+class VeillePresetSource {
+  final String id;
+  final String name;
+  final String url;
+  final String? logoUrl;
+
+  const VeillePresetSource({
+    required this.id,
+    required this.name,
+    required this.url,
+    this.logoUrl,
+  });
+
+  factory VeillePresetSource.fromJson(Map<String, dynamic> json) {
+    return VeillePresetSource(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      url: json['url'] as String,
+      logoUrl: json['logo_url'] as String?,
+    );
+  }
+}
+
+@immutable
+class VeillePreset {
+  final String slug;
+  final String label;
+  final String accroche;
+  final String themeId;
+  final String themeLabel;
+  final List<String> topics;
+  final List<String> purposes;
+  final String editorialBrief;
+  final List<VeillePresetSource> sources;
+
+  const VeillePreset({
+    required this.slug,
+    required this.label,
+    required this.accroche,
+    required this.themeId,
+    required this.themeLabel,
+    required this.topics,
+    required this.purposes,
+    required this.editorialBrief,
+    required this.sources,
+  });
+
+  factory VeillePreset.fromJson(Map<String, dynamic> json) {
+    return VeillePreset(
+      slug: json['slug'] as String,
+      label: json['label'] as String,
+      accroche: json['accroche'] as String,
+      themeId: json['theme_id'] as String,
+      themeLabel: json['theme_label'] as String,
+      topics: ((json['topics'] as List?) ?? const [])
+          .whereType<String>()
+          .toList(),
+      purposes: ((json['purposes'] as List?) ?? const [])
+          .whereType<String>()
+          .toList(),
+      editorialBrief: (json['editorial_brief'] as String?) ?? '',
+      sources: ((json['sources'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(VeillePresetSource.fromJson)
+          .toList(),
+    );
+  }
+}
+
 enum VeilleFrequency {
   weekly('weekly', 'Chaque semaine', recommended: true),
   biweekly('biweek', 'Tous les 15 jours'),

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -45,6 +45,11 @@ class VeilleConfigState {
   final int step;
   final int? loadingFrom;
 
+  /// Slug du pré-set en cours de prévisualisation (Step 1.5). Quand non-null,
+  /// `veille_config_screen` rend `Step1_5PresetPreviewScreen` au lieu du
+  /// step courant. PR A : sentinel uniquement, persistance push en PR B.
+  final String? previewPresetId;
+
   final String? selectedTheme;
   final Set<String> selectedTopics;
   final Set<String> selectedSuggestions;
@@ -64,6 +69,12 @@ class VeilleConfigState {
   /// Mapping slug → metadata pour sources (mock défauts + override API).
   final Map<String, VeilleSourceMeta> sourcesMeta;
 
+  /// V1 personalization (PR A : capturés via applyPreset, push backend en PR B).
+  final String? purpose;
+  final String? purposeOther;
+  final String? editorialBrief;
+  final String? presetId;
+
   /// Submit en cours — empêche les double-tap.
   final bool isSubmitting;
 
@@ -73,6 +84,7 @@ class VeilleConfigState {
   const VeilleConfigState({
     required this.step,
     required this.loadingFrom,
+    required this.previewPresetId,
     required this.selectedTheme,
     required this.selectedTopics,
     required this.selectedSuggestions,
@@ -83,6 +95,10 @@ class VeilleConfigState {
     required this.customTopics,
     required this.topicLabels,
     required this.sourcesMeta,
+    required this.purpose,
+    required this.purposeOther,
+    required this.editorialBrief,
+    required this.presetId,
     required this.isSubmitting,
     required this.lastError,
   });
@@ -90,6 +106,7 @@ class VeilleConfigState {
   factory VeilleConfigState.initial() => VeilleConfigState(
         step: 1,
         loadingFrom: null,
+        previewPresetId: null,
         selectedTheme: null,
         selectedTopics: {},
         selectedSuggestions: {},
@@ -100,6 +117,10 @@ class VeilleConfigState {
         customTopics: [],
         topicLabels: {},
         sourcesMeta: {},
+        purpose: null,
+        purposeOther: null,
+        editorialBrief: null,
+        presetId: null,
         isSubmitting: false,
         lastError: null,
       );
@@ -114,6 +135,7 @@ class VeilleConfigState {
   VeilleConfigState copyWith({
     int? step,
     Object? loadingFrom = _Sentinel.value,
+    Object? previewPresetId = _Sentinel.value,
     Object? selectedTheme = _Sentinel.value,
     Set<String>? selectedTopics,
     Set<String>? selectedSuggestions,
@@ -124,6 +146,10 @@ class VeilleConfigState {
     List<VeilleTopic>? customTopics,
     Map<String, String>? topicLabels,
     Map<String, VeilleSourceMeta>? sourcesMeta,
+    Object? purpose = _Sentinel.value,
+    Object? purposeOther = _Sentinel.value,
+    Object? editorialBrief = _Sentinel.value,
+    Object? presetId = _Sentinel.value,
     bool? isSubmitting,
     Object? lastError = _Sentinel.value,
   }) =>
@@ -132,6 +158,9 @@ class VeilleConfigState {
         loadingFrom: loadingFrom == _Sentinel.value
             ? this.loadingFrom
             : loadingFrom as int?,
+        previewPresetId: previewPresetId == _Sentinel.value
+            ? this.previewPresetId
+            : previewPresetId as String?,
         selectedTheme: selectedTheme == _Sentinel.value
             ? this.selectedTheme
             : selectedTheme as String?,
@@ -144,6 +173,16 @@ class VeilleConfigState {
         customTopics: customTopics ?? this.customTopics,
         topicLabels: topicLabels ?? this.topicLabels,
         sourcesMeta: sourcesMeta ?? this.sourcesMeta,
+        purpose:
+            purpose == _Sentinel.value ? this.purpose : purpose as String?,
+        purposeOther: purposeOther == _Sentinel.value
+            ? this.purposeOther
+            : purposeOther as String?,
+        editorialBrief: editorialBrief == _Sentinel.value
+            ? this.editorialBrief
+            : editorialBrief as String?,
+        presetId:
+            presetId == _Sentinel.value ? this.presetId : presetId as String?,
         isSubmitting: isSubmitting ?? this.isSubmitting,
         lastError:
             lastError == _Sentinel.value ? this.lastError : lastError as String?,
@@ -392,6 +431,69 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       );
       rethrow;
     }
+  }
+
+  /// Affiche l'écran preview pré-set (Step 1.5). Le step courant reste à 1
+  /// sous le capot — le screen orchestrator détecte `previewPresetId != null`.
+  void openPresetPreview(String presetSlug) {
+    if (state.previewPresetId == presetSlug) return;
+    state = state.copyWith(previewPresetId: presetSlug);
+  }
+
+  /// Ferme l'écran preview sans appliquer le pré-set (retour Step 1).
+  void closePresetPreview() {
+    if (state.previewPresetId == null) return;
+    state = state.copyWith(previewPresetId: null);
+  }
+
+  /// Hydrate le state depuis un pré-set : thème, topics (matérialisés en
+  /// custom topics + cochés), sources curées (followed + apiSourceId), purpose
+  /// + brief éditorial. Si `jumpToStep4` → bascule direct au rythme
+  /// (« Continuer avec ce pré-set »). Sinon retour Step 1 personnalisable.
+  void applyPreset(VeillePreset preset, {required bool jumpToStep4}) {
+    final topicSlugs = <String>{};
+    final newCustomTopics = <VeilleTopic>[];
+    final nextLabels = Map<String, String>.from(state.topicLabels);
+    for (final label in preset.topics) {
+      final slug = _slugifyCustom(label);
+      topicSlugs.add(slug);
+      nextLabels[slug] = label;
+      if (!state.customTopics.any((t) => t.id == slug)) {
+        newCustomTopics.add(
+          VeilleTopic(id: slug, label: label, reason: 'depuis « ${preset.label} »'),
+        );
+      }
+    }
+
+    final nextMeta = Map<String, VeilleSourceMeta>.from(state.sourcesMeta);
+    final followed = <String>{};
+    for (final s in preset.sources) {
+      nextMeta[s.id] = VeilleSourceMeta(
+        slug: s.id,
+        name: s.name,
+        kind: 'followed',
+        apiSourceId: s.id,
+        url: s.url,
+      );
+      followed.add(s.id);
+    }
+
+    state = state.copyWith(
+      step: jumpToStep4 ? 4 : 1,
+      previewPresetId: null,
+      selectedTheme: preset.themeId,
+      selectedTopics: topicSlugs,
+      selectedSuggestions: const <String>{},
+      customTopics: [...state.customTopics, ...newCustomTopics],
+      topicLabels: nextLabels,
+      followedSources: followed,
+      nicheSources: const <String>{},
+      sourcesMeta: nextMeta,
+      purpose: preset.purposes.isNotEmpty ? preset.purposes.first : null,
+      purposeOther: null,
+      editorialBrief: preset.editorialBrief.isEmpty ? null : preset.editorialBrief,
+      presetId: preset.slug,
+    );
   }
 
   void clearError() => state = state.copyWith(lastError: null);

--- a/apps/mobile/lib/features/veille/providers/veille_presets_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_presets_provider.dart
@@ -1,0 +1,25 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/providers.dart';
+import '../models/veille_config.dart';
+
+/// Charge les pré-sets V1 (`GET /api/veille/presets`) affichés en bas du
+/// Step 1. Endpoint public (pas d'auth) : la liste est statique côté serveur
+/// + sources curées hydratées depuis la table `sources`.
+///
+/// Fallback silencieux à `[]` en cas d'erreur réseau — la grille de thèmes
+/// du Step 1 reste utilisable, on perd juste l'inspiration.
+final veillePresetsProvider = FutureProvider<List<VeillePreset>>((ref) async {
+  final apiClient = ref.watch(apiClientProvider);
+  try {
+    final response = await apiClient.dio.get<dynamic>('veille/presets');
+    final raw = response.data as List<dynamic>;
+    return raw
+        .whereType<Map<String, dynamic>>()
+        .map(VeillePreset.fromJson)
+        .toList();
+  } on DioException {
+    return const <VeillePreset>[];
+  }
+});

--- a/apps/mobile/lib/features/veille/screens/steps/step1_5_preset_preview_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step1_5_preset_preview_screen.dart
@@ -1,0 +1,352 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../../config/theme.dart';
+import '../../models/veille_config.dart';
+import '../../providers/veille_config_provider.dart';
+import '../../providers/veille_presets_provider.dart';
+import '../../widgets/veille_widgets.dart';
+
+/// Step 1.5 — Preview pré-set. Affiche le recap (thème + topics + sources
+/// curées) et propose 2 actions :
+/// - « Personnaliser » : applyPreset puis retour Step 1 pour ajuster
+/// - « Continuer avec ce pré-set » : applyPreset puis jump direct au Step 4
+///
+/// Le state.step reste à 1 sous le capot ; c'est `state.previewPresetId`
+/// (non-null) qui force l'orchestrator à rendre cet écran.
+class Step15PresetPreviewScreen extends ConsumerWidget {
+  final String presetSlug;
+  final VoidCallback onClose;
+
+  const Step15PresetPreviewScreen({
+    super.key,
+    required this.presetSlug,
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncPresets = ref.watch(veillePresetsProvider);
+    final notifier = ref.read(veilleConfigProvider.notifier);
+
+    return asyncPresets.when(
+      loading: () => _Scaffold(
+        onClose: onClose,
+        onBack: notifier.closePresetPreview,
+        body: const Center(child: CircularProgressIndicator()),
+      ),
+      error: (_, __) => _Scaffold(
+        onClose: onClose,
+        onBack: notifier.closePresetPreview,
+        body: _ErrorState(onBack: notifier.closePresetPreview),
+      ),
+      data: (presets) {
+        final preset = presets.where((p) => p.slug == presetSlug).firstOrNull;
+        if (preset == null) {
+          return _Scaffold(
+            onClose: onClose,
+            onBack: notifier.closePresetPreview,
+            body: _ErrorState(onBack: notifier.closePresetPreview),
+          );
+        }
+        return _Scaffold(
+          onClose: onClose,
+          onBack: notifier.closePresetPreview,
+          body: _PreviewBody(preset: preset),
+          footer: _Footer(
+            onCustomize: () =>
+                notifier.applyPreset(preset, jumpToStep4: false),
+            onContinue: () =>
+                notifier.applyPreset(preset, jumpToStep4: true),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _Scaffold extends StatelessWidget {
+  final VoidCallback onClose;
+  final VoidCallback onBack;
+  final Widget body;
+  final Widget? footer;
+
+  const _Scaffold({
+    required this.onClose,
+    required this.onBack,
+    required this.body,
+    this.footer,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        VeilleStepHeader(
+          step: 1,
+          canGoBack: true,
+          onBack: onBack,
+          onClose: onClose,
+        ),
+        Expanded(child: body),
+        if (footer != null) footer!,
+      ],
+    );
+  }
+}
+
+class _PreviewBody extends StatelessWidget {
+  final VeillePreset preset;
+  const _PreviewBody({required this.preset});
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(20, 24, 20, 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            preset.label,
+            style: GoogleFonts.dmSerifDisplay(
+              fontSize: 26,
+              height: 1.2,
+              color: const Color(0xFF2C2A29),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            preset.accroche,
+            style: GoogleFonts.dmSans(
+              fontSize: 14,
+              height: 1.5,
+              color: const Color(0xFF5D5B5A),
+            ),
+          ),
+          const SizedBox(height: 20),
+          _ChipRow(label: 'Thème', items: [preset.themeLabel]),
+          if (preset.topics.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            _ChipRow(label: 'Sujets', items: preset.topics),
+          ],
+          const SizedBox(height: 20),
+          Text(
+            'Sources curées (${preset.sources.length})',
+            style: GoogleFonts.courierPrime(
+              fontSize: 11,
+              letterSpacing: 0.5,
+              color: const Color(0xFF8B7E63),
+            ),
+          ),
+          const SizedBox(height: 10),
+          if (preset.sources.isEmpty)
+            Text(
+              'Aucune source curée trouvée pour ce thème.',
+              style: GoogleFonts.dmSans(
+                fontSize: 13,
+                color: const Color(0xFF8B7E63),
+              ),
+            )
+          else
+            _SourcesGrid(sources: preset.sources),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChipRow extends StatelessWidget {
+  final String label;
+  final List<String> items;
+  const _ChipRow({required this.label, required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label.toUpperCase(),
+          style: GoogleFonts.courierPrime(
+            fontSize: 11,
+            letterSpacing: 0.5,
+            color: const Color(0xFF8B7E63),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 6,
+          runSpacing: 6,
+          children: [
+            for (final t in items)
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                decoration: BoxDecoration(
+                  color: FacteurColors.veilleTint,
+                  borderRadius: BorderRadius.circular(100),
+                  border: Border.all(
+                    color: FacteurColors.veilleLineSoft,
+                  ),
+                ),
+                child: Text(
+                  t,
+                  style: GoogleFonts.dmSans(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                    color: const Color(0xFF2C2A29),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _SourcesGrid extends StatelessWidget {
+  final List<VeillePresetSource> sources;
+  const _SourcesGrid({required this.sources});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (final s in sources)
+          Container(
+            width: 96,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(color: FacteurColors.veilleLineSoft),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (s.logoUrl != null && s.logoUrl!.isNotEmpty)
+                  ClipOval(
+                    child: Image.network(
+                      s.logoUrl!,
+                      width: 32,
+                      height: 32,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => _SourceInitial(name: s.name),
+                    ),
+                  )
+                else
+                  _SourceInitial(name: s.name),
+                const SizedBox(height: 6),
+                Text(
+                  s.name,
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: GoogleFonts.dmSans(
+                    fontSize: 11,
+                    height: 1.2,
+                    color: const Color(0xFF2C2A29),
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _SourceInitial extends StatelessWidget {
+  final String name;
+  const _SourceInitial({required this.name});
+
+  @override
+  Widget build(BuildContext context) {
+    final letter = name.isEmpty ? '?' : name[0].toUpperCase();
+    return Container(
+      width: 32,
+      height: 32,
+      decoration: const BoxDecoration(
+        color: FacteurColors.veilleTint,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        letter,
+        style: GoogleFonts.dmSerifDisplay(
+          fontSize: 16,
+          color: FacteurColors.veille,
+        ),
+      ),
+    );
+  }
+}
+
+class _Footer extends StatelessWidget {
+  final VoidCallback onCustomize;
+  final VoidCallback onContinue;
+
+  const _Footer({required this.onCustomize, required this.onContinue});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+      decoration: const BoxDecoration(
+        border: Border(
+          top: BorderSide(color: FacteurColors.veilleLineSoft, width: 1),
+        ),
+      ),
+      child: Column(
+        children: [
+          VeilleCtaButton(
+            label: 'Continuer avec ce pré-set',
+            trailingIcon: PhosphorIcons.arrowRight(),
+            onPressed: onContinue,
+          ),
+          const SizedBox(height: 8),
+          GhostLink(
+            label: 'Personnaliser',
+            icon: PhosphorIcons.pencilSimple(),
+            onTap: onCustomize,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  final VoidCallback onBack;
+  const _ErrorState({required this.onBack});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'Impossible de charger ce pré-set.',
+            textAlign: TextAlign.center,
+            style: GoogleFonts.dmSans(
+              fontSize: 14,
+              color: const Color(0xFF5D5B5A),
+            ),
+          ),
+          const SizedBox(height: 16),
+          GhostLink(
+            label: 'Retour aux thèmes',
+            icon: PhosphorIcons.arrowLeft(),
+            onTap: onBack,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart
@@ -6,6 +6,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../models/veille_config.dart';
 import '../../providers/veille_config_provider.dart';
 import '../../providers/veille_preset_topics_provider.dart';
+import '../../providers/veille_presets_provider.dart';
 import '../../providers/veille_themes_provider.dart';
 import '../../widgets/veille_widgets.dart';
 
@@ -150,6 +151,8 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
                     ],
                   ),
                 ),
+                const SizedBox(height: 28),
+                const _InspirationsSection(),
               ],
             ),
           ),
@@ -435,6 +438,77 @@ Future<void> _openAddTopicSheet(
 
   controller.dispose();
   if (result != null && result.isNotEmpty) onAdd(result);
+}
+
+class _InspirationsSection extends ConsumerWidget {
+  const _InspirationsSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncPresets = ref.watch(veillePresetsProvider);
+    final notifier = ref.read(veilleConfigProvider.notifier);
+
+    return asyncPresets.when(
+      loading: () => const _PresetCardSkeleton(),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (presets) {
+        if (presets.isEmpty) return const SizedBox.shrink();
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'INSPIRATIONS',
+              style: GoogleFonts.courierPrime(
+                fontSize: 11,
+                letterSpacing: 0.5,
+                color: const Color(0xFF8B7E63),
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Pas sûr·e par où commencer ? Pioche un pré-set.',
+              style: GoogleFonts.dmSans(
+                fontSize: 13,
+                color: const Color(0xFF5D5B5A),
+              ),
+            ),
+            const SizedBox(height: 12),
+            for (var i = 0; i < presets.length; i++) ...[
+              if (i > 0) const SizedBox(height: 8),
+              PresetCard(
+                label: presets[i].label,
+                accroche: presets[i].accroche,
+                icon: phosphorThemeIcon(presets[i].themeId),
+                onTap: () => notifier.openPresetPreview(presets[i].slug),
+              ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _PresetCardSkeleton extends StatelessWidget {
+  const _PresetCardSkeleton();
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: List.generate(
+        3,
+        (i) => Padding(
+          padding: EdgeInsets.only(top: i == 0 ? 0 : 8),
+          child: Container(
+            height: 70,
+            decoration: BoxDecoration(
+              color: const Color(0xFFF5F0E5),
+              borderRadius: BorderRadius.circular(14),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _Footer extends StatelessWidget {

--- a/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
@@ -7,6 +7,7 @@ import '../../../config/theme.dart';
 import '../providers/veille_active_config_provider.dart';
 import '../providers/veille_config_provider.dart';
 import '../repositories/veille_repository.dart';
+import 'steps/step1_5_preset_preview_screen.dart';
 import 'steps/step1_theme_screen.dart';
 import 'steps/step2_suggestions_screen.dart';
 import 'steps/step3_sources_screen.dart';
@@ -73,8 +74,16 @@ class VeilleConfigScreen extends ConsumerWidget {
     }
 
     Widget body;
+    String key;
     if (state.isLoading) {
       body = FlowLoadingScreen(from: state.loadingFrom!);
+      key = 'load-${state.loadingFrom}';
+    } else if (state.previewPresetId != null) {
+      body = Step15PresetPreviewScreen(
+        presetSlug: state.previewPresetId!,
+        onClose: close,
+      );
+      key = 'preset-${state.previewPresetId}';
     } else {
       switch (state.step) {
         case 1:
@@ -93,6 +102,7 @@ class VeilleConfigScreen extends ConsumerWidget {
             onSubmit: handleSubmit,
           );
       }
+      key = 'step-${state.step}';
     }
 
     return Scaffold(
@@ -104,9 +114,7 @@ class VeilleConfigScreen extends ConsumerWidget {
           switchInCurve: Curves.easeOut,
           switchOutCurve: Curves.easeIn,
           child: KeyedSubtree(
-            key: ValueKey(
-              state.isLoading ? 'load-${state.loadingFrom}' : 'step-${state.step}',
-            ),
+            key: ValueKey(key),
             child: body,
           ),
         ),

--- a/apps/mobile/lib/features/veille/widgets/veille_widgets.dart
+++ b/apps/mobile/lib/features/veille/widgets/veille_widgets.dart
@@ -1188,3 +1188,90 @@ class GhostLink extends StatelessWidget {
     );
   }
 }
+
+/// Carte d'« Inspirations » affichée en bas du Step 1 — propose un pré-set
+/// V1 (label + accroche). Tap → ouvre l'écran preview Step 1.5.
+class PresetCard extends StatelessWidget {
+  final String label;
+  final String accroche;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  const PresetCard({
+    super.key,
+    required this.label,
+    required this.accroche,
+    required this.icon,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(14, 14, 14, 14),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: FacteurColors.veilleLineSoft,
+              width: 1.5,
+            ),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: const BoxDecoration(
+                  color: FacteurColors.veilleTint,
+                  shape: BoxShape.circle,
+                ),
+                alignment: Alignment.center,
+                child: Icon(icon, size: 18, color: FacteurColors.veille),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      label,
+                      style: GoogleFonts.dmSans(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                        height: 1.25,
+                        color: const Color(0xFF2C2A29),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      accroche,
+                      style: GoogleFonts.dmSans(
+                        fontSize: 12,
+                        height: 1.4,
+                        color: const Color(0xFF5D5B5A),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              Icon(
+                PhosphorIcons.arrowRight(),
+                size: 16,
+                color: const Color(0xFF8B7E63),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/veille/models/veille_presets_test.dart
+++ b/apps/mobile/test/features/veille/models/veille_presets_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/veille/models/veille_config.dart';
+
+void main() {
+  group('VeillePreset.fromJson', () {
+    test('parses full payload including sources', () {
+      final preset = VeillePreset.fromJson({
+        'slug': 'ia_agentique',
+        'label': 'Outils IA agentique',
+        'accroche': 'Les derniers outils IA',
+        'theme_id': 'tech',
+        'theme_label': 'Technologie',
+        'topics': ['A', 'B'],
+        'purposes': ['progresser_au_travail'],
+        'editorial_brief': 'brief',
+        'sources': [
+          {
+            'id': '11111111-1111-1111-1111-111111111111',
+            'name': 'Source A',
+            'url': 'https://a.example.com',
+            'logo_url': 'https://logo.example.com/a.png',
+          },
+        ],
+      });
+
+      expect(preset.slug, 'ia_agentique');
+      expect(preset.themeLabel, 'Technologie');
+      expect(preset.topics, ['A', 'B']);
+      expect(preset.purposes, ['progresser_au_travail']);
+      expect(preset.sources.length, 1);
+      expect(preset.sources.first.logoUrl, 'https://logo.example.com/a.png');
+    });
+
+    test('handles missing optional fields with safe defaults', () {
+      final preset = VeillePreset.fromJson({
+        'slug': 's',
+        'label': 'L',
+        'accroche': 'A',
+        'theme_id': 'tech',
+        'theme_label': 'Tech',
+      });
+
+      expect(preset.topics, isEmpty);
+      expect(preset.purposes, isEmpty);
+      expect(preset.editorialBrief, '');
+      expect(preset.sources, isEmpty);
+    });
+  });
+}

--- a/apps/mobile/test/features/veille/providers/veille_presets_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_presets_provider_test.dart
@@ -1,0 +1,118 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:facteur/core/api/api_client.dart';
+import 'package:facteur/core/api/providers.dart';
+import 'package:facteur/features/veille/providers/veille_presets_provider.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+class _MockDio extends Mock implements Dio {}
+
+void main() {
+  late _MockApiClient api;
+  late _MockDio dio;
+
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  setUp(() {
+    api = _MockApiClient();
+    dio = _MockDio();
+    when(() => api.dio).thenReturn(dio);
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [apiClientProvider.overrideWithValue(api)],
+    );
+  }
+
+  Response<dynamic> okResponse(List<Map<String, Object?>> rows) {
+    return Response<dynamic>(
+      requestOptions: RequestOptions(path: 'veille/presets'),
+      statusCode: 200,
+      data: rows,
+    );
+  }
+
+  test('parses 3 presets from the API and exposes their fields', () async {
+    when(() => dio.get<dynamic>('veille/presets')).thenAnswer(
+      (_) async => okResponse([
+        {
+          'slug': 'ia_agentique',
+          'label': 'Outils IA agentique',
+          'accroche': 'Les derniers outils IA',
+          'theme_id': 'tech',
+          'theme_label': 'Technologie',
+          'topics': ['Agents LLM', 'Frameworks'],
+          'purposes': ['progresser_au_travail'],
+          'editorial_brief': 'Plutôt analyses concrètes.',
+          'sources': [
+            {
+              'id': 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+              'name': 'Source A',
+              'url': 'https://a.example.com',
+              'logo_url': null,
+            },
+          ],
+        },
+        {
+          'slug': 'geopolitique_long',
+          'label': 'Géopolitique long format',
+          'accroche': 'Comprendre les recompositions',
+          'theme_id': 'international',
+          'theme_label': 'Géopolitique',
+          'topics': [],
+          'purposes': [],
+          'editorial_brief': '',
+          'sources': [],
+        },
+        {
+          'slug': 'transition_climat',
+          'label': 'Transition climatique',
+          'accroche': 'Suivre la transition',
+          'theme_id': 'environment',
+          'theme_label': 'Environnement',
+          'topics': ['Politiques publiques'],
+          'purposes': ['preparer_projet'],
+          'editorial_brief': 'Articles factuels',
+          'sources': [],
+        },
+      ]),
+    );
+
+    final container = makeContainer();
+    addTearDown(container.dispose);
+    final presets = await container.read(veillePresetsProvider.future);
+
+    expect(presets.length, 3);
+    expect(presets[0].slug, 'ia_agentique');
+    expect(presets[0].label, 'Outils IA agentique');
+    expect(presets[0].themeId, 'tech');
+    expect(presets[0].topics, ['Agents LLM', 'Frameworks']);
+    expect(presets[0].purposes, ['progresser_au_travail']);
+    expect(presets[0].sources.length, 1);
+    expect(presets[0].sources.first.name, 'Source A');
+
+    expect(presets[1].slug, 'geopolitique_long');
+    expect(presets[1].sources, isEmpty);
+
+    expect(presets[2].editorialBrief, 'Articles factuels');
+  });
+
+  test('falls back to empty list when the API throws', () async {
+    when(() => dio.get<dynamic>('veille/presets')).thenThrow(
+      DioException(requestOptions: RequestOptions(path: 'veille/presets')),
+    );
+
+    final container = makeContainer();
+    addTearDown(container.dispose);
+    final presets = await container.read(veillePresetsProvider.future);
+
+    expect(presets, isEmpty);
+  });
+}

--- a/apps/mobile/test/features/veille/screens/step1_5_preset_preview_screen_test.dart
+++ b/apps/mobile/test/features/veille/screens/step1_5_preset_preview_screen_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/veille/models/veille_config.dart';
+import 'package:facteur/features/veille/providers/veille_config_provider.dart';
+import 'package:facteur/features/veille/providers/veille_presets_provider.dart';
+import 'package:facteur/features/veille/screens/steps/step1_5_preset_preview_screen.dart';
+
+const _preset = VeillePreset(
+  slug: 'ia_agentique',
+  label: 'Outils IA agentique',
+  accroche: 'Les derniers outils et bonnes pratiques.',
+  themeId: 'tech',
+  themeLabel: 'Technologie',
+  topics: ['Agents LLM', 'Frameworks dev'],
+  purposes: ['progresser_au_travail'],
+  editorialBrief: 'Plutôt analyses concrètes.',
+  sources: [
+    VeillePresetSource(
+      id: '11111111-1111-1111-1111-111111111111',
+      name: 'Source A',
+      url: 'https://a.example.com',
+    ),
+  ],
+);
+
+ProviderContainer _makeContainer() {
+  return ProviderContainer(
+    overrides: [
+      veillePresetsProvider.overrideWith((ref) async => [_preset]),
+    ],
+  );
+}
+
+Widget _wrap(ProviderContainer container) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      home: Scaffold(
+        body: Step15PresetPreviewScreen(
+          presetSlug: 'ia_agentique',
+          onClose: () {},
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('renders preset label, accroche, topics and source', (tester) async {
+    final container = _makeContainer();
+    await tester.pumpWidget(_wrap(container));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Outils IA agentique'), findsOneWidget);
+    expect(find.text('Les derniers outils et bonnes pratiques.'), findsOneWidget);
+    expect(find.text('Agents LLM'), findsOneWidget);
+    expect(find.text('Frameworks dev'), findsOneWidget);
+    expect(find.text('Source A'), findsOneWidget);
+    expect(find.text('Continuer avec ce pré-set'), findsOneWidget);
+    expect(find.text('Personnaliser'), findsOneWidget);
+
+    container.dispose();
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('"Continuer avec ce pré-set" applies preset and jumps to step 4',
+      (tester) async {
+    final container = _makeContainer();
+    container.read(veilleConfigProvider.notifier).openPresetPreview('ia_agentique');
+
+    await tester.pumpWidget(_wrap(container));
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.text('Continuer avec ce pré-set'));
+    await tester.pump();
+
+    final state = container.read(veilleConfigProvider);
+    expect(state.step, 4);
+    expect(state.previewPresetId, isNull);
+    expect(state.selectedTheme, 'tech');
+    expect(state.presetId, 'ia_agentique');
+    expect(state.purpose, 'progresser_au_travail');
+    expect(state.editorialBrief, 'Plutôt analyses concrètes.');
+    expect(state.followedSources.contains('11111111-1111-1111-1111-111111111111'), isTrue);
+
+    container.dispose();
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('"Personnaliser" applies preset and stays on step 1',
+      (tester) async {
+    final container = _makeContainer();
+    container.read(veilleConfigProvider.notifier).openPresetPreview('ia_agentique');
+
+    await tester.pumpWidget(_wrap(container));
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.text('Personnaliser'));
+    await tester.pump();
+
+    final state = container.read(veilleConfigProvider);
+    expect(state.step, 1);
+    expect(state.previewPresetId, isNull);
+    expect(state.selectedTheme, 'tech');
+    expect(state.presetId, 'ia_agentique');
+
+    container.dispose();
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+}

--- a/apps/mobile/test/features/veille/widgets/preset_card_test.dart
+++ b/apps/mobile/test/features/veille/widgets/preset_card_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import 'package:facteur/features/veille/widgets/veille_widgets.dart';
+
+void main() {
+  testWidgets('PresetCard renders label + accroche and triggers onTap',
+      (tester) async {
+    var tapped = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PresetCard(
+            label: 'Outils IA agentique',
+            accroche: 'Les derniers outils et bonnes pratiques',
+            icon: PhosphorIcons.lightning(),
+            onTap: () => tapped++,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Outils IA agentique'), findsOneWidget);
+    expect(find.text('Les derniers outils et bonnes pratiques'), findsOneWidget);
+
+    await tester.tap(find.byType(InkWell));
+    expect(tapped, 1);
+  });
+}

--- a/packages/api/alembic/versions/vp01_veille_personalization_columns.py
+++ b/packages/api/alembic/versions/vp01_veille_personalization_columns.py
@@ -1,0 +1,59 @@
+"""veille personalization columns + notif veille toggle
+
+Revision ID: vp01
+Revises: ls01
+Create Date: 2026-05-03
+
+Pose les fondations DB pour la refonte V1 de la veille (PR A) :
+- 4 colonnes nullables sur `veille_configs` pour capturer purpose/brief/preset
+  (PR B câblera la persistance via le router /config).
+- Toggle `notif_veille_enabled` sur `user_notification_preferences` pour la
+  modal opt-in notif veille (PR C).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "vp01"
+down_revision: str | Sequence[str] | None = "ls01"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "veille_configs",
+        sa.Column("purpose", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "veille_configs",
+        sa.Column("purpose_other", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "veille_configs",
+        sa.Column("editorial_brief", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "veille_configs",
+        sa.Column("preset_id", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "user_notification_preferences",
+        sa.Column(
+            "notif_veille_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_notification_preferences", "notif_veille_enabled")
+    op.drop_column("veille_configs", "preset_id")
+    op.drop_column("veille_configs", "editorial_brief")
+    op.drop_column("veille_configs", "purpose_other")
+    op.drop_column("veille_configs", "purpose")

--- a/packages/api/app/data/veille_presets.py
+++ b/packages/api/app/data/veille_presets.py
@@ -1,0 +1,81 @@
+"""Pré-sets V1 de la veille — affichés en bas du Step 1 (« Inspirations »).
+
+Stockés en JSON statique côté serveur (pas de table DB) : modifier la liste se
+fait par redéploiement, sans migration. Les sources curées sont résolues au
+runtime via `Source.theme + is_curated` (cf. routers/veille.py:list_presets)
+afin qu'un re-seed du catalogue ne casse pas la liste.
+"""
+
+from __future__ import annotations
+
+VEILLE_PRESETS: list[dict] = [
+    {
+        "slug": "ia_agentique",
+        "label": "Outils IA agentique",
+        "accroche": (
+            "Les derniers outils et bonnes pratiques pour développer à "
+            "l'ère de l'IA agentique."
+        ),
+        "theme_id": "tech",
+        "theme_label": "Technologie",
+        "topics": [
+            "Agents LLM & frameworks",
+            "Outils dev & productivité IA",
+            "Modèles open-source",
+            "Cas d'usage en production",
+        ],
+        "purposes": ["progresser_au_travail"],
+        "editorial_brief": (
+            "Plutôt analyses concrètes et retours d'expérience d'équipes "
+            "tech que hype marketing. Focus sur ce qui marche en production."
+        ),
+    },
+    {
+        "slug": "geopolitique_long",
+        "label": "Géopolitique long format",
+        "accroche": (
+            "Comprendre les recompositions géopolitiques actuelles via "
+            "l'analyse long format."
+        ),
+        "theme_id": "international",
+        "theme_label": "Géopolitique",
+        "topics": [
+            "Tensions sino-américaines",
+            "Recompositions du Sud global",
+            "Conflits & sécurité",
+            "Énergie & matières premières",
+        ],
+        "purposes": ["culture_generale"],
+        "editorial_brief": (
+            "Analyses long format avec mise en perspective historique, "
+            "plutôt que breaking news. Sources de référence et chercheurs."
+        ),
+    },
+    {
+        "slug": "transition_climat",
+        "label": "Transition climatique",
+        "accroche": (
+            "Suivre la transition climatique : politiques publiques, "
+            "ruptures techno, retours d'expérience."
+        ),
+        "theme_id": "environment",
+        "theme_label": "Environnement",
+        "topics": [
+            "Politiques publiques climat",
+            "Énergies bas carbone",
+            "Industrie & décarbonation",
+            "Adaptation & risques",
+        ],
+        "purposes": ["preparer_projet"],
+        "editorial_brief": (
+            "Articles factuels et chiffrés sur ce qui change vraiment, "
+            "avec un focus sur les implications concrètes (politiques, "
+            "industrie, territoires)."
+        ),
+    },
+]
+
+
+def get_presets() -> list[dict]:
+    """Renvoie la liste des pré-sets. Helper pour faciliter le mock en tests."""
+    return VEILLE_PRESETS

--- a/packages/api/app/models/user_notification_preferences.py
+++ b/packages/api/app/models/user_notification_preferences.py
@@ -50,7 +50,6 @@ class UserNotificationPreferences(Base):
         Boolean, nullable=False, default=False, server_default="false"
     )
 
-    # Opt-in spécifique notif veille (migration vp01) — câblage en PR C.
     notif_veille_enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default="false"
     )

--- a/packages/api/app/models/user_notification_preferences.py
+++ b/packages/api/app/models/user_notification_preferences.py
@@ -50,6 +50,11 @@ class UserNotificationPreferences(Base):
         Boolean, nullable=False, default=False, server_default="false"
     )
 
+    # Opt-in spécifique notif veille (migration vp01) — câblage en PR C.
+    notif_veille_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow
     )

--- a/packages/api/app/models/veille.py
+++ b/packages/api/app/models/veille.py
@@ -118,7 +118,6 @@ class VeilleConfig(Base):
         onupdate=text("now()"),
     )
 
-    # V1 personalization (migration vp01) — câblage router en PR B.
     purpose: Mapped[str | None] = mapped_column(Text, nullable=True)
     purpose_other: Mapped[str | None] = mapped_column(Text, nullable=True)
     editorial_brief: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/packages/api/app/models/veille.py
+++ b/packages/api/app/models/veille.py
@@ -118,6 +118,12 @@ class VeilleConfig(Base):
         onupdate=text("now()"),
     )
 
+    # V1 personalization (migration vp01) — câblage router en PR B.
+    purpose: Mapped[str | None] = mapped_column(Text, nullable=True)
+    purpose_other: Mapped[str | None] = mapped_column(Text, nullable=True)
+    editorial_brief: Mapped[str | None] = mapped_column(Text, nullable=True)
+    preset_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+
 
 class VeilleTopic(Base):
     """Topic rattaché à une veille_config."""

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -17,6 +17,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
+from app.data.veille_presets import get_presets
 from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
 from app.jobs.veille_generation_job import run_veille_generation_for_config
@@ -36,6 +37,7 @@ from app.schemas.veille import (
     VeilleDeliveryListItem,
     VeilleDeliveryResponse,
     VeilleGenerateRequest,
+    VeillePresetResponse,
     VeilleSourceLite,
     VeilleSourceResponse,
     VeilleSourceSuggestion,
@@ -355,6 +357,50 @@ async def delete_config(
     cfg.status = VeilleStatus.ARCHIVED.value
     await db.commit()
     return None
+
+
+# ─── Endpoints presets ───────────────────────────────────────────────────────
+
+
+@router.get("/presets", response_model=list[VeillePresetResponse])
+async def list_presets(db: AsyncSession = Depends(get_db)):
+    """Liste les pré-sets V1 affichés en bas du Step 1 (« Inspirations »).
+
+    Pas d'auth : la liste est publique (utilisée pendant l'onboarding).
+    Les sources curées sont résolues au runtime depuis la table `sources`.
+    """
+    out: list[VeillePresetResponse] = []
+    for preset in get_presets():
+        srcs = (
+            (
+                await db.execute(
+                    select(Source)
+                    .where(
+                        Source.theme == preset["theme_id"],
+                        Source.is_curated.is_(True),
+                        Source.is_active.is_(True),
+                    )
+                    .order_by(Source.name)
+                    .limit(6)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        out.append(
+            VeillePresetResponse(
+                slug=preset["slug"],
+                label=preset["label"],
+                accroche=preset["accroche"],
+                theme_id=preset["theme_id"],
+                theme_label=preset["theme_label"],
+                topics=preset["topics"],
+                purposes=preset["purposes"],
+                editorial_brief=preset["editorial_brief"],
+                sources=[VeilleSourceLite.model_validate(s) for s in srcs],
+            )
+        )
+    return out
 
 
 # ─── Endpoints suggestions ───────────────────────────────────────────────────

--- a/packages/api/app/schemas/veille.py
+++ b/packages/api/app/schemas/veille.py
@@ -86,6 +86,12 @@ class VeilleConfigResponse(BaseModel):
     updated_at: datetime
     topics: list[VeilleTopicResponse] = []
     sources: list[VeilleSourceResponse] = []
+    # V1 personalization (migration vp01) — toujours None tant que la PR B
+    # ne câble pas la persistance dans le router /config.
+    purpose: str | None = None
+    purpose_other: str | None = None
+    editorial_brief: str | None = None
+    preset_id: str | None = None
 
 
 class VeilleTopicSelection(BaseModel):
@@ -123,6 +129,12 @@ class VeilleConfigUpsert(BaseModel):
     day_of_week: int | None = Field(default=None, ge=0, le=6)
     delivery_hour: int = Field(default=7, ge=0, le=23)
     timezone: str = Field(default="Europe/Paris", max_length=64)
+    # V1 personalization — acceptés par le schéma (PR A) mais persistance
+    # cablée plus tard (PR B).
+    purpose: str | None = Field(default=None, max_length=80)
+    purpose_other: str | None = Field(default=None, max_length=80)
+    editorial_brief: str | None = Field(default=None, max_length=280)
+    preset_id: str | None = Field(default=None, max_length=80)
 
 
 class VeilleConfigPatch(BaseModel):
@@ -131,6 +143,10 @@ class VeilleConfigPatch(BaseModel):
     delivery_hour: int | None = Field(default=None, ge=0, le=23)
     timezone: str | None = Field(default=None, max_length=64)
     status: Literal["active", "paused", "archived"] | None = None
+    purpose: str | None = Field(default=None, max_length=80)
+    purpose_other: str | None = Field(default=None, max_length=80)
+    editorial_brief: str | None = Field(default=None, max_length=280)
+    preset_id: str | None = Field(default=None, max_length=80)
 
 
 # ─── Suggestions ─────────────────────────────────────────────────────────────
@@ -226,3 +242,25 @@ class VeilleGenerateRequest(BaseModel):
     """Force une génération pour la config courante au target_date=today."""
 
     target_date: date | None = None
+
+
+# ─── Presets (V1 onboarding) ─────────────────────────────────────────────────
+
+
+class VeillePresetResponse(BaseModel):
+    """Pré-set d'inspiration affiché en bas du Step 1 du flow veille.
+
+    Les `sources` sont hydratées au runtime depuis la table `sources` (filtre
+    `theme + is_curated`) plutôt que d'être hardcodées en UUIDs : ainsi un
+    re-seed du catalogue ne casse pas la liste.
+    """
+
+    slug: str
+    label: str
+    accroche: str
+    theme_id: str
+    theme_label: str
+    topics: list[str] = Field(default_factory=list)
+    purposes: list[str] = Field(default_factory=list)
+    editorial_brief: str = ""
+    sources: list[VeilleSourceLite] = Field(default_factory=list)

--- a/packages/api/tests/test_veille_personalization_columns.py
+++ b/packages/api/tests/test_veille_personalization_columns.py
@@ -1,0 +1,82 @@
+"""Verrouille la migration vp01 : les 4 colonnes V1 sur veille_configs et le
+toggle notif_veille_enabled sur user_notification_preferences existent et
+acceptent la persistance des valeurs cibles.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.models.user import UserProfile
+from app.models.user_notification_preferences import UserNotificationPreferences
+from app.models.veille import VeilleConfig, VeilleStatus
+
+
+@pytest.mark.asyncio
+async def test_veille_config_persists_v1_personalization_fields(db_session):
+    user = UserProfile(
+        user_id=uuid4(),
+        display_name="vp01 user",
+        onboarding_completed=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    cfg = VeilleConfig(
+        id=uuid4(),
+        user_id=user.user_id,
+        theme_id="tech",
+        theme_label="Technologie",
+        frequency="weekly",
+        day_of_week=0,
+        delivery_hour=7,
+        timezone="Europe/Paris",
+        status=VeilleStatus.ACTIVE.value,
+        purpose="progresser_au_travail",
+        purpose_other=None,
+        editorial_brief="Plutôt analyses concrètes que hype.",
+        preset_id="ia_agentique",
+    )
+    db_session.add(cfg)
+    await db_session.commit()
+    await db_session.refresh(cfg)
+
+    assert cfg.purpose == "progresser_au_travail"
+    assert cfg.purpose_other is None
+    assert cfg.editorial_brief == "Plutôt analyses concrètes que hype."
+    assert cfg.preset_id == "ia_agentique"
+
+
+@pytest.mark.asyncio
+async def test_notif_veille_enabled_default_false_and_writable(db_session):
+    user = UserProfile(
+        user_id=uuid4(),
+        display_name="notif vp01 user",
+        onboarding_completed=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    prefs = UserNotificationPreferences(user_id=user.user_id)
+    db_session.add(prefs)
+    await db_session.commit()
+    await db_session.refresh(prefs)
+    assert prefs.notif_veille_enabled is False
+
+    prefs.notif_veille_enabled = True
+    await db_session.commit()
+
+    fetched = (
+        (
+            await db_session.execute(
+                select(UserNotificationPreferences).where(
+                    UserNotificationPreferences.user_id == user.user_id
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert fetched is not None
+    assert fetched.notif_veille_enabled is True

--- a/packages/api/tests/test_veille_presets.py
+++ b/packages/api/tests/test_veille_presets.py
@@ -1,0 +1,117 @@
+"""Tests pour GET /api/veille/presets + module de données.
+
+Couvre :
+- Le module statique `veille_presets.py` charge sans crash et expose 3
+  pré-sets avec la structure attendue (verrouille les slugs cibles V1).
+- L'endpoint hydrate les sources curées depuis la table `sources`
+  (filtre `theme + is_curated`) sans contrat sur le nombre exact (le seed
+  prod garantit ≥4 mais les tests posent leurs propres fixtures).
+"""
+
+from uuid import uuid4
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.data.veille_presets import VEILLE_PRESETS, get_presets
+from app.database import get_db
+from app.main import app
+from app.models.enums import SourceType
+from app.models.source import Source
+
+EXPECTED_SLUGS = ["ia_agentique", "geopolitique_long", "transition_climat"]
+EXPECTED_THEMES = {
+    "ia_agentique": "tech",
+    "geopolitique_long": "international",
+    "transition_climat": "environment",
+}
+
+
+def _client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+@pytest_asyncio.fixture
+async def db_override(db_session):
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        yield db_session
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def curated_sources_per_theme(db_session):
+    """Pose 4 sources curées (active) par thème ciblé par les pré-sets."""
+    created: list[Source] = []
+    for theme in EXPECTED_THEMES.values():
+        for i in range(4):
+            src = Source(
+                id=uuid4(),
+                name=f"Source {theme} {i}",
+                url=f"https://{theme}{i}.example.com",
+                feed_url=f"https://{theme}{i}.example.com/feed-{uuid4()}.xml",
+                type=SourceType.ARTICLE,
+                theme=theme,
+                is_active=True,
+                is_curated=True,
+            )
+            db_session.add(src)
+            created.append(src)
+    await db_session.commit()
+    return created
+
+
+def test_get_presets_module_loads():
+    """Sanity check : le module charge et expose la structure attendue."""
+    presets = get_presets()
+    assert presets is VEILLE_PRESETS
+    assert len(presets) == 3
+    assert [p["slug"] for p in presets] == EXPECTED_SLUGS
+
+    required_keys = {
+        "slug",
+        "label",
+        "accroche",
+        "theme_id",
+        "theme_label",
+        "topics",
+        "purposes",
+        "editorial_brief",
+    }
+    for p in presets:
+        assert required_keys.issubset(p.keys())
+        assert p["theme_id"] == EXPECTED_THEMES[p["slug"]]
+        assert isinstance(p["topics"], list) and len(p["topics"]) >= 1
+        assert isinstance(p["purposes"], list)
+
+
+async def test_list_presets_returns_three_items(db_override, curated_sources_per_theme):
+    async with _client() as ac:
+        resp = await ac.get("/api/veille/presets")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 3
+    assert [p["slug"] for p in data] == EXPECTED_SLUGS
+
+
+async def test_presets_hydrate_curated_sources(db_override, curated_sources_per_theme):
+    async with _client() as ac:
+        resp = await ac.get("/api/veille/presets")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    for preset in data:
+        sources = preset["sources"]
+        assert len(sources) >= 4, (
+            f"preset {preset['slug']} doit hydrater ≥4 sources curées"
+        )
+        for src in sources:
+            assert src["theme"] == preset["theme_id"]
+            assert src["is_curated"] is True
+            assert "name" in src and "url" in src


### PR DESCRIPTION
# PR — Veille V1 personalization (PR A : fondations DB + presets)

## Summary

Première brique de la refonte V1 « Ma veille ». Pose les colonnes DB pour
capturer purpose / editorial_brief / preset_id (PR B câblera la persistance via
le router `/config`) et expose un endpoint public `GET /api/veille/presets`
qui alimente la nouvelle section « Inspirations » du Step 1 + le nouvel écran
Step 1.5 « preset preview » côté mobile.

## What

### Backend

- **Migration `vp01`** (heads `ls01` → `vp01`) :
  - 4 colonnes nullables sur `veille_configs` (`purpose`, `purpose_other`,
    `editorial_brief`, `preset_id`).
  - `notif_veille_enabled BOOLEAN NOT NULL DEFAULT false` sur
    `user_notification_preferences` (toggle pour la modal opt-in PR C).
- **`GET /api/veille/presets`** (public, no-auth) — retourne les presets V1
  avec leurs sources curées (résolution runtime via
  `Source.theme + is_curated + is_active`, ordre `name`, limite 6).
- Données : `app/data/veille_presets.py`.
- Schemas : `VeillePresetResponse` + adjacents.

### Mobile

- Nouvel écran `step1_5_preset_preview_screen.dart` (preview du preset entre
  Step 1 thème et Step 2 topics).
- `veille_presets_provider.dart` (Async list provider, GET `/presets`).
- Step 1 thème enrichi : section « Inspirations » avec preset cards.
- `veille_config_provider.dart` étendu (purpose, editorialBrief, presetId).
- Modèles + serializers `VeilleConfig` étendus.
- Tests : presets model/provider + screens
  (`step1_5_preset_preview_screen_test.dart`) + widgets
  (`preset_card_test.dart`).

## How ça a été vérifié

- [ ] `pytest -v` (backend complet, incl. `test_veille_presets` +
      `test_veille_personalization_columns`)
- [ ] `ruff format --check && ruff check` (lint Python)
- [ ] `alembic heads` → 1 head (`vp01`) ; `alembic upgrade head` OK local
- [ ] `flutter test && flutter analyze`
- [ ] `curl GET /api/veille/presets` → 200 sans auth, body non vide
- [ ] Playwright MCP : Step 1 → preset card → Step 1.5 preview → Step 2
- [ ] `/simplify` passé

## Hors scope (PR B / PR C)

- PR B : câblage persistance des champs `purpose / editorial_brief / preset_id`
  dans POST `/api/veille/config` (router).
- PR C : modal opt-in notif veille (toggle `notif_veille_enabled`).

## Zones à risque

- **Migration** : ajout colonnes nullable + 1 NOT NULL avec
  `server_default('false')` → safe sur table existante, compatible rolling
  deploy. Pas d'index ajouté.
- **Endpoint `/presets` no-auth** : OK (lecture seule, pas de PII, pas de
  rate-limit dédié — la donnée est statique côté serveur).
