### PR TITLE
feat(mobile): 3 micro-corrections UI — feed header + reader CTA + comparaisons toggle

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -1443,6 +1443,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         setState(() {
           _perspectivesResponse = response;
           _perspectivesLoading = false;
+          if (response.perspectives.isEmpty) _perspectivesExpanded = false;
         });
         _maybeTriggerPerspectivesCta();
       }
@@ -2300,7 +2301,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
                       final label = isWebViewMode
                           ? 'Lire via Navigateur'
-                          : 'Lire sur ${content.source.name}';
+                          : 'Article complet';
                       final showLogo = !isWebViewMode &&
                           content.source.logoUrl != null;
                       final iconData = isWebViewMode

--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -770,9 +770,6 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                         ),
                       ),
                     ),
-                    SliverToBoxAdapter(
-                      child: _FeedTourneeHeader(),
-                    ),
                     // Re-nudge banner (≥7j après refus, cap 3, espacement
                     // 14j) — gaté par l'orchestrateur (1 nudge max, pas en
                     // parallèle d'une modal).
@@ -1884,38 +1881,6 @@ class _PullToRefreshHintState extends State<_PullToRefreshHint>
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-/// Header "Bonjour {prénom}, votre tournée du jour" en haut du feed,
-/// avec une overline date façon tampon postal et le toggle Normal/Serein
-/// aligné à droite.
-class _FeedTourneeHeader extends ConsumerWidget {
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = context.facteurColors;
-    final profile = ref.watch(userProfileProvider);
-    final firstName = (profile.displayName ?? '').trim().split(' ').first;
-    final hello = DateTime.now().hour >= 18 ? 'Bonsoir' : 'Bonjour';
-    final greeting = firstName.isEmpty ? '$hello,' : '$hello $firstName,';
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 2),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            greeting,
-            style: FacteurTypography.serifTitle(colors.textPrimary)
-                .copyWith(fontSize: 22, height: 1.1),
-          ),
-          Text(
-            'voici vos nouvelles du jour',
-            style: FacteurTypography.serifTitle(colors.textPrimary)
-                .copyWith(fontSize: 22, height: 1.1),
-          ),
-        ],
       ),
     );
   }


### PR DESCRIPTION
## What

- Supprime le titre de salutation « Bonjour {prénom}, voici vos nouvelles du jour » en haut du feed
- Renomme le CTA du reader « Lire sur [Source] » → « Article complet » (logo de source conservé)
- Ferme le toggle « Comparaisons » par défaut lorsqu'aucune perspective n'est disponible pour un article

## Why

Allège l'interface : le titre était redondant, le label CTA est plus générique, et le toggle vide ouvert par défaut créait une section vide inutile.

## Type

- [ ] Feature
- [ ] Bug fix
- [x] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)