### PR TITLE
feat(veille): personnalisation purpose + brief libre injectés au LLM

### DIFF
--- a/apps/mobile/lib/features/veille/models/veille_config_dto.dart
+++ b/apps/mobile/lib/features/veille/models/veille_config_dto.dart
@@ -113,6 +113,10 @@ class VeilleConfigDto {
   final DateTime updatedAt;
   final List<VeilleTopicDto> topics;
   final List<VeilleSourceDto> sources;
+  final String? purpose;
+  final String? purposeOther;
+  final String? editorialBrief;
+  final String? presetId;
 
   const VeilleConfigDto({
     required this.id,
@@ -130,6 +134,10 @@ class VeilleConfigDto {
     required this.updatedAt,
     required this.topics,
     required this.sources,
+    this.purpose,
+    this.purposeOther,
+    this.editorialBrief,
+    this.presetId,
   });
 
   factory VeilleConfigDto.fromJson(Map<String, dynamic> json) {
@@ -159,6 +167,10 @@ class VeilleConfigDto {
           .whereType<Map<String, dynamic>>()
           .map(VeilleSourceDto.fromJson)
           .toList(),
+      purpose: json['purpose'] as String?,
+      purposeOther: json['purpose_other'] as String?,
+      editorialBrief: json['editorial_brief'] as String?,
+      presetId: json['preset_id'] as String?,
     );
   }
 }
@@ -244,6 +256,10 @@ class VeilleConfigUpsertRequest {
   final int? dayOfWeek;
   final int deliveryHour;
   final String timezone;
+  final String? purpose;
+  final String? purposeOther;
+  final String? editorialBrief;
+  final String? presetId;
 
   const VeilleConfigUpsertRequest({
     required this.themeId,
@@ -254,6 +270,10 @@ class VeilleConfigUpsertRequest {
     required this.dayOfWeek,
     this.deliveryHour = 7,
     this.timezone = 'Europe/Paris',
+    this.purpose,
+    this.purposeOther,
+    this.editorialBrief,
+    this.presetId,
   });
 
   Map<String, dynamic> toJson() => {
@@ -265,6 +285,11 @@ class VeilleConfigUpsertRequest {
         if (dayOfWeek != null) 'day_of_week': dayOfWeek,
         'delivery_hour': deliveryHour,
         'timezone': timezone,
+        // Toujours envoyés (même si null) : permet de clear côté serveur.
+        'purpose': purpose,
+        'purpose_other': purposeOther,
+        'editorial_brief': editorialBrief,
+        'preset_id': presetId,
       };
 }
 

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -308,6 +308,34 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
   void setFrequency(VeilleFrequency f) => state = state.copyWith(frequency: f);
   void setDay(VeilleDay d) => state = state.copyWith(day: d);
 
+  /// Quand on choisit un purpose autre que 'autre', on clear `purposeOther`
+  /// pour éviter qu'un free-text orphelin soit envoyé au LLM.
+  void setPurpose(String? slug) {
+    if (slug == state.purpose) return;
+    if (slug == 'autre') {
+      state = state.copyWith(purpose: slug);
+    } else {
+      state = state.copyWith(purpose: slug, purposeOther: null);
+    }
+  }
+
+  void setPurposeOther(String? value) {
+    final normalized = _emptyToNull(value);
+    if (normalized == state.purposeOther) return;
+    state = state.copyWith(purposeOther: normalized);
+  }
+
+  void setEditorialBrief(String? value) {
+    final normalized = _emptyToNull(value);
+    if (normalized == state.editorialBrief) return;
+    state = state.copyWith(editorialBrief: normalized);
+  }
+
+  static String? _emptyToNull(String? value) {
+    final trimmed = (value ?? '').trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+
   /// Avance d'une étape, en passant par un loading screen IA (sauf si on est
   /// déjà sur la dernière étape — auquel cas `submit()` doit être appelé).
   void goNext() {
@@ -575,6 +603,10 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       sourceSelections: sourceSelections,
       frequency: _frequencyToWire(s.frequency),
       dayOfWeek: _dayToWire(s.day, s.frequency),
+      purpose: s.purpose,
+      purposeOther: s.purposeOther,
+      editorialBrief: s.editorialBrief,
+      presetId: s.presetId,
     );
   }
 

--- a/apps/mobile/lib/features/veille/providers/veille_suggestions_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_suggestions_provider.dart
@@ -12,11 +12,17 @@ class VeilleTopicsSuggestionParams {
   final String themeId;
   final String themeLabel;
   final List<String> selectedTopicIds;
+  final String? purpose;
+  final String? purposeOther;
+  final String? editorialBrief;
 
   const VeilleTopicsSuggestionParams({
     required this.themeId,
     required this.themeLabel,
     required this.selectedTopicIds,
+    this.purpose,
+    this.purposeOther,
+    this.editorialBrief,
   });
 
   @override
@@ -25,22 +31,37 @@ class VeilleTopicsSuggestionParams {
     return other is VeilleTopicsSuggestionParams &&
         other.themeId == themeId &&
         other.themeLabel == themeLabel &&
-        listEquals(other.selectedTopicIds, selectedTopicIds);
+        listEquals(other.selectedTopicIds, selectedTopicIds) &&
+        other.purpose == purpose &&
+        other.purposeOther == purposeOther &&
+        other.editorialBrief == editorialBrief;
   }
 
   @override
-  int get hashCode =>
-      Object.hash(themeId, themeLabel, Object.hashAll(selectedTopicIds));
+  int get hashCode => Object.hash(
+        themeId,
+        themeLabel,
+        Object.hashAll(selectedTopicIds),
+        purpose,
+        purposeOther,
+        editorialBrief,
+      );
 }
 
 @immutable
 class VeilleSourcesSuggestionParams {
   final String themeId;
   final List<String> topicLabels;
+  final String? purpose;
+  final String? purposeOther;
+  final String? editorialBrief;
 
   const VeilleSourcesSuggestionParams({
     required this.themeId,
     required this.topicLabels,
+    this.purpose,
+    this.purposeOther,
+    this.editorialBrief,
   });
 
   @override
@@ -48,11 +69,20 @@ class VeilleSourcesSuggestionParams {
     if (identical(this, other)) return true;
     return other is VeilleSourcesSuggestionParams &&
         other.themeId == themeId &&
-        listEquals(other.topicLabels, topicLabels);
+        listEquals(other.topicLabels, topicLabels) &&
+        other.purpose == purpose &&
+        other.purposeOther == purposeOther &&
+        other.editorialBrief == editorialBrief;
   }
 
   @override
-  int get hashCode => Object.hash(themeId, Object.hashAll(topicLabels));
+  int get hashCode => Object.hash(
+        themeId,
+        Object.hashAll(topicLabels),
+        purpose,
+        purposeOther,
+        editorialBrief,
+      );
 }
 
 // ─── Topics ──────────────────────────────────────────────────────────────────
@@ -83,6 +113,9 @@ class VeilleTopicsSuggestionsNotifier
         themeLabel: _params.themeLabel,
         selectedTopicIds: _params.selectedTopicIds,
         excludeTopicIds: excludeIds,
+        purpose: _params.purpose,
+        purposeOther: _params.purposeOther,
+        editorialBrief: _params.editorialBrief,
       );
       final keptIds = _kept.map((t) => t.topicId).toSet();
       final fresh = items.where((t) => !keptIds.contains(t.topicId)).toList();
@@ -134,6 +167,9 @@ class VeilleSourcesSuggestionsNotifier
         themeId: _params.themeId,
         topicLabels: _params.topicLabels,
         excludeSourceIds: excludeIds,
+        purpose: _params.purpose,
+        purposeOther: _params.purposeOther,
+        editorialBrief: _params.editorialBrief,
       );
       final keptIds = _keptNiche.map((s) => s.sourceId).toSet();
       final freshNiche =

--- a/apps/mobile/lib/features/veille/repositories/veille_repository.dart
+++ b/apps/mobile/lib/features/veille/repositories/veille_repository.dart
@@ -89,6 +89,9 @@ class VeilleRepository {
     required String themeLabel,
     List<String> selectedTopicIds = const [],
     List<String> excludeTopicIds = const [],
+    String? purpose,
+    String? purposeOther,
+    String? editorialBrief,
   }) async {
     try {
       final response = await _dio.post<dynamic>(
@@ -98,6 +101,9 @@ class VeilleRepository {
           'theme_label': themeLabel,
           'selected_topic_ids': selectedTopicIds,
           'exclude_topic_ids': excludeTopicIds,
+          if (purpose != null) 'purpose': purpose,
+          if (purposeOther != null) 'purpose_other': purposeOther,
+          if (editorialBrief != null) 'editorial_brief': editorialBrief,
         },
       );
       final raw = response.data as List<dynamic>;
@@ -114,6 +120,9 @@ class VeilleRepository {
     required String themeId,
     List<String> topicLabels = const [],
     List<String> excludeSourceIds = const [],
+    String? purpose,
+    String? purposeOther,
+    String? editorialBrief,
   }) async {
     try {
       final response = await _dio.post<dynamic>(
@@ -122,6 +131,9 @@ class VeilleRepository {
           'theme_id': themeId,
           'topic_labels': topicLabels,
           'exclude_source_ids': excludeSourceIds,
+          if (purpose != null) 'purpose': purpose,
+          if (purposeOther != null) 'purpose_other': purposeOther,
+          if (editorialBrief != null) 'editorial_brief': editorialBrief,
         },
       );
       return VeilleSourceSuggestionsResponse.fromJson(

--- a/apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart
@@ -70,7 +70,9 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
               children: [
                 VeilleToggleSection(
                   index: 1,
-                  title: 'Sur quel sujet veux-tu une veille ?',
+                  title:
+                      'Sur quel thème aimerais-tu recevoir un condensé des '
+                      'meilleurs articles récents ?',
                   subtitleWhenCollapsed:
                       hasTheme ? selectedThemeLabel.toUpperCase() : null,
                   expanded: _openSection == 1,
@@ -151,6 +153,86 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
                     ],
                   ),
                 ),
+                const SizedBox(height: 18),
+                VeilleToggleSection(
+                  index: 3,
+                  title: 'Pour quoi faire ?',
+                  enabled: hasTheme,
+                  expanded: _openSection == 3 && hasTheme,
+                  subtitleWhenCollapsed:
+                      _purposeSubtitle(state.purpose, state.purposeOther),
+                  onToggle: () {
+                    if (!hasTheme) return;
+                    setState(() => _openSection = 3);
+                  },
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        "Ça nous aide à choisir la bonne profondeur d'analyse.",
+                        style: GoogleFonts.dmSans(
+                          fontSize: 13,
+                          height: 1.45,
+                          color: const Color(0xFF5D5B5A),
+                        ),
+                      ),
+                      const SizedBox(height: 14),
+                      VeillePurposeSelector(
+                        selected: state.purpose,
+                        onSelect: (slug) {
+                          notifier.setPurpose(slug);
+                          // Auto-bascule vers la section brief dès qu'un
+                          // purpose ≠ 'autre' est choisi (un purpose=autre
+                          // demande encore le free-text).
+                          if (slug != null && slug != 'autre') {
+                            setState(() => _openSection = 4);
+                          }
+                        },
+                      ),
+                      if (state.purpose == 'autre') ...[
+                        const SizedBox(height: 12),
+                        VeillePurposeOtherField(
+                          value: state.purposeOther,
+                          onChanged: notifier.setPurposeOther,
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 18),
+                VeilleToggleSection(
+                  index: 4,
+                  title: 'Décris ta veille idéale',
+                  enabled: hasTheme,
+                  expanded: _openSection == 4 && hasTheme,
+                  subtitleWhenCollapsed:
+                      (state.editorialBrief ?? '').trim().isEmpty
+                          ? null
+                          : 'BRIEF RENSEIGNÉ',
+                  onToggle: () {
+                    if (!hasTheme) return;
+                    setState(() => _openSection = 4);
+                  },
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'En quelques mots, à quoi elle ressemblerait pour toi. '
+                        "C'est optionnel mais ça aide vraiment le facteur.",
+                        style: GoogleFonts.dmSans(
+                          fontSize: 13,
+                          height: 1.45,
+                          color: const Color(0xFF5D5B5A),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      VeilleEditorialBriefField(
+                        value: state.editorialBrief,
+                        onChanged: notifier.setEditorialBrief,
+                      ),
+                    ],
+                  ),
+                ),
                 const SizedBox(height: 28),
                 const _InspirationsSection(),
               ],
@@ -173,6 +255,20 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
       ],
     );
   }
