### PR TITLE
feat(ml): détection is_ad — filtre les publicités/native ads du pipeline

### DIFF
--- a/packages/api/alembic/versions/ad01_add_is_ad_to_contents.py
+++ b/packages/api/alembic/versions/ad01_add_is_ad_to_contents.py
@@ -1,0 +1,27 @@
+"""add is_ad column to contents
+
+Détection des articles publicitaires / native ads dans le pipeline de
+classification Pass 1 (mistral-small). NULL = non encore classifié (articles
+antérieurs à la migration), traité comme False dans les filtres aval pour
+préserver la compatibilité ascendante.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "ad01_add_is_ad_to_contents"
+down_revision: str | None = "sd01_soft_delete_user_profiles"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "contents",
+        sa.Column("is_ad", sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("contents", "is_ad")

--- a/packages/api/app/models/content.py
+++ b/packages/api/app/models/content.py
@@ -98,6 +98,8 @@ class Content(Base):
     is_good_news: Mapped[bool | None] = mapped_column(
         Boolean, nullable=True, default=None
     )
+    # Publicité / native ad: contenu sponsorisé ou promotionnel déguisé en éditorial.
+    is_ad: Mapped[bool | None] = mapped_column(Boolean, nullable=True, default=None)
     # In-App Reading: content quality signal ('full', 'partial', 'none')
     content_quality: Mapped[str | None] = mapped_column(
         String(20), nullable=True, default=None

--- a/packages/api/app/services/classification_queue_service.py
+++ b/packages/api/app/services/classification_queue_service.py
@@ -109,8 +109,9 @@ class ClassificationQueueService:
         entities: list[dict],
         is_serene: bool | None = None,
         is_good_news: bool | None = None,
+        is_ad: bool | None = None,
     ) -> None:
-        """Marque un élément comme complété avec topics, entités, sérénité et good news.
+        """Marque un élément comme complété avec topics, entités, sérénité, good news et is_ad.
 
         Args:
             queue_id: ID de l'élément dans la file
@@ -119,6 +120,7 @@ class ClassificationQueueService:
             is_serene: True si article non-anxiogène, False sinon, None si inconnu
             is_good_news: True si véritable bonne nouvelle (espoir, progrès tangible),
                 False sinon, None si inconnu. Indépendant d'is_serene.
+            is_ad: True si publicité / native ad, False sinon, None si inconnu.
         """
         import structlog
 
@@ -157,6 +159,14 @@ class ClassificationQueueService:
                 except (AttributeError, Exception) as e:
                     logger.warning(
                         "is_good_news_column_missing",
+                        error=str(e),
+                        content_id=str(content.id),
+                    )
+                try:
+                    content.is_ad = is_ad
+                except (AttributeError, Exception) as e:
+                    logger.warning(
+                        "is_ad_column_missing",
                         error=str(e),
                         content_id=str(content.id),
                     )

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -41,6 +41,7 @@ from app.models.user import UserProfile, UserSubtopic
 from app.schemas.digest import DigestScoreBreakdown
 from app.services.briefing.importance_detector import ImportanceDetector
 from app.services.recommendation.filter_presets import (
+    apply_ad_filter,
     apply_good_news_filter,
     is_sport_content,
 )
@@ -787,6 +788,8 @@ class DigestSelector:
                         Content.is_paid.is_not(True)
                     )
 
+            user_sources_query = apply_ad_filter(user_sources_query)
+
             # Mode "serein" devient "Bonnes nouvelles du jour" : hard-filter
             # is_good_news=True. La promesse prime sur la quantité (digest
             # potentiellement partiel). Les `sensitive_themes` n'ont plus
@@ -824,6 +827,8 @@ class DigestSelector:
                 ~excluded_stmt,
                 Content.published_at >= since,
                 Source.is_curated,
+                # Exclure les publicités / native ads (NULL = non classifié → toléré)
+                or_(Content.is_ad.is_(None), Content.is_ad == False),  # noqa: E712
                 Content.id.notin_(list(existing_ids)) if existing_ids else True,
                 Source.id.notin_(list(context.muted_sources))
                 if context.muted_sources
@@ -862,6 +867,8 @@ class DigestSelector:
                 )
             else:
                 curated_query = curated_query.where(Content.is_paid.is_not(True))
+
+        curated_query = apply_ad_filter(curated_query)
 
         # Mode "Bonnes nouvelles" : hard-filter is_good_news=True (cf. supra).
         if mode == "serein":

