### PR TITLE
fix(lettres): target_route sur les actions + fix détection add_2_personal_sources

### DIFF
--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -475,10 +475,13 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: RoutePaths.digest,
         name: RouteNames.digest,
-        pageBuilder: (context, state) => const FullSwipeCupertinoPage(
-          transitionDurationOverride: Duration(milliseconds: 480),
-          child: DigestScreen(),
-        ),
+        pageBuilder: (context, state) {
+          final serein = state.uri.queryParameters['serein'] == '1';
+          return FullSwipeCupertinoPage(
+            transitionDurationOverride: const Duration(milliseconds: 480),
+            child: DigestScreen(initialSerein: serein),
+          );
+        },
       ),
 
       // Topic Explorer (outside ShellRoute to hide bottom nav)

--- a/apps/mobile/lib/features/digest/screens/digest_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/digest_screen.dart
@@ -40,7 +40,13 @@ import '../../../core/ui/notification_service.dart';
 /// Main digest screen showing the daily "Essentiel" with 7 articles
 /// Uses DigestBriefingSection with Feed-style header and segmented progress bar
 class DigestScreen extends ConsumerStatefulWidget {
-  const DigestScreen({super.key});
+  /// When true (e.g. via `/digest?serein=1`), force serein mode locally for
+  /// this visit only and fire the bonnes_nouvelles_opened analytics event,
+  /// matching the entry-card flow. The user's persisted preference isn't
+  /// touched.
+  final bool initialSerein;
+
+  const DigestScreen({super.key, this.initialSerein = false});
 
   @override
   ConsumerState<DigestScreen> createState() => _DigestScreenState();
@@ -51,6 +57,13 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
   final ScrollController _scrollController = ScrollController();
   // Sprint 2 PR1 — dedupe digest_opened + digest_item_viewed per digest_id.
   String? _trackedDigestId;
+  bool? _sereinOriginal;
+
+  @override
+  void deactivate() {
+    _restoreSereinIfNeeded();
+    super.deactivate();
+  }
 
   @override
   void dispose() {
@@ -58,10 +71,35 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
     super.dispose();
   }
 
+  void _restoreSereinIfNeeded() {
+    final original = _sereinOriginal;
+    if (original == null) return;
+    final notifier = ref.read(sereinToggleProvider.notifier);
+    if (ref.read(sereinToggleProvider).enabled != original) {
+      notifier.setEnabledLocal(original);
+    }
+    _sereinOriginal = null;
+  }
+
   @override
   void initState() {
     super.initState();
     WidgetService.initWidgetIfNeeded();
+    if (widget.initialSerein) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final current = ref.read(sereinToggleProvider).enabled;
+        _sereinOriginal = current;
+        if (!current) {
+          ref.read(sereinToggleProvider.notifier).setEnabledLocal(true);
+        }
+        unawaited(
+          ref
+              .read(analyticsServiceProvider)
+              .trackBonnesNouvellesOpened(targetDate: DateTime.now()),
+        );
+      });
+    }
   }
 
   /// Intercept exit from the digest to nudge the user (once) to pin the
@@ -74,6 +112,7 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
       await WidgetPinNudge.show(context, ref);
     }
     if (!mounted) return;
+    _restoreSereinIfNeeded();
     if (context.canPop()) {
       context.pop();
     } else {

--- a/apps/mobile/lib/features/lettres/models/letter.dart
+++ b/apps/mobile/lib/features/lettres/models/letter.dart
@@ -24,6 +24,7 @@ class LetterAction {
   final String help;
   final LetterActionStatus status;
   final String? completionPalier;
+  final String? targetRoute;
 
   const LetterAction({
     required this.id,
@@ -31,6 +32,7 @@ class LetterAction {
     required this.help,
     required this.status,
     this.completionPalier,
+    this.targetRoute,
   });
 }
 
@@ -99,6 +101,7 @@ class Letter {
         help: raw['help'] as String? ?? '',
         status: actionStatus,
         completionPalier: raw['completion_palier'] as String?,
+        targetRoute: raw['target_route'] as String?,
       ));
     }
 

--- a/apps/mobile/lib/features/lettres/screens/open_letter_screen.dart
+++ b/apps/mobile/lib/features/lettres/screens/open_letter_screen.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
@@ -23,7 +24,8 @@ class OpenLetterScreen extends ConsumerStatefulWidget {
   ConsumerState<OpenLetterScreen> createState() => _OpenLetterScreenState();
 }
 
