### PR TITLE
feat(observability): notif_diag boot telemetry

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -104,6 +104,8 @@ Future<void> _bootstrap() async {
   }
 
   // Initialiser les notifications push locales (sans forcer la permission)
+  Map<String, dynamic>? bootNotifDiag;
+  bool? bootPushEnabledHive;
   try {
     debugPrint('Main: Initializing push notifications...');
     final pushNotificationService = PushNotificationService();
@@ -114,6 +116,7 @@ Future<void> _bootstrap() async {
     final settingsBox = Hive.box<dynamic>('settings');
     final pushEnabled = settingsBox.get('push_notifications_enabled',
         defaultValue: true) as bool;
+    bootPushEnabledHive = pushEnabled;
     if (pushEnabled) {
       // S'assurer que la permission exact alarm est toujours valide
       // (peut être révoquée par une mise à jour Android ou un changement système)
@@ -141,11 +144,12 @@ Future<void> _bootstrap() async {
         debugPrint(
             'Main: Digest notification already scheduled — skipping static placeholder.');
       }
-
-      // Logger l'état complet pour diagnostic
-      final diag = await pushNotificationService.getDiagnostics();
-      debugPrint('Main: Push diagnostics: $diag');
     }
+
+    // Toujours collecter le diagnostic — y compris quand pushEnabled=false —
+    // pour mesurer le parc côté télémétrie (cf. bug-notifications-stalled).
+    bootNotifDiag = await pushNotificationService.getDiagnostics();
+    debugPrint('Main: Push diagnostics: $bootNotifDiag');
     debugPrint('Main: Push notifications initialized (enabled: $pushEnabled)');
   } catch (e, s) {
     debugPrint('ERROR: Failed to initialize push notifications: $e\n$s');
@@ -206,6 +210,19 @@ Future<void> _bootstrap() async {
     // auth state stream to identify/reset the distinct_id automatically.
     final posthog = PostHogService();
     await posthog.init();
+
+    // Émettre l'état des notifs locales collecté au boot (capture après init
+    // PostHog : avant, capture() est un no-op silencieux).
+    if (bootNotifDiag != null) {
+      final diagProps = <String, Object>{
+        'push_enabled_hive': bootPushEnabledHive ?? false,
+      };
+      bootNotifDiag.forEach((k, v) {
+        if (v != null) diagProps[k] = v as Object;
+      });
+      unawaited(posthog.capture(event: 'notif_diag', properties: diagProps));
+    }
+
     if (hasSession) {
       final user = Supabase.instance.client.auth.currentUser;
       if (user != null) {

--- a/docs/bugs/bug-notifications-stalled.md
+++ b/docs/bugs/bug-notifications-stalled.md
@@ -1,0 +1,55 @@
+# Bug — Notifs Android qui ne s'envoient plus
+
+**Statut** : investigation en cours.
+**Plateforme** : Android.
+**Date du signal** : 2026-05-05.
+
+## Signal
+
+Un beta-testeur Android constate qu'il ne reçoit plus la notification quotidienne « depuis quelques jours ».
+
+PostHog (14 j) confirme un drop net :
+
+| Date | DAU | digest_opened (count) | digest_opened (uniq users) |
+|------|-----|------------------------|----------------------------|
+| 2026-04-29 | 18 | 39 | 14 |
+| 2026-04-30 | 14 | 45 | 11 |
+| **2026-05-01** | **16** | **13** | **7** |
+| 2026-05-02 | 9 | 7 | 3 |
+| 2026-05-03 | 10 | 11 | 4 |
+| 2026-05-04 | 15 | 8 | 4 |
+| 2026-05-05 | 14 | 17 | 7 |
+
+DAU stable (9–18/j), `digest_opened` divisé par ~3 → ce n'est pas un drop d'usage, c'est une régression du chemin notif → digest.
+
+## Cadrage technique
+
+Les notifs Facteur sont **100 % locales** (`flutter_local_notifications` + `AlarmManager`). Aucun envoi backend, aucun token device, aucun cron Railway. La planification est posée par le mobile et l'OS la rejoue chaque jour à la même heure (`matchDateTimeComponents: DateTimeComponents.time`).
+
+Code clé :
+- `apps/mobile/lib/core/services/push_notification_service.dart` — service
+- `apps/mobile/lib/main.dart:106-152` — bootstrap (plante un placeholder si rien n'est schedulé)
+- `apps/mobile/lib/features/digest/providers/digest_provider.dart:298-330` — re-schedule avec teasers personnalisés
+- `apps/mobile/android/app/src/main/AndroidManifest.xml:103-111` — receivers boot + permissions exact-alarm
+
+## Hypothèses
+
+1. **H1 — Régression discoverability + body statique post-PR #512** (30/04, `d8b0da86`). L'onglet Digest a été supprimé. `_updateNotificationWithTopics()` ne tourne plus que si l'utilisateur ouvre l'écran Digest (`digestProvider` n'est lu que par `features/digest/*`), donc la notif retombe sur le placeholder « Ton récap du jour t'attend quand tu veux. ». Le payload a aussi oscillé `route:/digest` ↔ `route:/feed` entre #512 et #519.
+2. **H3 — `SCHEDULE_EXACT_ALARM` révoquée** (Android 14+ ou OEM). Mesurable via `getDiagnostics().exactAlarmsGranted`.
+3. **H2 — Crash boot WorkManager (1–2 mai)**. Bornée dans le temps, fix mergé dans #542. Validation Sentry impossible (projet `flutter` créé après l'incident).
+
+## Actions
+
+### PR 1 — Télémétrie `notif_diag` au boot
+Capturer `getDiagnostics()` à chaque cold start, parc-wide. 24 h de données suffit pour quantifier H1 vs H3.
+
+### PR 2 — Câbler le DSN Sentry mobile
+Le projet Sentry `flutter` existe maintenant ; câbler `--dart-define=SENTRY_DSN=…` dans le pipeline de build pour capturer les futures crashs (notamment au boot).
+
+**Statut** : câblé via `SENTRY_DSN_FLUTTER` (GitHub Secret) → workflows `build-apk.yml` / `build-ipa.yml`. Injecté comme `--dart-define=SENTRY_DSN=…`. Documenté dans `docs/infra/claude-access-setup.md` §1, §2.4.bis. Healthcheck ajouté (validation format). Actif à partir du prochain build.
+
+### PR 3 (conditionnel)
+Selon la donnée `notif_diag` :
+- `digestScheduled=false` malgré `pushEnabled=true` → re-câbler une replanif systématique au bootstrap, indépendante de l'écran Digest.
+- `exactAlarmsGranted=false` répandu → nudge dans `notifications_screen.dart`.
+- Tout `true` mais drop persiste → c'est H1 pur → revoir copy par défaut + déplacer `_updateNotificationWithTopics()` vers un point d'entrée plus fréquent (par ex. `feed_provider`).


### PR DESCRIPTION
## Summary

Capture l'état des notifs locales à chaque cold boot via PostHog (event `notif_diag`). Sert à discriminer les hypothèses du drop `digest_opened` documenté dans `docs/bugs/bug-notifications-stalled.md` (DAU stable, ouvertures ÷ ~3 depuis le 1er mai sur Android).

## Why

Sans ces données on ne peut pas choisir entre :
- **H1 raffinée** : `_updateNotificationWithTopics()` ne tourne plus quotidiennement (post-#512 l'écran Digest n'est plus mounté au cold boot) → notif retombe sur le placeholder statique → moins compelling → moins de taps.
- **H3** : `SCHEDULE_EXACT_ALARM` révoquée Android 14+.

H2 (crash WorkManager #540 → #542) écartée comme cause majeure (fenêtre 2 h trop courte).

## Données collectées

`push_enabled_hive`, `digestScheduled`, `communityScheduled`, `pendingCount`, `notificationsEnabled`, `exactAlarmsGranted`, `initialized`, `platform`.

`getDiagnostics()` est appelé **hors** du `if (pushEnabled)` pour mesurer le parc total (utile pour calculer les ratios).

## Plan post-merge

24-48 h après déploiement, query PostHog pour répartir le parc et choisir le fix dans une PR3 séparée :

\`\`\`sql
SELECT properties.digestScheduled,
       properties.exactAlarmsGranted,
       properties.push_enabled_hive,
       count() AS n
FROM events
WHERE event = 'notif_diag'
  AND timestamp > now() - interval 24 hour
GROUP BY 1, 2, 3
ORDER BY n DESC
\`\`\`

## Risques

- Aucun changement de comportement utilisateur.
- `posthog.capture()` est un no-op silencieux si PostHog n'est pas initialisé — vérifié `posthog_service.dart:58`.
- `getDiagnostics()` est déjà appelé pour `debugPrint` aujourd'hui ; on ne fait que rediriger sa sortie vers PostHog.

## Test plan

- [ ] CI green (flutter analyze + tests)
- [ ] Vérifier après déploiement qu'au moins un event `notif_diag` arrive dans PostHog (project 129581)
- [ ] À 24 h : query ci-dessus pour décider du fix PR3

🤖 Generated with [Claude Code](https://claude.com/claude-code)