### PR TITLE
hotfix(alembic): merge heads 22a1 + cta01 (feed prod cassé)

### DIFF
--- a/packages/api/alembic/versions/5de67819bc61_merge_22a1_interest_state_cta01_cluster_.py
+++ b/packages/api/alembic/versions/5de67819bc61_merge_22a1_interest_state_cta01_cluster_.py
@@ -1,0 +1,36 @@
+"""merge 22a1 interest_state + cta01 cluster_title_annotations
+
+Hotfix : les PRs Story 22.1 (interest_state + favoris) et perspectives 7.4
+(cluster_title_annotations) ont mergé en parallèle deux migrations descendant
+toutes deux de `ad01_add_is_ad_to_contents` → branchpoint Alembic, 2 heads.
+Le `Dockerfile` exécute `alembic upgrade head` (singulier) au boot Railway et
+échoue avec "Multiple head revisions are present" → la prod est restée figée
+sur `cta01_cluster_title_annotations` et `22a1_interest_state_favorites` n'a
+jamais été appliquée. Conséquence : les colonnes `user_interests.state`,
+`user_sources.state` et les tables `user_favorite_*` n'existent pas en prod,
+toutes les requêtes feed renvoient `UndefinedColumn` → /api/feed/* en 500.
+
+Cette révision unifie le graphe sans DDL : au prochain boot, Alembic
+appliquera naturellement `22a1` (DDL + backfill embarqué) puis ce merge.
+
+Revision ID: 5de67819bc61
+Revises: 22a1_interest_state_favorites, cta01_cluster_title_annotations
+Create Date: 2026-05-18 16:32:54.816174
+
+"""
+
+revision: str = "5de67819bc61"
+down_revision: tuple[str, ...] = (
+    "22a1_interest_state_favorites",
+    "cta01_cluster_title_annotations",
+)
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Symptôme prod

Depuis ce matin, plus aucun article ne charge en prod :
- Sections thématiques vides
- Section Explorer vide
- **Ancienne version du feed également cassée** (apps mobiles non MAJ)

## Cause racine — confirmée empiriquement

Les PRs **Story 22.1** (interest_state + favoris, commits \`1c3dece9\`/\`c351b5c7\`/\`a659990e\`) et **Perspectives 7.4** (PR #616/#618, cluster_title_annotations) ont mergé en parallèle deux migrations descendant toutes deux de \`ad01_add_is_ad_to_contents\` → **branchpoint Alembic, 2 heads non mergées**.

\`\`\`
$ alembic heads
22a1_interest_state_favorites (head)
cta01_cluster_title_annotations (head)
\`\`\`

Le \`Dockerfile\` exécute \`alembic upgrade head\` (singulier) au boot Railway et échoue avec *"Multiple head revisions are present"*. Le CMD retry 3× puis démarre quand même → \`app/checks.py\` valide \`script_directory.get_heads()[0]\` qui est \`cta01\` (= \`current_rev\` en prod) → pas de crash, mais la migration 22a1 **n'a jamais tourné**.

### Évidence en prod (via Supabase MCP)

\`\`\`sql
SELECT version_num FROM alembic_version;
-- cta01_cluster_title_annotations

SELECT column_name FROM information_schema.columns
WHERE table_name IN ('user_interests','user_sources') AND column_name='state';
-- (0 rows)

SELECT table_name FROM information_schema.tables
WHERE table_name IN ('user_favorite_interests','user_favorite_sources');
-- (0 rows)
\`\`\`

Le code récent (\`recommendation_service.py:304-312\`, \`models/user.py:102\`, \`models/source.py:160-201\`) référence \`UserInterest.state\` → toute requête feed lève \`column "state" does not exist\` → /api/feed/* en 500 → mobile vide (vieux ET nouveau client, même endpoint backend).

## Fix

Migration de merge vide qui unifie le graphe : \`down_revision = ("22a1_interest_state_favorites", "cta01_cluster_title_annotations")\`. Au prochain boot Railway, Alembic appliquera naturellement :
1. \`22a1_interest_state_favorites\` (crée enum + colonnes + tables + backfill)
2. \`5de67819bc61\` (merge, no-op)

Pas de \`alembic stamp\` manuel requis : la chaîne se rejoue toute seule.

## Test plan

- [x] \`alembic upgrade head\` sur DB vide → toute la chaîne passe
- [x] \`alembic stamp cta01 && alembic upgrade head\` (scénario prod) → applique 22a1 puis le merge, sans erreur
- [x] Vérification schéma post-migration : \`user_interests.state\` (interest_state), \`user_sources.state\`, tables \`user_favorite_*\` créées
- [x] \`pytest tests/alembic/test_interest_state_migration.py\` : 8 passed
- [x] \`pytest -x\` (suite backend complète) : **1167 passed, 13 skipped**

## Vérification post-déploiement

Dès que Railway redéploie :
\`\`\`sql
SELECT version_num FROM alembic_version;  -- doit être 5de67819bc61
SELECT column_name FROM information_schema.columns
  WHERE table_name='user_interests' AND column_name='state';  -- 1 row
\`\`\`
- Sentry : la classe \`UndefinedColumn\` doit s'arrêter
- Test app : feed thématique + Explorer rechargent

## Follow-up (hors hotfix)

- Renforcer \`post-edit-alembic-heads.sh\` pour qu'il tourne aussi en CI (pas seulement par session) — sinon scénario reproductible à la prochaine PR parallèle. À planifier dans une story Maintenance dédiée.

Référence : [runbook drift Alembic](../blob/main/docs/runbooks/recover-from-alembic-drift.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)