### PR TITLE
fix(digest): décaler le cron 06:00 → 07:30 Paris pour inclure les Unes du matin

### DIFF
--- a/docs/bugs/bug-digest-evening-content.md
+++ b/docs/bugs/bug-digest-evening-content.md
@@ -1,0 +1,106 @@
+# Bug — Digest rempli d'articles d'hier soir (~22h)
+
+> Statut : fix prêt — décalage du cron 06:00 → 07:30 Paris.
+
+## Observation utilisateur
+
+Le digest "Essentiel" du matin contient des articles datés de la veille au soir (~22h), pas les Unes du matin attendues. Reporté plusieurs fois sur des digests générés à 06:01 Paris, avec des articles publiés entre 22h la veille et 04h ce matin.
+
+## Cause racine (confirmée par les données prod)
+
+Le digest est bien **généré à 06:01 Paris** (le cron fonctionne, la timezone est correcte). Le problème n'est pas le moment de génération — c'est le **contenu sélectionné**.
+
+À 06:00 Paris, le pool d'articles candidats (`packages/api/app/jobs/digest_generation_job.py:329`) est :
+```python
+cutoff = datetime.now(UTC) - timedelta(hours=48)
+stmt.where(Content.published_at >= cutoff).order_by(Content.published_at.desc()).limit(200)
+```
+Les 200 contenus les plus récents à 06:00 Paris sont mécaniquement ceux publiés entre **~22h la veille et 04h ce matin** (édition du soir + dépêches nocturnes). **Les Unes du matin** (Le Monde ~06h30, Le Figaro ~07h, Libération ~07h) **ne sont pas encore publiées** quand le cron démarre.
+
+### Preuve : digest Essentiel du 13/05 (généré à 06:01:33 Paris)
+
+Sujet rank 1 — « Mort en garde à vue à Agde » :
+- Le Figaro : publié 12/05 22:28 Paris
+- lanouvellerepublique.fr : publié 12/05 23:08 Paris
+- Le Monde : publié 13/05 01:05 Paris
+
+### Distribution `published_at` par heure Paris (7 derniers jours)
+
+```
+h_paris | articles
+--------+---------
+   0    | 122
+   1    | 106
+   2    | 101
+   3    |  64
+   4    |  83
+   5    | 215   ← rampe AFP / wires nocturnes
+   6    | 509   ← saut net : Unes du matin commencent à tomber
+   7    | 490
+   8    | 438
+   9    | 408
+  ...   |
+```
+
+Le saut 215 → 509 entre 5h et 6h Paris est la fenêtre de publication des Unes du matin. À 07:30 Paris, le pool candidat couvre intégralement cette fenêtre.
+
+## Pourquoi les patchs précédents ont raté
+
+Les agents précédents ont cherché :
+- Des bugs de timezone (correct : UTC vs Paris)
+- Des bugs de cron APScheduler
+- Des bugs de notif Android
+- Des bugs de throughput batch
+
+Personne n'a regardé **le `published_at` des articles dans le digest** — la vraie observation utilisateur. Le timestamp `generated_at` du digest est correct ; les *articles* dedans ne le sont pas.
+
+Le commentaire du code disait explicitement la cause (`scheduler.py:186` avant fix) :
+> *« 6h00 Paris — avancé de 8h pour pré-générer avant le réveil »*
+
+L'intention (digest prêt quand l'utilisateur se réveille) était bonne, l'effet est inverse : on génère **avant** que les rédactions n'aient publié leurs Unes du matin.
+
+## Correction
+
+Décalage du cron 06:00 → **07:30 Paris** :
+
+| Fichier | Avant | Après |
+|---------|-------|-------|
+| `app/workers/scheduler.py` — `DIGEST_CRON_HOUR_PARIS` | `6` | `7` |
+| `app/workers/scheduler.py` — `DIGEST_CRON_MINUTE_PARIS` | (absent, implicite `0`) | `30` |
+| `app/workers/scheduler.py` — trigger `daily_digest` | 06:00 | 07:30 |
+| `app/workers/scheduler.py` — trigger `digest_watchdog` | 07:30 | 08:15 (après le cron principal) |
+| `app/main.py` — garde catchup | `if now.hour < CRON_HOUR` | `if now_minutes < cron_minutes or now.hour >= 10` |
+| `tests/workers/test_scheduler.py` | assertions hour=6, watchdog 7:30 | hour=7 minute=30, watchdog 8:15 |
+| `docs/data-architecture/data-pipeline.md` | 08:00 (déjà périmé) | 07:30 |
+
+### Garde catchup : pourquoi `hour >= 10` ?
+
+Avant : `if now.hour < DIGEST_CRON_HOUR_PARIS: return` — un redéploiement Railway l'après-midi laissait passer le catchup, qui pouvait régénérer un digest avec du contenu d'après-midi. Après : fenêtre stricte `[07:30, 10:00[`. Si la fenêtre est ratée, on attend le lendemain — mieux qu'un digest pourri à 16h.
+
+## Ce qui n'est PAS le bug (pistes mortes)
+
+- Timezone APScheduler → OK
+- `now_paris()` / `today_paris()` → OK (`zoneinfo`, vérifié)
+- Throughput batch / variantes is_serene=false générées tard → existe mais c'est **secondaire** (impact 1-2 users par jour) ; à observer après le patch principal pour décider s'il faut l'attaquer aussi
+- Notifs Android locales → 100% device-side, sans impact sur le contenu serveur
+
+## Monitoring post-merge
+
+Sur 3-5 jours, refaire la requête « `published_at` des articles dans le digest du jour » pour confirmer que les Unes du matin remontent :
+
+```sql
+SELECT
+  dd.target_date,
+  dd.generated_at AT TIME ZONE 'Europe/Paris' AS gen_paris,
+  c.published_at AT TIME ZONE 'Europe/Paris' AS pub_paris,
+  c.source_id, c.title
+FROM daily_digest dd
+CROSS JOIN LATERAL jsonb_array_elements(dd.articles) AS art
+JOIN contents c ON c.id = (art->>'content_id')::uuid
+WHERE dd.target_date = current_date
+  AND dd.is_serene = false
+ORDER BY dd.user_id, pub_paris DESC
+LIMIT 50;
+```
+
+Critère de succès : la majorité des articles ont `pub_paris` du jour entre 05h et 07h30, pas la veille au soir.

