### PR TITLE
feat(api): LLMBiasAnnotationService offline-only (Phase 4 PR 1)

### DIFF
--- a/packages/api/app/services/llm_bias_annotation_service.py
+++ b/packages/api/app/services/llm_bias_annotation_service.py
@@ -1,0 +1,373 @@
+"""LLM bias annotation service (Phase 4 — analyse fine des biais éditoriaux).
+
+Wrappe `EditorialLLMClient.chat_json(model="mistral-medium-latest")` pour
+produire des annotations au schéma v2 strict (target_spans pondérés +
+exclude_spans binaires + justification par span). Sortie consommée par le
+harness de calibration offline (PR 2) puis par le pipeline production (PR 4).
+
+PR 1 : service + validateur tolérant (drop + log), **pas branché au pipeline**.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from app.services.editorial.llm_client import EditorialLLMClient
+
+logger = structlog.get_logger(__name__)
+
+LLM_VERSION = "mistral-medium-latest-v1"
+DEFAULT_MODEL = "mistral-medium-latest"
+
+TARGET_CATEGORIES = frozenset(
+    {
+        "editorial_angle",
+        "fact",
+        "multi_token_expression",
+        "framing_noun",
+        "foreign_lang",
+    }
+)
+EXCLUDE_CATEGORIES = frozenset(
+    {
+        "pivot_entity",
+        "neutral_verb",
+        "entity_alias",
+        "geographic_alias",
+        "noise",
+    }
+)
+ALLOWED_WEIGHTS = frozenset({0.25, 0.5, 1.0})
+
+
+SCHEMA_DESCRIPTION = """\
+Tu es un assistant d'annotation éditoriale pour Facteur, une app qui met en
+regard plusieurs titres de presse couvrant la même actualité. Ta tâche : pour
+chaque titre "alt" (une perspective parmi plusieurs sur le même évènement),
+identifier les fragments qui méritent d'être SURLIGNÉS car ils relèvent d'un
+choix éditorial du média, par opposition aux faits avérés.
+
+Tu reçois pour chaque appel :
+1. Le titre de référence du cluster (point de comparaison neutre, souvent un
+   média grand public).
+2. Le titre de la perspective à annoter, avec son `bias_stance`.
+3. Quelques autres titres du même cluster (contexte — n'annote PAS ces titres).
+
+Tu retournes UN JSON strict avec cette forme :
+{
+  "target_spans": [
+    {"start": int, "end": int, "text": str, "category": str,
+     "weight": float, "justification": str}
+  ],
+  "exclude_spans": [
+    {"start": int, "end": int, "text": str, "category": str}
+  ],
+  "notes": str,
+  "confidence": float
+}
+
+Où :
+- `target_spans` = fragments à SURLIGNER (l'éditorialisation du média).
+  - `category` ∈ {"editorial_angle", "fact", "multi_token_expression",
+    "framing_noun", "foreign_lang"}
+    - editorial_angle : verbe ou adjectif chargé ("crispe", "écrase",
+      "insulte").
+    - fact : mot factuel utilisé comme cadrage clivant ("gauche", "droite").
+    - multi_token_expression : expression de 2+ mots contiguës ("vent debout",
+      "mettre les egos de côté", "nie s'être inspiré"). UN SEUL span couvrant
+      toute l'expression.
+    - framing_noun : nom abstrait choisi pour cadrer ("mainmise",
+      "indépendance", "polémique").
+    - foreign_lang : à utiliser quand la perspective n'est pas en français
+      (anglais, allemand, italien…) — annote les fragments éditorialisants
+      dans la langue d'origine.
+  - `weight` ∈ {0.25, 0.5, 1.0} :
+    - 0.25 : très légère éditorialisation.
+    - 0.5  : cadrage modéré (factuel + nuance assumée).
+    - 1.0  : éditorialisation forte (verbes chargés, jeux de mots, synthèses
+             partisanes, expressions clivantes).
+  - `justification` : 1 phrase courte (max 140 caractères) expliquant pourquoi
+    ce fragment a été retenu. Affichée à l'utilisateur final dans un tooltip.
+- `exclude_spans` = fragments à NE PAS SURLIGNER même si une pipeline
+  mécanique les capturerait. Sans `weight` (binaire).
+  - `category` ∈ {"pivot_entity", "neutral_verb", "entity_alias",
+    "geographic_alias", "noise"}
+    - pivot_entity : entité présente dans la majorité des titres du cluster
+      (Trump, Macron, "Banque de France"…).
+    - neutral_verb : verbe descriptif sans charge ("annonce", "confirme",
+      "désigne", "appelle").
+    - entity_alias : nom propre alternatif ("Donald Trump" ⊂ "Trump").
+    - geographic_alias : variante d'un lieu.
+    - noise : faits secondaires (titres de films, dates, noms de poste).
+
+RÈGLES IMPORTANTES :
+- Tes `start`/`end` doivent référer EXACTEMENT à des indices dans le titre
+  fourni (codepoints Unicode). Le champ `text` doit être ce que donne
+  `titre[start:end]`.
+- Si un fragment éditorialisant fait 2+ mots contigus, fais UN span
+  `multi_token_expression` couvrant toute l'expression — pas plusieurs.
+- Pas de chevauchement entre target_spans et exclude_spans.
+- L'absence totale d'éditorialisation est légitime : `target_spans: []` est
+  valide pour un titre 100 % factuel.
+- `confidence` ∈ [0, 1] : auto-évaluation de la difficulté du cas.
+- `notes` : 1 phrase justifiant l'analyse globale du titre (utile au debug).
+- Réponds UNIQUEMENT par le JSON, sans markdown, sans préambule.
+"""
+
+
+def _norm(s: str) -> str:
+    """Normalise apostrophes typographiques + NBSP pour matching tolérant."""
+    return s.replace("’", "'").replace("\xa0", " ")
+
+
+def find_span(title: str, text: str) -> tuple[int, int] | None:
+    """Localise un fragment dans un titre, tolérant aux apostrophes
+    typographiques et aux NBSP. Retourne None si introuvable."""
+    if not text:
+        return None
+    idx = title.find(text)
+    if idx >= 0:
+        return (idx, idx + len(text))
+    nt = _norm(title)
+    ntxt = _norm(text)
+    idx = nt.find(ntxt)
+    if idx >= 0:
+        return (idx, idx + len(ntxt))
+    return None
+
+
+def _validate_target(raw: object, title: str, index: int) -> dict | None:
+    if not isinstance(raw, dict):
+        logger.warning("llm_bias.target_drop", reason="not_dict", index=index)
+        return None
+    text = (raw.get("text") or "").strip()
+    category = raw.get("category", "")
+    if category not in TARGET_CATEGORIES:
+        logger.warning(
+            "llm_bias.target_drop",
+            reason="bad_category",
+            index=index,
+            category=category,
+        )
+        return None
+    try:
+        weight = float(raw.get("weight", 0))
+    except (TypeError, ValueError):
+        logger.warning(
+            "llm_bias.target_drop", reason="bad_weight_type", index=index
+        )
+        return None
+    if weight not in ALLOWED_WEIGHTS:
+        logger.warning(
+            "llm_bias.target_drop",
+            reason="bad_weight_value",
+            index=index,
+            weight=weight,
+        )
+        return None
+    span = find_span(title, text)
+    if span is None:
+        logger.warning(
+            "llm_bias.target_drop",
+            reason="span_not_found",
+            index=index,
+            text=text[:60],
+        )
+        return None
+    justification_raw = raw.get("justification")
+    justification = (
+        str(justification_raw).strip() if justification_raw else None
+    ) or None
+    return {
+        "start": span[0],
+        "end": span[1],
+        "text": title[span[0] : span[1]],
+        "category": category,
+        "weight": weight,
+        "justification": justification,
+    }
+
+
+def _validate_exclude(raw: object, title: str, index: int) -> dict | None:
+    if not isinstance(raw, dict):
+        logger.warning("llm_bias.exclude_drop", reason="not_dict", index=index)
+        return None
+    text = (raw.get("text") or "").strip()
+    category = raw.get("category", "")
+    if category not in EXCLUDE_CATEGORIES:
+        logger.warning(
+            "llm_bias.exclude_drop",
+            reason="bad_category",
+            index=index,
+            category=category,
+        )
+        return None
+    span = find_span(title, text)
+    if span is None:
+        logger.warning(
+            "llm_bias.exclude_drop",
+            reason="span_not_found",
+            index=index,
+            text=text[:60],
+        )
+        return None
+    return {
+        "start": span[0],
+        "end": span[1],
+        "text": title[span[0] : span[1]],
+        "category": category,
+    }
+
+
+class LLMBiasAnnotationService:
+    """Wrapper offline-only autour de `EditorialLLMClient` pour l'annotation
+    fine des biais éditoriaux.
+
+    Le validateur fonctionne en mode tolérant : un span hallucinant ou avec
+    catégorie/poids invalide est **dropped + logué**, l'annotation reste
+    valide avec les spans restants. Seule une racine non-objet ou un champ
+    `target_spans`/`exclude_spans` non-liste invalide la réponse complète
+    (retour `None`).
+    """
+
+    LLM_VERSION = LLM_VERSION
+    DEFAULT_MODEL = DEFAULT_MODEL
+
+    def __init__(
+        self,
+        client: EditorialLLMClient | None = None,
+        model: str = DEFAULT_MODEL,
+    ) -> None:
+        self._client = client or EditorialLLMClient()
+        self._model = model
+
+    @property
+    def is_ready(self) -> bool:
+        return self._client.is_ready
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def close(self) -> None:
+        await self._client.close()
+
+    def build_system_prompt(
+        self, fewshot_examples: list[str] | None = None
+    ) -> str:
+        if not fewshot_examples:
+            return SCHEMA_DESCRIPTION
+        return (
+            SCHEMA_DESCRIPTION
+            + "\n\n## Exemples calibrés par le PO\n\n"
+            + "\n\n".join(fewshot_examples)
+        )
+
+    @staticmethod
+    def build_user_prompt(
+        ref_title: str,
+        variant_title: str,
+        bias_stance: str,
+        peers: list[str] | None = None,
+    ) -> str:
+        peer_block = ""
+        if peers:
+            peer_block = (
+                "\nAutres titres du cluster (contexte, ne pas annoter) :\n"
+                + "\n".join(f"- {t}" for t in peers)
+            )
+        return (
+            f"Titre référence : {ref_title}\n"
+            f"Titre perspective (bias = {bias_stance}) : {variant_title}"
+            f"{peer_block}\n\n"
+            "Annote la perspective. Retourne le JSON strict."
+        )
+
+    @staticmethod
+    def validate_response(
+        payload: object, title: str
+    ) -> dict | None:
+        """Valide la réponse LLM contre le schéma v2.
+
+        - Retourne `None` si la racine est non-dict ou si target/exclude_spans
+          ne sont pas des listes.
+        - Sinon retourne un dict normalisé. Les spans invalides individuels
+          sont droppés + logués (graceful degradation).
+        """
+        if not isinstance(payload, dict):
+            logger.warning(
+                "llm_bias.invalid_root", got=type(payload).__name__
+            )
+            return None
+
+        targets_raw = payload.get("target_spans", [])
+        excludes_raw = payload.get("exclude_spans", [])
+        if not isinstance(targets_raw, list) or not isinstance(
+            excludes_raw, list
+        ):
+            logger.warning("llm_bias.invalid_spans_field")
+            return None
+
+        cleaned_targets: list[dict] = []
+        for i, raw in enumerate(targets_raw):
+            t = _validate_target(raw, title, i)
+            if t is not None:
+                cleaned_targets.append(t)
+
+        cleaned_excludes: list[dict] = []
+        for i, raw in enumerate(excludes_raw):
+            e = _validate_exclude(raw, title, i)
+            if e is not None:
+                cleaned_excludes.append(e)
+
+        confidence_raw = payload.get("confidence")
+        confidence: float | None
+        try:
+            confidence = (
+                float(confidence_raw) if confidence_raw is not None else None
+            )
+        except (TypeError, ValueError):
+            confidence = None
+
+        return {
+            "target_spans": cleaned_targets,
+            "exclude_spans": cleaned_excludes,
+            "notes": str(payload.get("notes", "")),
+            "confidence": confidence,
+        }
+
+    async def annotate_variant(
+        self,
+        ref_title: str,
+        variant_title: str,
+        bias_stance: str,
+        peers: list[str] | None = None,
+        fewshot_examples: list[str] | None = None,
+    ) -> dict | None:
+        """Annote un variant unique.
+
+        Retourne le dict validé ou `None` si la racine de la réponse LLM est
+        invalide (pas de retry interne — la stratégie de retry est portée par
+        l'appelant, ex. script calibration en PR 2 ou pipeline en PR 4).
+        """
+        system = self.build_system_prompt(fewshot_examples)
+        user = self.build_user_prompt(
+            ref_title=ref_title,
+            variant_title=variant_title,
+            bias_stance=bias_stance,
+            peers=peers,
+        )
+        raw = await self._client.chat_json(
+            system=system,
+            user_message=user,
+            model=self._model,
+            temperature=0.1,
+            max_tokens=1500,
+        )
+        if raw is None:
+            logger.warning(
+                "llm_bias.no_response",
+                variant_preview=variant_title[:60],
+            )
+            return None
+        return self.validate_response(raw, variant_title)

--- a/packages/api/app/services/llm_bias_annotation_service.py
+++ b/packages/api/app/services/llm_bias_annotation_service.py
@@ -153,9 +153,7 @@ def _validate_target(raw: object, title: str, index: int) -> dict | None:
     try:
         weight = float(raw.get("weight", 0))
     except (TypeError, ValueError):
-        logger.warning(
-            "llm_bias.target_drop", reason="bad_weight_type", index=index
-        )
+        logger.warning("llm_bias.target_drop", reason="bad_weight_type", index=index)
         return None
     if weight not in ALLOWED_WEIGHTS:
         logger.warning(
@@ -252,9 +250,7 @@ class LLMBiasAnnotationService:
     async def close(self) -> None:
         await self._client.close()
 
-    def build_system_prompt(
-        self, fewshot_examples: list[str] | None = None
-    ) -> str:
+    def build_system_prompt(self, fewshot_examples: list[str] | None = None) -> str:
         if not fewshot_examples:
             return SCHEMA_DESCRIPTION
         return (
@@ -284,9 +280,7 @@ class LLMBiasAnnotationService:
         )
 
     @staticmethod
-    def validate_response(
-        payload: object, title: str
-    ) -> dict | None:
+    def validate_response(payload: object, title: str) -> dict | None:
         """Valide la réponse LLM contre le schéma v2.
 
         - Retourne `None` si la racine est non-dict ou si target/exclude_spans
@@ -295,16 +289,12 @@ class LLMBiasAnnotationService:
           sont droppés + logués (graceful degradation).
         """
         if not isinstance(payload, dict):
-            logger.warning(
-                "llm_bias.invalid_root", got=type(payload).__name__
-            )
+            logger.warning("llm_bias.invalid_root", got=type(payload).__name__)
             return None
 
         targets_raw = payload.get("target_spans", [])
         excludes_raw = payload.get("exclude_spans", [])
-        if not isinstance(targets_raw, list) or not isinstance(
-            excludes_raw, list
-        ):
+        if not isinstance(targets_raw, list) or not isinstance(excludes_raw, list):
             logger.warning("llm_bias.invalid_spans_field")
             return None
 
@@ -323,9 +313,7 @@ class LLMBiasAnnotationService:
         confidence_raw = payload.get("confidence")
         confidence: float | None
         try:
-            confidence = (
-                float(confidence_raw) if confidence_raw is not None else None
-            )
+            confidence = float(confidence_raw) if confidence_raw is not None else None
         except (TypeError, ValueError):
             confidence = None
 

--- a/packages/api/tests/services/test_llm_bias_annotation_service.py
+++ b/packages/api/tests/services/test_llm_bias_annotation_service.py
@@ -1,0 +1,445 @@
+"""Tests pour `LLMBiasAnnotationService` (PR 1 Phase 4 — LLM bias annotation).
+
+Tests hermétiques : aucun appel API réel (mock `chat_json`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.llm_bias_annotation_service import (
+    ALLOWED_WEIGHTS,
+    DEFAULT_MODEL,
+    EXCLUDE_CATEGORIES,
+    LLM_VERSION,
+    SCHEMA_DESCRIPTION,
+    TARGET_CATEGORIES,
+    LLMBiasAnnotationService,
+    find_span,
+)
+
+
+SNAPSHOT_PATH = (
+    Path(__file__).resolve().parents[1] / "snapshots" / "llm_system_prompt.txt"
+)
+
+
+# ---------------------------------------------------------------------------
+# Constantes
+# ---------------------------------------------------------------------------
+
+
+def test_constants_locked():
+    """Verrouille les contrats publics du module (cf. plan.md)."""
+    assert LLM_VERSION == "mistral-medium-latest-v1"
+    assert DEFAULT_MODEL == "mistral-medium-latest"
+    assert TARGET_CATEGORIES == {
+        "editorial_angle",
+        "fact",
+        "multi_token_expression",
+        "framing_noun",
+        "foreign_lang",
+    }
+    assert EXCLUDE_CATEGORIES == {
+        "pivot_entity",
+        "neutral_verb",
+        "entity_alias",
+        "geographic_alias",
+        "noise",
+    }
+    assert ALLOWED_WEIGHTS == {0.25, 0.5, 1.0}
+
+
+# ---------------------------------------------------------------------------
+# find_span (apostrophes typographiques + NBSP)
+# ---------------------------------------------------------------------------
+
+
+def test_find_span_direct():
+    assert find_span("Trump écrase Massie", "écrase") == (6, 12)
+
+
+def test_find_span_typographic_apostrophe():
+    title = "L’étrange voyage de Marco Rubio"
+    res = find_span(title, "L'étrange")
+    assert res is not None
+    s, e = res
+    assert title[s:e] == "L’étrange"
+
+
+def test_find_span_nbsp():
+    title = "Bolloré\xa0: nouvelle polémique"
+    res = find_span(title, "Bolloré : nouvelle polémique")
+    assert res is not None
+    s, e = res
+    assert title[s:e] == "Bolloré\xa0: nouvelle polémique"
+
+
+def test_find_span_not_found():
+    assert find_span("Trump écrase Massie", "Macron") is None
+
+
+def test_find_span_empty():
+    assert find_span("title", "") is None
+
+
+# ---------------------------------------------------------------------------
+# Snapshot du prompt système (anti-dérive silencieuse)
+# ---------------------------------------------------------------------------
+
+
+def test_schema_description_matches_snapshot():
+    """Anti-dérive : si le prompt change, le test échoue → décision explicite
+    d'incrémenter `LLM_VERSION` + de regénérer le snapshot."""
+    snapshot = SNAPSHOT_PATH.read_text(encoding="utf-8")
+    assert SCHEMA_DESCRIPTION == snapshot, (
+        "SCHEMA_DESCRIPTION a divergé du snapshot. "
+        "Si le changement est volontaire : incrémente `LLM_VERSION` "
+        "dans llm_bias_annotation_service.py puis regénère le snapshot."
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_system_prompt / build_user_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_build_system_prompt_without_examples():
+    svc = LLMBiasAnnotationService(client=_dummy_client())
+    assert svc.build_system_prompt() == SCHEMA_DESCRIPTION
+
+
+def test_build_system_prompt_with_examples():
+    svc = LLMBiasAnnotationService(client=_dummy_client())
+    prompt = svc.build_system_prompt(
+        fewshot_examples=["### exemple 1 ...", "### exemple 2 ..."]
+    )
+    assert prompt.startswith(SCHEMA_DESCRIPTION)
+    assert "Exemples calibrés par le PO" in prompt
+    assert "### exemple 1" in prompt
+    assert "### exemple 2" in prompt
+
+
+def test_build_user_prompt_shape():
+    prompt = LLMBiasAnnotationService.build_user_prompt(
+        ref_title="Trump bat Massie",
+        variant_title="Trump écrase Massie",
+        bias_stance="left",
+        peers=["Massie défait", "Le Kentucky vote"],
+    )
+    assert "Trump bat Massie" in prompt
+    assert "Trump écrase Massie" in prompt
+    assert "bias = left" in prompt
+    assert "Massie défait" in prompt
+    assert "Le Kentucky vote" in prompt
+
+
+def test_build_user_prompt_without_peers():
+    prompt = LLMBiasAnnotationService.build_user_prompt(
+        ref_title="ref",
+        variant_title="variant",
+        bias_stance="center",
+    )
+    assert "Autres titres du cluster" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# validate_response — happy path
+# ---------------------------------------------------------------------------
+
+
+TITLE = "Trump écrase Massie : la mainmise sur le parti"
+
+
+def test_validate_nominal():
+    payload = {
+        "target_spans": [
+            {
+                "text": "écrase",
+                "category": "editorial_angle",
+                "weight": 1.0,
+                "justification": "Verbe chargé qui éditorialise la défaite.",
+            },
+            {
+                "text": "mainmise",
+                "category": "framing_noun",
+                "weight": 1.0,
+                "justification": "Choix nominal partisan.",
+            },
+        ],
+        "exclude_spans": [
+            {"text": "Trump", "category": "pivot_entity"},
+            {"text": "Massie", "category": "pivot_entity"},
+        ],
+        "notes": "ok",
+        "confidence": 0.8,
+    }
+    cleaned = LLMBiasAnnotationService.validate_response(payload, TITLE)
+    assert cleaned is not None
+    assert len(cleaned["target_spans"]) == 2
+    assert len(cleaned["exclude_spans"]) == 2
+    assert cleaned["target_spans"][0]["text"] == "écrase"
+    assert cleaned["target_spans"][0]["start"] == TITLE.index("écrase")
+    assert cleaned["target_spans"][0]["justification"].startswith("Verbe chargé")
+    assert cleaned["confidence"] == 0.8
+
+
+def test_validate_accepts_empty_spans():
+    cleaned = LLMBiasAnnotationService.validate_response(
+        {"target_spans": [], "exclude_spans": [], "notes": ""}, TITLE
+    )
+    assert cleaned is not None
+    assert cleaned["target_spans"] == []
+    assert cleaned["exclude_spans"] == []
+
+
+def test_validate_justification_missing_yields_none():
+    payload = {
+        "target_spans": [
+            {"text": "écrase", "category": "editorial_angle", "weight": 1.0}
+        ],
+        "exclude_spans": [],
+    }
+    cleaned = LLMBiasAnnotationService.validate_response(payload, TITLE)
+    assert cleaned is not None
+    assert cleaned["target_spans"][0]["justification"] is None
+
+
+def test_validate_typographic_apostrophe_round_trips():
+    title = "L’étrange retour"
+    payload = {
+        "target_spans": [
+            {
+                "text": "L'étrange",  # apostrophe ASCII
+                "category": "editorial_angle",
+                "weight": 0.5,
+            }
+        ],
+        "exclude_spans": [],
+    }
+    cleaned = LLMBiasAnnotationService.validate_response(payload, title)
+    assert cleaned is not None
+    span = cleaned["target_spans"][0]
+    assert title[span["start"] : span["end"]] == "L’étrange"
+
+
+# ---------------------------------------------------------------------------
+# validate_response — drop-and-log graceful degradation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_drops_unknown_target_category_keeps_valid_ones():
+    payload = {
+        "target_spans": [
+            {"text": "écrase", "category": "editorial_angle", "weight": 1.0},
+            {"text": "mainmise", "category": "wat", "weight": 1.0},  # bad
+        ],
+        "exclude_spans": [],
+    }
+    cleaned = LLMBiasAnnotationService.validate_response(payload, TITLE)
+    assert cleaned is not None
+    assert len(cleaned["target_spans"]) == 1
+    assert cleaned["target_spans"][0]["text"] == "écrase"
+
+
+def test_validate_drops_bad_weight():
+    payload = {
+        "target_spans": [
+            {"text": "écrase", "category": "editorial_angle", "weight": 0.7}
+        ],
+        "exclude_spans": [],
+    }
+    cleaned = LLMBiasAnnotationService.validate_response(payload, TITLE)
+    assert cleaned is not None
+    assert cleaned["target_spans"] == []
+
+
+def test_validate_drops_span_text_not_in_title():
+    payload = {
+        "target_spans": [
+            {"text": "Macron", "category": "editorial_angle", "weight": 1.0}
+        ],
+        "exclude_spans": [],
+    }
+    cleaned = LLMBiasAnnotationService.validate_response(payload, TITLE)
+    assert cleaned is not None
+    assert cleaned["target_spans"] == []
+
+
+def test_validate_drops_unknown_exclude_category():
+    payload = {
+        "target_spans": [],
+        "exclude_spans": [{"text": "Trump", "category": "alien"}],
+    }
+    cleaned = LLMBiasAnnotationService.validate_response(payload, TITLE)
+    assert cleaned is not None
+    assert cleaned["exclude_spans"] == []
+
+
+def test_validate_drops_non_dict_span_entries():
+    payload = {
+        "target_spans": [
+            "string-instead-of-dict",
+            {"text": "écrase", "category": "editorial_angle", "weight": 1.0},
+        ],
+        "exclude_spans": [],
+    }
+    cleaned = LLMBiasAnnotationService.validate_response(payload, TITLE)
+    assert cleaned is not None
+    assert len(cleaned["target_spans"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# validate_response — racine invalide → None
+# ---------------------------------------------------------------------------
+
+
+def test_validate_non_dict_root_returns_none():
+    assert LLMBiasAnnotationService.validate_response([], TITLE) is None
+    assert LLMBiasAnnotationService.validate_response("nope", TITLE) is None
+    assert LLMBiasAnnotationService.validate_response(None, TITLE) is None
+
+
+def test_validate_target_spans_not_a_list_returns_none():
+    assert (
+        LLMBiasAnnotationService.validate_response(
+            {"target_spans": "oops", "exclude_spans": []}, TITLE
+        )
+        is None
+    )
+
+
+def test_validate_exclude_spans_not_a_list_returns_none():
+    assert (
+        LLMBiasAnnotationService.validate_response(
+            {"target_spans": [], "exclude_spans": "oops"}, TITLE
+        )
+        is None
+    )
+
+
+def test_validate_confidence_unparseable_becomes_none():
+    payload = {
+        "target_spans": [],
+        "exclude_spans": [],
+        "confidence": "high",
+    }
+    cleaned = LLMBiasAnnotationService.validate_response(payload, TITLE)
+    assert cleaned is not None
+    assert cleaned["confidence"] is None
+
+
+# ---------------------------------------------------------------------------
+# annotate_variant — async + mocks
+# ---------------------------------------------------------------------------
+
+
+def _dummy_client() -> MagicMock:
+    client = MagicMock()
+    client.is_ready = True
+    client.chat_json = AsyncMock(return_value=None)
+    client.close = AsyncMock()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_annotate_variant_calls_chat_json_with_v2_schema():
+    client = _dummy_client()
+    client.chat_json.return_value = {
+        "target_spans": [
+            {
+                "text": "écrase",
+                "category": "editorial_angle",
+                "weight": 1.0,
+                "justification": "verbe chargé",
+            }
+        ],
+        "exclude_spans": [],
+        "notes": "",
+        "confidence": 0.9,
+    }
+    svc = LLMBiasAnnotationService(client=client)
+
+    result = await svc.annotate_variant(
+        ref_title="Trump bat Massie",
+        variant_title=TITLE,
+        bias_stance="left",
+        peers=["autre titre"],
+    )
+
+    client.chat_json.assert_awaited_once()
+    call_kwargs = client.chat_json.await_args.kwargs
+    assert call_kwargs["model"] == DEFAULT_MODEL
+    assert call_kwargs["temperature"] == 0.1
+    assert "bias = left" in call_kwargs["user_message"]
+    assert "Trump bat Massie" in call_kwargs["user_message"]
+    assert call_kwargs["system"].startswith(SCHEMA_DESCRIPTION[:80])
+
+    assert result is not None
+    assert len(result["target_spans"]) == 1
+    assert result["target_spans"][0]["start"] == TITLE.index("écrase")
+
+
+@pytest.mark.asyncio
+async def test_annotate_variant_returns_none_when_client_returns_none():
+    client = _dummy_client()
+    client.chat_json.return_value = None
+    svc = LLMBiasAnnotationService(client=client)
+    result = await svc.annotate_variant(
+        ref_title="r", variant_title="v", bias_stance="center"
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_annotate_variant_returns_none_on_bad_root_payload():
+    client = _dummy_client()
+    client.chat_json.return_value = ["not", "a", "dict"]
+    svc = LLMBiasAnnotationService(client=client)
+    result = await svc.annotate_variant(
+        ref_title="r", variant_title="v", bias_stance="center"
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_annotate_variant_drops_hallucinated_spans_but_returns_dict():
+    """Si le LLM hallucine un span (`text` introuvable), on droppe ce span
+    seul et on renvoie quand même un dict avec les autres spans valides —
+    pas de crash. Cf. plan.md cas limite « LLM hallucine start/end »."""
+    client = _dummy_client()
+    client.chat_json.return_value = {
+        "target_spans": [
+            {
+                "text": "écrase",
+                "category": "editorial_angle",
+                "weight": 1.0,
+            },
+            {
+                "text": "phantom",
+                "category": "editorial_angle",
+                "weight": 1.0,
+            },
+        ],
+        "exclude_spans": [],
+        "notes": "",
+        "confidence": 0.5,
+    }
+    svc = LLMBiasAnnotationService(client=client)
+    result = await svc.annotate_variant(
+        ref_title="r", variant_title=TITLE, bias_stance="left"
+    )
+    assert result is not None
+    texts = [s["text"] for s in result["target_spans"]]
+    assert texts == ["écrase"]
+
+
+@pytest.mark.asyncio
+async def test_service_close_propagates():
+    client = _dummy_client()
+    svc = LLMBiasAnnotationService(client=client)
+    await svc.close()
+    client.close.assert_awaited_once()

--- a/packages/api/tests/snapshots/llm_system_prompt.txt
+++ b/packages/api/tests/snapshots/llm_system_prompt.txt
@@ -1,0 +1,71 @@
+Tu es un assistant d'annotation éditoriale pour Facteur, une app qui met en
+regard plusieurs titres de presse couvrant la même actualité. Ta tâche : pour
+chaque titre "alt" (une perspective parmi plusieurs sur le même évènement),
+identifier les fragments qui méritent d'être SURLIGNÉS car ils relèvent d'un
+choix éditorial du média, par opposition aux faits avérés.
+
+Tu reçois pour chaque appel :
+1. Le titre de référence du cluster (point de comparaison neutre, souvent un
+   média grand public).
+2. Le titre de la perspective à annoter, avec son `bias_stance`.
+3. Quelques autres titres du même cluster (contexte — n'annote PAS ces titres).
+
+Tu retournes UN JSON strict avec cette forme :
+{
+  "target_spans": [
+    {"start": int, "end": int, "text": str, "category": str,
+     "weight": float, "justification": str}
+  ],
+  "exclude_spans": [
+    {"start": int, "end": int, "text": str, "category": str}
+  ],
+  "notes": str,
+  "confidence": float
+}
+
+Où :
+- `target_spans` = fragments à SURLIGNER (l'éditorialisation du média).
+  - `category` ∈ {"editorial_angle", "fact", "multi_token_expression",
+    "framing_noun", "foreign_lang"}
+    - editorial_angle : verbe ou adjectif chargé ("crispe", "écrase",
+      "insulte").
+    - fact : mot factuel utilisé comme cadrage clivant ("gauche", "droite").
+    - multi_token_expression : expression de 2+ mots contiguës ("vent debout",
+      "mettre les egos de côté", "nie s'être inspiré"). UN SEUL span couvrant
+      toute l'expression.
+    - framing_noun : nom abstrait choisi pour cadrer ("mainmise",
+      "indépendance", "polémique").
+    - foreign_lang : à utiliser quand la perspective n'est pas en français
+      (anglais, allemand, italien…) — annote les fragments éditorialisants
+      dans la langue d'origine.
+  - `weight` ∈ {0.25, 0.5, 1.0} :
+    - 0.25 : très légère éditorialisation.
+    - 0.5  : cadrage modéré (factuel + nuance assumée).
+    - 1.0  : éditorialisation forte (verbes chargés, jeux de mots, synthèses
+             partisanes, expressions clivantes).
+  - `justification` : 1 phrase courte (max 140 caractères) expliquant pourquoi
+    ce fragment a été retenu. Affichée à l'utilisateur final dans un tooltip.
+- `exclude_spans` = fragments à NE PAS SURLIGNER même si une pipeline
+  mécanique les capturerait. Sans `weight` (binaire).
+  - `category` ∈ {"pivot_entity", "neutral_verb", "entity_alias",
+    "geographic_alias", "noise"}
+    - pivot_entity : entité présente dans la majorité des titres du cluster
+      (Trump, Macron, "Banque de France"…).
+    - neutral_verb : verbe descriptif sans charge ("annonce", "confirme",
+      "désigne", "appelle").
+    - entity_alias : nom propre alternatif ("Donald Trump" ⊂ "Trump").
+    - geographic_alias : variante d'un lieu.
+    - noise : faits secondaires (titres de films, dates, noms de poste).
+
+RÈGLES IMPORTANTES :
+- Tes `start`/`end` doivent référer EXACTEMENT à des indices dans le titre
+  fourni (codepoints Unicode). Le champ `text` doit être ce que donne
+  `titre[start:end]`.
+- Si un fragment éditorialisant fait 2+ mots contigus, fais UN span
+  `multi_token_expression` couvrant toute l'expression — pas plusieurs.
+- Pas de chevauchement entre target_spans et exclude_spans.
+- L'absence totale d'éditorialisation est légitime : `target_spans: []` est
+  valide pour un titre 100 % factuel.
+- `confidence` ∈ [0, 1] : auto-évaluation de la difficulté du cas.
+- `notes` : 1 phrase justifiant l'analyse globale du titre (utile au debug).
+- Réponds UNIQUEMENT par le JSON, sans markdown, sans préambule.


### PR DESCRIPTION
## Contexte

Première PR du chantier **Phase 4 — LLM bias annotation** (cf. `.context/handoff-phase-4-llm-bias.md`, plan complet dans `.context/attachments/LMzuXB/plan.md`).

La revue PO du 2026-05-20 a tranché : brancher un LLM puissant **uniquement sur les articles du digest** (~50 titres/jour) pour disséquer chaque choix de cadrage — le pipeline spaCy plafonne à F1_span ≈ 0.40 sur le gold (Story 7.4).

PR 1 livre la fondation **offline-only** : un service qui produit des annotations au schéma v2 (target_spans pondérés + exclude_spans binaires + justification par span). **Aucun branchement** au pipeline ni à l'API → risque production = 0.

## Summary

- Nouveau service `app/services/llm_bias_annotation_service.py` — wrapper async autour de `EditorialLLMClient.chat_json(model="mistral-medium-latest")`.
- Schéma v2 strict avec champ `justification: str | None` par span (prépare l'item 5 — tap-to-justification PR 7).
- Validateur **drop + log graceful** : un span hallucinant ou avec catégorie/poids invalide est silencieusement écarté, l'annotation reste valide avec les spans restants. Retour `None` uniquement si la racine est non-dict ou si `target_spans`/`exclude_spans` ne sont pas des listes.
- `find_span` tolérant aux apostrophes typographiques (`'` ↔ `'`) et NBSP (`\xa0`).
- Snapshot `tests/snapshots/llm_system_prompt.txt` + test de non-régression → toute dérive silencieuse du prompt fera échouer le CI (forçant un bump explicite de `LLM_VERSION`).

## Test plan

- [x] `pytest tests/services/test_llm_bias_annotation_service.py -v` → 29 tests verts (mock `chat_json`, aucun appel API réel).
- [x] Aucune régression sur les tests adjacents (`test_title_annotation_service.py`, `tests/scripts/test_*` → 65 tests verts).
- [x] Pas de migration Alembic (slot `semantic_equiv` dormant déjà existant).
- [x] Pas d'`import` depuis `pipeline.py`, `contents.py` ou tout autre code de production — vérifiable via `git diff origin/main...` (3 fichiers, tous nouveaux).
- [ ] CI verte sur GitHub Actions.

## Prochaine PR (PR 2 — gate GO/NOGO)

Refactor de `scripts/llm_annotate_titles.py` pour consommer le nouveau service, puis run de calibration offline sur le gold dataset PO (`highlight-dataset-llm-pass2-2026-05-20.json`). Rapport prose vulgarisé au PO + décision GO/NOGO sur la PR+2 spaCy multi-tokens (gate ΔF1_span ≥ +0.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)