### PR TITLE
feat(flux-continu): polish UI feed (tirets, illustrations, play, images cassées)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -29,7 +29,7 @@ import '../../gamification/widgets/streak_indicator.dart';
 import '../../lettres/widgets/lettres_notification_banner.dart';
 import '../../notifications/widgets/notification_renudge_banner.dart';
 import '../../well_informed/widgets/well_informed_prompt.dart';
-import '../../../shared/widgets/loaders/facteur_loader.dart';
+import '../../../shared/widgets/loaders/loading_view.dart';
 import '../models/flux_continu_models.dart';
 import '../providers/flux_continu_provider.dart';
 import '../../feed/widgets/feed_filter_bar.dart';
@@ -480,7 +480,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
         child: Stack(
           children: [
             state.when(
-              loading: () => const _LoadingView(),
+              loading: () => const LoadingView(),
               error: (e, _) => _ErrorView(
                 error: e,
                 onRetry: () =>
@@ -1063,15 +1063,6 @@ class _PullToRefreshHintState extends State<_PullToRefreshHint>
         ),
       ),
     );
-  }
-}
-
-class _LoadingView extends StatelessWidget {
-  const _LoadingView();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(child: FacteurLoader(width: 96, height: 96));
   }
 }
 

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -85,7 +85,7 @@ class FluxArticleVM {
 ///   the right (radius 10).
 /// - Footer row (single-line) : source dot + name · theme pill · clock·time
 ///   · optional press-review trailing (Essentiel sections only).
-class FluxContinuArticleCard extends StatelessWidget {
+class FluxContinuArticleCard extends StatefulWidget {
   final Object article;
   final VoidCallback? onTap;
   final VoidCallback? onSwipeDismiss;
@@ -108,10 +108,22 @@ class FluxContinuArticleCard extends StatelessWidget {
   });
 
   @override
+  State<FluxContinuArticleCard> createState() => _FluxContinuArticleCardState();
+}
+
+class _FluxContinuArticleCardState extends State<FluxContinuArticleCard> {
+  bool _thumbErrored = false;
+
+  @override
   Widget build(BuildContext context) {
-    final vm = FluxArticleVM.from(article);
+    final vm = FluxArticleVM.from(widget.article);
     final colors = context.facteurColors;
-    final hasThumb = vm.thumbnailUrl != null && vm.thumbnailUrl!.isNotEmpty;
+    // Reclaim the thumb slot when the network image fails — avoids the
+    // grey/broken visual reported on many Reporterre articles (cached
+    // vignettes that 404 or load empty).
+    final hasThumb = vm.thumbnailUrl != null &&
+        vm.thumbnailUrl!.isNotEmpty &&
+        !_thumbErrored;
 
     Widget card = Padding(
       padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
@@ -120,13 +132,13 @@ class FluxContinuArticleCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(12),
         elevation: 0,
         child: GestureDetector(
-          onLongPressStart: (_) =>
-              ArticlePreviewOverlay.show(context, articleToContent(article)),
+          onLongPressStart: (_) => ArticlePreviewOverlay.show(
+              context, articleToContent(widget.article)),
           onLongPressMoveUpdate: (details) => ArticlePreviewOverlay.updateScroll(
               details.localOffsetFromOrigin.dy),
           onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
           child: InkWell(
-            onTap: onTap,
+            onTap: widget.onTap,
             borderRadius: BorderRadius.circular(12),
             child: Ink(
               decoration: BoxDecoration(
@@ -169,6 +181,11 @@ class FluxContinuArticleCard extends StatelessWidget {
                             url: vm.thumbnailUrl!,
                             isVideo: _isVideo(vm.contentType),
                             accent: colors.primary,
+                            onError: () {
+                              if (mounted && !_thumbErrored) {
+                                setState(() => _thumbErrored = true);
+                              }
+                            },
                           ),
                         ],
                       ],
@@ -177,9 +194,10 @@ class FluxContinuArticleCard extends StatelessWidget {
                     _Footer(
                       vm: vm,
                       colors: colors,
-                      showPressReview: isEssentiel && pressReviewCount > 0,
-                      pressReviewCount: pressReviewCount,
-                      perspectiveSources: perspectiveSources,
+                      showPressReview:
+                          widget.isEssentiel && widget.pressReviewCount > 0,
+                      pressReviewCount: widget.pressReviewCount,
+                      perspectiveSources: widget.perspectiveSources,
                     ),
                   ],
                 ),
@@ -190,12 +208,12 @@ class FluxContinuArticleCard extends StatelessWidget {
       ),
     );
 
-    if (onTap != null) {
+    if (widget.onTap != null) {
       card = SwipeToOpenCard(
-        onSwipeOpen: onTap!,
-        onSwipeDismiss: onSwipeDismiss,
-        enableHintAnimation: enableSwipeHint,
-        onHintAnimationComplete: onSwipeHintComplete,
+        onSwipeOpen: widget.onTap!,
+        onSwipeDismiss: widget.onSwipeDismiss,
+        enableHintAnimation: widget.enableSwipeHint,
+        onHintAnimationComplete: widget.onSwipeHintComplete,
         child: card,
       );
     }
@@ -247,17 +265,18 @@ class _Thumbnail extends StatelessWidget {
   final String url;
   final bool isVideo;
   final Color accent;
+  final VoidCallback onError;
 
   const _Thumbnail({
     required this.url,
     required this.isVideo,
     required this.accent,
+    required this.onError,
   });
 
   @override
   Widget build(BuildContext context) {
-    final colors = context.facteurColors;
-    final placeholder = Container(
+    final loadingPlaceholder = Container(
       width: 78,
       height: 78,
       decoration: BoxDecoration(
@@ -271,21 +290,69 @@ class _Thumbnail extends StatelessWidget {
         ),
         borderRadius: BorderRadius.circular(10),
       ),
-      child: Icon(
-        isVideo ? Icons.play_arrow_rounded : Icons.article_outlined,
-        color: colors.textTertiary,
-        size: 24,
-      ),
     );
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(10),
-      child: FacteurImage(
-        imageUrl: url,
+      child: SizedBox(
         width: 78,
         height: 78,
-        placeholder: (_) => placeholder,
-        errorWidget: (_) => placeholder,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            FacteurImage(
+              imageUrl: url,
+              width: 78,
+              height: 78,
+              placeholder: (_) => loadingPlaceholder,
+              errorWidget: (_) {
+                // Bubble up so the parent card can drop the thumb slot
+                // entirely (next rebuild). Returning shrink keeps the
+                // current frame from flashing a placeholder.
+                WidgetsBinding.instance
+                    .addPostFrameCallback((_) => onError());
+                return const SizedBox.shrink();
+              },
+            ),
+            if (isVideo)
+              const Center(
+                child: _VideoPlayBadge(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Small play badge overlay for YouTube/video thumbnails — sized for the
+/// 78×78 article-card thumb (the shared [VideoPlayOverlay] is tuned for
+/// large reader hero images).
+class _VideoPlayBadge extends StatelessWidget {
+  const _VideoPlayBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 32,
+      height: 32,
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.88),
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.18),
+            blurRadius: 4,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Center(
+        child: Icon(
+          PhosphorIcons.play(PhosphorIconsStyle.fill),
+          size: 14,
+          color: Colors.black87,
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/flux_continu/widgets/folded_section_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/folded_section_card.dart
@@ -4,20 +4,18 @@ import 'package:google_fonts/google_fonts.dart';
 import '../../../config/theme.dart';
 
 /// Compact "menu-list" version of [SectionBanner] used when the user has
-/// already consumed a section. Identity reduces to: accent filet (brand cue),
-/// section title, article count, chevron — over the bare parchment, with a
-/// hairline separator. No accent fill, no illustration: the card recedes to
-/// pure navigation once the day's content has been read.
+/// already consumed a section. Identity reduces to: section title, article
+/// count, chevron — over the bare parchment, with a hairline separator.
+/// No accent fill, no illustration: the card recedes to pure navigation
+/// once the day's content has been read.
 class FoldedSectionCard extends StatelessWidget {
   final String title;
-  final Color accent;
   final int? articleCount;
   final VoidCallback? onTap;
 
   const FoldedSectionCard({
     super.key,
     required this.title,
-    required this.accent,
     this.articleCount,
     this.onTap,
   });
@@ -43,15 +41,6 @@ class FoldedSectionCard extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Container(
-                width: 18,
-                height: 1.5,
-                decoration: BoxDecoration(
-                  color: accent.withValues(alpha: 0.70),
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-              const SizedBox(width: 10),
               Expanded(
                 child: Text(
                   title,

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -112,15 +112,6 @@ class SectionBanner extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
               children: [
-                Container(
-                  width: 28,
-                  height: 2,
-                  margin: const EdgeInsets.only(bottom: 12),
-                  decoration: BoxDecoration(
-                    color: accent.withValues(alpha: 0.80),
-                    borderRadius: BorderRadius.circular(2),
-                  ),
-                ),
                 FractionallySizedBox(
                   widthFactor: textWidthFactor,
                   alignment: AlignmentDirectional.centerStart,
@@ -243,10 +234,10 @@ class _BannerIllustration extends StatelessWidget {
               opacity: 0.72,
               child: Image.asset(
                 asset,
-                height: 120,
+                height: 96,
                 // Source PNGs are 1024² — decode at 2× display height to
                 // keep texture memory bounded (saves ~10× per image).
-                cacheHeight: 240,
+                cacheHeight: 192,
                 fit: BoxFit.contain,
                 errorBuilder: (_, __, ___) => const SizedBox.shrink(),
               ),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -78,7 +78,6 @@ class SectionBlock extends StatelessWidget {
   Widget _buildFolded() {
     return FoldedSectionCard(
       title: section.label,
-      accent: section.accent,
       articleCount: section.totalCount,
       onTap: onUnfold,
     );


### PR DESCRIPTION
## Quoi

5 ajustements UI ciblés sur le flux continu post-migration :

1. **Tirets colorés retirés** sur les héros (`SectionBanner`) et leur version repliée (`FoldedSectionCard`) — bruit visuel sans signal.
2. **Illustrations héros réduites** : 120 → 96 px (cacheHeight 240 → 192).
3. **Badge play** réintégré sur vignettes vidéo YouTube (`_VideoPlayBadge` 32 px, calibré pour le thumb 78×78 — distinct du `VideoPlayOverlay` hero).
4. **Images cassées vraiment masquées** : `FluxContinuArticleCard` devient stateful, l'`errorWidget` remonte via postFrame callback pour libérer le slot 78×78 (fix placeholders gris Reporterre & autres URLs mortes).
5. **Bonus — citations au chargement** : `_LoadingView` local remplacé par le `LoadingView` partagé qui affiche les citations rotatives (`EditorialLoaderCard`) après 3 s, comme l'ancien feed.

## Pourquoi

Retours utilisateur post-migration vers le flux continu : bruit visuel, vidéos non identifiables au coup d'œil, placeholders cassés moches sur de nombreux articles Reporterre, et perte des citations qui adoucissaient l'attente du chargement.

## Comment ça a été vérifié

- [x] `flutter analyze` : aucune erreur sur les fichiers touchés
- [x] `flutter test test/features/flux_continu/` : **49/49 passés**
- [x] Tests qui échouent ailleurs (topic_chip, digest_completion) : vérifiés en `git stash` → **échecs pré-existants sur `dc986c87`, sans rapport**
- [x] Skill `simplify` passée — pas de duplication exploitable (le `VideoPlayOverlay` partagé est calibré hero, pas thumb)
- [ ] Validation Chrome (Playwright MCP) : à faire post-merge ou via `/validate-feature` si besoin

## Zones à risque

- `FluxContinuArticleCard` : passage Stateless → Stateful. Tous les call sites accèdent désormais aux props via `widget.`. Pas de changement d'API publique.
- `FoldedSectionCard` : champ `accent` retiré du constructeur. Seul caller (`section_block.dart`) mis à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)