+}
+
+String? _purposeSubtitle(String? purpose, String? purposeOther) {
+  if (purpose == null) return null;
+  final option = kVeillePurposeOptions.firstWhere(
+    (o) => o.slug == purpose,
+    orElse: () => const VeillePurposeOption('', ''),
+  );
+  if (option.slug.isEmpty) return null;
+  if (option.slug == 'autre') {
+    final other = (purposeOther ?? '').trim();
+    return other.isEmpty ? 'AUTRE' : 'AUTRE — $other'.toUpperCase();
+  }
+  return option.label.toUpperCase();
 }
 
 class _ThemeGrid extends StatelessWidget {

--- a/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
@@ -27,6 +27,9 @@ class Step2SuggestionsScreen extends ConsumerWidget {
             themeId: themeId,
             themeLabel: themeLabel,
             selectedTopicIds: state.selectedTopics.toList()..sort(),
+            purpose: state.purpose,
+            purposeOther: state.purposeOther,
+            editorialBrief: state.editorialBrief,
           )
         : null;
 

--- a/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
@@ -30,6 +30,9 @@ class Step3SourcesScreen extends ConsumerWidget {
         : VeilleSourcesSuggestionParams(
             themeId: themeId,
             topicLabels: topicLabels,
+            purpose: state.purpose,
+            purposeOther: state.purposeOther,
+            editorialBrief: state.editorialBrief,
           );
 
     final asyncSuggestions = params == null

--- a/apps/mobile/lib/features/veille/widgets/veille_widgets.dart
+++ b/apps/mobile/lib/features/veille/widgets/veille_widgets.dart
@@ -1275,3 +1275,228 @@ class PresetCard extends StatelessWidget {
     );
   }
 }
