### PR TITLE
feat(web): modal "Ajouter à l'écran d'accueil" pour iOS Safari

### DIFF
--- a/apps/mobile/lib/core/nudges/nudge_ids.dart
+++ b/apps/mobile/lib/core/nudges/nudge_ids.dart
@@ -23,4 +23,7 @@ class NudgeIds {
 
   // Story 14.3 — self-reported "well-informed" score (NPS-style).
   static const wellInformedPoll = 'well_informed_poll';
+
+  // Story web.1 — Modal "Ajouter à l'écran d'accueil" sur iOS Safari.
+  static const iosAddToHome = 'ios_add_to_home';
 }

--- a/apps/mobile/lib/core/nudges/nudge_registry.dart
+++ b/apps/mobile/lib/core/nudges/nudge_registry.dart
@@ -117,5 +117,17 @@ class NudgeRegistry {
       frequency: NudgeFrequency.cooldown,
       cooldown: Duration(days: 5),
     ),
+
+    // Story web.1 — iOS Safari "Ajouter à l'écran d'accueil". Cooldown 7j
+    // pour les utilisateurs qui ferment via "Plus tard" ; `markSeen`
+    // permanent quand l'utilisateur confirme "C'est fait".
+    const Nudge(
+      id: NudgeIds.iosAddToHome,
+      surface: NudgeSurface.global,
+      placement: NudgePlacement.modal,
+      priority: NudgePriority.high,
+      frequency: NudgeFrequency.cooldown,
+      cooldown: Duration(days: 7),
+    ),
   ];
 }

--- a/apps/mobile/lib/core/orchestration/first_impression_orchestrator.dart
+++ b/apps/mobile/lib/core/orchestration/first_impression_orchestrator.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../auth/auth_state.dart';
 import '../web/web_perf.dart';
 import '../../features/notifications/providers/notification_renudge_provider.dart';
+import '../../features/onboarding/providers/ios_add_to_home_provider.dart';
 import '../../features/settings/providers/notifications_settings_provider.dart';
 import '../../features/well_informed/providers/well_informed_prompt_provider.dart';
 
