### PR TITLE
chore(api): offline calibration harness + cross-LLM compare (Phase 4 PR 2)

### DIFF
--- a/docs/maintenance/maintenance-highlight-calibration.md
+++ b/docs/maintenance/maintenance-highlight-calibration.md
@@ -1,0 +1,203 @@
+# Maintenance — Calibration data-driven du highlighting (suite Story 7.4)
+
+> **Date** : 2026-05-19
+> **Branche** : `boujonlaurin-dotcom/fix-article-highlight`
+> **PR ciblée** : `main`
+> **Type** : investigation / outillage (read-only, pipeline non modifiée)
+> **Prérequis** : [`maintenance-highlight-cartography.md`](./maintenance-highlight-cartography.md)
+
+## Contexte
+
+La cartographie initiale (30 titres, 5 pseudo-clusters) a rendu visibles
+plusieurs catégories d'erreurs (faux positifs sur entités-pivots, verbes
+neutres, alias d'entités simples, expressions multi-tokens fragmentées),
+mais le volume est trop faible pour en déduire des règles de calibration
+défendables. La démarche est donc **inversée** : avant toute modification
+de `TitleAnnotationService`, on construit un dataset annoté de référence
+et un évaluateur reproductible, puis on pose une **baseline chiffrée**.
+
+> Règle d'or PO : **volume avant règle**. Pas de filtre POS / stopword
+> métier inféré à partir de <30 clusters annotés.
+
+## Décision
+
+1. **Pipeline non modifiée dans cette PR.** Livrables : dataset annotable,
+   évaluateur, baseline mesurée, journal de calibration. Les ajustements
+   chirurgicaux (un paramètre par PR) viennent ensuite.
+2. **Pas de Mistral** (phase 2 Story 7.4 reste dormante — décision
+   réévaluée après calibration).
+3. **Pas de modification UI** dans cette PR.
+
+## Livrables
+
+| Fichier | Rôle |
+|---------|------|
+| `packages/api/scripts/build_highlight_dataset.py` | Construit le dataset stratifié (≥33 clusters, ≥165 titres) à partir d'un dump brut MCP Supabase. |
+| `packages/api/scripts/evaluate_title_annotations.py` | Évaluateur : P/R/F1 token-lemma + span fusionné, catégorisation FP/FN, top-N lemmes, mode `--compare`. |
+| `packages/api/tests/scripts/test_evaluate_title_annotations.py` | 12 tests hermétiques (FakeNlp), dont 1 smoke bout-en-bout. |
+| `packages/api/tests/scripts/fixtures/toy_dataset.json` | Toy dataset 1 cluster × 2 articles utilisé par le smoke test. |
+| `.context/highlight-dataset-<date>.json` | Dataset annotable (annotations vides à remplir). |
+| `.context/highlight-baseline-<date>.{md,json}` | Baseline mesurée (iter 0). |
+| `.context/highlight-calibration-log.md` | Journal append-only des itérations. |
+
+## Workflow
+
+### 1. Extraction du pool d'articles (MCP Supabase)
+
+Le rôle `claude_analytics_ro` (DATABASE_URL_RO) est filtré par RLS et voit
+0 row sur `contents`. Toujours passer par MCP Supabase :
+
+```sql
+SELECT c.id, c.title, c.url, c.published_at, c.theme, c.entities, c.language,
+       s.name AS source_name, s.bias_stance, c.source_id
+FROM contents c
+JOIN sources s ON s.id = c.source_id
+WHERE c.published_at >= NOW() - INTERVAL '7 days'
+  AND c.published_at <= NOW() - INTERVAL '1 hour'
+  AND c.language = 'fr'
+  AND c.title IS NOT NULL
+  AND c.entities IS NOT NULL
+  AND array_length(c.entities, 1) >= 2;
+```
+
+Le résultat MCP est repackagé en JSON :
+
+```json
+{ "generated_at": "...", "articles": [ { "id":"...", "title":"...", ... } ] }
+```
+
+et écrit dans `.context/raw-articles-<date>.json` (gitignored).
+
+### 2. Construction du dataset
+
+```bash
+cd packages/api && source venv/bin/activate
+python scripts/build_highlight_dataset.py \
+    --raw .context/raw-articles-2026-05-19.json \
+    --out .context/highlight-dataset-2026-05-19.json
+```
+
+Filtres appliqués (modifiables en CLI) :
+
+- `--min-size 4` articles par cluster
+- `--max-per-cluster 7` (les plus récents conservés)
+- `--window-hours 36` (≤ 36 h entre 1er et dernier article)
+- `--min-pair-ratio 0.7` (≥ 70 % des paires partagent ≥ 2 entités)
+- `--min-shared-entities 2` (entités PERSON/ORG/EVENT)
+- Dédup par `source_id` (1 article par source)
+
+Stratification par défaut : `politics` (6) · `international+geopolitics` (6)
+· `economy` (5) · `culture` (4) · `society+environment` (5) · `science+tech`
+(4). Chaque cluster doit avoir ≥ 2 stances distinctes (≥ 3 pour `politics`
+et `international`).
+
+### 3. Annotation
+
+#### 3.1 Conventions d'annotation
+
+Chaque perspective (article ≠ référence du cluster) peut recevoir un
+bloc `annotations.<source>` (par défaut `po_synchronous` ou `agent_mirror`) :
+
+```json
+{
+  "target_spans":  [{"start":29, "end":34, "text":"Paris", "category":"fact"}],
+  "exclude_spans": [{"start":0,  "end":6,  "text":"Donald","category":"entity_alias"}],
+  "notes": "Paris = seul fait nouveau ; Donald = alias de Trump"
+}
+```
+
+**Catégories fermées** :
+
+- `target_spans.category` : `editorial_angle`, `fact`,
+  `multi_token_expression`, `framing_noun`
+- `exclude_spans.category` : `pivot_entity`, `neutral_verb`,
+  `entity_alias`, `geographic_alias` (loggé mais hors-scope V1), `noise`
+
+#### 3.2 Phases d'annotation
+
+| Phase | Quoi | Champ JSON |
+|-------|------|------------|
+| A — gold synchrone PO | 12 clusters (≈ 60-80 titres) annotés en visio avec Laurin. Couvre 2 clusters par thème majeur + 1 par thème mineur. | `po_synchronous` |
+| B — miroir agent | Agent annote les ≥ 21 clusters restants en suivant les conventions du gold. | `agent_mirror` |
+| C — validation par échantillonnage | 3 clusters tirés au hasard du miroir, diff vs prédictions, PO valide ou corrige. Désaccord token-lemma > 15 % ⇒ re-passe du miroir. | n/a |
+
+### 4. Évaluation
+
+```bash
+python scripts/evaluate_title_annotations.py \
+    --dataset .context/highlight-dataset-2026-05-19.json \
+    --annotator po_synchronous \
+    --tag baseline
+```
+
+Produit :
+
+- `.context/highlight-baseline-<date>.json` (machine, consommé par `--compare`)
+- `.context/highlight-baseline-<date>.md` (lisible humain)
+
+Métriques produites :
+
+- **Token-lemma** : sets de lemmes, P/R/F1 micro.
+- **Span fusionné** : intervalles `(start, end)` après fusion des spans
+  contigus (gap ≤ 1 char), match exact.
+- **FP par catégorie** : croisement avec `exclude_spans` (FP_pivot_entity,
+  FP_neutral_verb, FP_entity_alias…).
+- **FN par catégorie** : tagué via `target_spans.category`.
+- **Top-30 lemmes** FP/FN — base data-driven pour inférer une éventuelle
+  whitelist ou un stopword métier *à partir des données*, pas de
+  l'intuition.
+
+### 5. Journal de calibration
+
+`.context/highlight-calibration-log.md`, append-only :
+
+```
+| Iter | Date | Param modifié | P_tok | R_tok | F1_tok | P_span | R_span | F1_span | ΔF1_tok | Top FP | Top FN | Notes |
+| 0    | 2026-05-19 | baseline (état actuel) | … | … | … | … | … | … | — | … | … | PR baseline |
+```
+
+Cette PR pose la ligne **Iter 0**. Chaque PR de calibration ajoute une
+ligne et une seule (**règle : un paramètre par PR**) en fournissant le
+delta vs baseline. Mode `--compare` :
+
+```bash
+python scripts/evaluate_title_annotations.py --compare \
+    .context/highlight-baseline-2026-05-19.json \
+    .context/highlight-after-iter1.json
+```
+
+## Tests
+
+```
+cd packages/api && pytest tests/scripts/test_evaluate_title_annotations.py -v
+cd packages/api && pytest tests/services/test_title_annotation_service.py -v   # régression
+cd packages/api && pytest tests/routers/test_contents_perspectives_highlights.py -v
+```
+
+12 tests évaluateur (10 unitaires + 2 smoke bout-en-bout) ; 29 tests de
+régression sur le service et le router restent verts (vérifié 2026-05-19).
+
+## Pièges
+
+1. `Source.bias_stance` est un `StrEnum` SQLAlchemy ⇒ sérialiser via
+   `.value` (cf. `scripts/inspect_title_annotations.py:139`).
+2. `Content.entities` est `text[]` de JSON strings ⇒ `json.loads(raw)`
+   par élément, pas `c.entities[0]["name"]`.
+3. MCP Supabase tronque à ~1 000 rows ⇒ paginer (`OFFSET/LIMIT` ou
+   filtre par jour) si le pool dépasse.
+4. Match gold vs pred sur **lemma** (pas sur text) — sinon "martèle"
+   et "martèlent" ratent.
+5. Fusion de spans : `gap ≤ 1 char` côté gold ET pred (cohérence).
+6. Ne pas réimplémenter spaCy dans l'évaluateur : appeler
+   `get_title_annotation_service()` pour rester aligné sur la pipeline.
+7. PR base `main` obligatoire ; `staging` bloqué par hook.
+8. **Aucune modif de `TitleAnnotationService` dans cette PR** — la
+   calibration commence en PR+1, une variable à la fois.
+
+## Suite (hors-scope de cette PR)
+
+- Phase A d'annotation (séance synchrone PO).
+- Phase B (miroir agent) + C (validation).
+- PR+1 : `pivot_entity_lemmas` paramètre passé à `diff_spans`.
+- PR+2 : alias d'entités simples (substring).
+- PR+3+ : selon les top-FP/FN observés dans Iter 0.

