### PR TITLE
fix(analytics): supprimer le double prefix /analytics sur le router

### DIFF
--- a/packages/api/app/routers/analytics.py
+++ b/packages/api/app/routers/analytics.py
@@ -10,7 +10,7 @@ from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.services.analytics_service import AnalyticsService
 
-router = APIRouter(prefix="/analytics", tags=["Analytics"])
+router = APIRouter(tags=["Analytics"])
 
 
 class EventCreate(BaseModel):


### PR DESCRIPTION
## Quoi

Une ligne : supprime `prefix=\"/analytics\"` du `APIRouter()` dans `routers/analytics.py`. Le prefix `/api/analytics` est déjà appliqué via `main.py:444 include_router(...)`, exactement comme tous les autres routers du repo.

## Pourquoi

Le double prefix produisait l'URL réelle `/api/analytics/analytics/events` côté serveur. Le mobile poste vers `/api/analytics/events` → **404 silencieux** (le `try/except` dans `analytics_service.dart:_logEvent` avale l'erreur avec un simple `debugPrint`).

Conséquence vérifiée en prod : `analytics_events` ne contient que les events `perspectives_opened` (loggés côté serveur dans `contents.py`). Zéro `digest_opened`, zéro `bonnes_nouvelles_opened` → les détecteurs `read_first_essentiel` et `read_first_bonnes_nouvelles` de **Lettre 2** retournent toujours `False` → les étapes \"Lire L'essentiel du jour\" et \"Découvrir Les bonnes nouvelles\" ne se valident jamais.

## Comment ça a été vérifié

- [x] Routes mountées après fix : `/api/analytics/events` + `/api/analytics/digest-metrics` (introspection `app.routes`)
- [x] `POST /api/analytics/events` (no auth) → **403** (endpoint existe, auth required ✓)
- [x] `POST /api/analytics/analytics/events` → **404** (ancien chemin cassé, disparu ✓)
- [x] `pytest tests/routers/test_letters_routes.py -v` → **22/22 OK** (inclut `test_read_first_essentiel_detected` + `test_read_first_bonnes_nouvelles_detected`)
- [x] Suite backend complète → **1095 passed, 13 skipped, 0 failed**
- [x] Aucune autre référence à `/api/analytics/analytics/*` dans le repo (mobile + backend)
- [x] Alembic : 1 head (`ad01_add_is_ad_to_contents`), pas de migration ajoutée
- [x] `/simplify` : N/A (suppression d'1 ligne, rien à factoriser)

## Zones à risque

Aucune zone critique (Auth/Router/DB/Infra) touchée au sens guardrails — c'est un fix de routage interne au router analytics. Pas de mobile change, pas de migration.

**Note** : après déploiement, les events historiquement perdus depuis le 15 janvier 2026 ne sont pas récupérables. Les détecteurs Lettre 2 se valideront à partir de la prochaine ouverture du digest.