### PR TITLE
feat: digest displayLimit 3/5/7 + flux continu pagination +10

### DIFF
--- a/apps/mobile/lib/features/digest/screens/digest_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/digest_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -276,6 +277,10 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
     final colors = context.facteurColors;
     final digestAsync = ref.watch(digestProvider);
     final sereinState = ref.watch(sereinToggleProvider);
+    final dailyArticleCount = ref.watch(
+          onboardingProvider.select((s) => s.answers.dailyArticleCount),
+        ) ??
+        5;
 
     // Initialiser le format depuis la réponse API
     ref.listen(digestProvider, (previous, next) {
@@ -440,29 +445,17 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
                       ),
                     ),
 
-                    // Hero : pill + titre + meta + illustration facteur.
-                    // articleCount = ce que l'utilisateur va voir (clampé sur
-                    // sa pref weekly_goal), pas le total backend (jusqu'à 10).
+                    // Hero : articleCount clampé sur la pref user, pas sur le
+                    // total backend (jusqu'à 10).
                     SliverToBoxAdapter(
-                      child: Builder(
-                        builder: (context) {
-                          final digestItems =
-                              digestAsync.valueOrNull?.items.length ?? 5;
-                          final userPrefHero = ref
-                                  .watch(onboardingProvider)
-                                  .answers
-                                  .dailyArticleCount ??
-                              5;
-                          final displayed = digestItems < userPrefHero
-                              ? digestItems
-                              : userPrefHero;
-                          return DigestHero(
-                            articleCount: displayed,
-                            targetDate: digestAsync.valueOrNull?.targetDate ??
-                                DateTime.now(),
-                            isSerein: sereinState.enabled,
-                          );
-                        },
+                      child: DigestHero(
+                        articleCount: math.min(
+                          digestAsync.valueOrNull?.items.length ?? 5,
+                          dailyArticleCount,
+                        ),
+                        targetDate: digestAsync.valueOrNull?.targetDate ??
+                            DateTime.now(),
+                        isSerein: sereinState.enabled,
                       ),
                     ),
 
@@ -616,14 +609,8 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
                             }
 
                             final notifier = ref.read(digestProvider.notifier);
-                            final total = notifier.totalCount;
-                            final userPref = ref
-                                    .watch(onboardingProvider)
-                                    .answers
-                                    .dailyArticleCount ??
-                                5;
                             final denominator =
-                                total < userPref ? total : userPref;
+                                math.min(notifier.totalCount, dailyArticleCount);
 
                             return DigestBriefingSection(
                               digest: digest,
@@ -631,9 +618,7 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
                               topics: digest.usesTopics ? digest.topics : null,
                               processedCount: notifier.processedCount,
                               dailyGoal: denominator,
-                              // B.3 — n'afficher que `userPref` topics par
-                              // défaut, le reste est révélé par "Voir plus".
-                              displayLimit: userPref,
+                              displayLimit: dailyArticleCount,
                               onItemTap: _openArticle,
                               onLike: _handleLike,
                               onSave: _handleSave,

--- a/apps/mobile/lib/features/digest/screens/digest_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/digest_screen.dart
@@ -440,14 +440,29 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
                       ),
                     ),
 
-                    // Hero : pill + titre + meta + illustration facteur
+                    // Hero : pill + titre + meta + illustration facteur.
+                    // articleCount = ce que l'utilisateur va voir (clampé sur
+                    // sa pref weekly_goal), pas le total backend (jusqu'à 10).
                     SliverToBoxAdapter(
-                      child: DigestHero(
-                        articleCount:
-                            digestAsync.valueOrNull?.items.length ?? 5,
-                        targetDate: digestAsync.valueOrNull?.targetDate ??
-                            DateTime.now(),
-                        isSerein: sereinState.enabled,
+                      child: Builder(
+                        builder: (context) {
+                          final digestItems =
+                              digestAsync.valueOrNull?.items.length ?? 5;
+                          final userPrefHero = ref
+                                  .watch(onboardingProvider)
+                                  .answers
+                                  .dailyArticleCount ??
+                              5;
+                          final displayed = digestItems < userPrefHero
+                              ? digestItems
+                              : userPrefHero;
+                          return DigestHero(
+                            articleCount: displayed,
+                            targetDate: digestAsync.valueOrNull?.targetDate ??
+                                DateTime.now(),
+                            isSerein: sereinState.enabled,
+                          );
+                        },
                       ),
                     ),
 
@@ -616,6 +631,9 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
                               topics: digest.usesTopics ? digest.topics : null,
                               processedCount: notifier.processedCount,
                               dailyGoal: denominator,
+                              // B.3 — n'afficher que `userPref` topics par
+                              // défaut, le reste est révélé par "Voir plus".
+                              displayLimit: userPref,
                               onItemTap: _openArticle,
                               onLike: _handleLike,
                               onSave: _handleSave,

--- a/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
@@ -48,6 +48,11 @@ class DigestBriefingSection extends StatefulWidget {
   final List<CommunityCarouselItem> communityCarousel;
   final void Function(CommunityCarouselItem)? onCommunityArticleTap;
 
+  /// Nombre max de topics affichés par défaut (selon pref user 3/5/7).
+  /// Au-delà, le reste est révélé par le bouton "Voir N autres articles".
+  /// `null` ou 0 = pas de limite (legacy behavior, on affiche tout).
+  final int? displayLimit;
+
   const DigestBriefingSection({
     super.key,
     required this.items,
@@ -74,6 +79,7 @@ class DigestBriefingSection extends StatefulWidget {
     this.dailyGoal = 5,
     this.communityCarousel = const [],
     this.onCommunityArticleTap,
+    this.displayLimit,
   });
 
   @override
@@ -83,6 +89,26 @@ class DigestBriefingSection extends StatefulWidget {
 class _DigestBriefingSectionState extends State<DigestBriefingSection> {
   bool get _usesTopics =>
       widget.topics != null && widget.topics!.isNotEmpty;
+
+  /// État du toggle "Voir plus" / "Réduire". Local au widget : reset à chaque
+  /// rebuild externe (changement pref user, rafraîchissement digest).
+  bool _showAll = false;
+
+  /// Nombre effectif d'éléments à afficher en tenant compte de la limite
+  /// utilisateur et de l'état du toggle. Retourne `total` si pas de limite ou
+  /// si `_showAll` est activé.
+  int _effectiveCount(int total) {
+    final limit = widget.displayLimit;
+    if (limit == null || limit <= 0) return total;
+    if (_showAll) return total;
+    return total < limit ? total : limit;
+  }
+
+  /// Liste tronquée selon `_effectiveCount`.
+  List<T> _sliced<T>(List<T> source) {
+    final count = _effectiveCount(source.length);
+    return source.length <= count ? source : source.sublist(0, count);
+  }
 
   // --- Dismiss banner state ---
   String? _activeDismissalId;
@@ -218,45 +244,73 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
     );
   }
 
+  /// Indique si le toggle "Voir plus / Réduire" doit être rendu pour une
+  /// liste de taille `total`. True quand displayLimit > 0 ET total > limit.
+  bool _shouldShowToggle(int total) {
+    final limit = widget.displayLimit ?? 0;
+    return limit > 0 && total > limit;
+  }
+
   /// Flat layout: existing list of ranked cards (flat_v1 / legacy)
   Widget _buildFlatLayout(BuildContext context) {
     final visibleItems =
         widget.items.where((item) => !item.isDismissed).toList();
-    return ListView.separated(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      itemCount: visibleItems.length,
-      separatorBuilder: (context, index) => const SizedBox(height: 2),
-      itemBuilder: (context, index) {
-        final item = visibleItems[index];
-        return _buildRankedCard(context, item, index + 1);
-      },
+    final displayed = _sliced(visibleItems);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ListView.separated(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: displayed.length,
+          separatorBuilder: (context, index) => const SizedBox(height: 2),
+          itemBuilder: (context, index) {
+            final item = displayed[index];
+            return _buildRankedCard(context, item, index + 1);
+          },
+        ),
+        if (_shouldShowToggle(visibleItems.length))
+          _buildShowMoreButton(visibleItems.length - displayed.length),
+      ],
     );
   }
 
   /// Topics layout: sections with horizontal article scroll (topics_v1)
   Widget _buildTopicsLayout() {
-    return ListView.separated(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      itemCount: widget.topics!.length,
-      separatorBuilder: (_, __) => const SizedBox(height: 14),
-      itemBuilder: (_, i) => TopicSection(
-        topic: widget.topics![i],
-        totalTopics: widget.topics!.length,
-        onArticleTap: widget.onItemTap,
-        onSave: widget.onSave,
-        onNotInterested: widget.onNotInterested,
-        onSourceTap: widget.onSourceTap,
-        onSwipeDismiss: widget.onSwipeDismiss != null
-            ? _handleLocalSwipeDismiss
-            : null,
-        activeDismissalId: _activeDismissalId,
-        onDismissUndo: _handleLocalUndo,
-        onDismissAutoResolve: _handleLocalAutoResolve,
-        onDismissMuteSource: _handleLocalMuteSource,
-        onDismissMuteTopic: _handleLocalMuteTopic,
-      ),
+    final allTopics = widget.topics!;
+    final displayed = _sliced(allTopics);
+    final effective = displayed.length;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ListView.separated(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: effective,
+          separatorBuilder: (_, __) => const SizedBox(height: 14),
+          itemBuilder: (_, i) => TopicSection(
+            topic: displayed[i],
+            // totalTopics drives indicator animations (TopicSection :243-247).
+            // On garde le total visible — pas le total backend — pour que le
+            // libellé "Sujet i/N" colle à ce qu'utilisateur voit à l'écran.
+            totalTopics: effective,
+            onArticleTap: widget.onItemTap,
+            onSave: widget.onSave,
+            onNotInterested: widget.onNotInterested,
+            onSourceTap: widget.onSourceTap,
+            onSwipeDismiss: widget.onSwipeDismiss != null
+                ? _handleLocalSwipeDismiss
+                : null,
+            activeDismissalId: _activeDismissalId,
+            onDismissUndo: _handleLocalUndo,
+            onDismissAutoResolve: _handleLocalAutoResolve,
+            onDismissMuteSource: _handleLocalMuteSource,
+            onDismissMuteTopic: _handleLocalMuteTopic,
+          ),
+        ),
+        if (_shouldShowToggle(allTopics.length))
+          _buildShowMoreButton(allTopics.length - effective),
+      ],
     );
   }
 
@@ -295,15 +349,19 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
     // Quote + counter for serein mode are rendered above this widget (in
     // build()) so the spacing counter→first-topic matches Essentiel exactly.
 
-    // Topics with intro text, editorial DigestCards, and transition text
-    for (int i = 0; i < widget.topics!.length; i++) {
-      final topic = widget.topics![i];
+    // Topics with intro text, editorial DigestCards, and transition text.
+    // B.3 — on slice selon displayLimit / _showAll. À la Une (rank 1) reste
+    // visible car _sliced préserve l'ordre et displayLimit >= 3.
+    final allTopics = widget.topics!;
+    final displayedTopics = _sliced(allTopics);
+    for (int i = 0; i < displayedTopics.length; i++) {
+      final topic = displayedTopics[i];
 
       // Topic section with editorial cards (intro handled inside TopicSection)
       sections.add(
         TopicSection(
           topic: topic,
-          totalTopics: widget.topics!.length,
+          totalTopics: displayedTopics.length,
           editorialMode: true,
           isSerene: isSerene,
           onArticleTap: widget.onItemTap,
@@ -323,9 +381,18 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
       );
 
       // Transition text between topics (not after last one)
-      if (topic.transitionText != null && i < widget.topics!.length - 1) {
+      if (topic.transitionText != null && i < displayedTopics.length - 1) {
         sections.add(TransitionText(text: topic.transitionText!));
       }
+    }
+
+    // Bouton "Voir N autres articles" / "Réduire" — inséré juste après la
+    // dernière card topic, avant les sections spéciales (pépite, etc.) pour
+    // garder le toggle proche du contenu qu'il révèle.
+    if (_shouldShowToggle(allTopics.length)) {
+      sections.add(
+        _buildShowMoreButton(allTopics.length - displayedTopics.length),
+      );
     }
 
     // Section divider before special picks
@@ -561,6 +628,42 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
       default:
         return SourceType.article;
     }
+  }
+
+  /// Bouton toggle "Voir N autres articles" / "Réduire".
+  /// `hidden` = nombre de topics actuellement masqués (0 quand _showAll).
+  Widget _buildShowMoreButton(int hidden) {
+    final colors = context.facteurColors;
+    final label = _showAll
+        ? 'Réduire'
+        : (hidden == 1
+            ? 'Voir 1 autre article'
+            : 'Voir $hidden autres articles');
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 4),
+      child: Align(
+        alignment: Alignment.center,
+        child: TextButton.icon(
+          key: const ValueKey('digest_show_more_toggle'),
+          onPressed: () => setState(() => _showAll = !_showAll),
+          icon: Icon(
+            _showAll
+                ? PhosphorIcons.caretUp(PhosphorIconsStyle.bold)
+                : PhosphorIcons.caretDown(PhosphorIconsStyle.bold),
+            size: 16,
+            color: colors.primary,
+          ),
+          label: Text(
+            label,
+            style: TextStyle(
+              color: colors.primary,
+              fontWeight: FontWeight.w600,
+              fontSize: 14,
+            ),
+          ),
+        ),
+      ),
+    );
   }
 
   /// Clean up reason strings for display.

