### PR TITLE
fix(veille): /suggestions/sources savepoint + timeouts + retry mobile

### DIFF
--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -64,7 +64,7 @@ Hotfix critique sur le bug "loading infini" perçu en Step 3 de l'onboarding vei
 - Le candidat fautif est remonté à Sentry via `sentry_sdk.capture_exception`.
 
 ## Critères d'acceptation
-- [ ] **Backend** : `pytest tests/test_veille_source_ingestion.py` → 16 tests verts (incluant 4 nouveaux : `test_failing_candidate_does_not_poison_others`, `test_session_recovers_from_integrity_error`, `test_slow_candidate_is_skipped`, `test_llm_timeout_falls_back_to_curated`).
+- [ ] **Backend** : `pytest tests/test_veille_source_ingestion.py` → tests verts (incluant 3 nouveaux : `test_session_recovers_from_integrity_error`, `test_slow_candidate_is_skipped`, `test_llm_timeout_falls_back_to_curated`).
 - [ ] **Mobile** : `flutter test test/features/veille/screens/step3_sources_screen_test.dart` → 1 test vert (bouton Réessayer présent + cliquable + déclenche fetch).
 - [ ] **Sentry** : zéro nouvelle occurrence PYTHON-3P 24 h après merge en prod.
 - [ ] **Supabase** : `SELECT count(*) FROM sources WHERE created_at > NOW() - INTERVAL '24 hours' AND is_curated = false` > 0 (preuve qu'au moins une ingestion réussit).

--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,114 +1,91 @@
-# QA Handoff — Veille V3 PR3 « UX polish »
+# QA Handoff — Veille `/suggestions/sources` : savepoint + timeouts + retry mobile
 
 ## Feature développée
-
-Trois améliorations UX du flow de configuration veille (mobile, 4 étapes) :
-- **T4** — Pré-loading actif des suggestions LLM entre les steps (animation halo + checklist déclenche désormais le fetch en arrière-plan, durée adaptive 1.5 s min → data|error).
-- **T5** — Nouvel écran d'introduction veille au premier accès (single-page : pitch + halo + CTA « C'est parti »), affiché avant Step1.
-- **T6** — Repositionnement des pré-sets : suppression de la section bas de Step1, ajout d'un teaser tappable haut + bottom sheet listant tous les pré-sets.
+Hotfix critique sur le bug "loading infini" perçu en Step 3 de l'onboarding veille (PYTHON-3P/3Q : 13 occurrences en 3 h, 2 users). Trois corrections backend (savepoint par candidat, timeouts par candidat + global LLM, sentry capture) + une correction mobile (réintroduction du bouton « Réessayer » perdu dans PR2 #562).
 
 ## PR associée
-
-À créer via `/go` — base `main`.
+À créer après /go (cible : `main`).
 
 ## Écrans impactés
-
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| `VeilleIntroScreen` | `/veille/config` (état pré-Step1) | NOUVEAU (T5) |
-| `VeilleConfigScreen` | `/veille/config` | Modifié (T4 + T5) |
-| `Step1ThemeScreen` | `/veille/config` (étape 1) | Modifié (T6) |
-| `VeillePresetsSheet` | bottom sheet de Step1 | NOUVEAU (T6) |
-| `FlowLoadingScreen` | écran de transition | Inchangé (déjà multi-step) |
+| Step 3 — Sources | `/veille/config` (step 3) | Modifié (bouton Réessayer dans `_MockSourcesFallback`) |
 
 ## Scénarios de test
 
-### Scénario 1 — Happy path complet (premier accès)
-
+### Scénario 1 : Happy path — sources arrivent normalement
 **Parcours** :
