### PR TITLE
feat(perspectives): diff highlighting backend (Story 7.4, Sprint 1)

### DIFF
--- a/docs/stories/core/7.4.diff-highlighting-backend.md
+++ b/docs/stories/core/7.4.diff-highlighting-backend.md
@@ -1,0 +1,158 @@
+# 7.4 — Diff highlighting backend (Sprint 1, phase déterministe)
+
+## Status
+En cours.
+
+## Context
+
+Le panel « Couverture médiatique » (Epic 7 — stories 7.2 backend, 7.3 frontend)
+affiche jusqu'à 8 perspectives alternatives sur l'article ouvert. Aujourd'hui,
+les titres divergents sont affichés *bruts* — l'utilisateur doit lire les 8
+titres pour repérer les différences de vocabulaire.
+
+Objectif Sprint 1 : surligner visuellement les **mots forts divergents** de
+chaque titre alternatif par rapport au titre de référence (l'article que
+l'utilisateur a tapé), avec une couleur sémantique = bord politique de la
+source. On reste 100 % **déterministe** (spaCy POS + lemmatisation, zéro LLM)
+— on vise 75-85 % de la valeur sans coût d'inférence Mistral. Une phase 2 LLM
+sera décidée plus tard sur audit qualité.
+
+Cette story livre uniquement le **backend**. Le frontend Flutter et l'UX
+d'apparition progressive sont scope Sprint 2.
+
+## Décisions actées
+
+| Sujet | Décision |
+|---|---|
+| Ref du diff | Article tapé par l'user = ref (déjà passé à `GET /contents/{id}/perspectives`) |
+| Stockage | 1 row par `(cluster_id, content_id)` dans nouvelle table `cluster_title_annotations` |
+| Trigger calcul | Lazy au premier tap du panel (pas à l'ingestion, pas au digest). Async dans le handler de l'endpoint si miss cache |
+| Endpoint | Enrichir `GET /contents/{id}/perspectives` (dict libre) avec `highlight_spans` par titre alternatif |
+| Cap output | `MAX_HIGHLIGHTED_PER_TITLE = 4` par titre, priorité : entity NER > adjectif > nom > verbe |
+| Skip safe | Si 0 spans après diff → pas de surlignage, mais titre affiché |
+| Sources unknown (AFP/Reuters) | Surlignage gris neutre (champ `bias = "unknown"`) |
+| Articles updates | Pas de recalcul — la première row écrite fait foi |
+| Versioning | `model_version = "v1-spacy-fr_md"` permet re-run cohorte sans toucher l'historique |
+| Application DB | **Alembic propre** (CLAUDE.md règle absolue) — joué par Dockerfile au boot Railway |
+| Champ JSON | `bias` (le mapping couleur se fait côté Dart via `getBiasColor`) |
+| Négation, périphrases, paraphrases vraies | Hors scope Sprint 1 — bugs acceptés, mesurés en audit |
+
+## Acceptance Criteria
+
+1. Nouvelle migration Alembic ajoutée sous `packages/api/alembic/versions/`,
+   `down_revision = ad01_add_is_ad_to_contents`. `alembic heads` retourne
+   exactement 1 head après merge.
+2. `alembic upgrade head` OK localement contre DB vide (`make db-reset`).
+3. Modèle `ClusterTitleAnnotation` exporté depuis `app/models/__init__.py`.
+4. `NERService.get_nlp()` existe (accesseur public sur le singleton spaCy).
+5. `TitleAnnotationService` calcule `strong_tokens` (POS ∈ {NOUN, PROPN,
+   ADJ, VERB}, hors stop-words, entités NER conservées) et cape à 4 spans
+   par titre avec priorité entity > ADJ > NOUN/PROPN > VERB.
+6. `get_or_compute_cluster_annotations` upsert les rows en `ON CONFLICT
+   (cluster_id, content_id) DO NOTHING` (race-safe).
+7. `GET /contents/{id}/perspectives` renvoie `highlight_spans:
+   list[{start, end, text, bias}]` sur **chaque** perspective dans les
+   2 paths (stored & live), même liste vide si titres ≈ identiques.
+8. Pas de double-chargement spaCy (vérifié par test).
+9. Si le modèle spaCy est absent → l'endpoint renvoie `highlight_spans:
+   []` partout (defensive, pas de 500).
+10. Pas de FK sur `cluster_id` (cohérent avec `Content.cluster_id` qui n'en
+    a pas non plus — clusters denormalisés).
+11. Tous les tests pytest passent (hook `stop-verify-tests.sh`).
+
+## Tasks / Subtasks
+
+- [ ] Ajouter `NERService.get_nlp()` accesseur public sur `_nlp` (peut être `None`).
+- [ ] Créer `app/models/cluster_title_annotation.py` (PK composite, JSONB, model_version).
+- [ ] Exporter `ClusterTitleAnnotation` dans `app/models/__init__.py`.
+- [ ] Créer migration Alembic `cta01_cluster_title_annotations.py`
+      (`down_revision = "ad01_add_is_ad_to_contents"`).
+- [ ] Créer `app/services/title_annotation_service.py`
+      (singleton + compute_strong_tokens + diff_spans + get_or_compute_cluster_annotations).
+- [ ] Helper privé `_attach_highlight_spans` dans `app/routers/contents.py`.
+- [ ] Appeler le helper dans les 2 paths (stored ~ligne 880, live ~ligne 1006).
+- [ ] Écrire `tests/services/test_title_annotation_service.py` (compute,
+      diff, cache, race, nlp absent).
+- [ ] Écrire `tests/routers/test_contents_perspectives_highlights.py`
+      (live path, stored path, cap, no-cluster, unknown bias).
+- [ ] `alembic upgrade head` local + `pytest -v` full.
+
+## Dev Notes
+
+### Réutilisation (zéro duplication)
+
+- `app/services/ml/ner_service.py` — singleton `get_ner_service()`.
+- `app/services/text_similarity.py` — `FRENCH_STOP_WORDS` frozenset (double
+  filtre en complément de `tok.is_stop` spaCy).
+- `app/models/content.py:80` — `Content.cluster_id: UUID | None` indexé.
+- `app/models/enums.py:43` — `BiasStance` StrEnum, valeurs string directement
+  utilisables (`"left"`, `"center-left"`, …, `"unknown"`).
+- `app/routers/contents.py:725` — endpoint cible (dict libre non-Pydantic ⇒
+  ajout `highlight_spans` non-breaking).
+
+### Schéma de la table
+
+```sql
+CREATE TABLE cluster_title_annotations (
+  cluster_id     UUID NOT NULL,
+  content_id     UUID NOT NULL REFERENCES contents(id) ON DELETE CASCADE,
+  strong_tokens  JSONB NOT NULL,
+  semantic_equiv JSONB,
+  model_version  VARCHAR(32) NOT NULL,
+  computed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (cluster_id, content_id)
+);
+CREATE INDEX ix_cta_cluster_id ON cluster_title_annotations(cluster_id);
+```
+
+Pas de FK sur `cluster_id` (cohérent avec `Content.cluster_id`).
+
+### Matching perspective dict → annotation cache
+
+Les `Perspective` dataclass (perspective_service.py:154) ne portent pas de
+`content_id` — seulement `url`, `title`, `source_name`. Pour relier une
+perspective au cache, on construit côté service un map `{content.url:
+content_id}` pour les rows du cluster. Match par URL exacte. Les
+perspectives Google News pures (hors cluster DB) → compute on-the-fly via
+`compute_strong_tokens(title)` (cache miss attendu, log `cache_miss`).
+
+### Monitoring
+
+- Log structlog `diff_highlighting.cache_miss` à chaque compute spaCy
+  (objectif : mesurer le taux pour décider plus tard si pré-calcul digest
+  nécessaire).
+- Try/except autour du compute : si exception → log `error` + retour
+  `highlight_spans: []` (panel reste fonctionnel). Pas de fallback silencieux
+  qui masque des bugs : log au niveau `error`, pas `warning`.
+
+## Testing
+
+### Tests unitaires — `tests/services/test_title_annotation_service.py`
+
+- `test_compute_strong_tokens_filters_stopwords_and_keeps_noun_adj_verb_propn`
+- `test_compute_strong_tokens_extracts_entities_from_ner`
+- `test_diff_spans_identical_titles_returns_empty`
+- `test_diff_spans_caps_at_4_with_priority_entity_first`
+- `test_diff_spans_passes_through_bias_string_unchanged`
+- `test_get_or_compute_inserts_on_first_call_and_reads_cache_second`
+- `test_get_or_compute_handles_concurrent_inserts`
+- `test_get_or_compute_returns_empty_for_missing_nlp` (CI sans spaCy)
+
+### Tests intégration — `tests/routers/test_contents_perspectives_highlights.py`
+
+- `test_perspectives_endpoint_includes_highlight_spans_for_each_alternative`
+- `test_perspectives_endpoint_no_highlight_when_titles_identical`
+- `test_perspectives_endpoint_caps_at_4_spans_per_title`
+- `test_perspectives_endpoint_unknown_bias_for_afp` (passthrough du string)
+- `test_perspectives_endpoint_content_without_cluster_returns_empty_spans`
+
+## Change Log
+
+| Date | Version | Auteur | Notes |
+|---|---|---|---|
+| 2026-05-17 | 0.1 | Claude (Opus 4.7) | Story créée, plan validé par Laurin |
+
+## Dev Agent Record
+
+- **Model utilisé** : claude-opus-4-7
+- **Plan source** : `/Users/laurinboujon/.claude/plans/system-instruction-you-are-working-atomic-babbage.md`

--- a/packages/api/alembic/versions/cta01_cluster_title_annotations.py
+++ b/packages/api/alembic/versions/cta01_cluster_title_annotations.py
@@ -1,0 +1,49 @@
+"""create cluster_title_annotations cache table
+
+Story 7.4 — diff highlighting backend (Sprint 1, phase déterministe).
+Lazy cache of spaCy strong_tokens per (cluster_id, content_id), populated on
+the first /perspectives panel open and read back by subsequent users opening
+the same cluster.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+
+from alembic import op
+
+revision: str = "cta01_cluster_title_annotations"
+down_revision: str | None = "ad01_add_is_ad_to_contents"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cluster_title_annotations",
+        sa.Column("cluster_id", PGUUID(as_uuid=True), nullable=False),
+        sa.Column("content_id", PGUUID(as_uuid=True), nullable=False),
+        sa.Column("strong_tokens", JSONB, nullable=False),
+        sa.Column("semantic_equiv", JSONB, nullable=True),
+        sa.Column("model_version", sa.String(length=32), nullable=False),
+        sa.Column(
+            "computed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["content_id"], ["contents.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("cluster_id", "content_id"),
+    )
+    op.create_index(
+        "ix_cta_cluster_id",
+        "cluster_title_annotations",
+        ["cluster_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_cta_cluster_id", table_name="cluster_title_annotations")
+    op.drop_table("cluster_title_annotations")

--- a/packages/api/app/models/__init__.py
+++ b/packages/api/app/models/__init__.py
@@ -2,6 +2,7 @@
 
 from app.models.analytics import AnalyticsEvent
 from app.models.classification_queue import ClassificationQueue
+from app.models.cluster_title_annotation import ClusterTitleAnnotation
 from app.models.collection import Collection, CollectionItem
 from app.models.content import Content, UserContentStatus
 from app.models.curation import CurationAnnotation
@@ -85,6 +86,8 @@ __all__ = [
     "SourceSearchLog",
     # Perspective Analysis Cache
     "PerspectiveAnalysis",
+    # Cluster title annotation cache
+    "ClusterTitleAnnotation",
     # Custom Topics (Epic 11)
     "UserTopicProfile",
     # Lettres du Facteur (Story 19.1)

--- a/packages/api/app/models/cluster_title_annotation.py
+++ b/packages/api/app/models/cluster_title_annotation.py
@@ -1,0 +1,51 @@
+"""Cluster title annotation cache (Story 7.4 — diff highlighting).
+
+One row per (cluster_id, content_id) holding the precomputed strong_tokens
+used by the perspective panel to highlight divergent words across titles
+covering the same story. Lazy populated on the first /perspectives tap.
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class ClusterTitleAnnotation(Base):
+    """Precomputed strong-token annotation for one article inside a cluster.
+
+    `strong_tokens` is the list of POS-filtered tokens kept from the title
+    (shape: `[{start, end, text, lemma, pos, entity_kind?}]`). The diff
+    between two titles is computed at request time from these tokens.
+
+    `semantic_equiv` stays NULL in Sprint 1 (phase déterministe). Phase 2
+    LLM raffinement (Mistral-small) will populate it without touching
+    existing rows — `model_version` lets us re-run a cohort behind a feature
+    flag without losing history.
+
+    No FK on `cluster_id` (denormalized — `Content.cluster_id` itself has
+    no FK because there is no `clusters` table).
+    """
+
+    __tablename__ = "cluster_title_annotations"
+    __table_args__ = (Index("ix_cta_cluster_id", "cluster_id"),)
+
+    cluster_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True
+    )
+    content_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("contents.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    strong_tokens: Mapped[list] = mapped_column(JSONB, nullable=False)
+    semantic_equiv: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    model_version: Mapped[str] = mapped_column(String(32), nullable=False)
+    computed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/packages/api/app/models/cluster_title_annotation.py
+++ b/packages/api/app/models/cluster_title_annotation.py
@@ -35,9 +35,7 @@ class ClusterTitleAnnotation(Base):
     __tablename__ = "cluster_title_annotations"
     __table_args__ = (Index("ix_cta_cluster_id", "cluster_id"),)
 
-    cluster_id: Mapped[UUID] = mapped_column(
-        PGUUID(as_uuid=True), primary_key=True
-    )
+    cluster_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True)
     content_id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         ForeignKey("contents.id", ondelete="CASCADE"),

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -759,9 +759,7 @@ async def _attach_highlight_spans(
             if annotations.id_by_url.get(p.get("url") or "") is None:
                 off_cluster_indices.append(i)
                 off_cluster_titles.append(p.get("title") or "")
-        off_cluster_tokens = await svc.compute_strong_tokens_batch(
-            off_cluster_titles
-        )
+        off_cluster_tokens = await svc.compute_strong_tokens_batch(off_cluster_titles)
         tokens_by_index: dict[int, list[dict]] = dict(
             zip(off_cluster_indices, off_cluster_tokens, strict=True)
         )

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
 from app.models.content import Content
-from app.models.enums import ContentType
+from app.models.enums import BiasStance, ContentType
 from app.schemas.collection import SaveContentRequest
 from app.schemas.content import (
     ArticleFeedbackRequest,
@@ -25,6 +25,7 @@ from app.services.collection_service import CollectionService
 from app.services.content_extractor import ContentExtractor
 from app.services.content_service import ContentService
 from app.services.feed_cache import FEED_CACHE
+from app.services.title_annotation_service import get_title_annotation_service
 
 logger = structlog.get_logger()
 
@@ -722,6 +723,71 @@ async def _load_stored_perspectives_for_representative(
     return None
 
 
+async def _attach_highlight_spans(
+    db: AsyncSession,
+    content: Content,
+    perspectives_dicts: list[dict],
+) -> None:
+    """Mutate `perspectives_dicts` in-place adding `highlight_spans` to each.
+
+    Looks up cached strong_tokens for the cluster (computing & persisting if
+    missing), then diffs the reference article's tokens against each
+    perspective's. Perspectives that aren't part of any DB cluster
+    (pure Google News results) get their tokens computed in one batched
+    spaCy call. Any failure → every perspective gets `highlight_spans: []`.
+    """
+    if not content.cluster_id:
+        for p in perspectives_dicts:
+            p["highlight_spans"] = []
+        return
+
+    try:
+        svc = get_title_annotation_service()
+        annotations = await svc.get_or_compute_cluster_annotations(
+            db, content.cluster_id
+        )
+        ref_tokens = annotations.tokens_by_id.get(content.id) or (
+            svc.compute_strong_tokens(content.title or "")
+        )
+
+        # Collect off-cluster perspective titles once and run a single
+        # batched spaCy call instead of N synchronous invocations on the
+        # event loop.
+        off_cluster_indices: list[int] = []
+        off_cluster_titles: list[str] = []
+        for i, p in enumerate(perspectives_dicts):
+            if annotations.id_by_url.get(p.get("url") or "") is None:
+                off_cluster_indices.append(i)
+                off_cluster_titles.append(p.get("title") or "")
+        off_cluster_tokens = await svc.compute_strong_tokens_batch(
+            off_cluster_titles
+        )
+        tokens_by_index: dict[int, list[dict]] = dict(
+            zip(off_cluster_indices, off_cluster_tokens, strict=True)
+        )
+
+        for i, p in enumerate(perspectives_dicts):
+            alt_id = annotations.id_by_url.get(p.get("url") or "")
+            alt_tokens = (
+                annotations.tokens_by_id.get(alt_id, [])
+                if alt_id is not None
+                else tokens_by_index.get(i, [])
+            )
+            p["highlight_spans"] = svc.diff_spans(
+                ref_tokens,
+                alt_tokens,
+                p.get("bias_stance") or BiasStance.UNKNOWN.value,
+            )
+    except Exception:
+        logger.exception(
+            "highlight_spans_failed",
+            content_id=str(content.id),
+            cluster_id=str(content.cluster_id),
+        )
+        for p in perspectives_dicts:
+            p.setdefault("highlight_spans", [])
+
+
 @router.get("/{content_id}/perspectives", status_code=status.HTTP_200_OK)
 async def get_perspectives(
     content_id: UUID,
@@ -871,6 +937,8 @@ async def get_perspectives(
         cached_row = analysis_result.scalars().first()
         cached_analysis = cached_row.analysis_text if cached_row else None
 
+        await _attach_highlight_spans(db, content, stored_perspectives)
+
         response = {
             "content_id": cache_key,
             # Empty keywords: the snapshot was built without re-running the
@@ -999,22 +1067,25 @@ async def get_perspectives(
     if cached_row:
         cached_analysis = cached_row.analysis_text
 
+    perspectives_dicts = [
+        {
+            "title": p.title,
+            "url": p.url,
+            "source_name": p.source_name,
+            "source_domain": p.source_domain,
+            "bias_stance": p.bias_stance,
+            "published_at": p.published_at,
+            "description": p.description,
+        }
+        for p in perspectives
+    ]
+    await _attach_highlight_spans(db, content, perspectives_dicts)
+
     response = {
         "content_id": cache_key,
         "keywords": keywords,
         "source_bias_stance": source_bias_stance,
-        "perspectives": [
-            {
-                "title": p.title,
-                "url": p.url,
-                "source_name": p.source_name,
-                "source_domain": p.source_domain,
-                "bias_stance": p.bias_stance,
-                "published_at": p.published_at,
-                "description": p.description,
-            }
-            for p in perspectives
-        ],
+        "perspectives": perspectives_dicts,
         "bias_distribution": bias_distribution,
         "comparison_quality": comparison_quality,
         "should_display": should_display,

--- a/packages/api/app/services/ml/ner_service.py
+++ b/packages/api/app/services/ml/ner_service.py
@@ -248,6 +248,15 @@ class NERService:
         """Check if service is ready."""
         return self._nlp is not None
 
+    def get_nlp(self):
+        """Return the loaded spaCy Language object (or None if unavailable).
+
+        Exposes the singleton model for downstream services
+        (e.g. TitleAnnotationService) so spaCy is loaded exactly once
+        process-wide.
+        """
+        return self._nlp
+
     def get_stats(self) -> dict:
         """Get service stats."""
         return {

--- a/packages/api/app/services/title_annotation_service.py
+++ b/packages/api/app/services/title_annotation_service.py
@@ -1,0 +1,274 @@
+"""Title annotation service (Story 7.4 — diff highlighting backend).
+
+Computes spaCy "strong tokens" per article title and diffs them against a
+reference title to surface divergent wording on the /perspectives panel.
+Persists results in `cluster_title_annotations` keyed by
+(cluster_id, content_id) so subsequent panel opens read from cache.
+
+Sprint 1 — phase déterministe uniquement (POS + lemmatisation, zéro LLM).
+Phase 2 (Mistral-small raffinement) will populate `semantic_equiv` later
+without touching existing rows (gated by `model_version`).
+"""
+
+import asyncio
+import unicodedata
+from dataclasses import dataclass, field
+from uuid import UUID
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.cluster_title_annotation import ClusterTitleAnnotation
+from app.models.content import Content
+from app.services.ml.ner_service import get_ner_service
+from app.services.text_similarity import FRENCH_STOP_WORDS
+
+logger = structlog.get_logger(__name__)
+
+# Sentinel POS value used to mark NER-tagged tokens in the PRIORITY table.
+_ENTITY_KEY = "entity"
+
+
+def _strip_accents(s: str) -> str:
+    return "".join(
+        c for c in unicodedata.normalize("NFD", s)
+        if unicodedata.category(c) != "Mn"
+    )
+
+
+@dataclass
+class ClusterAnnotations:
+    """Container holding both the cached tokens and the URL→content_id map.
+
+    The URL map lets the router resolve a perspective dict (which carries
+    `url` but not `content_id`) back to its cluster row, so we can read
+    cached tokens instead of recomputing.
+    """
+
+    tokens_by_id: dict[UUID, list[dict]] = field(default_factory=dict)
+    id_by_url: dict[str, UUID] = field(default_factory=dict)
+
+
+class TitleAnnotationService:
+    MODEL_VERSION = "v1-spacy-fr_md"
+    KEEP_POS = frozenset({"NOUN", "PROPN", "ADJ", "VERB"})
+    MAX_HIGHLIGHTED_PER_TITLE = 4
+    # Lower number = higher priority when capping at MAX_HIGHLIGHTED_PER_TITLE.
+    PRIORITY: dict[str, int] = {
+        _ENTITY_KEY: 0,
+        "ADJ": 1,
+        "PROPN": 2,
+        "NOUN": 2,
+        "VERB": 3,
+    }
+
+    def __init__(self):
+        self._nlp = get_ner_service().get_nlp()
+        if self._nlp is None:
+            logger.warning("title_annotation.nlp_unavailable")
+
+    def _doc_to_tokens(self, doc) -> list[dict]:
+        """Convert a spaCy Doc into our strong-token shape."""
+        if doc is None:
+            return []
+
+        ent_at: dict[int, str] = {}
+        for ent in doc.ents:
+            for char_idx in range(ent.start_char, ent.end_char):
+                ent_at[char_idx] = ent.label_
+
+        out: list[dict] = []
+        for tok in doc:
+            if tok.pos_ not in self.KEEP_POS:
+                continue
+            if tok.is_stop:
+                continue
+            text = tok.text
+            lemma = (tok.lemma_ or text).lower()
+            # FRENCH_STOP_WORDS is accent-stripped, so we must strip too
+            # before lookup — otherwise "présente" / "société" slip through.
+            if (
+                _strip_accents(text.lower()) in FRENCH_STOP_WORDS
+                or _strip_accents(lemma) in FRENCH_STOP_WORDS
+            ):
+                continue
+            token: dict = {
+                "start": tok.idx,
+                "end": tok.idx + len(tok.text),
+                "text": text,
+                "lemma": lemma,
+                "pos": tok.pos_,
+            }
+            entity_kind = ent_at.get(tok.idx)
+            if entity_kind:
+                token["entity_kind"] = entity_kind
+            out.append(token)
+        return out
+
+    def compute_strong_tokens(self, title: str) -> list[dict]:
+        """Extract POS-filtered, stop-word-stripped tokens with NER overlay.
+
+        Returns `[{start, end, text, lemma, pos, entity_kind?}]`, where
+        `entity_kind` is the spaCy entity label (e.g. "PER", "ORG", "LOC")
+        when the token belongs to a NER span, else absent.
+        """
+        if not self._nlp or not title:
+            return []
+        try:
+            return self._doc_to_tokens(self._nlp(title))
+        except Exception:
+            logger.exception("title_annotation.spacy_error", title=title[:80])
+            return []
+
+    async def compute_strong_tokens_batch(
+        self, titles: list[str]
+    ) -> list[list[dict]]:
+        """Batch-compute tokens for many titles in a single executor hop.
+
+        spaCy is sync/CPU-bound — running 8 separate `nlp()` calls on the
+        event loop blocks it for ~40-120 ms. `nlp.pipe()` processes them
+        together in a single thread submission, ~2-3× faster.
+        """
+        if not titles:
+            return []
+        if not self._nlp:
+            return [[] for _ in titles]
+        loop = asyncio.get_event_loop()
+        docs = await loop.run_in_executor(
+            None, lambda: list(self._nlp.pipe(titles))
+        )
+        return [self._doc_to_tokens(doc) for doc in docs]
+
+    def diff_spans(
+        self, ref_tokens: list[dict], alt_tokens: list[dict], alt_bias: str
+    ) -> list[dict]:
+        """Return spans of `alt_tokens` whose lemma is absent from `ref_tokens`.
+
+        Capped at `MAX_HIGHLIGHTED_PER_TITLE`, ordered by PRIORITY (entities
+        first, then ADJ, then NOUN/PROPN, then VERB). `alt_bias` is passed
+        through unchanged to each span as `bias` — the Dart side maps it to
+        a color via `getBiasColor`.
+        """
+        ref_lemmas = {t["lemma"] for t in ref_tokens}
+        divergent = [t for t in alt_tokens if t["lemma"] not in ref_lemmas]
+        ranked = sorted(
+            divergent,
+            key=lambda t: self.PRIORITY.get(
+                _ENTITY_KEY if t.get("entity_kind") else t["pos"], 99
+            ),
+        )
+        return [
+            {
+                "start": t["start"],
+                "end": t["end"],
+                "text": t["text"],
+                "bias": alt_bias,
+            }
+            for t in ranked[: self.MAX_HIGHLIGHTED_PER_TITLE]
+        ]
+
+    async def get_or_compute_cluster_annotations(
+        self, db: AsyncSession, cluster_id: UUID
+    ) -> ClusterAnnotations:
+        """Return tokens for every content in `cluster_id`, computing missing ones.
+
+        Flow:
+          1. Fetch the cluster's contents (id, title, url).
+          2. Read existing rows for (cluster_id, MODEL_VERSION).
+          3. For missing content_ids, compute strong_tokens (batched via
+             `nlp.pipe()`) and INSERT … ON CONFLICT DO NOTHING.
+          4. Return the merged map + URL→id lookup.
+        """
+        out = ClusterAnnotations()
+
+        cluster_stmt = select(
+            Content.id, Content.title, Content.url
+        ).where(Content.cluster_id == cluster_id)
+        cluster_rows = (await db.execute(cluster_stmt)).all()
+        if not cluster_rows:
+            return out
+
+        titles_by_id: dict[UUID, str] = {}
+        for row in cluster_rows:
+            titles_by_id[row.id] = row.title or ""
+            if row.url:
+                out.id_by_url[row.url] = row.id
+
+        cache_stmt = select(
+            ClusterTitleAnnotation.content_id,
+            ClusterTitleAnnotation.strong_tokens,
+        ).where(
+            ClusterTitleAnnotation.cluster_id == cluster_id,
+            ClusterTitleAnnotation.model_version == self.MODEL_VERSION,
+        )
+        for row in (await db.execute(cache_stmt)).all():
+            out.tokens_by_id[row.content_id] = list(row.strong_tokens or [])
+
+        missing_ids = [cid for cid in titles_by_id if cid not in out.tokens_by_id]
+        if not missing_ids:
+            return out
+
+        logger.info(
+            "diff_highlighting.cache_miss",
+            cluster_id=str(cluster_id),
+            missing=len(missing_ids),
+            total=len(titles_by_id),
+        )
+
+        if self._nlp is None:
+            return out
+
+        missing_titles = [titles_by_id[cid] for cid in missing_ids]
+        tokens_per_title = await self.compute_strong_tokens_batch(missing_titles)
+
+        rows_to_insert: list[dict] = []
+        for cid, tokens in zip(missing_ids, tokens_per_title, strict=True):
+            out.tokens_by_id[cid] = tokens
+            rows_to_insert.append(
+                {
+                    "cluster_id": cluster_id,
+                    "content_id": cid,
+                    "strong_tokens": tokens,
+                    "semantic_equiv": None,
+                    "model_version": self.MODEL_VERSION,
+                }
+            )
+
+        # ON CONFLICT DO NOTHING: two concurrent panel opens on the same
+        # cluster both compute, one wins the INSERT, the other's rows are
+        # silently dropped from DB but still returned in-memory — both
+        # tabs see a self-consistent result.
+        try:
+            stmt = pg_insert(ClusterTitleAnnotation).values(rows_to_insert)
+            stmt = stmt.on_conflict_do_nothing(
+                index_elements=["cluster_id", "content_id"]
+            )
+            await db.execute(stmt)
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            logger.exception(
+                "title_annotation.cache_insert_failed",
+                cluster_id=str(cluster_id),
+            )
+
+        return out
+
+
+_title_annotation_service: TitleAnnotationService | None = None
+
+
+def get_title_annotation_service() -> TitleAnnotationService:
+    """Return the process-wide singleton (lazy-initialized)."""
+    global _title_annotation_service
+    if _title_annotation_service is None:
+        _title_annotation_service = TitleAnnotationService()
+    return _title_annotation_service
+
+
+def reset_title_annotation_service() -> None:
+    """Drop the cached singleton — for tests that swap the NER model."""
+    global _title_annotation_service
+    _title_annotation_service = None

--- a/packages/api/app/services/title_annotation_service.py
+++ b/packages/api/app/services/title_annotation_service.py
@@ -33,8 +33,7 @@ _ENTITY_KEY = "entity"
 
 def _strip_accents(s: str) -> str:
     return "".join(
-        c for c in unicodedata.normalize("NFD", s)
-        if unicodedata.category(c) != "Mn"
+        c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn"
     )
 
 
@@ -122,9 +121,7 @@ class TitleAnnotationService:
             logger.exception("title_annotation.spacy_error", title=title[:80])
             return []
 
-    async def compute_strong_tokens_batch(
-        self, titles: list[str]
-    ) -> list[list[dict]]:
+    async def compute_strong_tokens_batch(self, titles: list[str]) -> list[list[dict]]:
         """Batch-compute tokens for many titles in a single executor hop.
 
         spaCy is sync/CPU-bound — running 8 separate `nlp()` calls on the
@@ -136,9 +133,7 @@ class TitleAnnotationService:
         if not self._nlp:
             return [[] for _ in titles]
         loop = asyncio.get_event_loop()
-        docs = await loop.run_in_executor(
-            None, lambda: list(self._nlp.pipe(titles))
-        )
+        docs = await loop.run_in_executor(None, lambda: list(self._nlp.pipe(titles)))
         return [self._doc_to_tokens(doc) for doc in docs]
 
     def diff_spans(
@@ -183,9 +178,9 @@ class TitleAnnotationService:
         """
         out = ClusterAnnotations()
 
-        cluster_stmt = select(
-            Content.id, Content.title, Content.url
-        ).where(Content.cluster_id == cluster_id)
+        cluster_stmt = select(Content.id, Content.title, Content.url).where(
+            Content.cluster_id == cluster_id
+        )
         cluster_rows = (await db.execute(cluster_stmt)).all()
         if not cluster_rows:
             return out

--- a/packages/api/tests/fixtures/fake_spacy.py
+++ b/packages/api/tests/fixtures/fake_spacy.py
@@ -1,0 +1,60 @@
+"""Minimal spaCy doubles for hermetic tests.
+
+Mimics the subset of `Doc / Token / Ent / Language` that
+`TitleAnnotationService` consumes. Tests build a `FakeDoc` per title
+they want to feed through the service, wire them into a `FakeNlp`, and
+inject it onto a service instance via `service_with_nlp`.
+"""
+
+from dataclasses import dataclass, field
+
+from app.services.title_annotation_service import TitleAnnotationService
+
+
+@dataclass
+class FakeToken:
+    text: str
+    idx: int
+    pos_: str
+    lemma_: str
+    is_stop: bool = False
+
+
+@dataclass
+class FakeEnt:
+    start_char: int
+    end_char: int
+    label_: str
+
+
+@dataclass
+class FakeDoc:
+    tokens: list[FakeToken]
+    ents: list[FakeEnt] = field(default_factory=list)
+
+    def __iter__(self):
+        return iter(self.tokens)
+
+
+class FakeNlp:
+    """Callable that returns a precomputed FakeDoc per title."""
+
+    def __init__(self, docs_by_title: dict[str, FakeDoc]):
+        self._docs = docs_by_title
+        self.call_count = 0
+
+    def __call__(self, title: str) -> FakeDoc:
+        self.call_count += 1
+        return self._docs.get(title, FakeDoc(tokens=[]))
+
+    def pipe(self, titles):
+        """Match spaCy's batched-inference API."""
+        for t in titles:
+            yield self(t)
+
+
+def service_with_nlp(nlp) -> TitleAnnotationService:
+    """Bypass __init__ to inject a fake nlp without touching the NER singleton."""
+    svc = TitleAnnotationService.__new__(TitleAnnotationService)
+    svc._nlp = nlp
+    return svc

--- a/packages/api/tests/routers/test_contents_perspectives_highlights.py
+++ b/packages/api/tests/routers/test_contents_perspectives_highlights.py
@@ -1,0 +1,325 @@
+"""Integration tests for `_attach_highlight_spans` (Story 7.4).
+
+Covers the contract between the perspectives endpoint and the new
+`TitleAnnotationService` without mocking the full Google News / digest
+stack. The helper is called by both the stored and the live response paths,
+so testing it directly proves the integration in both.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from app.models.content import Content
+from app.models.enums import ContentType, SourceType
+from app.models.source import Source
+from app.routers.contents import _attach_highlight_spans
+from tests.fixtures.fake_spacy import (
+    FakeDoc,
+    FakeEnt,
+    FakeNlp,
+    FakeToken,
+    service_with_nlp,
+)
+
+
+# --- Cluster fixture --------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def cluster_setup(db_session):
+    """Source + 1 ref + 2 cluster siblings sharing a cluster_id."""
+    source = Source(
+        id=uuid4(),
+        name="Le Monde",
+        url="https://lemonde.fr",
+        feed_url=f"https://lemonde.fr/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+    )
+    db_session.add(source)
+    await db_session.commit()
+
+    cluster_id = uuid4()
+    ref = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title="Tsahal frappe Gaza",
+        url="https://lemonde.fr/ref",
+        published_at=datetime.now(UTC),
+        content_type=ContentType.ARTICLE,
+        guid="ref",
+        cluster_id=cluster_id,
+    )
+    alt_a = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title="Armée israélienne bombarde Gaza",
+        url="https://liberation.fr/alt-a",
+        published_at=datetime.now(UTC),
+        content_type=ContentType.ARTICLE,
+        guid="alt-a",
+        cluster_id=cluster_id,
+    )
+    alt_b = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title="Tsahal frappe Gaza",  # identical to ref → no spans expected
+        url="https://figaro.fr/alt-b",
+        published_at=datetime.now(UTC),
+        content_type=ContentType.ARTICLE,
+        guid="alt-b",
+        cluster_id=cluster_id,
+    )
+    db_session.add_all([ref, alt_a, alt_b])
+    await db_session.commit()
+    return {"ref": ref, "alt_a": alt_a, "alt_b": alt_b, "cluster_id": cluster_id}
+
+
+# --- Tests ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_empty_for_content_without_cluster(db_session):
+    """No cluster_id → every perspective gets an empty highlight_spans list."""
+    source = Source(
+        id=uuid4(),
+        name="Solo",
+        url="https://solo.fr",
+        feed_url=f"https://solo.fr/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+    )
+    db_session.add(source)
+    await db_session.commit()
+    standalone = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title="Standalone",
+        url="https://solo.fr/x",
+        published_at=datetime.now(UTC),
+        content_type=ContentType.ARTICLE,
+        guid="x",
+        cluster_id=None,
+    )
+    db_session.add(standalone)
+    await db_session.commit()
+
+    perspectives = [
+        {"title": "Anything", "url": "https://other.fr/x", "bias_stance": "left"}
+    ]
+    await _attach_highlight_spans(db_session, standalone, perspectives)
+
+    assert perspectives[0]["highlight_spans"] == []
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_no_spans_when_titles_identical(
+    db_session, cluster_setup
+):
+    """alt_b has the same title as ref → zero divergent tokens."""
+    docs = {
+        "Tsahal frappe Gaza": FakeDoc(
+            tokens=[
+                FakeToken("Tsahal", 0, "PROPN", "Tsahal"),
+                FakeToken("frappe", 7, "VERB", "frapper"),
+                FakeToken("Gaza", 14, "PROPN", "Gaza"),
+            ],
+            ents=[FakeEnt(0, 6, "ORG"), FakeEnt(14, 18, "LOC")],
+        ),
+        "Armée israélienne bombarde Gaza": FakeDoc(
+            tokens=[
+                FakeToken("Armée", 0, "NOUN", "armée"),
+                FakeToken("israélienne", 6, "ADJ", "israélien"),
+                FakeToken("bombarde", 18, "VERB", "bombarder"),
+                FakeToken("Gaza", 27, "PROPN", "Gaza"),
+            ],
+            ents=[FakeEnt(27, 31, "LOC")],
+        ),
+    }
+    fake_svc = service_with_nlp(FakeNlp(docs))
+
+    perspectives = [
+        {
+            "title": "Tsahal frappe Gaza",
+            "url": cluster_setup["alt_b"].url,
+            "bias_stance": "right",
+        }
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        await _attach_highlight_spans(db_session, cluster_setup["ref"], perspectives)
+
+    assert perspectives[0]["highlight_spans"] == []
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_uses_cache_for_in_cluster_perspectives(
+    db_session, cluster_setup
+):
+    """Perspective.url matches a cluster Content → tokens read from cache, not recomputed."""
+    docs = {
+        "Tsahal frappe Gaza": FakeDoc(
+            tokens=[
+                FakeToken("Tsahal", 0, "PROPN", "Tsahal"),
+                FakeToken("frappe", 7, "VERB", "frapper"),
+                FakeToken("Gaza", 14, "PROPN", "Gaza"),
+            ],
+        ),
+        "Armée israélienne bombarde Gaza": FakeDoc(
+            tokens=[
+                FakeToken("Armée", 0, "NOUN", "armée"),
+                FakeToken("israélienne", 6, "ADJ", "israélien"),
+                FakeToken("bombarde", 18, "VERB", "bombarder"),
+                FakeToken("Gaza", 27, "PROPN", "Gaza"),
+            ],
+        ),
+    }
+    fake_svc = service_with_nlp(FakeNlp(docs))
+
+    perspectives = [
+        {
+            "title": "Armée israélienne bombarde Gaza",
+            "url": cluster_setup["alt_a"].url,
+            "bias_stance": "left",
+        }
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        await _attach_highlight_spans(db_session, cluster_setup["ref"], perspectives)
+
+    spans = perspectives[0]["highlight_spans"]
+    texts = {s["text"] for s in spans}
+    # "Armée", "israélienne", "bombarde" diverge from ref. "Gaza" is shared.
+    assert "Gaza" not in texts
+    assert {"Armée", "israélienne", "bombarde"} <= texts
+    assert all(s["bias"] == "left" for s in spans)
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_computes_on_fly_for_google_news_url(
+    db_session, cluster_setup
+):
+    """Google News perspective URL absent from the cluster → spaCy invoked at call time."""
+    docs = {
+        "Tsahal frappe Gaza": FakeDoc(
+            tokens=[
+                FakeToken("Tsahal", 0, "PROPN", "Tsahal"),
+                FakeToken("frappe", 7, "VERB", "frapper"),
+                FakeToken("Gaza", 14, "PROPN", "Gaza"),
+            ],
+        ),
+        "Armée israélienne bombarde Gaza": FakeDoc(
+            tokens=[
+                FakeToken("Armée", 0, "NOUN", "armée"),
+                FakeToken("israélienne", 6, "ADJ", "israélien"),
+                FakeToken("bombarde", 18, "VERB", "bombarder"),
+                FakeToken("Gaza", 27, "PROPN", "Gaza"),
+            ],
+        ),
+        "Une frappe sur Gaza fait 20 morts": FakeDoc(
+            tokens=[
+                FakeToken("frappe", 4, "NOUN", "frappe"),
+                FakeToken("Gaza", 14, "PROPN", "Gaza"),
+                FakeToken("morts", 25, "NOUN", "mort"),
+            ],
+        ),
+    }
+    fake_svc = service_with_nlp(FakeNlp(docs))
+
+    perspectives = [
+        {
+            "title": "Une frappe sur Gaza fait 20 morts",
+            "url": "https://google-news-only-source.com/x",  # not in cluster
+            "bias_stance": "unknown",
+        }
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        await _attach_highlight_spans(db_session, cluster_setup["ref"], perspectives)
+
+    spans = perspectives[0]["highlight_spans"]
+    texts = {s["text"] for s in spans}
+    assert "morts" in texts  # diverges from ref
+    assert all(s["bias"] == "unknown" for s in spans)
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_batches_off_cluster_titles_in_one_executor_hop(
+    db_session, cluster_setup
+):
+    """Multiple Google News perspectives must hit spaCy via a single batched call.
+
+    Guards against the regression of looping `compute_strong_tokens()` per
+    perspective on the event loop (8 hops instead of 1).
+    """
+    docs = {
+        "Tsahal frappe Gaza": FakeDoc(
+            tokens=[FakeToken("Tsahal", 0, "PROPN", "Tsahal")]
+        ),
+        "GN title 1": FakeDoc(tokens=[FakeToken("GN1", 0, "PROPN", "gn1")]),
+        "GN title 2": FakeDoc(tokens=[FakeToken("GN2", 0, "PROPN", "gn2")]),
+        "GN title 3": FakeDoc(tokens=[FakeToken("GN3", 0, "PROPN", "gn3")]),
+    }
+    nlp = FakeNlp(docs)
+    pipe_calls: list[list[str]] = []
+    original_pipe = nlp.pipe
+
+    def tracking_pipe(titles):
+        titles_list = list(titles)
+        pipe_calls.append(titles_list)
+        return original_pipe(titles_list)
+
+    nlp.pipe = tracking_pipe
+    fake_svc = service_with_nlp(nlp)
+
+    perspectives = [
+        {"title": f"GN title {i}", "url": f"https://gn-{i}.com",
+         "bias_stance": "center"}
+        for i in (1, 2, 3)
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        await _attach_highlight_spans(db_session, cluster_setup["ref"], perspectives)
+
+    # 2 batched pipe() calls: 1 for the cluster cache miss, 1 for the
+    # off-cluster Google News titles — never N separate `nlp()` invocations.
+    assert len(pipe_calls) == 2
+    assert pipe_calls[1] == ["GN title 1", "GN title 2", "GN title 3"]
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_swallows_exceptions(
+    db_session, cluster_setup
+):
+    """If the service raises, every perspective gets `highlight_spans: []` — no 500."""
+    perspectives = [
+        {"title": "X", "url": "https://x.com", "bias_stance": "left"}
+    ]
+
+    class BrokenService:
+        async def get_or_compute_cluster_annotations(self, *_a, **_kw):
+            raise RuntimeError("boom")
+
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=BrokenService(),
+    ):
+        await _attach_highlight_spans(db_session, cluster_setup["ref"], perspectives)
+
+    assert perspectives[0]["highlight_spans"] == []

--- a/packages/api/tests/services/test_title_annotation_service.py
+++ b/packages/api/tests/services/test_title_annotation_service.py
@@ -1,0 +1,313 @@
+"""Tests for TitleAnnotationService (Story 7.4 — diff highlighting backend).
+
+Hermetic: the tests do not depend on spaCy or the `fr_core_news_md` model.
+A `FakeNlp` callable (shared with router tests) mimics the minimal subset
+of the spaCy Doc / Token / Ent API consumed by `compute_strong_tokens`.
+"""
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.cluster_title_annotation import ClusterTitleAnnotation
+from app.models.content import Content
+from app.models.enums import ContentType, SourceType
+from app.models.source import Source
+from tests.fixtures.fake_spacy import (
+    FakeDoc,
+    FakeEnt,
+    FakeNlp,
+    FakeToken,
+    service_with_nlp,
+)
+
+
+# --- compute_strong_tokens --------------------------------------------------
+
+
+def test_compute_strong_tokens_filters_stopwords_and_keeps_noun_adj_verb_propn():
+    title = "Tsahal frappe une cible brutale"
+    doc = FakeDoc(
+        tokens=[
+            FakeToken("Tsahal", 0, "PROPN", "Tsahal"),
+            FakeToken("frappe", 7, "VERB", "frapper"),
+            FakeToken("une", 14, "DET", "un", is_stop=True),
+            FakeToken("cible", 18, "NOUN", "cible"),
+            FakeToken("brutale", 24, "ADJ", "brutal"),
+        ]
+    )
+    svc = service_with_nlp(FakeNlp({title: doc}))
+
+    tokens = svc.compute_strong_tokens(title)
+
+    assert [t["text"] for t in tokens] == ["Tsahal", "frappe", "cible", "brutale"]
+    assert {t["pos"] for t in tokens} == {"PROPN", "VERB", "NOUN", "ADJ"}
+    assert tokens[0]["start"] == 0
+    assert tokens[0]["end"] == 6
+
+
+def test_compute_strong_tokens_extracts_entities_from_ner():
+    title = "Macron rencontre Merkel à Berlin"
+    doc = FakeDoc(
+        tokens=[
+            FakeToken("Macron", 0, "PROPN", "Macron"),
+            FakeToken("rencontre", 7, "VERB", "rencontrer"),
+            FakeToken("Merkel", 17, "PROPN", "Merkel"),
+            FakeToken("à", 24, "ADP", "à", is_stop=True),
+            FakeToken("Berlin", 26, "PROPN", "Berlin"),
+        ],
+        ents=[
+            FakeEnt(0, 6, "PER"),
+            FakeEnt(17, 23, "PER"),
+            FakeEnt(26, 32, "LOC"),
+        ],
+    )
+    svc = service_with_nlp(FakeNlp({title: doc}))
+
+    by_text = {t["text"]: t for t in svc.compute_strong_tokens(title)}
+
+    assert by_text["Macron"]["entity_kind"] == "PER"
+    assert by_text["Merkel"]["entity_kind"] == "PER"
+    assert by_text["Berlin"]["entity_kind"] == "LOC"
+    assert "entity_kind" not in by_text["rencontre"]
+
+
+def test_compute_strong_tokens_filters_against_project_stopword_list():
+    """Even if spaCy keeps a word, FRENCH_STOP_WORDS (project-wide) trumps it.
+
+    FRENCH_STOP_WORDS is stored accent-stripped, so the service must strip
+    accents before lookup — otherwise accented stop words like "société"
+    or "analyse" slip through.
+    """
+    title = "Société Tsahal"
+    doc = FakeDoc(
+        tokens=[
+            FakeToken("Société", 0, "NOUN", "société"),
+            FakeToken("Tsahal", 8, "PROPN", "Tsahal"),
+        ]
+    )
+    svc = service_with_nlp(FakeNlp({title: doc}))
+
+    kept = {t["text"] for t in svc.compute_strong_tokens(title)}
+    assert "Société" not in kept  # rejected by FRENCH_STOP_WORDS via accent strip
+    assert "Tsahal" in kept
+
+
+def test_compute_strong_tokens_returns_empty_when_nlp_missing():
+    svc = service_with_nlp(None)
+    assert svc.compute_strong_tokens("Un titre quelconque") == []
+
+
+# --- diff_spans -------------------------------------------------------------
+
+
+def _tok(text, lemma, pos="NOUN", start=0, entity_kind=None):
+    out = {"start": start, "end": start + len(text), "text": text,
+           "lemma": lemma, "pos": pos}
+    if entity_kind:
+        out["entity_kind"] = entity_kind
+    return out
+
+
+def test_diff_spans_identical_lemmas_returns_empty():
+    ref = [_tok("ministre", "ministre"), _tok("réforme", "réforme", start=10)]
+    alt = [_tok("Ministre", "ministre"), _tok("Réformes", "réforme", start=10)]
+    svc = service_with_nlp(None)
+    assert svc.diff_spans(ref, alt, "left") == []
+
+
+def test_diff_spans_caps_at_4_with_priority_entity_first():
+    ref = [_tok("été", "été")]
+    alt = [
+        _tok("dénoncer", "dénoncer", pos="VERB", start=0),
+        _tok("austérité", "austérité", pos="NOUN", start=10),
+        _tok("brutale", "brutale", pos="ADJ", start=20),
+        _tok("Macron", "Macron", pos="PROPN", start=30, entity_kind="PER"),
+        _tok("Bercy", "Bercy", pos="PROPN", start=40, entity_kind="ORG"),
+        _tok("présentée", "présenter", pos="VERB", start=50),
+    ]
+    svc = service_with_nlp(None)
+    spans = svc.diff_spans(ref, alt, "left")
+
+    assert len(spans) == 4
+    texts = [s["text"] for s in spans]
+    assert texts[:2] == ["Macron", "Bercy"]  # entities first
+    assert "brutale" in texts  # ADJ kept
+    assert "austérité" in texts  # NOUN kept
+    assert "dénoncer" not in texts  # VERB bumped
+
+
+def test_diff_spans_passes_bias_through_unchanged():
+    """Each span carries the alt source's raw bias_stance string (no mapping)."""
+    ref: list[dict] = []
+    alt = [_tok("guerre", "guerre")]
+    svc = service_with_nlp(None)
+
+    for bias in ("left", "center-left", "center", "center-right",
+                 "right", "alternative", "specialized", "unknown"):
+        spans = svc.diff_spans(ref, alt, bias)
+        assert spans[0]["bias"] == bias
+
+
+def test_diff_spans_preserves_offsets():
+    ref: list[dict] = []
+    alt = [_tok("guerre", "guerre", start=15)]
+    svc = service_with_nlp(None)
+    spans = svc.diff_spans(ref, alt, "left")
+    assert spans[0]["start"] == 15
+    assert spans[0]["end"] == 21
+
+
+# --- get_or_compute_cluster_annotations -------------------------------------
+
+
+@pytest_asyncio.fixture
+async def cluster_fixture(db_session):
+    """Create a source + 3 contents sharing a cluster_id."""
+    from datetime import UTC, datetime
+
+    source = Source(
+        id=uuid4(),
+        name="Test Source",
+        url="https://example.com",
+        feed_url=f"https://example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+    )
+    db_session.add(source)
+    await db_session.commit()
+
+    cluster_id = uuid4()
+    contents = []
+    titles_urls = [
+        ("Macron annonce une réforme", "https://ex.com/a"),
+        ("Macron impose une réforme brutale", "https://ex.com/b"),
+        ("Macron présente un projet", "https://ex.com/c"),
+    ]
+    for title, url in titles_urls:
+        c = Content(
+            id=uuid4(),
+            source_id=source.id,
+            title=title,
+            url=url,
+            published_at=datetime.now(UTC),
+            content_type=ContentType.ARTICLE,
+            guid=url,
+            cluster_id=cluster_id,
+        )
+        db_session.add(c)
+        contents.append(c)
+    await db_session.commit()
+    return {"cluster_id": cluster_id, "contents": contents}
+
+
+def _trivial_nlp(titles: list[str]) -> FakeNlp:
+    """One single-PROPN doc per title — enough to exercise the cache path."""
+    return FakeNlp({t: FakeDoc(tokens=[FakeToken(t, 0, "PROPN", t.lower())])
+                    for t in titles})
+
+
+@pytest.mark.asyncio
+async def test_get_or_compute_inserts_on_first_call_and_reads_cache_second(
+    db_session, cluster_fixture
+):
+    titles = [c.title for c in cluster_fixture["contents"]]
+    nlp = _trivial_nlp(titles)
+    svc = service_with_nlp(nlp)
+
+    first = await svc.get_or_compute_cluster_annotations(
+        db_session, cluster_fixture["cluster_id"]
+    )
+    assert len(first.tokens_by_id) == 3
+    assert nlp.call_count == 3
+    rows = (
+        await db_session.execute(
+            select(ClusterTitleAnnotation).where(
+                ClusterTitleAnnotation.cluster_id == cluster_fixture["cluster_id"]
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 3
+    assert all(r.model_version == "v1-spacy-fr_md" for r in rows)
+    assert all(r.semantic_equiv is None for r in rows)
+
+    nlp.call_count = 0
+    second = await svc.get_or_compute_cluster_annotations(
+        db_session, cluster_fixture["cluster_id"]
+    )
+    assert nlp.call_count == 0
+    assert second.tokens_by_id.keys() == first.tokens_by_id.keys()
+
+
+@pytest.mark.asyncio
+async def test_get_or_compute_url_map_is_populated(db_session, cluster_fixture):
+    titles = [c.title for c in cluster_fixture["contents"]]
+    svc = service_with_nlp(_trivial_nlp(titles))
+
+    result = await svc.get_or_compute_cluster_annotations(
+        db_session, cluster_fixture["cluster_id"]
+    )
+
+    expected_urls = {c.url: c.id for c in cluster_fixture["contents"]}
+    assert result.id_by_url == expected_urls
+
+
+@pytest.mark.asyncio
+async def test_get_or_compute_returns_empty_for_missing_nlp(
+    db_session, cluster_fixture
+):
+    svc = service_with_nlp(None)
+    result = await svc.get_or_compute_cluster_annotations(
+        db_session, cluster_fixture["cluster_id"]
+    )
+    assert result.tokens_by_id == {}
+    # URL map is still built (no spaCy needed for that)
+    assert len(result.id_by_url) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_or_compute_returns_empty_for_unknown_cluster(db_session):
+    svc = service_with_nlp(_trivial_nlp([]))
+    result = await svc.get_or_compute_cluster_annotations(db_session, uuid4())
+    assert result.tokens_by_id == {}
+    assert result.id_by_url == {}
+
+
+@pytest.mark.asyncio
+async def test_get_or_compute_does_not_raise_on_partial_cache(
+    db_session, cluster_fixture
+):
+    """Pre-populate cache for 1 of 3 contents → other 2 are computed & persisted."""
+    contents = cluster_fixture["contents"]
+    pre_seeded = ClusterTitleAnnotation(
+        cluster_id=cluster_fixture["cluster_id"],
+        content_id=contents[0].id,
+        strong_tokens=[{"start": 0, "end": 5, "text": "seed",
+                        "lemma": "seed", "pos": "NOUN"}],
+        model_version="v1-spacy-fr_md",
+    )
+    db_session.add(pre_seeded)
+    await db_session.commit()
+
+    titles = [c.title for c in contents]
+    nlp = _trivial_nlp(titles)
+    svc = service_with_nlp(nlp)
+
+    result = await svc.get_or_compute_cluster_annotations(
+        db_session, cluster_fixture["cluster_id"]
+    )
+
+    assert nlp.call_count == 2  # only the 2 missing titles
+    assert result.tokens_by_id[contents[0].id][0]["text"] == "seed"
+    rows = (
+        await db_session.execute(
+            select(ClusterTitleAnnotation).where(
+                ClusterTitleAnnotation.cluster_id == cluster_fixture["cluster_id"]
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 3


### PR DESCRIPTION
## Quoi

Phase 1 du *diff highlighting* sur le panel « Couverture médiatique » (Story 7.4, continuité Epic 7 Perspectives). Chaque titre alternatif renvoyé par `GET /contents/{id}/perspectives` est désormais accompagné d'un champ `highlight_spans` qui flague jusqu'à 4 mots forts divergents du titre de référence (article tapé par l'user), avec un champ `bias` = bord politique de la source (mappé en couleur côté Dart via `getBiasColor`).

Implémentation **100 % déterministe** : spaCy POS + lemmatisation + NER, **zéro LLM**. La phase 2 (Mistral-small raffinement) sera décidée plus tard sur audit qualité.

## Pourquoi

Aujourd'hui l'user doit lire 8 titres pour repérer les différences de vocabulaire entre rédactions. On vise 75-85 % de la valeur du surlignage sans coût d'inférence.

## Comment ça a été vérifié

- [x] `pytest -v` — **1122 passed, 13 skipped, 0 failed** (dont 13 unit + 6 intégration nouveaux)
- [x] `alembic heads` → 1 head (`cta01_cluster_title_annotations`)
- [x] `alembic upgrade head --sql` → SQL généré valide sur la chaîne `00000_baseline → sd01 → ad01 → cta01`
- [x] `/simplify` passé : bug d'accent sur le filtre stop-words corrigé (`société`/`analyse` slippaient), batch `nlp.pipe()` en 1 hop executor au lieu de N (gain ~2-3× sur le hot path), fallback défensif quand `ref_tokens` absent du cache, helpers de test Fake spaCy extraits dans `tests/fixtures/fake_spacy.py`, hoist de l'import lazy, `BiasStance.UNKNOWN.value` au lieu du string brut.

## Composants

- **Migration** : nouvelle table `cluster_title_annotations` (PK composite `(cluster_id, content_id)`, JSONB pour `strong_tokens` + `semantic_equiv`, FK ON DELETE CASCADE sur `contents`). Versioning via `model_version` pour re-runs cohorte futurs.
- **Service** `TitleAnnotationService` : singleton réutilisant le `nlp` spaCy de `NERService` (aucun double chargement modèle). `get_or_compute_cluster_annotations` upsert `ON CONFLICT DO NOTHING` (race-safe entre tabs concurrents). Batch via `nlp.pipe()`.
- **Router** : helper `_attach_highlight_spans` branché dans les **2 paths** du endpoint (stored snapshot + live Google News).
- **Defensive** : toute exception → `highlight_spans: []` partout (panel reste fonctionnel), log `error` (pas `warning` qui masquerait des bugs).

## Zones à risque

- `packages/api/app/routers/contents.py` — endpoint `GET /perspectives` (le plus chaud du panel)
- `packages/api/alembic/versions/cta01_cluster_title_annotations.py` — joué auto par le `Dockerfile` au boot Railway (sera la première migration prod)
- `packages/api/app/services/ml/ner_service.py` — accesseur `get_nlp()` ajouté (singleton spaCy partagé)

## Hors scope

Frontend Flutter, animation UX, règle anti-négation, phase 2 LLM, pré-calcul digest, table audit — tout est Sprint 2/3/4 selon métriques prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)