--- a/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/digest_briefing_section.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/theme.dart';
@@ -90,21 +92,14 @@ class _DigestBriefingSectionState extends State<DigestBriefingSection> {
   bool get _usesTopics =>
       widget.topics != null && widget.topics!.isNotEmpty;
 
-  /// État du toggle "Voir plus" / "Réduire". Local au widget : reset à chaque
-  /// rebuild externe (changement pref user, rafraîchissement digest).
   bool _showAll = false;
 
-  /// Nombre effectif d'éléments à afficher en tenant compte de la limite
-  /// utilisateur et de l'état du toggle. Retourne `total` si pas de limite ou
-  /// si `_showAll` est activé.
   int _effectiveCount(int total) {
     final limit = widget.displayLimit;
-    if (limit == null || limit <= 0) return total;
-    if (_showAll) return total;
-    return total < limit ? total : limit;
+    if (limit == null || limit <= 0 || _showAll) return total;
+    return math.min(total, limit);
   }
 
-  /// Liste tronquée selon `_effectiveCount`.
   List<T> _sliced<T>(List<T> source) {
     final count = _effectiveCount(source.length);
     return source.length <= count ? source : source.sublist(0, count);

--- a/apps/mobile/lib/features/feed/repositories/feed_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/feed_repository.dart
@@ -89,6 +89,7 @@ class FeedRepository {
     String? keyword,
     bool includeUnfollowed = false,
     bool serein = false,
+    bool personalized = false,
     bool forceFresh = false,
   }) async {
     final result = await getFeedWithRaw(
@@ -105,6 +106,7 @@ class FeedRepository {
       keyword: keyword,
       includeUnfollowed: includeUnfollowed,
       serein: serein,
+      personalized: personalized,
       forceFresh: forceFresh,
     );
     return result.feed;
@@ -132,14 +134,18 @@ class FeedRepository {
     String? keyword,
     bool includeUnfollowed = false,
     bool serein = false,
+    bool personalized = false,
     bool forceFresh = false,
   }) async {
     // R5.1 — single-flight + dedupe gate for the default view only.
+    // `personalized=true` opts out: theme/topic sections of the Tournée
+    // are a different shape and must not share the default-view cache.
     final bool isDefaultView = page == 1 &&
         limit == 20 &&
         !serein &&
         !savedOnly &&
         !hasNote &&
+        !personalized &&
         contentType == null &&
         mode == null &&
         theme == null &&
@@ -173,6 +179,7 @@ class FeedRepository {
         keyword: keyword,
         includeUnfollowed: includeUnfollowed,
         serein: serein,
+        personalized: personalized,
       );
       _defaultViewInflight = future;
       try {
@@ -203,6 +210,7 @@ class FeedRepository {
       keyword: keyword,
       includeUnfollowed: includeUnfollowed,
       serein: serein,
+      personalized: personalized,
     );
   }
 
@@ -220,6 +228,7 @@ class FeedRepository {
     String? keyword,
     bool includeUnfollowed = false,
     bool serein = false,
+    bool personalized = false,
   }) async {
     try {
       // Le backend renvoie directement une List<dynamic> pour le moment
@@ -273,6 +282,10 @@ class FeedRepository {
 
       if (serein) {
         queryParams['serein'] = true;
+      }
+
+      if (personalized) {
+        queryParams['personalized'] = true;
       }
 
       final sw = Stopwatch()..start();

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -87,6 +87,18 @@ class FeedThemeSection extends FluxSection {
   final String? customTopicId;
   final List<Content> items;
 
+  /// Last page already fetched and appended into [items]. Starts at 1 (the
+  /// initial fetch). Bumped by the provider when "Voir +10" loads more.
+  final int currentPage;
+
+  /// Backend has more pages available. When false, the load-more button is
+  /// disabled (label becomes "Plus rien à voir").
+  final bool hasMore;
+
+  /// Set while a load-more request is in flight. Used by the button to show
+  /// the "Chargement…" label and ignore taps.
+  final bool isLoadingMore;
+
   const FeedThemeSection({
     required super.kind,
     required super.label,
@@ -95,12 +107,37 @@ class FeedThemeSection extends FluxSection {
     required this.items,
     this.themeSlug,
     this.customTopicId,
+    this.currentPage = 1,
+    this.hasMore = true,
+    this.isLoadingMore = false,
     super.blurb,
     super.illustrationAsset,
   });
 
   @override
   int get totalCount => items.length;
+
+  FeedThemeSection copyWith({
+    List<Content>? items,
+    int? currentPage,
+    bool? hasMore,
+    bool? isLoadingMore,
+  }) {
+    return FeedThemeSection(
+      kind: kind,
+      label: label,
+      accent: accent,
+      coreVisibleCount: coreVisibleCount,
+      items: items ?? this.items,
+      themeSlug: themeSlug,
+      customTopicId: customTopicId,
+      currentPage: currentPage ?? this.currentPage,
+      hasMore: hasMore ?? this.hasMore,
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      blurb: blurb,
+      illustrationAsset: illustrationAsset,
+    );
+  }
 }
 
 /// Picks the lead article for a digest topic.

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -340,6 +340,86 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     state = AsyncData(current.copyWith(moreOpen: next));
   }
 
+  /// In-place pagination for the Tournée du jour theme sections. Fetches the
+  /// next page from `/api/feed?theme=…&personalized=true` (or topic UUID for
+  /// custom topics) and appends it to the section's [FeedThemeSection.items]
+  /// — same backend curation as the initial load, so users only see articles
+  /// from sources they follow, within the last 24h.
+  ///
+  /// No-op when the section is not in [state.sections], is already loading,
+  /// or the backend reported no more pages.
+  Future<void> loadMoreTheme(String key) async {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    final idx = current.sections.indexWhere(
+      (s) => s is FeedThemeSection && sectionKey(s) == key,
+    );
+    if (idx < 0) return;
+    final target = current.sections[idx] as FeedThemeSection;
+    if (target.isLoadingMore || !target.hasMore) return;
+
+    final loading = target.copyWith(isLoadingMore: true);
+    final loadingSections = List<FluxSection>.from(current.sections)
+      ..[idx] = loading;
+    state = AsyncData(current.copyWith(sections: loadingSections));
+
+    final isSerene = current.isSerene;
+    final nextPage = target.currentPage + 1;
+    final theme = target.themeSlug;
+    final topic = target.customTopicId;
+    FeedResponse? response;
+    try {
+      response = await _feedRepo.getFeed(
+        page: nextPage,
+        limit: 10,
+        theme: theme,
+        topic: topic,
+        serein: isSerene,
+        personalized: true,
+      );
+    } catch (e, st) {
+      // ignore: avoid_print
+      print('[ERR] flux_continu loadMoreTheme($key) failed: $e\n$st');
+    }
+
+    // Re-read state in case it shifted while the request was in flight.
+    final afterCurrent = state.valueOrNull;
+    if (afterCurrent == null) return;
+    final afterIdx = afterCurrent.sections.indexWhere(
+      (s) => s is FeedThemeSection && sectionKey(s) == key,
+    );
+    if (afterIdx < 0) return;
+    final afterTarget = afterCurrent.sections[afterIdx] as FeedThemeSection;
+
+    final FeedThemeSection updated;
+    if (response == null || response.items.isEmpty) {
+      // Treat empty/error response as "no more" so the button settles into
+      // the disabled "Plus rien à voir" state rather than spinning forever.
+      updated = afterTarget.copyWith(
+        isLoadingMore: false,
+        hasMore: false,
+      );
+    } else {
+      // Dedupe by content id — guards against a new article being published
+      // between page 1 and page 2 and shifting the chronological cursor.
+      final existingIds = {for (final item in afterTarget.items) item.id};
+      final appended = [
+        ...afterTarget.items,
+        for (final item in response.items)
+          if (!existingIds.contains(item.id)) item,
+      ];
+      updated = afterTarget.copyWith(
+        items: appended,
+        currentPage: nextPage,
+        hasMore: response.pagination.hasNext,
+        isLoadingMore: false,
+      );
+    }
+    final nextSections = List<FluxSection>.from(afterCurrent.sections)
+      ..[afterIdx] = updated;
+    state = AsyncData(afterCurrent.copyWith(sections: nextSections));
+  }
+
   /// Records that the user has scrolled past [section] in this session, **but
   /// does not collapse it on screen**. The section will appear as a
   /// [FoldedSectionCard] on the next cold launch. This avoids the visible
@@ -578,6 +658,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   }) {
     final items = feed?.items ?? const <Content>[];
     if (items.length < 2) return null;
+    // Propagate the backend's pagination cursor so the "Voir +10" button
+    // settles into the disabled "Plus rien à voir" state immediately when
+    // page 1 already exhausted the pool.
+    final hasMore = feed?.pagination.hasNext ?? false;
     return FeedThemeSection(
       kind: SectionKind.theme,
       label: label,
@@ -588,6 +672,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       themeSlug: themeSlug,
       customTopicId: customTopicId,
       items: items,
+      hasMore: hasMore,
     );
   }
 
@@ -662,6 +747,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   }
 
   Future<FeedResponse?> _fetchOneTheme(FavoriteRef favRef, bool isSerene) {
+    // `personalized: true` flips the backend to "followed sources only +
+    // 24h window + user_subtopics boost" for the Tournée du jour theme
+    // sections (vs. the unrestricted exploration mode used by feed chips).
     return switch (favRef) {
       ThemeFavoriteRef(:final slug) => _safe<FeedResponse>(
           () => _feedRepo.getFeed(
@@ -669,8 +757,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             limit: 10,
             theme: slug,
             serein: isSerene,
+            personalized: true,
           ),
-          'getFeed?theme=$slug',
+          'getFeed?theme=$slug&personalized=true',
         ),
       // Backend `/api/feed` accepts a UUID stringified in the `topic` param
       // (story 22.1) — looked up against `user_topic_profiles` scoped on the
@@ -681,8 +770,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             limit: 10,
             topic: id,
             serein: isSerene,
+            personalized: true,
           ),
-          'getFeed?topic=$id',
+          'getFeed?topic=$id&personalized=true',
         ),
     };
   }

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -367,20 +367,17 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     final nextPage = target.currentPage + 1;
     final theme = target.themeSlug;
     final topic = target.customTopicId;
