### PR TITLE
feat(feed): onglets sujets/thèmes favoris au-dessus du filtre

### DIFF
--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -62,6 +62,7 @@ import '../../well_informed/widgets/well_informed_prompt.dart';
 import '../widgets/feed_refresh_undo_banner.dart';
 import '../../custom_topics/providers/custom_topics_provider.dart';
 import '../widgets/empty_filter_state.dart';
+import '../widgets/favorite_topic_tabs.dart';
 import '../widgets/filter_collapsible_panel.dart';
 import '../widgets/follow_keyword_suggestion_card.dart';
 import '../widgets/interest_filter_sheet.dart';
@@ -513,9 +514,6 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
     final notifier = ref.read(feedProvider.notifier);
     var count = 0;
     if (notifier.selectedSourceId != null) count++;
-    if (notifier.selectedTheme != null ||
-        notifier.selectedTopic != null ||
-        notifier.selectedEntity != null) count++;
     if (notifier.selectedKeyword != null &&
         notifier.selectedKeyword!.isNotEmpty) count++;
     return count;
@@ -525,11 +523,75 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
     final notifier = ref.read(feedProvider.notifier);
     final hasSearch = notifier.selectedKeyword != null &&
         notifier.selectedKeyword!.isNotEmpty;
+    final feedItems =
+        ref.watch(feedProvider).valueOrNull?.items ?? const <Content>[];
     return FilterCollapsiblePanel(
       activeCount: _activeFilterCount(),
       chipsRow: _buildFilterChipsRow(context),
+      leadingContent: FavoriteTopicTabs(
+        items: feedItems,
+        selectedTopicSlug: notifier.selectedTopic,
+        selectedThemeSlug: notifier.selectedTheme,
+        selectedEntitySlug: notifier.selectedEntity,
+        onTabTap: (kind, slug) {
+          _withFeedLoading(() async {
+            switch (kind) {
+              case FavoriteTabKind.tous:
+                await notifier.setTopic(null);
+                await notifier.setTheme(null);
+                await notifier.setEntity(null);
+                break;
+              case FavoriteTabKind.subjectTopic:
+                await notifier.setTopic(slug);
+                break;
+              case FavoriteTabKind.subjectEntity:
+                await notifier.setEntity(slug);
+                break;
+              case FavoriteTabKind.theme:
+                await notifier.setTheme(slug);
+                break;
+            }
+          });
+          if (mounted) {
+            setState(() {
+              _selectedInterestName = null;
+              _selectedIsTheme = kind == FavoriteTabKind.theme;
+            });
+          }
+          _scrollToTop();
+        },
+        onTapActiveTab: _scrollToTop,
+        onAddFavorite: () {
+          HapticFeedback.mediumImpact();
+          InterestFilterSheet.show(
+            context,
+            currentTopicSlug: notifier.selectedTopic ??
+                notifier.selectedTheme ??
+                notifier.selectedEntity,
+            currentIsTheme: notifier.selectedTheme != null,
+            onInterestSelected:
+                (slug, name, {bool isTheme = false, bool isEntity = false}) {
+              setState(() {
+                _selectedInterestName = name;
+                _selectedIsTheme = isTheme;
+              });
+              _withFeedLoading(() async {
+                if (isTheme) {
+                  await notifier.setTheme(slug);
+                } else if (isEntity) {
+                  await notifier.setEntity(slug);
+                } else {
+                  await notifier.setTopic(slug);
+                }
+              });
+              _scrollToTop();
+            },
+          );
+        },
+      ),
       leadingTrigger: _SearchTriggerButton(
         active: hasSearch,
+        flat: true,
         keyword: notifier.selectedKeyword,
         onTap: () {
           HapticFeedback.mediumImpact();
@@ -590,6 +652,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
             selectedSourceId: selectedSourceId,
             selectedSourceName: selectedSourceName,
             selectedSourceLogoUrl: selectedSourceLogoUrl,
+            discreet: true,
             onSourceChanged: (sourceId) {
               if (sourceId != null) {
                 _withFeedLoading(() => notifier.setSource(sourceId));
@@ -608,6 +671,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                 notifier.selectedEntity,
             selectedName: _selectedInterestName,
             selectedIsTheme: _selectedIsTheme,
+            discreet: true,
             onInterestChanged: (slug, name,
                 {isTheme = false, isEntity = false}) {
               setState(() {
@@ -2081,6 +2145,7 @@ class _RefreshConfirmSheet extends StatelessWidget {
 
 class _SearchTriggerButton extends StatelessWidget {
   final bool active;
+  final bool flat;
   final String? keyword;
   final VoidCallback onTap;
   final VoidCallback onClear;
@@ -2090,6 +2155,7 @@ class _SearchTriggerButton extends StatelessWidget {
     required this.keyword,
     required this.onTap,
     required this.onClear,
+    this.flat = false,
   });
 
   @override
@@ -2144,6 +2210,23 @@ class _SearchTriggerButton extends StatelessWidget {
                 ),
               ),
             ],
+          ),
+        ),
+      );
+    }
+    if (flat) {
+      return GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: SizedBox(
+          height: 32,
+          width: 32,
+          child: Center(
+            child: Icon(
+              PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
+              size: 18,
+              color: colors.textSecondary,
+            ),
           ),
         ),
       );

--- a/apps/mobile/lib/features/feed/widgets/compact_source_chip.dart
+++ b/apps/mobile/lib/features/feed/widgets/compact_source_chip.dart
@@ -17,6 +17,7 @@ class CompactSourceChip extends StatelessWidget {
   final String? selectedSourceName;
   final String? selectedSourceLogoUrl;
   final ValueChanged<String?> onSourceChanged;
+  final bool discreet;
 
   const CompactSourceChip({
     super.key,
@@ -25,6 +26,7 @@ class CompactSourceChip extends StatelessWidget {
     this.selectedSourceName,
     this.selectedSourceLogoUrl,
     required this.onSourceChanged,
+    this.discreet = false,
   });
 
   bool get _isActive => selectedSourceId != null;
@@ -46,6 +48,7 @@ class CompactSourceChip extends StatelessWidget {
               key: ValueKey('source_active_$selectedSourceId'),
               sourceLogoUrl: selectedSourceLogoUrl,
               sourceName: selectedSourceName ?? 'Source',
+              discreet: discreet,
               onClear: () {
                 HapticFeedback.mediumImpact();
                 onSourceChanged(null);
@@ -125,6 +128,7 @@ class _ActiveChip extends StatelessWidget {
   final String sourceName;
   final VoidCallback onClear;
   final VoidCallback onTap;
+  final bool discreet;
 
   const _ActiveChip({
     super.key,
@@ -132,12 +136,18 @@ class _ActiveChip extends StatelessWidget {
     required this.sourceName,
     required this.onClear,
     required this.onTap,
+    this.discreet = false,
   });
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final primary = colors.primary;
+    final bg = discreet ? colors.surface : primary.withOpacity(0.12);
+    final borderColor = primary;
+    final borderWidth = discreet ? 1.5 : 1.0;
+    final labelColor = discreet ? colors.textPrimary : primary;
+    final iconColor = discreet ? colors.textSecondary : primary;
 
     return GestureDetector(
       onTap: onTap,
@@ -146,8 +156,8 @@ class _ActiveChip extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 10),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(FacteurRadius.full),
-          color: primary.withOpacity(0.12),
-          border: Border.all(color: primary),
+          color: bg,
+          border: Border.all(color: borderColor, width: borderWidth),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
@@ -164,7 +174,7 @@ class _ActiveChip extends StatelessWidget {
                 style: TextStyle(
                   fontSize: 13,
                   fontWeight: FontWeight.w600,
-                  color: primary,
+                  color: labelColor,
                 ),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
@@ -178,7 +188,7 @@ class _ActiveChip extends StatelessWidget {
                 child: Icon(
                   PhosphorIcons.x(PhosphorIconsStyle.bold),
                   size: 13,
-                  color: primary,
+                  color: iconColor,
                 ),
               ),
             ),

--- a/apps/mobile/lib/features/feed/widgets/compact_theme_chip.dart
+++ b/apps/mobile/lib/features/feed/widgets/compact_theme_chip.dart
@@ -11,6 +11,7 @@ class CompactThemeChip extends StatelessWidget {
   final bool selectedIsTheme;
   final void Function(String? slug, String? name,
       {bool isTheme, bool isEntity}) onInterestChanged;
+  final bool discreet;
 
   const CompactThemeChip({
     super.key,
@@ -18,6 +19,7 @@ class CompactThemeChip extends StatelessWidget {
     this.selectedName,
     this.selectedIsTheme = false,
     required this.onInterestChanged,
+    this.discreet = false,
   });
 
   bool get _isActive => selectedSlug != null;
@@ -38,6 +40,7 @@ class CompactThemeChip extends StatelessWidget {
           ? _ActiveChip(
               key: ValueKey('theme_active_$selectedSlug'),
               name: selectedName ?? 'Thème',
+              discreet: discreet,
               onClear: () {
                 HapticFeedback.mediumImpact();
                 onInterestChanged(null, null,
@@ -118,17 +121,25 @@ class _ActiveChip extends StatelessWidget {
   final String name;
   final VoidCallback onClear;
   final VoidCallback onTap;
+  final bool discreet;
 
   const _ActiveChip({
     super.key,
     required this.name,
     required this.onClear,
     required this.onTap,
+    this.discreet = false,
   });
 
   @override
   Widget build(BuildContext context) {
+    final colors = context.facteurColors;
     final primary = Theme.of(context).colorScheme.primary;
+    final bg = discreet ? colors.surface : primary.withOpacity(0.12);
+    final borderColor = primary;
+    final borderWidth = discreet ? 1.5 : 1.0;
+    final labelColor = discreet ? colors.textPrimary : primary;
+    final iconColor = discreet ? colors.textSecondary : primary;
 
     return GestureDetector(
       onTap: onTap,
@@ -137,8 +148,8 @@ class _ActiveChip extends StatelessWidget {
         padding: const EdgeInsets.only(left: 10),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(FacteurRadius.full),
-          color: primary.withOpacity(0.12),
-          border: Border.all(color: primary),
+          color: bg,
+          border: Border.all(color: borderColor, width: borderWidth),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
@@ -149,7 +160,7 @@ class _ActiveChip extends StatelessWidget {
                 style: TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.w600,
-                  color: primary,
+                  color: labelColor,
                 ),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
@@ -163,7 +174,7 @@ class _ActiveChip extends StatelessWidget {
                 child: Icon(
                   PhosphorIcons.x(PhosphorIconsStyle.bold),
                   size: 13,
-                  color: primary,
+                  color: iconColor,
                 ),
               ),
             ),

--- a/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
+++ b/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
@@ -1,0 +1,425 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../../../config/topic_labels.dart';
+import '../../custom_topics/models/topic_models.dart';
+import '../../custom_topics/providers/custom_topics_provider.dart';
+import '../../custom_topics/providers/theme_priority_provider.dart';
+import '../models/content_model.dart';
+
+enum FavoriteTabKind { tous, subjectTopic, subjectEntity, theme }
+
+@immutable
+class FavoriteTabModel {
+  final FavoriteTabKind kind;
+  final String? slug; // null for "Tous"
+  final String label;
+  final String emoji; // empty if none
+  final int count;
+  final bool active;
+
+  const FavoriteTabModel({
+    required this.kind,
+    required this.slug,
+    required this.label,
+    required this.emoji,
+    required this.count,
+    required this.active,
+  });
+}
+
+class FavoriteTopicTabs extends ConsumerStatefulWidget {
+  final List<Content> items;
+  final String? selectedTopicSlug;
+  final String? selectedThemeSlug;
+  final String? selectedEntitySlug;
+  final void Function(FavoriteTabKind kind, String? slug) onTabTap;
+  final VoidCallback onTapActiveTab;
+  final VoidCallback onAddFavorite;
+
+  const FavoriteTopicTabs({
+    super.key,
+    required this.items,
+    this.selectedTopicSlug,
+    this.selectedThemeSlug,
+    this.selectedEntitySlug,
+    required this.onTabTap,
+    required this.onTapActiveTab,
+    required this.onAddFavorite,
+  });
+
+  @override
+  ConsumerState<FavoriteTopicTabs> createState() => _FavoriteTopicTabsState();
+}
+
+class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
+  final ScrollController _scrollController = ScrollController();
+  final Map<String, GlobalKey> _itemKeys = {};
+  GlobalKey? _activeKey;
+
+  @override
+  void didUpdateWidget(covariant FavoriteTopicTabs old) {
+    super.didUpdateWidget(old);
+    final selectionChanged =
+        old.selectedTopicSlug != widget.selectedTopicSlug ||
+            old.selectedThemeSlug != widget.selectedThemeSlug ||
+            old.selectedEntitySlug != widget.selectedEntitySlug;
+    if (selectionChanged) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _scrollActiveIntoView();
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scrollActiveIntoView() {
+    final ctx = _activeKey?.currentContext;
+    if (ctx != null) {
+      Scrollable.ensureVisible(
+        ctx,
+        duration: const Duration(milliseconds: 240),
+        curve: Curves.easeOutCubic,
+        alignment: 0.2,
+      );
+    }
+  }
+
+  GlobalKey _keyFor(FavoriteTabModel tab) {
+    final id = '${tab.kind.name}:${tab.slug ?? '_'}';
+    final key = _itemKeys.putIfAbsent(id, () => GlobalKey());
+    if (tab.active) _activeKey = key;
+    return key;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final topicsAsync = ref.watch(customTopicsProvider);
+    final themePriorityAsync = ref.watch(themePriorityProvider);
+
+    final topics = topicsAsync.valueOrNull ?? const <UserTopicProfile>[];
+    final themePriority =
+        themePriorityAsync.valueOrNull ?? const <String, double>{};
+
+    final tabs = _buildTabModels(
+      topics: topics,
+      themePriority: themePriority,
+      items: widget.items,
+      selectedTopicSlug: widget.selectedTopicSlug,
+      selectedThemeSlug: widget.selectedThemeSlug,
+      selectedEntitySlug: widget.selectedEntitySlug,
+    );
+
+    _activeKey = null;
+
+    return SizedBox(
+      height: 32,
+      child: ShaderMask(
+        shaderCallback: (rect) {
+          return const LinearGradient(
+            begin: Alignment.centerLeft,
+            end: Alignment.centerRight,
+            colors: [Colors.white, Colors.white, Colors.transparent],
+            stops: [0.0, 0.92, 1.0],
+          ).createShader(rect);
+        },
+        blendMode: BlendMode.dstIn,
+        child: ListView.separated(
+          controller: _scrollController,
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.only(right: 16),
+          itemCount: tabs.length + 1,
+          separatorBuilder: (_, __) => const SizedBox(width: 2),
+          itemBuilder: (ctx, i) {
+            if (i == tabs.length) {
+              return _AddFavoritePill(
+                onTap: () {
+                  HapticFeedback.mediumImpact();
+                  widget.onAddFavorite();
+                },
+                colors: colors,
+              );
+            }
+            final tab = tabs[i];
+            return _FavoriteTabItem(
+              key: _keyFor(tab),
+              tab: tab,
+              colors: colors,
+              onTap: () {
+                if (tab.active) {
+                  widget.onTapActiveTab();
+                } else {
+                  HapticFeedback.selectionClick();
+                  widget.onTabTap(tab.kind, tab.slug);
+                }
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+final Map<String, String> _apiSlugToMacroLabel = {
+  for (final e in macroThemeToApiSlug.entries) e.value: e.key,
+};
+
+@visibleForTesting
+List<FavoriteTabModel> buildFavoriteTabModelsForTest({
+  required List<UserTopicProfile> topics,
+  required Map<String, double> themePriority,
+  required List<Content> items,
+  String? selectedTopicSlug,
+  String? selectedThemeSlug,
+  String? selectedEntitySlug,
+}) =>
+    _buildTabModels(
+      topics: topics,
+      themePriority: themePriority,
+      items: items,
+      selectedTopicSlug: selectedTopicSlug,
+      selectedThemeSlug: selectedThemeSlug,
+      selectedEntitySlug: selectedEntitySlug,
+    );
+
+List<FavoriteTabModel> _buildTabModels({
+  required List<UserTopicProfile> topics,
+  required Map<String, double> themePriority,
+  required List<Content> items,
+  String? selectedTopicSlug,
+  String? selectedThemeSlug,
+  String? selectedEntitySlug,
+}) {
+  final themeApiSlugs = macroThemeToApiSlug.values.toSet();
+
+  final entitySubjects = topics
+      .where((t) => t.entityType != null && t.priorityMultiplier == 2.0)
+      .toList()
+    ..sort((a, b) => b.compositeScore.compareTo(a.compositeScore));
+
+  final topicSubjects = topics
+      .where((t) =>
+          t.entityType == null &&
+          t.priorityMultiplier == 2.0 &&
+          !themeApiSlugs.contains(t.slugParent))
+      .toList()
+    ..sort((a, b) {
+      final byPriority = b.priorityMultiplier.compareTo(a.priorityMultiplier);
+      if (byPriority != 0) return byPriority;
+      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+    });
+
+  final favoriteThemes = macroThemeOrder
+      .where((label) => (themePriority[label] ?? 1.0) == 2.0)
+      .toList();
+
+  final cutoff = DateTime.now().subtract(const Duration(hours: 48));
+  final tabs = <FavoriteTabModel>[];
+
+  // 1. Tous (always first).
+  tabs.add(FavoriteTabModel(
+    kind: FavoriteTabKind.tous,
+    slug: null,
+    label: 'Tous',
+    emoji: '',
+    count: _countUnreadRecent(items,
+        cutoff: cutoff, kind: FavoriteTabKind.tous, slug: null),
+    active: selectedTopicSlug == null &&
+        selectedThemeSlug == null &&
+        selectedEntitySlug == null,
+  ));
+
+  // 2. Sujets favoris : entités puis topics.
+  for (final entity in entitySubjects) {
+    final slug = entity.canonicalName ?? entity.name;
+    tabs.add(FavoriteTabModel(
+      kind: FavoriteTabKind.subjectEntity,
+      slug: slug,
+      label: entity.name,
+      emoji: '',
+      count: _countUnreadRecent(items,
+          cutoff: cutoff, kind: FavoriteTabKind.subjectEntity, slug: slug),
+      active: selectedEntitySlug != null && selectedEntitySlug == slug,
+    ));
+  }
+
+  for (final topic in topicSubjects) {
+    final slug = topic.slugParent ?? topic.id;
+    tabs.add(FavoriteTabModel(
+      kind: FavoriteTabKind.subjectTopic,
+      slug: slug,
+      label: topic.name,
+      emoji: '',
+      count: _countUnreadRecent(items,
+          cutoff: cutoff, kind: FavoriteTabKind.subjectTopic, slug: slug),
+      active: selectedTopicSlug != null && selectedTopicSlug == slug,
+    ));
+  }
+
+  // 3. Thèmes favoris.
+  for (final label in favoriteThemes) {
+    final apiSlug = macroThemeToApiSlug[label];
+    if (apiSlug == null) continue;
+    tabs.add(FavoriteTabModel(
+      kind: FavoriteTabKind.theme,
+      slug: apiSlug,
+      label: label,
+      emoji: getMacroThemeEmoji(label),
+      count: _countUnreadRecent(items,
+          cutoff: cutoff, kind: FavoriteTabKind.theme, slug: apiSlug),
+      active: selectedThemeSlug != null && selectedThemeSlug == apiSlug,
+    ));
+  }
+
+  return tabs;
+}
+
+int _countUnreadRecent(
+  List<Content> items, {
+  required DateTime cutoff,
+  required FavoriteTabKind kind,
+  required String? slug,
+}) {
+  bool matches(Content c) {
+    switch (kind) {
+      case FavoriteTabKind.tous:
+        return true;
+      case FavoriteTabKind.subjectTopic:
+        return slug != null && c.topics.contains(slug);
+      case FavoriteTabKind.subjectEntity:
+        if (slug == null) return false;
+        final lower = slug.toLowerCase();
+        return c.entities.any((e) => e.text.toLowerCase() == lower);
+      case FavoriteTabKind.theme:
+        if (slug == null) return false;
+        final label = _apiSlugToMacroLabel[slug];
+        if (label == null) return false;
+        final themeSlugs = getSlugsForMacroTheme(label);
+        return c.topics.any(themeSlugs.contains);
+    }
+  }
+
+  return items
+      .where((c) =>
+          c.status == ContentStatus.unseen &&
+          c.publishedAt.isAfter(cutoff) &&
+          matches(c))
+      .length;
+}
+
+class _FavoriteTabItem extends StatelessWidget {
+  final FavoriteTabModel tab;
+  final FacteurColors colors;
+  final VoidCallback onTap;
+
+  const _FavoriteTabItem({
+    super.key,
+    required this.tab,
+    required this.colors,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final labelColor =
+        tab.active ? colors.textPrimary : colors.textSecondary;
+    final labelWeight = tab.active ? FontWeight.w700 : FontWeight.w500;
+    final countColor =
+        tab.active ? colors.primary : colors.textTertiary;
+    final showLabel =
+        tab.emoji.isNotEmpty ? '${tab.emoji} ${tab.label}' : tab.label;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            IntrinsicWidth(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    showLabel,
+                    style: TextStyle(
+                      fontSize: 14.5,
+                      fontWeight: labelWeight,
+                      color: labelColor,
+                      height: 1.15,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Container(
+                    height: 1.5,
+                    decoration: BoxDecoration(
+                      color: tab.active ? colors.primary : Colors.transparent,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (tab.count > 0) ...[
+              const SizedBox(width: 4),
+              Transform.translate(
+                offset: const Offset(0, -6),
+                child: Text(
+                  '${tab.count}',
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: countColor,
+                    height: 1.0,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AddFavoritePill extends StatelessWidget {
+  final VoidCallback onTap;
+  final FacteurColors colors;
+
+  const _AddFavoritePill({
+    required this.onTap,
+    required this.colors,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: SizedBox(
+        width: 28,
+        height: 32,
+        child: Center(
+          child: Icon(
+            PhosphorIcons.plus(PhosphorIconsStyle.regular),
+            size: 16,
+            color: colors.textSecondary,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
+++ b/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
@@ -6,21 +6,24 @@ import '../../../config/theme.dart';
 
 /// Filter row with the trigger button on the RIGHT.
 ///
-/// - Collapsed + no active filter: "Flux continu" label + thin grey rule fills
-///   the left side ; "Filtres" pill sits on the right.
-/// - Collapsed + active filter(s): empty space on the left ; pill shows count.
+/// - Collapsed + no active filter: [leadingContent] (or "Flux continu"
+///   fallback) fills the left side ; "Filtres" pill sits on the right.
+/// - Collapsed + active filter(s): [leadingContent] still shown when provided
+///   (e.g. favorite topic tabs) ; pill shows count.
 /// - Expanded: pills slide in to the left ; the trigger morphs into a pill of
 ///   the same shape with an × icon (primary, "selected" look).
 class FilterCollapsiblePanel extends StatefulWidget {
   final int activeCount;
   final Widget chipsRow;
   final Widget? leadingTrigger;
+  final Widget? leadingContent;
 
   const FilterCollapsiblePanel({
     super.key,
     required this.activeCount,
     required this.chipsRow,
     this.leadingTrigger,
+    this.leadingContent,
   });
 
   @override
@@ -57,34 +60,46 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
                       padding: const EdgeInsets.only(right: 8),
                       child: widget.chipsRow,
                     )
-                  : (hasActive
-                      ? const SizedBox.shrink(key: ValueKey('idle'))
-                      : Padding(
-                          key: const ValueKey('flux-continu'),
-                          padding: const EdgeInsets.only(right: 12),
-                          child: Row(
-                            children: [
-                              Text(
-                                'FLUX CONTINU',
-                                style: FacteurTypography.stamp(
-                                        colors.textTertiary)
-                                    .copyWith(letterSpacing: 1.2),
+                  : (widget.leadingContent != null
+                      ? KeyedSubtree(
+                          key: const ValueKey('leading-content'),
+                          child: widget.leadingContent!,
+                        )
+                      : (hasActive
+                          ? const SizedBox.shrink(key: ValueKey('idle'))
+                          : Padding(
+                              key: const ValueKey('flux-continu'),
+                              padding: const EdgeInsets.only(right: 12),
+                              child: Row(
+                                children: [
+                                  Text(
+                                    'FLUX CONTINU',
+                                    style: FacteurTypography.stamp(
+                                            colors.textTertiary)
+                                        .copyWith(letterSpacing: 1.2),
+                                  ),
+                                  const SizedBox(width: 10),
+                                  Expanded(
+                                    child: Container(
+                                      height: 1,
+                                      color: colors.border.withOpacity(0.5),
+                                    ),
+                                  ),
+                                ],
                               ),
-                              const SizedBox(width: 10),
-                              Expanded(
-                                child: Container(
-                                  height: 1,
-                                  color: colors.border.withOpacity(0.5),
-                                ),
-                              ),
-                            ],
-                          ),
-                        )),
+                            ))),
             ),
           ),
+          if (widget.leadingContent != null && !_expanded)
+            Container(
+              width: 1,
+              height: 16,
+              margin: const EdgeInsets.symmetric(horizontal: 8),
+              color: colors.border.withOpacity(0.6),
+            ),
           if (widget.leadingTrigger != null) ...[
             widget.leadingTrigger!,
-            const SizedBox(width: 8),
+            const SizedBox(width: 4),
           ],
           GestureDetector(
             onTap: _toggle,
@@ -93,17 +108,15 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
               duration: const Duration(milliseconds: 180),
               height: 32,
               padding: EdgeInsets.symmetric(
-                horizontal: hasActive && !_expanded ? 12 : 10,
+                horizontal: hasActive && !_expanded ? 12 : 8,
               ),
               decoration: BoxDecoration(
                 color: (_expanded || hasActive)
                     ? colors.primary.withOpacity(0.12)
-                    : colors.surface,
-                border: Border.all(
-                  color: (_expanded || hasActive)
-                      ? colors.primary
-                      : colors.border,
-                ),
+                    : Colors.transparent,
+                border: (_expanded || hasActive)
+                    ? Border.all(color: colors.primary)
+                    : null,
                 borderRadius: BorderRadius.circular(FacteurRadius.full),
               ),
               child: Row(
@@ -113,7 +126,7 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
                     _expanded
                         ? PhosphorIcons.x(PhosphorIconsStyle.bold)
                         : PhosphorIcons.funnel(PhosphorIconsStyle.regular),
-                    size: 16,
+                    size: 18,
                     color: (_expanded || hasActive)
                         ? colors.primary
                         : colors.textSecondary,

--- a/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
+++ b/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
@@ -1,0 +1,270 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/custom_topics/models/topic_models.dart';
+import 'package:facteur/features/custom_topics/providers/custom_topics_provider.dart';
+import 'package:facteur/features/custom_topics/providers/theme_priority_provider.dart';
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/feed/widgets/favorite_topic_tabs.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+
+UserTopicProfile _topic({
+  required String id,
+  required String name,
+  String? slugParent,
+  double priorityMultiplier = 1.0,
+  String? entityType,
+  String? canonicalName,
+  double compositeScore = 0.0,
+}) {
+  return UserTopicProfile(
+    id: id,
+    name: name,
+    slugParent: slugParent,
+    priorityMultiplier: priorityMultiplier,
+    entityType: entityType,
+    canonicalName: canonicalName,
+    compositeScore: compositeScore,
+  );
+}
+
+Content _content({
+  required String id,
+  required List<String> topics,
+  ContentStatus status = ContentStatus.unseen,
+  Duration ageBeforeNow = const Duration(hours: 1),
+  List<ContentEntity> entities = const [],
+}) {
+  return Content(
+    id: id,
+    title: 'Title $id',
+    url: 'https://example.com/$id',
+    contentType: ContentType.article,
+    publishedAt: DateTime.now().subtract(ageBeforeNow),
+    source: Source.fallback(),
+    status: status,
+    topics: topics,
+    entities: entities,
+  );
+}
+
+void main() {
+  group('buildFavoriteTabModelsForTest', () {
+    test('0 favoris → only "Tous" tab', () {
+      final tabs = buildFavoriteTabModelsForTest(
+        topics: const [],
+        themePriority: const {},
+        items: const [],
+      );
+
+      expect(tabs, hasLength(1));
+      expect(tabs.first.kind, FavoriteTabKind.tous);
+      expect(tabs.first.label, 'Tous');
+      expect(tabs.first.active, isTrue);
+    });
+
+    test('2 sujets + 1 thème → 4 tabs in order subjects → themes', () {
+      final topics = [
+        _topic(
+          id: 't1',
+          name: 'IA santé',
+          slugParent: 'ai-health',
+          priorityMultiplier: 2.0,
+        ),
+        _topic(
+          id: 't2',
+          name: 'Trump',
+          entityType: 'PERSON',
+          canonicalName: 'Donald Trump',
+          priorityMultiplier: 2.0,
+          compositeScore: 0.8,
+        ),
+      ];
+
+      final tabs = buildFavoriteTabModelsForTest(
+        topics: topics,
+        themePriority: const {'Environnement': 2.0},
+        items: const [],
+      );
+
+      expect(tabs.map((t) => t.kind).toList(), [
+        FavoriteTabKind.tous,
+        FavoriteTabKind.subjectEntity,
+        FavoriteTabKind.subjectTopic,
+        FavoriteTabKind.theme,
+      ]);
+      expect(tabs[1].label, 'Trump');
+      expect(tabs[2].label, 'IA santé');
+      expect(tabs[3].label, 'Environnement');
+      expect(tabs[3].slug, 'environment');
+      expect(tabs[3].emoji, isNotEmpty);
+    });
+
+    test('topics whose slugParent is a macro-theme slug are excluded', () {
+      // slugParent == "tech" matches the Technologie macro-theme apiSlug.
+      final topics = [
+        _topic(
+          id: 't1',
+          name: 'Technologie raw',
+          slugParent: 'tech',
+          priorityMultiplier: 2.0,
+        ),
+      ];
+
+      final tabs = buildFavoriteTabModelsForTest(
+        topics: topics,
+        themePriority: const {},
+        items: const [],
+      );
+
+      // Only "Tous" should appear — the topic was filtered out.
+      expect(tabs, hasLength(1));
+      expect(tabs.first.kind, FavoriteTabKind.tous);
+    });
+
+    test('count = unseen items < 48h matching slug', () {
+      final items = [
+        // Match topic "ai", recent + unseen → counted
+        _content(id: 'c1', topics: ['ai']),
+        // Match topic "ai", recent but seen → NOT counted
+        _content(id: 'c2', topics: ['ai'], status: ContentStatus.seen),
+        // Match topic "ai", unseen but too old → NOT counted
+        _content(
+          id: 'c3',
+          topics: ['ai'],
+          ageBeforeNow: const Duration(hours: 72),
+        ),
+        // Wrong topic → NOT counted
+        _content(id: 'c4', topics: ['climate']),
+      ];
+
+      final topics = [
+        _topic(
+          id: 't1',
+          name: 'IA',
+          slugParent: 'ai',
+          priorityMultiplier: 2.0,
+        ),
+      ];
+
+      final tabs = buildFavoriteTabModelsForTest(
+        topics: topics,
+        themePriority: const {},
+        items: items,
+      );
+
+      final iaTab =
+          tabs.firstWhere((t) => t.kind == FavoriteTabKind.subjectTopic);
+      expect(iaTab.count, 1);
+
+      final tousTab =
+          tabs.firstWhere((t) => t.kind == FavoriteTabKind.tous);
+      // Tous = unseen + recent: c1 + c4 = 2.
+      expect(tousTab.count, 2);
+    });
+
+    test('selected slug marks the matching tab as active', () {
+      final topics = [
+        _topic(
+          id: 't1',
+          name: 'IA',
+          slugParent: 'ai',
+          priorityMultiplier: 2.0,
+        ),
+      ];
+
+      final tabs = buildFavoriteTabModelsForTest(
+        topics: topics,
+        themePriority: const {},
+        items: const [],
+        selectedTopicSlug: 'ai',
+      );
+
+      expect(
+        tabs.firstWhere((t) => t.slug == 'ai').active,
+        isTrue,
+      );
+      expect(
+        tabs.firstWhere((t) => t.kind == FavoriteTabKind.tous).active,
+        isFalse,
+      );
+    });
+  });
+
+  group('FavoriteTopicTabs widget', () {
+    Widget host({
+      required Widget child,
+      List<UserTopicProfile> topics = const [],
+      Map<String, double> themePriority = const {},
+    }) {
+      return ProviderScope(
+        overrides: [
+          customTopicsProvider.overrideWith(() {
+            return _StaticCustomTopicsNotifier(topics);
+          }),
+          themePriorityProvider.overrideWith((ref) async => themePriority),
+        ],
+        child: MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: Scaffold(body: child),
+        ),
+      );
+    }
+
+    testWidgets('tap on active tab calls onTapActiveTab, not onTabTap',
+        (tester) async {
+      var tapActiveCalls = 0;
+      var tabTapCalls = 0;
+
+      await tester.pumpWidget(host(
+        child: FavoriteTopicTabs(
+          items: const [],
+          onTabTap: (_, __) => tabTapCalls++,
+          onTapActiveTab: () => tapActiveCalls++,
+          onAddFavorite: () {},
+        ),
+      ));
+      // Let async providers resolve.
+      await tester.pumpAndSettle();
+
+      // "Tous" is the active tab when no selection is set.
+      await tester.tap(find.text('Tous'));
+      await tester.pump();
+
+      expect(tapActiveCalls, 1);
+      expect(tabTapCalls, 0);
+    });
+
+    testWidgets('tap on + pill calls onAddFavorite', (tester) async {
+      var addCalls = 0;
+
+      await tester.pumpWidget(host(
+        child: FavoriteTopicTabs(
+          items: const [],
+          onTabTap: (_, __) {},
+          onTapActiveTab: () {},
+          onAddFavorite: () => addCalls++,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // The + pill is the only icon in the row.
+      await tester.tap(find.byType(Icon).first);
+      await tester.pump();
+
+      expect(addCalls, 1);
+    });
+  });
+}
+
+/// Test-only notifier that returns a static list and skips network/cache.
+class _StaticCustomTopicsNotifier extends CustomTopicsNotifier {
+  _StaticCustomTopicsNotifier(this._topics);
+
+  final List<UserTopicProfile> _topics;
+
+  @override
+  Future<List<UserTopicProfile>> build() async => _topics;
+}


### PR DESCRIPTION
## Quoi

Ajoute une rangée de tabs scrollables au-dessus du panneau de filtres du feed pour accéder rapidement aux sujets/thèmes favoris (entités, topics, macro-thèmes prioritaires) avec compteur d'articles non-lus < 48h par tab.

## Pourquoi

Aujourd'hui l'utilisateur doit ouvrir le panneau de filtres puis sélectionner un chip pour passer d'un favori à l'autre. Les tabs raccourcissent ce flux à un seul tap et donnent une vue d'ensemble (badge non-lus) qui guide l'attention vers les contenus pertinents. Cohérent avec le pattern Essentiel/Flux du widget livré dans #580.

## Détails

- `FavoriteTopicTabs` (nouveau) : Tous + sujets favoris (entités puis topics, `priorityMultiplier == 2.0`) + thèmes favoris (`themePriority == 2.0`). Pill `+` ouvre `InterestFilterSheet`.
- Tap sur tab actif → `_scrollToTop`. Tap sur tab inactif → applique le filtre via `FeedNotifier.setTopic/Theme/Entity`.
- `FilterCollapsiblePanel` reçoit un `leadingContent` optionnel + séparateur vertical quand présent.
- `CompactSourceChip` / `CompactThemeChip` : mode `discreet` (outlined sobre) pour cohabiter avec les tabs.
- `_SearchTriggerButton` : mode `flat` (icône loupe seule, sans bordure).
- Scroll-into-view de l'onglet actif via `Scrollable.ensureVisible` (post-frame, sur selection change). GlobalKeys stables (pas de churn par build).
- `_apiSlugToMacroLabel` dérivé de `macroThemeToApiSlug` (source unique dans `topic_labels.dart`).

## Comment ça a été vérifié

- [x] `flutter test test/features/feed/widgets/favorite_topic_tabs_test.dart` — 7/7 passent (build models : Tous, ordre sujets→thèmes, exclusion topics dont slugParent == macro-theme slug, count unread <48h, active flag ; widget : tap actif vs inactif, tap pill `+`).
- [x] `flutter test` (suite complète) — 562 OK / 38 KO **identique au baseline `origin/main`** (échecs pré-existants, aucune régression introduite).
- [x] `flutter analyze lib/features/feed/widgets/favorite_topic_tabs.dart` — clean.
- [x] `flutter analyze` (global) — pas de nouveau warning sur les fichiers modifiés.
- [x] Skill `simplify` passée : `_apiSlugToMacroLabel` dérivé du map canonique, GlobalKey churn supprimé (`_itemKeys.clear()` retiré, `_activeKey` tracké directement), `DateTime.now()` hissé hors de `_countUnreadRecent`.

## Zones à risque

- **Performance feed** : `feedProvider` est désormais watché dans `_buildFilterPanel` pour alimenter les compteurs ; rebuild du panneau à chaque changement de feed (acceptable, le panneau rebuild déjà sur ces évènements).
- **GlobalKey lifecycle** : keys stables par `kind:slug`, persistées sur la durée du widget. La map ne croît pas au-delà du nombre de favoris (~20 max).
- **`InterestFilterSheet`** réutilisé tel quel via `onAddFavorite` — pas de modification de son API.