--- a/packages/api/app/services/ml/classification_service.py
+++ b/packages/api/app/services/ml/classification_service.py
@@ -49,7 +49,12 @@ _EMPTY_RESULT: dict = {
     "topics": [],
     "serene": None,
     "entities": [],
+    "is_ad": None,
 }
+
+
+def _coerce_bool(value: object) -> bool | None:
+    return value if isinstance(value, bool) else None
 
 
 # 51 topic slugs in the Facteur taxonomy
@@ -283,9 +288,26 @@ Règles :
 7. Assigne 2-3 topics si l'article couvre clairement plusieurs sujets
 8. Le premier topic est le PLUS pertinent
 
+## PUBLICITÉ / NATIVE AD (is_ad)
+Détermine si l'article est un contenu publicitaire, sponsorisé ou promotionnel déguisé en contenu éditorial.
+
+is_ad = true si l'article est :
+- Un article "bons plans" ou deal commercial (mention d'un prix réduit, remise, code promo, "au meilleur prix", "bradé", lien vers un site marchand)
+- Un contenu d'affiliation ou comparatif orienté achat ("quel est le meilleur produit", "guide d'achat", "top N produits à acheter")
+- Un communiqué de presse déguisé en article (annonce produit sans analyse ni recul critique)
+- Un "test" ou "unboxing" dont l'objectif principal est la conversion commerciale sans critique négative
+
+is_ad = false si l'article est :
+- Une actualité, analyse, enquête ou opinion journalistique, même si un produit y est mentionné
+- Une actualité sur une entreprise avec contexte et recul éditorial (licenciements, stratégie, etc.)
+- Un guide pratique (comment faire X) à valeur informative sans lien marchand
+- Un test comparatif avec véritable critique nuancée ou négative
+
+En cas de doute, is_ad = false (préférer les faux négatifs aux faux positifs).
+
 ## FORMAT
 Réponds en JSON array. Chaque élément :
-{"topics": ["slug1", "slug2"], "serene": true/false, "entities": [{"name": "Nom Complet", "type": "PERSON"}]}
+{"topics": ["slug1", "slug2"], "serene": true/false, "entities": [{"name": "Nom Complet", "type": "PERSON"}], "is_ad": true/false}
 Pas de texte avant ou après."""
 
 CLASSIFICATION_MODEL = "mistral-small-latest"
@@ -557,14 +579,14 @@ class ClassificationService:
             f"Classifie chacun de ces {len(items)} articles.\n"
             f"Réponds en JSON array de exactement {len(items)} éléments.\n"
             'Exemple pour 2 articles: [{"topics": ["politics", "europe"], "serene": false, '
-            '"entities": [{"name": "Emmanuel Macron", "type": "PERSON"}]}, '
+            '"entities": [{"name": "Emmanuel Macron", "type": "PERSON"}], "is_ad": false}, '
             '{"topics": ["health", "science"], "serene": true, '
-            '"entities": [{"name": "Institut Pasteur", "type": "ORG"}]}]\n\n'
+            '"entities": [{"name": "Institut Pasteur", "type": "ORG"}], "is_ad": false}]\n\n'
             f"{articles_text}"
         )
 
     def _parse_topics(self, raw: str, top_k: int) -> dict:
-        """Parse la réponse du LLM pour un article unique. Retourne dict avec topics, serene et entities."""
+        """Parse la réponse du LLM pour un article unique. Retourne dict avec topics, serene, entities et is_ad."""
         raw = raw.strip()
 
         # Try JSON parse first (new format: single object or array with one element)
@@ -576,14 +598,12 @@ class ClassificationService:
                     for s in parsed["topics"]
                     if isinstance(s, str) and s.strip().lower() in VALID_TOPIC_SLUGS
                 ]
-                serene = parsed.get("serene")
-                if not isinstance(serene, bool):
-                    serene = None
                 entities = _validate_entities(parsed.get("entities", []))
                 return {
                     "topics": topics[:top_k],
-                    "serene": serene,
+                    "serene": _coerce_bool(parsed.get("serene")),
                     "entities": entities,
+                    "is_ad": _coerce_bool(parsed.get("is_ad")),
                 }
             if (
                 isinstance(parsed, list)
@@ -596,14 +616,12 @@ class ClassificationService:
                     for s in item.get("topics", [])
                     if isinstance(s, str) and s.strip().lower() in VALID_TOPIC_SLUGS
                 ]
-                serene = item.get("serene")
-                if not isinstance(serene, bool):
-                    serene = None
                 entities = _validate_entities(item.get("entities", []))
                 return {
                     "topics": topics[:top_k],
-                    "serene": serene,
+                    "serene": _coerce_bool(item.get("serene")),
                     "entities": entities,
+                    "is_ad": _coerce_bool(item.get("is_ad")),
                 }
         except (json.JSONDecodeError, TypeError):
             pass
@@ -616,6 +634,7 @@ class ClassificationService:
             "topics": valid[:top_k],
             "serene": None,
             "entities": [],
+            "is_ad": None,
         }
 
     def _parse_batch_response(
@@ -634,7 +653,7 @@ class ClassificationService:
                         raw=raw[:200],
                     )
 
-                # Array of objects with "topics", "serene" and "entities"
+                # Array of objects with "topics", "serene", "entities" and "is_ad"
                 if parsed and isinstance(parsed[0], dict):
                     results = []
                     for item in parsed[:expected_count]:
@@ -645,25 +664,23 @@ class ClassificationService:
                                 if isinstance(s, str)
                                 and s.strip().lower() in VALID_TOPIC_SLUGS
                             ]
-                            serene = item.get("serene")
-                            if not isinstance(serene, bool):
-                                serene = None
                             entities = _validate_entities(item.get("entities", []))
                             results.append(
                                 {
                                     "topics": topics[:top_k],
-                                    "serene": serene,
+                                    "serene": _coerce_bool(item.get("serene")),
                                     "entities": entities,
+                                    "is_ad": _coerce_bool(item.get("is_ad")),
                                 }
                             )
                         else:
-                            results.append(_EMPTY_RESULT)
+                            results.append(_EMPTY_RESULT.copy())
                     # Pad with empty results if Mistral returned fewer than expected
                     while len(results) < expected_count:
-                        results.append(_EMPTY_RESULT)
+                        results.append(_EMPTY_RESULT.copy())
                     return results
 
-                # Fallback: old format (array of arrays), treat serene as None
+                # Fallback: old format (array of arrays), treat serene/is_ad as None
                 if parsed and isinstance(parsed[0], list):
                     log.info("classification_service.batch_old_format_fallback")
                     results = []
@@ -680,12 +697,13 @@ class ClassificationService:
                                     "topics": valid[:top_k],
                                     "serene": None,
                                     "entities": [],
+                                    "is_ad": None,
                                 }
                             )
                         else:
-                            results.append(_EMPTY_RESULT)
+                            results.append(_EMPTY_RESULT.copy())
                     while len(results) < expected_count:
-                        results.append(_EMPTY_RESULT)
+                        results.append(_EMPTY_RESULT.copy())
                     return results
 
         except (json.JSONDecodeError, TypeError):
@@ -704,11 +722,12 @@ class ClassificationService:
                     "topics": valid[:top_k],
                     "serene": None,
                     "entities": [],
+                    "is_ad": None,
                 }
             )
 
         while len(results) < expected_count:
-            results.append(_EMPTY_RESULT)
+            results.append(_EMPTY_RESULT.copy())
 
         return results
 

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -193,6 +193,7 @@ def apply_serein_filter(
         ),
     )
     query = query.where(serene_condition)
+    query = apply_ad_filter(query)
 
     # User-personalized theme exclusions override LLM is_serene=True: if the
     # user explicitly said "no tech", hide every tech article regardless of
@@ -205,6 +206,13 @@ def apply_serein_filter(
         if topic_exclusion is not None:
             query = query.where(topic_exclusion)
     return query
+
+
+def apply_ad_filter(query):
+    """Exclut les articles classifiés is_ad=True. NULL toléré (articles non encore classifiés)."""
+    return query.where(
+        or_(Content.is_ad.is_(None), Content.is_ad == False)  # noqa: E712
+    )
 
 
 def apply_good_news_filter(
@@ -221,6 +229,7 @@ def apply_good_news_filter(
     pour respecter les préférences personnelles.
     """
     query = query.where(Content.is_good_news == True)  # noqa: E712
+    query = apply_ad_filter(query)
     if excluded_topics:
         topic_exclusion = _topic_exclusion_condition(excluded_topics)
         if topic_exclusion is not None:

--- a/packages/api/app/workers/classification_worker.py
+++ b/packages/api/app/workers/classification_worker.py
@@ -299,6 +299,7 @@ class ClassificationWorker:
                         "topics": [],
                         "serene": None,
                         "good_news": None,
+                        "is_ad": None,
                         "entities": [],
                     }
                     for _ in batch_items
