### PR TITLE
feat(mobile): account deletion, Sign in with Apple, legal links (Store compliance)

### DIFF
--- a/apps/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B7E1C2D3F4A5B6C7D8E9F0A1 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		A38DA047D97D8931631AD8A2 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		B0A93E77D37D44B01EDFC427 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		C6F6F53FCD8B73ACA343552F /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -148,6 +149,7 @@
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
+				B7E1C2D3F4A5B6C7D8E9F0A1 /* Runner.entitlements */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
@@ -470,6 +472,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -652,6 +655,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -674,6 +678,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/apps/mobile/ios/Runner/Runner.entitlements
+++ b/apps/mobile/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/apps/mobile/lib/config/constants.dart
+++ b/apps/mobile/lib/config/constants.dart
@@ -279,6 +279,16 @@ class ExternalLinks {
       'https://chat.whatsapp.com/Fq4oKgSDEgc9AmAyZR9uhJ?mode=gi_t';
 }
 
+/// Liens légaux et support — exposés via le backend FastAPI (`/legal/*`).
+/// Synchronisés avec `packages/api/app/routers/legal.py`.
+class LegalLinks {
+  LegalLinks._();
+
+  static const String privacy = 'https://api.facteur.app/legal/privacy';
+  static const String terms = 'https://api.facteur.app/legal/terms';
+  static const String supportEmail = 'mailto:support@facteur.app';
+}
+
 /// Contact direct du créateur — utilisé par le fallback "Quelques pépins"
 /// quand l'app n'arrive plus à charger malgré plusieurs retries.
 class LaurinContact {

--- a/apps/mobile/lib/core/api/user_api_service.dart
+++ b/apps/mobile/lib/core/api/user_api_service.dart
@@ -76,6 +76,14 @@ class UserApiService {
     return UserProfile.fromJson(data);
   }
 
+  /// Soft delete du compte courant.
+  /// Le backend marque `users.deleted_at` et anonymise l'email ; un cron purge
+  /// définitivement après 30 jours (cf. PR backend B1, Apple Guideline 5.1.1(v)).
+  /// Retourne 204 No Content en cas de succès.
+  Future<void> deleteAccount() async {
+    await _apiClient.dio.delete<void>('users/me');
+  }
+
   /// Formate les réponses pour l'API (camelCase → snake_case).
   ///
   /// Défense en profondeur : applique des défauts neutres si l'état mobile

--- a/apps/mobile/lib/features/auth/screens/login_screen.dart
+++ b/apps/mobile/lib/features/auth/screens/login_screen.dart
@@ -1,7 +1,13 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
 
+import '../../../config/constants.dart';
 import '../../../config/theme.dart';
 import '../../../core/auth/auth_state.dart';
 import '../../../shared/widgets/buttons/primary_button.dart';
@@ -27,13 +33,27 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
   bool _rememberMe = true;
 
+  late final TapGestureRecognizer _termsRecognizer = TapGestureRecognizer()
+    ..onTap = () => _openUrl(LegalLinks.terms);
+  late final TapGestureRecognizer _privacyRecognizer = TapGestureRecognizer()
+    ..onTap = () => _openUrl(LegalLinks.privacy);
+
   @override
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();
     _firstNameController.dispose();
     _lastNameController.dispose();
+    _termsRecognizer.dispose();
+    _privacyRecognizer.dispose();
     super.dispose();
+  }
+
+  Future<void> _openUrl(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
   }
 
   void _toggleMode() {
@@ -496,6 +516,51 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                     ),
                   ),
 
