### PR TITLE
fix(perspectives): synchroniser cascade highlight avec AnimatedSize parent (item 2 PR+3.b)

### DIFF
--- a/apps/mobile/lib/features/feed/widgets/diff_title.dart
+++ b/apps/mobile/lib/features/feed/widgets/diff_title.dart
@@ -28,9 +28,13 @@ class DiffTitle extends StatefulWidget {
   final bool animateIn;
   final int maxLines;
 
-  /// Délai avant que la cascade commence (laisse le panel se positionner
-  /// avant l'animation pour éviter le jank d'expand).
-  static const Duration kStartDelay = Duration(milliseconds: 80);
+  /// Délai avant que la cascade commence. Doit dépasser la durée du
+  /// `AnimatedSize` parent dans `PerspectivesInlineSection` (250 ms) pour
+  /// que la cascade soit visible — sinon les highlights atteignent leur
+  /// opacité finale pendant que le panel grandit encore en taille, et
+  /// l'utilisateur perçoit un état arrivé directement à l'ouverture
+  /// (bug signalé par le PO 2026-05-22).
+  static const Duration kStartDelay = Duration(milliseconds: 280);
   static const Duration kPerSpan = Duration(milliseconds: 220);
   static const Duration kSpanGap = Duration(milliseconds: 25);
 

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1613,7 +1613,7 @@ class _PivotedRefTitleState extends State<_PivotedRefTitle>
       duration: const Duration(milliseconds: 300),
     );
     if (widget.pivot != null) {
-      Future.delayed(const Duration(milliseconds: 80), () {
+      Future.delayed(DiffTitle.kStartDelay, () {
         if (mounted) _controller.forward();
       });
     } else {

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_animation_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_animation_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart'
+    show HighlightSpan, TokenSpan;
+import 'package:facteur/features/feed/widgets/diff_title.dart';
+import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
+
+Perspective _persp(String name, String bias) => Perspective(
+      title: 'Titre court avec mot fort',
+      url: 'https://example.com/$name',
+      sourceName: name,
+      sourceDomain: '',
+      biasStance: bias,
+      highlightSpans: const [
+        HighlightSpan(start: 18, end: 22, text: 'fort', bias: 'left'),
+      ],
+      sharedTokens: const [TokenSpan(start: 0, end: 5, text: 'Titre')],
+    );
+
+class _Harness extends StatefulWidget {
+  final bool initialExpanded;
+  const _Harness({required this.initialExpanded});
+  @override
+  State<_Harness> createState() => _HarnessState();
+}
+
+class _HarnessState extends State<_Harness> {
+  late bool _expanded;
+  @override
+  void initState() {
+    super.initState();
+    _expanded = widget.initialExpanded;
+  }
+
+  void toggle() => setState(() => _expanded = !_expanded);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: SizedBox(
+          width: 390,
+          child: PerspectivesInlineSection(
+            perspectives: [
+              _persp('Source-Gauche', 'left'),
+              _persp('Source-Centre', 'center'),
+              _persp('Source-Droite', 'right'),
+            ],
+            biasDistribution: const {'left': 1, 'center': 1, 'right': 1},
+            keywords: const [],
+            contentId: 'test',
+            externalSelectedSegments: null,
+            onSegmentTap: (_) {},
+            onClearSegments: () {},
+            onToggle: toggle,
+            isExpanded: _expanded,
+            referenceTitle: 'Titre référence',
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> _pumpHarness(
+  WidgetTester tester, {
+  required bool initialExpanded,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: _Harness(initialExpanded: initialExpanded),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  test(
+      'kStartDelay must outlast PerspectivesInlineSection AnimatedSize (250 ms)',
+      () {
+    // The bug the PO reported: when the panel expands, the AnimatedSize
+    // takes 250 ms to grow. If DiffTitle starts its cascade before then,
+    // the highlights finalize while still hidden behind the growing
+    // container and the user perceives them as already there.
+    expect(
+      DiffTitle.kStartDelay.inMilliseconds,
+      greaterThan(250),
+      reason:
+          'kStartDelay must exceed the 250 ms AnimatedSize duration so the '
+          'cascade is visible after the panel finishes expanding.',
+    );
+  });
+
+  testWidgets('section starts collapsed → no DiffTitle in the tree',
+      (tester) async {
+    await _pumpHarness(tester, initialExpanded: false);
+    expect(find.byType(DiffTitle), findsNothing);
+  });
+
+  testWidgets('tap toggle → DiffTitle mounts and is still pending its anim',
+      (tester) async {
+    await _pumpHarness(tester, initialExpanded: false);
+    expect(find.byType(DiffTitle), findsNothing);
+
+    tester.state<_HarnessState>(find.byType(_Harness)).toggle();
+    await tester.pump();
+
+    // Right after expand, DiffTitle widgets exist in the tree.
+    expect(find.byType(DiffTitle), findsWidgets);
+
+    // Drain the pending Future.delayed timers so flutter_test doesn't
+    // complain about a pending timer at teardown.
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+    expect(find.byType(DiffTitle), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Quoi

Le PO a signalé le 2026-05-22 : « le déclenchement [de l'animation des
highlights] semble se faire au mauvais moment — ou alors ne fonctionne
pas, les highlights apparaissent directement à l'ouverture ».

Au tap sur le toggle « Couverture médiatique » dans la page article,
les highlights de chaque variante atteignaient leur opacité finale
**pendant que le panel grandissait encore en taille** (`AnimatedSize`
parent de 250 ms). Quand le panel atteignait sa hauteur finale, la
cascade était déjà à ~70 % — l'utilisateur n'avait pas le temps de la
percevoir.

```diff
- static const Duration kStartDelay = Duration(milliseconds: 80);
+ static const Duration kStartDelay = Duration(milliseconds: 280);
```

280 ms = juste au-dessus des 250 ms du `AnimatedSize` parent dans
`PerspectivesInlineSection`. La cascade démarre uniquement *après* que
le panel a fini sa transition de taille.

## Pourquoi

Le commentaire d'origine au-dessus de `kStartDelay` disait déjà
« laisse le panel se positionner avant l'animation pour éviter le jank
d'expand ». L'intention était la bonne, mais la valeur ne couvrait pas
la durée réelle de l'`AnimatedSize` parent (introduit après — drift
entre les deux constantes).

## Comment

| Fichier | Change |
|---|---|
| `lib/features/feed/widgets/diff_title.dart` | `kStartDelay` 80→280 ms, commentaire enrichi avec la cause exacte (référence au bug PO 2026-05-22 + la contrainte de 250 ms de l'`AnimatedSize` à ne pas oublier au prochain refactor). |
| `lib/features/feed/widgets/perspectives_bottom_sheet.dart` | `_PivotedRefTitle` utilisait `Future.delayed(80ms)` codé en dur — remplacé par `DiffTitle.kStartDelay` pour rester cohérent. |
| `test/features/feed/widgets/perspectives_inline_animation_test.dart` (nouveau) | 3 tests : assertion `kStartDelay > 250 ms`, mount/dispose correct des `DiffTitle` au toggle, drain des timers en pending. |

## Tests

```bash
flutter test test/features/feed/widgets/perspectives_inline_animation_test.dart  # 3 passed
flutter test test/features/feed/widgets/diff_title_test.dart                      # 4 passed (anim test existant tjs OK)
flutter analyze lib/features/feed/widgets/diff_title.dart \
                lib/features/feed/widgets/perspectives_bottom_sheet.dart \
                test/features/feed/widgets/perspectives_inline_animation_test.dart  # No issues
```

## Validation visuelle requise (post-merge)

Le bug est intrinsèquement visuel : les `Future.delayed` ne se
comportent pas en `tester.pump()` comme en production. Je recommande
au PO de lancer `/validate-feature` après merge pour confirmer
subjectivement : *« est-ce que je vois maintenant la cascade après le
tap sur Couverture médiatique ? »*.

## Zones à risque

Aucun changement de contrat API. Aucune migration. Effet de bord
possible : sur le `PerspectivesBottomSheet` (modal full-screen), la
cascade démarre désormais 280 ms après l'ouverture du modal. Le modal
lui-même a une transition `showModalBottomSheet` ~250 ms, donc la
synchronisation est cohérente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)