### PR TITLE
feat(api): pipeline LLM bias annotation pour les clusters du digest (Phase 4 PR 4)

### DIFF
--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -42,7 +42,12 @@ from app.services.editorial.schemas import (
     compute_divergence_level,
 )
 from app.services.editorial.writer import EditorialWriterService
+from app.services.llm_bias_annotation_service import LLMBiasAnnotationService
 from app.services.perspective_service import Perspective, PerspectiveService
+from app.services.title_annotation_service import (
+    TitleAnnotationService,
+    get_title_annotation_service,
+)
 
 logger = structlog.get_logger()
 
@@ -309,6 +314,44 @@ class EditorialPipelineService:
             hits=deep_hit_count,
             total=len(selected_topics),
             duration_ms=round(deep_time * 1000, 2),
+        )
+
+        # ÉTAPE 3B-bis: LLM bias annotation pour les clusters sélectionnés.
+        # Skip silencieux si MISTRAL_API_KEY absente (fallback spaCy hors-ligne
+        # géré ailleurs). Référence = cluster.label (best title du TopicSelector).
+        llm_bias_step_start = time.time()
+        llm_bias_service = LLMBiasAnnotationService()
+        title_service = get_title_annotation_service()
+        llm_bias_stats = {
+            "cluster_count": 0,
+            "variants_annotated": 0,
+            "variants_skipped": 0,
+            "cache_hits": 0,
+        }
+        if llm_bias_service.is_ready:
+            for topic in selected_topics:
+                cluster = cluster_map.get(topic.topic_id)
+                if not cluster or len(cluster.contents) < 2:
+                    continue
+                llm_bias_stats["cluster_count"] += 1
+                try:
+                    await _annotate_cluster_llm_bias(
+                        cluster=cluster,
+                        llm_service=llm_bias_service,
+                        title_service=title_service,
+                        short_session=self._short_session,
+                        stats=llm_bias_stats,
+                    )
+                except Exception:
+                    logger.exception(
+                        "editorial_pipeline.llm_bias_failed",
+                        cluster_id=str(cluster.cluster_id),
+                    )
+        logger.info(
+            "editorial_pipeline.llm_bias_done",
+            duration_ms=round((time.time() - llm_bias_step_start) * 1000, 2),
+            llm_version=LLMBiasAnnotationService.LLM_VERSION,
+            **llm_bias_stats,
         )
 
         # Build subjects with deep matches
@@ -912,3 +955,88 @@ class EditorialPipelineService:
     async def close(self) -> None:
         """Cleanup resources."""
         await self.llm.close()
