### PR TITLE
chore(infra): wire Flutter Sentry DSN in build pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,17 @@ POSTHOG_PROJECT_ID=
 POSTHOG_HOST=https://eu.i.posthog.com
 
 # ─── Sentry ───────────────────────────────────────────────────────────────────
+# Auth token (lecture issues/events via sentry-cli + MCP).
+# Obtenir : sentry.io > Settings > Auth Tokens (scopes : event:read, project:read, org:read).
 SENTRY_AUTH_TOKEN=
 SENTRY_ORG=
 SENTRY_PROJECT=
+
+# DSN client du projet Sentry mobile (Flutter). Injecté dans le build APK/IPA
+# via --dart-define=SENTRY_DSN=… pour activer la capture des crashs côté app.
+# Format : https://<key>@o<org>.ingest.<region>.sentry.io/<project>
+# Obtenir : sentry.io > Settings > Projects > flutter > Client Keys (DSN).
+SENTRY_DSN_FLUTTER=
 
 # ─── Test DB (local, loopback uniquement) ─────────────────────────────────────
 # Credentials utilisés par docker-compose.test.yml pour la DB Postgres locale

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -73,6 +73,8 @@ jobs:
             --dart-define="REVENUECAT_IOS_KEY=${{ secrets.REVENUECAT_IOS_KEY }}" \
             --dart-define="POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" \
             --dart-define="POSTHOG_HOST=${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}" \
+            --dart-define="SENTRY_DSN=${{ secrets.SENTRY_DSN_FLUTTER }}" \
+            --dart-define="SENTRY_ENVIRONMENT=${{ vars.SENTRY_ENVIRONMENT || 'production' }}" \
             --dart-define="APP_RELEASE_TAG=${{ steps.version.outputs.version }}"
 
       - name: Upload APK as artifact

--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -54,6 +54,8 @@ jobs:
             --dart-define="REVENUECAT_IOS_KEY=${{ secrets.REVENUECAT_IOS_KEY }}" \
             --dart-define="POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" \
             --dart-define="POSTHOG_HOST=${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}" \
+            --dart-define="SENTRY_DSN=${{ secrets.SENTRY_DSN_FLUTTER }}" \
+            --dart-define="SENTRY_ENVIRONMENT=${{ vars.SENTRY_ENVIRONMENT || 'production' }}" \
             --dart-define="APP_RELEASE_TAG=${{ steps.version.outputs.version }}"
 
       - name: Create unsigned IPA from xcarchive

--- a/docs/infra/claude-access-setup.md
+++ b/docs/infra/claude-access-setup.md
@@ -23,6 +23,7 @@ Principes :
 | **Supabase — DB directe** | Lancer requêtes SQL (analytics, debug) | Rôle PG `claude_analytics_ro` (SELECT only) | `DATABASE_URL_RO` |
 | **Railway** | Lire les logs prod, inspecter variables | Project Token scope **read-only** | `RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_SERVICE_ID` |
 | **Sentry** | Lire issues, events, session replay | Auth Token scope `event:read`, `project:read`, `org:read` | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` |
+| **Sentry — DSN mobile** | Capter les crashs Flutter en prod (injecté à build-time) | Client Key (DSN) du projet `flutter` | `SENTRY_DSN_FLUTTER` |
 | **PostHog** | Lire insights, cohortes, events | Personal API key scope `insight:read`, `cohort:read`, `event:read` | `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID`, `POSTHOG_HOST` |
 | **GitHub** | PR, issues, checks | Déjà géré via MCP côté Claude (app installée sur le repo) | *(rien à faire côté dev)* |
 
@@ -112,6 +113,27 @@ sentry-cli issues list --project $SENTRY_PROJECT --org $SENTRY_ORG
 sentry-cli events list --project $SENTRY_PROJECT --org $SENTRY_ORG --max-rows 10
 ```
 
+### 2.4.bis Sentry — DSN client mobile (`SENTRY_DSN_FLUTTER`)
+
+Le DSN n'est **pas un token d'API** : c'est la clé publique côté SDK qui dit
+au runtime Flutter « envoie tes crashs vers ce projet Sentry ». Il est
+embarqué dans l'APK/IPA via `--dart-define=SENTRY_DSN=…` au build, jamais
+appelé depuis un script agent.
+
+1. sentry.io → projet **flutter** → **Settings** → **Client Keys (DSN)**.
+2. Copie la valeur `https://<key>@o<org>.ingest.<region>.sentry.io/<project>`.
+3. Stocke-la dans `SENTRY_DSN_FLUTTER` (`.env` local + GitHub Secret).
+4. Les workflows `build-apk.yml` / `build-ipa.yml` la passent automatiquement
+   au build via `--dart-define="SENTRY_DSN=${{ secrets.SENTRY_DSN_FLUTTER }}"`.
+5. Côté app, c'est lu par `SentryConstants.dsn` dans
+   `apps/mobile/lib/config/constants.dart` ; si la valeur est vide,
+   `SentryFlutter.init()` est skipé silencieusement (pas de crash en dev).
+
+> Pourquoi un nom distinct (`SENTRY_DSN_FLUTTER`) plutôt que `SENTRY_DSN` tout
+> court : le backend FastAPI a déjà sa propre variable `SENTRY_DSN` (projet
+> `python-fastapi`) ; cohabiter dans le même environnement nécessite des noms
+> séparés. Le renommage en `SENTRY_DSN` se fait au moment du `--dart-define`.
+
 ### 2.5 PostHog — Personal API key scoped
 
 1. eu.posthog.com → **Settings** → **Personal API keys** → *Create*.
