### PR TITLE
fix(veille): /suggestions/sources Iter 4 — parallélisation boucle + transition mobile 25 s

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,30 +1,79 @@
-# PR — Veille V3 PR3 « UX polish (intro + presets + pré-loading) »
+# PR — fix(veille): /suggestions/sources Iter 4 — parallélisation boucle + transition mobile 25 s
 
 ## Summary
 
-PR3 du V3 veille (suite de #561 PR1 critical fixes et #562 PR2 sources rankées). Trois améliorations UX du flow de configuration, focalisées sur la perception de fluidité et l'accès aux pré-sets :
+Itération 4 du fix `/suggestions/sources` (suite de #561, #562, #567, #568, #572). Le pattern idle-in-tx de #572 est verrouillé (PYTHON-3Z/40 dernière occurrence à 14:38 UTC, instant du déploiement) mais l'utilisateur (`c959d7ef`) signalait toujours :
+1. Step 3 reste en spinner > 1 min puis bascule sur le mock — au refresh manuel, les sources sont là.
+2. La page de transition Step 2 → Step 3 (`flow_loading_screen`) ne sert pas à faire patienter — l'utilisateur arrive direct sur Step 3 spinner.
 
-- **T4** — Pré-loading actif des suggestions LLM entre les steps. L'animation halo (`FlowLoadingScreen`) reçoit désormais `topicsParams` / `sourcesParams` et déclenche le pré-fetch en arrière-plan dès le tap « Continuer ». Durée adaptive : 1.5 s minimum d'animation, puis on attend `data|error` du provider (cap 8 s). À l'arrivée sur Step2/Step3, plus de spinner secondaire dans le cas nominal.
-- **T5** — Nouvel écran `VeilleIntroScreen` au premier accès `/veille/config` (pas de config active, pas de mode édition). Single-page minimaliste : pitch + halo animé + CTA « C'est parti ». Skipé en mode édition et après `applyPreset`.
-- **T6** — Repositionnement des pré-sets dans Step1. Suppression de la section `_InspirationsSection` en bas du scroll. Ajout d'un teaser tappable « Pas inspiré ? Pioche un pré-set → » sous le header (visible sans scroll), qui ouvre une bottom sheet `VeillePresetsSheet` listant tous les pré-sets via `PresetCard` (workflow Step1.5 preview inchangé).
+Diagnostic Sentry post-#572 (event PYTHON-41, release `ecffd1bcff5dd0`) :
+- LLM Mistral seul = **~16 s** (déjà supérieur au cap mobile `_loadingMaxDuration=8 s`)
+- Boucle séquentielle 12 candidats × 0.85 s typique + jusqu'à 4 timeouts à 8 s = **30-60 s pire cas**
+- Donc dépassement systématique de `_loadingMaxDuration` (8 s) et fréquent du `Dio.timeout` (30 s)
+
+Deux fixes complémentaires shipped ensemble (l'un sans l'autre ne résout pas) :
+
+### Fix A — Paralléliser la boucle d'ingestion (perf serveur)
+
+`packages/api/app/services/veille/source_suggester.py:194-229` — boucle séquentielle `for cand in candidates:` refactorisée en deux phases :
+
+1. **Phase 1 (parallèle, sémaphore 4)** — `RSSParser.detect()` HTTP-only, hors session DB. `asyncio.gather` avec sémaphore polite (`_DETECT_CONCURRENCY=4`, aligné avec stage 4 RSSParser). `asyncio.wait_for(_HYDRATE_TIMEOUT_S=8s)` par candidat préservé.
+2. **Phase 2 (séquentielle)** — `_persist_detected()` fait le SELECT `feed_url` existant + INSERT si nouveau, dans un `session.begin_nested()` SAVEPOINT par candidat (préservé). SQLAlchemy AsyncSession n'étant pas safe pour des opérations concurrentes, l'ingest DB reste séquentiel — c'est le HTTP qui dominait, pas l'INSERT.
+
+Wall-clock : **⌈12/4⌉ × 0.85 ≈ 3 s** (au lieu de 10 s typique). Pire cas avec 4 timeouts simultanés : 8 s (au lieu de 32 s).
+
+Invariant #572 préservé : `await session.rollback()` avant LLM + `await apply_session_timeouts(session)` après LLM, intacts.
+
+### Fix B — Aligner le budget transition mobile (UX)
+
+`apps/mobile/lib/features/veille/providers/veille_config_provider.dart:230` — `_loadingMaxDuration` constante factorisée en `loadingMaxDurationFor(int from)` :
+- `from == 1` (Step 1 → Step 2, pré-fetch topics rapide) → **8 s** (inchangé)
+- `from == 2` (Step 2 → Step 3, LLM + boucle ingestion) → **25 s** (5 s de marge sous le `Dio.timeout=30 s`)
+
+Avec Fix A actif, la requête typique tient ~16-19 s — la transition halo joue toute la durée du fetch et l'utilisateur arrive sur Step 3 avec les sources déjà chargées.
 
 ## Fichiers modifiés
 
-- `apps/mobile/lib/features/veille/screens/veille_intro_screen.dart` (NOUVEAU)
-- `apps/mobile/lib/features/veille/screens/veille_config_screen.dart` (T4 + T5)
-- `apps/mobile/lib/features/veille/providers/veille_config_provider.dart` (T4 + T5 — durée adaptive, helpers params, `introCompleted`, `completeIntro`)
-- `apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart` (T6 — teaser + bottom sheet, suppression `_InspirationsSection`)
-- `docs/stories/core/19.3.veille-v3-pr3-ux-polish.md` (NOUVEAU — story doc)
+### Backend
+- `packages/api/app/services/veille/source_suggester.py` — refacto Phase 1/Phase 2, suppression `_hydrate_or_ingest`, ajout `_detect_candidate` + `_persist_detected`, constante `_DETECT_CONCURRENCY=4`. Imports : `RSSParser`, `DetectedFeed` (au lieu de `SourceService`).
+- `packages/api/tests/test_veille_source_ingestion.py` — patch sites `SourceService.detect_source` → `RSSParser.detect`, helper `_detect_response` retourne `DetectedFeed`. Nouveau test `TestParallelDetect::test_detect_runs_concurrently_within_semaphore` (assert wall-clock < 3 s pour 12 candidats × 0.5 s parallèle, max in-flight = 4).
+- `packages/api/tests/test_veille_source_suggester_eval.py` — adaptation patch site + factory `DetectedFeed`.
+
+### Mobile
+- `apps/mobile/lib/features/veille/providers/veille_config_provider.dart` — `_loadingMaxDuration` → `loadingMaxDurationFor(int from)` (8 s pour `from=1`, 25 s pour `from=2`).
+- `apps/mobile/test/features/veille/providers/veille_config_provider_test.dart` — 3 nouveaux tests sur `loadingMaxDurationFor`.
+
+### Doc
+- `docs/bugs/bug-veille-suggestions-sources-pending-rollback.md` — ajout section « Itération 4 (2026-05-05) — décalage budget temps client / serveur » avec timeline Sentry, diagnostic UX, fix A+B, hors scope confirmé.
 
 ## Tests
 
-- `flutter analyze` — pas de nouveau warning sur les fichiers veille.
-- `flutter test test/features/veille/` — 51/51 verts.
-- Suite complète : 554 verts. Les 37 échecs (digest, feed, custom_topics, etc.) sont **pré-existants** (vérifié sur `main` avant PR3, certains marqués « Test not implemented »).
-- Playwright MCP : flow complet validé (intro → Step1 → preset bottom sheet → Step1.5 preview → Step2/3 avec animation halo + données chargées → Step4 → submit).
+- **Backend pure-mock** (sans Postgres local — Docker disque plein) :
+  - `TestParallelDetect::test_detect_runs_concurrently_within_semaphore` : ✅ PASS (12 candidats × 0.5 s sleep, wall-clock 1.5 s, max in-flight = 4)
+  - `TestNoTxDuringLLM::test_rollback_before_llm_then_timeouts_reapplied` : ✅ PASS (invariant #572 verrouillé)
+- **Backend integration** (TestAlreadyFollowedFlag, TestIngestion, TestDedupByDomain, TestThemeGuard, TestSavepointIsolation, TestCandidateTimeout, TestLLMTimeout, TestNoTxDuringLLM::test_followed_ids_query_runs_after_llm, TestParametrizedEval) : skip local par manque de Postgres ; à valider en CI.
+- **Mobile** : `flutter test` lancé sur `veille_config_provider_test.dart` — 3 nouveaux tests sur `loadingMaxDurationFor` à valider.
+- **Lint** : `ruff check` + `ruff format --check` ✅ all green.
 
 ## Risques
 
-- **Cohérence des params** entre `goNext()` / `FlowLoadingScreen` / `step2_suggestions_screen` / `step3_sources_screen` : les helpers `notifier.topicsParamsFromState()` et `notifier.sourcesParamsFromState()` factorisent la construction et garantissent une clé `family.autoDispose` identique (sinon double fetch).
-- **`introCompleted: true` dans `applyPreset` et `hydrateFromActiveConfig`** : empêche l'intro de réapparaître après un preset apply ou en mode édition.
-- **Annulation pendant loading** : `_waitAndAdvance` vérifie `state.loadingFrom != from` avant de pousser la transition pour éviter un push stale si l'utilisateur close le flow ou submit pendant l'animation.
+- **Concurrence DB** : 4 SAVEPOINT séquentiels en Phase 2 — préservé exactement comme avant. Aucun nested begin parallèle. Risque nul de race SQLAlchemy.
+- **Httpx pool** : 4 requêtes parallèles via `httpx.AsyncClient` partagé (`max_connections=100` par défaut). Sites cibles non pollués (sémaphore polite, aligné sur stage 4 interne).
+- **curl-cffi sync vs async** : `curl_cffi.requests.AsyncSession` est async (`rss_parser.py:139`), donc `asyncio.wait_for(8s)` cancel correctement le coro — pas de hang non-cancellable.
+- **Timeout Dio 30 s** : avec Fix A le wall-clock typique tombe à ~19 s, donc largement sous timeout. Pire cas (LLM lent + 4 timeouts) : ~24 s. Si Mistral renvoie 30 s+, on tombe en error Dio comme avant — la transition se ferme via la branche error, comportement inchangé.
+
+## Verification post-merge
+
+1. Surveiller Sentry release post-merge :
+   - Aucun nouvel event `IdleInTransactionSessionTimeout` (PYTHON-3Z/3R) ou `PendingRollbackError` (PYTHON-3P/3S) → invariant #572 toujours verrouillé.
+   - Volume PYTHON-41 / PYTHON-3T / PYTHON-3X (échecs RSSParser sur candidats LLM exotiques) inchangé — c'est attendu, ce sont les sites qui bloquent les bots, pas un bug.
+2. Tester via TestFlight le flow Step 2 → Step 3 :
+   - Tap valider Step 2 → animation halo joue 16-25 s (au lieu de 8 s)
+   - Arrivée sur Step 3 : sources affichées immédiatement (pas de spinner secondaire)
+
+## Hors scope explicite
+
+- Cache négatif par hostname — gain marginal post-parallélisation.
+- Skip RSSParser pour candidats LLM — change la qualité du `feed_url`, story dédiée si besoin.
+- Streaming SSE — refactor architectural lourd, pas justifié.
+- Refactor `safe_async_session` event-listener `after_begin` — déjà hors scope #572.

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -227,7 +227,20 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
   /// Cap maximal d'attente du provider pré-fetché. Au-delà, on laisse
   /// passer à l'étape suivante : Step2/Step3 affichera son skeleton
   /// normal le temps que le LLM réponde.
-  static const Duration _loadingMaxDuration = Duration(seconds: 8);
+  ///
+  /// Step1 → Step2 (`from=1`) : pré-fetch topics rapide (~3-5 s observés),
+  /// 8 s suffisent.
+  ///
+  /// Step2 → Step3 (`from=2`) : la requête `/suggestions/sources` enchaîne
+  /// LLM Mistral (~16 s) + boucle d'ingestion HTTP parallèle (~3-8 s),
+  /// donc ~19-24 s typique. On porte le cap à 25 s pour que la transition
+  /// halo joue toute la durée du fetch (5 s de marge sous le `Dio.timeout`
+  /// de 30 s — `apps/mobile/lib/config/constants.dart:31`). Au-delà, le
+  /// `_awaitAsyncSettled` complète sur la branche error de Dio et la
+  /// transition se ferme proprement.
+  @visibleForTesting
+  static Duration loadingMaxDurationFor(int from) =>
+      from == 2 ? const Duration(seconds: 25) : const Duration(seconds: 8);
 
   static const Duration _veilleNotificationLeadTime = Duration(minutes: 30);
 
@@ -355,7 +368,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
   /// déjà sur la dernière étape — auquel cas `submit()` doit être appelé).
   ///
   /// Durée adaptive : `min(_loadingMinDuration, attente du provider cible
-  /// jusqu'à `data|error`, cap `_loadingMaxDuration`)`. L'animation halo
+  /// jusqu'à `data|error`, cap `loadingMaxDurationFor(from)`)`. L'animation halo
   /// joue toujours au moins 1.5 s pour la perception ; au-delà, on
   /// attend que le pré-fetch (déclenché par `FlowLoadingScreen` via les
   /// params) soit terminé pour arriver sur Step2/Step3 avec les
@@ -382,7 +395,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     await minDelay;
     if (providerReady != null) {
       await providerReady.timeout(
-        _loadingMaxDuration,
+        loadingMaxDurationFor(from),
         onTimeout: () {},
       );
     }

--- a/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
@@ -207,4 +207,37 @@ void main() {
       expect(s.day, VeilleDay.mon);
     });
   });
