### PR TITLE
feat(ml): pipeline 2-passes pour `is_good_news` (mistral-large gating FR)

### DIFF
--- a/docs/stories/core/15.2.good-news-strict-curation.story.md
+++ b/docs/stories/core/15.2.good-news-strict-curation.story.md
@@ -1,0 +1,98 @@
+# 15.2 — Curation stricte des « Bonnes nouvelles du jour »
+
+**Type :** Feature (re-architecture filtre)
+**Statut :** En cours
+**Branche :** `claude/improve-good-news-curation-PckVr`
+**Liée à :** 15.1 (mode serein refine), pipeline `is_good_news`
+
+---
+
+## Contexte
+
+Audit manuel sur 60 articles classifiés `is_good_news=true` produits par la
+pipeline actuelle (mistral-small en passe unique) sur les 5 derniers jours :
+**19 / 60 = 32 % de précision**. La majorité des faux positifs sont :
+
+- Tristesse résiduelle (mort, déportation, tragédie « miracle »).
+- Découverte / record sans application humaine claire.
+- IA frontier (Mythos, OpenAI Trusted Contact) — anxiogène, pas une bonne nouvelle.
+- Anecdotique / fait divers / curiosité légère.
+- Sortie commerciale (jeu vidéo, produit) sauf cas souveraineté.
+- Articles en anglais (14 / 60) — aucun filtre langue n'existe aujourd'hui.
+
+Le PO conclut : **mistral-small est sous-dimensionné** pour la finesse requise.
+
+## Objectif
+
+Atteindre une précision ≥ 80 % sur les articles classifiés `is_good_news=true`,
+sans dégrader le débit d'ingestion.
+
+## Décisions d'architecture
+
+1. **Pipeline 2-passes** :
+   - Passe 1 (existante, inchangée pour topics/serene/entities) : `mistral-small-latest` en batch sur tous les articles.
+   - Passe 2 (nouvelle) : `mistral-large-latest` en batch dédié `is_good_news`,
+     **gatée** par `serene=true ∧ source francophone ∧ titre non-anglais`.
+2. **Filtre langue** : whitelist de sources FR (`Le Monde`, `Le Figaro`, …) +
+   garde-fou heuristique sur le titre (tokens `the/of/and/for/this/that/is/are/with/from`).
+   Zéro nouvelle dépendance, zéro champ DB.
+3. **Le champ `good_news` est retiré de la prompt mistral-small** — cette passe
+   n'émet plus que `topics + serene + entities`.
+
+## Critères d'acceptation
+
+- [ ] La passe mistral-small ne renvoie plus `good_news`.
+- [ ] Un nouveau service `GoodNewsClassifier` appelle `mistral-large-latest`
+      avec un prompt strict tiré des retours PO (cf. § Patterns).
+- [ ] Le worker `classification_worker.py` orchestre la passe 2 uniquement sur
+      les survivants serene+FR (réduction ~10× des appels au modèle large).
+- [ ] Un module `language_filter.py` expose `is_french_source(name) -> bool`
+      et `looks_english(title) -> bool`, couvert par tests unitaires.
+- [ ] La précision attendue sur le jeu de 60 articles annotés (19 OK / 41 KO)
+      est ≥ 80 % côté faux positifs (≤ 8 KO classés `True` après la passe 2).
+
+## Patterns (consolidés depuis l'annotation PO)
+
+### Vraies bonnes nouvelles (`good_news = true`)
+
+- Progrès tangible avec **application humaine claire** (santé, éducation,
+  environnement, droits, souveraineté numérique).
+- Accalmie d'un conflit ou désamorçage d'une actualité stressante en cours.
+- Réparation / reconnaissance historique qui apaise une douleur collective.
+- Avancée infrastructurelle ou structurelle sur la transition écologique
+  ou un enjeu social majeur (logement, retraite, gouvernance climatique).
+- Émancipation (femmes, peuples opprimés, libération animale) avec impact
+  mesurable.
+
+### Anti-patterns (`good_news = false`)
+
+- Mort, deuil, tragédie même teintée d'un final positif.
+- Découverte / exploit / record **sans application humaine démontrée**.
+- Reportage rétrospectif (« le jour où… ») — pas une actualité.
+- IA frontier ou modèles ultra-puissants — anxiogènes par nature.
+- Salaire / pension qui « suit l'inflation » : absence de perte ≠ gain.
+- Élitisme / people qui se « fait plaisir » en aidant.
+- Anecdotique / fait divers / curiosité légère.
+- Sortie commerciale (produit, jeu vidéo) sauf bénéfice humain direct.
+- Personnalité culturelle (anniversaire, hommage).
+- Tourisme / loisirs / sport (résultats).
+- Article non francophone, quel que soit le sujet.
+
+## Fichiers impactés
+
+- `packages/api/app/services/ml/classification_service.py` — retire
+  `good_news` du prompt et de tous les chemins de parsing.
+- `packages/api/app/services/ml/language_filter.py` — **nouveau**.
+- `packages/api/app/services/ml/good_news_classifier.py` — **nouveau**.
+- `packages/api/app/workers/classification_worker.py` — orchestration 2-passes.
+- `packages/api/tests/ml/test_language_filter.py` — **nouveau**.
+- `packages/api/tests/ml/test_good_news_classifier.py` — **nouveau**.
+- `packages/api/tests/ml/test_classification_service.py` — retire les
+  assertions sur `good_news`.
+
+## Hors scope
+
+- Pas de migration Alembic (le champ `Content.is_good_news` existe déjà).
+- Pas de re-classification rétroactive des articles déjà ingérés (un job
+  séparé pourra purger `is_good_news=true` et requeue plus tard si besoin).
+- Pas de changement UI mobile.

