### PR TITLE
fix(reader): immunise le chrome aux sticky-headers des sites (Le Monde, Reddit)

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -371,13 +371,28 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       (function() {
         var lastTouchY = 0;
         var lastProgress = 0;
+        // Track the user's finger direction so we can gate scrollY deltas
+        // that don't match it: some sites (Le Monde, Reddit, …) collapse
+        // their own sticky header on scroll, which mutates the document
+        // layout and emits scrollY deltas opposite to the gesture. Without
+        // gating, our reader chrome flips direction on these site-driven
+        // shifts and flickers.
+        //   touchDir = +1 → finger moving up = page scrolls down
+        //   touchDir = -1 → finger moving down = page scrolls up
+        // Kept across touchend so momentum frames still gate on the last
+        // gesture direction; reset on the next touchstart.
+        var touchDir = 0;
         document.addEventListener('touchstart', function(e) {
           lastTouchY = e.touches[0].clientY;
+          touchDir = 0;
         }, { passive: true });
         document.addEventListener('touchmove', function(e) {
           var currentY = e.touches[0].clientY;
-          var isScrollingUp = currentY > lastTouchY;
-          if (isScrollingUp && window.scrollY <= 0) {
+          var dy = currentY - lastTouchY;
+          if (Math.abs(dy) >= 1) {
+            touchDir = dy < 0 ? 1 : -1;
+          }
+          if (currentY > lastTouchY && window.scrollY <= 0) {
             ScrollBridge.postMessage('overscroll_top');
           }
           lastTouchY = currentY;
@@ -399,11 +414,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           var currentScrollY = window.scrollY;
           var scrollDelta = currentScrollY - lastScrollY;
           lastScrollY = currentScrollY;
-          // Sub-pixel filter: with rAF cadence (~16 ms) we want native
-          // granularity; a 1 px floor is enough to drop true noise.
-          if (Math.abs(scrollDelta) >= 1) {
-            ScrollBridge.postMessage('scroll_delta:' + scrollDelta + ':' + currentScrollY);
+          if (Math.abs(scrollDelta) < 1) return;
+          // Drop deltas that don't match the user's finger direction. These
+          // are typically site-driven (sticky-header collapse, content
+          // reflow) and would flip the reader chrome direction even though
+          // the user is still scrolling the same way. lastScrollY is
+          // advanced above so the swallowed delta isn't re-emitted.
+          if (touchDir !== 0) {
+            var deltaDir = scrollDelta > 0 ? 1 : -1;
+            if (deltaDir !== touchDir) return;
           }
+          ScrollBridge.postMessage('scroll_delta:' + scrollDelta + ':' + currentScrollY);
         }
         var progressTimer = null;
         function flushProgress() {


### PR DESCRIPTION
## What

Gate les \`scroll_delta\` envoyés par le bridge JS WebView sur la direction réelle du doigt (tracée via \`touchmove\`). Les deltas opposés au geste sont droppés.

## Why

Patch de #599. Sur certains sites (Le Monde, Reddit), le bandeau de tête du site lui-même se rétracte sur scroll-down, ce qui mute le layout et émet un \`scrollY\` delta inverse au geste (~50-80 px en 1 frame). Au-delà du seuil d'hystérésis 6 px, ça flippait la direction du reader, révélait le chrome puis le re-cachait à la frame suivante quand le scroll réel reprenait — d'où le clignotement en cascade signalé par l'utilisateur.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Comment ça a été vérifié

- [x] \`flutter analyze\` — 14 infos pré-existantes, 0 nouvelle
- [ ] À valider en runtime sur Le Monde + Reddit (sticky-header collapse)

## Zones à risque

- WebView reader uniquement. Le reader in-app classique n'utilise pas ce bridge.
- \`touchDir\` est conservé après \`touchend\` pour gater les frames de momentum ; reset au prochain \`touchstart\`. Cas limite : un scroll JS programmé avant tout geste (rare) ne sera pas gaté — comportement souhaité (CTA-driven reveal continue de marcher).

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed (Le Monde + Reddit + un site sans sticky header)
- [ ] N/A (docs/config only change)