+
+  group('VeilleConfigNotifier — loadingMaxDurationFor (Iter 4)', () {
+    test('Step1 → Step2 reste à 8 s (pré-fetch topics rapide)', () {
+      expect(
+        VeilleConfigNotifier.loadingMaxDurationFor(1),
+        const Duration(seconds: 8),
+      );
+    });
+
+    test('Step2 → Step3 monte à 25 s (LLM 16s + boucle)', () {
+      // Décalage budget client/serveur documenté dans
+      // docs/bugs/bug-veille-suggestions-sources-pending-rollback.md (Iter 4) :
+      // la requête /suggestions/sources prend ~19-24 s typique, donc 8 s
+      // est trop court et l'utilisateur basculait sur Step3 spinner au
+      // lieu de la transition halo. 25 s laisse 5 s de marge sous le
+      // Dio.timeout = 30 s.
+      expect(
+        VeilleConfigNotifier.loadingMaxDurationFor(2),
+        const Duration(seconds: 25),
+      );
+    });
+
+    test('autres steps tombent sur le défaut 8 s', () {
+      expect(
+        VeilleConfigNotifier.loadingMaxDurationFor(0),
+        const Duration(seconds: 8),
+      );
+      expect(
+        VeilleConfigNotifier.loadingMaxDurationFor(3),
+        const Duration(seconds: 8),
+      );
+    });
+  });
 }