--- a/packages/api/app/services/ml/classification_service.py
+++ b/packages/api/app/services/ml/classification_service.py
@@ -48,7 +48,6 @@ def _validate_entities(raw_entities: list) -> list[dict]:
 _EMPTY_RESULT: dict = {
     "topics": [],
     "serene": None,
-    "good_news": None,
     "entities": [],
 }
 
@@ -265,25 +264,6 @@ serene = false : tout sujet susceptible de provoquer de l'anxiété chez le lect
 Règle : si le sujet principal de l'article est anxiogène, même partiellement, marque false.
 En cas de doute, marque false.
 
-## BONNE NOUVELLE
-Pour chaque article, détermine "good_news": true ou false.
-good_news = true UNIQUEMENT si l'article rapporte une VRAIE bonne nouvelle, c'est-à-dire :
-- Un progrès tangible et concret (avancée scientifique réalisée, traitement médical efficace, libération, sauvetage, réussite environnementale mesurée)
-- Un impact positif net sur la vie des gens, l'environnement ou la société
-- Quelque chose qui suscite un optimisme fondé, donne de l'espoir, donne envie d'en savoir plus
-
-good_news = false dans TOUS les autres cas, en particulier :
-- Sport (résultats de match, exploits sportifs anodins, transferts) → toujours false
-- Politique : votes, lois, déclarations, polémiques → false (sauf signal d'espoir EXPLICITE et MAJEUR : accord de paix signé, abolition concrète d'une oppression)
-- People, célébrités, buzz, divertissement médiatique, lifestyle léger → false
-- Annonces, intentions, promesses, projets sans réalisation → false
-- Nouveautés tech/produits commerciaux (sortie d'iPhone, IA d'OpenAI) → false sauf bénéfice humain direct et démontré
-- Sujets simplement "neutres" ou "non-anxiogènes" → false (l'absence de mauvaise nouvelle n'est PAS une bonne nouvelle)
-- Tout sujet anxiogène → false
-
-Règle d'or : en cas de doute, marque false. On préfère manquer une bonne nouvelle que d'en signaler une fausse.
-Une bonne nouvelle peut être marquée serene=true ET good_news=true. L'inverse n'est PAS automatique : la majorité des serene=true ne sont PAS good_news=true.
-
 ## ENTITÉS NOMMÉES
 Pour chaque article, extrais 3 à 5 entités nommées principales.
 Types autorisés : PERSON, ORG, EVENT, LOCATION, PRODUCT
@@ -305,7 +285,7 @@ Règles :
 
 ## FORMAT
 Réponds en JSON array. Chaque élément :
