### PR TITLE
fix(veille): permettre la relance de la première veille après échec

### DIFF
--- a/apps/mobile/lib/features/veille/providers/veille_deliveries_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_deliveries_provider.dart
@@ -30,3 +30,20 @@ final veilleDeliveryProvider = FutureProvider.autoDispose
     return repo.getDelivery(deliveryId);
   },
 );
+
+/// Dernière livraison (limit 1) — utilisé par le dashboard pour gating la CTA
+/// « Lancer ma première veille » sans tirer la liste de 20.
+class VeilleLastDeliveryNotifier
+    extends AsyncNotifier<VeilleDeliveryListItem?> {
+  @override
+  Future<VeilleDeliveryListItem?> build() async {
+    final repo = ref.read(veilleRepositoryProvider);
+    final list = await repo.listDeliveries(limit: 1);
+    return list.isEmpty ? null : list.first;
+  }
+}
+
+final veilleLastDeliveryProvider = AsyncNotifierProvider<
+    VeilleLastDeliveryNotifier, VeilleDeliveryListItem?>(
+  VeilleLastDeliveryNotifier.new,
+);

--- a/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
@@ -7,11 +7,10 @@ import 'package:go_router/go_router.dart';
 import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../notifications/widgets/notification_activation_modal.dart';
-import '../models/veille_delivery.dart';
 import '../providers/veille_active_config_provider.dart';
 import '../providers/veille_config_provider.dart';
-import '../providers/veille_repository_provider.dart';
 import '../repositories/veille_repository.dart';
+import '../utils/poll_first_delivery.dart';
 import 'steps/step1_5_preset_preview_screen.dart';
 import 'steps/step1_theme_screen.dart';
 import 'steps/step2_suggestions_screen.dart';
@@ -101,7 +100,7 @@ class VeilleConfigScreen extends ConsumerWidget {
 
         var pollSucceeded = false;
         if (deliveryId != null) {
-          pollSucceeded = await _pollFirstDelivery(
+          pollSucceeded = await pollFirstDelivery(
             context: context,
             ref: ref,
             deliveryId: deliveryId,
@@ -214,57 +213,3 @@ class VeilleConfigScreen extends ConsumerWidget {
   }
 }
 
-/// Poll `/deliveries/{id}` jusqu'à `succeeded` (succès) ou 90 s écoulées.
-/// Backoff 2 s pendant les 20 premières secondes (≈ p50 de la génération),
-/// puis 5 s ensuite — l'objectif est de limiter la charge serveur quand le
-/// volume utilisateur scalera. Renvoie `true` si la livraison est `succeeded`,
-/// `false` sinon (failed, timeout, ou widget unmount). Affiche un snackbar en
-/// cas de timeout/failed.
-Future<bool> _pollFirstDelivery({
-  required BuildContext context,
-  required WidgetRef ref,
-  required String deliveryId,
-  required String onTimeoutMessage,
-}) async {
-  const totalBudget = Duration(seconds: 90);
-  const fastInterval = Duration(seconds: 2);
-  const slowInterval = Duration(seconds: 5);
-  const fastWindow = Duration(seconds: 20);
-
-  final repo = ref.read(veilleRepositoryProvider);
-  final start = DateTime.now();
-
-  while (true) {
-    if (!context.mounted) return false;
-    final elapsed = DateTime.now().difference(start);
-    if (elapsed >= totalBudget) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(onTimeoutMessage)),
-      );
-      return false;
-    }
-
-    try {
-      final delivery = await repo.getDelivery(deliveryId);
-      if (delivery.generationState == VeilleGenerationState.succeeded) {
-        return true;
-      }
-      if (delivery.generationState == VeilleGenerationState.failed) {
-        if (!context.mounted) return false;
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text(
-              'La génération a échoué. On retentera à la prochaine livraison.',
-            ),
-          ),
-        );
-        return false;
-      }
-    } on VeilleApiException {
-      // Erreur transitoire — on continue à poll, le timeout protégera.
-    }
-
-    final next = elapsed < fastWindow ? fastInterval : slowInterval;
-    await Future<void>.delayed(next);
-  }
-}

--- a/apps/mobile/lib/features/veille/screens/veille_dashboard_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_dashboard_screen.dart
@@ -7,9 +7,13 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/routes.dart';
 import '../../../core/services/push_notification_service.dart';
 import '../models/veille_config_dto.dart';
+import '../models/veille_delivery.dart';
 import '../providers/veille_active_config_provider.dart';
+import '../providers/veille_deliveries_provider.dart';
 import '../providers/veille_repository_provider.dart';
 import '../repositories/veille_repository.dart';
