### PR TITLE
fix(prefs): retire le cap dur position 0..2 sur les favoris (Story 22.2)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/widgets/my_interests_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/my_interests_sheet.dart
@@ -93,7 +93,7 @@ class _MyInterestsContent extends ConsumerWidget {
                       ),
                     ),
                     Text(
-                      '${rows.length}/${interests?.favoriteCap ?? 3} FAVORIS',
+                      '${rows.length} FAVORIS',
                       style: GoogleFonts.dmSans(
                         fontSize: 11,
                         fontWeight: FontWeight.w700,

--- a/apps/mobile/lib/features/my_interests/models/user_interests_state.dart
+++ b/apps/mobile/lib/features/my_interests/models/user_interests_state.dart
@@ -204,5 +204,4 @@ class UserInterestsState {
     };
   }
 
-  bool get isAtCap => favoriteCount >= favoriteCap;
 }

--- a/apps/mobile/lib/features/my_interests/models/user_sources_state.dart
+++ b/apps/mobile/lib/features/my_interests/models/user_sources_state.dart
@@ -109,5 +109,4 @@ class UserSourcesState {
         InterestState.unfollowed;
   }
 
-  bool get isAtCap => favoriteCount >= favoriteCap;
 }

--- a/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
@@ -24,7 +24,6 @@ import '../../digest/providers/serein_toggle_provider.dart';
 import '../../feed/repositories/personalization_repository.dart';
 import '../models/user_interests_state.dart';
 import '../providers/user_interests_provider.dart';
-import '../repositories/user_interests_repository.dart' show FavoriteCapReachedException;
 import '../widgets/favorites_reorderable_section.dart';
 import '../widgets/interest_state_picker_sheet.dart';
 
@@ -70,47 +69,22 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
     }
   }
 
