### PR TITLE
feat(widget): switch Essentiel/Flux + simplification header

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,79 +1,43 @@
-# PR — fix(veille): /suggestions/sources Iter 4 — parallélisation boucle + transition mobile 25 s
+# PR — feat(widget): switch Essentiel/Flux + simplification header
 
 ## Summary
 
-Itération 4 du fix `/suggestions/sources` (suite de #561, #562, #567, #568, #572). Le pattern idle-in-tx de #572 est verrouillé (PYTHON-3Z/40 dernière occurrence à 14:38 UTC, instant du déploiement) mais l'utilisateur (`c959d7ef`) signalait toujours :
-1. Step 3 reste en spinner > 1 min puis bascule sur le mock — au refresh manuel, les sources sont là.
-2. La page de transition Step 2 → Step 3 (`flow_loading_screen`) ne sert pas à faire patienter — l'utilisateur arrive direct sur Step 3 spinner.
+Refonte du widget Android pour intégrer le Flux (feed) en complément de l'Essentiel du jour, avec switch dans le header. Simplification visuelle et titres jusqu'à 4 lignes pour se rapprocher du style Google News / feed in-app.
 
-Diagnostic Sentry post-#572 (event PYTHON-41, release `ecffd1bcff5dd0`) :
-- LLM Mistral seul = **~16 s** (déjà supérieur au cap mobile `_loadingMaxDuration=8 s`)
-- Boucle séquentielle 12 candidats × 0.85 s typique + jusqu'à 4 timeouts à 8 s = **30-60 s pire cas**
-- Donc dépassement systématique de `_loadingMaxDuration` (8 s) et fréquent du `Dio.timeout` (30 s)
+- **Switch Essentiel ↔ Flux** dans le header (segmented control). Mode persisté localement (`widget_mode` SharedPreferences) via PendingIntent broadcast — le tap d'onglet écrit la clé puis `notifyAppWidgetViewDataChanged`.
+- **Header simplifié** : suppression wordmark "Facteur", streak 🔥, refresh button, sous-titre.
+- **Footer simplifié** : suppression du bouton "Ouvrir Facteur".
+- **Cartes article** : `maxLines` 2 → 4, thumbnail 86dp inchangée à droite.
+- **Flux scrollable** alimenté par le cache de `feedProvider` (jusqu'à 30 items, plafond Binder ~1 MB), poussé en debounced 1 s à chaque mise à jour de l'état du feed (default view, sans filtre). Thumbnails téléchargées seulement pour les 10 premiers items pour rester sous la limite IPC.
+- **Tap article** : deeplink dépendant du mode — `digest/<id>` en Essentiel (inchangé), `feed/content/<id>` en Flux (route déjà gérée par `DeepLinkService` + redirect `routes.dart`).
+- **Empty state Flux** : « Ouvre Facteur pour charger ton flux » (cold-start friendly, le widget se peuple en < 1 s dès que `feedProvider` charge).
 
-Deux fixes complémentaires shipped ensemble (l'un sans l'autre ne résout pas) :
+Pas d'iOS (aucune extension widget iOS aujourd'hui). Pas de fetch réseau natif.
 
-### Fix A — Paralléliser la boucle d'ingestion (perf serveur)
+## Test plan
 
-`packages/api/app/services/veille/source_suggester.py:194-229` — boucle séquentielle `for cand in candidates:` refactorisée en deux phases :
+- [x] `flutter test test/core/services/widget_service_test.dart` — 9/9 ✅ (Digest + nouveau Feed serialization)
+- [x] `flutter test test/core/services/deep_link_service_test.dart` — 10/10 ✅ (route `feed/content/<id>` validée)
+- [x] `flutter analyze lib/core/services/widget_service.dart lib/features/feed/providers/feed_provider.dart` — 0 erreurs, 0 warnings/infos imputables aux changements
+- [ ] **Test manuel Android** (à effectuer par le reviewer ou en QA) :
+  - Header simplifié, segmented control [Essentiel | Flux] uniquement
+  - Tap "Flux" → liste bascule, scrollable, deeplink `feed/content/<id>`
+  - Tap "Essentiel" → retour aux 5 articles digest, deeplink `digest/<id>`
+  - Mode persisté après kill app
+  - Cold-start Flux → empty state puis populé après ouverture app
+  - Titres longs : jusqu'à 4 lignes sans truncation, ellipsize au-delà
+  - Vérifier sur Samsung OneUI si dispo
 
-1. **Phase 1 (parallèle, sémaphore 4)** — `RSSParser.detect()` HTTP-only, hors session DB. `asyncio.gather` avec sémaphore polite (`_DETECT_CONCURRENCY=4`, aligné avec stage 4 RSSParser). `asyncio.wait_for(_HYDRATE_TIMEOUT_S=8s)` par candidat préservé.
-2. **Phase 2 (séquentielle)** — `_persist_detected()` fait le SELECT `feed_url` existant + INSERT si nouveau, dans un `session.begin_nested()` SAVEPOINT par candidat (préservé). SQLAlchemy AsyncSession n'étant pas safe pour des opérations concurrentes, l'ingest DB reste séquentiel — c'est le HTTP qui dominait, pas l'INSERT.
+## Hors-scope
 
-Wall-clock : **⌈12/4⌉ × 0.85 ≈ 3 s** (au lieu de 10 s typique). Pire cas avec 4 timeouts simultanés : 8 s (au lieu de 32 s).
+- Pas d'iOS widget extension (n'existe pas).
+- Pas de fetch réseau natif (le widget reflète le cache app).
+- Pas de pull-to-refresh / loading spinner dans le widget (incompatible RemoteViews).
 
-Invariant #572 préservé : `await session.rollback()` avant LLM + `await apply_session_timeouts(session)` après LLM, intacts.
+## Notes
 
-### Fix B — Aligner le budget transition mobile (UX)
+- Test pré-existant `feed_refresh_undo_banner_test.dart` "tapping Annuler while auto-dismiss is animating" échoue sur la branche, **avant** comme **après** mes changements (vérifié via `git stash` → `flutter test` → même échec). Hors scope.
 
-`apps/mobile/lib/features/veille/providers/veille_config_provider.dart:230` — `_loadingMaxDuration` constante factorisée en `loadingMaxDurationFor(int from)` :
-- `from == 1` (Step 1 → Step 2, pré-fetch topics rapide) → **8 s** (inchangé)
-- `from == 2` (Step 2 → Step 3, LLM + boucle ingestion) → **25 s** (5 s de marge sous le `Dio.timeout=30 s`)
+## Story / Doc
 
