### PR TITLE
fix(feed): chip Suivre+ sur sources suivies + feed vide filtre entité + badges onglets

### DIFF
--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -97,6 +97,11 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
   final Set<String> _consumedContentIds =
       {}; // Track content being animated out
 
+  // Snapshot of the last unfiltered feed (no topic/theme/entity active).
+  // Used by FavoriteTopicTabs to compute all tab badges independently of
+  // which tab is currently selected.
+  List<Content> _globalItems = [];
+
   Timer? _widgetPushDebounce;
   String? _lastWidgetPushSignature;
   static const Duration _widgetPushDelay = Duration(seconds: 1);
@@ -109,6 +114,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
   String? get selectedSourceId => _selectedSourceId;
   String? get selectedEntity => _selectedEntity;
   String? get selectedKeyword => _selectedKeyword;
+  List<Content> get globalItems => _globalItems;
+
+  bool get _isUnfiltered =>
+      _selectedTopic == null &&
+      _selectedTheme == null &&
+      _selectedEntity == null;
 
   @override
   FutureOr<FeedState> build() async {
@@ -171,6 +182,7 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         if (ageSeconds >= _silentRevalSkipSeconds) {
           _scheduleSilentRevalidation();
         }
+        _globalItems = parsed.items;
         print(
             '[PERF] feedProvider.build(): cache hit (${parsed.items.length} items, age=${ageSeconds}s, silent_reval=${ageSeconds >= _silentRevalSkipSeconds})');
         return FeedState(items: parsed.items, carousels: parsed.carousels);
@@ -187,6 +199,7 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     sw.stop();
     print('[PERF] feedProvider.build(): ${sw.elapsedMilliseconds}ms (${response.items.length} items)');
 
+    _globalItems = response.items;
     return FeedState(items: response.items, carousels: response.carousels);
   }
 
