### PR TITLE
feat(mobile/web): gate push notifications UI behind kSupportsPushNotifications

### DIFF
--- a/apps/mobile/lib/core/orchestration/first_impression_orchestrator.dart
+++ b/apps/mobile/lib/core/orchestration/first_impression_orchestrator.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../auth/auth_state.dart';
+import '../web/web_perf.dart';
 import '../../features/notifications/providers/notification_renudge_provider.dart';
 import '../../features/settings/providers/notifications_settings_provider.dart';
 import '../../features/well_informed/providers/well_informed_prompt_provider.dart';
@@ -47,7 +48,10 @@ final firstImpressionSlotProvider = Provider<FirstImpressionSlot>((ref) {
   }
   if (auth.needsOnboarding) return FirstImpressionSlot.none;
 
-  if (!modalConsumed && notif.synced && !notif.modalSeen) {
+  if (kSupportsPushNotifications &&
+      !modalConsumed &&
+      notif.synced &&
+      !notif.modalSeen) {
     return FirstImpressionSlot.notifModal;
   }
 

--- a/apps/mobile/lib/core/web/web_perf.dart
+++ b/apps/mobile/lib/core/web/web_perf.dart
@@ -1,3 +1,4 @@
+import 'dart:io' show Platform;
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
@@ -9,6 +10,14 @@ import 'package:flutter/material.dart';
 /// on Android/iOS native builds.
 
 const bool kWebPerf = kIsWeb;
+
+/// Push notifications locales (`flutter_local_notifications`) — indispo sur
+/// Flutter Web. Sert de gate centralisé pour toute UI/provider qui
+/// déclenche une demande de permission ou planifie un slot.
+const bool kSupportsPushNotifications = !kIsWeb;
+
+/// Home-screen widget — Android natif uniquement (FacteurWidget Kotlin).
+bool get kSupportsHomeWidget => !kIsWeb && Platform.isAndroid;
 
 /// Replaces a `BackdropFilter` by an opaque fill on web.
 /// On mobile, returns the blurred widget unchanged.

--- a/apps/mobile/lib/features/notifications/providers/notification_renudge_provider.dart
+++ b/apps/mobile/lib/features/notifications/providers/notification_renudge_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/web/web_perf.dart';
 import '../../settings/providers/notifications_settings_provider.dart';
 
 /// Cap : maximum 3 affichages du re-nudge au total (brief §5.1).
@@ -12,6 +13,7 @@ const Duration kRenudgeMinSinceRefusal = Duration(days: 7);
 const Duration kRenudgeMinBetween = Duration(days: 14);
 
 bool shouldShowRenudge(NotificationsSettings s, {required DateTime now}) {
+  if (!kSupportsPushNotifications) return false;
   if (s.pushEnabled) return false;
   if (s.renudgeShownCount >= kRenudgeMaxShown) return false;
 

--- a/apps/mobile/lib/features/notifications/widgets/notification_activation_modal.dart
+++ b/apps/mobile/lib/features/notifications/widgets/notification_activation_modal.dart
@@ -5,6 +5,7 @@ import '../../../config/theme.dart';
 import '../../../core/api/notification_preferences_api_service.dart';
 import '../../../core/providers/analytics_provider.dart';
 import '../../../core/services/push_notification_service.dart';
+import '../../../core/web/web_perf.dart';
 import '../../settings/providers/notifications_settings_provider.dart';
 import 'preset_selector.dart';
 import 'time_slot_selector.dart';
@@ -26,6 +27,9 @@ Future<void> showNotificationActivationModal(
   WidgetRef ref, {
   required ActivationTrigger trigger,
 }) async {
+  // Push local indispo sur Web (flutter_local_notifications n'a pas de plugin
+  // Web) — on no-op pour ne pas crasher ni proposer une activation morte.
+  if (!kSupportsPushNotifications) return;
   if (trigger == ActivationTrigger.veille) {
     final settings = ref.read(notificationsSettingsProvider);
     if (settings.pushEnabled) {
@@ -38,7 +42,7 @@ Future<void> showNotificationActivationModal(
   return showDialog<void>(
     context: context,
     barrierDismissible: false,
-    barrierColor: Colors.black87,
+    barrierColor: Colors.black.withOpacity(0.6),
     useRootNavigator: true,
     builder: (_) => Dialog(
       insetPadding: const EdgeInsets.symmetric(

--- a/apps/mobile/lib/features/settings/screens/profile_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/profile_screen.dart
@@ -41,11 +41,12 @@ class ProfileScreen extends ConsumerWidget {
                   subtitle: 'Gérer vos informations',
                   onTap: () => context.pushNamed(RouteNames.account),
                 ),
-                _Tile(
-                  icon: Icons.notifications_none,
-                  title: 'Notifications',
-                  onTap: () => context.pushNamed(RouteNames.notifications),
-                ),
+                if (!kIsWeb)
+                  _Tile(
+                    icon: Icons.notifications_none,
+                    title: 'Notifications',
+                    onTap: () => context.pushNamed(RouteNames.notifications),
+                  ),
               ],
             ),
             const SizedBox(height: FacteurSpacing.space6),


### PR DESCRIPTION
## What

Adds `kSupportsPushNotifications` and `kSupportsHomeWidget` constants in `web_perf.dart` and uses them to guard all push notification UI/logic on Flutter Web.

## Why

`flutter_local_notifications` has no Web plugin — without these guards the app crashes or renders dead UI (notifications tile, activation modal, renudge) on Web. This centralizes the platform check instead of scattering `!kIsWeb` checks everywhere.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)