@@ -314,7 +315,7 @@ class ClassificationWorker:
                         await service.mark_completed_with_entities(item.id, [], [])
                         continue
 
-                    # Get topics, serene and entities from batch result
+                    # Get topics, serene, is_ad and entities from batch result
                     if i in batch_indices:
                         result = (
                             all_results[batch_result_idx]
@@ -323,6 +324,7 @@ class ClassificationWorker:
                                 "topics": [],
                                 "serene": None,
                                 "good_news": None,
+                                "is_ad": None,
                                 "entities": [],
                             }
                         )
@@ -330,11 +332,13 @@ class ClassificationWorker:
                         topics = result.get("topics", [])
                         is_serene = result.get("serene")
                         is_good_news = result.get("good_news")
+                        is_ad = result.get("is_ad")
                         entities = result.get("entities", [])
                     else:
                         topics = []
                         is_serene = None
                         is_good_news = None
+                        is_ad = None
                         entities = []
 
                     # If still no topics after individual retry, let the retry
@@ -356,6 +360,7 @@ class ClassificationWorker:
                         entities,
                         is_serene=is_serene,
                         is_good_news=is_good_news,
+                        is_ad=is_ad,
                     )
 
                 except Exception as e:

--- a/packages/api/tests/ml/test_classification_service.py
+++ b/packages/api/tests/ml/test_classification_service.py
@@ -74,36 +74,45 @@ class TestParseTopics:
         self.service = ClassificationService.__new__(ClassificationService)
 
     def test_parse_json_object(self):