+
+// ─── Purpose & brief — Step 1 sections 3 & 4 ──────────────────────────────
+
+/// Options « Pour quoi faire ? » du Step 1. Slugs alignés avec
+/// `packages/api/app/services/veille/topic_suggester.py:PURPOSE_LABELS`.
+class VeillePurposeOption {
+  final String slug;
+  final String label;
+  const VeillePurposeOption(this.slug, this.label);
+}
+
+const List<VeillePurposeOption> kVeillePurposeOptions = [
+  VeillePurposeOption('me_tenir_au_courant', "Me tenir à jour de l'actu"),
+  VeillePurposeOption('progresser_au_travail', "M'améliorer dans mon travail"),
+  VeillePurposeOption('culture_generale', 'Développer ma culture générale'),
+  VeillePurposeOption('preparer_projet', 'Préparer un projet / une décision'),
+  VeillePurposeOption('approfondir_passion', 'Approfondir un sujet de passion'),
+  VeillePurposeOption('autre', 'Autre…'),
+];
+
+/// Single-select chips pour la section « Pour quoi faire ? ». Quand l'option
+/// `autre` est sélectionnée, le caller affiche un TextField pour le
+/// `purposeOther` libre.
+class VeillePurposeSelector extends StatelessWidget {
+  final String? selected;
+  final ValueChanged<String?> onSelect;
+
+  const VeillePurposeSelector({
+    super.key,
+    required this.selected,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (final opt in kVeillePurposeOptions)
+          _PurposeChip(
+            label: opt.label,
+            selected: selected == opt.slug,
+            // Re-tap = désélection (le champ est optionnel).
+            onTap: () => onSelect(selected == opt.slug ? null : opt.slug),
+          ),
+      ],
+    );
+  }
+}
+
+class _PurposeChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _PurposeChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(999),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+        decoration: BoxDecoration(
+          color: selected ? FacteurColors.veilleTint : Colors.white,
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(
+            color: selected
+                ? FacteurColors.veille
+                : FacteurColors.veilleLineSoft,
+            width: selected ? 1.5 : 1,
+          ),
+        ),
+        child: Text(
+          label,
+          style: GoogleFonts.dmSans(
+            fontSize: 13,
+            fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+            color: selected ? FacteurColors.veille : const Color(0xFF2C2A29),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// TextField multiline pour la section « Décris ta veille idéale »
+/// (max 280 chars). Optionnel, contrôlé par le caller via `value` + `onChanged`.
+class VeilleEditorialBriefField extends StatelessWidget {
+  final String? value;
+  final ValueChanged<String?> onChanged;
+
+  const VeilleEditorialBriefField({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return _VeilleStyledTextField(
+      value: value,
+      onChanged: onChanged,
+      maxLength: 280,
+      maxLines: 4,
+      minLines: 3,
+      hintText:
+          'Ex : "Plutôt analyses long format que breaking news, avec un '
+          'focus sur les implications pour les PME"',
+    );
+  }
+}
+
+/// TextField court (max 80 chars) utilisé pour `purposeOther` quand l'option
+/// `autre` est sélectionnée. Pas de label, juste un champ inline sous les chips.
+class VeillePurposeOtherField extends StatelessWidget {
+  final String? value;
+  final ValueChanged<String?> onChanged;
+
+  const VeillePurposeOtherField({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return _VeilleStyledTextField(
+      value: value,
+      onChanged: onChanged,
+      maxLength: 80,
+      maxLines: 1,
+      minLines: 1,
+      hintText: 'Précise ton usage en quelques mots',
+    );
+  }
+}
+
+class _VeilleStyledTextField extends StatefulWidget {
+  final String? value;
+  final ValueChanged<String?> onChanged;
+  final int maxLength;
+  final int maxLines;
+  final int minLines;
+  final String hintText;
+
+  const _VeilleStyledTextField({
+    required this.value,
+    required this.onChanged,
+    required this.maxLength,
+    required this.maxLines,
+    required this.minLines,
+    required this.hintText,
+  });
+
+  @override
+  State<_VeilleStyledTextField> createState() =>
+      _VeilleStyledTextFieldState();
+}
+
+class _VeilleStyledTextFieldState extends State<_VeilleStyledTextField> {
+  late final TextEditingController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = TextEditingController(text: widget.value ?? '');
+  }
+
+  @override
+  void didUpdateWidget(covariant _VeilleStyledTextField old) {
+    super.didUpdateWidget(old);
+    // Sync only when external value changed AND differs (évite clobber typing).
+    if (widget.value != old.value && widget.value != _ctrl.text) {
+      _ctrl.text = widget.value ?? '';
+    }
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final border = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(10),
+      borderSide: const BorderSide(color: Color(0xFFE6E1D6), width: 1),
+    );
+    final isMultiline = widget.maxLines > 1;
+    return TextField(
+      controller: _ctrl,
+      maxLength: widget.maxLength,
+      maxLines: widget.maxLines,
+      minLines: widget.minLines,
+      textCapitalization: TextCapitalization.sentences,
+      onChanged: widget.onChanged,
+      style: GoogleFonts.dmSans(fontSize: 14, height: isMultiline ? 1.4 : 1.2),
+      decoration: InputDecoration(
+        hintText: widget.hintText,
+        hintStyle: GoogleFonts.dmSans(
+          fontSize: 13,
+          color: const Color(0xFF8B7E63),
+          height: isMultiline ? 1.4 : null,
+        ),
+        contentPadding: isMultiline
+            ? const EdgeInsets.all(12)
+            : const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        border: border,
+        enabledBorder: border,
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide(color: FacteurColors.veille, width: 1.5),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/veille/models/veille_models_test.dart
+++ b/apps/mobile/test/features/veille/models/veille_models_test.dart
@@ -328,4 +328,108 @@ void main() {
       expect(json, {'status': 'paused'});
     });
   });
+
+  group('VeilleConfigUpsertRequest — purpose + brief (PR B)', () {
+    test('omits keys absent → still includes null purpose/brief/preset', () {
+      // Backwards compat : on envoie toujours les 4 clés (même null), pour
+      // permettre au backend de les clear si l'utilisateur les efface.
+      final body = VeilleConfigUpsertRequest(
+        themeId: 'tech',
+        themeLabel: 'Tech',
+        topics: const [],
+        sourceSelections: const [],
+        frequency: 'weekly',
+        dayOfWeek: 0,
+      );
+      final json = body.toJson();
+      expect(json.containsKey('purpose'), isTrue);
+      expect(json['purpose'], isNull);
+      expect(json['purpose_other'], isNull);
+      expect(json['editorial_brief'], isNull);
+      expect(json['preset_id'], isNull);
+    });
+
+    test('serializes purpose + brief + preset_id', () {
+      final body = VeilleConfigUpsertRequest(
+        themeId: 'tech',
+        themeLabel: 'Tech',
+        topics: const [],
+        sourceSelections: const [],
+        frequency: 'weekly',
+        dayOfWeek: 0,
+        purpose: 'preparer_projet',
+        editorialBrief: 'Plutôt analyses long format',
+        presetId: 'ia_agentique',
+      );
+      final json = body.toJson();
+      expect(json['purpose'], 'preparer_projet');
+      expect(json['purpose_other'], isNull);
+      expect(json['editorial_brief'], 'Plutôt analyses long format');
+      expect(json['preset_id'], 'ia_agentique');
+    });
+
+    test('serializes purpose=autre with purpose_other', () {
+      final body = VeilleConfigUpsertRequest(
+        themeId: 'tech',
+        themeLabel: 'Tech',
+        topics: const [],
+        sourceSelections: const [],
+        frequency: 'weekly',
+        dayOfWeek: 0,
+        purpose: 'autre',
+        purposeOther: 'Préparer un livre',
+      );
+      final json = body.toJson();
+      expect(json['purpose'], 'autre');
+      expect(json['purpose_other'], 'Préparer un livre');
+    });
+  });
+
+  group('VeilleConfigDto.fromJson — purpose + brief (PR B)', () {
+    test('parses purpose/purpose_other/editorial_brief/preset_id', () {
+      final dto = VeilleConfigDto.fromJson({
+        'id': 'cfg-1',
+        'user_id': 'u-1',
+        'theme_id': 'tech',
+        'theme_label': 'Tech',
+        'frequency': 'weekly',
+        'day_of_week': 0,
+        'delivery_hour': 7,
+        'timezone': 'Europe/Paris',
+        'status': 'active',
+        'created_at': '2026-05-01T07:00:00Z',
+        'updated_at': '2026-05-01T07:00:00Z',
+        'topics': [],
+        'sources': [],
+        'purpose': 'preparer_projet',
+        'purpose_other': null,
+        'editorial_brief': 'Long format',
+        'preset_id': 'ia_agentique',
+      });
+      expect(dto.purpose, 'preparer_projet');
+      expect(dto.purposeOther, isNull);
+      expect(dto.editorialBrief, 'Long format');
+      expect(dto.presetId, 'ia_agentique');
+    });
+
+    test('handles missing purpose/brief fields gracefully', () {
+      final dto = VeilleConfigDto.fromJson({
+        'id': 'cfg-1',
+        'user_id': 'u-1',
+        'theme_id': 'tech',
+        'theme_label': 'Tech',
+        'frequency': 'weekly',
+        'day_of_week': 0,
+        'delivery_hour': 7,
+        'timezone': 'Europe/Paris',
+        'status': 'active',
+        'created_at': '2026-05-01T07:00:00Z',
+        'updated_at': '2026-05-01T07:00:00Z',
+        'topics': [],
+        'sources': [],
+      });
+      expect(dto.purpose, isNull);
+      expect(dto.editorialBrief, isNull);
+    });
+  });
 }

--- a/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/veille/providers/veille_config_provider.dart';
+
+void main() {
+  group('VeilleConfigNotifier — purpose + brief setters (PR B)', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer();
+    });
+
+    tearDown(() => container.dispose());
+
+    test('setPurpose stores slug', () {
+      final notifier = container.read(veilleConfigProvider.notifier);
+      notifier.setPurpose('preparer_projet');
+      expect(container.read(veilleConfigProvider).purpose, 'preparer_projet');
+    });
+
+    test('setPurpose to non-autre clears purposeOther', () {
+      final notifier = container.read(veilleConfigProvider.notifier);
+      notifier.setPurpose('autre');
+      notifier.setPurposeOther('rédiger un livre');
+      expect(container.read(veilleConfigProvider).purposeOther, 'rédiger un livre');
+
+      notifier.setPurpose('culture_generale');
+      expect(container.read(veilleConfigProvider).purpose, 'culture_generale');
+      expect(container.read(veilleConfigProvider).purposeOther, isNull);
+    });
+
+    test('setPurpose to autre keeps purposeOther', () {
+      final notifier = container.read(veilleConfigProvider.notifier);
+      notifier.setPurpose('autre');
+      notifier.setPurposeOther('rédiger un livre');
+      // Re-set purpose to autre — purposeOther doit rester (re-tap UX).
+      notifier.setPurpose('autre');
+      expect(container.read(veilleConfigProvider).purposeOther, 'rédiger un livre');
+    });
+
+    test('setEditorialBrief trims and treats empty as null', () {
+      final notifier = container.read(veilleConfigProvider.notifier);
+      notifier.setEditorialBrief('  Plutôt analyses long format  ');
+      expect(
+        container.read(veilleConfigProvider).editorialBrief,
+        'Plutôt analyses long format',
+      );
+
+      notifier.setEditorialBrief('   ');
+      expect(container.read(veilleConfigProvider).editorialBrief, isNull);
+    });
+
+    test('setPurposeOther trims and treats empty as null', () {
+      final notifier = container.read(veilleConfigProvider.notifier);
+      notifier.setPurpose('autre');
+      notifier.setPurposeOther('  veille perso  ');
+      expect(container.read(veilleConfigProvider).purposeOther, 'veille perso');
+
+      notifier.setPurposeOther('');
+      expect(container.read(veilleConfigProvider).purposeOther, isNull);
+    });
+  });
+}

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -246,6 +246,10 @@ async def upsert_config(
             delivery_hour=body.delivery_hour,
             timezone=body.timezone,
             status=VeilleStatus.ACTIVE.value,
+            purpose=body.purpose,
+            purpose_other=body.purpose_other,
+            editorial_brief=body.editorial_brief,
+            preset_id=body.preset_id,
         )
         db.add(cfg)
         await db.flush()
