### PR TITLE
fix(veille): /suggestions/sources — LLM avant SELECT pour éviter idle-in-tx

### DIFF
--- a/docs/bugs/bug-veille-suggestions-sources-pending-rollback.md
+++ b/docs/bugs/bug-veille-suggestions-sources-pending-rollback.md
@@ -136,3 +136,56 @@ Stack:
 ... (20 more)
 [8:57:06Z]  GET https://www.binge.audio/feed/  status=None
 ```
+
+---
+
+## Itération 2 — pourquoi #567 n'a pas suffi (2026-05-05 11:00 UTC)
+
+Hotfix #567 (commit `58a82e23`, déployé ~09:48 UTC) a ajouté
+`session.begin_nested()` + `asyncio.wait_for` autour de chaque candidat.
+**Le bug a continué à fire** : 6 nouveaux events sur cette release en
+5 min, dernier 10:53 UTC (même user `c959d7ef`).
+
+### Cause racine réelle (HIGH confidence)
+
+Breadcrumbs de l'event PYTHON-3P `97ac66340f6c4d92b8ec3cca928a0222` :
+
+| t (UTC) | event |
+|---|---|
+| 10:52:56.380 | `SET LOCAL idle_in_transaction_session_timeout = 10000` |
+| 10:52:56.403 | `SELECT user_sources WHERE user_id=…` (`_followed_source_ids`) — **ouvre une tx** |
+| 10:52:56 → 10:53:09 | appel LLM Mistral 13 s, AUCUNE activité DB → **tx idle > 10 s** |
+| ~10:53:06 | (côté PG) `IdleInTransactionSessionTimeout` → connexion tuée serveur-side (Sentry PYTHON-3R) |
+| 10:53:09.469 | `SAVEPOINT sa_savepoint_1` envoyé sur connexion morte |
+| 10:53:19 | `await db.commit()` (router) → `PendingRollbackError` (PYTHON-3P/3S) → 503 |
+
+Le SAVEPOINT du #567 protégeait la **boucle d'ingestion**, mais la
+session était déjà cramée AVANT d'y entrer. Cause directe : **une SELECT
+sur `user_sources` ouvrait une tx avant l'appel LLM**, qui restait idle
+13 s pendant le call Mistral, dépassant le `idle_in_transaction_session_timeout=10s`
+(filet anti-zombie posé après l'incident 2026-04-28, `database.py:166`).
+
+Règle déjà documentée : `docs/stories/core/18.1.veille-backend-foundations.md:53`
+— *« Pas de session ouverte pendant un appel LLM »*. `SourceSuggester.suggest_sources`
+la violait via `_followed_source_ids`.
+
+### Fix réel
+
+`source_suggester.py:131-167` — déplacer
+`await self._followed_source_ids(...)` de dessus le bloc LLM à dessous,
+juste avant le `if not candidates:`. Aucune autre modif.
+
+`followed_ids` n'est consommé que dans `_fallback` (purement DB) et la
+list-comp finale → ré-ordonnancement sûr.
+
+### Test anti-régression
+
+`tests/test_veille_source_ingestion.py::TestNoTxDuringLLM::test_followed_ids_query_runs_after_llm`
+enregistre l'ordre des appels (`llm`, `followed_ids`) et assert qu'ils
+sont dans cet ordre. Si une régression future remet une SELECT avant le
+LLM, ce test bloque.
+
+### Pourquoi pas relâcher `idle_in_transaction_session_timeout` ?
+
+10 s = filet global anti-zombies posé après incident 2026-04-28
+(`database.py:151-156`). L'augmenter recrée le risque. Hors scope.

--- a/packages/api/app/services/veille/source_suggester.py
+++ b/packages/api/app/services/veille/source_suggester.py
@@ -130,8 +130,10 @@ class SourceSuggester:
             `SourceSuggestions(sources=...)` triée par pertinence.
         """
         excluded = set(excluded_source_ids or [])
-        followed_ids = await self._followed_source_ids(session, user_id)
 
+        # LLM AVANT toute requête DB : une SELECT ouvre une tx, l'idle
+        # pendant l'appel Mistral dépasse `idle_in_transaction_session_timeout`
+        # (10s, cf. database.py:166) → connexion tuée → PendingRollbackError.
         candidates: list[_LLMSourceCandidate] = []
         if self._llm.is_ready:
             user_message = (
@@ -161,6 +163,8 @@ class SourceSuggester:
                 )
                 # Fallback curé — pas de sentry capture (timeout LLM = condition
                 # business connue, pas un bug applicatif).
+
+        followed_ids = await self._followed_source_ids(session, user_id)
 
         if not candidates:
             sources = await self._fallback(session, theme_id, excluded, followed_ids)

--- a/packages/api/tests/test_veille_source_ingestion.py
+++ b/packages/api/tests/test_veille_source_ingestion.py
@@ -588,3 +588,43 @@ class TestLLMTimeout:
         # Bascule sur le fallback curé.
         assert len(result.sources) == 3
         assert all(s.relevance_score is None for s in result.sources)
+
+
+class TestNoTxDuringLLM:
+    """Anti-régression : aucune requête DB ne doit ouvrir une transaction
+    AVANT l'appel LLM. Sinon la tx reste idle pendant l'appel réseau et
+    `idle_in_transaction_session_timeout` (10 s, cf. database.py:166) tue
+    la connexion → PendingRollbackError au commit final (PYTHON-3P)."""
+
+    async def test_followed_ids_query_runs_after_llm(self, db_session, test_user):
+        order: list[str] = []
+
+        llm = AsyncMock()
+        llm.is_ready = True
+
+        async def _record_chat(*args, **kwargs):
+            order.append("llm")
+            return {"sources": []}
+
+        llm.chat_json = _record_chat
+        suggester = SourceSuggester(llm=llm)
+
+        original_followed = suggester._followed_source_ids
+
+        async def _record_followed(session, user_id):
+            order.append("followed_ids")
+            return await original_followed(session, user_id)
+
+        suggester._followed_source_ids = _record_followed
+
+        await suggester.suggest_sources(
+            session=db_session,
+            user_id=test_user.user_id,
+            theme_id="science",
+            topic_labels=[],
+        )
+
+        assert order == ["llm", "followed_ids"], (
+            "LLM doit être appelé AVANT la SELECT user_sources, sinon la tx "
+            "reste idle pendant l'appel Mistral et PG tue la connexion."
+        )


### PR DESCRIPTION
## Quoi

Suite du #567. Le SAVEPOINT a bien corrigé l'isolation des `IntegrityError` au flush, mais le bug `PendingRollbackError` (PYTHON-3P/3S) persistait : Sentry confirme **6 nouveaux events sur la release `58a82e23`** en 5 min, dernier 10:53 UTC, même user.

Cette PR déplace `_followed_source_ids` APRÈS l'appel LLM dans `SourceSuggester.suggest_sources` pour ne plus tenir une transaction ouverte pendant les 13 secondes du call Mistral.

## Pourquoi

Breadcrumbs de l'event `97ac66340f6c4d92b8ec3cca928a0222` :

| t (UTC) | event |
|---|---|
| 10:52:56.380 | `SET LOCAL idle_in_transaction_session_timeout = 10000` |
| 10:52:56.403 | `SELECT user_sources WHERE user_id=…` (`_followed_source_ids`) — **ouvre une tx** |
| 10:52:56 → 10:53:09 | appel LLM Mistral 13s, AUCUNE activité DB → tx idle > 10s |
| ~10:53:06 | (côté PG) `IdleInTransactionSessionTimeout` → connexion tuée serveur-side (PYTHON-3R) |
| 10:53:09.469 | `SAVEPOINT sa_savepoint_1` envoyé sur connexion morte |
| 10:53:19 | `await db.commit()` (router) → `PendingRollbackError` → 503 |

Le SAVEPOINT du #567 protégeait la **boucle d'ingestion**, mais la session était déjà cramée AVANT d'y entrer. La SELECT user_sources ouvrait une tx avant l'appel LLM ; les 13s d'idle dépassaient le filet anti-zombie `idle_in_transaction_session_timeout=10s` (`database.py:166`, posé après l'incident 2026-04-28).

C'est exactement la règle déjà documentée dans `docs/stories/core/18.1.veille-backend-foundations.md:53` — *« Pas de session ouverte pendant un appel LLM »* — qui était violée.

## Comment

`packages/api/app/services/veille/source_suggester.py:131-167` — déplacer `await self._followed_source_ids(...)` de dessus le bloc LLM à dessous, juste avant `if not candidates:`. `followed_ids` n'est consommé que par `_fallback` (purement DB) et la list-comp finale → ré-ordonnancement sûr, aucun changement de signature.

## Comment ça a été vérifié

- [x] `ruff check` + `ruff format --check` — `All checks passed`
- [x] `pytest --collect-only` — 14 tests collectés sans erreur (incluant le nouveau `TestNoTxDuringLLM`)
- [ ] **`pytest -v` non exécuté en local** — Docker absent du Mac de dev → pas de Postgres local sur 54322. À valider via CI.
- [x] Code review manuel : un seul réordonnancement, aucun changement de signature, comment WHY conservé pour bloquer la régression naturelle.

## Test anti-régression

`TestNoTxDuringLLM::test_followed_ids_query_runs_after_llm` enregistre l'ordre d'invocation (`llm`, puis `followed_ids`) et assert qu'ils sont dans cet ordre. Si une régression future remet une SELECT avant le LLM, ce test bloque.

## Hors scope

- **Optim RSSParser bail-out** : 14 variants suffix testés à chaque candidat = O(N×14) appels HTTP, vu en breadcrumbs (22× même URL `binge.audio/feed/`). Issue séparée.
- **Mobile retry button** : déjà en place (#567), aucune action.
- **`idle_in_transaction_session_timeout` à 10s** : laissé tel quel — c'est le filet global anti-zombies critique posé après l'incident 2026-04-28.

## Zones à risque

- `SourceSuggester.suggest_sources` (hot path onboarding Step 3 veille).
- Aucun impact attendu sur les autres callers — la signature publique est identique.

## Vérification post-deploy

Monitorer Sentry PYTHON-3P / PYTHON-3R / PYTHON-3S pendant 1h après deploy. Aucun nouvel event sur la release suivante = fix OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)