--- a/packages/api/scripts/build_highlight_dataset.py
+++ b/packages/api/scripts/build_highlight_dataset.py
@@ -1,0 +1,378 @@
+"""Construit le dataset d'annotation pour la calibration data-driven du
+highlighting (Story 7.4, suite).
+
+Workflow :
+    1. L'utilisateur extrait un dump brut via MCP Supabase (cf. README de
+       la doc de maintenance).
+    2. Ce script :
+       a. groupe les articles en pseudo-clusters par entité partagée
+          (reprend `build_pseudo_clusters` de `inspect_title_annotations.py`),
+       b. filtre les clusters mal formés (≥70 % des paires partagent ≥2
+          entités PERSON/ORG/EVENT, fenêtre ≤36 h, 1 article par source),
+       c. stratifie pour respecter un quota par thème + diversité de stance,
+       d. dump le dataset annotable (champ `annotations` vide par article)
+          dans `.context/highlight-dataset-<date>.json`.
+
+Forme du dump d'entrée (un sur-ensemble du format accepté par
+`inspect_title_annotations.py:25-39`) :
+
+    {
+      "generated_at": "2026-05-19T15:00:00Z",
+      "articles": [
+        {
+          "id": "uuid",
+          "title": "...",
+          "url": "...",
+          "published_at": "2026-05-19T08:00:00Z",
+          "source_name": "Le Monde",
+          "source_id": "uuid",
+          "bias_stance": "center-left",
+          "theme": "politics",
+          "entities": ["{\"name\": \"Macron\", \"type\": \"PERSON\"}", ...]
+        }, ...
+      ]
+    }
+
+Usage :
+    cd packages/api && source venv/bin/activate
+    python scripts/build_highlight_dataset.py \\
+        --raw .context/raw-articles-2026-05-19.json \\
+        --out .context/highlight-dataset-2026-05-19.json
+
+Sortie :
+    JSON sérialisé (schéma documenté dans `docs/maintenance/
+    maintenance-highlight-calibration.md`).
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from itertools import combinations
+from pathlib import Path
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.inspect_title_annotations import (  # noqa: E402
+    DISCRIMINANT_TYPES,
+    build_pseudo_clusters,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTEXT_DIR = REPO_ROOT / ".context"
+
+# Stratification par défaut. Les slugs viennent de `THEME_LABELS`
+# (`app/services/recommendation_service.py:1911-1923`).
+DEFAULT_QUOTAS: dict[str, dict] = {
+    "politics":      {"target_clusters": 6, "min_stances": 3, "themes": ["politics"]},
+    "international": {"target_clusters": 6, "min_stances": 3, "themes": ["international", "geopolitics"]},
+    "economy":       {"target_clusters": 5, "min_stances": 2, "themes": ["economy"]},
+    "culture":       {"target_clusters": 4, "min_stances": 2, "themes": ["culture", "culture_ideas"]},
+    "society":       {"target_clusters": 5, "min_stances": 2, "themes": ["society", "society_climate", "environment"]},
+    "science_tech":  {"target_clusters": 4, "min_stances": 2, "themes": ["science", "tech"]},
+}
+
+
+@dataclass
+class Article:
+    id: str
+    title: str
+    url: str
+    published_at: datetime
+    source_name: str
+    source_id: str
+    bias_stance: str
+    theme: str
+    entities: list[str]
+
+    def entity_keys(self) -> list[tuple[str, str]]:
+        out: list[tuple[str, str]] = []
+        for raw in self.entities or []:
+            try:
+                obj = json.loads(raw)
+            except (ValueError, TypeError):
+                continue
+            if obj.get("type") not in DISCRIMINANT_TYPES:
+                continue
+            name = (obj.get("name") or "").strip()
+            if name:
+                out.append((name.lower(), name))
+        return out
+
+    def discriminant_entity_set(self) -> set[str]:
+        return {k for k, _ in self.entity_keys()}
+
+
+@dataclass
+class Cluster:
+    key: str
+    display: str
+    articles: list[Article]
+    theme: str = ""
+    distinct_stances: int = 0
+
+
+@dataclass
+class BuildStats:
+    n_articles: int = 0
+    n_pseudo_clusters: int = 0
+    n_well_formed: int = 0
+    n_after_window: int = 0
+    n_after_source_dedup: int = 0
+    n_selected: int = 0
+    per_group: dict[str, int] = field(default_factory=dict)
+    skipped_themes: list[str] = field(default_factory=list)
+
+
+def load_articles(path: Path) -> list[Article]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    out: list[Article] = []
+    for a in data["articles"]:
+        out.append(
+            Article(
+                id=str(a["id"]),
+                title=a["title"] or "",
+                url=a.get("url") or "",
+                published_at=datetime.fromisoformat(
+                    a["published_at"].replace("Z", "+00:00")
+                ),
+                source_name=a.get("source_name") or "?",
+                source_id=str(a.get("source_id") or ""),
+                bias_stance=a.get("bias_stance") or "unknown",
+                theme=(a.get("theme") or "").strip(),
+                entities=list(a.get("entities") or []),
+            )
+        )
+    return out
+
+
+def dedup_by_source(arts: list[Article]) -> list[Article]:
+    """Garde l'article le plus récent par source dans un cluster."""
+    by_source: dict[str, Article] = {}
+    for a in arts:
+        existing = by_source.get(a.source_id)
+        if existing is None or a.published_at > existing.published_at:
+            by_source[a.source_id] = a
+    return list(by_source.values())
+
+
+def within_window(arts: list[Article], hours: int) -> bool:
+    if len(arts) < 2:
+        return True
+    ts = [a.published_at for a in arts]
+    return (max(ts) - min(ts)) <= timedelta(hours=hours)
+
+
+def well_formed(arts: list[Article], min_pair_ratio: float, min_shared: int) -> bool:
+    """≥ `min_pair_ratio` des paires d'articles partagent ≥ `min_shared` entités."""
+    if len(arts) < 2:
+        return False
+    pairs = list(combinations(arts, 2))
+    if not pairs:
+        return False
+    sets = {a.id: a.discriminant_entity_set() for a in arts}
+    good = sum(1 for a, b in pairs if len(sets[a.id] & sets[b.id]) >= min_shared)
+    return (good / len(pairs)) >= min_pair_ratio
+
+
+def pick_theme(arts: list[Article]) -> str:
+    counts = Counter(a.theme for a in arts if a.theme)
+    if not counts:
+        return ""
+    return counts.most_common(1)[0][0]
+
+
+def count_stances(arts: list[Article]) -> int:
+    return len({a.bias_stance for a in arts if a.bias_stance and a.bias_stance != "unknown"})
+
+
+def build_clusters(
+    articles: list[Article],
+    min_size: int,
+    window_hours: int,
+    min_pair_ratio: float,
+    min_shared_entities: int,
+    stats: BuildStats,
+) -> list[Cluster]:
+    """Pipeline complet de construction des clusters bien formés."""
+    raw = build_pseudo_clusters(articles, min_size=min_size, top_n=10_000)
+    stats.n_pseudo_clusters = len(raw)
+
+    clusters: list[Cluster] = []
+    for key, display, arts in raw:
+        deduped = dedup_by_source(arts)
+        if len(deduped) < min_size:
+            continue
+        stats.n_after_source_dedup += 1
+        if not within_window(deduped, window_hours):
+            continue
+        stats.n_after_window += 1
+        if not well_formed(deduped, min_pair_ratio, min_shared_entities):
+            continue
+        stats.n_well_formed += 1
+        clusters.append(
+            Cluster(
+                key=key,
+                display=display,
+                articles=deduped,
+                theme=pick_theme(deduped),
+                distinct_stances=count_stances(deduped),
+            )
+        )
+    return clusters
+
+
+def stratify(
+    clusters: list[Cluster],
+    quotas: dict[str, dict],
+    max_per_cluster: int,
+    stats: BuildStats,
+) -> list[Cluster]:
+    """Sélectionne les clusters selon les quotas par groupe thématique."""
+    theme_to_group: dict[str, str] = {}
+    for group, cfg in quotas.items():
+        for theme in cfg["themes"]:
+            theme_to_group[theme] = group
+
+    # Tri par taille descendante (les gros clusters sont mieux pour annoter)
+    sorted_clusters = sorted(clusters, key=lambda c: len(c.articles), reverse=True)
+
+    selected: list[Cluster] = []
+    taken_per_group: dict[str, int] = defaultdict(int)
+
+    for cluster in sorted_clusters:
+        group = theme_to_group.get(cluster.theme)
+        if group is None:
+            continue
+        cfg = quotas[group]
+        if taken_per_group[group] >= cfg["target_clusters"]:
+            continue
+        if cluster.distinct_stances < cfg["min_stances"]:
+            continue
+        # Cap articles par cluster (les plus récents conservés)
+        cluster.articles = sorted(
+            cluster.articles, key=lambda a: a.published_at, reverse=True
+        )[:max_per_cluster]
+        selected.append(cluster)
+        taken_per_group[group] += 1
+
+    stats.per_group = dict(taken_per_group)
+    stats.skipped_themes = [
+        g for g, cfg in quotas.items()
+        if taken_per_group[g] < cfg["target_clusters"]
+    ]
+    stats.n_selected = len(selected)
+    return selected
+
+
+def serialize(selected: list[Cluster], model_version: str, quotas: dict[str, dict]) -> dict:
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "generated_at": now,
+        "schema_version": 1,
+        "model_version": model_version,
+        "stratification": {g: cfg["target_clusters"] for g, cfg in quotas.items()},
+        "clusters": [
+            {
+                "cluster_key": c.key,
+                "cluster_display": c.display,
+                "theme": c.theme,
+                "reference_article_id": min(
+                    c.articles, key=lambda a: a.published_at
+                ).id,
+                "articles": [
+                    {
+                        "id": a.id,
+                        "title": a.title,
+                        "url": a.url,
+                        "published_at": a.published_at.isoformat(),
+                        "source_name": a.source_name,
+                        "source_id": a.source_id,
+                        "bias_stance": a.bias_stance,
+                        "entities": a.entities,
+                        "annotations": {},
+                    }
+                    for a in sorted(c.articles, key=lambda a: a.published_at)
+                ],
+            }
+            for c in selected
+        ],
+    }
+
+
+def print_stats(stats: BuildStats, selected: list[Cluster]) -> None:
+    print(f"Articles chargés                 : {stats.n_articles}")
+    print(f"Pseudo-clusters bruts (≥min_size): {stats.n_pseudo_clusters}")
+    print(f"  après dedup source             : {stats.n_after_source_dedup}")
+    print(f"  après fenêtre temporelle       : {stats.n_after_window}")
+    print(f"  après filtre 'bien formé'      : {stats.n_well_formed}")
+    print(f"Clusters sélectionnés (quotas)   : {stats.n_selected}")
+    print("Répartition par groupe :")
+    for group, n in sorted(stats.per_group.items()):
+        print(f"  - {group:14s} : {n}")
+    if stats.skipped_themes:
+        print(
+            f"⚠️  Quotas non atteints pour : {', '.join(stats.skipped_themes)}",
+            file=sys.stderr,
+        )
+    n_titles = sum(len(c.articles) for c in selected)
+    print(f"Titres annotables                : {n_titles}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--raw", required=True, help="Dump JSON brut (cf. docstring)")
+    parser.add_argument("--out", default=None, help="Chemin de sortie")
+    parser.add_argument("--min-size", type=int, default=4)
+    parser.add_argument("--max-per-cluster", type=int, default=7)
+    parser.add_argument("--window-hours", type=int, default=36)
+    parser.add_argument(
+        "--min-pair-ratio",
+        type=float,
+        default=0.7,
+        help="Fraction min des paires qui doivent partager ≥min-shared entités",
+    )
+    parser.add_argument("--min-shared-entities", type=int, default=2)
+    parser.add_argument(
+        "--model-version",
+        default="v1-spacy-fr_md",
+        help="Annoté dans le JSON pour aligner sur la pipeline",
+    )
+    args = parser.parse_args()
+
+    articles = load_articles(Path(args.raw))
+    if not articles:
+        print("⚠️  Dump vide.", file=sys.stderr)
+        sys.exit(1)
+
+    stats = BuildStats(n_articles=len(articles))
+    clusters = build_clusters(
+        articles,
+        min_size=args.min_size,
+        window_hours=args.window_hours,
+        min_pair_ratio=args.min_pair_ratio,
+        min_shared_entities=args.min_shared_entities,
+        stats=stats,
+    )
+    selected = stratify(clusters, DEFAULT_QUOTAS, args.max_per_cluster, stats)
+
+    payload = serialize(selected, args.model_version, DEFAULT_QUOTAS)
+
+    today = datetime.now(timezone.utc).date().isoformat()
+    out_path = (
+        Path(args.out)
+        if args.out
+        else CONTEXT_DIR / f"highlight-dataset-{today}.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print_stats(stats, selected)
+    print(f"✅ Dataset écrit : {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/compare_annotations.py
+++ b/packages/api/scripts/compare_annotations.py
@@ -1,0 +1,389 @@
+"""Compare deux annotateurs sur le même dataset (Story 7.4, Phase 2.B).
+
+Cas d'usage principal : mesurer l'accord LLM↔PO sur les perspectives
+PO-reviewed après un run `llm_annotate_titles.py --mode blind`. Le "left"
+joue le rôle de gold, le "right" celui de prédiction.
+
+Métriques :
+- Span-level (intervalles fusionnés) : P / R / F1
+- Token-lemma (lemmes spaCy chevauchant les spans) : P / R / F1
+- Accord `weight` : MAE et Cohen κ sur les target spans matchés
+- Accord `category` : matrice de confusion + accord brut
+- Top N désaccords pour relecture humaine
+
+Usage :
+    python scripts/compare_annotations.py \\
+        --dataset .context/highlight-dataset-llm-pass2-<date>.json \\
+        --left po_synchronous --right llm_pass2 \\
+        --filter po_reviewed=true \\
+        --out .context/llm-vs-po-agreement-<date>.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from app.services.title_annotation_service import (  # noqa: E402
+    get_title_annotation_service,
+)
+from scripts.evaluate_title_annotations import (  # noqa: E402
+    _safe_div,
+    _f1,
+    fuse_spans,
+    spans_overlap,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTEXT_DIR = REPO_ROOT / ".context"
+
+
+# ---------------------------------------------------------------------------
+# Match spans LLM ↔ PO (overlap = matched pair)
+# ---------------------------------------------------------------------------
+
+
+def match_spans(
+    gold: list[dict], pred: list[dict]
+) -> tuple[list[tuple[dict, dict]], list[dict], list[dict]]:
+    """Apparie gold ↔ pred par chevauchement (un-à-un, plus grand overlap d'abord).
+
+    Retourne (paires, gold_non_matchés, pred_non_matchés).
+    """
+    pairs: list[tuple[dict, dict]] = []
+    used_pred: set[int] = set()
+    used_gold: set[int] = set()
+    # Tri par overlap descendant
+    candidates: list[tuple[int, int, int]] = []
+    for gi, g in enumerate(gold):
+        g_range = (g["start"], g["end"])
+        for pi, p in enumerate(pred):
+            p_range = (p["start"], p["end"])
+            if spans_overlap(g_range, p_range):
+                overlap = min(g["end"], p["end"]) - max(g["start"], p["start"])
+                candidates.append((overlap, gi, pi))
+    candidates.sort(reverse=True)
+    for _, gi, pi in candidates:
+        if gi in used_gold or pi in used_pred:
+            continue
+        pairs.append((gold[gi], pred[pi]))
+        used_gold.add(gi)
+        used_pred.add(pi)
+    fn = [gold[i] for i in range(len(gold)) if i not in used_gold]
+    fp = [pred[i] for i in range(len(pred)) if i not in used_pred]
+    return pairs, fn, fp
+
+
+# ---------------------------------------------------------------------------
+# Cohen κ (catégoriel)
+# ---------------------------------------------------------------------------
+
+
+def cohen_kappa(pairs: list[tuple[str, str]]) -> float:
+    """Cohen κ sur catégories discrètes — supporte input arbitraire."""
+    if not pairs:
+        return 0.0
+    cats: set[str] = set()
+    for a, b in pairs:
+        cats.add(a)
+        cats.add(b)
+    n = len(pairs)
+    p_observed = sum(1 for a, b in pairs if a == b) / n
+    counts_a: Counter = Counter(a for a, _ in pairs)
+    counts_b: Counter = Counter(b for _, b in pairs)
+    p_expected = sum((counts_a[c] / n) * (counts_b[c] / n) for c in cats)
+    if p_expected >= 1.0:
+        return 1.0
+    return (p_observed - p_expected) / (1.0 - p_expected)
+
+
+# ---------------------------------------------------------------------------
+# Per-perspective scoring
+# ---------------------------------------------------------------------------
+
+
+def score_perspective(
+    title: str, gold_ann: dict, pred_ann: dict, svc=None
+) -> dict:
+    g_targets = gold_ann.get("target_spans") or []
+    p_targets = pred_ann.get("target_spans") or []
+    g_excludes = gold_ann.get("exclude_spans") or []
+    p_excludes = pred_ann.get("exclude_spans") or []
+
+    # --- Span-level (intervalles fusionnés)
+    g_fused = set(fuse_spans(g_targets))
+    p_fused = set(fuse_spans(p_targets))
+    tp_span = sorted(g_fused & p_fused)
+    fp_span = sorted(p_fused - g_fused)
+    fn_span = sorted(g_fused - p_fused)
+
+    # --- Token-lemma (chevauchements via spaCy)
+    tp_tok: set[str] = set()
+    fp_tok: set[str] = set()
+    fn_tok: set[str] = set()
+    if svc is not None and svc.is_nlp_available:
+        tokens = svc.compute_strong_tokens(title)
+        g_lemmas = {
+            t["lemma"] for s in g_targets for t in tokens
+            if spans_overlap((t["start"], t["end"]), (s["start"], s["end"]))
+        }
+        p_lemmas = {
+            t["lemma"] for s in p_targets for t in tokens
+            if spans_overlap((t["start"], t["end"]), (s["start"], s["end"]))
+        }
+        tp_tok = g_lemmas & p_lemmas
+        fp_tok = p_lemmas - g_lemmas
+        fn_tok = g_lemmas - p_lemmas
+
+    # --- Matching pour accord weight/category
+    target_pairs, target_fn, target_fp = match_spans(g_targets, p_targets)
+    exclude_pairs, _, _ = match_spans(g_excludes, p_excludes)
+
+    weight_diffs: list[tuple[float, float]] = []
+    cat_target_pairs: list[tuple[str, str]] = []
+    for g, p in target_pairs:
+        weight_diffs.append((float(g.get("weight", 0)), float(p.get("weight", 0))))
+        cat_target_pairs.append((g.get("category", "?"), p.get("category", "?")))
+    cat_exclude_pairs = [
+        (g.get("category", "?"), p.get("category", "?")) for g, p in exclude_pairs
+    ]
+
+    return {
+        "title": title,
+        "tp_span": tp_span, "fp_span": fp_span, "fn_span": fn_span,
+        "tp_tok": tp_tok, "fp_tok": fp_tok, "fn_tok": fn_tok,
+        "weight_diffs": weight_diffs,
+        "cat_target_pairs": cat_target_pairs,
+        "cat_exclude_pairs": cat_exclude_pairs,
+        "disagreement_score": len(fp_span) + len(fn_span),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def aggregate(scores: list[dict]) -> dict:
+    tp_span = sum(len(s["tp_span"]) for s in scores)
+    fp_span = sum(len(s["fp_span"]) for s in scores)
+    fn_span = sum(len(s["fn_span"]) for s in scores)
+    p_span = _safe_div(tp_span, tp_span + fp_span)
+    r_span = _safe_div(tp_span, tp_span + fn_span)
+    f1_span = _f1(p_span, r_span)
+
+    tp_tok = sum(len(s["tp_tok"]) for s in scores)
+    fp_tok = sum(len(s["fp_tok"]) for s in scores)
+    fn_tok = sum(len(s["fn_tok"]) for s in scores)
+    p_tok = _safe_div(tp_tok, tp_tok + fp_tok)
+    r_tok = _safe_div(tp_tok, tp_tok + fn_tok)
+    f1_tok = _f1(p_tok, r_tok)
+
+    weight_diffs = [d for s in scores for d in s["weight_diffs"]]
+    if weight_diffs:
+        mae = sum(abs(a - b) for a, b in weight_diffs) / len(weight_diffs)
+        # κ catégoriel sur valeurs discrètes 0.25/0.5/1.0
+        kappa_pairs = [(str(a), str(b)) for a, b in weight_diffs]
+        kappa = cohen_kappa(kappa_pairs)
+    else:
+        mae = 0.0
+        kappa = 0.0
+
+    cat_target_pairs = [p for s in scores for p in s["cat_target_pairs"]]
+    cat_exclude_pairs = [p for s in scores for p in s["cat_exclude_pairs"]]
+    cat_target_kappa = cohen_kappa(cat_target_pairs)
+    cat_exclude_kappa = cohen_kappa(cat_exclude_pairs)
+
+    # Matrices de confusion
+    confusion_target: dict[str, Counter] = defaultdict(Counter)
+    for g, p in cat_target_pairs:
+        confusion_target[g][p] += 1
+    confusion_exclude: dict[str, Counter] = defaultdict(Counter)
+    for g, p in cat_exclude_pairs:
+        confusion_exclude[g][p] += 1
+
+    return {
+        "n_perspectives": len(scores),
+        "span": {"tp": tp_span, "fp": fp_span, "fn": fn_span,
+                 "precision": p_span, "recall": r_span, "f1": f1_span},
+        "token": {"tp": tp_tok, "fp": fp_tok, "fn": fn_tok,
+                  "precision": p_tok, "recall": r_tok, "f1": f1_tok},
+        "weight_agreement": {
+            "n": len(weight_diffs), "mae": mae, "cohen_kappa": kappa,
+        },
+        "category_target_kappa": cat_target_kappa,
+        "category_exclude_kappa": cat_exclude_kappa,
+        "confusion_target": {k: dict(v) for k, v in confusion_target.items()},
+        "confusion_exclude": {k: dict(v) for k, v in confusion_exclude.items()},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+
+def render(
+    metrics: dict, scores: list[dict], left: str, right: str, top_n: int = 10
+) -> str:
+    today = datetime.now(timezone.utc).date().isoformat()
+    out = [
+        f"# Accord `{left}` ↔ `{right}` ({today})",
+        "",
+        f"- Perspectives évaluées : {metrics['n_perspectives']}",
+        f"- `{left}` = gold, `{right}` = prediction",
+        "",
+        "## Span-level (intervalles fusionnés)",
+        "",
+        f"- TP={metrics['span']['tp']} · FP={metrics['span']['fp']} · "
+        f"FN={metrics['span']['fn']}",
+        f"- P = {metrics['span']['precision']:.3f} · "
+        f"R = {metrics['span']['recall']:.3f} · "
+        f"**F1 = {metrics['span']['f1']:.3f}**",
+        "",
+        "## Token-lemma (chevauchement via spaCy)",
+        "",
+        f"- TP={metrics['token']['tp']} · FP={metrics['token']['fp']} · "
+        f"FN={metrics['token']['fn']}",
+        f"- P = {metrics['token']['precision']:.3f} · "
+        f"R = {metrics['token']['recall']:.3f} · "
+        f"**F1 = {metrics['token']['f1']:.3f}**",
+        "",
+        "## Accord `weight` (sur target_spans appariés)",
+        "",
+        f"- N spans matchés : {metrics['weight_agreement']['n']}",
+        f"- MAE : {metrics['weight_agreement']['mae']:.3f}",
+        f"- Cohen κ : {metrics['weight_agreement']['cohen_kappa']:.3f}",
+        "",
+        "## Accord `category`",
+        "",
+        f"- κ target : {metrics['category_target_kappa']:.3f}",
+        f"- κ exclude : {metrics['category_exclude_kappa']:.3f}",
+        "",
+    ]
+
+    # Top désaccords
+    out.append(f"## Top {top_n} désaccords (FP+FN spans)")
+    out.append("")
+    sorted_scores = sorted(scores, key=lambda s: s["disagreement_score"], reverse=True)
+    for s in sorted_scores[:top_n]:
+        if s["disagreement_score"] == 0:
+            break
+        out.append(f"### {s['title']}")
+        if s["fp_span"]:
+            out.append(f"- FP (uniquement `{right}`) : " + ", ".join(
+                f"[{a}:{b}]" for a, b in s["fp_span"]
+            ))
+        if s["fn_span"]:
+            out.append(f"- FN (manquant dans `{right}`) : " + ", ".join(
+                f"[{a}:{b}]" for a, b in s["fn_span"]
+            ))
+        out.append("")
+
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def _matches_filter(ann: dict, filter_spec: str | None) -> bool:
+    if not filter_spec:
+        return True
+    key, _, val = filter_spec.partition("=")
+    actual = ann.get(key)
+    if val.lower() in ("true", "false"):
+        return bool(actual) == (val.lower() == "true")
+    return str(actual) == val
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--left", default="po_synchronous",
+                        help="Annotateur gold")
+    parser.add_argument("--right", default="llm_pass2",
+                        help="Annotateur prediction")
+    parser.add_argument(
+        "--filter",
+        default=None,
+        help="Filtre sur l'annotation gold (ex: po_reviewed=true)",
+    )
+    parser.add_argument("--out", default=None)
+    parser.add_argument("--out-json", default=None)
+    parser.add_argument("--top-n", type=int, default=10)
+    parser.add_argument("--no-spacy", action="store_true",
+                        help="Skip métriques token-lemma (utile en test sans spaCy)")
+    args = parser.parse_args()
+
+    dataset = json.loads(Path(args.dataset).read_text(encoding="utf-8"))
+    svc = None
+    if not args.no_spacy:
+        svc = get_title_annotation_service()
+        if not svc.is_nlp_available:
+            print(
+                "⚠️  spaCy indisponible — métriques token-lemma à 0. "
+                "Ajoute --no-spacy pour acquitter explicitement.",
+                file=sys.stderr,
+            )
+
+    scores: list[dict] = []
+    for cluster in dataset["clusters"]:
+        ref_id = cluster["reference_article_id"]
+        for art in cluster["articles"]:
+            if art["id"] == ref_id:
+                continue
+            ann = art.get("annotations") or {}
+            if ann.get("dropped"):
+                continue
+            gold = ann.get(args.left)
+            pred = ann.get(args.right)
+            if not gold or not pred:
+                continue
+            if not _matches_filter(gold, args.filter):
+                continue
+            scores.append(score_perspective(art["title"], gold, pred, svc=svc))
+
+    metrics = aggregate(scores)
+    report = render(metrics, scores, args.left, args.right, top_n=args.top_n)
+
+    today = datetime.now(timezone.utc).date().isoformat()
+    out_md = Path(args.out) if args.out else (
+        CONTEXT_DIR / f"llm-vs-po-agreement-{today}.md"
+    )
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(report, encoding="utf-8")
+
+    out_json = Path(args.out_json) if args.out_json else (
+        CONTEXT_DIR / f"llm-vs-po-agreement-{today}.json"
+    )
+    out_json.write_text(
+        json.dumps(
+            {
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "dataset": args.dataset,
+                "left": args.left, "right": args.right,
+                "filter": args.filter,
+                "metrics": metrics,
+            },
+            ensure_ascii=False, indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    print(f"✅ Rapport MD : {out_md}")
+    print(f"✅ Rapport JSON : {out_json}")
+    print()
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/compare_llm_models.py
+++ b/packages/api/scripts/compare_llm_models.py
@@ -1,0 +1,399 @@
+"""Compare deux runs LLM (ex: mistral-medium vs mistral-large) sur le même
+gold dataset.
+
+Produit un rapport markdown combinant :
+- Tableau métriques medium-vs-PO, large-vs-PO et large-vs-medium
+  (F1_span, F1_tok, accord weight κ + MAE, accord catégorie κ).
+- Section qualitative : N titres sample, montrant côte-à-côte
+  target_spans avec text + weight + category + justification pour
+  chaque annotateur, plus le gold PO en référence.
+
+Le picker qualitatif privilégie les titres où les deux modèles divergent
+(soit en spans, soit en weight, soit en justification) — c'est là que
+l'écart de qualité se voit le mieux.
+
+Usage :
+    cd packages/api && python scripts/compare_llm_models.py \\
+        --medium ../../.context/highlight-dataset-llm-pass-3-2026-05-22.json \\
+        --large  ../../.context/highlight-dataset-llm-pass-3-large-2026-05-22.json \\
+        --out    ../../.context/llm-medium-vs-large-2026-05-22.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.compare_annotations import (  # noqa: E402
+    aggregate,
+    cohen_kappa,
+    match_spans,
+    score_perspective,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTEXT_DIR = REPO_ROOT / ".context"
+
+
+# ---------------------------------------------------------------------------
+# Dataset merging
+# ---------------------------------------------------------------------------
+
+
+def merge_datasets(medium: dict, large: dict) -> dict:
+    """Fusionne le slot llm_pass2 de chaque dataset en deux slots distincts
+    `llm_pass2_medium` et `llm_pass2_large` dans le dataset medium (base)."""
+    large_by_id: dict[str, dict] = {}
+    for c in large["clusters"]:
+        for art in c["articles"]:
+            ann = (art.get("annotations") or {}).get("llm_pass2")
+            if ann is not None:
+                large_by_id[art["id"]] = ann
+
+    merged = json.loads(json.dumps(medium))  # deep copy
+    for c in merged["clusters"]:
+        for art in c["articles"]:
+            ann = art.get("annotations") or {}
+            if "llm_pass2" in ann:
+                ann["llm_pass2_medium"] = ann.pop("llm_pass2")
+            if art["id"] in large_by_id:
+                ann["llm_pass2_large"] = large_by_id[art["id"]]
+    return merged
+
+
+def collect_pairs(
+    dataset: dict, left_key: str, right_key: str
+) -> list[tuple[str, dict, dict, dict]]:
+    """Yield (title, ref_title, left_ann, right_ann) pour les perspectives
+    où les deux annotateurs sont présents et la perspective est PO-reviewed
+    (filtre dur — on compare sur le gold uniquement)."""
+    pairs: list[tuple[str, dict, dict, dict]] = []
+    for c in dataset["clusters"]:
+        ref_id = c["reference_article_id"]
+        ref = next(a for a in c["articles"] if a["id"] == ref_id)
+        for art in c["articles"]:
+            if art["id"] == ref_id:
+                continue
+            ann = art.get("annotations") or {}
+            if ann.get("dropped"):
+                continue
+            po = ann.get("po_synchronous") or {}
+            if not po.get("po_reviewed"):
+                continue
+            left = ann.get(left_key)
+            right = ann.get(right_key)
+            if not left or not right:
+                continue
+            pairs.append((art["title"], ref["title"], left, right))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+def metrics_against(dataset: dict, llm_key: str) -> dict:
+    """Calcule les métriques d'un annotateur LLM vs po_synchronous gold."""
+    scores: list[dict] = []
+    for c in dataset["clusters"]:
+        ref_id = c["reference_article_id"]
+        for art in c["articles"]:
+            if art["id"] == ref_id:
+                continue
+            ann = art.get("annotations") or {}
+            if ann.get("dropped"):
+                continue
+            po = ann.get("po_synchronous")
+            llm = ann.get(llm_key)
+            if not po or not llm:
+                continue
+            if not po.get("po_reviewed"):
+                continue
+            scores.append(score_perspective(art["title"], po, llm, svc=None))
+    return aggregate(scores)
+
+
+def metrics_llm_vs_llm(dataset: dict, left_key: str, right_key: str) -> dict:
+    """Métriques croisées entre deux LLMs (sans gold PO)."""
+    scores: list[dict] = []
+    for c in dataset["clusters"]:
+        ref_id = c["reference_article_id"]
+        for art in c["articles"]:
+            if art["id"] == ref_id:
+                continue
+            ann = art.get("annotations") or {}
+            if ann.get("dropped"):
+                continue
+            left = ann.get(left_key)
+            right = ann.get(right_key)
+            if not left or not right:
+                continue
+            scores.append(score_perspective(art["title"], left, right, svc=None))
+    return aggregate(scores)
+
+
+# ---------------------------------------------------------------------------
+# Qualitative picker
+# ---------------------------------------------------------------------------
+
+
+def _span_set(ann: dict) -> set[tuple[int, int]]:
+    return {(s["start"], s["end"]) for s in (ann.get("target_spans") or [])}
+
+
+def _disagreement_signal(
+    medium: dict, large: dict, po: dict
+) -> tuple[int, int]:
+    """Retourne (n_total_disagreements, n_pure_LLM_diffs).
+
+    Le premier sert au tri (cas globalement intéressants), le second
+    privilégie les cas où medium et large divergent (le coeur de l'étude)."""
+    m = _span_set(medium)
+    L = _span_set(large)
+    g = _span_set(po)
+    total = len((m - g) | (g - m) | (L - g) | (g - L))
+    llm_only = len((m - L) | (L - m))
+    return total, llm_only
+
+
+def pick_qualitative_samples(
+    pairs: list[tuple[str, dict, dict, dict]],
+    medium_anns: dict[str, dict],
+    large_anns: dict[str, dict],
+    po_anns: dict[str, dict],
+    n: int = 12,
+) -> list[tuple[str, dict, dict, dict]]:
+    """Trie les titres par signal de désaccord LLM↔LLM décroissant.
+
+    Retourne au plus n titres, en priorisant les cas où medium et large
+    divergent — c'est là que l'écart de qualité saute aux yeux."""
+    ranked: list[tuple[tuple[int, int], str, dict, dict, dict]] = []
+    for title, ref_title, medium_ann, large_ann in pairs:
+        po = po_anns[title]
+        signal = _disagreement_signal(medium_ann, large_ann, po)
+        # Tri prioritaire : (LLM-only diffs DESC, total diffs DESC)
+        ranked.append(((-signal[1], -signal[0]), title, medium_ann, large_ann, po))
+    ranked.sort(key=lambda r: r[0])
+    return [(t, m, lg, po) for _, t, m, lg, po in ranked[:n]]
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def _format_target_spans(spans: list[dict], with_just: bool = True) -> str:
+    if not spans:
+        return "_(aucun)_"
+    lines = []
+    for s in spans:
+        weight = s.get("weight")
+        cat = s.get("category", "?")
+        text = s.get("text", "")
+        head = f"**{text!r}** · `{cat}`"
+        if weight is not None:
+            head += f" · weight={weight}"
+        if with_just and s.get("justification"):
+            head += f"  \n  _“{s['justification']}”_"
+        lines.append(f"- {head}")
+    return "\n".join(lines)
+
+
+def _format_exclude_spans(spans: list[dict]) -> str:
+    if not spans:
+        return "_(aucun)_"
+    return ", ".join(
+        f"`{s.get('text','')}`/{s.get('category','?')}" for s in spans
+    )
+
+
+def render_metric_row(label: str, m: dict) -> str:
+    return (
+        f"| {label} | {m['span']['f1']:.3f} | {m['token']['f1']:.3f} | "
+        f"{m['weight_agreement']['mae']:.3f} | "
+        f"{m['weight_agreement']['cohen_kappa']:.3f} | "
+        f"{m['category_target_kappa']:.3f} |"
+    )
+
+
+def render_report(
+    medium_metrics: dict,
+    large_metrics: dict,
+    cross_metrics: dict,
+    samples: list[tuple[str, dict, dict, dict]],
+    n_pairs: int,
+) -> str:
+    today = datetime.now(timezone.utc).date().isoformat()
+    out: list[str] = [
+        f"# Comparaison Mistral-medium ↔ Mistral-large ({today})",
+        "",
+        f"- Perspectives PO-reviewed évaluées : {n_pairs}",
+        "- Gold : `po_synchronous` (annotation PO synchrone).",
+        "- Métriques : F1_span (intervalles fusionnés), F1_tok (lemmes "
+        "chevauchant les spans, via spaCy), MAE et κ sur `weight` (sur "
+        "target_spans appariés par overlap), κ sur `category` (target).",
+        "",
+        "## Métriques quantitatives",
+        "",
+        "| Annotateur | F1_span | F1_tok | MAE weight | κ weight | "
+        "κ category |",
+        "|---|---:|---:|---:|---:|---:|",
+        render_metric_row("mistral-medium vs PO", medium_metrics),
+        render_metric_row("mistral-large vs PO", large_metrics),
+        render_metric_row("mistral-large vs mistral-medium", cross_metrics),
+        "",
+        "### Écart large ↔ medium (vs PO)",
+        "",
+        "| Métrique | medium | large | Δ |",
+        "|---|---:|---:|---:|",
+    ]
+    for label, key, sub in [
+        ("F1_span", "span", "f1"),
+        ("F1_tok", "token", "f1"),
+        ("MAE weight", "weight_agreement", "mae"),
+        ("κ weight", "weight_agreement", "cohen_kappa"),
+        ("κ category target", "category_target_kappa", None),
+    ]:
+        if sub is None:
+            mv = medium_metrics[key]
+            lv = large_metrics[key]
+        else:
+            mv = medium_metrics[key][sub]
+            lv = large_metrics[key][sub]
+        out.append(f"| {label} | {mv:.3f} | {lv:.3f} | {lv - mv:+.3f} |")
+
+    out.extend(
+        [
+            "",
+            "## Échantillon qualitatif",
+            "",
+            "Titres triés par désaccord LLM↔LLM décroissant — c'est là que "
+            "l'écart entre medium et large se voit le mieux. Le gold PO "
+            "est fourni en référence.",
+            "",
+        ]
+    )
+
+    for title, medium_ann, large_ann, po_ann in samples:
+        out.append(f"### {title}")
+        out.append("")
+        out.append("**Gold PO :**")
+        out.append(_format_target_spans(po_ann.get("target_spans") or [], with_just=False))
+        if po_ann.get("notes"):
+            out.append(f"  \n_Note PO :_ {po_ann['notes']}")
+        out.append("")
+        out.append("**mistral-medium :**")
+        out.append(_format_target_spans(medium_ann.get("target_spans") or []))
+        out.append(
+            f"  \nExclude : { _format_exclude_spans(medium_ann.get('exclude_spans') or []) }"
+        )
+        if medium_ann.get("notes"):
+            out.append(f"  \n_Note :_ {medium_ann['notes']}")
+        out.append("")
+        out.append("**mistral-large :**")
+        out.append(_format_target_spans(large_ann.get("target_spans") or []))
+        out.append(
+            f"  \nExclude : { _format_exclude_spans(large_ann.get('exclude_spans') or []) }"
+        )
+        if large_ann.get("notes"):
+            out.append(f"  \n_Note :_ {large_ann['notes']}")
+        out.append("")
+
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--medium", required=True,
+        help="Dataset annoté par mistral-medium (slot `llm_pass2`).",
+    )
+    parser.add_argument(
+        "--large", required=True,
+        help="Dataset annoté par mistral-large (slot `llm_pass2`).",
+    )
+    parser.add_argument(
+        "--out", default=None,
+        help="Chemin du rapport markdown (défaut : .context/llm-medium-vs-large-<date>.md)",
+    )
+    parser.add_argument(
+        "--out-json", default=None,
+        help="Chemin du dataset fusionné (utile pour audit) — optionnel.",
+    )
+    parser.add_argument(
+        "--samples", type=int, default=12,
+        help="Nombre de titres montrés en section qualitative.",
+    )
+    args = parser.parse_args()
+
+    medium = json.loads(Path(args.medium).read_text(encoding="utf-8"))
+    large = json.loads(Path(args.large).read_text(encoding="utf-8"))
+    merged = merge_datasets(medium, large)
+
+    # Index annotations par titre pour le picker qualitatif
+    medium_by_title: dict[str, dict] = {}
+    large_by_title: dict[str, dict] = {}
+    po_by_title: dict[str, dict] = {}
+    for c in merged["clusters"]:
+        for art in c["articles"]:
+            ann = art.get("annotations") or {}
+            if "llm_pass2_medium" in ann:
+                medium_by_title[art["title"]] = ann["llm_pass2_medium"]
+            if "llm_pass2_large" in ann:
+                large_by_title[art["title"]] = ann["llm_pass2_large"]
+            if (ann.get("po_synchronous") or {}).get("po_reviewed"):
+                po_by_title[art["title"]] = ann["po_synchronous"]
+
+    pairs = collect_pairs(merged, "llm_pass2_medium", "llm_pass2_large")
+    if not pairs:
+        print("❌ Aucun titre commun aux deux runs LLM.", file=sys.stderr)
+        sys.exit(2)
+
+    medium_metrics = metrics_against(merged, "llm_pass2_medium")
+    large_metrics = metrics_against(merged, "llm_pass2_large")
+    cross_metrics = metrics_llm_vs_llm(merged, "llm_pass2_medium", "llm_pass2_large")
+    samples = pick_qualitative_samples(
+        pairs, medium_by_title, large_by_title, po_by_title, n=args.samples
+    )
+
+    report = render_report(
+        medium_metrics, large_metrics, cross_metrics, samples, n_pairs=len(pairs)
+    )
+
+    today = datetime.now(timezone.utc).date().isoformat()
+    out_md = (
+        Path(args.out) if args.out else (CONTEXT_DIR / f"llm-medium-vs-large-{today}.md")
+    )
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(report, encoding="utf-8")
+    print(f"✅ Rapport : {out_md}")
+
+    if args.out_json:
+        Path(args.out_json).write_text(
+            json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        print(f"✅ Dataset fusionné : {args.out_json}")
+
+    print()
+    print(f"  medium vs PO : F1_span={medium_metrics['span']['f1']:.3f}")
+    print(f"  large  vs PO : F1_span={large_metrics['span']['f1']:.3f}")
+    print(
+        f"  Δ F1_span (large - medium) = "
+        f"{large_metrics['span']['f1'] - medium_metrics['span']['f1']:+.3f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/evaluate_title_annotations.py
+++ b/packages/api/scripts/evaluate_title_annotations.py
@@ -1,0 +1,487 @@
+"""Évaluateur data-driven de la pipeline `TitleAnnotationService`
+(Story 7.4, suite — calibration).
+
+Charge un dataset annoté (cf. `build_highlight_dataset.py` + annotation
+PO/agent), lance la pipeline sur chaque cluster, et produit :
+
+- Métriques precision/recall/F1 au niveau **token-lemma** et au niveau
+  **span fusionné** (spans contigus collés en une unité).
+- Catégorisation des erreurs : FP croisés avec `exclude_spans` du gold
+  (FP_pivot_entity, FP_neutral_verb, FP_entity_alias…), FN tagués via
+  `target_spans.category` (FN_editorial_angle, FN_multi_token_expression…).
+- Top-N lemmes en FP et FN — utile pour inférer une whitelist/stopword
+  *depuis les données*, pas l'intuition.
+
+Le mode `--compare baseline.json after.json` charge deux runs précédents
+et imprime le delta de métriques (utilisé par les PRs de calibration).
+
+Usage :
+    cd packages/api && source venv/bin/activate
+    python scripts/evaluate_title_annotations.py \\
+        --dataset .context/highlight-dataset-2026-05-19.json \\
+        --tag baseline
+    python scripts/evaluate_title_annotations.py \\
+        --compare .context/highlight-baseline-2026-05-19.json \\
+                  .context/highlight-after-iter1.json
+
+Sorties :
+    .context/highlight-<tag>-<date>.json   (machine, consommé par --compare)
+    .context/highlight-<tag>-<date>.md     (lisible humain)
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from app.services.title_annotation_service import (  # noqa: E402
+    TitleAnnotationService,
+    get_title_annotation_service,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTEXT_DIR = REPO_ROOT / ".context"
+
+
+# ---------------------------------------------------------------------------
+# Span helpers
+# ---------------------------------------------------------------------------
+
+
+def fuse_spans(spans: list[dict], gap: int = 1) -> list[tuple[int, int]]:
+    """Fusionne les spans contigus (écart ≤ `gap` chars) en intervalles.
+
+    Préserve l'ordre. Travaille sur (start, end) uniquement.
+    """
+    if not spans:
+        return []
+    sorted_spans = sorted(spans, key=lambda s: (s["start"], s["end"]))
+    fused: list[tuple[int, int]] = []
+    cur_s, cur_e = sorted_spans[0]["start"], sorted_spans[0]["end"]
+    for s in sorted_spans[1:]:
+        if s["start"] - cur_e <= gap:
+            cur_e = max(cur_e, s["end"])
+        else:
+            fused.append((cur_s, cur_e))
+            cur_s, cur_e = s["start"], s["end"]
+    fused.append((cur_s, cur_e))
+    return fused
+
+
+def spans_overlap(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    return not (a[1] <= b[0] or b[1] <= a[0])
+
+
+# ---------------------------------------------------------------------------
+# Per-article evaluation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ArticleScore:
+    cluster_key: str
+    article_id: str
+    title: str
+    tp_lemmas: set[str] = field(default_factory=set)
+    fp_lemmas: set[str] = field(default_factory=set)
+    fn_lemmas: set[str] = field(default_factory=set)
+    # span-level (start, end) tuples after fusion
+    tp_spans: list[tuple[int, int]] = field(default_factory=list)
+    fp_spans: list[tuple[int, int]] = field(default_factory=list)
+    fn_spans: list[tuple[int, int]] = field(default_factory=list)
+    # error categories : {"FP_pivot_entity": [(span, lemma), ...]}
+    fp_by_category: dict[str, list[tuple[tuple[int, int], str]]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    fn_by_category: dict[str, list[tuple[tuple[int, int], str]]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+
+
+def _lemmas_in_range(
+    tokens: list[dict], start: int, end: int
+) -> list[str]:
+    """Renvoie les lemmes des tokens qui chevauchent [start, end]."""
+    return [
+        t["lemma"]
+        for t in tokens
+        if spans_overlap((t["start"], t["end"]), (start, end))
+    ]
+
+
+def _categorize_fp(
+    fp_span: tuple[int, int], exclude_spans: list[dict]
+) -> str:
+    for ex in exclude_spans:
+        ex_range = (ex["start"], ex["end"])
+        if spans_overlap(fp_span, ex_range):
+            cat = ex.get("category") or "other"
+            return f"FP_{cat}"
+    return "FP_other"
+
+
+def _categorize_fn(
+    fn_span: tuple[int, int], target_spans: list[dict]
+) -> str:
+    for tg in target_spans:
+        tg_range = (tg["start"], tg["end"])
+        if spans_overlap(fn_span, tg_range):
+            cat = tg.get("category") or "other"
+            return f"FN_{cat}"
+    return "FN_other"
+
+
+def score_article(
+    svc: TitleAnnotationService,
+    cluster_key: str,
+    article_id: str,
+    alt_title: str,
+    alt_tokens: list[dict],
+    pred_spans: list[dict],
+    target_spans: list[dict],
+    exclude_spans: list[dict],
+) -> ArticleScore:
+    """Compare prédictions et gold pour un seul article (perspective).
+
+    Token-level : ensemble des lemmes. Span-level : intervalles fusionnés.
+    """
+    score = ArticleScore(
+        cluster_key=cluster_key, article_id=article_id, title=alt_title
+    )
+
+    pred_lemmas = {
+        s["text"].lower(): s
+        for s in pred_spans
+    }
+    # On préfère matcher sur les lemmes calculés par le service côté pred.
+    # Pour les gold, on retrouve les lemmes via la tokenisation du titre.
+    pred_lemma_set: set[str] = set()
+    pred_span_to_lemma: dict[tuple[int, int], str] = {}
+    for s in pred_spans:
+        lemmas = _lemmas_in_range(alt_tokens, s["start"], s["end"])
+        if lemmas:
+            pred_lemma_set.update(lemmas)
+            pred_span_to_lemma[(s["start"], s["end"])] = lemmas[0]
+
+    gold_lemma_set: set[str] = set()
+    gold_span_to_lemma: dict[tuple[int, int], str] = {}
+    for s in target_spans:
+        lemmas = _lemmas_in_range(alt_tokens, s["start"], s["end"])
+        for lemma in lemmas:
+            gold_lemma_set.add(lemma)
+            gold_span_to_lemma.setdefault((s["start"], s["end"]), lemma)
+
+    score.tp_lemmas = pred_lemma_set & gold_lemma_set
+    score.fp_lemmas = pred_lemma_set - gold_lemma_set
+    score.fn_lemmas = gold_lemma_set - pred_lemma_set
+
+    # Span-level (intervalles fusionnés, match exact)
+    pred_fused = fuse_spans(pred_spans)
+    gold_fused = fuse_spans(target_spans)
+    pred_set = set(pred_fused)
+    gold_set = set(gold_fused)
+    score.tp_spans = sorted(pred_set & gold_set)
+    score.fp_spans = sorted(pred_set - gold_set)
+    score.fn_spans = sorted(gold_set - pred_set)
+
+    # Catégorisation : à partir des spans en erreur, plus parlant que les lemmes
+    for fp_span in score.fp_spans:
+        cat = _categorize_fp(fp_span, exclude_spans)
+        lemma = pred_span_to_lemma.get(fp_span, "?")
+        score.fp_by_category[cat].append((fp_span, lemma))
+    for fn_span in score.fn_spans:
+        cat = _categorize_fn(fn_span, target_spans)
+        lemma = gold_span_to_lemma.get(fn_span, "?")
+        score.fn_by_category[cat].append((fn_span, lemma))
+
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _safe_div(num: float, denom: float) -> float:
+    return num / denom if denom else 0.0
+
+
+def _f1(precision: float, recall: float) -> float:
+    return _safe_div(2 * precision * recall, precision + recall)
+
+
+def aggregate(scores: list[ArticleScore]) -> dict:
+    tp_tok = sum(len(s.tp_lemmas) for s in scores)
+    fp_tok = sum(len(s.fp_lemmas) for s in scores)
+    fn_tok = sum(len(s.fn_lemmas) for s in scores)
+    p_tok = _safe_div(tp_tok, tp_tok + fp_tok)
+    r_tok = _safe_div(tp_tok, tp_tok + fn_tok)
+
+    tp_span = sum(len(s.tp_spans) for s in scores)
+    fp_span = sum(len(s.fp_spans) for s in scores)
+    fn_span = sum(len(s.fn_spans) for s in scores)
+    p_span = _safe_div(tp_span, tp_span + fp_span)
+    r_span = _safe_div(tp_span, tp_span + fn_span)
+
+    fp_cats: Counter = Counter()
+    fn_cats: Counter = Counter()
+    fp_lemma_counter: Counter = Counter()
+    fn_lemma_counter: Counter = Counter()
+    for s in scores:
+        for cat, errs in s.fp_by_category.items():
+            fp_cats[cat] += len(errs)
+            for _, lemma in errs:
+                fp_lemma_counter[lemma] += 1
+        for cat, errs in s.fn_by_category.items():
+            fn_cats[cat] += len(errs)
+            for _, lemma in errs:
+                fn_lemma_counter[lemma] += 1
+
+    return {
+        "n_perspectives": len(scores),
+        "token": {
+            "tp": tp_tok, "fp": fp_tok, "fn": fn_tok,
+            "precision": p_tok, "recall": r_tok, "f1": _f1(p_tok, r_tok),
+        },
+        "span": {
+            "tp": tp_span, "fp": fp_span, "fn": fn_span,
+            "precision": p_span, "recall": r_span, "f1": _f1(p_span, r_span),
+        },
+        "fp_categories": dict(fp_cats.most_common()),
+        "fn_categories": dict(fn_cats.most_common()),
+        "top_fp_lemmas": fp_lemma_counter.most_common(30),
+        "top_fn_lemmas": fn_lemma_counter.most_common(30),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Prediction & evaluation runner
+# ---------------------------------------------------------------------------
+
+
+def load_dataset(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def evaluate_dataset(
+    dataset: dict,
+    svc: TitleAnnotationService,
+    annotator: str,
+) -> list[ArticleScore]:
+    """Lance la pipeline sur chaque perspective et compare aux annotations."""
+    scores: list[ArticleScore] = []
+    for cluster in dataset["clusters"]:
+        articles = cluster["articles"]
+        ref_id = cluster["reference_article_id"]
+        ref = next(a for a in articles if a["id"] == ref_id)
+
+        titles = [a["title"] for a in articles]
+        # Sync path: pas asyncio nécessaire pour un script CLI sur N petits batchs.
+        tokens_list = [svc.compute_strong_tokens(t) for t in titles]
+        tokens_by_id = {a["id"]: tokens_list[i] for i, a in enumerate(articles)}
+        ref_tokens = tokens_by_id[ref_id]
+
+        for art in articles:
+            if art["id"] == ref_id:
+                continue
+            if (art.get("annotations") or {}).get("dropped"):
+                # Perspective marquée comme à exclure (ex : mauvais clustering)
+                continue
+            ann = (art.get("annotations") or {}).get(annotator)
+            if not ann:
+                # Pas annoté → on saute pour ne pas pourrir les métriques
+                continue
+            pred_spans = svc.diff_spans(
+                ref_tokens, tokens_by_id[art["id"]], art.get("bias_stance", "unknown")
+            )
+            scores.append(
+                score_article(
+                    svc=svc,
+                    cluster_key=cluster["cluster_key"],
+                    article_id=art["id"],
+                    alt_title=art["title"],
+                    alt_tokens=tokens_by_id[art["id"]],
+                    pred_spans=pred_spans,
+                    target_spans=ann.get("target_spans") or [],
+                    exclude_spans=ann.get("exclude_spans") or [],
+                )
+            )
+    return scores
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def format_metric_block(metrics: dict, label: str) -> list[str]:
+    out = [f"### {label}"]
+    tok = metrics["token"]
+    span = metrics["span"]
+    out.append(
+        f"- **Token-lemma** : P = {tok['precision']:.3f} · R = {tok['recall']:.3f} · "
+        f"F1 = {tok['f1']:.3f}  (TP={tok['tp']} FP={tok['fp']} FN={tok['fn']})"
+    )
+    out.append(
+        f"- **Span fusionné** : P = {span['precision']:.3f} · R = {span['recall']:.3f} · "
+        f"F1 = {span['f1']:.3f}  (TP={span['tp']} FP={span['fp']} FN={span['fn']})"
+    )
+    if metrics["fp_categories"]:
+        out.append("- **FP par catégorie** :")
+        for cat, n in metrics["fp_categories"].items():
+            out.append(f"  - {cat}: {n}")
+    if metrics["fn_categories"]:
+        out.append("- **FN par catégorie** :")
+        for cat, n in metrics["fn_categories"].items():
+            out.append(f"  - {cat}: {n}")
+    if metrics["top_fp_lemmas"]:
+        out.append("- **Top FP lemmes** : " + ", ".join(
+            f"{lemma}({n})" for lemma, n in metrics["top_fp_lemmas"][:15]
+        ))
+    if metrics["top_fn_lemmas"]:
+        out.append("- **Top FN lemmes** : " + ", ".join(
+            f"{lemma}({n})" for lemma, n in metrics["top_fn_lemmas"][:15]
+        ))
+    return out
+
+
+def render_report(
+    metrics: dict, dataset_path: Path, model_version: str, tag: str
+) -> str:
+    today = datetime.now(timezone.utc).date().isoformat()
+    out = [
+        f"# Évaluation highlighting — `{tag}` ({today})",
+        "",
+        f"- Dataset : `{dataset_path.name}`",
+        f"- Pipeline : `{model_version}`",
+        f"- Perspectives évaluées : {metrics['n_perspectives']}",
+        "",
+    ]
+    out.extend(format_metric_block(metrics, "Métriques globales"))
+    out.append("")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Compare mode
+# ---------------------------------------------------------------------------
+
+
+def render_compare(baseline: dict, after: dict) -> str:
+    def d(metric_path: list[str]) -> float:
+        a = after
+        b = baseline
+        for k in metric_path:
+            a = a[k]
+            b = b[k]
+        return a - b
+
+    lines = [
+        "# Comparaison baseline ↔ after",
+        "",
+        f"Perspectives baseline = {baseline['n_perspectives']} · "
+        f"after = {after['n_perspectives']}",
+        "",
+        "| Niveau | Métrique | baseline | after | Δ |",
+        "|--------|----------|----------|-------|---|",
+    ]
+    for level in ("token", "span"):
+        for metric in ("precision", "recall", "f1"):
+            b = baseline[level][metric]
+            a = after[level][metric]
+            lines.append(
+                f"| {level} | {metric} | {b:.3f} | {a:.3f} | {a-b:+.3f} |"
+            )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", help="Dataset annoté (mode évaluation)")
+    parser.add_argument(
+        "--annotator",
+        default="po_synchronous",
+        help="Source d'annotation à scorer (po_synchronous / agent_mirror)",
+    )
+    parser.add_argument(
+        "--tag",
+        default="baseline",
+        help="Nom de l'itération (intégré aux noms de fichiers de sortie)",
+    )
+    parser.add_argument(
+        "--compare",
+        nargs=2,
+        metavar=("BASELINE", "AFTER"),
+        help="Mode comparaison : 2 chemins JSON produits par ce script",
+    )
+    parser.add_argument("--out-json", default=None)
+    parser.add_argument("--out-md", default=None)
+    args = parser.parse_args()
+
+    if args.compare:
+        baseline = json.loads(Path(args.compare[0]).read_text(encoding="utf-8"))
+        after = json.loads(Path(args.compare[1]).read_text(encoding="utf-8"))
+        report = render_compare(baseline["metrics"], after["metrics"])
+        print(report)
+        return
+
+    if not args.dataset:
+        parser.error("--dataset requis (sauf en mode --compare)")
+
+    dataset_path = Path(args.dataset)
+    dataset = load_dataset(dataset_path)
+    svc = get_title_annotation_service()
+    if not svc.is_nlp_available:
+        print(
+            "❌ spaCy fr_core_news_md indisponible. "
+            "Installe : pip install spacy==3.8.11 "
+            "&& python -m spacy download fr_core_news_md",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    scores = evaluate_dataset(dataset, svc, args.annotator)
+    metrics = aggregate(scores)
+
+    today = datetime.now(timezone.utc).date().isoformat()
+    out_json = Path(
+        args.out_json or CONTEXT_DIR / f"highlight-{args.tag}-{today}.json"
+    )
+    out_md = Path(
+        args.out_md or CONTEXT_DIR / f"highlight-{args.tag}-{today}.md"
+    )
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "dataset": dataset_path.name,
+        "annotator": args.annotator,
+        "tag": args.tag,
+        "model_version": svc.MODEL_VERSION,
+        "metrics": metrics,
+    }
+    out_json.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    out_md.write_text(
+        render_report(metrics, dataset_path, svc.MODEL_VERSION, args.tag),
+        encoding="utf-8",
+    )
+
+    print(f"✅ Résultats : {out_json}")
+    print(f"✅ Rapport   : {out_md}")
+    print()
+    print(render_report(metrics, dataset_path, svc.MODEL_VERSION, args.tag))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/llm_annotate_titles.py
+++ b/packages/api/scripts/llm_annotate_titles.py
@@ -1,0 +1,320 @@
+"""Annotation LLM-assistée des perspectives (Story 7.4 → Phase 4 PR 2).
+
+Itère sur le dataset d'annotations gold et demande au `LLMBiasAnnotationService`
+(Mistral-medium par défaut, cf. décision PO 2026-05-20) de produire une
+annotation au schéma v2 (`target_spans` avec `weight ∈ {0.25, 0.5, 1.0}` +
+`exclude_spans` binaires + `justification` par span).
+
+Écrit le résultat dans `annotations.llm_pass2` — **`po_synchronous` n'est
+jamais modifié**. Le PO relit ensuite et fusionne manuellement.
+
+Modes :
+    --mode blind  : refait les perspectives PO-reviewed sans leur montrer le
+                    gold (pour mesurer l'accord LLM↔PO via compare_annotations).
+    --mode fill   : annote les perspectives unreviewed (po_reviewed=false).
+    --mode all    : les deux.
+
+Garde-fous :
+    - Skip toute perspective `annotations.dropped == true` (ex : 3b85efa6).
+    - `LLM_ANNOTATE_DRY_RUN=1` → mock réponse vide (utilisé par les tests).
+
+Le validateur du service est tolérant : spans hallucinants ou catégorie/poids
+invalides sont droppés + logués (graceful degradation). L'annotation reste
+écrite dans le dataset avec les spans restants.
+
+Usage :
+    cd packages/api && python scripts/llm_annotate_titles.py \\
+        --dataset ../../.context/highlight-dataset-llm-pass2-2026-05-20.json \\
+        --mode blind --tag llm-pass-3
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+import structlog  # noqa: E402
+
+from app.services.llm_bias_annotation_service import (  # noqa: E402
+    DEFAULT_MODEL,
+    LLMBiasAnnotationService,
+)
+
+logger = structlog.get_logger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTEXT_DIR = REPO_ROOT / ".context"
+
+
+# ---------------------------------------------------------------------------
+# Few-shot selection from PO-reviewed examples
+# ---------------------------------------------------------------------------
+
+
+def _format_example(persp: dict, ref_title: str) -> str:
+    ann = persp["annotations"]["po_synchronous"]
+    return (
+        f"### Exemple — bias {persp.get('bias_stance', 'unknown')}\n"
+        f"Titre référence : {ref_title}\n"
+        f"Titre perspective : {persp['title']}\n"
+        f"Annotation attendue :\n"
+        + json.dumps(
+            {
+                "target_spans": ann.get("target_spans", []),
+                "exclude_spans": ann.get("exclude_spans", []),
+                "notes": ann.get("notes", ""),
+                "confidence": 1.0,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+
+def _select_fewshot(dataset: dict, max_examples: int = 10) -> list[dict]:
+    """Sélectionne des perspectives PO-reviewed diversifiées (axes : bias,
+    target catégorie × weight, exclude catégorie). Retourne la liste brute
+    de candidats — `_build_examples_from_selection` les formate."""
+    candidates: list[tuple[dict, str, set[tuple]]] = []
+    for cluster in dataset["clusters"]:
+        ref_id = cluster["reference_article_id"]
+        ref = next(a for a in cluster["articles"] if a["id"] == ref_id)
+        for art in cluster["articles"]:
+            if art["id"] == ref_id:
+                continue
+            if (art.get("annotations") or {}).get("dropped"):
+                continue
+            ann = (art.get("annotations") or {}).get("po_synchronous") or {}
+            if not ann.get("po_reviewed"):
+                continue
+            signature: set[tuple] = set()
+            signature.add(("bias", art.get("bias_stance", "unknown")))
+            for s in ann.get("target_spans", []):
+                signature.add(
+                    (
+                        "target",
+                        s.get("category", "?"),
+                        float(s.get("weight", 1.0)),
+                    )
+                )
+            for s in ann.get("exclude_spans", []):
+                signature.add(("exclude", s.get("category", "?")))
+            candidates.append((art, ref["title"], signature))
+
+    selected: list[dict] = []
+    covered: set[tuple] = set()
+    while candidates and len(selected) < max_examples:
+        candidates.sort(key=lambda c: len(c[2] - covered), reverse=True)
+        best, ref_title, sig = candidates.pop(0)
+        if not (sig - covered) and selected:
+            break
+        selected.append({"persp": best, "ref_title": ref_title})
+        covered |= sig
+    return selected
+
+
+def build_fewshot_examples(dataset: dict, max_examples: int = 10) -> list[str]:
+    """Formate les few-shot du gold dataset pour injection dans le prompt."""
+    return [
+        _format_example(s["persp"], s["ref_title"])
+        for s in _select_fewshot(dataset, max_examples=max_examples)
+    ]
+
+
+def build_system_prompt(dataset: dict, max_examples: int = 10) -> str:
+    """Construit le prompt système complet (service + few-shot gold)."""
+    service = LLMBiasAnnotationService()
+    return service.build_system_prompt(
+        fewshot_examples=build_fewshot_examples(dataset, max_examples=max_examples)
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLM call (avec dry-run + delegation au service)
+# ---------------------------------------------------------------------------
+
+
+def _is_dry_run() -> bool:
+    return os.environ.get("LLM_ANNOTATE_DRY_RUN") == "1"
+
+
+async def annotate_one(
+    service: LLMBiasAnnotationService | None,
+    persp: dict,
+    ref_title: str,
+    peers: list[str],
+    fewshot_examples: list[str],
+) -> dict | None:
+    """Annote UNE perspective via le service. Retourne dict validé ou None."""
+    if _is_dry_run():
+        return {
+            "target_spans": [],
+            "exclude_spans": [],
+            "notes": "DRY RUN — aucun appel API",
+            "confidence": 0.0,
+        }
+    assert service is not None, "service requis hors dry-run"
+    return await service.annotate_variant(
+        ref_title=ref_title,
+        variant_title=persp["title"],
+        bias_stance=persp.get("bias_stance", "unknown"),
+        peers=peers,
+        fewshot_examples=fewshot_examples,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def iter_perspectives_to_annotate(
+    dataset: dict, mode: str
+) -> Iterable[tuple[str, dict, dict, list[str]]]:
+    """Yield (cluster_key, ref_article, perspective, peers) à annoter.
+
+    Modes :
+        - blind : po_reviewed=True (réannote pour mesurer l'accord LLM↔PO)
+        - fill  : po_reviewed=False et non dropped
+        - all   : les deux
+    """
+    for cluster in dataset["clusters"]:
+        ref_id = cluster["reference_article_id"]
+        ref = next(a for a in cluster["articles"] if a["id"] == ref_id)
+        other_titles = [
+            a["title"] for a in cluster["articles"] if a["id"] != ref_id
+        ]
+        for art in cluster["articles"]:
+            if art["id"] == ref_id:
+                continue
+            ann = art.get("annotations") or {}
+            if ann.get("dropped"):
+                continue
+            po = ann.get("po_synchronous") or {}
+            reviewed = bool(po.get("po_reviewed"))
+            if mode == "blind" and not reviewed:
+                continue
+            if mode == "fill" and reviewed:
+                continue
+            peers = [t for t in other_titles if t != art["title"]][:3]
+            yield cluster["cluster_key"], ref, art, peers
+
+
+async def run(
+    dataset_path: Path,
+    mode: str,
+    model: str,
+    out_path: Path,
+    limit: int | None,
+) -> None:
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+    fewshot_examples = build_fewshot_examples(dataset)
+
+    service: LLMBiasAnnotationService | None = None
+    if not _is_dry_run():
+        service = LLMBiasAnnotationService(model=model)
+        if not service.is_ready:
+            print(
+                "❌ MISTRAL_API_KEY non défini. Set LLM_ANNOTATE_DRY_RUN=1 "
+                "pour un run sans API.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    n_done = 0
+    n_failed = 0
+    annotated_by = model if not _is_dry_run() else "dry-run"
+    try:
+        for cluster_key, ref, persp, peers in iter_perspectives_to_annotate(
+            dataset, mode
+        ):
+            if limit is not None and n_done >= limit:
+                break
+            result = await annotate_one(
+                service=service,
+                persp=persp,
+                ref_title=ref["title"],
+                peers=peers,
+                fewshot_examples=fewshot_examples,
+            )
+            if result is None:
+                n_failed += 1
+                logger.warning(
+                    "llm_annotate.failed",
+                    article_id=persp["id"][:8],
+                    title=persp["title"][:60],
+                )
+                continue
+            persp.setdefault("annotations", {})["llm_pass2"] = {
+                "annotated_by": annotated_by,
+                "annotated_at": datetime.now(timezone.utc).isoformat(),
+                **result,
+            }
+            n_done += 1
+            print(
+                f"  ✅ {cluster_key[:24]:<24} {persp['id'][:8]} "
+                f"targets={len(result['target_spans'])} "
+                f"excludes={len(result['exclude_spans'])}"
+            )
+    finally:
+        if service is not None:
+            await service.close()
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(dataset, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(f"\n✅ Annotation LLM terminée : {n_done} succès, {n_failed} échecs")
+    print(f"   Dataset enrichi : {out_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument(
+        "--mode", choices=("blind", "fill", "all"), default="blind"
+    )
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Cap N annotations (utile en dev)"
+    )
+    parser.add_argument(
+        "--tag",
+        default="llm-pass2",
+        help="Tag intégré au nom de fichier de sortie (défaut : llm-pass2).",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Chemin de sortie explicite (sinon : .context/highlight-dataset-<tag>-<date>.json)",
+    )
+    args = parser.parse_args()
+
+    today = datetime.now(timezone.utc).date().isoformat()
+    out_path = (
+        Path(args.out)
+        if args.out
+        else (CONTEXT_DIR / f"highlight-dataset-{args.tag}-{today}.json")
+    )
+
+    asyncio.run(
+        run(
+            dataset_path=Path(args.dataset),
+            mode=args.mode,
+            model=args.model,
+            out_path=out_path,
+            limit=args.limit,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/tests/scripts/fixtures/toy_dataset.json
+++ b/packages/api/tests/scripts/fixtures/toy_dataset.json
@@ -1,0 +1,51 @@
+{
+  "generated_at": "2026-05-19T00:00:00+00:00",
+  "schema_version": 1,
+  "model_version": "v1-spacy-fr_md",
+  "stratification": {"politics": 1},
+  "clusters": [
+    {
+      "cluster_key": "macron",
+      "cluster_display": "Macron",
+      "theme": "politics",
+      "reference_article_id": "ref-1",
+      "articles": [
+        {
+          "id": "ref-1",
+          "title": "Macron rencontre Trump",
+          "url": "https://example.com/ref",
+          "published_at": "2026-05-19T08:00:00+00:00",
+          "source_name": "Le Monde",
+          "source_id": "src-1",
+          "bias_stance": "center",
+          "entities": ["{\"name\": \"Macron\", \"type\": \"PERSON\"}", "{\"name\": \"Trump\", \"type\": \"PERSON\"}"],
+          "annotations": {}
+        },
+        {
+          "id": "alt-1",
+          "title": "Donald Trump reçoit Macron à Paris",
+          "url": "https://example.com/alt1",
+          "published_at": "2026-05-19T10:00:00+00:00",
+          "source_name": "Libération",
+          "source_id": "src-2",
+          "bias_stance": "left",
+          "entities": ["{\"name\": \"Trump\", \"type\": \"PERSON\"}", "{\"name\": \"Macron\", \"type\": \"PERSON\"}", "{\"name\": \"Paris\", \"type\": \"LOC\"}"],
+          "annotations": {
+            "po_synchronous": {
+              "annotated_by": "po",
+              "annotated_at": "2026-05-19T12:00:00+00:00",
+              "target_spans": [
+                {"start": 29, "end": 34, "text": "Paris", "category": "fact"}
+              ],
+              "exclude_spans": [
+                {"start": 0, "end": 6, "text": "Donald", "category": "entity_alias"},
+                {"start": 13, "end": 19, "text": "reçoit", "category": "neutral_verb"}
+              ],
+              "notes": "Paris est le seul fait nouveau ; Donald = alias de Trump ; reçoit = verbe neutre."
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/api/tests/scripts/test_compare_annotations.py
+++ b/packages/api/tests/scripts/test_compare_annotations.py
@@ -1,0 +1,188 @@
+"""Tests hermétiques pour `scripts/compare_annotations.py`."""
+
+from __future__ import annotations
+
+import math
+
+from scripts.compare_annotations import (
+    aggregate,
+    cohen_kappa,
+    match_spans,
+    score_perspective,
+)
+
+
+# ---------------------------------------------------------------------------
+# match_spans
+# ---------------------------------------------------------------------------
+
+
+def test_match_spans_one_to_one_by_overlap():
+    gold = [{"start": 0, "end": 10}, {"start": 20, "end": 30}]
+    pred = [{"start": 2, "end": 8}, {"start": 25, "end": 35}]
+    pairs, fn, fp = match_spans(gold, pred)
+    assert len(pairs) == 2
+    assert fn == [] and fp == []
+
+
+def test_match_spans_unmatched_become_fn_fp():
+    gold = [{"start": 0, "end": 5}]
+    pred = [{"start": 10, "end": 15}]
+    pairs, fn, fp = match_spans(gold, pred)
+    assert pairs == []
+    assert fn == gold
+    assert fp == pred
+
+
+def test_match_spans_picks_bigger_overlap():
+    gold = [{"start": 0, "end": 10}]
+    pred = [{"start": 0, "end": 3}, {"start": 0, "end": 9}]
+    pairs, fn, fp = match_spans(gold, pred)
+    assert len(pairs) == 1
+    # Le span pred (0,9) gagne (overlap=9) vs (0,3) (overlap=3)
+    assert pairs[0][1]["end"] == 9
+    assert fp == [{"start": 0, "end": 3}]
+
+
+# ---------------------------------------------------------------------------
+# cohen_kappa
+# ---------------------------------------------------------------------------
+
+
+def test_kappa_perfect_agreement():
+    pairs = [("a", "a"), ("b", "b"), ("a", "a")]
+    assert cohen_kappa(pairs) == 1.0
+
+
+def test_kappa_complete_disagreement():
+    # Deux annotateurs jamais d'accord, mais distribution = même
+    pairs = [("a", "b"), ("b", "a"), ("a", "b"), ("b", "a")]
+    # p_obs=0, p_exp=0.5 → κ=-1
+    assert cohen_kappa(pairs) == -1.0
+
+
+def test_kappa_chance_level():
+    # Annotateurs d'accord exactement au niveau du hasard → κ proche de 0
+    pairs = [("a", "a"), ("a", "b"), ("b", "a"), ("b", "b")]
+    kappa = cohen_kappa(pairs)
+    assert abs(kappa) < 1e-9
+
+
+def test_kappa_empty_pairs():
+    assert cohen_kappa([]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# score_perspective sans spaCy
+# ---------------------------------------------------------------------------
+
+
+def test_score_perspective_perfect_match():
+    title = "Trump écrase Massie : la mainmise"
+    spans = [
+        {"start": 6, "end": 12, "text": "écrase",
+         "category": "editorial_angle", "weight": 1.0},
+        {"start": 25, "end": 33, "text": "mainmise",
+         "category": "framing_noun", "weight": 1.0},
+    ]
+    gold = {"target_spans": spans, "exclude_spans": []}
+    pred = {"target_spans": spans, "exclude_spans": []}
+    s = score_perspective(title, gold, pred, svc=None)
+    assert len(s["tp_span"]) == 2
+    assert s["fp_span"] == [] and s["fn_span"] == []
+    assert s["disagreement_score"] == 0
+    # 2 matchs avec weight=1.0 chacun
+    assert all(a == b for a, b in s["weight_diffs"])
+
+
+def test_score_perspective_weight_disagreement_yields_mae():
+    title = "écrase"  # 6 chars
+    gold = {
+        "target_spans": [
+            {"start": 0, "end": 6, "text": "écrase",
+             "category": "editorial_angle", "weight": 1.0},
+        ],
+        "exclude_spans": [],
+    }
+    pred = {
+        "target_spans": [
+            {"start": 0, "end": 6, "text": "écrase",
+             "category": "editorial_angle", "weight": 0.5},
+        ],
+        "exclude_spans": [],
+    }
+    s = score_perspective(title, gold, pred, svc=None)
+    # Span matché mais weight différent
+    assert s["weight_diffs"] == [(1.0, 0.5)]
+    # Span identique → pas de désaccord span-level
+    assert s["fp_span"] == [] and s["fn_span"] == []
+
+
+def test_score_perspective_fp_and_fn():
+    title = "Trump écrase Massie : la mainmise"
+    gold = {
+        "target_spans": [
+            {"start": 6, "end": 12, "text": "écrase",
+             "category": "editorial_angle", "weight": 1.0},
+        ],
+        "exclude_spans": [],
+    }
+    pred = {
+        "target_spans": [
+            {"start": 25, "end": 33, "text": "mainmise",
+             "category": "framing_noun", "weight": 1.0},
+        ],
+        "exclude_spans": [],
+    }
+    s = score_perspective(title, gold, pred, svc=None)
+    assert s["fn_span"] == [(6, 12)]
+    assert s["fp_span"] == [(25, 33)]
+    assert s["disagreement_score"] == 2
+
+
+# ---------------------------------------------------------------------------
+# aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_combines_scores():
+    title = "Trump écrase Massie"
+    spans = [
+        {"start": 6, "end": 12, "text": "écrase",
+         "category": "editorial_angle", "weight": 1.0},
+    ]
+    gold = {"target_spans": spans, "exclude_spans": []}
+    pred = {"target_spans": spans, "exclude_spans": []}
+
+    scores = [
+        score_perspective(title, gold, pred, svc=None),
+        score_perspective(title, gold, pred, svc=None),
+    ]
+    m = aggregate(scores)
+    assert m["n_perspectives"] == 2
+    assert m["span"]["precision"] == 1.0
+    assert m["span"]["recall"] == 1.0
+    assert m["span"]["f1"] == 1.0
+    assert m["weight_agreement"]["n"] == 2
+    assert m["weight_agreement"]["mae"] == 0.0
+
+
+def test_aggregate_weight_mae():
+    title = "écrase"
+    gold = {
+        "target_spans": [
+            {"start": 0, "end": 6, "text": "écrase",
+             "category": "editorial_angle", "weight": 1.0},
+        ],
+        "exclude_spans": [],
+    }
+    pred = {
+        "target_spans": [
+            {"start": 0, "end": 6, "text": "écrase",
+             "category": "editorial_angle", "weight": 0.25},
+        ],
+        "exclude_spans": [],
+    }
+    scores = [score_perspective(title, gold, pred, svc=None)]
+    m = aggregate(scores)
+    assert math.isclose(m["weight_agreement"]["mae"], 0.75)

--- a/packages/api/tests/scripts/test_evaluate_title_annotations.py
+++ b/packages/api/tests/scripts/test_evaluate_title_annotations.py
@@ -1,0 +1,286 @@
+"""Tests hermétiques pour `scripts/evaluate_title_annotations.py`.
+
+Vérifie les fonctions pures (fusion de spans, agrégation, catégorisation
+d'erreurs, mode --compare) puis exécute un smoke test bout-en-bout avec
+un `FakeNlp` injecté et un toy dataset.
+"""
+
+import json
+from pathlib import Path
+
+from scripts.evaluate_title_annotations import (
+    aggregate,
+    evaluate_dataset,
+    fuse_spans,
+    render_compare,
+    score_article,
+    spans_overlap,
+)
+from tests.fixtures.fake_spacy import (
+    FakeDoc,
+    FakeEnt,
+    FakeNlp,
+    FakeToken,
+    service_with_nlp,
+)
+
+
+# ---------------------------------------------------------------------------
+# Span helpers
+# ---------------------------------------------------------------------------
+
+
+def test_fuse_spans_merges_contiguous():
+    """Spans contigus (gap ≤ 1) sont fusionnés en un seul intervalle."""
+    spans = [{"start": 0, "end": 4}, {"start": 5, "end": 10}]
+    assert fuse_spans(spans, gap=1) == [(0, 10)]
+
+
+def test_fuse_spans_respects_gap_threshold():
+    """Spans séparés par > gap chars restent distincts."""
+    spans = [{"start": 0, "end": 4}, {"start": 8, "end": 10}]
+    assert fuse_spans(spans, gap=1) == [(0, 4), (8, 10)]
+
+
+def test_fuse_spans_empty():
+    assert fuse_spans([]) == []
+
+
+def test_spans_overlap_basic():
+    assert spans_overlap((0, 5), (3, 7)) is True
+    assert spans_overlap((0, 5), (5, 7)) is False  # touching but non-overlapping
+    assert spans_overlap((0, 5), (10, 12)) is False
+
+
+# ---------------------------------------------------------------------------
+# score_article (pure : pas de spaCy)
+# ---------------------------------------------------------------------------
+
+
+def _alt_tokens_for_donald_trump_paris():
+    """Tokens fabriqués manuellement pour 'Donald Trump reçoit Macron à Paris'."""
+    return [
+        {"start": 0, "end": 6, "text": "Donald", "lemma": "donald", "pos": "PROPN"},
+        {"start": 7, "end": 12, "text": "Trump", "lemma": "trump", "pos": "PROPN"},
+        {"start": 13, "end": 19, "text": "reçoit", "lemma": "recevoir", "pos": "VERB"},
+        {"start": 20, "end": 26, "text": "Macron", "lemma": "macron", "pos": "PROPN"},
+        {"start": 29, "end": 34, "text": "Paris", "lemma": "paris", "pos": "PROPN"},
+    ]
+
+
+def test_score_article_perfect_match():
+    """Pred = gold ⟹ TP rempli, pas de FP/FN."""
+    tokens = _alt_tokens_for_donald_trump_paris()
+    pred = [{"start": 29, "end": 34, "text": "Paris", "bias": "left"}]
+    target = [{"start": 29, "end": 34, "text": "Paris", "category": "fact"}]
+
+    score = score_article(
+        svc=None,
+        cluster_key="c",
+        article_id="a",
+        alt_title="Donald Trump reçoit Macron à Paris",
+        alt_tokens=tokens,
+        pred_spans=pred,
+        target_spans=target,
+        exclude_spans=[],
+    )
+
+    assert score.tp_lemmas == {"paris"}
+    assert score.fp_lemmas == set()
+    assert score.fn_lemmas == set()
+    assert score.tp_spans == [(29, 34)]
+    assert score.fp_spans == []
+    assert score.fn_spans == []
+
+
+def test_score_article_zero_recall_when_no_prediction():
+    """Pred vide, gold non-vide ⟹ R = 0 et tous les FN tagués par catégorie."""
+    tokens = _alt_tokens_for_donald_trump_paris()
+    target = [{"start": 29, "end": 34, "text": "Paris", "category": "fact"}]
+
+    score = score_article(
+        svc=None, cluster_key="c", article_id="a",
+        alt_title="t", alt_tokens=tokens,
+        pred_spans=[], target_spans=target, exclude_spans=[],
+    )
+
+    assert score.tp_lemmas == set()
+    assert score.fn_lemmas == {"paris"}
+    assert "FN_fact" in score.fn_by_category
+    assert score.fn_by_category["FN_fact"][0][1] == "paris"
+
+
+def test_score_article_categorizes_fp_against_exclude_spans():
+    """Span prédit qui chevauche un exclude_span ⟹ FP_<category>."""
+    tokens = _alt_tokens_for_donald_trump_paris()
+    pred = [
+        {"start": 0, "end": 6, "text": "Donald", "bias": "left"},
+        {"start": 13, "end": 19, "text": "reçoit", "bias": "left"},
+    ]
+    target = [{"start": 29, "end": 34, "text": "Paris", "category": "fact"}]
+    exclude = [
+        {"start": 0, "end": 6, "text": "Donald", "category": "entity_alias"},
+        {"start": 13, "end": 19, "text": "reçoit", "category": "neutral_verb"},
+    ]
+
+    score = score_article(
+        svc=None, cluster_key="c", article_id="a",
+        alt_title="t", alt_tokens=tokens,
+        pred_spans=pred, target_spans=target, exclude_spans=exclude,
+    )
+
+    assert "FP_entity_alias" in score.fp_by_category
+    assert "FP_neutral_verb" in score.fp_by_category
+    assert score.fp_by_category["FP_entity_alias"][0][1] == "donald"
+    assert score.fp_by_category["FP_neutral_verb"][0][1] == "recevoir"
+
+
+# ---------------------------------------------------------------------------
+# aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_top_n_lemma_counter():
+    """3 articles avec FP sur 'dire' ⟹ top FP[0] == ('dire', 3)."""
+    tokens = [{"start": 0, "end": 3, "text": "dit", "lemma": "dire", "pos": "VERB"}]
+    pred = [{"start": 0, "end": 3, "text": "dit", "bias": "right"}]
+    exclude = [{"start": 0, "end": 3, "text": "dit", "category": "neutral_verb"}]
+
+    scores = [
+        score_article(
+            svc=None, cluster_key=f"c{i}", article_id=f"a{i}",
+            alt_title="t", alt_tokens=tokens,
+            pred_spans=pred, target_spans=[], exclude_spans=exclude,
+        )
+        for i in range(3)
+    ]
+    metrics = aggregate(scores)
+
+    assert metrics["top_fp_lemmas"][0] == ("dire", 3)
+    assert metrics["fp_categories"]["FP_neutral_verb"] == 3
+    assert metrics["token"]["fp"] == 3
+    assert metrics["token"]["tp"] == 0
+
+
+def test_aggregate_perfect_recall_no_fp():
+    tokens = [{"start": 0, "end": 5, "text": "Paris", "lemma": "paris", "pos": "PROPN"}]
+    pred = [{"start": 0, "end": 5, "text": "Paris", "bias": "left"}]
+    target = [{"start": 0, "end": 5, "text": "Paris", "category": "fact"}]
+
+    score = score_article(
+        svc=None, cluster_key="c", article_id="a",
+        alt_title="t", alt_tokens=tokens,
+        pred_spans=pred, target_spans=target, exclude_spans=[],
+    )
+    metrics = aggregate([score])
+
+    assert metrics["token"]["precision"] == 1.0
+    assert metrics["token"]["recall"] == 1.0
+    assert metrics["token"]["f1"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# render_compare
+# ---------------------------------------------------------------------------
+
+
+def test_render_compare_delta():
+    baseline = {
+        "n_perspectives": 10,
+        "token": {"precision": 0.5, "recall": 0.5, "f1": 0.5, "tp": 0, "fp": 0, "fn": 0},
+        "span":  {"precision": 0.5, "recall": 0.5, "f1": 0.5, "tp": 0, "fp": 0, "fn": 0},
+    }
+    after = {
+        "n_perspectives": 10,
+        "token": {"precision": 0.7, "recall": 0.6, "f1": 0.65, "tp": 0, "fp": 0, "fn": 0},
+        "span":  {"precision": 0.7, "recall": 0.6, "f1": 0.65, "tp": 0, "fp": 0, "fn": 0},
+    }
+
+    report = render_compare(baseline, after)
+
+    # Le delta pour token/f1 = 0.65 - 0.5 = +0.150
+    assert "+0.150" in report
+    assert "token" in report
+    assert "span" in report
+
+
+# ---------------------------------------------------------------------------
+# Smoke test bout-en-bout sur toy dataset (avec FakeNlp injecté)
+# ---------------------------------------------------------------------------
+
+
+def _toy_fake_nlp() -> FakeNlp:
+    """FakeNlp couvrant les 2 titres du toy dataset."""
+    ref = FakeDoc(
+        tokens=[
+            FakeToken("Macron", 0, "PROPN", "Macron"),
+            FakeToken("rencontre", 7, "VERB", "rencontrer"),
+            FakeToken("Trump", 17, "PROPN", "Trump"),
+        ],
+        ents=[FakeEnt(0, 6, "PER"), FakeEnt(17, 22, "PER")],
+    )
+    alt = FakeDoc(
+        tokens=[
+            FakeToken("Donald", 0, "PROPN", "Donald"),
+            FakeToken("Trump", 7, "PROPN", "Trump"),
+            FakeToken("reçoit", 13, "VERB", "recevoir"),
+            FakeToken("Macron", 20, "PROPN", "Macron"),
+            FakeToken("à", 27, "ADP", "à", is_stop=True),
+            FakeToken("Paris", 29, "PROPN", "Paris"),
+        ],
+        ents=[
+            FakeEnt(0, 12, "PER"),  # Donald Trump
+            FakeEnt(20, 26, "PER"),
+            FakeEnt(29, 34, "LOC"),
+        ],
+    )
+    return FakeNlp({
+        "Macron rencontre Trump": ref,
+        "Donald Trump reçoit Macron à Paris": alt,
+    })
+
+
+def test_evaluate_dataset_smoke_on_toy():
+    """Bout-en-bout : 1 cluster, 1 perspective annotée.
+
+    Pred (capé à 4, priorité PROPN < VERB) doit contenir Donald, Paris,
+    reçoit (3 spans).
+    Gold target = {Paris}, exclude = {Donald, reçoit}.
+    Attendu :
+      TP_token = {paris}, FP = {donald, recevoir}, FN = {}
+      FP_entity_alias = 1, FP_neutral_verb = 1
+    """
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "toy_dataset.json"
+    )
+    dataset = json.loads(fixture_path.read_text(encoding="utf-8"))
+    svc = service_with_nlp(_toy_fake_nlp())
+
+    scores = evaluate_dataset(dataset, svc, annotator="po_synchronous")
+    metrics = aggregate(scores)
+
+    assert metrics["n_perspectives"] == 1
+    assert metrics["token"]["tp"] == 1
+    assert metrics["token"]["fp"] == 2
+    assert metrics["token"]["fn"] == 0
+    assert metrics["fp_categories"]["FP_entity_alias"] == 1
+    assert metrics["fp_categories"]["FP_neutral_verb"] == 1
+    # paris doit être un TP, donc absent des top FP
+    top_fp_lemmas = {lemma for lemma, _ in metrics["top_fp_lemmas"]}
+    assert "paris" not in top_fp_lemmas
+    assert "donald" in top_fp_lemmas
+    assert "recevoir" in top_fp_lemmas
+
+
+def test_evaluate_dataset_skips_unannotated_perspectives():
+    """Une perspective sans annotation `po_synchronous` ne doit pas être scorée."""
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "toy_dataset.json"
+    )
+    dataset = json.loads(fixture_path.read_text(encoding="utf-8"))
+    # Vide les annotations sur la seule perspective
+    dataset["clusters"][0]["articles"][1]["annotations"] = {}
+    svc = service_with_nlp(_toy_fake_nlp())
+
+    scores = evaluate_dataset(dataset, svc, annotator="po_synchronous")
+    assert scores == []

--- a/packages/api/tests/scripts/test_llm_annotate_titles.py
+++ b/packages/api/tests/scripts/test_llm_annotate_titles.py
@@ -1,0 +1,292 @@
+"""Tests hermétiques pour `scripts/llm_annotate_titles.py`.
+
+Le script délègue prompt + validation au `LLMBiasAnnotationService` (testé
+exhaustivement dans `tests/services/test_llm_bias_annotation_service.py`).
+Les tests ici couvrent la logique script-spécifique : few-shot diversifié
+depuis le gold, itération de dataset selon mode, run dry-run end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from app.services.llm_bias_annotation_service import SCHEMA_DESCRIPTION
+from scripts.llm_annotate_titles import (
+    annotate_one,
+    build_fewshot_examples,
+    build_system_prompt,
+    iter_perspectives_to_annotate,
+    run,
+)
+
+
+# ---------------------------------------------------------------------------
+# Toy dataset (couvre po_reviewed, dropped, multi-bias)
+# ---------------------------------------------------------------------------
+
+
+def _toy_dataset() -> dict:
+    return {
+        "clusters": [
+            {
+                "cluster_key": "fixture",
+                "reference_article_id": "REF",
+                "articles": [
+                    {
+                        "id": "REF",
+                        "title": "Trump bat Massie",
+                        "bias_stance": "center",
+                    },
+                    {
+                        "id": "ALT1",
+                        "title": "Trump écrase Massie : la mainmise",
+                        "bias_stance": "left",
+                        "annotations": {
+                            "po_synchronous": {
+                                "po_reviewed": True,
+                                "target_spans": [
+                                    {
+                                        "start": 6,
+                                        "end": 12,
+                                        "text": "écrase",
+                                        "category": "editorial_angle",
+                                        "weight": 1.0,
+                                    },
+                                    {
+                                        "start": 25,
+                                        "end": 33,
+                                        "text": "mainmise",
+                                        "category": "framing_noun",
+                                        "weight": 1.0,
+                                    },
+                                ],
+                                "exclude_spans": [],
+                                "notes": "verbes chargés",
+                            },
+                        },
+                    },
+                    {
+                        "id": "ALT2",
+                        "title": "Trump élimine Massie",
+                        "bias_stance": "right",
+                        "annotations": {
+                            "po_synchronous": {
+                                "po_reviewed": False,
+                                "target_spans": [],
+                                "exclude_spans": [],
+                            },
+                        },
+                    },
+                    {
+                        "id": "ALT3",
+                        "title": "Massie battu en primaire",
+                        "bias_stance": "left",
+                        "annotations": {
+                            "dropped": True,
+                            "po_synchronous": {
+                                "po_reviewed": False,
+                                "target_spans": [],
+                                "exclude_spans": [],
+                            },
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# iter_perspectives_to_annotate
+# ---------------------------------------------------------------------------
+
+
+def test_iter_blind_yields_only_reviewed():
+    out = list(iter_perspectives_to_annotate(_toy_dataset(), mode="blind"))
+    assert len(out) == 1
+    assert out[0][2]["id"] == "ALT1"
+
+
+def test_iter_fill_yields_only_unreviewed_and_not_dropped():
+    out = list(iter_perspectives_to_annotate(_toy_dataset(), mode="fill"))
+    assert len(out) == 1
+    assert out[0][2]["id"] == "ALT2"  # ALT3 droppée
+
+
+def test_iter_all_yields_both_but_not_dropped():
+    out = list(iter_perspectives_to_annotate(_toy_dataset(), mode="all"))
+    ids = {p[2]["id"] for p in out}
+    assert ids == {"ALT1", "ALT2"}
+
+
+def test_iter_provides_peers_excluding_self():
+    out = list(iter_perspectives_to_annotate(_toy_dataset(), mode="all"))
+    by_id = {p[2]["id"]: p for p in out}
+    persp_peers = by_id["ALT1"][3]
+    assert "Trump écrase Massie : la mainmise" not in persp_peers
+    assert len(persp_peers) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Few-shot building + prompt assembly
+# ---------------------------------------------------------------------------
+
+
+def test_build_fewshot_examples_picks_reviewed_only():
+    examples = build_fewshot_examples(_toy_dataset())
+    # 1 seule perspective po_reviewed dans le toy dataset → 1 exemple
+    assert len(examples) == 1
+    assert "écrase" in examples[0]
+    assert "bias left" in examples[0]
+
+
+def test_build_system_prompt_combines_service_schema_and_fewshot():
+    prompt = build_system_prompt(_toy_dataset())
+    assert prompt.startswith(SCHEMA_DESCRIPTION)
+    assert "Exemples calibrés par le PO" in prompt
+    assert "écrase" in prompt
+
+
+def test_build_system_prompt_returns_just_schema_when_no_reviewed():
+    empty_dataset = {
+        "clusters": [
+            {
+                "cluster_key": "k",
+                "reference_article_id": "REF",
+                "articles": [
+                    {"id": "REF", "title": "ref", "bias_stance": "center"},
+                ],
+            }
+        ]
+    }
+    prompt = build_system_prompt(empty_dataset)
+    assert prompt == SCHEMA_DESCRIPTION
+
+
+# ---------------------------------------------------------------------------
+# annotate_one — délégation au service
+# ---------------------------------------------------------------------------
+
+
+def test_annotate_one_dry_returns_empty(monkeypatch):
+    monkeypatch.setenv("LLM_ANNOTATE_DRY_RUN", "1")
+    persp = {"id": "x", "title": "any", "bias_stance": "left"}
+    result = asyncio.run(
+        annotate_one(
+            service=None,
+            persp=persp,
+            ref_title="ref",
+            peers=[],
+            fewshot_examples=[],
+        )
+    )
+    assert result == {
+        "target_spans": [],
+        "exclude_spans": [],
+        "notes": "DRY RUN — aucun appel API",
+        "confidence": 0.0,
+    }
+
+
+def test_annotate_one_delegates_to_service_with_correct_args():
+    service = MagicMock()
+    service.annotate_variant = AsyncMock(
+        return_value={"target_spans": [], "exclude_spans": [], "notes": "", "confidence": 0.5}
+    )
+    persp = {"id": "x", "title": "Trump écrase Massie", "bias_stance": "left"}
+    asyncio.run(
+        annotate_one(
+            service=service,
+            persp=persp,
+            ref_title="Trump bat Massie",
+            peers=["peer1"],
+            fewshot_examples=["### ex"],
+        )
+    )
+    service.annotate_variant.assert_awaited_once_with(
+        ref_title="Trump bat Massie",
+        variant_title="Trump écrase Massie",
+        bias_stance="left",
+        peers=["peer1"],
+        fewshot_examples=["### ex"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end dry-run — invariant po_synchronous + skip dropped
+# ---------------------------------------------------------------------------
+
+
+def test_run_dry_does_not_mutate_po_synchronous(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_ANNOTATE_DRY_RUN", "1")
+    dataset_path = tmp_path / "ds.json"
+    ds = _toy_dataset()
+    dataset_path.write_text(json.dumps(ds), encoding="utf-8")
+    out_path = tmp_path / "out.json"
+
+    asyncio.run(
+        run(
+            dataset_path=dataset_path,
+            mode="blind",
+            model="mistral-medium-latest",
+            out_path=out_path,
+            limit=None,
+        )
+    )
+
+    out_ds = json.loads(out_path.read_text(encoding="utf-8"))
+    alt1 = next(a for a in out_ds["clusters"][0]["articles"] if a["id"] == "ALT1")
+    assert (
+        alt1["annotations"]["po_synchronous"]["target_spans"]
+        == ds["clusters"][0]["articles"][1]["annotations"]["po_synchronous"]["target_spans"]
+    )
+    assert "llm_pass2" in alt1["annotations"]
+    assert alt1["annotations"]["llm_pass2"]["annotated_by"] == "dry-run"
+
+
+def test_run_dry_skips_dropped(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_ANNOTATE_DRY_RUN", "1")
+    dataset_path = tmp_path / "ds.json"
+    dataset_path.write_text(json.dumps(_toy_dataset()), encoding="utf-8")
+    out_path = tmp_path / "out.json"
+
+    asyncio.run(
+        run(
+            dataset_path=dataset_path,
+            mode="all",
+            model="mistral-medium-latest",
+            out_path=out_path,
+            limit=None,
+        )
+    )
+
+    out_ds = json.loads(out_path.read_text(encoding="utf-8"))
+    alt3 = next(a for a in out_ds["clusters"][0]["articles"] if a["id"] == "ALT3")
+    assert "llm_pass2" not in alt3["annotations"]
+
+
+def test_run_dry_respects_limit(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_ANNOTATE_DRY_RUN", "1")
+    dataset_path = tmp_path / "ds.json"
+    dataset_path.write_text(json.dumps(_toy_dataset()), encoding="utf-8")
+    out_path = tmp_path / "out.json"
+
+    asyncio.run(
+        run(
+            dataset_path=dataset_path,
+            mode="all",
+            model="mistral-medium-latest",
+            out_path=out_path,
+            limit=1,
+        )
+    )
+
+    out_ds = json.loads(out_path.read_text(encoding="utf-8"))
+    annotated = [
+        a
+        for a in out_ds["clusters"][0]["articles"]
+        if "llm_pass2" in (a.get("annotations") or {})
+    ]
+    assert len(annotated) == 1


### PR DESCRIPTION
> **DRAFT** — basée sur PR #644 (PR 1 du chantier). À retarget si PR 1 merge avant cette PR.

## Contexte

PR 2 du chantier **Phase 4 — LLM bias annotation** (cf. `.context/handoff-phase-4-llm-bias.md`). Refactor de `scripts/llm_annotate_titles.py` pour consommer `LLMBiasAnnotationService` (PR 1) + harness complet de calibration offline (build dataset, comparateur LLM↔PO, évaluateur spaCy↔PO).

Le run de calibration réel produit le rapport prose pour le PO → **décision GO/NOGO sur la PR+2 spaCy multi-tokens** (gate ΔF1_span ≥ +0.10 par rapport à la baseline-v4).

Aucun code production · aucun feature flag · aucune migration Alembic.

## Summary

- **Refactor `scripts/llm_annotate_titles.py`** : prompt, `find_span` et validation déléguées au service. Le script conserve uniquement la logique gold-dataset-spécifique (sélection gloutonne de few-shot diversifiée sur bias × catégorie × weight) et l'orchestration CLI (modes `blind/fill/all`, `--limit`, `--tag`, `--out`).
- **Harness existant bundle** : `build_highlight_dataset.py` (dump MCP Supabase → dataset stratifié), `compare_annotations.py` (LLM↔PO sur F1 + κ + MAE weight + matrices de confusion), `evaluate_title_annotations.py` (spaCy↔PO avec mode `--compare baseline/after`).
- **Tests** : 36 tests hermétiques (FakeNlp pour les évaluateurs ; `LLM_ANNOTATE_DRY_RUN=1` pour le script LLM ; mock `service.annotate_variant` pour la délégation). Aucun appel API réseau pendant les tests.

## Test plan

- [x] `pytest tests/scripts/ -v` → 36 tests verts.
- [x] `pytest tests/services/test_llm_bias_annotation_service.py -v` → 29 tests verts (régression PR 1).
- [x] `LLM_ANNOTATE_DRY_RUN=1 python scripts/llm_annotate_titles.py --dataset .context/highlight-dataset-llm-pass2-2026-05-20.json --mode blind` → sortie générée sans appel Mistral.
- [ ] **Run calibration complet** (~\$0.05, ~10 min) : `python scripts/llm_annotate_titles.py --dataset .context/highlight-dataset-llm-pass2-2026-05-20.json --mode blind --tag llm-pass-3` puis `python scripts/compare_annotations.py --dataset <output> --left po_synchronous --right llm_pass2 --filter po_reviewed=true` → publication du rapport prose pour décision PO (en cours).
- [ ] CI verte sur GitHub Actions.

## Dépendance

Cette PR consomme `LLMBiasAnnotationService` introduit en PR 1 (#644). Si PR 1 n'est pas encore mergée, attendre ou rebase au moment du merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)