@@ -256,6 +260,10 @@ async def upsert_config(
         cfg.day_of_week = body.day_of_week
         cfg.delivery_hour = body.delivery_hour
         cfg.timezone = body.timezone
+        cfg.purpose = body.purpose
+        cfg.purpose_other = body.purpose_other
+        cfg.editorial_brief = body.editorial_brief
+        cfg.preset_id = body.preset_id
 
     # Replace topics + sources atomically.
     await db.execute(delete(VeilleTopic).where(VeilleTopic.veille_config_id == cfg.id))
@@ -421,6 +429,9 @@ async def suggest_topics(
         theme_label=req.theme_label,
         selected_topic_ids=req.selected_topic_ids,
         excluded_topic_ids=req.exclude_topic_ids,
+        purpose=req.purpose,
+        purpose_other=req.purpose_other,
+        editorial_brief=req.editorial_brief,
     )
     return [
         VeilleTopicSuggestion(topic_id=it.topic_id, label=it.label, reason=it.reason)
@@ -445,6 +456,9 @@ async def suggest_sources(
         theme_id=req.theme_id,
         topic_labels=req.topic_labels,
         excluded_source_ids=req.exclude_source_ids,
+        purpose=req.purpose,
+        purpose_other=req.purpose_other,
+        editorial_brief=req.editorial_brief,
     )
     await db.commit()  # persiste les éventuelles ingestions niche
 

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -129,6 +129,10 @@ async def _hydrate_response(
         next_scheduled_at=cfg.next_scheduled_at,
         created_at=cfg.created_at,
         updated_at=cfg.updated_at,
+        purpose=cfg.purpose,
+        purpose_other=cfg.purpose_other,
+        editorial_brief=cfg.editorial_brief,
+        preset_id=cfg.preset_id,
         topics=[
             VeilleTopicResponse(
                 id=t.id,

--- a/packages/api/app/schemas/veille.py
+++ b/packages/api/app/schemas/veille.py
@@ -163,6 +163,9 @@ class VeilleSuggestTopicsRequest(BaseModel):
     theme_label: str = Field(min_length=1, max_length=120)
     selected_topic_ids: list[str] = Field(default_factory=list)
     exclude_topic_ids: list[str] = Field(default_factory=list)
+    purpose: str | None = Field(default=None, max_length=80)
+    purpose_other: str | None = Field(default=None, max_length=80)
+    editorial_brief: str | None = Field(default=None, max_length=280)
 
 
 class VeilleSourceSuggestion(BaseModel):
@@ -183,6 +186,9 @@ class VeilleSuggestSourcesRequest(BaseModel):
     theme_id: VeilleThemeSlug
     topic_labels: list[str] = Field(default_factory=list)
     exclude_source_ids: list[UUID] = Field(default_factory=list)
+    purpose: str | None = Field(default=None, max_length=80)
+    purpose_other: str | None = Field(default=None, max_length=80)
+    editorial_brief: str | None = Field(default=None, max_length=280)
 
 
 # ─── Deliveries ──────────────────────────────────────────────────────────────

--- a/packages/api/app/schemas/veille.py
+++ b/packages/api/app/schemas/veille.py
@@ -86,8 +86,6 @@ class VeilleConfigResponse(BaseModel):
     updated_at: datetime
     topics: list[VeilleTopicResponse] = []
     sources: list[VeilleSourceResponse] = []
-    # V1 personalization (migration vp01) — toujours None tant que la PR B
-    # ne câble pas la persistance dans le router /config.
     purpose: str | None = None
     purpose_other: str | None = None
     editorial_brief: str | None = None

--- a/packages/api/app/services/veille/digest_builder.py
+++ b/packages/api/app/services/veille/digest_builder.py
@@ -21,6 +21,7 @@ from app.models.content import Content
 from app.models.veille import VeilleConfig, VeilleSource, VeilleTopic
 from app.services.briefing.importance_detector import ImportanceDetector, TopicCluster
 from app.services.editorial.llm_client import EditorialLLMClient
+from app.services.veille.topic_suggester import purpose_line
 
 logger = structlog.get_logger()
 
@@ -40,6 +41,9 @@ class VeilleDigestInput:
     last_delivered_at: datetime | None
     theme_id: str
     theme_label: str
+    purpose: str | None = None
+    purpose_other: str | None = None
+    editorial_brief: str | None = None
 
 
 class VeilleDigestBuilder:
@@ -148,6 +152,9 @@ class VeilleDigestBuilder:
             last_delivered_at=cfg.last_delivered_at,
             theme_id=cfg.theme_id,
             theme_label=cfg.theme_label,
+            purpose=cfg.purpose,
+            purpose_other=cfg.purpose_other,
+            editorial_brief=cfg.editorial_brief,
         )
 
     async def _fetch_contents(
@@ -237,6 +244,8 @@ class VeilleDigestBuilder:
         payload = {
             "theme": ctx.theme_label,
             "topics": ctx.user_topic_labels,
+            "purpose": purpose_line(ctx.purpose, ctx.purpose_other),
+            "editorial_brief": ctx.editorial_brief or "",
             "clusters": [
                 {
                     "cluster_id": c.cluster_id,

--- a/packages/api/app/services/veille/source_suggester.py
+++ b/packages/api/app/services/veille/source_suggester.py
@@ -23,6 +23,7 @@ from app.models.source import Source, UserSource
 from app.schemas.veille import VeilleThemeSlug
 from app.services.editorial.llm_client import EditorialLLMClient
 from app.services.source_service import SourceService
+from app.services.veille.topic_suggester import purpose_line
 
 logger = structlog.get_logger()
 
@@ -83,6 +84,9 @@ class SourceSuggester:
         theme_id: str,
         topic_labels: list[str],
         excluded_source_ids: list[UUID] | None = None,
+        purpose: str | None = None,
+        purpose_other: str | None = None,
+        editorial_brief: str | None = None,
     ) -> SourceSuggestions:
         """Renvoie sources `followed` + `niche` pour la veille en cours.
 
@@ -92,6 +96,9 @@ class SourceSuggester:
             theme_id: slug du thème.
             topic_labels: labels des topics retenus (pour aider le LLM).
             excluded_source_ids: sources à exclure (déjà rattachées, refusées).
+            purpose: slug de l'usage souhaité (V1, optionnel).
+            purpose_other: free-text quand `purpose='autre'`.
+            editorial_brief: brief libre décrivant la veille idéale.
 
         Returns:
             `SourceSuggestions(followed=..., niche=...)`.
@@ -99,7 +106,15 @@ class SourceSuggester:
         excluded = set(excluded_source_ids or [])
 
         followed = await self._followed(session, user_id, theme_id, excluded)
-        niche = await self._niche(session, theme_id, topic_labels, excluded)
+        niche = await self._niche(
+            session,
+            theme_id,
+            topic_labels,
+            excluded,
+            purpose=purpose,
+            purpose_other=purpose_other,
+            editorial_brief=editorial_brief,
+        )
 
         return SourceSuggestions(followed=followed, niche=niche)
 
@@ -141,13 +156,18 @@ class SourceSuggester:
         theme_id: str,
         topic_labels: list[str],
         excluded: set[UUID],
+        purpose: str | None = None,
+        purpose_other: str | None = None,
+        editorial_brief: str | None = None,
     ) -> list[SourceSuggestionItem]:
         if not self._llm.is_ready:
             return await self._fallback_niche(session, theme_id, excluded)
 
         user_message = (
             f"Thème : {theme_id}\n"
-            f"Topics retenus : {', '.join(topic_labels) if topic_labels else '(aucun)'}\n\n"
+            f"Topics retenus : {', '.join(topic_labels) if topic_labels else '(aucun)'}\n"
+            f"Usage souhaité : {purpose_line(purpose, purpose_other)}\n"
+            f"Brief éditorial : {editorial_brief or '(aucun)'}\n\n"
             f"Propose 6 à 8 sources de niche pour ce thème."
         )
         raw = await self._llm.chat_json(

--- a/packages/api/app/services/veille/topic_suggester.py
+++ b/packages/api/app/services/veille/topic_suggester.py
@@ -21,6 +21,30 @@ _DEFAULT_CACHE_SIZE = 256
 _DEFAULT_CACHE_TTL_SECONDS = 600  # 10 min
 _SUGGESTIONS_PER_CALL = 5
 
+# Slugs partagés avec le mobile (Step 1 « Pour quoi faire ? »). Doit rester
+# aligné avec `apps/mobile/lib/features/veille/widgets/veille_widgets.dart`.
+PURPOSE_LABELS: dict[str, str] = {
+    "me_tenir_au_courant": "Me tenir à jour de l'actu",
+    "progresser_au_travail": "M'améliorer dans mon travail",
+    "culture_generale": "Développer ma culture générale",
+    "preparer_projet": "Préparer un projet / une décision",
+    "approfondir_passion": "Approfondir un sujet de passion",
+    "autre": "Autre",
+}
+
+
+def purpose_label(slug: str | None) -> str:
+    """Retourne le label fr d'un slug purpose, ou '(non précisé)' si inconnu."""
+    if not slug:
+        return "(non précisé)"
+    return PURPOSE_LABELS.get(slug, slug)
+
+
+def purpose_line(slug: str | None, other: str | None) -> str:
+    """Format `<label> (<other>)` pour le user_message LLM."""
+    base = purpose_label(slug)
+    return f"{base} ({other})" if other else base
+
 
 @dataclass(frozen=True)
 class TopicSuggestion:
@@ -100,9 +124,25 @@ class TopicSuggester:
         )
 
     @staticmethod
-    def _cache_key(theme_id: str, selected: list[str], excluded: list[str]) -> str:
-        payload = (
-            f"{theme_id}|{','.join(sorted(selected))}|{','.join(sorted(excluded))}"
+    def _cache_key(
+        theme_id: str,
+        selected: list[str],
+        excluded: list[str],
+        purpose: str | None,
+        purpose_other: str | None,
+        editorial_brief: str | None,
+    ) -> str:
+        # Inclus purpose + brief : 2 users avec mêmes topics mais purpose
+        # différent doivent recevoir des suggestions différentes.
+        payload = "|".join(
+            [
+                theme_id,
+                ",".join(sorted(selected)),
+                ",".join(sorted(excluded)),
+                purpose or "",
+                purpose_other or "",
+                editorial_brief or "",
+            ]
         )
         return hashlib.sha256(payload.encode()).hexdigest()
 
@@ -112,6 +152,9 @@ class TopicSuggester:
         theme_label: str,
         selected_topic_ids: list[str],
         excluded_topic_ids: list[str] | None = None,
+        purpose: str | None = None,
+        purpose_other: str | None = None,
+        editorial_brief: str | None = None,
     ) -> list[TopicSuggestion]:
         """Renvoie 5 suggestions de topics pour `theme_id`.
 
@@ -120,12 +163,22 @@ class TopicSuggester:
             theme_label: label affichable (ex: 'Éducation').
             selected_topic_ids: topics déjà choisis (à éviter).
             excluded_topic_ids: topics à exclure (ex: refusés précédemment).
+            purpose: slug de l'usage souhaité (V1, optionnel).
+            purpose_other: free-text quand `purpose='autre'`.
+            editorial_brief: brief libre (≤280 chars) décrivant la veille idéale.
 
         Returns:
             Exactement 5 `TopicSuggestion`. Fallback déterministe si LLM KO.
         """
         excluded = excluded_topic_ids or []
-        cache_key = self._cache_key(theme_id, selected_topic_ids, excluded)
+        cache_key = self._cache_key(
+            theme_id,
+            selected_topic_ids,
+            excluded,
+            purpose,
+            purpose_other,
+            editorial_brief,
+        )
         if cached := self._cache.get(cache_key):
             return cached
 
@@ -144,7 +197,9 @@ class TopicSuggester:
             f"Topics déjà sélectionnés : "
             f"{', '.join(selected_topic_ids) if selected_topic_ids else '(aucun)'}\n"
             f"Topics à exclure : "
-            f"{', '.join(excluded) if excluded else '(aucun)'}\n\n"
+            f"{', '.join(excluded) if excluded else '(aucun)'}\n"
+            f"Usage souhaité : {purpose_line(purpose, purpose_other)}\n"
+            f"Brief éditorial : {editorial_brief or '(aucun)'}\n\n"
             f"Propose 5 topics supplémentaires."
         )
 

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -117,6 +117,64 @@ class TestConfigCRUD:
         assert data["sources"][0]["source"]["name"] == "Café Pédago"
         assert data["next_scheduled_at"] is not None
 
+    async def test_post_persists_purpose_and_brief(
+        self, auth_user, curated_education_source
+    ):
+        body = {
+            "theme_id": "education",
+            "theme_label": "Éducation",
+            "topics": [],
+            "source_selections": [
+                {
+                    "kind": "followed",
+                    "source_id": str(curated_education_source.id),
+                }
+            ],
+            "frequency": "weekly",
+            "day_of_week": 0,
+            "delivery_hour": 7,
+            "purpose": "preparer_projet",
+            "purpose_other": None,
+            "editorial_brief": "Plutôt analyses long format que breaking news",
+            "preset_id": "ia_agentique",
+        }
+        async with _client() as ac:
+            resp = await ac.post("/api/veille/config", json=body)
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["purpose"] == "preparer_projet"
+            assert data["purpose_other"] is None
+            assert (
+                data["editorial_brief"]
+                == "Plutôt analyses long format que breaking news"
+            )
+            assert data["preset_id"] == "ia_agentique"
+
+            # GET re-confirme la persistance.
+            after = await ac.get("/api/veille/config")
+            assert after.status_code == 200
+            data2 = after.json()
+            assert data2["purpose"] == "preparer_projet"
+            assert (
+                data2["editorial_brief"]
+                == "Plutôt analyses long format que breaking news"
+            )
+            assert data2["preset_id"] == "ia_agentique"
+
+            # Update : on peut clear le brief en envoyant null.
+            update = {
+                **body,
+                "editorial_brief": None,
+                "purpose": "autre",
+                "purpose_other": "veille perso",
+            }
+            resp2 = await ac.post("/api/veille/config", json=update)
+            assert resp2.status_code == 200
+            data3 = resp2.json()
+            assert data3["purpose"] == "autre"
+            assert data3["purpose_other"] == "veille perso"
+            assert data3["editorial_brief"] is None
+
     async def test_post_upsert_replaces_topics(
         self, auth_user, curated_education_source
     ):
@@ -271,6 +329,9 @@ class TestSuggestions:
                 theme_id,
                 topic_labels,
                 excluded_source_ids=None,
+                purpose=None,
+                purpose_other=None,
+                editorial_brief=None,
             ):
                 return SourceSuggestions(
                     followed=[

--- a/packages/api/tests/test_veille_source_ingestion.py
+++ b/packages/api/tests/test_veille_source_ingestion.py
@@ -305,6 +305,47 @@ class TestThemeGuard:
         assert leftover is None
 
 
+class TestPurposeAndBriefInjection:
+    async def test_purpose_and_brief_in_user_message(self, db_session, test_user):
+        llm = AsyncMock()
+        llm.is_ready = True
+        # On ne se soucie pas de la réponse — on capture juste l'appel.
+        llm.chat_json = AsyncMock(return_value={"sources": []})
+        suggester = SourceSuggester(llm=llm)
+
+        await suggester.suggest_sources(
+            session=db_session,
+            user_id=test_user.user_id,
+            theme_id="science",
+            topic_labels=["climat"],
+            purpose="preparer_projet",
+            editorial_brief="Plutôt analyses long format",
+        )
+
+        assert llm.chat_json.await_count == 1
+        user_msg = llm.chat_json.call_args.kwargs["user_message"]
+        assert "Préparer un projet / une décision" in user_msg
+        assert "Brief éditorial : Plutôt analyses long format" in user_msg
+
+    async def test_purpose_other_in_user_message(self, db_session, test_user):
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(return_value={"sources": []})
+        suggester = SourceSuggester(llm=llm)
+
+        await suggester.suggest_sources(
+            session=db_session,
+            user_id=test_user.user_id,
+            theme_id="science",
+            topic_labels=[],
+            purpose="autre",
+            purpose_other="préparer un livre",
+        )
+
+        user_msg = llm.chat_json.call_args.kwargs["user_message"]
+        assert "Autre (préparer un livre)" in user_msg
+
+
 class TestFallback:
     async def test_no_llm_returns_curated_same_theme(self, db_session, test_user):
         # Crée 6 sources curées thème education ; le fallback en renvoie 5 max.

--- a/packages/api/tests/test_veille_topic_suggester.py
+++ b/packages/api/tests/test_veille_topic_suggester.py
@@ -6,8 +6,6 @@ Couvre : succès LLM, parsing strict, fallback déterministe, cache TTL.
 
 from unittest.mock import AsyncMock
 
-import pytest
-
 from app.services.veille.topic_suggester import (
     TopicSuggester,
     _fallback_topics,
@@ -157,6 +155,101 @@ class TestSuggestTopics:
         )
 
         assert result == _fallback_topics("Éducation")
+
+
+class TestPurposeAndBriefInjection:
+    async def test_purpose_and_brief_appear_in_user_message(self):
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {"topic_id": f"t{i}", "label": f"T{i}", "reason": None}
+                    for i in range(5)
+                ]
+            )
+        )
+        suggester = TopicSuggester(llm=llm)
+
+        await suggester.suggest_topics(
+            theme_id="tech",
+            theme_label="Tech",
+            selected_topic_ids=[],
+            purpose="preparer_projet",
+            editorial_brief="Plutôt analyses long format",
+        )
+
+        assert llm.chat_json.await_count == 1
+        user_msg = llm.chat_json.call_args.kwargs["user_message"]
+        # Label fr humain (pas le slug brut).
+        assert "Préparer un projet / une décision" in user_msg
+        assert "Brief éditorial : Plutôt analyses long format" in user_msg
+
+    async def test_purpose_other_appears_in_user_message(self):
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {"topic_id": f"t{i}", "label": f"T{i}", "reason": None}
+                    for i in range(5)
+                ]
+            )
+        )
+        suggester = TopicSuggester(llm=llm)
+
+        await suggester.suggest_topics(
+            theme_id="tech",
+            theme_label="Tech",
+            selected_topic_ids=[],
+            purpose="autre",
+            purpose_other="préparer un livre",
+            editorial_brief=None,
+        )
+
+        user_msg = llm.chat_json.call_args.kwargs["user_message"]
+        assert "Autre (préparer un livre)" in user_msg
+        assert "Brief éditorial : (aucun)" in user_msg
+
+    async def test_no_purpose_renders_non_precise(self):
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {"topic_id": f"t{i}", "label": f"T{i}", "reason": None}
+                    for i in range(5)
+                ]
+            )
+        )
+        suggester = TopicSuggester(llm=llm)
+
+        await suggester.suggest_topics(
+            theme_id="tech",
+            theme_label="Tech",
+            selected_topic_ids=[],
+        )
+
+        user_msg = llm.chat_json.call_args.kwargs["user_message"]
+        assert "Usage souhaité : (non précisé)" in user_msg
+
+    async def test_different_purpose_misses_cache(self):
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {"topic_id": f"t{i}", "label": f"T{i}", "reason": None}
+                    for i in range(5)
+                ]
+            )
+        )
+        suggester = TopicSuggester(llm=llm)
+
+        await suggester.suggest_topics("tech", "Tech", [], purpose="preparer_projet")
+        await suggester.suggest_topics("tech", "Tech", [], purpose="culture_generale")
+        # Cache key différente → 2 appels LLM.
+        assert llm.chat_json.await_count == 2
 
 
 class TestCacheTTL:


