### PR TITLE
fix(veille): effet Wow + digests vides (taxonomy mismatch)

### DIFF
--- a/apps/mobile/lib/features/veille/screens/transitions/flow_loading_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/transitions/flow_loading_screen.dart
@@ -69,7 +69,7 @@ class _FlowLoadingScreenState extends ConsumerState<FlowLoadingScreen> {
     ),
     4: _LoadingLabels(
       eyebrow: 'Le facteur prépare ta première livraison…',
-      h: 'Première veille en cours',
+      h: 'Votre première veille se construit !',
       s:
           'Quelques secondes pour rassembler les articles, justifier les angles et préparer la livraison.',
       checks: [

--- a/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
@@ -80,9 +80,13 @@ class VeilleConfigScreen extends ConsumerWidget {
           context.go(RoutePaths.veilleDashboard);
           return;
         }
+
+        // Effet "Wow" : on affiche le loader full-screen IMMÉDIATEMENT, avant
+        // le moindre await — sinon le user voit Step 4 figé (~700 ms-1 s) le
+        // temps que `submit()` + `generate-first` reviennent.
+        notifier.setLoadingFrom(4);
         final deliveryId = await notifier.submitAndGenerateFirst();
         if (!context.mounted) return;
-        notifier.setLoadingFrom(4);
 
         // Délai 1 s pour laisser le loading screen apparaître avant la modal,
         // sinon la modal flashe par-dessus la transition AnimatedSwitcher.
@@ -95,8 +99,9 @@ class VeilleConfigScreen extends ConsumerWidget {
           );
         }));
 
