### PR TITLE
feat(tracking): track app version per user for distribution dashboard

### DIFF
--- a/apps/mobile/lib/core/api/api_client.dart
+++ b/apps/mobile/lib/core/api/api_client.dart
@@ -27,7 +27,13 @@ class ApiClient {
     String? baseUrl,
     this.onAuthError,
     this.onAuthRecovered,
+    String? appVersion,
   }) {
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      if (appVersion != null) 'X-App-Version': appVersion,
+    };
     _dio = Dio(
       BaseOptions(
         baseUrl: baseUrl ?? ApiConstants.baseUrl,
@@ -35,10 +41,7 @@ class ApiClient {
         // Backend optimizations are in progress, this buys time for those to take effect
         connectTimeout: const Duration(seconds: 30),
         receiveTimeout: ApiConstants.timeout,
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-        },
+        headers: headers,
       ),
     );
 

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 import 'package:facteur/core/api/api_client.dart';
@@ -21,6 +22,7 @@ class AnalyticsService {
   String? _deviceId;
   String? _sessionId;
   DateTime? _sessionStartTime;
+  String? _appVersion;
 
   AnalyticsService(ApiClient this._apiClient, {PostHogService? posthog})
       : _posthog = posthog;
@@ -39,6 +41,12 @@ class AnalyticsService {
       _deviceId = const Uuid().v4();
       await prefs.setString('analytics_device_id', _deviceId!);
     }
+    try {
+      final info = await PackageInfo.fromPlatform();
+      _appVersion = '${info.version}+${info.buildNumber}';
+    } catch (_) {
+      // Best-effort — version tracking degrades gracefully if unavailable
+    }
   }
 
   Future<void> startSession({bool isOrganic = true}) async {
@@ -49,6 +57,7 @@ class AnalyticsService {
       'session_id': _sessionId,
       'is_organic': isOrganic,
       'platform': defaultTargetPlatform.toString(),
+      if (_appVersion != null) 'app_version': _appVersion,
     });
     // Story 14.1 — PostHog uses `app_open` as the conventional event name
     // for DAU/retention computation. We mirror session_start to it.