+                  // Bouton Sign in with Apple — requis par Apple Guideline 4.8
+                  // dès lors qu'un autre provider OAuth (Google) est offert.
+                  // Affiché sur iOS et web ; macOS/Android n'ont pas l'expérience
+                  // native attendue.
+                  if (kIsWeb || (!kIsWeb && Platform.isIOS)) ...[
+                    const SizedBox(height: 12),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 52,
+                      child: OutlinedButton.icon(
+                        onPressed: authState.isLoading
+                            ? null
+                            : () {
+                                ref
+                                    .read(authStateProvider.notifier)
+                                    .signInWithApple();
+                              },
+                        style: OutlinedButton.styleFrom(
+                          side: BorderSide(color: colors.border),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          backgroundColor: colors.surfacePaper,
+                        ),
+                        // TODO(apple-asset): remplacer par le logo officiel
+                        // Apple (cf. Apple HIG Sign in with Apple) avant
+                        // soumission App Store.
+                        icon: Icon(
+                          Icons.apple,
+                          size: 22,
+                          color: colors.textPrimary,
+                        ),
+                        label: Text(
+                          _isSignUp
+                              ? 'S\'inscrire avec Apple'
+                              : 'Se connecter avec Apple',
+                          style:
+                              Theme.of(context).textTheme.labelLarge?.copyWith(
+                                    color: colors.textPrimary,
+                                  ),
+                        ),
+                      ),
+                    ),
+                  ],
+
                   const SizedBox(height: 16),
 
                   // Toggle inscription/connexion amélioré
@@ -569,12 +634,35 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
                   const SizedBox(height: 24),
 
-                  // CGV
-                  Text(
-                    'En continuant, tu acceptes nos Conditions d\'utilisation et notre Politique de confidentialité.',
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: colors.textTertiary,
+                  // CGV — liens cliquables vers les pages légales hébergées
+                  // par l'API (Apple 5.1.1 / Play Console).
+                  Text.rich(
+                    TextSpan(
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colors.textTertiary,
+                          ),
+                      children: [
+                        const TextSpan(text: 'En continuant, tu acceptes nos '),
+                        TextSpan(
+                          text: 'Conditions d\'utilisation',
+                          style: TextStyle(
+                            color: colors.primary,
+                            decoration: TextDecoration.underline,
+                          ),
+                          recognizer: _termsRecognizer,
                         ),
+                        const TextSpan(text: ' et notre '),
+                        TextSpan(
+                          text: 'Politique de confidentialité',
+                          style: TextStyle(
+                            color: colors.primary,
+                            decoration: TextDecoration.underline,
+                          ),
+                          recognizer: _privacyRecognizer,
+                        ),
+                        const TextSpan(text: '.'),
+                      ],
+                    ),
                     textAlign: TextAlign.center,
                   ),
                 ],

--- a/apps/mobile/lib/features/settings/screens/about_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/about_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../config/constants.dart';
 import '../../../config/theme.dart';
 import '../../../widgets/design/facteur_logo.dart';
 
