### PR TITLE
feat(feed): refresh automatique au retour en foreground (≥60s)

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -8,6 +8,7 @@ import 'core/providers/analytics_provider.dart';
 import 'core/services/deep_link_service.dart';
 import 'core/services/widget_service.dart';
 import 'features/feed/providers/feed_preload_provider.dart';
+import 'features/feed/providers/feed_provider.dart';
 import 'features/onboarding/providers/onboarding_sync_provider.dart';
 import 'features/settings/providers/theme_provider.dart';
 
@@ -24,6 +25,7 @@ class FacteurApp extends ConsumerStatefulWidget {
 class _FacteurAppState extends ConsumerState<FacteurApp>
     with WidgetsBindingObserver {
   bool _deepLinksStarted = false;
+  bool _wasBackgrounded = false;
 
   @override
   void initState() {
@@ -45,8 +47,16 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState appState) {
-    if (appState == AppLifecycleState.resumed) {
+    if (appState == AppLifecycleState.paused) {
+      _wasBackgrounded = true;
+    } else if (appState == AppLifecycleState.resumed) {
       _flushFluxScrollMetricIfAny();
+      if (_wasBackgrounded) {
+        _wasBackgrounded = false;
+        if (ref.read(authStateProvider).isAuthenticated) {
+          ref.read(feedProvider.notifier).refresh();
+        }
+      }
     }
   }
 

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -26,6 +26,7 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
     with WidgetsBindingObserver {
   bool _deepLinksStarted = false;
   bool _wasBackgrounded = false;
+  DateTime? _backgroundedAt;
 
   @override
   void initState() {
@@ -49,11 +50,16 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
   void didChangeAppLifecycleState(AppLifecycleState appState) {
     if (appState == AppLifecycleState.paused) {
       _wasBackgrounded = true;
+      _backgroundedAt = DateTime.now();
     } else if (appState == AppLifecycleState.resumed) {
       _flushFluxScrollMetricIfAny();
       if (_wasBackgrounded) {
         _wasBackgrounded = false;
-        if (ref.read(authStateProvider).isAuthenticated) {
+        final elapsed = _backgroundedAt != null
+            ? DateTime.now().difference(_backgroundedAt!)
+            : null;
+        if (ref.read(authStateProvider).isAuthenticated &&
+            (elapsed == null || elapsed.inSeconds >= 60)) {
           ref.read(feedProvider.notifier).refresh();
         }
       }


### PR DESCRIPTION
## What

Quand l'utilisateur revient dans l'app depuis l'arrière-plan, le feed se rafraîchit silencieusement. Un seuil de 60s évite les appels réseau superflus lors de brefs passages en arrière-plan (aligné sur le stale-while-revalidate existant du feed provider).

## Why

Le feed n'était pas rafraîchi au retour en foreground. La navigation in-app (retour d'article, changement d'onglet) ne déclenche pas de refresh — seul le cycle `AppLifecycleState.paused → resumed` (passage OS en arrière-plan) le fait.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)