### PR TITLE
feat(veille): PR C — génération immédiate + opt-in notif + source preview

### DIFF
--- a/apps/mobile/lib/core/api/notification_preferences_api_service.dart
+++ b/apps/mobile/lib/core/api/notification_preferences_api_service.dart
@@ -38,6 +38,7 @@ class NotificationPreferencesDto {
   final DateTime? lastRenudgeAt;
   final int renudgeShownCount;
   final bool modalSeen;
+  final bool notifVeilleEnabled;
 
   const NotificationPreferencesDto({
     required this.pushEnabled,
@@ -49,6 +50,7 @@ class NotificationPreferencesDto {
     required this.lastRenudgeAt,
     required this.renudgeShownCount,
     required this.modalSeen,
+    required this.notifVeilleEnabled,
   });
 
   factory NotificationPreferencesDto.fromJson(Map<String, dynamic> json) =>
@@ -62,6 +64,7 @@ class NotificationPreferencesDto {
         lastRenudgeAt: _parseDate(json['last_renudge_at']),
         renudgeShownCount: json['renudge_shown_count'] as int? ?? 0,
         modalSeen: json['modal_seen'] as bool? ?? false,
+        notifVeilleEnabled: json['notif_veille_enabled'] as bool? ?? false,
       );
 
   static DateTime? _parseDate(dynamic v) =>
@@ -96,6 +99,7 @@ class NotificationPreferencesApiService {
     DateTime? lastRenudgeAt,
     int? renudgeShownCount,
     bool? modalSeen,
+    bool? notifVeilleEnabled,
   }) async {
     final body = <String, dynamic>{};
     if (pushEnabled != null) body['push_enabled'] = pushEnabled;
@@ -113,6 +117,9 @@ class NotificationPreferencesApiService {
       body['renudge_shown_count'] = renudgeShownCount;
     }
     if (modalSeen != null) body['modal_seen'] = modalSeen;
+    if (notifVeilleEnabled != null) {
+      body['notif_veille_enabled'] = notifVeilleEnabled;
+    }
 
     if (body.isEmpty) return null;
 

--- a/apps/mobile/lib/features/notifications/widgets/notification_activation_modal.dart
+++ b/apps/mobile/lib/features/notifications/widgets/notification_activation_modal.dart
@@ -10,14 +10,31 @@ import 'preset_selector.dart';
 import 'time_slot_selector.dart';
 
 /// Trigger d'affichage de la modal — utilisé pour l'event tracking.
-enum ActivationTrigger { onboarding, update, renudge }
+///
+/// `veille` est un canal opt-in distinct du digest principal : titre/bullets/
+/// CTA dédiés, sections preset/time-slot/good-news masquées, et appel à
+/// `setNotifVeilleEnabled` au lieu de `confirmActivation`.
+enum ActivationTrigger { onboarding, update, renudge, veille }
 
 /// Affiche la modal d'activation comme dialogue flottant translucide.
+///
+/// Pour `ActivationTrigger.veille`, si l'OS-level push est déjà accordé
+/// (`pushEnabled == true`), on skip la modal et on opt-in directement —
+/// inutile de redemander une permission déjà donnée.
 Future<void> showNotificationActivationModal(
   BuildContext context,
   WidgetRef ref, {
   required ActivationTrigger trigger,
-}) {
+}) async {
+  if (trigger == ActivationTrigger.veille) {
+    final settings = ref.read(notificationsSettingsProvider);
+    if (settings.pushEnabled) {
+      await ref
+          .read(notificationsSettingsProvider.notifier)
+          .setNotifVeilleEnabled(true);
+      return;
+    }
+  }
   return showDialog<void>(
     context: context,
     barrierDismissible: false,
@@ -84,24 +101,32 @@ class _NotificationActivationModalState
       await PushNotificationService().requestExactAlarmPermission();
     }
 
-    await notifier.confirmActivation(
-      preset: _preset,
-      timeSlot: _timeSlot,
-      osGranted: granted,
-    );
-
-    if (_goodNewsEnabled) {
-      await notifier.confirmGoodNewsActivation(
-        timeSlot: _goodNewsTimeSlot,
+    if (widget.trigger == ActivationTrigger.veille) {
+      // Canal séparé du digest — on n'écrit jamais `confirmActivation` ici
+      // pour ne pas activer le digest sans consentement explicite.
+      if (granted) {
+        await notifier.setNotifVeilleEnabled(true);
+      }
+    } else {
+      await notifier.confirmActivation(
+        preset: _preset,
+        timeSlot: _timeSlot,
         osGranted: granted,
       );
-    }
 
-    analytics.trackModalNotifConfirmed(
-      preset: _preset,
-      timeSlot: _timeSlot,
-      osPermissionGranted: granted,
-    );
+      if (_goodNewsEnabled) {
+        await notifier.confirmGoodNewsActivation(
+          timeSlot: _goodNewsTimeSlot,
+          osGranted: granted,
+        );
+      }
+
+      analytics.trackModalNotifConfirmed(
+        preset: _preset,
+        timeSlot: _timeSlot,
+        osPermissionGranted: granted,
+      );
+    }
 
     if (!mounted) return;
     Navigator.of(context).pop();
@@ -133,6 +158,7 @@ class _NotificationActivationModalState
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final theme = Theme.of(context);
+    final isVeille = widget.trigger == ActivationTrigger.veille;
 
     return Material(
       color: colors.backgroundPrimary,
@@ -154,7 +180,9 @@ class _NotificationActivationModalState
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                "Mieux s'informer, à son rythme",
+                isVeille
+                    ? 'Te prévenir quand ta veille est prête ?'
+                    : "Mieux s'informer, à son rythme",
                 style: theme.textTheme.displaySmall
                     ?.copyWith(fontWeight: FontWeight.bold),
                 textAlign: TextAlign.center,
@@ -168,67 +196,82 @@ class _NotificationActivationModalState
                 ),
               ),
               const SizedBox(height: FacteurSpacing.space3),
-              Text(
-                "Du mal à suivre l'essentiel ?",
-                style: theme.textTheme.bodyMedium
-                    ?.copyWith(color: colors.textSecondary),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: FacteurSpacing.space4),
-              _BulletPoint(
-                text: "Un message par jour, à l'heure que tu préfères.",
-              ),
-              const SizedBox(height: FacteurSpacing.space2),
-              _BulletPoint(
-                text: "Pas de breaking news, pas de scroll inutile.",
-              ),
-              const SizedBox(height: FacteurSpacing.space2),
-              _BulletPoint(
-                text: "L'essentiel filtré pour toi, quand tu veux le recevoir.",
-              ),
-              const SizedBox(height: FacteurSpacing.space4),
-              Text(
-                "Un exemple de ce que Facteur t'envoie :",
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: colors.textSecondary,
-                  fontStyle: FontStyle.italic,
+              if (!isVeille) ...[
+                Text(
+                  "Du mal à suivre l'essentiel ?",
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: colors.textSecondary),
+                  textAlign: TextAlign.center,
                 ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: FacteurSpacing.space2),
-              _NotificationPreview(timeSlot: _timeSlot),
-              const SizedBox(height: FacteurSpacing.space6),
-              const _SectionHeader(label: 'Définis ton rythme'),
-              const SizedBox(height: FacteurSpacing.space3),
-              PresetSelector(
-                value: _preset,
-                onChanged: (p) {
-                  setState(() => _preset = p);
-                  ref
-                      .read(analyticsServiceProvider)
-                      .trackModalNotifPresetChanged(preset: p);
-                },
-              ),
-              const SizedBox(height: FacteurSpacing.space4),
-              const _SectionHeader(label: 'À quel moment ?'),
-              const SizedBox(height: FacteurSpacing.space3),
-              TimeSlotSelector(
-                value: _timeSlot,
-                onChanged: (s) {
-                  setState(() => _timeSlot = s);
-                  ref
-                      .read(analyticsServiceProvider)
-                      .trackModalNotifTimeChanged(timeSlot: s);
-                },
-              ),
-              const SizedBox(height: FacteurSpacing.space6),
-              _GoodNewsSection(
-                enabled: _goodNewsEnabled,
-                timeSlot: _goodNewsTimeSlot,
-                onToggle: (v) => setState(() => _goodNewsEnabled = v),
-                onTimeSlotChanged: (s) =>
-                    setState(() => _goodNewsTimeSlot = s),
-              ),
+                const SizedBox(height: FacteurSpacing.space4),
+                _BulletPoint(
+                  text: "Un message par jour, à l'heure que tu préfères.",
+                ),
+                const SizedBox(height: FacteurSpacing.space2),
+                _BulletPoint(
+                  text: "Pas de breaking news, pas de scroll inutile.",
+                ),
+                const SizedBox(height: FacteurSpacing.space2),
+                _BulletPoint(
+                  text:
+                      "L'essentiel filtré pour toi, quand tu veux le recevoir.",
+                ),
+                const SizedBox(height: FacteurSpacing.space4),
+                Text(
+                  "Un exemple de ce que Facteur t'envoie :",
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colors.textSecondary,
+                    fontStyle: FontStyle.italic,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: FacteurSpacing.space2),
+                _NotificationPreview(timeSlot: _timeSlot),
+                const SizedBox(height: FacteurSpacing.space6),
+                const _SectionHeader(label: 'Définis ton rythme'),
+                const SizedBox(height: FacteurSpacing.space3),
+                PresetSelector(
+                  value: _preset,
+                  onChanged: (p) {
+                    setState(() => _preset = p);
+                    ref
+                        .read(analyticsServiceProvider)
+                        .trackModalNotifPresetChanged(preset: p);
+                  },
+                ),
+                const SizedBox(height: FacteurSpacing.space4),
+                const _SectionHeader(label: 'À quel moment ?'),
+                const SizedBox(height: FacteurSpacing.space3),
+                TimeSlotSelector(
+                  value: _timeSlot,
+                  onChanged: (s) {
+                    setState(() => _timeSlot = s);
+                    ref
+                        .read(analyticsServiceProvider)
+                        .trackModalNotifTimeChanged(timeSlot: s);
+                  },
+                ),
+                const SizedBox(height: FacteurSpacing.space6),
+                _GoodNewsSection(
+                  enabled: _goodNewsEnabled,
+                  timeSlot: _goodNewsTimeSlot,
+                  onToggle: (v) => setState(() => _goodNewsEnabled = v),
+                  onTimeSlotChanged: (s) =>
+                      setState(() => _goodNewsTimeSlot = s),
+                ),
+              ] else ...[
+                _BulletPoint(
+                  text: 'Notif quand ton digest est livré.',
+                ),
+                const SizedBox(height: FacteurSpacing.space2),
+                _BulletPoint(
+                  text: "Pas de spam, juste l'arrivée du courrier.",
+                ),
+                const SizedBox(height: FacteurSpacing.space2),
+                _BulletPoint(
+                  text: 'Activable/désactivable à tout moment.',
+                ),
+              ],
               const SizedBox(height: FacteurSpacing.space6),
               SizedBox(
                 height: 48,
@@ -240,9 +283,12 @@ class _NotificationActivationModalState
                       borderRadius: BorderRadius.circular(FacteurRadius.large),
                     ),
                   ),
-                  child: const Text(
-                    'Activer ton Facteur',
-                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                  child: Text(
+                    isVeille ? "M'en informer" : 'Activer ton Facteur',
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 ),
               ),

--- a/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
+++ b/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
@@ -22,6 +22,7 @@ class NotificationsSettings {
   final bool emailDigestEnabled;
   final bool goodNewsEnabled;
   final NotifTimeSlot goodNewsTimeSlot;
+  final bool notifVeilleEnabled;
 
   /// True dès que la phase load Hive + sync backend (succès OU échec) est
   /// terminée. Tant que false, ne pas déclencher la modal d'activation
@@ -40,6 +41,7 @@ class NotificationsSettings {
     this.emailDigestEnabled = false,
     this.goodNewsEnabled = false,
     this.goodNewsTimeSlot = NotifTimeSlot.evening,
+    this.notifVeilleEnabled = false,
     this.synced = false,
   });
 
@@ -55,6 +57,7 @@ class NotificationsSettings {
     bool? emailDigestEnabled,
     bool? goodNewsEnabled,
     NotifTimeSlot? goodNewsTimeSlot,
+    bool? notifVeilleEnabled,
     bool? synced,
   }) {
     return NotificationsSettings(
@@ -69,6 +72,7 @@ class NotificationsSettings {
       emailDigestEnabled: emailDigestEnabled ?? this.emailDigestEnabled,
       goodNewsEnabled: goodNewsEnabled ?? this.goodNewsEnabled,
       goodNewsTimeSlot: goodNewsTimeSlot ?? this.goodNewsTimeSlot,
+      notifVeilleEnabled: notifVeilleEnabled ?? this.notifVeilleEnabled,
       synced: synced ?? this.synced,
     );
   }
@@ -107,6 +111,7 @@ class NotificationsSettingsNotifier
   static const _kPendingSync = 'notif_prefs_pending_sync';
   static const _kGoodNewsEnabled = 'notif_good_news_enabled';
   static const _kGoodNewsTimeSlot = 'notif_good_news_time_slot';
+  static const _kNotifVeilleEnabled = 'notif_veille_enabled';
 
   Future<Box<dynamic>> _box() => Hive.openBox<dynamic>(_boxName);
 
@@ -128,6 +133,8 @@ class NotificationsSettingsNotifier
       goodNewsTimeSlot: NotifTimeSlotX.fromWire(
         box.get(_kGoodNewsTimeSlot) as String?,
       ),
+      notifVeilleEnabled:
+          box.get(_kNotifVeilleEnabled, defaultValue: false) as bool,
     );
   }
 