@@ -170,7 +192,7 @@ session est déclenchée sur ce repo.
    - `SUPABASE_ACCESS_TOKEN`
    - `DATABASE_URL_RO`
    - `RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_SERVICE_ID`
-   - `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`
+   - `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_DSN_FLUTTER`
    - `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID`, `POSTHOG_HOST`
 4. (Pas dans Secrets mais dans **Variables**) : tout ce qui n'est **pas
    sensible** peut aller dans **Variables** plutôt que Secrets — ex.
@@ -207,6 +229,8 @@ jobs:
           SENTRY_AUTH_TOKEN:        ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG:               ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT:           ${{ vars.SENTRY_PROJECT }}
+          # SENTRY_DSN_FLUTTER : utilisé uniquement par les workflows de build
+          # (build-apk.yml / build-ipa.yml), pas par les agents au runtime.
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
           POSTHOG_PROJECT_ID:       ${{ vars.POSTHOG_PROJECT_ID }}
           POSTHOG_HOST:             ${{ vars.POSTHOG_HOST }}
@@ -307,6 +331,7 @@ Après rotation :
 - [ ] Lancer le SQL §2.2 → noter la `DATABASE_URL_RO`
 - [ ] Créer Project Token Railway (scope Read) → `RAILWAY_TOKEN` + IDs
 - [ ] Créer Auth Token Sentry (scopes read uniquement) → `SENTRY_AUTH_TOKEN`
+- [ ] Récupérer le DSN du projet Sentry `flutter` → `SENTRY_DSN_FLUTTER`
 - [ ] Créer Personal API key PostHog (read-only) → `POSTHOG_PERSONAL_API_KEY`
 - [ ] Remplir `.env` local (copier depuis `.env.example`)
 - [ ] `direnv allow` (ou `export $(grep -v '^#' .env | xargs)`)

--- a/scripts/healthcheck-agent-secrets.sh
+++ b/scripts/healthcheck-agent-secrets.sh
@@ -164,6 +164,20 @@ else
   fi
 fi
 
+# ─── Sentry DSN mobile (Flutter) ────────────────────────────────────────────
+hdr "Sentry — DSN Flutter (SENTRY_DSN_FLUTTER, build-time only)"
+if [[ -z "${SENTRY_DSN_FLUTTER:-}" ]]; then
+  sk "SENTRY_DSN_FLUTTER"
+else
+  # Pas d'auth-check possible (DSN = clé publique write-only). On valide le
+  # format, ce qui suffit pour détecter un copier/coller cassé avant build.
+  if [[ "$SENTRY_DSN_FLUTTER" =~ ^https://[a-f0-9]+@o[0-9]+\.ingest\.[a-z]+\.sentry\.io/[0-9]+$ ]]; then
+    ok "format DSN valide (sera injecté via --dart-define au build APK/IPA)"
+  else
+    ko "format DSN inattendu — vérifier que la valeur n'a pas été tronquée"
+  fi
+fi
+
 # ─── PostHog ─────────────────────────────────────────────────────────────────
 hdr "PostHog (POSTHOG_PERSONAL_API_KEY)"
 if [[ -z "${POSTHOG_PERSONAL_API_KEY:-}" ]]; then


### PR DESCRIPTION
## Summary

Câble `SENTRY_DSN_FLUTTER` dans les workflows de build APK/IPA via `--dart-define=SENTRY_DSN=…`. But : capter les futurs crashs Flutter dans le projet Sentry `flutter` (actuellement vide ; aucune capture rétroactive possible sur le drop notif 1-3 mai documenté dans `docs/bugs/bug-notifications-stalled.md`).

## Pourquoi un nom distinct

Le backend FastAPI a déjà sa propre variable `SENTRY_DSN` (projet `python-fastapi`). Cohabiter dans le même environnement `.env` / GitHub Secrets nécessite des noms séparés ; le renommage en `SENTRY_DSN` se fait au build-time côté workflow.

## Fichiers

- `.env.example` — déclare `SENTRY_DSN_FLUTTER` (avec instructions d'obtention).
- `.github/workflows/build-apk.yml` + `build-ipa.yml` — `--dart-define="SENTRY_DSN=\${{ secrets.SENTRY_DSN_FLUTTER }}"`.
- `docs/infra/claude-access-setup.md` — §1 tableau, nouvelle §2.4.bis (DSN client mobile), §7 checklist agents.
- `scripts/healthcheck-agent-secrets.sh` — validation regex format DSN au démarrage de session (pas d'auth-check possible, c'est une clé publique write-only).

## Action manuelle requise (hors PR)

Ajouter `SENTRY_DSN_FLUTTER` comme **GitHub Secret** (Settings → Secrets and variables → Actions). Sans ce secret :
- PR mergeable sans casse (le workflow passe la chaîne vide au `--dart-define`).
- `SentryFlutter.init()` skipé silencieusement côté app (`SentryConstants.isEnabled => dsn.isNotEmpty`, `constants.dart:266`).
- Crashs Flutter pas remontés tant que le secret n'est pas posé.

## Risques

- Build APK/IPA : aucun (la chaîne vide est gérée). Le healthcheck local détecte un copier/coller cassé en amont.
- Aucun impact runtime tant que l'app n'est pas re-buildée et redéployée.

## Test plan

- [ ] CI green sur les 2 workflows de build (APK + IPA).
- [ ] Une fois le GitHub Secret posé : prochain build → vérifier dans les logs CI que `--dart-define="SENTRY_DSN=***"` apparaît (masqué).
- [ ] Forcer un crash test (`Sentry.captureException`) post-déploiement → vérifier qu'il arrive dans projet Sentry `flutter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)