### PR TITLE
feat(favoris): intègre la veille comme 3ᵉ type de favori (Story 23.1, PR-3/4)

### DIFF
--- a/docs/qa/scripts/verify_veille_favorite.sh
+++ b/docs/qa/scripts/verify_veille_favorite.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Story 23.1 PR-3 — smoke E2E : veille comme 3ᵉ type de favori.
+#
+# Vérifie que :
+#  1. POST /api/veille/config crée automatiquement un favori dans
+#     user_favorite_interests.
+#  2. GET /api/user/interests retourne ce favori avec kind=veille.
+#  3. GET /api/users/top-themes le sérialise avec kind=veille + veille_config_id.
+#  4. DELETE /api/veille/config retire le favori dans la même transaction.
+#
+# Pré-requis : `uvicorn app.main:app --port 8080` en cours, $JWT exporté
+# (token Supabase Bearer pour un user existant en DB).
+#
+# Usage :
+#   export JWT="..."
+#   bash docs/qa/scripts/verify_veille_favorite.sh
+
+set -euo pipefail
+
+API="${API:-http://localhost:8080}"
+JWT="${JWT:?JWT env var required (Supabase Bearer token)}"
+
+if ! command -v jq &>/dev/null; then
+  echo "❌ jq requis (brew install jq)"
+  exit 1
+fi
+
+auth=(-H "Authorization: Bearer $JWT" -H "Content-Type: application/json")
+
+# Source curated nécessaire pour le payload — on prend la première disponible.
+SOURCE_ID=$(curl -s "${auth[@]}" "$API/api/sources/curated?theme=tech&limit=1" | jq -r '.[0].id // empty')
+if [[ -z "$SOURCE_ID" ]]; then
+  echo "❌ Aucune source curated tech disponible — la DB de test n'est pas seedée."
+  exit 1
+fi
+
+echo "→ POST /api/veille/config (theme=tech, source=$SOURCE_ID)…"
+cfg=$(curl -s "${auth[@]}" -X POST "$API/api/veille/config" -d "{
+  \"theme_id\": \"tech\",
+  \"theme_label\": \"Tech\",
+  \"topics\": [],
+  \"source_selections\": [{\"kind\":\"followed\",\"source_id\":\"$SOURCE_ID\"}],
+  \"keywords\": [{\"keyword\":\"GPT-5\"}]
+}")
+CFG_ID=$(echo "$cfg" | jq -r '.id')
+[[ -n "$CFG_ID" && "$CFG_ID" != "null" ]] || { echo "❌ POST échoue : $cfg"; exit 1; }
+echo "✓ veille_config_id=$CFG_ID"
+
+echo "→ GET /api/user/interests — vérifie kind=veille présent…"
+interests=$(curl -s "${auth[@]}" "$API/api/user/interests")
+veille_fav=$(echo "$interests" | jq --arg id "$CFG_ID" \
+  '.favorites[] | select(.kind=="veille" and .target_id==$id)')
+[[ -n "$veille_fav" ]] || {
+  echo "❌ Favori veille absent de /api/user/interests"
+  echo "$interests" | jq '.favorites'
+  exit 1
+}
+echo "✓ favori veille présent"
+
+echo "→ GET /api/users/top-themes — vérifie kind=veille + veille_config_id…"
+top=$(curl -s "${auth[@]}" "$API/api/users/top-themes")
+slot=$(echo "$top" | jq --arg id "$CFG_ID" \
+  '.[] | select(.kind=="veille" and .veille_config_id==$id)')
+[[ -n "$slot" ]] || {
+  echo "❌ Slot veille absent de /api/users/top-themes"
+  echo "$top"
+  exit 1
+}
+echo "✓ slot veille présent dans la Tournée"
+
+echo "→ DELETE /api/veille/config…"
+status=$(curl -s -o /dev/null -w "%{http_code}" "${auth[@]}" -X DELETE "$API/api/veille/config")
+[[ "$status" == "204" ]] || { echo "❌ DELETE status=$status"; exit 1; }
+echo "✓ DELETE 204"
+
+echo "→ GET /api/user/interests — vérifie que le favori a disparu…"
+interests=$(curl -s "${auth[@]}" "$API/api/user/interests")
+gone=$(echo "$interests" | jq --arg id "$CFG_ID" \
+  '[.favorites[] | select(.kind=="veille" and .target_id==$id)] | length')
+[[ "$gone" == "0" ]] || {
+  echo "❌ Favori veille toujours présent après DELETE"
+  echo "$interests" | jq '.favorites'
+  exit 1
+}
+echo "✓ favori veille bien supprimé"
+
+echo ""
+echo "✅ verify_veille_favorite OK"

