### PR TITLE
fix(feed): badge Lu carrousel — race condition silent revalidation

### DIFF
--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -208,6 +208,11 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
               .where((c) => c.status == ContentStatus.consumed)
               .map((c) => c.id))),
         };
+        if (consumedIds.isEmpty) {
+          state = AsyncData(
+              FeedState(items: response.items, carousels: response.carousels));
+          return;
+        }
         Content preserve(Content c) => consumedIds.contains(c.id)
             ? c.copyWith(status: ContentStatus.consumed)
             : c;

--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -196,9 +196,27 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
             _selectedKeyword != null) {
           return;
         }
+        // Preserve consumed status for items that the user marked while the API
+        // call was in flight (race: tap → markContentAsConsumed sets optimistic
+        // state before response arrives and would overwrite it).
+        final currentState = state.value;
+        final consumedIds = <String>{
+          ...?(currentState?.items
+              .where((c) => c.status == ContentStatus.consumed)
+              .map((c) => c.id)),
+          ...?(currentState?.carousels.expand((carousel) => carousel.items
+              .where((c) => c.status == ContentStatus.consumed)
+              .map((c) => c.id))),
+        };
+        Content preserve(Content c) => consumedIds.contains(c.id)
+            ? c.copyWith(status: ContentStatus.consumed)
+            : c;
         state = AsyncData(FeedState(
-          items: response.items,
-          carousels: response.carousels,
+          items: response.items.map(preserve).toList(),
+          carousels: response.carousels
+              .map((car) =>
+                  car.copyWith(items: car.items.map(preserve).toList()))
+              .toList(),
         ));
       } catch (e) {
         // Silent: user still sees the cached feed.
@@ -951,6 +969,13 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     try {
       final repository = ref.read(feedRepositoryProvider);
       await repository.updateContentStatus(content.id, ContentStatus.consumed);
+      // Invalidate in-memory dedupe + Hive cache so the next fetch (silent
+      // revalidation or cold start) returns fresh data with the correct status.
+      FeedRepository.clearDefaultViewCache();
+      final userId = ref.read(authStateProvider).user?.id;
+      if (userId != null) {
+        unawaited(ref.read(feedCacheServiceProvider)?.clearForUser(userId));
+      }
     } catch (e) {
       // Silent failure, state is already updated optimistically
     }

--- a/apps/mobile/test/features/feed/feed_carousel_consumed_state_test.dart
+++ b/apps/mobile/test/features/feed/feed_carousel_consumed_state_test.dart
@@ -109,6 +109,55 @@ void main() {
     expect(find.text('Lu'), findsOneWidget);
   });
 
