### PR TITLE
fix(perspectives): activer surlignage des titres sans dépendre du clustering

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,221 +1,30 @@
-# PR — feat: système d'intérêts unifié (22.1) + Flux Continu V1.8/V2.0 + couplage favoris (21.1)
-
-> **PR finale unique** regroupant la story 22.1 (système d'intérêts) ET la
-> story 21.1 (Flux Continu V1.8/V2.0 + couplage favoris) — l'absence de
-> staging impose ce ship groupé.
->
-> Commits (depuis `origin/main`) :
-> 1. `ae59c924` — backend interest state + favorites tables + endpoints (22.1.1)
-> 2. `2dee657a` — écrans intérêts/sources sur le moteur 4-états (22.1.2)
-> 3. `0db30ad4` — backfill favoris legacy + sync mobile one-shot (22.1.3)
-> 4. Commits Flux Continu V1.8 + V2.0 (Story 21.1, ~13 commits cherry-pickés)
-> 5. `90fe4b7a` — WIP V10 : amorce couplage favoris (recovery du stash pré-pivot)
-> 6. `<HEAD>` — refacto SectionKind string-keyed + couplage favoris finalisé
->
-> Cible : `--base main` (staging déprécié).
+# PR — fix: surlignage progressif des titres (Couverture médiatique) invisible en prod
 
 ## Summary
 
-- **Refonte complète du système d'intérêts** autour d'un unique modèle 4-états (`hidden` / `unfollowed` / `followed` / `favorite`) appliqué aux Thèmes, Sujets et Sources. Cap dur à 3 favoris par catégorie (intérêts vs sources, séparés). Ordre canonique éditable par drag.
-- **Backend** : enum `interest_state`, 2 nouvelles tables (`user_favorite_interests`, `user_favorite_sources`), 6 nouveaux endpoints, câblage `state` dans la Pertinence (`hidden`=0 ; `favorite`=floor 1.5).
-- **Mobile** : suppression du slider 1→3 + SharedPrefs `theme_priority_*`, nouveau `userInterestsProvider` (source de vérité unique), écrans Mes intérêts/Mes sources refondus, sheet feed reconnectée sur `favorites`.
-- **Backfill + sync legacy (commit 3)** : la migration peuple `user_favorite_interests` pour 100 % des users existants (cible ≥ 2 favoris, cap 3) ; au 1er lancement mobile post-MeP, un service silencieux promeut les Thèmes 3/3 hérités vers les favoris backend puis purge les SharedPrefs.
+Surlignage progressif des titres invisible en prod (section "Couverture médiatique" / perspectives) car la pipeline backend renvoyait toujours `highlight_spans: []`. Vérifié sur Supabase : `0 / 41 045` contents ont un `cluster_id`, donc l'early-return `if not content.cluster_id` de `_attach_highlight_spans` court-circuitait pour tous les articles. Le batch off-cluster `nlp.pipe()` prévu plus bas n'était jamais atteint.
 
-## Changements (commit 3 — détail)
+Bug doc complet : `docs/bugs/bug-perspectives-highlight-spans-missing.md`.
 
-### Backend
+## Changes
 
-- `app/constants.py` : ajout `MIN_BACKFILL_FAVORITES=2` et `CANONICAL_THEME_SLUGS` (9 macro-thèmes).
-- `alembic/versions/22a1_interest_state_favorites.py` : extension `upgrade()` avec CTE backfill SQL pur (idempotent via `ON CONFLICT DO NOTHING`) qui construit jusqu'à 3 favoris/user dans cet ordre :
-  1. Sujets custom à `priority_multiplier=2.0`
-  2. Top weight ML Thèmes (skip ceux passés `hidden` à l'étape précédente)
-  3. Fallback `tech` + `science` pour les users sans aucun signal
-  - Ensuite `UPDATE state='favorite'` sur les rows sources + `INSERT user_interests` pour les fallback themes.
-- `tests/alembic/test_interest_state_migration.py` : 5 nouveaux tests (promo Sujet 2.0, complétion à min 2, fallback canonical, cap 3, idempotence re-run).
+### Backend — Cause racine
+- `packages/api/app/routers/contents.py` (`_attach_highlight_spans`) : retire l'early-return sur `not content.cluster_id`. La fonction n'appelle `get_or_compute_cluster_annotations()` que si `cluster_id` est présent (évite un scan `WHERE cluster_id IS NULL` sur les 41 k contents standalone). Le batch off-cluster existant calcule alors les tokens spaCy pour toutes les perspectives, `ref_tokens` est obtenu via le fallback `compute_strong_tokens(title)`, et `diff_spans` / `compute_shared_tokens` / `compute_reference_pivot` produisent les données attendues par le mobile.
 
-### Mobile
-
-- `apps/mobile/lib/features/my_interests/services/interests_sync_service.dart` : service one-shot lit les `SharedPreferences.theme_priority_<MacroLabel>` (legacy), promeut chaque thème à `multiplier >= 2.0` en favori via `setInterestState`, absorbe `FavoriteCapReachedException` silencieusement, purge toutes les clés legacy + pose le flag `interests_v2_legacy_synced`.
-- `apps/mobile/lib/app.dart` : `ref.watch(interestsSyncProvider)` dans `FacteurApp.build()` (pattern miroir d'`onboardingSyncProvider`).
-- `test/features/my_interests/services/interests_sync_service_test.dart` : 5 tests (promo, idempotence, cap absorption, purge prefs, macro-label inconnu).
-
-## Changements (commit 6 — couplage Flux Continu ↔ favoris finalisé)
-
-> Cette PR finalise ce que le WIP V10 (`90fe4b7a`) avait amorcé. Le couplage
-> est désormais complet, sans dette technique reportée.
-
-### Refacto `SectionKind` en clés string-based
-
-- `apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart` :
-  - `enum SectionKind { essentiel, bonnes, theme }` (un seul `theme`,
-    plus de `theme1`/`theme2`).
-  - `FeedThemeSection` gagne `String? customTopicId` (XOR avec `themeSlug`)
-    pour distinguer Thème vs Sujet favori.
-  - Top-level helper `String sectionKey(FluxSection s)` : retourne
-    `'essentiel'` / `'bonnes'` / `'theme:<slug>'` / `'topic:<uuid>'`.
-  - `Map<SectionKind, bool>` → `Map<String, bool>` pour `folded`/`moreOpen`.
-    Helpers `isOpen(FluxSection)`/`isFolded(FluxSection)` (la dérivation de
-    clé reste dans le modèle).
-
-### Provider piloté par les favoris (`flux_continu_provider.dart`)
-
-- `_themes` devient une `List<FeedThemeSection>` dynamique (0..3) au lieu
-  de deux variables `_theme1`/`_theme2`.
-- `_pickFavorites()` lit `userInterestsProvider.favorites` en priorité ;
-  fallback `top-themes` legacy puis padding canonique `[tech, environment,
-  science]` pour les comptes encore sans favori (filet pour
-  pré-backfill 22.1.3).
-- Pour chaque `FavoriteRef` :
-  - `ThemeFavoriteRef(slug)` → `getFeed(theme: slug, ...)`
-  - `CustomTopicFavoriteRef(id)` → `getFeed(topic: id, ...)` (l'endpoint
-    backend `_resolve_topic_param` accepte slug OU UUID stringified
-    scoped user — pas de cross-user leak).
-- `ref.listen(userInterestsProvider, ...)` : sur changement de `favorites`,
-  appelle `_refetchThemesOnly()` qui rejoue uniquement les `getFeed(theme/
-  topic)` (économise digest + feed continu).
-- Hydration SharedPreferences tolérante : `_isLiveFoldedKey` ignore
-  silencieusement les anciennes clés `theme1`/`theme2` (purge journalier
-  les nettoie dans <24h).
-
-### Adaptations écran + widgets
-
-- `flux_continu_screen.dart` : `_isFavoriteKind` → `_isFavoriteSection`,
-  `_markSectionsAboveAsScrolledPast(FluxSection? fromSection)` (compare
-  via `sectionKey`).
-- `widgets/section_block.dart` : callback `onTapArticle(article,
-  FluxSection)` au lieu de `(article, SectionKind)`.
-- `widgets/my_interests_sheet.dart` : lit directement
-  `userInterestsProvider.favorites` (au lieu de
-  `fluxContinuProvider.sections.whereType<FeedThemeSection>()`), affiche
-  `N/3 FAVORIS`, résout label/accent via `themeMap` (Theme) ou
-  `customTopics` (Sujet).
+### Mobile — Bug latent
+- `apps/mobile/lib/features/digest/widgets/topic_section.dart` et `article_viewer_modal.dart` : les 2 mappings `PerspectiveData → Perspective` oubliaient `highlightSpans` et `sharedTokens`. Le widget `DiffTitle` recevait `const []` et basculait silencieusement en Mode 2 fallback. Ajout des 2 champs dans les 2 mappings.
 
 ### Tests
-
-- `test/features/flux_continu/models/flux_continu_models_test.dart` :
-  +4 tests `sectionKey` (digest/theme/topic/slug-less), Maps réécrits en
-  string-keys.
-- `test/features/flux_continu/providers/flux_continu_provider_test.dart` :
-  +5 tests favoris-driven (0 favori → 3 canoniques fetched, 1 Theme,
-  1 Sujet → `getFeed(topic:)`, cap 3, hydration tolère `theme1`/`theme2`).
-- `test/features/flux_continu/widgets/my_interests_sheet_test.dart` :
-  refait sur stub `UserInterestsNotifier`, couvre custom topic + empty
-  hint.
-
-Total mobile flux_continu : **49 tests verts** (vs 6 avant).
-
-## Mobile rétrocompat & sécurité du staged rollout
-
-Les endpoints legacy (`PUT /api/personalization/topics/{id}`, `PUT /api/sources/{id}/weight`, `GET /api/users/top-themes`) **restent intacts** : un client mobile pré-22.1.2 continue de fonctionner sans cassure pendant la fenêtre de roll-out. Le sync mobile s'exécute uniquement après auth, fire-and-forget, et est silencieux sur toute erreur (404, 422, 5xx).
-
-## Migration impact (rappel)
-
-- **Tables touchées** : `user_interests` (+ `state` + UNIQUE `(user_id, interest_slug)`), `user_topic_profiles` (+ `state`), `user_sources` (+ `state`).
-- **Tables créées** : `user_favorite_interests`, `user_favorite_sources`.
-- **Type créé** : `interest_state` (ENUM 4 valeurs).
-- **Dedupe défensif** : 39 doublons `(user_id, interest_slug)` purgés (garde la row de plus grand weight).
-- **Migration de données** : `weight ≤ 0.5` → `hidden` ; `priority_multiplier = 0.2` → `hidden` ; **backfill** des favoris pour tous les users existants.
-- **Downgrade** : `DROP TABLE` cascade tout, round-trip testé.
-
-## Plan rollback exécutable
-
-1. **Si la migration plante au boot Railway** :
-   - Revert la PR sur GitHub → redéploie le commit précédent (chaîne pointe sur `ad01`).
-   - Cas extrême : SSH pod prod + `alembic downgrade -1` manuel.
-2. **Si la migration passe mais comportement cassé** :
-   - Revert la PR. Les endpoints legacy intacts maintiennent les anciens clients mobile.
-   - Le nouveau mobile (publié après la PR) gère gracieusement les 5xx via caches existants.
-   - Les favoris backfillés sont droppés en cascade par le downgrade (table détruite).
-3. **Intégrité post-rollback** :
-   ```sql
-   SELECT COUNT(*) FROM user_interests;        -- doit matcher baseline pre-MeP (à part les 39 doublons dédupés)
-   SELECT COUNT(*) FROM information_schema.tables WHERE table_name LIKE 'user_favorite_%';  -- = 0
-   SELECT COUNT(*) FROM pg_type WHERE typname='interest_state';  -- = 0
-   ```
-
-## Smoke tests post-MeP (à T+10min après déploiement Railway)
-
-```bash
-# 1. Healthcheck
-curl https://api.facteur.app/health  # 200
-
-# 2. Backfill effectif : aucun user à 0 favori
-psql $DATABASE_URL -c "
-  SELECT COUNT(*) FROM user_profiles up
-  WHERE NOT EXISTS (
-    SELECT 1 FROM user_favorite_interests ufi WHERE ufi.user_id = up.user_id
-  );
-"  # → 0 (ou très petit nombre d'edge cases acceptables)
-
-# 3. Distribution des favoris par user
-psql $DATABASE_URL -c "
-  SELECT cnt, COUNT(*) FROM (
-    SELECT user_id, COUNT(*) AS cnt
-    FROM user_favorite_interests GROUP BY user_id
-  ) s GROUP BY cnt ORDER BY cnt;
-"  # → majorité à 2 ou 3, aucun > 3
-
-# 4. Cap respecté
-psql $DATABASE_URL -c "
-  SELECT COUNT(*) FROM (
-    SELECT user_id FROM user_favorite_interests GROUP BY user_id HAVING COUNT(*) > 3
-  ) s;
-"  # → 0
-
-# 5. state='favorite' cohérent
-psql $DATABASE_URL -c "
-  SELECT COUNT(*) FROM user_favorite_interests ufi
-  LEFT JOIN user_interests ui ON ui.user_id = ufi.user_id AND ui.interest_slug = ufi.interest_slug
-  WHERE ufi.interest_slug IS NOT NULL AND (ui.state != 'favorite' OR ui.state IS NULL);
-"  # → 0
-
-# 6. GET interests sur compte de test
-curl -H "Authorization: Bearer $JWT_TEST" https://api.facteur.app/api/user/interests \
-  | jq '{count: .favorite_count, cap: .favorite_cap, favorites: .favorites}'
-# → favorite_count >= 2, cap = 3
-
-# 7. PATCH au-delà du cap → 422
-# (après avoir 3 favoris)
-curl -X PATCH https://api.facteur.app/api/user/interests \
-  -H "Authorization: Bearer $JWT_TEST" \
-  -d '{"kind":"theme","target_id":"sport","state":"favorite"}'  # → 422
-
-# 8. PostHog (à T+1h)
-# Dashboard PostHog : événements `interest_state_changed` doivent arriver
-# dans l'heure suivant la MeP (sync mobile des Thèmes 3/3 legacy).
-```
-
-## PostHog events
-
-Hérités de PR 22.1.1 (convention flat snake_case) :
-- `interest_state_changed` (kind, target_id, new_state, prev_state)
-- `interest_favorite_reordered` (favorite_count, kind)
-- `interest_cap_blocked` (kind, target_id, current_count)
-
-Le sync mobile post-MeP émet `interest_state_changed` une fois par Thème legacy promu — métrique idéale pour mesurer le taux de couverture sync sur 30j.
+- `packages/api/tests/routers/test_contents_perspectives_highlights.py` :
+  - Remplace l'ancien test qui assertait `highlight_spans == []` sans cluster (comportement bogué) par `test_attach_highlight_spans_computes_for_content_without_cluster` validant le nouveau contrat.
+  - Ajoute `test_attach_highlight_spans_without_cluster_skips_db_scan` pour garder l'invariant "pas de scan DB sur cluster_id IS NULL".
 
 ## Test plan
 
-- [x] `pytest -v` complet : 1121+5 passed, 0 failures (+ tests backfill)
-- [x] `flutter test test/features/flux_continu/` : 49/49 verts (5 nouveaux
-      tests couplage favoris finalisé + 1 hydration tolerance)
-- [x] `flutter test` complet : 639 tests, 36 échecs **tous pré-existants**
-      (digest stubs « Test not implemented », topic_chip icon finder, auth/
-      notification/feed scenarios — zéro régression dans `flux_continu` ou
-      `my_interests`)
-- [x] `flutter analyze` flux_continu/my_interests/tests : 0 erreur
-      (9 infos `withOpacity`/`activeColor` pré-existantes)
-- [x] `alembic heads` local → 1 ligne (`22a1_interest_state_favorites`)
-- [x] Head Alembic prod vérifié = `ad01_add_is_ad_to_contents` (matche
-      `down_revision` de la nouvelle migration — pas de drift)
-- [x] Audit prod : 39 doublons `(user_id, interest_slug)` confirmés
-      (gérés par le dedupe défensif de la migration)
-- [x] Audit prod : enum `interest_state` / table `user_favorite_interests` /
-      colonne `user_interests.state` tous absents → migration tournera
-      cleanly sans collision
-- [x] `rg "SectionKind\\.(theme1|theme2)" apps/mobile/` → 0 résultat
-- [ ] `/validate-feature` (Chrome 390x844) APPROVED : 9 scénarios A. 22.1 +
-      9 scénarios B. 21.1 + 7 scénarios C. couplage (9a→9g) du
-      `.context/qa-handoff.md`
-- [ ] Smoke tests F1-F8 ci-dessus à T+10min post-déploiement Railway
-- [ ] Vérification PostHog `interest_state_changed` à T+1h
+- [x] `pytest tests/routers/test_contents_perspectives_highlights.py` → 8/8 passent
+- [x] Suite backend complète → 1167 passed, 13 skipped
+- [x] `flutter analyze` sur les 2 fichiers mobile modifiés → 0 erreurs
+- [x] `flutter test` widgets touchés (DiffTitle, PerspectivesInline, fromJson) → 20/20 passent
+- [ ] **Validation prod après merge** : appeler `GET /api/v1/contents/{id}/perspectives` sur un article récent et vérifier que `.perspectives[0].highlight_spans` est non-vide. Visuellement, ouvrir la section "Couverture médiatique" d'un article avec ≥ 3 sources et observer le surlignage progressif des titres dans la vue inline (`PerspectivesInlineSection` → `DiffTitle`).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -884,6 +884,8 @@ class _TopicSectionState extends ConsumerState<TopicSection>
                   sourceDomain: p.sourceDomain,
                   biasStance: p.biasStance,
                   publishedAt: p.publishedAt,
+                  highlightSpans: p.highlightSpans,
+                  sharedTokens: p.sharedTokens,
                 ))
             .toList(),
         biasDistribution: response.biasDistribution,

--- a/apps/mobile/lib/features/feed/widgets/article_viewer_modal.dart
+++ b/apps/mobile/lib/features/feed/widgets/article_viewer_modal.dart
@@ -172,6 +172,8 @@ class _ArticleViewerModalState extends ConsumerState<ArticleViewerModal> {
                     sourceDomain: p.sourceDomain,
                     biasStance: p.biasStance,
                     publishedAt: p.publishedAt,
+                    highlightSpans: p.highlightSpans,
+                    sharedTokens: p.sharedTokens,
                   ),
                 )
                 .toList(),

