### PR TITLE
feat(widget): refonte UI Android — ListView scroll + bouton refresh + deep link fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -78,9 +78,8 @@
       "type": "dart",
       "program": "apps/mobile/lib/main.dart",
       "preLaunchTask": "Launch Android Emulator",
+      "deviceId": "emulator-5554",
       "args": [
-        "-d",
-        "emulator-5554",
         "--dart-define=API_BASE_URL=https://facteur-production.up.railway.app/api/",
         "--dart-define=SUPABASE_URL=https://ykuadtelnzavrqzbfdve.supabase.co",
         "--dart-define=SUPABASE_ANON_KEY=sb_publishable_0L_kPMbe0Pk9eBdzeEsIZg_0pogzm3k"
@@ -92,9 +91,8 @@
       "type": "dart",
       "program": "apps/mobile/lib/main.dart",
       "preLaunchTask": "Android Emulator + Backend API",
+      "deviceId": "emulator-5554",
       "args": [
-        "-d",
-        "emulator-5554",
         // 10.0.2.2 = adresse du host machine depuis l'émulateur Android
         "--dart-define=API_BASE_URL=http://10.0.2.2:8080/api/",
         "--dart-define=SUPABASE_URL=https://ykuadtelnzavrqzbfdve.supabase.co",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,10 +23,18 @@
     {
       "label": "Launch Android Emulator",
       "type": "shell",
-      "command": "ADB=${env:HOME}/Library/Android/sdk/platform-tools/adb; EMU=${env:HOME}/Library/Android/sdk/emulator/emulator; DEVICE=emulator-5554; if [ \"$($ADB -s $DEVICE get-state 2>/dev/null || true)\" = \"device\" ]; then while [ \"$($ADB -s $DEVICE shell getprop sys.boot_completed 2>/dev/null || true)\" != \"1\" ]; do sleep 2; done; echo 'Emulator already running'; exit 0; fi; $EMU -avd Medium_Phone_API_36.1 -no-audio -no-boot-anim -gpu host & $ADB wait-for-device; while [ \"$($ADB -s $DEVICE shell getprop sys.boot_completed 2>/dev/null)\" != \"1\" ]; do sleep 2; done; echo 'Emulator ready'",
-      "isBackground": false,
+      "command": "ADB=${env:HOME}/Library/Android/sdk/platform-tools/adb; EMU=${env:HOME}/Library/Android/sdk/emulator/emulator; AVD_NAME=Pixel_5_API_30_Lite; if $ADB devices | grep -q 'emulator-'; then DEVICE=$($ADB devices | grep 'emulator-' | head -n1 | awk '{print $1}'); else DEVICE='emulator-5554'; fi; if [ \"$($ADB -s $DEVICE get-state 2>/dev/null || true)\" = \"device\" ]; then while [ \"$($ADB -s $DEVICE shell getprop sys.boot_completed 2>/dev/null || true)\" != \"1\" ]; do sleep 2; done; echo \"Emulator ready\"; exit 0; fi; echo \"Starting emulator ($AVD_NAME)...\"; $EMU -avd $AVD_NAME -no-audio -no-boot-anim -gpu software -no-snapshot-load & $ADB -e wait-for-device; while [ \"$($ADB -e shell getprop sys.boot_completed 2>/dev/null)\" != \"1\" ]; do sleep 2; done; echo 'Emulator ready'; wait",
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": { "regexp": "^$" },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^Starting emulator.*$",
+          "endsPattern": "^Emulator ready$"
+        }
+      },
       "presentation": {
-        "reveal": "silent",
+        "reveal": "always",
         "panel": "shared",
         "showReuseMessage": false
       }

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -57,6 +57,10 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/facteur_widget_info" />
         </receiver>
+        <service
+            android:name=".FacteurWidgetService"
+            android:permission="android.permission.BIND_REMOTEVIEWS"
+            android:exported="false" />
 
         <!-- flutter_downloader : provider FileProvider pour partager l'APK
              téléchargé avec l'installeur Android, et init custom pour limiter

--- a/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt
@@ -3,43 +3,42 @@ package com.example.facteur
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.Canvas
-import android.graphics.Paint
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffXfermode
-import android.graphics.RectF
 import android.net.Uri
 import android.util.Log
 import android.view.View
 import android.widget.RemoteViews
 import es.antonborri.home_widget.HomeWidgetPlugin
-import org.json.JSONArray
-import org.json.JSONObject
-import java.io.File
-import java.time.Duration
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 
 /**
- * Home-screen widget rendering up to 5 digest articles inline.
+ * Home-screen widget rendering up to 5 digest articles in a scrollable
+ * `ListView` bound to [FacteurWidgetService].
  *
- * Earlier iterations used a ListView bound to a RemoteViewsService. That
- * pattern is unreliable on Samsung One UI launchers (the RemoteViewsAdapter
- * never receives data and the system shows "Chargement…" forever). We now
- * parse `articles_json` directly in [onUpdate] and append one
- * `widget_article_row` RemoteViews per article into `articles_container`.
+ * Only header text + adapter wiring live here; row construction happens in
+ * the service so the list survives system kills and is re-fed via
+ * [AppWidgetManager.notifyAppWidgetViewDataChanged].
  */
 class FacteurWidget : AppWidgetProvider() {
 
     companion object {
         private const val TAG = "FacteurWidget"
-        private const val MAX_ROWS = 5
-        private const val STALE_THRESHOLD_MS = 36L * 60 * 60 * 1000 // 36h
+        const val ACTION_REFRESH = "com.example.facteur.action.REFRESH_WIDGET"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        if (intent.action == ACTION_REFRESH) {
+            val mgr = AppWidgetManager.getInstance(context)
+            val ids = mgr.getAppWidgetIds(
+                ComponentName(context, FacteurWidget::class.java),
+            )
+            if (ids.isNotEmpty()) {
+                Log.d(TAG, "ACTION_REFRESH ids=${ids.size}")
+                onUpdate(context, mgr, ids)
+            }
+        }
     }
 
     override fun onUpdate(
@@ -55,15 +54,14 @@ class FacteurWidget : AppWidgetProvider() {
                 Log.d(TAG, "onUpdate id=$appWidgetId json.len=${json?.length ?: -1}")
 
                 renderHeader(views, prefs)
-                Log.d(TAG, "header rendered id=$appWidgetId")
-                renderArticles(context, views, json)
-                Log.d(TAG, "articles rendered id=$appWidgetId")
+                bindArticleList(context, views, appWidgetId, json)
                 wireClickIntents(context, views, appWidgetId)
-                Log.d(TAG, "intents wired id=$appWidgetId")
 
-                Log.d(TAG, "calling updateAppWidget id=$appWidgetId")
                 appWidgetManager.updateAppWidget(appWidgetId, views)
-                Log.d(TAG, "updateAppWidget returned id=$appWidgetId")
+                appWidgetManager.notifyAppWidgetViewDataChanged(
+                    appWidgetId,
+                    R.id.articles_list,
+                )
             } catch (t: Throwable) {
                 Log.e(TAG, "Widget update failed for id=$appWidgetId", t)
             }
@@ -83,137 +81,43 @@ class FacteurWidget : AppWidgetProvider() {
             else -> "L'Essentiel du jour"
         }
         views.setTextViewText(R.id.subtitle, subtitle)
+    }
 
-        val updatedAt = prefs?.getString("articles_updated_at", "0")?.toLongOrNull() ?: 0L
-        val isStale = updatedAt > 0 &&
-            (System.currentTimeMillis() - updatedAt) > STALE_THRESHOLD_MS
+    private fun bindArticleList(
+        context: Context,
+        views: RemoteViews,
+        appWidgetId: Int,
+        json: String?,
+    ) {
+        // Adapter intent — unique URI per appWidgetId so the system keeps
+        // a separate factory instance per widget on the home screen.
+        val adapterIntent = Intent(context, FacteurWidgetService::class.java).apply {
+            putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
+        }
+        views.setRemoteAdapter(R.id.articles_list, adapterIntent)
+        views.setEmptyView(R.id.articles_list, R.id.empty_view)
+
+        val isEmpty = json.isNullOrBlank() || json == "[]"
         views.setViewVisibility(
-            R.id.stale_banner,
-            if (isStale) View.VISIBLE else View.GONE,
+            R.id.empty_view,
+            if (isEmpty) View.VISIBLE else View.GONE,
         )
-    }
 
-    private fun renderArticles(context: Context, views: RemoteViews, json: String?) {
-        views.removeAllViews(R.id.articles_container)
-
-        val articles = parseArticles(json)
-        Log.d(TAG, "parseArticles count=${articles.size}")
-        if (articles.isEmpty()) {
-            views.addView(
-                R.id.articles_container,
-                buildPlaceholderRow(context, "Ouvre Facteur pour charger ton essentiel"),
-            )
-            return
-        }
-
-        for ((index, article) in articles.withIndex()) {
-            Log.d(TAG, "buildArticleRow idx=$index id=${article.id} thumb=${article.thumbnailPath.isNotBlank()} logo=${article.sourceLogoPath.isNotBlank()}")
-            val row = buildArticleRow(context, article)
-            views.addView(R.id.articles_container, row)
-            Log.d(TAG, "addView ok idx=$index")
-        }
-    }
-
-    private fun parseArticles(json: String?): List<Article> {
-        if (json.isNullOrBlank() || json == "[]") return emptyList()
-        return try {
-            val arr = JSONArray(json)
-            (0 until arr.length()).take(MAX_ROWS).mapNotNull { i ->
-                arr.optJSONObject(i)?.let(::parseArticle)
-            }
-        } catch (e: Exception) {
-            Log.w(TAG, "parseArticles failed", e)
-            emptyList()
-        }
-    }
-
-    private fun parseArticle(obj: JSONObject): Article = Article(
-        id = obj.optString("id"),
-        rank = obj.optInt("rank", 0),
-        topicId = obj.optString("topic_id"),
-        topicLabel = obj.optString("topic_label"),
-        isMain = obj.optBoolean("is_main", false),
-        title = obj.optString("title"),
-        sourceName = obj.optString("source_name"),
-        sourceLogoPath = obj.optString("source_logo_path"),
-        thumbnailPath = obj.optString("thumbnail_path"),
-        perspectiveCount = obj.optInt("perspective_count", 0),
-        publishedAtIso = obj.optString("published_at_iso"),
-    )
-
-    private fun buildArticleRow(context: Context, article: Article): RemoteViews {
-        val rv = RemoteViews(context.packageName, R.layout.widget_article_row)
-
-        rv.setTextViewText(
-            R.id.row_topic,
-            "${article.rank} — ${article.topicLabel.ifBlank { "Actu" }}",
-        )
-        rv.setViewVisibility(
-            R.id.row_a_la_une,
-            if (article.isMain) View.VISIBLE else View.GONE,
-        )
-        rv.setTextViewText(R.id.row_title, article.title)
-
-        val thumb = loadBitmap(context, article.thumbnailPath, 60)?.let {
-            roundCorners(context, it, 8f)
-        }
-        if (thumb != null) {
-            rv.setImageViewBitmap(R.id.row_thumbnail, thumb)
-            rv.setViewVisibility(R.id.row_thumbnail, View.VISIBLE)
-        } else {
-            rv.setViewVisibility(R.id.row_thumbnail, View.GONE)
-        }
-
-        val logo = loadBitmap(context, article.sourceLogoPath, 16)
-        if (logo != null) {
-            rv.setImageViewBitmap(R.id.row_source_logo, logo)
-            rv.setViewVisibility(R.id.row_source_logo, View.VISIBLE)
-        } else {
-            rv.setViewVisibility(R.id.row_source_logo, View.GONE)
-        }
-        rv.setTextViewText(R.id.row_source_name, article.sourceName)
-
-        if (article.perspectiveCount > 0) {
-            rv.setTextViewText(R.id.row_perspective, "+${article.perspectiveCount}")
-            rv.setViewVisibility(R.id.row_perspective, View.VISIBLE)
-        } else {
-            rv.setViewVisibility(R.id.row_perspective, View.GONE)
-        }
-
-        rv.setTextViewText(R.id.row_time, formatTime(article.publishedAtIso))
-
-        // Tap target — open the article via deep link.
-        val tapIntent = Intent(context, MainActivity::class.java).apply {
+        // Per-row tap delivers a fillInIntent merged with this template.
+        // FLAG_MUTABLE is required (Android 12+) so the system can write the
+        // fillInIntent's data URI into the template at click time.
+        val template = Intent(context, MainActivity::class.java).apply {
             action = Intent.ACTION_VIEW
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            data = Uri.parse("io.supabase.facteur://digest/${article.id}")
-                .buildUpon()
-                .appendQueryParameter("pos", article.rank.toString())
-                .appendQueryParameter("topicId", article.topicId)
-                .build()
         }
-        val pending = PendingIntent.getActivity(
+        val templatePending = PendingIntent.getActivity(
             context,
-            article.id.hashCode(),
-            tapIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            appWidgetId,
+            template,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
         )
-        rv.setOnClickPendingIntent(R.id.row_root, pending)
-
-        return rv
-    }
-
-    private fun buildPlaceholderRow(context: Context, text: String): RemoteViews {
-        val rv = RemoteViews(context.packageName, R.layout.widget_article_row)
-        rv.setTextViewText(R.id.row_topic, "")
-        rv.setViewVisibility(R.id.row_a_la_une, View.GONE)
-        rv.setTextViewText(R.id.row_title, text)
-        rv.setViewVisibility(R.id.row_thumbnail, View.GONE)
-        rv.setViewVisibility(R.id.row_source_logo, View.GONE)
-        rv.setTextViewText(R.id.row_source_name, "")
-        rv.setViewVisibility(R.id.row_perspective, View.GONE)
-        rv.setTextViewText(R.id.row_time, "")
-        return rv
+        views.setPendingIntentTemplate(R.id.articles_list, templatePending)
     }
 
     private fun wireClickIntents(context: Context, views: RemoteViews, appWidgetId: Int) {
@@ -228,90 +132,19 @@ class FacteurWidget : AppWidgetProvider() {
             openIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
-        views.setOnClickPendingIntent(R.id.widget_header, openPending)
+        views.setOnClickPendingIntent(R.id.app_name, openPending)
         views.setOnClickPendingIntent(R.id.subtitle, openPending)
         views.setOnClickPendingIntent(R.id.btn_open, openPending)
-        views.setOnClickPendingIntent(R.id.stale_banner, openPending)
-    }
 
-    // ──────────────────────────────────────────────────────────────
-    // Helpers
-    // ──────────────────────────────────────────────────────────────
-
-    private data class Article(
-        val id: String,
-        val rank: Int,
-        val topicId: String,
-        val topicLabel: String,
-        val isMain: Boolean,
-        val title: String,
-        val sourceName: String,
-        val sourceLogoPath: String,
-        val thumbnailPath: String,
-        val perspectiveCount: Int,
-        val publishedAtIso: String,
-    )
-
-    /**
-     * Decode a bitmap downscaled to fit within [targetSizeDp]² to keep the
-     * RemoteViews payload small. Inlining 5 unscaled article thumbnails into
-     * a single RemoteViews trips Binder's ~1 MB IPC limit, surfacing as
-     * "Impossible d'ajouter le widget" on the host launcher.
-     */
-    private fun loadBitmap(context: Context, path: String?, targetSizeDp: Int): Bitmap? {
-        if (path.isNullOrBlank()) return null
-        return try {
-            val file = File(path)
-            if (!file.exists()) return null
-
-            val targetPx = (targetSizeDp * context.resources.displayMetrics.density).toInt()
-                .coerceAtLeast(1)
-
-            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-            BitmapFactory.decodeFile(file.absolutePath, bounds)
-            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
-
-            var sample = 1
-            while (
-                bounds.outWidth / (sample * 2) >= targetPx &&
-                bounds.outHeight / (sample * 2) >= targetPx
-            ) {
-                sample *= 2
-            }
-
-            val opts = BitmapFactory.Options().apply { inSampleSize = sample }
-            BitmapFactory.decodeFile(file.absolutePath, opts)
-        } catch (e: Exception) {
-            Log.w(TAG, "Bitmap decode failed: $path", e)
-            null
+        val refreshIntent = Intent(context, FacteurWidget::class.java).apply {
+            action = ACTION_REFRESH
         }
-    }
-
-    private fun roundCorners(context: Context, src: Bitmap, radiusDp: Float): Bitmap {
-        val r = radiusDp * context.resources.displayMetrics.density
-        val output = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
-        val canvas = Canvas(output)
-        val paint = Paint(Paint.ANTI_ALIAS_FLAG)
-        val rect = RectF(0f, 0f, src.width.toFloat(), src.height.toFloat())
-        canvas.drawRoundRect(rect, r, r, paint)
-        paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
-        canvas.drawBitmap(src, 0f, 0f, paint)
-        return output
-    }
-
-    private fun formatTime(iso: String): String {
-        if (iso.isBlank()) return ""
-        return try {
-            val parsed = OffsetDateTime.parse(iso, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-            val minutes = Duration.between(parsed, OffsetDateTime.now()).toMinutes()
-            when {
-                minutes < 1 -> "à l'instant"
-                minutes < 60 -> String.format(Locale.FRENCH, "%dmin", minutes)
-                minutes < 24 * 60 -> String.format(Locale.FRENCH, "%dh", minutes / 60)
-                else -> String.format(Locale.FRENCH, "%dj", minutes / (60 * 24))
-            }
-        } catch (e: Exception) {
-            ""
-        }
+        val refreshPending = PendingIntent.getBroadcast(
+            context,
+            appWidgetId,
+            refreshIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        views.setOnClickPendingIntent(R.id.btn_refresh, refreshPending)
     }
 }

--- a/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidgetService.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidgetService.kt
@@ -1,0 +1,120 @@
+package com.example.facteur
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import android.view.View
+import android.widget.RemoteViews
+import android.widget.RemoteViewsService
+import es.antonborri.home_widget.HomeWidgetPlugin
+
+/**
+ * RemoteViewsService backing the home-screen widget's scrollable article list.
+ *
+ * Reads the same `articles_json` SharedPreferences key that
+ * [FacteurWidget] uses, so refresh paths stay consistent: any caller that
+ * already invokes `appWidgetManager.notifyAppWidgetViewDataChanged(id, R.id.articles_list)`
+ * triggers a re-read here.
+ */
+class FacteurWidgetService : RemoteViewsService() {
+    override fun onGetViewFactory(intent: Intent): RemoteViewsFactory {
+        return FacteurRemoteViewsFactory(applicationContext)
+    }
+}
+
+private class FacteurRemoteViewsFactory(
+    private val context: Context,
+) : RemoteViewsService.RemoteViewsFactory {
+
+    private companion object {
+        const val TAG = "FacteurWidgetSvc"
+    }
+
+    private var articles: List<WidgetRendering.Article> = emptyList()
+
+    override fun onCreate() {
+        // Initial population happens in onDataSetChanged when the host calls it.
+    }
+
+    override fun onDataSetChanged() {
+        val prefs = HomeWidgetPlugin.getData(context)
+        val json = prefs?.getString("articles_json", null)
+        articles = WidgetRendering.parseArticles(json)
+        Log.d(TAG, "onDataSetChanged count=${articles.size}")
+    }
+
+    override fun onDestroy() {
+        articles = emptyList()
+    }
+
+    override fun getCount(): Int = articles.size
+
+    override fun getViewAt(position: Int): RemoteViews {
+        val article = articles.getOrNull(position) ?: return loadingRow()
+        val rv = RemoteViews(context.packageName, R.layout.widget_article_row)
+
+        rv.setTextViewText(
+            R.id.row_topic,
+            "${article.rank} — ${article.topicLabel.ifBlank { "Actu" }}",
+        )
+        rv.setViewVisibility(
+            R.id.row_a_la_une,
+            if (article.isMain) View.VISIBLE else View.GONE,
+        )
+        rv.setTextViewText(R.id.row_title, article.title)
+
+        val thumb = WidgetRendering.loadBitmap(context, article.thumbnailPath, 72)?.let {
+            WidgetRendering.roundCorners(context, it, 8f)
+        }
+        if (thumb != null) {
+            rv.setImageViewBitmap(R.id.row_thumbnail, thumb)
+            rv.setViewVisibility(R.id.row_thumbnail, View.VISIBLE)
+        } else {
+            rv.setViewVisibility(R.id.row_thumbnail, View.GONE)
+        }
+
+        val logo = WidgetRendering.loadBitmap(context, article.sourceLogoPath, 18)
+        if (logo != null) {
+            rv.setImageViewBitmap(R.id.row_source_logo, logo)
+            rv.setViewVisibility(R.id.row_source_logo, View.VISIBLE)
+        } else {
+            rv.setViewVisibility(R.id.row_source_logo, View.GONE)
+        }
+        rv.setTextViewText(R.id.row_source_name, article.sourceName)
+
+        if (article.perspectiveCount > 0) {
+            rv.setTextViewText(R.id.row_perspective, "+${article.perspectiveCount}")
+            rv.setViewVisibility(R.id.row_perspective, View.VISIBLE)
+        } else {
+            rv.setViewVisibility(R.id.row_perspective, View.GONE)
+        }
+
+        rv.setTextViewText(R.id.row_time, WidgetRendering.formatTime(article.publishedAtIso))
+
+        // Per-row tap → fillInIntent merged into the template PendingIntent
+        // declared by FacteurWidget.onUpdate (setPendingIntentTemplate).
+        val fillIn = Intent().apply {
+            data = Uri.parse("io.supabase.facteur://digest/${article.id}")
+                .buildUpon()
+                .appendQueryParameter("pos", article.rank.toString())
+                .appendQueryParameter("topicId", article.topicId)
+                .build()
+        }
+        rv.setOnClickFillInIntent(R.id.row_root, fillIn)
+
+        return rv
+    }
+
+    override fun getLoadingView(): RemoteViews? = null
+
+    override fun getViewTypeCount(): Int = 1
+
+    override fun getItemId(position: Int): Long =
+        articles.getOrNull(position)?.id?.hashCode()?.toLong() ?: position.toLong()
+
+    override fun hasStableIds(): Boolean = true
+
+    private fun loadingRow(): RemoteViews =
+        RemoteViews(context.packageName, R.layout.widget_article_row)
+}

--- a/apps/mobile/android/app/src/main/kotlin/com/example/facteur/WidgetRendering.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/facteur/WidgetRendering.kt
@@ -1,0 +1,129 @@
+package com.example.facteur
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.RectF
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/**
+ * Shared parsing + bitmap helpers used by both [FacteurWidget] (header
+ * rendering, MAX_ROWS cap) and [FacteurWidgetService]'s RemoteViewsFactory
+ * (row rendering inside the ListView).
+ */
+internal object WidgetRendering {
+
+    private const val TAG = "FacteurWidget"
+    const val MAX_ROWS = 5
+
+    data class Article(
+        val id: String,
+        val rank: Int,
+        val topicId: String,
+        val topicLabel: String,
+        val isMain: Boolean,
+        val title: String,
+        val sourceName: String,
+        val sourceLogoPath: String,
+        val thumbnailPath: String,
+        val perspectiveCount: Int,
+        val publishedAtIso: String,
+    )
+
+    fun parseArticles(json: String?): List<Article> {
+        if (json.isNullOrBlank() || json == "[]") return emptyList()
+        return try {
+            val arr = JSONArray(json)
+            (0 until arr.length()).take(MAX_ROWS).mapNotNull { i ->
+                arr.optJSONObject(i)?.let(::parseArticle)
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "parseArticles failed", e)
+            emptyList()
+        }
+    }
+
+    private fun parseArticle(obj: JSONObject): Article = Article(
+        id = obj.optString("id"),
+        rank = obj.optInt("rank", 0),
+        topicId = obj.optString("topic_id"),
+        topicLabel = obj.optString("topic_label"),
+        isMain = obj.optBoolean("is_main", false),
+        title = obj.optString("title"),
+        sourceName = obj.optString("source_name"),
+        sourceLogoPath = obj.optString("source_logo_path"),
+        thumbnailPath = obj.optString("thumbnail_path"),
+        perspectiveCount = obj.optInt("perspective_count", 0),
+        publishedAtIso = obj.optString("published_at_iso"),
+    )
+
+    /**
+     * Decode a bitmap downscaled to fit within [targetSizeDp]² to keep the
+     * RemoteViews payload small. Inlining unscaled thumbnails into a single
+     * RemoteViews trips Binder's ~1 MB IPC limit, surfacing as
+     * "Impossible d'ajouter le widget" on the host launcher.
+     */
+    fun loadBitmap(context: Context, path: String?, targetSizeDp: Int): Bitmap? {
+        if (path.isNullOrBlank()) return null
+        return try {
+            val targetPx = (targetSizeDp * context.resources.displayMetrics.density).toInt()
+                .coerceAtLeast(1)
+
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeFile(path, bounds)
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+
+            var sample = 1
+            while (
+                bounds.outWidth / (sample * 2) >= targetPx &&
+                bounds.outHeight / (sample * 2) >= targetPx
+            ) {
+                sample *= 2
+            }
+
+            val opts = BitmapFactory.Options().apply { inSampleSize = sample }
+            BitmapFactory.decodeFile(path, opts)
+        } catch (e: Exception) {
+            Log.w(TAG, "Bitmap decode failed: $path", e)
+            null
+        }
+    }
+
+    fun roundCorners(context: Context, src: Bitmap, radiusDp: Float): Bitmap {
+        val r = radiusDp * context.resources.displayMetrics.density
+        val output = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(output)
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+        val rect = RectF(0f, 0f, src.width.toFloat(), src.height.toFloat())
+        canvas.drawRoundRect(rect, r, r, paint)
+        paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
+        canvas.drawBitmap(src, 0f, 0f, paint)
+        return output
+    }
+
+    fun formatTime(iso: String): String {
+        if (iso.isBlank()) return ""
+        return try {
+            val parsed = OffsetDateTime.parse(iso, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+            val minutes = Duration.between(parsed, OffsetDateTime.now()).toMinutes()
+            when {
+                minutes < 1 -> "à l'instant"
+                minutes < 60 -> String.format(Locale.FRENCH, "%dmin", minutes)
+                minutes < 24 * 60 -> String.format(Locale.FRENCH, "%dh", minutes / 60)
+                else -> String.format(Locale.FRENCH, "%dj", minutes / (60 * 24))
+            }
+        } catch (e: Exception) {
+            ""
+        }
+    }
+}

--- a/apps/mobile/android/app/src/main/res/drawable/ic_widget_refresh.xml
+++ b/apps/mobile/android/app/src/main/res/drawable/ic_widget_refresh.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/facteur_accent">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/apps/mobile/android/app/src/main/res/layout/facteur_widget.xml
+++ b/apps/mobile/android/app/src/main/res/layout/facteur_widget.xml
@@ -7,18 +7,28 @@
     android:background="@drawable/widget_root_bg"
     android:padding="16dp">
 
-    <!-- Header: Facteur wordmark + streak end-aligned -->
-    <RelativeLayout
+    <!-- Header: refresh button (start) | Facteur wordmark (center) | streak (end) -->
+    <LinearLayout
         android:id="@+id/widget_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="4dp">
+        android:layout_marginBottom="4dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:id="@+id/btn_refresh"
+            android:layout_width="28dp"
+            android:layout_height="28dp"
+            android:padding="2dp"
+            android:src="@drawable/ic_widget_refresh"
+            android:contentDescription="Recharger l'essentiel" />
 
         <TextView
             android:id="@+id/app_name"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_centerHorizontal="true"
+            android:layout_weight="1"
             android:gravity="center"
             android:text="Facteur"
             android:textSize="22sp"
@@ -31,12 +41,12 @@
             android:id="@+id/streak_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true"
+            android:minWidth="28dp"
+            android:gravity="end"
             android:text=""
             android:textSize="14sp"
             android:textColor="@color/facteur_accent" />
-    </RelativeLayout>
+    </LinearLayout>
 
     <!-- Subtitle -->
     <TextView
@@ -50,28 +60,27 @@
         android:fontFamily="sans-serif"
         android:textColor="@color/facteur_text_secondary" />
 
-    <!-- Stale banner (shown when articles_updated_at > 36h) -->
-    <TextView
-        android:id="@+id/stale_banner"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:padding="8dp"
-        android:gravity="center"
-        android:background="@color/facteur_stale_banner_bg"
-        android:textSize="11sp"
-        android:textStyle="bold"
-        android:textColor="@color/facteur_accent"
-        android:visibility="gone"
-        android:text="Mets à jour ton essentiel" />
-
-    <!-- Article container — populated inline by FacteurWidget.onUpdate() -->
-    <LinearLayout
-        android:id="@+id/articles_container"
+    <!-- Scrollable article list — bound to FacteurWidgetService via setRemoteAdapter. -->
+    <ListView
+        android:id="@+id/articles_list"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:orientation="vertical" />
+        android:divider="@null"
+        android:dividerHeight="0dp"
+        android:scrollbars="none" />
+
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:padding="16dp"
+        android:textSize="13sp"
+        android:textColor="@color/facteur_text_secondary"
+        android:visibility="gone"
+        android:text="Ouvre Facteur pour charger ton essentiel" />
 
     <!-- Footer: single CTA opening the digest -->
     <TextView

--- a/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
+++ b/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
@@ -6,8 +6,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingTop="10dp"
-    android:paddingBottom="10dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp"
     android:paddingStart="0dp"
     android:paddingEnd="0dp">
 
@@ -24,7 +24,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textSize="11sp"
+            android:textSize="12sp"
             android:textAllCaps="true"
             android:letterSpacing="0.05"
             android:textColor="@color/facteur_text_secondary"
@@ -63,19 +63,19 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textSize="15sp"
+            android:textSize="17sp"
             android:textStyle="bold"
             android:fontFamily="sans-serif-medium"
             android:textColor="@color/facteur_text_primary"
-            android:lineSpacingExtra="2dp"
+            android:lineSpacingExtra="3dp"
             android:maxLines="2"
             android:ellipsize="end"
-            android:layout_marginEnd="8dp" />
+            android:layout_marginEnd="12dp" />
 
         <ImageView
             android:id="@+id/row_thumbnail"
-            android:layout_width="60dp"
-            android:layout_height="60dp"
+            android:layout_width="72dp"
+            android:layout_height="72dp"
             android:scaleType="centerCrop"
             android:contentDescription="Article thumbnail"
             android:visibility="gone" />
@@ -91,8 +91,8 @@
 
         <ImageView
             android:id="@+id/row_source_logo"
-            android:layout_width="16dp"
-            android:layout_height="16dp"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
             android:layout_marginEnd="6dp"
             android:scaleType="fitCenter"
             android:visibility="gone"
@@ -102,7 +102,7 @@
             android:id="@+id/row_source_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="11sp"
+            android:textSize="12sp"
             android:textColor="@color/facteur_text_secondary"
             android:maxLines="1"
             android:ellipsize="end" />
@@ -112,7 +112,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
-            android:textSize="11sp"
+            android:textSize="12sp"
             android:textStyle="bold"
             android:textColor="@color/facteur_accent"
             android:visibility="gone" />
@@ -129,7 +129,7 @@
             android:id="@+id/row_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="11sp"
+            android:textSize="12sp"
             android:textColor="@color/facteur_text_tertiary" />
     </LinearLayout>
 

--- a/apps/mobile/android/app/src/main/res/values/colors.xml
+++ b/apps/mobile/android/app/src/main/res/values/colors.xml
@@ -11,5 +11,4 @@
     <color name="facteur_accent">#D35400</color>
     <color name="facteur_border">#E5E1D9</color>
     <color name="facteur_a_la_une_bg">#D35400</color>
-    <color name="facteur_stale_banner_bg">#FCEBD3</color>
 </resources>

--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -39,6 +39,7 @@ import '../features/saved/screens/saved_all_screen.dart';
 import '../features/saved/screens/collection_detail_screen.dart';
 import '../core/auth/auth_state.dart';
 import '../core/nudges/widgets/nudge_host.dart';
+import '../core/services/deep_link_service.dart';
 import '../core/ui/notification_service.dart';
 import '../shared/widgets/navigation/modal_bottom_sheet_page.dart';
 
@@ -130,6 +131,16 @@ final routerProvider = Provider<GoRouter>((ref) {
     debugLogDiagnostics: true,
     refreshListenable: refreshNotifier,
     redirect: (context, state) {
+      // Intercept widget deep links pushed by PlatformRouteInformationProvider.
+      // Without this, a raw `io.supabase.facteur://digest/<id>` URI lands in
+      // GoRouter and falls through to errorBuilder ("Page non trouvée") before
+      // DeepLinkService (app_links) can route. Idempotent with DeepLinkService:
+      // both ultimately call router.go on the same in-app path.
+      if (state.uri.scheme == 'io.supabase.facteur') {
+        final action = DeepLinkService.parse(state.uri);
+        return action.route ?? RoutePaths.feed;
+      }
+
       final authState = ref.read(authStateProvider);
 
       // Attendre que l'auth state soit initialisé

--- a/apps/mobile/lib/features/digest/screens/digest_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/digest_screen.dart
@@ -62,12 +62,23 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
   void initState() {
     super.initState();
     WidgetService.initWidgetIfNeeded();
-    // Nudge to pin the Android widget once after first display.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        WidgetPinNudge.show(context, ref);
-      }
-    });
+  }
+
+  /// Intercept exit from the digest to nudge the user (once) to pin the
+  /// Android widget before returning to the feed. Nothing happens on iOS or
+  /// after the nudge has already been seen — `WidgetPinNudge.shouldShow`
+  /// gates both.
+  Future<void> _handleBack() async {
+    final shouldShow = await WidgetPinNudge.shouldShow();
+    if (shouldShow && mounted) {
+      await WidgetPinNudge.show(context, ref);
+    }
+    if (!mounted) return;
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.go(RoutePaths.feed);
+    }
   }
 
   /// Show the closure screen as a modal (slides up from bottom) instead of
@@ -113,8 +124,8 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
     // mark-as-read state mutation (which rebuilds the digest tree) is deferred
     // to a microtask so it doesn't compete with the push for the next frame.
     final content = _convertToContent(item);
-    final pushFuture = context
-        .push<Content?>('/feed/content/${item.contentId}', extra: content);
+    final pushFuture = context.push<Content?>('/feed/content/${item.contentId}',
+        extra: content);
 
     if (!item.isRead && !item.isDismissed) {
       Future.microtask(() {
@@ -142,7 +153,8 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
   /// backend deduplicates Feed↔Digest carousels, but a digest article picked
   /// for the carousel would still look duplicated to the user.
   List<CommunityCarouselItem> _filterCommunityCarousel(DigestResponse digest) {
-    final all = ref.watch(communityCarouselProvider).valueOrNull?.digestCarousel;
+    final all =
+        ref.watch(communityCarouselProvider).valueOrNull?.digestCarousel;
     if (all == null || all.isEmpty) return const [];
     final shownIds = <String>{
       for (final it in digest.items) it.contentId,
@@ -299,329 +311,350 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
     });
 
     // Background is static — only the card changes color per mode
-    final veilColor = sereinState.enabled
-        ? SereinColors.sereinColor
-        : colors.primary;
+    final veilColor =
+        sereinState.enabled ? SereinColors.sereinColor : colors.primary;
 
-    return Stack(
-      children: [
-        Container(
-          color: colors.backgroundPrimary,
-        ),
-        // Subtle top-right veil — color of the active mode's card.
-        Positioned(
-          top: 0,
-          right: 0,
-          child: IgnorePointer(
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 400),
-              curve: Curves.easeInOut,
-              width: 220,
-              height: 220,
-              decoration: BoxDecoration(
-                gradient: RadialGradient(
-                  center: Alignment.topRight,
-                  radius: 0.9,
-                  colors: [
-                    veilColor.withOpacity(0.14),
-                    veilColor.withOpacity(0.0),
-                  ],
-                  stops: const [0.0, 1.0],
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        unawaited(_handleBack());
+      },
+      child: Stack(
+        children: [
+          Container(
+            color: colors.backgroundPrimary,
+          ),
+          // Subtle top-right veil — color of the active mode's card.
+          Positioned(
+            top: 0,
+            right: 0,
+            child: IgnorePointer(
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 400),
+                curve: Curves.easeInOut,
+                width: 220,
+                height: 220,
+                decoration: BoxDecoration(
+                  gradient: RadialGradient(
+                    center: Alignment.topRight,
+                    radius: 0.9,
+                    colors: [
+                      veilColor.withOpacity(0.14),
+                      veilColor.withOpacity(0.0),
+                    ],
+                    stops: const [0.0, 1.0],
+                  ),
                 ),
               ),
             ),
           ),
-        ),
-        Positioned(
-          top: 0,
-          left: 0,
-          right: 0,
-          child: SafeArea(
-            bottom: false,
-            child: ModeAccent(isSerein: sereinState.enabled),
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: SafeArea(
+              bottom: false,
+              child: ModeAccent(isSerein: sereinState.enabled),
+            ),
           ),
-        ),
-        Scaffold(
-          backgroundColor: Colors.transparent,
-          body: SafeArea(
-            child: RefreshIndicator(
-              onRefresh: () async {
-                // Refresh both the digest itself and the community 🌻 carousel
-                // so newly-sunflowered articles appear after a pull-to-refresh.
-                ref.invalidate(communityCarouselProvider);
-                await ref.read(digestProvider.notifier).refreshDigest();
-              },
-              color: colors.primary,
-              child: CustomScrollView(
-                controller: _scrollController,
-                slivers: [
-                  // Header : back rond + titre majuscules
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(
-                        FacteurSpacing.space4,
-                        4,
-                        FacteurSpacing.space4,
-                        4,
-                      ),
-                      child: Row(
-                        children: [
-                          _CircularBackButton(onTap: () => context.pop()),
-                          const SizedBox(width: 12),
-                          Text(
-                            'Revenir au flux',
-                            style: FacteurTypography.stamp(
-                                    colors.textTertiary)
-                                .copyWith(
-                              fontSize: 13,
-                              letterSpacing: 0.2,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-
-                  // Hero : pill + titre + meta + illustration facteur
-                  SliverToBoxAdapter(
-                    child: DigestHero(
-                      articleCount:
-                          digestAsync.valueOrNull?.items.length ?? 5,
-                      targetDate:
-                          digestAsync.valueOrNull?.targetDate ?? DateTime.now(),
-                      isSerein: sereinState.enabled,
-                    ),
-                  ),
-
-                  // Success banner when digest is completed
-                  SliverToBoxAdapter(
-                    child: Builder(
-                      builder: (context) {
-                        // Check if completed using valueOrNull to avoid loading state issues
-                        final digest = digestAsync.valueOrNull;
-                        final isLoading = digestAsync.isLoading;
-
-                        if (digest?.isCompleted == true) {
-                          return Stack(
-                            children: [
-                              Container(
-                                margin: const EdgeInsets.symmetric(
-                                  horizontal: 8,
-                                  vertical: 8,
-                                ),
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 16,
-                                  vertical: 16,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: colors.success.withOpacity(0.15),
-                                  borderRadius: BorderRadius.circular(16),
-                                  border: Border.all(
-                                    color:
-                                        colors.success.withOpacity(0.3),
-                                  ),
-                                ),
-                                child: Row(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Icon(
-                                      PhosphorIcons.checkCircle(
-                                          PhosphorIconsStyle.fill),
-                                      color: colors.success,
-                                      size: 24,
-                                    ),
-                                    const SizedBox(width: 12),
-                                    Expanded(
-                                      child: Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          Text(
-                                            'Briefing terminé !',
-                                            style: TextStyle(
-                                              color: colors.textPrimary,
-                                              fontWeight: FontWeight.w700,
-                                              fontSize: 16,
-                                            ),
-                                          ),
-                                          const SizedBox(height: 4),
-                                          Text(
-                                            'Revenez demain à 8h pour votre prochaine sélection.',
-                                            style: TextStyle(
-                                              color: colors.textSecondary,
-                                              fontWeight: FontWeight.w400,
-                                              fontSize: 14,
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                  ],
-                                ),
+          Scaffold(
+            backgroundColor: Colors.transparent,
+            body: SafeArea(
+              child: RefreshIndicator(
+                onRefresh: () async {
+                  // Refresh both the digest itself and the community 🌻 carousel
+                  // so newly-sunflowered articles appear after a pull-to-refresh.
+                  ref.invalidate(communityCarouselProvider);
+                  await ref.read(digestProvider.notifier).refreshDigest();
+                },
+                color: colors.primary,
+                child: CustomScrollView(
+                  controller: _scrollController,
+                  slivers: [
+                    // Header : back rond + titre majuscules
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(
+                          FacteurSpacing.space4,
+                          4,
+                          FacteurSpacing.space4,
+                          4,
+                        ),
+                        child: Row(
+                          children: [
+                            _CircularBackButton(
+                                onTap: () => unawaited(_handleBack())),
+                            const SizedBox(width: 12),
+                            Text(
+                              'Revenir au flux',
+                              style:
+                                  FacteurTypography.stamp(colors.textTertiary)
+                                      .copyWith(
+                                fontSize: 13,
+                                letterSpacing: 0.2,
+                                fontWeight: FontWeight.w600,
                               ),
-                              // Refresh button - top right (disabled during loading)
-                              if (!isLoading)
-                                Positioned(
-                                  top: 16,
-                                  right: 24,
-                                  child: Material(
-                                    color: Colors.transparent,
-                                    child: InkWell(
-                                      onTap: () async {
-                                        // Show confirmation dialog before regenerating
-                                        final confirmed =
-                                            await showDialog<bool>(
-                                          context: context,
-                                          builder: (context) => AlertDialog(
-                                            title: const Text(
-                                                'Générer un nouvel essentiel ?'),
-                                            content: const Text(
-                                              'Votre essentiel actuel sera remplacé par 5 nouveaux articles. Cette action est irréversible.',
-                                            ),
-                                            actions: [
-                                              TextButton(
-                                                onPressed: () => Navigator.pop(
-                                                    context, false),
-                                                child: const Text('Annuler'),
-                                              ),
-                                              FilledButton(
-                                                onPressed: () => Navigator.pop(
-                                                    context, true),
-                                                child: const Text('Confirmer'),
-                                              ),
-                                            ],
-                                          ),
-                                        );
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
 
-                                        if (confirmed == true &&
-                                            context.mounted) {
-                                          final notifier =
-                                              ref.read(digestProvider.notifier);
-                                          notifier.forceRegenerate();
-                                        }
-                                      },
-                                      borderRadius: BorderRadius.circular(16),
-                                      child: Container(
-                                        padding: const EdgeInsets.all(6),
-                                        decoration: BoxDecoration(
-                                          color: colors.textSecondary
-                                              .withOpacity(0.15),
-                                          borderRadius:
-                                              BorderRadius.circular(16),
+                    // Hero : pill + titre + meta + illustration facteur
+                    SliverToBoxAdapter(
+                      child: DigestHero(
+                        articleCount:
+                            digestAsync.valueOrNull?.items.length ?? 5,
+                        targetDate: digestAsync.valueOrNull?.targetDate ??
+                            DateTime.now(),
+                        isSerein: sereinState.enabled,
+                      ),
+                    ),
+
+                    // Success banner when digest is completed
+                    SliverToBoxAdapter(
+                      child: Builder(
+                        builder: (context) {
+                          // Check if completed using valueOrNull to avoid loading state issues
+                          final digest = digestAsync.valueOrNull;
+                          final isLoading = digestAsync.isLoading;
+
+                          if (digest?.isCompleted == true) {
+                            return Stack(
+                              children: [
+                                Container(
+                                  margin: const EdgeInsets.symmetric(
+                                    horizontal: 8,
+                                    vertical: 8,
+                                  ),
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 16,
+                                    vertical: 16,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: colors.success.withOpacity(0.15),
+                                    borderRadius: BorderRadius.circular(16),
+                                    border: Border.all(
+                                      color: colors.success.withOpacity(0.3),
+                                    ),
+                                  ),
+                                  child: Row(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Icon(
+                                        PhosphorIcons.checkCircle(
+                                            PhosphorIconsStyle.fill),
+                                        color: colors.success,
+                                        size: 24,
+                                      ),
+                                      const SizedBox(width: 12),
+                                      Expanded(
+                                        child: Column(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            Text(
+                                              'Briefing terminé !',
+                                              style: TextStyle(
+                                                color: colors.textPrimary,
+                                                fontWeight: FontWeight.w700,
+                                                fontSize: 16,
+                                              ),
+                                            ),
+                                            const SizedBox(height: 4),
+                                            Text(
+                                              'Revenez demain à 8h pour votre prochaine sélection.',
+                                              style: TextStyle(
+                                                color: colors.textSecondary,
+                                                fontWeight: FontWeight.w400,
+                                                fontSize: 14,
+                                              ),
+                                            ),
+                                          ],
                                         ),
-                                        child: Icon(
-                                          PhosphorIcons.arrowClockwise(
-                                              PhosphorIconsStyle.bold),
-                                          color: colors.textSecondary,
-                                          size: 16,
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                // Refresh button - top right (disabled during loading)
+                                if (!isLoading)
+                                  Positioned(
+                                    top: 16,
+                                    right: 24,
+                                    child: Material(
+                                      color: Colors.transparent,
+                                      child: InkWell(
+                                        onTap: () async {
+                                          // Show confirmation dialog before regenerating
+                                          final confirmed =
+                                              await showDialog<bool>(
+                                            context: context,
+                                            builder: (context) => AlertDialog(
+                                              title: const Text(
+                                                  'Générer un nouvel essentiel ?'),
+                                              content: const Text(
+                                                'Votre essentiel actuel sera remplacé par 5 nouveaux articles. Cette action est irréversible.',
+                                              ),
+                                              actions: [
+                                                TextButton(
+                                                  onPressed: () =>
+                                                      Navigator.pop(
+                                                          context, false),
+                                                  child: const Text('Annuler'),
+                                                ),
+                                                FilledButton(
+                                                  onPressed: () =>
+                                                      Navigator.pop(
+                                                          context, true),
+                                                  child:
+                                                      const Text('Confirmer'),
+                                                ),
+                                              ],
+                                            ),
+                                          );
+
+                                          if (confirmed == true &&
+                                              context.mounted) {
+                                            final notifier = ref
+                                                .read(digestProvider.notifier);
+                                            notifier.forceRegenerate();
+                                          }
+                                        },
+                                        borderRadius: BorderRadius.circular(16),
+                                        child: Container(
+                                          padding: const EdgeInsets.all(6),
+                                          decoration: BoxDecoration(
+                                            color: colors.textSecondary
+                                                .withOpacity(0.15),
+                                            borderRadius:
+                                                BorderRadius.circular(16),
+                                          ),
+                                          child: Icon(
+                                            PhosphorIcons.arrowClockwise(
+                                                PhosphorIconsStyle.bold),
+                                            color: colors.textSecondary,
+                                            size: 16,
+                                          ),
                                         ),
                                       ),
                                     ),
                                   ),
-                                ),
-                            ],
-                          );
-                        }
-                        return const SizedBox.shrink();
-                      },
-                    ),
-                  ),
-
-                  // Digest Briefing Section
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 4),
-                      child: digestAsync.when(
-                        data: (digest) {
-                          if (digest == null ||
-                              (digest.items.isEmpty && digest.topics.isEmpty)) {
-                            return _buildEmptyState(colors);
+                              ],
+                            );
                           }
-
-                          final notifier = ref.read(digestProvider.notifier);
-                          final total = notifier.totalCount;
-                          final userPref = ref.watch(onboardingProvider).answers.dailyArticleCount ?? 5;
-                          final denominator = total < userPref ? total : userPref;
-
-                          return DigestBriefingSection(
-                            digest: digest,
-                            items: digest.items,
-                            topics: digest.usesTopics ? digest.topics : null,
-                            processedCount: notifier.processedCount,
-                            dailyGoal: denominator,
-                            onItemTap: _openArticle,
-                            onLike: _handleLike,
-                            onSave: _handleSave,
-                            onNotInterested: _handleNotInterested,
-                            onReportNotSerene: sereinState.enabled
-                                ? _handleReportNotSerene
-                                : null,
-                            onSwipeDismiss: _handleSwipeDismiss,
-                            onSourceTap: (sourceId) {
-                              ref.read(feedProvider.notifier).setSource(sourceId);
-                              context.goNamed(RouteNames.feed);
-                            },
-                            onMuteSource: (sourceId) => ref
-                                .read(feedProvider.notifier)
-                                .muteSourceById(sourceId),
-                            onMuteTopic: (topic) => ref
-                                .read(feedProvider.notifier)
-                                .muteTopic(topic),
-                            isSerein: sereinState.enabled,
-                            usesEditorial: digest.usesEditorial,
-                            pepite: digest.usesEditorial ? digest.pepite : null,
-                            coupDeCoeur: digest.usesEditorial
-                                ? digest.coupDeCoeur
-                                : null,
-                            actuDecalee: digest.usesEditorial
-                                ? digest.actuDecalee
-                                : null,
-                            headerText:
-                                digest.usesEditorial ? digest.headerText : null,
-                            closureText: digest.usesEditorial
-                                ? digest.closureText
-                                : null,
-                            ctaText:
-                                digest.usesEditorial ? digest.ctaText : null,
-                            communityCarousel:
-                                _filterCommunityCarousel(digest),
-                            onCommunityArticleTap: (item) {
-                              // Convert community carousel item to Content for navigation
-                              final content = Content(
-                                id: item.contentId,
-                                title: item.title,
-                                url: item.url,
-                                thumbnailUrl: item.thumbnailUrl,
-                                source: Source(
-                                  id: item.sourceId ?? '',
-                                  name: item.sourceName,
-                                  type: SourceType.article,
-                                  logoUrl: item.sourceLogoUrl,
-                                ),
-                                contentType: ContentType.article,
-                                publishedAt: item.publishedAt ?? DateTime.now(),
-                              );
-                              context.pushNamed(
-                                RouteNames.contentDetail,
-                                pathParameters: {'id': item.contentId},
-                                extra: content,
-                              );
-                            },
-                          );
+                          return const SizedBox.shrink();
                         },
-                        loading: () => _buildLoadingState(),
-                        error: (error, stack) =>
-                            _buildErrorState(context, ref, error),
                       ),
                     ),
-                  ),
-                ],
+
+                    // Digest Briefing Section
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 4),
+                        child: digestAsync.when(
+                          data: (digest) {
+                            if (digest == null ||
+                                (digest.items.isEmpty &&
+                                    digest.topics.isEmpty)) {
+                              return _buildEmptyState(colors);
+                            }
+
+                            final notifier = ref.read(digestProvider.notifier);
+                            final total = notifier.totalCount;
+                            final userPref = ref
+                                    .watch(onboardingProvider)
+                                    .answers
+                                    .dailyArticleCount ??
+                                5;
+                            final denominator =
+                                total < userPref ? total : userPref;
+
+                            return DigestBriefingSection(
+                              digest: digest,
+                              items: digest.items,
+                              topics: digest.usesTopics ? digest.topics : null,
+                              processedCount: notifier.processedCount,
+                              dailyGoal: denominator,
+                              onItemTap: _openArticle,
+                              onLike: _handleLike,
+                              onSave: _handleSave,
+                              onNotInterested: _handleNotInterested,
+                              onReportNotSerene: sereinState.enabled
+                                  ? _handleReportNotSerene
+                                  : null,
+                              onSwipeDismiss: _handleSwipeDismiss,
+                              onSourceTap: (sourceId) {
+                                ref
+                                    .read(feedProvider.notifier)
+                                    .setSource(sourceId);
+                                context.goNamed(RouteNames.feed);
+                              },
+                              onMuteSource: (sourceId) => ref
+                                  .read(feedProvider.notifier)
+                                  .muteSourceById(sourceId),
+                              onMuteTopic: (topic) => ref
+                                  .read(feedProvider.notifier)
+                                  .muteTopic(topic),
+                              isSerein: sereinState.enabled,
+                              usesEditorial: digest.usesEditorial,
+                              pepite:
+                                  digest.usesEditorial ? digest.pepite : null,
+                              coupDeCoeur: digest.usesEditorial
+                                  ? digest.coupDeCoeur
+                                  : null,
+                              actuDecalee: digest.usesEditorial
+                                  ? digest.actuDecalee
+                                  : null,
+                              headerText: digest.usesEditorial
+                                  ? digest.headerText
+                                  : null,
+                              closureText: digest.usesEditorial
+                                  ? digest.closureText
+                                  : null,
+                              ctaText:
+                                  digest.usesEditorial ? digest.ctaText : null,
+                              communityCarousel:
+                                  _filterCommunityCarousel(digest),
+                              onCommunityArticleTap: (item) {
+                                // Convert community carousel item to Content for navigation
+                                final content = Content(
+                                  id: item.contentId,
+                                  title: item.title,
+                                  url: item.url,
+                                  thumbnailUrl: item.thumbnailUrl,
+                                  source: Source(
+                                    id: item.sourceId ?? '',
+                                    name: item.sourceName,
+                                    type: SourceType.article,
+                                    logoUrl: item.sourceLogoUrl,
+                                  ),
+                                  contentType: ContentType.article,
+                                  publishedAt:
+                                      item.publishedAt ?? DateTime.now(),
+                                );
+                                context.pushNamed(
+                                  RouteNames.contentDetail,
+                                  pathParameters: {'id': item.contentId},
+                                  extra: content,
+                                );
+                              },
+                            );
+                          },
+                          loading: () => _buildLoadingState(),
+                          error: (error, stack) =>
+                              _buildErrorState(context, ref, error),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/apps/mobile/lib/features/digest/widgets/widget_pin_nudge.dart
+++ b/apps/mobile/lib/features/digest/widgets/widget_pin_nudge.dart
@@ -41,13 +41,11 @@ class WidgetPinNudge {
     final analytics = ref.read(analyticsServiceProvider);
     unawaited(analytics.trackWidgetPinNudgeShown());
 
-    unawaited(
-      showModalBottomSheet<void>(
-        context: context,
-        backgroundColor: Colors.transparent,
-        isScrollControlled: true,
-        builder: (_) => _WidgetPinSheet(analytics: analytics),
-      ),
+    await showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => _WidgetPinSheet(analytics: analytics),
     );
   }
 }

--- a/docs/stories/core/widget.3.refonte-ui-scroll-refresh.story.md
+++ b/docs/stories/core/widget.3.refonte-ui-scroll-refresh.story.md
@@ -1,0 +1,77 @@
+# Story: Widget Android — Refonte UI scroll + bouton refresh + fix tap article
+
+## Contexte
+
+Suite à `widget.2.refonte-scrollable-deep-link.story.md`, deux régressions persistent en prod (captures v34/v35) :
+
+1. **Tap sur article ouvre `Page non trouvée: io.supabase.facteur://digest/<id>`** — l'URI custom-scheme arrive brute dans GoRouter (via `PlatformRouteInformationProvider`) et tombe sur `errorBuilder` avant que `DeepLinkService` (app_links) n'ait le temps de router. Bug critique : tap = écran d'erreur.
+2. **Widget pas scrollable** — le 5ᵉ article est tronqué quand la cell est petite (la précédente tentative ListView avait été retirée à cause d'un bug Samsung One UI).
+3. **Densité visuelle** — titres 15sp, vignettes 60dp, paddings serrés : illisible/peu engageant.
+4. **Bandeau "Mets à jour ton essentiel" inutile** — non interactif, prend de la place ; remplacé par un bouton refresh local.
+
+## Décisions UX validées (utilisateur)
+
+- **Refresh button** : re-render local depuis SharedPrefs (pas de fetch réseau).
+- **5 articles** : nombre inchangé.
+- **Scroll** : retour à `ListView + RemoteViewsService`, gating sur Samsung One UI lors du VERIFY ; fallback inline + paddings réduits si régression.
+- **Stale banner supprimé** : pas de detection 36h (compromis assumé).
+- **Routing** : on garde les 2 chemins (redirect GoRouter + DeepLinkService) — idempotents, et DeepLinkService conserve l'instrumentation analytics.
+
+## Tâches
+
+### Track 4 — Fix bug "Page non trouvée" (P0, fait en premier)
+
+- [ ] `lib/config/routes.dart` : ajouter dans `redirect` une interception du scheme `io.supabase.facteur` qui appelle `DeepLinkService.parse` et retourne la route interne (ou `RoutePaths.feed` en fallback). Placer AVANT la logique auth.
+- [ ] `test/config/routes_redirect_test.dart` (ou existing test file) : cas widget tap article → route `/feed/content/<id>`.
+- [ ] Vérifier que le double routing (redirect + DeepLinkService._route) reste idempotent.
+
+### Track 2 + 3 — Sizing bumps + refresh button + suppression stale banner
+
+- [ ] `widget_article_row.xml` : titre 15→17sp, thumb 60→72dp, logo 16→18dp, meta 11→12sp, padding row 10→12dp, marginEnd 8→12dp.
+- [ ] `FacteurWidget.kt` : ajuster `loadBitmap(... , 72)` et `loadBitmap(... , 18)` pour matcher la décode resolution.
+- [ ] `facteur_widget.xml` : remplacer `RelativeLayout widget_header` par un layout 3 colonnes (refresh icon | "Facteur" | streak), supprimer `stale_banner`.
+- [ ] `FacteurWidget.kt` : supprimer `STALE_THRESHOLD_MS` + bloc isStale ; supprimer `setOnClickPendingIntent(R.id.stale_banner, ...)`.
+- [ ] `FacteurWidget.kt` : ajouter `ACTION_REFRESH` + `onReceive` qui appelle `notifyAppWidgetViewDataChanged` et re-déclenche `onUpdate`.
+- [ ] Drawable `ic_widget_refresh.xml` (vector 24dp, accent color).
+- [ ] `wireClickIntents` : câbler `R.id.btn_refresh` sur le PendingIntent broadcast `ACTION_REFRESH`.
+
+### Track 1 — Re-introduction ListView + RemoteViewsService (gating Samsung)
+
+- [ ] NEW `FacteurWidgetService.kt` : `RemoteViewsService` + `RemoteViewsFactory`, lit `articles_json` via `HomeWidgetPlugin.getData`, déplace `loadBitmap`/`roundCorners`/`formatTime` dans un `WidgetRendering.kt` partagé.
+- [ ] `facteur_widget.xml` : remplacer `LinearLayout articles_container` par `ListView articles_list` + `TextView empty_view`.
+- [ ] `FacteurWidget.kt` `onUpdate` : `setRemoteAdapter` + `setEmptyView` + `setPendingIntentTemplate` + `notifyAppWidgetViewDataChanged`.
+- [ ] `AndroidManifest.xml` : déclarer `<service android:name=".FacteurWidgetService" android:permission="android.permission.BIND_REMOTEVIEWS" android:exported="false" />`.
+- [ ] **VERIFY OBLIGATOIRE** sur Samsung One UI. En cas d'échec : revert Track 1, garder inline rendering + réduire paddings 12→6dp pour faire tenir 5 rows dans la cell la plus petite.
+
+## Fichiers
+
+### Flutter (MODIFIED)
+- `apps/mobile/lib/config/routes.dart`
+- `apps/mobile/test/core/services/deep_link_service_test.dart` (cas additionnel)
+- `apps/mobile/test/config/routes_redirect_test.dart` (NEW)
+
+### Android (MODIFIED)
+- `apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt`
+- `apps/mobile/android/app/src/main/res/layout/facteur_widget.xml`
+- `apps/mobile/android/app/src/main/res/layout/widget_article_row.xml`
+- `apps/mobile/android/app/src/main/AndroidManifest.xml`
+
+### Android (NEW)
+- `apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidgetService.kt`
+- `apps/mobile/android/app/src/main/kotlin/com/example/facteur/WidgetRendering.kt`
+- `apps/mobile/android/app/src/main/res/drawable/ic_widget_refresh.xml`
+
+## Verify
+
+- `cd apps/mobile && flutter test`
+- `cd apps/mobile && flutter analyze`
+- `cd apps/mobile && flutter build apk --debug`
+- Manuel : install APK, ajouter widget, tap article → `/feed/content/<id>` (PAS `Page non trouvée`), tap refresh → re-render, scroll OK sur cell réduite, **test Samsung One UI**.
+
+## Status
+
+- [ ] Track 4 (deep link fix) implémenté + tests
+- [ ] Track 2+3 (sizing + refresh) implémentés
+- [ ] Track 1 (ListView) implémenté ou fallback documenté
+- [ ] VERIFY (flutter test + analyze + APK)
+- [ ] PR créée vers `main`


### PR DESCRIPTION
## Quoi

Refonte UI du widget Android Facteur (story `widget.3`) en 4 tracks :

- **Track 1 — ListView scrollable** : `RemoteViewsService` + `RemoteViewsFactory` (NEW `FacteurWidgetService.kt`, helpers partagés dans `WidgetRendering.kt`) pour que les 5 articles ne soient plus tronqués sur les cells réduites.
- **Track 2/3 — Lisibilité + refresh** : titre 15→17sp, thumb 60→72dp, logo 16→18dp, paddings ajustés. Suppression du bandeau "stale" (non interactif) remplacé par un bouton refresh broadcast (`ACTION_REFRESH`) qui re-render depuis SharedPrefs (pas de fetch réseau).
- **Track 4 — Fix tap article "Page non trouvée"** : intercept du scheme `io.supabase.facteur://` dans GoRouter `redirect` avant que la fall-through `errorBuilder` ne s'exécute. Idempotent avec `DeepLinkService` (app_links).

Bonus : nudge "pin widget" déplacé de l'entrée du digest (post-frame) à la sortie (`PopScope` + `await sheet`) pour ne plus couper l'engagement immédiat.

## Pourquoi

Suite à `widget.2.refonte-scrollable-deep-link` (#544), 4 régressions persistaient en prod (captures v34/v35) : tap article = écran d'erreur, 5e article tronqué, densité visuelle illisible, bandeau "stale" inutile. Cette PR clôt la story.

## Comment ça a été vérifié

- [x] `flutter analyze` — 0 erreur (717 info/warning pré-existants, identique à main)
- [x] `flutter test` — 551 pass / 37 fail (les 37 sont des `fail('Test not implemented')` pré-existants sur main, pas de régression introduite)
- [x] `simplify` passé — 2 fixes appliqués :
  - `FacteurWidget.kt onReceive` : suppression du `notifyAppWidgetViewDataChanged` redondant (déjà appelé par `onUpdate`)
  - `WidgetRendering.loadBitmap` : suppression du `File.exists()` TOCTOU (decodeFile retourne null on failure)
- [ ] **À faire en QA manuel** : install APK Samsung One UI (gating Track 1) + tap article → `/feed/content/<id>` (PAS "Page non trouvée") + tap refresh → re-render + scroll OK sur cell réduite

## Zones à risque

- `apps/mobile/lib/config/routes.dart` : ajout d'une branche redirect tout en haut. Idempotent avec `DeepLinkService` mais à valider sur le double routing.
- `RemoteViewsService` lifecycle : tester pin/unpin du widget (factory recréée).
- Bitmap decoded sans cache (recommandation efficiency report) — à monitorer si scroll laggy ; cache à ajouter en suivi si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)