-        """New format: JSON object with topics and serene."""
-        raw = '{"topics": ["sport", "health"], "serene": true}'
+        """New format: JSON object with topics, serene and is_ad."""
+        raw = '{"topics": ["sport", "health"], "serene": true, "is_ad": false}'
         result = self.service._parse_topics(raw, top_k=3)
         assert result["topics"] == ["sport", "health"]
         assert result["serene"] is True
+        assert result["is_ad"] is False
+
+    def test_parse_json_object_is_ad_true(self):
+        """is_ad=true is parsed correctly."""
+        raw = '{"topics": ["tech"], "serene": true, "is_ad": true}'
+        result = self.service._parse_topics(raw, top_k=3)
+        assert result["is_ad"] is True
 
     def test_parse_json_array_single_element(self):
         """New format: JSON array with one object."""
-        raw = '[{"topics": ["ai", "tech"], "serene": false}]'
+        raw = '[{"topics": ["ai", "tech"], "serene": false, "is_ad": false}]'
         result = self.service._parse_topics(raw, top_k=3)
         assert result["topics"] == ["ai", "tech"]
         assert result["serene"] is False
+        assert result["is_ad"] is False
 
     def test_parse_comma_separated_fallback(self):
-        """Old format: comma-separated slugs → serene is None."""
+        """Old format: comma-separated slugs → serene and is_ad are None."""
         raw = "sport, health, wellness"
         result = self.service._parse_topics(raw, top_k=3)
         assert result["topics"] == ["sport", "health", "wellness"]
         assert result["serene"] is None
+        assert result["is_ad"] is None
 
     def test_filters_invalid_slugs(self):
         """Invalid slugs are filtered out."""
-        raw = '{"topics": ["sport", "invalid_slug", "tech"], "serene": true}'
+        raw = '{"topics": ["sport", "invalid_slug", "tech"], "serene": true, "is_ad": false}'
         result = self.service._parse_topics(raw, top_k=3)
         assert result["topics"] == ["sport", "tech"]
         assert "invalid_slug" not in result["topics"]
 
     def test_top_k_limits(self):
         """top_k limits the number of returned topics."""
-        raw = '{"topics": ["sport", "health", "wellness", "tech"], "serene": true}'
+        raw = '{"topics": ["sport", "health", "wellness", "tech"], "serene": true, "is_ad": false}'
         result = self.service._parse_topics(raw, top_k=2)
         assert len(result["topics"]) == 2
 
@@ -112,12 +121,25 @@ class TestParseTopics:
         raw = ""
         result = self.service._parse_topics(raw, top_k=3)
         assert result["topics"] == []