-  void _showCapSnackbar() {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: const Text(
-            'Tu as déjà 3 favoris. Retire-en un d\'abord pour en ajouter un nouveau.'),
-        duration: const Duration(seconds: 3),
-        action: SnackBarAction(
-          label: 'OK',
-          onPressed: () =>
-              ScaffoldMessenger.of(context).hideCurrentSnackBar(),
-        ),
-      ),
-    );
-  }
-
   Future<void> _pickState({
     required String title,
     required FavoriteRef refTarget,
     required InterestState currentState,
   }) async {
-    final interests = ref.read(userInterestsProvider).value;
-    final atCap = interests?.isAtCap ?? false;
     final selected = await InterestStatePickerSheet.show(
       context,
       title: title,
       currentState: currentState,
-      favoriteAvailable: !atCap || currentState == InterestState.favorite,
     );
     if (selected == null || selected == currentState) return;
-
-    if (selected == InterestState.favorite && atCap) {
-      _showCapSnackbar();
-      return;
-    }
 
     try {
       await ref
           .read(userInterestsProvider.notifier)
           .setInterestState(refTarget, selected);
-    } on FavoriteCapReachedException {
-      _showCapSnackbar();
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -386,7 +360,7 @@ class _HeroBlock extends StatelessWidget {
           Text(
             sereinMode
                 ? 'Choisissez ce qui reste dans vos bonnes nouvelles. Cochez pour garder, décochez pour mettre de côté.'
-                : 'Étoilez vos favoris (jusqu\'à 3) pour les voir en tête du flux. Masquez ce qui ne vous parle pas.',
+                : 'Étoilez vos favoris pour les voir en tête du flux. Les 3 premiers (ordre modifiable) constituent votre Tournée du jour.',
             style: textTheme.bodyMedium?.copyWith(
               color: colors.textSecondary,
             ),
@@ -568,8 +542,14 @@ class _ThemeBlock extends ConsumerWidget {
         .firstOrNull;
     final themeState = themeRow?.state ?? InterestState.unfollowed;
 
+    // slug_parent en DB est un slug fin (ex. 'cinema', 'ai', 'feminism'). On
+    // remonte au macro-thème via getTopicMacroTheme() pour matcher le bloc
+    // affiché. Avant : comparaison directe `slugParent == themeSlug` qui
+    // masquait ~85% des sujets followed (PR #622).
     final topics = interests.customTopics
-        .where((c) => c.slugParent == themeSlug && c.state != InterestState.hidden)
+        .where((c) =>
+            getTopicMacroTheme(c.slugParent) == macroLabel &&
+            c.state != InterestState.hidden)
         .toList();
 
     // Hide the whole block in normal mode when there's nothing to show

--- a/apps/mobile/lib/features/my_interests/widgets/favorites_reorderable_section.dart
+++ b/apps/mobile/lib/features/my_interests/widgets/favorites_reorderable_section.dart
@@ -1,8 +1,9 @@
-/// Story 22.1 — section « Favoris (n/3) » réordonnable.
+/// Story 22.1 — section « Favoris » réordonnable.
 ///
-/// Conçue pour fonctionner avec n'importe quel type d'item (intérêts ou sources)
-/// via un builder. Cap d'affichage = 3 ; tout overflow est tronqué silencieusement
-/// (la cap est imposée par le backend, ce widget reste défensif).
+/// Cap retiré (Story 22.2) : l'utilisateur peut épingler autant de favoris
+/// qu'il veut. Les `kFavoriteCap` (3) premiers items, par position, sont
+/// matérialisés visuellement comme appartenant à la « Tournée du jour » via
+/// un divider + caption au-dessus du (kFavoriteCap)-ième item.
 library;
 
 import 'package:flutter/material.dart';
@@ -37,8 +38,6 @@ class FavoritesReorderableSection<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
-    final clamped =
-        items.length > kFavoriteCap ? items.sublist(0, kFavoriteCap) : items;
 
     return Padding(
       padding: padding,
@@ -58,24 +57,29 @@ class FavoritesReorderableSection<T> extends StatelessWidget {
                 FacteurSpacing.space4,
                 FacteurSpacing.space1,
               ),
-              child: Row(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Icon(
-                    PhosphorIcons.star(PhosphorIconsStyle.fill),
-                    color: colors.primary,
-                    size: 16,
+                  Row(
+                    children: [
+                      Icon(
+                        PhosphorIcons.star(PhosphorIconsStyle.fill),
+                        color: colors.primary,
+                        size: 16,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Favoris',
+                        style: textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: colors.textPrimary,
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 8),
+                  const SizedBox(height: 2),
                   Text(
-                    'Favoris',
-                    style: textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w700,
-                      color: colors.textPrimary,
-                    ),
-                  ),
-                  const SizedBox(width: 6),
-                  Text(
-                    '(${clamped.length}/$kFavoriteCap)',
+                    'Les $kFavoriteCap premiers (ordre modifiable) sont dans votre Tournée du jour.',
                     style: textTheme.bodySmall?.copyWith(
                       color: colors.textTertiary,
                     ),
@@ -83,7 +87,7 @@ class FavoritesReorderableSection<T> extends StatelessWidget {
                 ],
               ),
             ),
-            if (clamped.isEmpty)
+            if (items.isEmpty)
               Padding(
                 padding: const EdgeInsets.fromLTRB(
                   FacteurSpacing.space4,
@@ -103,36 +107,81 @@ class FavoritesReorderableSection<T> extends StatelessWidget {
                 shrinkWrap: true,
                 physics: const NeverScrollableScrollPhysics(),
                 buildDefaultDragHandles: false,
-                itemCount: clamped.length,
+                itemCount: items.length,
                 padding: const EdgeInsets.only(bottom: FacteurSpacing.space2),
                 itemBuilder: (context, index) {
-                  final item = clamped[index];
-                  return Padding(
+                  final item = items[index];
+                  final inTour = index < kFavoriteCap;
+                  final isTourBoundary =
+                      index == kFavoriteCap && items.length > kFavoriteCap;
+                  return Column(
                     key: keyOf(item),
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: FacteurSpacing.space2,
-                    ),
-                    child: Row(
-                      children: [
-                        Expanded(child: itemBuilder(context, item)),
-                        ReorderableDragStartListener(
-                          index: index,
-                          child: Padding(
-                            padding: const EdgeInsets.all(8),
-                            child: Icon(
-                              PhosphorIcons.dotsSixVertical(
-                                  PhosphorIconsStyle.regular),
-                              color: colors.textTertiary,
-                              size: 18,
-                            ),
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (isTourBoundary)
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(
+                            FacteurSpacing.space4,
+                            FacteurSpacing.space2,
+                            FacteurSpacing.space4,
+                            FacteurSpacing.space1,
+                          ),
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: Divider(
+                                  color: colors.surfaceElevated,
+                                  height: 1,
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Text(
+                                'Hors Tournée du jour',
+                                style: textTheme.bodySmall?.copyWith(
+                                  color: colors.textTertiary,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Divider(
+                                  color: colors.surfaceElevated,
+                                  height: 1,
+                                ),
+                              ),
+                            ],
                           ),
                         ),
-                      ],
-                    ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: FacteurSpacing.space2,
+                        ),
+                        child: Opacity(
+                          opacity: inTour ? 1.0 : 0.55,
+                          child: Row(
+                            children: [
+                              Expanded(child: itemBuilder(context, item)),
+                              ReorderableDragStartListener(
+                                index: index,
+                                child: Padding(
+                                  padding: const EdgeInsets.all(8),
+                                  child: Icon(
+                                    PhosphorIcons.dotsSixVertical(
+                                        PhosphorIconsStyle.regular),
+                                    color: colors.textTertiary,
+                                    size: 18,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
                   );
                 },
                 onReorder: (oldIndex, newIndex) {
-                  final reordered = [...clamped];
+                  final reordered = [...items];
                   final adjusted = newIndex > oldIndex ? newIndex - 1 : newIndex;
                   final moved = reordered.removeAt(oldIndex);
                   reordered.insert(adjusted, moved);

--- a/apps/mobile/lib/features/my_interests/widgets/interest_state_picker_sheet.dart
+++ b/apps/mobile/lib/features/my_interests/widgets/interest_state_picker_sheet.dart
@@ -10,13 +10,11 @@ import '../models/user_interests_state.dart';
 class InterestStatePickerSheet extends StatelessWidget {
   final String title;
   final InterestState currentState;
-  final bool favoriteAvailable;
 
   const InterestStatePickerSheet({
     super.key,
     required this.title,
     required this.currentState,
-    this.favoriteAvailable = true,
   });
 
   /// Affiche le picker et retourne l'état choisi (ou `null` si annulé).
@@ -24,7 +22,6 @@ class InterestStatePickerSheet extends StatelessWidget {
     BuildContext context, {
     required String title,
     required InterestState currentState,
-    bool favoriteAvailable = true,
   }) {
     return showModalBottomSheet<InterestState>(
       context: context,
@@ -33,7 +30,6 @@ class InterestStatePickerSheet extends StatelessWidget {
       builder: (_) => InterestStatePickerSheet(
         title: title,
         currentState: currentState,
-        favoriteAvailable: favoriteAvailable,
       ),
     );
   }
@@ -79,9 +75,8 @@ class InterestStatePickerSheet extends StatelessWidget {
             _StateOption(
               state: InterestState.favorite,
               label: 'Favori',
-              description: favoriteAvailable
-                  ? 'En haut de votre flux, jusqu\'à 3'
-                  : 'Limite atteinte (3) — retirez-en un d\'abord',
+              description:
+                  'En haut de votre flux. Les 3 premiers sont dans la Tournée du jour.',
               iconBuilder: (color) => Icon(
                 PhosphorIcons.star(PhosphorIconsStyle.fill),
                 color: color,
@@ -89,8 +84,7 @@ class InterestStatePickerSheet extends StatelessWidget {
               ),
               accent: colors.primary,
               isSelected: currentState == InterestState.favorite,
-              enabled:
-                  favoriteAvailable || currentState == InterestState.favorite,
+              enabled: true,
             ),
             _StateOption(
               state: InterestState.followed,

--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -92,29 +92,19 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
 
   Future<void> _pickSourceState(Source source) async {
     final state = ref.read(userSourcesStateProvider).value;
-    final atCap = state?.isAtCap ?? false;
     final currentState = state?.stateOf(source.id) ?? InterestState.followed;
 
     final picked = await InterestStatePickerSheet.show(
       context,
       title: source.name,
       currentState: currentState,
-      favoriteAvailable:
-          !atCap || currentState == InterestState.favorite,
     );
     if (picked == null || picked == currentState) return;
-
-    if (picked == InterestState.favorite && atCap) {
-      _showCapSnackbar();
-      return;
-    }
 
     try {
       await ref
           .read(userSourcesStateProvider.notifier)
           .setSourceState(source.id, picked);
-    } on FavoriteCapReachedException {
-      _showCapSnackbar();
     } catch (_) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -124,16 +114,6 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
         ),
       );
     }
-  }
-
-  void _showCapSnackbar() {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text(
-            'Tu as déjà 3 sources favorites. Retire-en une d\'abord.'),
-        duration: Duration(seconds: 3),
-      ),
-    );
   }
 
   @override

--- a/apps/mobile/test/features/flux_continu/widgets/my_interests_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/my_interests_sheet_test.dart
@@ -78,7 +78,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Mes intérêts'), findsOneWidget);
-      expect(find.text('2/3 FAVORIS'), findsOneWidget);
+      expect(find.text('2 FAVORIS'), findsOneWidget);
       // Custom topic name resolved from interests.customTopics
       expect(find.text('IA & éducation'), findsOneWidget);
       // Theme slug → canonical visual label
@@ -103,7 +103,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Aucun favori pour le moment.'), findsOneWidget);
-      expect(find.text('0/3 FAVORIS'), findsOneWidget);
+      expect(find.text('0 FAVORIS'), findsOneWidget);
     });
 
     testWidgets('Fermer dismisses the sheet', (tester) async {

--- a/apps/mobile/test/features/my_interests/widgets/interest_state_picker_sheet_test.dart
+++ b/apps/mobile/test/features/my_interests/widgets/interest_state_picker_sheet_test.dart
@@ -68,7 +68,7 @@ void main() {
     expect(returned, InterestState.hidden);
   });
 
-  testWidgets('favorite option disabled when cap reached and not currently favorite',
+  testWidgets('Story 22.2 — favorite option is always tappable (cap removed)',
       (tester) async {
     InterestState? returned;
     await tester.pumpWidget(
@@ -82,7 +82,6 @@ void main() {
                   context,
                   title: 'Sport',
                   currentState: InterestState.followed,
-                  favoriteAvailable: false,
                 );
               },
               child: const Text('open'),
@@ -95,12 +94,9 @@ void main() {
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();
 
-    // Tapping disabled "Favori" should not pop the sheet (InkWell.onTap = null).
     await tester.tap(find.text('Favori'));
-    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pumpAndSettle();
 
-    expect(returned, isNull);
-    // The sheet is still open.
-    expect(find.text('Favori'), findsOneWidget);
+    expect(returned, InterestState.favorite);
   });
 }

--- a/packages/api/alembic/versions/22a2_drop_favorite_position_cap.py
+++ b/packages/api/alembic/versions/22a2_drop_favorite_position_cap.py
@@ -1,0 +1,44 @@
+"""drop CHECK constraints position BETWEEN 0..2 sur les tables favoris (Story 22.2).
+
+La limite de 3 favoris devient un cap d'affichage Tournée du jour, plus une
+limite dure DB. La PK composite (user_id, position) reste suffisante pour
+garantir l'unicité du slot.
+
+Revision ID: 22a2_drop_favorite_position_cap
+Revises: 5de67819bc61
+Create Date: 2026-05-18
+
+"""
+
+from alembic import op
+
+revision: str = "22a2_drop_favorite_position_cap"
+down_revision: str | None = "5de67819bc61"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "user_favorite_interests_position_range",
+        "user_favorite_interests",
+        type_="check",
+    )
+    op.drop_constraint(
+        "user_favorite_sources_position_range",
+        "user_favorite_sources",
+        type_="check",
+    )
+
+
+def downgrade() -> None:
+    op.create_check_constraint(
+        "user_favorite_interests_position_range",
+        "user_favorite_interests",
+        "position BETWEEN 0 AND 2",
+    )
+    op.create_check_constraint(
+        "user_favorite_sources_position_range",
+        "user_favorite_sources",
+        "position BETWEEN 0 AND 2",
+    )

--- a/packages/api/app/constants.py
+++ b/packages/api/app/constants.py
@@ -7,11 +7,13 @@ sont hard-codées pour rester en phase avec le mobile (constante miroir
 """
 
 FAVORITE_CAP: int = 3
-"""Cap dur du nombre de favoris par catégorie (intérêts vs sources, séparés).
+"""Cap d'affichage de la « Tournée du jour » (Story 22.2 — révision 2026-05-18).
 
-Story 22.1 — décision PO 2026-05-15 : cap=3, hard-coded partagé serveur+client,
-modifié par redeploy. Cap appliqué séparément aux intérêts (Thèmes+Sujets) et
-aux Sources.
+N'est PLUS un cap dur : l'utilisateur peut avoir > 3 favoris ; seuls les 3
+premiers (ordre `position` modifiable) sont retenus pour la Tournée du jour.
+Conservé sous le nom `FAVORITE_CAP` pour compat des imports ; sémantiquement
+équivalent à `DAILY_TOUR_CAP`. Mirror mobile : `dailyTourCap` dans
+`apps/mobile/lib/config/constants.dart`.
 """
 
 MIN_BACKFILL_FAVORITES: int = 2

--- a/packages/api/app/models/user_favorites.py
+++ b/packages/api/app/models/user_favorites.py
@@ -1,7 +1,9 @@
-"""Favoris ordonnés — Story 22.1.
+"""Favoris ordonnés — Story 22.1 (cap retiré 2026-05-18, Story 22.2).
 
-Deux tables dédiées (intérêts vs sources) parce que le cap=3 est séparé pour
-chaque catégorie. La position 0..2 est garantie par CHECK + PK composite.
+Deux tables dédiées (intérêts vs sources). La position n'est plus bornée à
+0..2 : l'utilisateur peut épingler autant de favoris qu'il veut, et seuls
+les `FAVORITE_CAP` premiers (par position ASC) sont affichés dans la
+« Tournée du jour ».
 """
 
 from datetime import UTC, datetime
@@ -23,18 +25,14 @@ from app.database import Base
 
 
 class UserFavoriteInterest(Base):
-    """Favori intérêt (Thème OU Sujet, XOR), ordonné par position 0..2.
+    """Favori intérêt (Thème OU Sujet, XOR), ordonné par position.
 
-    PK composite (user_id, position) → garantit unicité du slot et cap=3.
-    Aucune ligne ne peut exister à position=3+.
+    PK composite (user_id, position) → garantit unicité du slot. La position
+    est entière >= 0 (plus de cap dur depuis 2026-05-18).
     """
 
     __tablename__ = "user_favorite_interests"
     __table_args__ = (
-        CheckConstraint(
-            "position BETWEEN 0 AND 2",
-            name="user_favorite_interests_position_range",
-        ),
         CheckConstraint(
             "(interest_slug IS NOT NULL)::int + (custom_topic_id IS NOT NULL)::int = 1",
             name="user_favorite_interests_target_xor",
@@ -61,7 +59,7 @@ class UserFavoriteInterest(Base):
 
 
 class UserFavoriteSource(Base):
-    """Favori source, ordonné par position 0..2.
+    """Favori source, ordonné par position (>=0, plus de cap dur depuis 2026-05-18).
 
     UNIQUE (user_id, source_id) en plus du PK composite : un même source ne
     peut pas occuper deux slots simultanément.
@@ -69,10 +67,6 @@ class UserFavoriteSource(Base):
 
     __tablename__ = "user_favorite_sources"
     __table_args__ = (
-        CheckConstraint(
-            "position BETWEEN 0 AND 2",
-            name="user_favorite_sources_position_range",
-        ),
         UniqueConstraint(
             "user_id", "source_id", name="user_favorite_sources_user_source_uniq"
         ),

--- a/packages/api/app/routers/users.py
+++ b/packages/api/app/routers/users.py
@@ -313,14 +313,14 @@ async def get_top_themes(
     user_id: str = Depends(get_current_user_id),
     db: AsyncSession = Depends(get_db),
 ) -> list[TopThemeResponse]:
-    """Retourne les thèmes de l'utilisateur, dans l'ordre canonique des favoris
-    si déclarés, sinon en fallback sur le poids appris.
+    """Retourne les thèmes de la « Tournée du jour ».
 
     Story 22.1 — la table `user_favorite_interests` (ordre user) prime ; les
     Sujets favoris (custom topics) sont projetés sur leur `slug_parent` pour
     rester compatibles avec le format `TopThemeResponse` (rétrocompat mobile).
-    Cap à 3 côté serveur pour rester cohérent avec `FAVORITE_CAP`. Les thèmes
-    sans article récent (14 derniers jours) sont exclus du fallback.
+    Story 22.2 — le user peut avoir > 3 favoris, mais seuls les `FAVORITE_CAP`
+    premiers (par `position` ASC) sont sélectionnés pour la Tournée du jour.
+    Les thèmes sans article récent (14 derniers jours) sont exclus du fallback.
     """
     from app.constants import FAVORITE_CAP
     from app.models.content import Content

--- a/packages/api/app/schemas/user_interests.py
+++ b/packages/api/app/schemas/user_interests.py
@@ -129,9 +129,7 @@ class ReorderSourceFavoritesRequest(BaseModel):
 
     @field_validator("favorites")
     @classmethod
-    def _validate_positions(
-        cls, v: list[SourceFavoriteRef]
-    ) -> list[SourceFavoriteRef]:
+    def _validate_positions(cls, v: list[SourceFavoriteRef]) -> list[SourceFavoriteRef]:
         positions = [f.position for f in v]
         if sorted(positions) != list(range(len(v))):
             raise ValueError("positions must be a contiguous 0..N-1 sequence")

--- a/packages/api/app/schemas/user_interests.py
+++ b/packages/api/app/schemas/user_interests.py
@@ -1,9 +1,9 @@
-"""Schemas — système d'intérêts unifié (Story 22.1).
+"""Schemas — système d'intérêts unifié (Story 22.1, cap retiré Story 22.2).
 
 Couvre les écrans « Mes intérêts » (Thèmes + Sujets) et « Mes sources ». L'enum
 `InterestState` est l'axe sémantique unique (hidden/unfollowed/followed/favorite)
-partagé par les 3 entités. Le cap `FAVORITE_CAP=3` est appliqué séparément aux
-intérêts et aux sources.
+partagé par les 3 entités. `FAVORITE_CAP=3` n'est plus une limite dure mais le
+cap d'affichage de la « Tournée du jour » (les 3 premiers favoris par position).
 """
 
 from typing import Literal
@@ -11,7 +11,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from app.constants import FAVORITE_CAP
 from app.models.enums import InterestState
 
 InterestKind = Literal["theme", "custom_topic"]
@@ -22,7 +21,7 @@ class FavoriteRef(BaseModel):
 
     kind: InterestKind
     target_id: str  # interest_slug (theme) ou str(UUID) (custom_topic)
-    position: int = Field(ge=0, le=FAVORITE_CAP - 1)
+    position: int = Field(ge=0)
 
 
 class ThemeInterestResponse(BaseModel):
@@ -68,7 +67,7 @@ class SetInterestStateRequest(BaseModel):
     kind: InterestKind
     target_id: str
     state: InterestState
-    position: int | None = Field(None, ge=0, le=FAVORITE_CAP - 1)
+    position: int | None = Field(None, ge=0)
 
 
 class ReorderFavoritesRequest(BaseModel):
@@ -82,9 +81,7 @@ class ReorderFavoritesRequest(BaseModel):
 
     @field_validator("favorites")
     @classmethod
-    def _validate_cap_and_positions(cls, v: list[FavoriteRef]) -> list[FavoriteRef]:
-        if len(v) > FAVORITE_CAP:
-            raise ValueError(f"too many favorites (max={FAVORITE_CAP})")
+    def _validate_positions(cls, v: list[FavoriteRef]) -> list[FavoriteRef]:
         positions = [f.position for f in v]
         if sorted(positions) != list(range(len(v))):
             raise ValueError("positions must be a contiguous 0..N-1 sequence")
@@ -105,7 +102,7 @@ class SourceFavoriteRef(BaseModel):
     """Favori source ordonné (pas de XOR, juste position + source_id)."""
 
     source_id: UUID
-    position: int = Field(ge=0, le=FAVORITE_CAP - 1)
+    position: int = Field(ge=0)
 
 
 class UserSourcesStateResponse(BaseModel):
@@ -122,7 +119,7 @@ class SetSourceStateRequest(BaseModel):
 
     source_id: UUID
     state: InterestState
-    position: int | None = Field(None, ge=0, le=FAVORITE_CAP - 1)
+    position: int | None = Field(None, ge=0)
 
 
 class ReorderSourceFavoritesRequest(BaseModel):
@@ -132,11 +129,9 @@ class ReorderSourceFavoritesRequest(BaseModel):
 
     @field_validator("favorites")
     @classmethod
-    def _validate_cap_and_positions(
+    def _validate_positions(
         cls, v: list[SourceFavoriteRef]
     ) -> list[SourceFavoriteRef]:
-        if len(v) > FAVORITE_CAP:
-            raise ValueError(f"too many favorites (max={FAVORITE_CAP})")
         positions = [f.position for f in v]
         if sorted(positions) != list(range(len(v))):
             raise ValueError("positions must be a contiguous 0..N-1 sequence")

--- a/packages/api/app/services/user_interests_service.py
+++ b/packages/api/app/services/user_interests_service.py
@@ -227,18 +227,10 @@ class UserInterestsService:
                         return
                     current.position = position
                 return
-            # Nouveau favori : check cap.
-            if len(existing) >= FAVORITE_CAP:
-                raise FavoriteCapReached(
-                    kind=kind, target_id=target_id, current_count=len(existing)
-                )
-            if position is None:
-                taken = {f.position for f in existing}
-                position = next(p for p in range(FAVORITE_CAP) if p not in taken)
-            elif any(f.position == position for f in existing):
-                # Slot occupé — fallback sur next free.
-                taken = {f.position for f in existing}
-                position = next(p for p in range(FAVORITE_CAP) if p not in taken)
+            # Nouveau favori : plus de cap dur (Story 22.2). Append à la fin.
+            taken = {f.position for f in existing}
+            if position is None or position in taken:
+                position = (max(taken) + 1) if taken else 0
 
             row = UserFavoriteInterest(
                 user_id=user_id,
@@ -403,15 +395,10 @@ class UserSourcesStateService:
                         return
                     current.position = position
                 return
-            if len(existing) >= FAVORITE_CAP:
-                raise FavoriteCapReached(
-                    kind="source",
-                    target_id=str(source_id),
-                    current_count=len(existing),
-                )
-            if position is None or any(f.position == position for f in existing):
-                taken = {f.position for f in existing}
-                position = next(p for p in range(FAVORITE_CAP) if p not in taken)
+            # Plus de cap dur (Story 22.2) — append à la fin.
+            taken = {f.position for f in existing}
+            if position is None or position in taken:
+                position = (max(taken) + 1) if taken else 0
 
             self.db.add(
                 UserFavoriteSource(

--- a/packages/api/tests/routers/test_user_interests.py
+++ b/packages/api/tests/routers/test_user_interests.py
@@ -97,14 +97,14 @@ async def test_patch_promotes_theme_to_favorite(auth_user_with_themes, db_sessio
 
 
 @pytest.mark.asyncio
-async def test_patch_returns_422_when_cap_reached(
+async def test_patch_accepts_more_than_cap_favorites(
     auth_user_with_themes, db_session
 ):
-    """Au-delà du 3ème favori, le 4ème renvoie 422 favorite_cap_reached."""
+    """Story 22.2 — cap retiré : un 4e favori est accepté (position=3)."""
     transport = ASGITransport(app=app)
     with patch(
         "app.routers.user_interests.get_posthog_client", return_value=MagicMock()
-    ) as mock_ph:
+    ):
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             for slug in ("tech", "society", "culture"):
                 resp = await ac.patch(
@@ -117,14 +117,11 @@ async def test_patch_returns_422_when_cap_reached(
                 "/api/user/interests",
                 json={"kind": "theme", "target_id": "science", "state": "favorite"},
             )
-    assert resp4.status_code == 422
-    assert resp4.json()["detail"] == {
-        "error": "favorite_cap_reached",
-        "cap": FAVORITE_CAP,
-    }
-    capture = mock_ph.return_value.capture
-    events = [c.kwargs.get("event") for c in capture.call_args_list]
-    assert "interest_cap_blocked" in events
+    assert resp4.status_code == 200, resp4.text
+    body = resp4.json()
+    assert body["favorite_count"] == 4
+    positions = sorted(f["position"] for f in body["favorites"])
+    assert positions == [0, 1, 2, 3]
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/routers/test_user_sources_state.py
+++ b/packages/api/tests/routers/test_user_sources_state.py
@@ -94,7 +94,8 @@ async def test_patch_promotes_source_to_favorite(auth_user_with_sources):
 
 
 @pytest.mark.asyncio
-async def test_source_cap_reached(auth_user_with_sources):
+async def test_source_accepts_more_than_cap_favorites(auth_user_with_sources):
+    """Story 22.2 — cap retiré : un 4e favori est accepté (position=3)."""
     _, sources = auth_user_with_sources
     transport = ASGITransport(app=app)
     with patch(
@@ -108,12 +109,12 @@ async def test_source_cap_reached(auth_user_with_sources):
                     json={"source_id": str(s.id), "state": "favorite"},
                 )
                 assert ok.status_code == 200, ok.text
-            ko = await ac.patch(
+            ok4 = await ac.patch(
                 "/api/user/sources",
                 json={"source_id": str(sources[3].id), "state": "favorite"},
             )
-    assert ko.status_code == 422
-    assert ko.json()["detail"] == {
-        "error": "favorite_cap_reached",
-        "cap": FAVORITE_CAP,
-    }
+    assert ok4.status_code == 200, ok4.text
+    body = ok4.json()
+    assert body["favorite_count"] == 4
+    positions = sorted(f["position"] for f in body["favorites"])
+    assert positions == [0, 1, 2, 3]


### PR DESCRIPTION
## Quoi
Suppression des `CHECK BETWEEN 0 AND 2` sur les tables `user_favorite_interests` et `user_favorite_sources` via la migration Alembic `22a2_drop_favorite_position_cap`. Le `FAVORITE_CAP=3` devient un cap d'affichage (Tournée du jour) plutôt qu'une contrainte DB dure.

## Pourquoi
L'utilisateur doit pouvoir avoir plus de 3 favoris — seuls les 3 premiers (par position ASC) sont affichés dans la Tournée du jour. La limite dure bloquait l'ajout au-delà du 3ème slot côté API.

## Comment ça a été vérifié
- [x] flutter test (13 tests my_interests + flux_continu OK)
- [x] flutter analyze (0 erreurs)
- [x] alembic heads : exactement 1 head (22a2)
- [x] /simplify passé

## Zones à risque
- Migration Alembic : suppression CHECK contraints sur 2 tables — réversible via `downgrade`
- `FAVORITE_CAP` renommé sémantiquement (cap d'affichage, pas cap dur) — compat imports conservée