-{"topics": ["slug1", "slug2"], "serene": true/false, "good_news": true/false, "entities": [{"name": "Nom Complet", "type": "PERSON"}]}
+{"topics": ["slug1", "slug2"], "serene": true/false, "entities": [{"name": "Nom Complet", "type": "PERSON"}]}
 Pas de texte avant ou après."""
 
 CLASSIFICATION_MODEL = "mistral-small-latest"
@@ -576,9 +556,9 @@ class ClassificationService:
         return (
             f"Classifie chacun de ces {len(items)} articles.\n"
             f"Réponds en JSON array de exactement {len(items)} éléments.\n"
-            'Exemple pour 2 articles: [{"topics": ["politics", "europe"], "serene": false, "good_news": false, '
+            'Exemple pour 2 articles: [{"topics": ["politics", "europe"], "serene": false, '
             '"entities": [{"name": "Emmanuel Macron", "type": "PERSON"}]}, '
-            '{"topics": ["health", "science"], "serene": true, "good_news": true, '
+            '{"topics": ["health", "science"], "serene": true, '
             '"entities": [{"name": "Institut Pasteur", "type": "ORG"}]}]\n\n'
             f"{articles_text}"
         )
@@ -599,14 +579,10 @@ class ClassificationService:
                 serene = parsed.get("serene")
                 if not isinstance(serene, bool):
                     serene = None
-                good_news = parsed.get("good_news")
-                if not isinstance(good_news, bool):
-                    good_news = None
                 entities = _validate_entities(parsed.get("entities", []))
                 return {
                     "topics": topics[:top_k],
                     "serene": serene,
-                    "good_news": good_news,
                     "entities": entities,
                 }
             if (
@@ -623,14 +599,10 @@ class ClassificationService:
                 serene = item.get("serene")
                 if not isinstance(serene, bool):
                     serene = None
-                good_news = item.get("good_news")
-                if not isinstance(good_news, bool):
-                    good_news = None
                 entities = _validate_entities(item.get("entities", []))
                 return {
                     "topics": topics[:top_k],
                     "serene": serene,
-                    "good_news": good_news,
                     "entities": entities,
                 }
         except (json.JSONDecodeError, TypeError):
@@ -643,7 +615,6 @@ class ClassificationService:
         return {
             "topics": valid[:top_k],
             "serene": None,
-            "good_news": None,
             "entities": [],
         }
 
@@ -677,15 +648,11 @@ class ClassificationService:
                             serene = item.get("serene")
                             if not isinstance(serene, bool):
                                 serene = None
-                            good_news = item.get("good_news")
-                            if not isinstance(good_news, bool):
-                                good_news = None
                             entities = _validate_entities(item.get("entities", []))
                             results.append(
                                 {
                                     "topics": topics[:top_k],
                                     "serene": serene,
-                                    "good_news": good_news,
                                     "entities": entities,
                                 }
                             )
@@ -712,7 +679,6 @@ class ClassificationService:
                                 {
                                     "topics": valid[:top_k],
                                     "serene": None,
-                                    "good_news": None,
                                     "entities": [],
                                 }
                             )
@@ -737,7 +703,6 @@ class ClassificationService:
                 {
                     "topics": valid[:top_k],
                     "serene": None,
-                    "good_news": None,
                     "entities": [],
                 }
             )

--- a/packages/api/app/services/ml/good_news_classifier.py
+++ b/packages/api/app/services/ml/good_news_classifier.py
@@ -1,0 +1,240 @@
+"""Classifieur dédié `is_good_news` (passe 2 du pipeline).
+
+La passe 1 (`ClassificationService` / mistral-small-latest) classifie
+topics + serene + entities en batch sur tous les articles. Cette passe 2
+prend uniquement les survivants `serene=true` issus de sources francophones
+et leur applique un prompt strict sur `mistral-large-latest` pour décider
+si l'article est une vraie « bonne nouvelle » au sens du PO.
+
+Pourquoi un service séparé ?
+- mistral-small a montré 32 % de précision sur l'audit PO du 10/05/2026.
+- Le coût d'un appel large reste maîtrisé : ~10 % des articles passent le
+  gate (serene=true ∧ source FR).
+- La séparation permet d'itérer sur le prompt sans toucher la passe 1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import structlog
+
+from app.config import get_settings
+from app.services.ml.classification_service import _clean_text
+
+log = structlog.get_logger()
+
+GOOD_NEWS_MODEL = "mistral-large-latest"
+MISTRAL_API_URL = "https://api.mistral.ai/v1/chat/completions"
+
+
+_SYSTEM_PROMPT = """Tu es un éditeur expérimenté chargé de sélectionner les "vraies" bonnes nouvelles pour un digest quotidien apaisant.
+
+Tu réponds STRICTEMENT en JSON, sans texte autour.
+
+## RÈGLE D'OR
+En cas de doute, réponds false. On préfère manquer une bonne nouvelle plutôt qu'en signaler une fausse.
+
+## VRAIES BONNES NOUVELLES (true)
+
+Une bonne nouvelle DOIT cocher AU MOINS l'une de ces 5 cases :
+
+1. **Progrès tangible avec application humaine claire** : avancée scientifique, médicale, sociale, environnementale ou éducative qui se traduit en bénéfice concret et démontré pour des humains, des animaux ou un écosystème.
+2. **Accalmie d'un conflit ou d'une actualité stressante** : trêve, désescalade, accord de paix, libération d'otages, fin d'une crise sanitaire ou sociale.
+3. **Réparation / reconnaissance historique** : indemnisation des victimes, reconnaissance d'un crime d'État, restitution, geste qui apaise une douleur collective.
+4. **Avancée structurelle sur la transition écologique ou un enjeu social majeur** : législation contraignante actée, financement débloqué, infrastructure mise en service.
+5. **Émancipation** : avancée mesurable des droits des femmes, de minorités opprimées, du bien-être animal.
+
+## ANTI-PATTERNS (toujours false)
+
+- Mort, deuil, tragédie même teintée d'un final positif (ex. "miracle après une mort").
+- Découverte / exploit / record SANS application humaine immédiate démontrée.
+- Reportage rétrospectif ("le jour où…", anniversaire, hommage).
+- IA frontier, modèles ultra-puissants, chatbot émotionnel : anxiogènes par nature.
+- Salaire / pension qui "suit l'inflation" : ne pas perdre ≠ gagner.
+- Élitisme ou personnalité people qui "se fait plaisir" en aidant.
+- Anecdotique, fait divers, curiosité légère, animal mignon.
+- Sortie commerciale (jeu vidéo, produit, console) sauf souveraineté ou bénéfice humain direct évident.
+- Personnalité culturelle (anniversaire, hommage, biographie).
+- Tourisme, loisirs, sport (résultats de match, exploit sportif).
+- Article principalement en anglais, quel que soit le sujet.
+- Initiative limitée à une poignée d'individus sans portée plus large.
+
+## FORMAT
+Réponds en JSON array, exactement N éléments pour N articles.
+Chaque élément : {"good_news": true|false}
+Exemple pour 2 articles : [{"good_news": true}, {"good_news": false}]"""
+
+
+def _build_user_prompt(items: list[dict]) -> str:
+    """Construit le prompt utilisateur pour le batch."""
+    parts = []
+    for i, item in enumerate(items):
+        title = _clean_text(item.get("title", ""))
+        desc = _clean_text(item.get("description", "") or "")
+        if len(desc) > 240:
+            desc = desc[:240] + "..."
+        source_name = item.get("source_name", "")
+
+        header = f"[{i + 1}]"
+        if source_name:
+            header += f" [Source: {source_name}]"
+
+        text = f"{title}. {desc}".strip() if desc else title
+        parts.append(f"{header}\n{text}")
+
+    articles_text = "\n\n".join(parts)
+    return (
+        f"Évalue chacun de ces {len(items)} articles selon les règles ci-dessus.\n"
+        f"Réponds en JSON array de exactement {len(items)} éléments, "
+        'chacun {"good_news": true|false}.\n\n'
+        f"{articles_text}"
+    )
+
+
+def _parse_response(raw: str, expected_count: int) -> list[bool | None]:
+    """Parse la réponse JSON. Renvoie liste de bool | None de longueur expected_count."""
+    out: list[bool | None] = [None] * expected_count
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        log.warning("good_news_classifier.parse_failed", raw=raw[:200])
+        return out
+
+    if not isinstance(parsed, list):
+        log.warning("good_news_classifier.unexpected_shape", raw=raw[:200])
+        return out
+
+    for i, item in enumerate(parsed[:expected_count]):
+        if isinstance(item, dict):
+            value = item.get("good_news")
+        elif isinstance(item, bool):
+            value = item
+        else:
+            value = None
+        if isinstance(value, bool):
+            out[i] = value
+    return out
+
+
+class GoodNewsClassifier:
+    """Service de classification `is_good_news` (passe 2, mistral-large)."""
+
+    def __init__(self) -> None:
+        settings = get_settings()
+        self._api_key = settings.mistral_api_key
+        self._ready = bool(self._api_key)
+        self._client: httpx.AsyncClient | None = None
+
+        if self._ready:
+            log.info("good_news_classifier.initialized", model=GOOD_NEWS_MODEL)
+        else:
+            log.warning(
+                "good_news_classifier.no_api_key",
+                message="MISTRAL_API_KEY not set. Good-news pass disabled.",
+            )
+
+    def is_ready(self) -> bool:
+        return self._ready
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=30.0,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+        return self._client
+
+    async def _call(self, payload: dict, *, max_retries: int = 3) -> dict | None:
+        client = self._get_client()
+        for attempt in range(max_retries):
+            try:
+                response = await client.post(MISTRAL_API_URL, json=payload)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                if status == 429 and attempt < max_retries - 1:
+                    delay = 2**attempt
+                    log.warning(
+                        "good_news_classifier.rate_limited",
+                        attempt=attempt,
+                        delay=delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                log.error(
+                    "good_news_classifier.http_error",
+                    status_code=status,
+                    body=e.response.text[:300],
+                )
+                return None
+            except httpx.TimeoutException:
+                log.error("good_news_classifier.timeout", attempt=attempt)
+                return None
+            except json.JSONDecodeError as e:
+                log.error("good_news_classifier.json_error", error=str(e))
+                return None
+            except Exception as e:
+                log.error("good_news_classifier.unexpected", error=str(e))
+                return None
+        return None
+
+    async def classify_batch_async(self, items: list[dict]) -> list[bool | None]:
+        """Classifie un batch d'articles. Renvoie une liste alignée sur `items`.
+
+        Args:
+            items: liste de dicts {title, description, source_name}.
+
+        Returns:
+            Liste `[True | False | None]` de même longueur que `items`.
+            None signifie "le modèle n'a pas répondu de manière exploitable".
+        """
+        if not items:
+            return []
+        if not self._ready:
+            return [None] * len(items)
+
+        payload = {
+            "model": GOOD_NEWS_MODEL,
+            "messages": [
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": _build_user_prompt(items)},
+            ],
+            "temperature": 0.1,
+            "response_format": {"type": "json_object"},
+            "max_tokens": 32 * len(items) + 64,
+        }
+
+        data = await self._call(payload)
+        if not data:
+            return [None] * len(items)
+
+        try:
+            content = data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError):
+            log.error("good_news_classifier.malformed_response")
+            return [None] * len(items)
+
+        return _parse_response(content, expected_count=len(items))
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+
+_singleton: GoodNewsClassifier | None = None
+
+
+def get_good_news_classifier() -> GoodNewsClassifier:
+    """Retourne l'instance singleton du classifieur good-news."""
+    global _singleton
+    if _singleton is None:
+        _singleton = GoodNewsClassifier()
+    return _singleton