--- a/docs/bugs/bug-veille-suggestions-sources-pending-rollback.md
+++ b/docs/bugs/bug-veille-suggestions-sources-pending-rollback.md
@@ -266,3 +266,99 @@ foot-gun pour TOUS les endpoints qui font du long I/O sous `Depends(get_db)`.
 Hors scope du hotfix : changement architectural plus large, à sortir en
 story dédiée. Lister les autres endpoints à risque (rg `Depends\(get_db\)`
 + grep `httpx`/`mistral`/`anthropic` dans le même handler) avant.
+
+---
+
+## Itération 4 (2026-05-05) — décalage budget temps client / serveur
+
+### Symptômes restants post-#572
+
+L'utilisateur (`c959d7ef-d407-4a4a-a7cb-fdda6c065392`) signale :
+
+1. Step 3 reste en spinner > 1 min puis bascule sur le mock — au refresh,
+   les sources sont ingérées en DB (donc le serveur a fini, mais après le
+   timeout Dio de 30 s).
+2. La page de transition halo Step 2 → Step 3 (`flow_loading_screen`) ne
+   sert pas à faire patienter — l'utilisateur arrive directement sur
+   Step 3 en spinner.
+
+### Diagnostic Sentry post-#572
+
+Event PYTHON-41 (release `ecffd1bcff5dd0…`, post-merge #572) — timeline
+reconstituée à partir des breadcrumbs HTTP + queries :
+
+| t (UTC) | événement | Δ depuis t0 |
+|---------|-----------|-------------|
+| 15:45:32.315 | `SET LOCAL statement_timeout` (init `safe_async_session`) | 0 s |
+| 15:45:32.358 | `SET LOCAL idle_in_transaction_session_timeout` | +43 ms |
+| 15:45:48.437 | retour HTTP `api.mistral.ai` (LLM Mistral) | **+16.1 s** |
+| 15:45:48.459 | `apply_session_timeouts` — SET LOCAL #1 (pattern #572) | +16.1 s |
+| 15:45:48.523 | SELECT `user_sources` (`_followed_source_ids`) | +16.2 s |
+| 15:45:48.673 | candidat 1 (thestack) — début HTTP | +16.4 s |
+| 15:45:50.564 | candidat 4 (mediapart) — début | +18.2 s |
+| 15:45:54.099 | candidat 6 (iapratique substack) — INSERT nouvelle source | +21.7 s |
+| 15:45:54.618 | candidat 8 (usine-digitale) — 403, `sentry_sdk.capture_exception` puis `continue` | **+22.3 s** |
+
+**Constats** :
+- LLM Mistral seul : **~16 s**.
+- Boucle d'ingestion : **~6 s pour 7 candidats** (≈0.85 s/cand) — la
+  parallélisation interne de RSSParser (Stage 4 suffix probe semaphore=4,
+  `rss_parser.py:839`) tient son rôle.
+- `idle_in_transaction_session_timeout` : aucune occurrence post-`ecffd1bc`
+  (PYTHON-3Z/40 dernière fire à 14:38, instant du déploiement) — fix #572
+  verrouillé.
+- Pire cas réaliste : LLM 16-20 s + N candidats avec ≥4 timeouts à 8 s
+  (cap `_HYDRATE_TIMEOUT_S`) = **30-60 s wall-clock**.
+
+### Cause racine UX
+
+`apps/mobile/lib/features/veille/providers/veille_config_provider.dart:230`
+définit `_loadingMaxDuration = Duration(seconds: 8)` comme cap maximal
+d'attente du provider pré-fetché. Le LLM seul prend déjà 16 s, donc la
+transition halo expire **systématiquement** avant le retour API. La nav
+bascule sur Step 3 qui ré-watch le même provider → spinner Step 3 visible
+au lieu de la transition halo, jusqu'à `data` (ou `Dio.timeout = 30 s`,
+`apps/mobile/lib/config/constants.dart:31`, qui mène à la branche `error`
+puis fallback mock).
+
+### Fix Itération 4
+
+Deux fixes complémentaires shipped ensemble :
+
+1. **Backend — paralléliser la boucle d'ingestion** :
+   `source_suggester.py:194-229` séquentiel → asyncio.gather avec sémaphore
+   sur la phase HTTP `detect_source` (parallèle, hors session) puis ingest
+   DB séquentiel (préserve SAVEPOINT par candidat). Wall-clock typique :
+   ⌈12/4⌉ × 0.85 ≈ 3 s (au lieu de 10 s) ; pire cas avec 4 timeouts
+   simultanés : 8 s (au lieu de 32 s).
+
+2. **Mobile — aligner le budget transition** :
+   `veille_config_provider.dart:230` — `_loadingMaxDuration` constante
+   factorisée en `_maxDurationFor(int from)` qui renvoie 8 s pour
+   `from=1` (Step 1→2 reste rapide) et 25 s pour `from=2` (Step 2→3 a
+   besoin de 16-19 s avec Fix A). 25 s laisse 5 s de marge sous le
+   `Dio.timeout=30 s`.
+
+### Pourquoi pas un timeout serveur global
+
+L'option de capper côté serveur à 25 s avec fallback curé (option E des
+hypothèses) sacrifierait les sources LLM dans tous les cas dépassant 25 s.
+Avec Fix A, on ne dépasse quasi plus 25 s — préférable de garder la
+version LLM riche.
+
+### Hors scope (re-confirmé)
+
+- Cache négatif par hostname — gain marginal post-parallélisation.
+- Skip RSSParser pour candidats LLM — change la qualité du `feed_url`,
+  story dédiée si besoin.
+- Streaming SSE — refactor architectural lourd, pas justifié.
+- Refactor `safe_async_session` event-listener `after_begin` — déjà
+  hors scope #572, statu quo.
+
+### Test anti-régression
+
+- Backend : `tests/services/veille/test_source_suggester.py` — assert
+  que 12 candidats avec 4 mocks lents (`asyncio.sleep(2)`) finissent en
+  ≤ 4 s wall-clock (vs ≤ 24 s en séquentiel).
+- Mobile : `test/features/veille/providers/veille_config_provider_test.dart`
+  — assert `_maxDurationFor(2) == 25 s`, `_maxDurationFor(1) == 8 s`.

