### PR TITLE
fix(android): répare la tuile alarme quick settings cassée par Facteur

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     <!-- Required for flutter_local_notifications scheduled notifications -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <application

--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -205,7 +205,7 @@ class PushNotificationService {
     final canUseExact =
         (await androidPlugin?.canScheduleExactNotifications()) ?? true;
     final scheduleMode = canUseExact
-        ? AndroidScheduleMode.alarmClock
+        ? AndroidScheduleMode.exactAllowWhileIdle
         : AndroidScheduleMode.inexactAllowWhileIdle;
 
     const sender = Person(
@@ -269,7 +269,7 @@ class PushNotificationService {
     final canUseExact =
         (await androidPlugin?.canScheduleExactNotifications()) ?? true;
     final scheduleMode = canUseExact
-        ? AndroidScheduleMode.alarmClock
+        ? AndroidScheduleMode.exactAllowWhileIdle
         : AndroidScheduleMode.inexactAllowWhileIdle;
 
     final androidDetails = AndroidNotificationDetails(
@@ -323,7 +323,7 @@ class PushNotificationService {
     final canUseExact =
         (await androidPlugin?.canScheduleExactNotifications()) ?? true;
     final scheduleMode = canUseExact
-        ? AndroidScheduleMode.alarmClock
+        ? AndroidScheduleMode.exactAllowWhileIdle
         : AndroidScheduleMode.inexactAllowWhileIdle;
 
     const sender = Person(
@@ -405,7 +405,7 @@ class PushNotificationService {
     final canUseExact =
         (await androidPlugin?.canScheduleExactNotifications()) ?? true;
     final scheduleMode = canUseExact
-        ? AndroidScheduleMode.alarmClock
+        ? AndroidScheduleMode.exactAllowWhileIdle
         : AndroidScheduleMode.inexactAllowWhileIdle;
 
     final androidDetails = AndroidNotificationDetails(


### PR DESCRIPTION
## Quoi

Quand Facteur est installé, la tuile « alarme » du panneau de notifications rapides Android affichait une heure figée (ex: « samedi 7:30 ») et ne répondait plus au tap. Désinstaller Facteur restaurait le comportement normal.

## Pourquoi

`AndroidScheduleMode.alarmClock` utilise `AlarmManager.setAlarmClock()` — une API réservée aux vraies apps horloge. Elle enregistre l'app appelante comme propriétaire de la prochaine alarme système, ce qui :
- affiche l'heure de la prochaine notification Facteur dans la tuile
- associe le tap de la tuile à Facteur (qui ne gère pas cet intent → tap mort)

`USE_EXACT_ALARM` (supprimée) est une permission réservée aux apps horloge/calendrier par Google Play policy — inutile ici, `SCHEDULE_EXACT_ALARM` suffit.

## Changements

- `push_notification_service.dart` : 4× `AndroidScheduleMode.alarmClock` → `AndroidScheduleMode.exactAllowWhileIdle` (même fiabilité Doze, sans hijack de la tuile)
- `AndroidManifest.xml` : suppression de `USE_EXACT_ALARM`

## Comment ça a été vérifié

- [x] `flutter test` — 6/6 tests push_notification_service ✅ (38 échecs pré-existants sans rapport)
- [x] `flutter analyze` — 0 erreur
- [x] /simplify passé — code propre, rien à corriger

## Zones à risque

`push_notification_service.dart` — touche le scheduling de toutes les notifications locales (digest, community, good news, veille). Comportement identique côté livraison, seul le side-effect système est supprimé.