### PR TITLE
fix(perspectives): filtre bias appliqué à PerspectivesInlineSection (item 6 PR+3.a)

### DIFF
--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1323,11 +1323,18 @@ class _PerspectivesInlineSectionState
     return sorted;
   }
 
+  List<Perspective> get _filteredPerspectives {
+    final sorted = _sortedPerspectives;
+    final selected = widget.externalSelectedSegments;
+    if (selected == null || selected.isEmpty) return sorted;
+    return sorted.where((p) => selected.contains(p.biasGroup)).toList();
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
-    final variants = _sortedPerspectives.take(8).toList();
+    final variants = _filteredPerspectives.take(8).toList();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_filter_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_filter_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
+
+Perspective _persp(String name, String bias) => Perspective(
+      title: 'Titre pour $name',
+      url: 'https://example.com/$name',
+      sourceName: name,
+      sourceDomain: '',
+      biasStance: bias,
+    );
+
+Future<void> _pumpSection(
+  WidgetTester tester, {
+  required Set<String>? selectedSegments,
+}) async {
+  final perspectives = [
+    _persp('Source-Gauche', 'left'),
+    _persp('Source-CentreG', 'center-left'),
+    _persp('Source-Centre', 'center'),
+    _persp('Source-CentreD', 'center-right'),
+    _persp('Source-Droite', 'right'),
+  ];
+
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SizedBox(
+              width: 390,
+              child: PerspectivesInlineSection(
+                perspectives: perspectives,
+                biasDistribution: const {
+                  'left': 1,
+                  'center-left': 1,
+                  'center': 1,
+                  'center-right': 1,
+                  'right': 1,
+                },
+                keywords: const [],
+                contentId: 'test-content-id',
+                externalSelectedSegments: selectedSegments,
+                onSegmentTap: (_) {},
+                onClearSegments: () {},
+                onToggle: () {},
+                isExpanded: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('shows all variants when selectedSegments is null', (tester) async {
+    await _pumpSection(tester, selectedSegments: null);
+
+    expect(find.text('Source-Gauche'), findsOneWidget);
+    expect(find.text('Source-CentreG'), findsOneWidget);
+    expect(find.text('Source-Centre'), findsOneWidget);
+    expect(find.text('Source-CentreD'), findsOneWidget);
+    expect(find.text('Source-Droite'), findsOneWidget);
+  });
+
+  testWidgets('shows all variants when selectedSegments is empty', (tester) async {
+    await _pumpSection(tester, selectedSegments: const <String>{});
+
+    expect(find.text('Source-Gauche'), findsOneWidget);
+    expect(find.text('Source-Centre'), findsOneWidget);
+    expect(find.text('Source-Droite'), findsOneWidget);
+  });
+
+  testWidgets("shows only left-leaning variants when selected = {'gauche'}",
+      (tester) async {
+    await _pumpSection(tester, selectedSegments: const {'gauche'});
+
+    expect(find.text('Source-Gauche'), findsOneWidget);
+    expect(find.text('Source-CentreG'), findsOneWidget);
+    expect(find.text('Source-Centre'), findsNothing);
+    expect(find.text('Source-CentreD'), findsNothing);
+    expect(find.text('Source-Droite'), findsNothing);
+  });
+
+  testWidgets("shows centre-only when selected = {'centre'}", (tester) async {
+    await _pumpSection(tester, selectedSegments: const {'centre'});
+
+    expect(find.text('Source-Gauche'), findsNothing);
+    expect(find.text('Source-CentreG'), findsNothing);
+    expect(find.text('Source-Centre'), findsOneWidget);
+    expect(find.text('Source-CentreD'), findsNothing);
+    expect(find.text('Source-Droite'), findsNothing);
+  });
+
+  testWidgets("shows gauche+droite when selected = {'gauche','droite'}",
+      (tester) async {
+    await _pumpSection(tester, selectedSegments: const {'gauche', 'droite'});
+
+    expect(find.text('Source-Gauche'), findsOneWidget);
+    expect(find.text('Source-CentreG'), findsOneWidget);
+    expect(find.text('Source-Centre'), findsNothing);
+    expect(find.text('Source-CentreD'), findsOneWidget);
+    expect(find.text('Source-Droite'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Quoi

`PerspectivesInlineSection` recevait bien `externalSelectedSegments`
depuis `content_detail_screen` mais ne s'en servait jamais pour filtrer
ses variants — `_sortedPerspectives.take(8)` retournait toutes les
perspectives, ignorant le segment sélectionné.

## Pourquoi

Signalé par le PO le 2026-05-22 : « si pas toutes les sources, on les
affiche toutes quand même ». Le bar de bias affichait correctement la
sélection (opacité dimmed sur les autres segments) mais la liste de
cartes en-dessous restait inchangée — incohérence visuelle d'autant
plus gênante que le `PerspectivesBottomSheet` cousin (utilisé dans le
modal full-screen) avait depuis le départ un `_filteredPerspectives`
qui faisait le bon truc.

## Comment

```dart
List<Perspective> get _filteredPerspectives {
  final sorted = _sortedPerspectives;
  final selected = widget.externalSelectedSegments;
  if (selected == null || selected.isEmpty) return sorted;
  return sorted.where((p) => selected.contains(p.biasGroup)).toList();
}
```

Puis `build()` utilise `_filteredPerspectives.take(8)` au lieu de
`_sortedPerspectives.take(8)`. Le cap-à-8 est donc appliqué **après**
le filtre, ce qui veut dire que l'utilisateur voit jusqu'à 8 variantes
du ou des segments qu'il a choisis (et non pas 8 non filtrées dont
seulement quelques-unes correspondent).

## Tests

`apps/mobile/test/features/feed/widgets/perspectives_inline_filter_test.dart` (nouveau)
couvre 5 scénarios :

| selected | Doit afficher |
|---|---|
| `null` | les 5 perspectives (left, center-left, center, center-right, right) |
| `{}` | les 5 perspectives |
| `{'gauche'}` | les 2 perspectives left + center-left |
| `{'centre'}` | la perspective center |
| `{'gauche','droite'}` | les 4 perspectives left/center-left/center-right/right (sans center) |

`flutter test test/features/feed/widgets/perspectives_inline_filter_test.dart` → 5 passed.
`flutter analyze` → No issues found.

## Zones à risque

Aucun changement de contrat API, aucune migration, aucun changement
visuel sur le bar lui-même (qui gère son opacité indépendamment). Le
fix est strictement borné à la dérivation des `variants` à partir de
`widget.perspectives` + `widget.externalSelectedSegments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)