--- a/docs/bugs/bug-perspectives-highlight-spans-missing.md
+++ b/docs/bugs/bug-perspectives-highlight-spans-missing.md
@@ -1,0 +1,104 @@
+# Bug: Surlignage progressif des titres invisible en prod (Couverture médiatique)
+
+## Status: IN PROGRESS
+
+## Date: 2026-05-18
+
+## Symptômes
+
+- À l'ouverture de la section "Couverture médiatique" d'un article (perspectives) avec plusieurs sources, le surlignage progressif des éléments identifiés n'apparaît jamais.
+- Comportement identique sur tous les articles en prod, depuis le déploiement de la feature.
+- Aucune erreur visible côté client ou API.
+
+## Investigation
+
+### Preuves récoltées (Supabase prod `ykuadtelnzavrqzbfdve`)
+
+| Vérif | Résultat |
+|------|----------|
+| Migration `cta01_cluster_title_annotations` appliquée | OUI (`alembic_version = 5de67819bc61`) |
+| Table `cluster_title_annotations` — lignes | **0** |
+| Table `perspective_analyses` — lignes | **0** |
+| `contents` avec `cluster_id IS NOT NULL` | **0 / 41 045** |
+| Table `clusters` | n'existe **pas** |
+| `daily_digest` 7 derniers jours | 1 110 lignes (pipeline tourne) |
+| Articles de perspective du dernier digest | 12 |
+| Articles de perspective avec `highlight_spans` non-vide | **0 / 12** |
+
+### Causes superposées
+
+**Cause B — Live + fast path bloqués par early-return** *(racine en prod)*
+
+`packages/api/app/routers/contents.py:791-795` :
+```python
+if not content.cluster_id:
+    for p in perspectives_dicts:
+        p["highlight_spans"] = []
+        p["shared_tokens"] = []
+    return None
+```
+Comme **0/41 045 contents** ont un `cluster_id` en prod (le clustering n'est jamais activé), ce early-return s'applique à tous les appels. Le batch off-cluster `nlp.pipe()` situé plus bas (qui pourrait calculer les annotations spaCy à la volée sans cluster) n'est jamais atteint.
+
+Cette fonction est appelée par :
+- Le **fast path** snapshot : `routers/contents.py:1012`
+- Le **live path** Google News : `routers/contents.py:1166`
+
+Donc les deux retournent toujours des listes vides → `highlight_spans: []` dans la réponse JSON.
+
+**Cause C — Mobile drop les champs lors du mapping** *(bug latent)*
+
+Deux conversions `PerspectiveData → Perspective` oublient `highlightSpans` et `sharedTokens` :
+- `apps/mobile/lib/features/digest/widgets/topic_section.dart:879-887`
+- `apps/mobile/lib/features/feed/widgets/article_viewer_modal.dart:168-175`
+
+Même après le fix backend, ces deux entrées (modale "Couverture médiatique" depuis le digest, et modale article viewer depuis le feed) ne montreraient rien. Seule la vue inline `content_detail_screen.dart:2822-2831, 3380-3388` passe correctement les champs.
+
+Le widget `DiffTitle` (`apps/mobile/lib/features/feed/widgets/diff_title.dart:37-39, 111-174`) a des defaults `const []` et bascule silencieusement en "Mode 2 fallback" quand les deux listes sont vides → aucune erreur, aucun rendu.
+
+## Fix appliqué
+
+### Backend (cette PR)
+
+**Fichier modifié** : `packages/api/app/routers/contents.py`
+
+`_attach_highlight_spans()` :
+- Retire le early-return sur `content.cluster_id is None`.
+- Protège l'appel à `get_or_compute_cluster_annotations()` (ne le déclenche que si `cluster_id` est présent, sinon `ClusterAnnotations()` vide — évite une scan complète de la table `contents` sur `WHERE cluster_id IS NULL`).
+- Le batch off-cluster `compute_strong_tokens_batch()` existant calcule alors les tokens spaCy pour toutes les perspectives, et `compute_strong_tokens()` calcule `ref_tokens` pour le titre référence.
+- `diff_spans()`, `compute_shared_tokens()` et `compute_reference_pivot()` produisent les données attendues par le mobile.
+
+### Mobile (PR suivante)
+
+Ajouter `highlightSpans` et `sharedTokens` dans les 2 mappings cassés. Aucun nouveau widget — `DiffTitle` est déjà utilisé par la vue inline qui marche.
+
+## Vérification
+
+### Local
+
+```bash
+cd packages/api && source venv/bin/activate
+pytest -v tests/routers/test_contents_perspectives_highlights.py
+uvicorn app.main:app --port 8080 &
+curl -s http://localhost:8080/api/v1/contents/<id>/perspectives \
+  -H "Authorization: Bearer <token>" | jq '.perspectives[0].highlight_spans'
+# Doit renvoyer un array non-vide [{start, end, text, bias}, ...]
+```
+
+### Prod (après déploiement)
+
+```sql
+-- Doit passer de 0 à >0 après prochaine régénération de digest OU au prochain GET /perspectives
+WITH recent AS (SELECT items FROM daily_digest ORDER BY created_at DESC LIMIT 1),
+subjects AS (SELECT jsonb_array_elements(items->'subjects') AS subj FROM recent)
+SELECT SUM((SELECT COUNT(*) FROM jsonb_array_elements(COALESCE(subj->'perspective_articles','[]'::jsonb)) p
+            WHERE jsonb_array_length(p->'highlight_spans') > 0))
+FROM subjects;
+```
+
+Note : la snapshot stockée dans `daily_digest.items` ne contiendra toujours pas `highlight_spans` (les snapshots sont écrites par la pipeline éditoriale, qui n'enrichit pas — c'est intentionnel). En revanche, à chaque `GET /perspectives`, le backend enrichit la snapshot lue à la volée via `_attach_highlight_spans()`. Donc pour valider en prod, appeler l'endpoint et inspecter la réponse plutôt que la table.
+
+## Plan tests unitaires
+
+Étendre `packages/api/tests/routers/test_contents_perspectives_highlights.py` :
+- Cas "content sans cluster_id" → `highlight_spans` non-vide pour les perspectives qui divergent du titre référence.
+- Cas "content avec cluster_id" inchangé (régression).

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -25,7 +25,10 @@ from app.services.collection_service import CollectionService
 from app.services.content_extractor import ContentExtractor
 from app.services.content_service import ContentService
 from app.services.feed_cache import FEED_CACHE
-from app.services.title_annotation_service import get_title_annotation_service
+from app.services.title_annotation_service import (
+    ClusterAnnotations,
+    get_title_annotation_service,
+)
 
 logger = structlog.get_logger()
 
@@ -788,16 +791,16 @@ async def _attach_highlight_spans(
     `None` — the caller bubbles it up to the response root so the front can
     wash the pivot in the `cm-ref-inline` block.
     """
-    if not content.cluster_id:
-        for p in perspectives_dicts:
-            p["highlight_spans"] = []
-            p["shared_tokens"] = []
-        return None
-
     try:
         svc = get_title_annotation_service()
-        annotations = await svc.get_or_compute_cluster_annotations(
-            db, content.cluster_id
+        # Skip the cluster cache lookup when the content isn't clustered —
+        # otherwise `get_or_compute_cluster_annotations(None)` would scan
+        # every `Content` row with `cluster_id IS NULL`. The off-cluster
+        # batch below handles all perspectives in that case.
+        annotations = (
+            await svc.get_or_compute_cluster_annotations(db, content.cluster_id)
+            if content.cluster_id
+            else ClusterAnnotations()
         )
         ref_tokens = annotations.tokens_by_id.get(content.id) or (
             svc.compute_strong_tokens(content.title or "")
@@ -836,7 +839,7 @@ async def _attach_highlight_spans(
         logger.exception(
             "highlight_spans_failed",
             content_id=str(content.id),
-            cluster_id=str(content.cluster_id),
+            cluster_id=str(content.cluster_id) if content.cluster_id else None,
         )
         for p in perspectives_dicts:
             p.setdefault("highlight_spans", [])

--- a/packages/api/tests/routers/test_contents_perspectives_highlights.py
+++ b/packages/api/tests/routers/test_contents_perspectives_highlights.py
@@ -25,7 +25,6 @@ from tests.fixtures.fake_spacy import (
     service_with_nlp,
 )
 
-
 # --- Cluster fixture --------------------------------------------------------
 
 
@@ -85,8 +84,13 @@ async def cluster_setup(db_session):
 
 
 @pytest.mark.asyncio
-async def test_attach_highlight_spans_empty_for_content_without_cluster(db_session):
-    """No cluster_id → every perspective gets an empty highlight_spans list."""
+async def test_attach_highlight_spans_computes_for_content_without_cluster(db_session):
+    """No cluster_id → highlight_spans are still computed via the off-cluster batch.
+
+    Regression for the prod incident where clustering was never activated,
+    so the early-return on `not content.cluster_id` silently disabled the
+    feature for every article.
+    """
     source = Source(
         id=uuid4(),
         name="Solo",
@@ -102,7 +106,7 @@ async def test_attach_highlight_spans_empty_for_content_without_cluster(db_sessi
     standalone = Content(
         id=uuid4(),
         source_id=source.id,
-        title="Standalone",
+        title="Tsahal frappe Gaza",
         url="https://solo.fr/x",
         published_at=datetime.now(UTC),
         content_type=ContentType.ARTICLE,
@@ -112,12 +116,44 @@ async def test_attach_highlight_spans_empty_for_content_without_cluster(db_sessi
     db_session.add(standalone)
     await db_session.commit()
 
-    perspectives = [
-        {"title": "Anything", "url": "https://other.fr/x", "bias_stance": "left"}
-    ]
-    await _attach_highlight_spans(db_session, standalone, perspectives)
+    docs = {
+        "Tsahal frappe Gaza": FakeDoc(
+            tokens=[
+                FakeToken("Tsahal", 0, "PROPN", "Tsahal"),
+                FakeToken("frappe", 7, "VERB", "frapper"),
+                FakeToken("Gaza", 14, "PROPN", "Gaza"),
+            ],
+        ),
+        "Une frappe sur Gaza fait 20 morts": FakeDoc(
+            tokens=[
+                FakeToken("frappe", 4, "NOUN", "frappe"),
+                FakeToken("Gaza", 14, "PROPN", "Gaza"),
+                FakeToken("morts", 25, "NOUN", "mort"),
+            ],
+        ),
+    }
+    fake_svc = service_with_nlp(FakeNlp(docs))
 
-    assert perspectives[0]["highlight_spans"] == []
+    perspectives = [
+        {
+            "title": "Une frappe sur Gaza fait 20 morts",
+            "url": "https://other.fr/x",
+            "bias_stance": "left",
+        }
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        pivot = await _attach_highlight_spans(db_session, standalone, perspectives)
+
+    texts = {s["text"] for s in perspectives[0]["highlight_spans"]}
+    assert "morts" in texts  # diverges from ref (lemma not in {Tsahal, frapper, Gaza})
+    assert all(s["bias"] == "left" for s in perspectives[0]["highlight_spans"])
+    # Reference pivot still resolves to the ref title's first VERB.
+    assert pivot == {"start": 7, "end": 13, "text": "frappe"}
+    # Shared tokens (lemma match): "Gaza".
+    assert [s["text"] for s in perspectives[0]["shared_tokens"]] == ["Gaza"]
 
 
 @pytest.mark.asyncio
@@ -376,8 +412,13 @@ async def test_attach_highlight_spans_returns_reference_pivot_and_shared_tokens(
 
 
 @pytest.mark.asyncio
-async def test_attach_highlight_spans_returns_none_pivot_without_cluster(db_session):
-    """No cluster_id → no pivot computed, shared_tokens defaulted to []."""
+async def test_attach_highlight_spans_without_cluster_skips_db_scan(db_session):
+    """No cluster_id → cluster cache lookup is skipped (no `WHERE cluster_id IS NULL` scan).
+
+    Guards against the cheap-to-make regression of calling
+    `get_or_compute_cluster_annotations(None)`, which would iterate every
+    standalone Content row in the DB.
+    """
     source = Source(
         id=uuid4(),
         name="Solo",
@@ -403,10 +444,26 @@ async def test_attach_highlight_spans_returns_none_pivot_without_cluster(db_sess
     db_session.add(standalone)
     await db_session.commit()
 
+    fake_svc = service_with_nlp(FakeNlp({}))
+    cluster_calls: list[object] = []
+
+    async def tracking_cluster_lookup(_db, cluster_id):
+        cluster_calls.append(cluster_id)
+        from app.services.title_annotation_service import ClusterAnnotations
+
+        return ClusterAnnotations()
+
+    fake_svc.get_or_compute_cluster_annotations = tracking_cluster_lookup
+
     perspectives = [
         {"title": "Anything", "url": "https://other.fr/y", "bias_stance": "left"}
     ]
-    pivot = await _attach_highlight_spans(db_session, standalone, perspectives)
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        await _attach_highlight_spans(db_session, standalone, perspectives)
 
-    assert pivot is None
+    assert cluster_calls == []  # no DB scan on cluster_id IS NULL
+    assert perspectives[0]["highlight_spans"] == []
     assert perspectives[0]["shared_tokens"] == []


### PR DESCRIPTION
# PR — fix: surlignage progressif des titres (Couverture médiatique) invisible en prod

## Summary

Surlignage progressif des titres invisible en prod (section "Couverture médiatique" / perspectives) car la pipeline backend renvoyait toujours `highlight_spans: []`. Vérifié sur Supabase : `0 / 41 045` contents ont un `cluster_id`, donc l'early-return `if not content.cluster_id` de `_attach_highlight_spans` court-circuitait pour tous les articles. Le batch off-cluster `nlp.pipe()` prévu plus bas n'était jamais atteint.

Bug doc complet : `docs/bugs/bug-perspectives-highlight-spans-missing.md`.

## Changes

### Backend — Cause racine
- `packages/api/app/routers/contents.py` (`_attach_highlight_spans`) : retire l'early-return sur `not content.cluster_id`. La fonction n'appelle `get_or_compute_cluster_annotations()` que si `cluster_id` est présent (évite un scan `WHERE cluster_id IS NULL` sur les 41 k contents standalone). Le batch off-cluster existant calcule alors les tokens spaCy pour toutes les perspectives, `ref_tokens` est obtenu via le fallback `compute_strong_tokens(title)`, et `diff_spans` / `compute_shared_tokens` / `compute_reference_pivot` produisent les données attendues par le mobile.

### Mobile — Bug latent
- `apps/mobile/lib/features/digest/widgets/topic_section.dart` et `article_viewer_modal.dart` : les 2 mappings `PerspectiveData → Perspective` oubliaient `highlightSpans` et `sharedTokens`. Le widget `DiffTitle` recevait `const []` et basculait silencieusement en Mode 2 fallback. Ajout des 2 champs dans les 2 mappings.

### Tests
- `packages/api/tests/routers/test_contents_perspectives_highlights.py` :
  - Remplace l'ancien test qui assertait `highlight_spans == []` sans cluster (comportement bogué) par `test_attach_highlight_spans_computes_for_content_without_cluster` validant le nouveau contrat.
  - Ajoute `test_attach_highlight_spans_without_cluster_skips_db_scan` pour garder l'invariant "pas de scan DB sur cluster_id IS NULL".

## Test plan

- [x] `pytest tests/routers/test_contents_perspectives_highlights.py` → 8/8 passent
- [x] Suite backend complète → 1167 passed, 13 skipped
- [x] `flutter analyze` sur les 2 fichiers mobile modifiés → 0 erreurs
- [x] `flutter test` widgets touchés (DiffTitle, PerspectivesInline, fromJson) → 20/20 passent
- [ ] **Validation prod après merge** : appeler `GET /api/v1/contents/{id}/perspectives` sur un article récent et vérifier que `.perspectives[0].highlight_spans` est non-vide. Visuellement, ouvrir la section "Couverture médiatique" d'un article avec ≥ 3 sources et observer le surlignage progressif des titres dans la vue inline (`PerspectivesInlineSection` → `DiffTitle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)