### PR TITLE
feat(veille): V3 PR3 — UX polish (intro + presets + pré-loading)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,80 +1,30 @@
-# PR — Veille V3 PR1 Critical Fixes (T1+T2+T3)
+# PR — Veille V3 PR3 « UX polish (intro + presets + pré-loading) »
 
 ## Summary
 
-Corrige le bug `loading infini` post-onboarding veille (50 % d'échec en bêta soft launch) en fermant 3 trous : **T1** persistance `failed` + retry + Sentry, **T2** résilience `/suggestions/sources` (503 propre), **T3** mode édition `?mode=edit` du flow Veille.
+PR3 du V3 veille (suite de #561 PR1 critical fixes et #562 PR2 sources rankées). Trois améliorations UX du flow de configuration, focalisées sur la perception de fluidité et l'accès aux pré-sets :
 
-## Investigation préalable
+- **T4** — Pré-loading actif des suggestions LLM entre les steps. L'animation halo (`FlowLoadingScreen`) reçoit désormais `topicsParams` / `sourcesParams` et déclenche le pré-fetch en arrière-plan dès le tap « Continuer ». Durée adaptive : 1.5 s minimum d'animation, puis on attend `data|error` du provider (cap 8 s). À l'arrivée sur Step2/Step3, plus de spinner secondaire dans le cas nominal.
+- **T5** — Nouvel écran `VeilleIntroScreen` au premier accès `/veille/config` (pas de config active, pas de mode édition). Single-page minimaliste : pitch + halo animé + CTA « C'est parti ». Skipé en mode édition et après `applyPreset`.
+- **T6** — Repositionnement des pré-sets dans Step1. Suppression de la section `_InspirationsSection` en bas du scroll. Ajout d'un teaser tappable « Pas inspiré ? Pioche un pré-set → » sous le header (visible sans scroll), qui ouvre une bottom sheet `VeillePresetsSheet` listant tous les pré-sets via `PresetCard` (workflow Step1.5 preview inchangé).
 
-Voir [`docs/bugs/bug-veille-gen-investigation.md`](../docs/bugs/bug-veille-gen-investigation.md). Cause racine : `_run_first_delivery` (router) + `_process_config_with_semaphore` (scanner) catchaient les exceptions sans persister `generation_state=failed` → row stuck en `running` indéfiniment, le poll mobile ne sortait jamais. Cause secondaire : EDBHANDLEREXITED Supabase pendant `db.commit()` du POST `/suggestions/sources` propage une session invalide qui plante la livraison qui suit.
+## Fichiers modifiés
 
-## What
-
-### T1 — Backend : `failed` state + retry + Sentry
-
-- `packages/api/app/routers/veille.py` : refactor `_run_first_delivery` → `_run_first_delivery_with_retry(config_id, target_date, delivery_id)`. Boucle retry 1× T+60 s. Si 2e échec → UPDATE `veille_deliveries` (FAILED, last_error, finished_at, attempts) via `safe_async_session`. Capture `sentry_sdk.capture_exception`. Logger `veille.first_delivery_failed_terminal`.
-- `packages/api/app/jobs/veille_generation_job.py` : symétrie scanner via `_mark_scanner_delivery_failed`. UPDATE FAILED + Sentry. Pas de retry intra-scanner (la passe suivante du scanner est le retry naturel).
-- Pas de catch spécifique EDBHANDLEREXITED — `safe_async_session()` rouvre une connexion saine, le retry suffit.
-
-### T2 — Backend résilience `/suggestions/sources` + Mobile retry CTA
-
-- `packages/api/app/routers/veille.py:464-506` : try/except double autour de `suggester.suggest_sources(...)` + `db.commit()`. `SQLAlchemyError` → rollback + 503 « Service temporairement indisponible. ». `httpx.TimeoutException`/`HTTPError` → 503 « Suggestions LLM indisponibles. ». Capture Sentry des deux côtés.
-- `apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart` : `_MockSourcesFallback` accepte un callback `onRetry` optionnel ; le parent (Step3SourcesScreen) le branche sur `refreshKeepingChecked` quand l'AsyncValue est en error. Bouton « Réessayer » avec icône.
-
-### T3 — Mobile : mode édition « Modifier ma veille »
-
-- `apps/mobile/lib/features/veille/screens/veille_dashboard_screen.dart:165` : CTA route `/veille/config?mode=edit`.
-- `apps/mobile/lib/config/routes.dart:415` : `pageBuilder` lit `state.uri.queryParameters['mode']` et passe `editMode` à `VeilleConfigScreen`.
-- `apps/mobile/lib/features/veille/screens/veille_config_screen.dart` :
-  - Ajout `final bool editMode;` au constructeur.
-  - Guard ajustée : redirect dashboard uniquement si `!editMode`. En mode edit + activeConfig non-null + state.selectedTheme null → `addPostFrameCallback(notifier.hydrateFromActiveConfig)`.
-  - `handleSubmit()` court-circuite la première livraison + la modal notif quand `editMode == true`. Snackbar « Veille mise à jour » + redirect dashboard.
-- `apps/mobile/lib/features/veille/providers/veille_config_provider.dart` : nouvelle méthode `hydrateFromActiveConfig(VeilleConfigDto cfg)` (idempotent via check `selectedTheme != null`). Mappe topics par `kind` (preset/custom/suggested), sources par `kind` (followed/niche), fréquence/jour avec helpers `_frequencyFromWire`/`_dayFromWire`.
+- `apps/mobile/lib/features/veille/screens/veille_intro_screen.dart` (NOUVEAU)
+- `apps/mobile/lib/features/veille/screens/veille_config_screen.dart` (T4 + T5)
+- `apps/mobile/lib/features/veille/providers/veille_config_provider.dart` (T4 + T5 — durée adaptive, helpers params, `introCompleted`, `completeIntro`)
+- `apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart` (T6 — teaser + bottom sheet, suppression `_InspirationsSection`)
+- `docs/stories/core/19.3.veille-v3-pr3-ux-polish.md` (NOUVEAU — story doc)
 
 ## Tests
 
-### Backend
-- `packages/api/tests/test_veille_first_delivery_failure.py` (3 cas) :
-  - T1 retry-then-fail → row FAILED + last_error + sentry.
-  - T1 retry-then-succeed → pas de FAILED persisté, pas de sentry.
-  - T1 scanner exception → row FAILED + sentry.
-- `packages/api/tests/routers/test_veille_routes.py::TestSuggestions` :
-  - `test_sources_db_error_returns_503` (OperationalError → 503).
-  - `test_sources_llm_timeout_returns_503` (httpx.TimeoutException → 503).
-- Patch test existant : `test_creates_pending_delivery` référence maintenant `_run_first_delivery_with_retry`.
+- `flutter analyze` — pas de nouveau warning sur les fichiers veille.
+- `flutter test test/features/veille/` — 51/51 verts.
+- Suite complète : 554 verts. Les 37 échecs (digest, feed, custom_topics, etc.) sont **pré-existants** (vérifié sur `main` avant PR3, certains marqués « Test not implemented »).
+- Playwright MCP : flow complet validé (intro → Step1 → preset bottom sheet → Step1.5 preview → Step2/3 avec animation halo + données chargées → Step4 → submit).
 
-### Mobile
-- `apps/mobile/test/features/veille/providers/veille_config_provider_test.dart` (3 nouveaux cas) :
-  - hydrate populates state from DTO (theme, topics, sources, frequency, day, purpose).
-  - hydrate idempotent (no-op si `selectedTheme` déjà set).
-  - monthly frequency → day par défaut (mon).
-- `flutter test` ciblé : 8/8 verts (5 anciens + 3 nouveaux).
+## Risques
 
-### E2E (à valider via /validate-feature)
-3 scénarios documentés dans `.context/qa-handoff.md` (S1 T1, S2 T2, S3 T3).
-
-## How ça a été vérifié
-
-- [x] `flutter test test/features/veille/providers/veille_config_provider_test.dart` → 8/8 verts.
-- [x] `flutter analyze` sur les 5 fichiers mobile touchés → 0 errors (info `prefer_const` pré-existants).
-- [ ] `pytest -v` (à lancer en /go — DB Supabase locale requise).
-- [ ] `ruff format --check && ruff check` (à lancer en /go).
-- [ ] `alembic heads` → 1 head (aucune migration ajoutée par cette PR).
-- [ ] /validate-feature S1/S2/S3 (post-merge ou en pre-merge selon dispo QA).
-
-## Hors scope (issues GitHub à créer)
-
-1. **Intégrité min-sources POST `/config`** : rejeter `body.source_selections == []` avec 422.
-2. **Cleanup script rows stuck > 15 min** : job périodique passe à FAILED toute row `generation_state='running' AND started_at < NOW() - INTERVAL '15 minutes'`.
-
-## Zones à risque
-
-- **BackgroundTask Sentry** : capture explicite obligatoire (FastAPI BackgroundTasks n'ont pas le middleware Sentry du request lifecycle). Vérifier en prod l'apparition d'un événement après un fail volontaire.
-- **Session SQLAlchemy après rollback** : aucune query subséquente sur la session après `await db.rollback()` (le `raise HTTPException` est immédiat).
-- **autoDispose + hydrate** : `veilleConfigProvider` est autoDispose ; le state est reset à chaque entrée du screen, donc l'hydratation se relance proprement à chaque visite en mode edit.
-
-## Notes
-
-- Branche créée depuis `origin/main` après `git fetch` (cf. memory `feedback_rebase_before_work.md`).
-- `ruff format --check` + `ruff check` à lancer avant push (cf. memory `feedback_python_ruff_format_check.md`).
-- Investigation doc `docs/bugs/bug-veille-gen-investigation.md` incluse dans la PR pour traçabilité.
+- **Cohérence des params** entre `goNext()` / `FlowLoadingScreen` / `step2_suggestions_screen` / `step3_sources_screen` : les helpers `notifier.topicsParamsFromState()` et `notifier.sourcesParamsFromState()` factorisent la construction et garantissent une clé `family.autoDispose` identique (sinon double fetch).
+- **`introCompleted: true` dans `applyPreset` et `hydrateFromActiveConfig`** : empêche l'intro de réapparaître après un preset apply ou en mode édition.
+- **Annulation pendant loading** : `_waitAndAdvance` vérifie `state.loadingFrom != from` avant de pousser la transition pour éviter un push stale si l'utilisateur close le flow ou submit pendant l'animation.

--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,131 +1,114 @@
-# QA Handoff — Veille V3 PR2 « Sources quality + custom sources »
+# QA Handoff — Veille V3 PR3 « UX polish »
 
 ## Feature développée
 
-PR2 du V3 veille : refonte du suggesteur de sources (le LLM produit
-maintenant **une seule liste rankée par pertinence**, plus la séparation
-followed/niche), nouveau wording « Connecter / Connectée », badge
-« CONFIANCE » sur les sources déjà suivies, et bouton « + Ajouter une
-source » dans Step 3 qui ouvre un sheet de recherche réutilisant le moteur
-de `add_source_screen`. Badge RSS (vert / orange) ajouté sur la preview
-d'ajout d'une source.
+Trois améliorations UX du flow de configuration veille (mobile, 4 étapes) :
+- **T4** — Pré-loading actif des suggestions LLM entre les steps (animation halo + checklist déclenche désormais le fetch en arrière-plan, durée adaptive 1.5 s min → data|error).
+- **T5** — Nouvel écran d'introduction veille au premier accès (single-page : pitch + halo + CTA « C'est parti »), affiché avant Step1.
+- **T6** — Repositionnement des pré-sets : suppression de la section bas de Step1, ajout d'un teaser tappable haut + bottom sheet listant tous les pré-sets.
 
 ## PR associée
 
-À créer via `/go` — base = `main`, branche
-`boujonlaurin-dotcom/veille-v3-pr2-sources-quality`.
+À créer via `/go` — base `main`.
 
 ## Écrans impactés
 
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| Veille flow Step 3 (sélection sources) | `/veille/config` (étape 3) | Modifié |
-| Sheet « Ajouter une source » (depuis Step 3) | (sheet) | Nouveau |
-| Add source (catalogue global) | `/sources/add` | Refacto interne (UI ≃ inchangée) |
-| Source detail modal (preview avant ajout) | (modale) | Modifié — badge RSS |
+| `VeilleIntroScreen` | `/veille/config` (état pré-Step1) | NOUVEAU (T5) |
+| `VeilleConfigScreen` | `/veille/config` | Modifié (T4 + T5) |
+| `Step1ThemeScreen` | `/veille/config` (étape 1) | Modifié (T6) |
+| `VeillePresetsSheet` | bottom sheet de Step1 | NOUVEAU (T6) |
+| `FlowLoadingScreen` | écran de transition | Inchangé (déjà multi-step) |
 
 ## Scénarios de test
 
-### Scénario 1 : Step 3 — liste flat triée par pertinence (happy path)
+### Scénario 1 — Happy path complet (premier accès)
 
-1. Démarrer un nouveau flow Veille → choisir un thème (ex. « Tech »).
-2. Step 2 : cocher quelques topics, optionnellement remplir un brief.
-3. Step 3 : attendre le chargement des suggestions.
+**Parcours** :
+1. Aller sur `/veille/config` (compte sans config active).
+2. Vérifier qu'on voit l'écran **VeilleIntroScreen** (eyebrow « Le facteur prépare ta veille » + titre « Une veille pensée pour toi » + halo animé + CTA « C'est parti »).
+3. Tap « C'est parti ».
+4. Sur Step1 : vérifier le **teaser pré-sets** (« Pas inspiré ? Pioche un pré-set ») visible dès l'ouverture (sans scroll).
+5. Sélectionner un thème (ex. Tech).
+6. Sélectionner un sujet pré-suggéré, tap « Continuer ».
+7. **Animation halo** + checklist (FlowLoadingScreen) ≥ 1.5 s.
+8. Step2 affiché : suggestions topics **déjà chargées** (pas de spinner secondaire en cas nominal).
+9. Cocher 1-2 suggestions, tap « Continuer ».
+10. **Animation halo** vers Step3 puis sources **déjà chargées**.
+11. Tap « Continuer ».
+12. Step4 (rythme), tap « Démarrer ma veille ».
+13. Animation post-submit (from=4) + redirection dashboard.
 
-**Résultat attendu** :
-- Une seule liste de sources (8–12 items typiquement), pas de section.
-- Sous-titre « Classées par pertinence pour ta veille ».
-- Les sources que l'utilisateur suit déjà ont un badge **CONFIANCE**.
-- Toutes les cards ont un CTA « Connecter » (ou « Connectée » si pré-cochée).
-- Pas d'overflow sur le bouton « Connectée » (viewport 390x844).
+**Résultat attendu** : flow ininterrompu, halo entre chaque step, pas de spinner secondaire à l'arrivée sur Step2/Step3.
 
-### Scénario 2 : Toggle Connecter / Connectée
+### Scénario 2 — Pré-set via bottom sheet
 
-1. Sur Step 3, tap sur « Connecter » d'une source non sélectionnée → devient
-   « Connectée ».
-2. Re-tap → repasse à « Connecter ».
+**Parcours** :
+1. Aller sur `/veille/config` (sans config), passer l'intro.
+2. Sur Step1, tap teaser « Pas inspiré ? Pioche un pré-set ».
+3. Vérifier la **bottom sheet** : titre « Pré-sets », liste des PresetCard.
+4. Tap sur un pré-set.
+5. Vérifier que la sheet se ferme et que **Step1.5 preview** s'affiche (label + accroche + topics + sources).
+6. Tap « Utiliser ce pré-set » → bascule Step4 (jumpToStep4).
+7. Tap « Démarrer ma veille » → submit.
 
-**Résultat attendu** : compteur de sources reflète l'état, pas de glitch.
+**Résultat attendu** : workflow preview→use inchangé. Pas d'intro réaffichée pendant la session.
 
-### Scénario 3 : Ajouter une source custom depuis Step 3 (happy path)
+### Scénario 3 — Mode édition (skip intro)
 
-1. Sur Step 3, scroller jusqu'au bouton **« Ajouter une source »**.
-2. Tap → un sheet s'ouvre (≈92% de la hauteur) avec champ de recherche +
-   drag handle + bouton close.
-3. Taper « next inpact » → résultats apparaissent.
-4. Tap résultat → modale détail s'ouvre avec badge RSS.
-5. Tap « Ajouter ».
+**Parcours** :
+1. Avoir une config active.
+2. Naviguer sur `/veille/config?mode=edit`.
+3. Vérifier que **Step1 est affiché directement** (pas d'intro).
+4. Vérifier que les sélections sont hydratées depuis la config existante.
 
-**Résultat attendu** :
-- Modale fermée, sheet fermé.
-- La nouvelle source apparaît dans la liste Step 3, **pré-cochée**
-  (« Connectée »).
-- Pas de duplication si la source était déjà dans la liste.
+**Résultat attendu** : intro skipped, hydratation OK.
 
-### Scénario 4 : Badge RSS sur la preview
+### Scénario 4 — Config active sans edit (redirect)
 
-**Parcours A — RSS détecté** :
-1. Step 3 → bouton « Ajouter une source ».
-2. Coller une URL d'un média avec flux RSS (ex. `https://www.lemonde.fr`).
-3. Tap résultat → preview.
+**Parcours** :
+1. Avoir une config active.
+2. Naviguer sur `/veille/config` (sans `?mode=edit`).
 
-**Résultat A** : pill **verte** « RSS détecté ».
+**Résultat attendu** : redirect immédiat vers `/veille/dashboard`. Pas d'intro affichée.
 
-**Parcours B — Pas de flux RSS** :
-1. Idem avec une URL sans RSS.
+### Scénario 5 — LLM lent (>1.5 s)
 
-**Résultat B** : pill **orange** « Pas de flux RSS — articles peuvent manquer ».
+**Parcours** :
+1. Throttler le réseau (Chrome devtools → Slow 3G), repasser le happy path Step1→Step2.
 
-### Scénario 5 : Edge — fallback mock si API down
+**Résultat attendu** : animation halo dépasse 1.5 s, attend le provider jusqu'à `data|error` (cap 8 s). Au-delà, Step2 affiche son skeleton normal — pas de blocage.
 
-1. Couper la connexion / faire échouer `/veille/suggestions/sources`.
-2. Atteindre Step 3.
+### Scénario 6 — Close depuis l'intro
 
-**Résultat attendu** : message « Suggestions indisponibles, conserve ta
-sélection. » + liste mock unique (followed + niche fusionnés). Les sources
-mock followed (`s-lm`, `s-cp`, `s-tc`) ont un badge CONFIANCE.
+**Parcours** :
+1. Sur l'intro, tap la croix (haut droite).
 
-### Scénario 6 : Add source screen catalogue (régression)
-
-1. Ouvrir l'écran catalogue `/sources/add`.
-2. Effectuer une recherche, ajouter une source.
-
-**Résultat attendu** : comportement identique à avant la refacto. Le badge
-RSS apparaît sur la preview.
+**Résultat attendu** : retour `/feed` (pas de pop si pas de history).
 
 ## Critères d'acceptation
 
-- [ ] Liste unique flat sur Step 3 (pas de section followed/niche).
-- [ ] Sources `is_already_followed=true` → badge CONFIANCE.
-- [ ] CTA « Connecter / Connectée » sans overflow.
-- [ ] Bouton « Ajouter une source » ouvre un sheet avec drag handle + close.
-- [ ] Source ajoutée via le sheet → pré-cochée dans Step 3.
-- [ ] Badge RSS visible sur la preview source detail (vert ou orange).
-- [ ] AddSourceScreen catalogue : aucune régression.
+- [ ] Premier accès `/veille/config` sans config → intro affichée.
+- [ ] Tap « C'est parti » → bascule Step1 (animation AnimatedSwitcher).
+- [ ] `?mode=edit` → intro skipped (Step1 directement).
+- [ ] `activeConfig != null` → redirect dashboard.
+- [ ] Step1 : teaser pré-sets visible sans scroll.
+- [ ] Tap teaser → bottom sheet liste tous les pré-sets.
+- [ ] Tap pré-set → sheet ferme + Step1.5 preview.
+- [ ] Plus aucune section "Inspirations" en bas du scroll Step1.
+- [ ] Step1→Step2 : animation halo ≥ 1.5 s + suggestions topics chargées à l'arrivée (cas nominal).
+- [ ] Step2→Step3 : animation halo ≥ 1.5 s + sources chargées à l'arrivée (cas nominal).
+- [ ] Si LLM lent : on attend jusqu'à 8 s puis on passe (skeleton normal).
 
 ## Zones de risque
 
-1. **State migration** : les tests `step1_5_preset_preview_screen_test`,
-   `veille_config_provider_test`, `veille_models_test`,
-   `veille_source_card_test` ont été adaptés. Le feed
-   (`compact_source_chip.dart`, `feed_screen.dart`) utilise un nom homonyme
-   `followedSources` mais NON-relié au state veille — vérifier en QA visuel
-   que le feed n'est pas cassé.
-2. **Preset application** : `applyPreset` place toutes les sources d'un
-   preset dans `selectedSourceIds`, avec `kind='followed'` dans `sourcesMeta`.
-   Le wire backend reste identique.
-3. **Hydratation édition** : `hydrateFromActiveConfig` (mode édition d'une
-   veille existante) préserve le `kind` côté `sourcesMeta`, donc
-   l'aller-retour API doit rester stable.
-4. **Bordure card Step 3** : la couleur dépend maintenant de
-   `isAlreadyFollowed` (avant : `isNiche`).
+- **Params identiques entre `goNext()`/`FlowLoadingScreen` et Step2/Step3** : si différents (ordre topicLabels, sort des topicIds), `family.autoDispose` créera deux instances → double-fetch et perte du préload. Helpers `topicsParamsFromState` / `sourcesParamsFromState` sont la single source of truth, alignés sur l'instanciation des Steps.
+- **`introCompleted` marqué dans `applyPreset` et `hydrateFromActiveConfig`** : critique pour ne pas réafficher l'intro après un preset apply ou en mode édition.
+- **Annulation du loading** : si l'utilisateur close le flow pendant l'animation halo, la guard `state.loadingFrom != from` dans `_waitAndAdvance` évite un push de transition stale.
 
 ## Dépendances
 
-- API endpoint :
-  - `POST /veille/suggestions/sources` — réponse changée
-    `{sources: [...]}` (au lieu de `{followed, niche}`). Chaque item porte
-    `is_already_followed: bool` + `relevance_score: float | None`.
-- Backend tests : `test_veille_source_ingestion.py` +
-  `test_veille_source_suggester_eval.py` (10 fixtures structurelles).
-- Mobile tests : `flutter test` — 51 tests passants.
+- Backend : aucune modif (les endpoints `/api/veille/suggestions/topics` et `/sources` sont inchangés).
+- Mobile : `flutter_riverpod` (ProviderSubscription, déjà utilisé).
+- Pas de migration DB.

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -11,6 +11,7 @@ import '../models/veille_suggestion.dart';
 import '../repositories/veille_repository.dart';
 import 'veille_active_config_provider.dart';
 import 'veille_repository_provider.dart';
+import 'veille_suggestions_provider.dart';
 import 'veille_themes_provider.dart';
 
 /// Métadonnées attachées à une source dans le state du flow. Permet de
@@ -44,6 +45,11 @@ class VeilleSourceMeta {
 class VeilleConfigState {
   final int step;
   final int? loadingFrom;
+
+  /// Vrai après que l'utilisateur a passé l'écran d'introduction (« C'est
+  /// parti »). Tant que `false` et qu'il n'y a pas de config active, le
+  /// host rend `VeilleIntroScreen` au lieu de Step1.
+  final bool introCompleted;
 
   /// Slug du pré-set en cours de prévisualisation (Step 1.5). Quand non-null,
   /// `veille_config_screen` rend `Step1_5PresetPreviewScreen` au lieu du
@@ -85,6 +91,7 @@ class VeilleConfigState {
   const VeilleConfigState({
     required this.step,
     required this.loadingFrom,
+    required this.introCompleted,
     required this.previewPresetId,
     required this.selectedTheme,
     required this.selectedTopics,
@@ -106,6 +113,7 @@ class VeilleConfigState {
   factory VeilleConfigState.initial() => VeilleConfigState(
         step: 1,
         loadingFrom: null,
+        introCompleted: false,
         previewPresetId: null,
         selectedTheme: null,
         selectedTopics: const {},
@@ -137,6 +145,7 @@ class VeilleConfigState {
   VeilleConfigState copyWith({
     int? step,
     Object? loadingFrom = _Sentinel.value,
+    bool? introCompleted,
     Object? previewPresetId = _Sentinel.value,
     Object? selectedTheme = _Sentinel.value,
     Set<String>? selectedTopics,
@@ -159,6 +168,7 @@ class VeilleConfigState {
         loadingFrom: loadingFrom == _Sentinel.value
             ? this.loadingFrom
             : loadingFrom as int?,
+        introCompleted: introCompleted ?? this.introCompleted,
         previewPresetId: previewPresetId == _Sentinel.value
             ? this.previewPresetId
             : previewPresetId as String?,
@@ -208,10 +218,17 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
 
   final Ref _ref;
 
-  static const Duration _loadingDuration = Duration(milliseconds: 2500);
-  static const Duration _veilleNotificationLeadTime = Duration(minutes: 30);
+  /// Durée minimale d'affichage de l'animation halo (`FlowLoadingScreen`)
+  /// entre deux steps. En-dessous, la transition flashe et l'animation
+  /// halo + checklist n'a pas le temps de jouer.
+  static const Duration _loadingMinDuration = Duration(milliseconds: 1500);
 
-  Timer? _loadingTimer;
+  /// Cap maximal d'attente du provider pré-fetché. Au-delà, on laisse
+  /// passer à l'étape suivante : Step2/Step3 affichera son skeleton
+  /// normal le temps que le LLM réponde.
+  static const Duration _loadingMaxDuration = Duration(seconds: 8);
+
+  static const Duration _veilleNotificationLeadTime = Duration(minutes: 30);
 
   void selectTheme(String id) {
     // Changer de thème reset les topics pré-sélectionnés (les preset topics
@@ -335,15 +352,137 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
 
   /// Avance d'une étape, en passant par un loading screen IA (sauf si on est
   /// déjà sur la dernière étape — auquel cas `submit()` doit être appelé).
+  ///
+  /// Durée adaptive : `min(_loadingMinDuration, attente du provider cible
+  /// jusqu'à `data|error`, cap `_loadingMaxDuration`)`. L'animation halo
+  /// joue toujours au moins 1.5 s pour la perception ; au-delà, on
+  /// attend que le pré-fetch (déclenché par `FlowLoadingScreen` via les
+  /// params) soit terminé pour arriver sur Step2/Step3 avec les
+  /// suggestions déjà chargées.
+  /// Subscriptions actives au provider pré-fetché pendant `_waitAndAdvance`.
+  /// On les garde sur le notifier pour pouvoir les `close()` proprement
+  /// si l'utilisateur quitte le flow (close, reset, dispose) pendant
+  /// l'animation halo — sinon le `Completer` sous-jacent ne complète
+  /// jamais et la subscription leak.
+  ProviderSubscription<Object?>? _pendingSub;
+  Completer<void>? _pendingCompleter;
+
   void goNext() {
     if (state.isLoading || state.step >= 4) return;
     final from = state.step;
     state = state.copyWith(loadingFrom: from);
-    _loadingTimer?.cancel();
-    _loadingTimer = Timer(_loadingDuration, () {
-      if (!mounted) return;
-      state = state.copyWith(step: from + 1, loadingFrom: null);
-    });
+    _waitAndAdvance(from);
+  }
+
+  Future<void> _waitAndAdvance(int from) async {
+    final minDelay = Future<void>.delayed(_loadingMinDuration);
+    final providerReady = _waitProviderReady(from);
+
+    await minDelay;
+    if (providerReady != null) {
+      await providerReady.timeout(
+        _loadingMaxDuration,
+        onTimeout: () {},
+      );
+    }
+    _disposePending();
+
+    if (!mounted) return;
+    // Sécurité : si entre-temps un autre flow a modifié `loadingFrom`
+    // (close, reset, submit…), on ne pousse pas une transition stale.
+    if (state.loadingFrom != from) return;
+    state = state.copyWith(step: from + 1, loadingFrom: null);
+  }
+
+  /// Renvoie un Future qui complète quand le provider de suggestions
+  /// ciblé pour le prochain step a `data|error`. `null` si pas de
+  /// pré-fetch à attendre (entre Step3 et Step4).
+  Future<void>? _waitProviderReady(int from) {
+    if (from == 1) {
+      final params = topicsParamsFromState();
+      if (params == null) return null;
+      return _awaitAsyncSettled(veilleTopicSuggestionsProvider(params));
+    }
+    if (from == 2) {
+      final params = sourcesParamsFromState();
+      if (params == null) return null;
+      return _awaitAsyncSettled(veilleSourceSuggestionsProvider(params));
+    }
+    return null;
+  }
+
+  /// Attend que `provider` sorte du `loading` (`data` ou `error`). Court-circuite
+  /// si l'état est déjà settled. La subscription est stockée sur le notifier
+  /// pour permettre `_disposePending()` de l'annuler en cas de sortie de flow.
+  Future<void> _awaitAsyncSettled<T>(
+    ProviderListenable<AsyncValue<T>> provider,
+  ) {
+    final current = _ref.read(provider);
+    if (current.hasValue || current.hasError) return Future.value();
+
+    _disposePending();
+    final completer = Completer<void>();
+    _pendingCompleter = completer;
+    _pendingSub = _ref.listen<AsyncValue<T>>(
+      provider,
+      (_, next) {
+        if (!completer.isCompleted &&
+            (next.hasValue || next.hasError)) {
+          completer.complete();
+        }
+      },
+      fireImmediately: true,
+    );
+    return completer.future;
+  }
+
+  void _disposePending() {
+    _pendingSub?.close();
+    _pendingSub = null;
+    if (_pendingCompleter != null && !_pendingCompleter!.isCompleted) {
+      _pendingCompleter!.complete();
+    }
+    _pendingCompleter = null;
+  }
+
+  /// Construit les params topics depuis le state courant. Utilisé par
+  /// `goNext()` pour pré-fetcher pendant l'animation halo, ET par
+  /// `veille_config_screen` pour passer les mêmes params au
+  /// `FlowLoadingScreen` (sinon double instance via `family.autoDispose`).
+  ///
+  /// **Doit produire des params strictement identiques** à ceux instanciés
+  /// dans `step2_suggestions_screen.dart` (theme + topics triés).
+  VeilleTopicsSuggestionParams? topicsParamsFromState() {
+    final themeId = state.selectedTheme;
+    if (themeId == null) return null;
+    return VeilleTopicsSuggestionParams(
+      themeId: themeId,
+      themeLabel: veilleThemeLabelForSlug(themeId),
+      selectedTopicIds: state.selectedTopics.toList()..sort(),
+      purpose: state.purpose,
+      purposeOther: state.purposeOther,
+      editorialBrief: state.editorialBrief,
+    );
+  }
+
+  /// Construit les params sources depuis le state courant. **Doit produire
+  /// des params strictement identiques** à ceux instanciés dans
+  /// `step3_sources_screen.dart` (theme + topicLabels en ordre
+  /// d'insertion Set : selectedTopics puis selectedSuggestions).
+  VeilleSourcesSuggestionParams? sourcesParamsFromState() {
+    final themeId = state.selectedTheme;
+    if (themeId == null) return null;
+    final topicLabels = <String>[
+      ...state.selectedTopics.map((id) => state.topicLabels[id] ?? id),
+      ...state.selectedSuggestions.map((id) => state.topicLabels[id] ?? id),
+    ];
+    return VeilleSourcesSuggestionParams(
+      themeId: themeId,
+      topicLabels: topicLabels,
+      purpose: state.purpose,
+      purposeOther: state.purposeOther,
+      editorialBrief: state.editorialBrief,
+    );
   }
 
   /// Recul instantané (pas de loading).
@@ -505,6 +644,13 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     state = state.copyWith(loadingFrom: from);
   }
 
+  /// L'utilisateur a tapé « C'est parti » sur l'écran d'introduction —
+  /// l'intro disparaît, on bascule sur Step1.
+  void completeIntro() {
+    if (state.introCompleted) return;
+    state = state.copyWith(introCompleted: true);
+  }
+
   /// Affiche l'écran preview pré-set (Step 1.5). Le step courant reste à 1
   /// sous le capot — le screen orchestrator détecte `previewPresetId != null`.
   void openPresetPreview(String presetSlug) {
@@ -552,6 +698,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
 
     state = state.copyWith(
       step: jumpToStep4 ? 4 : 1,
+      introCompleted: true,
       previewPresetId: null,
       selectedTheme: preset.themeId,
       selectedTopics: topicSlugs,
@@ -616,6 +763,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
 
     state = state.copyWith(
       step: 1,
+      introCompleted: true,
       selectedTheme: cfg.themeId,
       selectedTopics: selectedTopics,
       selectedSuggestions: selectedSuggestions,
@@ -651,8 +799,14 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
   /// Réinitialise le flow (utilisé après suppression / pour repartir d'une
   /// nouvelle config depuis le dashboard).
   void reset() {
-    _loadingTimer?.cancel();
+    _disposePending();
     state = VeilleConfigState.initial();
+  }
+
+  @override
+  void dispose() {
+    _disposePending();
+    super.dispose();
   }
 
   Set<String> _toggle(Set<String> set, String id) {
@@ -739,11 +893,6 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     };
   }
 
-  @override
-  void dispose() {
-    _loadingTimer?.cancel();
-    super.dispose();
-  }
 }
 
 final veilleConfigProvider =

--- a/apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+import '../../../../config/theme.dart';
 import '../../models/veille_config.dart';
 import '../../providers/veille_config_provider.dart';
 import '../../providers/veille_preset_topics_provider.dart';
@@ -62,6 +63,7 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
           canGoBack: false,
           onClose: widget.onClose,
         ),
+        _PresetTeaserLink(onTap: () => _openPresetSheet(context)),
         Expanded(
           child: SingleChildScrollView(
             padding: const EdgeInsets.fromLTRB(20, 20, 20, 24),
@@ -233,8 +235,7 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
                     ],
                   ),
                 ),
-                const SizedBox(height: 28),
-                const _InspirationsSection(),
+                const SizedBox(height: 16),
               ],
             ),
           ),
@@ -536,51 +537,173 @@ Future<void> _openAddTopicSheet(
   if (result != null && result.isNotEmpty) onAdd(result);
 }
 
-class _InspirationsSection extends ConsumerWidget {
-  const _InspirationsSection();
+/// Lien teaser sous le header Step1 — visible sans scroll. Tap → ouvre
+/// la bottom sheet `VeillePresetsSheet`.
+class _PresetTeaserLink extends StatelessWidget {
+  final VoidCallback onTap;
+  const _PresetTeaserLink({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
+      child: Material(
+        color: FacteurColors.veilleTint,
+        borderRadius: BorderRadius.circular(10),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(10),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            child: Row(
+              children: [
+                Icon(
+                  PhosphorIcons.sparkle(),
+                  size: 16,
+                  color: FacteurColors.veille,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Pas inspiré ? Pioche un pré-set',
+                    style: GoogleFonts.dmSans(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: FacteurColors.veille,
+                    ),
+                  ),
+                ),
+                Icon(
+                  PhosphorIcons.arrowRight(),
+                  size: 14,
+                  color: FacteurColors.veille,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> _openPresetSheet(BuildContext context) async {
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: const Color(0xFFF2E8D5),
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
+    ),
+    builder: (_) => const _VeillePresetsSheet(),
+  );
+}
+
+class _VeillePresetsSheet extends ConsumerWidget {
+  const _VeillePresetsSheet();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final asyncPresets = ref.watch(veillePresetsProvider);
     final notifier = ref.read(veilleConfigProvider.notifier);
 
-    return asyncPresets.when(
-      loading: () => const _PresetCardSkeleton(),
-      error: (_, __) => const SizedBox.shrink(),
-      data: (presets) {
-        if (presets.isEmpty) return const SizedBox.shrink();
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+    return SafeArea(
+      top: false,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.85,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
-              'INSPIRATIONS',
-              style: GoogleFonts.courierPrime(
-                fontSize: 11,
-                letterSpacing: 0.5,
-                color: const Color(0xFF8B7E63),
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: const Color(0xFF2C2A29).withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(4),
+                ),
               ),
             ),
-            const SizedBox(height: 4),
-            Text(
-              'Pas sûr·e par où commencer ? Pioche un pré-set.',
-              style: GoogleFonts.dmSans(
-                fontSize: 13,
-                color: const Color(0xFF5D5B5A),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Pré-sets',
+                    style: GoogleFonts.fraunces(
+                      fontSize: 22,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: -0.4,
+                      color: const Color(0xFF2C2A29),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Une veille curée prête à l\'emploi.',
+                    style: GoogleFonts.dmSans(
+                      fontSize: 13,
+                      color: const Color(0xFF5D5B5A),
+                    ),
+                  ),
+                ],
               ),
             ),
             const SizedBox(height: 12),
-            for (var i = 0; i < presets.length; i++) ...[
-              if (i > 0) const SizedBox(height: 8),
-              PresetCard(
-                label: presets[i].label,
-                accroche: presets[i].accroche,
-                icon: phosphorThemeIcon(presets[i].themeId),
-                onTap: () => notifier.openPresetPreview(presets[i].slug),
+            Flexible(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(20, 4, 20, 20),
+                child: asyncPresets.when(
+                  loading: () => const _PresetCardSkeleton(),
+                  error: (_, __) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    child: Text(
+                      'Pré-sets indisponibles. Réessaie dans un instant.',
+                      style: GoogleFonts.dmSans(
+                        fontSize: 13,
+                        color: const Color(0xFF8B7E63),
+                      ),
+                    ),
+                  ),
+                  data: (presets) {
+                    if (presets.isEmpty) {
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        child: Text(
+                          'Aucun pré-set disponible pour l\'instant.',
+                          style: GoogleFonts.dmSans(
+                            fontSize: 13,
+                            color: const Color(0xFF8B7E63),
+                          ),
+                        ),
+                      );
+                    }
+                    return Column(
+                      children: [
+                        for (var i = 0; i < presets.length; i++) ...[
+                          if (i > 0) const SizedBox(height: 8),
+                          PresetCard(
+                            label: presets[i].label,
+                            accroche: presets[i].accroche,
+                            icon: phosphorThemeIcon(presets[i].themeId),
+                            onTap: () {
+                              Navigator.of(context).pop();
+                              notifier.openPresetPreview(presets[i].slug);
+                            },
+                          ),
+                        ],
+                      ],
+                    );
+                  },
+                ),
               ),
-            ],
+            ),
           ],
-        );
-      },
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
@@ -18,6 +18,7 @@ import 'steps/step2_suggestions_screen.dart';
 import 'steps/step3_sources_screen.dart';
 import 'steps/step4_frequency_screen.dart';
 import 'transitions/flow_loading_screen.dart';
+import 'veille_intro_screen.dart';
 
 /// Host du flow de configuration de la veille.
 ///
@@ -130,9 +131,32 @@ class VeilleConfigScreen extends ConsumerWidget {
 
     Widget body;
     String key;
-    if (state.isLoading) {
-      body = FlowLoadingScreen(from: state.loadingFrom!);
-      key = 'load-${state.loadingFrom}';
+    if (!editMode &&
+        !state.introCompleted &&
+        activeCfgValue == null &&
+        !activeConfig.isLoading) {
+      // Premier accès sans config : on cadre via l'intro avant Step1.
+      // En mode édition ou quand un preset a déjà hydraté le state,
+      // `introCompleted` vaut déjà `true` → cette branche est skipée.
+      body = VeilleIntroScreen(
+        onClose: close,
+        onStart: notifier.completeIntro,
+      );
+      key = 'intro';
+    } else if (state.isLoading) {
+      final from = state.loadingFrom!;
+      body = FlowLoadingScreen(
+        from: from,
+        // Pré-fetch des suggestions du step suivant pendant l'animation.
+        // Les params doivent être strictement identiques à ceux que
+        // Step2/Step3 instancient ensuite (sinon `family.autoDispose`
+        // crée deux instances et le pré-fetch ne sert à rien).
+        topicsParams:
+            from == 1 ? notifier.topicsParamsFromState() : null,
+        sourcesParams:
+            from == 2 ? notifier.sourcesParamsFromState() : null,
+      );
+      key = 'load-$from';
     } else if (state.previewPresetId != null) {
       body = Step15PresetPreviewScreen(
         presetSlug: state.previewPresetId!,

--- a/apps/mobile/lib/features/veille/screens/veille_intro_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_intro_screen.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../widgets/halo_loader.dart';
+import '../widgets/veille_widgets.dart';
+
+/// Écran d'introduction au flow Veille — affiché au premier accès
+/// (pas de config active, pas de mode édition). Cadre le pitch avant
+/// le wizard en 4 étapes.
+///
+/// Layout single-page : header simplifié (close), illustration centrale
+/// (HaloLoader animé), pitch, CTA primaire « C'est parti ».
+class VeilleIntroScreen extends StatelessWidget {
+  final VoidCallback onClose;
+  final VoidCallback onStart;
+
+  const VeilleIntroScreen({
+    super.key,
+    required this.onClose,
+    required this.onStart,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 14, 20, 14),
+          child: Row(
+            children: [
+              const Spacer(),
+              IconButton(
+                onPressed: onClose,
+                icon: Icon(
+                  PhosphorIcons.x(),
+                  size: 22,
+                  color: const Color(0xFF5D5B5A),
+                ),
+                tooltip: 'Fermer',
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(28, 24, 28, 24),
+            child: Column(
+              children: [
+                const SizedBox(height: 12),
+                const HaloLoader(),
+                const SizedBox(height: 28),
+                const VeilleAiEyebrow('Le facteur prépare ta veille'),
+                const SizedBox(height: 14),
+                Text(
+                  'Une veille pensée pour toi',
+                  textAlign: TextAlign.center,
+                  style: GoogleFonts.fraunces(
+                    fontSize: 26,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: -0.5,
+                    height: 1.2,
+                    color: const Color(0xFF2C2A29),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 320),
+                  child: Text(
+                    'Choisis un thème, on s\'occupe de trouver les bons '
+                    'angles, les bonnes sources, et de te livrer un digest '
+                    'au rythme qui te convient.',
+                    textAlign: TextAlign.center,
+                    style: GoogleFonts.dmSans(
+                      fontSize: 14,
+                      height: 1.5,
+                      color: const Color(0xFF5D5B5A),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Container(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+          decoration: const BoxDecoration(
+            border: Border(
+              top: BorderSide(color: FacteurColors.veilleLineSoft, width: 1),
+            ),
+          ),
+          child: VeilleCtaButton(
+            label: "C'est parti",
+            trailingIcon: PhosphorIcons.arrowRight(),
+            onPressed: onStart,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/docs/stories/core/19.3.veille-v3-pr3-ux-polish.md
+++ b/docs/stories/core/19.3.veille-v3-pr3-ux-polish.md
@@ -1,0 +1,126 @@
+# 19.3 — Veille V3 PR3 « UX polish (intro + presets + pré-loading) »
+
+## Status
+En cours.
+
+## Context
+
+PR1 (#561 — critical fixes : row stuck, 503 propre, mode édition) et PR2
+(#562 — sources rankées + ajout custom) sont mergées sur `main`. Le flow
+Veille beta tient désormais la route fonctionnellement, mais l'UX de
+configuration au premier accès souffre encore de trois frictions :
+
+1. **Page blanche entre les steps** — `FlowLoadingScreen` (animation halo
+   + checklist) est déjà rendu entre 1→2 et 2→3 pendant 2.5 s, mais ne
+   déclenche pas le pré-fetch des suggestions LLM. À l'arrivée sur Step2/
+   Step3, l'utilisateur revoit un skeleton pendant que le provider fetch
+   pour la première fois → animation perçue comme cosmétique.
+2. **Pas d'introduction au premier accès** — `/veille/config` ouvre
+   directement Step1 (« Sur quel thème… ») sans cadrage. Le user ne sait
+   pas où il est, ce que la veille va lui apporter, ni combien d'étapes
+   restent.
+3. **Pré-sets cachés en bas de Step1** — la section _InspirationsSection
+   est rendue après les 4 sections du formulaire, donc invisible sans
+   scroll. Les pré-sets sont pourtant le raccourci le plus efficace
+   pour qu'un user moins motivé arrive jusqu'à une veille livrée.
+
+Cette story = PR3.
+
+## Acceptance Criteria
+
+### T4 — Pré-loading actif entre steps
+
+1. `veille_config_screen.dart` passe les bons params au `FlowLoadingScreen`
+   pour déclencher le pré-fetch en arrière-plan dès le tap « Continuer » :
+   - `loadingFrom == 1` → `topicsParams` construit depuis le state.
+   - `loadingFrom == 2` → `sourcesParams` construit depuis le state.
+   - Les params sont strictement identiques à ceux que Step2/Step3
+     instancient ensuite (sinon double-fetch via `family.autoDispose`).
+2. `veille_config_provider.goNext` passe d'un timer fixe 2.5 s à une
+   durée adaptive `min(1500 ms, attendre data|error, cap 8 s)` :
+   - 1.5 s minimum d'animation halo (perception).
+   - Si le provider ciblé sort du loading avant 1.5 s → on attend la
+     fin de l'animation min.
+   - Si le provider est encore en loading après 1.5 s → on attend
+     `data|error` avec un cap 8 s pour éviter le blocage.
+3. À l'arrivée sur Step2/Step3 dans le cas nominal (LLM rapide), les
+   suggestions sont déjà chargées (pas de skeleton secondaire). Si le
+   LLM dépasse 1.5 s, Step2/Step3 affiche son skeleton normal — pas
+   de régression.
+
+### T5 — Page d'introduction veille
+
+1. Nouveau widget `VeilleIntroScreen` rendu **avant** Step1 quand
+   l'utilisateur arrive pour la première fois sur `/veille/config`
+   sans config active et sans mode édition.
+2. Layout single-page minimaliste : header simplifié (close), illustration
+   centrale (`HaloLoader` réutilisé), pitch (eyebrow + titre + sous-texte),
+   CTA primaire « C'est parti ».
+3. State : nouveau flag `introCompleted` dans `VeilleConfigState`
+   (default `false`). Méthode `notifier.completeIntro()` bascule à `true`.
+4. `hydrateFromActiveConfig` (mode édition) → `introCompleted: true`.
+   `applyPreset` → `introCompleted: true` (entrée via Lettres / preview
+   skip aussi l'intro).
+5. AC :
+   - Premier accès `/veille/config` sans config → intro affichée.
+   - Tap « C'est parti » → bascule Step1 (animation AnimatedSwitcher
+     existante).
+   - `activeConfig != null` → redirect dashboard (intro pas affichée).
+   - `?mode=edit` → intro skipped (Step1 directement).
+6. Pas de modification de `routes.dart` : path reste `/veille/config`,
+   l'intro est intercalée comme l'est déjà Step1.5 preview.
+
+### T6 — Repositionnement pré-sets Step1
+
+1. Suppression de `_InspirationsSection` en bas du scroll Step1.
+2. Ajout d'un teaser tappable sous le `VeilleStepHeader` (visible sans
+   scroll) : « Pas inspiré ? Pioche un pré-set → ».
+3. Tap teaser → ouvre une bottom sheet `VeillePresetsSheet` listant
+   tous les pré-sets via `PresetCard` (réutilisé tel quel).
+4. Tap sur un pré-set dans la sheet → `Navigator.pop(ctx)` puis
+   `notifier.openPresetPreview(preset.slug)` (workflow Step1.5
+   preview existant inchangé).
+5. AC :
+   - Teaser visible dès l'ouverture de Step1 (sans scroll).
+   - Bottom sheet liste tous les pré-sets, skeleton si loading.
+   - Workflow preview→use cohérent avec aujourd'hui.
+   - Plus aucune section "Inspirations" en bas de Step1.
+
+## Plan technique
+
+Voir le plan d'implémentation détaillé :
+`/Users/laurinboujon/.claude/plans/system-instruction-you-are-working-purring-pizza.md`.
+
+### Fichiers modifiés
+
+- `apps/mobile/lib/features/veille/screens/veille_config_screen.dart` (T4 + T5)
+- `apps/mobile/lib/features/veille/providers/veille_config_provider.dart` (T4 + T5)
+- `apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart` (T6)
+- `apps/mobile/lib/features/veille/screens/veille_intro_screen.dart` (NOUVEAU — T5)
+
+### Composants réutilisés (pas de création)
+
+- `FlowLoadingScreen` (`screens/transitions/flow_loading_screen.dart:11`) — accepte déjà `topicsParams` / `sourcesParams`.
+- `VeilleTopicsSuggestionParams` / `VeilleSourcesSuggestionParams` (`providers/veille_suggestions_provider.dart:11, 51`).
+- `HaloLoader` (`widgets/halo_loader.dart:8`).
+- `PresetCard` (`widgets/veille_widgets.dart:1194`).
+- `VeilleCtaButton`, `VeilleAiEyebrow`, `VeilleStepHeader`.
+- `notifier.openPresetPreview` (provider:510-513).
+
+## Tests
+
+- `flutter analyze` — pas de warning, pas d'unused.
+- `flutter test` — toute la suite verte.
+- Playwright MCP (viewport 390x844) — parcours full intro → Step1 →
+  preset bottom sheet → Step1.5 preview → Step2 (transition halo) →
+  Step3 (transition halo) → Step4 → submit. Edge cases :
+  `?mode=edit`, `activeConfig != null`, apply preset.
+
+## Tasks
+
+- [x] PLAN approuvé (ExitPlanMode).
+- [ ] T4 — Pré-loading actif entre steps.
+- [ ] T5 — VeilleIntroScreen + state introCompleted.
+- [ ] T6 — Teaser pré-sets + VeillePresetsSheet.
+- [ ] QA handoff (`.context/qa-handoff.md`).
+- [ ] `/go` (verify + simplify + PR base main).


### PR DESCRIPTION
# PR — Veille V3 PR3 « UX polish (intro + presets + pré-loading) »

## Summary

PR3 du V3 veille (suite de #561 PR1 critical fixes et #562 PR2 sources rankées). Trois améliorations UX du flow de configuration, focalisées sur la perception de fluidité et l'accès aux pré-sets :

- **T4** — Pré-loading actif des suggestions LLM entre les steps. L'animation halo (`FlowLoadingScreen`) reçoit désormais `topicsParams` / `sourcesParams` et déclenche le pré-fetch en arrière-plan dès le tap « Continuer ». Durée adaptive : 1.5 s minimum d'animation, puis on attend `data|error` du provider (cap 8 s). À l'arrivée sur Step2/Step3, plus de spinner secondaire dans le cas nominal.
- **T5** — Nouvel écran `VeilleIntroScreen` au premier accès `/veille/config` (pas de config active, pas de mode édition). Single-page minimaliste : pitch + halo animé + CTA « C'est parti ». Skipé en mode édition et après `applyPreset`.
- **T6** — Repositionnement des pré-sets dans Step1. Suppression de la section `_InspirationsSection` en bas du scroll. Ajout d'un teaser tappable « Pas inspiré ? Pioche un pré-set → » sous le header (visible sans scroll), qui ouvre une bottom sheet `VeillePresetsSheet` listant tous les pré-sets via `PresetCard` (workflow Step1.5 preview inchangé).

## Fichiers modifiés

- `apps/mobile/lib/features/veille/screens/veille_intro_screen.dart` (NOUVEAU)
- `apps/mobile/lib/features/veille/screens/veille_config_screen.dart` (T4 + T5)
- `apps/mobile/lib/features/veille/providers/veille_config_provider.dart` (T4 + T5 — durée adaptive, helpers params, `introCompleted`, `completeIntro`)
- `apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart` (T6 — teaser + bottom sheet, suppression `_InspirationsSection`)
- `docs/stories/core/19.3.veille-v3-pr3-ux-polish.md` (NOUVEAU — story doc)

## Tests

- `flutter analyze` — pas de nouveau warning sur les fichiers veille.
- `flutter test test/features/veille/` — 51/51 verts.
- Suite complète : 554 verts. Les 37 échecs (digest, feed, custom_topics, etc.) sont **pré-existants** (vérifié sur `main` avant PR3, certains marqués « Test not implemented »).
- Playwright MCP : flow complet validé (intro → Step1 → preset bottom sheet → Step1.5 preview → Step2/3 avec animation halo + données chargées → Step4 → submit).

## Risques

- **Cohérence des params** entre `goNext()` / `FlowLoadingScreen` / `step2_suggestions_screen` / `step3_sources_screen` : les helpers `notifier.topicsParamsFromState()` et `notifier.sourcesParamsFromState()` factorisent la construction et garantissent une clé `family.autoDispose` identique (sinon double fetch).
- **`introCompleted: true` dans `applyPreset` et `hydrateFromActiveConfig`** : empêche l'intro de réapparaître après un preset apply ou en mode édition.
- **Annulation pendant loading** : `_waitAndAdvance` vérifie `state.loadingFrom != from` avant de pousser la transition pour éviter un push stale si l'utilisateur close le flow ou submit pendant l'animation.