### PR TITLE
fix(veille): /suggestions/sources — rollback tx avant LLM (Itération 3)

### DIFF
--- a/docs/bugs/bug-veille-suggestions-sources-pending-rollback.md
+++ b/docs/bugs/bug-veille-suggestions-sources-pending-rollback.md
@@ -189,3 +189,80 @@ LLM, ce test bloque.
 
 10 s = filet global anti-zombies posé après incident 2026-04-28
 (`database.py:151-156`). L'augmenter recrée le risque. Hors scope.
+
+---
+
+## Itération 3 — pourquoi #568 n'a pas suffi (2026-05-05 14:38 UTC)
+
+Hotfix #568 (commit `f85b1da8` / merge `a7550f47`, release prod
+`ade40a80` déployée 14:25 UTC) a déplacé
+`await self._followed_source_ids(...)` APRÈS le call LLM.
+**Le bug a re-fire 12 minutes après le déploiement** :
+
+- Sentry **PYTHON-3Z** `IdleInTransactionSessionTimeout` (1 user, 2 events,
+  first 14:37:46 UTC, last 14:38:03 UTC)
+- Sentry **PYTHON-40** `HTTPException 503` (1 user, 2 events, first 14:37:46 UTC)
+  — couplé 1:1 avec PYTHON-3Z
+
+Sentry a indexé le bug sous deux NOUVELLES issues (fingerprint différent
+de PYTHON-3P/3Q/3R/3S de l'Itération 2) — confirmation que le chemin
+d'erreur a muté avec la release.
+
+### Cause racine réelle (verrouillée par breadcrumbs)
+
+Event Sentry `c5c381ebf5a74fbfa285bfa37e0698c7` (release `ade40a80`,
+user `c959d7ef`, transaction `app.routers.veille.suggest_sources`) :
+
+| t (UTC) | event |
+|---|---|
+| 14:37:50.785 | `SET LOCAL statement_timeout = 30000` — **ouvre la tx implicite** |
+| 14:37:50.829 | `SET LOCAL idle_in_transaction_session_timeout = 10000` |
+| 14:37:50 → 14:38:03 | `httpx` POST `api.mistral.ai` (≈12.85 s, AUCUNE activité DB) |
+| ~14:38:00.829 | (côté PG) idle > 10 s → connexion tuée serveur-side |
+| 14:38:03.685 | `SELECT user_sources WHERE user_id=…` (`_followed_source_ids`) → `IdleInTransactionSessionTimeout` |
+| → finally | `db.commit()` → `PendingRollbackError` → **503** |
+
+**Ce que l'Itération 2 a manqué :** l'agent qui a écrit la section
+précédente a accusé la SELECT `_followed_source_ids` d'ouvrir la tx.
+**C'était les `SET LOCAL` eux-mêmes :**
+
+- `safe_async_session()` (`database.py:204-234`) appelle
+  `apply_session_timeouts(session, …)` *immédiatement* après l'ouverture
+  du context, AVANT `yield`.
+- `apply_session_timeouts` exécute deux `SET LOCAL` qui, en SQLAlchemy
+  2.x async (lazy autobegin), **ouvrent la tx implicite**.
+- À partir de ce moment, toute pause `await` non-DB (LLM, HTTP) est de
+  l'idle-in-transaction. Déplacer la SELECT après le LLM ne change rien :
+  la tx était déjà ouverte par les SET LOCAL.
+
+### Fix réel
+
+`source_suggester.py:133-179` — encadrer le call LLM par :
+
+1. **AVANT** le bloc LLM : `await session.rollback()` ferme la tx
+   implicite ouverte par les SET LOCAL. Aucun travail user n'a été
+   committé entre-temps, le rollback est sans effet métier.
+2. **APRÈS** le bloc LLM (et avant la première query DB suivante) :
+   `await apply_session_timeouts(session)` ré-émet les SET LOCAL sur la
+   nouvelle tx que la prochaine query ouvrira → filet anti-zombie
+   restauré pour la boucle d'ingestion + commit final.
+
+Le helper `_push_session_timeouts` est promu en `apply_session_timeouts`
+(public) pour être importable depuis le service.
+
+### Test anti-régression
+
+`tests/test_veille_source_ingestion.py::TestNoTxDuringLLM::test_rollback_before_llm_then_timeouts_reapplied`
+verrouille l'ordre :
+`session.rollback() → llm → apply_session_timeouts → followed_ids`.
+Toute régression future qui retire le rollback avant LLM ou le re-push
+après bloque ce test.
+
+### Pourquoi pas la refacto architecturale (event listener `after_begin`) ?
+
+Plus propre : émettre SET LOCAL automatiquement à chaque nouvelle tx
+via un `event.listens_for(SyncSession, "after_begin")` éliminerait le
+foot-gun pour TOUS les endpoints qui font du long I/O sous `Depends(get_db)`.
+Hors scope du hotfix : changement architectural plus large, à sortir en
+story dédiée. Lister les autres endpoints à risque (rg `Depends\(get_db\)`
++ grep `httpx`/`mistral`/`anthropic` dans le même handler) avant.

--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -170,18 +170,25 @@ SessionMaker = Callable[..., AbstractAsyncContextManager[AsyncSession]]
 """Type alias pour une factory `safe_async_session` injectable (tests)."""
 
 
-async def _push_session_timeouts(
+async def apply_session_timeouts(
     session: AsyncSession,
-    statement_timeout_ms: int,
-    idle_in_tx_timeout_ms: int,
+    statement_timeout_ms: int = _DEFAULT_STATEMENT_TIMEOUT_MS,
+    idle_in_tx_timeout_ms: int = _DEFAULT_IDLE_IN_TX_TIMEOUT_MS,
 ) -> None:
-    """Pousse `SET LOCAL` au début de la tx pour cap server-side.
+    """Pousse `SET LOCAL` sur la tx en cours (l'ouvre si besoin) pour cap
+    server-side.
 
     Les `SET LOCAL` ne s'appliquent qu'à la transaction en cours →
     n'écrasent pas les valeurs des autres sessions du pool. Best-effort :
     si le SET échoue (DB down, pooler en panique), on laisse passer pour
     ne pas bloquer la requête utilisateur — `handle_error` se chargera
     de la connexion morte.
+
+    Use-case (en plus de l'appel auto par `safe_async_session`) :
+    après un `await session.rollback()` qui ferme la tx implicite (ex.
+    pour ne pas la laisser idle pendant un long await LLM), il faut
+    re-pousser ces timeouts sur la NOUVELLE tx que la prochaine query
+    ouvrira — sans ça, on perd le filet anti-zombie côté Postgres.
     """
     try:
         await session.execute(
@@ -228,7 +235,7 @@ async def safe_async_session(
     """
     async with async_session_maker() as session:
         try:
-            await _push_session_timeouts(
+            await apply_session_timeouts(
                 session, statement_timeout_ms, idle_in_tx_timeout_ms
             )
             yield session

--- a/packages/api/app/services/veille/source_suggester.py
+++ b/packages/api/app/services/veille/source_suggester.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field, ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import apply_session_timeouts
 from app.models.enums import SourceType
 from app.models.source import Source, UserSource
 from app.schemas.veille import VeilleThemeSlug
@@ -131,9 +132,17 @@ class SourceSuggester:
         """
         excluded = set(excluded_source_ids or [])
 
-        # LLM AVANT toute requête DB : une SELECT ouvre une tx, l'idle
-        # pendant l'appel Mistral dépasse `idle_in_transaction_session_timeout`
-        # (10s, cf. database.py:166) → connexion tuée → PendingRollbackError.
+        # Aucune tx ouverte pendant l'await LLM. `safe_async_session` (via
+        # `Depends(get_db)`) émet 2× `SET LOCAL` au début de la session, ce
+        # qui ouvre la tx implicite. Sans ce rollback, l'await Mistral
+        # (~13 s observés) dépasse `idle_in_transaction_session_timeout`
+        # (10 s, database.py:166) → Postgres tue la connexion server-side
+        # → la prochaine query lève `IdleInTransactionSessionTimeout`
+        # (Sentry PYTHON-3Z post-#568, event c5c381eb…). Rollback ferme
+        # la tx ; les SET LOCAL sont perdus mais ré-appliqués juste après
+        # le LLM avant la première query DB.
+        await session.rollback()
+
         candidates: list[_LLMSourceCandidate] = []
         if self._llm.is_ready:
             user_message = (
@@ -163,6 +172,11 @@ class SourceSuggester:
                 )
                 # Fallback curé — pas de sentry capture (timeout LLM = condition
                 # business connue, pas un bug applicatif).
+
+        # Re-pousse SET LOCAL sur la nouvelle tx que la prochaine query
+        # va ouvrir : sans ça, le filet anti-zombie côté Postgres est
+        # perdu pour la suite (boucle d'ingestion + commit final).
+        await apply_session_timeouts(session)
 
         followed_ids = await self._followed_source_ids(session, user_id)
 

--- a/packages/api/tests/test_veille_source_ingestion.py
+++ b/packages/api/tests/test_veille_source_ingestion.py
@@ -628,3 +628,71 @@ class TestNoTxDuringLLM:
             "LLM doit être appelé AVANT la SELECT user_sources, sinon la tx "
             "reste idle pendant l'appel Mistral et PG tue la connexion."
         )
+
+    async def test_rollback_before_llm_then_timeouts_reapplied(self):
+        """Anti-régression PYTHON-3Z (post-#568) : `safe_async_session`
+        émet 2× SET LOCAL au début de la session → tx implicite ouverte.
+        Sans rollback explicite avant l'appel LLM, l'await Mistral
+        (~13 s observés) dépasse `idle_in_transaction_session_timeout=10s`
+        → PG tue la connexion → IdleInTransactionSessionTimeout sur la
+        SELECT suivante (event Sentry c5c381eb…). Verrouille l'ordre :
+            session.rollback() → llm → apply_session_timeouts → followed_ids
+
+        Pure mock (pas de db_session) : on teste l'ordre des appels, pas
+        l'exécution SQL réelle.
+        """
+        from sqlalchemy.ext.asyncio import AsyncSession
+
+        order: list[str] = []
+
+        session = AsyncMock(spec=AsyncSession)
+
+        async def _record_rollback():
+            order.append("rollback")
+
+        session.rollback = _record_rollback
+
+        llm = AsyncMock()
+        llm.is_ready = True
+
+        async def _record_chat(*args, **kwargs):
+            order.append("llm")
+            return {"sources": []}
+
+        llm.chat_json = _record_chat
+        suggester = SourceSuggester(llm=llm)
+
+        async def _record_followed(s, user_id):
+            order.append("followed_ids")
+            return set()
+
+        suggester._followed_source_ids = _record_followed
+
+        async def _record_fallback(s, theme_id, excluded, followed_ids):
+            order.append("fallback")
+            return []
+
+        suggester._fallback = _record_fallback
+
+        async def _record_apply_timeouts(s, *args, **kwargs):
+            order.append("apply_timeouts")
+
+        with patch(
+            "app.services.veille.source_suggester.apply_session_timeouts",
+            new=_record_apply_timeouts,
+        ):
+            await suggester.suggest_sources(
+                session=session,
+                user_id=uuid4(),
+                theme_id="science",
+                topic_labels=[],
+            )
+
+        # Le suggester va aussi appeler _fallback (candidates vide), peu
+        # importe ici — on verrouille le PRÉFIXE d'ordre.
+        assert order[:4] == [
+            "rollback",
+            "llm",
+            "apply_timeouts",
+            "followed_ids",
+        ], order


### PR DESCRIPTION
## What

Ferme la tx implicite avant l'appel LLM Mistral dans `SourceSuggester.suggest_sources`, puis ré-applique `SET LOCAL` après pour conserver le filet anti-zombie. Promotion de `_push_session_timeouts` → `apply_session_timeouts` (public). Test pure-mock anti-régression. Bug doc mis à jour (Itération 3).

## Why

Bug `IdleInTransactionSessionTimeout` → 503 sur `/api/veille/suggestions/sources`, **toujours présent après #568** (PYTHON-3Z + PYTHON-40, 12 min après le déploiement de la release `ade40a80`). #568 avait déplacé la SELECT `user_sources` après le LLM en pensant qu'elle ouvrait la tx — en réalité ce sont les `SET LOCAL` émis par `safe_async_session` qui ouvrent la tx implicite, et le déplacement de la SELECT n'a aucun effet. Preuve breadcrumbs event Sentry `c5c381eb…` : `SET LOCAL` à 14:37:50 → Mistral 12.85s d'idle → SELECT meurt à 14:38:03. Détails complets dans `docs/bugs/bug-veille-suggestions-sources-pending-rollback.md` (section Itération 3).

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (test pure-mock OK ; suite DB non lançable localement, disque overlayfs Docker plein — CI validera)
- [x] Linting passes (`ruff check` + `ruff format --check`)
- [x] No new Python `List[]` imports (use `list[]`)
- [x] If touching auth/DB: read Safety Guardrails (préserve `idle_in_transaction_session_timeout=10s`, filet anti-zombie 04-28)
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)