### PR TITLE
docs(alembic): align workflow docs + add drift-recovery runbook

### DIFF
--- a/.claude-hooks/pre-edit-alembic-deploy.sh
+++ b/.claude-hooks/pre-edit-alembic-deploy.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 # Hook: PreToolUse (Edit/Write)
-# Bloque toute modification de fichiers de deploy liée à alembic/migrations
-# Les migrations SQL doivent être fournies à copier-coller dans Supabase SQL Editor
+# Avertit (sans bloquer) quand un fichier de deploy est édité avec du contenu
+# touchant Alembic. Le `Dockerfile` exécute légitimement `alembic upgrade head`
+# au démarrage du conteneur Railway — toute erreur dans la chaîne plante le
+# déploiement (le CMD a un fallback qui démarre uvicorn avec un WARNING dans
+# les logs, donc une migration cassée peut passer inaperçue).
+#
+# Historique : avant le squash de baseline (PR #515, mai 2026), ce hook
+# bloquait les edits et orientait vers du SQL manuel via Supabase SQL Editor.
+# C'est exactement le pattern qui a causé l'incident de drift d'avril 2026 ;
+# Alembic est désormais la seule source de vérité pour le schéma.
 
 file=$(echo "$CLAUDE_TOOL_INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('file_path',''))" 2>/dev/null)
 
-# Ne vérifier que les fichiers de deploy
 case "$file" in
   *Dockerfile*|*docker-compose*|*railway.json|*deploy*|*.github/workflows/deploy*)
     ;;
@@ -14,7 +21,6 @@ case "$file" in
     ;;
 esac
 
