### PR TITLE
chore(scheduler): retire les jobs veille async (Story 23.1, PR-1/4)

### DIFF
--- a/docs/stories/core/23.1.veille-refonte-filtre-temps-reel.md
+++ b/docs/stories/core/23.1.veille-refonte-filtre-temps-reel.md
@@ -1,0 +1,302 @@
+# 23.1 — Refonte Veille : du curateur LLM au filtre temps-réel
+
+> Bascule la veille d'un pipeline LLM asynchrone (3 appels Mistral, clusters, deliveries) vers un **filtre temps-réel composé** appliqué live sur le feed Facteur principal.
+
+**Status** : 📝 Plan validé PO 2026-05-19 — exécution en cours.
+**Type** : Maintenance + refonte produit (réduction de complexité).
+**Plan source** : `/tmp/attachments/plan.md` (validé par PO 2026-05-19, archivé ci-dessous).
+
+---
+
+## Contexte
+
+La feature **veille** est aujourd'hui un système de curation LLM lourd :
+
+- **3 appels Mistral** par delivery (suggestions topics, suggestions sources, copie cluster « why it matters »).
+- Pipeline asynchrone scheduler `*/30 min` qui génère des `veille_deliveries` (clusters d'articles + texte LLM).
+- **4 tables dédiées** : `veille_configs`, `veille_topics`, `veille_sources`, `veille_deliveries`.
+- Flow mobile **4 étapes** + écrans dashboard/deliveries/details/transitions (~8 500 lignes Flutter).
+- **Total** : ~3 946 lignes backend + ~8 500 lignes Flutter.
+
+**Problèmes** :
+
+- Complexité algorithmique disproportionnée pour la valeur produit observée.
+- Dépendance Mistral coûteuse (3 appels/config) et non scalable (1 LLM call par delivery).
+- Génération différée : pas de feedback live à la création/édition.
+- Debuggabilité faible (chaîne LLM opaque, états `RUNNING`/`FAILED` à suivre).
+- Surface de test énorme (≈ 1 800 lignes de tests dédiés au pipeline LLM).
+
+**Vision cible** : la veille devient un **filtre temps-réel sur le feed Facteur principal**, sans LLM, sans génération asynchrone. La config utilisateur (thèmes + topics + sujets/angles + sources) compose une expression de filtre `OR` qui s'applique live à chaque pull du feed. Les sources sélectionnées reçoivent un boost de scoring.
+
+**Bénéfices attendus** :
+
+- **−2 000 à −2 500 lignes nettes** (suppression LLM + écrans deliveries).
+- Suppression dépendance Mistral pour la veille (3 sites de moins par config).
+- Réactivité immédiate : pas d'attente de génération, le feed s'affiche dès la création.
+- Debuggabilité totale (SQL pur, filtres lisibles).
+- Réutilisation maximale de l'infra `RecommendationService` existante (filter presets, scoring engine).
+
+---
+
+## Décisions PO actées (2026-05-19)
+
+| # | Décision | Valeur |
+|---|---|---|
+| Q1 | Multi-veille | **1 seule veille par user** (partial unique conservé sur `veille_configs`) |
+| Q2 | Historique `veille_deliveries` | **Drop sec** — table supprimée, pas d'archive |
+| Q3 | Digest périodique email/push | **Drop total V1** — feed live uniquement |
+| Q4 | Stratégie déploiement | **Big bang** — 1 cycle, 4 PRs séquencés |
+
+## Décisions architecturales (à valider par lecture)
+
+| # | Sujet | Recommandation |
+|---|---|---|
+| A1 | Schéma DB | Recycler `veille_configs` (drop scheduling cols) + nouvelle table `veille_keywords` |
+| A2 | Matching | Hybride : filtre OR sur thèmes/topics/sources/keywords + boost via `VeilleMatchLayer` (nouvelle layer scoring) |
+| A3 | API | Nouvel endpoint `GET /api/veille/feed` (factorisation `_compute_feed`) |
+| A4 | UX mobile | Écran dédié `/veille` conservé (réutilise `theme.veille` + branding) + flow config réduit à 3 étapes |
+| A5 | Sources niche custom | **Conserver** l'ingestion via URL (déjà investie, valeur produit) |
+| A6 | Sémantique angle vs sujet | **Un seul champ UX « mots-clés »** ; pas de distinction DB en V1 |
+| A7 | Compteur badge non-vus | **Drop V1** ; pas de badge sur la veille (à réintroduire si signal user) |
+| A8 | Mode serein | Hérite du toggle global user (pas de toggle dédié veille) |
+
+---
+
+## Architecture cible
+
+### 1. Schéma DB (1 migration consolidée `vf01_veille_filter_refonte.py`)
+
+```sql
+-- veille_configs : DROP colonnes scheduling
+ALTER TABLE veille_configs
+  DROP COLUMN frequency,
+  DROP COLUMN day_of_week,
+  DROP COLUMN delivery_hour,
+  DROP COLUMN timezone,
+  DROP COLUMN last_delivered_at,
+  DROP COLUMN next_scheduled_at,
+  DROP COLUMN purpose_other;
+-- garde : id, user_id, theme_id, theme_label, status,
+--         purpose, editorial_brief, preset_id, created_at, updated_at
+-- garde le partial unique (user_id) WHERE status='active'
+
+-- veille_topics : inchangée
+-- veille_sources : inchangée
+
+-- veille_keywords : NOUVELLE
+CREATE TABLE veille_keywords (
+  id UUID PRIMARY KEY,
+  veille_config_id UUID NOT NULL REFERENCES veille_configs(id) ON DELETE CASCADE,
+  keyword VARCHAR(80) NOT NULL,  -- normalized lowercase
+  position INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_veille_keywords UNIQUE (veille_config_id, keyword)
+);
+CREATE INDEX ix_veille_keywords_config ON veille_keywords (veille_config_id);
+
+-- veille_deliveries : DROP table entière
+DROP TABLE veille_deliveries CASCADE;
+```
+
+### 2. Algorithme de matching (filtre OR + scoring boost)
+
+**Filtre `OR`** dans `_get_candidates()` :
+
+```python
+query = query.where(or_(
+    Content.theme.in_(veille_themes),                        # apply_theme_focus_filter
+    Content.topics.overlap(veille_topic_slugs),              # apply_topic_filter (GIN)
+    Content.source_id.in_(veille_source_ids),                # source match
+    or_(*[Content.title.ilike(f"%{k}%") for k in veille_keywords],
+        *[Content.description.ilike(f"%{k}%") for k in veille_keywords]),
+))
+```
+
+**Boost scoring** via nouvelle `VeilleMatchLayer` (sœur de `UserCustomTopicLayer`) :
+
+```python
+score = (
+    BASE × (n_themes_matched + n_topics_matched + n_keywords_matched)
+    + SOURCE_BOOST si source_id ∈ veille_sources
+)
+```
+
+Indexes existants suffisent : `ix_contents_theme_published`, `ix_contents_topics` (GIN), `ix_contents_source_id`. **Vigilance** : ILIKE titre+description sans index trigramme — benchmark requis en PR-2 ; si p95 > 200 ms, ajouter `CREATE INDEX … USING gin (title gin_trgm_ops)` (extension `pg_trgm`) en PR-2.1.
+
+### 3. Contract API
+
+| Endpoint | Verbe | État | Notes |
+|---|---|---|---|
+| `/api/veille/config` | GET | Refondu | Retourne config + topics + sources + **keywords** |
+| `/api/veille/config` | POST | Refondu | Upsert, accepte `keywords[]` |
+| `/api/veille/config` | PATCH | Refondu | Partial update |
+| `/api/veille/config` | DELETE | Inchangé | Soft archive |
+| `/api/veille/feed` | GET | **NOUVEAU** | Réplique signature `/api/feed/` (limit, offset, serein) |
+| `/api/veille/presets` | GET | Inchangé | Pour onboarding step 1 |
+| `/api/veille/sources/{id}/examples` | GET | Inchangé | Aperçu sources step 3 |
+| `/api/veille/suggestions/topics` | POST | **DROP** | |
+| `/api/veille/suggestions/sources` | POST | **DROP** | |
+| `/api/veille/deliveries` | GET | **DROP** | |
+| `/api/veille/deliveries/{id}` | GET | **DROP** | |
+| `/api/veille/deliveries/generate` | POST | **DROP** | |
+| `/api/veille/deliveries/generate-first` | POST | **DROP** | |
+
+Validation Pydantic `VeilleConfigUpsert` :
+
+- Au moins UN parmi `themes`, `topics`, `sources`, `keywords` doit être non-vide.
+- `keywords[i]` : `2 ≤ len ≤ 60`, normalisé lowercase, dédupliqué.
+- Max **20 keywords** par config (cf. R6).
+
+### 4. UX mobile (3 écrans config + 1 écran feed)
+
+**Nouveau flow config** (3 étapes au lieu de 5) :
+
+1. **Step 1 — Thème** : sélecteur thème + preset facultatif (réutilise existant).
+2. **Step 2 — Précise ta veille** : chips topics présélectionnés (depuis preset) + champ free-text « ajoute des sujets ou angles » + sélection sources curées (multi-select + niche URL).
+3. **Step 3 — Récap & lancer** : vue éditable + CTA « Lancer ma veille » → navigation directe au feed.
+
+**Écran principal** : `veille_feed_screen.dart` — Scaffold avec app-bar « Ma Veille » + bouton edit (re-ouvre flow), corps = `VeilleFeedNotifier` (calque de `FeedNotifier`), réutilise `FeedCard`/`ArticleCard`, pull-to-refresh, empty-state CTA configurer.
+
+---
+
+## Plan d'exécution (4 PRs séquencés)
+
+### PR-1 — Stop scheduler [S, ~2h] ⚡
+
+**But** : couper la génération asynchrone sans rien casser pour le client.
+
+- `packages/api/app/workers/scheduler.py` : retirer les `add_job` `veille_generation` + `veille_stuck_cleanup`, l'import correspondant, et les entrées dans le log final.
+- Aucun impact client (endpoints `/deliveries/*` répondent toujours, simplement plus de nouvelles deliveries générées par le scheduler).
+- Tests `test_veille_generation_job.py` / `test_veille_first_delivery_failure.py` : conservés tels quels (testent la fonction directement, pas la registration scheduler) — seront drop en PR-4.
+
+**Verification** :
+
+- `pytest packages/api/tests/test_veille_*.py -v` reste vert.
+- Logs Railway post-deploy : disparition des entrées `run_veille_generation` aux `:00` et `:30`.
+- Vérification SQL : aucune nouvelle row dans `veille_deliveries` avec `created_at > deploy_time`.
+
+### PR-2 — Backend filtre temps-réel [M, ~2j]
+
+**But** : implémenter le filtre live et la nouvelle config.
+
+- Migration Alembic `vf01_veille_filter_refonte.py` (cf. SQL ci-dessus).
+- Modèles : drop `VeilleDelivery`, `VeilleGenerationState`, `VeilleFrequency` ; drop colonnes scheduling de `VeilleConfig` ; ajout modèle `VeilleKeyword`.
+- Schemas Pydantic : ajout `VeilleKeywordSelection` ; étension `VeilleConfigUpsert/Response` avec `keywords[]` ; drop `VeilleSuggest*Request`, `VeilleDelivery*Response`, `VeilleGenerateRequest`.
+- Nouvelle layer `services/recommendation/layers/veille_match.py` (`VeilleMatchLayer(ScoringLayer)`).
+- Nouveau service `services/veille/feed_filter.py` (`load_veille_filters`, `build_or_predicate`).
+- Factorisation `RecommendationService._compute_feed` pour accepter un `extra_where_clause` optionnel.
+- Router : refondre `POST/GET/PATCH /config` pour `keywords[]` ; **NOUVEAU** `GET /feed` ; SUPPRIMER `/suggestions/*` et `/deliveries/*`.
+
+**Verification** :
+
+- `pytest packages/api/tests/test_veille_*.py -v` all green.
+- `uvicorn app.main:app --port 8080` + `curl GET /api/veille/feed` avec config seeded → articles filtrés.
+- Bench `curl … -w "%{time_total}"` < 500 ms p95 sur DB avec 50k articles.
+- `alembic upgrade head && alembic downgrade -1 && alembic upgrade head` OK.
+
+### PR-3 — Mobile refonte UX [L, ~3-4j]
+
+**But** : remplacer les 14 écrans veille par 4 (3 config + 1 feed) en réutilisant le feed.
+
+**Fichiers à supprimer** : `veille_intro_screen`, `veille_dashboard_screen`, `veille_deliveries_screen`, `veille_delivery_detail_screen`, `steps/step2_suggestions_screen`, `steps/step4_frequency_screen`, `transitions/flow_loading_screen`, `widgets/veille_cluster_card`, `widgets/halo_loader`, `models/veille_delivery`, `models/veille_suggestion`, `providers/veille_deliveries_provider`, `providers/veille_suggestions_provider`, `data/veille_mock_data`, `utils/poll_first_delivery`.
+
+**Fichiers à refondre** : `models/veille_config_dto.dart` (drop scheduling, add `keywords`), `providers/veille_config_provider.dart` (931 → ~400 lignes, state machine 3-step), `screens/veille_config_screen.dart` (3 étapes), `steps/step3_sources_screen.dart` (devient « Précise »), `widgets/veille_widgets.dart` (1 502 → ~800 lignes), `repositories/veille_repository.dart` (drop `getSuggestions/Deliveries`, add `getFeed`).
+
+**Fichiers à créer** : `screens/veille_feed_screen.dart` (~250 lignes), `providers/veille_feed_provider.dart` (~150 lignes).
+
+**Routes** : drop `veilleDashboard/Deliveries/DeliveryDetail` ; garder `veilleConfig` + ajouter `veilleFeed` (`/veille`). Entry depuis settings sheet : `pushNamed(veilleFeed)`.
+
+**Verification** :
+
+- `cd apps/mobile && flutter test && flutter analyze` 0 warning.
+- Parcours complet : Settings → Configurer veille → 3 steps → Lancer → feed s'affiche → modifier → save → feed refresh.
+- `/validate-feature` exécuté avec `.context/qa-handoff.md` rédigé.
+
+### PR-4 — Backend cleanup [S, ~3h]
+
+**But** : drop tout le code LLM curation devenu mort. **À merger seulement après PR-3 déployé et adoption ≥ 95 % des sessions mobile.**
+
+**Fichiers à supprimer** :
+
+- `services/veille/digest_builder.py` (298 lignes)
+- `services/veille/topic_suggester.py` (255 lignes)
+- `services/veille/source_suggester.py` (423 lignes)
+- `services/veille/scheduling.py` (148 lignes)
+- `jobs/veille_generation_job.py` (386 lignes)
+- Tests associés (`test_veille_digest_builder`, `..._topic_suggester`, `..._source_suggester_eval`, `..._generation_job`, `..._first_delivery_failure`, `..._scheduling`) — 1 775 lignes.
+
+**Vérifs avant drop** :
+
+- Grep `EditorialLLMClient` → plus aucun usage hors `services/editorial/` (drop OK).
+- Grep `ImportanceDetector` → toujours utilisé par `services/briefing/` (garde).
+- Grep `RSSParser` → usage hors veille (garde).
+
+**Verification** :
+
+- `pytest packages/api/tests/ -v` green (suite réduite mais 100 % passante).
+- `grep -r "veille_generation_job\|topic_suggester\|source_suggester\|digest_builder" packages/api/app/` → aucun résultat.
+- Railway : aucune erreur de démarrage liée à imports manquants.
+
+---
+
+## Risques & mitigations
+
+| # | Risque | Mitigation |
+|---|---|---|
+| R1 | Performance ILIKE keywords sans index trigramme | Benchmark obligatoire en PR-2 ; si p95 > 500 ms, ajouter migration `pg_trgm` + index GIN trigram en PR-2.1 |
+| R2 | Users avec `VeilleConfig` active perdent leur historique deliveries | PO a validé drop sec ; communication in-app via release note suffisante |
+| R3 | `editorial_brief` était lu par LLM `digest_builder` — risque de garder un champ orphelin | **Décision : KEEP** pour V2 (intent éditorial réutilisable côté scoring/UX). Inert sans LLM. |
+| R4 | Le `veille_intro_screen` peut être référencé depuis l'onboarding global | Grep `veilleIntro` dans `features/onboarding/` avant suppression PR-3 |
+| R5 | Erreurs Sentry sur clients mobile non-mis-à-jour appelant endpoints supprimés | **Décision : shim 410 Gone** sur `/suggestions/*` et `/deliveries/*` pendant 1 cycle (drop définitif en PR-4 + bump version min mobile) |
+| R6 | Sur quel volume de keywords un user max ? | Limite dure **20 keywords** par config dans validation Pydantic |
+| R7 | Mistral API key reste configurée pour `services/editorial/` (briefing) | Pas d'impact, garder env var ; vérifier qu'on n'a pas un secret orphelin |
+
+---
+
+## Critères d'acceptation
+
+### Produit
+
+- [ ] User configure une veille en < 60 s (3 étapes vs 5 actuelles).
+- [ ] Le feed veille s'affiche immédiatement après création (pas d'attente de génération).
+- [ ] Le feed veille se rafraîchit en temps réel (pull-to-refresh ou réouverture d'app).
+- [ ] Les articles affichés matchent au moins un critère (thème OU topic OU keyword OU source).
+- [ ] Les articles des sources sélectionnées apparaissent en priorité (boost scoring observable).
+- [ ] L'édition de la config met à jour le feed sans rechargement d'écran.
+
+### Technique
+
+- [ ] `pytest packages/api/tests/ -v` 100 % vert (suite réduite à ~1 500 lignes vs 3 946 actuels).
+- [ ] `cd apps/mobile && flutter test && flutter analyze` 0 warning.
+- [ ] `alembic upgrade head && alembic downgrade -1 && alembic upgrade head` OK.
+- [ ] Bench `GET /api/veille/feed` p95 < 500 ms (DB 50k articles, config 5 themes + 10 topics + 5 sources + 10 keywords).
+- [ ] Aucune référence orpheline aux modules supprimés.
+- [ ] Sentry : aucune nouvelle erreur 5xx sur `/api/veille/*` post-deploy.
+- [ ] Mistral API : baisse mesurable des appels (3 sites de moins par config créée).
+
+---
+
+## Estimation effort
+
+| PR | Description | Effort | Dépendances |
+|---|---|---|---|
+| PR-1 | Stop scheduler | S (~2h) | Aucune |
+| PR-2 | Backend filtre + nouvelle config | M (~2 jours) | PR-1 mergé |
+| PR-3 | Mobile refonte UX | L (~3-4 jours) | PR-2 mergé + déployé staging |
+| PR-4 | Cleanup backend | S (~3h) | PR-3 déployé avec adoption ≥ 95 % |
+
+**Total** : ~1 sprint (1 semaine dev), backend et mobile partiellement parallélisables après PR-1.
+**Net lignes** : −2 000 à −2 500 (élimination LLM + suppression écrans) ; +500 à +700 (nouvelle layer, feed_filter, feed screen).
+
+---
+
+## Tasks (suivi exécution)
+
+- [ ] PR-1 — Stop scheduler veille (branch dédiée, base `main`)
+- [ ] PR-2 — Backend filtre temps-réel (migration `vf01`, endpoint `/feed`, layer scoring)
+- [ ] PR-3 — Mobile refonte UX (suppression 15 fichiers, refonte 7, création 2)
+- [ ] PR-4 — Cleanup backend (drop modules LLM + tests, après adoption ≥ 95 %)
+
+## Change Log
+
+- 2026-05-19 — Story créée à partir du plan validé PO.

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -9,10 +9,6 @@ from apscheduler.triggers.interval import IntervalTrigger
 from app.config import get_settings
 from app.jobs.digest_generation_job import run_digest_generation
 from app.jobs.purge_deleted_users import purge_deleted_users
-from app.jobs.veille_generation_job import (
-    cleanup_stuck_running_deliveries,
-    run_veille_generation,
-)
 from app.workers.rss_sync import sync_all_sources
 from app.workers.storage_cleanup import cleanup_old_articles
 from app.workers.top3_job import generate_daily_top3_job
@@ -255,34 +251,6 @@ def start_scheduler() -> None:
         replace_existing=True,
     )
 