--- a/packages/api/app/services/ml/language_filter.py
+++ b/packages/api/app/services/ml/language_filter.py
@@ -1,0 +1,151 @@
+"""Filtre de langue pour la curation `is_good_news`.
+
+Deux fonctions complémentaires :
+
+- `is_french_source(name)` : whitelist explicite des sources francophones
+  connues du pipeline d'ingestion. Une source absente est considérée
+  non-francophone (rejet par défaut, pour éviter de polluer le digest).
+- `looks_english(title)` : garde-fou heuristique sur le titre. Détecte la
+  présence de mots fonctionnels typiquement anglais. Utilisé pour rattraper
+  les rares cas où une source whitelistée publie occasionnellement un article
+  en anglais (syndication, traduction).
+
+Aucune dépendance externe, aucun appel API. Tout se joue sur des sets en
+mémoire et un tokenizer minimal.
+"""
+
+from __future__ import annotations
+
+# Sous-chaînes (insensibles à la casse) qui identifient une source
+# francophone. Construit à partir de la liste réelle des sources observées
+# en production (cf. story 15.2). Volontairement permissif : on préfère
+# inclure une source borderline et laisser le garde-fou heuristique trier.
+_FRENCH_SOURCE_TOKENS: tuple[str, ...] = (
+    "actualités vidal",
+    "arte",
+    "assemblée nationale",
+    "bdm",
+    "blog du modérateur",
+    "cerveau & psycho",
+    "contrepoints",
+    "courrier international",
+    "europe 1",
+    "developpez.com",
+    "france culture",
+    "france info",
+    "franceinfo",
+    "frandroid",
+    "gamekult",
+    "ign france",
+    "l'humanité",
+    "humanité",
+    "la croix",
+    "la science cqfd",
+    "lcp",
+    "le figaro",
+    "le monde",
+    "le nouvel obs",
+    "le parisien",
+    "korben",
+    "linfodurable",
+    "mediapart",
+    "numerama",
+    "ouest-france",
+    "ouest france",
+    "r/france",
+    "reporterre",
+    "slate fr",
+    "télérama",
+    "telerama",
+    "trust my science",
+    "vertige media",
+    "20 minutes",
+    "rfi",
+    "rtl",
+    "rmc",
+    "bfm",
+    "lci",
+)
+
+# Mots fonctionnels anglais courants, en lowercase, à comparer après
+# tokenisation simple. La liste est volontairement courte : on cherche
+# des marqueurs très fréquents pour limiter les faux positifs sur du
+# français contenant un anglicisme isolé.
+_ENGLISH_FUNCTION_WORDS: frozenset[str] = frozenset(
+    {
+        "the",
+        "of",
+        "and",
+        "for",
+        "this",
+        "that",
+        "with",
+        "from",
+        "are",
+        "is",
+        "was",
+        "were",
+        "have",
+        "has",
+        "will",
+        "would",
+        "should",
+        "could",
+        "their",
+        "they",
+        "what",
+        "when",
+        "why",
+        "how",
+        "about",
+        "into",
+        "after",
+        "before",
+        "between",
+        "against",
+        "without",
+    }
+)
+
+
+def is_french_source(source_name: str | None) -> bool:
+    """Renvoie True si la source est listée comme francophone.
+
+    Args:
+        source_name: Nom de la source tel que stocké en base (peut être
+            None ou vide pour les contenus orphelins).
+
+    Returns:
+        True si une sous-chaîne de la whitelist est trouvée dans le nom
+        (insensible à la casse). False sinon — y compris pour None / "".
+    """
+    if not source_name:
+        return False
+    needle = source_name.casefold()
+    return any(token in needle for token in _FRENCH_SOURCE_TOKENS)
+
+
+def looks_english(title: str | None) -> bool:
+    """Renvoie True si le titre semble être en anglais.
+
+    Heuristique : on tokenise sur les espaces et la ponctuation simple,
+    puis on compte combien de tokens appartiennent à la liste de mots
+    fonctionnels anglais. À partir de 2 occurrences distinctes, on
+    considère que le titre est anglophone.
+
+    Args:
+        title: Titre de l'article. None / vide → False (on laisse passer
+            pour ne pas rejeter par excès de prudence).
+
+    Returns:
+        True si ≥ 2 mots fonctionnels anglais distincts sont trouvés.
+    """
+    if not title:
+        return False
+
+    normalized = "".join(
+        c if c.isalpha() or c == "'" else " " for c in title.casefold()
+    )
+    tokens = set(normalized.split())
+    matches = tokens & _ENGLISH_FUNCTION_WORDS
+    return len(matches) >= 2