+        assert result["is_ad"] is None
 
     def test_invalid_serene_becomes_none(self):
         """Non-boolean serene values become None."""
         raw = '{"topics": ["sport"], "serene": "maybe"}'
         result = self.service._parse_topics(raw, top_k=3)
         assert result["serene"] is None
+
+    def test_invalid_is_ad_becomes_none(self):
+        """Non-boolean is_ad values become None."""
+        raw = '{"topics": ["sport"], "serene": true, "is_ad": "maybe"}'
+        result = self.service._parse_topics(raw, top_k=3)
+        assert result["is_ad"] is None
+
+    def test_missing_is_ad_becomes_none(self):
+        """Missing is_ad field becomes None (backward compat)."""
+        raw = '{"topics": ["sport"], "serene": true}'
+        result = self.service._parse_topics(raw, top_k=3)
+        assert result["is_ad"] is None
 
 
 class TestParseBatchResponse:
@@ -127,13 +149,13 @@ class TestParseBatchResponse:
         self.service = ClassificationService.__new__(ClassificationService)
 
     def test_correct_count_new_format(self):
-        """JSON array of 5 objects parsed correctly."""
+        """JSON array of 5 objects parsed correctly including is_ad."""
         data = [
-            {"topics": ["sport"], "serene": True},
-            {"topics": ["ai", "tech"], "serene": True},
-            {"topics": ["geopolitics"], "serene": False},
-            {"topics": ["cinema", "art"], "serene": True},
-            {"topics": ["health"], "serene": False},
+            {"topics": ["sport"], "serene": True, "is_ad": False},
+            {"topics": ["ai", "tech"], "serene": True, "is_ad": False},
+            {"topics": ["geopolitics"], "serene": False, "is_ad": False},
+            {"topics": ["cinema", "art"], "serene": True, "is_ad": False},
+            {"topics": ["health"], "serene": False, "is_ad": True},
         ]
         raw = json.dumps(data)
         results = self.service._parse_batch_response(raw, expected_count=5, top_k=3)
@@ -141,16 +163,32 @@ class TestParseBatchResponse:
         assert len(results) == 5
         assert results[0]["topics"] == ["sport"]
         assert results[0]["serene"] is True
+        assert results[0]["is_ad"] is False
         assert results[1]["topics"] == ["ai", "tech"]
         assert results[2]["serene"] is False
+        assert results[4]["is_ad"] is True
+
+    def test_is_ad_stored_in_batch_result(self):
+        """is_ad=True is correctly stored from batch response."""
+        data = [{"topics": ["tech"], "serene": True, "is_ad": True}]
+        raw = json.dumps(data)
+        results = self.service._parse_batch_response(raw, expected_count=1, top_k=3)
+        assert results[0]["is_ad"] is True
+
+    def test_missing_is_ad_in_batch_becomes_none(self):
+        """Missing is_ad in batch item becomes None (backward compat)."""
+        data = [{"topics": ["sport"], "serene": True}]
+        raw = json.dumps(data)
+        results = self.service._parse_batch_response(raw, expected_count=1, top_k=3)
+        assert results[0]["is_ad"] is None
 
     def test_wrong_count_returns_partial_results(self):
         """JSON with fewer items than expected returns partial results, padded with empty."""
         data = [
-            {"topics": ["sport"], "serene": True},
-            {"topics": ["ai"], "serene": False},
-            {"topics": ["health"], "serene": True},
-            {"topics": ["cinema"], "serene": True},
+            {"topics": ["sport"], "serene": True, "is_ad": False},
+            {"topics": ["ai"], "serene": False, "is_ad": False},
+            {"topics": ["health"], "serene": True, "is_ad": False},
+            {"topics": ["cinema"], "serene": True, "is_ad": False},
         ]
         raw = json.dumps(data)
         results = self.service._parse_batch_response(raw, expected_count=5, top_k=3)
@@ -161,12 +199,13 @@ class TestParseBatchResponse:
         assert results[1]["topics"] == ["ai"]
         assert results[2]["topics"] == ["health"]
         assert results[3]["topics"] == ["cinema"]
-        # 5th should be padded empty
+        # 5th should be padded empty with is_ad=None
         assert results[4]["topics"] == []
         assert results[4]["serene"] is None
+        assert results[4]["is_ad"] is None
 
     def test_fallback_old_format(self):
