### PR TITLE
feat(perspectives): expose shared_tokens + reference_pivot (Story 7.4 Sprint 2)

### DIFF
--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -727,19 +727,24 @@ async def _attach_highlight_spans(
     db: AsyncSession,
     content: Content,
     perspectives_dicts: list[dict],
-) -> None:
-    """Mutate `perspectives_dicts` in-place adding `highlight_spans` to each.
+) -> dict | None:
+    """Mutate `perspectives_dicts` in-place adding `highlight_spans` + `shared_tokens`.
 
     Looks up cached strong_tokens for the cluster (computing & persisting if
     missing), then diffs the reference article's tokens against each
     perspective's. Perspectives that aren't part of any DB cluster
     (pure Google News results) get their tokens computed in one batched
-    spaCy call. Any failure → every perspective gets `highlight_spans: []`.
+    spaCy call. Any failure → every perspective gets empty lists.
+
+    Returns the reference title's pivot verb span `{start, end, text}` or
+    `None` — the caller bubbles it up to the response root so the front can
+    wash the pivot in the `cm-ref-inline` block.
     """
     if not content.cluster_id:
         for p in perspectives_dicts:
             p["highlight_spans"] = []
-        return
+            p["shared_tokens"] = []
+        return None
 
     try:
         svc = get_title_annotation_service()
@@ -776,6 +781,9 @@ async def _attach_highlight_spans(
                 alt_tokens,
                 p.get("bias_stance") or BiasStance.UNKNOWN.value,
             )
+            p["shared_tokens"] = svc.compute_shared_tokens(ref_tokens, alt_tokens)
+
+        return svc.compute_reference_pivot(ref_tokens)
     except Exception:
         logger.exception(
             "highlight_spans_failed",
@@ -784,6 +792,8 @@ async def _attach_highlight_spans(
         )
         for p in perspectives_dicts:
             p.setdefault("highlight_spans", [])
+            p.setdefault("shared_tokens", [])
+        return None
 
 
 @router.get("/{content_id}/perspectives", status_code=status.HTTP_200_OK)
@@ -935,7 +945,9 @@ async def get_perspectives(
         cached_row = analysis_result.scalars().first()
         cached_analysis = cached_row.analysis_text if cached_row else None
 
-        await _attach_highlight_spans(db, content, stored_perspectives)
+        reference_pivot = await _attach_highlight_spans(
+            db, content, stored_perspectives
+        )
 
         response = {
             "content_id": cache_key,
@@ -950,6 +962,7 @@ async def get_perspectives(
             "should_display": should_display,
             "analysis": cached_analysis,
             "analysis_cached": cached_analysis is not None,
+            "reference_pivot": reference_pivot,
         }
         _perspectives_cache[cache_key] = response
         logger.info(
@@ -1077,7 +1090,9 @@ async def get_perspectives(
         }
         for p in perspectives
     ]
-    await _attach_highlight_spans(db, content, perspectives_dicts)
+    reference_pivot = await _attach_highlight_spans(
+        db, content, perspectives_dicts
+    )
 
     response = {
         "content_id": cache_key,
@@ -1089,6 +1104,7 @@ async def get_perspectives(
         "should_display": should_display,
         "analysis": cached_analysis,
         "analysis_cached": cached_analysis is not None,
+        "reference_pivot": reference_pivot,
     }
 
     # Store in cache (TTLCache handles expiration automatically)

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -1090,9 +1090,7 @@ async def get_perspectives(
         }
         for p in perspectives
     ]
-    reference_pivot = await _attach_highlight_spans(
-        db, content, perspectives_dicts
-    )
+    reference_pivot = await _attach_highlight_spans(db, content, perspectives_dicts)
 
     response = {
         "content_id": cache_key,

--- a/packages/api/app/services/title_annotation_service.py
+++ b/packages/api/app/services/title_annotation_service.py
@@ -164,6 +164,35 @@ class TitleAnnotationService:
             for t in ranked[: self.MAX_HIGHLIGHTED_PER_TITLE]
         ]
 
+    def compute_shared_tokens(
+        self, ref_tokens: list[dict], alt_tokens: list[dict]
+    ) -> list[dict]:
+        """Return spans of `alt_tokens` whose lemma IS present in `ref_tokens`.
+
+        Symmetric to `diff_spans`: same lemma comparison, opposite filter,
+        no cap (the front wants every shared token rendered in tertiary so
+        the diff visualisation stays coherent). Preserves the alt token
+        ordering. Each span is `{start, end, text}` — no bias, no pos.
+        """
+        ref_lemmas = {t["lemma"] for t in ref_tokens}
+        return [
+            {"start": t["start"], "end": t["end"], "text": t["text"]}
+            for t in alt_tokens
+            if t["lemma"] in ref_lemmas
+        ]
+
+    def compute_reference_pivot(self, ref_tokens: list[dict]) -> dict | None:
+        """Return the first VERB span in `ref_tokens` as `{start, end, text}`.
+
+        Used by the hi-fi `cm-ref-inline` block to render the reference
+        title's pivot verb with a grey wash. Falls back to `None` when no
+        verb is found — the front then renders the title without wash.
+        """
+        for t in ref_tokens:
+            if t.get("pos") == "VERB":
+                return {"start": t["start"], "end": t["end"], "text": t["text"]}
+        return None
+
     async def get_or_compute_cluster_annotations(
         self, db: AsyncSession, cluster_id: UUID
     ) -> ClusterAnnotations:

--- a/packages/api/tests/routers/test_contents_perspectives_highlights.py
+++ b/packages/api/tests/routers/test_contents_perspectives_highlights.py
@@ -320,6 +320,93 @@ async def test_attach_highlight_spans_swallows_exceptions(
         "app.routers.contents.get_title_annotation_service",
         return_value=BrokenService(),
     ):
-        await _attach_highlight_spans(db_session, cluster_setup["ref"], perspectives)
+        pivot = await _attach_highlight_spans(
+            db_session, cluster_setup["ref"], perspectives
+        )
 
     assert perspectives[0]["highlight_spans"] == []
+    assert perspectives[0]["shared_tokens"] == []
+    assert pivot is None
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_returns_reference_pivot_and_shared_tokens(
+    db_session, cluster_setup
+):
+    """Happy path: ref pivot bubbles up, alt perspective carries shared_tokens."""
+    docs = {
+        "Tsahal frappe Gaza": FakeDoc(
+            tokens=[
+                FakeToken("Tsahal", 0, "PROPN", "Tsahal"),
+                FakeToken("frappe", 7, "VERB", "frapper"),
+                FakeToken("Gaza", 14, "PROPN", "Gaza"),
+            ],
+        ),
+        "Armée israélienne bombarde Gaza": FakeDoc(
+            tokens=[
+                FakeToken("Armée", 0, "NOUN", "armée"),
+                FakeToken("israélienne", 6, "ADJ", "israélien"),
+                FakeToken("bombarde", 18, "VERB", "bombarder"),
+                FakeToken("Gaza", 27, "PROPN", "Gaza"),
+            ],
+        ),
+    }
+    fake_svc = service_with_nlp(FakeNlp(docs))
+
+    perspectives = [
+        {
+            "title": "Armée israélienne bombarde Gaza",
+            "url": cluster_setup["alt_a"].url,
+            "bias_stance": "left",
+        }
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        pivot = await _attach_highlight_spans(
+            db_session, cluster_setup["ref"], perspectives
+        )
+
+    assert pivot == {"start": 7, "end": 13, "text": "frappe"}
+    shared = perspectives[0]["shared_tokens"]
+    assert [s["text"] for s in shared] == ["Gaza"]
+    assert shared[0]["start"] == 27
+    assert "bias" not in shared[0]
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_returns_none_pivot_without_cluster(db_session):
+    """No cluster_id → no pivot computed, shared_tokens defaulted to []."""
+    source = Source(
+        id=uuid4(),
+        name="Solo",
+        url="https://solo2.fr",
+        feed_url=f"https://solo2.fr/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+    )
+    db_session.add(source)
+    await db_session.commit()
+    standalone = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title="Standalone",
+        url="https://solo2.fr/x",
+        published_at=datetime.now(UTC),
+        content_type=ContentType.ARTICLE,
+        guid="solo2-x",
+        cluster_id=None,
+    )
+    db_session.add(standalone)
+    await db_session.commit()
+
+    perspectives = [
+        {"title": "Anything", "url": "https://other.fr/y", "bias_stance": "left"}
+    ]
+    pivot = await _attach_highlight_spans(db_session, standalone, perspectives)
+
+    assert pivot is None
+    assert perspectives[0]["shared_tokens"] == []

--- a/packages/api/tests/services/test_title_annotation_service.py
+++ b/packages/api/tests/services/test_title_annotation_service.py
@@ -160,6 +160,79 @@ def test_diff_spans_preserves_offsets():
     assert spans[0]["end"] == 21
 
 
+# --- compute_shared_tokens --------------------------------------------------
+
+
+def test_compute_shared_tokens_returns_alt_spans_with_matching_lemma():
+    ref = [_tok("ministre", "ministre"), _tok("réforme", "réforme", start=10)]
+    alt = [
+        _tok("Ministre", "ministre", start=0),
+        _tok("brutale", "brutal", pos="ADJ", start=10),
+        _tok("Réformes", "réforme", start=20),
+    ]
+    svc = service_with_nlp(None)
+
+    shared = svc.compute_shared_tokens(ref, alt)
+    texts = [s["text"] for s in shared]
+
+    assert texts == ["Ministre", "Réformes"]
+    # No bias / pos fields exposed — just position + text
+    assert all(set(s.keys()) == {"start", "end", "text"} for s in shared)
+
+
+def test_compute_shared_tokens_preserves_alt_offsets():
+    ref = [_tok("guerre", "guerre")]
+    alt = [_tok("guerre", "guerre", start=42)]
+    svc = service_with_nlp(None)
+
+    shared = svc.compute_shared_tokens(ref, alt)
+    assert shared == [{"start": 42, "end": 48, "text": "guerre"}]
+
+
+def test_compute_shared_tokens_empty_when_no_overlap():
+    ref = [_tok("paix", "paix")]
+    alt = [_tok("guerre", "guerre", start=10)]
+    svc = service_with_nlp(None)
+    assert svc.compute_shared_tokens(ref, alt) == []
+
+
+def test_compute_shared_tokens_is_uncapped():
+    """Unlike diff_spans, shared has no MAX cap — the front renders them all."""
+    ref = [_tok(f"w{i}", f"w{i}", start=i * 5) for i in range(8)]
+    alt = [_tok(f"W{i}", f"w{i}", start=i * 5) for i in range(8)]
+    svc = service_with_nlp(None)
+    assert len(svc.compute_shared_tokens(ref, alt)) == 8
+
+
+# --- compute_reference_pivot ------------------------------------------------
+
+
+def test_compute_reference_pivot_returns_first_verb():
+    ref = [
+        _tok("Macron", "Macron", pos="PROPN", start=0),
+        _tok("annonce", "annoncer", pos="VERB", start=7),
+        _tok("réforme", "réforme", pos="NOUN", start=15),
+        _tok("présente", "présenter", pos="VERB", start=23),
+    ]
+    svc = service_with_nlp(None)
+    pivot = svc.compute_reference_pivot(ref)
+    assert pivot == {"start": 7, "end": 14, "text": "annonce"}
+
+
+def test_compute_reference_pivot_none_when_no_verb():
+    ref = [
+        _tok("Macron", "Macron", pos="PROPN"),
+        _tok("réforme", "réforme", pos="NOUN", start=7),
+    ]
+    svc = service_with_nlp(None)
+    assert svc.compute_reference_pivot(ref) is None
+
+
+def test_compute_reference_pivot_none_when_empty():
+    svc = service_with_nlp(None)
+    assert svc.compute_reference_pivot([]) is None
+
+
 # --- get_or_compute_cluster_annotations -------------------------------------
 
 


### PR DESCRIPTION
## Summary

Mini-PR back préparant la refonte hi-fi de la couverture médiatique (front Story 7.4 Sprint 2 à suivre dans une PR séparée). Ajoute 2 champs à `GET /contents/{id}/perspectives` pour fidéliser le rendu Mode 3 (diff lexical) et le wash du verbe-pivot dans le bloc référence.

- `compute_shared_tokens(ref, alt)` — symétrique de `diff_spans`, renvoie les spans de l'alt dont le lemma est présent dans ref. Pas de cap (le front les rend tous en `text_tertiary`). Pas de bias.
- `compute_reference_pivot(ref)` — premier VERB du titre référence, `{start, end, text}` ou `None`. Permet au front de wash le verbe-pivot en gris dans le bloc `cm-ref-inline`.
- `_attach_highlight_spans` mute désormais aussi `shared_tokens` par perspective et renvoie le pivot ; les 2 paths de réponse (stored snapshot + live Google News) le propagent en `reference_pivot`.

Rétro-compatible : champs existants intacts, nouveaux champs `[]` / `null` quand le path cluster n'est pas dispo (no-cluster / exception).

## Test plan

- [x] `pytest tests/services/test_title_annotation_service.py tests/routers/test_contents_perspectives_highlights.py -v` → 28/28 ✓
- [x] `pytest tests/routers/ -v` → 84/84 ✓ (aucune régression)
- [ ] Une fois déployé : `curl -H "Authorization: Bearer <token>" https://api-staging/.../contents/{id}/perspectives | jq '.reference_pivot, .perspectives[0].shared_tokens'` doit renvoyer respectivement un objet `{start,end,text}` ou `null`, et une liste de spans.
- [ ] Mobile PR à suivre : `PerspectivesInlineSection` consommera ces nouveaux champs (Mode 3 fidèle) ; en attendant, le front ignore les champs absents → aucune action requise côté apps déployées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)