-# Vérifier si le contenu de l'édition touche à alembic/migrations
 content=$(echo "$CLAUDE_TOOL_INPUT" | python3 -c "
 import sys,json
 d=json.load(sys.stdin)
@@ -22,13 +28,15 @@ print(d.get('new_string','') + ' ' + d.get('content',''))
 " 2>/dev/null)
 
 if echo "$content" | grep -qiP 'alembic|migration'; then
-  echo "BLOQUÉ: Ne jamais modifier les migrations dans les fichiers de deploy."
-  echo ""
-  echo "Rappel Guardrail #4:"
-  echo "→ Les fichiers Alembic servent uniquement de tracking de révision."
-  echo "→ Les migrations SQL sont exécutées MANUELLEMENT dans Supabase SQL Editor."
-  echo "→ Fournis le SQL brut à l'utilisateur pour copier-coller."
-  exit 1
+  cat >&2 <<'WARN'
+[pre-edit-alembic-deploy] Édition d'un fichier de deploy touchant Alembic.
+  Rappel : le Dockerfile rejoue `alembic upgrade head` au boot Railway. Une
+  migration cassée plante le déploiement (le fallback du CMD démarre uvicorn
+  malgré l'erreur — surveille les logs après deploy). Pas de SQL manuel via
+  Supabase SQL Editor.
+  Si tu débogues une chaîne qui drift, consulte
+  docs/runbooks/recover-from-alembic-drift.md.
+WARN
 fi
 
 exit 0

--- a/.claude/commands/go.md
+++ b/.claude/commands/go.md
@@ -40,8 +40,9 @@ Choisis les vérifications selon ce qui a été modifié dans le diff
 ### Migration Alembic
 
 1. `cd packages/api && alembic heads` — exactement 1 head.
-2. `alembic upgrade head` sur une DB locale — doit passer sans erreur.
-3. **Ne JAMAIS exécuter Alembic sur Railway** (règle LOCKED de CLAUDE.md).
+2. `alembic upgrade head` sur une DB locale **vide** (`make db-reset` puis `alembic upgrade head`) — doit passer sans erreur sur une chaîne complète.
+3. **Le `Dockerfile` rejoue `alembic upgrade head` au démarrage de chaque conteneur Railway.** Si ta migration plante, le déploiement plantera. Le fallback du `CMD` démarre `uvicorn` malgré l'erreur (avec un WARNING dans les logs), donc une migration cassée peut passer inaperçue à l'œil — surveille les logs Railway après merge.
+4. Pas de SQL manuel via Supabase SQL Editor. Tout DDL chaîne après le head courant via `alembic revision --autogenerate -m "<desc>"`. Si la chaîne se met à diverger de prod malgré tout, voir [`docs/runbooks/recover-from-alembic-drift.md`](../../docs/runbooks/recover-from-alembic-drift.md).
 
 ### Suite complète (toujours, à la fin)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@
 - Python **3.12.x** uniquement (3.13+ casse pydantic)
 - `list[]`, `dict[]`, `X | None` natifs (jamais `from typing import List, Dict, Optional`)
 - JWT secret identique mobile ↔ backend
-- Alembic : exactement 1 head, jamais d'exécution sur Railway (SQL via Supabase SQL Editor)
+- **Alembic est la seule source de vérité pour le schéma DB.** Tout DDL (ALTER, CREATE, DROP) passe par une migration générée via `alembic revision --autogenerate -m "<desc>"` dans la PR qui le requiert. **Pas de SQL manuel via Supabase SQL Editor** — c'est le pattern qui a causé l'incident de drift d'avril 2026 (cf. [runbook de récupération](docs/runbooks/recover-from-alembic-drift.md)). Exactement 1 head Alembic. Le `Dockerfile` exécute `alembic upgrade head` au démarrage de chaque conteneur Railway — donc une migration cassée plante le déploiement, et stamper prod *avant* de merger une refonte de la chaîne est obligatoire (cf. runbook).
 - Zones à risque (Auth, Router, DB, Infra) → lire [Safety Guardrails](docs/agent-brain/safety-guardrails.md) AVANT modif
 
 ---
@@ -64,7 +64,7 @@ Après le GO utilisateur, implémente et teste en autonomie :
 
 | Hook | Quand | Effet |
 |------|-------|-------|
-| `pre-edit-alembic-deploy.sh` | Avant Edit/Write | Bloque si migration Alembic risquée |
+| `pre-edit-alembic-deploy.sh` | Avant Edit/Write | Avertit si édition d'un fichier deploy touche `alembic upgrade`/`stamp` (le `Dockerfile` exécute la chaîne au boot — toute erreur plante le déploiement Railway) |
 | `post-edit-python-guardrails.sh` | Après Edit/Write | Bloque si `List[]`/`Dict[]` from typing |
 | `post-edit-alembic-heads.sh` | Après Edit/Write | Bloque si >1 head Alembic |
 | `post-edit-auto-test.sh` | Après Edit/Write | Lance auto les tests du fichier modifié |
@@ -102,6 +102,7 @@ bash docs/qa/scripts/verify_<task>.sh
 - [Navigation Matrix](docs/agent-brain/navigation-matrix.md) — workflows par type de tâche
 - [Safety Guardrails](docs/agent-brain/safety-guardrails.md) — guardrails + safety protocols
 - [Investigation Playbook](docs/agent-brain/investigation-playbook.md) — outils par scénario prod (bug, usage, migration, logs, sécurité)
+- [Runbook : récupération de drift Alembic](docs/runbooks/recover-from-alembic-drift.md) — étapes à suivre si la chaîne Alembic se met à diverger de prod
 - [Claude Access Setup](docs/infra/claude-access-setup.md) — secrets + accès multi-services (Supabase/Railway/Sentry/PostHog)
 - [PRD](docs/prd.md) / [Architecture](docs/architecture.md) / [Front-end Spec](docs/front-end-spec.md)
 - Agents BMAD : `.bmad-core/agents/` (dev, po, architect, qa)
@@ -175,7 +176,7 @@ autonomie** les 3 étapes qui restent — avec la preuve que ça marche :
    - Mobile : `flutter test && flutter analyze` + Playwright MCP
      (viewport 390x844, console sans erreurs, réseau sans 4xx/5xx inattendus,
      edge cases).
-   - Alembic : exactement 1 head, `upgrade head` local OK, jamais sur Railway.
+   - Alembic : exactement 1 head, `upgrade head` local OK. Le `Dockerfile` rejouera `alembic upgrade head` au prochain boot Railway — une migration cassée plante le déploiement, donc tester localement contre une DB *vide* (`make db-reset`) est non-négociable.
    - Re-run systématique de la suite complète avant de conclure
      (anticipe le hook `stop-verify-tests.sh`).
 2. **SIMPLIFY** : invoque la skill `simplify` puis re-run VERIFY si du code a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,8 @@ Le container Docker `facteur-postgres-test` (port 54322) est la DB de référenc
 1. **Pas de SQL manuel sur prod via Supabase SQL Editor.** Tout DDL (ALTER TABLE, CREATE INDEX, etc.) DOIT atterrir comme migration Alembic dans la même PR. Si un hot-fix manuel est appliqué en urgence, il doit être back-fillé en migration sous 24h.
 2. **Toute nouvelle migration chaîne après le head courant.** Génère via `alembic revision --autogenerate -m "<description>"` (jamais d'ID manuel — cf. `docs/maintenance/maintenance-alembic-revision-collisions-feb26.md`).
 3. **Vérifie `alembic heads` avant de commit.** Doit retourner exactement 1 ligne. La CI (`alembic-smoke.yml`) la rejouera contre une DB vide à chaque PR.
-4. **La baseline est gelée.** `00000_baseline.py` est un snapshot de prod (cf. `docs/maintenance/maintenance-alembic-baseline-squash.md`). Ne la modifie pas — ajoute une migration forward à la place. Les anciennes migrations dans `_archive/` sont là pour la lecture archéologique uniquement.
+4. **La baseline est gelée.** `00000_baseline.py` est un snapshot de prod (cf. [`docs/maintenance/maintenance-alembic-baseline-squash.md`](docs/maintenance/maintenance-alembic-baseline-squash.md)). Ne la modifie pas — ajoute une migration forward à la place. Les anciennes migrations dans `_archive/` sont là pour la lecture archéologique uniquement.
+5. **Si la chaîne re-drift** (symptômes : `make bootstrap` plante sur les migrations, `alembic upgrade head` échoue contre une DB vide, `--autogenerate` produit un diff massif) → suis le [runbook de récupération](docs/runbooks/recover-from-alembic-drift.md). C'est le playbook qu'on a appliqué en mai 2026 ; il marche.
 
 ---
 

--- a/docs/maintenance/maintenance-alembic-baseline-squash.md
+++ b/docs/maintenance/maintenance-alembic-baseline-squash.md
@@ -154,3 +154,24 @@ Aucune donnée ne change pendant le stamp ; seul `alembic_version` est touché. 
 - Plan complet : `~/.claude/plans/this-is-the-error-sharded-pine.md`
 - Doc associée NER : `docs/maintenance/maintenance-ner-disabled.md`
 - Doc historique des collisions Alembic : `docs/maintenance/maintenance-alembic-revision-collisions-feb26.md`
+
+---
+
+## Closure (2026-05-05)
+
+**Statut : LIVRÉ.** PR [#515](https://github.com/boujonlaurin-dotcom/facteur/pull/515) mergée le 2026-05-05. Prod stampée à `00000_baseline` ; déploiement Railway suivant : OK (alembic upgrade head = no-op, conteneur boote normalement).
+
+### Différences vs le plan original
+
+- **Refresh du snapshot.** Le `prod-schema-2026-04-30.sql` initialement préparé est devenu obsolète pendant les 5 jours où la PR a attendu une fenêtre calme : 8 migrations supplémentaires ont landé sur `main` (`en01`, `gn01`, `lf01`, `ls01`, `sp01`, `tr01`, `vl01`, `vp01`). On a re-dumpé prod le 2026-05-05 (`prod-schema-2026-05-05.sql`, 2004 lignes, 42 tables) et archivé ces 8 fichiers en plus → **81 migrations archivées au total** (vs 74 initialement prévues).
+- **Sanitize.py durci pour pg_dump 17.x.** Le snapshot 04-30 venait du dashboard Supabase (syntax `CREATE TABLE IF NOT EXISTS "public"."foo"`). Le 05-05 a été pris via `pg_dump 17.9` (Homebrew), qui produit `CREATE TABLE public.foo` — moins idempotent et avec des particularités (`\restrict`/`\unrestrict` meta-commands, identifiants non quotés, `CREATE FUNCTION` au lieu de `CREATE OR REPLACE FUNCTION`). `sanitize.py` a été élargi pour gérer les deux dialectes.
+- **`Dockerfile` exécute `alembic upgrade head` au boot.** La règle CLAUDE.md "jamais d'exécution sur Railway" était fausse depuis longtemps. Découvert pendant la cérémonie de stamp ; documenté dans le runbook + corrigé dans CLAUDE.md.
+- **`alembic stamp` a nécessité `--purge`.** Sans `--purge`, alembic essaie de résoudre la révision courante (`ls01`, archivée) et plante avec `Can't locate revision identified by 'ls01'`. `--purge` vide `alembic_version` puis insère le stamp, ce qui contourne la résolution.
+
+### Drift audit Phase 4 — encore à traiter
+
+Les findings listés plus haut (host_feed_resolutions manquant en prod, tables orphelines `app_config`/`article_feedback`/`source_search_cache`, alignements NOT NULL, etc.) ne sont **pas adressés** par la PR #515. Ils restent ouverts comme PRs forward de suivi.
+
+### Runbook de récupération
+
+Si la chaîne re-drift dans le futur, suivre [`docs/runbooks/recover-from-alembic-drift.md`](../runbooks/recover-from-alembic-drift.md) — basé directement sur ce qu'on a fait ce coup-ci.

--- a/docs/runbooks/recover-from-alembic-drift.md
+++ b/docs/runbooks/recover-from-alembic-drift.md
@@ -1,0 +1,438 @@
+# Runbook : récupérer d'un drift Alembic (re-baseline depuis prod)
+
+> **À lire avant tout le reste**
+>
+> Depuis le squash de baseline (mai 2026), **un drift entre la chaîne Alembic et le schéma prod ne devrait plus se produire**. Les garde-fous en place :
+>
+> - Alembic est la seule source de vérité pour le schéma — pas de SQL manuel via Supabase SQL Editor (cf. CLAUDE.md "Contraintes Techniques").
+> - Le `Dockerfile` exécute `alembic upgrade head` au boot Railway, donc une migration cassée plante le déploiement (visible dans les logs).
+> - La CI `alembic-smoke.yml` rejoue `alembic upgrade head` contre une Postgres vide à chaque PR — toute chaîne qui ne se rejoue pas tape rouge avant le merge.
+>
+> Ce runbook existe **par précaution**, pour le cas où ces filets craqueraient. Si tu te retrouves à le suivre, ce n'est pas la fin du parcours : c'est le début. **Trouve aussi la cause-racine du drift** (qui a été contournée ? quel garde-fou n'a pas tenu ? pourquoi ?) et adresse-la avant de clore l'incident, sinon le re-baseline ne sera qu'un sparadrap qui se redécollera dans 3 mois.
+
+> **Quand utiliser ce runbook**
+>
+> - `make bootstrap` plante à l'étape `[4/6] Migrations Alembic`.
+> - Une migration référence un objet (table, colonne, index) qui n'existe pas localement mais existe en prod (ou inversement).
+> - `alembic upgrade head` contre une DB vide échoue alors que prod tourne.
+> - `alembic revision --autogenerate` produit un diff massif et inattendu contre prod.
+>
+> Ces symptômes ont une cause unique : la chaîne `versions/` ne décrit plus le schéma réel de prod. Ce runbook reconstruit la chaîne depuis le schéma réel.
+
+Ce playbook reproduit pas-à-pas ce qu'on a fait pendant l'incident d'avril–mai 2026 (PR [#515](https://github.com/boujonlaurin-dotcom/facteur/pull/515), cf. [`docs/maintenance/maintenance-alembic-baseline-squash.md`](../maintenance/maintenance-alembic-baseline-squash.md) pour le récit complet).
+
+---
+
+## Pré-requis
+
+- Accès à la chaîne de connexion **directe** prod (port 5432, **pas** le pooler 6543) — Supabase Dashboard → Project Settings → Database → "Direct connection".
+- `pg_dump` ≥ 14 installé localement (`brew install postgresql@17` si besoin).
+- `psql` accessible depuis le terminal.
+- `packages/api/.venv` configuré (alembic + psycopg installés).
+- Un Docker démarré (pour la DB locale de vérification).
+- Capacité d'annoncer une **fenêtre de gel** (~30–60 min) sur les merges qui touchent `packages/api/alembic/`. Pendant ce temps, personne ne mergera de nouvelle migration sur `main`.
+
+---
+
+## Vue d'ensemble
+
+```
+[Phase 0] Geler les merges + capturer l'état actuel de prod
+   ↓
+[Phase 1] pg_dump prod → sanitize → committer comme nouvelle baseline
+   ↓
+[Phase 2] Archiver toute la chaîne actuelle dans _archive/
+   ↓
+[Phase 3] Vérifier localement (DB vide → upgrade head → pytest)
+   ↓
+[Phase 4] CI green sur la PR
+   ↓
+[Phase 5] Stamp prod (alembic stamp 00000_baseline --purge)
+   ↓
+[Phase 6] Merger immédiatement, surveiller le déploiement Railway
+```
+
+Le seul moment fragile, c'est le **gap entre stamp et merge** : pendant cette fenêtre, prod est stampée à `00000_baseline` mais le code déployé sur Railway ne contient pas encore le fichier `versions/00000_baseline.py`. Un redéploiement involontaire (autre PR mergée, redémarrage manuel, crash conteneur) loggera des erreurs alembic mais l'API reste up grâce au fallback du `Dockerfile` CMD. Stamp puis merge le plus vite possible.
+
+---
+
+## Phase 0 — Préparer
+
+### 0.1 Geler les merges
+
+Annonce dans le canal dev :
+
+> Freeze sur `main` pour les PRs qui touchent `packages/api/alembic/`. Re-baseline en cours, durée ~45 min.
+
+### 0.2 Vérifier que `main` est propre
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only
+git log --oneline -5    # confirme que main est cohérent
+```
+
+### 0.3 Capturer l'état actuel de prod (rollback target)
+
+```bash
+export PSQL_URL="postgresql://postgres.<ref>:<password>@<host>:5432/postgres"
+
+psql "$PSQL_URL" -c "SELECT version_num FROM alembic_version;"
+```
+
+**Note la valeur** retournée — c'est ton point de retour si tout part en vrille. Stocke-la dans un fichier ou un message épinglé, pas juste dans le scrollback du terminal.
+
+### 0.4 Backup de prod (best effort)
+
+L'idéal : prendre un backup managé via Supabase (les noms de menu changent — cherche du côté de la section *Backups* dans le dashboard du projet). C'est un snapshot stocké hors de ton poste, restaurable rapidement.
+
+Sinon, un dump local fait office de filet de sécurité :
+
+```bash
+pg_dump --no-owner --no-privileges --no-tablespaces \
+  "$PSQL_URL" \
+  > "facteur-prod-backup-$(date +%Y%m%d-%H%M).sql"
+```
+
+Stocke le fichier hors du repo (par ex. `~/Downloads/`). Ce dump n'est PAS la source pour la baseline — il sert uniquement de filet de sécurité en cas de catastrophe.
+
+---
+
+## Phase 1 — Nouvelle baseline
+
+### 1.1 Créer une branche
+
+```bash
+git checkout -b <ton-handle>/rebaseline-alembic-$(date +%Y%m%d)
+```
+
+### 1.2 pg_dump schéma prod
+
+```bash
+pg_dump --schema-only --schema=public --no-owner --no-privileges --no-tablespaces \
+  --no-security-labels --no-comments \
+  "$PSQL_URL" \
+  > packages/api/alembic/baseline/prod-schema-raw.sql
+```
+
+`prod-schema-raw.sql` est gitignored — il contient des objets Supabase-spécifiques (RLS, FK vers `auth.users`, fonctions edge) qu'il ne faut pas committer.
+
+### 1.3 Sanitize
+
+```bash
+cd packages/api/alembic/baseline
+python3 sanitize.py prod-schema-raw.sql > prod-schema-$(date +%Y-%m-%d).sql
+```
+
+Le sanitize :
+- strippe `OWNER`/`GRANT`/`SET`/`REVOKE`/RLS/policies (objets Supabase, pas dans Postgres vanilla),
+- drop la FK vers `auth.users` (schéma Supabase absent en local),
+- drop la fonction `handle_new_user_notion_sync` (appelle `extensions.net.http_post`, Supabase-only),
+- drop le bloc `CREATE TABLE alembic_version` + son ADD CONSTRAINT (alembic recrée cette table lui-même),
+- préfixe le dump avec `CREATE SCHEMA IF NOT EXISTS extensions;` + `CREATE EXTENSION uuid-ossp/pg_trgm WITH SCHEMA extensions;`,
+- réécrit `CREATE SCHEMA public;` → `CREATE SCHEMA IF NOT EXISTS public;` (Postgres ship toujours avec `public`),
+- pour pg_dump ≥ 17 : strippe `\restrict <token>` / `\unrestrict <token>` (meta-commands psql que `op.execute()` ne comprend pas).
+
+### 1.4 Vérifier le sanitize
+
+```bash
+# Tous ces grep doivent retourner 0
+for pattern in "OWNER TO" "^GRANT " "^SET " "auth\.users" "CREATE POLICY " "ENABLE ROW LEVEL SECURITY" "handle_new_user_notion_sync" "^\\\\restrict" "^\\\\unrestrict"; do
+  count=$(grep -c "$pattern" prod-schema-$(date +%Y-%m-%d).sql || true)
+  echo "  $pattern: $count"
+done
+```
+
+Si un compteur est > 0, c'est probablement que `pg_dump` a sorti une variante de syntaxe pas couverte par `sanitize.py`. Lis le bloc concerné et ajoute la règle dans `sanitize.py`.
+
+### 1.5 Diff vs ancienne baseline (sanity)
+
+```bash
+# Liste les tables ajoutées / supprimées
+extract_tables() {
+  python3 -c '
+import re, sys
+text = open(sys.argv[1]).read()
+for m in re.finditer(r"CREATE TABLE\s+(?:IF NOT EXISTS\s+)?([\"\w.]+)", text):
+    name = m.group(1).replace("\"", "").split(".", 1)[-1]
+    print(name)
+' "$1" | sort -u
+}
+
+extract_tables packages/api/alembic/baseline/prod-schema-<ANCIENNE_DATE>.sql > /tmp/before.txt
+extract_tables packages/api/alembic/baseline/prod-schema-$(date +%Y-%m-%d).sql > /tmp/after.txt
+
+echo "Nouvelles tables :"
+comm -13 /tmp/before.txt /tmp/after.txt
+echo "Tables supprimées (devrait être vide) :"
+comm -23 /tmp/before.txt /tmp/after.txt
+```
+
+Tables supprimées non-vides = drapeau rouge. Investigue avant de continuer.
+
+---
+
+## Phase 2 — Archiver et pointer la baseline
+
+### 2.1 Mettre à jour `00000_baseline.py`
+
+Ouvre `packages/api/alembic/versions/00000_baseline.py` et change la date dans :
+- la docstring du module ("baseline — prod schema snapshot YYYY-MM-DD"),
+- le compteur d'archivées (texte de la docstring "Replaces the N pre-existing migrations"),
+- la variable `_BASELINE_SQL_PATH` (filename du nouveau dump).
+
+### 2.2 Archiver les migrations qui ne sont pas la baseline
+
+```bash
+cd packages/api/alembic
+# Lister tout sauf 00000_baseline.py
+ls versions/*.py | grep -v "00000_baseline.py" | xargs -I {} git mv {} _archive/
+git rm baseline/prod-schema-<ANCIENNE_DATE>.sql   # supprime l'ancien snapshot
+```
+
+### 2.3 Mettre à jour `_archive/README.md`
+
+Ajuster les compteurs (ex. "73 fichiers" → "81 fichiers"), la date du squash, et tout lien vers la baseline.
+
+### 2.4 Commit
+
+```bash
+git add -A
+git commit -m "fix(db): re-baseline alembic from fresh prod schema snapshot"
+```
+
+---
+
+## Phase 3 — Vérifier localement
+
+### 3.1 DB locale propre
+
+Si la DB de test (`facteur-postgres-test`, port 54322) est déjà up et utilisable :
+
+```bash
+make db-reset   # docker volume vide + alembic upgrade head
+```
+
+Si la DB tourne ailleurs (autre projet Supabase local sur 54322), spinne un Postgres jetable :
+
+```bash
+docker rm -f baseline-verify 2>/dev/null
+docker run -d --rm --name baseline-verify \
+  -p 54399:5432 -e POSTGRES_PASSWORD=t -e POSTGRES_DB=facteur_test \
+  postgres:15
+
+# attends qu'il soit prêt
+until docker exec baseline-verify pg_isready -U postgres -d facteur_test >/dev/null 2>&1; do sleep 1; done
+
+cd packages/api
+DATABASE_URL="postgresql+psycopg://postgres:t@localhost:54399/facteur_test?sslmode=disable" \
+  .venv/bin/alembic upgrade head
+```
+
+Sortie attendue :
+```
+INFO  [alembic.runtime.migration] Running upgrade  -> 00000_baseline, baseline — prod schema snapshot YYYY-MM-DD.
+[alembic] Migrations completed successfully
+```
+
+### 3.2 Sanity check tables
+
+```bash
+# Si DB de test :
+docker exec facteur-postgres-test psql -U facteur -d facteur_test -tAc \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
+
+# Si DB jetable :
+docker exec baseline-verify psql -U postgres -d facteur_test -tAc \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
+```
+
+Doit retourner ~le nombre de tables qu'on a comptées dans le diff Phase 1.5 + 1 (alembic_version).
+
+### 3.3 `alembic heads` et `alembic current`
+
+```bash
+.venv/bin/alembic heads     # → 00000_baseline (head)
+.venv/bin/alembic current   # → 00000_baseline (head)
+```
+
+Les deux doivent matcher.
+
+### 3.4 pytest
+
+Pytest a besoin d'une DB **vide** (le fixture `create_tables` fait `Base.metadata.drop_all + create_all`). Si tu utilises la DB jetable, crée une 2e database :
+
+```bash
+docker exec baseline-verify psql -U postgres -d postgres -c "CREATE DATABASE facteur_test_clean;"
+
+DATABASE_URL="postgresql+psycopg://postgres:t@localhost:54399/facteur_test_clean?sslmode=disable" \
+  PYTHONPATH="$(pwd)" .venv/bin/pytest tests/ -q
+```
+
+Doit passer 100% (ou au moins le même % qu'avant le re-baseline — les tests `test_veille_*` et autres dépendent de modèles à jour).
+
+### 3.5 Cleanup container jetable
+
+```bash
+docker rm -f baseline-verify
+```
+
+---
+
+## Phase 4 — Pousser et obtenir CI green
+
+```bash
+git push -u origin <ton-handle>/rebaseline-alembic-<date>
+gh pr create --base main --title "[DO NOT MERGE BEFORE PROD STAMP] fix(db): re-baseline alembic from fresh prod schema" \
+  --body-file .context/pr-handoff.md   # ou rédige le body inline, voir PR #515 pour modèle
+```
+
+CI à surveiller :
+- `Alembic smoke (upgrade head from empty)` — la sécu majeure. Doit être vert.
+- API tests, lint, build Docker — habituels.
+
+Si `alembic-smoke` échoue avec `ModuleNotFoundError`, le workflow installe peut-être trop peu de deps : confirmer que `.github/workflows/alembic-smoke.yml` fait `pip install -r packages/api/requirements.txt` (et non un sous-set). `env.py` importe `app.database` et `app.models`, qui transitivement requièrent fastapi/pydantic/structlog/etc.
+
+---
+
+## Phase 5 — Stamp prod
+
+**À ce stade :** CI green, reviewer (idéalement) approve, fenêtre de gel toujours active. Tu es à 5 minutes de la fin.
+
+### 5.1 S'assurer d'être sur la branche de la PR
+
+```bash
+git checkout <ton-handle>/rebaseline-alembic-<date>
+git status   # propre
+```
+
+C'est important : `alembic stamp 00000_baseline` regarde le fichier `versions/00000_baseline.py` dans le working tree pour valider que la révision existe. Si tu es sur `main`, il n'y existe pas encore.
+
+### 5.2 Connectivity test
+
+```bash
+export PROD_DB_URL="postgresql+psycopg://postgres.<ref>:<password>@<host>:5432/postgres"
+PSQL_URL="${PROD_DB_URL/+psycopg/}"
+
+psql "$PSQL_URL" -c "SELECT current_database(), inet_server_addr(), inet_server_port();"
+psql "$PSQL_URL" -c "SELECT version_num FROM alembic_version;"
+```
+
+Le 2e SELECT doit afficher la valeur que tu as captée à la Phase 0.3 (rollback target).
+
+### 5.3 Stamper
+
+```bash
+cd packages/api
+DATABASE_URL="$PROD_DB_URL" .venv/bin/alembic stamp 00000_baseline --purge
+```
+
+**`--purge` est obligatoire.** Sans lui, alembic essaie de résoudre la révision courante (qui est dans `_archive/`, pas dans `versions/`) et plante avec `Can't locate revision identified by '<old_rev>'`. `--purge` fait `DELETE FROM alembic_version` puis `INSERT INTO alembic_version (version_num) VALUES ('00000_baseline')`. Aucun changement de schéma, juste cette ligne.
+
+Sortie attendue :
+```
+INFO  [alembic.runtime.migration] Running stamp_revision  -> 00000_baseline
+[alembic] Migrations completed successfully
+```
+
+### 5.4 Vérifier
+
+```bash
+DATABASE_URL="$PROD_DB_URL" .venv/bin/alembic current
+```
+
+Doit afficher : `00000_baseline (head)` (sans erreur "Can't locate", sans warning).
+
+---
+
+## Phase 6 — Merger et surveiller
+
+### 6.1 Merger immédiatement
+
+```bash
+gh pr merge <PR_NUMBER> --squash --delete-branch
+```
+
+(Ou via le UI GitHub si tu préfères. Le strategy peu importe ; squash est plus propre.)
+
+**Ne traîne pas** entre la 5.4 et la 6.1 : tant que la PR n'est pas mergée, prod est stampée à `00000_baseline` mais le code déployé n'a pas le fichier `versions/00000_baseline.py`. Tout redéploiement involontaire dans cette fenêtre loggera l'erreur `Can't locate revision identified by '00000_baseline'`. Le `Dockerfile` CMD a un fallback qui démarre uvicorn malgré tout (avec un WARNING), donc l'API reste up — mais l'erreur dans les logs est bruyante.
+
+### 6.2 Surveiller le prochain déploiement Railway
+
+```bash
+railway logs    # ou via le dashboard Railway
+```
+
+Cherche dans les logs du conteneur qui boote :
+
+- ✅ Bon : `INFO  [alembic.runtime.migration] No revisions to upgrade` (alembic voit que prod est déjà au head, no-op), suivi de `Uvicorn running on http://0.0.0.0:8080`.
+- ⚠️ Inattendu : `Can't locate revision identified by ...` ou autre message rouge → Phase 7 (rollback).
+
+### 6.3 Lever le freeze
+
+Annonce :
+
+> Re-baseline mergée et déployée OK. Freeze levé. Toute nouvelle migration chaîne après `00000_baseline`.
+
+---
+
+## Phase 7 — Rollback (si quelque chose plante)
+
+### 7.1 Si le stamp lui-même a échoué
+
+Le stamp est un single SQL (`UPDATE alembic_version`) — soit il réussit, soit il n'a rien changé. En cas d'erreur, prod est intacte, pas de rollback nécessaire ; debug et reprends à la Phase 5.
+
+### 7.2 Si le déploiement post-merge plante
+
+```bash
+psql "$PSQL_URL" -c "UPDATE alembic_version SET version_num = '<rollback_target_capté_phase_0>';"
+```
+
+Puis fais un revert de la PR sur `main` :
+
+```bash
+git revert -m 1 <merge_commit_sha>
+git push origin main
+```
+
+Railway redéploie automatiquement, et alembic retrouve une chaîne dont il connaît la révision courante.
+
+### 7.3 Cas pathologique
+
+Si pour une raison X le revert ne suffit pas (ex. le code applicatif a déjà été appliqué et nécessite des colonnes que prod a, mais le revert les supprime), restore depuis le backup Phase 0.4 :
+
+- Restaure depuis le backup managé Supabase (cf. section *Backups* dans le dashboard du projet — l'UI change, cherche l'option "Restore"/"Restaurer").
+- Ou en dernier recours, `psql "$PSQL_URL" < facteur-prod-backup-*.sql` (long, et risque de couper l'API plus longtemps).
+
+---
+
+## Pièges connus
+
+| Symptôme | Cause | Fix |
+|---|---|---|
+| `Can't locate revision identified by 'XYZ'` au stamp | Tu n'as pas passé `--purge` | Réessaie avec `--purge` |
+| `password authentication failed for user "facteur"` | Tu utilises la DB locale par erreur (port 54322 pris par un autre projet Supabase) | Spinne un Postgres jetable sur un autre port (54399 par ex.) |
+| `pg_dump version mismatch: server has version 17, pg_dump version 14` | Ton `pg_dump` local est trop vieux | `brew install postgresql@17 && brew link --overwrite postgresql@17` |
+| Le sanitizé contient encore `auth.users` ou `handle_new_user_notion_sync` | pg_dump 17.x produit des syntaxes que sanitize.py ne couvre pas (identifiants non quotés, `CREATE FUNCTION` sans `OR REPLACE`) | Voir les règles déjà ajoutées dans `sanitize.py:60-115`, étendre si nécessaire |
+| `DependentObjectsStillExist: cannot drop table contents` au pytest | conftest fait `drop_all` mais des FK depuis des tables non-modélisées (`app_config`, `nps_responses`) bloquent | Use une DB vide pour pytest, ne réutilise pas la DB peuplée par alembic upgrade |
+| `unsupported startup parameter: ...` | Tu utilises l'URL pooler (port 6543) au lieu de la directe (5432) — pg_dump et alembic stamp ne marchent pas via le pooler | Récupère la "Direct connection" depuis Supabase Dashboard → Settings → Database |
+| CI smoke pète sur `ModuleNotFoundError: No module named 'X'` | `.github/workflows/alembic-smoke.yml` n'installe pas tous les imports d'`env.py` | Installer `requirements.txt` complet plutôt qu'une liste cherry-picked |
+
+---
+
+## À ne PAS faire pendant la procédure
+
+- **Pas de `git push --force` sur `main`.** Le hook `pre-bash-no-staging.sh` bloque déjà beaucoup, mais reste vigilant.
+- **Pas de `alembic upgrade head` contre prod manuellement.** Le `Dockerfile` le fait au prochain boot Railway ; tu duppliquerais et risquerais des conflits si une autre instance redémarre en même temps.
+- **Pas de SQL manuel via Supabase SQL Editor.** C'est le pattern qui a causé l'incident initial. Toute correction de schéma passe par une migration Alembic forward, point.
+- **Pas de "petite migration corrective vite faite avant le stamp".** Tout doit chaîner après le baseline. Si tu veux corriger un drift modèle ↔ prod, fais-le en PR forward séparée *après* que la PR de re-baseline soit mergée.
+
+---
+
+## Liens
+
+- Récit complet de l'incident : [`docs/maintenance/maintenance-alembic-baseline-squash.md`](../maintenance/maintenance-alembic-baseline-squash.md)
+- PR de référence : [#515](https://github.com/boujonlaurin-dotcom/facteur/pull/515)
+- Workflow CI : `.github/workflows/alembic-smoke.yml`
+- Sanitize script : `packages/api/alembic/baseline/sanitize.py`

--- a/packages/api/alembic/_archive/README.md
+++ b/packages/api/alembic/_archive/README.md
@@ -1,22 +1,30 @@
 # Migrations archivées
 
-Les 73 fichiers ici **ne font plus partie de la chaîne Alembic**. Ils sont gardés pour `git blame` / lecture archéologique uniquement.
+Les **81 fichiers** ici **ne font plus partie de la chaîne Alembic**. Ils sont gardés pour `git blame` / lecture archéologique uniquement.
 
 ## Pourquoi
 
-Ces migrations ont été squashées le 2026-04-30 dans une **baseline migration** (`packages/api/alembic/versions/00000_baseline.py`) qui exécute un snapshot direct du schéma prod.
+Ces migrations ont été remplacées par une **baseline** unique (`packages/api/alembic/versions/00000_baseline.py`) qui exécute un snapshot direct du schéma prod (`packages/api/alembic/baseline/prod-schema-2026-05-05.sql`).
 
-Raisons du squash :
-- Plusieurs migrations no-op (NER deferred, etc.) qui assumaient un SQL manuel appliqué via Supabase SQL Editor.
-- Migrations autogen contre des DB déjà drifted → impossible de rejouer la chaîne sur une DB vide.
+L'opération s'est faite en deux temps, suite à une dérive cumulée :
+- 2026-04-30 : premier squash de 73 migrations (PR #515 préparée).
+- 2026-05-05 : refresh du snapshot et absorption de 8 migrations supplémentaires landées entre-temps (`en01`, `gn01`, `lf01`, `ls01`, `sp01`, `tr01`, `vl01`, `vp01`). PR #515 mergée + prod stampée le même jour.
+
+Raisons de la décision :
+- Plusieurs migrations no-op (NER deferred, etc.) qui assumaient un SQL appliqué à la main via Supabase SQL Editor.
+- Migrations `--autogenerate` lancées contre des DB déjà drifted → impossible de rejouer la chaîne sur une DB vide.
 - `make bootstrap` cassé → les devs utilisaient prod comme env de dev.
 
-Détails complets : `docs/maintenance/maintenance-alembic-baseline-squash.md`.
+Détails complets : [`docs/maintenance/maintenance-alembic-baseline-squash.md`](../../../../docs/maintenance/maintenance-alembic-baseline-squash.md).
 
 ## Comment alembic les ignore
 
-`alembic.ini` n'a pas de `version_locations` custom, donc alembic ne scanne que `versions/`. Les fichiers ici sont invisibles pour `alembic upgrade`, `alembic heads`, etc.
+`alembic.ini` n'a pas de `version_locations` custom, donc alembic ne scanne que `versions/`. Les fichiers ici sont invisibles pour `alembic upgrade`, `alembic heads`, `alembic current`, etc.
 
 ## Si tu touches à un fichier ici
 
-**Ne touche pas.** Toute nouvelle migration chaîne après `00000_baseline` dans `versions/`. Si tu trouves un bug dans une migration archivée, c'est qu'elle a déjà été appliquée à prod — corrige avec une migration forward, pas en éditant l'archive.
+**Ne touche pas.** Toute nouvelle migration chaîne après `00000_baseline` dans `versions/`, jamais ici. Si tu trouves un bug dans une migration archivée :
+- elle a déjà été appliquée à prod (sinon prod serait cassée), donc inutile de la corriger ici ;
+- corrige avec une **migration forward** (nouveau fichier dans `versions/` chaîné après `00000_baseline`).
+
+Si tu te retrouves à vouloir réactiver l'archive ou regénérer la baseline, c'est probablement le signe que la chaîne a re-drifté — voir [`docs/runbooks/recover-from-alembic-drift.md`](../../../../docs/runbooks/recover-from-alembic-drift.md).


### PR DESCRIPTION
## Summary

Follow-up to #515. After the alembic baseline squash + prod stamp landed, several agent-facing docs still pointed at the pre-squash workflow ("manual SQL via Supabase SQL Editor", "Alembic never runs on Railway"). Both claims are now wrong and would actively mislead the next agent or contributor:

- Alembic is the **only** source of truth for the schema. Manual SQL via Supabase SQL Editor is the exact pattern that caused the April 2026 drift incident.
- \`packages/api/Dockerfile\` runs \`alembic upgrade head\` on every container boot. The CMD has a fallback that starts uvicorn even if migrations fail (with a WARNING in logs), so a broken migration can silently reach prod.

## Doc updates

| File | Change |
|---|---|
| \`CLAUDE.md\` | Rewrote the Alembic line in "Contraintes Techniques (LOCKED)", updated the hook table entry for \`pre-edit-alembic-deploy.sh\`, fixed the /go alembic checks, added a Références link to the new runbook. |
| \`CONTRIBUTING.md\` §3.1 | Added item 5 pointing at the runbook for future drift recurrence. |
| \`.claude/commands/go.md\` | Replaced the false "Ne JAMAIS exécuter Alembic sur Railway" with the Dockerfile reality (auto-migrate on boot, fallback hides errors → watch logs). |
| \`.claude-hooks/pre-edit-alembic-deploy.sh\` | Switched from blocking with stale "use Supabase SQL Editor" guidance to warn-only with current messaging. The hook would otherwise block legitimate edits to the Dockerfile (which legitimately runs \`alembic upgrade head\` in its CMD). |
| \`packages/api/alembic/_archive/README.md\` | Bumped count 73 → 81 and date 2026-04-30 → 2026-05-05 to match the actual squash; added a pointer to the runbook. |
| \`docs/maintenance/maintenance-alembic-baseline-squash.md\` | Added a "Closure (2026-05-05)" footer covering deltas vs the original plan: snapshot refresh, sanitize hardening for pg_dump 17, \`--purge\` requirement for stamp, drift-audit Phase 4 still open, runbook pointer. |

## New file

\`docs/runbooks/recover-from-alembic-drift.md\` — step-by-step playbook for re-baselining if the chain drifts again. Modeled directly on what we did in the May 2026 incident, including the gotchas we hit:

- \`alembic stamp <rev> --purge\` is required when the current revision is in \`_archive/\` (without \`--purge\`, alembic tries to resolve the old rev and errors).
- Port conflicts when another Supabase project occupies 54322 → spin a one-off Postgres on a free port.
- pg_dump 17.x syntax differences from the Supabase dashboard schema export (unquoted identifiers, \`\\restrict\`/\`\\unrestrict\` meta-commands, \`CREATE FUNCTION\` without \`OR REPLACE\`).
- Test fixtures' \`drop_all\` colliding with prod-derived tables not in \`Base.metadata\`.

The preamble explicitly states drift should **not** recur given the current guardrails (Alembic-as-source-of-truth, Dockerfile auto-migrate visibility, alembic-smoke CI). If it does, the runbook is only half the answer — the root cause must be analyzed and treated.

## Things left out (intentionally)

- No new sections in \`docs/architecture.md\` — alembic flow is implementation detail, not architectural.
- No new story doc — the incident is fully captured in #515 + the maintenance doc + commit history.
- No new CI tooling — the existing alembic-smoke workflow is the guardrail.

## Test plan

- [x] Read every modified file end-to-end; checked links resolve.
- [x] Verified the runbook commands match what we actually executed during the May 2026 incident.
- [ ] CI green on this PR.
- [ ] Reviewer: skim the runbook (especially Phases 5/7 which involve prod commands); confirm the prose accurately reflects the current model.