--- a/docs/data-architecture/data-pipeline.md
+++ b/docs/data-architecture/data-pipeline.md
@@ -6,7 +6,7 @@
 
 > **Important** : il y a deux surfaces utilisateur distinctes avec deux architectures différentes.
 > - **Feed** (`GET /api/feed`) — computation **temps réel** à chaque requête. C'est la surface principale aujourd'hui.
-> - **Digest** (`GET /api/digest`) — généré une fois par jour à 08:00 par un job batch. En cours de refonte.
+> - **Digest** (`GET /api/digest`) — généré une fois par jour à 07:30 Paris par un job batch. En cours de refonte.
 
 ```mermaid
 flowchart TB
@@ -30,7 +30,7 @@ flowchart TB
         TR -->|html_content +<br>content_quality| DB_C
     end
 
-    subgraph DIGEST["④ Digest Generation (08:00 Paris)"]
+    subgraph DIGEST["④ Digest Generation (07:30 Paris)"]
         DB_C --> CAND[Candidate Selection<br>7 derniers jours]
         CAND -->|filter: followed sources,<br>interests, exclude seen/hidden| CLUSTER[Topic Clustering<br>Jaccard ≥ 0.45]
         CLUSTER --> SCORE[Scoring v2<br>4 piliers pondérés]
@@ -160,7 +160,7 @@ Chaque article reçoit :
 ## ④ Digest Generation
 
 **Job** : `jobs/digest_generation_job.py` → `DigestService`
-**Schedule** : `CronTrigger(hour=8, minute=0, timezone=Europe/Paris)`
+**Schedule** : `CronTrigger(hour=7, minute=30, timezone=Europe/Paris)` — Unes du matin déjà publiées (cf. `bug-digest-evening-content.md`). Watchdog à 08:15 Paris.
 
 ```mermaid
 flowchart TB
