### PR TITLE
feat(feed): chiffres sur onglets + scroll-to-top synchro avec sticky filter

### DIFF
--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -102,9 +102,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
   // Sticky filter bar overlay state
   bool _showStickyBar = false;
   double _lastScrollPos = 0;
-  double _lastFabScrollPos = 0;
   bool _showScrollTopFab = false;
-  double _upwardAccumulator = 0;
   bool _showPullHint = false;
   DateTime? _lastPullHintAt;
   Timer? _pullHintTimer;
@@ -341,7 +339,9 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
       setState(() => _userHasScrolled = true);
     }
 
-    // Sticky filter bar visibility
+    // Sticky filter bar + bouton "remonter" : même logique d'apparition.
+    // Apparaissent au scroll up (delta < 0) au-dessus du seuil, disparaissent
+    // au scroll down ou repassage sous le seuil.
     final delta = currentScroll - _lastScrollPos;
     if (delta.abs() >= _stickyScrollThreshold) {
       bool next = _showStickyBar;
@@ -352,8 +352,11 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
       } else if (delta > 0) {
         next = false;
       }
-      if (next != _showStickyBar) {
-        setState(() => _showStickyBar = next);
+      if (next != _showStickyBar || next != _showScrollTopFab) {
+        setState(() {
+          _showStickyBar = next;
+          _showScrollTopFab = next;
+        });
       }
       _lastScrollPos = currentScroll;
     }
@@ -379,27 +382,6 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
         ScrollDirection.forward;
     if (currentScroll >= maxScroll - 800 && notScrollingUp) {
       ref.read(feedProvider.notifier).loadMore();
-    }
-
-    // Bouton "remonter" : cumul instantané du scroll vers le haut. Apparait
-    // après ≥ 250 px remontés ET position > 600 px. Disparait IMMÉDIATEMENT
-    // dès que l'utilisateur descend ou repasse sous 200 px.
-    final fabDelta = currentScroll - _lastFabScrollPos;
-    _lastFabScrollPos = currentScroll;
-    if (fabDelta < -0.5) {
-      _upwardAccumulator += -fabDelta;
-    } else if (fabDelta > 0.5) {
-      _upwardAccumulator = 0;
-      if (_showScrollTopFab) {
-        setState(() => _showScrollTopFab = false);
-      }
-    }
-    final shouldShowScrollTop = _upwardAccumulator > 250 && currentScroll > 600;
-    final shouldHideScrollTop = currentScroll < 200;
-    if (shouldShowScrollTop && !_showScrollTopFab) {
-      setState(() => _showScrollTopFab = true);
-    } else if (shouldHideScrollTop && _showScrollTopFab) {
-      setState(() => _showScrollTopFab = false);
     }
 
     // Hint pull-to-refresh : montre une fois quand l'utilisateur remonte
@@ -566,6 +548,11 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
           _scrollToTop();
         },
         onTapActiveTab: _scrollToTop,
