### PR TITLE
fix(essentiel): garde horaire bg regen + filtres pipeline (3 régressions liées)

### DIFF
--- a/docs/bugs/bug-essentiel-pipeline.md
+++ b/docs/bugs/bug-essentiel-pipeline.md
@@ -1,0 +1,140 @@
+# Bug Report : "L'Essentiel du jour" — 3 régressions en cascade
+
+**Status:** IN PROGRESS 🔧
+**Severity:** HIGH (qualité produit visible quotidiennement par tous les users)
+**Created:** 2026-05-19
+**Branch:** `boujonlaurin-dotcom/fix-essentiel-pipeline`
+
+---
+
+## Symptômes remontés par le user
+
+1. **Clusters faibles** : le 19/05, les 5 sujets ont `source_count = [2, 2, 2, 1, 1]`.
+   Vision produit : 5 plus gros clusters (≥ 3 sources) du jour, identiques pour tous les users.
+2. **Article ancien en 1er slot** : 14/05 rang 1 = `deep_article` "JOURNAL DE 12H30 du 12 mai"
+   (radio show, 7 jours) en absence d'actu. 17/05 rang 5 = deep du 28/04 (19 j).
+   Devrait apparaître en slot 6/7 avec badge "Prendre du recul", pas en article principal.
+3. **Génération à ~00h Paris au lieu de 07h30** : confirmé en DB —
+   `first_gen` quotidien ≈ 00:02–01:38 Paris, pas 07:30.
+
+## Cause racine (les 3 bugs sont liés)
+
+`packages/api/app/services/digest_service.py:75` — `_schedule_background_regen`
+se déclenche **dès qu'un user ouvre l'app et n'a pas de digest pour aujourd'hui**,
+sans aucune garde horaire. À 00:00:01 Paris, `today_paris()` bascule,
+`read_digest_or_fallback` ne trouve pas de digest pour aujourd'hui, sert le
+fallback de la veille, et lance un bg regen.
+
+Cascade :
+
+- Le pool `published_at >= now - 48h` à 00:00 est saturé de l'édition de la
+  veille (~22h). Les Unes du matin (Le Monde ~06h30, Figaro ~07h, Libé ~07h)
+  n'existent pas encore → clusters petits, articles récents rares (bug 1 + 2).
+- Le cron `daily_digest` à 07:30 ne régénère rien : le bg regen a déjà créé
+  un digest `editorial_v1`, et `digest_background_regen_skipped_good_format`
+  (digest_service.py:144-153) le préserve. Le watchdog à 08:15 voit > 90% de
+  couverture → skip.
+- Donc la pipeline tourne effectivement vers minuit Paris (bug 3).
+
+Le fix `06:00 → 07:30` du cron (commit `30dd671d`) ne change rien tant que
+le bg regen contourne le cron.
+
+## Données prod qui confirment
+
+```
+target_date | first_gen Paris | last_gen Paris
+2026-05-19  | 00:02:52        | 08:16:55
+2026-05-18  | 00:14:11        | 08:16:50
+2026-05-17  | 01:38:53        | 08:16:46
+2026-05-15  | 00:40:50        | 07:31:20  ← 1 jour propre
+2026-05-12  | 00:00:49        | 06:01:48
+```
+
+Digest 19/05 (généré 00:02 Paris) :
+
+```
+rank | source_count | actu_pub     | deep_pub
+1    | 2            | 19/05 03:12  | null
+2    | 2            | 19/05 05:01  | 23/04 (26j)
+3    | 2            | 19/05 04:42  | 11/05 (8j)
+4    | 1            | 19/05 05:42  | 14/05 (5j)
+5    | 1            | 19/05 06:03  | null
+```
+
+## Plan de fix
+
+### Fix 1 — garde horaire sur `_schedule_background_regen`
+
+`packages/api/app/services/digest_service.py` (début de la fonction, avant
+le rate-limit) — bloquer toute génération de `target_date == today` avant
+`DIGEST_CRON_HOUR_PARIS:DIGEST_CRON_MINUTE_PARIS` (07:30 Paris).
+
+Pattern repris à l'identique du startup catchup (`main.py:290-315`).
+
+### Fix 1bis — clone yesterday-from-any-user
+
+`packages/api/app/services/digest_service.py` —
+- Étendre `_try_clone_global_editorial_digest` à accepter un fallback
+  optionnel "tente target_date, sinon target_date - 1 jour".
+- Ajouter un step dans `read_digest_or_fallback` entre l'étape 3 (own yesterday)
+  et l'étape 4 (7-day own) : "clone yesterday's editorial_v1 from any user".
+
+Couvre le cas du nouvel user inscrit à 02h Paris : il voit l'Essentiel de
+la veille pré-existant (généré par le cron 07:30 d'hier pour les autres
+users) en attendant le cron de ce matin.
+
+### Fix 2 — drop subject sans `actu_article`
+
+`packages/api/app/services/editorial/pipeline.py:343` — passer de
+`if s.actu_article is None and s.deep_article is None` (AND) à
+`if s.actu_article is None`. Le `_SUBJECT_BUFFER = 2` (oversample) absorbe
+la perte. Un sujet sans actu fraîche n'est pas un sujet du jour.
+
+**Note** : la vision produit (slot 6/7 "Prendre du recul" pour les deeps
+orphelins) est un follow-up — schéma `DigestResponse` + UI à changer. Cette
+PR se contente de stopper la régression "deep ancien en article principal".
+
+### Fix 3 — filtre multi-source avant LLM curation
+
+`packages/api/app/services/editorial/curation.py:228` — filtrer le pool
+à `len(source_ids) >= 2` avant LLM, fallback à `available` si pool < count
+(jours pauvres : week-end, fériés). Symétrique du `a_la_une_pool`
+(`pipeline.py:176-179`).
+
+## Fichiers modifiés
+
+| Fichier | Lignes | Changement |
+|---|---|---|
+| `packages/api/app/services/digest_service.py` | ~75-105 | Garde horaire avant rate-limit |
+| `packages/api/app/services/digest_service.py` | ~311-435 | Nouveau step "clone yesterday from any user" |
+| `packages/api/app/services/digest_service.py` | ~1492 | `_try_clone_global_editorial_digest` accepte un `allow_yesterday` |
+| `packages/api/app/services/editorial/pipeline.py` | 343 | Drop subject sans `actu_article` |
+| `packages/api/app/services/editorial/curation.py` | 218-243 | Pool multi-source avant LLM |
+
+## Vérification
+
+1. **Tests unitaires** :
+   - `pytest packages/api/tests/test_digest_readonly_hotpath.py -v`
+   - `pytest packages/api/tests/test_digest_service.py -v`
+   - `pytest packages/api/tests/editorial/test_pipeline.py -v`
+   - `pytest packages/api/tests/editorial/test_curation.py -v`
+2. **Post-deploy Railway**, le lendemain matin :
+   ```sql
+   SELECT target_date,
+          MIN(generated_at AT TIME ZONE 'Europe/Paris') AS first_gen_paris
+   FROM daily_digest
+   WHERE target_date = CURRENT_DATE
+   GROUP BY target_date;
+   ```
+   `first_gen_paris` doit être ≥ 07:30. `source_count` rang 1 ≥ 3. Aucun
+   subject avec `actu_article = null`.
+
+## Risques
+
+- **Fix 1** : un user qui ouvre l'app entre 00h et 07h30 reçoit le digest
+  de la veille (déjà le comportement actuel, juste plus prévisible).
+- **Fix 1bis** : couvre le nouvel user à 02h. Sans cela, il aurait 0 contenu
+  jusqu'à 07h30.
+- **Fix 2** : potentiellement < 5 sujets certains jours (très rare, buffer
+  `_SUBJECT_BUFFER = 2` couvre). Log `subjects_under_target` déjà en place.
+- **Fix 3** : alourdit légèrement jours pauvres. Le fallback gère.

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -285,7 +285,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
                     from app.jobs.digest_generation_job import run_digest_generation
                     from app.models.daily_digest import DailyDigest
                     from app.models.user import UserProfile