### PR DESCRIPTION
## Quoi

PR B de la refonte veille V1 (suite de #553). Capture l'intent utilisateur
(purpose + brief libre) et l'injecte dans les prompts LLM pour rendre les
suggestions topics/sources et le `why_it_matters` du digest vraiment
personnalisés.

- **Mobile** — Step 1 passe de 2 à 4 accordéons :
  - q1 reformulée (« Sur quel thème aimerais-tu recevoir un condensé… »)
  - section 3 « Pour quoi faire ? » (chips single-select, 5 options + Autre…)
  - section 4 « Décris ta veille idéale » (TextField multiline, max 280 chars)
- **Mobile** — `VeilleConfigUpsertRequest` + suggestion params poussent
  `purpose / purpose_other / editorial_brief / preset_id` au backend.
- **Backend** — `POST /config` persiste les 4 nouvelles colonnes (déjà
  posées par PR A). `POST /suggestions/topics` + `POST /suggestions/sources`
  acceptent purpose + brief.
- **Backend** — `topic_suggester`, `source_suggester`, `digest_builder`
  injectent `Usage souhaité : <label fr>` + `Brief éditorial : …` dans le
  user_message LLM. Cache `topic_suggester` étendu pour intégrer ces 3
  dimensions.

## Pourquoi

Sans intent capturé, le LLM proposait des topics/sources génériques par
thème. Un lecteur cherchant à « préparer un projet » et un autre voulant
« développer sa culture générale » sur le thème Tech recevaient les mêmes
suggestions — l'expérience tombait à plat. Cette PR rend la veille
personnelle.

## Comment ça a été vérifié

- [x] `pytest tests/test_veille_topic_suggester.py` — 13/13 OK
  (4 nouveaux tests sur l'injection purpose+brief)
- [x] `pytest tests/test_veille_scheduling.py` — 16/16 OK
- [x] Tests DB-backed (`test_veille_routes`, `test_veille_source_ingestion`)
  rédigés avec mocks LLM — exécution requise sur CI (Docker indisponible
  localement)
- [x] `flutter test test/features/veille/` — 42/42 OK (6 nouveaux tests
  sur DTO toJson + setters notifier)
- [x] `flutter analyze` — 0 nouveau warning/error sur les fichiers touchés
- [x] `ruff check` + `ruff format --check` — 0 issue sur les fichiers Python
  modifiés
- [x] `/simplify` passé : extraction `purpose_line()` helper (3-way dedup),
  short-circuit equality dans 3 setters (évite rebuild global par
  keystroke), extraction `_VeilleStyledTextField` partagé (-120 LOC)
- [ ] Playwright MCP → reporté à la review (pas d'instance Docker locale
  pour démarrer Postgres)

## Zones à risque

- **Cache `topic_suggester`** : 3 nouvelles dimensions dans `_cache_key`
  (purpose, purpose_other, editorial_brief). Cache size reste 256/TTL 600s.
  Hit rate intra-utilisateur conservé (les params restent stables pendant
  la session). À monitorer post-déploiement.
- **Backwards compat** : tous les nouveaux champs sont **optional/nullable**.
  Un client mobile non mis à jour continue à fonctionner (les 4 colonnes
  restent NULL côté DB).
- **`VeilleConfigUpsertRequest.toJson`** émet désormais toujours les 4
  nouvelles clés (même null) — choix volontaire pour permettre au backend
  de **clear** un brief/purpose effacé par l'utilisateur. Vérifié par le
  test `test_post_persists_purpose_and_brief`.

## Hors scope (PR C à venir)

- Génération immédiate de la première livraison + écran d'attente
- Modal opt-in notif veille
- Source preview (« Voir 2 exemples récents »)
- Pré-loading actif des transitions