--- a/packages/api/app/services/veille/source_suggester.py
+++ b/packages/api/app/services/veille/source_suggester.py
@@ -2,8 +2,8 @@
 
 Le LLM produit une seule liste de sources francophones (médias établis pertinents
 au topic + niches indé), notées par `relevance_score`. Post-traitement :
-- hydrate / ingère via `SourceService.detect_source` ;
-- dédoublonne par domaine racine (keep highest score) ;
+- detect HTTP en parallèle (`RSSParser.detect`, sémaphore polite) ;
+- ingest DB séquentiel + dédoublonne par domaine racine (keep highest score) ;
 - flag `is_already_followed` calculé contre les `UserSource` du user ;
 - trie par `relevance_score` desc.
 
@@ -28,7 +28,7 @@ from app.models.enums import SourceType
 from app.models.source import Source, UserSource
 from app.schemas.veille import VeilleThemeSlug
 from app.services.editorial.llm_client import EditorialLLMClient
-from app.services.source_service import SourceService
+from app.services.rss_parser import DetectedFeed, RSSParser
 from app.services.veille.topic_suggester import purpose_line
 
 logger = structlog.get_logger()
@@ -45,6 +45,11 @@ _HYDRATE_TIMEOUT_S = 8.0
 
 # Cap global sur l'appel LLM (Mistral). Sur timeout → fallback curé.
 _LLM_TIMEOUT_S = 20.0
+
+# Phase 1 (HTTP detect) parallèle, borne polie côté sites cibles. Aligné
+# sur le sémaphore interne de RSSParser stage 4 suffix probe (4) pour
+# éviter d'amplifier la pression aval.
+_DETECT_CONCURRENCY = 4
 
 
 @dataclass(frozen=True)
@@ -101,8 +106,13 @@ def _root_domain(url: str) -> str:
 class SourceSuggester:
     """Suggère une liste unique de sources rankées pour une veille."""
 
-    def __init__(self, llm: EditorialLLMClient | None = None) -> None:
+    def __init__(
+        self,
+        llm: EditorialLLMClient | None = None,
+        rss_parser: RSSParser | None = None,
+    ) -> None:
         self._llm = llm or EditorialLLMClient()