@@ -150,6 +157,7 @@ class NotificationsSettingsNotifier
       _kEmailDigest: s.emailDigestEnabled,
       _kGoodNewsEnabled: s.goodNewsEnabled,
       _kGoodNewsTimeSlot: s.goodNewsTimeSlot.wire,
+      _kNotifVeilleEnabled: s.notifVeilleEnabled,
     });
   }
 
@@ -168,6 +176,7 @@ class NotificationsSettingsNotifier
         lastRefusalAt: dto.lastRefusalAt,
         lastRenudgeAt: dto.lastRenudgeAt,
         renudgeShownCount: dto.renudgeShownCount,
+        notifVeilleEnabled: dto.notifVeilleEnabled,
       );
       state = fresh;
       await _persist(fresh);
@@ -198,6 +207,7 @@ class NotificationsSettingsNotifier
         lastRefusalAt: s.lastRefusalAt,
         lastRenudgeAt: s.lastRenudgeAt,
         renudgeShownCount: s.renudgeShownCount,
+        notifVeilleEnabled: s.notifVeilleEnabled,
       );
       if (result == null) {
         final box = await _box();
@@ -324,6 +334,21 @@ class NotificationsSettingsNotifier
       goodNewsEnabled: osGranted,
       goodNewsTimeSlot: timeSlot,
     ));
+  }
+
+  /// Active/désactive la notif "Ta veille est prête".
+  ///
+  /// Canal séparé du push digest et bonnes nouvelles : on ne couple jamais
+  /// deux opt-ins. À la première activation, demande la permission OS si
+  /// pas déjà accordée.
+  Future<void> setNotifVeilleEnabled(bool value) async {
+    if (value && !state.pushEnabled) {
+      final pushService = PushNotificationService();
+      final granted = await pushService.requestPermission();
+      if (!granted) return;
+      await pushService.requestExactAlarmPermission();
+    }
+    await _commit(state.copyWith(notifVeilleEnabled: value));
   }
 }
 

--- a/apps/mobile/lib/features/veille/models/veille_delivery.dart
+++ b/apps/mobile/lib/features/veille/models/veille_delivery.dart
@@ -164,3 +164,47 @@ class VeilleDeliveryResponse {
     );
   }
 }
+
+@immutable
+class VeilleGenerateFirstResponse {
+  final String deliveryId;
+  final int estimatedSeconds;
+
+  const VeilleGenerateFirstResponse({
+    required this.deliveryId,
+    required this.estimatedSeconds,
+  });
+
+  factory VeilleGenerateFirstResponse.fromJson(Map<String, dynamic> json) {
+    return VeilleGenerateFirstResponse(
+      deliveryId: json['delivery_id'] as String,
+      estimatedSeconds: (json['estimated_seconds'] as num?)?.toInt() ?? 60,
+    );
+  }
+}
+
+@immutable
+class VeilleSourceExample {
+  final String title;
+  final String url;
+  final DateTime? publishedAt;
+  final String excerpt;
+
+  const VeilleSourceExample({
+    required this.title,
+    required this.url,
+    required this.publishedAt,
+    required this.excerpt,
+  });
+
+  factory VeilleSourceExample.fromJson(Map<String, dynamic> json) {
+    return VeilleSourceExample(
+      title: json['title'] as String,
+      url: json['url'] as String,
+      publishedAt: json['published_at'] != null
+          ? DateTime.parse(json['published_at'] as String)
+          : null,
+      excerpt: (json['excerpt'] as String?) ?? '',
+    );
+  }
+}

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -461,6 +461,31 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     }
   }
 
