### PR TITLE
fix(serein): hardening défensif upsert_preference (whitelist)

### DIFF
--- a/packages/api/app/routers/users.py
+++ b/packages/api/app/routers/users.py
@@ -11,7 +11,7 @@ import httpx
 import sentry_sdk
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response, status
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from sqlalchemy import func, text, update
 from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -38,7 +38,7 @@ from app.schemas.user import (
 from app.services.digest_service import schedule_initial_digest_generation
 from app.services.feed_cache import FEED_CACHE
 from app.services.streak_service import StreakService
-from app.services.user_service import UserService
+from app.services.user_service import ALLOWED_PREFERENCE_KEYS, UserService
 
 router = APIRouter()
 
@@ -271,6 +271,13 @@ class PreferenceUpdateRequest(BaseModel):
 
     key: str
     value: str
+
+    @field_validator("key")
+    @classmethod
+    def _validate_key(cls, v: str) -> str:
+        if v not in ALLOWED_PREFERENCE_KEYS:
+            raise ValueError(f"preference_key '{v}' is not allowed")
+        return v
 
 
 class PreferenceUpdateResponse(BaseModel):

--- a/packages/api/app/services/user_service.py
+++ b/packages/api/app/services/user_service.py
@@ -24,6 +24,24 @@ from app.services.ml.classification_service import SLUG_TO_LABEL
 logger = structlog.get_logger(__name__)
 
 
+ALLOWED_PREFERENCE_KEYS: frozenset[str] = frozenset(
+    {
+        "serein_enabled",
+        "serein_personalized",
+        "sensitive_themes",
+        "digest_format",
+        "objective",
+        "approach",
+        "perspective",
+        "response_style",
+        "content_recency",
+        "format_preference",
+        "personal_goal",
+        "acquisition_source",
+    }
+)
+
+
 class UserService:
     """Service pour la gestion des utilisateurs."""
 
@@ -371,6 +389,13 @@ class UserService:
 
     async def upsert_preference(self, user_id: str, key: str, value: str) -> None:
         """Upsert une préférence clé-valeur pour l'utilisateur."""
+        if key not in ALLOWED_PREFERENCE_KEYS:
+            logger.warning(
+                "upsert_preference_rejected_unknown_key",
+                user_id=user_id,
+                key=key,
+            )
+            raise ValueError(f"preference_key '{key}' is not allowed")
         uid = UUID(user_id)
         result = await self.db.execute(
             select(UserPreference).where(

--- a/packages/api/tests/routers/test_users_preferences.py
+++ b/packages/api/tests/routers/test_users_preferences.py
@@ -1,0 +1,117 @@
+"""Tests for PUT /api/users/preferences and the upsert_preference allowlist.
+
+Defensive hardening post-PR #604 (Mode Serein auto-activation): verrouille
+`upsert_preference` derrière une whitelist documentée pour bloquer toute
+écriture future de clé inattendue dans `user_preferences`.
+"""
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.user import UserPreference, UserProfile
+from app.services.user_service import UserService
+
+
+@pytest_asyncio.fixture
+async def auth_user(db_session):
+    """Create a UserProfile and override the auth + db dependencies."""
+    user_id = uuid4()
+    profile = UserProfile(
+        user_id=user_id,
+        onboarding_completed=True,
+    )
+    db_session.add(profile)
+    await db_session.commit()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        yield user_id
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_upsert_preference_allows_known_key(db_session):
+    """Une clé de l'allowlist est persistée normalement."""
+    user_id = uuid4()
+    profile = UserProfile(user_id=user_id, onboarding_completed=True)
+    db_session.add(profile)
+    await db_session.commit()
+
+    service = UserService(db_session)
+    await service.upsert_preference(str(user_id), "serein_enabled", "true")
+
+    row = (
+        await db_session.execute(
+            select(UserPreference).where(
+                UserPreference.user_id == user_id,
+                UserPreference.preference_key == "serein_enabled",
+            )
+        )
+    ).scalar_one()
+    assert row.preference_value == "true"
+
+
+@pytest.mark.asyncio
+async def test_upsert_preference_rejects_unknown_key(db_session):
+    """Une clé hors allowlist lève ValueError sans écrire en base."""
+    user_id = uuid4()
+    profile = UserProfile(user_id=user_id, onboarding_completed=True)
+    db_session.add(profile)
+    await db_session.commit()
+
+    service = UserService(db_session)
+    with pytest.raises(ValueError, match="not allowed"):
+        await service.upsert_preference(str(user_id), "wat", "x")
+
+    rows = (
+        (
+            await db_session.execute(
+                select(UserPreference).where(UserPreference.user_id == user_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_put_preferences_accepts_known_key_http(auth_user):
+    """PUT /users/preferences avec une clé valide → 200."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.put(
+            "/api/users/preferences",
+            json={"key": "serein_enabled", "value": "true"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"success": True, "key": "serein_enabled", "value": "true"}
+
+
+@pytest.mark.asyncio
+async def test_put_preferences_rejects_unknown_key_http(auth_user):
+    """PUT /users/preferences avec une clé inconnue → 422 (Pydantic)."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.put(
+            "/api/users/preferences",
+            json={"key": "wat", "value": "x"},
+        )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Hardening défensif post-PR #604 (Mode Serein auto-activation) : verrouille
`upsert_preference` + `PUT /users/preferences` derrière une whitelist
documentée des clés `user_preferences` réellement utilisées.

L'investigation n'a pas trouvé de nouveau chemin auto-toggle après PR #604
— `upsert_preference` était l'unique surface non-validée restante côté
backend, donc on la verrouille pour fail-fast en 422 (au lieu de silencieusement
écrire n'importe quelle clé envoyée par un client buggé).

## Changes

- `app/services/user_service.py` : constante `ALLOWED_PREFERENCE_KEYS` +
  `upsert_preference` rejette les clés hors liste (`ValueError` + log warning
  structuré).
- `app/routers/users.py` : `field_validator` Pydantic sur
  `PreferenceUpdateRequest.key` → 422 propre côté HTTP avant d'atteindre le
  service (défense en profondeur).
- `tests/routers/test_users_preferences.py` : 4 tests régression (clé
  acceptée au niveau service, clé refusée au niveau service, HTTP 200
  happy path, HTTP 422 clé inconnue).

## Test plan

- [x] `pytest -v tests/routers/test_users_preferences.py` — 4/4 passent
- [x] `pytest -x -q` (suite complète) — 1103 passed, 13 skipped
- [x] `ruff check` + `ruff format --check` sur les fichiers modifiés — clean
- [x] `alembic heads` — 1 head exactement, pas de migration ajoutée
- [ ] Smoke `PUT /users/preferences` `{key:"serein_enabled"}` → 200 (test HTTP couvre)
- [ ] Smoke `PUT /users/preferences` `{key:"wat"}` → 422 (test HTTP couvre)