+import '../utils/poll_first_delivery.dart';
+import 'transitions/flow_loading_screen.dart';
 
 class VeilleDashboardScreen extends ConsumerWidget {
   const VeilleDashboardScreen({super.key});
@@ -64,13 +68,28 @@ class VeilleDashboardScreen extends ConsumerWidget {
   }
 }
 
-class _DashboardBody extends ConsumerWidget {
+class _DashboardBody extends ConsumerStatefulWidget {
   final VeilleConfigDto cfg;
   const _DashboardBody({required this.cfg});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_DashboardBody> createState() => _DashboardBodyState();
+}
+
+class _DashboardBodyState extends ConsumerState<_DashboardBody> {
+  bool _isGeneratingFirst = false;
+
+  VeilleConfigDto get cfg => widget.cfg;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isGeneratingFirst) {
+      return const FlowLoadingScreen(from: 4);
+    }
+
     final isPaused = cfg.status == 'paused';
+    final lastDeliveryAsync = ref.watch(veilleLastDeliveryProvider);
+    final firstDeliveryState = _firstDeliveryState(lastDeliveryAsync);
 
     return ListView(
       padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
@@ -153,6 +172,13 @@ class _DashboardBody extends ConsumerWidget {
           ),
         ],
         const SizedBox(height: 24),
+        if (firstDeliveryState != _FirstDeliveryState.hideCta) ...[
+          _FirstDeliveryCta(
+            isRetry: firstDeliveryState == _FirstDeliveryState.retry,
+            onTap: _handleFirstDeliveryCta,
+          ),
+          const SizedBox(height: 10),
+        ],
         _PrimaryButton(
           icon: PhosphorIcons.envelope(),
           label: 'Voir l\'historique',
@@ -288,6 +314,67 @@ class _DashboardBody extends ConsumerWidget {
     return labels[dow];
   }
 
+  /// Hide la CTA tant qu'on a une 1re livraison valide OU sur état transitoire
+  /// (loading/error) — ne pas proposer d'action sur un état flou.
+  _FirstDeliveryState _firstDeliveryState(
+    AsyncValue<VeilleDeliveryListItem?> lastDeliveryAsync,
+  ) {
+    if (!lastDeliveryAsync.hasValue) return _FirstDeliveryState.hideCta;
+    final last = lastDeliveryAsync.value;
+    if (last == null) return _FirstDeliveryState.firstAttempt;
+
+    final isValid = last.generationState == VeilleGenerationState.succeeded &&
+        last.itemCount > 0;
+    if (isValid) return _FirstDeliveryState.hideCta;
+
+    final isInFlight =
+        last.generationState == VeilleGenerationState.pending ||
+            last.generationState == VeilleGenerationState.running;
+    if (isInFlight) {
+      final age = DateTime.now().difference(last.createdAt);
+      if (age < const Duration(minutes: 15)) {
+        return _FirstDeliveryState.hideCta;
+      }
+    }
+    return _FirstDeliveryState.retry;
+  }
+
+  Future<void> _handleFirstDeliveryCta() async {
+    if (_isGeneratingFirst) return;
+    setState(() => _isGeneratingFirst = true);
+    try {
+      final repo = ref.read(veilleRepositoryProvider);
+      final response = await repo.generateFirstDelivery();
+      if (!mounted) return;
+      final ok = await pollFirstDelivery(
+        context: context,
+        ref: ref,
+        deliveryId: response.deliveryId,
+        onTimeoutMessage:
+            "On t'enverra une notif quand ta veille est prête.",
+        onFailedMessage:
+            'La génération a échoué. Tu peux relancer depuis le dashboard.',
+      );
+      if (!mounted) return;
+      if (ok) {
+        context.go('${RoutePaths.veilleDeliveries}/${response.deliveryId}');
+      } else {
+        ref.invalidate(veilleLastDeliveryProvider);
+      }
+    } on VeilleApiException catch (e) {
+      if (!mounted) return;
+      final message = e.statusCode == 409
+          ? 'Génération en cours, patiente quelques instants.'
+          : 'Impossible de relancer la génération (${e.statusCode ?? '?'}). Réessaie.';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message)),
+      );
+      ref.invalidate(veilleLastDeliveryProvider);
+    } finally {
+      if (mounted) setState(() => _isGeneratingFirst = false);
+    }
+  }
+
   static String _formatNextScheduled(DateTime d) {
     final local = d.toLocal();
     const months = [
@@ -308,6 +395,76 @@ class _DashboardBody extends ConsumerWidget {
     final hh = local.hour.toString().padLeft(2, '0');
     final mm = local.minute.toString().padLeft(2, '0');
     return '${local.day} $m ${local.year} · $hh:$mm';
+  }
+}
+
+enum _FirstDeliveryState { firstAttempt, retry, hideCta }
+
+class _FirstDeliveryCta extends StatelessWidget {
+  final bool isRetry;
+  final VoidCallback onTap;
+  const _FirstDeliveryCta({required this.isRetry, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 14, 14, 12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFF8EC),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFFE0C97A)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            isRetry
+                ? 'Ta première veille n\'a pas abouti.'
+                : 'Lance ta première veille pour voir ce que ça donne.',
+            style: GoogleFonts.dmSans(
+              fontSize: 13,
+              color: const Color(0xFF2A2419),
+            ),
+          ),
+          const SizedBox(height: 10),
+          SizedBox(
+            height: 44,
+            child: Material(
+              color: const Color(0xFF2A2419),
+              borderRadius: BorderRadius.circular(10),
+              child: InkWell(
+                onTap: onTap,
+                borderRadius: BorderRadius.circular(10),
+                child: Center(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        PhosphorIcons.sparkle(),
+                        color: Colors.white,
+                        size: 16,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        isRetry
+                            ? 'Relancer ma première veille'
+                            : 'Lancer ma première veille',
+                        style: GoogleFonts.dmSans(
+                          color: Colors.white,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/apps/mobile/lib/features/veille/utils/poll_first_delivery.dart
+++ b/apps/mobile/lib/features/veille/utils/poll_first_delivery.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/veille_delivery.dart';
+import '../providers/veille_repository_provider.dart';
+import '../repositories/veille_repository.dart';
+
+/// Poll `/deliveries/{id}` jusqu'à `succeeded` ou 90 s écoulées. Backoff 2 s
+/// pendant les 20 premières secondes (≈ p50 de la génération), puis 5 s.
+/// Renvoie `true` si la livraison est `succeeded`, `false` sinon (failed,
+/// timeout, ou widget unmount). Affiche un snackbar en cas de timeout/failed.
+Future<bool> pollFirstDelivery({
+  required BuildContext context,
+  required WidgetRef ref,
+  required String deliveryId,
+  required String onTimeoutMessage,
+  String onFailedMessage =
+      'La génération a échoué. On retentera à la prochaine livraison.',
+}) async {
+  const totalBudget = Duration(seconds: 90);
+  const fastInterval = Duration(seconds: 2);
+  const slowInterval = Duration(seconds: 5);
+  const fastWindow = Duration(seconds: 20);
+
+  final repo = ref.read(veilleRepositoryProvider);
+  final start = DateTime.now();
+
+  while (true) {
+    if (!context.mounted) return false;
+    final elapsed = DateTime.now().difference(start);
+    if (elapsed >= totalBudget) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(onTimeoutMessage)),
+      );
+      return false;
+    }
+
+    try {
+      final delivery = await repo.getDelivery(deliveryId);
+      if (!context.mounted) return false;
+      if (delivery.generationState == VeilleGenerationState.succeeded) {
+        return true;
+      }
+      if (delivery.generationState == VeilleGenerationState.failed) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(onFailedMessage)),
+        );
+        return false;
+      }
+    } on VeilleApiException {
+      // Erreur transitoire — on continue à poll, le timeout protégera.
+    }
+
+    final next = elapsed < fastWindow ? fastInterval : slowInterval;
+    await Future<void>.delayed(next);
+    if (!context.mounted) return false;
+  }
+}