@@ -89,6 +92,33 @@ class AboutScreen extends StatelessWidget {
             ),
             const SizedBox(height: FacteurSpacing.space8),
             Center(
+              child: Wrap(
+                alignment: WrapAlignment.center,
+                spacing: FacteurSpacing.space2,
+                children: [
+                  const _LegalLink(
+                    label: 'Confidentialité',
+                    url: LegalLinks.privacy,
+                  ),
+                  Text('•',
+                      style: textTheme.labelSmall
+                          ?.copyWith(color: colors.textTertiary)),
+                  const _LegalLink(
+                    label: 'CGU',
+                    url: LegalLinks.terms,
+                  ),
+                  Text('•',
+                      style: textTheme.labelSmall
+                          ?.copyWith(color: colors.textTertiary)),
+                  const _LegalLink(
+                    label: 'Support',
+                    url: LegalLinks.supportEmail,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: FacteurSpacing.space4),
+            Center(
               child: Text(
                 'Version Beta 1.0 • Open Source',
                 style:
@@ -170,6 +200,38 @@ class AboutScreen extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _LegalLink extends StatelessWidget {
+  const _LegalLink({required this.label, required this.url});
+
+  final String label;
+  final String url;
+
+  Future<void> _open() async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return InkWell(
+      onTap: _open,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+        child: Text(
+          label,
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: colors.primary,
+                decoration: TextDecoration.underline,
+              ),
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/settings/screens/account_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/account_screen.dart
@@ -1,11 +1,15 @@
 import 'dart:io';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+import '../../../config/routes.dart';
 import '../../../config/theme.dart';
+import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
 import '../../../core/services/widget_service.dart';
 import '../providers/user_profile_provider.dart';
@@ -191,7 +195,7 @@ class AccountScreen extends ConsumerWidget {
             SizedBox(
               width: double.infinity,
               child: TextButton(
-                onPressed: () => _showDeleteConfirmation(context, ref),
+                onPressed: () => _showDeleteConfirmation(context),
                 style: TextButton.styleFrom(
                   foregroundColor: colors.error,
                   padding: const EdgeInsets.symmetric(
@@ -209,40 +213,11 @@ class AccountScreen extends ConsumerWidget {
     );
   }
 
-  void _showDeleteConfirmation(BuildContext context, WidgetRef ref) {
-    final colors = context.facteurColors;
-
+  void _showDeleteConfirmation(BuildContext context) {
     showDialog<void>(
       context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: colors.surface,
-        title: Text(
-          'Supprimer mon compte ?',
-          style: TextStyle(color: colors.textPrimary),
-        ),
-        content: Text(
-          'Cette action est irréversible. Toutes vos données seront perdues.',
-          style: TextStyle(color: colors.textSecondary),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child:
-                Text('Annuler', style: TextStyle(color: colors.textSecondary)),
-          ),
-          TextButton(
-            onPressed: () async {
-              Navigator.of(context).pop();
-              // TODO: Implémenter la suppression via Supabase RPC
-              // Pour l'instant, on se contente de déconnecter
-              NotificationService.showError(
-                'Contactez le support pour supprimer votre compte.',
-              );
-            },
-            child: Text('Supprimer', style: TextStyle(color: colors.error)),
-          ),
-        ],
-      ),
+      barrierDismissible: false,
+      builder: (_) => const _DeleteAccountDialog(),
     );
   }
 
@@ -332,6 +307,130 @@ class _InfoRow extends StatelessWidget {
           Icon(Icons.edit_outlined, color: colors.textTertiary, size: 18),
         ],
       ),
+    );
+  }
+}
+
+/// Dialog de confirmation de suppression de compte avec garde-fou textuel.
+///
+/// Apple 5.1.1(v) et Google Play Account Deletion : la suppression doit être
+/// initiable depuis l'app et exécutable sans interaction manuelle du support.
+/// Le backend fait un soft-delete (deleted_at + email_hash) avec purge cron à
+/// J+30 — l'utilisateur peut se reconnecter pendant cette fenêtre pour annuler.
+class _DeleteAccountDialog extends ConsumerStatefulWidget {
+  const _DeleteAccountDialog();
+
+  @override
+  ConsumerState<_DeleteAccountDialog> createState() =>
+      _DeleteAccountDialogState();
+}
+
+class _DeleteAccountDialogState extends ConsumerState<_DeleteAccountDialog> {
+  static const _confirmationKeyword = 'SUPPRIMER';
+
+  final _controller = TextEditingController();
+  bool _isDeleting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  bool get _canDelete =>
+      !_isDeleting && _controller.text == _confirmationKeyword;
+
+  Future<void> _confirmDelete() async {
+    setState(() => _isDeleting = true);
+    try {
+      await ref.read(userApiServiceProvider).deleteAccount();
+      await ref.read(authStateProvider.notifier).signOut();
+      if (!mounted) return;
+      // Sortir explicitement du stack Settings vers le login. Le router a déjà
+      // un redirect basé sur isAuthenticated, mais goNamed garantit qu'on ne
+      // revient pas dans un écran orphelin (ex. Profile) après le pop.
+      Navigator.of(context).pop();
+      context.goNamed(RouteNames.login);
+    } on DioException {
+      if (!mounted) return;
+      setState(() => _isDeleting = false);
+      NotificationService.showError(
+        'Suppression impossible. Vérifie ta connexion et réessaye.',
+      );
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _isDeleting = false);
+      NotificationService.showError(
+        'Une erreur est survenue. Réessaye plus tard.',
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    return AlertDialog(
+      backgroundColor: colors.surface,
+      title: Text(
+        'Supprimer mon compte ?',
+        style: TextStyle(color: colors.textPrimary),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Toutes tes données (profil, préférences, historique de lecture) '
+            'seront supprimées. Tu as 30 jours pour annuler la suppression en '
+            'te reconnectant — passé ce délai, l\'effacement est définitif.',
+            style: TextStyle(color: colors.textSecondary),
+          ),
+          const SizedBox(height: FacteurSpacing.space4),
+          Text(
+            'Tape $_confirmationKeyword pour confirmer.',
+            style: textTheme.bodySmall?.copyWith(color: colors.textSecondary),
+          ),
+          const SizedBox(height: FacteurSpacing.space2),
+          TextField(
+            controller: _controller,
+            autofocus: true,
+            enabled: !_isDeleting,
+            textCapitalization: TextCapitalization.characters,
+            style: TextStyle(color: colors.textPrimary),
+            decoration: InputDecoration(
+              hintText: _confirmationKeyword,
+              hintStyle: TextStyle(color: colors.textTertiary),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isDeleting ? null : () => Navigator.of(context).pop(),
+          child: Text('Annuler', style: TextStyle(color: colors.textSecondary)),
+        ),
+        TextButton(
+          onPressed: _canDelete ? _confirmDelete : null,
+          child: _isDeleting
+              ? SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: colors.error,
+                  ),
+                )
+              : Text('Supprimer', style: TextStyle(color: colors.error)),
+        ),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
 
+import '../../../config/constants.dart';
 import '../../../config/routes.dart';
 import '../../../config/serein_colors.dart';
 import '../../../config/theme.dart';
@@ -84,6 +86,8 @@ class SettingsSheet extends ConsumerWidget {
                       _ContentShortcuts(),
                       SizedBox(height: FacteurSpacing.space4),
                       _FeedbackTile(),
+                      SizedBox(height: FacteurSpacing.space4),
+                      _LegalShortcuts(),
                     ],
                   ),
                 ),
@@ -389,6 +393,44 @@ class _FeedbackTile extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _LegalShortcuts extends StatelessWidget {
+  const _LegalShortcuts();
+
+  Future<void> _open(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _SheetCard(
+      child: Column(
+        children: [
+          _ShortcutTile(
+            icon: PhosphorIcons.shieldCheck(PhosphorIconsStyle.regular),
+            label: 'Politique de confidentialité',
+            onTap: () => _open(LegalLinks.privacy),
+          ),
+          const _Divider(),
+          _ShortcutTile(
+            icon: PhosphorIcons.fileText(PhosphorIconsStyle.regular),
+            label: 'Conditions d\'utilisation',
+            onTap: () => _open(LegalLinks.terms),
+          ),
+          const _Divider(),
+          _ShortcutTile(
+            icon: PhosphorIcons.lifebuoy(PhosphorIconsStyle.regular),
+            label: 'Contacter le support',
+            onTap: () => _open(LegalLinks.supportEmail),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
# PR — feat(mobile): suppression compte + Apple Sign-In + liens légaux (PR 3/5 store-compliance)

## Summary

Adresse 3 bloqueurs Apple/Play Store sur l'app mobile Flutter (cf. plan global `store-compliance-mvp`) :

- **B1 — Suppression compte fonctionnelle** : refonte de `_showDeleteConfirmation()` (`apps/mobile/lib/features/settings/screens/account_screen.dart`). Garde-fou textuel (tape `SUPPRIMER`), appel `DELETE /users/me` via `UserApiService.deleteAccount()` (nouveau), sign-out + navigation `/login`. Message info "Tu as 30 jours pour annuler en te reconnectant". Apple 5.1.1(v) + Google Play Account Deletion.
- **B2 — Bouton Sign in with Apple** : ajouté sous le bouton Google sur `login_screen.dart` (visible iOS + Web). Réutilise `signInWithApple()` déjà implémenté via Supabase OAuth (`auth_state.dart:565`). Entitlement iOS créé : `apps/mobile/ios/Runner/Runner.entitlements` (`com.apple.developer.applesignin`) + référence ajoutée aux 3 build configs du target Runner dans `project.pbxproj`. Apple Guideline 4.8.
- **B3 (volet UI) — Liens Privacy/CGU/Support** :
  - `login_screen.dart` : `Text` plat → `Text.rich` avec `TapGestureRecognizer` pour Privacy + CGU.
  - `settings_sheet.dart` : nouveau bloc `_LegalShortcuts` (3 tuiles) après `_FeedbackTile`.
  - `about_screen.dart` : footer avec 3 liens (Confidentialité / CGU / Support) avant "Version Beta 1.0".
  - Constantes ajoutées dans `apps/mobile/lib/config/constants.dart` (classe `LegalLinks` → `https://api.facteur.app/legal/{privacy,terms}` + `mailto:support@facteur.app`).

## Dépendances

Cette PR est **mergeable** mais les flows ne fonctionneront end-to-end qu'une fois ces 2 autres PRs déployées :
- **PR 1 (legal routes)** : expose `GET /legal/privacy` et `/legal/terms` côté FastAPI.
- **PR 2 (DELETE /users/me)** : endpoint soft-delete avec migration `users.deleted_at` + cron 30j.

Les imports/contrats sont déjà câblés contre les URLs cibles ; un retry suffira post-merge des dépendances.

## Action manuelle PO post-merge

Configuration **hors code** à faire pour activer Sign in with Apple en prod :

1. **Apple Developer Portal** : activer la capability « Sign In with Apple » sur l'App ID `com.example.facteur` (à renommer vers le bundle ID définitif avant soumission).
2. **Supabase Auth Dashboard** (project Facteur) : Authentication → Providers → Apple → enable + remplir Service ID, Team ID, Key ID, et uploader le `.p8` privé. Callback URL : `https://<project-ref>.supabase.co/auth/v1/callback`.
3. **Xcode (optionnel)** : ouvrir `apps/mobile/ios/Runner.xcworkspace`, target Runner → Signing & Capabilities → vérifier que « Sign in with Apple » est présent (sinon `+ Capability` pour le re-générer). Le fichier `Runner.entitlements` est déjà attaché aux 3 configs (Debug/Release/Profile) via le pbxproj.

## Tests

- `flutter analyze` : aucune nouvelle erreur sur les fichiers modifiés (seules des `info`/`deprecated_member_use` héritées sur `withOpacity`).
- `flutter test test/features/auth test/features/settings test/core/api test/core/auth` : 65 passed, 2 failed (`router_redirection_test.dart`) — **failures identiques sur `main` sans cette PR** (baseline mesurée par stash + rerun).
- Suite complète : 585 passed / 38 failed sur cette branche vs 583 / 38 sur main → +2 passing, **0 régression** introduite.

## Hors scope

- Asset logo officiel Apple (TODO dans le code — `Icons.apple` Material en placeholder).
- Sign in with Apple **natif** (package `sign_in_with_apple`) : on garde l'OAuth Supabase webview, accepté par Apple depuis iOS 13. Migration possible post-launch si feedback UX négatif.
- Product flavors Android + Info.plist iOS usage descriptions → PR 4.
- RevenueCat → PR 5.

## Validation visuelle recommandée post-merge des dépendances

- Login : tap sur "Conditions" / "Politique" → browser externe sur `api.facteur.app/legal/*`.
- Settings sheet : 3 tuiles légales fonctionnelles.
- About screen : footer cliquable.
- Suppression compte : dialog refuse "supprimer" lowercase, accepte "SUPPRIMER", appel DELETE → 204 → retour login. Reconnexion sous 30 jours doit annuler la suppression (à valider quand PR 2 est en prod).