-    # Veille generation scanner — */30 min Paris.
-    # Scan ultra-léger (1 SELECT indexé sur next_scheduled_at) puis traitement
-    # par config avec session courte. Concurrence bornée à 5 (vs 10 du digest)
-    # car la veille tourne moins souvent → on peut être plus prudent côté
-    # pool DB (cf. bug-infinite-load-requests.md).
-    scheduler.add_job(
-        run_veille_generation,
-        trigger=CronTrigger(minute="*/30", timezone=_PARIS_TZ),
-        id="veille_generation",
-        name="Veille Generation Scanner",
-        replace_existing=True,
-        misfire_grace_time=900,
-        coalesce=True,
-        max_instances=1,
-    )
-
-    # Filet final : passe FAILED toute row veille_deliveries restée RUNNING
-    # > 15 min — couvre les SIGKILL/OOM Railway que ni le retry router ni le
-    # watchdog `_phase1_mark_running` ne reprennent (config plus `due`).
-    scheduler.add_job(
-        cleanup_stuck_running_deliveries,
-        trigger=IntervalTrigger(minutes=5),
-        id="veille_stuck_cleanup",
-        name="Veille stuck-running cleanup (>15 min)",
-        replace_existing=True,
-        max_instances=1,
-    )
-
     scheduler.start()
     logger.info(
         "Scheduler started",
@@ -294,8 +262,6 @@ def start_scheduler() -> None:
             "storage_cleanup",
             "purge_deleted_users",
             "zombie_session_sweeper",
-            "veille_generation",
-            "veille_stuck_cleanup",
         ],
         rss_interval_minutes=settings.rss_sync_interval_minutes,
         digest_cron="07:30 Europe/Paris",