--- a/apps/mobile/test/features/veille/screens/flow_loading_screen_test.dart
+++ b/apps/mobile/test/features/veille/screens/flow_loading_screen_test.dart
@@ -25,7 +25,7 @@ void main() {
       find.text('LE FACTEUR PRÉPARE TA PREMIÈRE LIVRAISON…'),
       findsOneWidget,
     );
-    expect(find.text('Première veille en cours'), findsOneWidget);
+    expect(find.text('Votre première veille se construit !'), findsOneWidget);
 
     await _disposeTree(tester);
   });

--- a/apps/mobile/test/features/veille/screens/veille_dashboard_screen_test.dart
+++ b/apps/mobile/test/features/veille/screens/veille_dashboard_screen_test.dart
@@ -1,0 +1,163 @@
+// Test : dashboard veille — visibilité de la CTA « Lancer ma première veille »
+// selon l'état de la dernière livraison.
+//
+// Bug `bug-first-veille-no-retry.md` : tant qu'aucune livraison succeeded
+// non-vide n'existe, on doit proposer une option de relance. Une livraison
+// pending/running de moins de 15 min reste invisible (génération en cours).
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/veille/models/veille_config_dto.dart';
+import 'package:facteur/features/veille/models/veille_delivery.dart';
+import 'package:facteur/features/veille/providers/veille_active_config_provider.dart';
+import 'package:facteur/features/veille/providers/veille_deliveries_provider.dart'
+    show VeilleLastDeliveryNotifier, veilleLastDeliveryProvider;
+import 'package:facteur/features/veille/screens/veille_dashboard_screen.dart';
+
+VeilleConfigDto _fakeCfg() {
+  final now = DateTime.now();
+  return VeilleConfigDto(
+    id: 'cfg-1',
+    userId: 'user-1',
+    themeId: 'tech',
+    themeLabel: 'Tech',
+    frequency: 'weekly',
+    dayOfWeek: 0,
+    deliveryHour: 7,
+    timezone: 'Europe/Paris',
+    status: 'active',
+    lastDeliveredAt: null,
+    nextScheduledAt: null,
+    createdAt: now,
+    updatedAt: now,
+    topics: const [],
+    sources: const [],
+  );
+}
+
+VeilleDeliveryListItem _delivery({
+  required VeilleGenerationState state,
+  int itemCount = 0,
+  Duration ageFromNow = Duration.zero,
+}) {
+  final now = DateTime.now();
+  return VeilleDeliveryListItem(
+    id: 'd-1',
+    veilleConfigId: 'cfg-1',
+    targetDate: now,
+    generationState: state,
+    itemCount: itemCount,
+    generatedAt: state == VeilleGenerationState.succeeded ? now : null,
+    createdAt: now.subtract(ageFromNow),
+  );
+}
+
+class _FakeActiveCfgNotifier extends VeilleActiveConfigNotifier {
+  final VeilleConfigDto? initial;
+  _FakeActiveCfgNotifier(this.initial);
+  @override
+  Future<VeilleConfigDto?> build() async => initial;
+}
+
+class _FakeLastDeliveryNotifier extends VeilleLastDeliveryNotifier {
+  final VeilleDeliveryListItem? initial;
+  _FakeLastDeliveryNotifier(this.initial);
+  @override
+  Future<VeilleDeliveryListItem?> build() async => initial;
+}
+
+Widget _wrap({
+  required VeilleConfigDto cfg,
+  VeilleDeliveryListItem? lastDelivery,
+}) {
+  return ProviderScope(
+    overrides: [
+      veilleActiveConfigProvider.overrideWith(
+        () => _FakeActiveCfgNotifier(cfg),
+      ),
+      veilleLastDeliveryProvider.overrideWith(
+        () => _FakeLastDeliveryNotifier(lastDelivery),
+      ),
+    ],
+    child: const MaterialApp(home: VeilleDashboardScreen()),
+  );
+}
+
+const _ctaFirst = 'Lancer ma première veille';
+const _ctaRetry = 'Relancer ma première veille';
+
+void main() {
+  testWidgets('aucune livraison → CTA "Lancer" visible', (tester) async {
+    await tester.pumpWidget(_wrap(cfg: _fakeCfg()));
+    await tester.pumpAndSettle();
+
+    expect(find.text(_ctaFirst), findsOneWidget);
+    expect(find.text(_ctaRetry), findsNothing);
+  });
+
+  testWidgets('dernière livraison failed → CTA "Relancer" visible',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      cfg: _fakeCfg(),
+      lastDelivery: _delivery(state: VeilleGenerationState.failed),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text(_ctaRetry), findsOneWidget);
+    expect(find.text(_ctaFirst), findsNothing);
+  });
+
+  testWidgets('dernière livraison succeeded mais vide → CTA "Relancer"',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      cfg: _fakeCfg(),
+      lastDelivery:
+          _delivery(state: VeilleGenerationState.succeeded, itemCount: 0),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text(_ctaRetry), findsOneWidget);
+  });
+
+  testWidgets('dernière livraison succeeded avec items → CTA cachée',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      cfg: _fakeCfg(),
+      lastDelivery:
+          _delivery(state: VeilleGenerationState.succeeded, itemCount: 3),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text(_ctaFirst), findsNothing);
+    expect(find.text(_ctaRetry), findsNothing);
+  });
+
+  testWidgets('running récent (<15 min) → CTA cachée', (tester) async {
+    await tester.pumpWidget(_wrap(
+      cfg: _fakeCfg(),
+      lastDelivery: _delivery(
+        state: VeilleGenerationState.running,
+        ageFromNow: const Duration(minutes: 2),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text(_ctaFirst), findsNothing);
+    expect(find.text(_ctaRetry), findsNothing);
+  });
+
+  testWidgets('running stuck (>15 min) → CTA "Relancer" visible',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      cfg: _fakeCfg(),
+      lastDelivery: _delivery(
+        state: VeilleGenerationState.running,
+        ageFromNow: const Duration(minutes: 30),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text(_ctaRetry), findsOneWidget);
+  });
+}

