### PR TITLE
feat(reader): ajustements UI feed/reader (post-#587/#588)

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -27,6 +27,7 @@ import '../../feed/repositories/feed_repository.dart';
 import '../../feed/widgets/perspectives_bottom_sheet.dart';
 import '../../lettres/providers/letters_provider.dart';
 import '../../sources/providers/sources_providers.dart';
+import '../../sources/widgets/source_logo_avatar.dart';
 import '../../../widgets/sunflower_icon.dart';
 import '../providers/nudge_provider.dart' show NudgeTracker;
 import '../widgets/article_reader_widget.dart';
@@ -471,6 +472,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   }
 
   void _maybeRequestReadOnSiteNudge(double progress) {
+    if (_isPartialContent) return;
     if (_readOnSiteNudgeRequested) return;
     if (_showReadOnSiteNudge) return;
     if (progress < 0.5) return;
@@ -643,6 +645,62 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     final shouldStick = perspScreenY < appHeaderBottomY;
     if (shouldStick != _showStickyPerspectivesHeader.value) {
       _showStickyPerspectivesHeader.value = shouldStick;
+    }
+  }
+
+  /// Shared handler for the inline "Couverture médiatique" toggle. On
+  /// expand-from-collapsed, scrolls the perspectives divider into view and
+  /// flips [_atPerspectivesSection] so the floating "Lancer l'analyse Facteur"
+  /// button reappears. On collapse, preserves the existing recheck behaviour.
+  void _onPerspectivesToggle() {
+    HapticFeedback.lightImpact();
+    final wasCollapsed = !_perspectivesExpanded;
+    setState(() {
+      _perspectivesExpanded = !_perspectivesExpanded;
+      _suppressPerspectivesCheck = true;
+    });
+    if (wasCollapsed) {
+      _atPerspectivesSection.value = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final ctx = _perspectivesDividerKey.currentContext;
+        if (ctx != null) {
+          Scrollable.ensureVisible(
+            ctx,
+            alignment: 0.0,
+            duration: const Duration(milliseconds: 400),
+            curve: Curves.easeInOut,
+          );
+          // Re-trigger after AnimatedSize expansion settles maxScrollExtent.
+          Future.delayed(const Duration(milliseconds: 250), () {
+            if (!mounted) return;
+            final c = _perspectivesDividerKey.currentContext;
+            if (c != null) {
+              Scrollable.ensureVisible(
+                c,
+                alignment: 0.0,
+                duration: const Duration(milliseconds: 250),
+                curve: Curves.easeOut,
+              );
+            }
+          });
+        }
+        Future.delayed(const Duration(milliseconds: 550), () {
+          if (mounted) {
+            setState(() => _suppressPerspectivesCheck = false);
+          }
+        });
+      });
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _checkAtPerspectivesSection(force: true);
+        Future.delayed(const Duration(milliseconds: 200), () {
+          if (mounted) {
+            setState(() => _suppressPerspectivesCheck = false);
+          }
+        });
+      });
     }
   }
 
@@ -1995,7 +2053,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
               // Article: dynamic "Article complet" / "Lire via Navigateur"
               // with permanent-orange logic. Video/audio: simple external CTA.
               Flexible(
-                fit: isArticle ? FlexFit.loose : FlexFit.tight,
+                fit: FlexFit.loose,
                 child: SizedBox(
                   height: 53,
                   child: isArticle
@@ -2011,8 +2069,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       final label = isWebViewMode
                           ? 'Lire via Navigateur'
                           : 'Article complet';
-                      final showLogo = !isWebViewMode &&
-                          content.source.logoUrl != null;
+                      final showLogo = !isWebViewMode;
                       final iconData = isWebViewMode
                           ? PhosphorIcons.arrowUpRight(
                               PhosphorIconsStyle.regular)
@@ -2021,16 +2078,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
                       final children = <Widget>[
                         if (showLogo) ...[
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(8),
-                            child: CachedNetworkImage(
-                              imageUrl: content.source.logoUrl!,
-                              width: 28,
-                              height: 28,
-                              fit: BoxFit.cover,
-                              errorWidget: (_, __, ___) =>
-                                  const SizedBox.shrink(),
-                            ),
+                          SourceLogoAvatar(
+                            source: content.source,
+                            size: 28,
+                            radius: 8,
                           ),
                           const SizedBox(width: 6),
                         ],
@@ -2106,9 +2157,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       : _buildExternalCtaButton(context, content),
                 ),
               ),
-              if (isArticle) ...[
-                const SizedBox(width: 4),
-
+              Expanded(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+              if (isArticle)
                 // Autres points de vue / Retour à l'article
                 ValueListenableBuilder<bool>(
                   valueListenable: _atPerspectivesSection,
@@ -2271,7 +2324,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   );
                 },
                 ),
-              ],
 
               // Sauvegarder (long-press → collection picker)
               GestureDetector(
@@ -2323,6 +2375,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     inactiveColor: colors.textSecondary,
                   ),
                   tooltip: 'Recommander',