--- a/packages/api/app/workers/classification_worker.py
+++ b/packages/api/app/workers/classification_worker.py
@@ -17,6 +17,8 @@ from app.models.content import Content
 from app.models.source import Source
 from app.services.classification_queue_service import ClassificationQueueService
 from app.services.ml.classification_service import get_classification_service
+from app.services.ml.good_news_classifier import get_good_news_classifier
+from app.services.ml.language_filter import is_french_source, looks_english
 
 settings = get_settings()
 
@@ -59,6 +61,7 @@ class ClassificationWorker:
         )
 
         self._classifier = None
+        self._good_news_classifier = None
         self._loop_count = 0
 
     def _get_classifier(self):
@@ -66,6 +69,12 @@ class ClassificationWorker:
         if self._classifier is None:
             self._classifier = get_classification_service()
         return self._classifier
+
+    def _get_good_news_classifier(self):
+        """Lazy load good-news classifier (mistral-large pass 2)."""
+        if self._good_news_classifier is None:
+            self._good_news_classifier = get_good_news_classifier()
+        return self._good_news_classifier
 
     async def start(self):
         """Start the worker in the background."""
@@ -114,6 +123,10 @@ class ClassificationWorker:
         classifier = self._get_classifier()
         if classifier:
             await classifier.close()
