### PR TITLE
feat(users): soft-delete account + 30d purge cron (App Store 5.1.1(v))

### DIFF
--- a/packages/api/alembic/versions/sd01_soft_delete_user_profiles.py
+++ b/packages/api/alembic/versions/sd01_soft_delete_user_profiles.py
@@ -1,0 +1,38 @@
+"""soft delete user profiles — deleted_at + email_hash + index.
+
+App Store 5.1.1(v) + Play Store account deletion compliance. The DELETE
+/api/users/me endpoint sets `deleted_at` and stores a SHA256 hash of the
+email captured from auth.users; a daily cron purges rows older than 30
+days (cascading to user_preferences/interests/subtopics/etc.).
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "sd01_soft_delete_user_profiles"
+down_revision: str | None = "00000_baseline"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_profiles",
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "user_profiles",
+        sa.Column("email_hash", sa.String(length=64), nullable=True),
+    )
+    op.create_index(
+        "ix_user_profiles_deleted_at",
+        "user_profiles",
+        ["deleted_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_profiles_deleted_at", table_name="user_profiles")
+    op.drop_column("user_profiles", "email_hash")
+    op.drop_column("user_profiles", "deleted_at")

--- a/packages/api/app/jobs/purge_deleted_users.py
+++ b/packages/api/app/jobs/purge_deleted_users.py
@@ -1,0 +1,50 @@
+"""Daily purge of soft-deleted user accounts.
+
+Hard-deletes `user_profiles` rows whose `deleted_at` is older than 30 days.
+The `ON DELETE CASCADE` on `user_preferences`, `user_interests`,
+`user_subtopics`, `user_letter_progress`, `user_personalization`,
+`user_notification_preferences`, `user_topic_profile` and the `veille_*`
+tables takes care of the dependent rows.
+
+Tables without a FK (user_streaks, daily_digest, subscriptions, analytics…)
+intentionally keep their rows: they only reference the user_id UUID and
+contain no PII once the profile is gone, which is OK for anonymous
+aggregate stats.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import delete
+
+from app.database import safe_async_session
+from app.models.user import UserProfile
+
+logger = structlog.get_logger()
+
+PURGE_AFTER_DAYS = 30
+
+
+async def purge_deleted_users() -> dict:
+    """Delete user_profiles soft-deleted more than PURGE_AFTER_DAYS ago.
+
+    Returns a stats dict suitable for logging/tests:
+        {"deleted_count": int, "cutoff": iso-timestamp}
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=PURGE_AFTER_DAYS)
+    async with safe_async_session() as session:
+        result = await session.execute(
+            delete(UserProfile).where(
+                UserProfile.deleted_at.is_not(None),
+                UserProfile.deleted_at < cutoff,
+            )
+        )
+        await session.commit()
+        deleted_count = result.rowcount or 0
+
+    logger.info(
+        "purge_deleted_users_completed",
+        deleted_count=deleted_count,
+        cutoff=cutoff.isoformat(),
+    )
+    return {"deleted_count": deleted_count, "cutoff": cutoff.isoformat()}

--- a/packages/api/app/models/user.py
+++ b/packages/api/app/models/user.py
@@ -25,6 +25,14 @@ class UserProfile(Base):
     onboarding_completed: Mapped[bool] = mapped_column(Boolean, default=False)
     gamification_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     weekly_goal: Mapped[int] = mapped_column(Integer, default=10)
+    # Soft-delete (App Store 5.1.1(v) + Play Store account deletion).
+    # `deleted_at` set by DELETE /api/users/me ; cron purge after 30 days.
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+    # SHA256 of the auth.users email captured at delete-time — kept post-purge
+    # for support/legal traceability without storing PII.
+    email_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow
     )

--- a/packages/api/app/routers/users.py
+++ b/packages/api/app/routers/users.py
@@ -1,22 +1,29 @@
 """Routes utilisateur."""
 
+import hashlib
 import logging
 import time
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
+import certifi
+import httpx
+import sentry_sdk
 import structlog
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response, status
 from pydantic import BaseModel
-from sqlalchemy import func
+from sqlalchemy import func, text, update
 from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
 
 logger = logging.getLogger(__name__)
 _perf_logger = structlog.get_logger("streak_perf")
 
 from app.database import get_db
 from app.dependencies import get_current_user_id
+from app.models.user import UserProfile
 from app.schemas.streak import StreakResponse
 from app.schemas.user import (
     AlgorithmProfileResponse,
@@ -333,3 +340,121 @@ async def get_top_themes(
         for i in themes
         if theme_counts.get(i.interest_slug, 0) > 0
     ]
+
+
+# ─── Account deletion ────────────────────────────────────────────────────────
+# App Store Guideline 5.1.1(v) + Play Store account deletion policy.
+# The flow: anonymise the user_profiles row + drop the auth.users row via the
+# Supabase Admin API, then a daily cron purges soft-deleted rows after 30 days
+# (cf. app/jobs/purge_deleted_users.py).
+
+
+async def _fetch_auth_email(db: AsyncSession, user_id: str) -> str | None:
+    """Read the user email from auth.users (Supabase-managed schema).
+
+    Extracted as a module-level helper so tests can monkeypatch it without
+    needing the auth schema in the SQLAlchemy test fixture (the test DB only
+    creates tables from Base.metadata, which excludes auth.*).
+    """
+    row = (
+        await db.execute(
+            text("SELECT email FROM auth.users WHERE id = :uid"),
+            {"uid": user_id},
+        )
+    ).first()
+    return row[0] if row else None
+
+
+async def _delete_supabase_auth_user(user_id: str) -> None:
+    """Call Supabase Admin REST API to remove auth.users row (idempotent).
+
+    Failures are logged but never raised: the local `deleted_at` flag is
+    already set, so the cron will purge the row in 30 days regardless. We
+    must not return 5xx to a user who has just deleted their account.
+    """
+    settings = get_settings()
+    if not (settings.supabase_url and settings.supabase_service_role_key):
+        logger.warning("delete_user_supabase_admin_skipped_missing_config")
+        return
+
+    url = f"{settings.supabase_url}/auth/v1/admin/users/{user_id}"
+    headers = {
+        "Authorization": f"Bearer {settings.supabase_service_role_key}",
+        "apikey": settings.supabase_service_role_key,
+    }
+    try:
+        async with httpx.AsyncClient(verify=certifi.where(), timeout=10.0) as client:
+            resp = await client.delete(url, headers=headers)
+        if resp.status_code in (200, 204):
+            return
+        if resp.status_code == 404:
+            # Already gone — treat as success for idempotence.
+            logger.info("delete_user_supabase_admin_already_deleted", user_id=user_id)
+            return
+        logger.warning(
+            "delete_user_supabase_admin_unexpected_status",
+            user_id=user_id,
+            status=resp.status_code,
+            body=resp.text[:500],
+        )
+        sentry_sdk.capture_message(
+            "delete_user_supabase_admin_unexpected_status", level="warning"
+        )
+    except Exception as exc:
+        logger.warning(
+            "delete_user_supabase_admin_exception", user_id=user_id, error=str(exc)
+        )
+        sentry_sdk.capture_exception(exc)
+
+
+@router.delete("/me", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_account(
+    user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Soft-delete the current account (App Store 5.1.1(v) compliance).
+
+    - Anonymises the user_profiles row (display_name/age_range/gender → NULL).
+    - Stores SHA256(email) for legal/support traceability post-purge.
+    - Removes the auth.users row via Supabase Admin API → blocks reconnection.
+    - Idempotent: a 2nd call on an already soft-deleted account returns 204.
+    - Cron purge after 30 days (cf. app/jobs/purge_deleted_users.py).
+    """
+    profile = (
+        await db.execute(
+            sa_select(UserProfile).where(UserProfile.user_id == UUID(user_id))
+        )
+    ).scalar_one_or_none()
+
+    if profile is None:
+        # No profile yet (user finished signup but skipped onboarding).
+        # We still call the Supabase admin endpoint to drop auth.users so
+        # reconnection is blocked.
+        await _delete_supabase_auth_user(user_id)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    if profile.deleted_at is not None:
+        # Idempotent: already soft-deleted, nothing more to do.
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    email = await _fetch_auth_email(db, user_id)
+    email_hash = hashlib.sha256(email.encode("utf-8")).hexdigest() if email else None
+
+    await db.execute(
+        update(UserProfile)
+        .where(UserProfile.user_id == UUID(user_id))
+        .values(
+            display_name=None,
+            age_range=None,
+            gender=None,
+            email_hash=email_hash,
+            deleted_at=func.now(),
+        )
+    )
+    await db.commit()
+
+    await _delete_supabase_auth_user(user_id)
+
+    FEED_CACHE.invalidate(UUID(user_id))
+    logger.info("user_account_soft_deleted", user_id=user_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -8,6 +8,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from app.config import get_settings
 from app.jobs.digest_generation_job import run_digest_generation
+from app.jobs.purge_deleted_users import purge_deleted_users
 from app.jobs.veille_generation_job import (
     cleanup_stuck_running_deliveries,
     run_veille_generation,
@@ -215,6 +216,16 @@ def start_scheduler() -> None:
         replace_existing=True,
     )
 
+    # Hard-delete soft-deleted user accounts older than 30 days (4h00 Paris,
+    # heure creuse, après storage_cleanup). Cf. App Store 5.1.1(v) compliance.
+    scheduler.add_job(
+        purge_deleted_users,
+        trigger=CronTrigger(hour=4, minute=0, timezone=_PARIS_TZ),
+        id="purge_deleted_users",
+        name="Purge soft-deleted users (>30d)",
+        replace_existing=True,
+    )
+
     # Zombie session sweeper — kill Supavisor sessions stuck in
     # `idle in transaction` > 5 min (filet de sécurité par-dessus le
     # timeout Postgres + le rollback() en finally de safe_async_session).
@@ -263,6 +274,7 @@ def start_scheduler() -> None:
             "daily_digest",
             "digest_watchdog",
             "storage_cleanup",
+            "purge_deleted_users",
             "zombie_session_sweeper",
             "veille_generation",
             "veille_stuck_cleanup",

--- a/packages/api/tests/routers/test_users_delete.py
+++ b/packages/api/tests/routers/test_users_delete.py
@@ -1,0 +1,202 @@
+"""Tests for DELETE /api/users/me (App Store 5.1.1(v) compliance)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.user import UserInterest, UserPreference, UserProfile
+
+
+@pytest_asyncio.fixture
+async def auth_user(db_session):
+    """Create a UserProfile and override the auth + db dependencies."""
+    user_id = uuid4()
+    profile = UserProfile(
+        user_id=user_id,
+        display_name="To Delete",
+        age_range="25-34",
+        gender="other",
+        onboarding_completed=True,
+    )
+    db_session.add(profile)
+    await db_session.commit()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        yield user_id
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_delete_me_anonymizes_profile(auth_user, db_session):
+    """Happy path: profile is anonymised, email_hash stored, 204 returned."""
+    transport = ASGITransport(app=app)
+    with (
+        patch(
+            "app.routers.users._fetch_auth_email",
+            new=AsyncMock(return_value="alice@example.com"),
+        ),
+        patch(
+            "app.routers.users._delete_supabase_auth_user",
+            new=AsyncMock(return_value=None),
+        ) as supa_mock,
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.delete("/api/users/me")
+
+    assert resp.status_code == 204
+    assert resp.content == b""
+    supa_mock.assert_awaited_once_with(str(auth_user))
+
+    # Profil anonymisé en DB
+    profile = (
+        await db_session.execute(
+            select(UserProfile).where(UserProfile.user_id == auth_user)
+        )
+    ).scalar_one()
+    assert profile.deleted_at is not None
+    assert profile.display_name is None
+    assert profile.age_range is None
+    assert profile.gender is None
+    # SHA256 hex digest = 64 chars
+    assert profile.email_hash is not None
+    assert len(profile.email_hash) == 64
+    # Hash déterministe vs email injecté
+    import hashlib
+
+    assert profile.email_hash == hashlib.sha256(b"alice@example.com").hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_delete_me_idempotent(auth_user, db_session):
+    """Second DELETE on an already-soft-deleted account returns 204 silently."""
+    transport = ASGITransport(app=app)
+    with (
+        patch(
+            "app.routers.users._fetch_auth_email",
+            new=AsyncMock(return_value="bob@example.com"),
+        ),
+        patch(
+            "app.routers.users._delete_supabase_auth_user",
+            new=AsyncMock(return_value=None),
+        ) as supa_mock,
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            r1 = await ac.delete("/api/users/me")
+            r2 = await ac.delete("/api/users/me")
+
+    assert r1.status_code == 204
+    assert r2.status_code == 204
+    # Le 2e appel ne doit PAS retoucher Supabase admin (déjà supprimé).
+    assert supa_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_me_cascades_user_dependents(auth_user, db_session):
+    """Cascade FK : preferences/interests are wiped when the profile is purged.
+
+    The endpoint itself only soft-deletes (sets deleted_at) ; the hard delete
+    is exercised via a manual purge to verify the CASCADE chain works with
+    the test schema (Base.metadata.create_all reflects the model FKs).
+    """
+    # Insère 2 lignes dépendantes
+    db_session.add(
+        UserPreference(
+            user_id=auth_user,
+            preference_key="theme",
+            preference_value="dark",
+        )
+    )
+    db_session.add(UserInterest(user_id=auth_user, interest_slug="society", weight=1.0))
+    await db_session.commit()
+
+    transport = ASGITransport(app=app)
+    with (
+        patch(
+            "app.routers.users._fetch_auth_email",
+            new=AsyncMock(return_value="cascade@example.com"),
+        ),
+        patch(
+            "app.routers.users._delete_supabase_auth_user",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.delete("/api/users/me")
+    assert resp.status_code == 204
+
+    # Soft-delete : préférences/intérêts encore là (purgés par le cron à J+30)
+    prefs = (
+        await db_session.execute(
+            select(UserPreference).where(UserPreference.user_id == auth_user)
+        )
+    ).all()
+    assert len(prefs) == 1
+
+    # Hard-delete via purge → cascade vide les dépendants
+    from sqlalchemy import delete as sa_delete
+
+    await db_session.execute(
+        sa_delete(UserProfile).where(UserProfile.user_id == auth_user)
+    )
+    await db_session.commit()
+
+    prefs_after = (
+        await db_session.execute(
+            select(UserPreference).where(UserPreference.user_id == auth_user)
+        )
+    ).all()
+    interests_after = (
+        await db_session.execute(
+            select(UserInterest).where(UserInterest.user_id == auth_user)
+        )
+    ).all()
+    assert prefs_after == []
+    assert interests_after == []
+
+
+@pytest.mark.asyncio
+async def test_supabase_admin_404_silently_ignored(monkeypatch):
+    """A 404 from Supabase admin must not raise — the function returns silently."""
+    from app.routers import users as users_router
+
+    # Force la config (sinon early-return en l'absence de service_role_key)
+    monkeypatch.setattr(
+        users_router,
+        "get_settings",
+        lambda: MagicMock(
+            supabase_url="https://example.supabase.co",
+            supabase_service_role_key="srv_key_xxx",
+        ),
+    )
+
+    fake_response = MagicMock(status_code=404, text="not found")
+    fake_client = MagicMock()
+    fake_client.delete = AsyncMock(return_value=fake_response)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    monkeypatch.setattr(
+        users_router.httpx, "AsyncClient", lambda **_kwargs: fake_client
+    )
+
+    # Ne doit rien lever
+    await users_router._delete_supabase_auth_user(
+        "00000000-0000-0000-0000-000000000001"
+    )

--- a/packages/api/tests/test_purge_deleted_users.py
+++ b/packages/api/tests/test_purge_deleted_users.py
@@ -1,0 +1,102 @@
+"""Tests for the daily purge of soft-deleted user accounts (>30d)."""
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from app.jobs import purge_deleted_users as job_module
+from app.models.user import UserInterest, UserProfile
+
+
+@pytest.fixture
+def patch_session_maker(monkeypatch, db_session):
+    """Make safe_async_session() yield the test db_session (savepoint-isolated)."""
+
+    @asynccontextmanager
+    async def _maker():
+        yield db_session
+
+    monkeypatch.setattr(job_module, "safe_async_session", _maker)
+
+
+@pytest.mark.asyncio
+async def test_purge_skips_recent_deletions(db_session, patch_session_maker):
+    user_id = uuid4()
+    db_session.add(
+        UserProfile(
+            user_id=user_id,
+            display_name=None,
+            onboarding_completed=True,
+            deleted_at=datetime.now(UTC) - timedelta(days=29),
+        )
+    )
+    await db_session.commit()
+
+    stats = await job_module.purge_deleted_users()
+
+    assert stats["deleted_count"] == 0
+    # User toujours là
+    from sqlalchemy import select
+
+    remaining = (
+        await db_session.execute(
+            select(UserProfile).where(UserProfile.user_id == user_id)
+        )
+    ).scalar_one_or_none()
+    assert remaining is not None
+
+
+@pytest.mark.asyncio
+async def test_purge_removes_old_deletions_with_cascade(
+    db_session, patch_session_maker
+):
+    user_id = uuid4()
+    db_session.add(
+        UserProfile(
+            user_id=user_id,
+            display_name=None,
+            onboarding_completed=True,
+            deleted_at=datetime.now(UTC) - timedelta(days=31),
+        )
+    )
+    db_session.add(UserInterest(user_id=user_id, interest_slug="society", weight=1.0))
+    await db_session.commit()
+
+    stats = await job_module.purge_deleted_users()
+
+    assert stats["deleted_count"] == 1
+    from sqlalchemy import select
+
+    profile = (
+        await db_session.execute(
+            select(UserProfile).where(UserProfile.user_id == user_id)
+        )
+    ).scalar_one_or_none()
+    assert profile is None
+    # Cascade : interests purgés
+    interests = (
+        await db_session.execute(
+            select(UserInterest).where(UserInterest.user_id == user_id)
+        )
+    ).all()
+    assert interests == []
+
+
+@pytest.mark.asyncio
+async def test_purge_ignores_non_soft_deleted(db_session, patch_session_maker):
+    """Active users (deleted_at IS NULL) must never be touched."""
+    user_id = uuid4()
+    db_session.add(
+        UserProfile(
+            user_id=user_id,
+            display_name="Active",
+            onboarding_completed=True,
+            deleted_at=None,
+        )
+    )
+    await db_session.commit()
+
+    stats = await job_module.purge_deleted_users()
+    assert stats["deleted_count"] == 0


### PR DESCRIPTION
## Quoi

PR 2/5 du chantier compliance App Store + Play Store. Implémente la suppression de compte côté backend :

- `DELETE /api/users/me` : anonymise `user_profiles` (`display_name`/`age_range`/`gender` → NULL), stocke `SHA256(email)` dans `email_hash`, set `deleted_at`, puis supprime `auth.users` via Supabase Admin REST. Idempotent (2e appel → 204 silencieux).
- Migration Alembic `sd01_soft_delete_user_profiles` : ajoute `deleted_at` + `email_hash` + index sur `user_profiles` (1 head).
- Cron quotidien à 4h Paris (`app/jobs/purge_deleted_users.py`) : hard-delete les profils soft-deleted depuis > 30 jours. Les FK `ON DELETE CASCADE` couvrent `user_preferences`/`user_interests`/`user_subtopics`/`user_letter_progress`/`user_personalization`/`user_notification_preferences`/`user_topic_profile`/`veille_*`.

## Pourquoi

App Store Guideline 5.1.1(v) + Google Play Account Deletion policy : sans endpoint de suppression fonctionnel, l'app est rejetée à la soumission. L'écran `account_screen.dart` affichait jusqu'ici un placeholder "Contactez le support" (TODO).

Note de divergence vs plan initial : la table `users` mentionnée dans le brief n'existe pas — notre schéma a `user_profiles` (managed) et `auth.users` (Supabase). Les colonnes `email`/`first_name`/`last_name` du brief n'existent pas non plus. Adapté en conséquence : email lu depuis `auth.users` au moment du delete, hash stocké sur `user_profiles`.

## Comment ça a été vérifié

- [x] `pytest -v` : **1017 passed, 13 skipped** (dont 7 nouveaux tests : 4 endpoint + 3 cron).
- [x] `alembic heads` : 1 head (`sd01_soft_delete_user_profiles`).
- [x] `alembic upgrade head` sur DB vide (volume Docker wipe + recreate) : OK, baseline + sd01 chaînées sans erreur. Colonnes + index vérifiés via `\d user_profiles`.
- [x] `ruff check` + `ruff format --check` : clean.
- [ ] Test mobile : hors scope (PR 3 branchera l'appel côté `account_screen.dart`).

## Tests inclus

- `tests/routers/test_users_delete.py` (4 tests) : happy path + anonymisation + hash, idempotence, cascade FK, Supabase admin 404 silencieux.
- `tests/test_purge_deleted_users.py` (3 tests) : skip < 30j, purge > 30j + cascade, ignore les actifs.

## Zones à risque

- **Auth/Supabase** : `_delete_supabase_auth_user` utilise la service_role_key. Failure modes loggés (Sentry) mais ne lèvent jamais — l'utilisateur a déjà sa trace `deleted_at` localement, le cron purgera quoi qu'il arrive.
- **Migration** : ajout de colonnes nullable + index, pas de backfill, sans risque de lock prolongé. Le `Dockerfile` rejouera `alembic upgrade head` au boot Railway.
- **Hors scope cron** : tables sans FK (`user_streaks`, `daily_digest`, `subscriptions`, `analytics`…) gardent leurs lignes — `user_id` devient un UUID orphelin sans PII, conforme à la stratégie "stats agrégées anonymes" du plan compliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)