+                ),
+              ),
+                  ],
                 ),
               ),
             ],
@@ -2453,21 +2508,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             behavior: HitTestBehavior.opaque,
                             child: Row(
                               children: [
-                                // Source logo (reduced from 32 to 28)
-                                if (content.source.logoUrl != null)
-                                  ClipRRect(
-                                    borderRadius: BorderRadius.circular(10),
-                                    child: CachedNetworkImage(
-                                      imageUrl: content.source.logoUrl!,
-                                      width: 28,
-                                      height: 28,
-                                      fit: BoxFit.cover,
-                                      errorWidget: (_, __, ___) =>
-                                          _buildSourcePlaceholder(colors),
-                                    ),
-                                  )
-                                else
-                                  _buildSourcePlaceholder(colors),
+                                // Source logo (28px, fallback initiales)
+                                SourceLogoAvatar(
+                                  source: content.source,
+                                  size: 28,
+                                  radius: 10,
+                                ),
                                 const SizedBox(width: 8),
 
                                 // Source Name + Time + Badges
@@ -2919,18 +2965,58 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     );
   }
 
-  Widget _buildSourcePlaceholder(FacteurColors colors) {
-    return Container(
-      width: 24,
-      height: 24,
-      decoration: BoxDecoration(
-        color: colors.surfaceElevated,
-        borderRadius: BorderRadius.circular(12),
+  /// Inline "Article complet" button shown at the end of the body when the
+  /// article is in partial mode — replaces the dismissible nudge for partial
+  /// articles since reading-on-site is the only path to the full content.
+  Widget _buildPartialArticleInlineButton(BuildContext context, Content content) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: FacteurSpacing.space4,
+        vertical: FacteurSpacing.space4,
       ),
-      child: Icon(
-        PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
-        size: 14,
-        color: colors.textTertiary,
+      child: SizedBox(
+        height: 53,
+        child: OutlinedButton(
+          onPressed: _onReadOnSiteTap,
+          style: OutlinedButton.styleFrom(
+            backgroundColor: Colors.white.withValues(alpha: 0.5),
+            foregroundColor: colors.textPrimary,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            side: BorderSide(color: colors.border.withValues(alpha: 0.5)),
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SourceLogoAvatar(
+                source: content.source,
+                size: 24,
+                radius: 6,
+              ),
+              const SizedBox(width: 6),
+              Flexible(
+                child: Text(
+                  'Article complet',
+                  style: textTheme.labelMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: colors.textPrimary,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: 4),
+              Icon(
+                PhosphorIcons.arrowDown(PhosphorIconsStyle.regular),
+                size: 16,
+                color: colors.textSecondary,
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
@@ -3107,7 +3193,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 ),
                                 const SizedBox(height: FacteurSpacing.space3),
                               ],
-                              Divider(color: colors.border, height: 1),
                               const SizedBox(height: FacteurSpacing.space4),
                             ],
                           ),
@@ -3120,6 +3205,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         ),
                       ),
 
+                      if (isPartial && _contentResolved)
+                        _buildPartialArticleInlineButton(context, content),
+
                       // ZONE 2: Inline perspectives (articles only)
                       if (_perspectivesResponse != null ||
                           _perspectivesLoading) ...[
@@ -3128,7 +3216,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           color: colors.backgroundPrimary,
                           padding: const EdgeInsets.symmetric(
                             horizontal: FacteurSpacing.space4,
-                            vertical: FacteurSpacing.space6,
+                            vertical: FacteurSpacing.space4,
                           ),
                           child: Divider(color: colors.border, height: 1),
                         ),
@@ -3183,29 +3271,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                       analysisZoneKey: _analysisZoneKey,
                                       firstCardKey: _firstPerspectiveCardKey,
                                       isExpanded: _perspectivesExpanded,
-                                      onToggle: () {
-                                        setState(() {
-                                          _perspectivesExpanded =
-                                              !_perspectivesExpanded;
-                                          _suppressPerspectivesCheck = true;
-                                        });
-                                        WidgetsBinding.instance
-                                            .addPostFrameCallback((_) {
-                                          if (mounted) {
-                                            _checkAtPerspectivesSection(
-                                                force: true);
-                                            Future.delayed(
-                                                const Duration(
-                                                    milliseconds: 200), () {
-                                              if (mounted) {
-                                                setState(() =>
-                                                    _suppressPerspectivesCheck =
-                                                        false);
-                                              }
-                                            });
-                                          }
-                                        });
-                                      },
+                                      onToggle: _onPerspectivesToggle,
                                     )
                                   : const SizedBox.shrink(),
                         ),