@@ -56,6 +65,7 @@ class AnalyticsService {
       'session_id': _sessionId,
       'is_organic': isOrganic,
       'platform': defaultTargetPlatform.toString(),
+      if (_appVersion != null) 'app_version': _appVersion,
     });
   }
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -211,6 +212,14 @@ Future<void> _bootstrap() async {
     final posthog = PostHogService();
     await posthog.init();
 
+    String? appVersion;
+    try {
+      final info = await PackageInfo.fromPlatform();
+      appVersion = '${info.version}+${info.buildNumber}';
+    } catch (_) {
+      // Best-effort — version tracking degrades gracefully
+    }
+
     // Émettre l'état des notifs locales collecté au boot (capture après init
     // PostHog : avant, capture() est un no-op silencieux).
     if (bootNotifDiag != null) {
@@ -228,7 +237,7 @@ Future<void> _bootstrap() async {
       if (user != null) {
         await posthog.identify(
           userId: user.id,
-          properties: _userIdentifyProperties(user),
+          properties: _userIdentifyProperties(user, appVersion: appVersion),
         );
       }
     }
@@ -241,7 +250,7 @@ Future<void> _bootstrap() async {
           if (user != null) {
             posthog.identify(
               userId: user.id,
-              properties: _userIdentifyProperties(user),
+              properties: _userIdentifyProperties(user, appVersion: appVersion),
             );
           }
           break;
@@ -269,7 +278,7 @@ Future<void> _bootstrap() async {
 /// User properties pushed à chaque `$identify` PostHog. Permet de filtrer
 /// dashboard et insights par email/provider sans devoir matcher manuellement
 /// les distinct_id Supabase.
-Map<String, Object> _userIdentifyProperties(User user) {
+Map<String, Object> _userIdentifyProperties(User user, {String? appVersion}) {
   final props = <String, Object>{};
   if (user.email != null && user.email!.isNotEmpty) {
     props['email'] = user.email!;
@@ -277,6 +286,9 @@ Map<String, Object> _userIdentifyProperties(User user) {
   final providers = user.appMetadata['providers'];
   if (providers is List) {
     props['auth_providers'] = providers.join(',');
+  }
+  if (appVersion != null) {
+    props['app_version'] = appVersion;
   }
   return props;
 }

--- a/packages/api/alembic/versions/vt01_user_app_version.py
+++ b/packages/api/alembic/versions/vt01_user_app_version.py
@@ -1,0 +1,36 @@
+"""user app version tracking — app_version + app_version_updated_at on user_profiles.
+
+Stores the last app version seen per user, updated on each session_start event.
+Enables a version distribution dashboard without requiring dedicated device tables.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "vt01_user_app_version"
+down_revision: str | None = "23a3_custom_topic_fav_drop"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_profiles",
+        sa.Column("app_version", sa.String(length=20), nullable=True),
+    )
+    op.add_column(
+        "user_profiles",
+        sa.Column("app_version_updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_user_profiles_app_version",
+        "user_profiles",
+        ["app_version"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_profiles_app_version", table_name="user_profiles")
+    op.drop_column("user_profiles", "app_version_updated_at")
+    op.drop_column("user_profiles", "app_version")

--- a/packages/api/app/models/user.py
+++ b/packages/api/app/models/user.py
@@ -44,6 +44,13 @@ class UserProfile(Base):
     # SHA256 of the auth.users email captured at delete-time — kept post-purge
     # for support/legal traceability without storing PII.
     email_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Last app version seen for this user (e.g. "1.2.3+42"), updated on session_start.
+    app_version: Mapped[str | None] = mapped_column(
+        String(20), nullable=True, index=True
+    )
+    app_version_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow
     )

--- a/packages/api/app/routers/analytics.py
+++ b/packages/api/app/routers/analytics.py
@@ -1,6 +1,6 @@
 """Router pour les analytics."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Header
@@ -36,7 +36,7 @@ async def _update_app_version(user_id: UUID, app_version: str) -> None:
                   AND app_version IS DISTINCT FROM :v
                 """
             ),
-            {"v": app_version, "ts": datetime.now(timezone.utc), "uid": str(user_id)},
+            {"v": app_version, "ts": datetime.now(UTC), "uid": str(user_id)},
         )
         await db.commit()
 

--- a/packages/api/app/routers/analytics.py
+++ b/packages/api/app/routers/analytics.py
@@ -1,12 +1,14 @@
 """Router pour les analytics."""
 
+from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends, Header
 from pydantic import BaseModel, Field
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import get_db
+from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
 from app.services.analytics_service import AnalyticsService
 
@@ -21,11 +23,31 @@ class EventCreate(BaseModel):
     device_id: str | None = Field(None, description="Identifiant unique du device")
 
 
+async def _update_app_version(user_id: UUID, app_version: str) -> None:
+    """Met à jour app_version sur user_profiles si la version a changé (fire-and-forget)."""
+    async with safe_async_session() as db:
+        await db.execute(
+            text(
+                """
+                UPDATE user_profiles
+                SET app_version = :v,
+                    app_version_updated_at = :ts
+                WHERE user_id = :uid
+                  AND app_version IS DISTINCT FROM :v
+                """
+            ),
+            {"v": app_version, "ts": datetime.now(timezone.utc), "uid": str(user_id)},
+        )
+        await db.commit()
+
+
 @router.post("/events", status_code=201)
 async def log_event(
     event: EventCreate,
+    background_tasks: BackgroundTasks,
     user_id: UUID = Depends(get_current_user_id),
     db: AsyncSession = Depends(get_db),
+    x_app_version: str | None = Header(None, alias="X-App-Version"),
 ):
     """Enregistre un événement analytique."""
     service = AnalyticsService(db)
@@ -35,6 +57,17 @@ async def log_event(
         event_data=event.event_data,
         device_id=event.device_id,
     )
+
+    # Update per-user version tracking on session_start or when header is present.
+    # Priority: explicit header > event_data field.
+    app_version = x_app_version or (
+        event.event_data.get("app_version")
+        if event.event_type == "session_start"
+        else None
+    )
+    if app_version:
+        background_tasks.add_task(_update_app_version, user_id, app_version)
+
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Quoi

Ajoute le tracking de la version d'app installée par utilisateur, côté backend et mobile. Deux nouvelles colonnes sur `user_profiles` (`app_version`, `app_version_updated_at`) mises à jour en background à chaque `session_start`.

## Pourquoi

Débloquer la donnée nécessaire pour un futur dashboard de distribution des versions (quel % d'utilisateurs sont sur quelle version). Scope de cette PR : data layer uniquement — le dashboard sera construit séparément.

## Architecture

- **Mobile → Backend** : la version (`1.2.3+42`) est incluse dans le payload de l'event `session_start` (`event_data.app_version`) via `AnalyticsService.init()` + `PackageInfo.fromPlatform()`
- **Backend** : `POST /analytics/events` lit le header `X-App-Version` (prioritaire) ou `event_data.app_version` sur `session_start`, et lance un `BackgroundTask` qui fait un `UPDATE ... WHERE app_version IS DISTINCT FROM :v` (0 write si version inchangée)
- **PostHog** : `app_version` ajouté aux properties de `identify()` au boot pour les insights PostHog

## Migration

`vt01_user_app_version` : ajoute `app_version VARCHAR(20)` + `app_version_updated_at TIMESTAMPTZ` + index sur `user_profiles`.

## Requête dashboard (pour la prochaine PR)

```sql
SELECT app_version, COUNT(*) AS users
FROM user_profiles
WHERE deleted_at IS NULL AND app_version IS NOT NULL
GROUP BY app_version ORDER BY users DESC;
```

## Comment ça a été vérifié

- [x] `alembic heads` → 1 seul head (`vt01_user_app_version`)
- [x] Migration appliquée sur DB locale — colonnes présentes confirmées
- [x] `pytest` → 1100 passed (failure NER pré-existante exclue)
- [x] `flutter analyze` → 0 erreurs
- [x] API locale démarrée, endpoint `/api/health` OK
- [x] `/simplify` passé — dead code `ApiClient.create()` supprimé, import Python déplacé au niveau module

## Zones à risque

- `packages/api/app/routers/analytics.py` — endpoint `POST /analytics/events` modifié (ajout BackgroundTask, lecture header)
- `packages/api/alembic/versions/vt01_user_app_version.py` — nouvelle migration (rejouée au boot Railway)