@@ -221,6 +234,7 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
               .map((c) => c.id))),
         };
         if (consumedIds.isEmpty) {
+          _globalItems = response.items;
           state = AsyncData(
               FeedState(items: response.items, carousels: response.carousels));
           return;
@@ -228,8 +242,10 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         Content preserve(Content c) => consumedIds.contains(c.id)
             ? c.copyWith(status: ContentStatus.consumed)
             : c;
+        final mergedItems = response.items.map(preserve).toList();
+        _globalItems = mergedItems;
         state = AsyncData(FeedState(
-          items: response.items.map(preserve).toList(),
+          items: mergedItems,
           carousels: response.carousels
               .map((car) =>
                   car.copyWith(items: car.items.map(preserve).toList()))
@@ -477,6 +493,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       // call (the backend cache will still give a fast response, but the
       // user has the right to ask for fresh data).
       final response = await _fetchPage(page: 1, forceFresh: true);
+      if (_isUnfiltered) {
+        _globalItems = response.items;
+      }
       state = AsyncData(FeedState(
         items: response.items,
         carousels: response.carousels,

--- a/apps/mobile/lib/features/feed/providers/tab_counts_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/tab_counts_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/providers.dart';
+import '../repositories/feed_repository.dart';
+
+final tabCountsProvider = FutureProvider.autoDispose<TabCounts>((ref) async {
+  final apiClient = ref.watch(apiClientProvider);
+  final repo = FeedRepository(apiClient);
+  return repo.getTabCounts();
+});

--- a/apps/mobile/lib/features/feed/repositories/feed_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/feed_repository.dart
@@ -874,6 +874,20 @@ class FeedRepository {
     }
   }
 
+  Future<TabCounts> getTabCounts() async {
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        'feed/tab-counts',
+      );
+      if (response.statusCode == 200 && response.data != null) {
+        return TabCounts.fromJson(response.data!);
+      }
+    } catch (e) {
+      print('FeedRepository: [ERROR] getTabCounts: $e');
+    }
+    return const TabCounts();
+  }
+
   /// Fetch perspectives for a content via Google News search
   Future<PerspectivesResponse> getPerspectives(String contentId) async {
     try {
@@ -892,6 +906,37 @@ class FeedRepository {
       return PerspectivesResponse(
           perspectives: [], keywords: [], biasDistribution: {});
     }
+  }
+}
+
+class TabCounts {
+  final int total;
+  final Map<String, int> topics;
+  final Map<String, int> entities;
+  final Map<String, int> themes;
+
+  const TabCounts({
+    this.total = 0,
+    this.topics = const {},
+    this.entities = const {},
+    this.themes = const {},
+  });
+
+  factory TabCounts.fromJson(Map<String, dynamic> json) {
+    return TabCounts(
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      topics: _castIntMap(json['topics']),
+      entities: _castIntMap(json['entities']),
+      themes: _castIntMap(json['themes']),
+    );
+  }
+
+  static Map<String, int> _castIntMap(dynamic raw) {
+    if (raw is! Map) return const {};
+    return {
+      for (final e in raw.entries)
+        e.key.toString(): (e.value as num?)?.toInt() ?? 0,
+    };
   }
 }
 

--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -66,6 +66,7 @@ import '../widgets/favorite_topic_tabs.dart';
 import '../widgets/filter_collapsible_panel.dart';
 import '../widgets/follow_keyword_suggestion_card.dart';
 import '../widgets/interest_filter_sheet.dart';
+import '../providers/tab_counts_provider.dart';
 import '../../digest/providers/serein_toggle_provider.dart';
 import '../../settings/providers/user_profile_provider.dart';
 import '../../sources/providers/sources_providers.dart';
@@ -525,11 +526,15 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
         notifier.selectedKeyword!.isNotEmpty;
     final feedItems =
         ref.watch(feedProvider).valueOrNull?.items ?? const <Content>[];
+    final globalItems = notifier.globalItems;
+    final badgeItems = globalItems.isNotEmpty ? globalItems : feedItems;
+    final serverCounts = ref.watch(tabCountsProvider).valueOrNull;
     return FilterCollapsiblePanel(
       activeCount: _activeFilterCount(),
       chipsRow: _buildFilterChipsRow(context),
       leadingContent: FavoriteTopicTabs(
-        items: feedItems,
+        items: badgeItems,
+        serverCounts: serverCounts,
         selectedTopicSlug: notifier.selectedTopic,
         selectedThemeSlug: notifier.selectedTheme,
         selectedEntitySlug: notifier.selectedEntity,

--- a/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
+++ b/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
@@ -9,6 +9,7 @@ import '../../custom_topics/models/topic_models.dart';
 import '../../custom_topics/providers/custom_topics_provider.dart';
 import '../../custom_topics/providers/theme_priority_provider.dart';
 import '../models/content_model.dart';
+import '../repositories/feed_repository.dart';
 
 enum FavoriteTabKind { tous, subjectTopic, subjectEntity, theme }
 
@@ -33,6 +34,7 @@ class FavoriteTabModel {
 
 class FavoriteTopicTabs extends ConsumerStatefulWidget {
   final List<Content> items;
+  final TabCounts? serverCounts;
   final String? selectedTopicSlug;
   final String? selectedThemeSlug;
   final String? selectedEntitySlug;
@@ -43,6 +45,7 @@ class FavoriteTopicTabs extends ConsumerStatefulWidget {
   const FavoriteTopicTabs({
     super.key,
     required this.items,
+    this.serverCounts,
     this.selectedTopicSlug,
     this.selectedThemeSlug,
     this.selectedEntitySlug,
@@ -113,6 +116,7 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
       topics: topics,
       themePriority: themePriority,
       items: widget.items,
+      serverCounts: widget.serverCounts,
       selectedTopicSlug: widget.selectedTopicSlug,
       selectedThemeSlug: widget.selectedThemeSlug,
       selectedEntitySlug: widget.selectedEntitySlug,
@@ -178,6 +182,7 @@ List<FavoriteTabModel> buildFavoriteTabModelsForTest({
   required List<UserTopicProfile> topics,
   required Map<String, double> themePriority,
   required List<Content> items,
+  TabCounts? serverCounts,
   String? selectedTopicSlug,
   String? selectedThemeSlug,
   String? selectedEntitySlug,
@@ -186,6 +191,7 @@ List<FavoriteTabModel> buildFavoriteTabModelsForTest({
       topics: topics,
       themePriority: themePriority,
       items: items,
+      serverCounts: serverCounts,
       selectedTopicSlug: selectedTopicSlug,
       selectedThemeSlug: selectedThemeSlug,
       selectedEntitySlug: selectedEntitySlug,
@@ -195,11 +201,13 @@ List<FavoriteTabModel> _buildTabModels({
   required List<UserTopicProfile> topics,
   required Map<String, double> themePriority,
   required List<Content> items,
+  TabCounts? serverCounts,
   String? selectedTopicSlug,
   String? selectedThemeSlug,
   String? selectedEntitySlug,
 }) {
   final themeApiSlugs = macroThemeToApiSlug.values.toSet();
+  final useServer = serverCounts != null && serverCounts.total > 0;
 
   final entitySubjects = topics
       .where((t) => t.entityType != null && t.priorityMultiplier == 2.0)
@@ -231,8 +239,10 @@ List<FavoriteTabModel> _buildTabModels({
     slug: null,
     label: 'Tous',
     emoji: '',
-    count: _countUnreadRecent(items,
-        cutoff: cutoff, kind: FavoriteTabKind.tous, slug: null),
+    count: useServer
+        ? serverCounts.total
+        : _countUnreadRecent(items,
+            cutoff: cutoff, kind: FavoriteTabKind.tous, slug: null),
     active: selectedTopicSlug == null &&
         selectedThemeSlug == null &&
         selectedEntitySlug == null,
@@ -246,8 +256,10 @@ List<FavoriteTabModel> _buildTabModels({
       slug: slug,
       label: entity.name,
       emoji: '',
-      count: _countUnreadRecent(items,
-          cutoff: cutoff, kind: FavoriteTabKind.subjectEntity, slug: slug),
+      count: useServer
+          ? (serverCounts.entities[slug.toLowerCase()] ?? 0)
+          : _countUnreadRecent(items,
+              cutoff: cutoff, kind: FavoriteTabKind.subjectEntity, slug: slug),
       active: selectedEntitySlug != null && selectedEntitySlug == slug,
     ));
   }
@@ -259,8 +271,10 @@ List<FavoriteTabModel> _buildTabModels({
       slug: slug,
       label: topic.name,
       emoji: '',
-      count: _countUnreadRecent(items,
-          cutoff: cutoff, kind: FavoriteTabKind.subjectTopic, slug: slug),
+      count: useServer
+          ? (serverCounts.topics[slug] ?? 0)
+          : _countUnreadRecent(items,
+              cutoff: cutoff, kind: FavoriteTabKind.subjectTopic, slug: slug),
       active: selectedTopicSlug != null && selectedTopicSlug == slug,
     ));
   }
@@ -274,8 +288,10 @@ List<FavoriteTabModel> _buildTabModels({
       slug: apiSlug,
       label: label,
       emoji: getMacroThemeEmoji(label),
-      count: _countUnreadRecent(items,
-          cutoff: cutoff, kind: FavoriteTabKind.theme, slug: apiSlug),
+      count: useServer
+          ? (serverCounts.themes[apiSlug] ?? 0)
+          : _countUnreadRecent(items,
+              cutoff: cutoff, kind: FavoriteTabKind.theme, slug: apiSlug),
       active: selectedThemeSlug != null && selectedThemeSlug == apiSlug,
     ));
   }

--- a/packages/api/app/routers/feed.py
+++ b/packages/api/app/routers/feed.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import re
 from datetime import UTC, datetime, timedelta
@@ -506,6 +507,140 @@ async def mark_briefing_item_read(
         )
 
     return {"message": "Briefing item marked as read", "updated": result.rowcount}
+
+
+@router.get("/tab-counts")
+async def get_tab_counts(
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Comptages d'articles récents non-lus pour chaque onglet favori.
+
+    Requête légère (projection minimale, pas de scoring) appelée au
+    chargement du feed pour afficher les badges sur les onglets.
+    """
+    import json as _json
+
+    from sqlalchemy import exists, or_, select
+
+    from app.models.content import Content
+    from app.models.source import UserSource
+    from app.models.user_topic_profile import UserTopicProfile
+    from app.schemas.feed import TabCountsResponse
+    from app.services.ml.topic_theme_mapper import TOPIC_TO_THEME
+
+    user_uuid = UUID(current_user_id)
+    cutoff = datetime.now(UTC) - timedelta(hours=48)
+
+    # 1. Fetch user's followed sources + favorite topics in parallel
+    followed_stmt = select(UserSource.source_id).where(UserSource.user_id == user_uuid)
+    favorites_stmt = select(UserTopicProfile).where(
+        UserTopicProfile.user_id == user_uuid,
+        UserTopicProfile.priority_multiplier == 2.0,
+    )
+
+    followed_result, favorites_result = await asyncio.gather(
+        db.execute(followed_stmt),
+        db.scalars(favorites_stmt),
+    )
+    followed_source_ids = {row[0] for row in followed_result.all()}
+    favorite_profiles = list(favorites_result.all())
+
+    if not followed_source_ids:
+        return TabCountsResponse(total=0)
+
+    # 2. Extract favorite slugs/names to count
+    fav_topic_slugs: set[str] = set()
+    fav_entity_names: set[str] = set()
+    for prof in favorite_profiles:
+        if prof.entity_type is not None:
+            if prof.canonical_name:
+                fav_entity_names.add(prof.canonical_name.lower())
+        else:
+            if prof.slug_parent:
+                fav_topic_slugs.add(prof.slug_parent)
+
+    # Build reverse theme map: theme_slug → set of topic slugs
+    theme_to_topics: dict[str, set[str]] = {}
+    for topic_slug, theme_slug in TOPIC_TO_THEME.items():
+        theme_to_topics.setdefault(theme_slug, set()).add(topic_slug)
+
+    # 3. Lightweight query: only columns needed for counting
+    exclude_stmt = exists().where(
+        UserContentStatus.content_id == Content.id,
+        UserContentStatus.user_id == user_uuid,
+        or_(
+            UserContentStatus.is_hidden,
+            UserContentStatus.status.in_(["seen", "consumed"]),
+        ),
+    )
+
+    stmt = select(Content.id, Content.topics, Content.entities).where(
+        Content.source_id.in_(list(followed_source_ids)),
+        Content.published_at >= cutoff,
+        ~exclude_stmt,
+    )
+    rows = (await db.execute(stmt)).all()
+
+    # 4. Count in Python (single pass over lightweight rows)
+    total = len(rows)
+    topic_counts: dict[str, int] = {}
+    entity_counts: dict[str, int] = {}
+    theme_counts: dict[str, int] = {}
+
+    for row in rows:
+        topics = row.topics or []
+        entities_raw = row.entities or []
+
+        # Topic matching
+        for slug in fav_topic_slugs:
+            if slug in topics:
+                topic_counts[slug] = topic_counts.get(slug, 0) + 1
+
+        # Entity matching (JSON-encoded strings in the array)
+        if fav_entity_names and entities_raw:
+            for raw_entity in entities_raw:
+                try:
+                    parsed = _json.loads(raw_entity)
+                    name = parsed.get("name", "").lower()
+                except (ValueError, AttributeError):
+                    name = raw_entity.lower()
+                if name in fav_entity_names:
+                    entity_counts[name] = entity_counts.get(name, 0) + 1
+
+        # Theme matching: check if any topic belongs to each theme
+        for topic_slug in topics:
+            theme_slug = TOPIC_TO_THEME.get(topic_slug)
+            if theme_slug:
+                theme_counts[theme_slug] = theme_counts.get(theme_slug, 0) + 1
+
+    # Deduplicate theme counts (an article can match multiple topics in the
+    # same theme — count it once per theme)
+    theme_counts_dedup: dict[str, int] = {}
+    for theme_slug in theme_counts:
+        theme_topic_slugs = theme_to_topics.get(theme_slug, set())
+        count = 0
+        for row in rows:
+            row_topics = row.topics or []
+            if any(t in theme_topic_slugs for t in row_topics):
+                count += 1
+        theme_counts_dedup[theme_slug] = count
+
+    logger.info(
+        "tab_counts_served",
+        user_id=current_user_id,
+        total=total,
+        topic_count=len(topic_counts),
+        entity_count=len(entity_counts),
+        theme_count=len(theme_counts_dedup),
+    )
+
+    return TabCountsResponse(
+        total=total,
+        topics=topic_counts,
+        entities=entity_counts,
+        themes=theme_counts_dedup,
+    )
 
 
 @router.get("/trending-topics", response_model=list[TrendingTopicResponse])

--- a/packages/api/app/schemas/content.py
+++ b/packages/api/app/schemas/content.py
@@ -114,6 +114,7 @@ class ContentResponse(BaseModel):
     reading_progress: int = 0
     note_text: str | None = None
     note_updated_at: datetime | None = None
+    is_followed_source: bool = False
 
     @field_serializer("topics", when_used="always")
     def serialize_topics(self, value: list[str] | None) -> list[str]:

--- a/packages/api/app/schemas/feed.py
+++ b/packages/api/app/schemas/feed.py
@@ -118,6 +118,15 @@ class FeedResponse(BaseModel):
     carousels: list[CarouselInfo] = []
 
 
+class TabCountsResponse(BaseModel):
+    """Comptages d'articles récents non-lus par onglet favori."""
+
+    total: int
+    topics: dict[str, int] = {}
+    entities: dict[str, int] = {}
+    themes: dict[str, int] = {}
+
+
 class TrendingTopicResponse(BaseModel):
     """Un sujet tendance détecté par clustering de titres."""
 

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -26,6 +26,18 @@ logger = structlog.get_logger()
 # Cf. docs/bugs/bug-feed-default-hang.md
 _FEED_TWO_PHASE_TIMEOUT_S = 8.0
 
+# Suffixes corporate courants strippés pour matcher "Anthropic" avec
+# "Anthropic, PBC" ou "OpenAI" avec "OpenAI Inc." côté post-filtre entité.
+_CORP_SUFFIX_RE = re.compile(
+    r"[,\s]+(pbc|inc|llc|ltd|sa|sas|gmbh|co|corp|corporation|"
+    r"company|nv|ag|spa|srl|plc)\.?\s*$",
+    re.IGNORECASE,
+)
+
+
+def _normalize_entity_name(name: str) -> str:
+    return _CORP_SUFFIX_RE.sub("", name.strip().lower()).strip()
+
 
 @dataclass
 class InterestContext:
@@ -428,7 +440,7 @@ class RecommendationService:
         if entity:
             import json as _json
 
-            entity_lower = entity.lower()
+            entity_norm = _normalize_entity_name(entity)
 
             def _matches_entity(c: Content) -> bool:
                 if not c.entities:
@@ -438,7 +450,7 @@ class RecommendationService:
                         e = _json.loads(raw)
                         if (
                             isinstance(e, dict)
-                            and e.get("name", "").lower() == entity_lower
+                            and _normalize_entity_name(e.get("name", "")) == entity_norm
                         ):
                             return True
                     except (ValueError, TypeError):
@@ -2320,22 +2332,17 @@ class RecommendationService:
 
         # Base source filter
         # source_id: show only articles from this specific source
-        # theme/topic/entity: show curated sources (broader discovery)
-        # keyword + include_unfollowed: same broader discovery as theme/topic/entity
+        # theme/topic/entity: filtre explicite — toutes les sources actives
+        #   Facteur (curated + non-curated + tier=deep), pour ne pas écarter
+        #   de matches potentiels. La distinction suivie/non-suivie est rendue
+        #   à l'affichage via la chip "Suivre +".
+        # keyword + include_unfollowed: même politique d'élargissement.
         # followed_source_ids: followed sources only (no curated enrichment)
         _use_two_phase = False
         if source_id:
             query = query.where(Content.source_id == source_id)
         elif theme or topic or entity or (keyword and include_unfollowed):
-            if followed_source_ids:
-                query = query.where(
-                    or_(
-                        and_(Source.is_curated, Source.source_tier != "deep"),
-                        Source.id.in_(list(followed_source_ids)),
-                    )
-                )
-            else:
-                query = query.where(Source.is_curated, Source.source_tier != "deep")
+            pass
         elif followed_source_ids:
             # Don't apply source filter yet — two-phase fetch after all filters
             _use_two_phase = True


### PR DESCRIPTION
## Quoi

3 régressions post-PR #581 (onglets sujets/thèmes) :

- **Bug 1** — Chip « Suivre + » affichée sur **tous** les articles en vue filtrée, y compris les sources déjà suivies
- **Bug 2** — Feed **vide** lors d'un filtre entité (ex. « Anthropic », « Patrick Pouyanné »)
- **Bug 3** — Compteurs des onglets thèmes tombent à 0 dès qu'un onglet est actif

## Pourquoi

- **Bug 1** : `ContentResponse` ne déclarait pas `is_followed_source` (présent sur `DigestItem` mais oublié côté feed) → le JSON n'incluait jamais le champ → mobile fallback `false` → chip toujours affichée
- **Bug 2a** : le filtre source restreignait à `is_curated ∧ tier≠deep` même en mode filtre explicite — sources comme Les Échos ou blogs spécialisés IA (non-curated ou tier=deep) étaient systématiquement exclues
- **Bug 2b** : post-filtre entité utilisait une égalité stricte `str == str` → « Anthropic » ne matchait pas « Anthropic, PBC »
- **Bug 3** : `FavoriteTopicTabs` recevait `feedItems` (liste filtrée) → badges des autres onglets tombaient à 0

## Comment

| Fichier | Changement |
|---|---|
| `packages/api/app/schemas/content.py` | `is_followed_source: bool = False` ajouté à `ContentResponse` |
| `packages/api/app/services/recommendation_service.py` | Drop restriction `is_curated/tier=deep` sur path `theme/topic/entity` ; normalisation entity (lower + strip suffixes corp PBC/Inc/SAS/GmbH…) + égalité stricte ; regex + helper hoistés au module level |
| `apps/mobile/lib/features/feed/providers/feed_provider.dart` | Snapshot `_globalItems` du feed non-filtré, mis à jour à chaque fetch initial/refresh non-filtré |
| `apps/mobile/lib/features/feed/screens/feed_screen.dart` | Passe `badgeItems` (global si dispo, sinon feedItems) à `FavoriteTopicTabs` |

## Comment ça a été vérifié

- [x] `ruff check` + `ruff format --check` clean
- [x] 847 tests unitaires backend passent (11 erreurs infra Docker non dispo)
- [x] `is_followed_source` présent dans OpenAPI `FeedItemResponse`
- [x] Normalisation entity : 7 cas edge validés (Anthropic/PBC, Meta/Metaverse, TotalEnergies/SA…)
- [x] `/simplify` : regex hoistée au module level (compilée 1x au lieu de par-request)
- [x] `flutter test` non lancé (Docker down en local) — à valider en CI

## Zones à risque

- `_get_candidates` path `theme/topic/entity` : plus de filtre source → retourne potentiellement plus de rows Postgres. Compensé par le post-filtre entity en Python + pagination existante (LIMIT upstream).
- Normalisation entity : suffixes courts (`sa`, `co`) pourraient matcher des cas légitimes — liste conservative, couvre les cas observés.