-class _OpenLetterScreenState extends ConsumerState<OpenLetterScreen> {
+class _OpenLetterScreenState extends ConsumerState<OpenLetterScreen>
+    with WidgetsBindingObserver {
   bool _completionShown = false;
   // Anti-cascade : on snapshot les actions déjà done au premier load pour ne
   // pas afficher de toast pour des paliers déjà acquis avant cette session.
@@ -33,10 +35,42 @@ class _OpenLetterScreenState extends ConsumerState<OpenLetterScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    // Seed le snapshot dès maintenant si l'état Riverpod est déjà chargé,
+    // pour que la transition todo→done qui suivra le refresh ci-dessous
+    // déclenche bien un toast (sinon elle serait avalée par la 1ʳᵉ émission).
+    final initial = ref.read(lettersProvider).valueOrNull;
+    if (initial != null) {
+      final letter = initial.letters
+          .where((l) => l.id == widget.letterId)
+          .cast<Letter?>()
+          .firstOrNull;
+      if (letter != null) {
+        _seenDoneActionIds.addAll(
+          letter.actions
+              .where((a) => a.status == LetterActionStatus.done)
+              .map((a) => a.id),
+        );
+        _seenInitialized = true;
+      }
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       ref.read(lettersProvider.notifier).refreshLetterStatus(widget.letterId);
     });
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed && mounted) {
+      ref.read(lettersProvider.notifier).refreshLetterStatus(widget.letterId);
+    }
   }
 
   void _maybeShowCompletion(LetterProgressState state) {
@@ -354,8 +388,16 @@ class _Body extends ConsumerWidget {
                 ...letter.actions.map(
                   (a) => LetterActionTile(
                     action: a,
-                    onTap: () =>
-                        ref.read(lettersProvider.notifier).silentRefresh(),
+                    onTap: () async {
+                      final route = a.targetRoute;
+                      if (route != null && route.isNotEmpty) {
+                        await context.push<void>(route);
+                      }
+                      if (!context.mounted) return;
+                      await ref
+                          .read(lettersProvider.notifier)
+                          .refreshLetterStatus(letter.id);
+                    },
                   ),
                 ),
                 const SizedBox(height: 24),

--- a/apps/mobile/test/features/lettres/models/letter_test.dart
+++ b/apps/mobile/test/features/lettres/models/letter_test.dart
@@ -22,6 +22,36 @@ void main() {
       expect(l.introPalier, isNull);
       expect(l.completionVoeu, isNull);
       expect(l.actions.single.completionPalier, isNull);
+      expect(l.actions.single.targetRoute, isNull);
+    });
+
+    test('parses target_route on actions', () {
+      final l = Letter.fromJson({
+        'id': 'letter_1',
+        'num': '01',
+        'title': 'X',
+        'message': 'm',
+        'signature': 's',
+        'status': 'active',
+        'actions': [
+          {
+            'id': 'a1',
+            'label': 'A',
+            'help': 'h',
+            'target_route': '/settings/sources/add',
+          },
+          {
+            'id': 'a2',
+            'label': 'B',
+            'help': 'h',
+          },
+        ],
+        'completed_actions': <String>[],
+        'progress': 0.0,
+      });
+
+      expect(l.actions[0].targetRoute, '/settings/sources/add');
+      expect(l.actions[1].targetRoute, isNull);
     });
 
     test('parses L2 payload with narrative fields', () {

--- a/packages/api/app/services/letters/catalog.py
+++ b/packages/api/app/services/letters/catalog.py
@@ -28,6 +28,7 @@ LETTER_1: dict = {
             "id": "define_editorial_line",
             "label": "Définir ta ligne éditoriale",
             "help": "3 à 5 centres d'intérêt — tech, climat, culture…",
+            "target_route": "/settings/interests",
         },
         {
             "id": "add_5_sources",
@@ -35,16 +36,19 @@ LETTER_1: dict = {
             "help": (
                 "Pioche dans la liste suggérée. Tu peux toujours en retirer plus tard."
             ),
+            "target_route": "/settings/sources",
         },
         {
             "id": "add_2_personal_sources",
             "label": "Ajouter 2 sources personnelles",
             "help": "Un blog, une newsletter, un site que tu lis déjà.",
+            "target_route": "/settings/sources/add",
         },
         {
             "id": "first_perspectives_open",
             "label": "Lancer ta première analyse de comparaison",
             "help": "Compare deux angles sur le même sujet.",
+            "target_route": "/feed",
         },
     ],
     "message": (
@@ -69,6 +73,7 @@ LETTER_2: dict = {
             "label": "Lire L'essentiel du jour",
             "help": "Cinq articles, choisis pour toi. C'est le rendez-vous quotidien.",
             "completion_palier": "Premier rendez-vous tenu. Ça commence ici.",
+            "target_route": "/digest",
         },
         {
             "id": "read_first_bonnes_nouvelles",
@@ -77,6 +82,7 @@ LETTER_2: dict = {
             "completion_palier": (
                 "Tu sais maintenant que la lecture peut aussi faire du bien."
             ),
+            "target_route": "/digest?serein=1",
         },
         {
             "id": "read_3_long_articles",
@@ -85,6 +91,7 @@ LETTER_2: dict = {
             "completion_palier": (
                 "Trois lectures menées au bout. C'est ce qui te distingue déjà."
             ),
+            "target_route": "/feed",
         },
         {
             "id": "read_first_video_podcast",
@@ -93,6 +100,7 @@ LETTER_2: dict = {
             "completion_palier": (
                 "Tu varies les formats. C'est comme ça qu'on s'enrichit."
             ),
+            "target_route": "/feed",
         },
         {
             "id": "recommend_first_article",
@@ -101,6 +109,7 @@ LETTER_2: dict = {
                 "Un like (🌻), c'est un signal. Il oriente ta sélection et celle des autres."
             ),
             "completion_palier": "Un signal envoyé. Le Facteur écoute.",
+            "target_route": "/feed",
         },
     ],
     "message": (

--- a/packages/api/app/services/letters/service.py
+++ b/packages/api/app/services/letters/service.py
@@ -54,13 +54,29 @@ async def _detect_add_5_sources(user_id: UUID, db: AsyncSession) -> bool:
 
 
 async def _detect_add_2_personal_sources(user_id: UUID, db: AsyncSession) -> bool:
-    """≥2 user_sources avec is_custom=True."""
-    stmt = (
+    """≥2 user_sources ajoutées après le démarrage de la Lettre 1.
+
+    Compte toute association (curée OU custom) ajoutée après que l'utilisateur
+    soit entré dans la Lettre 1, pour valider l'effort post-onboarding sans
+    dépendre du flag is_custom (qui ne couvre que les ajouts par URL libre).
+    """
+    started_at = await db.scalar(
+        select(UserLetterProgress.started_at).where(
+            UserLetterProgress.user_id == user_id,
+            UserLetterProgress.letter_id == "letter_1",
+        )
+    )
+    if started_at is None:
+        return False
+    count = await db.scalar(
         select(func.count())
         .select_from(UserSource)
-        .where(UserSource.user_id == user_id, UserSource.is_custom.is_(True))
+        .where(
+            UserSource.user_id == user_id,
+            UserSource.added_at >= started_at,
+        )
     )
-    return ((await db.execute(stmt)).scalar() or 0) >= 2
+    return (count or 0) >= 2
 
 
 def _first_event_detector(event_type: str):
@@ -155,7 +171,7 @@ def _serialize(row: UserLetterProgress, catalog: dict) -> dict:
     serialized_actions = [
         {
             k: a[k]
-            for k in ("id", "label", "help", "completion_palier")
+            for k in ("id", "label", "help", "completion_palier", "target_route")
             if k in a and a[k] is not None
         }
         for a in actions

--- a/packages/api/tests/routers/test_letters_routes.py
+++ b/packages/api/tests/routers/test_letters_routes.py
@@ -11,7 +11,7 @@ Couvre :
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
 import pytest_asyncio
@@ -75,8 +75,19 @@ async def _add_topics(db_session, user_id: UUID, count: int) -> None:
     await db_session.commit()
 
 
-async def _add_sources(db_session, user_id: UUID, total: int, custom: int) -> None:
-    """Crée `total` user_sources dont `custom` avec is_custom=True."""
+async def _add_sources(
+    db_session,
+    user_id: UUID,
+    total: int,
+    custom: int,
+    *,
+    added_at: datetime | None = None,
+) -> None:
+    """Crée `total` user_sources dont `custom` avec is_custom=True.
+
+    `added_at` permet de simuler des ajouts antérieurs ou postérieurs au
+    démarrage de la Lettre 1, ce qui matter pour `_detect_add_2_personal_sources`.
+    """
     for i in range(total):
         src = Source(
             id=uuid4(),
@@ -89,14 +100,46 @@ async def _add_sources(db_session, user_id: UUID, total: int, custom: int) -> No
         )
         db_session.add(src)
         await db_session.flush()
-        db_session.add(
-            UserSource(
-                user_id=user_id,
-                source_id=src.id,
-                is_custom=i < custom,
-            )
-        )
+        kwargs: dict = {
+            "user_id": user_id,
+            "source_id": src.id,
+            "is_custom": i < custom,
+        }
+        if added_at is not None:
+            kwargs["added_at"] = added_at
+        db_session.add(UserSource(**kwargs))
     await db_session.commit()
+
+
+async def _ensure_letter_1_started(db_session, user_id: UUID) -> datetime:
+    """Initialise les rows letter_progress (L1 active) et retourne started_at."""
+    now = datetime.now(UTC)
+    db_session.add_all(
+        [
+            UserLetterProgress(
+                user_id=user_id,
+                letter_id="letter_0",
+                status="archived",
+                completed_actions=[],
+                archived_at=now,
+            ),
+            UserLetterProgress(
+                user_id=user_id,
+                letter_id="letter_1",
+                status="active",
+                completed_actions=[],
+                started_at=now,
+            ),
+            UserLetterProgress(
+                user_id=user_id,
+                letter_id="letter_2",
+                status="upcoming",
+                completed_actions=[],
+            ),
+        ]
+    )
+    await db_session.commit()
+    return now
 
 
 async def _add_perspectives_event(db_session, user_id: UUID) -> None:
@@ -261,7 +304,16 @@ class TestAutoDetection:
         assert "define_editorial_line" not in resp.json()["completed_actions"]
 
     async def test_sources_actions_detected(self, auth_user, db_session):
-        await _add_sources(db_session, auth_user, total=5, custom=2)
+        # L1 doit être démarrée avant l'ajout de sources : `add_2_personal_sources`
+        # ne compte que les sources ajoutées après `letter_1.started_at`.
+        started_at = await _ensure_letter_1_started(db_session, auth_user)
+        await _add_sources(
+            db_session,
+            auth_user,
+            total=5,
+            custom=2,
+            added_at=started_at + timedelta(seconds=1),
+        )
 
         async with _client() as ac:
             resp = await ac.post("/api/letters/letter_1/refresh-status")
@@ -269,6 +321,44 @@ class TestAutoDetection:
         completed = resp.json()["completed_actions"]
         assert "add_5_sources" in completed
         assert "add_2_personal_sources" in completed
+
+    async def test_curated_sources_count_after_letter_1_started(
+        self, auth_user, db_session
+    ):
+        """Régression : 2 sources curées (is_custom=False) ajoutées après le
+        démarrage de la Lettre 1 doivent valider `add_2_personal_sources`."""
+        started_at = await _ensure_letter_1_started(db_session, auth_user)
+        await _add_sources(
+            db_session,
+            auth_user,
+            total=2,
+            custom=0,
+            added_at=started_at + timedelta(seconds=1),
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_1/refresh-status")
+
+        assert "add_2_personal_sources" in resp.json()["completed_actions"]
+
+    async def test_sources_added_before_letter_1_not_counted(
+        self, auth_user, db_session
+    ):
+        """Les sources ajoutées avant le démarrage de la Lettre 1 (ex.
+        onboarding) ne valident pas `add_2_personal_sources`."""
+        started_at = await _ensure_letter_1_started(db_session, auth_user)
+        await _add_sources(
+            db_session,
+            auth_user,
+            total=3,
+            custom=3,
+            added_at=started_at - timedelta(hours=1),
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_1/refresh-status")
+
+        assert "add_2_personal_sources" not in resp.json()["completed_actions"]
 
     async def test_perspectives_event_detected(self, auth_user, db_session):
         await _add_perspectives_event(db_session, auth_user)
@@ -281,8 +371,15 @@ class TestAutoDetection:
 
 class TestChaining:
     async def test_l1_archived_unlocks_l2(self, auth_user, db_session):
+        started_at = await _ensure_letter_1_started(db_session, auth_user)
         await _add_topics(db_session, auth_user, 3)
-        await _add_sources(db_session, auth_user, total=5, custom=2)
+        await _add_sources(
+            db_session,
+            auth_user,
+            total=5,
+            custom=2,
+            added_at=started_at + timedelta(seconds=1),
+        )
         await _add_perspectives_event(db_session, auth_user)
 
         async with _client() as ac:
@@ -316,8 +413,15 @@ class TestIdempotence:
         self, auth_user, db_session
     ):
         # Archive L1 manuellement
+        started_at = await _ensure_letter_1_started(db_session, auth_user)
         await _add_topics(db_session, auth_user, 3)
-        await _add_sources(db_session, auth_user, total=5, custom=2)
+        await _add_sources(
+            db_session,
+            auth_user,
+            total=5,
+            custom=2,
+            added_at=started_at + timedelta(seconds=1),
+        )
         await _add_perspectives_event(db_session, auth_user)
 
         async with _client() as ac:


### PR DESCRIPTION
## What

Ajoute `target_route` sur chaque action de lettre pour naviguer directement vers l'écran concerné depuis la fiche lettre. Corrige également le détecteur `add_2_personal_sources` qui ne comptait que les sources `is_custom=True` au lieu des sources ajoutées après le démarrage de la Lettre 1.

## Why

Les actions restaient passives (pas cliquables vers un écran). La correction du détecteur permet de valider l'action même avec des sources curées ajoutées post-onboarding.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)