-    FeedResponse? response;
-    try {
-      response = await _feedRepo.getFeed(
+    final response = await _safe<FeedResponse>(
+      () => _feedRepo.getFeed(
         page: nextPage,
         limit: 10,
         theme: theme,
         topic: topic,
         serein: isSerene,
         personalized: true,
-      );
-    } catch (e, st) {
-      // ignore: avoid_print
-      print('[ERR] flux_continu loadMoreTheme($key) failed: $e\n$st');
-    }
+      ),
+      'loadMoreTheme($key)',
+    );
 
     // Re-read state in case it shifted while the request was in flight.
     final afterCurrent = state.valueOrNull;

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -795,6 +795,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             onTapFavorite: isFavorite
                 ? () => showMyInterestsBottomSheet(context)
                 : null,
+            onLoadMore: section is FeedThemeSection
+                ? () => notifier.loadMoreTheme(sectionKey(section))
+                : null,
           ),
         ),
       ));

--- a/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
@@ -2,16 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../../../config/theme.dart';
 
-/// In-place pagination button for [FeedThemeSection]s of the Tournée du
-/// jour. Tapping appends the next 10 articles in the same section instead
-/// of expanding a folded list. Replaces the legacy `Plus de / Replier`
-/// toggle for theme/topic sections — the digest sections keep using
-/// [PlusDeButton] (a binary fold toggle).
-///
-/// Behavior:
-/// - `hasMore=true,  isLoadingMore=false` → "Voir +10 de [label]" (active)
-/// - `hasMore=true,  isLoadingMore=true`  → "Chargement…"        (disabled)
-/// - `hasMore=false`                      → "Plus rien à voir"   (disabled)
+/// In-place pagination button for [FeedThemeSection]s. Tapping appends
+/// the next 10 articles in the same section.
 class LoadMoreButton extends StatelessWidget {
   final String sectionLabel;
   final bool hasMore;

--- a/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
@@ -2,6 +2,88 @@ import 'package:flutter/material.dart';
 
 import '../../../config/theme.dart';
 
+/// In-place pagination button for [FeedThemeSection]s of the Tournée du
+/// jour. Tapping appends the next 10 articles in the same section instead
+/// of expanding a folded list. Replaces the legacy `Plus de / Replier`
+/// toggle for theme/topic sections — the digest sections keep using
+/// [PlusDeButton] (a binary fold toggle).
+///
+/// Behavior:
+/// - `hasMore=true,  isLoadingMore=false` → "Voir +10 de [label]" (active)
+/// - `hasMore=true,  isLoadingMore=true`  → "Chargement…"        (disabled)
+/// - `hasMore=false`                      → "Plus rien à voir"   (disabled)
+class LoadMoreButton extends StatelessWidget {
+  final String sectionLabel;
+  final bool hasMore;
+  final bool isLoadingMore;
+  final VoidCallback onTap;
+
+  const LoadMoreButton({
+    super.key,
+    required this.sectionLabel,
+    required this.hasMore,
+    required this.isLoadingMore,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final String label;
+    if (isLoadingMore) {
+      label = 'Chargement…';
+    } else if (hasMore) {
+      label = 'Voir +10 de $sectionLabel';
+    } else {
+      label = 'Plus rien à voir';
+    }
+    final bool enabled = hasMore && !isLoadingMore;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+      child: Material(
+        color: colors.surfaceElevated
+            .withValues(alpha: enabled ? 0.5 : 0.25),
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          onTap: enabled ? onTap : null,
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (isLoadingMore) ...[
+                  SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        colors.textSecondary,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                ],
+                Text(
+                  label,
+                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                        color: enabled
+                            ? colors.textSecondary
+                            : colors.textSecondary.withValues(alpha: 0.5),
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// "Plus de…" expand/collapse button for a Flux Continu section.
 ///
 /// Soft off-white pill, single neutral colour across all sections — section

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -27,6 +27,11 @@ class SectionBlock extends StatelessWidget {
   final void Function(Object article, FluxSection section) onTapArticle;
   final ValueChanged<String>? onDismissArticle;
 
+  /// Append the next page of articles to a [FeedThemeSection]. Wired by the
+  /// flux_continu screen to `provider.loadMoreTheme(sectionKey)`. Ignored
+  /// for [DigestTopicSection] which keeps its legacy fold/expand button.
+  final VoidCallback? onLoadMore;
+
   /// IDs of articles currently in the inline-feedback pending state. When
   /// non-empty, the matching cards are swapped for a [FeedbackInline] at the
   /// same position.
@@ -63,6 +68,7 @@ class SectionBlock extends StatelessWidget {
     this.enableSwipeHintOnFirstCard = false,
     this.onSwipeHintComplete,
     this.onTapFavorite,
+    this.onLoadMore,
   });
 
   @override
@@ -72,7 +78,12 @@ class SectionBlock extends StatelessWidget {
     // viewport visually doesn't move. An animated transition here would defeat
     // the compensation by leaving the height in flux when the post-frame
     // callback measures it.
-    return isFolded ? _buildFolded() : _buildExpanded();
+    //
+    // [FeedThemeSection] never folds: it uses the in-place "Voir +10"
+    // pagination, so the fold UX of digest sections would conflict with
+    // that affordance. Only digest sections (essentiel / bonnes) fold.
+    final bool canFold = section is DigestTopicSection;
+    return (isFolded && canFold) ? _buildFolded() : _buildExpanded();
   }
 
   Widget _buildFolded() {
@@ -85,6 +96,7 @@ class SectionBlock extends StatelessWidget {
 
   Widget _buildExpanded() {
     final cards = _buildCards();
+    final section = this.section;
     final hiddenCount = section.totalCount - section.coreVisibleCount;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -94,11 +106,18 @@ class SectionBlock extends StatelessWidget {
           accent: section.accent,
           blurb: section.blurb,
           illustrationAsset: section.illustrationAsset,
-          onTapFold: onFold,
+          onTapFold: section is DigestTopicSection ? onFold : null,
           onTapFavorite: onTapFavorite,
         ),
         ...cards,
-        if (section.hasOverflow)
+        if (section is FeedThemeSection)
+          LoadMoreButton(
+            sectionLabel: section.label,
+            hasMore: section.hasMore,
+            isLoadingMore: section.isLoadingMore,
+            onTap: onLoadMore ?? () {},
+          )
+        else if (section.hasOverflow)
           PlusDeButton(
             sectionLabel: section.label,
             isOpen: isOpen,
@@ -157,9 +176,11 @@ class SectionBlock extends StatelessWidget {
                         : null,
               ),
         ];
-      case FeedThemeSection(:final items, :final coreVisibleCount):
-        final visible =
-            isOpen ? items : items.take(coreVisibleCount).toList();
+      case FeedThemeSection(:final items):
+        // FeedThemeSection always renders the full accumulated list; the
+        // in-place LoadMoreButton appends +10 items at a time instead of
+        // hiding behind a fold/expand toggle.
+        final visible = items;
         return [
           for (var i = 0; i < visible.length; i++)
             if (pendingFeedbackIds.contains(visible[i].id))

--- a/apps/mobile/test/features/digest/widgets/digest_briefing_section_display_limit_test.dart
+++ b/apps/mobile/test/features/digest/widgets/digest_briefing_section_display_limit_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/features/digest/models/digest_models.dart';
+import 'package:facteur/features/digest/widgets/digest_briefing_section.dart';
+import 'package:facteur/features/digest/widgets/topic_section.dart';
+
+DigestItem _item(String id) => DigestItem(
+      contentId: id,
+      title: 'Article $id',
+      url: 'https://example.com/$id',
+      source: const SourceMini(id: 'src-1', name: 'Source 1'),
+    );
+
+DigestTopic _topic(int rank) => DigestTopic(
+      topicId: 'topic-$rank',
+      label: 'Sujet $rank',
+      rank: rank,
+      articles: [_item('content-$rank-a')],
+    );
+
+void main() {
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async => null);
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  Widget buildWidget({
+    required List<DigestTopic> topics,
+    required int displayLimit,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: DigestBriefingSection(
+            items: const [],
+            topics: topics,
+            displayLimit: displayLimit,
+            onItemTap: (_) {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('DigestBriefingSection.displayLimit (topics layout)', () {
+    testWidgets('renders only displayLimit topics and a "Voir N autres" CTA',
+        (tester) async {
+      final topics = List.generate(10, (i) => _topic(i + 1));
+
+      await tester.pumpWidget(buildWidget(topics: topics, displayLimit: 3));
+      await tester.pump();
+
+      // 3 sujets rendus, pas 10.
+      expect(find.byType(TopicSection), findsNWidgets(3));
+
+      // Le bouton est bien rendu (hidden = 10 - 3 = 7).
+      expect(find.byKey(const ValueKey('digest_show_more_toggle')),
+          findsOneWidget);
+      expect(find.text('Voir 7 autres articles'), findsOneWidget);
+    });
+
+    testWidgets('tapping CTA reveals all topics and flips label to "Réduire"',
+        (tester) async {
+      final topics = List.generate(10, (i) => _topic(i + 1));
+
+      await tester.pumpWidget(buildWidget(topics: topics, displayLimit: 3));
+      await tester.pump();
+      expect(find.byType(TopicSection), findsNWidgets(3));
+
+      await tester.tap(find.byKey(const ValueKey('digest_show_more_toggle')));
+      await tester.pump();
+
+      // Tous les topics maintenant rendus.
+      expect(find.byType(TopicSection), findsNWidgets(10));
+
+      // Le label a basculé sur "Réduire".
+      expect(find.text('Réduire'), findsOneWidget);
+      expect(find.text('Voir 7 autres articles'), findsNothing);
+    });
+
+    testWidgets('hides CTA entirely when topics.length <= displayLimit',
+        (tester) async {
+      final topics = List.generate(3, (i) => _topic(i + 1));
+
+      await tester.pumpWidget(buildWidget(topics: topics, displayLimit: 5));
+      await tester.pump();
+
+      expect(find.byType(TopicSection), findsNWidgets(3));
+      expect(find.byKey(const ValueKey('digest_show_more_toggle')),
+          findsNothing);
+    });
+
+    testWidgets('falls back to "Voir 1 autre article" when only 1 hidden',
+        (tester) async {
+      final topics = List.generate(4, (i) => _topic(i + 1));
+
+      await tester.pumpWidget(buildWidget(topics: topics, displayLimit: 3));
+      await tester.pump();
+
+      expect(find.text('Voir 1 autre article'), findsOneWidget);
+    });
+
+    testWidgets('displayLimit=null disables slicing (legacy behavior)',
+        (tester) async {
+      final topics = List.generate(10, (i) => _topic(i + 1));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: DigestBriefingSection(
+                items: const [],
+                topics: topics,
+                onItemTap: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Sans displayLimit, tous les topics sont rendus, pas de toggle.
+      expect(find.byType(TopicSection), findsNWidgets(10));
+      expect(find.byKey(const ValueKey('digest_show_more_toggle')),
+          findsNothing);
+    });
+  });
+}

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -75,6 +75,28 @@ FeedResponse _feedResponseWith(int items) {
   );
 }
 
+FeedResponse _feedResponseWithIds(
+  List<String> ids, {
+  int page = 1,
+  bool hasNext = false,
+}) {
+  return FeedResponse(
+    items: ids
+        .map((id) => Content(
+              id: id,
+              title: 'title-$id',
+              url: 'https://x.test/$id',
+              contentType: ContentType.article,
+              publishedAt: DateTime(2026, 1, 1),
+              source: Source(id: 's', name: 'S', type: SourceType.article),
+            ))
+        .toList(),
+    pagination:
+        Pagination(page: page, perPage: 10, total: 0, hasNext: hasNext),
+    carousels: const [],
+  );
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -114,6 +136,7 @@ void main() {
           theme: any(named: 'theme'),
           topic: any(named: 'topic'),
           serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
         )).thenThrow(Exception('mock: no feed'));
   });
 
@@ -329,6 +352,7 @@ void main() {
             limit: any(named: 'limit'),
             theme: any(named: 'theme'),
             serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
           )).thenAnswer((_) async => _feedResponseWith(3));
 
       final container = makeContainer(); // 0 favorites in stub
@@ -342,6 +366,7 @@ void main() {
             limit: any(named: 'limit'),
             theme: captureAny(named: 'theme'),
             serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
           )).captured;
       expect(captured, containsAll(['tech', 'environment', 'science']));
     });
@@ -353,6 +378,7 @@ void main() {
             limit: any(named: 'limit'),
             theme: any(named: 'theme'),
             serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
           )).thenAnswer((_) async => _feedResponseWith(3));
 
       final container = makeContainer(
@@ -369,6 +395,7 @@ void main() {
             limit: any(named: 'limit'),
             theme: 'culture',
             serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
           )).called(1);
     });
 
@@ -379,6 +406,7 @@ void main() {
             limit: any(named: 'limit'),
             topic: any(named: 'topic'),
             serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
           )).thenAnswer((_) async => _feedResponseWith(3));
 
       const customId = 'aaaa-bbbb-cccc';
@@ -405,6 +433,7 @@ void main() {
             limit: any(named: 'limit'),
             topic: customId,
             serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
           )).called(1);
 
       final themeSections =
@@ -421,6 +450,7 @@ void main() {
             limit: any(named: 'limit'),
             theme: any(named: 'theme'),
             serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
           )).thenAnswer((_) async => _feedResponseWith(3));
 
       final container = makeContainer(
@@ -439,6 +469,177 @@ void main() {
           .map((s) => s.themeSlug)
           .toList();
       expect(slugs, ['tech', 'science', 'culture']);
+    });
+  });
+
+  group('FluxContinuNotifier — Tournée du jour curation (personalized)', () {
+    test('Theme favorite forwards personalized:true to getFeed', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      when(() => feedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            theme: any(named: 'theme'),
+            serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
+          )).thenAnswer((_) async => _feedResponseWith(3));
+
+      final container = makeContainer(
+        interests: _interestsState(favorites: const [
+          ThemeFavoriteRef(slug: 'tech'),
+        ]),
+      );
+      addTearDown(container.dispose);
+
+      await container.read(fluxContinuProvider.future);
+
+      // The Tournée du jour theme sections opt in to the backend curation
+      // (followed sources only + 24h window + user_subtopics boost).
+      verify(() => feedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            theme: 'tech',
+            serein: any(named: 'serein'),
+            personalized: true,
+          )).called(1);
+    });
+
+    test('Custom topic favorite forwards personalized:true to getFeed',
+        () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      when(() => feedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            topic: any(named: 'topic'),
+            serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
+          )).thenAnswer((_) async => _feedResponseWith(3));
+
+      const customId = 'aaaa-bbbb-cccc';
+      final container = makeContainer(
+        interests: _interestsState(
+          favorites: const [CustomTopicFavoriteRef(id: customId)],
+          customTopics: const [
+            CustomTopicInterest(
+              id: customId,
+              topicName: 'IA & éducation',
+              slugParent: 'tech',
+              state: InterestState.favorite,
+              priorityMultiplier: 2.0,
+            ),
+          ],
+        ),
+      );
+      addTearDown(container.dispose);
+
+      await container.read(fluxContinuProvider.future);
+
+      verify(() => feedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            topic: customId,
+            serein: any(named: 'serein'),
+            personalized: true,
+          )).called(1);
+    });
+  });
+
+  group('FluxContinuNotifier — loadMoreTheme pagination', () {
+    test('appends next page items, increments page, propagates hasMore',
+        () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      // Initial fetch (page 1) — 2 items, hasNext=true.
+      when(() => feedRepo.getFeed(
+            page: 1,
+            limit: any(named: 'limit'),
+            theme: any(named: 'theme'),
+            serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
+          )).thenAnswer((_) async =>
+          _feedResponseWithIds(const ['a1', 'a2'], page: 1, hasNext: true));
+      // Load-more fetch (page 2) — 2 new items, hasNext=false.
+      when(() => feedRepo.getFeed(
+            page: 2,
+            limit: any(named: 'limit'),
+            theme: any(named: 'theme'),
+            serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
+          )).thenAnswer((_) async =>
+          _feedResponseWithIds(const ['a3', 'a4'], page: 2, hasNext: false));
+
+      final container = makeContainer(
+        interests: _interestsState(favorites: const [
+          ThemeFavoriteRef(slug: 'tech'),
+        ]),
+      );
+      addTearDown(container.dispose);
+
+      final initial = await container.read(fluxContinuProvider.future);
+      final themeSection =
+          initial.sections.whereType<FeedThemeSection>().single;
+      expect(themeSection.items.map((c) => c.id), ['a1', 'a2']);
+      expect(themeSection.currentPage, 1);
+      expect(themeSection.hasMore, true);
+
+      await container
+          .read(fluxContinuProvider.notifier)
+          .loadMoreTheme(sectionKey(themeSection));
+
+      final after = container.read(fluxContinuProvider).requireValue;
+      final updated =
+          after.sections.whereType<FeedThemeSection>().single;
+      expect(updated.items.map((c) => c.id), ['a1', 'a2', 'a3', 'a4']);
+      expect(updated.currentPage, 2);
+      expect(updated.hasMore, false);
+      expect(updated.isLoadingMore, false);
+    });
+
+    test('does nothing when section is already at end (hasMore=false)',
+        () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      when(() => feedRepo.getFeed(
+            page: 1,
+            limit: any(named: 'limit'),
+            theme: any(named: 'theme'),
+            serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
+          )).thenAnswer((_) async =>
+          _feedResponseWithIds(const ['a1', 'a2'], page: 1, hasNext: false));
+
+      final container = makeContainer(
+        interests: _interestsState(favorites: const [
+          ThemeFavoriteRef(slug: 'tech'),
+        ]),
+      );
+      addTearDown(container.dispose);
+
+      final initial = await container.read(fluxContinuProvider.future);
+      final themeSection =
+          initial.sections.whereType<FeedThemeSection>().single;
+      expect(themeSection.hasMore, false);
+
+      // Call loadMoreTheme — backend must NOT be hit a second time.
+      await container
+          .read(fluxContinuProvider.notifier)
+          .loadMoreTheme(sectionKey(themeSection));
+
+      // Theme=tech fetch happens exactly once (initial). The page=1
+      // continuation fetch in `_fetchAll` is not theme-scoped and matched
+      // separately by the default mock; we only assert on theme fetches.
+      verify(() => feedRepo.getFeed(
+            page: 1,
+            limit: any(named: 'limit'),
+            theme: 'tech',
+            serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
+          )).called(1);
+      verifyNever(() => feedRepo.getFeed(
+            page: 2,
+            limit: any(named: 'limit'),
+            theme: 'tech',
+            serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
+          ));
     });
   });
 }

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -751,26 +751,46 @@ async def _load_stored_perspectives_for_representative(
     if not digests:
         return None
 
+    import structlog
+
+    log = structlog.get_logger(__name__)
+
     target_str = str(content_id)
     for digest in digests:
         items = digest.items if isinstance(digest.items, dict) else {}
         for subject in items.get("subjects", []):
             actu = subject.get("actu_article")
             extras = subject.get("extra_actu_articles", []) or []
+            deep = subject.get("deep_article") or {}
             ids = {subject.get("representative_content_id")}
             if actu and actu.get("content_id"):
                 ids.add(actu["content_id"])
             for extra in extras:
                 if extra.get("content_id"):
                     ids.add(extra["content_id"])
+            # deep_article doit aussi matcher : sans ça, un tap sur la card
+            # "pas de recul" tombe en live path et le count diverge du badge.
+            # pepite / coup_de_coeur ne sont pas rattachés à un sujet aujourd'hui ;
+            # si un jour ils le sont, ajouter ici.
+            if deep.get("content_id"):
+                ids.add(deep["content_id"])
             if target_str in ids:
                 stored = subject.get("perspective_articles")
                 bias = subject.get("bias_distribution") or {}
                 if stored is not None:
                     return list(stored), dict(bias)
-                # Subject found but no stored snapshot (legacy digest pre-fix
-                # or pipeline bug) → caller falls back to live compute.
-                return None
+                # Subject trouvé dans un digest récent mais snapshot absent
+                # (legacy digest, ou bug pipeline). Pour préserver l'invariant
+                # "content_id du digest → toujours stored, jamais live",
+                # on retourne explicitement vide plutôt que de retomber en
+                # live path qui divergerait du badge preview.
+                log.warning(
+                    "perspectives_stored_snapshot_missing",
+                    content_id=target_str,
+                    digest_id=str(digest.id),
+                    subject_topic_id=subject.get("topic_id"),
+                )
+                return [], dict(bias)
     return None
 
 
@@ -1035,7 +1055,10 @@ async def get_perspectives(
         logger.info(
             "perspectives_endpoint_stored_snapshot",
             content_id=cache_key,
+            path="stored_snapshot",
             count=count,
+            bias_groups=bias_groups,
+            bias_sum=sum(stored_bias.values()),
         )
         return response
 
@@ -1088,14 +1111,27 @@ async def get_perspectives(
         if not ref_url_key_live
         or _normalize_url_for_match(getattr(p, "url", None)) != ref_url_key_live
     ]
-    perspectives = [p for p in merged if p.bias_stance != "unknown"]
+    known_perspectives = [p for p in merged if p.bias_stance != "unknown"]
+
+    # Safety net (parity avec pipeline.py:494-510) : si aucune perspective
+    # n'a un bias connu, on retombe sur les sources du cluster pour ne pas
+    # sous-compter la couverture. La bias_distribution reste all-zero et
+    # la spectrum bar UI doit déjà gérer ce cas.
+    safety_net_triggered = False
+    if not known_perspectives and cluster_perspectives:
+        perspectives = cluster_perspectives
+        safety_net_triggered = True
+    else:
+        perspectives = known_perspectives
 
     logger.info(
         "perspectives_composition",
         content_id=cache_key,
-        cluster_sources=len(cluster_perspectives),
+        path="live",
+        cluster_sources_count=len(cluster_perspectives),
         gnews_added=len(new_gnews),
-        known_bias=len(perspectives),
+        known_bias=len(known_perspectives),
+        safety_net_triggered=safety_net_triggered,
     )
 
     # Calculate bias distribution (without "unknown")

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -751,10 +751,6 @@ async def _load_stored_perspectives_for_representative(
     if not digests:
         return None
 
-    import structlog
-
-    log = structlog.get_logger(__name__)
-
     target_str = str(content_id)
     for digest in digests:
         items = digest.items if isinstance(digest.items, dict) else {}
@@ -784,7 +780,7 @@ async def _load_stored_perspectives_for_representative(
                 # "content_id du digest → toujours stored, jamais live",
                 # on retourne explicitement vide plutôt que de retomber en
                 # live path qui divergerait du badge preview.
-                log.warning(
+                logger.warning(
                     "perspectives_stored_snapshot_missing",
                     content_id=target_str,
                     digest_id=str(digest.id),

--- a/packages/api/app/routers/feed.py
+++ b/packages/api/app/routers/feed.py
@@ -102,6 +102,7 @@ def _is_default_view(
     source_id: str | None,
     entity: str | None,
     keyword: str | None,
+    personalized: bool,
 ) -> bool:
     """Eligibility predicate for the page-1 cache.
 
@@ -123,6 +124,7 @@ def _is_default_view(
         and source_id is None
         and entity is None
         and keyword is None
+        and not personalized
     )
 
 
@@ -154,6 +156,14 @@ async def get_personalized_feed(
             "sources the user does not follow (used by trending chip taps)."
         ),
     ),
+    personalized: bool = Query(
+        False,
+        description=(
+            "Restrict theme/topic candidates to followed sources, narrow to a "
+            "24h window, and boost articles matching user_subtopics. Used by "
+            "the Tournée du jour theme sections."
+        ),
+    ),
     db: AsyncSession = Depends(get_db),
     current_user_id: str = Depends(get_current_user_id),
 ):
@@ -183,6 +193,7 @@ async def get_personalized_feed(
         source_id=source_id,
         entity=entity,
         keyword=keyword,
+        personalized=personalized,
     )
 
     if cache_eligible:
@@ -214,6 +225,7 @@ async def get_personalized_feed(
                 entity=entity,
                 keyword=keyword,
                 include_unfollowed=include_unfollowed,
+                personalized=personalized,
             )
             payload = json.dumps(response.model_dump(mode="json")).encode("utf-8")
             FEED_CACHE.put(user_uuid, payload)
@@ -235,6 +247,7 @@ async def get_personalized_feed(
         entity=entity,
         keyword=keyword,
         include_unfollowed=include_unfollowed,
+        personalized=personalized,
     )
     return response
 
@@ -256,6 +269,7 @@ async def _compute_feed(
     entity: str | None,
     keyword: str | None,
     include_unfollowed: bool = False,
+    personalized: bool = False,
 ) -> FeedResponse:
     """Run the full recommendation pipeline. Identical to the pre-Round-5
     body of `get_personalized_feed`, extracted for cache-miss reuse."""
@@ -284,6 +298,7 @@ async def _compute_feed(
         keyword=keyword,
         serein=serein,
         include_unfollowed=include_unfollowed,
+        personalized=personalized,
     )
 
     # Epic 11: Build clusters from custom topics (reuse from service, no duplicate query)

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -2606,6 +2606,24 @@ class DigestService:
                     source=q.get("source"),
                 )
 
+        # B.2 — completion_threshold = pref user clampée 3-10 (target_size),
+        # plafonnée par le nombre de topics réellement renvoyés. Permet à la
+        # barre de progression mobile (totalCount / goalCount) de coller à la
+        # pref user au lieu d'exiger l'épuisement des 10 sujets backend.
+        from app.models.user import UserProfile as _UP
+        from app.services.digest_selector import DiversityConstraints as _DC
+
+        _user_profile = await self.session.scalar(
+            select(_UP).where(_UP.user_id == user_id)
+        )
+        _raw_goal = (
+            _user_profile.weekly_goal
+            if _user_profile and _user_profile.weekly_goal
+            else _DC.TARGET_DIGEST_SIZE
+        )
+        _target_size = max(3, min(_raw_goal, 10))
+        editorial_completion_threshold = min(_target_size, len(response_topics))
+
         return DigestResponse(
             digest_id=digest.id,
             user_id=digest.user_id,
@@ -2616,7 +2634,7 @@ class DigestService:
             format_version="editorial_v1",
             items=flat_items,
             topics=response_topics,
-            completion_threshold=len(response_topics),
+            completion_threshold=editorial_completion_threshold,
             is_completed=completion is not None,
             completed_at=completion.completed_at if completion else None,
             header_text=items_data.get("header_text"),

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -561,6 +561,22 @@ class DigestService:
         self.selector = DigestSelector(session, session_maker=session_maker)
         self.streak_service = StreakService(session)
 
+    async def _compute_target_size(self, user_id: UUID) -> int:
+        """`weekly_goal` clampé dans la fenêtre [3, 10]. Fallback sur
+        ``DiversityConstraints.TARGET_DIGEST_SIZE`` quand pas de pref user."""
+        from app.models.user import UserProfile
+        from app.services.digest_selector import DiversityConstraints
+
+        profile = await self.session.scalar(
+            select(UserProfile).where(UserProfile.user_id == user_id)
+        )
+        raw_goal = (
+            profile.weekly_goal
+            if profile and profile.weekly_goal
+            else DiversityConstraints.TARGET_DIGEST_SIZE
+        )
+        return max(3, min(raw_goal, 10))
+
     async def get_or_create_digest(
         self,
         user_id: UUID,
@@ -2606,23 +2622,11 @@ class DigestService:
                     source=q.get("source"),
                 )
 
-        # B.2 — completion_threshold = pref user clampée 3-10 (target_size),
-        # plafonnée par le nombre de topics réellement renvoyés. Permet à la
-        # barre de progression mobile (totalCount / goalCount) de coller à la
-        # pref user au lieu d'exiger l'épuisement des 10 sujets backend.
-        from app.models.user import UserProfile as _UP
-        from app.services.digest_selector import DiversityConstraints as _DC
-
-        _user_profile = await self.session.scalar(
-            select(_UP).where(_UP.user_id == user_id)
-        )
-        _raw_goal = (
-            _user_profile.weekly_goal
-            if _user_profile and _user_profile.weekly_goal
-            else _DC.TARGET_DIGEST_SIZE
-        )
-        _target_size = max(3, min(_raw_goal, 10))
-        editorial_completion_threshold = min(_target_size, len(response_topics))
+        # Sans ce plafond, la barre de progression mobile exigerait
+        # l'épuisement des 10 sujets backend même quand la pref user en
+        # demande 3 ou 5.
+        target_size = await self._compute_target_size(user_id)
+        editorial_completion_threshold = min(target_size, len(response_topics))
 
         return DigestResponse(
             digest_id=digest.id,

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -9,6 +9,7 @@ Per-user phase (run_for_user): actu matching only, no LLM.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -46,8 +47,30 @@ from app.services.perspective_service import Perspective, PerspectiveService
 logger = structlog.get_logger()
 
 # Curation oversample : on demande +N sujets de plus que la cible pour
-# absorber les échecs d'actu/deep matching et toujours servir 5 sujets.
-_SUBJECT_BUFFER = 2
+# absorber les échecs d'actu/deep matching et toujours servir target sujets.
+# Defaults : target=10, buffer=4 (cf. plan passage 5→10). Surcouchable via env
+# pour rollback safe (EDITORIAL_TARGET_SUBJECT_COUNT=5 ramène au comportement
+# antérieur).
+_DEFAULT_TARGET_SUBJECT_COUNT = 10
+_DEFAULT_SUBJECT_BUFFER = 4
+
+
+def _read_target_subject_count() -> int:
+    try:
+        return max(1, int(os.environ.get("EDITORIAL_TARGET_SUBJECT_COUNT", "")))
+    except ValueError:
+        return _DEFAULT_TARGET_SUBJECT_COUNT
+
+
+def _read_subject_buffer() -> int:
+    try:
+        return max(0, int(os.environ.get("EDITORIAL_SUBJECT_BUFFER", "")))
+    except ValueError:
+        return _DEFAULT_SUBJECT_BUFFER
+
+
+# Conservé pour compat ascendante (tests/imports externes).
+_SUBJECT_BUFFER = _DEFAULT_SUBJECT_BUFFER
 
 
 class EditorialPipelineService:
@@ -146,10 +169,10 @@ class EditorialPipelineService:
         # Cap low-priority clusters (sport + faits divers) — applies to both
         # modes. Clusters are sorted by size desc so the largest — typically
         # the most trending — is kept. Skip the cap if the remaining non-
-        # low-priority pool would be too small to pick 5 subjects.
+        # low-priority pool would be too small pour atteindre la cible sujets.
         sorted_by_size = sorted(clusters, key=lambda c: len(c.source_ids), reverse=True)
         capped = cap_low_priority_clusters(sorted_by_size)
-        if len(capped) >= 5:
+        if len(capped) >= _read_target_subject_count():
             dropped = len(sorted_by_size) - len(capped)
             clusters = capped
             logger.info(
@@ -231,11 +254,12 @@ class EditorialPipelineService:
         # digest à 5 sujets sans replonger en LLM. Cf. bug-digest-pipeline-fallbacks.md.
         step_start = time.time()
         excluded_ids = {a_la_une_topic.topic_id} if a_la_une_topic else set()
-        target_subject_count = 5
+        target_subject_count = _read_target_subject_count()
+        subject_buffer = _read_subject_buffer()
         remaining_count = (
             (target_subject_count - 1) if a_la_une_topic else target_subject_count
         )
-        oversample_count = remaining_count + _SUBJECT_BUFFER
+        oversample_count = remaining_count + subject_buffer
         selected_topics = await self.curation.select_topics(
             clusters,
             subjects_count=oversample_count,
@@ -547,8 +571,9 @@ class EditorialPipelineService:
             ]
 
             # Axe C — observability: log the composition so we can verify in
-            # prod that the cluster count, perspective count and LLM analysis
-            # describe the same media set.
+            # prod que cluster count, perspective count et LLM analysis
+            # décrivent le même media set. final_persisted_count = ce que
+            # le fast path retournera (doit toujours == perspective_count).
             logger.info(
                 "editorial_pipeline.perspectives_composition",
                 topic_id=subject.topic_id,
@@ -557,6 +582,8 @@ class EditorialPipelineService:
                 total_merged=len(merged_perspectives),
                 known_bias=len(known_perspectives),
                 unknown_bias=len(merged_perspectives) - len(known_perspectives),
+                final_persisted_count=len(subject.perspective_articles or []),
+                perspective_count=subject.perspective_count,
             )
 
             # Build perspective_sources — max 6, deduplicated by domain.

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -46,31 +46,28 @@ from app.services.perspective_service import Perspective, PerspectiveService
 
 logger = structlog.get_logger()
 
-# Curation oversample : on demande +N sujets de plus que la cible pour
-# absorber les échecs d'actu/deep matching et toujours servir target sujets.
-# Defaults : target=10, buffer=4 (cf. plan passage 5→10). Surcouchable via env
-# pour rollback safe (EDITORIAL_TARGET_SUBJECT_COUNT=5 ramène au comportement
-# antérieur).
+# Curation oversample : on demande +buffer sujets de plus que la cible pour
+# absorber les échecs d'actu/deep matching. EDITORIAL_TARGET_SUBJECT_COUNT=5
+# permet un rollback safe au comportement pré-passage 5→10.
 _DEFAULT_TARGET_SUBJECT_COUNT = 10
 _DEFAULT_SUBJECT_BUFFER = 4
 
 
-def _read_target_subject_count() -> int:
+def _read_int_env(name: str, default: int, *, floor: int = 0) -> int:
     try:
-        return max(1, int(os.environ.get("EDITORIAL_TARGET_SUBJECT_COUNT", "")))
+        return max(floor, int(os.environ.get(name, "")))
     except ValueError:
-        return _DEFAULT_TARGET_SUBJECT_COUNT
+        return default
+
+
+def _read_target_subject_count() -> int:
+    return _read_int_env(
+        "EDITORIAL_TARGET_SUBJECT_COUNT", _DEFAULT_TARGET_SUBJECT_COUNT, floor=1
+    )
 
 
 def _read_subject_buffer() -> int:
-    try:
-        return max(0, int(os.environ.get("EDITORIAL_SUBJECT_BUFFER", "")))
-    except ValueError:
-        return _DEFAULT_SUBJECT_BUFFER
-
-
-# Conservé pour compat ascendante (tests/imports externes).
-_SUBJECT_BUFFER = _DEFAULT_SUBJECT_BUFFER
+    return _read_int_env("EDITORIAL_SUBJECT_BUFFER", _DEFAULT_SUBJECT_BUFFER)
 
 
 class EditorialPipelineService:
@@ -248,10 +245,11 @@ class EditorialPipelineService:
         une_time = time.time() - step_start
 
         # ÉTAPE 2: LLM curation — select remaining topics + buffer.
-        # On oversample de `_SUBJECT_BUFFER` clusters supplémentaires : si
+        # On oversample de `subject_buffer` clusters supplémentaires : si
         # actu/deep matching échoue sur un sujet (cluster sans article éligible
         # < 24h, deep_match LLM négatif), on a une réserve pour garder le
-        # digest à 5 sujets sans replonger en LLM. Cf. bug-digest-pipeline-fallbacks.md.
+        # digest à target sujets sans replonger en LLM.
+        # Cf. bug-digest-pipeline-fallbacks.md.
         step_start = time.time()
         excluded_ids = {a_la_une_topic.topic_id} if a_la_une_topic else set()
         target_subject_count = _read_target_subject_count()
@@ -356,11 +354,11 @@ class EditorialPipelineService:
         )
 
         # ÉTAPE 3A-bis: trim au target_subject_count.
-        # On a oversamplé de _SUBJECT_BUFFER ; on exige qu'un sujet ait un
+        # On a oversamplé de subject_buffer ; on exige qu'un sujet ait un
         # `actu_article` (parution récente). Un sujet avec seulement un
         # `deep_article` (parfois plusieurs jours) ne mérite pas d'être
         # promu en article principal — sa place est sur le rail "Prendre
-        # du recul", pas dans les 5 sujets du jour. Cf. bug-essentiel-pipeline.md.
+        # du recul", pas dans les sujets du jour. Cf. bug-essentiel-pipeline.md.
         # Le buffer permet généralement de combler les drops ; si on retombe
         # quand même < target, on logge en error pour visibilité.
         empty_dropped: list[str] = []

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -2313,7 +2313,9 @@ class RecommendationService:
         # sources suivies + fenêtre 24h + boost user_subtopics. Inerte sans
         # personalized=true côté client (rétro-compat).
         personalized_theme_mode = (
-            personalized and (theme is not None or topic is not None) and source_id is None
+            personalized
+            and (theme is not None or topic is not None)
+            and source_id is None
         )
 
         explicit_filter = (

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -201,6 +201,7 @@ class RecommendationService:
         keyword: str | None = None,
         serein: bool = False,
         include_unfollowed: bool = False,
+        personalized: bool = False,
     ) -> list[Content]:
         """
         Génère un feed personnalisé pour l'utilisateur.
@@ -454,6 +455,10 @@ class RecommendationService:
             # Trending chip fallback: expand search to all sources when keyword is set
             include_unfollowed=include_unfollowed,
             excluded_topics=_user_excluded_topics,
+            # Tournée du jour : restrict theme/topic candidates to followed
+            # sources + 24h window + boost user_subtopics.
+            personalized=personalized,
+            user_subtopics=user_subtopics,
         )
         self.total_candidates = len(candidates)
 
@@ -2279,6 +2284,8 @@ class RecommendationService:
         sensitive_themes: list[str] | None = None,
         include_unfollowed: bool = False,
         excluded_topics: list[Any] | None = None,
+        personalized: bool = False,
+        user_subtopics: set[str] | None = None,
     ) -> list[Content]:
         """Récupère les N contenus les plus récents que l'utilisateur n'a pas encore vus/consommés et qui ne sont pas masqués."""
         from sqlalchemy import and_, or_
@@ -2302,10 +2309,17 @@ class RecommendationService:
         # Otherwise, exclude hidden + saved + seen + consumed (default feed).
         from sqlalchemy import exists
 
+        # Tournée du jour : sections curées par thème/topic restreintes aux
+        # sources suivies + fenêtre 24h + boost user_subtopics. Inerte sans
+        # personalized=true côté client (rétro-compat).
+        personalized_theme_mode = (
+            personalized and (theme is not None or topic is not None) and source_id is None
+        )
+
         explicit_filter = (
             source_id is not None
-            or theme is not None
-            or topic is not None
+            or (theme is not None and not personalized_theme_mode)
+            or (topic is not None and not personalized_theme_mode)
             or entity is not None
             or keyword is not None
         )
@@ -2371,9 +2385,17 @@ class RecommendationService:
         #   à l'affichage via la chip "Suivre +".
         # keyword + include_unfollowed: même politique d'élargissement.
         # followed_source_ids: followed sources only (no curated enrichment)
+        # personalized_theme_mode: theme/topic restreint aux followed → reuse
+        #   two-phase path (timeout + curated fallback hérités).
         _use_two_phase = False
         if source_id:
             query = query.where(Content.source_id == source_id)
+        elif personalized_theme_mode and followed_source_ids:
+            _use_two_phase = True
+        elif personalized_theme_mode:
+            # Edge: user follows zero sources → fallback curated pour ne pas
+            # rendre la section vide.
+            query = query.where(Source.is_curated, Source.source_tier != "deep")
         elif theme or topic or entity or (keyword and include_unfollowed):
             pass
         elif followed_source_ids:
@@ -2481,6 +2503,14 @@ class RecommendationService:
         if keyword and not source_id:
             query = apply_keyword_filter(query, keyword)
 
+        # Tournée du jour : fenêtre 24h sur les sections curées par thème/topic.
+        # Aligne le pool de candidats avec la notion de "fraîcheur du jour".
+        if personalized_theme_mode:
+            since_24h = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+                hours=24
+            )
+            query = query.where(Content.published_at >= since_24h)
+
         if _use_two_phase:
             # Followed sources only — no curated enrichment in default feed.
             # Curated enrichment is reserved for digest (digest_selector.py).
@@ -2494,9 +2524,19 @@ class RecommendationService:
                 )
             else:
                 user_query = query.where(Source.id.in_(list(followed_source_ids)))
-            user_query = user_query.order_by(Content.published_at.desc()).limit(
-                limit_candidates
-            )
+            if personalized_theme_mode and user_subtopics:
+                # Soft boost via ORDER BY : articles matchant un user_subtopic
+                # remontent en tête, mais pas de section vide si l'intersection
+                # est nulle (`overlap` retourne False, on dégrade vers le tri
+                # chronologique pur).
+                user_query = user_query.order_by(
+                    Content.topics.overlap(list(user_subtopics)).desc(),
+                    Content.published_at.desc(),
+                ).limit(limit_candidates)
+            else:
+                user_query = user_query.order_by(Content.published_at.desc()).limit(
+                    limit_candidates
+                )
             # The followed-only query on the default (unfiltered) view can
             # hang under a bad plan when the user has many followed sources —
             # other branches dodge it thanks to their `is_curated` narrowing.

--- a/packages/api/tests/editorial/test_pipeline.py
+++ b/packages/api/tests/editorial/test_pipeline.py
@@ -440,7 +440,17 @@ class TestSubjectTrimAndRenumber:
 
         clusters = [_make_cluster_mock(f"c{i}", f"Cluster {i}") for i in range(1, 7)]
 
-        with patch(
+        # Le test mesure la boucle drop+renumber sur la frontière "target".
+        # On épingle target=5/buffer=2 (config legacy) pour découpler la garantie
+        # du défaut courant (qui a évolué à 10/4 en mai 2026).
+        with patch.dict(
+            "os.environ",
+            {
+                "EDITORIAL_TARGET_SUBJECT_COUNT": "5",
+                "EDITORIAL_SUBJECT_BUFFER": "2",
+            },
+            clear=False,
+        ), patch(
             "app.services.editorial.pipeline.ImportanceDetector"
         ) as mock_detector_cls:
             mock_detector = MagicMock()

--- a/packages/api/tests/editorial/test_pipeline_mode_filters.py
+++ b/packages/api/tests/editorial/test_pipeline_mode_filters.py
@@ -191,7 +191,8 @@ class TestLowPrioritySportCap:
         from app.services.editorial.pipeline import EditorialPipelineService
 
         # 3 sport clusters + enough non-sport clusters so the cap is applied
-        # (cap is skipped when it would leave < 5 clusters for curation).
+        # (cap is skipped when it would leave < target clusters for curation).
+        # On épingle target=5 pour découpler ce test de l'évolution du défaut.
         clusters = [
             _make_cluster("sport1", ["PSG OM"], theme="sport", source_count=5),
             _make_cluster("sport2", ["Tennis Roland-Garros"], theme="sport"),
@@ -215,7 +216,9 @@ class TestLowPrioritySportCap:
         mock_deps["curation"].select_topics.side_effect = _capture_select_topics
 
         svc = EditorialPipelineService(AsyncMock())
-        with patch(
+        with patch.dict(
+            "os.environ", {"EDITORIAL_TARGET_SUBJECT_COUNT": "5"}, clear=False
+        ), patch(
             "app.services.editorial.pipeline.ImportanceDetector"
         ) as mock_detector_cls:
             mock_detector = MagicMock()

--- a/packages/api/tests/test_personalized_theme_mode.py
+++ b/packages/api/tests/test_personalized_theme_mode.py
@@ -1,0 +1,193 @@
+"""Unit tests for the Tournée du jour personalized theme mode.
+
+When `?personalized=true` is combined with `?theme=` or `?topic=` on
+`/api/feed/`, `_get_candidates` must:
+  1. restrict the candidate pool to articles published in the last 24h,
+  2. restrict sources to the user's followed sources (with the existing
+     two-phase + curated fallback path on empty follow set), and
+  3. boost articles whose `Content.topics` overlap `user_subtopics` via a
+     secondary ORDER BY (soft boost — does not exclude non-matchers).
+
+When `personalized=False`, the existing exploration mode (chip taps) must
+behave exactly as before: no source restriction, no time window, no
+subtopic ORDER BY tweak.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.services.recommendation_service import RecommendationService
+
+
+def _stub_scalars(captured: list):
+    """Return an async `session.scalars` that captures the compiled SQL."""
+
+    result = MagicMock()
+    result.all.return_value = []
+
+    async def _scalars(stmt):
+        captured.append(
+            stmt.compile(compile_kwargs={"literal_binds": False}).__str__()
+        )
+        return result
+
+    return _scalars, result
+
+
+def _make_service():
+    session = MagicMock()
+    session.rollback = AsyncMock()
+    return RecommendationService(session), session
+
+
+@pytest.mark.asyncio
+async def test_personalized_theme_filters_to_followed_sources():
+    """personalized=True + theme + followed → SQL restricts to followed sources."""
+    service, session = _make_service()
+    captured: list[str] = []
+    session.scalars, _ = _stub_scalars(captured)
+
+    followed = {uuid4(), uuid4()}
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            theme="tech",
+            personalized=True,
+            followed_source_ids=followed,
+        ),
+        timeout=5.0,
+    )
+
+    assert captured, "expected at least one SQL statement to be issued"
+    sql = captured[0].lower()
+    # Two-phase path → followed-only WHERE clause.
+    assert "sources.id in" in sql or "source.id in" in sql, (
+        "personalized theme mode should filter on followed sources via "
+        f"two-phase. Got:\n{captured[0]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_personalized_theme_applies_24h_window():
+    """personalized=True + theme → SQL adds Content.published_at >= now-24h."""
+    service, session = _make_service()
+    captured: list[str] = []
+    session.scalars, _ = _stub_scalars(captured)
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            theme="tech",
+            personalized=True,
+            followed_source_ids={uuid4()},
+        ),
+        timeout=5.0,
+    )
+
+    sql = captured[0].lower()
+    assert "published_at" in sql and ">=" in sql, (
+        "personalized theme mode should add a published_at >= cutoff filter."
+        f" Got:\n{captured[0]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_personalized_theme_subtopic_boost_in_order_by():
+    """personalized=True + theme + user_subtopics → ORDER BY includes overlap."""
+    service, session = _make_service()
+    captured: list[str] = []
+    session.scalars, _ = _stub_scalars(captured)
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            theme="tech",
+            personalized=True,
+            followed_source_ids={uuid4()},
+            user_subtopics={"ai", "startups"},
+        ),
+        timeout=5.0,
+    )
+
+    sql = captured[0].lower()
+    # `Content.topics.overlap([...])` compiles to the `&&` operator on
+    # Postgres dialect; on the default SA dialect it emits "overlap".
+    assert "overlap" in sql or "&&" in sql, (
+        "subtopic boost should add an overlap-based ORDER BY tie-breaker. "
+        f"Got:\n{captured[0]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_personalized_theme_no_followed_falls_back_to_curated():
+    """personalized=True + theme + no followed sources → curated fallback,
+    not two-phase. Section never empty just because user follows nothing."""
+    service, session = _make_service()
+    captured: list[str] = []
+    session.scalars, _ = _stub_scalars(captured)
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            theme="tech",
+            personalized=True,
+            followed_source_ids=set(),
+        ),
+        timeout=5.0,
+    )
+
+    sql = captured[0].lower()
+    assert "is_curated" in sql, (
+        "personalized theme mode with zero followed sources must fall back "
+        f"to the curated query. Got:\n{captured[0]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_filter_unchanged_when_personalized_false():
+    """Regression guard for the exploration chip path.
+
+    theme set + personalized=False → existing behavior: no source
+    restriction (all active sources), no 24h window, no subtopic ORDER BY.
+    """
+    service, session = _make_service()
+    captured: list[str] = []
+    session.scalars, _ = _stub_scalars(captured)
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            theme="tech",
+            personalized=False,
+            followed_source_ids={uuid4()},
+            user_subtopics={"ai"},
+        ),
+        timeout=5.0,
+    )
+
+    sql = captured[0].lower()
+    # Exploration mode must NOT restrict on followed sources or curated:
+    # neither the followed-source IN-list nor the curated filter applies.
+    assert "sources.id in" not in sql and "source.id in" not in sql, (
+        "exploration (personalized=False) must not restrict on followed "
+        f"sources. Got:\n{captured[0]}"
+    )
+    # No 24h window either.
+    assert ">= " not in sql or "published_at" not in sql, (
+        "exploration must not add a 24h published_at filter. "
+        f"Got:\n{captured[0]}"
+    )
+    # No overlap-based ORDER BY.
+    assert "overlap" not in sql and "&&" not in sql, (
+        "exploration must not add a subtopic overlap ORDER BY. "
+        f"Got:\n{captured[0]}"
+    )

--- a/packages/api/tests/test_perspectives_alignment.py
+++ b/packages/api/tests/test_perspectives_alignment.py
@@ -1,0 +1,230 @@
+"""Garantit l'invariant "tout content_id appartenant à un digest editorial_v1
+récent → fast path stored snapshot, jamais live recompute".
+
+Bug fixé : `_load_stored_perspectives_for_representative` ne matchait pas
+`deep_article.content_id`. Un tap sur la card "pas de recul" tombait alors en
+live path → count diverge du badge preview.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.models.daily_digest import DailyDigest
+from app.routers.contents import _load_stored_perspectives_for_representative
+
+
+def _make_digest(subjects: list[dict]) -> DailyDigest:
+    digest = DailyDigest()
+    digest.id = uuid4()
+    digest.user_id = uuid4()
+    digest.target_date = date(2026, 5, 20)
+    digest.format_version = "editorial_v1"
+    digest.is_serene = False
+    digest.items = {"subjects": subjects}
+    return digest
+
+
+def _make_subject(
+    representative_id: UUID,
+    actu_id: UUID,
+    extra_ids: list[UUID],
+    deep_id: UUID | None,
+    perspective_count: int = 5,
+    *,
+    omit_snapshot: bool = False,
+) -> dict:
+    """Build a subject dict matching the pipeline persistence shape."""
+    snapshot = [
+        {
+            "title": f"Perspective {i}",
+            "url": f"https://example.com/p{i}",
+            "source_name": f"Source {i}",
+            "source_domain": f"src{i}.com",
+            "bias_stance": "center",
+            "published_at": None,
+            "description": None,
+        }
+        for i in range(perspective_count)
+    ]
+    return {
+        "topic_id": "topic-1",
+        "representative_content_id": str(representative_id),
+        "actu_article": {"content_id": str(actu_id)},
+        "extra_actu_articles": [{"content_id": str(eid)} for eid in extra_ids],
+        "deep_article": {"content_id": str(deep_id)} if deep_id else None,
+        "perspective_articles": None if omit_snapshot else snapshot,
+        "bias_distribution": {
+            "left": 0,
+            "center-left": 0,
+            "center": perspective_count,
+            "center-right": 0,
+            "right": 0,
+        },
+        "perspective_count": perspective_count,
+    }
+
+
+def _mock_db_returning(digest: DailyDigest) -> AsyncMock:
+    db = AsyncMock()
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = [digest] if digest else []
+    result.scalars.return_value = scalars
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_fast_path_matches_representative():
+    representative = uuid4()
+    actu = uuid4()
+    extra = uuid4()
+    deep = uuid4()
+    subject = _make_subject(representative, actu, [extra], deep, perspective_count=5)
+    digest = _make_digest([subject])
+    db = _mock_db_returning(digest)
+
+    result = await _load_stored_perspectives_for_representative(
+        db=db, content_id=representative, user_id=digest.user_id
+    )
+
+    assert result is not None
+    perspectives, bias = result
+    assert len(perspectives) == 5
+    assert bias["center"] == 5
+
+
+@pytest.mark.asyncio
+async def test_fast_path_matches_actu():
+    representative = uuid4()
+    actu = uuid4()
+    deep = uuid4()
+    subject = _make_subject(representative, actu, [], deep, perspective_count=5)
+    digest = _make_digest([subject])
+    db = _mock_db_returning(digest)
+
+    result = await _load_stored_perspectives_for_representative(
+        db=db, content_id=actu, user_id=digest.user_id
+    )
+    assert result is not None
+    assert len(result[0]) == 5
+
+
+@pytest.mark.asyncio
+async def test_fast_path_matches_extra_actu():
+    representative = uuid4()
+    actu = uuid4()
+    extra = uuid4()
+    deep = uuid4()
+    subject = _make_subject(representative, actu, [extra], deep, perspective_count=4)
+    digest = _make_digest([subject])
+    db = _mock_db_returning(digest)
+
+    result = await _load_stored_perspectives_for_representative(
+        db=db, content_id=extra, user_id=digest.user_id
+    )
+    assert result is not None
+    assert len(result[0]) == 4
+
+
+@pytest.mark.asyncio
+async def test_fast_path_matches_deep_article():
+    """Régression principale : tap sur card 'pas de recul' (deep_article)
+    doit hit fast path et retourner le même snapshot que les autres IDs.
+    """
+    representative = uuid4()
+    actu = uuid4()
+    deep = uuid4()
+    subject = _make_subject(representative, actu, [], deep, perspective_count=5)
+    digest = _make_digest([subject])
+    db = _mock_db_returning(digest)
+
+    result = await _load_stored_perspectives_for_representative(
+        db=db, content_id=deep, user_id=digest.user_id
+    )
+    assert result is not None
+    perspectives, bias = result
+    assert len(perspectives) == 5
+    assert bias["center"] == 5
+
+
+@pytest.mark.asyncio
+async def test_fast_path_all_five_ids_return_same_snapshot():
+    """Tous les content_ids rattachés au même sujet doivent retourner
+    exactement le même snapshot."""
+    representative = uuid4()
+    actu = uuid4()
+    extras = [uuid4(), uuid4()]
+    deep = uuid4()
+    subject = _make_subject(
+        representative, actu, extras, deep, perspective_count=5
+    )
+    digest = _make_digest([subject])
+
+    all_ids = [representative, actu, *extras, deep]
+    snapshots = []
+    for cid in all_ids:
+        db = _mock_db_returning(digest)
+        result = await _load_stored_perspectives_for_representative(
+            db=db, content_id=cid, user_id=digest.user_id
+        )
+        assert result is not None, f"content_id {cid} should hit fast path"
+        snapshots.append(result[0])
+
+    # Toutes les listes doivent être identiques (même nombre, mêmes urls).
+    urls = [tuple(p["url"] for p in s) for s in snapshots]
+    assert len(set(urls)) == 1, "All matched IDs must return the same snapshot"
+
+
+@pytest.mark.asyncio
+async def test_fast_path_returns_empty_when_snapshot_missing():
+    """Invariant A.2 : si le sujet est trouvé mais perspective_articles is None
+    (legacy / bug pipeline), retourner ([], bias) plutôt que None, pour
+    empêcher le fallback live qui divergerait du badge."""
+    representative = uuid4()
+    actu = uuid4()
+    deep = uuid4()
+    subject = _make_subject(
+        representative, actu, [], deep, perspective_count=5, omit_snapshot=True
+    )
+    digest = _make_digest([subject])
+    db = _mock_db_returning(digest)
+
+    result = await _load_stored_perspectives_for_representative(
+        db=db, content_id=representative, user_id=digest.user_id
+    )
+
+    assert result is not None, "must NOT fall back to live path"
+    perspectives, _ = result
+    assert perspectives == []
+
+
+@pytest.mark.asyncio
+async def test_fast_path_returns_none_for_unrelated_content():
+    """content_id hors digest récent → None → live path."""
+    representative = uuid4()
+    actu = uuid4()
+    deep = uuid4()
+    subject = _make_subject(representative, actu, [], deep)
+    digest = _make_digest([subject])
+    db = _mock_db_returning(digest)
+
+    unrelated = uuid4()
+    result = await _load_stored_perspectives_for_representative(
+        db=db, content_id=unrelated, user_id=digest.user_id
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fast_path_returns_none_when_no_digest():
+    db = _mock_db_returning(None)
+    result = await _load_stored_perspectives_for_representative(
+        db=db, content_id=uuid4(), user_id=uuid4()
+    )
+    assert result is None

--- a/packages/api/tests/test_pipeline_target_count.py
+++ b/packages/api/tests/test_pipeline_target_count.py
@@ -1,0 +1,109 @@
+"""Contrat env-var pour le passage 5 → 10 sujets.
+
+Les hyper-paramètres `target_subject_count` et `_SUBJECT_BUFFER` sont
+maintenant lus depuis les variables d'environnement
+`EDITORIAL_TARGET_SUBJECT_COUNT` / `EDITORIAL_SUBJECT_BUFFER`. Le defaut est
+10 / 4 ; un override `=5` ramène au comportement antérieur pour rollback safe.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.services.editorial.pipeline import (
+    _DEFAULT_SUBJECT_BUFFER,
+    _DEFAULT_TARGET_SUBJECT_COUNT,
+    _read_subject_buffer,
+    _read_target_subject_count,
+)
+
+
+def test_default_target_subject_count_is_ten():
+    assert _DEFAULT_TARGET_SUBJECT_COUNT == 10
+
+
+def test_default_subject_buffer_is_four():
+    assert _DEFAULT_SUBJECT_BUFFER == 4
+
+
+def test_target_count_uses_default_when_env_unset():
+    with patch.dict("os.environ", {}, clear=False):
+        # On retire la variable si elle existe au cas où.
+        import os
+
+        os.environ.pop("EDITORIAL_TARGET_SUBJECT_COUNT", None)
+        assert _read_target_subject_count() == 10
+
+
+def test_target_count_honors_env_override():
+    with patch.dict(
+        "os.environ", {"EDITORIAL_TARGET_SUBJECT_COUNT": "5"}, clear=False
+    ):
+        assert _read_target_subject_count() == 5
+
+
+def test_target_count_invalid_env_falls_back_to_default():
+    with patch.dict(
+        "os.environ", {"EDITORIAL_TARGET_SUBJECT_COUNT": "not-a-number"},
+        clear=False,
+    ):
+        assert _read_target_subject_count() == 10
+
+
+def test_target_count_floor_is_one():
+    """Even with EDITORIAL_TARGET_SUBJECT_COUNT=0 we must keep >=1 subject."""
+    with patch.dict(
+        "os.environ", {"EDITORIAL_TARGET_SUBJECT_COUNT": "0"}, clear=False
+    ):
+        assert _read_target_subject_count() >= 1
+
+
+def test_subject_buffer_uses_default_when_env_unset():
+    import os
+
+    os.environ.pop("EDITORIAL_SUBJECT_BUFFER", None)
+    assert _read_subject_buffer() == 4
+
+
+def test_subject_buffer_honors_env_override():
+    with patch.dict("os.environ", {"EDITORIAL_SUBJECT_BUFFER": "3"}, clear=False):
+        assert _read_subject_buffer() == 3
+
+
+def test_subject_buffer_invalid_env_falls_back_to_default():
+    with patch.dict(
+        "os.environ", {"EDITORIAL_SUBJECT_BUFFER": "abc"}, clear=False
+    ):
+        assert _read_subject_buffer() == 4
+
+
+def test_subject_buffer_floor_is_zero():
+    with patch.dict("os.environ", {"EDITORIAL_SUBJECT_BUFFER": "-5"}, clear=False):
+        assert _read_subject_buffer() == 0
+
+
+def test_oversample_count_with_a_la_une_at_default():
+    """Quand À la Une est sélectionnée, on demande (target-1) + buffer topics."""
+    target = _read_target_subject_count()  # 10
+    buffer = _read_subject_buffer()  # 4
+    remaining = target - 1
+    oversample = remaining + buffer
+    assert oversample == 13
+
+
+def test_oversample_count_legacy_5_rollback():
+    """Avec rollback EDITORIAL_TARGET_SUBJECT_COUNT=5 + buffer=2,
+    l'oversample doit redescendre à 6 (= ancien comportement)."""
+    with patch.dict(
+        "os.environ",
+        {
+            "EDITORIAL_TARGET_SUBJECT_COUNT": "5",
+            "EDITORIAL_SUBJECT_BUFFER": "2",
+        },
+        clear=False,
+    ):
+        target = _read_target_subject_count()
+        buffer = _read_subject_buffer()
+        assert target == 5
+        assert buffer == 2
+        assert (target - 1) + buffer == 6


### PR DESCRIPTION
## Quoi

Deux features mobile bundlées, plus une passe simplify.

**1. Digest briefing — limite d'affichage 3/5/7**
- Nouvelle prop `displayLimit` sur `DigestBriefingSection` + toggle local « Voir N autres / Réduire ».
- Hero et `dailyGoal` clampés sur la pref user `dailyArticleCount` au lieu du total backend (jusqu'à 10).
- Backend : `contents.py` / `digest_service.py` / `editorial/pipeline.py` respectent la pref user. `_compute_target_size()` mutualisé entre `select_for_user` et `_build_editorial_response`.
- Pipeline editorial : `_read_target_subject_count` / `_read_subject_buffer` surcouchables via env (`EDITORIAL_TARGET_SUBJECT_COUNT`, `EDITORIAL_SUBJECT_BUFFER`) — rollback safe au comportement 5-sujets antérieur.

**2. Flux Continu — pagination in-place « +10 »**
- Nouveau `LoadMoreButton` qui appende 10 articles dans la même section (remplace l'ancien toggle Plus de / Replier pour les `FeedThemeSection`).
- `flux_continu_provider.loadMoreTheme()` étendu : dedupe par `content_id`, gestion `isLoadingMore` / `hasMore`, recovery state si réorganisation entre les pages.
- Backend : `feed.py` / `recommendation_service.py` étendus avec un mode personnalisé (followed sources + user subtopics) pour la pagination thématique.

**3. Refactor simplify**
- `_compute_target_size()` extrait (dédupe SQL UserProfile).
- `_read_int_env()` factorise les helpers env-int.
- `loadMoreTheme` route via le helper `_safe<>` existant (au lieu d'un try/catch + `print`).
- Cleanup des imports inline et commentaires narratifs.

## Pourquoi

Le digest forçait jusqu'à 10 sujets quel que soit le réglage utilisateur — la barre de progression ne se complétait jamais à 3/5/7. Le flux continu repliait toute une section dès le 10ᵉ article alors que la lecture continue est l'attendu produit.

## Comment ça a été vérifié

- [x] `pytest -q` backend → 1135 passed, 2 NER flaky pré-existants (pas touché)
- [x] Tests ciblés : `tests/test_pipeline_target_count.py`, `tests/test_personalized_theme_mode.py`, `tests/test_perspectives_alignment.py`, `tests/editorial/` → 149 passed
- [x] `flutter test test/features/digest test/features/flux_continu` → 130 passed (14 placeholders pré-existants `Test not implemented` dans des fichiers non touchés)
- [x] `flutter analyze` → 0 erreurs, 0 nouveaux warnings sur les fichiers du PR
- [x] /simplify passé (commit 8f9962a0)

## Zones à risque

- `digest_service.py` hotpath lecture digest (cache hit `_build_editorial_response`)
- `editorial/pipeline.py` : passage du target par défaut 5 → 10, env-var de rollback (`EDITORIAL_TARGET_SUBJECT_COUNT=5`)
- `recommendation_service.py` : nouveau mode personnalisé (theme + subtopics overlap) pour pagination
- `flux_continu_provider.dart` : state machine pagination (re-read state après await pour gérer reorder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)