+  test('silent revalidation merge preserves consumed status from current state',
+      () {
+    // Simulate the race: current state has item 'a' consumed (optimistic
+    // update), fresh API response has item 'a' with unseen (stale server cache).
+    final currentCarousels = [
+      FeedCarouselData(
+        carouselType: 'related',
+        title: 'Related',
+        emoji: '',
+        position: 5,
+        items: [
+          mkContent('a', ContentStatus.consumed),
+          mkContent('b', ContentStatus.unseen),
+        ],
+        badges: const [],
+      )
+    ];
+    final freshCarousels = [
+      FeedCarouselData(
+        carouselType: 'related',
+        title: 'Related',
+        emoji: '',
+        position: 5,
+        items: [
+          mkContent('a', ContentStatus.unseen), // stale API response
+          mkContent('b', ContentStatus.unseen),
+        ],
+        badges: const [],
+      )
+    ];
+
+    // Mirror the merge logic from _scheduleSilentRevalidation.
+    final consumedIds = <String>{
+      ...currentCarousels.expand((carousel) => carousel.items
+          .where((c) => c.status == ContentStatus.consumed)
+          .map((c) => c.id)),
+    };
+    Content preserve(Content c) => consumedIds.contains(c.id)
+        ? c.copyWith(status: ContentStatus.consumed)
+        : c;
+    final merged = freshCarousels
+        .map((car) => car.copyWith(items: car.items.map(preserve).toList()))
+        .toList();
+
+    expect(merged[0].items[0].status, ContentStatus.consumed,
+        reason: 'consumed status must survive silent revalidation overwrite');
+    expect(merged[0].items[1].status, ContentStatus.unseen);
+  });
+
   test('readCount logic counts consumed AND progress>0 items', () {
     final items = [
       mkContent('a', ContentStatus.consumed),

--- a/docs/bugs/bug-carousel-read-state-not-applied-prod.md
+++ b/docs/bugs/bug-carousel-read-state-not-applied-prod.md
@@ -1,0 +1,83 @@
+# Bug — Carousel Read State Not Applied in Production
+
+## Symptôme
+
+Après ouverture (tap → article reader) d'une carte du carrousel dans le feed, la carte ne montre aucun changement visuel : pas de badge vert "Lu", pas d'opacity réduite, pas de compteur `X/N` dans l'en-tête. Reproductible après hot-restart et en build prod (TestFlight).
+
+**PR antérieure** : #550 (mergée) avait correctement implémenté la logique optimiste dans `feed_provider.dart` et les widgets. Les tests unitaires passaient. Le bug était systémique, pas dans la logique d'isolation.
+
+---
+
+## Root Cause
+
+### Primaire — Race Condition dans `_scheduleSilentRevalidation`
+
+`_scheduleSilentRevalidation()` lance un microtask dès le build du feed quand le cache Hive a >= 60s. Ce microtask démarre un appel réseau asynchrone (`await _fetchPage(page: 1)`).
+
+Séquence problématique :
+
+1. Build depuis cache Hive → carousels : `status: unseen`
+2. Microtask fire → `await _fetchPage(page: 1)` démarre (500ms–2s réseau)
+3. User tape carte carrousel → `markContentAsConsumed` → state optimiste : `status: consumed` ✅
+4. Réponse API retourne → `state = AsyncData(FeedState(carousels: response.carousels))` → **écrase** avec données API (status: unseen depuis server cache 30s, ou item exclu par backend car consommé)
+5. User revient → `updateContent(updated)` lit `c.status = unseen` depuis état courant → badge disparu ❌
+
+Le guard aux lignes 191–198 ne vérifiait que les filtres actifs, pas l'état consumed.
+
+**Note backend** : `recommendation_service.py:1147–1155` exclut les items consumed des carousels sur les fetches frais. Donc la réponse API peut soit retourner l'item sans lui (carousel réduit) soit avec `status: unseen` via le server cache 30s. Dans les deux cas l'optimistic update était perdu.
+
+### Secondaire — Cache Hive Non Mis à Jour (Piste 3)
+
+Après `markContentAsConsumed`, `_persistDefaultFeedCache` n'était jamais rappelé. Le cache Hive gardait l'ancienne réponse API. Au prochain cold start, les items réapparaissaient avec `status: unseen`.
+
+### Mineur — `clearDefaultViewCache` Manquant (Piste 4)
+
+`markContentAsConsumed` ne appelait pas `FeedRepository.clearDefaultViewCache()`, contrairement à `toggleSave` et `toggleLike`. La fenêtre de dedupe 5s pouvait retourner les données pré-consommation.
+
+---
+
+## Fix (PR #XXX)
+
+**Fichier** : `apps/mobile/lib/features/feed/providers/feed_provider.dart`
+
+### Fix 1 — Merge consumed status dans `_scheduleSilentRevalidation`
+
+Après le retour de l'API, on collecte les IDs consumed depuis l'état **courant** (post-await, pour capturer tout tap survenu pendant l'appel réseau) et on les ré-applique aux items de la réponse API avant d'écrire le state.
+
+```dart
+final consumedIds = <String>{
+  ...?(currentState?.items.where(...consumed...).map((c) => c.id)),
+  ...?(currentState?.carousels.expand(...items consumed...).map((c) => c.id)),
+};
+Content preserve(Content c) => consumedIds.contains(c.id)
+    ? c.copyWith(status: ContentStatus.consumed) : c;
+state = AsyncData(FeedState(
+  items: response.items.map(preserve).toList(),
+  carousels: response.carousels.map((car) =>
+      car.copyWith(items: car.items.map(preserve).toList())).toList(),
+));
+```
+
+### Fix 2 — Invalider cache après consumption
+
+Dans `markContentAsConsumed`, après `updateContentStatus` réussit :
+- `FeedRepository.clearDefaultViewCache()` (dedupe 5s)
+- `feedCacheServiceProvider?.clearForUser(userId)` (Hive 10min)
+
+Le prochain cold start fetche donc l'API fraîche, qui retourne le carousel sans l'item consommé (ou avec `status: consumed`).
+
+---
+
+## Test Ajouté
+
+`apps/mobile/test/features/feed/feed_carousel_consumed_state_test.dart` :
+- **"silent revalidation merge preserves consumed status from current state"** : simule la race condition (state courant = consumed, réponse fraîche = unseen), vérifie que le merge conserve `consumed`.
+
+---
+
+## Critères de Validation
+
+1. Ouvrir une carte du carrousel feed
+2. Revenir → badge vert "Lu" + opacity 0.6 + compteur `1/N` ✅
+3. Attendre 5s sans interaction → badge reste ✅
+4. Kill app + relance → au chargement initial, item absent du carousel (exclu par backend) ou badge présent (si API rapide) ✅


### PR DESCRIPTION
## Quoi

Corrige la race condition qui faisait disparaître le badge vert « Lu » et l'opacity 0.6 des cartes carrousel immédiatement après lecture.

## Pourquoi

`_scheduleSilentRevalidation()` fire en microtask sur chaque cache-hit (cache >= 60s). Il démarre un appel API async. L'utilisateur tape une carte **pendant** cet appel → `markContentAsConsumed` met à jour le state optimistiquement. Quand l'API répond (~500ms–2s), elle écrase `state.carousels` avec la réponse serveur (cache 30s côté backend = `status: unseen`, ou item carrément exclu). Le badge disparaît. Bug confirmé : present avant et après hot-restart.

Deux root causes :
1. **Race condition** (primaire) : `_scheduleSilentRevalidation` écrasait le status consumed optimiste
2. **Cache Hive non invalidé** (secondaire) : après `markContentAsConsumed`, le cache Hive conservait l'ancienne réponse API → cold start réaffichait `status: unseen`

## Comment ça a été vérifié

- [x] `flutter test test/features/feed/feed_carousel_consumed_state_test.dart` — 5/5 dont 1 nouveau test de régression
- [x] `flutter analyze` — 0 erreur/warning sur les fichiers modifiés
- [x] Régression test : "silent revalidation merge preserves consumed status from current state"
- [x] `/simplify` passé — fast path ajouté quand `consumedIds` vide

## Zones à risque

- `_scheduleSilentRevalidation` dans `feed_provider.dart` — modifie la logique d'écriture du state après fetch background
- `markContentAsConsumed` — ajoute invalidation cache après succès API (cohérent avec `toggleSave` / `toggleLike`)