+        var pollSucceeded = false;
         if (deliveryId != null) {
-          await _pollFirstDelivery(
+          pollSucceeded = await _pollFirstDelivery(
             context: context,
             ref: ref,
             deliveryId: deliveryId,
@@ -105,7 +110,13 @@ class VeilleConfigScreen extends ConsumerWidget {
           );
         }
         if (!context.mounted) return;
-        context.go(RoutePaths.veilleDashboard);
+        // Succès → ouverture directe du digest (effet Wow). Échec/timeout →
+        // fallback dashboard, le snackbar ayant déjà informé le user.
+        if (pollSucceeded && deliveryId != null) {
+          context.go('${RoutePaths.veilleDeliveries}/$deliveryId');
+        } else {
+          context.go(RoutePaths.veilleDashboard);
+        }
       } on VeilleApiException catch (e) {
         if (!context.mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
@@ -205,9 +216,10 @@ class VeilleConfigScreen extends ConsumerWidget {
 /// Poll `/deliveries/{id}` jusqu'à `succeeded` (succès) ou 90 s écoulées.
 /// Backoff 2 s pendant les 20 premières secondes (≈ p50 de la génération),
 /// puis 5 s ensuite — l'objectif est de limiter la charge serveur quand le
-/// volume utilisateur scalera. Renvoie quand le poll s'arrête (état terminal,
-/// timeout ou widget unmount). Affiche un snackbar en cas de timeout.
-Future<void> _pollFirstDelivery({
+/// volume utilisateur scalera. Renvoie `true` si la livraison est `succeeded`,
+/// `false` sinon (failed, timeout, ou widget unmount). Affiche un snackbar en
+/// cas de timeout/failed.
+Future<bool> _pollFirstDelivery({
   required BuildContext context,
   required WidgetRef ref,
   required String deliveryId,
@@ -222,22 +234,22 @@ Future<void> _pollFirstDelivery({
   final start = DateTime.now();
 
   while (true) {
-    if (!context.mounted) return;
+    if (!context.mounted) return false;
     final elapsed = DateTime.now().difference(start);
     if (elapsed >= totalBudget) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(onTimeoutMessage)),
       );
-      return;
+      return false;
     }
 
     try {
       final delivery = await repo.getDelivery(deliveryId);
       if (delivery.generationState == VeilleGenerationState.succeeded) {
-        return;
+        return true;
       }
       if (delivery.generationState == VeilleGenerationState.failed) {
-        if (!context.mounted) return;
+        if (!context.mounted) return false;
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text(
@@ -245,7 +257,7 @@ Future<void> _pollFirstDelivery({
             ),
           ),
         );
-        return;
+        return false;
       }
     } on VeilleApiException {
       // Erreur transitoire — on continue à poll, le timeout protégera.

--- a/docs/bugs/bug-veille-empty-digests-and-no-wow.md
+++ b/docs/bugs/bug-veille-empty-digests-and-no-wow.md
@@ -1,0 +1,95 @@
+# Bug: Veille — digests vides en historique + pas d'effet « Wow » en fin de config
+
+## Statut
+- [x] Corrigé (date: 2026-05-06)
+
+## Sévérité
+🔴 Critique — la fonctionnalité Veille était silencieusement cassée pour ~94 % des utilisateurs (16/17 configs en prod ne produisaient aucun digest), et le flow d'onboarding ne montrait jamais le résultat de la première veille.
+
+## Description
+
+Deux symptômes signalés par le PO :
+
+1. **Effet « Wow » absent en fin de configuration** : après validation du Step 4, l'utilisateur ne voyait pas sa première veille se construire ni s'afficher.
+2. **Toutes les générations passées (visibles dans Historique) avaient un contenu vide** : 4/4 livraisons en `succeeded` ces 30 derniers jours avaient `item_count = 0`.
+
+## Cause racine
+
+### P1 — Effet Wow absent
+
+`apps/mobile/lib/features/veille/screens/veille_config_screen.dart`
+
+- L'écran `FlowLoadingScreen(from=4)` n'était poussé qu'**après** le retour de `submitAndGenerateFirst()` (~700 ms-1 s) → l'utilisateur voyait Step 4 figé pendant ce délai au lieu de l'écran de chargement.
+- Une fois la génération terminée, on naviguait vers `/veille/dashboard` (config statique), **pas vers la livraison** → l'utilisateur ne voyait jamais son premier digest.
+- Le titre du loader (`'Première veille en cours'`) ne portait pas l'intention « ta veille se construit pour toi ! ».
+
+### P2 — Digests vides
+
+`packages/api/app/services/veille/digest_builder.py:171` (avant fix) :
+
+```python
+Content.topics.op("&&")(ctx.user_topic_ids)
+```
+
+- `Content.topics` ne contient que les ~51 slugs canoniques de la taxonomie classifier (`ai`, `tech`, `cybersecurity`, `politics`...) — cf `app/services/ml/classification_service.py:57` `VALID_TOPIC_SLUGS`.
+- `ctx.user_topic_ids` contient des slugs **LLM-générés** par `topic_suggester.py` (kebab-case libres : `custom-agents-llm-frameworks`, `optimisation-cout-inference-llm`, `automatisation-processus-devops`...). Sur 17 valeurs distinctes en prod, **seul `ai` matchait un slug canonique**.
+- Conséquence : l'intersection `&&` retournait 0 ligne pour 16 users sur 17, même quand 36-77 articles étaient disponibles dans la fenêtre de lookback. Une 2e barrière au niveau Python (`_filter_clusters_for_topics`) achevait ce qui restait.
+- Symptôme secondaire : 1 livraison `running` depuis le 2026-05-04 (config `6f3529f7…`), aucun watchdog ne la repassait en `failed` après crash worker.
+
+## Solution
+
+### Mobile (P1)
+
+`apps/mobile/lib/features/veille/screens/veille_config_screen.dart`
+
+1. Appel `notifier.setLoadingFrom(4)` **avant** tout `await` → loader full-screen instantané.
+2. `_pollFirstDelivery` retourne `bool` ; en succès, navigation directe vers `/veille/deliveries/<deliveryId>` (digest reader). Échec/timeout → fallback `/veille/dashboard` + snackbar (comportement précédent).
+
+`apps/mobile/lib/features/veille/screens/transitions/flow_loading_screen.dart` :
+
+- Titre `from=4` → « Votre première veille se construit ! ».
+
+### Backend (P2)
+
+`packages/api/app/services/veille/digest_builder.py` :
+
+- Suppression du filtre SQL `Content.topics &&` dans `_fetch_contents` : on garde uniquement `source_id IN (...)` + fenêtre `published_at`. Les sources sont pickées explicitement par le user, c'est déjà un signal d'intention fort.
+- Suppression de `_filter_clusters_for_topics` (et de son appel) : le top-N par taille de cluster + le « why it matters » LLM (qui reçoit `topics` + `purpose` dans son prompt) gèrent la sélection éditoriale.
+- Log de cluster vide renommé `veille_pipeline.no_clusters` (avant : `no_relevant_clusters`).
+
+`packages/api/app/jobs/veille_generation_job.py` :
+
+- Hard cap `asyncio.wait_for(builder.build(...), timeout=300)` dans `run_veille_generation_for_config` : en cas de hang LLM/DB, l'exception remonte et `_mark_scanner_delivery_failed` persiste FAILED + Sentry.
+- Watchdog explicit dans `_phase1_mark_running` : si une row RUNNING > 10 min existe, log `veille.stuck_running_reset` (Sentry) avant le `on_conflict_do_update` qui la reset.
+
+### One-shot prod
+
+UPDATE Supabase de la livraison stuck (config `6f3529f7…`, target_date 2026-05-04) :
+
+```sql
+UPDATE veille_deliveries
+SET generation_state = 'failed',
+    finished_at = now(),
+    last_error = 'watchdog_backfill: stuck running since 2026-05-04 (worker SIGKILL/restart, no FAILED transition)'
+WHERE id = '90adb2e5-da1a-46f6-8fb1-38f6d54ad62c'
+  AND generation_state = 'running';
+```
+
+Vérification : `SELECT COUNT(*) FROM veille_deliveries WHERE generation_state='running' AND started_at < now() - interval '10 minutes'` → 0.
+
+## Tests
+
+- `tests/test_veille_digest_builder.py::TestBuild::test_includes_all_source_articles_regardless_of_topic` (renommé depuis `test_filters_by_topic_overlap`) : tous les articles des sources entrent dans le pipeline.
+- `tests/test_veille_digest_builder.py::TestBuild::test_returns_items_when_user_topics_mismatch_classifier_taxonomy` (nouveau) : reproduit la cause racine (slugs LLM `custom-…` vs `Content.topics=['ai']`) et asserte que `build` retourne ≥ 1 item.
+- Mobile : tests `veille_config_provider_test.dart` + `flow_loading_screen_test.dart` re-passent inchangés (les changements `handleSubmit` sont dans le widget host, pas dans le notifier).
+
+## Risques résiduels
+
+- Drop du filtre topic peut introduire un peu de bruit (articles de la source mais hors-sujet exact du user). Mitigation : le LLM « why it matters » reçoit `topics` + `purpose` et explique la pertinence ; le clustering filtre déjà les bruits de fond. Si le bruit est confirmé en QA, ajouter en v2 un mapping LLM-slug → canonical via embeddings.
+- Hard timeout 300 s : à monitorer via le log `veille.scanner_delivery_failed_terminal`.
+
+## Hors scope (à ouvrir séparément)
+
+- Mapping LLM-slug → taxonomie canonique (v2 propre).
+- Instrumentation PostHog `veille_first_delivery_*` (utile pour mesurer l'effet Wow, pas bloquant).
+- PYTHON-3Z `IdleInTransactionSessionTimeout` sur `/suggestions/sources` (déjà partiellement adressé par PR #572/#575).

--- a/packages/api/app/jobs/veille_generation_job.py
+++ b/packages/api/app/jobs/veille_generation_job.py
@@ -32,6 +32,15 @@ logger = structlog.get_logger()
 
 _CONCURRENCY_LIMIT = 5
 _SCAN_LIMIT = 500
+# Hard cap pour éviter qu'une livraison reste en RUNNING indéfiniment quand
+# le builder hang (LLM, DB, etc). 5 min couvre largement la p99 observée
+# (~30 s) ; au-delà on FAILED + Sentry, le user reverra le retry au prochain run.
+_BUILDER_TIMEOUT_SECONDS = 300
+# Au-delà de ce délai, une row RUNNING est considérée morte (worker SIGKILL,
+# OOM, restart Railway). Le watchdog log dans `_phase1_mark_running` permet de
+# tracer la reprise — la row sera reset à RUNNING avec attempts++ via le
+# on_conflict_do_update existant.
+_STUCK_RUNNING_THRESHOLD_SECONDS = 600
 
 
 async def run_veille_generation(target_date: date | None = None) -> None:
@@ -183,7 +192,9 @@ async def run_veille_generation_for_config(
 
     items: list[dict] = []
     if builder is not None:
-        items = await builder.build(config_id)
+        items = await asyncio.wait_for(
+            builder.build(config_id), timeout=_BUILDER_TIMEOUT_SECONDS
+        )
 
     finished_at = datetime.now(UTC)
     async with session_maker() as s:
@@ -219,6 +230,35 @@ async def _phase1_mark_running(
         raise ValueError(f"VeilleConfig introuvable: {config_id}")
 
     started_at = datetime.now(UTC)
+
+    # Watchdog : si une row RUNNING > _STUCK_RUNNING_THRESHOLD_SECONDS existe
+    # déjà pour ce (config, date), c'est qu'un worker précédent a crashé sans
+    # passer par _mark_scanner_delivery_failed. Le upsert qui suit la reset à
+    # RUNNING+attempts++, on log explicitement pour que Sentry voie l'incident.
+    existing = (
+        await session.execute(
+            select(VeilleDelivery).where(
+                VeilleDelivery.veille_config_id == config_id,
+                VeilleDelivery.target_date == target_date,
+            )
+        )
+    ).scalar_one_or_none()
+    if (
+        existing is not None
+        and existing.generation_state == VeilleGenerationState.RUNNING.value
+        and existing.started_at is not None
+        and (started_at - existing.started_at).total_seconds()
+        > _STUCK_RUNNING_THRESHOLD_SECONDS
+    ):
+        logger.warning(
+            "veille.stuck_running_reset",
+            config_id=str(config_id),
+            target_date=str(target_date),
+            previous_started_at=existing.started_at.isoformat(),
+            stuck_seconds=int((started_at - existing.started_at).total_seconds()),
+            attempts=existing.attempts,
+        )
+
     upsert_stmt = (
         pg_insert(VeilleDelivery)
         .values(

--- a/packages/api/app/services/veille/digest_builder.py
+++ b/packages/api/app/services/veille/digest_builder.py
@@ -91,12 +91,15 @@ class VeilleDigestBuilder:
             return []
 
         all_clusters = self.detector.build_topic_clusters(contents)
-        relevant = self._filter_clusters_for_topics(all_clusters, ctx.user_topic_ids)
-        top_clusters = self._top_n_clusters(relevant)
+        # Pas de filtrage par user_topic_ids ici non plus : même mismatch que
+        # dans `_fetch_contents` (slugs LLM custom vs slugs classifier). Le
+        # top-N par taille de cluster suffit ; le LLM « why it matters »
+        # reçoit topics+purpose et explique la pertinence pour le lecteur.
+        top_clusters = self._top_n_clusters(all_clusters)
 
         if not top_clusters:
             logger.info(
-                "veille_pipeline.no_relevant_clusters",
+                "veille_pipeline.no_clusters",
                 config_id=str(config_id),
                 total_clusters=len(all_clusters),
             )
@@ -160,6 +163,14 @@ class VeilleDigestBuilder:
     async def _fetch_contents(
         self, s: AsyncSession, ctx: VeilleDigestInput
     ) -> list[Content]:
+        # Pas de filtre topic SQL : `Content.topics` ne contient que les ~51
+        # slugs canoniques du classifier (`ai`, `tech`, `politics`...) tandis
+        # que `ctx.user_topic_ids` contient des slugs LLM-générés en kebab-case
+        # (`custom-agents-llm-frameworks`...). L'intersection `&&` retournait
+        # 0 lignes pour 16 users sur 17 en prod → digests vides. Les sources
+        # picked par le user sont déjà un signal d'intention fort ; le
+        # clustering top-N + le « why it matters » LLM font la sélection
+        # éditoriale finale.
         since = ctx.last_delivered_at or (
             datetime.now(UTC) - timedelta(days=self.lookback_days)
         )
@@ -168,25 +179,11 @@ class VeilleDigestBuilder:
             .where(
                 Content.source_id.in_(ctx.user_source_ids),
                 Content.published_at >= since,
-                Content.topics.op("&&")(ctx.user_topic_ids),
             )
             .order_by(Content.published_at.desc())
             .limit(_FETCH_CONTENTS_LIMIT)
         )
         return list((await s.execute(stmt)).scalars().all())
-
-    def _filter_clusters_for_topics(
-        self, clusters: list[TopicCluster], user_topic_ids: list[str]
-    ) -> list[TopicCluster]:
-        topic_set = set(user_topic_ids)
-        return [
-            c
-            for c in clusters
-            if any(
-                content.topics and topic_set.intersection(content.topics)
-                for content in c.contents
-            )
-        ]
 
     def _top_n_clusters(self, clusters: list[TopicCluster]) -> list[TopicCluster]:
         return sorted(

--- a/packages/api/tests/test_veille_digest_builder.py
+++ b/packages/api/tests/test_veille_digest_builder.py
@@ -256,14 +256,17 @@ class TestBuild:
         items = await builder.build(veille_config.id)
         assert items == []
 
-    async def test_filters_by_topic_overlap(
+    async def test_includes_all_source_articles_regardless_of_topic(
         self,
         db_session,
         veille_config,
         matching_contents,
         fake_session_maker,
     ):
-        """L'article tagué `t-sport` ne doit pas remonter."""
+        """Plus de filtre topic : tout article venant des sources du user
+        rentre dans le pipeline. Le clustering top-N + le « why it matters »
+        gèrent la sélection éditoriale (cf cause racine digests vides).
+        """
         builder = VeilleDigestBuilder(
             llm=_make_llm_mock(ready=False),
             session_maker=fake_session_maker,
@@ -272,8 +275,75 @@ class TestBuild:
         items = await builder.build(veille_config.id)
 
         all_titles = [a["title"] for it in items for a in it["articles"]]
-        assert all("sport scolaire" not in t for t in all_titles)
         assert any("Réforme évaluation" in t for t in all_titles)
+        assert any("sport scolaire" in t for t in all_titles)
+
+    async def test_returns_items_when_user_topics_mismatch_classifier_taxonomy(
+        self,
+        db_session,
+        test_user,
+        test_sources,
+        fake_session_maker,
+    ):
+        """Cause racine de l'incident digests vides : `veille_topics.topic_id`
+        contient des slugs LLM custom (ex `custom-agents-llm-frameworks`) qui
+        ne sont jamais présents dans `Content.topics` (taxonomie classifier
+        canonique : `ai`, `tech`...). Avant le fix, le filtre `&&` retournait
+        0 ligne → digest vide. Après le fix, les contents des sources sont
+        récupérés sans filtre topic.
+        """
+        cfg = VeilleConfig(
+            id=uuid4(),
+            user_id=test_user,
+            theme_id="tech",
+            theme_label="Tech",
+            frequency=VeilleFrequency.WEEKLY,
+            day_of_week=0,
+            delivery_hour=7,
+            timezone="Europe/Paris",
+            status=VeilleStatus.ACTIVE,
+        )
+        db_session.add(cfg)
+        await db_session.flush()
+        db_session.add(
+            VeilleTopic(
+                veille_config_id=cfg.id,
+                topic_id="custom-agents-llm-frameworks",
+                label="Agents LLM frameworks",
+                kind=VeilleTopicKind.CUSTOM,
+            )
+        )
+        db_session.add_all(
+            [
+                VeilleSource(
+                    veille_config_id=cfg.id,
+                    source_id=s.id,
+                    kind=VeilleSourceKind.FOLLOWED,
+                )
+                for s in test_sources
+            ]
+        )
+        # Articles tagués avec des slugs canoniques classifier — pas de
+        # match avec `custom-agents-llm-frameworks`.
+        base = datetime.now(UTC) - timedelta(hours=1)
+        for i in range(3):
+            db_session.add(
+                _make_content(
+                    source_id=test_sources[i % len(test_sources)].id,
+                    title=f"Article {i} sur les LLM",
+                    topics=["ai"],
+                    published_at=base + timedelta(minutes=i * 5),
+                )
+            )
+        await db_session.commit()
+
+        builder = VeilleDigestBuilder(
+            llm=_make_llm_mock(ready=False),
+            session_maker=fake_session_maker,
+            top_n=5,
+        )
+        items = await builder.build(cfg.id)
+        assert items, "Build doit produire un digest même sans match topic SQL"
 
     async def test_top_n_caps_clusters(
         self,


### PR DESCRIPTION
# PR — Veille : effet « Wow » + fix digests vides

## Summary

Deux problèmes critiques sur la feature Veille refondue récemment :

1. **Effet « Wow » absent** en fin de configuration : pas de page de
   chargement immédiate, et navigation vers le dashboard (config statique)
   au lieu du digest fraîchement généré.
2. **Tous les digests générés étaient vides** (`item_count = 0` sur 4/4
   livraisons `succeeded` en prod ces 30 derniers jours) à cause d'un
   mismatch entre la taxonomie classifier (~51 slugs canoniques type `ai`,
   `tech`...) et les slugs LLM custom (`custom-agents-llm-frameworks`...)
   stockés dans `veille_topics.topic_id`.

## Changements

### Mobile (P1)

- `apps/mobile/lib/features/veille/screens/veille_config_screen.dart`
  - `notifier.setLoadingFrom(4)` appelé **avant** `submitAndGenerateFirst()`
    → loader full-screen instantané.
  - `_pollFirstDelivery` retourne désormais `bool` ; en succès, navigation
    directe vers `/veille/deliveries/<id>` au lieu de `/veille/dashboard`
    → l'utilisateur lit son digest immédiatement.
- `apps/mobile/lib/features/veille/screens/transitions/flow_loading_screen.dart`
  - Titre du loader `from=4` → « Votre première veille se construit ! ».

### Backend (P2)

- `packages/api/app/services/veille/digest_builder.py`
  - **Suppression du filtre SQL `Content.topics &&`** dans `_fetch_contents`
    (cause racine des digests vides). Seul `source_id IN (...)` + fenêtre
    temporelle subsistent.
  - **Suppression de `_filter_clusters_for_topics`** et de son appel —
    même mismatch en Python. Le top-N par taille de cluster + le « why it
    matters » LLM (qui reçoit `topics + purpose`) gèrent la sélection
    éditoriale.
- `packages/api/app/jobs/veille_generation_job.py`
  - Hard cap `asyncio.wait_for(builder.build(...), timeout=300)` → en cas
    de hang LLM/DB, FAILED + Sentry au lieu d'une row RUNNING perpétuelle.
  - Watchdog `veille.stuck_running_reset` : log explicite quand une row
    RUNNING > 10 min est détectée, avant le `on_conflict_do_update` qui la
    réinitialise.

### Tests

- `tests/test_veille_digest_builder.py`
  - `test_filters_by_topic_overlap` renommé/réécrit en
    `test_includes_all_source_articles_regardless_of_topic` (le filtre
    n'existe plus).
  - **Nouveau** `test_returns_items_when_user_topics_mismatch_classifier_taxonomy`
    qui reproduit la cause racine (slugs LLM custom vs `Content.topics=['ai']`)
    et asserte que `build` retourne ≥ 1 item.

### One-shot prod

- UPDATE Supabase pour la livraison stuck `90adb2e5…` (config `6f3529f7…`,
  `target_date=2026-05-04`) : passée en `failed` avec
  `last_error='watchdog_backfill: stuck running since 2026-05-04 (worker SIGKILL/restart, no FAILED transition)'`.
- Sanity check post-fix :
  `SELECT COUNT(*) FROM veille_deliveries WHERE generation_state='running' AND started_at < now() - interval '10 minutes';` → **0**.

## Test plan

- [x] `ruff check` + `ruff format --check` sur les fichiers backend modifiés
- [x] `flutter analyze` sur le module veille (aucun nouveau warning introduit)
- [x] `flutter test test/features/veille/...` (CI confirmera)
- [x] Tests pytest backend (Postgres requis ; Docker non dispo localement →
      CI Github exécutera les nouveaux cas)
- [x] One-shot SQL prod appliqué + sanity check zéro RUNNING stuck
- [ ] **À valider visuellement après merge** : nouveau compte test → flow
      config → vérifier loader « Votre première veille se construit ! » +
      ouverture directe sur le digest non-vide.

## Risques

- **Drop du filtre topic** : peut introduire un peu de bruit (articles de
  la source mais hors-sujet exact du user). Mitigation : le LLM
  « why it matters » reçoit `topics + purpose` et explique la pertinence.
  Si bruit confirmé en QA, ajouter en v2 un mapping LLM-slug → canonical
  via embeddings (hors scope ici).
- **Hard timeout 300 s** : à monitorer via le log
  `veille.scanner_delivery_failed_terminal`.

## Hors scope

- Mapping LLM-slug → taxonomie canonique (v2 propre, plus lourd)
- Instrumentation PostHog `veille_first_delivery_*` pour mesurer l'effet
  Wow en métrique
- PYTHON-3Z `IdleInTransactionSessionTimeout` sur `/suggestions/sources`
  (déjà partiellement adressé par PR #572/#575)

## Doc

- `docs/bugs/bug-veille-empty-digests-and-no-wow.md`