### PR TITLE
fix(serein): supprimer l'activation automatique du Mode Serein global

### DIFF
--- a/apps/mobile/lib/features/custom_topics/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/custom_topics/screens/my_interests_screen.dart
@@ -47,7 +47,7 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       ref.read(sereinExclusionsProvider.notifier).loadIfNeeded();
-      if (widget.forceSereinOn) {
+      if (widget.forceSereinOn && !ref.read(sereinToggleProvider).enabled) {
         ref.read(sereinToggleProvider.notifier).setEnabledLocal(true);
       }
     });

--- a/apps/mobile/lib/features/custom_topics/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/custom_topics/screens/my_interests_screen.dart
@@ -47,9 +47,8 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       ref.read(sereinExclusionsProvider.notifier).loadIfNeeded();
-      if (widget.forceSereinOn &&
-          !ref.read(sereinToggleProvider).enabled) {
-        ref.read(sereinToggleProvider.notifier).toggle();
+      if (widget.forceSereinOn) {
+        ref.read(sereinToggleProvider.notifier).setEnabledLocal(true);
       }
     });
   }

--- a/packages/api/app/services/user_service.py
+++ b/packages/api/app/services/user_service.py
@@ -137,7 +137,7 @@ class UserService:
             "content_recency": answers.content_recency,
             "format_preference": answers.format_preference,
             "personal_goal": answers.personal_goal,
-            "serein_enabled": getattr(answers, "serein_enabled", None),
+            "serein_enabled": str(answers.digest_mode == "serein").lower() if answers.digest_mode is not None else None,
         }
 
         pref_count = 0

--- a/packages/api/app/services/user_service.py
+++ b/packages/api/app/services/user_service.py
@@ -137,7 +137,9 @@ class UserService:
             "content_recency": answers.content_recency,
             "format_preference": answers.format_preference,
             "personal_goal": answers.personal_goal,
-            "serein_enabled": str(answers.digest_mode == "serein").lower() if answers.digest_mode is not None else None,
+            "serein_enabled": ("true" if answers.digest_mode == "serein" else "false")
+            if answers.digest_mode is not None
+            else None,
         }
 
         pref_count = 0


### PR DESCRIPTION
## What

Supprime le déclenchement automatique du Mode Serein global lors de la navigation vers l'écran "Mes Intérêts" depuis l'onboarding. Corrige aussi la persistance de `serein_enabled` lors de la finalisation de l'onboarding.

## Why

Le CTA "Personnaliser mon mode serein" (onboarding) passait `forceSereinOn=true` à `MyInterestsScreen`, qui appelait automatiquement `toggle()` en `initState` — persistant `serein_enabled=true` sur le serveur sans action explicite de l'utilisateur. Les rechargements ultérieurs du digest (`initFromApi`) réactivaient alors Mode Serein globalement, même pendant une simple navigation dans les bonnes nouvelles. Par ailleurs, `save_onboarding` ne sauvegardait jamais `serein_enabled` (champ inexistant dans `OnboardingAnswers`) — l'auto-toggle était le seul mécanisme de sauvegarde, d'où son existence problématique.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [x] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)