+
+
+async def _annotate_cluster_llm_bias(
+    *,
+    cluster: TopicCluster,
+    llm_service: LLMBiasAnnotationService,
+    title_service: TitleAnnotationService,
+    short_session,
+    stats: dict[str, int],
+) -> None:
+    """Annote tous les variants d'un cluster avec le LLM bias service.
+
+    Pré-condition assurée ici : `get_or_compute_cluster_annotations` crée
+    les rows spaCy (UPDATE-only de `write_llm_annotations` exige des rows
+    existantes). Skip variant self-référent (`title == cluster.label`)
+    et utilise le cache si la signature est stable.
+    """
+    ref_title = cluster.label or ""
+    if not ref_title:
+        return
+
+    cluster_id_uuid = UUID(cluster.cluster_id)
+    signature = title_service.compute_cluster_signature(
+        [c.id for c in cluster.contents]
+    )
+    # Garde nécessaire : si tous les variants partagent le titre du best
+    # title (cluster artificiel à doublons), `expected == 0` et len(cached)
+    # est trivialement ≥ 0 — sans la garde on incrémenterait à tort.
+    expected = sum(1 for c in cluster.contents if c.title and c.title != ref_title)
+    if expected == 0:
+        return
+
+    async with short_session() as session:
+        cached = await title_service.get_llm_annotations(
+            session, cluster_id_uuid, LLMBiasAnnotationService.LLM_VERSION, signature
+        )
+        if len(cached) >= expected:
+            stats["cache_hits"] += 1
+            return
+
+        # `write_llm_annotations` est UPDATE-only — pré-condition PR 3 :
+        # les rows `cluster_title_annotations` doivent exister avec
+        # `strong_tokens` (spaCy). On les garantit ici juste avant l'écriture.
+        await title_service.get_or_compute_cluster_annotations(
+            session, cluster_id_uuid
+        )
+
+        annotations: dict[UUID, dict] = {}
+        for variant in cluster.contents:
+            if not variant.title or variant.title == ref_title:
+                continue
+            if variant.id in cached:
+                continue
+            peers = [
+                c.title
+                for c in cluster.contents
+                if c.id != variant.id and c.title
+            ][:3]
+            stance = getattr(variant.source, "bias_stance", None)
+            bias_stance = getattr(stance, "value", stance) or "unknown"
+            result = await llm_service.annotate_variant(
+                ref_title=ref_title,
+                variant_title=variant.title,
+                bias_stance=bias_stance,
+                peers=peers,
+            )
+            if result is None:
+                stats["variants_skipped"] += 1
+                logger.warning(
+                    "editorial_pipeline.llm_bias_variant_skipped",
+                    cluster_id=str(cluster.cluster_id),
+                    content_id=str(variant.id),
+                )
+                continue
+            annotations[variant.id] = result
+            stats["variants_annotated"] += 1
+
+        if annotations:
+            await title_service.write_llm_annotations(
+                session,
+                cluster_id_uuid,
+                LLMBiasAnnotationService.LLM_VERSION,
+                signature,
+                annotations,
+            )

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -998,9 +998,7 @@ async def _annotate_cluster_llm_bias(
         # `write_llm_annotations` est UPDATE-only — pré-condition PR 3 :
         # les rows `cluster_title_annotations` doivent exister avec
         # `strong_tokens` (spaCy). On les garantit ici juste avant l'écriture.
-        await title_service.get_or_compute_cluster_annotations(
-            session, cluster_id_uuid
-        )
+        await title_service.get_or_compute_cluster_annotations(session, cluster_id_uuid)
 
         annotations: dict[UUID, dict] = {}
         for variant in cluster.contents:
@@ -1009,9 +1007,7 @@ async def _annotate_cluster_llm_bias(
             if variant.id in cached:
                 continue
             peers = [
-                c.title
-                for c in cluster.contents
-                if c.id != variant.id and c.title
+                c.title for c in cluster.contents if c.id != variant.id and c.title
             ][:3]
             stance = getattr(variant.source, "bias_stance", None)
             bias_stance = getattr(stance, "value", stance) or "unknown"

--- a/packages/api/tests/editorial/test_pipeline.py
+++ b/packages/api/tests/editorial/test_pipeline.py
@@ -16,13 +16,14 @@ from app.services.editorial.schemas import (
 )
 
 
-def _make_content_mock(title="Test article"):
+def _make_content_mock(title="Test article", bias_stance="center"):
     c = MagicMock()
     c.id = uuid4()
     c.title = title
     c.source_id = uuid4()
     c.source = MagicMock()
     c.source.name = "Test Source"
+    c.source.bias_stance = bias_stance
     c.published_at = datetime.now(UTC)
     c.is_paid = False
     return c
@@ -922,3 +923,400 @@ class TestPerspectiveCountAlignment:
         # Footer logos — one per outlet, matching the count.
         assert subject.perspective_sources is not None
         assert len(subject.perspective_sources) == 2
+
+
+# ============================================================================
+# LLM bias annotation step (PR 4)
+# ============================================================================
+
+
+class TestLLMBiasAnnotationStep:
+    """Couvre l'étape 3B-bis : annotation LLM des variants des clusters
+    sélectionnés, et le helper `_annotate_cluster_llm_bias` qui orchestre
+    spaCy → signature → cache → LLM → write."""
+
+    @staticmethod
+    def _mock_llm_bias_module(
+        is_ready: bool = True,
+        annotate_result: dict | None = None,
+        cached: dict | None = None,
+    ):
+        """Patch in-context : LLMBiasAnnotationService + get_title_annotation_service."""
+        mock_llm_service = MagicMock()
+        mock_llm_service.is_ready = is_ready
+        mock_llm_service.annotate_variant = AsyncMock(
+            return_value=annotate_result
+            if annotate_result is not None
+            else {
+                "target_spans": [
+                    {
+                        "start": 0,
+                        "end": 4,
+                        "text": "Test",
+                        "category": "framing",
+                        "weight": 0.7,
+                    }
+                ],
+                "exclude_spans": [],
+                "notes": "",
+                "confidence": 0.8,
+            }
+        )
+
+        mock_title_service = MagicMock()
+        mock_title_service.compute_cluster_signature = MagicMock(return_value="sig-abc")
+        mock_title_service.get_or_compute_cluster_annotations = AsyncMock()
+        mock_title_service.get_llm_annotations = AsyncMock(return_value=cached or {})
+        mock_title_service.write_llm_annotations = AsyncMock(return_value=0)
+        return mock_llm_service, mock_title_service
+
+    # ---------- Tests pipeline-level (gates `is_ready` / singleton / crash) ----
+
+    @pytest.mark.asyncio
+    async def test_skips_when_service_not_ready(self, mock_dependencies):
+        from app.services.editorial.pipeline import EditorialPipelineService
+
+        mock_llm_service, mock_title_service = self._mock_llm_bias_module(
+            is_ready=False
+        )
+
+        cluster = _make_cluster_mock(
+            "c1", "Retraites", contents=[_make_content_mock("A"), _make_content_mock("B")]
+        )
+        cluster.is_trending = False
+        cluster.is_multi_source = False
+
+        with (
+            patch(
+                "app.services.editorial.pipeline.ImportanceDetector"
+            ) as mock_detector_cls,
+            patch(
+                "app.services.editorial.pipeline.LLMBiasAnnotationService",
+                return_value=mock_llm_service,
+            ),
+            patch(
+                "app.services.editorial.pipeline.get_title_annotation_service",
+                return_value=mock_title_service,
+            ),
+        ):
+            mock_detector = MagicMock()
+            mock_detector.build_topic_clusters.return_value = [cluster]
+            mock_detector_cls.return_value = mock_detector
+
+            mock_dependencies["curation"].select_topics.return_value = [
+                SelectedTopic(
+                    topic_id="c1",
+                    label="Retraites",
+                    selection_reason="R",
+                    deep_angle="D",
+                )
+            ]
+            mock_dependencies["deep"].match_for_topics.return_value = {"c1": None}
+
+            def _populate_actu(subjects, clusters, **_):
+                out = []
+                for s in subjects:
+                    actu = MagicMock(spec=MatchedActuArticle)
+                    actu.content_id = uuid4()
+                    actu.source_id = uuid4()
+                    out.append(s.model_copy(update={"actu_article": actu}))
+                return out
+
+            mock_dependencies["actu"].match_global.side_effect = _populate_actu
+
+            svc = EditorialPipelineService(AsyncMock())
+            result = await svc.compute_global_context([_make_content_mock()])
+
+        assert result is not None
+        mock_llm_service.annotate_variant.assert_not_called()
+        mock_title_service.write_llm_annotations.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_singleton_clusters(self, mock_dependencies):
+        from app.services.editorial.pipeline import EditorialPipelineService
+
+        mock_llm_service, mock_title_service = self._mock_llm_bias_module()
+
+        # Singleton: 1 seul variant → rien à comparer.
+        cluster = _make_cluster_mock(
+            "c1", "Solo", contents=[_make_content_mock("Solo")]
+        )
+        cluster.is_trending = False
+        cluster.is_multi_source = False
+
+        with (
+            patch(
+                "app.services.editorial.pipeline.ImportanceDetector"
+            ) as mock_detector_cls,
+            patch(
+                "app.services.editorial.pipeline.LLMBiasAnnotationService",
+                return_value=mock_llm_service,
+            ),
+            patch(
+                "app.services.editorial.pipeline.get_title_annotation_service",
+                return_value=mock_title_service,
+            ),
+        ):
+            mock_detector = MagicMock()
+            mock_detector.build_topic_clusters.return_value = [cluster]
+            mock_detector_cls.return_value = mock_detector
+
+            mock_dependencies["curation"].select_topics.return_value = [
+                SelectedTopic(
+                    topic_id="c1",
+                    label="Solo",
+                    selection_reason="R",
+                    deep_angle="D",
+                )
+            ]
+            mock_dependencies["deep"].match_for_topics.return_value = {"c1": None}
+
+            def _populate_actu(subjects, clusters, **_):
+                out = []
+                for s in subjects:
+                    actu = MagicMock(spec=MatchedActuArticle)
+                    actu.content_id = uuid4()
+                    actu.source_id = uuid4()
+                    out.append(s.model_copy(update={"actu_article": actu}))
+                return out
+
+            mock_dependencies["actu"].match_global.side_effect = _populate_actu
+
+            svc = EditorialPipelineService(AsyncMock())
+            await svc.compute_global_context([_make_content_mock()])
+
+        # Singleton cluster → pas d'appel LLM, pas d'écriture.
+        mock_llm_service.annotate_variant.assert_not_called()
+        mock_title_service.write_llm_annotations.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failure_does_not_crash_digest(self, mock_dependencies):
+        from app.services.editorial.pipeline import EditorialPipelineService
+
+        # Helper raise une exception interne → le try/except doit la rattraper.
+        mock_llm_service, mock_title_service = self._mock_llm_bias_module()
+        mock_title_service.get_or_compute_cluster_annotations.side_effect = (
+            RuntimeError("DB explosion")
+        )
+
+        cluster = _make_cluster_mock(
+            "c1",
+            "Retraites",
+            contents=[_make_content_mock("A"), _make_content_mock("B")],
+        )
+        cluster.is_trending = False
+        cluster.is_multi_source = False
+
+        with (
+            patch(
+                "app.services.editorial.pipeline.ImportanceDetector"
+            ) as mock_detector_cls,
+            patch(
+                "app.services.editorial.pipeline.LLMBiasAnnotationService",
+                return_value=mock_llm_service,
+            ),
+            patch(
+                "app.services.editorial.pipeline.get_title_annotation_service",
+                return_value=mock_title_service,
+            ),
+        ):
+            mock_detector = MagicMock()
+            mock_detector.build_topic_clusters.return_value = [cluster]
+            mock_detector_cls.return_value = mock_detector
+
+            mock_dependencies["curation"].select_topics.return_value = [
+                SelectedTopic(
+                    topic_id="c1",
+                    label="Retraites",
+                    selection_reason="R",
+                    deep_angle="D",
+                )
+            ]
+            mock_dependencies["deep"].match_for_topics.return_value = {"c1": None}
+
+            def _populate_actu(subjects, clusters, **_):
+                out = []
+                for s in subjects:
+                    actu = MagicMock(spec=MatchedActuArticle)
+                    actu.content_id = uuid4()
+                    actu.source_id = uuid4()
+                    out.append(s.model_copy(update={"actu_article": actu}))
+                return out
+
+            mock_dependencies["actu"].match_global.side_effect = _populate_actu
+
+            svc = EditorialPipelineService(AsyncMock())
+            result = await svc.compute_global_context([_make_content_mock()])
+
+        # Digest produit malgré l'erreur LLM.
+        assert result is not None
+
+    # ---------- Tests helper-level (cache / signature / self-ref / write) -----
+
+    @pytest.mark.asyncio
+    async def test_writes_annotations_for_digest_clusters(self):
+        from app.services.editorial.pipeline import _annotate_cluster_llm_bias
+        from app.services.llm_bias_annotation_service import LLMBiasAnnotationService
+
+        mock_llm_service, mock_title_service = self._mock_llm_bias_module()
+
+        v1 = _make_content_mock("Variant gauche", bias_stance="left")
+        v2 = _make_content_mock("Variant droite", bias_stance="right")
+        v3 = _make_content_mock("Variant centre (best)", bias_stance="center")
+        cluster_id_str = str(uuid4())
+        cluster = _make_cluster_mock(
+            cluster_id_str, "Variant centre (best)", contents=[v1, v2, v3]
+        )
+
+        session_cm = AsyncMock()
+        session_cm.__aenter__.return_value = AsyncMock()
+        session_cm.__aexit__.return_value = None
+        short_session = MagicMock(return_value=session_cm)
+
+        stats = {
+            "cluster_count": 0,
+            "variants_annotated": 0,
+            "variants_skipped": 0,
+            "cache_hits": 0,
+        }
+        await _annotate_cluster_llm_bias(
+            cluster=cluster,
+            llm_service=mock_llm_service,
+            title_service=mock_title_service,
+            short_session=short_session,
+            stats=stats,
+        )
+
+        # 2 variants annotés (le self-ref `v3` est skippé).
+        assert mock_llm_service.annotate_variant.await_count == 2
+        assert stats["variants_annotated"] == 2
+
+        # write_llm_annotations appelé avec la version + signature + payload.
+        mock_title_service.write_llm_annotations.assert_awaited_once()
+        kwargs = mock_title_service.write_llm_annotations.await_args
+        # signature de write_llm_annotations:
+        # (session, cluster_id_uuid, llm_version, signature, annotations)
+        assert kwargs.args[2] == LLMBiasAnnotationService.LLM_VERSION
+        assert kwargs.args[3] == "sig-abc"
+        annotations_arg = kwargs.args[4]
+        assert set(annotations_arg.keys()) == {v1.id, v2.id}
+
+    @pytest.mark.asyncio
+    async def test_uses_cache_when_signature_matches(self):
+        from app.services.editorial.pipeline import _annotate_cluster_llm_bias
+
+        v1 = _make_content_mock("A")
+        v2 = _make_content_mock("B")
+        v3 = _make_content_mock("C (best)")
+        cluster = _make_cluster_mock(
+            str(uuid4()), "C (best)", contents=[v1, v2, v3]
+        )
+
+        # Cache contient déjà toutes les annotations attendues (v1, v2 ; v3 self-ref).
+        cached = {v1.id: {"target_spans": []}, v2.id: {"target_spans": []}}
+        mock_llm_service, mock_title_service = self._mock_llm_bias_module(
+            cached=cached
+        )
+
+        session_cm = AsyncMock()
+        session_cm.__aenter__.return_value = AsyncMock()
+        session_cm.__aexit__.return_value = None
+        short_session = MagicMock(return_value=session_cm)
+
+        stats = {
+            "cluster_count": 0,
+            "variants_annotated": 0,
+            "variants_skipped": 0,
+            "cache_hits": 0,
+        }
+        await _annotate_cluster_llm_bias(
+            cluster=cluster,
+            llm_service=mock_llm_service,
+            title_service=mock_title_service,
+            short_session=short_session,
+            stats=stats,
+        )
+
+        mock_llm_service.annotate_variant.assert_not_awaited()
+        mock_title_service.write_llm_annotations.assert_not_awaited()
+        assert stats["cache_hits"] == 1
+        assert stats["variants_annotated"] == 0
+
+    @pytest.mark.asyncio
+    async def test_recomputes_on_signature_mismatch(self):
+        from app.services.editorial.pipeline import _annotate_cluster_llm_bias
+
+        v1 = _make_content_mock("A")
+        v2 = _make_content_mock("B")
+        v3 = _make_content_mock("C (best)")
+        cluster = _make_cluster_mock(
+            str(uuid4()), "C (best)", contents=[v1, v2, v3]
+        )
+
+        # PR 3 filtre strict : signature qui ne match pas → get_llm_annotations
+        # retourne {} → on doit re-déclencher le LLM pour les 2 variants non self-ref.
+        mock_llm_service, mock_title_service = self._mock_llm_bias_module(cached={})
+
+        session_cm = AsyncMock()
+        session_cm.__aenter__.return_value = AsyncMock()
+        session_cm.__aexit__.return_value = None
+        short_session = MagicMock(return_value=session_cm)
+
+        stats = {
+            "cluster_count": 0,
+            "variants_annotated": 0,
+            "variants_skipped": 0,
+            "cache_hits": 0,
+        }
+        await _annotate_cluster_llm_bias(
+            cluster=cluster,
+            llm_service=mock_llm_service,
+            title_service=mock_title_service,
+            short_session=short_session,
+            stats=stats,
+        )
+
+        assert mock_llm_service.annotate_variant.await_count == 2
+        assert stats["cache_hits"] == 0
+        assert stats["variants_annotated"] == 2
+
+    @pytest.mark.asyncio
+    async def test_skips_self_reference_variant(self):
+        from app.services.editorial.pipeline import _annotate_cluster_llm_bias
+
+        # cluster.label == v2.title → v2 doit être skippé (auto-référence).
+        v1 = _make_content_mock("Variant A")
+        v2 = _make_content_mock("Le meilleur titre")
+        v3 = _make_content_mock("Variant C")
+        cluster = _make_cluster_mock(
+            str(uuid4()), "Le meilleur titre", contents=[v1, v2, v3]
+        )
+
+        mock_llm_service, mock_title_service = self._mock_llm_bias_module()
+
+        session_cm = AsyncMock()
+        session_cm.__aenter__.return_value = AsyncMock()
+        session_cm.__aexit__.return_value = None
+        short_session = MagicMock(return_value=session_cm)
+
+        stats = {
+            "cluster_count": 0,
+            "variants_annotated": 0,
+            "variants_skipped": 0,
+            "cache_hits": 0,
+        }
+        await _annotate_cluster_llm_bias(
+            cluster=cluster,
+            llm_service=mock_llm_service,
+            title_service=mock_title_service,
+            short_session=short_session,
+            stats=stats,
+        )
+
+        # Seulement v1 et v3 sont annotés. v2 (== label) est skippé.
+        assert mock_llm_service.annotate_variant.await_count == 2
+        annotated_titles = {
+            call.kwargs["variant_title"]
+            for call in mock_llm_service.annotate_variant.await_args_list
+        }
+        assert annotated_titles == {"Variant A", "Variant C"}


### PR DESCRIPTION
## Quoi

PR 4 du chantier **Phase 4 — LLM bias annotation**. Branche le service
`LLMBiasAnnotationService` (PR 1 #644) sur la pipeline éditoriale via
`TitleAnnotationService.write_llm_annotations` (PR 3 #646). Sans cette
PR, tout le chantier resterait dormant en prod : `semantic_equiv`
NULL à perpétuité, PRs 5/6/7 (API + UI) sans données enrichies à servir.

## Pourquoi

Le service sait annoter (PR 1), le harness sait calibrer offline
(PR 2 #645), la persistance sait stocker (PR 3 #646) — mais rien
n'appelle ces outils en prod. Cette PR est la passerelle.

Décisions PO actées :
- **Pas de feature flag.** Gating par présence de `MISTRAL_API_KEY`
  (via `LLMBiasAnnotationService.is_ready`). Cost borné par
  `mistral_monthly_cap`. Sans clé Mistral → fallback spaCy auto
  (risque prod = 0).
- **Référence = `cluster.label`** (best title du `TopicSelector`), pas
  de dépendance à `deep_article` (option 1 sur 3 proposées au PO). Le
  variant dont `title == cluster.label` est skippé (self-référence
  triviale).
- **Sequential `annotate_variant`** par variant — ~30-60s de blocking
  pour ~50 variants/digest jugé acceptable, parallélisation reportée
  en optimisation future.

## Comportement

Dans `EditorialPipelineService.compute_global_context`, après
`deep_matching_done` :

1. Gate `is_ready` → sinon skip silencieux (fallback spaCy déjà en place).
2. Pour chaque cluster sélectionné non-singleton, helper
   `_annotate_cluster_llm_bias` :
   - Signature stable via `compute_cluster_signature([content_ids])`.
   - **Cache-check avant spaCy** : si `len(cached) >= expected`, on
     skip sans toucher la DB ni le LLM.
   - Sinon : `get_or_compute_cluster_annotations` (pré-condition
     UPDATE-only de PR 3) → boucle séquentielle `annotate_variant`
     (peers = jusqu'à 3 autres titres du cluster) → `write_llm_annotations`
     avec `LLM_VERSION` + signature.
   - `bias_stance` extrait via le pattern existant
     `getattr(stance, "value", stance)` (matche `pepite_service.py:173`).
3. Try/except global : une exception LLM/DB ne crashe **jamais** le
   digest. Log structuré `editorial_pipeline.llm_bias_done` avec
   `cluster_count`, `variants_annotated`, `variants_skipped`,
   `cache_hits`, `duration_ms`, `llm_version`.

**Aucune migration Alembic** (slot `semantic_equiv` JSONB déjà présent
depuis Story 7.4 Sprint 1). **Aucun changement de contrat API** — la
sérialisation enrichie `weight`/`category`/`justification` côté
`/contents/{id}/perspectives` arrive en PR 5.

## Comment ça a été vérifié

- [x] `pytest tests/editorial/test_pipeline.py::TestLLMBiasAnnotationStep` → **7/7 OK** (3 pipeline-level + 4 helper-level)
- [x] `pytest tests/editorial/` → **131 passed** (0 régression)
- [x] `pytest -q` suite complète → **1249 passed**, 1 skipped, 2 xfailed, **0 failed**
- [x] `alembic heads` → 1 seul head (`23a4_restore_ct_favorites`)
- [x] `/simplify` passé : pattern `getattr(stance, "value", stance)`
      pour `bias_stance` (cohérent avec le reste), cache-check avant
      `get_or_compute_cluster_annotations` (évite spaCy quand
      fully-cached), commentaires narration "Étape A/B/C/D" supprimés.
- [x] Rebase sur `origin/main` (post #647 essentiel endpoint) — pas de conflit.

## Zones à risque

- **Pipeline éditoriale globale** (`compute_global_context`) — chemin
  partagé global → user. Mitigation : try/except global, gate
  `is_ready`, skip singletons, tests pipeline-level couvrent les 3
  fail modes (not ready, singleton, helper crash).
- **Performance hot path** : ~50 appels Mistral séquentiels ajoutent
  ~30-60s à `compute_global_context` quand la clé Mistral est
  présente. Suivi via `editorial_pipeline.llm_bias_done.duration_ms`
  post-merge. Parallélisation reportée en optimisation future.

## Vérification staging post-merge

1. Ajouter `MISTRAL_API_KEY` à Railway staging si pas déjà en place.
2. Trigger manuel d'un digest staging.
3. SQL :
   \`\`\`sql
   SELECT cluster_id,
          COUNT(*) FILTER (WHERE semantic_equiv IS NOT NULL) AS annotated,
          COUNT(*) AS total
   FROM cluster_title_annotations
   GROUP BY cluster_id
   ORDER BY annotated DESC;
   \`\`\`
   Attendu : ~10 clusters × ~5 variants ≈ 50 rows non-NULL pour le
   digest du jour.
4. Logs `editorial_pipeline.llm_bias_done` :
   `cluster_count ≈ 10`, `variants_annotated ≈ 40-50`,
   `cache_hits = 0` au 1er run, élevé au 2e run du même jour.

## Dépendances

- **Dépend** : PRs 1 (#644), 3 (#646) — toutes mergées dans `origin/main`.
- **Bloque** : PR 5 (API enriched contract), PR 6 (mobile opacity), PR 7 (mobile tap-to-justification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)