-        """Old format (array of arrays) → topics OK, serene=None."""
+        """Old format (array of arrays) → topics OK, serene=None, is_ad=None."""
         data = [
             ["sport", "health"],
             ["ai", "tech"],
@@ -178,12 +217,13 @@ class TestParseBatchResponse:
         assert len(results) == 3
         assert results[0]["topics"] == ["sport", "health"]
         assert results[0]["serene"] is None
+        assert results[0]["is_ad"] is None
         assert results[1]["topics"] == ["ai", "tech"]
 
     def test_filters_invalid_slugs_in_batch(self):
         """Invalid slugs are filtered in batch responses."""
         data = [
-            {"topics": ["sport", "invalid"], "serene": True},
+            {"topics": ["sport", "invalid"], "serene": True, "is_ad": False},
         ]
         raw = json.dumps(data)
         results = self.service._parse_batch_response(raw, expected_count=1, top_k=3)
@@ -404,7 +444,7 @@ class TestResponseFormatInPayloads:
             resp.raise_for_status = MagicMock()
             resp.json.return_value = {
                 "choices": [
-                    {"message": {"content": '{"topics": ["sport"], "serene": true}'}}
+                    {"message": {"content": '{"topics": ["sport"], "serene": true, "is_ad": false}'}}
                 ],
                 "usage": {},
             }
@@ -429,7 +469,7 @@ class TestResponseFormatInPayloads:
             resp.raise_for_status = MagicMock()
             resp.json.return_value = {
                 "choices": [
-                    {"message": {"content": '[{"topics": ["sport"], "serene": true}]'}}
+                    {"message": {"content": '[{"topics": ["sport"], "serene": true, "is_ad": false}]'}}
                 ],
                 "usage": {},
             }


### PR DESCRIPTION
## Quoi

Ajoute le champ `is_ad: bool | None` au Pass 1 de classification Mistral (mistral-small) pour détecter les contenus publicitaires/native ads déguisés en éditorial (articles \"bons plans\", deals affiliés, comparatifs orientés achat, communiqués de presse). Les articles `is_ad=True` sont exclus des feeds, digests et veilles. `NULL` = non encore classifié (articles antérieurs à la migration) → toléré pour la compatibilité ascendante.

## Pourquoi

Des articles publicitaires (surtout Frandroid `/bons-plans/` et Numérama guides d'achat) apparaissaient dans les feeds et digests. La solution s'intègre naturellement dans le Pass 1 existant sans coût supplémentaire (même appel Mistral).

## Fichiers modifiés

| Fichier | Changement |
|---------|-----------|
| `classification_service.py` | Section `is_ad` ajoutée au system prompt + parsing (+ `_coerce_bool` helper) |
| `content.py` | Colonne `is_ad: bool \| None` |
| `alembic/versions/ad01_add_is_ad_to_contents.py` | Migration Alembic — 1 head ✓ |
| `classification_queue_service.py` | `mark_completed_with_entities` accepte `is_ad` |
| `classification_worker.py` | Extrait et passe `is_ad` depuis le résultat Pass 1 |
| `filter_presets.py` | `apply_ad_filter()` helper + appliqué dans `apply_serein_filter` et `apply_good_news_filter` |
| `digest_selector.py` | `apply_ad_filter()` appliqué sur les 2 requêtes candidats |
| `test_classification_service.py` | Tests `is_ad` parsing + backward compat NULL |

## Comment ça a été vérifié

- [x] `pytest tests/ml/ tests/recommendation/` — 147 passed, 0 failed
- [x] `alembic heads` — exactement 1 head (`ad01_add_is_ad_to_contents`)
- [x] `ruff check` + `ruff format --check` — all clean
- [x] `/simplify` passé — extraction `_coerce_bool` (6 répétitions → 1) + `apply_ad_filter` (4 → 1)

## Zones à risque

- **System prompt Pass 1** : ajout d'une section `is_ad` — surveiller la qualité des classifications sur les premiers articles en prod (PostHog)
- **Backward compat** : `is_ad=NULL` est délibérément toléré dans tous les filtres aval — les anciens articles non reclassifiés ne sont pas filtrés
- **max_tokens** : +~13 tokens/article dans la réponse Mistral pour `"is_ad": false` — budget 200×batch_size toujours suffisant pour batch_size=5

🤖 Generated with [Claude Code](https://claude.com/claude-code)