### PR TITLE
fix(feed): dédupliquer par ID dans loadMore pour éliminer les doublons

### DIFF
--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -395,8 +395,23 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       final currentItems = state.value?.items ?? [];
       final currentCarousels = state.value?.carousels ?? [];
 
+      // Deduplicate by content ID: stale cache on page 1 + fresh API on page 2
+      // can produce overlapping articles when new content was ingested in between.
+      final existingIds = Set<String>.from(currentItems.map((c) => c.id));
+      final dedupedNewItems =
+          newItems.where((c) => !existingIds.contains(c.id)).toList();
+
+      if (dedupedNewItems.isEmpty && newItems.isNotEmpty) {
+        // All items were duplicates — pagination is fully misaligned (e.g. stale
+        // cache vs. heavily updated candidate pool). Stop paging to avoid a loop.
+        print(
+            'FeedNotifier: loadMore page $nextPage fully deduplicated (${newItems.length} dupes), stopping pagination.');
+        _hasNext = false;
+        return;
+      }
+
       state = AsyncData(FeedState(
-        items: [...currentItems, ...newItems],
+        items: [...currentItems, ...dedupedNewItems],
         carousels: currentCarousels, // Keep page 1 carousels
       ));
     } catch (e) {


### PR DESCRIPTION
## Quoi

Déduplication par `content.id` dans `FeedNotifier.loadMore()` : on filtre les articles déjà présents dans `state.value.items` avant de les ajouter à la liste paginée.

Si **tous** les éléments retournés par l'API sont des doublons, on coupe la pagination (`_hasNext = false`) pour éviter une boucle de chargement infinie sur un cache stale fortement désaligné.

## Pourquoi

Les utilisateurs voyaient des articles dupliqués dans le feed après scroll. Cause : la page 1 sert souvent depuis un cache (stale) tandis que la page 2 frappe l'API fraîche — si du nouveau contenu a été ingéré entre les deux, le cursor de pagination se chevauche et les mêmes IDs reviennent.

## Comment ça a été vérifié

- [x] Diff isolé au seul `loadMore()` — les autres branches (`build()`, `refresh()`) ne sont pas touchées
- [x] `flutter analyze` sur `feed_provider.dart` : seuls des `info • avoid_print` (cohérents avec les ~18 prints déjà présents dans le fichier), 0 warning/error
- [x] Tests Flutter : les 38 échecs observés en suite complète existent **déjà sur `origin/main`** (vérifié en checkout du fichier depuis main : `feed_refresh_recovery_test` et `feed_sources_test` échouent à l'identique). Pré-existants, non régressifs.
- [x] Logique : `Set<String>` lookup O(1), filtre O(n), pas de copie supplémentaire de `currentItems`

## Zones à risque

- **Pagination** : si l'API renvoie systématiquement un mix doublons + nouveaux items, on garde le comportement attendu (on append uniquement les nouveaux). Le `_hasNext = false` ne s'active que sur un lot **100% doublons**, signal clair que le cursor est désaligné.
- **Pas d'impact sur `refresh()` ni `build()`** : la dédup est strictement dans la branche `loadMore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)