### PR TITLE
fix(perspectives): vraie cause racine du surlignage invisible (post-#624)

### DIFF
--- a/apps/mobile/lib/features/feed/widgets/diff_title.dart
+++ b/apps/mobile/lib/features/feed/widgets/diff_title.dart
@@ -42,7 +42,7 @@ class DiffTitle extends StatefulWidget {
     required this.biasColor,
     required this.baseStyle,
     this.animateIn = true,
-    this.maxLines = 2,
+    this.maxLines = 4,
   });
 
   @override

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -608,18 +608,25 @@ class _PerspectiveCard extends ConsumerWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Expanded(
-                        child: Text(
-                          perspective.title
+                        child: DiffTitle(
+                          title: perspective.title
                               .replaceAll(RegExp(r'\s+[-–|]\s+[^-–|]+$'), '')
                               .trim(),
-                          style: textTheme.bodyMedium?.copyWith(
-                            fontWeight: FontWeight.w500,
-                            color: colors.textPrimary,
-                            fontSize:
-                                (textTheme.bodyMedium?.fontSize ?? 14) + 1,
-                          ),
+                          highlightSpans: perspective.highlightSpans,
+                          sharedTokens: perspective.sharedTokens,
+                          biasColor: perspective.getBiasColor(colors),
+                          baseStyle: textTheme.bodyMedium?.copyWith(
+                                color: colors.textPrimary,
+                                fontSize:
+                                    (textTheme.bodyMedium?.fontSize ?? 14) + 1,
+                                height: 1.35,
+                              ) ??
+                              TextStyle(
+                                color: colors.textPrimary,
+                                fontSize: 15,
+                                height: 1.35,
+                              ),
                           maxLines: 4,
-                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
                       const SizedBox(width: 8),

--- a/docs/bugs/bug-perspectives-highlight-spans-missing.md
+++ b/docs/bugs/bug-perspectives-highlight-spans-missing.md
@@ -1,8 +1,8 @@
 # Bug: Surlignage progressif des titres invisible en prod (Couverture médiatique)
 
-## Status: IN PROGRESS
+## Status: IN PROGRESS (round 2 — vraie cause racine)
 
-## Date: 2026-05-18
+## Date: 2026-05-18 (round 1), 2026-05-19 (round 2)
 
 ## Symptômes
 
@@ -102,3 +102,85 @@ Note : la snapshot stockée dans `daily_digest.items` ne contiendra toujours pas
 Étendre `packages/api/tests/routers/test_contents_perspectives_highlights.py` :
 - Cas "content sans cluster_id" → `highlight_spans` non-vide pour les perspectives qui divergent du titre référence.
 - Cas "content avec cluster_id" inchangé (régression).
+
+---
+
+## Round 2 — re-test post-déploiement PR #624 : toujours invisible
+
+PR #624 mergée + déployée sur Railway. Re-test mobile : **aucun surlignage**.
+Les Causes B et C ci-dessus étaient des effets, pas les vraies racines. Deux
+bugs indépendants se cumulent et la PR #624 n'en règle aucun pour le chemin
+réellement utilisé par l'utilisateur ("Couverture médiatique" = modale).
+
+### Cause racine #1 — Backend : spaCy n'est plus installé en prod
+
+`packages/api/requirements-ml.txt` (ligne 9) :
+```
+# spacy==3.8.11 (NER, ~100MB RAM)
+```
+…liste spaCy parmi les *"Previous local dependencies (removed)"*. Le
+`requirements.txt` ne contient effectivement plus `spacy`, et le `Dockerfile`
+ne télécharge plus le modèle `fr_core_news_md`.
+
+Chaîne de dégradation 100 % silencieuse :
+1. `ner_service.py:_load_model()` catche `ImportError` → `self._nlp = None`
+   (log unique `ner.spacy_not_installed`)
+2. `title_annotation_service.py:__init__` log `title_annotation.nlp_unavailable`
+   puis continue avec `_nlp = None`
+3. `compute_strong_tokens` / `compute_strong_tokens_batch` retournent `[]` dès
+   que `_nlp is None`
+4. `routers/contents.py:_attach_highlight_spans` (lignes 838-847) catche toute
+   exception et pose `highlight_spans=[]` partout
+
+→ Le batch off-cluster `nlp.pipe()` que la PR #624 a "réactivé" en supprimant
+l'early-return ne tourne donc **jamais** : il n'y a pas de `nlp` à appeler.
+
+### Cause racine #2 — Mobile : la modale ignore complètement DiffTitle
+
+"Couverture médiatique" ouvre :
+- `apps/mobile/lib/features/digest/widgets/topic_section.dart:878` →
+  `showModalBottomSheet(PerspectivesBottomSheet(...))`
+- `apps/mobile/lib/features/feed/widgets/article_viewer_modal.dart:165` →
+  idem
+
+Dans cette modale, `_PerspectiveCard.build()`
+(`perspectives_bottom_sheet.dart:611`) rend le titre via un **`Text()` brut** —
+pas `DiffTitle`. Les champs `highlightSpans` / `sharedTokens` ajoutés sur l'objet
+`Perspective` par la PR #624 arrivent bien sur l'objet mais sont **totalement
+ignorés** par ce widget.
+
+Le widget inline `_VariantRow` (ligne 1785 du même fichier) utilise bien
+`DiffTitle`, mais ce n'est pas le chemin que l'utilisateur emprunte depuis
+"Couverture médiatique".
+
+→ Conséquence : même après le fix Cause racine #1 (backend), le titre de la
+modale resterait gris uni. La PR #624 a corrigé deux faux problèmes.
+
+## Fix round 2
+
+### Backend
+- `packages/api/requirements.txt` : ajouter `spacy==3.8.11`
+- `packages/api/Dockerfile` : ajouter `RUN python -m spacy download fr_core_news_md`
+- `packages/api/requirements-ml.txt` : retirer le commentaire "removed" sur spacy
+- Nouvel endpoint `/api/internal/admin/ner-health` : retourne
+  `{nlp_available, model_version, sample_tokens}` pour un titre canonique →
+  permet de diagnostiquer sans redéployer à l'aveugle la prochaine fois.
+
+### Mobile
+- `perspectives_bottom_sheet.dart` (`_PerspectiveCard`, ligne 611) :
+  migration `Text(...)` → `DiffTitle(...)` en suivant le pattern de
+  `_VariantRow` ligne 1785.
+- `maxLines: 4` propagé sur tous les usages de `DiffTitle` (le défaut à 2
+  coupait trop tôt et masquait la moitié des mots-clés divergents).
+
+### Leçons apprises
+- **Une suppression "soft" de spaCy (retirée du requirements.txt + commentée
+  dans requirements-ml.txt) sans audit des appelants laisse des chaînes de
+  code qui tournent dans le vide.** Les logs `nlp_unavailable` étaient bien
+  émis, mais personne ne les surveillait.
+- **Pas d'endpoint de santé interne pour les services ML** → la seule façon
+  de détecter ce drift était d'observer l'UX cassée. À corriger avec
+  `/admin/ner-health`.
+- **Les tests existants mockaient `FakeNlp`** : ils ne pouvaient pas détecter
+  l'absence réelle de spaCy en prod. Limite connue, à compléter à terme par
+  un smoke test E2E qui appelle l'endpoint health au boot.

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -8,6 +8,10 @@ WORKDIR /app
 COPY packages/api/requirements.txt .
 RUN pip install --no-cache-dir --timeout 300 --retries 5 -r requirements.txt
 
+# Télécharge le modèle spaCy fr_core_news_md utilisé par TitleAnnotationService
+# pour le surlignage des titres de perspectives. ~40 MB.
+RUN python -m spacy download fr_core_news_md
+
 # Copy application AND required configs/scripts
 COPY packages/api/app/ app/
 COPY packages/api/config/ config/

--- a/packages/api/app/routers/internal.py
+++ b/packages/api/app/routers/internal.py
@@ -3,6 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.services.classification_queue_service import ClassificationQueueService
+from app.services.title_annotation_service import get_title_annotation_service
 from app.workers.rss_sync import sync_all_sources
 
 router = APIRouter()
@@ -74,3 +75,20 @@ async def backfill_serene(
     service = ClassificationQueueService(session)
     count = await service.requeue_missing_serene(batch_limit=batch_limit)
     return {"message": "Backfill serene queued", "articles_queued": count}
+
+
+@router.get("/admin/ner-health", status_code=status.HTTP_200_OK)
+async def get_ner_health(
+    sample_title: str = Query(
+        default="Tsahal frappe Gaza et tue plusieurs civils",
+        max_length=200,
+    ),
+):
+    """Diagnostique la santé du pipeline NER (spaCy fr_core_news_md)."""
+    svc = get_title_annotation_service()
+    return {
+        "nlp_available": svc.is_nlp_available,
+        "model_version": svc.MODEL_VERSION,
+        "sample_title": sample_title,
+        "sample_tokens": svc.compute_strong_tokens(sample_title),
+    }

--- a/packages/api/app/services/title_annotation_service.py
+++ b/packages/api/app/services/title_annotation_service.py
@@ -68,6 +68,10 @@ class TitleAnnotationService:
         if self._nlp is None:
             logger.warning("title_annotation.nlp_unavailable")
 
+    @property
+    def is_nlp_available(self) -> bool:
+        return self._nlp is not None
+
     def _doc_to_tokens(self, doc) -> list[dict]:
         """Convert a spaCy Doc into our strong-token shape."""
         if doc is None:

--- a/packages/api/requirements-ml.txt
+++ b/packages/api/requirements-ml.txt
@@ -1,9 +1,11 @@
-# ML dependencies are no longer needed locally.
 # Classification is now handled via Mistral API (see classification_service.py).
-# httpx (already in requirements.txt) is the only dependency needed.
+# httpx (already in requirements.txt) is the only dependency for classification.
+#
+# Note : spaCy a été ré-ajouté à requirements.txt principal pour le NER des
+# titres (TitleAnnotationService). Le modèle fr_core_news_md est téléchargé
+# par le Dockerfile.
 #
 # Previous local dependencies (removed):
 # - transformers==4.38.2 (mDeBERTa zero-shot, ~890MB RAM)
 # - torch==2.2.0
 # - numpy>=1.26.0,<2.0
-# - spacy==3.8.11 (NER, ~100MB RAM)

--- a/packages/api/requirements.txt
+++ b/packages/api/requirements.txt
@@ -60,5 +60,9 @@ pytest-asyncio==0.23.5
 protobuf==5.26.1
 curl-cffi==0.7.4
 
+# NER pour le surlignage des titres de perspectives (Story 7.4)
+# Le modèle fr_core_news_md (~40 MB) est téléchargé dans le Dockerfile.
+spacy==3.8.11
+
 # Editorial Pipeline (Story 10.23)
 PyYAML>=6.0

--- a/packages/api/tests/routers/test_contents_perspectives_highlights.py
+++ b/packages/api/tests/routers/test_contents_perspectives_highlights.py
@@ -340,6 +340,33 @@ async def test_attach_highlight_spans_batches_off_cluster_titles_in_one_executor
 
 
 @pytest.mark.asyncio
+async def test_attach_highlight_spans_returns_empty_when_nlp_unavailable(
+    db_session, cluster_setup
+):
+    """`_nlp is None` → spans vides sans crash (cf. bug doc round 2)."""
+    fake_svc = service_with_nlp(None)
+
+    perspectives = [
+        {
+            "title": "Une frappe sur Gaza fait 20 morts",
+            "url": "https://other.fr/x",
+            "bias_stance": "left",
+        }
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        pivot = await _attach_highlight_spans(
+            db_session, cluster_setup["ref"], perspectives
+        )
+
+    assert perspectives[0]["highlight_spans"] == []
+    assert perspectives[0]["shared_tokens"] == []
+    assert pivot is None
+
+
+@pytest.mark.asyncio
 async def test_attach_highlight_spans_swallows_exceptions(
     db_session, cluster_setup
 ):

--- a/packages/api/tests/routers/test_internal_ner_health.py
+++ b/packages/api/tests/routers/test_internal_ner_health.py
@@ -1,0 +1,67 @@
+"""Tests pour `/api/internal/admin/ner-health`.
+
+Endpoint diagnostique ajouté après l'incident du 19 mai 2026 où spaCy n'était
+plus installé dans l'image Railway. La chaîne `TitleAnnotationService`
+dégradait silencieusement sans erreur visible côté client — d'où ce health
+check explicite.
+"""
+
+from unittest.mock import patch
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from tests.fixtures.fake_spacy import FakeDoc, FakeNlp, FakeToken, service_with_nlp
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+async def test_ner_health_reports_available_when_nlp_loaded(client):
+    docs = {
+        "Tsahal frappe Gaza": FakeDoc(
+            tokens=[
+                FakeToken("Tsahal", 0, "PROPN", "Tsahal"),
+                FakeToken("frappe", 7, "VERB", "frapper"),
+                FakeToken("Gaza", 14, "PROPN", "Gaza"),
+            ],
+        ),
+    }
+    fake_svc = service_with_nlp(FakeNlp(docs))
+
+    with patch(
+        "app.routers.internal.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        response = await client.get(
+            "/api/internal/admin/ner-health",
+            params={"sample_title": "Tsahal frappe Gaza"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["nlp_available"] is True
+    assert body["model_version"] == "v1-spacy-fr_md"
+    assert body["sample_title"] == "Tsahal frappe Gaza"
+    token_texts = [t["text"] for t in body["sample_tokens"]]
+    assert "Tsahal" in token_texts
+
+
+async def test_ner_health_reports_unavailable_when_nlp_missing(client):
+    fake_svc = service_with_nlp(None)
+
+    with patch(
+        "app.routers.internal.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        response = await client.get("/api/internal/admin/ner-health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["nlp_available"] is False
+    assert body["sample_tokens"] == []


### PR DESCRIPTION
## Quoi

PR #624 prétendait fixer l'invisibilité du surlignage des titres dans
"Couverture médiatique". Re-test post-déploiement : toujours invisible.
L'investigation révèle **deux bugs cumulés**, indépendants, et la PR
précédente n'en règle aucun pour le chemin réellement utilisé.

## Pourquoi

**Cause racine #1 — Backend : spaCy n'est plus installé en prod.**
`requirements.txt` ne liste plus `spacy`, le `Dockerfile` ne télécharge
plus `fr_core_news_md`. Toute la chaîne `_attach_highlight_spans` retourne
silencieusement `[]` parce que `NerService._nlp = None`. Le batch off-cluster
`nlp.pipe()` que #624 avait "réactivé" ne tourne donc jamais.

**Cause racine #2 — Mobile : la modale ignore complètement DiffTitle.**
"Couverture médiatique" ouvre `showModalBottomSheet(PerspectivesBottomSheet)`.
Dans la modale, `_PerspectiveCard` (perspectives_bottom_sheet.dart:611) rend
le titre via `Text(...)` brut. Les champs `highlightSpans`/`sharedTokens`
ajoutés par #624 arrivent sur l'objet mais sont totalement ignorés.

Bug doc complet (round 2) : `docs/bugs/bug-perspectives-highlight-spans-missing.md`.

## Comment

**Backend** :
- `requirements.txt` : ajout `spacy==3.8.11`
- `Dockerfile` : `RUN python -m spacy download fr_core_news_md` (~40 MB)
- `requirements-ml.txt` : nettoyage commentaire obsolète
- `title_annotation_service.py` : property `is_nlp_available`
- `internal.py` : nouveau endpoint `GET /api/internal/admin/ner-health`
  retournant `{nlp_available, model_version, sample_title, sample_tokens}`
  pour diagnostiquer le drift NER sans redéployer à l'aveugle la prochaine fois

**Mobile** :
- `perspectives_bottom_sheet.dart:611` : `_PerspectiveCard` migré de
  `Text()` vers `DiffTitle` (pattern de `_VariantRow` ligne 1785)
- `diff_title.dart:45` : défaut `maxLines` 2 → 4 (le défaut à 2 coupait
  trop tôt et masquait la moitié des mots-clés divergents)

## Comment ça a été vérifié

- [x] `pytest -v` backend : **1078 passed**, 0 failed
- [x] `pytest tests/routers/test_contents_perspectives_highlights.py
       tests/routers/test_internal_ner_health.py` : **11/11** (dont 3 nouveaux :
       régression `nlp_unavailable` + 2 happy/sad path endpoint)
- [x] `flutter test test/features/feed/widgets/` : 23/24 verts (1 échec
       pré-existant `feed_refresh_undo_banner_test`, sans rapport)
- [x] `flutter analyze` sur fichiers modifiés : **0 issue**
- [x] API locale + curl `/api/internal/admin/ner-health` : shape OK,
       `nlp_available: false` cohérent (spaCy absent localement = état pré-fix)
- [x] `/simplify` passé (trim docstrings endpoint + test)

## Zones à risque

- **Image Docker plus lourde** : +40 MB modèle + ~100 MB RAM runtime.
  C'est ce qui avait motivé le retrait initial — réintégré ici car
  TitleAnnotationService n'a pas d'alternative non-spaCy.
- **Cache `_perspectives_cache` TTL 2h** : après déploiement, certains
  workers serviront pendant max 2h d'anciennes données vides. Surveillance
  Sentry sur `title_annotation.*` recommandée pendant 1h post-merge.
- **Offsets `highlightSpans` côté modale** : `DiffTitle` reçoit le titre
  tronqué (sans suffixe " - Source"). Les spans hors limites sont
  silencieusement clampés (`diff_title.dart:115-122`) — pas de crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)