### PR TITLE
feat(veille): URL stable /api/app/update/apk pour fallback hors-app

### DIFF
--- a/packages/api/app/routers/app_update.py
+++ b/packages/api/app/routers/app_update.py
@@ -9,6 +9,7 @@ import time
 import httpx
 import structlog
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import RedirectResponse
 
 from app.config import get_settings
 
@@ -135,3 +136,16 @@ async def get_download_url() -> dict[str, str]:
         headers=dict(resp.headers),
     )
     raise HTTPException(status_code=502, detail="Failed to get download URL")
+
+
+@router.get("/update/apk", include_in_schema=False)
+async def download_apk_redirect() -> RedirectResponse:
+    """Redirige (302) vers l'APK pré-signé de la dernière release.
+
+    URL stable et publique destinée à être partagée hors-app aux utilisateurs
+    bloqués par un in-app updater défaillant : un tap dans le navigateur
+    Android déclenche un download direct + install in-place (même clé de
+    signing → données préservées, pas de désinstallation).
+    """
+    payload = await get_download_url()
+    return RedirectResponse(url=payload["url"], status_code=302)

--- a/packages/api/tests/routers/test_app_update.py
+++ b/packages/api/tests/routers/test_app_update.py
@@ -1,0 +1,29 @@
+"""Tests for the app_update router."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_apk_redirect_returns_302_to_signed_url():
+    """The /apk endpoint must 302-redirect to the GitHub-signed APK URL.
+
+    This is the public out-of-app fallback for users stuck with a broken
+    in-app updater — a single tap in the browser must land on the APK
+    download, no JSON envelope.
+    """
+    signed_url = "https://objects.githubusercontent.com/foo.apk?token=abc"
+    with patch(
+        "app.routers.app_update.get_download_url",
+        new=AsyncMock(return_value={"url": signed_url}),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/app/update/apk", follow_redirects=False)
+
+    assert resp.status_code == 302
+    assert resp.headers["location"] == signed_url


### PR DESCRIPTION
## Quoi

Nouvel endpoint public `GET /api/app/update/apk` qui 302-redirige vers l'URL S3 pré-signée du dernier APK GitHub.

## Pourquoi

Les utilisateurs déjà installés avec un in-app updater cassé (cf #564) ne peuvent pas recevoir le fix in-app — catch-22. Le seul chemin de recovery réel est un download direct via le navigateur Android : tap → DL → install in-place (même clé de signing → données préservées, pas de désinstall).

Cet endpoint donne une **URL stable et partageable** (à mettre derrière un short-link type `bit.ly/facteur-update`) qui pointera toujours vers la dernière release. À diffuser aux users bloqués via email / Telegram / story / SMS.

## Comment

- Réutilise `get_download_url()` existant (qui interroge GitHub avec auth + récupère la Location S3)
- `RedirectResponse(status_code=302)` plutôt que JSON
- `include_in_schema=False` (endpoint utilitaire, pas dans la doc OpenAPI publique)

## Comment ça a été vérifié

- [x] Test unitaire : `tests/routers/test_app_update.py::test_apk_redirect_returns_302_to_signed_url` PASS
- [x] `ruff check` + `ruff format --check` OK

## Zones à risque

Aucune. Endpoint en lecture seule, réutilise un flow existant, pas de modif schéma DB ni d'auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)