-Avec Fix A actif, la requête typique tient ~16-19 s — la transition halo joue toute la durée du fetch et l'utilisateur arrive sur Step 3 avec les sources déjà chargées.
-
-## Fichiers modifiés
-
-### Backend
-- `packages/api/app/services/veille/source_suggester.py` — refacto Phase 1/Phase 2, suppression `_hydrate_or_ingest`, ajout `_detect_candidate` + `_persist_detected`, constante `_DETECT_CONCURRENCY=4`. Imports : `RSSParser`, `DetectedFeed` (au lieu de `SourceService`).
-- `packages/api/tests/test_veille_source_ingestion.py` — patch sites `SourceService.detect_source` → `RSSParser.detect`, helper `_detect_response` retourne `DetectedFeed`. Nouveau test `TestParallelDetect::test_detect_runs_concurrently_within_semaphore` (assert wall-clock < 3 s pour 12 candidats × 0.5 s parallèle, max in-flight = 4).
-- `packages/api/tests/test_veille_source_suggester_eval.py` — adaptation patch site + factory `DetectedFeed`.
-
-### Mobile
-- `apps/mobile/lib/features/veille/providers/veille_config_provider.dart` — `_loadingMaxDuration` → `loadingMaxDurationFor(int from)` (8 s pour `from=1`, 25 s pour `from=2`).
-- `apps/mobile/test/features/veille/providers/veille_config_provider_test.dart` — 3 nouveaux tests sur `loadingMaxDurationFor`.
-
-### Doc
-- `docs/bugs/bug-veille-suggestions-sources-pending-rollback.md` — ajout section « Itération 4 (2026-05-05) — décalage budget temps client / serveur » avec timeline Sentry, diagnostic UX, fix A+B, hors scope confirmé.
-
-## Tests
-
-- **Backend pure-mock** (sans Postgres local — Docker disque plein) :
-  - `TestParallelDetect::test_detect_runs_concurrently_within_semaphore` : ✅ PASS (12 candidats × 0.5 s sleep, wall-clock 1.5 s, max in-flight = 4)
-  - `TestNoTxDuringLLM::test_rollback_before_llm_then_timeouts_reapplied` : ✅ PASS (invariant #572 verrouillé)
-- **Backend integration** (TestAlreadyFollowedFlag, TestIngestion, TestDedupByDomain, TestThemeGuard, TestSavepointIsolation, TestCandidateTimeout, TestLLMTimeout, TestNoTxDuringLLM::test_followed_ids_query_runs_after_llm, TestParametrizedEval) : skip local par manque de Postgres ; à valider en CI.
-- **Mobile** : `flutter test` lancé sur `veille_config_provider_test.dart` — 3 nouveaux tests sur `loadingMaxDurationFor` à valider.
-- **Lint** : `ruff check` + `ruff format --check` ✅ all green.
-
-## Risques
-
-- **Concurrence DB** : 4 SAVEPOINT séquentiels en Phase 2 — préservé exactement comme avant. Aucun nested begin parallèle. Risque nul de race SQLAlchemy.
-- **Httpx pool** : 4 requêtes parallèles via `httpx.AsyncClient` partagé (`max_connections=100` par défaut). Sites cibles non pollués (sémaphore polite, aligné sur stage 4 interne).
-- **curl-cffi sync vs async** : `curl_cffi.requests.AsyncSession` est async (`rss_parser.py:139`), donc `asyncio.wait_for(8s)` cancel correctement le coro — pas de hang non-cancellable.
-- **Timeout Dio 30 s** : avec Fix A le wall-clock typique tombe à ~19 s, donc largement sous timeout. Pire cas (LLM lent + 4 timeouts) : ~24 s. Si Mistral renvoie 30 s+, on tombe en error Dio comme avant — la transition se ferme via la branche error, comportement inchangé.
-
-## Verification post-merge
-
-1. Surveiller Sentry release post-merge :
-   - Aucun nouvel event `IdleInTransactionSessionTimeout` (PYTHON-3Z/3R) ou `PendingRollbackError` (PYTHON-3P/3S) → invariant #572 toujours verrouillé.
-   - Volume PYTHON-41 / PYTHON-3T / PYTHON-3X (échecs RSSParser sur candidats LLM exotiques) inchangé — c'est attendu, ce sont les sites qui bloquent les bots, pas un bug.
-2. Tester via TestFlight le flow Step 2 → Step 3 :
-   - Tap valider Step 2 → animation halo joue 16-25 s (au lieu de 8 s)
-   - Arrivée sur Step 3 : sources affichées immédiatement (pas de spinner secondaire)
-
-## Hors scope explicite
-
-- Cache négatif par hostname — gain marginal post-parallélisation.
-- Skip RSSParser pour candidats LLM — change la qualité du `feed_url`, story dédiée si besoin.
-- Streaming SSE — refactor architectural lourd, pas justifié.
-- Refactor `safe_async_session` event-listener `after_begin` — déjà hors scope #572.
+- [docs/stories/core/widget.4.essentiel-flux-switch.story.md](../docs/stories/core/widget.4.essentiel-flux-switch.story.md)

--- a/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt
@@ -10,34 +10,51 @@ import android.net.Uri
 import android.util.Log
 import android.view.View
 import android.widget.RemoteViews
+import androidx.core.content.ContextCompat
 import es.antonborri.home_widget.HomeWidgetPlugin
 
 /**
- * Home-screen widget rendering up to 5 digest articles in a scrollable
- * `ListView` bound to [FacteurWidgetService].
+ * Home-screen widget rendering up to 5 Essentiel articles or up to 30 Flux
+ * (feed) articles, switchable from the in-widget tab bar.
  *
- * Only header text + adapter wiring live here; row construction happens in
- * the service so the list survives system kills and is re-fed via
- * [AppWidgetManager.notifyAppWidgetViewDataChanged].
+ * Data flow: Flutter writes `articles_json` (Essentiel) and `feed_articles_json`
+ * (Flux) via the `home_widget` package. The active mode is persisted natively
+ * in `widget_mode` SharedPreferences (`essentiel` | `flux`, default `essentiel`)
+ * and toggled via PendingIntent broadcasts on the two header tabs.
  */
 class FacteurWidget : AppWidgetProvider() {
 
     companion object {
         private const val TAG = "FacteurWidget"
-        const val ACTION_REFRESH = "com.example.facteur.action.REFRESH_WIDGET"
+        const val ACTION_SET_MODE_ESSENTIEL = "com.example.facteur.action.SET_MODE_ESSENTIEL"
+        const val ACTION_SET_MODE_FLUX = "com.example.facteur.action.SET_MODE_FLUX"
+
+        const val MODE_ESSENTIEL = "essentiel"
+        const val MODE_FLUX = "flux"
+        const val PREF_KEY_MODE = "widget_mode"
+        const val EXTRA_MODE = "widget_mode"
     }
 
     override fun onReceive(context: Context, intent: Intent) {
         super.onReceive(context, intent)
-        if (intent.action == ACTION_REFRESH) {
-            val mgr = AppWidgetManager.getInstance(context)
-            val ids = mgr.getAppWidgetIds(
-                ComponentName(context, FacteurWidget::class.java),
-            )
-            if (ids.isNotEmpty()) {
-                Log.d(TAG, "ACTION_REFRESH ids=${ids.size}")
-                onUpdate(context, mgr, ids)
-            }
+        val newMode = when (intent.action) {
+            ACTION_SET_MODE_ESSENTIEL -> MODE_ESSENTIEL
+            ACTION_SET_MODE_FLUX -> MODE_FLUX
+            else -> null
+        } ?: return
+
+        // Persist mode then re-render every instance of the widget so the tabs
+        // and list reflect the new selection immediately.
+        val prefs = HomeWidgetPlugin.getData(context)
+        prefs?.edit()?.putString(PREF_KEY_MODE, newMode)?.apply()
+
+        val mgr = AppWidgetManager.getInstance(context)
+        val ids = mgr.getAppWidgetIds(
+            ComponentName(context, FacteurWidget::class.java),
+        )
+        if (ids.isNotEmpty()) {
+            Log.d(TAG, "mode=$newMode ids=${ids.size}")
+            onUpdate(context, mgr, ids)
         }
     }
 
@@ -50,12 +67,13 @@ class FacteurWidget : AppWidgetProvider() {
             try {
                 val views = RemoteViews(context.packageName, R.layout.facteur_widget)
                 val prefs = HomeWidgetPlugin.getData(context)
-                val json = prefs?.getString("articles_json", null)
-                Log.d(TAG, "onUpdate id=$appWidgetId json.len=${json?.length ?: -1}")
+                val mode = prefs?.getString(PREF_KEY_MODE, MODE_ESSENTIEL) ?: MODE_ESSENTIEL
+                val jsonKey = if (mode == MODE_FLUX) "feed_articles_json" else "articles_json"
+                val json = prefs?.getString(jsonKey, null)
+                Log.d(TAG, "onUpdate id=$appWidgetId mode=$mode json.len=${json?.length ?: -1}")
 
-                renderHeader(views, prefs)
-                bindArticleList(context, views, appWidgetId, json)
-                wireClickIntents(context, views, appWidgetId)
+                renderTabs(context, views, appWidgetId, mode)
+                bindArticleList(context, views, appWidgetId, mode, json)
 
                 appWidgetManager.updateAppWidget(appWidgetId, views)
                 appWidgetManager.notifyAppWidgetViewDataChanged(
@@ -68,31 +86,70 @@ class FacteurWidget : AppWidgetProvider() {
         }
     }
 
-    private fun renderHeader(views: RemoteViews, prefs: android.content.SharedPreferences?) {
-        val streak = prefs?.getString("streak", "0")?.toIntOrNull() ?: 0
-        views.setTextViewText(
-            R.id.streak_text,
-            if (streak > 0) "🔥 ${streak}j" else "",
-        )
+    private fun renderTabs(
+        context: Context,
+        views: RemoteViews,
+        appWidgetId: Int,
+        mode: String,
+    ) {
+        val isEssentiel = mode != MODE_FLUX
+        styleTab(context, views, R.id.tab_essentiel, isEssentiel)
+        styleTab(context, views, R.id.tab_flux, !isEssentiel)
 
-        val subtitle = when (prefs?.getString("digest_status", "none")) {
-            "completed" -> "Essentiel du jour complété ✓"
-            "in_progress" -> "Continue ton essentiel"
-            else -> "L'Essentiel du jour"
+        // Each tab toggles the mode via a broadcast; onReceive persists the
+        // choice and re-renders. Distinct request codes keep the two
+        // PendingIntents from being collapsed into one.
+        val essentielIntent = Intent(context, FacteurWidget::class.java).apply {
+            action = ACTION_SET_MODE_ESSENTIEL
         }
-        views.setTextViewText(R.id.subtitle, subtitle)
+        val essentielPending = PendingIntent.getBroadcast(
+            context,
+            appWidgetId * 10,
+            essentielIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        views.setOnClickPendingIntent(R.id.tab_essentiel, essentielPending)
+
+        val fluxIntent = Intent(context, FacteurWidget::class.java).apply {
+            action = ACTION_SET_MODE_FLUX
+        }
+        val fluxPending = PendingIntent.getBroadcast(
+            context,
+            appWidgetId * 10 + 1,
+            fluxIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        views.setOnClickPendingIntent(R.id.tab_flux, fluxPending)
+    }
+
+    private fun styleTab(
+        context: Context,
+        views: RemoteViews,
+        tabId: Int,
+        active: Boolean,
+    ) {
+        val bg = if (active) R.drawable.widget_tab_active else R.drawable.widget_tab_inactive
+        views.setInt(tabId, "setBackgroundResource", bg)
+
+        val color = ContextCompat.getColor(
+            context,
+            if (active) R.color.facteur_text_primary else R.color.facteur_text_secondary,
+        )
+        views.setTextColor(tabId, color)
     }
 
     private fun bindArticleList(
         context: Context,
         views: RemoteViews,
         appWidgetId: Int,
+        mode: String,
         json: String?,
     ) {
-        // Adapter intent — unique URI per appWidgetId so the system keeps
-        // a separate factory instance per widget on the home screen.
+        // Adapter intent — unique URI per (appWidgetId, mode) so the system
+        // keeps a separate factory instance and reloads when the mode flips.
         val adapterIntent = Intent(context, FacteurWidgetService::class.java).apply {
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            putExtra(EXTRA_MODE, mode)
             data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
         }
         views.setRemoteAdapter(R.id.articles_list, adapterIntent)
@@ -102,6 +159,17 @@ class FacteurWidget : AppWidgetProvider() {
         views.setViewVisibility(
             R.id.empty_view,
             if (isEmpty) View.VISIBLE else View.GONE,
+        )
+        val emptyCopy = if (mode == MODE_FLUX) {
+            "Ouvre Facteur pour charger ton flux"
+        } else {
+            "Ouvre Facteur pour charger ton essentiel"
+        }
+        views.setTextViewText(R.id.empty_view, emptyCopy)
+        // Tapping the empty view opens the right tab in the app.
+        views.setOnClickPendingIntent(
+            R.id.empty_view,
+            buildOpenAppPendingIntent(context, appWidgetId, mode),
         )
 
         // Per-row tap delivers a fillInIntent merged with this template.
@@ -120,31 +188,27 @@ class FacteurWidget : AppWidgetProvider() {
         views.setPendingIntentTemplate(R.id.articles_list, templatePending)
     }
 
-    private fun wireClickIntents(context: Context, views: RemoteViews, appWidgetId: Int) {
+    private fun buildOpenAppPendingIntent(
+        context: Context,
+        appWidgetId: Int,
+        mode: String,
+    ): PendingIntent {
         val openIntent = Intent(context, MainActivity::class.java).apply {
             action = Intent.ACTION_VIEW
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            data = Uri.parse("io.supabase.facteur://digest")
+            data = Uri.parse(
+                if (mode == MODE_FLUX) {
+                    "io.supabase.facteur://feed"
+                } else {
+                    "io.supabase.facteur://digest"
+                },
+            )
         }
-        val openPending = PendingIntent.getActivity(
+        return PendingIntent.getActivity(
             context,
-            appWidgetId,
+            appWidgetId * 10 + 2,
             openIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
-        views.setOnClickPendingIntent(R.id.app_name, openPending)
-        views.setOnClickPendingIntent(R.id.subtitle, openPending)
-        views.setOnClickPendingIntent(R.id.btn_open, openPending)
-
-        val refreshIntent = Intent(context, FacteurWidget::class.java).apply {
-            action = ACTION_REFRESH
-        }
-        val refreshPending = PendingIntent.getBroadcast(
-            context,
-            appWidgetId,
-            refreshIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-        )
-        views.setOnClickPendingIntent(R.id.btn_refresh, refreshPending)
     }
 }

--- a/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidgetService.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidgetService.kt
@@ -12,19 +12,21 @@ import es.antonborri.home_widget.HomeWidgetPlugin
 /**
  * RemoteViewsService backing the home-screen widget's scrollable article list.
  *
- * Reads the same `articles_json` SharedPreferences key that
- * [FacteurWidget] uses, so refresh paths stay consistent: any caller that
- * already invokes `appWidgetManager.notifyAppWidgetViewDataChanged(id, R.id.articles_list)`
- * triggers a re-read here.
+ * Reads either `articles_json` (Essentiel) or `feed_articles_json` (Flux) from
+ * the SharedPreferences shared with Flutter via `home_widget`, depending on
+ * the `widget_mode` extra passed by [FacteurWidget] in the adapter intent.
  */
 class FacteurWidgetService : RemoteViewsService() {
     override fun onGetViewFactory(intent: Intent): RemoteViewsFactory {
-        return FacteurRemoteViewsFactory(applicationContext)
+        val mode = intent.getStringExtra(FacteurWidget.EXTRA_MODE)
+            ?: FacteurWidget.MODE_ESSENTIEL
+        return FacteurRemoteViewsFactory(applicationContext, mode)
     }
 }
 
 private class FacteurRemoteViewsFactory(
     private val context: Context,
+    private val mode: String,
 ) : RemoteViewsService.RemoteViewsFactory {
 
     private companion object {
@@ -39,9 +41,14 @@ private class FacteurRemoteViewsFactory(
 
     override fun onDataSetChanged() {
         val prefs = HomeWidgetPlugin.getData(context)
-        val json = prefs?.getString("articles_json", null)
-        articles = WidgetRendering.parseArticles(json)
-        Log.d(TAG, "onDataSetChanged count=${articles.size}")
+        val (jsonKey, maxRows) = if (mode == FacteurWidget.MODE_FLUX) {
+            "feed_articles_json" to WidgetRendering.MAX_ROWS_FLUX
+        } else {
+            "articles_json" to WidgetRendering.MAX_ROWS_ESSENTIEL
+        }
+        val json = prefs?.getString(jsonKey, null)
+        articles = WidgetRendering.parseArticles(json, maxRows)
+        Log.d(TAG, "onDataSetChanged mode=$mode count=${articles.size}")
     }
 
     override fun onDestroy() {
@@ -54,10 +61,8 @@ private class FacteurRemoteViewsFactory(
         val article = articles.getOrNull(position) ?: return loadingRow()
         val rv = RemoteViews(context.packageName, R.layout.widget_article_row)
 
-        rv.setTextViewText(
-            R.id.row_topic,
-            "${article.rank} — ${article.topicLabel.ifBlank { "Actu" }}",
-        )
+        val topicSegment = article.topicLabel.ifBlank { "Actu" }
+        rv.setTextViewText(R.id.row_topic, "${article.rank} — $topicSegment")
         rv.setViewVisibility(
             R.id.row_a_la_une,
             if (article.isMain) View.VISIBLE else View.GONE,
@@ -94,9 +99,15 @@ private class FacteurRemoteViewsFactory(
 
         // Per-row tap → fillInIntent merged into the template PendingIntent
         // declared by FacteurWidget.onUpdate (setPendingIntentTemplate).
+        // Deep link host depends on the mode: Essentiel routes through the
+        // digest article reader; Flux through the feed reader.
+        val baseUri = if (mode == FacteurWidget.MODE_FLUX) {
+            Uri.parse("io.supabase.facteur://feed/content/${article.id}")
+        } else {
+            Uri.parse("io.supabase.facteur://digest/${article.id}")
+        }
         val fillIn = Intent().apply {
-            data = Uri.parse("io.supabase.facteur://digest/${article.id}")
-                .buildUpon()
+            data = baseUri.buildUpon()
                 .appendQueryParameter("pos", article.rank.toString())
                 .appendQueryParameter("topicId", article.topicId)
                 .build()

--- a/apps/mobile/android/app/src/main/kotlin/com/example/facteur/WidgetRendering.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/facteur/WidgetRendering.kt
@@ -17,14 +17,16 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 /**
- * Shared parsing + bitmap helpers used by both [FacteurWidget] (header
- * rendering, MAX_ROWS cap) and [FacteurWidgetService]'s RemoteViewsFactory
- * (row rendering inside the ListView).
+ * Shared parsing + bitmap helpers used by both [FacteurWidget] (tabs +
+ * empty state) and [FacteurWidgetService]'s RemoteViewsFactory (row
+ * rendering inside the ListView). Row caps differ by mode: Essentiel is
+ * capped at 5 (one per topic), Flux at 30 (Binder IPC ceiling).
  */
 internal object WidgetRendering {
 
     private const val TAG = "FacteurWidget"
-    const val MAX_ROWS = 5
+    const val MAX_ROWS_ESSENTIEL = 5
+    const val MAX_ROWS_FLUX = 30
 
     data class Article(
         val id: String,
@@ -40,11 +42,11 @@ internal object WidgetRendering {
         val publishedAtIso: String,
     )
 
-    fun parseArticles(json: String?): List<Article> {
+    fun parseArticles(json: String?, maxRows: Int = MAX_ROWS_ESSENTIEL): List<Article> {
         if (json.isNullOrBlank() || json == "[]") return emptyList()
         return try {
             val arr = JSONArray(json)
-            (0 until arr.length()).take(MAX_ROWS).mapNotNull { i ->
+            (0 until arr.length()).take(maxRows).mapNotNull { i ->
                 arr.optJSONObject(i)?.let(::parseArticle)
             }
         } catch (e: Exception) {

--- a/apps/mobile/android/app/src/main/res/drawable/widget_tab_active.xml
+++ b/apps/mobile/android/app/src/main/res/drawable/widget_tab_active.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/facteur_card" />
+    <stroke android:width="1dp" android:color="@color/facteur_border" />
+    <corners android:radius="999dp" />
+</shape>

--- a/apps/mobile/android/app/src/main/res/drawable/widget_tab_inactive.xml
+++ b/apps/mobile/android/app/src/main/res/drawable/widget_tab_inactive.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/transparent" />
+    <corners android:radius="999dp" />
+</shape>

--- a/apps/mobile/android/app/src/main/res/layout/facteur_widget.xml
+++ b/apps/mobile/android/app/src/main/res/layout/facteur_widget.xml
@@ -7,58 +7,46 @@
     android:background="@drawable/widget_root_bg"
     android:padding="16dp">
 
-    <!-- Header: refresh button (start) | Facteur wordmark (center) | streak (end) -->
+    <!-- Segmented control: [ Essentiel ] [ Flux ]
+         Each tab is a TextView wired to a broadcast PendingIntent that
+         persists `widget_mode` and re-renders the widget. -->
     <LinearLayout
-        android:id="@+id/widget_header"
+        android:id="@+id/widget_tabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="4dp"
+        android:layout_marginBottom="10dp"
         android:orientation="horizontal"
         android:gravity="center_vertical">
 
-        <ImageView
-            android:id="@+id/btn_refresh"
-            android:layout_width="28dp"
-            android:layout_height="28dp"
-            android:padding="2dp"
-            android:src="@drawable/ic_widget_refresh"
-            android:contentDescription="Recharger l'essentiel" />
+        <TextView
+            android:id="@+id/tab_essentiel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="6dp"
+            android:gravity="center"
+            android:text="Essentiel"
+            android:textSize="14sp"
+            android:fontFamily="sans-serif-medium"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp" />
 
         <TextView
-            android:id="@+id/app_name"
+            android:id="@+id/tab_flux"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:gravity="center"
-            android:text="Facteur"
-            android:textSize="22sp"
-            android:fontFamily="serif"
-            android:textStyle="bold"
-            android:letterSpacing="-0.02"
-            android:textColor="@color/facteur_text_primary" />
-
-        <TextView
-            android:id="@+id/streak_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:minWidth="28dp"
-            android:gravity="end"
-            android:text=""
+            android:text="Flux"
             android:textSize="14sp"
-            android:textColor="@color/facteur_accent" />
+            android:fontFamily="sans-serif-medium"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp" />
     </LinearLayout>
-
-    <!-- Subtitle -->
-    <TextView
-        android:id="@+id/subtitle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="12dp"
-        android:gravity="center"
-        android:text="L'Essentiel du jour"
-        android:textSize="13sp"
-        android:fontFamily="sans-serif"
-        android:textColor="@color/facteur_text_secondary" />
 
     <!-- Scrollable article list — bound to FacteurWidgetService via setRemoteAdapter. -->
     <ListView
@@ -81,21 +69,4 @@
         android:textColor="@color/facteur_text_secondary"
         android:visibility="gone"
         android:text="Ouvre Facteur pour charger ton essentiel" />
-
-    <!-- Footer: single CTA opening the digest -->
-    <TextView
-        android:id="@+id/btn_open"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:text="Ouvrir Facteur"
-        android:textSize="14sp"
-        android:textStyle="bold"
-        android:textColor="#FDFBF7"
-        android:background="@drawable/widget_btn_primary"
-        android:paddingTop="10dp"
-        android:paddingBottom="10dp"
-        android:paddingStart="12dp"
-        android:paddingEnd="12dp"
-        android:gravity="center" />
 </LinearLayout>

--- a/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
+++ b/apps/mobile/android/app/src/main/res/layout/widget_article_row.xml
@@ -68,7 +68,7 @@
             android:fontFamily="sans-serif-medium"
             android:textColor="@color/facteur_text_primary"
             android:lineSpacingExtra="4dp"
-            android:maxLines="2"
+            android:maxLines="4"
             android:ellipsize="end"
             android:layout_marginEnd="14dp" />
 

--- a/apps/mobile/lib/core/services/widget_service.dart
+++ b/apps/mobile/lib/core/services/widget_service.dart
@@ -6,31 +6,36 @@ import 'package:home_widget/home_widget.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:dio/dio.dart';
 
+import '../../config/topic_labels.dart';
 import '../../features/digest/models/digest_models.dart';
+import '../../features/feed/models/content_model.dart';
 import '../../features/gamification/models/streak_model.dart';
 
 /// Service to push digest data to the Android home screen widget.
 ///
 /// Data flows: Flutter → SharedPreferences (via home_widget) → FacteurWidget.kt
 ///
-/// Schema (since refonte v2):
-/// - `articles_json` : JSON array of up to 5 articles (see [_serializeArticle])
+/// Schema:
+/// - `articles_json` : Essentiel — JSON array of up to 5 articles
+/// - `feed_articles_json` : Flux — JSON array of up to 30 feed items
 /// - `articles_updated_at` : epoch millis of last successful refresh
 /// - `digest_status` : 'none' | 'available' | 'in_progress' | 'completed'
 /// - `digest_progress` : 'X/Y'
 /// - `streak` : current streak as string
+/// - `widget_mode` : 'essentiel' | 'flux' (written natively at tab tap)
 class WidgetService {
   static const _androidName = 'FacteurWidget';
   static const _maxArticles = 5;
+  static const _maxFeedArticles = 30;
+  // Cap thumbnails to keep RemoteViews IPC under Binder's ~1 MB ceiling.
+  static const _maxFeedThumbnails = 10;
   static final _dio = Dio();
 
-  /// Update the home screen widget with the latest digest and/or streak data.
-  ///
-  /// Each parameter is independent: passing only `streak` will refresh the
-  /// streak counter without touching `articles_json`. This avoids wiping
-  /// previously saved articles when streak refresh fires after digest fetch.
+  /// Update the home screen widget with the latest digest, feed and/or streak.
+  /// Each parameter is independent — passing only one preserves the others.
   static Future<void> updateWidget({
     DigestResponse? digest,
+    List<Content>? feedItems,
     StreakModel? streak,
   }) async {
     try {
@@ -51,6 +56,14 @@ class WidgetService {
         await HomeWidget.saveWidgetData(
           'digest_progress',
           _computeProgress(digest),
+        );
+      }
+
+      if (feedItems != null) {
+        final items = await _buildFeedArticleList(feedItems);
+        await HomeWidget.saveWidgetData(
+          'feed_articles_json',
+          jsonEncode(items),
         );
       }
 
@@ -85,10 +98,12 @@ class WidgetService {
   static Future<void> clear() async {
     try {
       await HomeWidget.saveWidgetData('articles_json', '[]');
+      await HomeWidget.saveWidgetData('feed_articles_json', '[]');
       await HomeWidget.saveWidgetData('articles_updated_at', '0');
       await HomeWidget.saveWidgetData('digest_status', 'none');
       await HomeWidget.saveWidgetData('digest_progress', '0/0');
       await HomeWidget.saveWidgetData('streak', '0');
+      await HomeWidget.saveWidgetData('widget_mode', 'essentiel');
       await HomeWidget.updateWidget(androidName: _androidName);
     } catch (e) {
       debugPrint('WidgetService: clear failed: $e');
@@ -171,6 +186,66 @@ class WidgetService {
       'thumbnail_path': thumbPath ?? '',
       'perspective_count': topic.perspectiveCount,
       'published_at_iso': article.publishedAt?.toUtc().toIso8601String() ?? '',
+    };
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // Feed (Flux) serialization
+  // ──────────────────────────────────────────────────────────────
+
+  /// Build the Flux article list (max 30) from the current feed state.
+  /// Thumbnails only downloaded for the first [_maxFeedThumbnails] entries
+  /// to keep the RemoteViews IPC payload under Binder's ~1 MB ceiling.
+  static Future<List<Map<String, dynamic>>> _buildFeedArticleList(
+    List<Content> items,
+  ) async {
+    if (items.isEmpty) return const [];
+    final capped = items.take(_maxFeedArticles).toList(growable: false);
+    return Future.wait([
+      for (var i = 0; i < capped.length; i++)
+        _serializeFeedItem(
+          item: capped[i],
+          rank: i + 1,
+          downloadThumbnail: i < _maxFeedThumbnails,
+        ),
+    ]);
+  }
+
+  static Future<Map<String, dynamic>> _serializeFeedItem({
+    required Content item,
+    required int rank,
+    required bool downloadThumbnail,
+  }) async {
+    final downloads = await Future.wait([
+      downloadThumbnail
+          ? _downloadIfPresent(
+              item.thumbnailUrl,
+              'widget_feed_thumbnail_$rank.jpg',
+            )
+          : Future<String?>.value(null),
+      _downloadIfPresent(
+        item.source.logoUrl,
+        'widget_feed_logo_$rank.png',
+      ),
+    ]);
+    final thumbPath = downloads[0];
+    final logoPath = downloads[1];
+
+    final topicSlug = item.topics.isNotEmpty ? item.topics.first : '';
+    final topicLabel = topicSlugToLabel[topicSlug] ?? '';
+
+    return {
+      'id': item.id,
+      'rank': rank,
+      'topic_id': topicSlug,
+      'topic_label': topicLabel,
+      'is_main': false,
+      'title': item.title,
+      'source_name': item.source.name,
+      'source_logo_path': logoPath ?? '',
+      'thumbnail_path': thumbPath ?? '',
+      'perspective_count': 0,
+      'published_at_iso': item.publishedAt.toUtc().toIso8601String(),
     };
   }
 

--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
+import '../../../core/services/widget_service.dart';
 import '../models/content_model.dart';
 import '../repositories/feed_repository.dart';
 import '../repositories/personalization_repository.dart';
@@ -96,6 +97,10 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
   final Set<String> _consumedContentIds =
       {}; // Track content being animated out
 
+  Timer? _widgetPushDebounce;
+  String? _lastWidgetPushSignature;
+  static const Duration _widgetPushDelay = Duration(seconds: 1);
+
   bool get isLoadingMore => _isLoadingMore;
   bool get hasNext => _hasNext;
   String? get selectedFilter => _selectedFilter;
@@ -107,6 +112,13 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
 
   @override
   FutureOr<FeedState> build() async {
+    listenSelf((previous, next) {
+      next.whenData((data) => _scheduleWidgetPush(data.items));
+    });
+    ref.onDispose(() {
+      _widgetPushDebounce?.cancel();
+    });
+
     // Watch auth state to handle logout/user change
     final authState = ref.watch(authStateProvider);
 
@@ -227,6 +239,31 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         // Silent: user still sees the cached feed.
         print('FeedNotifier: silent revalidation failed: $e');
       }
+    });
+  }
+
+  /// Push the current default feed to the home-screen widget. No-op when a
+  /// filter/theme/source/etc. is active — only the canonical, unfiltered Flux
+  /// is mirrored to the widget. Debounced + signature-guarded so optimistic
+  /// taps and loadMore bursts don't churn SharedPreferences.
+  void _scheduleWidgetPush(List<Content> items) {
+    if (_selectedFilter != null ||
+        _selectedTheme != null ||
+        _selectedTopic != null ||
+        _selectedSourceId != null ||
+        _selectedEntity != null ||
+        _selectedKeyword != null) {
+      return;
+    }
+    final slice = items.take(30).toList(growable: false);
+    final signature = slice.isEmpty
+        ? '0'
+        : '${slice.length}|${slice.first.id}|${slice.last.id}';
+    if (signature == _lastWidgetPushSignature) return;
+    _widgetPushDebounce?.cancel();
+    _widgetPushDebounce = Timer(_widgetPushDelay, () {
+      _lastWidgetPushSignature = signature;
+      WidgetService.updateWidget(feedItems: slice);
     });
   }
 

--- a/apps/mobile/test/core/services/widget_service_test.dart
+++ b/apps/mobile/test/core/services/widget_service_test.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 
+import 'package:facteur/config/topic_labels.dart';
 import 'package:facteur/features/digest/models/digest_models.dart';
 import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// These tests exercise the pure article-list builder side of WidgetService.
@@ -70,6 +72,51 @@ void main() {
       expect((decoded.first as Map).containsKey('is_main'), isTrue);
       expect((decoded.first as Map).containsKey('topic_label'), isTrue);
       expect((decoded.first as Map).containsKey('perspective_count'), isTrue);
+    });
+  });
+
+  group('Feed → widget article shape', () {
+    test('preserves order, ranks from 1, is_main always false', () {
+      final items = [
+        _content('c1', 'Première'),
+        _content('c2', 'Deuxième'),
+        _content('c3', 'Troisième'),
+      ];
+      final picked = _pickFeedList(items);
+      expect(picked.map((e) => e['id']), ['c1', 'c2', 'c3']);
+      expect(picked.map((e) => e['rank']), [1, 2, 3]);
+      expect(picked.every((e) => e['is_main'] == false), isTrue);
+    });
+
+    test('caps at 30 items even with longer feed', () {
+      final items = List.generate(50, (i) => _content('c$i', 'T$i'));
+      final picked = _pickFeedList(items);
+      expect(picked.length, 30);
+      expect(picked.last['id'], 'c29');
+    });
+
+    test('maps known topic slug to French label, falls back to empty', () {
+      final picked = _pickFeedList([
+        _content('c1', 'Tech', topics: ['ai']),
+        _content('c2', 'Inconnu', topics: ['totally-unknown-slug']),
+        _content('c3', 'Sans topic', topics: []),
+      ]);
+      expect(picked[0]['topic_label'], topicSlugToLabel['ai']);
+      expect(picked[1]['topic_label'], '');
+      expect(picked[2]['topic_label'], '');
+    });
+
+    test('source name + published_at_iso round-trip via JSON', () {
+      final items = [
+        _content('c1', 'Titre', sourceName: 'Le Monde'),
+      ];
+      final picked = _pickFeedList(items);
+      final encoded = jsonEncode(picked);
+      final decoded = jsonDecode(encoded) as List<dynamic>;
+      final first = decoded.first as Map<String, dynamic>;
+      expect(first['source_name'], 'Le Monde');
+      expect((first['published_at_iso'] as String).endsWith('Z'), isTrue);
+      expect(first['perspective_count'], 0);
     });
   });
 }
@@ -152,5 +199,57 @@ DigestItem _article(
     isFollowedSource: isFollowedSource,
     source: const SourceMini(id: 's1', name: 'Le Monde'),
     publishedAt: DateTime.utc(2026, 4, 26, 7, 30),
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// Feed reference picker — mirrors WidgetService._buildFeedArticleList
+// without the SharedPreferences/dio image fetch dependencies.
+// ──────────────────────────────────────────────────────────────
+
+const _maxFeedArticles = 30;
+
+List<Map<String, dynamic>> _pickFeedList(List<Content> items) {
+  final capped = items.take(_maxFeedArticles).toList();
+  final result = <Map<String, dynamic>>[];
+  for (var i = 0; i < capped.length; i++) {
+    final item = capped[i];
+    final topicSlug = item.topics.isNotEmpty ? item.topics.first : '';
+    final topicLabel = topicSlugToLabel[topicSlug] ?? '';
+    result.add({
+      'id': item.id,
+      'rank': i + 1,
+      'topic_id': topicSlug,
+      'topic_label': topicLabel,
+      'is_main': false,
+      'title': item.title,
+      'source_name': item.source.name,
+      'source_logo_path': '',
+      'thumbnail_path': '',
+      'perspective_count': 0,
+      'published_at_iso': item.publishedAt.toUtc().toIso8601String(),
+    });
+  }
+  return result;
+}
+
+Content _content(
+  String id,
+  String title, {
+  String sourceName = 'Le Monde',
+  List<String> topics = const [],
+}) {
+  return Content(
+    id: id,
+    title: title,
+    url: 'https://example.com/$id',
+    contentType: ContentType.article,
+    publishedAt: DateTime.utc(2026, 5, 6, 9, 0),
+    source: Source(
+      id: 's1',
+      name: sourceName,
+      type: SourceType.article,
+    ),
+    topics: topics,
   );
 }

--- a/docs/stories/core/widget.4.essentiel-flux-switch.story.md
+++ b/docs/stories/core/widget.4.essentiel-flux-switch.story.md
@@ -1,0 +1,95 @@
+# Story: Widget Android — Switch Essentiel/Flux + simplification du header
+
+## Contexte
+
+Le widget Android actuel (post `widget.3.refonte-ui-scroll-refresh`) n'expose que l'Essentiel du jour : 5 articles plafonnés, header chargé (refresh button + wordmark "Facteur" + streak + sous-titre), CTA "Ouvrir Facteur" en footer, titres tronqués à 2 lignes.
+
+Demande utilisateur (2026-05-06) :
+
+1. Intégrer le **Flux** (feed) en complément de l'Essentiel — switch Essentiel ↔ Flux dans le header.
+2. **Simplifier** : retirer wordmark, streak, refresh, sous-titre, et le bouton "Ouvrir Facteur".
+3. **Élargir les cartes** : titres tronqués seulement au-delà de 4 lignes (vs 2 aujourd'hui), thumbnail 86dp à droite inchangée. Style ≈ Google News + feed in-app.
+
+Pas d'iOS (aucune extension widget iOS aujourd'hui).
+
+## Décisions UX validées (utilisateur)
+
+- Vignette : conservée à 86dp à droite ; on autorise simplement le titre à monter à 4 lignes.
+- Streak : **supprimé** du widget (la valeur reste dispo in-app).
+- Source data Flux : **cache feedProvider** poussé depuis Flutter — pas de fetch réseau côté natif. Si le cache est vide au cold-start, empty state explicite ; le widget se peuple en < 1 s dès que l'app charge le feed.
+- Cap Flux : ~30 items (compromis Binder ~1 MB).
+- Persistance du mode : clé locale `widget_mode` côté natif (par device).
+
+## Tâches
+
+### Track 1 — Plomberie data Flutter
+
+- [ ] `apps/mobile/lib/core/services/widget_service.dart`
+  - [ ] Étendre `updateWidget(...)` avec `List<Content>? feedItems`.
+  - [ ] Nouveau `_buildFeedArticleList(List<Content>)` (max 30, thumbnails top 10 only) écrivant `feed_articles_json`.
+  - [ ] Mapping : `contentId→id`, `topicId/topicLabel`, `source.name/logo`, `is_main=false`, `perspectiveCount`, `publishedAt`.
+- [ ] `apps/mobile/lib/features/feed/providers/feed_provider.dart`
+  - [ ] Helper `_pushFeedToWidget(items)` debounced 1 s ; appelé après chaque transition `state = AsyncData(...)` (initial, refresh, loadMore).
+- [ ] `apps/mobile/test/core/services/widget_service_test.dart`
+  - [ ] Cas : `updateWidget(feedItems:)` écrit `feed_articles_json` (taille, ordre, mapping).
+
+### Track 2 — UI Android (XML + drawables)
+
+- [ ] `apps/mobile/android/app/src/main/res/layout/facteur_widget.xml`
+  - [ ] Remplacer header + sous-titre par `LinearLayout` horizontal de 2 onglets (`tab_essentiel`, `tab_flux`).
+  - [ ] Supprimer `btn_open` (footer).
+- [ ] Drawables : `widget_tab_active.xml`, `widget_tab_inactive.xml` (shape simple radius 6dp).
+- [ ] `apps/mobile/android/app/src/main/res/layout/widget_article_row.xml`
+  - [ ] `row_title` `maxLines` 2 → 4.
+
+### Track 3 — Logic Android (Kotlin)
+
+- [ ] `FacteurWidget.kt`
+  - [ ] Constantes `ACTION_SET_MODE_ESSENTIEL`, `ACTION_SET_MODE_FLUX`.
+  - [ ] `onReceive` persiste `widget_mode` dans HomeWidgetPlugin SharedPreferences puis re-render.
+  - [ ] `renderTabs(views, mode)` peint actif/inactif et câble PendingIntents broadcast.
+  - [ ] `bindArticleList` : lit le mode, passe en extra adapter, choisit la `templatePending` deeplink (`digest` vs `feed/content`) et l'empty-state copy.
+  - [ ] Supprimer `wireClickIntents` (plus de `btn_open`/`btn_refresh`).
+  - [ ] Conserver `ACTION_REFRESH` ? Non — onglet actif re-tappé peut juste re-render. Suppression complète du refresh.
+- [ ] `FacteurWidgetService.kt`
+  - [ ] `onGetViewFactory` lit l'extra `widget_mode`.
+  - [ ] `onDataSetChanged` → bonne clé JSON.
+  - [ ] `getViewAt` : `fillInIntent` `digest/<id>` ou `feed/content/<id>`.
+- [ ] `WidgetRendering.kt`
+  - [ ] `parseArticles(json, maxRows)` paramétrable (5 essentiel / 30 flux).
+
+### Track 4 — VERIFY
+
+- [ ] `flutter test test/core/services/widget_service_test.dart`
+- [ ] `flutter analyze`
+- [ ] `flutter test`
+- [ ] E2E manuel (émulateur) : header simplifié, switch fonctionne, deeplinks par mode, titre 4 lignes, cold-start Flux empty state puis populé.
+
+## Critères d'acceptation
+
+- [ ] Header n'affiche que le segmented control [Essentiel | Flux].
+- [ ] Tap onglet bascule la liste sans relancer l'app, mode persisté.
+- [ ] Mode Essentiel : 5 articles digest, deeplink `digest/<id>` (inchangé).
+- [ ] Mode Flux : ≤ 30 articles feed scrollables, deeplink `feed/content/<id>`.
+- [ ] Titres jusqu'à 4 lignes ; troncature `ellipsize=end` au-delà.
+- [ ] PR `--base main`, CI verte, `flutter analyze` clean.
+
+## Hors-scope
+
+- Pas d'iOS.
+- Pas de fetch réseau natif Android.
+- Pas de pull-to-refresh / loading spinner dans le widget (incompatible RemoteViews).
+- Pas de modification du flux Essentiel.
+
+## Fichiers modifiés
+
+- `apps/mobile/lib/core/services/widget_service.dart`
+- `apps/mobile/lib/features/feed/providers/feed_provider.dart`
+- `apps/mobile/test/core/services/widget_service_test.dart`
+- `apps/mobile/android/app/src/main/res/layout/facteur_widget.xml`
+- `apps/mobile/android/app/src/main/res/layout/widget_article_row.xml`
+- `apps/mobile/android/app/src/main/res/drawable/widget_tab_active.xml` (nouveau)
+- `apps/mobile/android/app/src/main/res/drawable/widget_tab_inactive.xml` (nouveau)
+- `apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt`
+- `apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidgetService.kt`
+- `apps/mobile/android/app/src/main/kotlin/com/example/facteur/WidgetRendering.kt`


### PR DESCRIPTION
## Summary

Refonte du widget Android pour intégrer le Flux (feed) en complément de l'Essentiel du jour, avec switch dans le header. Simplification visuelle et titres jusqu'à 4 lignes pour se rapprocher du style Google News / feed in-app.

- **Switch Essentiel ↔ Flux** dans le header (segmented control). Mode persisté localement (`widget_mode` SharedPreferences) via PendingIntent broadcast — le tap d'onglet écrit la clé puis `notifyAppWidgetViewDataChanged`.
- **Header simplifié** : suppression wordmark « Facteur », streak 🔥, refresh button, sous-titre.
- **Footer simplifié** : suppression du bouton « Ouvrir Facteur ».
- **Cartes article** : `maxLines` 2 → 4, thumbnail 86dp inchangée à droite.
- **Flux scrollable** alimenté par le cache de `feedProvider` (jusqu'à 30 items, plafond Binder ~1 MB), poussé en debounced 1 s à chaque mise à jour de l'état du feed (default view, sans filtre). **Signature-guard** (length + first/last id) pour court-circuiter les pushs no-op (toggle optimiste, loadMore mid-flight). **Thumbnails parallélisées** via `Future.wait` ; 10 premiers items seulement, pour rester sous la limite IPC.
- **Tap article** : deeplink dépendant du mode — `digest/<id>` en Essentiel (inchangé), `feed/content/<id>` en Flux (route déjà gérée par `DeepLinkService` + redirect `routes.dart`).
- **Empty state Flux** : « Ouvre Facteur pour charger ton flux » (cold-start friendly, le widget se peuple en < 1 s dès que `feedProvider` charge).
- **`clear()`** réinitialise aussi `widget_mode` pour ne pas léguer l'état du compte précédent au logout.

Pas d'iOS (aucune extension widget iOS aujourd'hui). Pas de fetch réseau natif.

## Test plan

- [x] `flutter test test/core/services/widget_service_test.dart` — 9/9 ✅ (Digest + nouveau Feed serialization)
- [x] `flutter test test/core/services/deep_link_service_test.dart` — 10/10 ✅ (route `feed/content/<id>` validée)
- [x] Suite mobile complète : 566 pass / 38 fail — **0 régression vs baseline** (38 mêmes échecs pré-existants vérifiés via `git stash`).
- [x] `flutter analyze` sur les fichiers modifiés — 0 issues imputables (les `avoid_print` listés sont du code pré-existant).
- [ ] **Test manuel Android** (à effectuer par le reviewer ou en QA) :
  - Header simplifié, segmented control [Essentiel | Flux] uniquement
  - Tap « Flux » → liste bascule, scrollable, deeplink `feed/content/<id>`
  - Tap « Essentiel » → retour aux 5 articles digest, deeplink `digest/<id>`
  - Mode persisté après kill app
  - Cold-start Flux → empty state puis populé après ouverture app
  - Titres longs : jusqu'à 4 lignes sans truncation, ellipsize au-delà
  - Vérifier sur Samsung OneUI si dispo

## Hors-scope

- Pas d'iOS widget extension (n'existe pas).
- Pas de fetch réseau natif (le widget reflète le cache app).
- Pas de pull-to-refresh / loading spinner dans le widget (incompatible RemoteViews).

## Story / Doc

- [docs/stories/core/widget.4.essentiel-flux-switch.story.md](docs/stories/core/widget.4.essentiel-flux-switch.story.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)