+        self._rss_parser = rss_parser or RSSParser()
 
     async def suggest_sources(
         self,
@@ -132,15 +142,11 @@ class SourceSuggester:
         """
         excluded = set(excluded_source_ids or [])
 
-        # Aucune tx ouverte pendant l'await LLM. `safe_async_session` (via
-        # `Depends(get_db)`) émet 2× `SET LOCAL` au début de la session, ce
-        # qui ouvre la tx implicite. Sans ce rollback, l'await Mistral
-        # (~13 s observés) dépasse `idle_in_transaction_session_timeout`
-        # (10 s, database.py:166) → Postgres tue la connexion server-side
-        # → la prochaine query lève `IdleInTransactionSessionTimeout`
-        # (Sentry PYTHON-3Z post-#568, event c5c381eb…). Rollback ferme
-        # la tx ; les SET LOCAL sont perdus mais ré-appliqués juste après
-        # le LLM avant la première query DB.
+        # `safe_async_session` émet `SET LOCAL` au démarrage, ce qui ouvre
+        # une tx implicite. Sans rollback, l'await LLM dépasse
+        # `idle_in_transaction_session_timeout` (10 s) et Postgres tue la
+        # connexion. Les SET LOCAL sont ré-appliqués via
+        # `apply_session_timeouts` après le LLM.
         await session.rollback()
 
         candidates: list[_LLMSourceCandidate] = []
@@ -184,37 +190,40 @@ class SourceSuggester:
             sources = await self._fallback(session, theme_id, excluded, followed_ids)
             return SourceSuggestions(sources=sources)
 
-        # Hydrate / ingère + dédup par domaine (keep highest score).
-        # Chaque candidat est isolé dans un SAVEPOINT : sans ça, une
-        # `IntegrityError` au flush() (feed_url unique, name overflow…)
+        # Phase 1 — detect HTTP en parallèle (cap `_DETECT_CONCURRENCY` pour
+        # rester poli vers les sites cibles). RSSParser fait les requêtes
+        # via un `httpx.AsyncClient` partagé qui supporte la concurrence ;
+        # les sémaphores internes (stage 4 suffix probe) bornent la fan-out
+        # par hostname. La session DB n'est PAS touchée ici : SQLAlchemy
+        # AsyncSession n'est pas safe pour des opérations concurrentes,
+        # donc le SELECT existing + INSERT restent en Phase 2 séquentielle.
+        detect_sem = asyncio.Semaphore(_DETECT_CONCURRENCY)
+        detect_results = await asyncio.gather(
+            *(self._detect_candidate(detect_sem, cand) for cand in candidates),
+        )
+
+        # Phase 2 — ingest DB séquentiel + dédup par domaine (keep highest
+        # score). Chaque candidat reste isolé dans un SAVEPOINT : sans ça,
+        # une `IntegrityError` au flush() (feed_url unique, name overflow…)
         # empoisonne la session pour tous les candidats suivants
         # (PendingRollbackError au commit final).
         by_domain: dict[str, tuple[Source, _LLMSourceCandidate]] = {}
-        source_service = SourceService(session)
-        for cand in candidates:
+        for result in detect_results:
+            if result is None:
+                continue
+            cand, detected = result
             try:
                 async with session.begin_nested():
-                    hydrated = await asyncio.wait_for(
-                        self._hydrate_or_ingest(
-                            session, source_service, cand, theme_id
-                        ),
-                        timeout=_HYDRATE_TIMEOUT_S,
+                    hydrated = await self._persist_detected(
+                        session, cand, detected, theme_id
                     )
-            except TimeoutError:
-                logger.warning(
-                    "source_suggester.candidate_timeout",
-                    name=cand.name,
-                    url=cand.url,
-                    timeout_s=_HYDRATE_TIMEOUT_S,
-                )
-                continue
             except Exception as exc:
                 # Sentry capture obligatoire : le `logger.warning` seul ne
                 # remonte pas la stack ; sans ça on perd la cause racine
                 # des flush() qui foirent et on ne peut pas itérer dessus.
                 sentry_sdk.capture_exception(exc)
                 logger.warning(
-                    "source_suggester.hydrate_failed",
+                    "source_suggester.persist_failed",
                     name=cand.name,
                     url=cand.url,
                     error_class=type(exc).__name__,
@@ -253,16 +262,64 @@ class SourceSuggester:
         result = await session.execute(stmt)
         return set(result.scalars().all())
 
-    async def _hydrate_or_ingest(
+    async def _detect_candidate(
+        self,
+        sem: asyncio.Semaphore,
+        cand: _LLMSourceCandidate,
+    ) -> tuple[_LLMSourceCandidate, DetectedFeed] | None:
+        """Phase 1 — detect HTTP par candidat, sans toucher la session DB.
+
+        Wrap `_HYDRATE_TIMEOUT_S` pour cap par candidat ; les exceptions
+        sont avalées (logguées + capture Sentry pour les non-Value/Timeout)
+        de sorte que `asyncio.gather` ne propage pas une seule défaillance
+        et tue les autres candidats en cours.
+        """
+        async with sem:
+            try:
+                detected = await asyncio.wait_for(
+                    self._rss_parser.detect(cand.url),
+                    timeout=_HYDRATE_TIMEOUT_S,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "source_suggester.candidate_timeout",
+                    name=cand.name,
+                    url=cand.url,
+                    timeout_s=_HYDRATE_TIMEOUT_S,
+                )
+                return None
+            except ValueError as exc:
+                # ValueError = échec de détection RSS (404, 403, no feed,
+                # DNS fail). Cas business attendu, pas une stack à
+                # remonter à Sentry — un warning structuré suffit.
+                logger.warning(
+                    "source_suggester.detect_failed",
+                    name=cand.name,
+                    url=cand.url,
+                    error=str(exc),
+                )
+                return None
+            except Exception as exc:
+                # Inattendu — capture obligatoire pour pouvoir itérer.
+                sentry_sdk.capture_exception(exc)
+                logger.warning(
+                    "source_suggester.detect_unexpected",
+                    name=cand.name,
+                    url=cand.url,
+                    error_class=type(exc).__name__,
+                    error=str(exc),
+                )
+                return None
+        return cand, detected
+
+    async def _persist_detected(
         self,
         session: AsyncSession,
-        source_service: SourceService,
         cand: _LLMSourceCandidate,
+        detected: DetectedFeed,
         theme_id: str,
     ) -> Source:
-        """Ingest la source à la volée si absente du catalogue."""
-        detected = await source_service.detect_source(cand.url)
-
+        """Phase 2 — persiste une source détectée en DB (idempotent par feed_url)."""
         existing_stmt = select(Source).where(Source.feed_url == detected.feed_url)
         existing = (await session.execute(existing_stmt)).scalars().first()
         if existing:
@@ -276,14 +333,20 @@ class SourceSuggester:
                 f"{sorted(_ALLOWED_SOURCE_THEMES)}"
             )
 
+        # `RSSParser.detect()` retourne un feed_type dans
+        # {"rss","atom","youtube","podcast","reddit"}. SourceType n'a pas
+        # de valeur "rss"/"atom" → mapper vers ARTICLE comme dans
+        # `SourceService.detect_source`.
+        feed_type = detected.feed_type
+        source_type_str = "article" if feed_type in ("rss", "atom") else feed_type
         try:
-            source_type = SourceType(detected.detected_type)
+            source_type = SourceType(source_type_str)
         except ValueError:
             source_type = SourceType.ARTICLE
 
         new_source = Source(
             id=uuid4(),
-            name=cand.name or detected.name,
+            name=cand.name or detected.title,
             url=cand.url,
             feed_url=detected.feed_url,
             type=source_type,

--- a/packages/api/tests/test_veille_source_ingestion.py
+++ b/packages/api/tests/test_veille_source_ingestion.py
@@ -1,6 +1,6 @@
 """Tests pour SourceSuggester — liste unique rankée + ingestion à la volée.
 
-Mocke `SourceService.detect_source` (pas d'appel HTTP réel) + `EditorialLLMClient.chat_json`.
+Mocke `RSSParser.detect` (pas d'appel HTTP réel) + `EditorialLLMClient.chat_json`.
 Couvre :
 - Followed source : retournée dans la liste avec `is_already_followed=True`.
 - Ingestion : nouvelle source si feed_url absent du catalogue.
@@ -61,22 +61,17 @@ async def followed_source(db_session, test_user):
     return src
 
 
-def _detect_response(name: str, feed_url: str, source_type: str = "article"):
-    """Simule un SourceDetectResponse minimal."""
-    from app.schemas.source import SourceDetectResponse
+def _detect_response(name: str, feed_url: str, feed_type: str = "rss"):
+    """Simule un DetectedFeed minimal (retour de `RSSParser.detect`)."""
+    from app.services.rss_parser import DetectedFeed
 
-    return SourceDetectResponse(
-        source_id=None,
-        detected_type=source_type,
+    return DetectedFeed(
         feed_url=feed_url,
-        name=name,
+        title=name,
         description=f"{name} — média indé",
+        feed_type=feed_type,
         logo_url=None,
-        theme="science",
-        preview={"item_count": 0, "latest_titles": []},
-        bias_stance="unknown",
-        reliability_score="unknown",
-        bias_origin="unknown",
+        entries=[],
     )
 
 
@@ -105,7 +100,7 @@ class TestAlreadyFollowedFlag:
         suggester = SourceSuggester(llm=llm)
 
         with patch(
-            "app.services.veille.source_suggester.SourceService.detect_source",
+            "app.services.veille.source_suggester.RSSParser.detect",
             new=AsyncMock(
                 return_value=_detect_response(
                     followed_source.name, followed_source.feed_url
@@ -135,7 +130,7 @@ class TestAlreadyFollowedFlag:
         suggester = SourceSuggester(llm=llm)
 
         with patch(
-            "app.services.veille.source_suggester.SourceService.detect_source",
+            "app.services.veille.source_suggester.RSSParser.detect",
             new=AsyncMock(
                 return_value=_detect_response(
                     followed_source.name, followed_source.feed_url
@@ -173,7 +168,7 @@ class TestIngestion:
         new_feed = "https://mediapart-edu.example.com/feed.xml"
 
         with patch(
-            "app.services.veille.source_suggester.SourceService.detect_source",
+            "app.services.veille.source_suggester.RSSParser.detect",
             new=AsyncMock(
                 return_value=_detect_response("Mediapart Education", new_feed)
             ),
@@ -231,7 +226,7 @@ class TestIngestion:
         suggester = SourceSuggester(llm=llm)
 
         with patch(
-            "app.services.veille.source_suggester.SourceService.detect_source",
+            "app.services.veille.source_suggester.RSSParser.detect",
             new=AsyncMock(
                 return_value=_detect_response(
                     followed_source.name, followed_source.feed_url
@@ -279,7 +274,7 @@ class TestDedupByDomain:
             return _detect_response(url, f"{url}/feed.xml")
 
         with patch(
-            "app.services.veille.source_suggester.SourceService.detect_source",
+            "app.services.veille.source_suggester.RSSParser.detect",
             new=AsyncMock(side_effect=_detect),
         ):
             result = await suggester.suggest_sources(
@@ -315,7 +310,7 @@ class TestDedupByDomain:
             return _detect_response(url, f"{url}/feed.xml")
 
         with patch(
-            "app.services.veille.source_suggester.SourceService.detect_source",
+            "app.services.veille.source_suggester.RSSParser.detect",
             new=AsyncMock(side_effect=_detect),
         ):
             result = await suggester.suggest_sources(
@@ -331,7 +326,7 @@ class TestDedupByDomain:
 
 class TestThemeGuard:
     async def test_invalid_theme_skips_ingest(self, db_session, test_user):
-        """`_hydrate_or_ingest` doit lever ValueError avant l'INSERT si le
+        """`_persist_detected` doit lever ValueError avant l'INSERT si le
         theme_id viole `ck_source_theme_valid`. Sans ce garde-fou, l'INSERT
         empoisonne la session (PendingRollbackError sur tout commit suivant).
         """
@@ -348,7 +343,7 @@ class TestThemeGuard:
 
         new_feed = "https://climat.example.com/feed.xml"
         with patch(
-            "app.services.veille.source_suggester.SourceService.detect_source",
+            "app.services.veille.source_suggester.RSSParser.detect",
             new=AsyncMock(return_value=_detect_response("Climat Info", new_feed)),
         ):
             result = await suggester.suggest_sources(
@@ -480,7 +475,7 @@ class TestSavepointIsolation:
 
         with (
             patch(
-                "app.services.veille.source_suggester.SourceService.detect_source",
+                "app.services.veille.source_suggester.RSSParser.detect",
                 new=AsyncMock(side_effect=_detect),
             ),
             patch.object(db_session, "flush", new=_flush_failing_on_second),
@@ -528,7 +523,7 @@ class TestCandidateTimeout:
             return _detect_response(url, f"{url}/feed.xml")
 
         with patch(
-            "app.services.veille.source_suggester.SourceService.detect_source",
+            "app.services.veille.source_suggester.RSSParser.detect",
             new=AsyncMock(side_effect=_detect),
         ):
             result = await suggester.suggest_sources(
@@ -696,3 +691,124 @@ class TestNoTxDuringLLM:
             "apply_timeouts",
             "followed_ids",
         ], order
+
+
+class TestParallelDetect:
+    """Anti-régression Iter 4 : la phase HTTP detect doit s'exécuter en
+    parallèle (`_DETECT_CONCURRENCY=4`) pour que 12 candidats lents
+    finissent en ⌈12/4⌉ × delay et non 12 × delay. Sans la
+    parallélisation, le wall-clock dépassait le timeout Dio mobile (30 s)
+    et l'utilisateur tombait sur le fallback mock alors que les sources
+    finissaient par être ingérées en DB côté serveur."""
+
+    async def test_detect_runs_concurrently_within_semaphore(self):
+        from app.models.source import Source as SourceModel
+        from app.services.rss_parser import DetectedFeed
+        from app.services.veille.source_suggester import _DETECT_CONCURRENCY
+
+        in_flight = {"current": 0, "max_observed": 0}
+
+        async def _slow_detect(url: str) -> DetectedFeed:
+            in_flight["current"] += 1
+            in_flight["max_observed"] = max(
+                in_flight["max_observed"], in_flight["current"]
+            )
+            try:
+                await asyncio.sleep(0.5)
+            finally:
+                in_flight["current"] -= 1
+            return DetectedFeed(
+                feed_url=f"{url}/feed.xml",
+                title=url,
+                description="t",
+                feed_type="rss",
+                logo_url=None,
+                entries=[],
+            )
+
+        llm = AsyncMock()
+        llm.is_ready = True
+        llm.chat_json = AsyncMock(
+            return_value={
+                "sources": [
+                    _candidate(f"S{i}", f"https://s{i}.example.com", 0.5 + i * 0.01)
+                    for i in range(12)
+                ]
+            }
+        )
+
+        suggester = SourceSuggester(llm=llm)
+
+        # Bypass DB : pas de followed, persist stub renvoie un Source en
+        # mémoire. Évite la dépendance Postgres pour ce test perf.
+        async def _no_followed(s, user_id):
+            return set()
+
+        suggester._followed_source_ids = _no_followed
+
+        async def _stub_persist(s, cand, detected, theme_id):
+            return SourceModel(
+                id=uuid4(),
+                name=cand.name,
+                url=cand.url,
+                feed_url=detected.feed_url,
+                type=SourceType.ARTICLE,
+                theme=theme_id,
+                description=None,
+                logo_url=None,
+                is_curated=False,
+                is_active=True,
+            )
+
+        suggester._persist_detected = _stub_persist
+
+        # AsyncSession factice : seules `rollback` + `begin_nested` (async
+        # context manager) sont effectivement awaited par suggest_sources.
+        class _FakeNested:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+        class _FakeSession:
+            async def rollback(self):
+                return None
+
+            def begin_nested(self):
+                return _FakeNested()
+
+        session = _FakeSession()
+
+        with (
+            patch(
+                "app.services.veille.source_suggester.RSSParser.detect",
+                new=AsyncMock(side_effect=_slow_detect),
+            ),
+            patch(
+                "app.services.veille.source_suggester.apply_session_timeouts",
+                new=AsyncMock(),
+            ),
+        ):
+            loop = asyncio.get_event_loop()
+            t0 = loop.time()
+            result = await suggester.suggest_sources(
+                session=session,
+                user_id=uuid4(),
+                theme_id="science",
+                topic_labels=[],
+            )
+            elapsed = loop.time() - t0
+
+        assert len(result.sources) == 12
+        # Sémaphore 4 ⇒ ⌈12/4⌉ × 0.5 = 1.5 s wall-clock idéal.
+        # En séquentiel : 12 × 0.5 = 6 s. Marge × 2 pour CI : assert <3 s.
+        assert elapsed < 3.0, (
+            f"detect loop took {elapsed:.2f}s, expected ~1.5s parallel "
+            f"(régression de la parallélisation Iter 4 ?)"
+        )
+        # La concurrence atteinte doit être exactement le sémaphore.
+        assert in_flight["max_observed"] == _DETECT_CONCURRENCY, (
+            f"max in-flight = {in_flight['max_observed']}, "
+            f"expected {_DETECT_CONCURRENCY}"
+        )

--- a/packages/api/tests/test_veille_source_suggester_eval.py
+++ b/packages/api/tests/test_veille_source_suggester_eval.py
@@ -156,22 +156,17 @@ async def pre_followed_source(db_session, eval_user):
 
 def _detect_response_factory():
     """Pour chaque URL, renvoie un feed_url unique stable (basé sur l'URL)."""
-    from app.schemas.source import SourceDetectResponse
+    from app.services.rss_parser import DetectedFeed
 
-    async def _detect(url: str) -> SourceDetectResponse:
+    async def _detect(url: str) -> DetectedFeed:
         feed_url = f"{url.rstrip('/')}/feed.xml"
-        return SourceDetectResponse(
-            source_id=None,
-            detected_type="article",
+        return DetectedFeed(
             feed_url=feed_url,
-            name=url,
+            title=url,
             description=f"{url} — auto-detected",
+            feed_type="rss",
             logo_url=None,
-            theme="science",
-            preview={"item_count": 0, "latest_titles": []},
-            bias_stance="unknown",
-            reliability_score="unknown",
-            bias_origin="unknown",
+            entries=[],
         )
 
     return _detect
@@ -181,16 +176,17 @@ def _detect_response_factory():
 async def test_eval_case_structural(db_session, eval_user, pre_followed_source, case):
     """Pour chaque fixture, vérifie les invariants structurels."""
     # Pour les fixtures society/economy etc., on doit aligner le theme du
-    # pre_followed_source car _hydrate_or_ingest réutilise sa row si l'url
-    # match. On utilise un user secondaire ici via excluded_source_ids pour
-    # éviter la pollution croisée — mais on garde la row de mediapart.
+    # pre_followed_source car `_persist_detected` réutilise sa row si la
+    # feed_url match. On utilise un user secondaire ici via
+    # excluded_source_ids pour éviter la pollution croisée — mais on garde
+    # la row de mediapart.
     llm = AsyncMock()
     llm.is_ready = True
     llm.chat_json = AsyncMock(return_value={"sources": _canned_candidates()})
     suggester = SourceSuggester(llm=llm)
 
     with patch(
-        "app.services.veille.source_suggester.SourceService.detect_source",
+        "app.services.veille.source_suggester.RSSParser.detect",
         new=AsyncMock(side_effect=_detect_response_factory()),
     ):
         result = await suggester.suggest_sources(


### PR DESCRIPTION
# PR — fix(veille): /suggestions/sources Iter 4 — parallélisation boucle + transition mobile 25 s

## Summary

Itération 4 du fix `/suggestions/sources` (suite de #561, #562, #567, #568, #572). Le pattern idle-in-tx de #572 est verrouillé (PYTHON-3Z/40 dernière occurrence à 14:38 UTC, instant du déploiement) mais l'utilisateur (`c959d7ef`) signalait toujours :
1. Step 3 reste en spinner > 1 min puis bascule sur le mock — au refresh manuel, les sources sont là.
2. La page de transition Step 2 → Step 3 (`flow_loading_screen`) ne sert pas à faire patienter — l'utilisateur arrive direct sur Step 3 spinner.

Diagnostic Sentry post-#572 (event PYTHON-41, release `ecffd1bcff5dd0`) :
- LLM Mistral seul = **~16 s** (déjà supérieur au cap mobile `_loadingMaxDuration=8 s`)
- Boucle séquentielle 12 candidats × 0.85 s typique + jusqu'à 4 timeouts à 8 s = **30-60 s pire cas**
- Donc dépassement systématique de `_loadingMaxDuration` (8 s) et fréquent du `Dio.timeout` (30 s)

Deux fixes complémentaires shipped ensemble (l'un sans l'autre ne résout pas) :

### Fix A — Paralléliser la boucle d'ingestion (perf serveur)

`packages/api/app/services/veille/source_suggester.py:194-229` — boucle séquentielle `for cand in candidates:` refactorisée en deux phases :

1. **Phase 1 (parallèle, sémaphore 4)** — `RSSParser.detect()` HTTP-only, hors session DB. `asyncio.gather` avec sémaphore polite (`_DETECT_CONCURRENCY=4`, aligné avec stage 4 RSSParser). `asyncio.wait_for(_HYDRATE_TIMEOUT_S=8s)` par candidat préservé.
2. **Phase 2 (séquentielle)** — `_persist_detected()` fait le SELECT `feed_url` existant + INSERT si nouveau, dans un `session.begin_nested()` SAVEPOINT par candidat (préservé). SQLAlchemy AsyncSession n'étant pas safe pour des opérations concurrentes, l'ingest DB reste séquentiel — c'est le HTTP qui dominait, pas l'INSERT.

Wall-clock : **⌈12/4⌉ × 0.85 ≈ 3 s** (au lieu de 10 s typique). Pire cas avec 4 timeouts simultanés : 8 s (au lieu de 32 s).

Invariant #572 préservé : `await session.rollback()` avant LLM + `await apply_session_timeouts(session)` après LLM, intacts.

### Fix B — Aligner le budget transition mobile (UX)

`apps/mobile/lib/features/veille/providers/veille_config_provider.dart:230` — `_loadingMaxDuration` constante factorisée en `loadingMaxDurationFor(int from)` :
- `from == 1` (Step 1 → Step 2, pré-fetch topics rapide) → **8 s** (inchangé)
- `from == 2` (Step 2 → Step 3, LLM + boucle ingestion) → **25 s** (5 s de marge sous le `Dio.timeout=30 s`)

Avec Fix A actif, la requête typique tient ~16-19 s — la transition halo joue toute la durée du fetch et l'utilisateur arrive sur Step 3 avec les sources déjà chargées.

## Fichiers modifiés

### Backend
- `packages/api/app/services/veille/source_suggester.py` — refacto Phase 1/Phase 2, suppression `_hydrate_or_ingest`, ajout `_detect_candidate` + `_persist_detected`, constante `_DETECT_CONCURRENCY=4`. Imports : `RSSParser`, `DetectedFeed` (au lieu de `SourceService`).
- `packages/api/tests/test_veille_source_ingestion.py` — patch sites `SourceService.detect_source` → `RSSParser.detect`, helper `_detect_response` retourne `DetectedFeed`. Nouveau test `TestParallelDetect::test_detect_runs_concurrently_within_semaphore` (assert wall-clock < 3 s pour 12 candidats × 0.5 s parallèle, max in-flight = 4).
- `packages/api/tests/test_veille_source_suggester_eval.py` — adaptation patch site + factory `DetectedFeed`.

### Mobile
- `apps/mobile/lib/features/veille/providers/veille_config_provider.dart` — `_loadingMaxDuration` → `loadingMaxDurationFor(int from)` (8 s pour `from=1`, 25 s pour `from=2`).
- `apps/mobile/test/features/veille/providers/veille_config_provider_test.dart` — 3 nouveaux tests sur `loadingMaxDurationFor`.

### Doc
- `docs/bugs/bug-veille-suggestions-sources-pending-rollback.md` — ajout section « Itération 4 (2026-05-05) — décalage budget temps client / serveur » avec timeline Sentry, diagnostic UX, fix A+B, hors scope confirmé.

## Tests

- **Backend pure-mock** (sans Postgres local — Docker disque plein) :
  - `TestParallelDetect::test_detect_runs_concurrently_within_semaphore` : ✅ PASS (12 candidats × 0.5 s sleep, wall-clock 1.5 s, max in-flight = 4)
  - `TestNoTxDuringLLM::test_rollback_before_llm_then_timeouts_reapplied` : ✅ PASS (invariant #572 verrouillé)
- **Backend integration** (TestAlreadyFollowedFlag, TestIngestion, TestDedupByDomain, TestThemeGuard, TestSavepointIsolation, TestCandidateTimeout, TestLLMTimeout, TestNoTxDuringLLM::test_followed_ids_query_runs_after_llm, TestParametrizedEval) : skip local par manque de Postgres ; à valider en CI.
- **Mobile** : `flutter test` lancé sur `veille_config_provider_test.dart` — 3 nouveaux tests sur `loadingMaxDurationFor` à valider.
- **Lint** : `ruff check` + `ruff format --check` ✅ all green.

## Risques

- **Concurrence DB** : 4 SAVEPOINT séquentiels en Phase 2 — préservé exactement comme avant. Aucun nested begin parallèle. Risque nul de race SQLAlchemy.
- **Httpx pool** : 4 requêtes parallèles via `httpx.AsyncClient` partagé (`max_connections=100` par défaut). Sites cibles non pollués (sémaphore polite, aligné sur stage 4 interne).
- **curl-cffi sync vs async** : `curl_cffi.requests.AsyncSession` est async (`rss_parser.py:139`), donc `asyncio.wait_for(8s)` cancel correctement le coro — pas de hang non-cancellable.
- **Timeout Dio 30 s** : avec Fix A le wall-clock typique tombe à ~19 s, donc largement sous timeout. Pire cas (LLM lent + 4 timeouts) : ~24 s. Si Mistral renvoie 30 s+, on tombe en error Dio comme avant — la transition se ferme via la branche error, comportement inchangé.

## Verification post-merge

1. Surveiller Sentry release post-merge :
   - Aucun nouvel event `IdleInTransactionSessionTimeout` (PYTHON-3Z/3R) ou `PendingRollbackError` (PYTHON-3P/3S) → invariant #572 toujours verrouillé.
   - Volume PYTHON-41 / PYTHON-3T / PYTHON-3X (échecs RSSParser sur candidats LLM exotiques) inchangé — c'est attendu, ce sont les sites qui bloquent les bots, pas un bug.
2. Tester via TestFlight le flow Step 2 → Step 3 :
   - Tap valider Step 2 → animation halo joue 16-25 s (au lieu de 8 s)
   - Arrivée sur Step 3 : sources affichées immédiatement (pas de spinner secondaire)

## Hors scope explicite

- Cache négatif par hostname — gain marginal post-parallélisation.
- Skip RSSParser pour candidats LLM — change la qualité du `feed_url`, story dédiée si besoin.
- Streaming SSE — refactor architectural lourd, pas justifié.
- Refactor `safe_async_session` event-listener `after_begin` — déjà hors scope #572.