+
+        good_news_classifier = self._get_good_news_classifier()
+        if good_news_classifier:
+            await good_news_classifier.close()
 
         await self.engine.dispose()
 
@@ -238,6 +251,48 @@ class ClassificationWorker:
                         "classification_worker.entity_extraction_failed",
                         error=str(e),
                     )
+
+                # Step 3: Good-news pass (mistral-large) on serene+FR survivors
+                # Initialize good_news=None for all; only mutated for evaluated items
+                for r in all_results:
+                    r["good_news"] = None
+
+                good_news_indices: list[int] = []
+                good_news_items: list[dict] = []
+                for idx, (bi, result) in enumerate(zip(batch_items, all_results, strict=False)):
+                    if result.get("serene") is not True:
+                        continue
+                    source_name = bi.get("source_name", "")
+                    title = bi.get("title", "")
+                    if not is_french_source(source_name):
+                        continue
+                    if looks_english(title):
+                        continue
+                    good_news_indices.append(idx)
+                    good_news_items.append(bi)
+
+                if good_news_items:
+                    gn_classifier = self._get_good_news_classifier()
+                    if gn_classifier and gn_classifier.is_ready():
+                        try:
+                            gn_results = await gn_classifier.classify_batch_async(
+                                good_news_items
+                            )
+                            for offset, idx in enumerate(good_news_indices):
+                                if offset < len(gn_results):
+                                    all_results[idx]["good_news"] = gn_results[offset]
+                            logger.info(
+                                "classification_worker.good_news_pass",
+                                evaluated=len(good_news_items),
+                                positives=sum(
+                                    1 for v in gn_results if v is True
+                                ),
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "classification_worker.good_news_pass_failed",
+                                error=str(e),
+                            )
             else:
                 all_results = [
                     {

--- a/packages/api/app/workers/classification_worker.py
+++ b/packages/api/app/workers/classification_worker.py
@@ -259,7 +259,9 @@ class ClassificationWorker:
 
                 good_news_indices: list[int] = []
                 good_news_items: list[dict] = []
-                for idx, (bi, result) in enumerate(zip(batch_items, all_results, strict=False)):
+                for idx, (bi, result) in enumerate(
+                    zip(batch_items, all_results, strict=False)
+                ):
                     if result.get("serene") is not True:
                         continue
                     source_name = bi.get("source_name", "")
@@ -284,9 +286,7 @@ class ClassificationWorker:
                             logger.info(
                                 "classification_worker.good_news_pass",
                                 evaluated=len(good_news_items),
-                                positives=sum(
-                                    1 for v in gn_results if v is True
-                                ),
+                                positives=sum(1 for v in gn_results if v is True),
                             )
                         except Exception as e:
                             logger.warning(

--- a/packages/api/tests/ml/test_good_news_classifier.py
+++ b/packages/api/tests/ml/test_good_news_classifier.py
@@ -1,0 +1,136 @@
+"""Tests unitaires pour `good_news_classifier` (parsing + batch wiring).
+
+Pas d'appel réseau : on stubbe `_call` pour vérifier le parsing et la
+forme du payload.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.ml.good_news_classifier import (
+    GoodNewsClassifier,
+    _build_user_prompt,
+    _parse_response,
+)
+
+
+class TestParseResponse:
+    def test_array_of_dicts(self) -> None:
+        raw = '[{"good_news": true}, {"good_news": false}, {"good_news": true}]'
+        assert _parse_response(raw, expected_count=3) == [True, False, True]
+
+    def test_array_of_bools(self) -> None:
+        raw = "[true, false, true]"
+        assert _parse_response(raw, expected_count=3) == [True, False, True]
+
+    def test_padding_when_short(self) -> None:
+        raw = '[{"good_news": true}]'
+        assert _parse_response(raw, expected_count=3) == [True, None, None]
+
+    def test_truncation_when_long(self) -> None:
+        raw = '[{"good_news": true}, {"good_news": false}, {"good_news": true}]'
+        assert _parse_response(raw, expected_count=2) == [True, False]
+
+    def test_invalid_json(self) -> None:
+        assert _parse_response("not json", expected_count=2) == [None, None]
+
+    def test_non_bool_value(self) -> None:
+        raw = '[{"good_news": "yes"}, {"good_news": 1}, {"good_news": null}]'
+        assert _parse_response(raw, expected_count=3) == [None, None, None]
+
+    def test_dict_root_falls_back_to_none(self) -> None:
+        # Le modèle peut renvoyer un objet wrappé en JSON mode ; si la racine
+        # n'est pas une liste, on renvoie une liste de None.
+        raw = '{"results": [{"good_news": true}]}'
+        assert _parse_response(raw, expected_count=1) == [None]
+
+
+class TestBuildUserPrompt:
+    def test_includes_indices_and_titles(self) -> None:
+        prompt = _build_user_prompt(
+            [
+                {"title": "Article un", "description": "desc 1", "source_name": "Le Monde"},
+                {"title": "Article deux", "description": "desc 2", "source_name": "Reporterre"},
+            ]
+        )
+        assert "Article un" in prompt
+        assert "Article deux" in prompt
+        assert "[1]" in prompt
+        assert "[2]" in prompt
+        assert "Source: Le Monde" in prompt
+        assert "Source: Reporterre" in prompt
+        assert "exactement 2 éléments" in prompt
+
+    def test_truncates_long_description(self) -> None:
+        long_desc = "x" * 1000
+        prompt = _build_user_prompt(
+            [{"title": "T", "description": long_desc, "source_name": "S"}]
+        )
+        # 240 + ellipsis
+        assert "..." in prompt
+        assert "x" * 250 not in prompt
+
+    def test_handles_empty_description(self) -> None:
+        prompt = _build_user_prompt(
+            [{"title": "Titre seul", "description": "", "source_name": "Le Monde"}]
+        )
+        assert "Titre seul" in prompt
+
+
+class TestClassifierBatch:
+    @pytest.mark.asyncio
+    async def test_empty_input(self) -> None:
+        classifier = GoodNewsClassifier()
+        result = await classifier.classify_batch_async([])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_unready_returns_none_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        classifier = GoodNewsClassifier()
+        classifier._ready = False
+        items = [{"title": "a"}, {"title": "b"}]
+        result = await classifier.classify_batch_async(items)
+        assert result == [None, None]
+
+    @pytest.mark.asyncio
+    async def test_uses_call_response(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        classifier = GoodNewsClassifier()
+        classifier._ready = True
+
+        async def fake_call(payload: dict, *, max_retries: int = 3) -> dict:
+            assert payload["model"] == "mistral-large-latest"
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": '[{"good_news": true}, {"good_news": false}]'
+                        }
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(classifier, "_call", fake_call)
+        result = await classifier.classify_batch_async(
+            [
+                {"title": "A", "source_name": "Le Monde"},
+                {"title": "B", "source_name": "Le Monde"},
+            ]
+        )
+        assert result == [True, False]
+
+    @pytest.mark.asyncio
+    async def test_call_failure_returns_none_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        classifier = GoodNewsClassifier()
+        classifier._ready = True
+
+        async def fake_call(payload: dict, *, max_retries: int = 3) -> None:
+            return None
+
+        monkeypatch.setattr(classifier, "_call", fake_call)
+        result = await classifier.classify_batch_async(
+            [{"title": "A"}, {"title": "B"}, {"title": "C"}]
+        )
+        assert result == [None, None, None]

--- a/packages/api/tests/ml/test_language_filter.py
+++ b/packages/api/tests/ml/test_language_filter.py
@@ -1,0 +1,108 @@
+"""Tests unitaires pour `language_filter`."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.ml.language_filter import is_french_source, looks_english
+
+
+class TestIsFrenchSource:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Le Monde",
+            "le monde",
+            "LE MONDE",
+            "Le Figaro",
+            "Mediapart",
+            "France Culture",
+            "France Info",
+            "Numerama",
+            "Numerama — Décryptages",
+            "Ouest-France",
+            "Reporterre",
+            "Slate FR — Explainers",
+            "Télérama - Actus et critiques culturelles",
+            "Trust My Science",
+            "L'Humanité",
+            "Frandroid",
+            "Korben",
+            "Les news de Korben",
+            "Linfodurable.fr",
+            "Cerveau & Psycho",
+            "Courrier International",
+            "Contrepoints",
+            "Vertige Media",
+            "Gamekult - Jeux vidéo PC et consoles",
+            "IGN France",
+            "ARTE",
+            "Assemblée nationale",
+            "LCP - Assemblée nationale",
+            "BDM",
+            "Europe 1",
+            "La Croix — Analyses",
+            "La Science CQFD",
+            "Actualités VIDAL",
+        ],
+    )
+    def test_known_french_sources(self, name: str) -> None:
+        assert is_french_source(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "BBC News",
+            "The Guardian",
+            "The New York Times",
+            "Ars Technica",
+            "MIT Technology Review",
+            "Politico Europe",
+            "Techmeme",
+            "Reddit's Startup Community",
+            "Random English Outlet",
+            "",
+            None,
+        ],
+    )
+    def test_non_french_sources_rejected(self, name: str | None) -> None:
+        assert is_french_source(name) is False
+
+
+class TestLooksEnglish:
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "The future of AI is uncertain and slow",
+            "How the new policy will change the way we work",
+            "What this means for the industry",
+            "Five things to know about the deal",
+            "The rise and fall of the empire",
+        ],
+    )
+    def test_english_titles_detected(self, title: str) -> None:
+        assert looks_english(title) is True
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "L'Assemblée vote la fin du glyphosate dans les jardins publics",
+            "Le Monde publie une enquête inédite sur les retraites",
+            "Une avancée majeure contre le cancer du pancréas",
+            "Réchauffement climatique : la France adopte un plan ambitieux",
+            "Découverte d'une nouvelle exoplanète habitable",
+            "Mort de Charles Aznavour à 94 ans",
+            "",
+            None,
+        ],
+    )
+    def test_french_titles_pass(self, title: str | None) -> None:
+        assert looks_english(title) is False
+
+    def test_single_english_token_not_flagged(self) -> None:
+        # "the" tout seul ne doit pas suffire (les anglicismes sont fréquents
+        # dans la presse FR — ex. "the place to be").
+        assert looks_english("Voici the place to be cet été à Marseille") is False
+
+    def test_two_english_tokens_flagged(self) -> None:
+        assert looks_english("This is a test") is True


### PR DESCRIPTION
Le mistral-small-latest produisait 32 % de précision sur les "bonnes
nouvelles" (audit PO 60 articles, 10/05/2026). Trop de faux positifs :
tristesse résiduelle, IA frontier, anecdotique, anglais non filtré.

Refactor :

- Passe 1 (mistral-small) ne classe plus que topics + serene + entities.
- Nouvelle passe 2 (mistral-large) dédiée `is_good_news`, gatée par
  serene=true ∧ source FR whitelistée ∧ titre non-anglais (~10 % du flux,
  coût maîtrisé).
- Whitelist FR construite depuis la liste réelle des sources observées
  en prod, garde-fou heuristique sur tokens anglais courants.

Tests : 73 unitaires (whitelist 32 sources FR / 11 EN + parser batch
+ wiring asyncio mocké).