@@ -13,6 +14,7 @@ import '../../features/well_informed/providers/well_informed_prompt_provider.dar
 /// banner et well-informed prompt se cumulaient.
 enum FirstImpressionSlot {
   none,
+  iosAddToHome,
   notifModal,
   renudgeBanner,
   wellInformed,
@@ -29,11 +31,13 @@ final nudgeConsumedThisSessionProvider = StateProvider<bool>((_) => false);
 ///
 /// Règles :
 /// 1. Onboarding pas terminé → rien (l'onboarding occupe toute la fenêtre).
-/// 2. Sync préfs notif terminé ET `modalSeen=false` ET pas déjà consommé →
+/// 2. iOS Safari non standalone ET pas déjà consommé → `iosAddToHome`
+///    (priorité max sur web : c'est le seul levier d'install).
+/// 3. Sync préfs notif terminé ET `modalSeen=false` ET pas déjà consommé →
 ///    `notifModal`.
-/// 3. Re-nudge éligible (cap, espacement, refus passé) ET aucun nudge déjà
+/// 4. Re-nudge éligible (cap, espacement, refus passé) ET aucun nudge déjà
 ///    consommé cette session → `renudgeBanner`.
-/// 4. Well-informed prompt dû ET aucun nudge déjà consommé → `wellInformed`.
+/// 5. Well-informed prompt dû ET aucun nudge déjà consommé → `wellInformed`.
 final firstImpressionSlotProvider = Provider<FirstImpressionSlot>((ref) {
   final auth = ref.watch(authStateProvider);
   final notif = ref.watch(notificationsSettingsProvider);
@@ -42,11 +46,19 @@ final firstImpressionSlotProvider = Provider<FirstImpressionSlot>((ref) {
   final renudgeShould = ref.watch(notificationRenudgeShouldShowProvider);
   final wellInformedShould =
       ref.watch(wellInformedShouldShowProvider).valueOrNull ?? false;
+  final iosAddToHomeShould =
+      ref.watch(iosAddToHomeShouldShowProvider).valueOrNull ?? false;
+  final iosAddToHomeConsumed =
+      ref.watch(iosAddToHomeConsumedThisSessionProvider);
 
   if (!auth.isAuthenticated || !auth.isEmailConfirmed) {
     return FirstImpressionSlot.none;
   }
   if (auth.needsOnboarding) return FirstImpressionSlot.none;
+
+  if (!iosAddToHomeConsumed && iosAddToHomeShould) {
+    return FirstImpressionSlot.iosAddToHome;
+  }
 
   if (kSupportsPushNotifications &&
       !modalConsumed &&

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -577,6 +577,23 @@ class AnalyticsService {
     await _capturePostHog('modal_notif_dismissed', {});
   }
 
+  // ── iOS "Add to Home Screen" PWA modal (Story web.1) ────────────────
+
+  Future<void> trackIosAddToHomeShown() async {
+    await _logEvent('ios_add_to_home_shown', {});
+    await _capturePostHog('ios_add_to_home_shown', {});
+  }
+
+  Future<void> trackIosAddToHomeConfirmed() async {
+    await _logEvent('ios_add_to_home_confirmed', {});
+    await _capturePostHog('ios_add_to_home_confirmed', {});
+  }
+
+  Future<void> trackIosAddToHomeDismissed() async {
+    await _logEvent('ios_add_to_home_dismissed', {});
+    await _capturePostHog('ios_add_to_home_dismissed', {});
+  }
+
   Future<void> trackRenudgeShown({required int displayCount}) async {
     final props = <String, dynamic>{'display_count': displayCount};
     await _logEvent('renudge_shown', props);

--- a/apps/mobile/lib/core/web/ios_safari_install.dart
+++ b/apps/mobile/lib/core/web/ios_safari_install.dart
@@ -1,0 +1,10 @@
+import 'ios_safari_install_stub.dart'
+    if (dart.library.js_interop) 'ios_safari_install_web.dart';
+
+/// Vrai si l'utilisateur ouvre Facteur via iOS Safari **sans** l'avoir
+/// déjà ajouté à l'écran d'accueil (mode standalone). Faux ailleurs :
+/// app native, Android, Chrome iOS, mode standalone, etc.
+///
+/// Utilisé par `iosAddToHomeShouldShowProvider` pour gater la modal
+/// pédagogique "Ajouter à l'écran d'accueil".
+bool isIosSafariNonStandalone() => checkIosSafariNonStandalone();

--- a/apps/mobile/lib/core/web/ios_safari_install_stub.dart
+++ b/apps/mobile/lib/core/web/ios_safari_install_stub.dart
@@ -1,0 +1,2 @@
+/// Stub utilisé sur mobile/desktop natif — pas de notion d'install PWA.
+bool checkIosSafariNonStandalone() => false;

--- a/apps/mobile/lib/core/web/ios_safari_install_web.dart
+++ b/apps/mobile/lib/core/web/ios_safari_install_web.dart
@@ -1,0 +1,34 @@
+import 'dart:js_interop';
+
+import 'package:web/web.dart' as web;
+
+/// Lit `navigator.standalone` (propriété iOS-only non typée dans `package:web`).
+@JS('navigator.standalone')
+external JSAny? _navigatorStandalone;
+
+/// Vrai si l'utilisateur est sur iOS Safari (iPhone/iPad/iPod) **et** que la
+/// page n'est pas déjà en mode standalone (= déjà ajoutée à l'écran d'accueil
+/// et lancée comme PWA).
+///
+/// Exclut Chrome iOS (`CriOS`), Firefox iOS (`FxiOS`) et Edge iOS (`EdgiOS`) :
+/// ces navigateurs ne supportent pas "Ajouter à l'écran d'accueil" de la
+/// même manière, et la modal ne leur serait pas utile.
+bool? _cached;
+bool checkIosSafariNonStandalone() => _cached ??= _compute();
+
+bool _compute() {
+  final ua = web.window.navigator.userAgent;
+  final isIosDevice =
+      ua.contains('iPhone') || ua.contains('iPad') || ua.contains('iPod');
+  if (!isIosDevice) return false;
+
+  final isOtherBrowser =
+      ua.contains('CriOS') || ua.contains('FxiOS') || ua.contains('EdgiOS');
+  if (isOtherBrowser) return false;
+
+  if (!ua.contains('Safari')) return false;
+
+  final standalone = _navigatorStandalone;
+  final isStandalone = standalone != null && standalone.dartify() == true;
+  return !isStandalone;
+}

--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -56,6 +56,8 @@ import '../../app_update/providers/app_update_provider.dart';
 import '../../app_update/widgets/update_modal.dart';
 import '../../../core/orchestration/first_impression_orchestrator.dart';
 import '../../notifications/widgets/notification_activation_modal.dart';
+import '../../onboarding/providers/ios_add_to_home_provider.dart';
+import '../../onboarding/widgets/ios_add_to_home_sheet.dart';
 import '../../lettres/widgets/lettres_notification_banner.dart';
 import '../../notifications/widgets/notification_renudge_banner.dart';
 import '../../well_informed/widgets/well_informed_prompt.dart';
@@ -207,21 +209,38 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
     await NudgeCounters.increment(NudgeCounters.feedCardTapCount);
   }
 
-  /// Modal d'activation notif gatée par `firstImpressionSlotProvider` (au
+  /// Modal premier-impact gatée par `firstImpressionSlotProvider` (au
   /// plus 1 modal/session, arbitrée avec re-nudge banner + well-informed
-  /// prompt).
+  /// prompt). Dispatch sur le type de slot pour soit la modal notif (mobile
+  /// natif), soit la modal "Ajouter à l'écran d'accueil" (iOS Safari web).
   void _maybeShowActivationModal(FirstImpressionSlot slot) {
     if (_activationModalShown) return;
-    if (slot != FirstImpressionSlot.notifModal) return;
+    final VoidCallback action;
+    switch (slot) {
+      case FirstImpressionSlot.iosAddToHome:
+        action = () {
+          ref.read(iosAddToHomeConsumedThisSessionProvider.notifier).state =
+              true;
+          showIosAddToHomeSheet(context, ref);
+        };
+      case FirstImpressionSlot.notifModal:
+        action = () {
+          ref.read(notifModalConsumedThisSessionProvider.notifier).state = true;
+          showNotificationActivationModal(
+            context,
+            ref,
+            trigger: ActivationTrigger.update,
+          );
+        };
+      case FirstImpressionSlot.none:
+      case FirstImpressionSlot.renudgeBanner:
+      case FirstImpressionSlot.wellInformed:
+        return;
+    }
     _activationModalShown = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      ref.read(notifModalConsumedThisSessionProvider.notifier).state = true;
-      showNotificationActivationModal(
-        context,
-        ref,
-        trigger: ActivationTrigger.update,
-      );
+      action();
     });
   }
 

--- a/apps/mobile/lib/features/onboarding/providers/ios_add_to_home_provider.dart
+++ b/apps/mobile/lib/features/onboarding/providers/ios_add_to_home_provider.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/nudges/nudge_coordinator.dart';
+import '../../../core/nudges/nudge_ids.dart';
+import '../../../core/nudges/nudge_service.dart';
+import '../../../core/web/ios_safari_install.dart';
+
+/// Une fois la modal "Ajouter à l'écran d'accueil" affichée dans la session,
+/// on ne la déclenche pas une seconde fois avant le prochain cold start.
+final iosAddToHomeConsumedThisSessionProvider =
+    StateProvider<bool>((_) => false);
+
+/// Contrôleur de visibilité de la modal iOS "Ajouter à l'écran d'accueil".
+///
+/// Deux portes :
+///  - `isSeen` (permanent) — l'utilisateur a confirmé "C'est fait".
+///  - `canShow` (cooldown 7j) — l'utilisateur a fermé via "Plus tard".
+/// On combine les deux car `canShow` pour une fréquence `cooldown` ignore
+/// `isSeen`. Sans `isSeen` la modal reviendrait 7j après le "C'est fait".
+class IosAddToHomeController {
+  IosAddToHomeController({required NudgeService nudgeService})
+      : _nudgeService = nudgeService;
+
+  final NudgeService _nudgeService;
+
+  Future<bool> shouldShow() async {
+    if (!isIosSafariNonStandalone()) return false;
+    if (await _nudgeService.isSeen(NudgeIds.iosAddToHome)) return false;
+    return _nudgeService.canShow(NudgeIds.iosAddToHome);
+  }
+
+  /// L'utilisateur a confirmé l'installation — on ne re-montre plus jamais.
+  Future<void> markConfirmed() async {
+    await _nudgeService.markSeen(NudgeIds.iosAddToHome);
+  }
+
+  /// L'utilisateur a snoozé — on attend 7j (cooldown du nudge) avant de
+  /// re-proposer.
+  Future<void> markDismissed() async {
+    await _nudgeService.markShown(NudgeIds.iosAddToHome);
+  }
+}
+
+final iosAddToHomeControllerProvider = Provider<IosAddToHomeController>((ref) {
+  return IosAddToHomeController(
+    nudgeService: ref.watch(nudgeServiceProvider),
+  );
+});
+
+/// Provider async consommé par `firstImpressionSlotProvider`. Renvoie
+/// `false` par défaut tant que le check storage n'a pas répondu — l'orchestrateur
+/// laissera passer un autre slot, ce qui est OK : la modal s'affichera au
+/// rebuild suivant (le watch ré-évalue dès que l'AsyncValue passe à `data`).
+final iosAddToHomeShouldShowProvider = FutureProvider<bool>((ref) async {
+  final controller = ref.watch(iosAddToHomeControllerProvider);
+  return controller.shouldShow();
+});

--- a/apps/mobile/lib/features/onboarding/widgets/ios_add_to_home_sheet.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/ios_add_to_home_sheet.dart
@@ -1,0 +1,233 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../../../core/providers/analytics_provider.dart';
+import '../providers/ios_add_to_home_provider.dart';
+
+/// Affiche la modal pédagogique iOS Safari "Ajouter à l'écran d'accueil".
+///
+/// iOS ne supporte pas `beforeinstallprompt` — pas d'install programmatique
+/// possible. La modal explique en 3 étapes visuelles comment passer par le
+/// Share Sheet de Safari.
+///
+/// Retourne `true` si l'utilisateur a confirmé "C'est fait", `false` s'il a
+/// snoozé ("Plus tard") ou fermé via tap hors modal.
+Future<bool?> showIosAddToHomeSheet(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  unawaited(ref.read(analyticsServiceProvider).trackIosAddToHomeShown());
+  return showDialog<bool>(
+    context: context,
+    barrierDismissible: false,
+    barrierColor: Colors.black.withValues(alpha: 0.6),
+    useRootNavigator: true,
+    builder: (_) => const Dialog(
+      insetPadding: EdgeInsets.symmetric(
+        horizontal: FacteurSpacing.space4,
+        vertical: FacteurSpacing.space6,
+      ),
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      child: IosAddToHomeSheet(),
+    ),
+  );
+}
+
+class IosAddToHomeSheet extends ConsumerStatefulWidget {
+  const IosAddToHomeSheet({super.key});
+
+  @override
+  ConsumerState<IosAddToHomeSheet> createState() => _IosAddToHomeSheetState();
+}
+
+class _IosAddToHomeSheetState extends ConsumerState<IosAddToHomeSheet> {
+  bool _busy = false;
+
+  Future<void> _onConfirm() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    await ref.read(iosAddToHomeControllerProvider).markConfirmed();
+    unawaited(
+      ref.read(analyticsServiceProvider).trackIosAddToHomeConfirmed(),
+    );
+    if (!mounted) return;
+    Navigator.of(context).pop(true);
+  }
+
+  Future<void> _onSkip() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    await ref.read(iosAddToHomeControllerProvider).markDismissed();
+    unawaited(
+      ref.read(analyticsServiceProvider).trackIosAddToHomeDismissed(),
+    );
+    if (!mounted) return;
+    Navigator.of(context).pop(false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final theme = Theme.of(context);
+
+    return Material(
+      color: colors.backgroundPrimary,
+      borderRadius: BorderRadius.circular(FacteurRadius.xl),
+      clipBehavior: Clip.antiAlias,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.85,
+        ),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(
+            FacteurSpacing.space4,
+            FacteurSpacing.space6,
+            FacteurSpacing.space4,
+            FacteurSpacing.space4,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Center(
+                child: Container(
+                  width: 64,
+                  height: 64,
+                  decoration: BoxDecoration(
+                    color: colors.primaryMuted,
+                    borderRadius: BorderRadius.circular(FacteurRadius.large),
+                  ),
+                  child: Icon(
+                    PhosphorIcons.shareNetwork(PhosphorIconsStyle.regular),
+                    color: colors.primary,
+                    size: 32,
+                  ),
+                ),
+              ),
+              const SizedBox(height: FacteurSpacing.space4),
+              Text(
+                'Gardez Facteur à portée de main',
+                style: FacteurTypography.displayMedium(colors.textPrimary),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: FacteurSpacing.space3),
+              Text(
+                "Ajoutez Facteur à votre écran d'accueil pour le retrouver "
+                "d'un geste, comme une vraie app — plus rapide, toujours là.",
+                style: FacteurTypography.bodyMedium(colors.textSecondary),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: FacteurSpacing.space6),
+              _StepRow(
+                index: 1,
+                icon: PhosphorIcons.shareNetwork(PhosphorIconsStyle.regular),
+                text: 'Touchez l\'icône Partage en bas de Safari',
+              ),
+              const SizedBox(height: FacteurSpacing.space3),
+              _StepRow(
+                index: 2,
+                icon: PhosphorIcons.plusSquare(PhosphorIconsStyle.regular),
+                text: 'Choisissez "Sur l\'écran d\'accueil"',
+              ),
+              const SizedBox(height: FacteurSpacing.space3),
+              _StepRow(
+                index: 3,
+                icon: PhosphorIcons.checkCircle(PhosphorIconsStyle.regular),
+                text: 'Confirmez avec "Ajouter"',
+              ),
+              const SizedBox(height: FacteurSpacing.space6),
+              SizedBox(
+                height: 48,
+                child: ElevatedButton(
+                  onPressed: _busy ? null : _onConfirm,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: colors.primary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(FacteurRadius.large),
+                    ),
+                  ),
+                  child: const Text(
+                    "C'est fait",
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: FacteurSpacing.space2),
+              TextButton(
+                onPressed: _busy ? null : _onSkip,
+                child: Text(
+                  'Plus tard',
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: colors.textSecondary),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Une étape numérotée du tutoriel : numéro dans un cercle, icône iOS, texte.
+class _StepRow extends StatelessWidget {
+  final int index;
+  final IconData icon;
+  final String text;
+
+  const _StepRow({
+    required this.index,
+    required this.icon,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Container(
+      padding: const EdgeInsets.all(FacteurSpacing.space3),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        border: Border.all(color: colors.border),
+        borderRadius: BorderRadius.circular(FacteurRadius.medium),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Container(
+            width: 28,
+            height: 28,
+            decoration: BoxDecoration(
+              color: colors.primary,
+              shape: BoxShape.circle,
+            ),
+            child: Center(
+              child: Text(
+                '$index',
+                style: FacteurTypography.labelMedium(colors.backgroundPrimary)
+                    .copyWith(fontWeight: FontWeight.w700),
+              ),
+            ),
+          ),
+          const SizedBox(width: FacteurSpacing.space3),
+          Icon(icon, size: 24, color: colors.textSecondary),
+          const SizedBox(width: FacteurSpacing.space3),
+          Expanded(
+            child: Text(
+              text,
+              style: FacteurTypography.bodyMedium(colors.textPrimary),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -1590,7 +1590,7 @@ packages:
     source: hosted
     version: "1.2.1"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -90,6 +90,9 @@ dependencies:
   flutter_downloader: ^1.11.8
   flutter_inappwebview: ^6.1.5
 
+  # PWA install prompt detection (Story web.1 — iOS Safari add-to-home)
+  web: ^1.1.0
+
 dev_dependencies:
   mocktail: ^1.0.3
   mockito: ^5.4.4

--- a/apps/mobile/test/features/onboarding/ios_add_to_home_sheet_test.dart
+++ b/apps/mobile/test/features/onboarding/ios_add_to_home_sheet_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:facteur/core/nudges/nudge_coordinator.dart';
+import 'package:facteur/core/nudges/nudge_ids.dart';
+import 'package:facteur/core/nudges/nudge_service.dart';
+import 'package:facteur/core/nudges/nudge_storage.dart';
+import 'package:facteur/core/providers/analytics_provider.dart';
+import 'package:facteur/core/services/analytics_service.dart';
+import 'package:facteur/features/onboarding/providers/ios_add_to_home_provider.dart';
+import 'package:facteur/features/onboarding/widgets/ios_add_to_home_sheet.dart';
+
+class _NoopAnalytics implements AnalyticsService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) async {}
+}
+
+Widget _wrap({required List<Override> overrides, required Widget child}) {
+  return ProviderScope(
+    overrides: [
+      analyticsServiceProvider.overrideWithValue(_NoopAnalytics()),
+      ...overrides,
+    ],
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('rend le titre, les 3 étapes et les deux CTAs', (tester) async {
+    await tester.pumpWidget(_wrap(
+      overrides: const [],
+      child: const IosAddToHomeSheet(),
+    ));
+    await tester.pump();
+
+    expect(find.text('Gardez Facteur à portée de main'), findsOneWidget);
+    expect(find.textContaining("Touchez l'icône Partage"), findsOneWidget);
+    expect(find.textContaining("Sur l'écran d'accueil"), findsOneWidget);
+    expect(find.textContaining('Confirmez avec "Ajouter"'), findsOneWidget);
+    expect(find.text("C'est fait"), findsOneWidget);
+    expect(find.text('Plus tard'), findsOneWidget);
+  });
+
+  testWidgets('tap "C\'est fait" marque le nudge comme vu (permanent)',
+      (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    final storage = NudgeStorage(prefs: prefs);
+    final service = NudgeService(storage: storage);
+
+    await tester.pumpWidget(_wrap(
+      overrides: [
+        nudgeServiceProvider.overrideWithValue(service),
+      ],
+      child: const IosAddToHomeSheet(),
+    ));
+    await tester.pump();
+
+    await tester.ensureVisible(find.text("C'est fait"));
+    await tester.tap(find.text("C'est fait"));
+    await tester.pumpAndSettle();
+
+    expect(await service.isSeen(NudgeIds.iosAddToHome), isTrue);
+  });
+
+  testWidgets('tap "Plus tard" enregistre `lastShown` (snooze 7j)',
+      (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    final storage = NudgeStorage(prefs: prefs);
+    final service = NudgeService(storage: storage);
+
+    await tester.pumpWidget(_wrap(
+      overrides: [
+        nudgeServiceProvider.overrideWithValue(service),
+      ],
+      child: const IosAddToHomeSheet(),
+    ));
+    await tester.pump();
+
+    await tester.ensureVisible(find.text('Plus tard'));
+    await tester.tap(find.text('Plus tard'));
+    await tester.pumpAndSettle();
+
+    expect(await service.isSeen(NudgeIds.iosAddToHome), isFalse);
+    expect(await service.lastShown(NudgeIds.iosAddToHome), isNotNull);
+  });
+
+  test('controller.shouldShow=false hors web (stub)', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final service = NudgeService(storage: NudgeStorage(prefs: prefs));
+    final controller = IosAddToHomeController(nudgeService: service);
+    // En contexte de test (non-web), isIosSafariNonStandalone()=false
+    // donc shouldShow doit court-circuiter sans toucher au storage.
+    expect(await controller.shouldShow(), isFalse);
+  });
+
+  test('controller.markConfirmed → shouldShow reste false', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final service = NudgeService(storage: NudgeStorage(prefs: prefs));
+    final controller = IosAddToHomeController(nudgeService: service);
+
+    await controller.markConfirmed();
+    expect(await service.isSeen(NudgeIds.iosAddToHome), isTrue);
+    expect(await controller.shouldShow(), isFalse);
+  });
+
+  test('controller.markDismissed → lastShown enregistré', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final service = NudgeService(storage: NudgeStorage(prefs: prefs));
+    final controller = IosAddToHomeController(nudgeService: service);
+
+    await controller.markDismissed();
+    expect(await service.lastShown(NudgeIds.iosAddToHome), isNotNull);
+    expect(await service.isSeen(NudgeIds.iosAddToHome), isFalse);
+  });
+}

--- a/docs/stories/web/web.1.ios-add-to-home-modal.story.md
+++ b/docs/stories/web/web.1.ios-add-to-home-modal.story.md
@@ -1,0 +1,114 @@
+# Story web.1 : Modal "Ajouter à l'écran d'accueil" pour iOS Safari
+
+## Status: In Progress
+
+## Story
+
+**As a** utilisateur iOS qui accède à Facteur via Safari (et non l'app native),
+**I want** être guidé clairement pour ajouter Facteur à mon écran d'accueil,
+**so that** je retrouve l'app d'un geste, sans avoir à retaper l'URL ou chercher l'onglet — et je profite du chrome PWA (standalone, sans barre Safari).
+
+## Context
+
+### Problème produit
+
+Les utilisateurs iOS arrivent souvent sur Facteur via le web (lien partagé, recherche, marque-page). Sur Safari iOS, le site n'est pas une "app" : à chaque retour, ils doivent retaper `facteur.app` ou fouiller dans leurs onglets — friction qui dégrade la rétention sur ce segment.
+
+Le PWA est correctement configuré (`manifest.json` `display: standalone`, `apple-touch-icon`, `apple-mobile-web-app-capable`), mais aucun nudge n'incite à l'install. Or :
+
+- **iOS Safari ne supporte PAS `beforeinstallprompt`** : impossible de déclencher programmatiquement le Share Sheet ni "Ajouter à l'écran d'accueil". Seule Android Chrome le permet.
+- L'unique levier produit : une modal pédagogique claire (3 étapes visuelles) au bon moment.
+
+### Solution
+
+- À la prochaine ouverture web pour un utilisateur **iOS Safari non standalone** (= pas déjà installé en PWA), afficher une modal pédagogique immédiatement après auth, avant l'arrivée sur le feed.
+- 3 étapes visuelles : 1) Toucher le bouton Partage de Safari, 2) Choisir "Sur l'écran d'accueil", 3) Confirmer.
+- CTAs : « C'est fait » (marque seen permanent) / « Plus tard » (snooze 7 jours).
+- Gating via `FirstImpressionSlot` (mécanisme déjà en place pour notif modal, re-nudge, well-informed) → au plus un overlay/session.
+- Persistance via `NudgeStorage` (SharedPreferences) → snooze 7 jours.
+
+### Out-of-scope
+
+- Android Chrome / desktop / autres navigateurs : pas de modal (cible iOS Safari uniquement, choix explicite).
+- App native iOS : pas de modal (`kIsWeb=false` short-circuit).
+- iPadOS Safari (UA macOS depuis iOS 13) : pas de détection fiable, accepté.
+- Automatisation de l'install : impossible techniquement sur iOS Safari.
+
+## Acceptance Criteria
+
+1. ✅ Un utilisateur iOS Safari non-standalone voit la modal au prochain load post-auth.
+2. ✅ Un utilisateur Android, desktop, Chrome iOS (UA `CriOS`), Firefox iOS (`FxiOS`), Edge iOS (`EdgiOS`) ne voit pas la modal.
+3. ✅ Un utilisateur déjà en PWA (`navigator.standalone === true`) ne voit pas la modal.
+4. ✅ Un utilisateur sur l'app native (iOS ou Android) ne voit jamais la modal (`kIsWeb=false`).
+5. ✅ Tap « C'est fait » → modal fermée, jamais réaffichée (seen permanent).
+6. ✅ Tap « Plus tard » → modal fermée, réapparaît 7+ jours plus tard si non installé.
+7. ✅ Au plus une modal premier-impact par session : si la modal s'affiche, les autres nudges (re-nudge banner, well-informed) sont skippés cette session.
+8. ✅ Copy aligné design system : `FacteurTypography.displayMedium` pour le titre, `bodyMedium`/`labelLarge` pour le reste, `FacteurColors` pour les couleurs.
+9. ✅ Tone aligné Facteur : 2e personne pluriel, clair, calme, sans urgence ("Gardez Facteur à portée de main", "Pour le retrouver d'un geste").
+10. ✅ Analytics : événements `ios_add_to_home_shown`, `ios_add_to_home_confirmed`, `ios_add_to_home_dismissed`.
+11. ✅ Tests verts : `flutter test`, `flutter analyze`.
+
+## Plan technique
+
+### Détecteur (apps/mobile/lib/core/web/ios_safari_install.dart)
+
+- Index avec conditional import : stub mobile (`=> false`) / impl web (`ios_safari_install_web.dart`).
+- Web : lit `window.navigator.userAgent` + `(navigator as JSAny).standalone` via `package:web` + `dart:js_interop`.
+- Règles : `kIsWeb` ET (UA contient `iPhone|iPad|iPod`) ET (UA contient `Safari`) ET (UA NE contient PAS `CriOS|FxiOS|EdgiOS`) ET (`navigator.standalone !== true`).
+
+### Nudge (apps/mobile/lib/core/nudges/)
+
+- `nudge_ids.dart` : `static const iosAddToHome = 'ios_add_to_home';`
+- `nudge_registry.dart` : Nudge avec `frequency: cooldown`, `cooldown: 7d`, `priority: normal`, `surface: global`, `placement: modal`.
+
+### Provider (apps/mobile/lib/features/onboarding/providers/ios_add_to_home_provider.dart)
+
+- `iosAddToHomeShouldShowProvider` : Provider<bool> combinant détecteur + `NudgeService.canShow(NudgeIds.iosAddToHome)` (qui gère lui-même seen + cooldown).
+- `iosAddToHomeConsumedThisSessionProvider` : `StateProvider<bool>` pour bloquer une 2e ouverture en session.
+
+### Orchestrateur (apps/mobile/lib/core/orchestration/first_impression_orchestrator.dart)
+
+- Ajouter `iosAddToHome` à l'enum `FirstImpressionSlot`, **en première position** après `none` (priorité max : c'est la seule modal pertinente sur web, où `notifModal` est gaté off par `kSupportsPushNotifications=false`).
+- Branche dans `firstImpressionSlotProvider` avant `notifModal`.
+
+### Modal (apps/mobile/lib/features/onboarding/widgets/ios_add_to_home_sheet.dart)
+
+- `showIosAddToHomeSheet(context, ref)` → `showDialog<void>` translucide, pattern emprunté à `notification_activation_modal.dart`.
+- Contenu : titre + sous-titre + 3 étapes avec icônes (Phosphor `shareNetwork`, `plusSquare`, `checkCircle`) + boutons.
+- Sur tap « C'est fait » : `nudgeService.markSeen(iosAddToHome)` + analytics confirmed.
+- Sur tap « Plus tard » : `nudgeService.markShown(iosAddToHome)` (déclenche cooldown 7j) + analytics dismissed.
+
+### Trigger (apps/mobile/lib/features/feed/screens/feed_screen.dart)
+
+- Étendre `_maybeShowActivationModal(slot)` (l. 210) en switch sur le slot.
+- `case iosAddToHome` → `showIosAddToHomeSheet` puis flip `iosAddToHomeConsumedThisSessionProvider = true`.
+
+### Analytics (apps/mobile/lib/core/services/analytics_service.dart)
+
+- 3 nouvelles méthodes : `trackIosAddToHomeShown`, `trackIosAddToHomeConfirmed`, `trackIosAddToHomeDismissed`.
+
+## Files Modified
+
+### Created
+
+- `apps/mobile/lib/core/web/ios_safari_install.dart` (index)
+- `apps/mobile/lib/core/web/ios_safari_install_stub.dart`
+- `apps/mobile/lib/core/web/ios_safari_install_web.dart`
+- `apps/mobile/lib/features/onboarding/providers/ios_add_to_home_provider.dart`
+- `apps/mobile/lib/features/onboarding/widgets/ios_add_to_home_sheet.dart`
+- `apps/mobile/test/features/onboarding/ios_add_to_home_sheet_test.dart`
+
+### Modified
+
+- `apps/mobile/lib/core/nudges/nudge_ids.dart`
+- `apps/mobile/lib/core/nudges/nudge_registry.dart`
+- `apps/mobile/lib/core/orchestration/first_impression_orchestrator.dart`
+- `apps/mobile/lib/features/feed/screens/feed_screen.dart`
+- `apps/mobile/lib/core/services/analytics_service.dart`
+
+## Test Plan
+
+- **Unit/widget tests** : `test/features/onboarding/ios_add_to_home_sheet_test.dart` — rendering, CTAs, persistance via mock NudgeStorage.
+- **Manual web (Chrome devtools, UA iPhone Safari)** : afficher / dismiss / snooze 7j.
+- **Manual native** : flutter run iOS device → la modal n'apparaît jamais.
+- **Edge cases** : UA `CriOS`, `FxiOS`, Android, mode standalone — pas de modal.


### PR DESCRIPTION
## Quoi

Modal pédagogique 3 étapes pour aider les utilisateurs iOS Safari (non standalone) à installer Facteur sur l'écran d'accueil. S'affiche au premier load post-auth via `FirstImpressionSlot` (au plus 1 overlay/session).

## Pourquoi

Sur iOS Safari, l'app n'est pas installée → friction à chaque retour. iOS ne supporte pas `beforeinstallprompt` (Chrome Android only) : seul levier produit, une modal pédagogique qui pointe vers le Share Sheet.

## Comment

- **Détecteur** (`lib/core/web/ios_safari_install*.dart`) : conditional import — stub natif `=> false`, impl web lit `userAgent` (iPhone|iPad|iPod + Safari, exclut CriOS/FxiOS/EdgiOS) et `navigator.standalone !== true`. Résultat memoizé (UA immuable par session).
- **Nudge** (`ios_add_to_home`, cooldown 7j) — `markSeen` permanent sur « C'est fait », `markShown` (snooze 7j) sur « Plus tard ».
- **Orchestrateur** : ajouté à `FirstImpressionSlot` en priorité max sur web (`notifModal` est gaté off via `kSupportsPushNotifications=false`).
- **Modal** : 3 étapes visuelles avec icônes Phosphor (Share / Add / Confirm), tone Facteur (2e personne pluriel).
- **Analytics** : `ios_add_to_home_{shown,confirmed,dismissed}`.

## Vérifié

- [x] `flutter test test/features/onboarding/ios_add_to_home_sheet_test.dart` → 6/6 OK
- [x] `flutter test test/core/nudges` → 42/42 OK
- [x] `flutter analyze` sur fichiers modifiés → 0 nouvelle issue (échecs pré-existants inchangés)
- [x] Suite mobile complète : 598 passed (+8 vs main), 37 failed (pré-existants, -1 flaky)
- [x] `/simplify` passé — memoization UA, suppression `kIsWeb` redondant, refacto post-frame wrapper unifié

## Zones à risque

- `feed_screen.dart#_maybeShowActivationModal` : dispatch enum élargi à `iosAddToHome` + `notifModal` ; cases `none/renudgeBanner/wellInformed` toujours `return`.
- `firstImpressionSlotProvider` : ordre des slots déplacé (`iosAddToHome` avant `notifModal`).
- `pubspec.yaml` : `package:web ^1.1.0` promu de transitive → direct (déjà présent en transitive via shared_preferences_web).

## Hors scope

- Android Chrome / desktop (pas de modal) — `beforeinstallprompt` natif Android viendra plus tard.
- iPadOS Safari (UA = macOS Safari depuis iOS 13) : pas de détection fiable, accepté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)