### PR TITLE
feat(lettres): Lettre 2 « Tes premières lectures » — 5 paliers + narration (#19.1 PR4)

### DIFF
--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,168 +1,128 @@
-# QA Handoff — Story 18.3 « Ma veille » end-to-end
+# QA Handoff — Lettre 2 « Tes premières lectures » (Story 19.1, PR4)
 
 > Rempli par l'agent dev en fin de développement, après validation du PO.
 > Sert d'input à `/validate-feature`.
 
 ## Feature développée
 
-Câblage end-to-end du flow « Ma veille » sur l'app mobile :
-- Wiring du submit étape 4 → POST `/api/veille/config` (suppression du no-op).
-- Suggestions topics/sources réelles (POST `/api/veille/suggestions/{topics,sources}`) à l'entrée des étapes 2 et 3 (au lieu du mock).
-- Nouvel écran « Ma veille déjà configurée » (dashboard) — affiché si `GET /api/veille/config` = 200 ; redirige automatiquement depuis `/veille/config` au lieu de relancer le flow 4-steps.
-- Nouvel écran historique livraisons (`/veille/deliveries`) — liste 20 dernières.
-- Nouvel écran détail livraison (`/veille/deliveries/:id`) — clusters + `why_it_matters` + articles cliquables (InAppWebView).
-- Notif locale planifiée côté front au submit (`flutter_local_notifications`, NotifId=3, à `next_scheduled_at + 30 min`), deeplink `io.supabase.facteur://veille/dashboard`.
-
-Aucune modif backend (pipeline déjà livrée en 18.1/18.2).
+Remplace la Lettre 2 placeholder (1 action `set_frequency`) par 5 actions auto-détectées qui marquent un J+1 d'usage naturel : lire L'essentiel, lire Les bonnes nouvelles, lire 3 articles jusqu'au bout, consommer une vidéo/podcast (≥4min), recommander un article (like 🌻). Ajout d'une dimension narrative anti-FOMO : `intro_palier` (lettre), `completion_palier` (toast par action), `completion_voeu` (overlay cachet final). Aucun chiffre, aucune comparaison sociale, un seul toast à la fois.
 
 ## PR associée
 
-À créer via `/go` (PR vers `main`).
+À créer après validation QA (cible `main`).
 
 ## Écrans impactés
 
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| Flow Veille — Étape 1 (thème) | `/veille/config` | Modifié — redirect dashboard si config existe |
-| Flow Veille — Étape 2 (suggestions topics) | `/veille/config` | Modifié — POST `/suggestions/topics` au mount |
-| Flow Veille — Étape 3 (sources) | `/veille/config` | Modifié — POST `/suggestions/sources` au mount |
-| Flow Veille — Étape 4 (fréquence + submit) | `/veille/config` | Modifié — POST `/config` réel + planif notif locale |
-| Dashboard « Ma veille déjà configurée » | `/veille/dashboard` | **Nouveau** |
-| Historique livraisons | `/veille/deliveries` | **Nouveau** |
-| Détail livraison | `/veille/deliveries/:id` | **Nouveau** |
+| Feed (carrousel haut) | `/feed` | Modifié — 2è carte « Bonnes nouvelles » émet désormais un event |
+| Liste des lettres (Mon Courrier) | `/lettres` | Inchangé visuellement |
+| Lettre ouverte (L2) | `/lettres/letter_2` | Modifié — nouveau message, 5 actions, intro_palier, toasts paliers |
+| Overlay cachet final | (overlay sur `/lettres/letter_2` quand archivée) | Modifié — affiche `completion_voeu` au lieu du fallback |
 
 ## Scénarios de test
 
-### Scénario 1 : Happy path — première config & livraison
-
+### Scénario 1 — Forme de la Lettre 2 ouverte (état initial)
 **Parcours** :
-1. Auth dans l'app. Aucune veille configurée.
-2. Naviguer vers `/veille/config` (depuis settings ou route directe).
-3. Étape 1 : choisir thème « IA & éducation ».
-4. Étape 2 : observer le spinner pendant 1-3s, puis suggestions LLM affichées (différentes du mock figé). Sélectionner 3 topics.
-5. Étape 3 : spinner puis sources `followed` + `niche` réelles. Sélectionner 4 sources.
-6. Étape 4 : fréquence weekly · lundi · 7h. Tap « Configurer ma veille ».
-7. Vérifier : POST `/api/veille/config` → 200 dans logs uvicorn.
-8. Vérifier : redirection vers `/veille/dashboard` (pas le SnackBar mock).
-9. Vérifier (Android Studio Logcat ou debug print) : `PushNotificationService: scheduled veilleDelivery for <next_scheduled_at + 30min>`.
-10. (debug local) `POST /api/veille/deliveries/generate` → 200 succeeded.
-11. Re-ouvrir l'app → dashboard → bouton « Historique » → liste 1 livraison.
-12. Tap livraison → détail → 1+ cluster avec titre + `why_it_matters` + articles.
-13. Tap article → InAppWebView s'ouvre.
-
+1. Provisionner un user avec L2 active (DB ou faire passer par le chaînage L1→L2 standard).
+2. Naviguer vers `/lettres` puis ouvrir Lettre 2.
 **Résultat attendu** :
-- Aucune erreur réseau ni 4xx visible dans les logs.
-- La notif locale est bien planifiée (vérifiable via Logcat ou `flutter logs`).
-- Le dashboard affiche le thème, topics, sources, fréquence et un countdown vers `next_scheduled_at`.
-- Le détail livraison montre des clusters réels (ou fallback déterministe si `MISTRAL_API_KEY` absent localement, sans badge visible).
+- Titre « Tes premières lectures ».
+- Message principal en 2 paragraphes.
+- Sous le dernier paragraphe : phrase italique secondaire (`intro_palier`) « Ta sélection est posée. Voyons maintenant si tu sais en faire bon usage. »
+- 5 actions visibles : Lire L'essentiel / Découvrir Les bonnes nouvelles / Lire 3 articles jusqu'au bout / Écouter un podcast ou regarder une vidéo / Recommander un article.
+- Compteur en haut « 0/5 ».
 
-### Scénario 2 : Veille déjà configurée — redirect dashboard
-
+### Scénario 2 — Action « Lire L'essentiel » détectée
 **Parcours** :
-1. Avoir une veille active (cf. Scénario 1).
-2. Tap depuis settings le bouton « Configurer ma veille » (ou navigate manuel `/veille/config`).
-3. Observer.
-
+1. Sur `/lettres/letter_2` ouverte, retour au feed.
+2. Tap sur la carte « L'essentiel du jour ».
+3. Revenir aux lettres et rouvrir Lettre 2.
 **Résultat attendu** :
-- L'utilisateur voit le dashboard `/veille/dashboard`, pas le flow 4-steps (Step1).
-- Si l'utilisateur tap « Modifier ma veille » sur le dashboard → flow 4-steps relancé avec le state preset (thème, topics, sources cochés).
+- L'action « Lire L'essentiel du jour » apparaît cochée (strikethrough).
+- Compteur « 1/5 ».
+- Toast bottom (Fraunces italique) « Premier rendez-vous tenu. Ça commence ici. » s'affiche brièvement (≈4s).
 
-### Scénario 3 : Pause & Reprendre
-
+### Scénario 3 — Action « Bonnes nouvelles » détectée
 **Parcours** :
-1. Dashboard avec veille active.
-2. Tap « Mettre en pause ».
-3. Observer.
-
+1. Sur le feed, tap sur la 2è carte du carrousel « Les bonnes nouvelles ».
+2. Revenir aux lettres et rouvrir Lettre 2.
 **Résultat attendu** :
-- PATCH `/api/veille/config` → 200, `status="paused"`.
-- Le bouton devient « Reprendre ».
-- Le countdown disparaît (ou affiche « En pause »).
-- La notif locale précédemment planifiée est cancelled (vérifiable via debug print).
-- Tap « Reprendre » → PATCH status="active" + reschedule notif.
+- L'action « Découvrir Les bonnes nouvelles » cochée.
+- Toast « Tu sais maintenant que la lecture peut aussi faire du bien. ».
 
-### Scénario 4 : Suppression
-
+### Scénario 4 — Action « 3 articles jusqu'au bout »
 **Parcours** :
-1. Dashboard avec veille active.
-2. Tap « Supprimer ma veille » → confirm dialog → confirmer.
-3. Observer.
-
+1. Lire 3 articles de type `article` jusqu'au bout (scroll ≥90 % et passer ≥60 s sur chacun).
+2. Revenir aux lettres et rouvrir Lettre 2.
 **Résultat attendu** :
-- DELETE `/api/veille/config` → 204.
-- L'utilisateur est redirigé vers `/feed` (ou la route de fallback).
-- Re-ouvrir `/veille/config` → flow 4-steps de nouveau (état GET /config = 404).
-- Notif locale cancelled.
+- Action cochée.
+- Toast « Trois lectures menées au bout. C'est ce qui te distingue déjà. ».
+- Note : si 2 articles seulement OU 1 article avec time_spent <60s → action **non cochée** (régression à éviter).
 
-### Scénario 5 : Détail livraison failed
-
+### Scénario 5 — Action « Vidéo / podcast »
 **Parcours** :
-1. Forcer une livraison `failed` (peut nécessiter un seed DB côté QA — alternative : mocker côté UI test).
-2. Ouvrir l'historique → tap la livraison.
-
+1. Ouvrir un contenu de type `youtube` ou `podcast`, le consommer ≥4 minutes (240 s cumulés serveur).
+2. Rouvrir Lettre 2.
 **Résultat attendu** :
-- Le détail affiche un état d'erreur sympa (« La livraison a échoué — le scanner réessaiera bientôt »).
-- Pas de crash, pas d'erreur dans les logs front.
+- Action cochée.
+- Toast « Tu varies les formats. C'est comme ça qu'on s'enrichit. ».
 
-### Scénario 6 : Erreur réseau pendant suggestions
-
+### Scénario 6 — Action « Recommander un article »
 **Parcours** :
-1. Étape 2 (suggestions topics) : couper le wifi.
-2. Re-tenter le mount (back puis re-forward).
-
+1. Sur n'importe quel article, tap sur le bouton like (🌻).
+2. Rouvrir Lettre 2.
 **Résultat attendu** :
-- Toast `« Suggestions indisponibles, conserve ta sélection »`.
-- La grille reste fonctionnelle avec mock data (pas de crash).
-- Bouton « Réessayer » disponible.
+- Action cochée.
+- Toast « Un signal envoyé. Le Facteur écoute. ».
 
-### Scénario 7 : Tap notification locale
-
+### Scénario 7 — Anti-cascade (rafale)
 **Parcours** :
-1. Avoir une veille active avec notif schedulée.
-2. (Debug Android) déclencher la notif manuellement OU avancer la date système.
-3. Tap la notif depuis l'écran de verrouillage.
-
+1. Pré-remplir 4/5 actions L2 hors session.
+2. Ouvrir Lettre 2 (snapshot initial = 4 done).
+3. Déclencher la 5è action depuis l'écran.
 **Résultat attendu** :
-- L'app s'ouvre sur `/veille/dashboard` (deeplink `io.supabase.facteur://veille/dashboard`).
-- Si `target_date` du jour a une livraison `succeeded`, le bouton « Historique » l'affiche en haut.
+- L'overlay cachet final s'affiche avec `completion_voeu` (« Tu as appris à lire avec attention. C'est déjà beaucoup. La suite peut attendre. »).
+- **Aucun toast palier** ne s'affiche en plus (l'overlay remplace le dernier toast).
+
+Variante : 2 actions complétées simultanément (refresh + 2 nouveaux done) → **un seul toast** s'affiche (celui de la dernière action de la rafale), pas 2.
+
+### Scénario 8 — Anti-FOMO (vérification visuelle)
+**Parcours** :
+1. Inspecter visuellement Lettre 2 dans tous ses états (todo, partiellement done, archivée).
+2. Inspecter le toast palier et l'overlay cachet.
+**Résultat attendu** :
+- **Aucun pourcentage** affiché (pas de « 60 % » ni « top 10 % »).
+- **Aucun classement** ni comparaison sociale (pas de « comme 80 % des utilisateurs »).
+- **Aucun chiffre de performance** dans les wordings (le « 1/5 » du compteur d'actions reste OK, c'est neutre).
+- Grep automatisé : `grep -rE '\b\d+\s?%|percentile|classement|comme \d+%' apps/mobile/lib/features/lettres/ packages/api/app/services/letters/` doit retourner 0 résultat.
 
 ## Critères d'acceptation
 
-- [ ] Submit étape 4 fait un vrai POST `/api/veille/config` (plus de SnackBar mock).
-- [ ] Étapes 2 et 3 appellent les endpoints suggestions avec spinner bloquant.
-- [ ] Toute config existante (GET 200) déclenche un redirect vers `/veille/dashboard` au lieu du flow.
-- [ ] Dashboard rend thème, topics, sources, fréquence, countdown.
-- [ ] Boutons dashboard (Modifier/Pause/Supprimer/Voir historique) tous fonctionnels.
-- [ ] Historique liste 20 livraisons max, empty state si 0.
-- [ ] Détail livraison rend les clusters avec `why_it_matters` + articles.
-- [ ] Tap article ouvre InAppWebView (pas le navigateur externe).
-- [ ] Notif locale planifiée au submit, cancellée au pause/delete, re-schedulée au PATCH frequency.
-- [ ] Deeplink `io.supabase.facteur://veille/dashboard` mappé.
-- [ ] `flutter test` vert sur les fichiers touchés/créés.
-- [ ] `flutter analyze` ne crée pas de NOUVEAU error/warning.
+- [ ] L2 active retourne 5 actions, `intro_palier` non vide, `completion_voeu` non vide.
+- [ ] Chaque action a un `completion_palier` non vide.
+- [ ] Les 5 détecteurs s'évaluent correctement (cf. tests `TestLetter2Detection`).
+- [ ] L1 ne contient PAS les champs narratifs L2 (régression backward-compat).
+- [ ] L2 archivée reste archivée après refresh (idempotence).
+- [ ] Toast s'affiche bottom 32, fade in/out 250 ms, hold 4 s, max 2 lignes.
+- [ ] Anti-cascade : rafale de 2+ actions done = 1 seul toast.
+- [ ] Complétion totale : overlay cachet à la place du toast.
+- [ ] Aucune stat chiffrée dans les wordings.
 
 ## Zones de risque
 
-1. **UUIDs vs slugs mock** — le mock `veille_mock_data.dart` utilise des slugs (`s-lm`, `t-eval`) qui n'existent pas en DB. Le wiring API n'envoie QUE les UUIDs renvoyés par les endpoints suggestions. Vérifier qu'AUCUNE source mock-only (sans `apiSourceId`) ne fuit dans le POST /config (sinon 400 ou faux source ingéré).
-2. **Notif locale & timezone** — utiliser `tz.TZDateTime.from(when, tz.local)` (pattern `scheduleDailyDigestNotification`). Sinon DST Paris peut décaler la notif d'1h.
-3. **Retries cascadés** — la règle « max 1 sur 5xx, 0 sur 4xx » est CRITIQUE. Pas de retry cascadé type `digest_provider._loadBothDigests` (mémoire `bug-infinite-load-requests` : pool DB déjà saturé en prod).
-4. **Mistral KO côté backend** — `why_it_matters` reçoit alors un fallback déterministe (« 4 articles de 2 sources couvrent ce sujet »). À considérer comme valide, pas un état d'erreur. Pas de badge.
-5. **Multi-device** — la notif est purement locale. Si l'utilisateur configure depuis device A, device B ne recevra pas la notif. Documenté hors scope V1.
-6. **`generation_state == "running"`** — au moment où la notif tombe, le scanner peut encore tourner. Le détail doit gérer ce cas (afficher un loader « génération en cours, refresh dans X s »).
-7. **InAppWebView** — vérifier qu'on réutilise le même helper que le digest (`Grep "InAppWebView"` côté `features/digest/` ou `features/feed/`). Sinon implémenter un fallback `url_launcher` propre.
+- **`reading_progress` côté serveur** : la détection « 3 articles jusqu'au bout » dépend du PATCH `POST /contents/{id}/status` (`feed_repository.dart:824`) qui est fire-and-forget. Si l'utilisateur ferme l'app avant le sync, l'action peut tarder à se cocher. Pas un bug — c'est cohérent avec la détection backend.
+- **Listener `_seenDoneActionIds`** : le snapshot est par-instance d'écran. Si l'utilisateur quitte puis ré-ouvre Lettre 2, le snapshot est refait → pas de toast pour les actions déjà done avant la session. Comportement voulu.
+- **Wording éditorial** : les 7 chaînes (`intro_palier`, `completion_voeu`, 5 × `completion_palier`) sont rédigées par l'agent dans l'esprit Facteur, à valider par PO avant merge.
 
 ## Dépendances
 
-- Endpoints API (déjà livrés en 18.1/18.2) :
-  - `GET /api/veille/config`
-  - `POST /api/veille/config`
-  - `PATCH /api/veille/config`
-  - `DELETE /api/veille/config`
-  - `POST /api/veille/suggestions/topics`
-  - `POST /api/veille/suggestions/sources`
-  - `GET /api/veille/deliveries?limit=20`
-  - `GET /api/veille/deliveries/{id}`
-  - `POST /api/veille/deliveries/generate` (debug, dev only)
-- Pas de migration backend.
-- Pas de FCM/APNS (push 100% local via `flutter_local_notifications`).
-- Scanner backend `*/30 min` (déjà schedulé via APScheduler).
+- Endpoints réutilisés (aucun nouveau) : `POST /analytics/events`, `POST /contents/{id}/status`, `POST /contents/{id}/like`.
+- Migration DB : aucune.
+- Models touchés : `Letter`, `LetterAction` (mobile, +3 champs nullable).
+
+## Tests automatisés
+
+- Backend : `pytest tests/routers/test_letters_routes.py` → 20/20.
+- Mobile : `flutter test test/features/lettres/` → 34/34 (incluant `palier_toast_test`, `letter_test` backward-compat).
+- Suite mobile complète : 543 passed / 37 failed — les 37 failures sont pré-existantes sur staging, sans rapport avec L2 (vérifié par stash + run baseline).

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -235,6 +235,15 @@ class AnalyticsService {
     await _capturePostHog('digest_opened', props);
   }
 
+  Future<void> trackBonnesNouvellesOpened({DateTime? targetDate}) async {
+    final props = {
+      'session_id': _sessionId,
+      'target_date': targetDate?.toIso8601String(),
+    };
+    await _logEvent('bonnes_nouvelles_opened', props);
+    await _capturePostHog('bonnes_nouvelles_opened', props);
+  }
+
   Future<void> trackDigestItemViewed({
     required String digestDate,
     required String contentId,

--- a/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -6,11 +8,13 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/routes.dart';
 import '../../../config/serein_colors.dart';
 import '../../../config/theme.dart';
+import '../../../core/providers/analytics_provider.dart';
 import '../../../widgets/design/facteur_card.dart';
 import '../../digest/providers/digest_provider.dart';
 import '../../digest/providers/serein_toggle_provider.dart';
 import '../../digest/widgets/essentiel_pill.dart';
 import '../../digest/widgets/bonnes_nouvelles_pill.dart';
+import '../../lettres/providers/letters_provider.dart';
 
 /// Mini-carousel horizontal en tête du feed.
 ///
@@ -41,6 +45,14 @@ class DigestEntryCard extends ConsumerWidget {
         _peek;
 
     Future<void> openDigest({required bool requireSerein}) async {
+      if (requireSerein) {
+        unawaited(
+          ref.read(analyticsServiceProvider).trackBonnesNouvellesOpened(
+                targetDate: targetDate,
+              ),
+        );
+        unawaited(ref.read(lettersProvider.notifier).silentRefresh());
+      }
       final original = ref.read(sereinToggleProvider).enabled;
       final notifier = ref.read(sereinToggleProvider.notifier);
       if (requireSerein != original) {

--- a/apps/mobile/lib/features/lettres/models/letter.dart
+++ b/apps/mobile/lib/features/lettres/models/letter.dart
@@ -23,12 +23,14 @@ class LetterAction {
   final String label;
   final String help;
   final LetterActionStatus status;
+  final String? completionPalier;
 
   const LetterAction({
     required this.id,
     required this.label,
     required this.help,
     required this.status,
+    this.completionPalier,
   });
 }
 
@@ -45,6 +47,8 @@ class Letter {
   final double progress;
   final DateTime? startedAt;
   final DateTime? archivedAt;
+  final String? introPalier;
+  final String? completionVoeu;
 
   const Letter({
     required this.id,
@@ -58,6 +62,8 @@ class Letter {
     required this.progress,
     required this.startedAt,
     required this.archivedAt,
+    this.introPalier,
+    this.completionVoeu,
   });
 
   factory Letter.fromJson(Map<String, dynamic> json) {
@@ -92,6 +98,7 @@ class Letter {
         label: raw['label'] as String? ?? '',
         help: raw['help'] as String? ?? '',
         status: actionStatus,
+        completionPalier: raw['completion_palier'] as String?,
       ));
     }
 
@@ -112,6 +119,8 @@ class Letter {
       progress: (json['progress'] as num?)?.toDouble() ?? 0.0,
       startedAt: parseTs(json['started_at']),
       archivedAt: parseTs(json['archived_at']),
+      introPalier: json['intro_palier'] as String?,
+      completionVoeu: json['completion_voeu'] as String?,
     );
   }
 }

--- a/apps/mobile/lib/features/lettres/screens/open_letter_screen.dart
+++ b/apps/mobile/lib/features/lettres/screens/open_letter_screen.dart
@@ -12,6 +12,7 @@ import '../providers/letters_provider.dart';
 import '../widgets/envelope_thumb.dart';
 import '../widgets/letter_action_tile.dart';
 import '../widgets/letter_completion_overlay.dart';
+import '../widgets/palier_toast.dart';
 
 class OpenLetterScreen extends ConsumerStatefulWidget {
   final String letterId;
@@ -24,6 +25,10 @@ class OpenLetterScreen extends ConsumerStatefulWidget {
 
 class _OpenLetterScreenState extends ConsumerState<OpenLetterScreen> {
   bool _completionShown = false;
+  // Anti-cascade : on snapshot les actions déjà done au premier load pour ne
+  // pas afficher de toast pour des paliers déjà acquis avant cette session.
+  final Set<String> _seenDoneActionIds = <String>{};
+  bool _seenInitialized = false;
 
   @override
   void initState() {
@@ -58,6 +63,38 @@ class _OpenLetterScreenState extends ConsumerState<OpenLetterScreen> {
     });
   }
 
+  void _maybeShowPalierToast(LetterProgressState state) {
+    final letter = state.letters
+        .where((l) => l.id == widget.letterId)
+        .cast<Letter?>()
+        .firstOrNull;
+    if (letter == null) return;
+
+    final doneActions = letter.actions
+        .where((a) => a.status == LetterActionStatus.done)
+        .toList();
+
+    if (!_seenInitialized) {
+      _seenInitialized = true;
+      _seenDoneActionIds.addAll(doneActions.map((a) => a.id));
+      return;
+    }
+
+    final newlyDone =
+        doneActions.where((a) => !_seenDoneActionIds.contains(a.id)).toList();
+    if (newlyDone.isEmpty) return;
+    _seenDoneActionIds.addAll(newlyDone.map((a) => a.id));
+
+    // Anti-cascade : on n'affiche QUE le palier de la dernière action de la
+    // rafale. La complétion totale est traitée par _maybeShowCompletion
+    // (overlay cachet) — pas de toast en plus dans ce cas.
+    if (letter.status == LetterStatus.archived) return;
+    final last = newlyDone.last;
+    final msg = last.completionPalier;
+    if (msg == null || msg.isEmpty) return;
+    showPalierToast(context, msg);
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
@@ -65,7 +102,9 @@ class _OpenLetterScreenState extends ConsumerState<OpenLetterScreen> {
 
     ref.listen<AsyncValue<LetterProgressState>>(lettersProvider, (_, next) {
       final v = next.valueOrNull;
-      if (v != null) _maybeShowCompletion(v);
+      if (v == null) return;
+      _maybeShowPalierToast(v);
+      _maybeShowCompletion(v);
     });
 
     return Scaffold(
@@ -253,6 +292,18 @@ class _Body extends ConsumerWidget {
                     const SizedBox(height: 12),
                   ],
                 ),
+                if (letter.introPalier != null && letter.introPalier!.isNotEmpty) ...[
+                  Text(
+                    letter.introPalier!,
+                    style: GoogleFonts.fraunces(
+                      fontSize: 14.5,
+                      fontStyle: FontStyle.italic,
+                      height: 1.55,
+                      color: colors.textSecondary,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                ],
                 _Signature(letter: letter, colors: colors),
                 const SizedBox(height: 24),
                 Row(

--- a/apps/mobile/lib/features/lettres/widgets/letter_completion_overlay.dart
+++ b/apps/mobile/lib/features/lettres/widgets/letter_completion_overlay.dart
@@ -129,7 +129,7 @@ class _LetterCompletionOverlayState extends State<LetterCompletionOverlay>
               ),
               const SizedBox(height: 10),
               Text(
-                'On te prépare la suite !',
+                widget.letter.completionVoeu ?? 'On te prépare la suite !',
                 style: GoogleFonts.dmSans(
                   fontSize: 14.5,
                   height: 1.5,

--- a/apps/mobile/lib/features/lettres/widgets/palier_toast.dart
+++ b/apps/mobile/lib/features/lettres/widgets/palier_toast.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+
+/// Toast discret affiché quand un palier vient d'être validé.
+///
+/// L'appelant garantit l'anti-cascade (un seul toast par rafale d'actions).
+void showPalierToast(BuildContext context, String message) {
+  final overlay = Overlay.maybeOf(context, rootOverlay: true);
+  if (overlay == null) return;
+
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (ctx) => _PalierToast(
+      message: message,
+      onDismissed: () => entry.remove(),
+    ),
+  );
+  overlay.insert(entry);
+}
+
+class _PalierToast extends StatefulWidget {
+  final String message;
+  final VoidCallback onDismissed;
+
+  const _PalierToast({required this.message, required this.onDismissed});
+
+  @override
+  State<_PalierToast> createState() => _PalierToastState();
+}
+
+class _PalierToastState extends State<_PalierToast>
+    with SingleTickerProviderStateMixin {
+  static const _fade = Duration(milliseconds: 250);
+  static const _hold = Duration(milliseconds: 4000);
+
+  late final AnimationController _ctl;
+  Timer? _dismissTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctl = AnimationController(vsync: this, duration: _fade);
+    _ctl.forward();
+    _dismissTimer = Timer(_hold, _dismiss);
+  }
+
+  Future<void> _dismiss() async {
+    if (!mounted) return;
+    await _ctl.reverse();
+    if (!mounted) return;
+    widget.onDismissed();
+  }
+
+  @override
+  void dispose() {
+    _dismissTimer?.cancel();
+    _ctl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Positioned(
+      left: 24,
+      right: 24,
+      bottom: 32 + MediaQuery.of(context).viewPadding.bottom,
+      child: SafeArea(
+        top: false,
+        child: FadeTransition(
+          opacity: _ctl,
+          child: Material(
+            color: Colors.transparent,
+            child: Container(
+              padding: const EdgeInsets.fromLTRB(14, 14, 14, 14),
+              decoration: BoxDecoration(
+                color: colors.surface,
+                borderRadius: BorderRadius.circular(12),
+                border: Border(
+                  left: BorderSide(color: colors.primary, width: 3),
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.08),
+                    blurRadius: 16,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Text(
+                widget.message,
+                style: GoogleFonts.fraunces(
+                  fontSize: 14,
+                  fontStyle: FontStyle.italic,
+                  height: 1.45,
+                  color: colors.textPrimary,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/lettres/models/letter_test.dart
+++ b/apps/mobile/test/features/lettres/models/letter_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/lettres/models/letter.dart';
+
+void main() {
+  group('Letter.fromJson backward-compat', () {
+    test('parses minimal payload without narrative fields (L0/L1 shape)', () {
+      final l = Letter.fromJson({
+        'id': 'letter_1',
+        'num': '01',
+        'title': 'Tes premières sources',
+        'message': 'msg',
+        'signature': 'Le Facteur',
+        'status': 'active',
+        'actions': [
+          {'id': 'a1', 'label': 'A1', 'help': 'h'},
+        ],
+        'completed_actions': <String>[],
+        'progress': 0.0,
+      });
+
+      expect(l.introPalier, isNull);
+      expect(l.completionVoeu, isNull);
+      expect(l.actions.single.completionPalier, isNull);
+    });
+
+    test('parses L2 payload with narrative fields', () {
+      final l = Letter.fromJson({
+        'id': 'letter_2',
+        'num': '02',
+        'title': 'Tes premières lectures',
+        'message': 'msg',
+        'signature': 'Le Facteur',
+        'status': 'active',
+        'intro_palier': 'Voyons si tu sais en faire bon usage.',
+        'completion_voeu': 'Tu as appris à lire avec attention.',
+        'actions': [
+          {
+            'id': 'read_first_essentiel',
+            'label': "Lire L'essentiel",
+            'help': 'h',
+            'completion_palier': 'Premier rendez-vous tenu.',
+          },
+          {
+            'id': 'recommend_first_article',
+            'label': 'Recommander',
+            'help': 'h',
+            'completion_palier': 'Un signal envoyé.',
+          },
+        ],
+        'completed_actions': <String>[],
+        'progress': 0.0,
+      });
+
+      expect(l.introPalier, 'Voyons si tu sais en faire bon usage.');
+      expect(l.completionVoeu, 'Tu as appris à lire avec attention.');
+      expect(l.actions[0].completionPalier, 'Premier rendez-vous tenu.');
+      expect(l.actions[1].completionPalier, 'Un signal envoyé.');
+    });
+  });
+}

--- a/apps/mobile/test/features/lettres/widgets/palier_toast_test.dart
+++ b/apps/mobile/test/features/lettres/widgets/palier_toast_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/lettres/widgets/palier_toast.dart';
+
+Widget _harness({required void Function(BuildContext) onReady}) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [FacteurPalettes.light]),
+    home: Builder(
+      builder: (context) {
+        WidgetsBinding.instance.addPostFrameCallback((_) => onReady(context));
+        return const Scaffold(body: SizedBox.shrink());
+      },
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('shows the message then auto-dismisses', (tester) async {
+    await tester.pumpWidget(_harness(
+      onReady: (ctx) => showPalierToast(ctx, 'Premier rendez-vous tenu.'),
+    ));
+    // Frame 1: postFrameCallback fires, Overlay inserts entry.
+    await tester.pump();
+    // Frame 2: fade-in starts.
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(find.text('Premier rendez-vous tenu.'), findsOneWidget);
+
+    // Hold (4s) + fade-out (250ms) → entry removed.
+    await tester.pump(const Duration(milliseconds: 4000));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('Premier rendez-vous tenu.'), findsNothing);
+  });
+}

--- a/docs/qa/scripts/verify_letters.sh
+++ b/docs/qa/scripts/verify_letters.sh
@@ -4,8 +4,12 @@
 # Stratégie : on n'a pas de moyen simple de fabriquer un JWT Supabase valide
 # en local. On valide donc la chaîne :
 #   1. Smoke : la route est enregistrée et exige un token (401 sans auth).
-#   2. Logique : on lance la suite pytest dédiée — qui couvre les 8 cas
-#      (init, 4 détecteurs, chaînage, idempotence, cross-tenant, 404).
+#   2. Logique : on lance la suite pytest dédiée — qui couvre :
+#      - L1 : init, 4 détecteurs, chaînage, idempotence, cross-tenant, 404.
+#      - L2 (PR4) : 5 détecteurs (digest_opened, bonnes_nouvelles_opened,
+#        ≥3 long articles, vidéo/podcast 4min, like 🌻), shape JSON
+#        (intro_palier + completion_voeu + completion_palier par action),
+#        idempotence post-archivage.
 #
 # Usage:
 #   ./docs/qa/scripts/verify_letters.sh [API_BASE_URL]
@@ -54,7 +58,7 @@ else
 fi
 echo ""
 
-# --- 3. Smoke refresh-status route ---
+# --- 3. Smoke refresh-status route (L1) ---
 info "3. POST /api/letters/letter_1/refresh-status without auth → expect 401/403..."
 HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API/letters/letter_1/refresh-status" 2>/dev/null || true)
 if [ "$HTTP" = "401" ] || [ "$HTTP" = "403" ]; then
@@ -63,6 +67,18 @@ elif [ -z "$HTTP" ] || [ "$HTTP" = "000" ]; then
   info "API not reachable — skipping smoke"
 else
   red "POST refresh-status returned unexpected $HTTP"
+fi
+echo ""
+
+# --- 4. Smoke refresh-status route (L2 — PR4) ---
+info "4. POST /api/letters/letter_2/refresh-status without auth → expect 401/403..."
+HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API/letters/letter_2/refresh-status" 2>/dev/null || true)
+if [ "$HTTP" = "401" ] || [ "$HTTP" = "403" ]; then
+  green "POST /api/letters/letter_2/refresh-status returns $HTTP"
+elif [ -z "$HTTP" ] || [ "$HTTP" = "000" ]; then
+  info "API not reachable — skipping smoke"
+else
+  red "POST refresh-status (L2) returned unexpected $HTTP"
 fi
 echo ""
 

--- a/docs/stories/core/19.1.lettres-facteur.md
+++ b/docs/stories/core/19.1.lettres-facteur.md
@@ -173,3 +173,53 @@ Branche : `boujonlaurin-dotcom/lettres-ui`.
 ### Issues rencontrées
 
 (à alimenter au fil de l'eau)
+
+---
+
+## PR4 — Lettre 2 « Tes premières lectures »
+
+Remplace le placeholder `set_frequency` par 5 actions auto-détectées qui marquent un J+1 d'usage naturel + dimension narrative anti-FOMO (paliers, vœu final).
+
+### Mapping action → détecteur SQL → trigger mobile
+
+| Action | Détecteur (`packages/api/app/services/letters/service.py`) | Signal mobile |
+|---|---|---|
+| `read_first_essentiel` | `EXISTS (analytics_events.event_type='digest_opened')` | `trackDigestOpened` (`digest_screen.dart:253`) |
+| `read_first_bonnes_nouvelles` | `EXISTS (analytics_events.event_type='bonnes_nouvelles_opened')` | `trackBonnesNouvellesOpened` (nouveau, câblé `digest_entry_card.dart` 2è carte) |
+| `read_3_long_articles` | `COUNT(DISTINCT user_content_status.content_id) JOIN contents WHERE reading_progress≥90 AND time_spent_seconds≥60 AND content_type='article' >= 3` | `feed_repository.updateContentStatusWithProgress/Timespent` depuis `content_detail_screen.dart:1215/1222/1302` |
+| `read_first_video_podcast` | `EXISTS (UCS JOIN contents WHERE time_spent_seconds≥240 AND content_type IN ('podcast','youtube'))` | Même flow détail (cumul time_spent serveur) |
+| `recommend_first_article` | `EXISTS (UCS WHERE is_liked=true)` | `POST /contents/{id}/like` (bouton 🌻 existant) |
+
+### Décisions narratives (anti-FOMO non négociable)
+
+- **Aucun chiffre, aucun percentile, aucune comparaison sociale** — le wording évoque le geste, pas la performance.
+- **Un seul toast à la fois** : le listener `_maybeShowPalierToast` (`open_letter_screen.dart`) snapshot les actions déjà done au premier load, puis n'affiche QUE le palier de la dernière action de la rafale en cas de complétions multiples simultanées.
+- **Pas de toast lors de la complétion totale** : l'overlay cachet (`LetterCompletionOverlay`) avec `completion_voeu` remplace le dernier toast pour éviter la cascade.
+- **3 nouveaux champs JSON facultatifs** (backward-compatible avec L0/L1) :
+  - `letter.intro_palier` — phrase italique sous le message principal
+  - `letter.completion_voeu` — texte centré dans l'overlay cachet (remplace le fallback « On te prépare la suite ! »)
+  - `letter.actions[i].completion_palier` — toast bottom à la complétion d'une action
+
+### Fichiers modifiés (PR4)
+
+**Backend (3 + 1 test)** :
+- `packages/api/app/services/letters/catalog.py` — `LETTER_2` complet (5 actions + 3 narratifs)
+- `packages/api/app/services/letters/service.py` — 5 nouveaux détecteurs + `_serialize` étendu
+- `packages/api/tests/routers/test_letters_routes.py` — 8 nouveaux tests (TestLetter2Detection, TestLetter2Shape, TestLetter2Idempotence)
+- `docs/qa/scripts/verify_letters.sh` — smoke L2 + doc PR4
+
+**Mobile (5 + 2 tests + 1 nouveau)** :
+- `apps/mobile/lib/features/lettres/models/letter.dart` — 3 nouveaux champs nullable
+- `apps/mobile/lib/core/services/analytics_service.dart` — `trackBonnesNouvellesOpened`
+- `apps/mobile/lib/features/feed/widgets/digest_entry_card.dart` — câblage tracker + `silentRefresh`
+- `apps/mobile/lib/features/lettres/screens/open_letter_screen.dart` — affichage `introPalier` + listener anti-cascade
+- `apps/mobile/lib/features/lettres/widgets/letter_completion_overlay.dart` — affichage `completionVoeu`
+- `apps/mobile/lib/features/lettres/widgets/palier_toast.dart` — **NEW** OverlayEntry helper
+- `apps/mobile/test/features/lettres/widgets/palier_toast_test.dart` — affichage + auto-dismiss
+- `apps/mobile/test/features/lettres/models/letter_test.dart` — fromJson backward-compat
+
+### Notes pour Lettre 3 (hors scope)
+
+- Activation widget = scope ultérieur.
+- Détecteur prévu : `widget_pin_requested` ou `widget_app_opened` (events PostHog déjà émis par `analytics_service.dart`).
+- Le pattern « toast palier sans chiffre » établi par L2 doit être réutilisé.

--- a/packages/api/app/services/letters/catalog.py
+++ b/packages/api/app/services/letters/catalog.py
@@ -58,17 +58,61 @@ LETTER_1: dict = {
 LETTER_2: dict = {
     "id": "letter_2",
     "num": "02",
-    "title": "Ton rythme idéal",
+    "title": "Tes premières lectures",
     "default_status": "upcoming",
+    "intro_palier": (
+        "Ta sélection est posée. Voyons maintenant si tu sais en faire bon usage."
+    ),
     "actions": [
         {
-            "id": "set_frequency",
-            "label": "Choisir ta fréquence de digest",
-            "help": "Quotidien, hebdomadaire, ou à la demande.",
+            "id": "read_first_essentiel",
+            "label": "Lire L'essentiel du jour",
+            "help": "Cinq articles, choisis pour toi. C'est le rendez-vous quotidien.",
+            "completion_palier": "Premier rendez-vous tenu. Ça commence ici.",
+        },
+        {
+            "id": "read_first_bonnes_nouvelles",
+            "label": "Découvrir Les bonnes nouvelles",
+            "help": "Quand l'actu pèse, va voir ce qui s'allège.",
+            "completion_palier": (
+                "Tu sais maintenant que la lecture peut aussi faire du bien."
+            ),
+        },
+        {
+            "id": "read_3_long_articles",
+            "label": "Lire 3 articles jusqu'au bout",
+            "help": "Pas de scroll express. Prends le temps de finir.",
+            "completion_palier": (
+                "Trois lectures menées au bout. C'est ce qui te distingue déjà."
+            ),
+        },
+        {
+            "id": "read_first_video_podcast",
+            "label": "Écouter un podcast ou regarder une vidéo",
+            "help": "Au moins quatre minutes. Le temps que ça t'apporte quelque chose.",
+            "completion_palier": (
+                "Tu varies les formats. C'est comme ça qu'on s'enrichit."
+            ),
+        },
+        {
+            "id": "recommend_first_article",
+            "label": "Recommander un article",
+            "help": (
+                "Un like (🌻), c'est un signal. Il oriente ta sélection et celle des autres."
+            ),
+            "completion_palier": "Un signal envoyé. Le Facteur écoute.",
         },
     ],
-    "message": ("Maintenant que ta sélection est posée, choisissons ton rythme."),
+    "message": (
+        "Ta sélection est prête. Maintenant, faisons connaissance avec ce qu'elle "
+        "peut t'apporter au quotidien.\n\n"
+        "Pas de course à la lecture, pas de chiffres à atteindre — "
+        "juste cinq gestes simples pour entrer dans le rythme."
+    ),
     "signature": "Le Facteur",
+    "completion_voeu": (
+        "Tu as appris à lire avec attention. C'est déjà beaucoup. La suite peut attendre."
+    ),
 }
 
 LETTERS_ORDER: list[dict] = [LETTER_0, LETTER_1, LETTER_2]

--- a/packages/api/app/services/letters/service.py
+++ b/packages/api/app/services/letters/service.py
@@ -18,6 +18,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.analytics import AnalyticsEvent
+from app.models.content import Content, UserContentStatus
 from app.models.source import UserSource
 from app.models.user_letter_progress import UserLetterProgress
 from app.models.user_topic_profile import UserTopicProfile
@@ -62,13 +63,64 @@ async def _detect_add_2_personal_sources(user_id: UUID, db: AsyncSession) -> boo
     return ((await db.execute(stmt)).scalar() or 0) >= 2
 
 
-async def _detect_first_perspectives_open(user_id: UUID, db: AsyncSession) -> bool:
-    """Au moins un AnalyticsEvent event_type='perspectives_opened'."""
+def _first_event_detector(event_type: str):
+    async def _detect(user_id: UUID, db: AsyncSession) -> bool:
+        stmt = (
+            select(AnalyticsEvent.id)
+            .where(
+                AnalyticsEvent.user_id == user_id,
+                AnalyticsEvent.event_type == event_type,
+            )
+            .limit(1)
+        )
+        return (await db.execute(stmt)).scalar() is not None
+
+    return _detect
+
+
+_detect_first_perspectives_open = _first_event_detector("perspectives_opened")
+_detect_read_first_essentiel = _first_event_detector("digest_opened")
+_detect_read_first_bonnes_nouvelles = _first_event_detector("bonnes_nouvelles_opened")
+
+
+async def _detect_read_3_long_articles(user_id: UUID, db: AsyncSession) -> bool:
+    """≥3 contenus articles avec reading_progress≥90 et time_spent_seconds≥60."""
     stmt = (
-        select(AnalyticsEvent.id)
+        select(func.count(func.distinct(UserContentStatus.content_id)))
+        .select_from(UserContentStatus)
+        .join(Content, Content.id == UserContentStatus.content_id)
         .where(
-            AnalyticsEvent.user_id == user_id,
-            AnalyticsEvent.event_type == "perspectives_opened",
+            UserContentStatus.user_id == user_id,
+            UserContentStatus.reading_progress >= 90,
+            UserContentStatus.time_spent_seconds >= 60,
+            Content.content_type == "article",
+        )
+    )
+    return ((await db.execute(stmt)).scalar() or 0) >= 3
+
+
+async def _detect_read_first_video_podcast(user_id: UUID, db: AsyncSession) -> bool:
+    """Au moins un contenu podcast/youtube avec time_spent_seconds≥240."""
+    stmt = (
+        select(UserContentStatus.id)
+        .join(Content, Content.id == UserContentStatus.content_id)
+        .where(
+            UserContentStatus.user_id == user_id,
+            UserContentStatus.time_spent_seconds >= 240,
+            Content.content_type.in_(["podcast", "youtube"]),
+        )
+        .limit(1)
+    )
+    return (await db.execute(stmt)).scalar() is not None
+
+
+async def _detect_recommend_first_article(user_id: UUID, db: AsyncSession) -> bool:
+    """Au moins un UserContentStatus avec is_liked=True."""
+    stmt = (
+        select(UserContentStatus.id)
+        .where(
+            UserContentStatus.user_id == user_id,
+            UserContentStatus.is_liked.is_(True),
         )
         .limit(1)
     )
@@ -80,7 +132,11 @@ DETECTORS = {
     "add_5_sources": _detect_add_5_sources,
     "add_2_personal_sources": _detect_add_2_personal_sources,
     "first_perspectives_open": _detect_first_perspectives_open,
-    # `set_frequency` (L2) : à brancher quand l'UI sera prête (PR2/PR3).
+    "read_first_essentiel": _detect_read_first_essentiel,
+    "read_first_bonnes_nouvelles": _detect_read_first_bonnes_nouvelles,
+    "read_3_long_articles": _detect_read_3_long_articles,
+    "read_first_video_podcast": _detect_read_first_video_podcast,
+    "recommend_first_article": _detect_recommend_first_article,
 }
 
 
@@ -96,19 +152,32 @@ def _serialize(row: UserLetterProgress, catalog: dict) -> dict:
         if actions
         else 1.0
     )
-    return {
+    serialized_actions = [
+        {
+            k: a[k]
+            for k in ("id", "label", "help", "completion_palier")
+            if k in a and a[k] is not None
+        }
+        for a in actions
+    ]
+    payload: dict = {
         "id": catalog["id"],
         "num": catalog["num"],
         "title": catalog["title"],
         "message": catalog["message"],
         "signature": catalog["signature"],
-        "actions": actions,
+        "actions": serialized_actions,
         "status": row.status,
         "completed_actions": completed,
         "progress": round(progress, 4),
         "started_at": row.started_at.isoformat() if row.started_at else None,
         "archived_at": row.archived_at.isoformat() if row.archived_at else None,
     }
+    if catalog.get("intro_palier"):
+        payload["intro_palier"] = catalog["intro_palier"]
+    if catalog.get("completion_voeu"):
+        payload["completion_voeu"] = catalog["completion_voeu"]
+    return payload
 
 
 async def _get_rows(user_id: UUID, db: AsyncSession) -> dict[str, UserLetterProgress]:

--- a/packages/api/tests/routers/test_letters_routes.py
+++ b/packages/api/tests/routers/test_letters_routes.py
@@ -21,7 +21,8 @@ from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.main import app
 from app.models.analytics import AnalyticsEvent
-from app.models.enums import SourceType
+from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentType, SourceType
 from app.models.source import Source, UserSource
 from app.models.user import UserProfile
 from app.models.user_letter_progress import UserLetterProgress
@@ -105,6 +106,98 @@ async def _add_perspectives_event(db_session, user_id: UUID) -> None:
             event_type="perspectives_opened",
             event_data={"content_id": str(uuid4())},
         )
+    )
+    await db_session.commit()
+
+
+async def _add_event(db_session, user_id: UUID, event_type: str) -> None:
+    db_session.add(
+        AnalyticsEvent(
+            user_id=user_id,
+            event_type=event_type,
+            event_data={},
+        )
+    )
+    await db_session.commit()
+
+
+async def _make_source(db_session) -> Source:
+    src = Source(
+        id=uuid4(),
+        name=f"Src {uuid4()}",
+        url=f"https://src-{uuid4()}.example.com",
+        feed_url=f"https://src-{uuid4()}.example.com/feed.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+    )
+    db_session.add(src)
+    await db_session.flush()
+    return src
+
+
+async def _add_user_content_status(
+    db_session,
+    user_id: UUID,
+    *,
+    content_type: ContentType,
+    reading_progress: int = 0,
+    time_spent_seconds: int = 0,
+    is_liked: bool = False,
+) -> None:
+    src = await _make_source(db_session)
+    content = Content(
+        id=uuid4(),
+        source_id=src.id,
+        title="t",
+        url=f"https://x/{uuid4()}",
+        published_at=datetime.now(UTC),
+        content_type=content_type,
+        guid=str(uuid4()),
+    )
+    db_session.add(content)
+    await db_session.flush()
+    db_session.add(
+        UserContentStatus(
+            user_id=user_id,
+            content_id=content.id,
+            reading_progress=reading_progress,
+            time_spent_seconds=time_spent_seconds,
+            is_liked=is_liked,
+        )
+    )
+    await db_session.commit()
+
+
+async def _activate_l2(db_session, user_id: UUID) -> None:
+    """Force L2 active (bypass auto-archivage L1) en posant les rows initiales
+    avec L1 archivée et L2 active."""
+    now = datetime.now(UTC)
+    db_session.add_all(
+        [
+            UserLetterProgress(
+                user_id=user_id,
+                letter_id="letter_0",
+                status="archived",
+                completed_actions=[],
+                archived_at=now,
+            ),
+            UserLetterProgress(
+                user_id=user_id,
+                letter_id="letter_1",
+                status="archived",
+                completed_actions=[],
+                started_at=now,
+                archived_at=now,
+            ),
+            UserLetterProgress(
+                user_id=user_id,
+                letter_id="letter_2",
+                status="active",
+                completed_actions=[],
+                started_at=now,
+            ),
+        ]
     )
     await db_session.commit()
 
@@ -278,3 +371,162 @@ class TestErrors:
         async with _client() as ac:
             resp = await ac.post("/api/letters/letter_xxx/refresh-status")
         assert resp.status_code == 404
+
+
+# ─── Lettre 2 — Tes premières lectures ─────────────────────────────────────
+
+
+class TestLetter2Detection:
+    async def test_read_first_essentiel_detected(self, auth_user, db_session):
+        await _activate_l2(db_session, auth_user)
+        await _add_event(db_session, auth_user, "digest_opened")
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert resp.status_code == 200
+        assert "read_first_essentiel" in resp.json()["completed_actions"]
+
+    async def test_read_first_bonnes_nouvelles_detected(self, auth_user, db_session):
+        await _activate_l2(db_session, auth_user)
+        await _add_event(db_session, auth_user, "bonnes_nouvelles_opened")
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert "read_first_bonnes_nouvelles" in resp.json()["completed_actions"]
+
+    async def test_read_3_long_articles_detected(self, auth_user, db_session):
+        await _activate_l2(db_session, auth_user)
+        for _ in range(3):
+            await _add_user_content_status(
+                db_session,
+                auth_user,
+                content_type=ContentType.ARTICLE,
+                reading_progress=95,
+                time_spent_seconds=120,
+            )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert "read_3_long_articles" in resp.json()["completed_actions"]
+
+    async def test_read_3_long_articles_below_threshold_not_detected(
+        self, auth_user, db_session
+    ):
+        await _activate_l2(db_session, auth_user)
+        # 2 articles seulement → pas détecté
+        for _ in range(2):
+            await _add_user_content_status(
+                db_session,
+                auth_user,
+                content_type=ContentType.ARTICLE,
+                reading_progress=95,
+                time_spent_seconds=120,
+            )
+        # 1 article avec time_spent insuffisant → ne doit pas compter
+        await _add_user_content_status(
+            db_session,
+            auth_user,
+            content_type=ContentType.ARTICLE,
+            reading_progress=95,
+            time_spent_seconds=30,
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert "read_3_long_articles" not in resp.json()["completed_actions"]
+
+    async def test_read_first_video_podcast_detected(self, auth_user, db_session):
+        await _activate_l2(db_session, auth_user)
+        await _add_user_content_status(
+            db_session,
+            auth_user,
+            content_type=ContentType.YOUTUBE,
+            time_spent_seconds=300,
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert "read_first_video_podcast" in resp.json()["completed_actions"]
+
+    async def test_recommend_first_article_detected(self, auth_user, db_session):
+        await _activate_l2(db_session, auth_user)
+        await _add_user_content_status(
+            db_session,
+            auth_user,
+            content_type=ContentType.ARTICLE,
+            is_liked=True,
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert "recommend_first_article" in resp.json()["completed_actions"]
+
+
+class TestLetter2Shape:
+    async def test_l2_exposes_narrative_fields(self, auth_user, db_session):
+        await _activate_l2(db_session, auth_user)
+
+        async with _client() as ac:
+            resp = await ac.get("/api/letters")
+
+        l2 = next(letter for letter in resp.json() if letter["id"] == "letter_2")
+        assert l2["status"] == "active"
+        assert isinstance(l2.get("intro_palier"), str) and l2["intro_palier"]
+        assert isinstance(l2.get("completion_voeu"), str) and l2["completion_voeu"]
+        assert len(l2["actions"]) == 5
+        for action in l2["actions"]:
+            assert isinstance(action.get("completion_palier"), str)
+            assert action["completion_palier"]
+
+    async def test_l1_does_not_expose_l2_only_fields(self, auth_user):
+        async with _client() as ac:
+            resp = await ac.get("/api/letters")
+
+        l1 = next(letter for letter in resp.json() if letter["id"] == "letter_1")
+        # L1 ne définit ni intro_palier ni completion_voeu : champs absents.
+        assert "intro_palier" not in l1
+        assert "completion_voeu" not in l1
+        for action in l1["actions"]:
+            assert "completion_palier" not in action
+
+
+class TestLetter2Idempotence:
+    async def test_archived_l2_stays_archived(self, auth_user, db_session):
+        await _activate_l2(db_session, auth_user)
+        # Cocher toutes les actions
+        await _add_event(db_session, auth_user, "digest_opened")
+        await _add_event(db_session, auth_user, "bonnes_nouvelles_opened")
+        for _ in range(3):
+            await _add_user_content_status(
+                db_session,
+                auth_user,
+                content_type=ContentType.ARTICLE,
+                reading_progress=95,
+                time_spent_seconds=120,
+            )
+        await _add_user_content_status(
+            db_session,
+            auth_user,
+            content_type=ContentType.PODCAST,
+            time_spent_seconds=300,
+        )
+        await _add_user_content_status(
+            db_session,
+            auth_user,
+            content_type=ContentType.ARTICLE,
+            is_liked=True,
+        )
+
+        async with _client() as ac:
+            r1 = await ac.post("/api/letters/letter_2/refresh-status")
+            r2 = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert r1.json()["status"] == "archived"
+        assert r2.json()["status"] == "archived"
+        assert len(r1.json()["completed_actions"]) == 5


### PR DESCRIPTION
## Quoi

Remplace la Lettre 2 placeholder (1 action `set_frequency`) par **5 actions auto-détectées** marquant un J+1 d'usage naturel, et ajoute une dimension narrative anti-FOMO.

### Backend (`packages/api/`)
- 5 nouveaux détecteurs dans `app/services/letters/service.py` :
  `read_first_essentiel` (digest_opened), `read_first_bonnes_nouvelles`,
  `read_3_long_articles` (≥90 % progress · ≥60 s · type=article),
  `read_first_video_podcast` (≥240 s · podcast/youtube),
  `recommend_first_article` (is_liked).
- Factory `_first_event_detector(event_type)` factorise les 3 détecteurs
  « first AnalyticsEvent » (existant + 2 nouveaux).
- Catalogue L2 enrichi avec `intro_palier` (lettre), `completion_palier`
  (par action) et `completion_voeu` (overlay cachet). Aucune migration DB.
- `_serialize` re-projette les actions pour exposer `completion_palier`
  uniquement quand présent — L0/L1 conservent leur shape exacte.

### Mobile (`apps/mobile/`)
- `palier_toast.dart` (nouveau) — overlay Fraunces italique, fade 250 ms,
  hold 4 s, dismiss auto, max 2 lignes.
- `OpenLetterScreen` : snapshot des actions déjà done au premier reçu pour
  l'**anti-cascade** (un seul toast par rafale, pas de toast pour les paliers
  acquis hors session). Toast supprimé quand la lettre passe `archived` →
  l'overlay cachet final prend le relais avec `completion_voeu`.
- `Letter`/`LetterAction` : 3 nouveaux champs nullable
  (`introPalier`, `completionVoeu`, `completionPalier`) — backward-compatible.
- `digest_entry_card.dart` : émet `bonnes_nouvelles_opened` + déclenche un
  `silentRefresh` des lettres au tap sur la carte feed correspondante.
- `analyticsService.trackBonnesNouvellesOpened()` (logEvent + PostHog).
- `LetterCompletionOverlay` : retire la troncature silencieuse `maxLines: 4`
  (les voeux éditoriaux peuvent dépasser).

## Pourquoi

Story 19.1 PR4 : la L2 placeholder ne reflétait aucun usage réel. Cette PR
matérialise l'apprentissage J+1 (lire l'essentiel, varier les formats,
recommander, aller au bout) et installe un vocabulaire de récompense
**sans chiffres, sans comparaison sociale, anti-FOMO** — cohérent avec la
ligne éditoriale Facteur.

## Comment ça a été vérifié

- [x] `pytest tests/routers/test_letters_routes.py` → **20/20** (incl. 9
  nouveaux cas L2 : 5 détecteurs, shape JSON, idempotence post-archivage).
- [x] `pytest -q` (suite complète) → **969 pass, 1 fail TZ-only** sur
  `test_notification_preferences::test_patch_increments_refusal_count`
  (datetime locale Europe/Paris vs CI UTC, intouché par cette PR).
- [x] `ruff check app/ && ruff format --check app/` → clean.
- [x] `flutter test test/features/lettres/` → **34/34**.
- [x] `flutter test` (suite complète) → 543 pass / 37 fail (failures
  pré-existantes sur `main`, sans rapport avec L2 — vérifié par baseline).
- [x] `flutter analyze` sur les fichiers touchés → 0 erreur, 0 nouveau
  warning (uniquement des `info` `withOpacity`/`prefer_const` héritées).
- [x] `bash docs/qa/scripts/verify_letters.sh` → **4/4 pass** (route L1+L2
  enregistrées, auth requise).
- [x] Skill `simplify` passée — factory détecteurs extraite, comments
  task-rot retirés, troncature silencieuse retirée.

QA Handoff complet (5 scénarios + critères d'acceptation) :
[`.context/qa-handoff.md`](https://github.com/boujonlaurin-dotcom/facteur/blob/boujonlaurin-dotcom/lettre2-lectures/.context/qa-handoff.md).

## Zones à risque

- **Détection « 3 articles jusqu'au bout »** : dépend du PATCH
  `POST /contents/{id}/status` fire-and-forget côté mobile. Si l'utilisateur
  ferme l'app avant le sync, l'action peut tarder à se cocher. Cohérent avec
  les autres détecteurs.
- **Snapshot par-instance** dans `_OpenLetterScreenState` : à chaque réouverture
  de l'écran, le snapshot est refait → pas de toast pour les paliers acquis
  hors session. Comportement voulu (anti-spam).
- **Wording éditorial** : les 7 chaînes (`intro_palier` + `completion_voeu` +
  5 × `completion_palier`) sont rédigées dans l'esprit Facteur, à valider PO.
- **Pas de migration DB** : tout repose sur les modèles existants
  (`AnalyticsEvent`, `UserContentStatus`, `Content`).