@@ -273,7 +273,7 @@ RSS Feeds ──[30min]──> contents ──[continu]──> classification (t
                            │
                            ├──[temps réel]──> FEED ──> user interactions ──┐
                            │                                                │
-                           └──[08:00]──> DIGEST ──> user interactions ──┐  │
+                           └──[07:30]──> DIGEST ──> user interactions ──┐  │
                                                                          ↓  ↓
                                                               user_content_status
                                                                          │

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -284,21 +284,33 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
                     from app.models.daily_digest import DailyDigest
                     from app.models.user import UserProfile
                     from app.utils.time import now_paris
-                    from app.workers.scheduler import DIGEST_CRON_HOUR_PARIS
+                    from app.workers.scheduler import (
+                        DIGEST_CRON_HOUR_PARIS,
+                        DIGEST_CRON_MINUTE_PARIS,
+                    )
 
                     await asyncio.sleep(60)
 
-                    # Avant l'heure du cron, on laisse le scheduler générer à
-                    # 06:00 Paris : un deploy Railway entre 00:00 et 06:00
-                    # déclencherait sinon une génération à minuit avec un RSS
-                    # pas encore rafraîchi → digest pauvre.
+                    # Fenêtre stricte [cron_time, 10:00 Paris[ :
+                    # - Avant l'heure du cron : un deploy Railway de nuit
+                    #   déclencherait sinon une génération avec les Unes du
+                    #   matin pas encore publiées (bug-digest-evening-content).
+                    # - Après 10:00 : un redéploiement diurne ne doit PAS
+                    #   régénérer un digest avec du contenu d'après-midi.
+                    #   Si la fenêtre 07:30-10:00 est ratée, c'est cuit pour
+                    #   la journée — mieux qu'un digest pourri à 16h.
                     now = now_paris()
-                    if now.hour < DIGEST_CRON_HOUR_PARIS:
+                    cron_minutes = (
+                        DIGEST_CRON_HOUR_PARIS * 60 + DIGEST_CRON_MINUTE_PARIS
+                    )
+                    now_minutes = now.hour * 60 + now.minute
+                    if now_minutes < cron_minutes or now.hour >= 10:
                         logger.info(
-                            "digest_startup_catchup_too_early",
+                            "digest_startup_catchup_outside_window",
                             now_paris=str(now),
                             target_date=str(now.date()),
                             cron_hour=DIGEST_CRON_HOUR_PARIS,
+                            cron_minute=DIGEST_CRON_MINUTE_PARIS,
                         )
                         return
 

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -22,17 +22,28 @@ settings = get_settings()
 
 _PARIS_TZ = pytz.timezone("Europe/Paris")
 
-# Hour (Paris) at which the daily digest cron fires. Imported by the
+# Hour/minute (Paris) at which the daily digest cron fires. Imported by the
 # startup catchup in app/main.py so it never generates earlier than the
 # scheduled cron — avoids midnight regenerations on late-evening Railway
 # deploys (RSS not yet refreshed → poor digest content).
-DIGEST_CRON_HOUR_PARIS = 6
+#
+# Pourquoi 07:30 et pas 06:00 (bug-digest-evening-content) : à 06:00 Paris
+# les Unes du matin (Le Monde ~06h30, Le Figaro ~07h, Libération ~07h) ne
+# sont pas encore publiées. Le pool des 200 contents les plus récents
+# (hours_lookback=48 → ORDER BY published_at DESC LIMIT 200) est alors
+# saturé par l'édition de la veille au soir et les dépêches nocturnes,
+# donc le digest "Essentiel" servait des articles datés ~22h. La courbe
+# des `published_at` montre un saut de 215 → 509 articles/heure entre
+# 5h et 6h Paris : firer le cron à 07:30 garantit que les Unes du matin
+# sont déjà dans le pool candidat.
+DIGEST_CRON_HOUR_PARIS = 7
+DIGEST_CRON_MINUTE_PARIS = 30
 
 scheduler: AsyncIOScheduler | None = None
 
 
 async def _digest_watchdog() -> None:
-    """Watchdog 7h30 : vérifie la couverture digest et relance si nécessaire.
+    """Watchdog 8h15 : vérifie la couverture digest et relance si nécessaire.
 
     Counts `(user_id, is_serene)` pairs so a user is only considered
     "covered" when BOTH the normal and serein variants exist. Previously
@@ -183,12 +194,17 @@ def start_scheduler() -> None:
         replace_existing=True,
     )
 