+  /// Soumet la config puis lance la génération immédiate du premier digest.
+  /// Renvoie le `delivery_id` à poll côté UI. Si une livraison existe déjà
+  /// (403 — anti-doublon backend), on récupère la dernière via
+  /// `listDeliveries` plutôt que de remonter une erreur.
+  Future<String?> submitAndGenerateFirst() async {
+    await submit();
+    final repo = _ref.read(veilleRepositoryProvider);
+    try {
+      final res = await repo.generateFirstDelivery();
+      return res.deliveryId;
+    } on VeilleApiException catch (e) {
+      if (e.statusCode == 403) {
+        final list = await repo.listDeliveries(limit: 1);
+        return list.isEmpty ? null : list.first.id;
+      }
+      rethrow;
+    }
+  }
+
+  /// Affiche/masque le loading screen `from=4` (post-submit, en attente de la
+  /// première livraison). `null` = sortir du loading.
+  void setLoadingFrom(int? from) {
+    state = state.copyWith(loadingFrom: from);
+  }
+
   /// Affiche l'écran preview pré-set (Step 1.5). Le step courant reste à 1
   /// sous le capot — le screen orchestrator détecte `previewPresetId != null`.
   void openPresetPreview(String presetSlug) {

--- a/apps/mobile/lib/features/veille/providers/veille_source_examples_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_source_examples_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/veille_delivery.dart';
+import 'veille_repository_provider.dart';
+
+/// Renvoie ≤2 exemples d'articles récents pour une source donnée — Step 3
+/// du flow (preview inline). `autoDispose` car éphémère par expand.
+final veilleSourceExamplesProvider = FutureProvider.autoDispose
+    .family<List<VeilleSourceExample>, String>((ref, sourceId) async {
+  final repo = ref.read(veilleRepositoryProvider);
+  return repo.getSourceExamples(sourceId);
+});

--- a/apps/mobile/lib/features/veille/repositories/veille_repository.dart
+++ b/apps/mobile/lib/features/veille/repositories/veille_repository.dart
@@ -173,6 +173,38 @@ class VeilleRepository {
     }
   }
 