--- a/packages/api/tests/workers/test_scheduler.py
+++ b/packages/api/tests/workers/test_scheduler.py
@@ -291,6 +291,31 @@ class TestDigestJobConfiguration:
                 f"scheduled_restart job should not be registered. Jobs: {job_ids}"
             )
 
+    def test_veille_generation_jobs_are_not_registered(self):
+        """Regression guard: la veille bascule vers un filtre temps-réel sur
+        le feed (story 23.1). Les jobs `veille_generation` (scan */30 min) et
+        `veille_stuck_cleanup` (sweeper FAILED) ne doivent plus être enregistrés.
+        """
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
+            mock_scheduler = Mock()
+            mock_scheduler_class.return_value = mock_scheduler
+
+            job_ids = []
+
+            def capture_add_job(*args, **kwargs):
+                job_ids.append(kwargs.get("id"))
+
+            mock_scheduler.add_job = capture_add_job
+
+            start_scheduler()
+
+            assert "veille_generation" not in job_ids, (
+                f"veille_generation job should not be registered. Jobs: {job_ids}"
+            )
+            assert "veille_stuck_cleanup" not in job_ids, (
+                f"veille_stuck_cleanup job should not be registered. Jobs: {job_ids}"
+            )
+
 
 class TestDigestWatchdogCoverage:
     """Watchdog must count (user_id, is_serene) pairs, not distinct users.


### PR DESCRIPTION
## Summary

**PR-1/4 de la refonte veille** ([Story 23.1](../blob/boujonlaurin-dotcom/stop-veille-scheduler/docs/stories/core/23.1.veille-refonte-filtre-temps-reel.md)).

Coupe la génération asynchrone de la veille avant la bascule vers un filtre temps-réel sur le feed :

- Retire le job `run_veille_generation` (CronTrigger `*/30 min` Paris)
- Retire le job `cleanup_stuck_running_deliveries` (IntervalTrigger 5 min)
- Retire l'import correspondant et les entrées du log de démarrage

**Aucun impact client** : les endpoints `/api/veille/deliveries/generate*` restent fonctionnels — ils déclenchent eux-mêmes `run_veille_generation_for_config` côté router. Ils seront supprimés en PR-4 après la refonte mobile (PR-3).

## Pourquoi maintenant

Première étape du big bang. Cette PR est petite, isolée, immédiatement déployable, et bloque les générations 02h00/02h30 etc. qui produisent du contenu mort dès que les autres PRs landeront.

## Régression guard

Ajout d'un test `test_veille_generation_jobs_are_not_registered` calqué sur le pattern existant `scheduled_restart_is_not_registered` (regression guard contre une réintégration accidentelle).

## Test plan

- [x] `pytest tests/workers/test_scheduler.py -v` → 13/13 vert (dont nouveau test)
- [x] `python -c "from app.workers.scheduler import start_scheduler"` → import OK
- [x] `python -c "from app.jobs.veille_generation_job import run_veille_generation_for_config"` → router-used import OK
- [ ] CI green
- [ ] Post-deploy : logs Railway sans entrée `run_veille_generation` aux `:00`/`:30`
- [ ] Post-deploy : `SELECT COUNT(*) FROM veille_deliveries WHERE created_at > <deploy_ts>` → 0

## Suite

- **PR-2** : backend filtre temps-réel (migration `veille_keywords`, endpoint `GET /api/veille/feed`, `VeilleMatchLayer`)
- **PR-3** : mobile refonte UX (suppression 15 fichiers, refonte 7, création 2)
- **PR-4** : cleanup backend (drop `digest_builder`, `topic_suggester`, `source_suggester`, `veille_generation_job` + tests associés ~1 775 lignes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)