### PR TITLE
fix(mobile): widget câblé sur l'Essentiel + cartes articles +20%

### DIFF
--- a/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
+++ b/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
@@ -6,8 +6,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingTop="12dp"
-    android:paddingBottom="12dp"
+    android:paddingTop="14dp"
+    android:paddingBottom="14dp"
     android:paddingStart="0dp"
     android:paddingEnd="0dp">
 
@@ -17,14 +17,14 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center_vertical"
-        android:layout_marginBottom="4dp">
+        android:layout_marginBottom="5dp">
 
         <TextView
             android:id="@+id/row_topic"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textSize="12sp"
+            android:textSize="14sp"
             android:textAllCaps="true"
             android:letterSpacing="0.05"
             android:textColor="@color/facteur_text_secondary"
@@ -37,7 +37,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="6dp"
-            android:textSize="11sp"
+            android:textSize="13sp"
             android:textStyle="bold"
             android:textAllCaps="true"
             android:letterSpacing="0.05"
@@ -63,19 +63,19 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textSize="17sp"
+            android:textSize="20sp"
             android:textStyle="bold"
             android:fontFamily="sans-serif-medium"
             android:textColor="@color/facteur_text_primary"
-            android:lineSpacingExtra="3dp"
+            android:lineSpacingExtra="4dp"
             android:maxLines="2"
             android:ellipsize="end"
-            android:layout_marginEnd="12dp" />
+            android:layout_marginEnd="14dp" />
 
         <ImageView
             android:id="@+id/row_thumbnail"
-            android:layout_width="72dp"
-            android:layout_height="72dp"
+            android:layout_width="86dp"
+            android:layout_height="86dp"
             android:scaleType="centerCrop"
             android:contentDescription="Article thumbnail"
             android:visibility="gone" />
@@ -87,13 +87,13 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center_vertical"
-        android:layout_marginTop="6dp">
+        android:layout_marginTop="7dp">
 
         <ImageView
             android:id="@+id/row_source_logo"
-            android:layout_width="18dp"
-            android:layout_height="18dp"
-            android:layout_marginEnd="6dp"
+            android:layout_width="22dp"
+            android:layout_height="22dp"
+            android:layout_marginEnd="7dp"
             android:scaleType="fitCenter"
             android:visibility="gone"
             android:contentDescription="Source logo" />
@@ -102,7 +102,7 @@
             android:id="@+id/row_source_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="12sp"
+            android:textSize="14sp"
             android:textColor="@color/facteur_text_secondary"
             android:maxLines="1"
             android:ellipsize="end" />
@@ -112,7 +112,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
-            android:textSize="12sp"
+            android:textSize="14sp"
             android:textStyle="bold"
             android:textColor="@color/facteur_accent"
             android:visibility="gone" />
@@ -129,13 +129,13 @@
             android:id="@+id/row_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="12sp"
+            android:textSize="14sp"
             android:textColor="@color/facteur_text_tertiary" />
     </LinearLayout>
 
     <TextView
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="10dp"
         android:background="@color/facteur_border" />
 </LinearLayout>

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -283,10 +283,11 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
     }
   }
 
-  /// Push current digest state to the home screen widget.
+  /// Push the Essentiel (normal) digest to the home screen widget.
+  /// Always uses `_normalDigest` so the widget stays on L'Essentiel even when
+  /// the in-app Serein/"Bonnes Nouvelles" toggle is on.
   void _syncWidget() {
-    final digest = state.value;
-    WidgetService.updateWidget(digest: digest);
+    WidgetService.updateWidget(digest: _normalDigest);
   }
 
   /// Update the daily notification with topic keywords from the loaded digest.


### PR DESCRIPTION
## What

- `_syncWidget` pousse désormais `_normalDigest` au lieu de `state.value` — le widget Android reste sur l'Essentiel du jour même quand le toggle Serein/"Bonnes Nouvelles" est activé dans l'app.
- `widget_article_row.xml` : sizing +~20% sur les cartes articles (titre 17→20sp, vignette 72→86dp, source/heure 12→14sp, badge À la Une 11→13sp, paddings/margins ajustés).

## Why

Le widget home screen affichait les articles "Bonnes Nouvelles" quand le mode Serein était actif, alors qu'il doit toujours montrer l'Essentiel. Les cartes étaient aussi trop denses — +20% pour aérer la lecture.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`flutter test test/core/services/widget_service_test.dart` — 5/5)
- [ ] Linting passes (`ruff check app/`) — N/A (mobile only)
- [x] No new Python `List[]` imports (use `list[]`) — N/A
- [ ] If touching auth/DB: read Safety Guardrails — N/A
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (mobile-only change, pas de backend)