### PR TITLE
fix(flux-continu): corrige fold section source + préserve position scroll Explorer

### DIFF
--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -380,13 +380,22 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   /// `folded` state. Called only at moments where the editorial slivers
   /// are above the viewport (return from an Explorer article, scroll-to-top
   /// button) so the resulting resize is invisible to the user. Idempotent.
-  void applyPendingFoldsToState() {
+  ///
+  /// [exceptKeys] lets the caller skip specific section keys — typically the
+  /// section the user just read an article from, which must stay expanded on
+  /// return per the "fold only when leaving the section" rule. Excluded keys
+  /// remain in [_persistQueued] (and in SharedPreferences) so they will be
+  /// folded on the next cold launch — the section is considered consumed for
+  /// tomorrow's tournée even though we keep it visible right now.
+  void applyPendingFoldsToState({Set<String> exceptKeys = const {}}) {
     if (_persistQueued.isEmpty) return;
     final current = state.valueOrNull;
     if (current == null) return;
+    final toPromote = _persistQueued.difference(exceptKeys);
+    if (toPromote.isEmpty) return;
     final next = <String, bool>{
       ..._folded,
-      for (final k in _persistQueued) k: true,
+      for (final k in toPromote) k: true,
     };
     if (next.length == _folded.length &&
         next.entries.every((e) => _folded[e.key] == e.value)) {
@@ -395,6 +404,11 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     _folded = next;
     state = AsyncData(current.copyWith(folded: next));
   }
+
+  /// Read-only snapshot of the sections queued for fold at next apply.
+  /// Used by the screen to compute the height delta of slivers that are
+  /// about to resize, so it can compensate the scroll offset.
+  Set<String> persistQueuedSnapshot() => Set.unmodifiable(_persistQueued);
 
   /// Re-expands a folded section in the current session only (not persisted).
   /// Lets the user re-read a section they previously scrolled past without

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -337,12 +337,24 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   /// state. `fromSection == null` means the article was tapped from the
   /// Explorer feed (or via scroll-to-top sweep) — every editorial section
   /// is queued.
+  ///
+  /// The section the article was tapped from is excluded from the fold on
+  /// return so the user finds the section still expanded at the same scroll
+  /// position. For sections that *do* fold (those above [fromSection], or
+  /// all of them when reading from Explorer), we measure their cumulative
+  /// height before and after the resize and apply a silent
+  /// [ScrollPosition.correctBy] so the article the user just left stays
+  /// visually anchored.
   Future<void> _openArticle(
     BuildContext context,
     Object article, {
     FluxSection? fromSection,
   }) async {
     _markSectionsAboveAsScrolledPast(fromSection);
+    final exceptKeys = fromSection == null
+        ? const <String>{}
+        : {sectionKey(fromSection)};
+    final heightsBefore = _measureFoldCandidateHeights(exceptKeys);
     if (article is DigestItem) {
       await context
           .push('${RoutePaths.fluxContinu}/content/${article.contentId}');
@@ -355,7 +367,44 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       return;
     }
     if (!mounted) return;
-    ref.read(fluxContinuProvider.notifier).applyPendingFoldsToState();
+    ref
+        .read(fluxContinuProvider.notifier)
+        .applyPendingFoldsToState(exceptKeys: exceptKeys);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scroll.hasClients) return;
+      final heightsAfter = _measureFoldCandidateHeights(exceptKeys);
+      final delta = heightsBefore - heightsAfter;
+      if (delta <= 0.5) return;
+      final position = _scroll.position;
+      final corrected =
+          (position.pixels - delta).clamp(0.0, position.maxScrollExtent);
+      position.correctBy(corrected - position.pixels);
+    });
+  }
+
+  /// Cumulative on-screen height of the sections queued for fold (minus
+  /// [exceptKeys]). Used as the delta to compensate scroll offset when the
+  /// fold happens above the viewport.
+  double _measureFoldCandidateHeights(Set<String> exceptKeys) {
+    final value = ref.read(fluxContinuProvider).valueOrNull;
+    if (value == null) return 0.0;
+    final queued =
+        ref.read(fluxContinuProvider.notifier).persistQueuedSnapshot();
+    if (queued.isEmpty) return 0.0;
+    final count = math.min(value.sections.length, _sectionKeys.length);
+    double sum = 0.0;
+    for (var i = 0; i < count; i++) {
+      final section = value.sections[i];
+      final key = sectionKey(section);
+      if (!queued.contains(key)) continue;
+      if (exceptKeys.contains(key)) continue;
+      final ctx = _sectionKeys[i].currentContext;
+      if (ctx == null) continue;
+      final box = ctx.findRenderObject();
+      if (box is! RenderBox || !box.attached) continue;
+      sum += box.size.height;
+    }
+    return sum;
   }
 
   void _markSectionsAboveAsScrolledPast(FluxSection? fromSection) {

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -254,6 +254,69 @@ void main() {
       expect(after, isNotNull);
       expect(after!.folded, equals(initial.folded));
     });