--- a/docs/bugs/bug-first-veille-no-retry.md
+++ b/docs/bugs/bug-first-veille-no-retry.md
@@ -1,0 +1,71 @@
+# Bug: Première veille — aucune option de relance après échec/timeout/empty
+
+## Statut
+- [ ] En cours (date: 2026-05-12)
+
+## Sévérité
+🟠 Bloquant onboarding — 2e itération du même symptôme « la 1ère veille n'arrive pas » signalé par le PO. Le précédent fix [bug-veille-config-without-sources.md](./bug-veille-config-without-sources.md) (2026-05-07) a éliminé la branche « config sans sources », mais 4 autres modes d'échec laissent l'user dans un cul-de-sac UX 4 jours plus tard.
+
+## Description
+
+Symptôme PO (2026-05-12) :
+> Après avoir configuré une veille, **aucune option n'apparaît / n'est proposée** pour générer la première veille. Réessais multiples sans succès.
+
+## Cause racine
+
+La génération de la « première veille » est déclenchée **exactement une fois**, **automatiquement**, dans `handleSubmit` du Step 4 (`apps/mobile/lib/features/veille/screens/veille_config_screen.dart:69-142`). Aucun mécanisme de récupération pour les 4 modes d'échec :
+
+| # | Mode d'échec | Conséquence |
+|---|--------------|-------------|
+| 1 | Polling timeout (90 s) alors que la génération met >90 s | Snackbar « on t'enverra une notif », redirect dashboard, livraison finalise plus tard mais user jamais ramené dessus |
+| 2 | Génération `failed` (`last_error`) | `_pollFirstDelivery` retourne `false`, snackbar, redirect dashboard, aucune option pour relancer |
+| 3 | Digest vide (`succeeded` + `item_count=0`) — encore possible si taxonomy mismatch ou source crawlée trop fraîche | User atterrit sur `_DeliveryEmptyView` ou dashboard, aucune option pour régénérer |
+| 4 | Re-tentative depuis zéro : user retourne sur `/veille/configure` | Auto-redirect dashboard (`veille_config_screen.dart:46-52`). User ne peut **plus jamais** repasser par Step 4 |
+
+**Backend** : `POST /api/veille/deliveries/generate-first` (`packages/api/app/routers/veille.py:794-802`) retourne **403 si une row `VeilleDelivery` existe**, quel que soit son état. → Aucun moyen de demander une régénération, même si la précédente a échoué ou a produit un digest vide.
+
+**Dashboard** : `VeilleDashboardScreen` (`apps/mobile/lib/features/veille/screens/veille_dashboard_screen.dart:155-178`) ne propose que **Voir l'historique / Modifier / Pause / Supprimer**. Aucun bouton « Lancer ma première veille » ou « Générer maintenant ».
+
+## Solution
+
+Fix en 2 parties, sans introduire de nouveau cycle d'onboarding ni nouveau endpoint.
+
+### Partie A — Backend : autoriser la régénération propre
+
+Modifier `POST /deliveries/generate-first` pour traiter la première livraison comme **idempotente sur reprise d'erreur** :
+
+- Si la dernière row est `succeeded` avec `item_count > 0` → **403 inchangé** (anti-doublon réel).
+- Si la dernière row est `failed`, `succeeded` avec `item_count = 0`, ou `running` depuis >15 min, ou `pending` depuis >15 min → **DELETE** la row précédente puis créer une nouvelle row `PENDING` et planifier le BackgroundTask. **Décision PO Q1 = (a) DELETE** : la row failed/empty n'a aucune valeur user, Sentry/PostHog gardent la trace de l'échec.
+- Si la dernière row est `pending`/`running` récente (<15 min) → **409** « génération en cours, patiente quelques instants » (le mobile peut récupérer son `delivery_id` via `GET /deliveries`).
+
+Fichiers :
+- `packages/api/app/routers/veille.py` — handler `generate_first_delivery` (lignes 778-825).
+- `packages/api/tests/routers/test_veille_routes.py` — étendre `TestGenerateFirstDelivery`.
+
+### Partie B — Mobile : CTA dashboard « Lancer ma première veille »
+
+CTA conditionnelle sur `VeilleDashboardScreen` :
+- **Visible** tant qu'aucune livraison `succeeded` avec `item_count > 0` n'existe pour la config active. On fetch la dernière livraison via `repo.listDeliveries(limit: 1)` et on affiche la CTA si la liste est vide OU si la dernière entry est `failed`/`succeeded-empty`/`pending|running >15min`.
+- **Texte** : « Lancer ma première veille » (sous-texte « La précédente n'a pas abouti — on retente. » si retry).
+- **Action** : `repo.generateFirstDelivery()` puis `FlowLoadingScreen(from: 4)` + `pollFirstDelivery` partagé. Fin → navigation `/veille/deliveries/<id>` (effet Wow identique au flow d'onboarding).
+
+Décision PO Q2 = (b) — garder le polling à 90s, la CTA dashboard rend le timeout visible/analysable et on pourra raccourcir plus tard.
+
+Fichiers :
+- `apps/mobile/lib/features/veille/screens/veille_dashboard_screen.dart` — ajout d'un widget CTA conditionnel au-dessus de « Voir l'historique ».
+- `apps/mobile/lib/features/veille/screens/veille_config_screen.dart` — déplacer `_pollFirstDelivery` vers un helper partagé.
+- `apps/mobile/lib/features/veille/utils/poll_first_delivery.dart` — nouveau helper.
+- `apps/mobile/test/features/veille/screens/veille_dashboard_screen_test.dart` — 4 cas (no delivery / failed / empty / valid → CTA cachée).
+
+## Hors scope
+
+- Stabilisation de `/api/veille/suggestions/sources` (bug séparé)
+- Refonte du mode édition (la CTA n'apparaît qu'en post-onboarding, pas en edit)
+- Notification push de relance après échec (follow-up éventuel)
+
+## Validation
+
+1. `cd packages/api && pytest tests/routers/test_veille_routes.py -v -k generate` — 4 cas (202 first, 202 retry-after-failed, 202 retry-after-empty, 409 retry-after-running, 403 retry-after-success).
+2. `cd apps/mobile && flutter test test/features/veille/screens/veille_dashboard_screen_test.dart`.
+3. Suite complète : `pytest -v` backend + `flutter test && flutter analyze` mobile.
+4. `/go` pour enchaîner verify → simplify → PR vers `main`.

--- a/packages/api/app/jobs/veille_generation_job.py
+++ b/packages/api/app/jobs/veille_generation_job.py
@@ -7,7 +7,7 @@ incidents pool QueuePool docs/bugs/bug-infinite-load-requests.md (#363).
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from uuid import UUID
 
 import sentry_sdk
@@ -46,6 +46,7 @@ _STUCK_RUNNING_THRESHOLD_SECONDS = 600
 # configs `due`, et le watchdog `_phase1_mark_running` ne fire que si elle est
 # rescannée). On la marque FAILED + Sentry pour qu'elle disparaisse de l'UI.
 _STUCK_CLEANUP_THRESHOLD_SECONDS = 900
+STUCK_DELIVERY_THRESHOLD = timedelta(seconds=_STUCK_CLEANUP_THRESHOLD_SECONDS)
 
 
 async def run_veille_generation(target_date: date | None = None) -> None:

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -25,7 +25,10 @@ from app.config import get_settings
 from app.data.veille_presets import get_presets
 from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
-from app.jobs.veille_generation_job import run_veille_generation_for_config
+from app.jobs.veille_generation_job import (
+    STUCK_DELIVERY_THRESHOLD,
+    run_veille_generation_for_config,
+)
 from app.models.content import Content
 from app.models.enums import SourceType
 from app.models.source import Source
@@ -784,22 +787,58 @@ async def generate_first_delivery(
 
     Crée une row VeilleDelivery en PENDING tout de suite pour que le mobile
     puisse poll GET /deliveries/{id} pendant que le BackgroundTask tourne.
-    Refuse si une livraison existe déjà pour cette config (anti-doublon).
+
+    Idempotent sur reprise d'erreur :
+    - Si la dernière livraison a réussi avec ≥1 item → 403 (anti-doublon réel).
+    - Si elle est `failed`, `succeeded` mais vide, ou `pending|running` depuis
+      >15 min → on DELETE l'ancienne row et on relance proprement.
+    - Si elle est `pending|running` depuis <15 min → 409 (en cours, le mobile
+      doit récupérer son `delivery_id` via GET /deliveries).
     """
     user_uuid = UUID(current_user_id)
     cfg = await _get_active_config(db, user_uuid)
     if cfg is None:
         raise HTTPException(status_code=404, detail="Aucune veille active.")
 
-    existing = (
+    # FOR UPDATE sérialise les concurrents (double-clic sur la CTA dashboard)
+    # sur la dernière row : sans ce lock, deux requêtes peuvent toutes deux
+    # voir « failed », DELETE puis INSERT, et lancer 2 background tasks.
+    last = (
         await db.execute(
-            select(VeilleDelivery.id)
+            select(VeilleDelivery)
             .where(VeilleDelivery.veille_config_id == cfg.id)
+            .order_by(VeilleDelivery.created_at.desc())
             .limit(1)
+            .with_for_update()
         )
     ).scalar_one_or_none()
-    if existing is not None:
-        raise HTTPException(status_code=403, detail="Première livraison déjà générée.")
+
+    if last is not None:
+        state = last.generation_state
+        item_count = len(last.items or [])
+        succeeded = state == VeilleGenerationState.SUCCEEDED.value
+        if succeeded and item_count > 0:
+            raise HTTPException(
+                status_code=403, detail="Première livraison déjà générée."
+            )
+
+        in_flight = state in (
+            VeilleGenerationState.PENDING.value,
+            VeilleGenerationState.RUNNING.value,
+        )
+        created = last.created_at
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=UTC)
+        age = datetime.now(UTC) - created
+        if in_flight and age < STUCK_DELIVERY_THRESHOLD:
+            raise HTTPException(
+                status_code=409,
+                detail="Génération déjà en cours, patiente quelques instants.",
+            )
+
+        await db.execute(
+            delete(VeilleDelivery).where(VeilleDelivery.id == last.id)
+        )
 
     target = today_paris()
     delivery_id = uuid4()

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -836,9 +836,7 @@ async def generate_first_delivery(
                 detail="Génération déjà en cours, patiente quelques instants.",
             )
 
-        await db.execute(
-            delete(VeilleDelivery).where(VeilleDelivery.id == last.id)
-        )
+        await db.execute(delete(VeilleDelivery).where(VeilleDelivery.id == last.id))
 
     target = today_paris()
     delivery_id = uuid4()

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -6,10 +6,11 @@ LLM Mistral mocké via AsyncMock sur les singletons des suggesters.
 
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 
 from app.database import get_db
 from app.dependencies import get_current_user_id
@@ -566,11 +567,13 @@ class TestGenerateFirstDelivery:
     async def test_refuses_when_delivery_exists(
         self, db_session, auth_user, active_veille_config
     ):
+        # Succeeded AVEC items → vraie première livraison, on refuse 403.
         existing = VeilleDelivery(
             id=uuid4(),
             veille_config_id=active_veille_config.id,
             target_date=datetime.now(UTC).date(),
             generation_state=VeilleGenerationState.SUCCEEDED.value,
+            items=[{"cluster_id": "c1", "title": "x", "articles": []}],
         )
         db_session.add(existing)
         await db_session.commit()
@@ -584,6 +587,122 @@ class TestGenerateFirstDelivery:
         async with _client() as ac:
             resp = await ac.post("/api/veille/deliveries/generate-first")
         assert resp.status_code == 404
+
+    async def test_retries_after_failed_delivery(
+        self, monkeypatch, db_session, auth_user, active_veille_config
+    ):
+        from app.routers import veille as veille_module
+
+        failed = VeilleDelivery(
+            id=uuid4(),
+            veille_config_id=active_veille_config.id,
+            target_date=datetime.now(UTC).date() - timedelta(days=1),
+            generation_state=VeilleGenerationState.FAILED.value,
+            last_error="boom",
+        )
+        db_session.add(failed)
+        await db_session.commit()
+        failed_id = failed.id
+
+        bg_calls: list[tuple] = []
+
+        def _capture_add_task(self, func, *args, **kwargs):
+            bg_calls.append((func, args, kwargs))
+
+        monkeypatch.setattr(
+            "fastapi.BackgroundTasks.add_task",
+            _capture_add_task,
+            raising=True,
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/veille/deliveries/generate-first")
+
+        assert resp.status_code == 202, resp.text
+        # L'ancienne row a été supprimée.
+        await db_session.refresh(active_veille_config)
+        remaining = (
+            await db_session.execute(
+                select(VeilleDelivery.id).where(VeilleDelivery.id == failed_id)
+            )
+        ).scalar_one_or_none()
+        assert remaining is None
+        # Une nouvelle row PENDING est créée.
+        new_id = resp.json()["delivery_id"]
+        new_row = (
+            await db_session.execute(
+                select(VeilleDelivery).where(VeilleDelivery.id == UUID(new_id))
+            )
+        ).scalar_one()
+        assert new_row.generation_state == VeilleGenerationState.PENDING.value
+        assert any(
+            call[0] is veille_module._run_first_delivery_with_retry for call in bg_calls
+        ), bg_calls
+
+    async def test_retries_after_succeeded_empty(
+        self, monkeypatch, db_session, auth_user, active_veille_config
+    ):
+        empty = VeilleDelivery(
+            id=uuid4(),
+            veille_config_id=active_veille_config.id,
+            target_date=datetime.now(UTC).date() - timedelta(days=1),
+            generation_state=VeilleGenerationState.SUCCEEDED.value,
+            items=[],
+        )
+        db_session.add(empty)
+        await db_session.commit()
+
+        monkeypatch.setattr(
+            "fastapi.BackgroundTasks.add_task",
+            lambda self, *a, **kw: None,
+            raising=True,
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/veille/deliveries/generate-first")
+
+        assert resp.status_code == 202, resp.text
+
+    async def test_retries_after_stuck_running(
+        self, monkeypatch, db_session, auth_user, active_veille_config
+    ):
+        stuck = VeilleDelivery(
+            id=uuid4(),
+            veille_config_id=active_veille_config.id,
+            target_date=datetime.now(UTC).date(),
+            generation_state=VeilleGenerationState.RUNNING.value,
+            created_at=datetime.now(UTC) - timedelta(minutes=30),
+        )
+        db_session.add(stuck)
+        await db_session.commit()
+
+        monkeypatch.setattr(
+            "fastapi.BackgroundTasks.add_task",
+            lambda self, *a, **kw: None,
+            raising=True,
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/veille/deliveries/generate-first")
+
+        assert resp.status_code == 202, resp.text
+
+    async def test_conflict_when_running_recent(
+        self, db_session, auth_user, active_veille_config
+    ):
+        running = VeilleDelivery(
+            id=uuid4(),
+            veille_config_id=active_veille_config.id,
+            target_date=datetime.now(UTC).date(),
+            generation_state=VeilleGenerationState.RUNNING.value,
+        )
+        db_session.add(running)
+        await db_session.commit()
+
+        async with _client() as ac:
+            resp = await ac.post("/api/veille/deliveries/generate-first")
+
+        assert resp.status_code == 409
 
 
 class TestSourceExamples:


### PR DESCRIPTION
## Quoi
- `POST /deliveries/generate-first` devient **idempotent sur reprise d'erreur** : DELETE l'ancienne row + relance si `failed` / `succeeded`-vide / `pending|running` >15 min. 403 conservé uniquement sur `succeeded` non-vide, 409 si une génération récente est en cours.
- **CTA dashboard** « Lancer / Relancer ma première veille » conditionnelle, gating via un nouveau provider `veilleLastDeliveryProvider` (limit=1).
- Helper `pollFirstDelivery` extrait dans `utils/`, partagé entre `veille_config_screen` et `veille_dashboard_screen`.

## Pourquoi
Symptôme PO récurrent (2026-05-12) : « après avoir configuré une veille, aucune option n'apparaît pour générer/relancer la première veille ». Le précédent fix `bug-veille-config-without-sources` (2026-05-07) ne couvrait que la branche « config sans sources ». Les 4 autres modes d'échec (timeout >90s, failed, digest vide, retour sur `/configure` qui auto-redirect dashboard) laissaient l'utilisateur dans un cul-de-sac UX. Détails : [`docs/bugs/bug-first-veille-no-retry.md`](docs/bugs/bug-first-veille-no-retry.md).

## Comment ça a été vérifié
- [x] `pytest tests/routers/test_veille_routes.py` — 27/27 (5 nouveaux tests : retry-after-failed/empty/stuck, 409 running récent, 403 succeeded valide)
- [x] `pytest -v` (suite complète) — 1099 passed / 0 failed
- [x] `flutter test test/features/veille/` — 64/64 (6 nouveaux tests dashboard CTA + 1 fix label `flow_loading_screen_test` drive-by)
- [x] `flutter analyze lib/features/veille/` — 0 issue dans les fichiers touchés
- [x] `simplify` passé : promotion `STUCK_DELIVERY_THRESHOLD` partagée avec le job cleanup, `with_for_update()` anti-double-clic, provider dédié limit=1, suppression commentaires WHAT.

## Zones à risque
- `packages/api/app/routers/veille.py:778-840` — relâchement de la garde 403, ajout d'un `FOR UPDATE` (sérialise les concurrents sur la dernière row).
- `apps/mobile/lib/features/veille/screens/veille_dashboard_screen.dart` — passage de `ConsumerWidget` → `ConsumerStatefulWidget` pour gérer l'état `_isGeneratingFirst` durant le polling.
- Mode édition non touché : la CTA n'apparaît qu'en post-onboarding (CTA cachée dès qu'une livraison `succeeded` non-vide existe).

## Décisions PO actées
- **Q1 → DELETE** la row failed/empty (Sentry/PostHog conservent la trace, l'historique user reste net).
- **Q2 → polling 90s conservé**, la CTA dashboard rend les timeouts visibles/analysables.

## Hors scope
- Stabilisation `/api/veille/suggestions/sources` (bug séparé)
- Refonte du mode édition
- Notification push de relance après échec (follow-up éventuel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)