### PR TITLE
feat(api): endpoint GET /api/essentiel pour top 5 transversal (Story 9.1)

### DIFF
--- a/docs/stories/core/9.1.essentiel-endpoint.md
+++ b/docs/stories/core/9.1.essentiel-endpoint.md
@@ -1,0 +1,73 @@
+# Story 9.1 — Backend `GET /api/essentiel`
+
+**Status:** 🚧 En cours
+
+## But
+
+Livrer un endpoint backend dédié qui retourne **les 5 articles transversaux du jour** pour l'utilisateur authentifié, afin d'alimenter la nouvelle carte hi-fi « L'Essentiel du jour » du feed mobile (Story 9.2 — front, PR séparée).
+
+Cette PR est **backend-only**. Le mobile continue de tourner sur le digest existant en attendant la PR front.
+
+## Contexte
+
+- La spec design v3 de l'Essentiel (cf. plan PO du 2026-05-23) demande une carte hi-fi unique qui présente directement 5 articles (lead + 2 médiums + 2 lights) cross-topic, **distincts du digest classique**.
+- Le digest legacy (`GET /api/digest`) reste utilisé pour les sections thématiques (Bonnes Nouvelles + écran « Actus du jour » via *Voir plus de…*).
+- L'endpoint `/api/essentiel` est **read-only** au même titre que `/api/digest` : il consomme le digest déjà calculé par la cron nocturne et ne déclenche jamais le pipeline LLM.
+
+## Décisions PO
+
+1. **PR1 = backend seul** (cette story). Front livré en PR2 (Story 9.2).
+2. **Pas de DDL** : aucune table créée, aucune migration Alembic. On consomme `DailyDigest.topics_data` existant.
+3. **Backward compat** : `/api/digest` reste inchangé. Les Bonnes Nouvelles et l'écran « Actus du jour » (= ancien topic "L'Essentiel du jour" du digest) continuent de fonctionner identiquement.
+
+## Sélection des 5 articles transversaux
+
+Source de vérité : la réponse de `read_digest_or_fallback(db, user_uuid, today)` (même chaîne de fallback que `/api/digest` : own today → clone today → yesterday → last 7 days).
+
+Algorithme :
+1. Récupère la `DigestResponse` (mode `pour_vous`, format `topics_v1`).
+2. Parmi les `topics`, retient ceux avec au moins 1 article. Ordonne par `rank` croissant.
+3. Pour chaque topic, prend l'article de `rank=1` (le plus représentatif).
+4. Prend les **5 premiers articles** ainsi obtenus, en dédupliquant par `content_id`.
+5. Si moins de 5 topics → on complète avec les articles `rank=2` du premier topic, puis `rank=2` du deuxième, etc. (round-robin), toujours en dédupliquant.
+6. Si toujours < 5 (digest très pauvre) → on renvoie ce qu'on a (la liste peut être courte, le mobile gère).
+
+Mapping `DigestTopicArticle` → `EssentielArticle` :
+- `content_id`, `title`, `url`, `thumbnail_url`, `published_at` : recopiés.
+- `kind` : dérivé du `theme` du topic (mapping `theme → SectionKind` côté backend, fallback `essentiel`).
+- `section_label` : recopié de `DigestTopic.label`.
+- `source_name`, `source_letter` : depuis `source.name` (initiale en uppercase).
+- `perspective_count` : depuis `DigestTopic.perspective_count`.
+- `rank` : position dans la liste essentiel (1..5).
+- `is_read`, `is_saved`, `is_liked`, `is_dismissed` : recopiés (statut user).
+
+## Fichiers créés
+
+- `packages/api/app/schemas/essentiel.py` — `EssentielArticle`, `EssentielResponse`.
+- `packages/api/app/services/essentiel_service.py` — `build_essentiel_response(...)`.
+- `packages/api/app/routers/essentiel.py` — `GET /api/essentiel`.
+- `packages/api/tests/test_essentiel_endpoint.py` — happy path + cas limites.
+
+## Fichiers modifiés
+
+- `packages/api/app/main.py` — `include_router(essentiel.router, prefix="/api/essentiel", tags=["essentiel"])`.
+
+## Vérification
+
+```bash
+cd packages/api && pytest tests/test_essentiel_endpoint.py -v
+cd packages/api && pytest -v
+```
+
+Cas testés :
+- 200 OK avec digest présent → 5 articles, ordre lead/médiums/lights.
+- 200 OK avec digest dégradé (2 topics) → renvoie ≤ 5 articles, jamais d'erreur.
+- 202 `preparing` si aucun digest disponible (fallback chain épuisée).
+- 401 sans token.
+- `content_id` uniques (dédup OK).
+
+## Hors scope
+
+- Le scoring "transversal" lui-même (perspective_count) — utilisé tel quel.
+- Toute évolution du digest legacy.
+- Le front mobile (Story 9.2).

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -80,6 +80,7 @@ from app.routers import (
     contents,
     custom_topics,
     digest,
+    essentiel,
     feed,
     images,
     internal,
@@ -446,6 +447,7 @@ app.include_router(auth.router, prefix="/api/auth", tags=["Auth"])
 app.include_router(users.router, prefix="/api/users", tags=["Users"])
 app.include_router(feed.router, prefix="/api/feed", tags=["Feed"])
 app.include_router(digest.router, prefix="/api/digest", tags=["Digest"])
+app.include_router(essentiel.router, prefix="/api/essentiel", tags=["Essentiel"])
 app.include_router(contents.router, prefix="/api/contents", tags=["Contents"])
 app.include_router(images.router, prefix="/api/images", tags=["Images"])
 app.include_router(sources.router, prefix="/api/sources", tags=["Sources"])

--- a/packages/api/app/routers/essentiel.py
+++ b/packages/api/app/routers/essentiel.py
@@ -1,0 +1,75 @@
+"""Router pour `GET /api/essentiel` (Story 9.1).
+
+Renvoie les 5 articles transversaux du jour pour la carte hi-fi "L'Essentiel
+du jour" du feed mobile.
+
+Strictement read-only : pas de pipeline LLM au request time. Réutilise la
+chaîne de fallback de `/api/digest` via `read_digest_or_fallback`.
+"""
+
+import time
+from datetime import date
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.schemas.essentiel import EssentielResponse
+from app.services.digest_service import read_digest_or_fallback
+from app.services.essentiel_service import build_essentiel_response
+from app.utils.time import today_paris
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+
+def _preparing_response() -> JSONResponse:
+    return JSONResponse(
+        status_code=202,
+        content={
+            "status": "preparing",
+            "message": "Votre essentiel est en cours de préparation...",
+        },
+    )
+
+
+@router.get("", response_model=EssentielResponse)
+async def get_essentiel(
+    target_date: date | None = Query(
+        None, description="Date for essentiel (default: today)"
+    ),
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Retourne les 5 articles transversaux du jour pour l'utilisateur courant.
+
+    Source de vérité : la `DigestResponse` calculée par la cron nocturne
+    (variante `pour_vous`). Projection cross-topic via `build_essentiel_response`.
+
+    Renvoie 202 ``preparing`` si la chaîne de fallback du digest est épuisée.
+    """
+    user_uuid = UUID(current_user_id)
+    effective_date = target_date or today_paris()
+    start = time.monotonic()
+
+    digest = await read_digest_or_fallback(
+        db, user_uuid, effective_date, is_serene=False
+    )
+    if digest is None:
+        return _preparing_response()
+
+    response = build_essentiel_response(digest)
+
+    logger.info(
+        "essentiel_retrieved",
+        user_id=current_user_id,
+        elapsed_ms=round((time.monotonic() - start) * 1000, 1),
+        articles_count=len(response.articles),
+        is_stale_fallback=response.is_stale_fallback,
+    )
+    return response

--- a/packages/api/app/schemas/essentiel.py
+++ b/packages/api/app/schemas/essentiel.py
@@ -1,0 +1,79 @@
+"""Schemas pour l'endpoint `GET /api/essentiel` (Story 9.1).
+
+Renvoie les 5 articles transversaux du jour pour alimenter la carte hi-fi
+"L'Essentiel du jour" du feed mobile.
+
+Lecture seule : consomme le digest déjà calculé par la cron nocturne (jamais
+de pipeline LLM au request time, comme `/api/digest`).
+"""
+
+from datetime import date, datetime
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from app.schemas.content import SourceMini
+
+
+class EssentielKind(StrEnum):
+    """Famille de section côté mobile (pilote l'icône / l'accent générique).
+
+    Aligne avec `SectionKind` côté mobile (`apps/mobile/lib/features/
+    flux_continu/models/flux_continu_models.dart`).
+    """
+
+    ESSENTIEL = "essentiel"
+    BONNES = "bonnes"
+    THEME = "theme"
+    VEILLE = "veille"
+
+
+class EssentielArticle(BaseModel):
+    """Un article du top 5 transversal de l'Essentiel.
+
+    Reprend les champs nécessaires à la carte hi-fi (lead/médium/light) sans
+    réexposer toute la richesse d'un `DigestTopicArticle`.
+    """
+
+    content_id: UUID
+    title: str
+    url: str
+    thumbnail_url: str | None = None
+    published_at: datetime
+    source: SourceMini
+    source_letter: str = Field(
+        ..., min_length=1, max_length=1, description="Initiale source pour la pastille"
+    )
+    kind: EssentielKind = EssentielKind.THEME
+    theme: str | None = Field(
+        None, description="Slug du thème du topic d'origine (mapping couleur mobile)"
+    )
+    section_label: str = Field(..., description="Libellé du topic d'origine")
+    perspective_count: int = 0
+    rank: int = Field(..., ge=1, le=5, description="Position dans l'essentiel (1..5)")
+    is_read: bool = False
+    is_saved: bool = False
+    is_liked: bool = False
+    is_dismissed: bool = False
+
+    class Config:
+        from_attributes = True
+
+
+class EssentielResponse(BaseModel):
+    """Réponse pour `GET /api/essentiel`."""
+
+    target_date: date
+    generated_at: datetime
+    articles: list[EssentielArticle] = Field(default_factory=list)
+    is_stale_fallback: bool = Field(
+        default=False,
+        description=(
+            "True quand l'essentiel a été construit depuis le digest d'hier "
+            "en attendant que celui d'aujourd'hui soit prêt."
+        ),
+    )
+
+    class Config:
+        from_attributes = True

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -45,11 +45,9 @@ def _pick_transversal_articles(
     seen_content_ids: set[UUID] = set()
     picked: list[tuple[DigestTopic, DigestTopicArticle]] = []
 
-    max_rounds = max((len(t.articles) for t in sorted_topics), default=0)
+    max_rounds = max(len(t.articles) for t in sorted_topics)
     for round_idx in range(max_rounds):
         for topic in sorted_topics:
-            if len(picked) >= ESSENTIEL_MAX_ARTICLES:
-                return picked
             if round_idx >= len(topic.articles):
                 continue
             article = topic.articles[round_idx]
@@ -57,8 +55,8 @@ def _pick_transversal_articles(
                 continue
             seen_content_ids.add(article.content_id)
             picked.append((topic, article))
-        if len(picked) >= ESSENTIEL_MAX_ARTICLES:
-            return picked
+            if len(picked) >= ESSENTIEL_MAX_ARTICLES:
+                return picked
     return picked
 
 

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -1,0 +1,102 @@
+"""Service `essentiel` — top 5 articles transversaux du jour (Story 9.1).
+
+Strictement read-only : consomme la `DigestResponse` déjà calculée par la cron
+nocturne via `read_digest_or_fallback`, et la projette en 5 articles cross-topic
+pour la carte hi-fi "L'Essentiel du jour" du feed mobile.
+
+Algorithme :
+- 1 article par topic (l'article rank=1 de chaque topic, dans l'ordre des
+  topics).
+- Si < 5 topics distincts : round-robin sur les ranks suivants des topics déjà
+  visités.
+- Déduplication par `content_id`.
+- Tronqué à 5 (peut être plus court si le digest est très pauvre).
+"""
+
+from uuid import UUID
+
+from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
+from app.schemas.essentiel import EssentielArticle, EssentielKind, EssentielResponse
+
+ESSENTIEL_MAX_ARTICLES = 5
+
+
+def _source_letter(name: str) -> str:
+    """Initiale (uppercase) de la source pour la pastille mobile."""
+    for ch in name.strip():
+        if ch.isalnum():
+            return ch.upper()
+    return "?"
+
+
+def _pick_transversal_articles(
+    topics: list[DigestTopic],
+) -> list[tuple[DigestTopic, DigestTopicArticle]]:
+    """Pioche jusqu'à 5 articles cross-topic.
+
+    Round 1 : article `rank=1` de chaque topic (ordre des topics).
+    Rounds suivants : article suivant (rank=2, puis rank=3, …) des topics déjà
+    visités, dans le même ordre, jusqu'à atteindre 5 ou épuiser les articles.
+    """
+    sorted_topics = sorted((t for t in topics if t.articles), key=lambda t: t.rank)
+    if not sorted_topics:
+        return []
+
+    seen_content_ids: set[UUID] = set()
+    picked: list[tuple[DigestTopic, DigestTopicArticle]] = []
+
+    max_rounds = max((len(t.articles) for t in sorted_topics), default=0)
+    for round_idx in range(max_rounds):
+        for topic in sorted_topics:
+            if len(picked) >= ESSENTIEL_MAX_ARTICLES:
+                return picked
+            if round_idx >= len(topic.articles):
+                continue
+            article = topic.articles[round_idx]
+            if article.content_id in seen_content_ids:
+                continue
+            seen_content_ids.add(article.content_id)
+            picked.append((topic, article))
+        if len(picked) >= ESSENTIEL_MAX_ARTICLES:
+            return picked
+    return picked
+
+
+def _to_essentiel_article(
+    topic: DigestTopic,
+    article: DigestTopicArticle,
+    rank: int,
+) -> EssentielArticle:
+    return EssentielArticle(
+        content_id=article.content_id,
+        title=article.title,
+        url=article.url,
+        thumbnail_url=article.thumbnail_url,
+        published_at=article.published_at,
+        source=article.source,
+        source_letter=_source_letter(article.source.name),
+        kind=EssentielKind.THEME,
+        theme=topic.theme,
+        section_label=topic.label,
+        perspective_count=topic.perspective_count,
+        rank=rank,
+        is_read=article.is_read,
+        is_saved=article.is_saved,
+        is_liked=article.is_liked,
+        is_dismissed=article.is_dismissed,
+    )
+
+
+def build_essentiel_response(digest: DigestResponse) -> EssentielResponse:
+    """Projette une `DigestResponse` en `EssentielResponse` (5 articles max)."""
+    picks = _pick_transversal_articles(digest.topics)
+    articles = [
+        _to_essentiel_article(topic, article, rank=i + 1)
+        for i, (topic, article) in enumerate(picks)
+    ]
+    return EssentielResponse(
+        target_date=digest.target_date,
+        generated_at=digest.generated_at,
+        articles=articles,
+        is_stale_fallback=digest.is_stale_fallback,
+    )

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -1,0 +1,254 @@
+"""Tests pour `GET /api/essentiel` (Story 9.1).
+
+L'endpoint projette la `DigestResponse` du jour (ou son fallback) en 5
+articles transversaux pour la carte hi-fi mobile.
+
+Pour rester rapide et déterministe, on mocke `read_digest_or_fallback` ; le
+chemin de fallback lui-même est déjà couvert par `test_digest_readonly_hotpath.py`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.schemas.content import SourceMini
+from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
+from app.services.essentiel_service import (
+    ESSENTIEL_MAX_ARTICLES,
+    _source_letter,
+    build_essentiel_response,
+)
+
+
+def _make_source(name: str = "Le Monde") -> SourceMini:
+    return SourceMini(
+        id=uuid4(),
+        name=name,
+        logo_url=None,
+        type="rss",
+        theme=None,
+    )
+
+
+def _make_article(
+    *, rank: int, title: str = "Article", source_name: str = "Le Monde"
+) -> DigestTopicArticle:
+    return DigestTopicArticle(
+        content_id=uuid4(),
+        title=title,
+        url=f"https://example.com/{title.lower().replace(' ', '-')}",
+        published_at=datetime.now(UTC),
+        source=_make_source(source_name),
+        rank=rank,
+        reason="Test",
+    )
+
+
+def _make_topic(
+    *,
+    rank: int,
+    label: str = "Tech",
+    theme: str | None = "technologie",
+    perspective_count: int = 3,
+    n_articles: int = 1,
+) -> DigestTopic:
+    return DigestTopic(
+        topic_id=f"topic-{rank}",
+        label=label,
+        rank=rank,
+        reason="Test",
+        theme=theme,
+        perspective_count=perspective_count,
+        articles=[
+            _make_article(rank=i + 1, title=f"{label} {i + 1}")
+            for i in range(n_articles)
+        ],
+    )
+
+
+def _make_digest(
+    topics: list[DigestTopic], *, is_stale: bool = False
+) -> DigestResponse:
+    return DigestResponse(
+        digest_id=uuid4(),
+        user_id=uuid4(),
+        target_date=date.today(),
+        generated_at=datetime.now(UTC),
+        format_version="topics_v1",
+        items=[],
+        topics=topics,
+        is_stale_fallback=is_stale,
+    )
+
+
+# ─── Tests pure du service ────────────────────────────────────────────────
+
+
+def test_source_letter_picks_first_alnum():
+    assert _source_letter("Le Monde") == "L"
+    assert _source_letter("  La Croix") == "L"
+    assert _source_letter("42matters") == "4"
+    assert _source_letter("") == "?"
+    assert _source_letter("@@@") == "?"
+
+
+def test_build_essentiel_picks_one_article_per_topic():
+    topics = [
+        _make_topic(rank=i + 1, label=f"T{i + 1}", n_articles=3) for i in range(5)
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert len(response.articles) == ESSENTIEL_MAX_ARTICLES
+    # Round-robin rank 1 → 1 article par topic en priorité
+    for i, article in enumerate(response.articles):
+        assert article.rank == i + 1
+        assert article.section_label == f"T{i + 1}"
+
+
+def test_build_essentiel_round_robin_when_few_topics():
+    topics = [_make_topic(rank=1, label="Tech", n_articles=5)]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert len(response.articles) == ESSENTIEL_MAX_ARTICLES
+    # Tous viennent du même topic, ranks 1..5 de l'essentiel.
+    assert all(a.section_label == "Tech" for a in response.articles)
+    seen_ids = {a.content_id for a in response.articles}
+    assert len(seen_ids) == 5  # déduplication implicite OK
+
+
+def test_build_essentiel_handles_sparse_digest():
+    topics = [_make_topic(rank=1, label="Tech", n_articles=2)]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert len(response.articles) == 2
+    assert response.articles[0].rank == 1
+    assert response.articles[1].rank == 2
+
+
+def test_build_essentiel_empty_when_no_topics():
+    digest = _make_digest([])
+    response = build_essentiel_response(digest)
+    assert response.articles == []
+
+
+def test_build_essentiel_skips_topics_without_articles():
+    topics = [
+        _make_topic(rank=1, label="Empty", n_articles=0),
+        _make_topic(rank=2, label="Tech", n_articles=3),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert len(response.articles) == 3
+    assert all(a.section_label == "Tech" for a in response.articles)
+
+
+def test_build_essentiel_propagates_stale_flag():
+    topics = [_make_topic(rank=1, label="Tech")]
+    digest = _make_digest(topics, is_stale=True)
+
+    response = build_essentiel_response(digest)
+
+    assert response.is_stale_fallback is True
+
+
+# ─── Tests endpoint (HTTP) ────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def auth_override():
+    """Override `get_current_user_id` pour bypasser le JWT pendant le test."""
+    user_id = uuid4()
+
+    async def _fake_user() -> str:
+        return str(user_id)
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    try:
+        yield user_id
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+
+
+def _client() -> AsyncClient:
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_get_essentiel_returns_5_articles(auth_override: UUID):
+    topics = [
+        _make_topic(rank=i + 1, label=f"T{i + 1}", n_articles=2) for i in range(5)
+    ]
+    digest = _make_digest(topics)
+
+    with patch(
+        "app.routers.essentiel.read_digest_or_fallback",
+        new=AsyncMock(return_value=digest),
+    ):
+        async with _client() as client:
+            resp = await client.get("/api/essentiel")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["articles"]) == 5
+    assert [a["rank"] for a in body["articles"]] == [1, 2, 3, 4, 5]
+    assert body["is_stale_fallback"] is False
+    # `content_id` uniques (dédup OK).
+    assert len({a["content_id"] for a in body["articles"]}) == 5
+
+
+@pytest.mark.asyncio
+async def test_get_essentiel_returns_202_when_no_digest(auth_override: UUID):
+    with patch(
+        "app.routers.essentiel.read_digest_or_fallback",
+        new=AsyncMock(return_value=None),
+    ):
+        async with _client() as client:
+            resp = await client.get("/api/essentiel")
+
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["status"] == "preparing"
+
+
+@pytest.mark.asyncio
+async def test_get_essentiel_401_without_token():
+    """Sans override d'auth ni token, la route doit refuser l'accès."""
+    # On retire un éventuel override résiduel pour le test.
+    app.dependency_overrides.pop(get_current_user_id, None)
+    async with _client() as client:
+        resp = await client.get("/api/essentiel")
+
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_get_essentiel_propagates_stale_fallback(auth_override: UUID):
+    topics = [_make_topic(rank=1, label="Tech", n_articles=5)]
+    digest = _make_digest(topics, is_stale=True)
+
+    with patch(
+        "app.routers.essentiel.read_digest_or_fallback",
+        new=AsyncMock(return_value=digest),
+    ):
+        async with _client() as client:
+            resp = await client.get("/api/essentiel")
+
+    assert resp.status_code == 200
+    assert resp.json()["is_stale_fallback"] is True


### PR DESCRIPTION
## Summary

PR1 (backend-only) de la refonte **L'Essentiel du jour v3**.

Ajoute `GET /api/essentiel` qui projette la `DigestResponse` du jour (variante `pour_vous`) en **5 articles transversaux** pour alimenter la nouvelle carte hi-fi top-feed (livrée en PR2 côté mobile).

- **Strictement read-only** : réutilise `read_digest_or_fallback` (jamais de pipeline LLM au request time, même chaîne de fallback que `/api/digest`).
- **Pas de DDL** : aucune migration Alembic. Consomme `DailyDigest.topics_data` existant.
- **Algorithme cross-topic** : 1 article `rank=1` par topic (ordre des topics), puis round-robin sur les rangs suivants quand <5 topics distincts, déduplication par `content_id`, tronqué à 5.

Story doc : `docs/stories/core/9.1.essentiel-endpoint.md`.

## Backward compat

- `/api/digest` inchangé.
- Bonnes Nouvelles + écran « Actus du jour » (ex-topic "L'Essentiel du jour" du digest, accédé via *Voir plus de…*) continuent de fonctionner identiquement côté mobile.

## Test plan

- [x] `pytest tests/test_essentiel_endpoint.py -v` → 11 passed (service pur + endpoint HTTP)
- [x] `pytest -v` complet → 1197 passed, 13 skipped, 0 failed
- [x] `ruff check` + `ruff format` clean sur les nouveaux fichiers
- [ ] Smoke local : `curl -H "Authorization: Bearer <token>" http://localhost:8080/api/essentiel`
- [ ] CI green
- [ ] Front (PR2) bascule du mock digest vers cet endpoint dès merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)