-1. Aller sur `/veille/config` (compte sans config active).
-2. Vérifier qu'on voit l'écran **VeilleIntroScreen** (eyebrow « Le facteur prépare ta veille » + titre « Une veille pensée pour toi » + halo animé + CTA « C'est parti »).
-3. Tap « C'est parti ».
-4. Sur Step1 : vérifier le **teaser pré-sets** (« Pas inspiré ? Pioche un pré-set ») visible dès l'ouverture (sans scroll).
-5. Sélectionner un thème (ex. Tech).
-6. Sélectionner un sujet pré-suggéré, tap « Continuer ».
-7. **Animation halo** + checklist (FlowLoadingScreen) ≥ 1.5 s.
-8. Step2 affiché : suggestions topics **déjà chargées** (pas de spinner secondaire en cas nominal).
-9. Cocher 1-2 suggestions, tap « Continuer ».
-10. **Animation halo** vers Step3 puis sources **déjà chargées**.
-11. Tap « Continuer ».
-12. Step4 (rythme), tap « Démarrer ma veille ».
-13. Animation post-submit (from=4) + redirection dashboard.
+1. App connectée, sans veille active.
+2. Aller sur `/veille/config` → Step 1 (thème) → choisir « Tech ».
+3. Step 2 (topics) → choisir 2-3 topics.
+4. Step 2 → tap « Continuer ».
+5. Animation halo Step 2→3.
+**Résultat attendu** :
+- Le serveur répond en < 25 s (timeouts en place).
+- Step 3 affiche la liste rankée par pertinence (8-12 sources).
+- Aucun spinner infini.
 
-**Résultat attendu** : flow ininterrompu, halo entre chaque step, pas de spinner secondaire à l'arrivée sur Step2/Step3.
-
-### Scénario 2 — Pré-set via bottom sheet
-
+### Scénario 2 : Backend hang sur un domaine bad
 **Parcours** :
-1. Aller sur `/veille/config` (sans config), passer l'intro.
-2. Sur Step1, tap teaser « Pas inspiré ? Pioche un pré-set ».
-3. Vérifier la **bottom sheet** : titre « Pré-sets », liste des PresetCard.
-4. Tap sur un pré-set.
-5. Vérifier que la sheet se ferme et que **Step1.5 preview** s'affiche (label + accroche + topics + sources).
-6. Tap « Utiliser ce pré-set » → bascule Step4 (jumpToStep4).
-7. Tap « Démarrer ma veille » → submit.
+1. Reproduire localement avec un candidat URL qui hang (ex : `binge.audio/feed/`).
+2. Lancer `/api/veille/suggestions/sources`.
+**Résultat attendu** :
+- Backend skip le candidat après 8 s (`source_suggester.candidate_timeout` log).
+- Les autres candidats sont ingérés normalement.
+- Réponse 200 sous 25 s.
 
-**Résultat attendu** : workflow preview→use inchangé. Pas d'intro réaffichée pendant la session.
-
-### Scénario 3 — Mode édition (skip intro)
-
+### Scénario 3 : Backend 503 (PendingRollbackError simulé) — fallback mobile
 **Parcours** :
-1. Avoir une config active.
-2. Naviguer sur `/veille/config?mode=edit`.
-3. Vérifier que **Step1 est affiché directement** (pas d'intro).
-4. Vérifier que les sélections sont hydratées depuis la config existante.
+1. Backend down ou throw 503 sur `/suggestions/sources`.
+2. Step 3 mounted → spinner pendant ~30 s (timeout Dio) puis erreur API.
+**Résultat attendu** :
+- Mock fallback affiché avec message « Suggestions indisponibles, conserve ta sélection. ».
+- **Bouton « Réessayer » présent et cliquable** (régression PR2 #562 corrigée).
+- Tap « Réessayer » → relance la requête (`refreshKeepingChecked`).
+- Si backend toujours KO → reste sur le mock fallback ; si recovery → liste rankée affichée.
 
-**Résultat attendu** : intro skipped, hydratation OK.
-
-### Scénario 4 — Config active sans edit (redirect)
-
+### Scénario 4 : LLM Mistral timeout (> 20 s)
 **Parcours** :
-1. Avoir une config active.
-2. Naviguer sur `/veille/config` (sans `?mode=edit`).
+1. Configurer un délai artificiel sur le serveur mock LLM ou couper Mistral API.
+2. Appeler `/suggestions/sources`.
+**Résultat attendu** :
+- Backend bascule sur `_fallback` (sources curées du thème).
+- Réponse 200 avec `sources` non-vide (relevance_score=null).
+- Log `source_suggester.llm_timeout` émis.
 
-**Résultat attendu** : redirect immédiat vers `/veille/dashboard`. Pas d'intro affichée.
-
-### Scénario 5 — LLM lent (>1.5 s)
-
+### Scénario 5 : Une violation de contrainte ne poison plus la session
 **Parcours** :
-1. Throttler le réseau (Chrome devtools → Slow 3G), repasser le happy path Step1→Step2.
-
-**Résultat attendu** : animation halo dépasse 1.5 s, attend le provider jusqu'à `data|error` (cap 8 s). Au-delà, Step2 affiche son skeleton normal — pas de blocage.
-
-### Scénario 6 — Close depuis l'intro
-
-**Parcours** :
-1. Sur l'intro, tap la croix (haut droite).
-
-**Résultat attendu** : retour `/feed` (pas de pop si pas de history).
+1. LLM produit 3 candidats dont un avec un `name` > 200 chars (violation `String(200)`).
+2. Backend ingère.
+**Résultat attendu** :
+- Le candidat fautif est skippé via SAVEPOINT rollback.
+- Les 2 autres candidats sont ingérés et committés.
+- `db.commit()` final ne lève pas `PendingRollbackError`.
+- Le candidat fautif est remonté à Sentry via `sentry_sdk.capture_exception`.
 
 ## Critères d'acceptation
-
-- [ ] Premier accès `/veille/config` sans config → intro affichée.
-- [ ] Tap « C'est parti » → bascule Step1 (animation AnimatedSwitcher).
-- [ ] `?mode=edit` → intro skipped (Step1 directement).
-- [ ] `activeConfig != null` → redirect dashboard.
-- [ ] Step1 : teaser pré-sets visible sans scroll.
-- [ ] Tap teaser → bottom sheet liste tous les pré-sets.
-- [ ] Tap pré-set → sheet ferme + Step1.5 preview.
-- [ ] Plus aucune section "Inspirations" en bas du scroll Step1.
-- [ ] Step1→Step2 : animation halo ≥ 1.5 s + suggestions topics chargées à l'arrivée (cas nominal).
-- [ ] Step2→Step3 : animation halo ≥ 1.5 s + sources chargées à l'arrivée (cas nominal).
-- [ ] Si LLM lent : on attend jusqu'à 8 s puis on passe (skeleton normal).
+- [ ] **Backend** : `pytest tests/test_veille_source_ingestion.py` → 16 tests verts (incluant 4 nouveaux : `test_failing_candidate_does_not_poison_others`, `test_session_recovers_from_integrity_error`, `test_slow_candidate_is_skipped`, `test_llm_timeout_falls_back_to_curated`).
+- [ ] **Mobile** : `flutter test test/features/veille/screens/step3_sources_screen_test.dart` → 1 test vert (bouton Réessayer présent + cliquable + déclenche fetch).
+- [ ] **Sentry** : zéro nouvelle occurrence PYTHON-3P 24 h après merge en prod.
+- [ ] **Supabase** : `SELECT count(*) FROM sources WHERE created_at > NOW() - INTERVAL '24 hours' AND is_curated = false` > 0 (preuve qu'au moins une ingestion réussit).
+- [ ] **E2E mobile** : flow complet onboarding veille → Step 3 affiche des sources réelles (pas le mock fallback) sur thème `tech` avec topics IA.
 
 ## Zones de risque
 
-- **Params identiques entre `goNext()`/`FlowLoadingScreen` et Step2/Step3** : si différents (ordre topicLabels, sort des topicIds), `family.autoDispose` créera deux instances → double-fetch et perte du préload. Helpers `topicsParamsFromState` / `sourcesParamsFromState` sont la single source of truth, alignés sur l'instanciation des Steps.
-- **`introCompleted` marqué dans `applyPreset` et `hydrateFromActiveConfig`** : critique pour ne pas réafficher l'intro après un preset apply ou en mode édition.
-- **Annulation du loading** : si l'utilisateur close le flow pendant l'animation halo, la guard `state.loadingFrom != from` dans `_waitAndAdvance` évite un push de transition stale.
+1. **Savepoint behaviour avec test fixture `db_session`** : la fixture utilise `join_transaction_mode="create_savepoint"` ; les `session.begin_nested()` du code de prod créent des savepoints imbriqués. Vérifier que les tests de la suite pré-existante (15 dans `test_veille_source_ingestion.py`) restent verts.
+
+2. **`asyncio.wait_for` + httpx timeouts** : `EditorialLLMClient` a déjà un `httpx.Timeout(30.0)` ; `_LLM_TIMEOUT_S=20s` est plus strict, donc effectif. RSSParser a 7 s par requête HTTP → un candidat qui exécute 14 variants suffix peut quand même dépasser 8 s ; le timeout par candidat coupe net.
+
+3. **Sentry noise potential** : `sentry_sdk.capture_exception` dans le `except Exception` peut générer du bruit si le LLM produit régulièrement des candidats invalides. À surveiller dans les premiers jours post-merge ; ajuster le filter rule si > 50/jour.
 
 ## Dépendances
 
-- Backend : aucune modif (les endpoints `/api/veille/suggestions/topics` et `/sources` sont inchangés).
-- Mobile : `flutter_riverpod` (ProviderSubscription, déjà utilisé).
-- Pas de migration DB.
+- **Endpoints touchés** : POST `/api/veille/suggestions/sources`.
+- **Services backend** : `SourceSuggester`, `SourceService.detect_source` (RSSParser), `EditorialLLMClient` (Mistral).
+- **Mobile** : `VeilleSourcesSuggestionsNotifier` (provider famille autoDispose), `Step3SourcesScreen`.
+- **Doc** : `docs/bugs/bug-veille-suggestions-sources-pending-rollback.md` (diagnostic + fix complet).
+
+## Hors scope (à créer en issues séparées)
+
+- **Optim RSSParser** : éviter les 14 variants suffix sur un même domaine (les 100+ HTTP calls par request). Refactor `detect()` pour bail-out plus tôt.
+- **Cleanup script rows stuck `running > 15min`** : pré-existait à ce bug.

--- a/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
@@ -88,8 +88,16 @@ class Step3SourcesScreen extends ConsumerWidget {
                     padding: EdgeInsets.symmetric(vertical: 24),
                     child: Center(child: CircularProgressIndicator()),
                   ),
-                  error: (_, __) =>
-                      _MockSourcesFallback(state: state, notifier: notifier),
+                  error: (_, __) => _MockSourcesFallback(
+                    state: state,
+                    notifier: notifier,
+                    onRetry: params == null
+                        ? null
+                        : () => ref
+                            .read(veilleSourceSuggestionsProvider(params)
+                                .notifier)
+                            .refreshKeepingChecked(state.selectedSourceIds),
+                  ),
                   data: (resp) => _ApiSourceList(
                     resp: resp,
                     state: state,
@@ -213,7 +221,12 @@ class _ApiSourceList extends StatelessWidget {
 class _MockSourcesFallback extends StatelessWidget {
   final VeilleConfigState state;
   final VeilleConfigNotifier notifier;
-  const _MockSourcesFallback({required this.state, required this.notifier});
+  final VoidCallback? onRetry;
+  const _MockSourcesFallback({
+    required this.state,
+    required this.notifier,
+    this.onRetry,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -224,11 +237,27 @@ class _MockSourcesFallback extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Padding(
-          padding: EdgeInsets.only(bottom: 12),
-          child: Text(
-            'Suggestions indisponibles, conserve ta sélection.',
-            style: TextStyle(fontSize: 12, color: Color(0xFF8B7E63)),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  'Suggestions indisponibles, conserve ta sélection.',
+                  style: TextStyle(fontSize: 12, color: Color(0xFF8B7E63)),
+                ),
+              ),
+              if (onRetry != null)
+                TextButton.icon(
+                  onPressed: onRetry,
+                  icon: Icon(PhosphorIcons.arrowClockwise(), size: 16),
+                  label: const Text('Réessayer'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: const Color(0xFF8B7E63),
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                  ),
+                ),
+            ],
           ),
         ),
         for (int i = 0; i < allMockSources.length; i++) ...[

--- a/apps/mobile/test/features/veille/screens/step3_sources_screen_test.dart
+++ b/apps/mobile/test/features/veille/screens/step3_sources_screen_test.dart
@@ -1,0 +1,88 @@
+// Test : Step 3 sources — bouton « Réessayer » présent sur erreur API.
+//
+// Régression bug `bug-veille-suggestions-sources-pending-rollback` :
+// le bouton retry avait été retiré dans PR2 #562 (refonte UI sources rankées),
+// laissant l'user bloqué sur le mock fallback sans CTA pour relancer la
+// génération.
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/veille/models/veille_suggestion.dart';
+import 'package:facteur/features/veille/providers/veille_config_provider.dart';
+import 'package:facteur/features/veille/providers/veille_repository_provider.dart';
+import 'package:facteur/features/veille/repositories/veille_repository.dart';
+import 'package:facteur/features/veille/screens/steps/step3_sources_screen.dart';
+
+class _FakeRepo implements VeilleRepository {
+  int suggestSourcesCallCount = 0;
+
+  @override
+  Future<VeilleSourceSuggestionsResponse> suggestSources({
+    required String themeId,
+    List<String> topicLabels = const [],
+    List<String> excludeSourceIds = const [],
+    String? purpose,
+    String? purposeOther,
+    String? editorialBrief,
+  }) async {
+    suggestSourcesCallCount += 1;
+    throw const VeilleApiException('boom', statusCode: 503);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} non mocké');
+}
+
+ProviderContainer _container(_FakeRepo repo) {
+  final container = ProviderContainer(
+    overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+  );
+  // Pré-configure un thème + un topic pour que params != null et que
+  // le bouton "Réessayer" soit câblé.
+  final notifier = container.read(veilleConfigProvider.notifier);
+  notifier.selectTheme('tech');
+  notifier.toggleTopic('ia');
+  return container;
+}
+
+Widget _wrap(ProviderContainer container) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      home: Scaffold(
+        body: Step3SourcesScreen(onClose: () {}),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets(
+    'erreur API → fallback affiche bouton Réessayer cliquable',
+    (tester) async {
+      final repo = _FakeRepo();
+      final container = _container(repo);
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(_wrap(container));
+      // Attente : 1er fetch déclenché par le constructeur du notifier.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(repo.suggestSourcesCallCount, 1);
+      expect(find.text('Suggestions indisponibles, conserve ta sélection.'),
+          findsOneWidget);
+      expect(find.text('Réessayer'), findsOneWidget);
+
+      await tester.tap(find.text('Réessayer'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // Le tap déclenche un nouveau fetch — preuve que le câblage
+      // refreshKeepingChecked passe bien.
+      expect(repo.suggestSourcesCallCount, 2);
+    },
+  );
+}

--- a/docs/bugs/bug-veille-suggestions-sources-pending-rollback.md
+++ b/docs/bugs/bug-veille-suggestions-sources-pending-rollback.md
@@ -1,0 +1,138 @@
+# Bug — Veille `/suggestions/sources` : `PendingRollbackError` répété, loading infini perçu
+
+## TL;DR
+
+Sur prod (release `b6d2d3e4`, déployée 2026-05-05 ~02h15 Paris), POST `/api/veille/suggestions/sources` échoue systématiquement avec `PendingRollbackError` puis renvoie 503. Mobile reste 30 s en spinner (timeout Dio) puis affiche `_MockSourcesFallback` sans CTA retry → "loading infini" perçu, retry inutile.
+
+**Cause racine** (HIGH confidence, 13 occurrences en 3h sur 2 users) :
+
+1. `_hydrate_or_ingest` ne wrappe pas `await session.flush()` dans un savepoint. Une violation de contrainte (vraisemblablement `sources.feed_url` UNIQUE ou `sources.name` > 200 chars) empoisonne la session. Le `except Exception → continue` du loop ne fait pas de `rollback()`, donc tout `session.execute(...)` ultérieur lève `PendingRollbackError`. `db.commit()` final aussi.
+2. Pas de timeout par candidat sur `source_service.detect_source(cand.url)`. RSSParser teste 14 variants suffix (rss, feed, feed.xml, …) avec httpx 7 s + curl-cffi 10 s en fallback. Sur un domaine qui hang (vu `binge.audio/feed/` 22× status=None sur 3 minutes), un seul mauvais URL gèle tout le pipeline.
+3. Pas de timeout global sur `suggester.suggest_sources(...)`. La requête peut tourner > 3 min côté serveur, le mobile timeout à 30 s coupe la connexion mais le worker continue à brûler du CPU.
+4. Bouton "Réessayer" perdu dans le merge V3 PR2 (#562) : `_MockSourcesFallback` actuel n'a aucun CTA, l'user ne sait pas comment se sortir du mock.
+
+## Volumétrie (Sentry + Supabase, 2026-05-05 09:00 UTC)
+
+| Métrique | Valeur |
+|---|---|
+| Sentry PYTHON-3P `PendingRollbackError` | 13 occurrences, 2 users, last 08:57 UTC |
+| Sentry PYTHON-3Q `HTTPException 503` | 13 occurrences (suit 3P 1:1) |
+| Sources `is_curated=False` ingérées via /suggestions/sources, dernières 12 h | **0** (toutes les `flush()` échouent) |
+| Tentatives user `laurin.facteur@proton.me` en 2 min | 5 (08:55:40 → 08:57:10), toutes 503 |
+
+## Reconstruction du flow (event PYTHON-3P latest)
+
+User : `c959d7ef-d407-4a4a-a7cb-fdda6c065392` (`laurin.facteur@proton.me`)
+Body : `theme_id=tech`, 7 topic_labels (IA, désinformation, biais algo, …), `purpose=preparer_projet`, `editorial_brief="J'écris une vidéo sur les dangers de l'IA…"`.
+
+Breadcrumbs HTTP (100 captés, ~3 min de wall-clock) :
+- 78× status 200 (RSS detection sur binge.audio/podcast/* et affordance.typepad.com et lemonde.fr)
+- **22× status=None sur `https://www.binge.audio/feed/`** (timeout httpx 7 s, retry curl-cffi 10 s, boucle)
+- 1× 403 sur `ladn.eu/newsletter/`
+
+Request hang ~3 min côté serveur. Mobile timeout à 30 s → DioException → mock fallback sans CTA. User retry → même chemin de hang. PendingRollbackError final → 503 (ignoré côté mobile, déjà disconnecté).
+
+## Hypothèses confirmées
+
+| Hyp | Verdict | Evidence |
+|---|---|---|
+| `flush()` viole une contrainte → session poisonnée | **HIGH** | 0 source ingérée en 12h pour 13 tentatives. PYTHON-3P `_invalid_transaction` confirme transaction invalide. |
+| RSSParser hang sur certains URLs | **HIGH** | 22× retry sur même URL `binge.audio/feed/` avec status=None (timeout) en 3 min. |
+| Pas de timeout par candidat / global | **HIGH** | Code `_hydrate_or_ingest` ne wrappe pas dans `asyncio.wait_for`. Code router idem. |
+| Bouton retry mobile manquant | **HIGH** | `_MockSourcesFallback` (ligne 213-247 step3_sources_screen.dart) sans `onRetry`. Ajouté en PR1 (#561), retiré dans PR2 (#562) qui a refait le widget. |
+
+## Hypothèses réfutées
+
+| Hyp | Verdict | Evidence |
+|---|---|---|
+| Quota Mistral 429 | KO | Aucun event Sentry `httpx.HTTPStatusError 429`. |
+| EDBHANDLEREXITED Supabase | KO sur ce path | PYTHON-3N (EDBHANDLEREXITED) cassé sur `_run_first_delivery`, **pas** sur `suggest_sources`. |
+| Theme invalide (`ck_source_theme_valid`) | KO | Body request : `theme_id=tech` (valide). Guard `_ALLOWED_SOURCE_THEMES` actif. |
+
+## Fix recommandé
+
+### Backend `packages/api/app/services/veille/source_suggester.py`
+
+1. **Savepoint par candidat** dans la boucle d'ingestion :
+   ```python
+   for cand in candidates:
+       try:
+           async with session.begin_nested():  # SAVEPOINT
+               hydrated = await asyncio.wait_for(
+                   self._hydrate_or_ingest(session, source_service, cand, theme_id),
+                   timeout=8.0,
+               )
+       except (asyncio.TimeoutError, Exception) as exc:
+           sentry_sdk.capture_exception(exc)
+           logger.warning(
+               "source_suggester.hydrate_failed",
+               name=cand.name, url=cand.url, error_class=type(exc).__name__, error=str(exc),
+           )
+           continue
+       ...
+   ```
+   - Le savepoint isole les violations de contraintes : sur `IntegrityError`, seul le SAVEPOINT rollback, la session reste utilisable.
+   - `asyncio.wait_for(..., 8.0)` cap chaque candidat → un mauvais URL ne gèle plus tout le pipeline.
+   - `sentry_sdk.capture_exception` remonte la vraie cause des `flush()` qui foirent (jusque-là invisibles).
+
+2. **Timeout global LLM** sur `chat_json` :
+   ```python
+   raw = await asyncio.wait_for(
+       self._llm.chat_json(...),
+       timeout=20.0,
+   )
+   ```
+   Sur `TimeoutError` → bascule fallback curé.
+
+### Backend `packages/api/app/routers/veille.py` `suggest_sources`
+
+Aucun changement : le 503 sur SQLAlchemyError + httpx errors reste pertinent comme dernière barrière. Le savepoint en amont devrait éviter qu'on y arrive.
+
+### Mobile `apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart`
+
+3. Réintroduire bouton "Réessayer" dans `_MockSourcesFallback` (perdu en PR2 #562). Trigger : `ref.read(veilleSourceSuggestionsProvider(params).notifier).refreshKeepingChecked(state.selectedSourceIds)`.
+
+### Tests
+
+- `tests/test_veille_source_suggester.py::test_hydrate_savepoint_isolation` : mock `flush()` qui throw `IntegrityError` au candidat #2 → assert candidats #1, #3, #4 OK + `db.commit()` final OK.
+- `tests/test_veille_source_suggester.py::test_candidate_timeout` : mock `detect_source` qui sleep 30s → assert skip après 8s + log `candidate_timeout`.
+- `apps/mobile/test/features/veille/screens/step3_sources_screen_test.dart::testRetryButtonPresent` : `AsyncValue.error` → assert bouton "Réessayer" présent + tap → appel `refreshKeepingChecked`.
+
+## Hors scope (issues séparées)
+
+- **Optim RSSParser** : éviter les 14 variants de suffix sur le même domaine (cause des 100 HTTP calls). Refactor `detect()` pour bail-out plus tôt après 2-3 essais sur le même hostname.
+- **Cleanup script rows stuck `running > 15min`** : pré-existait à ce bug, pas lié à `/suggestions/sources`.
+
+## Logs bruts représentatifs
+
+### Sentry PYTHON-3P (latest 2026-05-05 08:57:10)
+
+```
+Exception: PendingRollbackError
+Module: sqlalchemy.exc
+Value: Can't reconnect until invalid transaction is rolled back. Please rollback() fully before proceeding
+Transaction: app.routers.veille.suggest_sources
+URL: POST /api/veille/suggestions/sources
+Release: b6d2d3e43e6af9825663d449d9bd42396e53edd5
+User: c959d7ef (laurin.facteur@proton.me)
+
+Top frame (in_app):
+  app/routers/veille.py: suggest_sources
+
+Stack:
+  sqlalchemy/ext/asyncio/session.py: commit
+  sqlalchemy/orm/session.py: commit
+  sqlalchemy/engine/base.py: _commit_impl
+  sqlalchemy/engine/base.py: _revalidate_connection
+  sqlalchemy/engine/base.py: _invalid_transaction
+```
+
+### Breadcrumbs HTTP (extrait, 22× même URL)
+
+```
+[8:54:41Z]  GET https://www.binge.audio/feed/  status=None  (timeout 7s)
+[8:54:48Z]  GET https://www.binge.audio/feed/  status=None
+[8:54:55Z]  GET https://www.binge.audio/feed/  status=None
+... (20 more)
+[8:57:06Z]  GET https://www.binge.audio/feed/  status=None
+```

--- a/packages/api/app/services/veille/source_suggester.py
+++ b/packages/api/app/services/veille/source_suggester.py
@@ -37,9 +37,9 @@ logger = structlog.get_logger()
 # la session (PendingRollbackError sur tout commit ultérieur).
 _ALLOWED_SOURCE_THEMES = frozenset(VeilleThemeSlug.__args__)
 
-# Cap par candidat (HTTP detect + flush DB). Au-delà, on skip pour ne pas
-# bloquer le pipeline sur un domaine qui hang (cf. bug-veille-suggestions
-# -sources-pending-rollback : binge.audio/feed/ retry 22× = 3min wall).
+# Cap par candidat (HTTP detect via RSSParser teste plusieurs variants
+# suffix avec httpx 7s + curl-cffi 10s). Sans cap, un seul URL qui hang
+# gèle le pipeline complet pour les 7-11 candidats restants.
 _HYDRATE_TIMEOUT_S = 8.0
 
 # Cap global sur l'appel LLM (Mistral). Sur timeout → fallback curé.
@@ -167,11 +167,10 @@ class SourceSuggester:
             return SourceSuggestions(sources=sources)
 
         # Hydrate / ingère + dédup par domaine (keep highest score).
-        # Chaque candidat est isolé dans un SAVEPOINT + cappé à 8 s :
-        # - savepoint évite qu'une `IntegrityError` (feed_url unique, name >
-        #   200 chars) empoisonne la session pour les candidats suivants ;
-        # - timeout évite qu'un mauvais URL fasse hang RSSParser (cf. bug
-        #   binge.audio/feed/ retry 22× = 3 min wall).
+        # Chaque candidat est isolé dans un SAVEPOINT : sans ça, une
+        # `IntegrityError` au flush() (feed_url unique, name overflow…)
+        # empoisonne la session pour tous les candidats suivants
+        # (PendingRollbackError au commit final).
         by_domain: dict[str, tuple[Source, _LLMSourceCandidate]] = {}
         source_service = SourceService(session)
         for cand in candidates:
@@ -192,10 +191,9 @@ class SourceSuggester:
                 )
                 continue
             except Exception as exc:
-                # Sentry capture obligatoire : sans ça on perd la cause
-                # racine des `flush()` qui foirent (ck_source_theme_valid,
-                # feed_url unique, name overflow…) et on ne peut pas
-                # itérer sur les vraies failures.
+                # Sentry capture obligatoire : le `logger.warning` seul ne
+                # remonte pas la stack ; sans ça on perd la cause racine
+                # des flush() qui foirent et on ne peut pas itérer dessus.
                 sentry_sdk.capture_exception(exc)
                 logger.warning(
                     "source_suggester.hydrate_failed",

--- a/packages/api/app/services/veille/source_suggester.py
+++ b/packages/api/app/services/veille/source_suggester.py
@@ -12,10 +12,12 @@ Sans `MISTRAL_API_KEY`, fallback déterministe sur 5 sources curées du même th
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
+import sentry_sdk
 import structlog
 from pydantic import BaseModel, Field, ValidationError
 from sqlalchemy import select
@@ -34,6 +36,14 @@ logger = structlog.get_logger()
 # `ck_source_theme_valid` : un INSERT avec un theme hors liste empoisonne
 # la session (PendingRollbackError sur tout commit ultérieur).
 _ALLOWED_SOURCE_THEMES = frozenset(VeilleThemeSlug.__args__)
+
+# Cap par candidat (HTTP detect + flush DB). Au-delà, on skip pour ne pas
+# bloquer le pipeline sur un domaine qui hang (cf. bug-veille-suggestions
+# -sources-pending-rollback : binge.audio/feed/ retry 22× = 3min wall).
+_HYDRATE_TIMEOUT_S = 8.0
+
+# Cap global sur l'appel LLM (Mistral). Sur timeout → fallback curé.
+_LLM_TIMEOUT_S = 20.0
 
 
 @dataclass(frozen=True)
@@ -131,32 +141,67 @@ class SourceSuggester:
                 f"Brief éditorial : {editorial_brief or '(aucun)'}\n\n"
                 f"Propose 8 à 12 sources rankées par pertinence pour ces topics et ce brief."
             )
-            raw = await self._llm.chat_json(
-                system=_SOURCES_SYSTEM_PROMPT,
-                user_message=user_message,
-                model="mistral-large-latest",
-                temperature=0.4,
-                max_tokens=1500,
-            )
-            candidates = self._parse_candidates(raw)
+            try:
+                raw = await asyncio.wait_for(
+                    self._llm.chat_json(
+                        system=_SOURCES_SYSTEM_PROMPT,
+                        user_message=user_message,
+                        model="mistral-large-latest",
+                        temperature=0.4,
+                        max_tokens=1500,
+                    ),
+                    timeout=_LLM_TIMEOUT_S,
+                )
+                candidates = self._parse_candidates(raw)
+            except TimeoutError:
+                logger.warning(
+                    "source_suggester.llm_timeout",
+                    timeout_s=_LLM_TIMEOUT_S,
+                    theme_id=theme_id,
+                )
+                # Fallback curé — pas de sentry capture (timeout LLM = condition
+                # business connue, pas un bug applicatif).
 
         if not candidates:
             sources = await self._fallback(session, theme_id, excluded, followed_ids)
             return SourceSuggestions(sources=sources)
 
-        # Hydrate / ingère + dédup par domaine (keep highest score)
+        # Hydrate / ingère + dédup par domaine (keep highest score).
+        # Chaque candidat est isolé dans un SAVEPOINT + cappé à 8 s :
+        # - savepoint évite qu'une `IntegrityError` (feed_url unique, name >
+        #   200 chars) empoisonne la session pour les candidats suivants ;
+        # - timeout évite qu'un mauvais URL fasse hang RSSParser (cf. bug
+        #   binge.audio/feed/ retry 22× = 3 min wall).
         by_domain: dict[str, tuple[Source, _LLMSourceCandidate]] = {}
         source_service = SourceService(session)
         for cand in candidates:
             try:
-                hydrated = await self._hydrate_or_ingest(
-                    session, source_service, cand, theme_id
+                async with session.begin_nested():
+                    hydrated = await asyncio.wait_for(
+                        self._hydrate_or_ingest(
+                            session, source_service, cand, theme_id
+                        ),
+                        timeout=_HYDRATE_TIMEOUT_S,
+                    )
+            except TimeoutError:
+                logger.warning(
+                    "source_suggester.candidate_timeout",
+                    name=cand.name,
+                    url=cand.url,
+                    timeout_s=_HYDRATE_TIMEOUT_S,
                 )
+                continue
             except Exception as exc:
+                # Sentry capture obligatoire : sans ça on perd la cause
+                # racine des `flush()` qui foirent (ck_source_theme_valid,
+                # feed_url unique, name overflow…) et on ne peut pas
+                # itérer sur les vraies failures.
+                sentry_sdk.capture_exception(exc)
                 logger.warning(
                     "source_suggester.hydrate_failed",
                     name=cand.name,
                     url=cand.url,
+                    error_class=type(exc).__name__,
                     error=str(exc),
                 )
                 continue

--- a/packages/api/tests/test_veille_source_ingestion.py
+++ b/packages/api/tests/test_veille_source_ingestion.py
@@ -10,11 +10,13 @@ Couvre :
 - Fallback déterministe sans `MISTRAL_API_KEY`.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest_asyncio
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from app.models.enums import SourceType
 from app.models.source import Source, UserSource
@@ -441,3 +443,196 @@ class TestFallback:
         assert len(result.sources) == 8
         assert all(s.relevance_score is None for s in result.sources)
         assert all(s.is_already_followed is False for s in result.sources)
+
+
+class TestSavepointIsolation:
+    """Bug `bug-veille-suggestions-sources-pending-rollback` : sans savepoint,
+    une `IntegrityError` sur un `flush()` empoisonnait toute la session ; tous
+    les candidats suivants levaient `PendingRollbackError` → 503 et 0 source
+    ingérée. Avec savepoint, seul le candidat fautif est rollback."""
+
+    async def test_failing_candidate_does_not_poison_others(
+        self, db_session, test_user
+    ):
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value={
+                "sources": [
+                    _candidate("Good 1", "https://good1.example.com", 0.8),
+                    _candidate("Bad", "https://bad.example.com", 0.7),
+                    _candidate("Good 2", "https://good2.example.com", 0.6),
+                ]
+            }
+        )
+        suggester = SourceSuggester(llm=llm)
+
+        async def _detect(url: str):
+            # Le candidat "bad" résout vers un feed_url volontairement
+            # invalide qui dépasse la limite text/varchar théorique du
+            # nom de Source (>200 chars) côté ingest. detect_source ne
+            # lève pas, c'est `flush()` qui doit échouer.
+            if "bad" in url:
+                return _detect_response("X" * 250, f"{url}/feed.xml")
+            return _detect_response(url, f"{url}/feed.xml")
+
+        with patch(
+            "app.services.veille.source_suggester.SourceService.detect_source",
+            new=AsyncMock(side_effect=_detect),
+        ):
+            result = await suggester.suggest_sources(
+                session=db_session,
+                user_id=test_user.user_id,
+                theme_id="science",
+                topic_labels=[],
+            )
+
+        # Le candidat fautif est skippé via savepoint rollback ; les 2 bons
+        # candidats sont ingérés.
+        names = sorted(s.name for s in result.sources)
+        assert "Bad" not in names
+        assert "https://good1.example.com" in {s.name for s in result.sources}
+        assert "https://good2.example.com" in {s.name for s in result.sources}
+
+        # La session est toujours utilisable après l'incident — un commit
+        # final ne lève pas PendingRollbackError.
+        await db_session.commit()
+
+    async def test_session_recovers_from_integrity_error(self, db_session, test_user):
+        """Force une `IntegrityError` directe au flush() du candidat #2 et
+        vérifie que le candidat #3 réussit + que la session reste utilisable."""
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value={
+                "sources": [
+                    _candidate("First", "https://first.example.com", 0.9),
+                    _candidate("Boom", "https://boom.example.com", 0.5),
+                    _candidate("Third", "https://third.example.com", 0.7),
+                ]
+            }
+        )
+        suggester = SourceSuggester(llm=llm)
+
+        async def _detect(url):
+            return _detect_response(url, f"{url}/feed.xml")
+
+        original_flush = db_session.flush
+        flush_calls = {"count": 0}
+
+        async def _flush_failing_on_second(*args, **kwargs):
+            flush_calls["count"] += 1
+            if flush_calls["count"] == 2:
+                raise IntegrityError("simulated", {}, Exception("constraint X"))
+            return await original_flush(*args, **kwargs)
+
+        with (
+            patch(
+                "app.services.veille.source_suggester.SourceService.detect_source",
+                new=AsyncMock(side_effect=_detect),
+            ),
+            patch.object(db_session, "flush", new=_flush_failing_on_second),
+        ):
+            result = await suggester.suggest_sources(
+                session=db_session,
+                user_id=test_user.user_id,
+                theme_id="science",
+                topic_labels=[],
+            )
+
+        names = {s.name for s in result.sources}
+        assert "Boom" not in names
+        assert len(result.sources) == 2
+
+        # La session doit être saine : un commit final ne lève pas.
+        await db_session.commit()
+
+
+class TestCandidateTimeout:
+    """Cap par candidat à 8 s : un mauvais URL qui hang ne doit pas geler
+    le pipeline (cf. bug binge.audio/feed/ retry 22× = 3 min wall)."""
+
+    async def test_slow_candidate_is_skipped(self, db_session, test_user, monkeypatch):
+        # On baisse le timeout à 0.1 s pour ne pas allonger la suite de tests.
+        monkeypatch.setattr(
+            "app.services.veille.source_suggester._HYDRATE_TIMEOUT_S", 0.1
+        )
+
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value={
+                "sources": [
+                    _candidate("Fast", "https://fast.example.com", 0.9),
+                    _candidate("Slow", "https://slow.example.com", 0.8),
+                ]
+            }
+        )
+        suggester = SourceSuggester(llm=llm)
+
+        async def _detect(url: str):
+            if "slow" in url:
+                await asyncio.sleep(2.0)  # bien au-dessus du timeout patché
+            return _detect_response(url, f"{url}/feed.xml")
+
+        with patch(
+            "app.services.veille.source_suggester.SourceService.detect_source",
+            new=AsyncMock(side_effect=_detect),
+        ):
+            result = await suggester.suggest_sources(
+                session=db_session,
+                user_id=test_user.user_id,
+                theme_id="science",
+                topic_labels=[],
+            )
+
+        names = {s.name for s in result.sources}
+        assert "Slow" not in names
+        assert len(result.sources) == 1
+        assert result.sources[0].name == "https://fast.example.com"
+
+
+class TestLLMTimeout:
+    """Cap global LLM à 20 s : sur timeout → fallback curé."""
+
+    async def test_llm_timeout_falls_back_to_curated(
+        self, db_session, test_user, monkeypatch
+    ):
+        monkeypatch.setattr("app.services.veille.source_suggester._LLM_TIMEOUT_S", 0.1)
+
+        # Crée 3 sources curées du thème pour vérifier le fallback.
+        for i in range(3):
+            db_session.add(
+                Source(
+                    id=uuid4(),
+                    name=f"Curated {i}",
+                    url=f"https://curated{i}.example.com",
+                    feed_url=f"https://curated{i}.example.com/feed-{uuid4()}.xml",
+                    type=SourceType.ARTICLE,
+                    theme="science",
+                    is_active=True,
+                    is_curated=True,
+                )
+            )
+        await db_session.commit()
+
+        llm = AsyncMock()
+        llm.is_ready = True
+
+        async def _slow_chat(*args, **kwargs):
+            await asyncio.sleep(2.0)
+            return {"sources": []}
+
+        llm.chat_json = _slow_chat
+        suggester = SourceSuggester(llm=llm)
+
+        result = await suggester.suggest_sources(
+            session=db_session,
+            user_id=test_user.user_id,
+            theme_id="science",
+            topic_labels=[],
+        )
+
+        # Bascule sur le fallback curé.
+        assert len(result.sources) == 3
+        assert all(s.relevance_score is None for s in result.sources)

--- a/packages/api/tests/test_veille_source_ingestion.py
+++ b/packages/api/tests/test_veille_source_ingestion.py
@@ -446,57 +446,9 @@ class TestFallback:
 
 
 class TestSavepointIsolation:
-    """Bug `bug-veille-suggestions-sources-pending-rollback` : sans savepoint,
-    une `IntegrityError` sur un `flush()` empoisonnait toute la session ; tous
-    les candidats suivants levaient `PendingRollbackError` → 503 et 0 source
+    """Sans savepoint, une `IntegrityError` au `flush()` empoisonne la session ;
+    tous les candidats suivants lèvent `PendingRollbackError` → 503 + 0 source
     ingérée. Avec savepoint, seul le candidat fautif est rollback."""
-
-    async def test_failing_candidate_does_not_poison_others(
-        self, db_session, test_user
-    ):
-        llm = AsyncMock()
-        llm.is_ready = True
-        llm.chat_json = AsyncMock(
-            return_value={
-                "sources": [
-                    _candidate("Good 1", "https://good1.example.com", 0.8),
-                    _candidate("Bad", "https://bad.example.com", 0.7),
-                    _candidate("Good 2", "https://good2.example.com", 0.6),
-                ]
-            }
-        )
-        suggester = SourceSuggester(llm=llm)
-
-        async def _detect(url: str):
-            # Le candidat "bad" résout vers un feed_url volontairement
-            # invalide qui dépasse la limite text/varchar théorique du
-            # nom de Source (>200 chars) côté ingest. detect_source ne
-            # lève pas, c'est `flush()` qui doit échouer.
-            if "bad" in url:
-                return _detect_response("X" * 250, f"{url}/feed.xml")
-            return _detect_response(url, f"{url}/feed.xml")
-
-        with patch(
-            "app.services.veille.source_suggester.SourceService.detect_source",
-            new=AsyncMock(side_effect=_detect),
-        ):
-            result = await suggester.suggest_sources(
-                session=db_session,
-                user_id=test_user.user_id,
-                theme_id="science",
-                topic_labels=[],
-            )
-
-        # Le candidat fautif est skippé via savepoint rollback ; les 2 bons
-        # candidats sont ingérés.
-        names = sorted(s.name for s in result.sources)
-        assert "Bad" not in names
-        assert "https://good1.example.com" in {s.name for s in result.sources}
-        assert "https://good2.example.com" in {s.name for s in result.sources}
-
-        # La session est toujours utilisable après l'incident — un commit
-        # final ne lève pas PendingRollbackError.
-        await db_session.commit()
 
     async def test_session_recovers_from_integrity_error(self, db_session, test_user):
         """Force une `IntegrityError` directe au flush() du candidat #2 et
@@ -549,8 +501,8 @@ class TestSavepointIsolation:
 
 
 class TestCandidateTimeout:
-    """Cap par candidat à 8 s : un mauvais URL qui hang ne doit pas geler
-    le pipeline (cf. bug binge.audio/feed/ retry 22× = 3 min wall)."""
+    """Cap par candidat à 8 s : un URL qui hang dans RSSParser ne doit pas
+    geler le pipeline pour les autres candidats."""
 
     async def test_slow_candidate_is_skipped(self, db_session, test_user, monkeypatch):
         # On baisse le timeout à 0.1 s pour ne pas allonger la suite de tests.
@@ -589,7 +541,7 @@ class TestCandidateTimeout:
         names = {s.name for s in result.sources}
         assert "Slow" not in names
         assert len(result.sources) == 1
-        assert result.sources[0].name == "https://fast.example.com"
+        assert result.sources[0].name == "Fast"
 
 
 class TestLLMTimeout:


### PR DESCRIPTION
## Quoi

Hotfix critique sur le bug "loading infini" perçu en Step 3 onboarding veille.

**Backend** (`source_suggester.py`) :
- `async with session.begin_nested()` autour de chaque candidat → IntegrityError isolée au SAVEPOINT, session reste utilisable.
- `asyncio.wait_for(_hydrate_or_ingest(...), timeout=8s)` → skip candidat sur hang.
- `asyncio.wait_for(self._llm.chat_json(...), timeout=20s)` → fallback curé sur timeout LLM.
- `sentry_sdk.capture_exception` dans le `except Exception` → on remonte enfin la cause racine des `flush()` foirés.

**Mobile** (`step3_sources_screen.dart`) :
- Réintroduction du bouton **« Réessayer »** dans `_MockSourcesFallback` (perdu dans PR2 #562, remplacé l'effort PR1 #561).

## Pourquoi

Sentry **PYTHON-3P/3Q** : 13 occurrences `PendingRollbackError` + 503 en 3 h sur 2 users (release `b6d2d3e4`). Supabase : **0 source ingérée en 12 h** alors que 13 tentatives. User flow : 30 s spinner Dio puis mock fallback **sans CTA retry** → "loading infini" perçu, retry manuel inutile.

Cause racine (HIGH confidence) : `_hydrate_or_ingest` ne wrappait pas `flush()` dans un savepoint. Une violation de contrainte (feed_url unique, name overflow…) empoisonnait la session, le `except Exception → continue` ne faisait pas de rollback, tous les ops suivants levaient `PendingRollbackError` → 503. Aggravant : pas de timeout par candidat → un domaine qui hang (ex. `binge.audio/feed/` retry 22× = 3 min wall) gelait tout le pipeline pour les autres candidats.

Diagnostic complet : `docs/bugs/bug-veille-suggestions-sources-pending-rollback.md`.

## Comment ça a été vérifié

- [x] **Lint backend** : `ruff check` + `ruff format --check` OK sur fichiers modifiés.
- [x] **Tests mobile** : `flutter test test/features/veille/` → 52/52 verts (incluant nouveau widget test `step3_sources_screen_test.dart`).
- [x] **Flutter analyze** : 0 issue sur les 2 fichiers modifiés.
- [ ] **Tests backend** : `pytest tests/test_veille_source_ingestion.py` n'a pas pu tourner localement (Postgres absent / pas de Docker sur la machine), CI validera. 3 nouveaux tests : `test_session_recovers_from_integrity_error`, `test_slow_candidate_is_skipped`, `test_llm_timeout_falls_back_to_curated`.
- [x] `/simplify` passé : suppression d'un test cassé (assertion sur `cand.name` masquant le déclencheur), correction d'un autre, nettoyage de 3 commentaires qui référençaient le bug.

## Zones à risque

- **Savepoint behaviour avec test fixture `db_session`** : la fixture utilise `join_transaction_mode="create_savepoint"` ; le `session.begin_nested()` du code de prod crée un savepoint imbriqué. Vérifier en CI que la suite pré-existante (10 tests) reste verte.
- **Sentry noise potential** : `sentry_sdk.capture_exception` dans le `except Exception` peut remonter du bruit si le LLM produit des candidats invalides. À surveiller post-merge ; ajuster filter si > 50/jour.

## Hors scope (issues séparées)

- Optim RSSParser pour bail-out plus tôt sur même domaine (cause des 100+ HTTP calls/request).
- Cleanup script rows stuck `running > 15min` (pré-existait à ce bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)