### PR TITLE
feat(legal): expose Privacy + CGU routes (HTML statique)

### DIFF
--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -83,6 +83,7 @@ from app.routers import (
     feed,
     images,
     internal,
+    legal,
     letters,
     notification_preferences,
     personalization,
@@ -470,6 +471,7 @@ app.include_router(
 )
 app.include_router(veille.router, prefix="/api/veille", tags=["Veille"])
 app.include_router(letters.router, prefix="/api/letters", tags=["Letters"])
+app.include_router(legal.router, prefix="/legal", tags=["Legal"])
 
 
 @app.exception_handler(Exception)

--- a/packages/api/app/routers/legal.py
+++ b/packages/api/app/routers/legal.py
@@ -1,0 +1,35 @@
+"""Router légal — sert les pages Privacy Policy et CGU statiques.
+
+Routes exposées au root (pas sous /api/) pour permettre des liens propres
+depuis App Store Connect, Play Console et le mobile.
+"""
+
+from pathlib import Path
+
+from fastapi import APIRouter
+from fastapi.responses import FileResponse
+
+router = APIRouter()
+
+_STATIC_DIR = Path(__file__).resolve().parent.parent / "static" / "legal"
+_CACHE_HEADERS = {"Cache-Control": "public, max-age=3600"}
+
+
+@router.get("/privacy", response_class=FileResponse)
+async def privacy_policy() -> FileResponse:
+    """Politique de confidentialité (HTML statique)."""
+    return FileResponse(
+        _STATIC_DIR / "privacy.html",
+        media_type="text/html",
+        headers=_CACHE_HEADERS,
+    )
+
+
+@router.get("/terms", response_class=FileResponse)
+async def terms_of_service() -> FileResponse:
+    """Conditions Générales d'Utilisation (HTML statique)."""
+    return FileResponse(
+        _STATIC_DIR / "terms.html",
+        media_type="text/html",
+        headers=_CACHE_HEADERS,
+    )

--- a/packages/api/app/static/legal/privacy.html
+++ b/packages/api/app/static/legal/privacy.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Politique de confidentialité — Facteur</title>
+    <style>
+        body {
+            max-width: 720px;
+            margin: 2rem auto;
+            padding: 0 1rem;
+            font-family: system-ui, -apple-system, sans-serif;
+            line-height: 1.6;
+            color: #222;
+        }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.15rem; margin-top: 2rem; }
+        a { color: #0a58ca; }
+        ul { padding-left: 1.25rem; }
+        .todo {
+            background: #fff8c4;
+            border-left: 3px solid #d4a017;
+            padding: 0.75rem 1rem;
+            margin: 0.5rem 0;
+            font-style: italic;
+            color: #5a4400;
+        }
+    </style>
+</head>
+<body>
+    <h1>Politique de confidentialité</h1>
+    <p><em>Dernière mise à jour : 2026-05-07</em></p>
+
+    <!-- TODO: contenu juridique réel à fournir par Laurin -->
+
+    <h2>1. Données collectées</h2>
+    <p>Facteur collecte les données suivantes pour fournir et améliorer son service :</p>
+    <ul>
+        <li>Adresse e-mail (création de compte, authentification)</li>
+        <li>Nom (prénom, nom — facultatif selon la méthode d'authentification)</li>
+        <li>Préférences de lecture (sujets, sources, fréquence du digest)</li>
+        <li>Événements d'usage agrégés (PostHog)</li>
+        <li>Erreurs techniques et journaux de plantage (Sentry)</li>
+        <li>Identifiants d'achat in-app (RevenueCat) — pas de données bancaires stockées par Facteur</li>
+    </ul>
+    <p class="todo">TODO : préciser bases légales (consentement / exécution contractuelle / intérêt légitime) pour chaque catégorie.</p>
+
+    <h2>2. Sous-traitants et destinataires</h2>
+    <p>Facteur s'appuie sur les prestataires suivants pour le traitement des données :</p>
+    <ul>
+        <li><strong>Supabase</strong> — base de données et authentification (UE)</li>
+        <li><strong>Railway</strong> — hébergement de l'API backend</li>
+        <li><strong>RevenueCat</strong> — gestion des abonnements in-app</li>
+        <li><strong>PostHog</strong> — analytique d'usage</li>
+        <li><strong>Sentry</strong> — supervision technique et journaux d'erreurs</li>
+        <li><strong>Apple</strong> et <strong>Google</strong> — traitement des paiements via leurs stores</li>
+    </ul>
+    <p class="todo">TODO : ajouter localisation des serveurs et garanties de transfert hors UE (clauses contractuelles types le cas échéant).</p>
+
+    <h2>3. Durée de conservation</h2>
+    <p class="todo">TODO : durées de conservation par catégorie (compte actif, compte supprimé, journaux techniques, achats).</p>
+
+    <h2>4. Droits des utilisateurs</h2>
+    <p>Conformément au RGPD, les utilisateurs disposent des droits suivants :</p>
+    <ul>
+        <li>Droit d'accès à leurs données</li>
+        <li>Droit de rectification</li>
+        <li>Droit à l'effacement (« droit à l'oubli »)</li>
+        <li>Droit à la portabilité</li>
+        <li>Droit d'opposition au traitement</li>
+    </ul>
+    <p>La suppression du compte est possible directement depuis l'application : <em>Réglages → Compte → Supprimer mon compte</em>.</p>
+    <p class="todo">TODO : préciser le délai de réponse aux demandes (1 mois RGPD) et la procédure exacte.</p>
+
+    <h2>5. Contact DPO</h2>
+    <p class="todo">TODO : adresse e-mail du Délégué à la Protection des Données + adresse postale du responsable de traitement.</p>
+</body>
+</html>

--- a/packages/api/app/static/legal/terms.html
+++ b/packages/api/app/static/legal/terms.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Conditions Générales d'Utilisation — Facteur</title>
+    <style>
+        body {
+            max-width: 720px;
+            margin: 2rem auto;
+            padding: 0 1rem;
+            font-family: system-ui, -apple-system, sans-serif;
+            line-height: 1.6;
+            color: #222;
+        }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.15rem; margin-top: 2rem; }
+        a { color: #0a58ca; }
+        ul { padding-left: 1.25rem; }
+        .todo {
+            background: #fff8c4;
+            border-left: 3px solid #d4a017;
+            padding: 0.75rem 1rem;
+            margin: 0.5rem 0;
+            font-style: italic;
+            color: #5a4400;
+        }
+    </style>
+</head>
+<body>
+    <h1>Conditions Générales d'Utilisation</h1>
+    <p><em>Dernière mise à jour : 2026-05-07</em></p>
+
+    <!-- TODO: contenu juridique réel à fournir par Laurin -->
+
+    <h2>1. Description du service</h2>
+    <p>Facteur est une application mobile fournissant un digest quotidien d'articles d'actualité personnalisés, conçu comme un « moment de fermeture » de l'information.</p>
+    <p class="todo">TODO : préciser le périmètre exact du service, les fonctionnalités gratuites vs payantes, et les éventuelles limitations géographiques.</p>
+
+    <h2>2. Compte utilisateur</h2>
+    <p>L'accès au service nécessite la création d'un compte via e-mail, Google ou Apple. L'utilisateur s'engage à fournir des informations exactes et à protéger ses identifiants.</p>
+    <p class="todo">TODO : conditions de création / suspension / résiliation du compte, âge minimum requis, comportements interdits.</p>
+
+    <h2>3. Abonnements</h2>
+    <p>Certaines fonctionnalités sont accessibles via un abonnement payant souscrit via l'App Store (Apple) ou le Play Store (Google).</p>
+    <ul>
+        <li>Le renouvellement est automatique sauf désactivation 24h avant l'échéance</li>
+        <li>La gestion (résiliation, modification) s'effectue depuis les réglages du store correspondant</li>
+        <li>Aucun remboursement n'est traité par Facteur — les demandes doivent être adressées à Apple ou Google selon le store d'achat</li>
+    </ul>
+    <p class="todo">TODO : préciser durées d'abonnement, prix par marché, période d'essai éventuelle, modalités de résiliation détaillées.</p>
+
+    <h2>4. Propriété intellectuelle</h2>
+    <p>Les contenus tiers (articles, sources) restent la propriété de leurs éditeurs respectifs. Facteur fournit un service d'agrégation et de personnalisation.</p>
+    <p class="todo">TODO : licence d'utilisation accordée à l'utilisateur, droits sur la marque et l'application, mention des sources.</p>
+
+    <h2>5. Limitation de responsabilité</h2>
+    <p class="todo">TODO : clauses limitatives de responsabilité (qualité du service, indisponibilité, contenus tiers, force majeure).</p>
+
+    <h2>6. Droit applicable et juridiction</h2>
+    <p class="todo">TODO : loi applicable (par défaut droit français), juridiction compétente, médiation préalable éventuelle.</p>
+</body>
+</html>

--- a/packages/api/tests/test_legal_routes.py
+++ b/packages/api/tests/test_legal_routes.py
@@ -1,0 +1,20 @@
+"""Tests pour les routes légales (Privacy + CGU)."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/legal/privacy", "/legal/terms"])
+async def test_legal_route_returns_html(path: str):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(path)
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert resp.headers.get("cache-control") == "public, max-age=3600"
+    assert len(resp.text) > 100
+    assert "Dernière mise à jour" in resp.text


### PR DESCRIPTION
## Quoi

Premier PR du chantier **Store Compliance MVP** (PR 1/5). Ajoute deux routes FastAPI publiques servant des templates HTML statiques :

- `GET /legal/privacy`
- `GET /legal/terms`

Headers `Cache-Control: public, max-age=3600`. Routes exposées au root (pas sous `/api/`) pour des liens propres depuis App Store Connect, Play Console et le mobile.

## Pourquoi

Bloqueur **B3** de l'audit compliance : Apple Guideline 5.1.1 et Play Console exigent une Privacy Policy publique accessible par URL — sans elle, la soumission est rejetée. L'app n'expose actuellement aucune route légale.

Cette PR pose **uniquement l'infra de service**. Le contenu juridique réel sera fourni par Laurin dans un PR séparé : ici, des templates HTML mobile-friendly avec sections RGPD attendues marquées `TODO`. En-tête « Dernière mise à jour : 2026-05-07 ».

## Comment ça a été vérifié

- [x] `pytest tests/test_legal_routes.py -v` → 2/2 OK (status 200, content-type HTML, Cache-Control présent, contenu non-vide)
- [x] Suite complète : 856 passed (les 154 errors sont des tests DB-dépendants pré-existants — Postgres local indisponible, aucun rapport au diff)
- [x] `ruff format --check` + `ruff check` sur les 3 fichiers Python touchés → OK
- [x] /simplify : 30 lignes de code, pas de duplication / abstraction prématurée à introduire

Pas de migration Alembic, pas d'impact DB, pas de hot path touché.

## Zones à risque

- Première route exposée hors préfixe `/api/`. Conscient et délibéré (cible de liens externes). Aucun routeur préexistant n'utilise ce préfixe → pas de collision.
- Premier usage de `packages/api/app/static/` (création du chemin). Pas de `StaticFiles` mount global — chaque fichier est servi via un handler explicite.

## Hors scope (PRs suivantes du chantier)

- PR 2 : soft delete `DELETE /users/me` + cron purge 30 jours
- PR 3 : liens cliquables côté mobile vers ces URLs
- PR 4 : RevenueCat (paywall + restore + webhook)
- PR 5 : product flavors Android (`beta` vs `playstore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)