-    # Job Digest Quotidien (6h00 Paris — avancé de 8h pour pré-générer avant le réveil)
+    # Job Digest Quotidien (07h30 Paris — voir DIGEST_CRON_HOUR_PARIS pour le
+    # rationale : à 06h les Unes du matin ne sont pas encore publiées).
     # misfire_grace_time=14400 (4h): couvre les redémarrages Railway longs.
     # coalesce=True: pas de double exécution si plusieurs triggers rattrapés.
     scheduler.add_job(
         run_digest_generation,
-        trigger=CronTrigger(hour=DIGEST_CRON_HOUR_PARIS, minute=0, timezone=_PARIS_TZ),
+        trigger=CronTrigger(
+            hour=DIGEST_CRON_HOUR_PARIS,
+            minute=DIGEST_CRON_MINUTE_PARIS,
+            timezone=_PARIS_TZ,
+        ),
         id="daily_digest",
         name="Daily Digest Generation",
         replace_existing=True,
@@ -196,10 +212,12 @@ def start_scheduler() -> None:
         coalesce=True,
     )
 
-    # Watchdog 7h30 — vérifie la couverture et relance si < 90%
+    # Watchdog 08h15 — vérifie la couverture et relance si < 90%.
+    # Doit tourner *après* le cron principal (07h30) pour avoir une chance
+    # de constater la couverture réelle avant de relancer.
     scheduler.add_job(
         _digest_watchdog,
-        trigger=CronTrigger(hour=7, minute=30, timezone=_PARIS_TZ),
+        trigger=CronTrigger(hour=8, minute=15, timezone=_PARIS_TZ),
         id="digest_watchdog",
         name="Digest Generation Watchdog",
         replace_existing=True,
@@ -280,8 +298,8 @@ def start_scheduler() -> None:
             "veille_stuck_cleanup",
         ],
         rss_interval_minutes=settings.rss_sync_interval_minutes,
-        digest_cron="06:00 Europe/Paris",
-        watchdog_cron="07:30 Europe/Paris",
+        digest_cron="07:30 Europe/Paris",
+        watchdog_cron="08:15 Europe/Paris",
         top3_cron="08:00 Europe/Paris",
         cleanup_cron="03:00 Europe/Paris",
     )

--- a/packages/api/tests/workers/test_scheduler.py
+++ b/packages/api/tests/workers/test_scheduler.py
@@ -5,15 +5,13 @@ to trigger at the expected times with correct timezones.
 
 Tests:
 - Scheduler job configuration
