### PR TITLE
fix(perspectives): bloquer faux-positifs clustering trop large (topic seul)

### DIFF
--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -24,6 +24,11 @@ logger = structlog.get_logger(__name__)
 # --- Post-filtre cohérence sujet (anti-clustering trop large) ---
 # Voir docs/bugs/bug-comparison-clustering-too-loose.md
 PERSPECTIVE_TITLE_JACCARD_MIN = 0.30
+# Jaccard minimum exigé même dans le chemin full_signals (bypass Layer 1).
+# Empêche qu'un seul topic générique ("politics") suffise à valider deux articles
+# sur des sujets radicalement différents (ex: Congo/prisonniers vs Ukraine/trêve)
+# partageant seulement un nom propre omniprésent (Trump, Macron…).
+PERSPECTIVE_MIN_JACCARD_FLOOR = 0.08
 PERSPECTIVE_MIN_VALID_RESULTS = 2
 PERSPECTIVE_MIN_BIAS_GROUPS = 2
 # Entités jugées suffisamment discriminantes (LOCATION exclu : trop générique)
@@ -509,9 +514,9 @@ class PerspectiveService:
         """Décide si un candidat est on-topic.
 
         - Si title_jaccard >= seuil → cohérent (signal fort).
-        - Sinon, si signaux complets (Layer 1 DB), accepter aussi sur :
-          shared_topics >= 1 OU shared_entities >= 2.
-        - Sinon (Layer 2/3 Google News, titre seul) → rejeter.
+        - Sinon, si signaux complets (Layer 1 DB) ET jaccard >= floor minimal :
+          (shared_topics >= 1 ET shared_entities >= 1) OU shared_entities >= 2.
+        - Sinon (Layer 2/3 Google News, ou jaccard trop faible) → rejeter.
 
         Retourne (is_coherent, reason). reason vide si cohérent.
         """
@@ -523,10 +528,21 @@ class PerspectiveService:
             and signals["shared_entities"] is not None
         )
         if full_signals:
-            if signals["shared_topics"] and signals["shared_topics"] >= 1:
-                return True, ""
+            # 2 entités discriminantes partagées → signal fort, pas de floor requis.
             if signals["shared_entities"] and signals["shared_entities"] >= 2:
                 return True, ""
+            # 1 topic + 1 entité : exiger aussi un Jaccard minimal pour bloquer
+            # les faux-positifs "même personnalité, sujets totalement différents"
+            # (ex: Congo/Trump vs Ukraine/Trump — seul token commun : "trump").
+            if signals["title_jaccard"] >= PERSPECTIVE_MIN_JACCARD_FLOOR:
+                topic_ok = bool(
+                    signals["shared_topics"] and signals["shared_topics"] >= 1
+                )
+                entity_ok = bool(
+                    signals["shared_entities"] and signals["shared_entities"] >= 1
+                )
+                if topic_ok and entity_ok:
+                    return True, ""
             return False, "no_signal"
         return False, "low_jaccard"
 

--- a/packages/api/tests/test_perspective_service.py
+++ b/packages/api/tests/test_perspective_service.py
@@ -198,21 +198,27 @@ def test_topical_signals_external_low_jaccard_rejected():
     assert reason == "low_jaccard"
 
 
-def test_topical_signals_shared_topic_rescues_low_jaccard():
-    """Si Jaccard titre faible mais 1 topic ML partagé → accepter (Layer 1)."""
+def test_topical_signals_shared_topic_alone_insufficient_with_zero_jaccard():
+    """1 topic partagé seul + Jaccard ≈ 0 → rejeter (faux-positif "Trump partout").
+
+    Un topic générique ("politics", "religion"…) partagé sans entité discriminante
+    ET sans aucune similarité de titre ne suffit plus à valider une perspective.
+    Empêche ex: Congo/Trump vs Ukraine/Trump via seul topic "politics".
+    """
     seed_tokens, seed_topics, _ = _seed_signals_inputs()
     signals = PerspectiveService._topical_signals(
         seed_tokens,
         seed_topics,
         seed_disc_entities=set(),
         cand_title="Article au titre totalement différent qui ne matche rien",
-        cand_topics=["religion"],  # 1 topic en commun
+        cand_topics=["religion"],  # 1 topic en commun, mais 0 entité, jaccard ≈ 0
         cand_entities=[],
     )
     assert signals["title_jaccard"] < PERSPECTIVE_TITLE_JACCARD_MIN
     assert signals["shared_topics"] == 1
-    is_ok, _ = PerspectiveService._is_topically_coherent(signals)
-    assert is_ok is True
+    is_ok, reason = PerspectiveService._is_topically_coherent(signals)
+    assert is_ok is False
+    assert reason == "no_signal"
 
 
 def test_topical_signals_2_shared_entities_rescues_low_jaccard():


### PR DESCRIPTION
## What

Durcit le filtre de cohérence sujet dans `_is_topically_coherent` (Layer 1, DB interne) : un topic générique partagé seul ("politics") ne suffit plus à valider une perspective — il faut désormais Jaccard ≥ 0.08 **et** au moins 1 entité discriminante. Les 2 entités partagées restent exemptées du floor (signal fort suffisant).

## Why

Un article sur Trump/Congo se retrouvait en "Couverture médiatique" avec des articles sur la trêve Ukraine, les sondages Trump, le Moyen-Orient — tous taggués "politics" et mentionnant Trump. Le bypass `shared_topics >= 1` court-circuitait complètement le seuil Jaccard dès qu'un tag générique était partagé.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)