+  /// Lance la génération immédiate du premier digest. 202 → on poll
+  /// `getDelivery(deliveryId)`. 403 si déjà générée → caller décide quoi faire.
+  Future<VeilleGenerateFirstResponse> generateFirstDelivery() async {
+    try {
+      final response = await _dio.post<dynamic>(
+        'veille/deliveries/generate-first',
+      );
+      return VeilleGenerateFirstResponse.fromJson(
+        response.data as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw _wrap(e);
+    }
+  }
+
+  /// `GET /api/veille/sources/{id}/examples` — preview ≤2 articles récents
+  /// (Step 3 du flow). Le backend cache déjà 24 h ; ici pas de cache local.
+  Future<List<VeilleSourceExample>> getSourceExamples(String sourceId) async {
+    try {
+      final response = await _dio.get<dynamic>(
+        'veille/sources/$sourceId/examples',
+      );
+      final raw = response.data as List<dynamic>;
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleSourceExample.fromJson)
+          .toList();
+    } on DioException catch (e) {
+      throw _wrap(e);
+    }
+  }
+
   VeilleApiException _wrap(DioException e) {
     final code = e.response?.statusCode;
     final detail = e.response?.data is Map

--- a/apps/mobile/lib/features/veille/screens/transitions/flow_loading_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/transitions/flow_loading_screen.dart
@@ -1,17 +1,36 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../../config/theme.dart';
+import '../../providers/veille_suggestions_provider.dart';
 import '../../widgets/halo_loader.dart';
 import '../../widgets/veille_widgets.dart';
 
-class FlowLoadingScreen extends StatelessWidget {
-  /// `from` = étape qu'on quitte (1, 2 ou 3).
+class FlowLoadingScreen extends ConsumerStatefulWidget {
+  /// `from` = étape qu'on quitte (1, 2, 3) ou 4 = première livraison.
   final int from;
-  const FlowLoadingScreen({super.key, required this.from});
 
-  static const _labels = {
+  /// Pré-loading actif de l'étape suivante : si fourni, déclenche un fetch
+  /// en arrière-plan dès l'affichage du loading pour que l'écran cible soit
+  /// prêt à la fin de l'animation.
+  final VeilleTopicsSuggestionParams? topicsParams;
+  final VeilleSourcesSuggestionParams? sourcesParams;
+
+  const FlowLoadingScreen({
+    super.key,
+    required this.from,
+    this.topicsParams,
+    this.sourcesParams,
+  });
+
+  @override
+  ConsumerState<FlowLoadingScreen> createState() => _FlowLoadingScreenState();
+}
+
+class _FlowLoadingScreenState extends ConsumerState<FlowLoadingScreen> {
+  static const _labels = <int, _LoadingLabels>{
     1: _LoadingLabels(
       eyebrow: 'Le facteur écoute…',
       h: 'Analyse de ton thème',
@@ -48,11 +67,39 @@ class FlowLoadingScreen extends StatelessWidget {
         _Check.todo('Justifications & biais'),
       ],
     ),
+    4: _LoadingLabels(
+      eyebrow: 'Le facteur prépare ta première livraison…',
+      h: 'Première veille en cours',
+      s:
+          'Quelques secondes pour rassembler les articles, justifier les angles et préparer la livraison.',
+      checks: [
+        _Check.done('Sources interrogées'),
+        _Check.done('Articles collectés'),
+        _Check.running('Sélection éditoriale…'),
+        _Check.todo('Mise en forme finale'),
+      ],
+    ),
   };
 
   @override
+  void initState() {
+    super.initState();
+    // Pré-loading actif : best-effort, on ignore silencieusement si
+    // les params ne sont pas fournis (ex : appelant qui n'utilise pas
+    // les suggestions ou qui veut juste l'animation cosmétique).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (widget.topicsParams != null) {
+        ref.read(veilleTopicSuggestionsProvider(widget.topicsParams!));
+      }
+      if (widget.sourcesParams != null) {
+        ref.read(veilleSourceSuggestionsProvider(widget.sourcesParams!));
+      }
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final cur = _labels[from] ?? _labels[1]!;
+    final cur = _labels[widget.from] ?? _labels[1]!;
     return Column(
       children: [
         // Header simplifié (pills uniquement, pas de back/close — le loading
@@ -67,7 +114,7 @@ class FlowLoadingScreen extends StatelessWidget {
                 child: Row(
                   children: List.generate(4, (i) {
                     final n = i + 1;
-                    final done = n <= from;
+                    final done = n <= widget.from;
                     return Expanded(
                       child: Container(
                         margin: EdgeInsets.only(right: i == 3 ? 0 : 5),

--- a/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
@@ -1,11 +1,16 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../config/routes.dart';
 import '../../../config/theme.dart';
+import '../../notifications/widgets/notification_activation_modal.dart';
+import '../models/veille_delivery.dart';
 import '../providers/veille_active_config_provider.dart';
 import '../providers/veille_config_provider.dart';
+import '../providers/veille_repository_provider.dart';
 import '../repositories/veille_repository.dart';
 import 'steps/step1_5_preset_preview_screen.dart';
 import 'steps/step1_theme_screen.dart';
@@ -49,7 +54,30 @@ class VeilleConfigScreen extends ConsumerWidget {
 
     Future<void> handleSubmit() async {
       try {
-        await notifier.submit();
+        final deliveryId = await notifier.submitAndGenerateFirst();
+        if (!context.mounted) return;
+        notifier.setLoadingFrom(4);
+
+        // Délai 1 s pour laisser le loading screen apparaître avant la modal,
+        // sinon la modal flashe par-dessus la transition AnimatedSwitcher.
+        unawaited(Future<void>.delayed(const Duration(seconds: 1), () async {
+          if (!context.mounted) return;
+          await showNotificationActivationModal(
+            context,
+            ref,
+            trigger: ActivationTrigger.veille,
+          );
+        }));
+
+        if (deliveryId != null) {
+          await _pollFirstDelivery(
+            context: context,
+            ref: ref,
+            deliveryId: deliveryId,
+            onTimeoutMessage:
+                "On t'enverra une notif quand ta veille est prête.",
+          );
+        }
         if (!context.mounted) return;
         context.go(RoutePaths.veilleDashboard);
       } on VeilleApiException catch (e) {
@@ -70,6 +98,8 @@ class VeilleConfigScreen extends ConsumerWidget {
             ),
           ),
         );
+      } finally {
+        if (context.mounted) notifier.setLoadingFrom(null);
       }
     }
 
@@ -120,5 +150,59 @@ class VeilleConfigScreen extends ConsumerWidget {
         ),
       ),
     );
+  }
+}
+
+/// Poll `/deliveries/{id}` jusqu'à `succeeded` (succès) ou 90 s écoulées.
+/// Backoff 2 s pendant les 20 premières secondes (≈ p50 de la génération),
+/// puis 5 s ensuite — l'objectif est de limiter la charge serveur quand le
+/// volume utilisateur scalera. Renvoie quand le poll s'arrête (état terminal,
+/// timeout ou widget unmount). Affiche un snackbar en cas de timeout.
+Future<void> _pollFirstDelivery({
+  required BuildContext context,
+  required WidgetRef ref,
+  required String deliveryId,
+  required String onTimeoutMessage,
+}) async {
+  const totalBudget = Duration(seconds: 90);
+  const fastInterval = Duration(seconds: 2);
+  const slowInterval = Duration(seconds: 5);
+  const fastWindow = Duration(seconds: 20);
+
+  final repo = ref.read(veilleRepositoryProvider);
+  final start = DateTime.now();
+
+  while (true) {
+    if (!context.mounted) return;
+    final elapsed = DateTime.now().difference(start);
+    if (elapsed >= totalBudget) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(onTimeoutMessage)),
+      );
+      return;
+    }
+
+    try {
+      final delivery = await repo.getDelivery(deliveryId);
+      if (delivery.generationState == VeilleGenerationState.succeeded) {
+        return;
+      }
+      if (delivery.generationState == VeilleGenerationState.failed) {
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'La génération a échoué. On retentera à la prochaine livraison.',
+            ),
+          ),
+        );
+        return;
+      }
+    } on VeilleApiException {
+      // Erreur transitoire — on continue à poll, le timeout protégera.
+    }
+
+    final next = elapsed < fastWindow ? fastInterval : slowInterval;
+    await Future<void>.delayed(next);
   }
 }

--- a/apps/mobile/lib/features/veille/widgets/veille_source_card.dart
+++ b/apps/mobile/lib/features/veille/widgets/veille_source_card.dart
@@ -1,15 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:timeago/timeago.dart' as timeago;
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../../config/theme.dart';
 import '../../sources/widgets/source_detail_modal.dart';
 import '../../sources/widgets/source_logo_avatar.dart';
 import '../models/veille_config.dart';
+import '../models/veille_delivery.dart';
+import '../providers/veille_source_examples_provider.dart';
 
 /// Carte source pour le flow Veille — palette sépia, logo réel,
 /// CTA "Suivre/Suivi" unifié, tap → SourceDetailModal en consultation.
-class VeilleSourceCard extends StatelessWidget {
+/// Footer expansible "Voir 2 exemples récents" qui charge à la demande
+/// les derniers articles de la source via [veilleSourceExamplesProvider].
+class VeilleSourceCard extends ConsumerStatefulWidget {
   final VeilleSource source;
   final bool inVeille;
   final bool isNiche;
@@ -24,12 +31,24 @@ class VeilleSourceCard extends StatelessWidget {
   });
 
   @override
+  ConsumerState<VeilleSourceCard> createState() => _VeilleSourceCardState();
+}
+
+class _VeilleSourceCardState extends ConsumerState<VeilleSourceCard> {
+  bool _expanded = false;
+
+  void _toggleExpanded() {
+    setState(() => _expanded = !_expanded);
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final source = widget.source;
     final catalogSource = source.toCatalogSource();
-    final showBiasDot = source.biasStance != 'unknown' &&
-        source.biasStance != 'neutral';
+    final showBiasDot =
+        source.biasStance != 'unknown' && source.biasStance != 'neutral';
     return Material(
-      color: inVeille ? FacteurColors.veilleTint : Colors.white,
+      color: widget.inVeille ? FacteurColors.veilleTint : Colors.white,
       borderRadius: BorderRadius.circular(12),
       child: InkWell(
         onTap: () => showModalBottomSheet<void>(
@@ -47,107 +66,306 @@ class VeilleSourceCard extends StatelessWidget {
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(12),
             border: Border.all(
-              color: inVeille
+              color: widget.inVeille
                   ? FacteurColors.veille
-                  : (isNiche
+                  : (widget.isNiche
                       ? FacteurColors.veilleLine
                       : FacteurColors.veilleLineSoft),
               width: 1.5,
             ),
           ),
-          child: Row(
+          child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              SourceLogoAvatar(
-                source: catalogSource,
-                size: 36,
-                radius: 8,
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SourceLogoAvatar(
+                    source: catalogSource,
+                    size: 36,
+                    radius: 8,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Flexible(
-                          child: Text(
-                            source.name,
-                            style: GoogleFonts.dmSans(
-                              fontSize: 13.5,
-                              fontWeight: FontWeight.w600,
-                              height: 1.3,
-                              color: const Color(0xFF2C2A29),
+                        Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                source.name,
+                                style: GoogleFonts.dmSans(
+                                  fontSize: 13.5,
+                                  fontWeight: FontWeight.w600,
+                                  height: 1.3,
+                                  color: const Color(0xFF2C2A29),
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
                             ),
-                            maxLines: 1,
+                            if (showBiasDot) ...[
+                              const SizedBox(width: 6),
+                              Container(
+                                width: 7,
+                                height: 7,
+                                decoration: BoxDecoration(
+                                  color: catalogSource.getBiasColor(),
+                                  shape: BoxShape.circle,
+                                ),
+                              ),
+                            ],
+                            if (!widget.isNiche) ...[
+                              const SizedBox(width: 6),
+                              const _SuivieStamp(),
+                            ],
+                          ],
+                        ),
+                        if (source.editorialMeta != null) ...[
+                          const SizedBox(height: 2),
+                          Text(
+                            source.editorialMeta!,
+                            style: GoogleFonts.dmSans(
+                              fontSize: 11.5,
+                              height: 1.35,
+                              color: const Color(0xFF959392),
+                            ),
+                            maxLines: 2,
                             overflow: TextOverflow.ellipsis,
                           ),
-                        ),
-                        if (showBiasDot) ...[
-                          const SizedBox(width: 6),
-                          Container(
-                            width: 7,
-                            height: 7,
-                            decoration: BoxDecoration(
-                              color: catalogSource.getBiasColor(),
-                              shape: BoxShape.circle,
-                            ),
-                          ),
                         ],
-                        if (!isNiche) ...[
-                          const SizedBox(width: 6),
-                          const _SuivieStamp(),
+                        if (widget.isNiche && source.why != null) ...[
+                          const SizedBox(height: 4),
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(top: 2),
+                                child: Icon(
+                                  PhosphorIcons.sparkle(),
+                                  size: 10,
+                                  color: FacteurColors.veille,
+                                ),
+                              ),
+                              const SizedBox(width: 4),
+                              Expanded(
+                                child: Text(
+                                  source.why!,
+                                  style: GoogleFonts.dmSans(
+                                    fontSize: 11.5,
+                                    fontStyle: FontStyle.italic,
+                                    height: 1.4,
+                                    color: FacteurColors.veille,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
                         ],
                       ],
                     ),
-                    if (source.editorialMeta != null) ...[
-                      const SizedBox(height: 2),
-                      Text(
-                        source.editorialMeta!,
-                        style: GoogleFonts.dmSans(
-                          fontSize: 11.5,
-                          height: 1.35,
-                          color: const Color(0xFF959392),
-                        ),
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
-                    if (isNiche && source.why != null) ...[
-                      const SizedBox(height: 4),
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Padding(
-                            padding: const EdgeInsets.only(top: 2),
-                            child: Icon(
-                              PhosphorIcons.sparkle(),
-                              size: 10,
-                              color: FacteurColors.veille,
-                            ),
-                          ),
-                          const SizedBox(width: 4),
-                          Expanded(
-                            child: Text(
-                              source.why!,
-                              style: GoogleFonts.dmSans(
-                                fontSize: 11.5,
-                                fontStyle: FontStyle.italic,
-                                height: 1.4,
-                                color: FacteurColors.veille,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ],
-                ),
+                  ),
+                  const SizedBox(width: 8),
+                  _FollowButton(
+                    active: widget.inVeille,
+                    onTap: widget.onToggle,
+                  ),
+                ],
               ),
-              const SizedBox(width: 8),
-              _FollowButton(active: inVeille, onTap: onToggle),
+              const SizedBox(height: 10),
+              _ExamplesToggle(
+                expanded: _expanded,
+                onTap: _toggleExpanded,
+              ),
+              AnimatedSize(
+                duration: const Duration(milliseconds: 220),
+                curve: Curves.easeOut,
+                alignment: Alignment.topCenter,
+                child: _expanded
+                    ? Padding(
+                        padding: const EdgeInsets.only(top: 8),
+                        child: _ExamplesPanel(sourceId: source.id),
+                      )
+                    : const SizedBox.shrink(),
+              ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ExamplesToggle extends StatelessWidget {
+  final bool expanded;
+  final VoidCallback onTap;
+  const _ExamplesToggle({required this.expanded, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+        child: Row(
+          children: [
+            Icon(
+              PhosphorIcons.arrowSquareOut(),
+              size: 12,
+              color: const Color(0xFF5D5B5A),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              'Voir 2 exemples récents',
+              style: GoogleFonts.dmSans(
+                fontSize: 11.5,
+                fontWeight: FontWeight.w600,
+                color: const Color(0xFF5D5B5A),
+              ),
+            ),
+            const Spacer(),
+            Icon(
+              expanded
+                  ? PhosphorIcons.caretUp()
+                  : PhosphorIcons.caretDown(),
+              size: 12,
+              color: const Color(0xFF5D5B5A),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ExamplesPanel extends ConsumerWidget {
+  final String sourceId;
+  const _ExamplesPanel({required this.sourceId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(veilleSourceExamplesProvider(sourceId));
+    return async.when(
+      loading: () => const Column(
+        children: [
+          _ExampleSkeleton(),
+          SizedBox(height: 6),
+          _ExampleSkeleton(),
+        ],
+      ),
+      error: (_, __) => const _ExamplesEmpty(),
+      data: (items) {
+        if (items.isEmpty) return const _ExamplesEmpty();
+        return Column(
+          children: [
+            for (int i = 0; i < items.length; i++) ...[
+              if (i > 0) const SizedBox(height: 6),
+              _ExampleRow(item: items[i]),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ExampleRow extends StatelessWidget {
+  final VeilleSourceExample item;
+  const _ExampleRow({required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    final dateLabel = _formatRelative(item.publishedAt);
+    return InkWell(
+      onTap: () async {
+        final uri = Uri.tryParse(item.url);
+        if (uri == null) return;
+        await launchUrl(uri, mode: LaunchMode.inAppBrowserView);
+      },
+      borderRadius: BorderRadius.circular(6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 3),
+              child: Icon(
+                PhosphorIcons.dotOutline(),
+                size: 10,
+                color: FacteurColors.veille,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    item.title,
+                    style: GoogleFonts.dmSans(
+                      fontSize: 12,
+                      height: 1.35,
+                      color: const Color(0xFF2C2A29),
+                      fontWeight: FontWeight.w500,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (dateLabel != null) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      dateLabel,
+                      style: GoogleFonts.dmSans(
+                        fontSize: 10.5,
+                        color: const Color(0xFF959392),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String? _formatRelative(DateTime? date) {
+    if (date == null) return null;
+    return timeago.format(date, locale: 'fr_short');
+  }
+}
+
+class _ExampleSkeleton extends StatelessWidget {
+  const _ExampleSkeleton();
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 26,
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      decoration: BoxDecoration(
+        color: FacteurColors.veilleSkel,
+        borderRadius: BorderRadius.circular(6),
+      ),
+    );
+  }
+}
+
+class _ExamplesEmpty extends StatelessWidget {
+  const _ExamplesEmpty();
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+      child: Text(
+        "Pas d'exemples récents disponibles.",
+        style: GoogleFonts.dmSans(
+          fontSize: 11.5,
+          fontStyle: FontStyle.italic,
+          color: const Color(0xFF959392),
         ),
       ),
     );

--- a/apps/mobile/test/features/notifications/notification_activation_modal_test.dart
+++ b/apps/mobile/test/features/notifications/notification_activation_modal_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'package:facteur/core/services/analytics_service.dart';
+import 'package:facteur/core/providers/analytics_provider.dart';
+import 'package:facteur/features/notifications/widgets/notification_activation_modal.dart';
+
+class _NoopAnalytics implements AnalyticsService {
+  @override
+  noSuchMethod(Invocation invocation) async {}
+}
+
+Widget _wrapModal(ActivationTrigger trigger) {
+  return ProviderScope(
+    overrides: [
+      analyticsServiceProvider.overrideWithValue(_NoopAnalytics()),
+    ],
+    child: MaterialApp(
+      home: Scaffold(
+        body: NotificationActivationModal(trigger: trigger),
+      ),
+    ),
+  );
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_modal_test_');
+    Hive.init(tempDir.path);
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  testWidgets(
+    'trigger=veille → titre + CTA dédiés, pas de section "Bonnes nouvelles"',
+    (tester) async {
+      await tester.pumpWidget(_wrapModal(ActivationTrigger.veille));
+      await tester.pump();
+
+      expect(
+        find.text('Te prévenir quand ta veille est prête ?'),
+        findsOneWidget,
+      );
+      expect(find.text("M'en informer"), findsOneWidget);
+      expect(find.text('Plus tard'), findsOneWidget);
+      expect(find.text('Définis ton rythme'), findsNothing);
+      expect(find.text('🌱 Bonnes nouvelles du jour'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'trigger=onboarding → titre digest + CTA "Activer ton Facteur"',
+    (tester) async {
+      await tester.pumpWidget(_wrapModal(ActivationTrigger.onboarding));
+      await tester.pump();
+
+      expect(find.text("Mieux s'informer, à son rythme"), findsOneWidget);
+      expect(find.text('Activer ton Facteur'), findsOneWidget);
+      expect(find.text('Définis ton rythme'), findsOneWidget);
+    },
+  );
+}

--- a/apps/mobile/test/features/veille/screens/flow_loading_screen_test.dart
+++ b/apps/mobile/test/features/veille/screens/flow_loading_screen_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/veille/screens/transitions/flow_loading_screen.dart';
+
+Widget _wrap({required int from}) {
+  return ProviderScope(
+    child: MaterialApp(
+      home: Scaffold(
+        body: FlowLoadingScreen(from: from),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('from=4 affiche eyebrow et titre dédiés à la première livraison',
+      (tester) async {
+    await tester.pumpWidget(_wrap(from: 4));
+    await tester.pump();
+
+    // L'eyebrow est rendu en majuscules par VeilleAiEyebrow.
+    expect(
+      find.text('LE FACTEUR PRÉPARE TA PREMIÈRE LIVRAISON…'),
+      findsOneWidget,
+    );
+    expect(find.text('Première veille en cours'), findsOneWidget);
+
+    await _disposeTree(tester);
+  });
+
+  testWidgets('from=1 affiche les labels du Step 1 (analyse thème)',
+      (tester) async {
+    await tester.pumpWidget(_wrap(from: 1));
+    await tester.pump();
+
+    expect(find.text('Analyse de ton thème'), findsOneWidget);
+
+    await _disposeTree(tester);
+  });
+
+  testWidgets('from inconnu → fallback sur le label Step 1', (tester) async {
+    await tester.pumpWidget(_wrap(from: 99));
+    await tester.pump();
+
+    expect(find.text('Analyse de ton thème'), findsOneWidget);
+
+    await _disposeTree(tester);
+  });
+}
+
+/// Force le démontage du widget tree pour disposer les AnimationControllers
+/// du loader et éviter les "Timer still pending" à la sortie du test.
+Future<void> _disposeTree(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox.shrink());
+  await tester.pump(const Duration(seconds: 1));
+}

--- a/apps/mobile/test/features/veille/widgets/veille_source_card_test.dart
+++ b/apps/mobile/test/features/veille/widgets/veille_source_card_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/veille/models/veille_config.dart';
+import 'package:facteur/features/veille/models/veille_delivery.dart';
+import 'package:facteur/features/veille/providers/veille_repository_provider.dart';
+import 'package:facteur/features/veille/repositories/veille_repository.dart';
+import 'package:facteur/features/veille/widgets/veille_source_card.dart';
+
+/// Repo factice : seuls `getSourceExamples` est utilisé par les tests.
+/// Le reste throw — si un test du widget appelle ces méthodes, c'est un bug
+/// d'instrumentation à corriger plutôt que d'accepter silencieusement.
+class _FakeRepo implements VeilleRepository {
+  final List<VeilleSourceExample> examples;
+  final Object? throwOnFetch;
+
+  _FakeRepo({this.examples = const [], this.throwOnFetch});
+
+  @override
+  Future<List<VeilleSourceExample>> getSourceExamples(String sourceId) async {
+    if (throwOnFetch != null) {
+      throw throwOnFetch is Exception
+          ? throwOnFetch as Exception
+          : Exception(throwOnFetch.toString());
+    }
+    return examples;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} non mocké');
+}
+
+const _source = VeilleSource(
+  id: 'src-1',
+  letter: 'L',
+  name: 'Le Monde',
+);
+
+Widget _wrap(ProviderContainer container) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      home: Scaffold(
+        body: VeilleSourceCard(
+          source: _source,
+          inVeille: true,
+          isNiche: false,
+          onToggle: () {},
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('toggle "Voir 2 exemples récents" → expand affiche les items',
+      (tester) async {
+    final repo = _FakeRepo(
+      examples: const [
+        VeilleSourceExample(
+          title: 'Article récent 1',
+          url: 'https://lemonde.fr/a1',
+          publishedAt: null,
+          excerpt: 'Excerpt 1',
+        ),
+        VeilleSourceExample(
+          title: 'Article récent 2',
+          url: 'https://lemonde.fr/a2',
+          publishedAt: null,
+          excerpt: 'Excerpt 2',
+        ),
+      ],
+    );
+    final container = ProviderContainer(
+      overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+    );
+
+    await tester.pumpWidget(_wrap(container));
+    await tester.pump();
+
+    // Avant tap : pas d'items visibles.
+    expect(find.text('Article récent 1'), findsNothing);
+
+    await tester.tap(find.text('Voir 2 exemples récents'));
+    await tester.pump(); // start expand
+    await tester.pump(const Duration(milliseconds: 250)); // settle AnimatedSize
+    await tester.pump(); // future resolves
+
+    expect(find.text('Article récent 1'), findsOneWidget);
+    expect(find.text('Article récent 2'), findsOneWidget);
+
+    container.dispose();
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('liste vide → fallback "Pas d\'exemples récents"',
+      (tester) async {
+    final repo = _FakeRepo(examples: const []);
+    final container = ProviderContainer(
+      overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+    );
+
+    await tester.pumpWidget(_wrap(container));
+    await tester.pump();
+
+    await tester.tap(find.text('Voir 2 exemples récents'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+
+    expect(find.text("Pas d'exemples récents disponibles."), findsOneWidget);
+
+    container.dispose();
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('erreur réseau → fallback affiché (pas de crash)',
+      (tester) async {
+    final repo = _FakeRepo(throwOnFetch: 'boom');
+    final container = ProviderContainer(
+      overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+    );
+
+    await tester.pumpWidget(_wrap(container));
+    await tester.pump();
+
+    await tester.tap(find.text('Voir 2 exemples récents'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+
+    expect(find.text("Pas d'exemples récents disponibles."), findsOneWidget);
+
+    container.dispose();
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+}

--- a/packages/api/app/routers/notification_preferences.py
+++ b/packages/api/app/routers/notification_preferences.py
@@ -35,6 +35,7 @@ class NotificationPreferencesResponse(BaseModel):
     last_renudge_at: datetime | None
     renudge_shown_count: int
     modal_seen: bool
+    notif_veille_enabled: bool
 
 
 class NotificationPreferencesPatch(BaseModel):
@@ -47,6 +48,7 @@ class NotificationPreferencesPatch(BaseModel):
     last_renudge_at: datetime | None = None
     renudge_shown_count: int | None = Field(default=None, ge=0)
     modal_seen: bool | None = None
+    notif_veille_enabled: bool | None = None
 
 
 def _to_response(row: UserNotificationPreferences) -> NotificationPreferencesResponse:
@@ -60,6 +62,7 @@ def _to_response(row: UserNotificationPreferences) -> NotificationPreferencesRes
         last_renudge_at=row.last_renudge_at,
         renudge_shown_count=row.renudge_shown_count,
         modal_seen=row.modal_seen,
+        notif_veille_enabled=row.notif_veille_enabled,
     )
 
 

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -8,11 +8,12 @@ session avant le LLM).
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, timedelta
 from uuid import UUID, uuid4
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query
+from cachetools import TTLCache
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,11 +22,13 @@ from app.data.veille_presets import get_presets
 from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
 from app.jobs.veille_generation_job import run_veille_generation_for_config
+from app.models.content import Content
 from app.models.enums import SourceType
 from app.models.source import Source
 from app.models.veille import (
     VeilleConfig,
     VeilleDelivery,
+    VeilleGenerationState,
     VeilleSource,
     VeilleStatus,
     VeilleTopic,
@@ -36,8 +39,10 @@ from app.schemas.veille import (
     VeilleConfigUpsert,
     VeilleDeliveryListItem,
     VeilleDeliveryResponse,
+    VeilleGenerateFirstResponse,
     VeilleGenerateRequest,
     VeillePresetResponse,
+    VeilleSourceExample,
     VeilleSourceLite,
     VeilleSourceResponse,
     VeilleSourceSuggestion,
@@ -48,6 +53,7 @@ from app.schemas.veille import (
     VeilleTopicSuggestion,
 )
 from app.services.editorial.llm_client import EditorialLLMClient
+from app.services.rss_parser import RSSParser
 from app.services.source_service import SourceService
 from app.services.veille.digest_builder import VeilleDigestBuilder
 from app.services.veille.scheduling import compute_next_scheduled_at
@@ -64,6 +70,14 @@ from app.utils.time import today_paris
 logger = structlog.get_logger()
 
 router = APIRouter()
+
+# Cache examples sources : in-process (suffit V1), à migrer Redis si scale
+# horizontal — cf. memory note. TTL 24 h aligné avec la fraîcheur attendue
+# d'un aperçu de feed.
+_SOURCE_EXAMPLES_CACHE: TTLCache = TTLCache(maxsize=512, ttl=86400)
+_SOURCE_EXAMPLES_LIMIT = 2
+_SOURCE_EXAMPLES_LOOKBACK_DAYS = 30
+_SOURCE_EXAMPLES_EXCERPT_MAX = 120
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -604,3 +618,206 @@ async def force_generate(
         await llm.close()
 
     return VeilleDeliveryResponse.model_validate(delivery)
+
+
+# ─── First delivery (génération immédiate post-onboarding) ───────────────────
+
+
+async def _run_first_delivery(config_id: UUID, target_date: date) -> None:
+    """BackgroundTask : owns LLM client + digest builder lifecycle.
+
+    Appelé après le 202 du POST /generate-first. La row VeilleDelivery a déjà
+    été créée en PENDING par le handler ; le job interne fait son propre UPSERT
+    sur (veille_config_id, target_date) et la passe à RUNNING puis SUCCEEDED.
+    """
+    llm = EditorialLLMClient()
+    try:
+        builder = VeilleDigestBuilder(llm=llm, session_maker=safe_async_session)
+        await run_veille_generation_for_config(
+            config_id,
+            target_date=target_date,
+            session_maker=safe_async_session,
+            builder=builder,
+        )
+    except Exception as exc:
+        logger.error(
+            "veille.first_delivery_failed",
+            config_id=str(config_id),
+            error=str(exc),
+        )
+    finally:
+        await llm.close()
+
+
+@router.post(
+    "/deliveries/generate-first",
+    status_code=202,
+    response_model=VeilleGenerateFirstResponse,
+)
+async def generate_first_delivery(
+    background_tasks: BackgroundTasks,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Lance la génération immédiate du premier digest après l'onboarding.
+
+    Crée une row VeilleDelivery en PENDING tout de suite pour que le mobile
+    puisse poll GET /deliveries/{id} pendant que le BackgroundTask tourne.
+    Refuse si une livraison existe déjà pour cette config (anti-doublon).
+    """
+    user_uuid = UUID(current_user_id)
+    cfg = await _get_active_config(db, user_uuid)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail="Aucune veille active.")
+
+    existing = (
+        await db.execute(
+            select(VeilleDelivery.id)
+            .where(VeilleDelivery.veille_config_id == cfg.id)
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise HTTPException(status_code=403, detail="Première livraison déjà générée.")
+
+    target = today_paris()
+    delivery_id = uuid4()
+    db.add(
+        VeilleDelivery(
+            id=delivery_id,
+            veille_config_id=cfg.id,
+            target_date=target,
+            generation_state=VeilleGenerationState.PENDING.value,
+        )
+    )
+    await db.commit()
+
+    background_tasks.add_task(
+        _run_first_delivery,
+        config_id=cfg.id,
+        target_date=target,
+    )
+    return VeilleGenerateFirstResponse(
+        delivery_id=delivery_id,
+        estimated_seconds=60,
+    )
+
+
+# ─── Source examples (preview Step 3) ────────────────────────────────────────
+
+
+async def _fetch_source_examples(
+    db: AsyncSession, source_id: UUID
+) -> list[VeilleSourceExample]:
+    """Renvoie jusqu'à 2 exemples récents d'une source. Cache TTL 24 h.
+
+    1. Tente le catalogue local `contents` (filtré 30 j) — chemin nominal.
+    2. Si vide, fallback RSS via `RSSParser.parse(feed_url)` pour les sources
+       fraîchement ingérées (niche).
+    3. Cache la réponse 24 h en mémoire (cf. limites scaling : à migrer Redis
+       si N workers > 2).
+    """
+    cache_key = str(source_id)
+    if cache_key in _SOURCE_EXAMPLES_CACHE:
+        return _SOURCE_EXAMPLES_CACHE[cache_key]
+
+    cutoff = datetime.now(UTC) - timedelta(days=_SOURCE_EXAMPLES_LOOKBACK_DAYS)
+    contents = (
+        (
+            await db.execute(
+                select(Content)
+                .where(
+                    Content.source_id == source_id,
+                    Content.published_at >= cutoff,
+                )
+                .order_by(Content.published_at.desc())
+                .limit(_SOURCE_EXAMPLES_LIMIT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if contents:
+        examples = [
+            VeilleSourceExample(
+                title=c.title,
+                url=c.url,
+                published_at=c.published_at,
+                excerpt=(c.description or "")[:_SOURCE_EXAMPLES_EXCERPT_MAX],
+            )
+            for c in contents
+        ]
+        _SOURCE_EXAMPLES_CACHE[cache_key] = examples
+        return examples
+
+    # Fallback RSS pour sources niche fraîchement ingérées (pas encore
+    # crawlées par le scanner).
+    source = (
+        (await db.execute(select(Source).where(Source.id == source_id)))
+        .scalars()
+        .first()
+    )
+    if source is None or not source.feed_url:
+        _SOURCE_EXAMPLES_CACHE[cache_key] = []
+        return []
+
+    parser = RSSParser()
+    try:
+        feed = await parser.parse(source.feed_url)
+    except Exception as exc:
+        logger.info(
+            "veille.source_examples_rss_failed",
+            source_id=str(source_id),
+            feed_url=source.feed_url,
+            error=str(exc),
+        )
+        _SOURCE_EXAMPLES_CACHE[cache_key] = []
+        return []
+    finally:
+        await parser.close()
+
+    # feedparser renvoie un FeedParserDict (attr-access) ; les tests mock un
+    # dict standard. On couvre les deux formes.
+    entries = (
+        getattr(feed, "entries", None)
+        or (feed.get("entries") if isinstance(feed, dict) else None)
+        or []
+    )
+    examples = []
+    for entry in entries[:_SOURCE_EXAMPLES_LIMIT]:
+        title = entry.get("title") or ""
+        link = entry.get("link") or ""
+        if not title or not link:
+            continue
+        published_at: datetime | None = None
+        published_parsed = entry.get("published_parsed")
+        if published_parsed:
+            try:
+                published_at = datetime(*published_parsed[:6], tzinfo=UTC)
+            except (TypeError, ValueError):
+                published_at = None
+        excerpt = (entry.get("summary") or "")[:_SOURCE_EXAMPLES_EXCERPT_MAX]
+        examples.append(
+            VeilleSourceExample(
+                title=title,
+                url=link,
+                published_at=published_at,
+                excerpt=excerpt,
+            )
+        )
+    _SOURCE_EXAMPLES_CACHE[cache_key] = examples
+    return examples
+
+
+@router.get(
+    "/sources/{source_id}/examples",
+    response_model=list[VeilleSourceExample],
+)
+async def get_source_examples(
+    source_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Renvoie un aperçu (≤2 articles) pour rassurer l'utilisateur au Step 3."""
+    UUID(current_user_id)  # validate JWT subject
+    return await _fetch_source_examples(db, source_id)

--- a/packages/api/app/schemas/veille.py
+++ b/packages/api/app/schemas/veille.py
@@ -248,6 +248,22 @@ class VeilleGenerateRequest(BaseModel):
     target_date: date | None = None
 
 
+class VeilleGenerateFirstResponse(BaseModel):
+    """Réponse 202 du POST /deliveries/generate-first."""
+
+    delivery_id: UUID
+    estimated_seconds: int = 60
+
+
+class VeilleSourceExample(BaseModel):
+    """Aperçu d'article récent d'une source — Step 3 du flow veille."""
+
+    title: str
+    url: str
+    published_at: datetime | None = None
+    excerpt: str = ""
+
+
 # ─── Presets (V1 onboarding) ─────────────────────────────────────────────────
 
 

--- a/packages/api/tests/routers/test_notification_preferences.py
+++ b/packages/api/tests/routers/test_notification_preferences.py
@@ -106,3 +106,22 @@ async def test_patch_increments_refusal_count(auth_user):
     body = resp.json()
     assert body["refusal_count"] == 1
     assert body["last_refusal_at"].startswith("2026-04-28T12:00:00")
+
+
+@pytest.mark.asyncio
+async def test_patch_notif_veille_enabled(auth_user):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        get_resp = await ac.get("/api/notification-preferences/")
+        assert get_resp.json()["notif_veille_enabled"] is False
+
+        patch_resp = await ac.patch(
+            "/api/notification-preferences/",
+            json={"notif_veille_enabled": True},
+        )
+        assert patch_resp.status_code == 200
+        assert patch_resp.json()["notif_veille_enabled"] is True
+
+        # Persistance vérifiée au GET suivant.
+        recheck = await ac.get("/api/notification-preferences/")
+        assert recheck.json()["notif_veille_enabled"] is True

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -4,6 +4,7 @@ Couvre les endpoints CRUD config + suggestions + deliveries avec auth mockée.
 LLM Mistral mocké via AsyncMock sur les singletons des suggesters.
 """
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -13,9 +14,16 @@ from httpx import ASGITransport, AsyncClient
 from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.main import app
-from app.models.enums import SourceType
+from app.models.content import Content
+from app.models.enums import ContentType, SourceType
 from app.models.source import Source
 from app.models.user import UserProfile
+from app.models.veille import (
+    VeilleConfig,
+    VeilleDelivery,
+    VeilleGenerationState,
+    VeilleStatus,
+)
 from app.services.veille.source_suggester import (
     SourceSuggester,
     SourceSuggestionItem,
@@ -409,3 +417,185 @@ class TestAuth:
             resp = await ac.get("/api/veille/config")
         # 401 (Unauthorized) ou 403 (Forbidden) — on accepte les deux.
         assert resp.status_code in (401, 403)
+
+
+@pytest_asyncio.fixture
+async def active_veille_config(db_session, auth_user):
+    cfg = VeilleConfig(
+        id=uuid4(),
+        user_id=auth_user,
+        theme_id="education",
+        theme_label="Éducation",
+        frequency="weekly",
+        day_of_week=0,
+        delivery_hour=7,
+        timezone="Europe/Paris",
+        status=VeilleStatus.ACTIVE.value,
+    )
+    db_session.add(cfg)
+    await db_session.commit()
+    return cfg
+
+
+class TestGenerateFirstDelivery:
+    async def test_creates_pending_delivery(
+        self, monkeypatch, auth_user, active_veille_config
+    ):
+        # Empêche le BackgroundTask de toucher le LLM réel.
+        from app.routers import veille as veille_module
+
+        bg_calls: list[tuple] = []
+
+        def _capture_add_task(self, func, *args, **kwargs):
+            bg_calls.append((func, args, kwargs))
+
+        monkeypatch.setattr(
+            "fastapi.BackgroundTasks.add_task",
+            _capture_add_task,
+            raising=True,
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/veille/deliveries/generate-first")
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["estimated_seconds"] == 60
+        assert body["delivery_id"] is not None
+
+        # BackgroundTask scheduled avec _run_first_delivery.
+        assert any(call[0] is veille_module._run_first_delivery for call in bg_calls), (
+            bg_calls
+        )
+
+    async def test_refuses_when_delivery_exists(
+        self, db_session, auth_user, active_veille_config
+    ):
+        existing = VeilleDelivery(
+            id=uuid4(),
+            veille_config_id=active_veille_config.id,
+            target_date=datetime.now(UTC).date(),
+            generation_state=VeilleGenerationState.SUCCEEDED.value,
+        )
+        db_session.add(existing)
+        await db_session.commit()
+
+        async with _client() as ac:
+            resp = await ac.post("/api/veille/deliveries/generate-first")
+
+        assert resp.status_code == 403
+
+    async def test_refuses_when_no_config(self, auth_user):
+        async with _client() as ac:
+            resp = await ac.post("/api/veille/deliveries/generate-first")
+        assert resp.status_code == 404
+
+
+class TestSourceExamples:
+    async def test_returns_two_most_recent_from_db(
+        self, db_session, auth_user, curated_education_source
+    ):
+        # Reset le cache module-level pour isoler le test.
+        from app.routers.veille import _SOURCE_EXAMPLES_CACHE
+
+        _SOURCE_EXAMPLES_CACHE.clear()
+
+        now = datetime.now(UTC)
+        for i in range(3):
+            db_session.add(
+                Content(
+                    id=uuid4(),
+                    source_id=curated_education_source.id,
+                    title=f"Article {i}",
+                    url=f"https://example.com/a{i}",
+                    description=f"Excerpt {i}",
+                    published_at=now - timedelta(days=i),
+                    content_type=ContentType.ARTICLE,
+                    guid=f"g{i}",
+                )
+            )
+        await db_session.commit()
+
+        async with _client() as ac:
+            resp = await ac.get(
+                f"/api/veille/sources/{curated_education_source.id}/examples"
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["title"] == "Article 0"
+        assert data[1]["title"] == "Article 1"
+        assert data[0]["url"] == "https://example.com/a0"
+        assert data[0]["excerpt"] == "Excerpt 0"
+
+    async def test_falls_back_to_rss_when_db_empty(
+        self, monkeypatch, auth_user, curated_education_source
+    ):
+        from app.routers.veille import _SOURCE_EXAMPLES_CACHE
+
+        _SOURCE_EXAMPLES_CACHE.clear()
+
+        fake_feed = {
+            "entries": [
+                {
+                    "title": "Niche Article 1",
+                    "link": "https://niche.example.com/1",
+                    "summary": "Summary 1",
+                    "published_parsed": (2026, 4, 28, 9, 0, 0, 0, 118, 0),
+                },
+                {
+                    "title": "Niche Article 2",
+                    "link": "https://niche.example.com/2",
+                    "summary": "Summary 2",
+                    "published_parsed": (2026, 4, 27, 9, 0, 0, 0, 117, 0),
+                },
+            ]
+        }
+
+        async def fake_parse(self, url):
+            return fake_feed
+
+        async def fake_close(self):
+            return None
+
+        from app.services.rss_parser import RSSParser
+
+        monkeypatch.setattr(RSSParser, "parse", fake_parse)
+        monkeypatch.setattr(RSSParser, "close", fake_close)
+
+        async with _client() as ac:
+            resp = await ac.get(
+                f"/api/veille/sources/{curated_education_source.id}/examples"
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["title"] == "Niche Article 1"
+        assert data[0]["url"] == "https://niche.example.com/1"
+
+    async def test_returns_empty_when_rss_fails(
+        self, monkeypatch, auth_user, curated_education_source
+    ):
+        from app.routers.veille import _SOURCE_EXAMPLES_CACHE
+
+        _SOURCE_EXAMPLES_CACHE.clear()
+
+        async def fake_parse(self, url):
+            raise ValueError("RSS unreachable")
+
+        async def fake_close(self):
+            return None
+
+        from app.services.rss_parser import RSSParser
+
+        monkeypatch.setattr(RSSParser, "parse", fake_parse)
+        monkeypatch.setattr(RSSParser, "close", fake_close)
+
+        async with _client() as ac:
+            resp = await ac.get(
+                f"/api/veille/sources/{curated_education_source.id}/examples"
+            )
+
+        assert resp.status_code == 200
+        assert resp.json() == []


### PR DESCRIPTION
# PR C — Veille V1 : génération immédiate + opt-in notif + source preview + pré-loading

Ferme la boucle de la refonte veille V1 (PR A: fondations DB + presets, PR B: purpose+brief LLM, **PR C** = celle-ci).

## Summary
- **Génération immédiate** : nouveau `POST /api/veille/deliveries/generate-first` (202) qui crée une row `pending` puis lance `run_veille_generation_for_config` en BackgroundTask. Anti-doublon via 403 si une livraison existe déjà.
- **Opt-in notif veille séparé** : `notif_veille_enabled` exposé sur `/api/notification-preferences/`, modal d'activation variant via `ActivationTrigger.veille` (titre/CTA/bullets dédiés, sections digest/bonnes-nouvelles masquées). Skip de la modal si `pushEnabled` déjà accordé → opt-in direct.
- **Source preview** : nouveau `GET /api/veille/sources/{id}/examples` (≤2 articles, cache TTL 24 h in-process, fallback RSS pour sources niche fraîchement ingérées). Carte Step 3 expand inline.
- **Pré-loading actif** : `FlowLoadingScreen` est désormais `ConsumerStatefulWidget` qui amorce les fetchs `topic`/`source` suggestions de l'étape suivante en arrière-plan. Nouveau label `from=4`.
- **Polling client** : `handleSubmit` fait un poll 2 s puis 5 s après 20 s, budget 90 s, snackbar de fallback si la génération dépasse 90 s.

## Critical files
- `packages/api/app/routers/veille.py` — endpoints + helpers + `_SOURCE_EXAMPLES_CACHE`
- `packages/api/app/routers/notification_preferences.py` — schémas étendus
- `packages/api/app/schemas/veille.py` — `VeilleGenerateFirstResponse`, `VeilleSourceExample`
- `apps/mobile/lib/features/veille/screens/veille_config_screen.dart` — nouveau `handleSubmit` + `_pollFirstDelivery`
- `apps/mobile/lib/features/veille/screens/transitions/flow_loading_screen.dart` — `ConsumerStatefulWidget` + step 4 + pré-loading
- `apps/mobile/lib/features/veille/widgets/veille_source_card.dart` — expand inline
- `apps/mobile/lib/features/notifications/widgets/notification_activation_modal.dart` — variant veille + skip si pushEnabled
- `apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart` — `notifVeilleEnabled` + `setNotifVeilleEnabled`

## Tests
- Backend (7 nouveaux) : `tests/routers/test_veille_routes.py` (`TestGenerateFirstDelivery` ×3, `TestSourceExamples` ×3) + `tests/routers/test_notification_preferences.py` (`test_patch_notif_veille_enabled`).
- Mobile (8 nouveaux) : `veille_source_card_test.dart` ×3, `flow_loading_screen_test.dart` ×3, `notification_activation_modal_test.dart` ×2. **Tous verts en local.**

## Test plan

- [ ] Backend : `cd packages/api && pytest tests/routers/test_veille_routes.py tests/routers/test_notification_preferences.py -v` ⇒ 8 nouveaux verts. (Local DB Postgres requise — non exécutable sur ce poste sans Docker, validation CI.)
- [ ] Backend full suite (CI) : `cd packages/api && pytest -v`.
- [ ] Backend lint touched files : `ruff format --check` + `ruff check` ⇒ all clear (validé localement).
- [ ] Mobile : `cd apps/mobile && flutter test test/features/notifications/notification_activation_modal_test.dart test/features/veille/widgets/veille_source_card_test.dart test/features/veille/screens/flow_loading_screen_test.dart` ⇒ 8 verts (validé localement).
- [ ] Mobile analyze : `flutter analyze lib/features/veille lib/features/notifications` ⇒ 0 error (validé).
- [ ] Smoke E2E (device réel) : login → /veille → flow custom → "Lancer ma veille" → loading screen `from=4` apparaît + modal veille s'affiche dans la seconde + dashboard chargé < 90 s + 1 livraison `succeeded`.
- [ ] Smoke source preview : Step 3 → tap "Voir 2 exemples récents" → expand → 2 articles, tap → in-app browser.
- [ ] Smoke skip modal : avec digest déjà activé (`pushEnabled=true`), "Lancer ma veille" → modal veille NON affichée + `notif_veille_enabled` patché à `true` côté backend.

## Notes opérationnelles

- Cache examples in-process (`TTLCache` 512×24 h) — V1 only ; à migrer Redis si scale horizontal > 2 workers.
- Polling 2 s/5 s : budget total 90 s, ~30 GET max par submit (avec backoff). Acceptable tant que volume utilisateur reste < 1k/jour ; au-delà, passer en SSE/WS.
- Aucun changement Alembic dans cette PR. La colonne `notif_veille_enabled` était déjà ajoutée par PR A.
- `staging` deprecated → `--base main`.

## Pre-existing failures (non liées à cette PR)

`flutter test` (full suite) montre 37 échecs pré-existants (`FormatException: advisoriesUpdated must be a String` + Hive setup) reproductibles sur `main` propre — non introduits par cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)