@@ -3710,14 +3776,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
                 const SizedBox(height: FacteurSpacing.space4),
 
-                // ── Divider: header / article ─────────────────────────────
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: FacteurSpacing.space4),
-                  child: Divider(color: colors.border, height: 1),
-                ),
-                const SizedBox(height: FacteurSpacing.space4),
-
                 // ── Article section ────────────────────────────────────────
                 // Zero-height marker at the end lets _measureArticleExtent()
                 // compute progress against article length only (excludes perspectives).
@@ -3725,6 +3783,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     articleWidget,
+                    if (isPartial && _contentResolved)
+                      _buildPartialArticleInlineButton(context, content),
                     if (_showReadOnSiteNudge) ...[
                       const SizedBox(height: FacteurSpacing.space4),
                       Padding(
@@ -3757,7 +3817,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         horizontal: FacteurSpacing.space4),
                     child: Divider(color: colors.border, height: 1),
                   ),
-                  const SizedBox(height: FacteurSpacing.space8),
+                  const SizedBox(height: FacteurSpacing.space4),
                   if (_perspectivesLoading && _perspectivesResponse == null)
                     const Center(child: CircularProgressIndicator())
                   else if (_perspectivesResponse != null)
@@ -3796,24 +3856,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       analysisZoneKey: _analysisZoneKey,
                       firstCardKey: _firstPerspectiveCardKey,
                       isExpanded: _perspectivesExpanded,
-                      onToggle: () {
-                        setState(() {
-                          _perspectivesExpanded = !_perspectivesExpanded;
-                          _suppressPerspectivesCheck = true;
-                        });
-                        WidgetsBinding.instance.addPostFrameCallback((_) {
-                          if (mounted) {
-                            _checkAtPerspectivesSection(force: true);
-                            Future.delayed(const Duration(milliseconds: 200),
-                                () {
-                              if (mounted) {
-                                setState(() =>
-                                    _suppressPerspectivesCheck = false);
-                              }
-                            });
-                          }
-                        });
-                      },
+                      onToggle: _onPerspectivesToggle,
                     ),
                 ],
 

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -788,38 +788,11 @@ class PerspectivesEmptyState extends StatelessWidget {
     return SizedBox(
       width: double.infinity,
       child: Padding(
-        padding: EdgeInsets.zero,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              PhosphorIcons.newspaperClipping(PhosphorIconsStyle.duotone),
-              size: 48,
-              color: colors.textSecondary.withValues(alpha: 0.5),
-            ),
-            const SizedBox(height: 8),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 32),
-              child: Text(
-                'Sujet peu couvert',
-                style: textTheme.titleSmall?.copyWith(
-                  color: colors.textSecondary,
-                  fontWeight: FontWeight.w600,
-                ),
-                textAlign: TextAlign.center,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 32),
-              child: Text(
-                "Ce sujet n'a pas encore été repris par d'autres médias.",
-                style:
-                    textTheme.bodySmall?.copyWith(color: colors.textTertiary),
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ],
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Text(
+          "Ce sujet n'a pas encore été repris par d'autres médias.",
+          style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
+          textAlign: TextAlign.center,
         ),
       ),
     );