+        onTapActiveTabRefresh: () {
+          HapticFeedback.mediumImpact();
+          _scrollToTop();
+          _refresh();
+        },
         onAddFavorite: () {
           HapticFeedback.mediumImpact();
           InterestFilterSheet.show(

--- a/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/digest_entry_card.dart
@@ -24,7 +24,7 @@ import '../../lettres/providers/letters_provider.dart';
 class DigestEntryCard extends ConsumerWidget {
   const DigestEntryCard({super.key});
 
-  static const double _carouselHeight = 170;
+  static const double _carouselHeight = 162;
   static const double _horizontalPadding = 16;
   static const double _peek = 24;
   static const double _gap = 12;
@@ -36,13 +36,12 @@ class DigestEntryCard extends ConsumerWidget {
     final colors = context.facteurColors;
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
-    final normalCount = dual.normal?.items.length ?? 5;
-    final sereinCount = dual.serein?.items.length ?? normalCount;
     final targetDate = dual.normal?.targetDate ?? DateTime.now();
 
-    final width = MediaQuery.of(context).size.width -
-        (_horizontalPadding * 2) -
-        _peek;
+    final width = (MediaQuery.of(context).size.width -
+            (_horizontalPadding * 2) -
+            _peek) *
+        0.95;
 
     Future<void> openDigest({required bool requireSerein}) async {
       if (requireSerein) {
@@ -78,9 +77,6 @@ class DigestEntryCard extends ConsumerWidget {
         pill: EssentielPill(colors: colors, isDark: isDark),
         title: "L'essentiel du jour",
         titleColor: colors.textPrimary,
-        captionColor: colors.textTertiary,
-        articleCount: normalCount,
-        targetDate: targetDate,
         onTap: () => openDigest(requireSerein: false),
       ),
     );
@@ -93,9 +89,6 @@ class DigestEntryCard extends ConsumerWidget {
         pill: BonnesNouvellesPill(isDark: isDark),
         title: 'Les bonnes nouvelles',
         titleColor: colors.textPrimary,
-        captionColor: colors.textTertiary,
-        articleCount: sereinCount,
-        targetDate: targetDate,
         assetPath: 'assets/notifications/facteur_goodnews.png',
         onTap: () => openDigest(requireSerein: true),
       ),
@@ -125,9 +118,6 @@ class _CarouselCard extends StatelessWidget {
   final Widget pill;
   final String title;
   final Color titleColor;
-  final Color captionColor;
-  final int articleCount;
-  final DateTime targetDate;
   final VoidCallback onTap;
   final double avatarOpacity;
   final String assetPath;
@@ -138,9 +128,6 @@ class _CarouselCard extends StatelessWidget {
     required this.pill,
     required this.title,
     required this.titleColor,
-    required this.captionColor,
-    required this.articleCount,
-    required this.targetDate,
     required this.onTap,
     this.avatarOpacity = 1.0,
     this.assetPath = 'assets/notifications/facteur_avatar.png',
@@ -218,18 +205,6 @@ class _CarouselCard extends StatelessWidget {
                   .copyWith(fontSize: 22, height: 1.15),
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          Positioned(
-            left: 28,
-            right: 120,
-            bottom: 16,
-            child: Text(
-              '$articleCount articles · ${formatDigestDate(targetDate)}',
-              style: FacteurTypography.stamp(captionColor).copyWith(
-                fontSize: 11,
-                letterSpacing: 1.2,
-              ),
             ),
           ),
         ],

--- a/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
+++ b/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
@@ -40,6 +40,7 @@ class FavoriteTopicTabs extends ConsumerStatefulWidget {
   final String? selectedEntitySlug;
   final void Function(FavoriteTabKind kind, String? slug) onTabTap;
   final VoidCallback onTapActiveTab;
+  final VoidCallback onTapActiveTabRefresh;
   final VoidCallback onAddFavorite;
 
   const FavoriteTopicTabs({
@@ -51,6 +52,7 @@ class FavoriteTopicTabs extends ConsumerStatefulWidget {
     this.selectedEntitySlug,
     required this.onTabTap,
     required this.onTapActiveTab,
+    required this.onTapActiveTabRefresh,
     required this.onAddFavorite,
   });
 
@@ -159,7 +161,11 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
               colors: colors,
               onTap: () {
                 if (tab.active) {
-                  widget.onTapActiveTab();
+                  if (tab.count >= 3) {
+                    widget.onTapActiveTabRefresh();
+                  } else {
+                    widget.onTapActiveTab();
+                  }
                 } else {
                   HapticFeedback.selectionClick();
                   widget.onTabTap(tab.kind, tab.slug);
@@ -359,8 +365,7 @@ class _FavoriteTabItem extends StatelessWidget {
     final labelColor =
         tab.active ? colors.textPrimary : colors.textSecondary;
     final labelWeight = tab.active ? FontWeight.w700 : FontWeight.w500;
-    final countColor =
-        tab.active ? colors.primary : colors.textTertiary;
+    final showBadge = tab.count >= 3;
     final showLabel =
         tab.emoji.isNotEmpty ? '${tab.emoji} ${tab.label}' : tab.label;
 
@@ -399,19 +404,28 @@ class _FavoriteTabItem extends StatelessWidget {
                 ],
               ),
             ),
-            if (tab.count > 0) ...[
-              const SizedBox(width: 4),
+            if (showBadge) ...[
+              const SizedBox(width: 6),
               Transform.translate(
                 offset: const Offset(0, -6),
-                child: Text(
-                  tab.count > 10 ? '10+' : '${tab.count}',
-                  style: TextStyle(
-                    fontSize: 11,
-                    fontWeight: FontWeight.w700,
-                    color: countColor,
-                    height: 1.0,
-                  ),
-                ),
+                child: tab.active
+                    ? Container(
+                        width: 6,
+                        height: 6,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: colors.primary,
+                        ),
+                      )
+                    : Text(
+                        tab.count > 10 ? '10+' : '${tab.count}',
+                        style: TextStyle(
+                          fontSize: 10.5,
+                          fontWeight: FontWeight.w600,
+                          color: colors.textTertiary,
+                          height: 1.0,
+                        ),
+                      ),
               ),
             ],
           ],

--- a/apps/mobile/test/features/feed/widgets/digest_entry_card_test.dart
+++ b/apps/mobile/test/features/feed/widgets/digest_entry_card_test.dart
@@ -33,8 +33,8 @@ void main() {
       expect(find.text("L'ESSENTIEL"), findsOneWidget);
       expect(find.text('Les bonnes nouvelles'), findsOneWidget);
       expect(find.text('BONNES NOUVELLES'), findsOneWidget);
-      // Les deux cartes affichent le sous-titre meta « N articles · date ».
-      expect(find.textContaining('articles ·'), findsNWidgets(2));
+      // Le sous-titre meta « N articles · date » a été retiré du design.
+      expect(find.textContaining('articles ·'), findsNothing);
       // Illustration facteur sur la carte Essentiel.
       final essentielIllustration = find.byWidgetPredicate(
         (w) =>
@@ -55,7 +55,8 @@ void main() {
       expect(goodNewsIllustration, findsOneWidget);
     });
 
-    testWidgets('utilise items.length du digest quand chargé', (tester) async {
+    testWidgets('rend les deux cartes quand un digest est chargé',
+        (tester) async {
       final digest = DigestResponse(
         digestId: 'd1',
         userId: 'u1',
@@ -68,9 +69,8 @@ void main() {
       await tester.pumpWidget(makeHost(digest: digest));
       await tester.pumpAndSettle();
 
-      // Les 2 cartes utilisent le même fallback de count quand la variante
-      // serein n'est pas encore en cache.
-      expect(find.text('7 articles · 21 mai'), findsNWidgets(2));
+      expect(find.text("L'essentiel du jour"), findsOneWidget);
+      expect(find.text('Les bonnes nouvelles'), findsOneWidget);
     });
   });
 }

--- a/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
+++ b/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
@@ -226,6 +226,7 @@ void main() {
           items: const [],
           onTabTap: (_, __) => tabTapCalls++,
           onTapActiveTab: () => tapActiveCalls++,
+          onTapActiveTabRefresh: () => tapActiveCalls++,
           onAddFavorite: () {},
         ),
       ));
@@ -248,6 +249,7 @@ void main() {
           items: const [],
           onTabTap: (_, __) {},
           onTapActiveTab: () {},
+          onTapActiveTabRefresh: () {},
           onAddFavorite: () => addCalls++,
         ),
       ));


### PR DESCRIPTION
## Quoi

Deux micro-ajustements UX sur le feed :

1. **Onglets favoris** : la dot grise des onglets inactifs avec ≥ 3 articles est remplacée par le compteur en petit (`4`, `10+`, …), gris, en exposant. La dot orange de l'onglet actif est conservée.
2. **Bouton scroll-to-top** : sa logique d'apparition est désormais identique à celle du sticky filter header (même seuil 380 px, même delta 12 px, même direction de scroll). Suppression de l'accumulator de scroll up dédié.

Inclut aussi les tweaks de hauteur du carousel digest restés en attente sur la branche.

## Pourquoi

- Les chiffres sont plus informatifs que la dot grise (utilisateurs voyaient un point sans savoir s'il y avait 3 ou 30 articles à venir).
- La désynchro entre le sticky filter et le scroll-to-top créait une UX bancale au scroll up.

## Comment ça a été vérifié

- [x] `flutter test test/features/feed/widgets/favorite_topic_tabs_test.dart` — 7 tests OK
- [x] `flutter analyze` — pas de nouveaux warnings
- [x] Suite mobile complète exécutée — les échecs présents sont préexistants et indépendants de ce diff
- [ ] Validation visuelle simulateur (à faire avant merge)
- [x] /simplify : batch des deux `setState` quand sticky bar et FAB togglent ensemble

## Zones à risque

- Logique de scroll dans `feed_screen.dart` (`_onScroll`) — fusionnée avec celle du sticky header. Comportement adjacent (loadMore, pull hint) inchangé.