--- a/packages/api/alembic/versions/vf02_favorite_veille_target.py
+++ b/packages/api/alembic/versions/vf02_favorite_veille_target.py
@@ -1,0 +1,71 @@
+"""Story 23.1 PR-3 : 3ᵉ type de favori (veille) sur user_favorite_interests.
+
+Ajoute la colonne `veille_config_id` (FK veille_configs.id ON DELETE CASCADE)
+et remplace la CheckConstraint XOR par sa version 3-way. La veille devient un
+favori au même titre qu'un Thème ou un Sujet personnalisé.
+
+Revision ID: vf02_favorite_veille_target
+Revises: vf01_veille_filter_refonte
+Create Date: 2026-05-19
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "vf02_favorite_veille_target"
+down_revision: str | None = "vf01_veille_filter_refonte"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "user_favorite_interests_target_xor",
+        "user_favorite_interests",
+        type_="check",
+    )
+    op.add_column(
+        "user_favorite_interests",
+        sa.Column(
+            "veille_config_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "user_favorite_interests_veille_config_fk",
+        "user_favorite_interests",
+        "veille_configs",
+        ["veille_config_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_check_constraint(
+        "user_favorite_interests_target_xor_v2",
+        "user_favorite_interests",
+        "(interest_slug IS NOT NULL)::int "
+        "+ (custom_topic_id IS NOT NULL)::int "
+        "+ (veille_config_id IS NOT NULL)::int = 1",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "user_favorite_interests_target_xor_v2",
+        "user_favorite_interests",
+        type_="check",
+    )
+    op.drop_constraint(
+        "user_favorite_interests_veille_config_fk",
+        "user_favorite_interests",
+        type_="foreignkey",
+    )
+    op.drop_column("user_favorite_interests", "veille_config_id")
+    op.create_check_constraint(
+        "user_favorite_interests_target_xor",
+        "user_favorite_interests",
+        "(interest_slug IS NOT NULL)::int + (custom_topic_id IS NOT NULL)::int = 1",
+    )

--- a/packages/api/app/models/user_favorites.py
+++ b/packages/api/app/models/user_favorites.py
@@ -1,4 +1,4 @@
-"""Favoris ordonnés — Story 22.1 (cap retiré 2026-05-18, Story 22.2).
+"""Favoris ordonnés — intérêts (Thème/Sujet/Veille, XOR) et sources.
 
 Deux tables dédiées (intérêts vs sources). La position n'est plus bornée à
 0..2 : l'utilisateur peut épingler autant de favoris qu'il veut, et seuls
@@ -25,7 +25,7 @@ from app.database import Base
 
 
 class UserFavoriteInterest(Base):
-    """Favori intérêt (Thème OU Sujet, XOR), ordonné par position.
+    """Favori intérêt (Thème OU Sujet OU Veille, XOR 3-way), ordonné par position.
 
     PK composite (user_id, position) → garantit unicité du slot. La position
     est entière >= 0 (plus de cap dur depuis 2026-05-18).
@@ -34,8 +34,10 @@ class UserFavoriteInterest(Base):
     __tablename__ = "user_favorite_interests"
     __table_args__ = (
         CheckConstraint(
-            "(interest_slug IS NOT NULL)::int + (custom_topic_id IS NOT NULL)::int = 1",
-            name="user_favorite_interests_target_xor",
+            "(interest_slug IS NOT NULL)::int "
+            "+ (custom_topic_id IS NOT NULL)::int "
+            "+ (veille_config_id IS NOT NULL)::int = 1",
+            name="user_favorite_interests_target_xor_v2",
         ),
     )
 
@@ -49,6 +51,11 @@ class UserFavoriteInterest(Base):
     custom_topic_id: Mapped[UUID | None] = mapped_column(
         PGUUID(as_uuid=True),
         ForeignKey("user_topic_profiles.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    veille_config_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("veille_configs.id", ondelete="CASCADE"),
         nullable=True,
     )
     created_at: Mapped[datetime] = mapped_column(

--- a/packages/api/app/routers/users.py
+++ b/packages/api/app/routers/users.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import time
 from datetime import UTC, datetime, timedelta
+from typing import Literal
 from uuid import UUID
 
 import certifi
@@ -301,11 +302,18 @@ async def update_preference(
 
 
 class TopThemeResponse(BaseModel):
-    """Un thème utilisateur avec son poids."""
+    """Un slot de la Tournée du jour.
+
+    Pour `kind="veille"`, `interest_slug` est le `theme_id` (slug parent) de la
+    `VeilleConfig` et `veille_config_id` est rempli — le mobile dispatche alors
+    vers `/api/veille/feed` au lieu de `/api/feed?theme=`.
+    """
 
     interest_slug: str
     weight: float
     article_count: int = 0
+    kind: Literal["theme", "veille"] = "theme"
+    veille_config_id: UUID | None = None
 
 
 @router.get("/top-themes", response_model=list[TopThemeResponse])
@@ -326,6 +334,7 @@ async def get_top_themes(
     from app.models.content import Content
     from app.models.user_favorites import UserFavoriteInterest
     from app.models.user_topic_profile import UserTopicProfile
+    from app.models.veille import VeilleConfig, VeilleStatus
 
     user_uuid = UUID(user_id)
 
@@ -344,8 +353,9 @@ async def get_top_themes(
     if fav_rows:
         # Résolution Theme/Sujet → slug. Pour les Sujets, on projette sur
         # `slug_parent` (ex: custom_topic "Donald Trump" → slug "international").
-        # Le mobile actuel n'a qu'un champ `interest_slug` — la perte d'info
-        # est actée jusqu'à la PR 22.1.3 qui enrichira la forme.
+        # Pour Veille, on hydrate la VeilleConfig pour récupérer son `theme_id`
+        # et on n'expose le slot que si la config est encore active — un favori
+        # orphelin (cfg archivée hors transaction) est skippé silencieusement.
         custom_topic_ids = [
             row.custom_topic_id for row in fav_rows if row.custom_topic_id
         ]
@@ -360,17 +370,59 @@ async def get_top_themes(
             ).all()
             topic_slug_by_id = {row[0]: row[1] for row in topic_rows}
 
-        seen: set[str] = set()
+        veille_cfg_ids = [
+            row.veille_config_id for row in fav_rows if row.veille_config_id
+        ]
+        veille_by_id: dict[UUID, VeilleConfig] = {}
+        if veille_cfg_ids:
+            veille_rows = (
+                (
+                    await db.execute(
+                        sa_select(VeilleConfig).where(
+                            VeilleConfig.id.in_(veille_cfg_ids),
+                            VeilleConfig.status == VeilleStatus.ACTIVE.value,
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            veille_by_id = {cfg.id: cfg for cfg in veille_rows}
+
+        # Dedup key = (kind, slug) : un favori veille et un favori thème
+        # partageant le même slug parent coexistent (sources distinctes).
+        seen: set[tuple[str, str]] = set()
         out: list[TopThemeResponse] = []
         for row in fav_rows:
+            if row.veille_config_id:
+                cfg = veille_by_id.get(row.veille_config_id)
+                if cfg is None:
+                    continue
+                key = ("veille", cfg.theme_id)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(
+                    TopThemeResponse(
+                        interest_slug=cfg.theme_id,
+                        weight=1.5,
+                        article_count=0,
+                        kind="veille",
+                        veille_config_id=cfg.id,
+                    )
+                )
+                continue
             slug = (
                 row.interest_slug
                 if row.interest_slug
                 else topic_slug_by_id.get(row.custom_topic_id)
             )
-            if slug is None or slug in seen:
+            if slug is None:
                 continue
-            seen.add(slug)
+            key = ("theme", slug)
+            if key in seen:
+                continue
+            seen.add(key)
             out.append(
                 TopThemeResponse(interest_slug=slug, weight=1.5, article_count=0)
             )

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -18,6 +18,7 @@ from app.dependencies import get_current_user_id
 from app.models.content import Content
 from app.models.enums import SourceType
 from app.models.source import Source
+from app.models.user_favorites import UserFavoriteInterest
 from app.models.veille import (
     VeilleConfig,
     VeilleKeyword,
@@ -39,6 +40,7 @@ from app.schemas.veille import (
 )
 from app.services.rss_parser import RSSParser
 from app.services.source_service import SourceService
+from app.services.user_interests_service import ensure_veille_favorite
 from app.services.veille.feed_filter import fetch_veille_feed
 
 logger = structlog.get_logger()
@@ -307,6 +309,10 @@ async def upsert_config(
             detail="Sélectionne au moins un thème, une source ou un mot-clé.",
         )
 
+    # La veille est un favori d'intérêt — on garantit sa présence dans
+    # user_favorite_interests à chaque upsert (idempotent).
+    await ensure_veille_favorite(db, user_uuid, cfg.id)
+
     await db.commit()
     await db.refresh(cfg)
 
@@ -339,6 +345,14 @@ async def delete_config(
     cfg = await _get_active_config(db, user_uuid)
     if cfg is None:
         return None
+    # Retire d'abord le favori, puis archive la config — même transaction,
+    # garantit qu'aucun favori orphelin ne survit à un crash entre les deux.
+    await db.execute(
+        delete(UserFavoriteInterest).where(
+            UserFavoriteInterest.user_id == user_uuid,
+            UserFavoriteInterest.veille_config_id == cfg.id,
+        )
+    )
     cfg.status = VeilleStatus.ARCHIVED.value
     await db.commit()
     return None

--- a/packages/api/app/schemas/user_interests.py
+++ b/packages/api/app/schemas/user_interests.py
@@ -13,14 +13,17 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.models.enums import InterestState
 
-InterestKind = Literal["theme", "custom_topic"]
+InterestKind = Literal["theme", "custom_topic", "veille"]
 
 
 class FavoriteRef(BaseModel):
-    """Référence ordonnée vers un favori (Thème OU Sujet)."""
+    """Référence ordonnée vers un favori (Thème, Sujet, ou Veille).
+
+    Pour `kind="veille"`, `target_id` est `str(veille_config_id)` (UUID).
+    """
 
     kind: InterestKind
-    target_id: str  # interest_slug (theme) ou str(UUID) (custom_topic)
+    target_id: str
     position: int = Field(ge=0)
 
 

--- a/packages/api/app/services/user_interests_service.py
+++ b/packages/api/app/services/user_interests_service.py
@@ -18,6 +18,7 @@ from app.models.source import UserSource
 from app.models.user import UserInterest
 from app.models.user_favorites import UserFavoriteInterest, UserFavoriteSource
 from app.models.user_topic_profile import UserTopicProfile
+from app.models.veille import VeilleConfig, VeilleStatus
 from app.schemas.user_interests import (
     CustomTopicInterestResponse,
     FavoriteRef,
@@ -90,14 +91,17 @@ class UserInterestsService:
             .all()
         )
 
-        favorites = [
-            FavoriteRef(
-                kind="theme" if row.interest_slug else "custom_topic",
-                target_id=row.interest_slug or str(row.custom_topic_id),
-                position=row.position,
+        favorites: list[FavoriteRef] = []
+        for row in favs_rows:
+            if row.interest_slug:
+                kind, target_id = "theme", row.interest_slug
+            elif row.custom_topic_id:
+                kind, target_id = "custom_topic", str(row.custom_topic_id)
+            else:
+                kind, target_id = "veille", str(row.veille_config_id)
+            favorites.append(
+                FavoriteRef(kind=kind, target_id=target_id, position=row.position)
             )
-            for row in favs_rows
-        ]
 
         return UserInterestsResponse(
             themes=[ThemeInterestResponse.model_validate(t) for t in themes_rows],
@@ -208,6 +212,11 @@ class UserInterestsService:
         def _matches(fav: UserFavoriteInterest) -> bool:
             if kind == "theme":
                 return fav.interest_slug == target_id
+            if kind == "veille":
+                return (
+                    fav.veille_config_id is not None
+                    and str(fav.veille_config_id) == target_id
+                )
             return (
                 fav.custom_topic_id is not None
                 and str(fav.custom_topic_id) == target_id
@@ -237,6 +246,7 @@ class UserInterestsService:
                 position=position,
                 interest_slug=target_id if kind == "theme" else None,
                 custom_topic_id=UUID(target_id) if kind == "custom_topic" else None,
+                veille_config_id=UUID(target_id) if kind == "veille" else None,
             )
             self.db.add(row)
         else:
@@ -265,6 +275,25 @@ class UserInterestsService:
                 if row is None or row.state != InterestState.FAVORITE:
                     raise TargetNotFavorite(
                         f"theme {fav.target_id} is not favorite for user {user_id}"
+                    )
+            elif fav.kind == "veille":
+                try:
+                    veille_uuid = UUID(fav.target_id)
+                except ValueError as e:
+                    raise TargetNotFound(
+                        f"invalid veille_config id: {fav.target_id}"
+                    ) from e
+                cfg = (
+                    await self.db.execute(
+                        select(VeilleConfig).where(
+                            VeilleConfig.user_id == user_id,
+                            VeilleConfig.id == veille_uuid,
+                        )
+                    )
+                ).scalar_one_or_none()
+                if cfg is None or cfg.status != VeilleStatus.ACTIVE.value:
+                    raise TargetNotFavorite(
+                        f"veille {fav.target_id} is not active for user {user_id}"
                     )
             else:
                 try:
@@ -298,9 +327,50 @@ class UserInterestsService:
                     custom_topic_id=UUID(fav.target_id)
                     if fav.kind == "custom_topic"
                     else None,
+                    veille_config_id=UUID(fav.target_id)
+                    if fav.kind == "veille"
+                    else None,
                 )
             )
         await self.db.commit()
+
+
+async def ensure_veille_favorite(
+    db: AsyncSession, user_id: UUID, veille_config_id: UUID
+) -> int:
+    """Idempotent : garantit que la veille active du user figure dans `user_favorite_interests`.
+
+    Si une row existe déjà avec ce `veille_config_id`, retourne sa position
+    sans rien faire. Sinon, append à la fin (`max(position)+1`, ou 0 si la
+    table est vide pour ce user). Ne commit pas — l'appelant (router veille)
+    gère la transaction englobante.
+    """
+    existing = (
+        (
+            await db.execute(
+                select(UserFavoriteInterest).where(
+                    UserFavoriteInterest.user_id == user_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for fav in existing:
+        if fav.veille_config_id == veille_config_id:
+            return fav.position
+
+    taken = {f.position for f in existing}
+    position = (max(taken) + 1) if taken else 0
+    db.add(
+        UserFavoriteInterest(
+            user_id=user_id,
+            position=position,
+            veille_config_id=veille_config_id,
+        )
+    )
+    await db.flush()
+    return position
 
 
 class UserSourcesStateService:

--- a/packages/api/tests/routers/test_top_themes_with_favorites.py
+++ b/packages/api/tests/routers/test_top_themes_with_favorites.py
@@ -16,6 +16,7 @@ from app.main import app
 from app.models.enums import InterestState
 from app.models.user import UserInterest, UserProfile
 from app.models.user_favorites import UserFavoriteInterest
+from app.models.veille import VeilleConfig, VeilleStatus
 
 
 @pytest_asyncio.fixture
@@ -89,3 +90,78 @@ async def test_falls_back_to_weight_when_no_favorites(
     assert resp.status_code == 200
     # Pas d'articles → fallback retourne [] (filtre 14j).
     assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_top_themes_includes_veille_with_kind_discriminator(
+    user_with_4_interests, db_session
+):
+    """Story 23.1 PR-3 : un favori veille est sérialisé avec kind=veille +
+    veille_config_id, son slug est le theme_id de la VeilleConfig."""
+    user_id = user_with_4_interests
+    cfg = VeilleConfig(
+        id=uuid4(),
+        user_id=user_id,
+        theme_id="tech",
+        theme_label="Tech",
+        status=VeilleStatus.ACTIVE.value,
+    )
+    db_session.add(cfg)
+    await db_session.flush()
+    db_session.add(
+        UserFavoriteInterest(
+            user_id=user_id, position=0, interest_slug="society"
+        )
+    )
+    db_session.add(
+        UserFavoriteInterest(user_id=user_id, position=1, veille_config_id=cfg.id)
+    )
+    await db_session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/users/top-themes")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 2
+    assert body[0]["interest_slug"] == "society"
+    assert body[0]["kind"] == "theme"
+    assert body[0]["veille_config_id"] is None
+    assert body[1]["interest_slug"] == "tech"
+    assert body[1]["kind"] == "veille"
+    assert body[1]["veille_config_id"] == str(cfg.id)
+
+
+@pytest.mark.asyncio
+async def test_top_themes_skips_archived_veille_favorite(
+    user_with_4_interests, db_session
+):
+    """Un favori orphelin (cfg archivée hors transaction) est skippé."""
+    user_id = user_with_4_interests
+    cfg = VeilleConfig(
+        id=uuid4(),
+        user_id=user_id,
+        theme_id="tech",
+        theme_label="Tech",
+        status=VeilleStatus.ARCHIVED.value,
+    )
+    db_session.add(cfg)
+    await db_session.flush()
+    db_session.add(
+        UserFavoriteInterest(
+            user_id=user_id, position=0, interest_slug="society"
+        )
+    )
+    db_session.add(
+        UserFavoriteInterest(user_id=user_id, position=1, veille_config_id=cfg.id)
+    )
+    await db_session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/users/top-themes")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["interest_slug"] == "society"
+    assert body[0]["kind"] == "theme"

--- a/packages/api/tests/routers/test_user_interests.py
+++ b/packages/api/tests/routers/test_user_interests.py
@@ -20,6 +20,7 @@ from app.main import app
 from app.models.enums import InterestState
 from app.models.user import UserInterest, UserProfile
 from app.models.user_favorites import UserFavoriteInterest
+from app.models.veille import VeilleConfig, VeilleStatus
 
 
 @pytest_asyncio.fixture
@@ -71,6 +72,37 @@ async def test_get_returns_empty_state_for_blank_user(auth_user):
     assert body["favorites"] == []
     assert body["favorite_count"] == 0
     assert body["favorite_cap"] == FAVORITE_CAP
+
+
+@pytest.mark.asyncio
+async def test_get_interests_returns_veille_favorite(auth_user, db_session):
+    """Story 23.1 PR-3 : un favori veille apparaît avec kind=veille et
+    target_id = str(veille_config_id)."""
+    cfg = VeilleConfig(
+        id=uuid4(),
+        user_id=auth_user,
+        theme_id="tech",
+        theme_label="Tech",
+        status=VeilleStatus.ACTIVE.value,
+    )
+    db_session.add(cfg)
+    await db_session.flush()
+    db_session.add(
+        UserFavoriteInterest(
+            user_id=auth_user, position=0, veille_config_id=cfg.id
+        )
+    )
+    await db_session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/user/interests")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["favorite_count"] == 1
+    assert body["favorites"][0]["kind"] == "veille"
+    assert body["favorites"][0]["target_id"] == str(cfg.id)
+    assert body["favorites"][0]["position"] == 0
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -12,6 +12,8 @@ from uuid import uuid4
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+from sqlalchemy import select
+
 from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.main import app
@@ -19,6 +21,8 @@ from app.models.content import Content
 from app.models.enums import ContentType, SourceType
 from app.models.source import Source
 from app.models.user import UserProfile
+from app.models.user_favorites import UserFavoriteInterest
+from app.models.veille import VeilleConfig, VeilleStatus
 
 
 @pytest_asyncio.fixture
@@ -196,6 +200,130 @@ class TestConfigCRUD:
             d2 = await c.delete("/api/veille/config")
         assert d1.status_code == 204
         assert d2.status_code == 204
+
+
+class TestFavoriteIntegration:
+    """Story 23.1 PR-3 : POST /config crée un favori, DELETE /config le retire."""
+
+    async def _favorites(self, db_session, user_id):
+        rows = (
+            await db_session.execute(
+                select(UserFavoriteInterest).where(
+                    UserFavoriteInterest.user_id == user_id
+                )
+            )
+        ).scalars().all()
+        return list(rows)
+
+    async def test_post_config_auto_creates_favorite(
+        self, auth_user, curated_tech_source, db_session
+    ):
+        payload = {
+            "theme_id": "tech",
+            "theme_label": "Tech",
+            "source_selections": [
+                {"kind": "followed", "source_id": str(curated_tech_source.id)}
+            ],
+        }
+        async with _client() as c:
+            r = await c.post("/api/veille/config", json=payload)
+        assert r.status_code == 200
+        cfg_id = r.json()["id"]
+
+        favs = await self._favorites(db_session, auth_user)
+        assert len(favs) == 1
+        assert str(favs[0].veille_config_id) == cfg_id
+        assert favs[0].position == 0
+        assert favs[0].interest_slug is None
+        assert favs[0].custom_topic_id is None
+
+    async def test_post_config_idempotent_favorite(
+        self, auth_user, curated_tech_source, db_session
+    ):
+        payload = {
+            "theme_id": "tech",
+            "theme_label": "Tech",
+            "source_selections": [
+                {"kind": "followed", "source_id": str(curated_tech_source.id)}
+            ],
+        }
+        async with _client() as c:
+            await c.post("/api/veille/config", json=payload)
+            await c.post("/api/veille/config", json=payload)
+
+        favs = await self._favorites(db_session, auth_user)
+        assert len(favs) == 1
+        assert favs[0].position == 0
+
+    async def test_post_config_favorite_appended_when_others_exist(
+        self, auth_user, curated_tech_source, db_session
+    ):
+        db_session.add(
+            UserFavoriteInterest(
+                user_id=auth_user, position=0, interest_slug="tech"
+            )
+        )
+        db_session.add(
+            UserFavoriteInterest(
+                user_id=auth_user, position=1, interest_slug="society"
+            )
+        )
+        await db_session.commit()
+
+        payload = {
+            "theme_id": "tech",
+            "theme_label": "Tech",
+            "source_selections": [
+                {"kind": "followed", "source_id": str(curated_tech_source.id)}
+            ],
+        }
+        async with _client() as c:
+            r = await c.post("/api/veille/config", json=payload)
+        assert r.status_code == 200
+
+        favs = sorted(
+            await self._favorites(db_session, auth_user), key=lambda f: f.position
+        )
+        assert len(favs) == 3
+        assert favs[2].position == 2
+        assert favs[2].veille_config_id is not None
+
+    async def test_delete_config_removes_favorite_in_same_tx(
+        self, auth_user, curated_tech_source, db_session
+    ):
+        payload = {
+            "theme_id": "tech",
+            "theme_label": "Tech",
+            "source_selections": [
+                {"kind": "followed", "source_id": str(curated_tech_source.id)}
+            ],
+        }
+        async with _client() as c:
+            create = await c.post("/api/veille/config", json=payload)
+            assert create.status_code == 200
+            cfg_id = create.json()["id"]
+            d = await c.delete("/api/veille/config")
+        assert d.status_code == 204
+
+        favs = await self._favorites(db_session, auth_user)
+        assert favs == []
+
+        cfg = (
+            await db_session.execute(
+                select(VeilleConfig).where(VeilleConfig.id == cfg_id)
+            )
+        ).scalar_one()
+        assert cfg.status == VeilleStatus.ARCHIVED.value
+
+    async def test_delete_config_idempotent_when_no_favorite_row(
+        self, auth_user, db_session
+    ):
+        async with _client() as c:
+            d = await c.delete("/api/veille/config")
+        assert d.status_code == 204
+
+        favs = await self._favorites(db_session, auth_user)
+        assert favs == []
 
 
 class TestFeed:

--- a/packages/api/tests/test_user_favorite_interests_veille.py
+++ b/packages/api/tests/test_user_favorite_interests_veille.py
@@ -1,0 +1,108 @@
+"""Tests modèle UserFavoriteInterest — 3-way XOR + cascade veille (Story 23.1 PR-3).
+
+Couvre la contrainte CHECK et la FK ON DELETE CASCADE introduites par la
+migration `vf02_favorite_veille_target`.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+
+from app.models.user import UserProfile
+from app.models.user_favorites import UserFavoriteInterest
+from app.models.veille import VeilleConfig, VeilleStatus
+
+
+async def _make_user(db_session) -> UserProfile:
+    user = UserProfile(user_id=uuid4(), onboarding_completed=True)
+    db_session.add(user)
+    await db_session.commit()
+    return user
+
+
+async def _make_veille(db_session, user_id) -> VeilleConfig:
+    cfg = VeilleConfig(
+        id=uuid4(),
+        user_id=user_id,
+        theme_id="tech",
+        theme_label="Tech",
+        status=VeilleStatus.ACTIVE.value,
+    )
+    db_session.add(cfg)
+    await db_session.commit()
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_3way_xor_accepts_veille_only(db_session):
+    user = await _make_user(db_session)
+    cfg = await _make_veille(db_session, user.user_id)
+    db_session.add(
+        UserFavoriteInterest(
+            user_id=user.user_id, position=0, veille_config_id=cfg.id
+        )
+    )
+    await db_session.commit()
+
+    row = (
+        await db_session.execute(
+            select(UserFavoriteInterest).where(
+                UserFavoriteInterest.user_id == user.user_id
+            )
+        )
+    ).scalar_one()
+    assert row.veille_config_id == cfg.id
+    assert row.interest_slug is None
+    assert row.custom_topic_id is None
+
+
+@pytest.mark.asyncio
+async def test_3way_xor_rejects_double_target(db_session):
+    user = await _make_user(db_session)
+    cfg = await _make_veille(db_session, user.user_id)
+    db_session.add(
+        UserFavoriteInterest(
+            user_id=user.user_id,
+            position=0,
+            interest_slug="tech",
+            veille_config_id=cfg.id,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_3way_xor_rejects_no_target(db_session):
+    user = await _make_user(db_session)
+    db_session.add(UserFavoriteInterest(user_id=user.user_id, position=0))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_favorite_cascade_delete_on_veille_hard_delete(db_session):
+    user = await _make_user(db_session)
+    cfg = await _make_veille(db_session, user.user_id)
+    db_session.add(
+        UserFavoriteInterest(
+            user_id=user.user_id, position=0, veille_config_id=cfg.id
+        )
+    )
+    await db_session.commit()
+
+    await db_session.execute(delete(VeilleConfig).where(VeilleConfig.id == cfg.id))
+    await db_session.commit()
+
+    remaining = (
+        await db_session.execute(
+            select(UserFavoriteInterest).where(
+                UserFavoriteInterest.user_id == user.user_id
+            )
+        )
+    ).all()
+    assert remaining == []


### PR DESCRIPTION
## Quoi

PR-3/4 de la Story 23.1. La veille devient un **3ᵉ type de favori d'intérêt**
au même titre qu'un Thème ou un Sujet personnalisé.

- Migration `vf02` : nouvelle colonne `user_favorite_interests.veille_config_id` (FK CASCADE) + contrainte CHECK 3-way XOR.
- `POST /api/veille/config` → ajoute automatiquement le favori dans `user_favorite_interests` (idempotent, append à la 1ʳᵉ position libre).
- `DELETE /api/veille/config` → retire le favori dans la même transaction puis archive la config.
- `GET /api/users/top-themes` → sérialise les slots veille avec `kind="veille"` + `veille_config_id` ; la mobile (PR-4) dispatchera vers `/api/veille/feed` au lieu de `/api/feed?theme=`.
- `GET /api/user/interests` → hydrate les favoris veille avec `kind="veille"` + `target_id = str(veille_config_id)`.
- `reorder_favorites` accepte le 3ᵉ `kind` ; validation = `VeilleConfig.status == ACTIVE`.

## Pourquoi

Vision PO (2026-05-19) : la veille n'est plus un espace produit séparé,
c'est une déclinaison enrichie d'un favori d'intérêt (sources dédiées +
keywords). PR-1 a drop le scheduler, PR-2 a basculé le feed en filtre
temps-réel ; cette PR-3 termine l'intégration côté backend pour qu'un user
qui configure une veille la voie dans « Mes intérêts » et dans la Tournée
du jour comme n'importe quel favori.

## Comment ça a été vérifié

- [x] `pytest -v` : **1087 passed, 13 skipped** (suite backend complète).
- [x] Tests dédiés Story 23.1 PR-3 : **35 passed** sur `test_user_favorite_interests_veille.py` (4 tests modèle/XOR/cascade) + extensions de `test_veille_routes.py` (5 tests POST/DELETE favori), `test_top_themes_with_favorites.py` (2 tests veille slot), `test_user_interests.py` (1 test GET).
- [x] Migration `vf02_favorite_veille_target` : up/down/up sur DB locale resetée — OK.
- [x] Ruff : aucun warning sur les fichiers touchés.
- [x] Smoke `uvicorn` : démarrage propre, endpoints `403 Not authenticated` sans token (attendu).
- [x] `simplify` passé : nettoyage des commentaires "Story X PR-Y" en préfixe (rot fodder), pas de nouvelle duplication actionnable.
- [ ] Script QA `docs/qa/scripts/verify_veille_favorite.sh` à lancer manuellement avec un JWT user (cible : staging/prod après merge).

## Zones à risque

- **Cascade FK** : la suppression d'une `VeilleConfig` (cas pathologique : hard delete hors flow normal) purge automatiquement le favori via `ON DELETE CASCADE` — couvert par `test_favorite_cascade_delete_on_veille_hard_delete`.
- **Ordre transactionnel DELETE** : le router veille fait `DELETE user_favorite_interests` AVANT `UPDATE veille_configs SET status=archived`, dans la même transaction (anti-orphelin si crash entre les deux).
- **Pas d'endpoint hot-path supplémentaire** : `get_top_themes` n'ajoute la 2ᵉ query batch (veille_configs IN (...)) que si au moins un favori veille existe (short-circuit `if veille_cfg_ids`).
- **Migration** : `Dockerfile` rejoue `alembic upgrade head` au boot Railway — si la chaîne plante, le déploiement plante. Up/down/up testé localement contre DB vierge.

## Suite

PR-4 : côté mobile, lire `kind="veille"` dans `top-themes` et `kind="veille"` dans `/api/user/interests`, dispatcher les appels feed vers `/api/veille/feed`, supprimer l'écran « veille » standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)