--- a/apps/mobile/lib/features/sources/widgets/source_logo_avatar.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_logo_avatar.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
 import '../../../config/theme.dart';
@@ -25,12 +26,12 @@ class SourceLogoAvatar extends StatelessWidget {
     if (url != null && url.isNotEmpty) {
       return ClipRRect(
         borderRadius: BorderRadius.circular(radius),
-        child: Image.network(
-          url,
+        child: CachedNetworkImage(
+          imageUrl: url,
           width: size,
           height: size,
           fit: BoxFit.cover,
-          errorBuilder: (_, __, ___) => _Initials(
+          errorWidget: (_, __, ___) => _Initials(
             name: source.name,
             size: size,
             radius: radius,


### PR DESCRIPTION
## Quoi

7 ajustements UI sur le reader pour finaliser le polish post-#587/#588 :

1. **Footer** — icônes distribuées homogènement à droite du CTA (`Flexible(loose)` + `Expanded(spaceEvenly)`), comportement uniforme article/video/audio
2. **Logo source** — `SourceLogoAvatar` partout (header reader + footer CTA + nouveau bouton partial), avec fallback initiales remplaçant l'icône newspaper. `_buildSourcePlaceholder` supprimé. `SourceLogoAvatar` migré vers `CachedNetworkImage` (cache navigateur + comportement uniforme avec les autres callsites)
3. **Empty state « Sujet peu couvert »** (`PerspectivesEmptyState`) — ne garde que la description (icône + titre retirés)
4. **Toggle Couverture médiatique** — helper `_onPerspectivesToggle` partagé entre scroll-to-site et in-app. Sur expand-from-collapsed, scrolle vers le divider et flippe `_atPerspectivesSection.value = true` → le bouton flottant « Lancer l'analyse Facteur » réapparaît. Pattern Scrollable.ensureVisible + double-call (250ms) calqué sur le wink-eye button existant
5. **Padding divider perspectives** — symétrique `space4` sur les 2 paths (`space6`/`space8` asymétriques avant)
6. **Articles partial** — nouveau bouton inline « Article complet » en fin de body (`_buildPartialArticleInlineButton`), gated `if (isPartial && _contentResolved)`. Early-return du nudge dismissible quand `_isPartialContent` (le bouton inline le remplace puisque lire-on-site est le seul path vers le contenu complet)
7. **Divider titre/corps** — retiré (header de l'article et corps continus visuellement)

## Pourquoi

Cohérence visuelle (logo source partout pareil, paddings homogènes) et meilleure découvrabilité du CTA « Article complet » sur les articles tronqués (~30% du feed). Polish post-merge des refontes #587 (footer unifié) et #588 (feed onglets).

## Comment ça a été vérifié

- [x] `flutter analyze` — 0 erreur (14 issues `info`, 13 pré-existantes + 1 lint identique au pattern wink-eye accepté ligne 2307)
- [x] `flutter test` sur features/sources, features/feed, features/detail — `+153 -15` identique au baseline `main` (15 stubs « Test not implemented » pré-existants)
- [x] `/simplify` passé : ajout du gate `&& _contentResolved` sur le path in-app pour cohérence avec scroll-to-site (évite flash du bouton inline avant résolution du contenu)
- [ ] Smoke navigateur 390×844 à valider en review (4 cas : article in-app contenu complet, article in-app partial, scroll-to-site complet, scroll-to-site partial ; + video/audio footer 2 icônes spaceEvenly ; + toggle Couverture médiatique expand/collapse)

## Zones à risque

- **iPhone SE / écrans étroits** : `Expanded(spaceEvenly)` peut saturer si CTA + 3 icônes (56×53). Fallback `MainAxisAlignment.spaceBetween` documenté dans le plan, à appliquer si overflow constaté
- **`SourceLogoAvatar` → `CachedNetworkImage`** : impacte les 4 callsites existants (`pepite_card`, `source_detail_modal`, `source_list_item`, `veille_source_card`). Différence visuelle nulle (cache de plus, fallback initiales identique)
- **Spam-tap toggle** : les `Future.delayed(550ms)` peuvent se télescoper. `_suppressPerspectivesCheck` (existant) sert de garde, re-set dans le helper évite les races

🤖 Generated with [Claude Code](https://claude.com/claude-code)