+
+    test('persistQueuedSnapshot exposes queued section keys', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      await container.read(fluxContinuProvider.future);
+      final notifier = container.read(fluxContinuProvider.notifier);
+
+      expect(notifier.persistQueuedSnapshot(), isEmpty);
+
+      const essentiel = DigestTopicSection(
+        kind: SectionKind.essentiel,
+        label: 'Essentiel',
+        accent: Color(0xFFB0470A),
+        coreVisibleCount: 3,
+        topics: [],
+      );
+      const tech = FeedThemeSection(
+        kind: SectionKind.theme,
+        label: 'Tech',
+        accent: Color(0xFF2C3E50),
+        coreVisibleCount: 3,
+        themeSlug: 'tech',
+        items: [],
+      );
+      await notifier.markScrolledPastForNextSession(essentiel);
+      await notifier.markScrolledPastForNextSession(tech);
+
+      expect(
+        notifier.persistQueuedSnapshot(),
+        equals(<String>{'essentiel', 'theme:tech'}),
+      );
+    });
+
+    test('applyPendingFoldsToState(exceptKeys: all) is a no-op', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      final initial = await container.read(fluxContinuProvider.future);
+      final notifier = container.read(fluxContinuProvider.notifier);
+
+      const essentiel = DigestTopicSection(
+        kind: SectionKind.essentiel,
+        label: 'Essentiel',
+        accent: Color(0xFFB0470A),
+        coreVisibleCount: 3,
+        topics: [],
+      );
+      await notifier.markScrolledPastForNextSession(essentiel);
+
+      notifier.applyPendingFoldsToState(exceptKeys: {'essentiel'});
+      final after = container.read(fluxContinuProvider).valueOrNull;
+
+      // Excluded keys are never promoted — state.folded stays unchanged.
+      expect(after, isNotNull);
+      expect(after!.folded, equals(initial.folded));
+      // But the queue is preserved (so the cold-launch persist still applies).
+      expect(notifier.persistQueuedSnapshot(), contains('essentiel'));
+    });
   });
 
   group('FluxContinuNotifier — favorites-driven theme sections', () {


### PR DESCRIPTION
## Quoi

Deux régressions corrigées dans le feed flux continu (\"Tournée du Jour\") :

1. **Section source pliée à tort** — la section dans laquelle l'user tapait un article se repliait au retour, même si c'était la section courante.
2. **Perte de position visuelle au retour d'Explorer** — après lecture d'un article depuis le feed Explorer, les sections éditoriales se repliaient au-dessus du viewport et décalaient l'user vers le bas dans la liste.

## Pourquoi

**Bug 1** : `_maybeFoldSections` (scroll listener) ajoutait la section courante à `_persistQueued` si l'user avait scrollé jusqu'au bas pour atteindre le dernier article. Au retour, `applyPendingFoldsToState` la pliait malgré le `break` correct dans `_markSectionsAboveAsScrolledPast`. La mécanique de fermeture ne doit s'enclencher que pour les sections *au-dessus* de celle qu'on vient de lire.

**Bug 2** : `ScrollController` conserve son offset pixel absolu. Quand les sections éditoriales au-dessus du viewport se repliaient (~400-600px → ~80px chacune), à offset constant le viewport affichait du contenu plus loin dans la liste.

## Comment ça a été vérifié

- [x] `flutter test test/features/flux_continu/` — 51/51 OK (dont 2 nouveaux tests)
- [x] `flutter analyze lib/features/flux_continu/` — clean
- [x] Suite complète `flutter test` — 36 échecs pré-existants non liés, 0 régression introduite
- [x] /simplify passé — 1 fix appliqué (`math.min()` à la place du ternaire)

## Zones à risque

- `FluxContinuNotifier.applyPendingFoldsToState` — signature élargie avec default `exceptKeys: const {}` (rétrocompatible, tous les appels existants conservent le comportement d'avant)
- `ScrollPosition.correctBy` — ajustement silencieux (sans `ScrollNotification`), ne re-déclenche pas `_maybeFoldSections` ni `loadMoreFeed`
- `persistQueuedSnapshot()` — expose `_persistQueued` en lecture seule ; la section exclue reste dans le set pour être pliée au cold launch du lendemain