-- Daily digest job at 6am Europe/Paris
+- Daily digest job at 07:30 Europe/Paris
 - Job trigger parameters
 """
 
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-import pytz
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
 from app.workers.scheduler import _digest_watchdog, start_scheduler, stop_scheduler
@@ -21,68 +19,84 @@ from app.workers.scheduler import _digest_watchdog, start_scheduler, stop_schedu
 
 class TestScheduler:
     """Tests for the background job scheduler configuration."""
-    
+
     def test_scheduler_has_daily_digest_job(self):
-        """TEST-01: Verify daily digest job is scheduled at 6am Paris time."""
-        with patch('app.workers.scheduler.AsyncIOScheduler') as mock_scheduler_class:
+        """TEST-01: Verify daily digest job is scheduled at 07:30 Paris time."""
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
             # Create a mock scheduler instance
             mock_scheduler = Mock()
             mock_scheduler_class.return_value = mock_scheduler
-            
+
             # Track the add_job calls
             add_job_calls = []
+
             def capture_add_job(*args, **kwargs):
-                add_job_calls.append({
-                    'func': args[0] if args else kwargs.get('func'),
-                    'trigger': kwargs.get('trigger'),
-                    'id': kwargs.get('id'),
-                    'name': kwargs.get('name'),
-                    'replace_existing': kwargs.get('replace_existing')
-                })
-            
+                add_job_calls.append(
+                    {
+                        "func": args[0] if args else kwargs.get("func"),
+                        "trigger": kwargs.get("trigger"),
+                        "id": kwargs.get("id"),
+                        "name": kwargs.get("name"),
+                        "replace_existing": kwargs.get("replace_existing"),
+                    }
+                )
+
             mock_scheduler.add_job = capture_add_job
-            
+
             # Start the scheduler
             start_scheduler()
-            
+
             # Verify the scheduler was started
             mock_scheduler.start.assert_called_once()
-            
+
             # Find the daily_digest job
-            digest_jobs = [call for call in add_job_calls if call.get('id') == 'daily_digest']
-            assert len(digest_jobs) == 1, f"Expected 1 daily_digest job, found {len(digest_jobs)}"
-            
+            digest_jobs = [
+                call for call in add_job_calls if call.get("id") == "daily_digest"
+            ]
+            assert len(digest_jobs) == 1, (
+                f"Expected 1 daily_digest job, found {len(digest_jobs)}"
+            )
+
             job = digest_jobs[0]
-            
+
             # Verify the trigger is a CronTrigger
-            assert isinstance(job['trigger'], CronTrigger), f"Expected CronTrigger, got {type(job['trigger'])}"
-            
+            assert isinstance(job["trigger"], CronTrigger), (
+                f"Expected CronTrigger, got {type(job['trigger'])}"
+            )
+
             # Verify the job uses run_digest_generation function
-            assert job['func'].__name__ == 'run_digest_generation', \
+            assert job["func"].__name__ == "run_digest_generation", (
                 f"Expected run_digest_generation, got {job['func'].__name__}"
-            
+            )
+
             # Verify timezone is Europe/Paris
-            trigger_tz = str(job['trigger'].timezone)
-            assert 'Europe/Paris' in trigger_tz or 'CET' in trigger_tz or 'CEST' in trigger_tz, \
-                f"Expected Europe/Paris timezone, got {trigger_tz}"
-            
+            trigger_tz = str(job["trigger"].timezone)
+            assert (
+                "Europe/Paris" in trigger_tz
+                or "CET" in trigger_tz
+                or "CEST" in trigger_tz
+            ), f"Expected Europe/Paris timezone, got {trigger_tz}"
+
             # Verify job name
-            assert job['name'] == 'Daily Digest Generation', \
+            assert job["name"] == "Daily Digest Generation", (
                 f"Expected 'Daily Digest Generation', got {job['name']}"
-            
+            )
+
             # Verify replace_existing is True
-            assert job['replace_existing'] is True, \
+            assert job["replace_existing"] is True, (
                 f"Expected replace_existing=True, got {job['replace_existing']}"
-    
+            )
+
     def test_daily_digest_job_trigger_params(self):
-        """TEST-01: Verify digest job triggers at exactly 6:00 daily."""
-        with patch('app.workers.scheduler.AsyncIOScheduler') as mock_scheduler_class:
+        """TEST-01: Verify digest job triggers at exactly 07:30 daily."""
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
             mock_scheduler = Mock()
             mock_scheduler_class.return_value = mock_scheduler
 
             captured_jobs = {}
+
             def capture_add_job(*args, **kwargs):
-                job_id = kwargs.get('id')
+                job_id = kwargs.get("id")
                 if job_id:
                     captured_jobs[job_id] = kwargs
 
@@ -91,135 +105,149 @@ class TestScheduler:
             start_scheduler()
 
             # Find the daily_digest job
-            assert 'daily_digest' in captured_jobs, \
+            assert "daily_digest" in captured_jobs, (
                 f"daily_digest job not found. Jobs: {list(captured_jobs.keys())}"
+            )
 
-            digest_job = captured_jobs['daily_digest']
-            trigger = digest_job['trigger']
+            digest_job = captured_jobs["daily_digest"]
+            trigger = digest_job["trigger"]
 
             # Verify it's a CronTrigger
-            assert isinstance(trigger, CronTrigger), \
+            assert isinstance(trigger, CronTrigger), (
                 f"Expected CronTrigger, got {type(trigger)}"
+            )
 
             # CronTrigger fields: [year, month, day, week, day_of_week, hour, minute, second]
-            # Verify hour=6, minute=0
-            assert str(trigger.fields[5]) == '6', \
-                f"Expected hour=6, got {trigger.fields[5]}"
-            assert str(trigger.fields[6]) == '0', \
-                f"Expected minute=0, got {trigger.fields[6]}"
-    
+            # Verify hour=7, minute=30 — see DIGEST_CRON_HOUR_PARIS comment
+            # for rationale (bug-digest-evening-content: Unes du matin pas
+            # encore publiées avant ~07:00 Paris).
+            assert str(trigger.fields[5]) == "7", (
+                f"Expected hour=7, got {trigger.fields[5]}"
+            )
+            assert str(trigger.fields[6]) == "30", (
+                f"Expected minute=30, got {trigger.fields[6]}"
+            )
+
     def test_scheduler_includes_rss_sync_job(self):
         """Verify RSS sync job is scheduled."""
-        with patch('app.workers.scheduler.AsyncIOScheduler') as mock_scheduler_class:
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
             mock_scheduler = Mock()
             mock_scheduler_class.return_value = mock_scheduler
-            
+
             job_ids = []
+
             def capture_add_job(*args, **kwargs):
-                job_ids.append(kwargs.get('id'))
-            
+                job_ids.append(kwargs.get("id"))
+
             mock_scheduler.add_job = capture_add_job
-            
+
             start_scheduler()
-            
+
             # Verify rss_sync job exists
-            assert 'rss_sync' in job_ids, f"rss_sync job not found. Jobs: {job_ids}"
-    
+            assert "rss_sync" in job_ids, f"rss_sync job not found. Jobs: {job_ids}"
+
     def test_scheduler_includes_daily_top3_job(self):
         """Verify Top 3 briefing job is scheduled."""
-        with patch('app.workers.scheduler.AsyncIOScheduler') as mock_scheduler_class:
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
             mock_scheduler = Mock()
             mock_scheduler_class.return_value = mock_scheduler
-            
+
             job_ids = []
+
             def capture_add_job(*args, **kwargs):
-                job_ids.append(kwargs.get('id'))
-            
+                job_ids.append(kwargs.get("id"))
+
             mock_scheduler.add_job = capture_add_job
-            
+
             start_scheduler()
-            
+
             # Verify daily_top3 job exists
-            assert 'daily_top3' in job_ids, f"daily_top3 job not found. Jobs: {job_ids}"
-    
+            assert "daily_top3" in job_ids, f"daily_top3 job not found. Jobs: {job_ids}"
+
     def test_stop_scheduler_shuts_down(self):
         """Verify stop_scheduler properly shuts down the scheduler."""
-        with patch('app.workers.scheduler.AsyncIOScheduler') as mock_scheduler_class:
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
             mock_scheduler = Mock()
             mock_scheduler_class.return_value = mock_scheduler
-            
+
             # Start and then stop
             start_scheduler()
             stop_scheduler()
-            
+
             # Verify shutdown was called
             mock_scheduler.shutdown.assert_called_once()
 
 
 class TestDigestJobConfiguration:
     """Tests specifically for the digest generation job configuration."""
-    
+
     def test_digest_job_timezone_europe_paris(self):
         """TEST-01: Verify digest job uses Europe/Paris timezone."""
-        with patch('app.workers.scheduler.AsyncIOScheduler') as mock_scheduler_class:
-            mock_scheduler = Mock()
-            mock_scheduler_class.return_value = mock_scheduler
-            
-            captured_triggers = {}
-            def capture_add_job(*args, **kwargs):
-                job_id = kwargs.get('id')
-                if job_id:
-                    captured_triggers[job_id] = kwargs.get('trigger')
-            
-            mock_scheduler.add_job = capture_add_job
-            
-            start_scheduler()
-            
-            # Check the daily_digest trigger timezone
-            digest_trigger = captured_triggers.get('daily_digest')
-            assert digest_trigger is not None, "daily_digest trigger not found"
-            
-            # Verify timezone (compare by IANA name — apscheduler may return
-            # either a pytz tz or a zoneinfo.ZoneInfo depending on version).
-            assert str(digest_trigger.timezone) == 'Europe/Paris', \
-                f"Expected Europe/Paris timezone, got {digest_trigger.timezone}"
-    
-    def test_digest_job_cron_expression(self):
-        """TEST-01: Verify digest job cron expression is 0 6 * * * (6am daily)."""
-        with patch('app.workers.scheduler.AsyncIOScheduler') as mock_scheduler_class:
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
             mock_scheduler = Mock()
             mock_scheduler_class.return_value = mock_scheduler
 
             captured_triggers = {}
+
             def capture_add_job(*args, **kwargs):
-                job_id = kwargs.get('id')
+                job_id = kwargs.get("id")
                 if job_id:
-                    captured_triggers[job_id] = kwargs.get('trigger')
+                    captured_triggers[job_id] = kwargs.get("trigger")
+
+            mock_scheduler.add_job = capture_add_job
+
+            start_scheduler()
+
+            # Check the daily_digest trigger timezone
+            digest_trigger = captured_triggers.get("daily_digest")
+            assert digest_trigger is not None, "daily_digest trigger not found"
+
+            # Verify timezone (compare by IANA name — apscheduler may return
+            # either a pytz tz or a zoneinfo.ZoneInfo depending on version).
+            assert str(digest_trigger.timezone) == "Europe/Paris", (
+                f"Expected Europe/Paris timezone, got {digest_trigger.timezone}"
+            )
+
+    def test_digest_job_cron_expression(self):
+        """TEST-01: Verify digest job cron expression is 30 7 * * * (07:30 daily)."""
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
+            mock_scheduler = Mock()
+            mock_scheduler_class.return_value = mock_scheduler
+
+            captured_triggers = {}
+
+            def capture_add_job(*args, **kwargs):
+                job_id = kwargs.get("id")
+                if job_id:
+                    captured_triggers[job_id] = kwargs.get("trigger")
 
             mock_scheduler.add_job = capture_add_job
 
             start_scheduler()
 
             # Check the daily_digest trigger
-            digest_trigger = captured_triggers.get('daily_digest')
+            digest_trigger = captured_triggers.get("daily_digest")
             assert digest_trigger is not None, "daily_digest trigger not found"
 
             # CronTrigger fields: [year, month, day, week, day_of_week, hour, minute, second]
-            # Verify hour=6 (index 5), minute=0 (index 6)
-            assert str(digest_trigger.fields[5]) == '6', \
-                f"Expected hour=6, got {digest_trigger.fields[5]}"
-            assert str(digest_trigger.fields[6]) == '0', \
-                f"Expected minute=0, got {digest_trigger.fields[6]}"
+            # Verify hour=7 (index 5), minute=30 (index 6)
+            assert str(digest_trigger.fields[5]) == "7", (
+                f"Expected hour=7, got {digest_trigger.fields[5]}"
+            )
+            assert str(digest_trigger.fields[6]) == "30", (
+                f"Expected minute=30, got {digest_trigger.fields[6]}"
+            )
 
     def test_scheduler_includes_watchdog_job(self):
-        """Verify digest watchdog job is scheduled at 7:30am."""
-        with patch('app.workers.scheduler.AsyncIOScheduler') as mock_scheduler_class:
+        """Verify digest watchdog job is scheduled at 08:15 Paris."""
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
             mock_scheduler = Mock()
             mock_scheduler_class.return_value = mock_scheduler
 
             captured_jobs = {}
+
             def capture_add_job(*args, **kwargs):
-                job_id = kwargs.get('id')
+                job_id = kwargs.get("id")
                 if job_id:
                     captured_jobs[job_id] = kwargs
 
@@ -227,35 +255,41 @@ class TestDigestJobConfiguration:
 
             start_scheduler()
 
-            assert 'digest_watchdog' in captured_jobs, \
+            assert "digest_watchdog" in captured_jobs, (
                 f"digest_watchdog job not found. Jobs: {list(captured_jobs.keys())}"
+            )
 
-            trigger = captured_jobs['digest_watchdog']['trigger']
+            trigger = captured_jobs["digest_watchdog"]["trigger"]
             assert isinstance(trigger, CronTrigger)
-            assert str(trigger.fields[5]) == '7', \
-                f"Expected hour=7, got {trigger.fields[5]}"
-            assert str(trigger.fields[6]) == '30', \
-                f"Expected minute=30, got {trigger.fields[6]}"
+            # Watchdog doit tourner APRÈS le cron principal (07:30) — 08:15
+            assert str(trigger.fields[5]) == "8", (
+                f"Expected hour=8, got {trigger.fields[5]}"
+            )
+            assert str(trigger.fields[6]) == "15", (
+                f"Expected minute=15, got {trigger.fields[6]}"
+            )
 
     def test_scheduled_restart_job_is_not_registered(self):
         """Regression guard: `scheduled_restart` was a temporary SIGTERM-based
         mitigation for a SQLAlchemy pool leak. Railway's `restartPolicyType:
         ALWAYS` now handles process recycling. The job must NOT be re-added.
         """
-        with patch('app.workers.scheduler.AsyncIOScheduler') as mock_scheduler_class:
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
             mock_scheduler = Mock()
             mock_scheduler_class.return_value = mock_scheduler
 
             job_ids = []
+
             def capture_add_job(*args, **kwargs):
-                job_ids.append(kwargs.get('id'))
+                job_ids.append(kwargs.get("id"))
 
             mock_scheduler.add_job = capture_add_job
 
             start_scheduler()
 
-            assert 'scheduled_restart' not in job_ids, \
+            assert "scheduled_restart" not in job_ids, (
                 f"scheduled_restart job should not be registered. Jobs: {job_ids}"
+            )
 
 
 class TestDigestWatchdogCoverage:


### PR DESCRIPTION
## Quoi

Décale le cron de génération du digest quotidien de **06:00 → 07:30 Paris** et le watchdog de **07:30 → 08:15 Paris**. Resserre aussi la fenêtre du catchup startup à `[07:30, 10:00[`.

## Pourquoi

Les utilisateurs signalaient un digest \"Essentiel\" rempli d'articles datés de la veille au soir (~22h). Le timestamp `generated_at` du digest était correct ; les *articles* dedans ne l'étaient pas.

**Cause racine** : à 06:00 Paris, les Unes du matin ne sont pas encore publiées (Le Monde ~06h30, Le Figaro ~07h, Libération ~07h). Le pool candidat (`hours_lookback=48` → `ORDER BY published_at DESC LIMIT 200`) est mécaniquement saturé par l'édition de la veille au soir + les dépêches nocturnes.

**Preuve** — distribution `published_at` par heure Paris (7 derniers jours) :

```
h_paris=5 → 215 articles    ← AFP / wires nocturnes
h_paris=6 → 509 articles    ← saut net : Unes du matin tombent
h_paris=7 → 490 articles
```

Le saut 215 → 509 entre 5h et 6h est la fenêtre de publication des Unes. À 07:30, le pool couvre intégralement cette fenêtre.

Précédentes pistes mortes : timezone APScheduler, `now_paris()`, throughput batch, notifs Android. Personne n'avait regardé le `published_at` des articles *dans le digest* — la vraie observation utilisateur.

## Comment ça a été vérifié

- [x] `pytest tests/workers/test_scheduler.py -v` → 12/12 OK (assertions cron 07:30 + watchdog 08:15 mises à jour)
- [x] `ruff format --check` + `ruff check` propres sur tous les fichiers touchés
- [x] Validation SQL prod : la courbe `published_at by hour_paris` confirme le pivot à 06h
- [x] Pas de migration Alembic, pas de changement UI → pas de Playwright nécessaire

## Zones à risque

- **`scheduler.py`** : zone à risque (Auth/Router/DB/Infra n'est pas touché, mais le scheduler oui). Le `Dockerfile` rejoue `start_scheduler()` au boot — un déploiement plantera si la config cron est invalide. Tests scheduler verts.
- **`main.py` lifespan** : la garde du catchup est resserrée. Un déploiement Railway entre 00h et 07h30, ou après 10h, ne déclenchera plus de catchup spontané — c'est intentionnel (cf. bug doc).
- **Aucun impact côté users existants** : digests déjà générés (jours antérieurs) intacts.

## Monitoring post-merge

Sur 3-5 jours, refaire la requête `published_at` des articles dans le digest du jour (cf. `docs/bugs/bug-digest-evening-content.md` § Monitoring) pour confirmer que les Unes du matin remontent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)