-                    from app.utils.time import now_paris
+                    from app.utils.time import is_before_paris_time, now_paris
                     from app.workers.scheduler import (
                         DIGEST_CRON_HOUR_PARIS,
                         DIGEST_CRON_MINUTE_PARIS,
@@ -302,11 +302,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
                     #   Si la fenêtre 07:30-10:00 est ratée, c'est cuit pour
                     #   la journée — mieux qu'un digest pourri à 16h.
                     now = now_paris()
-                    cron_minutes = (
-                        DIGEST_CRON_HOUR_PARIS * 60 + DIGEST_CRON_MINUTE_PARIS
+                    too_early = is_before_paris_time(
+                        now, DIGEST_CRON_HOUR_PARIS, DIGEST_CRON_MINUTE_PARIS
                     )
-                    now_minutes = now.hour * 60 + now.minute
-                    if now_minutes < cron_minutes or now.hour >= 10:
+                    if too_early or now.hour >= 10:
                         logger.info(
                             "digest_startup_catchup_outside_window",
                             now_paris=str(now),

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -449,9 +449,7 @@ async def read_digest_or_fallback(
         .order_by(DailyDigest.generated_at.desc())
         .limit(1)
     )
-    yesterday_clone = (
-        await session.execute(yesterday_clone_stmt)
-    ).scalar_one_or_none()
+    yesterday_clone = (await session.execute(yesterday_clone_stmt)).scalar_one_or_none()
     if yesterday_clone is not None:
         _schedule_background_regen(
             user_id=user_id, target_date=target_date, is_serene=is_serene

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -89,6 +89,33 @@ def _schedule_background_regen(
     """
     import time as _time
 
+    # Garde horaire : ne JAMAIS générer un digest pour `target_date == today`
+    # avant l'heure du cron principal. Sinon le pool `published_at >= now - 48h`
+    # est saturé d'articles du soir précédent et les Unes du matin (Le Monde
+    # ~06h30, Figaro/Libé ~07h) ne sont pas encore publiées. Conséquences :
+    # clusters petits + deeps anciens promus en article principal + digest
+    # gravé en DB qui bloque la régénération du cron 07:30 via
+    # `digest_background_regen_skipped_good_format`. Cf. bug-essentiel-pipeline.md.
+    from app.utils.time import is_before_paris_time, now_paris
+    from app.workers.scheduler import (
+        DIGEST_CRON_HOUR_PARIS,
+        DIGEST_CRON_MINUTE_PARIS,
+    )
+
+    now = now_paris()
+    if target_date == now.date() and is_before_paris_time(
+        now, DIGEST_CRON_HOUR_PARIS, DIGEST_CRON_MINUTE_PARIS
+    ):
+        logger.info(
+            "digest_background_regen_skipped_too_early",
+            user_id=str(user_id),
+            target_date=str(target_date),
+            is_serene=is_serene,
+            now_paris=now.strftime("%H:%M"),
+            cron_at=f"{DIGEST_CRON_HOUR_PARIS:02d}:{DIGEST_CRON_MINUTE_PARIS:02d}",
+        )
+        return
+
     key = (user_id, target_date, is_serene)
     now_mono = _time.monotonic()
     last = _BG_REGEN_RATE_LIMIT.get(key)
@@ -327,11 +354,15 @@ async def read_digest_or_fallback(
     2. Any other user's ``editorial_v1`` digest for today (clone, since
        editorial output is user-agnostic).
     3. Yesterday's ``editorial_v1``/``topics_v1`` digest for this user.
+    3b. Any other user's ``editorial_v1`` digest for *yesterday* (rendered
+        ephemerally, NOT persisted — persisting would graveyard the row as
+        today's editorial_v1 and trip the cron's "good format already exists"
+        guard at 07:30). Covers the new-user-signing-up-at-night case.
     4. Most recent digest within the last ``_HOTPATH_FALLBACK_DAYS`` days for
        this user.
     5. Nothing → schedule regen, return None.
 
-    Steps 3 and 4 set ``response.is_stale_fallback = True`` so the mobile
+    Steps 3, 3b and 4 set ``response.is_stale_fallback = True`` so the mobile
     client (already wired since #422) auto-refetches silently when the
     background regen lands.
     """
@@ -393,6 +424,53 @@ async def read_digest_or_fallback(
                 "digest_hotpath_yesterday_render_failed",
                 user_id=str(user_id),
                 format_version=yesterday_digest.format_version,
+            )
+
+    # 3b. Any other user's editorial_v1 for *yesterday*, rendered ephemerally.
+    # Covers a new user signing up before the morning batch: they have no
+    # own digest (steps 1 & 3 miss), no editorial_v1 today exists yet
+    # (step 2 misses — the bg regen guard blocks generation until 07:30
+    # Paris), so without this fallback they would land on the 7-day step
+    # (also empty for new users) and end up with a 202. We render any
+    # existing yesterday editorial_v1 — strictly ephemeral, never persisted,
+    # because writing a row with `target_date == today + format_version ==
+    # editorial_v1` would make the morning cron skip the real regeneration
+    # via `digest_background_regen_skipped_good_format`.
+    yesterday_clone_stmt = (
+        select(DailyDigest)
+        .where(
+            and_(
+                DailyDigest.user_id != user_id,
+                DailyDigest.target_date == yesterday,
+                DailyDigest.is_serene == is_serene,
+                DailyDigest.format_version == "editorial_v1",
+            )
+        )
+        .order_by(DailyDigest.generated_at.desc())
+        .limit(1)
+    )
+    yesterday_clone = (
+        await session.execute(yesterday_clone_stmt)
+    ).scalar_one_or_none()
+    if yesterday_clone is not None:
+        _schedule_background_regen(
+            user_id=user_id, target_date=target_date, is_serene=is_serene
+        )
+        try:
+            response = await svc._build_digest_response(yesterday_clone, user_id)
+            response.is_stale_fallback = True
+            logger.warning(
+                "digest_hotpath_serving_yesterday_clone",
+                user_id=str(user_id),
+                yesterday_date=str(yesterday),
+                source_user_id=str(yesterday_clone.user_id),
+            )
+            return response
+        except Exception:
+            logger.exception(
+                "digest_hotpath_yesterday_clone_render_failed",
+                user_id=str(user_id),
+                yesterday_date=str(yesterday),
             )
 
     # 4. Last 7 days fallback for this user.

--- a/packages/api/app/services/editorial/curation.py
+++ b/packages/api/app/services/editorial/curation.py
@@ -225,8 +225,23 @@ class CurationService:
                 c for c in clusters if c.cluster_id not in excluded_cluster_ids
             ]
 
+        # Préférer les clusters multi-source — un sujet du jour doit être
+        # repris par au moins 2 médias pour mériter le digest. Fallback aux
+        # singletons si le pool multi-source est insuffisant (week-end,
+        # jours fériés). Symétrique de `a_la_une_pool` (pipeline.py:176-179).
+        # Cf. bug-essentiel-pipeline.md.
+        multi_source = [c for c in available if len(c.source_ids) >= 2]
+        pool = multi_source if len(multi_source) >= count else available
+        if pool is not multi_source:
+            logger.info(
+                "curation.fallback_singletons_allowed",
+                multi_source=len(multi_source),
+                total=len(available),
+                required=count,
+            )
+
         # Take top clusters by source count
-        top_clusters = sorted(available, key=lambda c: len(c.source_ids), reverse=True)[
+        top_clusters = sorted(pool, key=lambda c: len(c.source_ids), reverse=True)[
             :limit
         ]
 

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -332,20 +332,23 @@ class EditorialPipelineService:
         )
 
         # ÉTAPE 3A-bis: trim au target_subject_count.
-        # On a oversamplé de _SUBJECT_BUFFER ; on conserve les sujets avec au
-        # moins un actu OU un deep article, dans l'ordre, jusqu'à atteindre
-        # `target_subject_count`. Les sujets vides sont droppés ici (loggés
-        # en warning), mais le buffer permet généralement de combler.
-        # Si on retombe quand même < target, on logge en error pour visibilité.
+        # On a oversamplé de _SUBJECT_BUFFER ; on exige qu'un sujet ait un
+        # `actu_article` (parution récente). Un sujet avec seulement un
+        # `deep_article` (parfois plusieurs jours) ne mérite pas d'être
+        # promu en article principal — sa place est sur le rail "Prendre
+        # du recul", pas dans les 5 sujets du jour. Cf. bug-essentiel-pipeline.md.
+        # Le buffer permet généralement de combler les drops ; si on retombe
+        # quand même < target, on logge en error pour visibilité.
         empty_dropped: list[str] = []
         kept: list[EditorialSubject] = []
         for s in subjects:
-            if s.actu_article is None and s.deep_article is None:
+            if s.actu_article is None:
                 empty_dropped.append(s.label or s.topic_id)
                 logger.warning(
-                    "editorial_pipeline.subject_no_articles",
+                    "editorial_pipeline.subject_no_actu",
                     topic_id=s.topic_id,
                     label=s.label,
+                    had_deep=s.deep_article is not None,
                 )
                 continue
             kept.append(s)

--- a/packages/api/app/utils/time.py
+++ b/packages/api/app/utils/time.py
@@ -24,3 +24,15 @@ def today_paris() -> date:
 def now_paris() -> datetime:
     """Return current datetime in Europe/Paris (timezone-aware)."""
     return datetime.now(PARIS_TZ)
+
+
+def is_before_paris_time(now: datetime, hour: int, minute: int) -> bool:
+    """True if `now` (Paris-time) is strictly before `hour:minute` on its own day.
+
+    Centralizes the "skip if too early" guard used by the digest cron startup
+    catchup (`main.py`) and the on-request background regen scheduler
+    (`digest_service.py`). Both must refuse to generate today's digest before
+    the morning batch — otherwise the pool of articles is saturated by the
+    previous evening's edition and the morning's Unes aren't published yet.
+    """
+    return now.hour * 60 + now.minute < hour * 60 + minute

--- a/packages/api/tests/editorial/test_curation.py
+++ b/packages/api/tests/editorial/test_curation.py
@@ -183,6 +183,54 @@ class TestSelectTopics:
 
         assert len(result) == 1
 
+    @pytest.mark.asyncio
+    async def test_filters_singletons_when_enough_multi_source(self):
+        """Régression bug-essentiel-pipeline.md : si on a assez de clusters
+        multi-source (≥2 sources), les singletons ne doivent JAMAIS être
+        présentés au LLM. Sinon le digest sort avec source_count=[1,1,...]."""
+        clusters = [
+            _make_cluster("c1", "Retraites", source_count=4, theme="politique"),
+            _make_cluster("c2", "Inflation", source_count=3, theme="economie"),
+            _make_cluster("c3", "Canicule", source_count=2, theme="environnement"),
+            _make_cluster("c4", "Logement", source_count=2, theme="societe"),
+            _make_cluster("c5", "Tech", source_count=2, theme="technologie"),
+            _make_cluster("c6", "Solo1", source_count=1, theme="culture"),
+            _make_cluster("c7", "Solo2", source_count=1, theme="sport"),
+        ]
+
+        llm = MagicMock()
+        llm.is_ready = False  # force deterministic + capture le pool retenu
+
+        svc = CurationService(llm, _make_config(subjects_count=5))
+        result = await svc.select_topics(clusters)
+
+        assert len(result) == 5
+        # Aucun singleton ne doit apparaître alors qu'on a 5 clusters multi-source.
+        topic_ids = {t.topic_id for t in result}
+        assert "c6" not in topic_ids
+        assert "c7" not in topic_ids
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_singletons_when_multi_source_insufficient(self):
+        """Jours pauvres (week-end, fériés) : si moins de N clusters multi-source,
+        on retombe sur le pool complet plutôt que de retourner < N sujets."""
+        clusters = [
+            _make_cluster("c1", "Retraites", source_count=2, theme="politique"),
+            _make_cluster("c2", "Inflation", source_count=2, theme="economie"),
+            _make_cluster("c3", "Solo1", source_count=1, theme="culture"),
+            _make_cluster("c4", "Solo2", source_count=1, theme="sport"),
+            _make_cluster("c5", "Solo3", source_count=1, theme="sciences"),
+        ]
+
+        llm = MagicMock()
+        llm.is_ready = False
+
+        svc = CurationService(llm, _make_config(subjects_count=5))
+        result = await svc.select_topics(clusters)
+
+        # Sans fallback, on n'aurait que 2 sujets ; avec fallback, on a les 5.
+        assert len(result) == 5
+
 
 class TestDeterministicSelect:
     def test_theme_diversity(self):

--- a/packages/api/tests/editorial/test_pipeline.py
+++ b/packages/api/tests/editorial/test_pipeline.py
@@ -500,6 +500,80 @@ class TestSubjectTrimAndRenumber:
         assert all(s.is_a_la_une is False for s in result.subjects[1:])
 
 
+    @pytest.mark.asyncio
+    async def test_drops_subject_with_only_deep_article(self, mock_dependencies):
+        """Régression bug-essentiel-pipeline.md : un sujet avec deep mais sans
+        actu fraîche ne doit PAS être promu en article principal du digest.
+        Le deep ancien (parfois plusieurs jours) finissait sinon en rang 1
+        quand actu_article était null."""
+        from app.services.editorial.pipeline import EditorialPipelineService
+
+        session = AsyncMock()
+        svc = EditorialPipelineService(session)
+
+        clusters = [_make_cluster_mock(f"c{i}", f"Cluster {i}") for i in range(1, 7)]
+
+        with patch(
+            "app.services.editorial.pipeline.ImportanceDetector"
+        ) as mock_detector_cls:
+            mock_detector = MagicMock()
+            mock_detector.build_topic_clusters.return_value = clusters
+            mock_detector_cls.return_value = mock_detector
+
+            mock_dependencies["curation"].select_a_la_une.return_value = SelectedTopic(
+                topic_id="c1",
+                label="A la une",
+                selection_reason="r",
+                deep_angle="D",
+                source_count=3,
+            )
+            mock_dependencies["curation"].select_topics.return_value = [
+                SelectedTopic(
+                    topic_id=f"c{i}",
+                    label=f"C{i}",
+                    selection_reason="r",
+                    deep_angle="D",
+                )
+                for i in range(2, 8)
+            ]
+            # c5 reçoit un deep mais aucun actu — doit être droppé.
+            deep_for_c5 = MagicMock(spec=MatchedDeepArticle)
+            deep_for_c5.content_id = uuid4()
+            deep_for_c5.source_id = uuid4()
+            mock_dependencies["deep"].match_for_topics.return_value = {
+                f"c{i}": None for i in range(1, 8)
+            } | {"c5": deep_for_c5}
+
+            def _populate_all_actus_except_c5(
+                subjects, clusters, excluded_source_ids=None, excluded_content_ids=None
+            ):
+                out = []
+                for s in subjects:
+                    if s.topic_id == "c5":
+                        # deep already attached by match_for_topics; pas d'actu.
+                        out.append(s)
+                        continue
+                    actu = MagicMock(spec=MatchedActuArticle)
+                    actu.content_id = uuid4()
+                    actu.source_id = uuid4()
+                    out.append(s.model_copy(update={"actu_article": actu}))
+                return out
+
+            mock_dependencies[
+                "actu"
+            ].match_global.side_effect = _populate_all_actus_except_c5
+
+            result = await svc.compute_global_context([_make_content_mock()])
+
+        assert result is not None
+        topic_ids = [s.topic_id for s in result.subjects]
+        assert "c5" not in topic_ids, (
+            f"c5 a un deep mais pas d'actu — il doit être droppé, got {topic_ids}"
+        )
+        # Tous les sujets gardés ont une actu fraîche.
+        assert all(s.actu_article is not None for s in result.subjects)
+
+
 class TestRunForUser:
     def test_populates_actu_articles(self, mock_dependencies):
         from app.services.editorial.pipeline import EditorialPipelineService

--- a/packages/api/tests/test_digest_readonly_hotpath.py
+++ b/packages/api/tests/test_digest_readonly_hotpath.py
@@ -191,6 +191,61 @@ async def test_step3_yesterday_fallback_marks_stale_and_schedules_regen(mock_ses
     )
 
 
+# ─── Step 3b — clone yesterday from any user (new-user-at-night case) ────────
+
+
+@pytest.mark.asyncio
+async def test_step3b_clones_yesterday_from_any_user_when_own_missing(mock_session):
+    """Régression bug-essentiel-pipeline.md : un nouvel user inscrit à 02h Paris
+    n'a aucun digest. Le bg regen est bloqué jusqu'à 07h30 (Fix 1). Sans le
+    step 3b, il tomberait sur le 7-day fallback (vide pour lui aussi) puis
+    sur le 202 "préparation". On veut qu'il voie l'Essentiel de la veille
+    pré-existant d'un autre user, rendu éphémèrement (PAS persisté pour ne
+    pas tripper le guard `digest_background_regen_skipped_good_format`)."""
+    user_id = uuid4()
+    target = date.today()
+    yesterday = target - timedelta(days=1)
+
+    yesterday_clone_row = _make_digest_row(
+        user_id=uuid4(),  # un autre user
+        target_date=yesterday,
+        is_serene=False,
+    )
+    rendered = _make_response()
+
+    exec_result = Mock()
+    exec_result.scalar_one_or_none = Mock(return_value=yesterday_clone_row)
+    mock_session.execute = AsyncMock(return_value=exec_result)
+
+    with (
+        patch.object(
+            digest_service.DigestService,
+            "_get_existing_digest",
+            new=AsyncMock(return_value=None),  # ni today, ni yesterday own
+        ),
+        patch.object(
+            digest_service.DigestService,
+            "_try_clone_global_editorial_digest",
+            new=AsyncMock(return_value=None),  # personne n'a today
+        ),
+        patch.object(
+            digest_service.DigestService,
+            "_build_digest_response",
+            new=AsyncMock(return_value=rendered),
+        ),
+        patch.object(digest_service, "_schedule_background_regen") as regen_mock,
+    ):
+        out = await read_digest_or_fallback(
+            mock_session, user_id, target, is_serene=False
+        )
+
+    assert out is rendered
+    assert out.is_stale_fallback is True
+    regen_mock.assert_called_once_with(
+        user_id=user_id, target_date=target, is_serene=False
+    )
+
+
 # ─── Step 4 — 7-day fallback ──────────────────────────────────────────────────
 
 

--- a/packages/api/tests/test_digest_service.py
+++ b/packages/api/tests/test_digest_service.py
@@ -541,6 +541,8 @@ class TestBackgroundRegenRateLimit:
 
     def test_rate_limit_blocks_repeat_calls_within_cooldown(self):
         """Second call within cooldown window is a no-op."""
+        from datetime import datetime
+
         from app.services import digest_service
 
         # Reset rate limit dict
@@ -549,7 +551,12 @@ class TestBackgroundRegenRateLimit:
         user_id = uuid4()
         target_date = date.today()
 
-        with patch("asyncio.create_task") as mock_create_task:
+        # Fixe l'heure à 09:00 Paris pour passer la garde horaire (Fix 1).
+        after_cron = datetime.combine(target_date, datetime.min.time()).replace(hour=9)
+        with (
+            patch("app.utils.time.now_paris", return_value=after_cron),
+            patch("asyncio.create_task") as mock_create_task,
+        ):
             digest_service._schedule_background_regen(
                 user_id=user_id, target_date=target_date, is_serene=False
             )
@@ -561,6 +568,8 @@ class TestBackgroundRegenRateLimit:
 
     def test_rate_limit_independent_per_serene_variant(self):
         """(user, date, False) and (user, date, True) are separate buckets."""
+        from datetime import datetime
+
         from app.services import digest_service
 
         digest_service._BG_REGEN_RATE_LIMIT.clear()
@@ -568,7 +577,11 @@ class TestBackgroundRegenRateLimit:
         user_id = uuid4()
         target_date = date.today()
 
-        with patch("asyncio.create_task") as mock_create_task:
+        after_cron = datetime.combine(target_date, datetime.min.time()).replace(hour=9)
+        with (
+            patch("app.utils.time.now_paris", return_value=after_cron),
+            patch("asyncio.create_task") as mock_create_task,
+        ):
             digest_service._schedule_background_regen(
                 user_id=user_id, target_date=target_date, is_serene=False
             )
@@ -577,6 +590,90 @@ class TestBackgroundRegenRateLimit:
             )
             # Both should go through — different variants
             assert mock_create_task.call_count == 2
+
+
+class TestBackgroundRegenCronGuard:
+    """Fix 1 — bug-essentiel-pipeline.md.
+
+    Avant 07:30 Paris, `_schedule_background_regen` doit refuser de générer
+    pour `target_date == today` : à minuit, le pool 48h est saturé du soir
+    précédent et les Unes du matin n'existent pas encore, donc le digest qui
+    serait produit est mauvais ET bloque la régen du cron de 07:30 via
+    `digest_background_regen_skipped_good_format`."""
+
+    def test_skips_when_called_before_cron_hour(self):
+        from datetime import datetime
+
+        from app.services import digest_service
+
+        digest_service._BG_REGEN_RATE_LIMIT.clear()
+
+        user_id = uuid4()
+        target_date = date.today()
+        before_cron = datetime.combine(target_date, datetime.min.time()).replace(
+            hour=2, minute=0
+        )
+
+        with (
+            patch("app.utils.time.now_paris", return_value=before_cron),
+            patch("asyncio.create_task") as mock_create_task,
+        ):
+            digest_service._schedule_background_regen(
+                user_id=user_id, target_date=target_date, is_serene=False
+            )
+
+        assert mock_create_task.call_count == 0
+        # La garde ne doit pas non plus consommer le slot rate-limit.
+        assert (user_id, target_date, False) not in digest_service._BG_REGEN_RATE_LIMIT
+
+    def test_proceeds_when_called_at_or_after_cron_hour(self):
+        from datetime import datetime
+
+        from app.services import digest_service
+
+        digest_service._BG_REGEN_RATE_LIMIT.clear()
+
+        user_id = uuid4()
+        target_date = date.today()
+        at_cron = datetime.combine(target_date, datetime.min.time()).replace(
+            hour=7, minute=30
+        )
+
+        with (
+            patch("app.utils.time.now_paris", return_value=at_cron),
+            patch("asyncio.create_task") as mock_create_task,
+        ):
+            digest_service._schedule_background_regen(
+                user_id=user_id, target_date=target_date, is_serene=False
+            )
+
+        assert mock_create_task.call_count == 1
+
+    def test_guard_only_applies_to_today(self):
+        """La garde protège uniquement target_date == today. Une régen pour
+        hier (ou un autre jour passé) doit toujours passer, à n'importe
+        quelle heure."""
+        from datetime import datetime
+
+        from app.services import digest_service
+
+        digest_service._BG_REGEN_RATE_LIMIT.clear()
+
+        user_id = uuid4()
+        yesterday = date.today() - timedelta(days=1)
+        before_cron = datetime.combine(date.today(), datetime.min.time()).replace(
+            hour=2, minute=0
+        )
+
+        with (
+            patch("app.utils.time.now_paris", return_value=before_cron),
+            patch("asyncio.create_task") as mock_create_task,
+        ):
+            digest_service._schedule_background_regen(
+                user_id=user_id, target_date=yesterday, is_serene=False
+            )
+
+        assert mock_create_task.call_count == 1
 
 
 # ─── Tests: Phase 5.2 — deferred stale-format deletion ────────────────────────


### PR DESCRIPTION
# PR — fix(essentiel): garde horaire + filtres pipeline (3 régressions liées)

## Summary

Corrige 3 régressions visibles tous les jours sur "L'Essentiel du jour" — toutes liées à la même cause racine : le bg regen `_schedule_background_regen` n'avait aucune garde horaire et générait le digest dès qu'un user ouvrait l'app à 00h Paris, avant que les Unes du matin (Le Monde 06h30, Figaro/Libé 07h) ne soient publiées. Le digest produit était alors faible (clusters petits, deeps anciens promus en article principal) et bloquait la régen du cron de 07h30 via `digest_background_regen_skipped_good_format`.

Cf. `docs/bugs/bug-essentiel-pipeline.md`.

### Fix 1 — garde horaire sur `_schedule_background_regen`
`digest_service.py:75-225`. Pour `target_date == today`, refuse de spawner avant `DIGEST_CRON_HOUR_PARIS:DIGEST_CRON_MINUTE_PARIS` (07:30 Paris). Pattern repris à l'identique de la garde startup catchup (`main.py:304-317`). Cible bug 3 (génération à 00h au lieu de 07h30) qui cascade sur bugs 1 et 2.

### Fix 1bis — clone yesterday from any user
`read_digest_or_fallback` : nouveau step 3b entre own-yesterday et 7-day-own. Pour un nouvel user inscrit à 02h Paris (pas de digest perso, pas de digest aujourd'hui non plus puisque Fix 1 bloque la génération), on rend éphémèrement le digest editorial_v1 de la veille d'un autre user, `is_stale_fallback=True`. **Pas de persistance** : insérer un row pour today avec format editorial_v1 tripperait le guard `digest_background_regen_skipped_good_format` à 07h30 (le bug qu'on corrige).

### Fix 2 — drop subject sans `actu_article`
`pipeline.py:343` : passer de `actu is None AND deep is None` à `actu is None`. Un sujet avec seulement un deep (parfois plusieurs jours) ne mérite pas d'être promu en article principal — sa place est sur le rail "Prendre du recul" (follow-up). `_SUBJECT_BUFFER = 2` absorbe la perte. Cible bug 2.

### Fix 3 — filtre multi-source avant LLM curation
`curation.py:218-243` : pré-filtre le pool à `source_count >= 2` avant LLM, fallback à `available` si pool < count (week-end, fériés). Symétrique du `a_la_une_pool` (`pipeline.py:176-179`). Cible bug 1 résiduel — empêche le LLM de remonter un singleton "intéressant" alors qu'on a assez de clusters multi-source.

## Test plan

- [x] `pytest tests/test_digest_service.py` (23 passed)
- [x] `pytest tests/test_digest_readonly_hotpath.py` (11 passed)
- [x] `pytest tests/editorial/test_pipeline.py` (12 passed)
- [x] `pytest tests/editorial/test_curation.py` (13 passed)
- [ ] Post-deploy : `SELECT MIN(generated_at AT TIME ZONE 'Europe/Paris') FROM daily_digest WHERE target_date = CURRENT_DATE` doit être ≥ 07:30.
- [ ] Post-deploy : `source_count` du rang 1 ≥ 3, aucun subject avec `actu_article = null`.
