### PR TITLE
feat(tournee): page dédiée par thème + sticky unifié

### DIFF
--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -11,6 +11,8 @@ import '../features/onboarding/screens/conclusion_animation_screen.dart';
 import '../features/feed/screens/feed_screen.dart';
 import '../features/feed/models/content_model.dart';
 import '../features/flux_continu/screens/flux_continu_screen.dart';
+import '../features/flux_continu/screens/theme_section_screen.dart';
+import '../features/flux_continu/models/flux_continu_models.dart';
 import '../features/auth/screens/email_confirmation_screen.dart';
 import '../features/detail/screens/content_detail_screen.dart';
 
@@ -265,6 +267,20 @@ final routerProvider = Provider<GoRouter>((ref) {
                 child: ContentDetailScreen(
                   contentId: contentId,
                   content: content,
+                ),
+              );
+            },
+          ),
+          GoRoute(
+            path: 'theme/:key',
+            parentNavigatorKey: NotificationService.navigatorKey,
+            pageBuilder: (context, state) {
+              final key = state.pathParameters['key']!;
+              final section = state.extra as FeedThemeSection?;
+              return FullSwipeCupertinoPage(
+                child: ThemeSectionScreen(
+                  sectionKeyValue: key,
+                  initialSection: section,
                 ),
               );
             },

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -32,7 +32,6 @@ import '../../well_informed/widgets/well_informed_prompt.dart';
 import '../../../shared/widgets/loaders/loading_view.dart';
 import '../models/flux_continu_models.dart';
 import '../providers/flux_continu_provider.dart';
-import '../../feed/widgets/feed_filter_bar.dart';
 import '../widgets/closing_card_v18.dart';
 import '../widgets/flux_continu_article_card.dart';
 import '../widgets/my_interests_intro.dart';
@@ -40,7 +39,6 @@ import '../widgets/my_interests_sheet.dart';
 import '../widgets/section_banner.dart';
 import '../widgets/section_block.dart';
 import '../widgets/section_hairline.dart';
-import '../widgets/sticky_backdrop.dart';
 import '../widgets/sticky_tab_bar.dart';
 
 /// Scroll offset at which the AppBar is swapped with the sticky tab bar.
@@ -131,11 +129,18 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       _stickyVisible.value = showSticky;
     }
     final max = pos.maxScrollExtent;
-    _scrollProgress.value = max > 0 ? (currentScroll / max).clamp(0.0, 1.0) : 0;
+    final nextProgress =
+        max > 0 ? (currentScroll / max).clamp(0.0, 1.0).toDouble() : 0.0;
+    if (_scrollProgress.value != nextProgress) {
+      _scrollProgress.value = nextProgress;
+    }
+    // Explore-mode flag must be refreshed before the active-section pass: the
+    // sticky's "Explorer" virtual tab is selected from that flag, and we want
+    // the same frame the user crosses the banner to swap to it.
+    _updateExploreMode();
     _updateActiveSection();
     _maybeFoldSections();
     _maybeDismissClosingCard();
-    _updateExploreMode();
 
     if (currentScroll > _maxScrollDepthPx) {
       _maxScrollDepthPx = currentScroll;
@@ -242,6 +247,18 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   }
 
   void _updateActiveSection() {
+    // Explorer is rendered as the last virtual tab in the sticky overlay.
+    // Once the user crosses the Explorer banner, that tab takes precedence
+    // over the editorial active-section measurement so the sticky reflects
+    // the zone the user is actually browsing.
+    if (_isInExploreMode.value) {
+      final exploreIndex = _sectionKeys.length;
+      if (_activeIndex.value != exploreIndex) {
+        _activeIndex.value = exploreIndex;
+        _alignTabsToActive(exploreIndex);
+      }
+      return;
+    }
     if (_sectionKeys.isEmpty) return;
     int activeAt = 0;
     for (var i = 0; i < _sectionKeys.length; i++) {
@@ -275,8 +292,12 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   }
 
   Future<void> _scrollToSection(int index) async {
-    if (index < 0 || index >= _sectionKeys.length) return;
-    final ctx = _sectionKeys[index].currentContext;
+    if (index < 0) return;
+    // Last tab is the virtual "Explorer" entry — scrolls to its banner key.
+    final GlobalKey targetKey = index >= _sectionKeys.length
+        ? _explorerKey
+        : _sectionKeys[index];
+    final ctx = targetKey.currentContext;
     if (ctx == null) return;
     final box = ctx.findRenderObject();
     if (box is! RenderBox) return;
@@ -330,6 +351,17 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
         curve: Curves.easeOutCubic,
       ));
     }
+  }
+
+  /// Opens the dedicated full-page view for a [FeedThemeSection]. The
+  /// section's current snapshot is passed via `extra` so the page renders
+  /// the cached items immediately rather than waiting on the provider.
+  void _openThemeSection(BuildContext context, FeedThemeSection section) {
+    final key = Uri.encodeComponent(sectionKey(section));
+    context.push(
+      '${RoutePaths.fluxContinu}/theme/$key',
+      extra: section,
+    );
   }
 
   /// Opens an article and, on return, promotes any sections the user
@@ -795,8 +827,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             onTapFavorite: isFavorite
                 ? () => showMyInterestsBottomSheet(context)
                 : null,
-            onLoadMore: section is FeedThemeSection
-                ? () => notifier.loadMoreTheme(sectionKey(section))
+            onSeeAll: section is FeedThemeSection
+                ? () => _openThemeSection(context, section)
                 : null,
           ),
         ),
@@ -887,11 +919,17 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   }
 }
 
-/// Sticky overlay that hosts either the editorial tab bar (top of the
-/// screen) or the feed filter bar (once the user crosses the Explorer
-/// banner). The header itself lives inside the scroll view, so it simply
-/// disappears upward as content moves up.
+/// Sticky overlay shown at the top of the screen once the user scrolls past
+/// the AppBar threshold. Always hosts the editorial tab bar — the "Explorer"
+/// virtual tab is appended at the end so the same bar covers the whole
+/// screen instead of swapping out when the user crosses the Explorer banner.
+/// When the user is in Explorer mode, [FeedFilterBar] morphs in under the
+/// tabs (within the same parchment surface) so filtering stays available.
+const String _kExplorerLabel = 'Explorer';
+const Color _kExplorerAccent = Color(0xFF5D4037);
+
 class _StickyHostOverlay extends ConsumerWidget {
+
   final ValueNotifier<bool> stickyVisible;
   final ValueNotifier<double> scrollProgress;
   final ValueNotifier<int> activeIndex;
@@ -924,66 +962,33 @@ class _StickyHostOverlay extends ConsumerWidget {
         valueListenable: stickyVisible,
         builder: (context, visible, _) {
           final showSticky = visible && sections.isNotEmpty;
-          return AnimatedSwitcher(
-            duration: const Duration(milliseconds: 150),
-            child: !showSticky
-                ? const SizedBox.shrink(key: ValueKey('hidden'))
-                : ValueListenableBuilder<bool>(
-                    key: const ValueKey('sticky'),
-                    valueListenable: isInExploreMode,
-                    builder: (context, explore, _) => AnimatedSwitcher(
-                      duration: const Duration(milliseconds: 120),
-                      child: explore
-                          ? const _ExplorerSticky(key: ValueKey('explore'))
-                          : ValueListenableBuilder<int>(
-                              key: const ValueKey('editorial'),
-                              valueListenable: activeIndex,
-                              builder: (context, idx, _) =>
-                                  ValueListenableBuilder<double>(
-                                valueListenable: scrollProgress,
-                                builder: (context, progress, _) => StickyTabBar(
-                                  sections: sections,
-                                  activeIndex:
-                                      idx.clamp(0, sections.length - 1),
-                                  progress: progress,
-                                  onTapTab: onTapTab,
-                                  tabsController: tabsController,
-                                ),
-                              ),
-                            ),
-                    ),
-                  ),
+          if (!showSticky) {
+            return const SizedBox.shrink();
+          }
+          final tabs = <StickyTab>[
+            for (final s in sections)
+              StickyTab(label: s.label, accent: s.accent),
+            const StickyTab(label: _kExplorerLabel, accent: _kExplorerAccent),
+          ];
+          return ValueListenableBuilder<bool>(
+            valueListenable: isInExploreMode,
+            builder: (context, explore, _) => ValueListenableBuilder<int>(
+              valueListenable: activeIndex,
+              builder: (context, idx, _) => ValueListenableBuilder<double>(
+                valueListenable: scrollProgress,
+                builder: (context, progress, _) => StickyTabBar(
+                  tabs: tabs,
+                  activeIndex: idx.clamp(0, tabs.length - 1),
+                  progress: progress,
+                  onTapTab: onTapTab,
+                  tabsController: tabsController,
+                  title: explore ? _kExplorerLabel : 'Les Actus du jour',
+                  showFilterBar: explore,
+                ),
+              ),
+            ),
           );
         },
-      ),
-    );
-  }
-}
-
-/// Sticky wrapper around [FeedFilterBar] sharing [StickyBackdrop] with
-/// [StickyTabBar] so the cross-fade between the two stickies feels like a
-/// single surface morphing rather than two distinct bars.
-class _ExplorerSticky extends StatelessWidget {
-  const _ExplorerSticky({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const StickyBackdrop(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          StickyHead(title: 'Explorer'),
-          Padding(
-            padding: EdgeInsets.fromLTRB(
-              FacteurSpacing.space4,
-              0,
-              FacteurSpacing.space4,
-              FacteurSpacing.space2,
-            ),
-            child: FeedFilterBar(),
-          ),
-        ],
       ),
     );
   }

--- a/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../config/routes.dart';
+import '../../../config/theme.dart';
+import '../../feed/models/content_model.dart';
+import '../models/flux_continu_models.dart';
+import '../providers/flux_continu_provider.dart';
+import '../widgets/flux_continu_article_card.dart';
+import '../widgets/section_banner.dart';
+
+/// Distance to the bottom (in px) at which we trigger the next page of
+/// articles for the current theme. Mirrors the threshold used on the main
+/// Flux Continu screen so the feel of the infinite scroll is identical.
+const double _kLoadMoreLeadingPx = 800.0;
+
+/// Full-page view of a Tournée du jour theme section (a `FeedThemeSection`).
+///
+/// Surfaces the same hero banner as the inline section + the complete list of
+/// articles with infinite scroll. Reuses [fluxContinuProvider.loadMoreTheme]
+/// so any new article loaded here also propagates back to the main feed when
+/// the user returns.
+class ThemeSectionScreen extends ConsumerStatefulWidget {
+  final String sectionKeyValue;
+
+  /// Optional snapshot captured at navigation time. Used as the immediate
+  /// render source while [fluxContinuProvider] is still loading, so the user
+  /// doesn't see an empty page during the slide-in transition.
+  final FeedThemeSection? initialSection;
+
+  const ThemeSectionScreen({
+    super.key,
+    required this.sectionKeyValue,
+    this.initialSection,
+  });
+
+  @override
+  ConsumerState<ThemeSectionScreen> createState() =>
+      _ThemeSectionScreenState();
+}
+
+class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
+  final ScrollController _scroll = ScrollController();
+  bool _loadingMore = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scroll.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scroll.removeListener(_onScroll);
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_scroll.hasClients) return;
+    final pos = _scroll.position;
+    if (pos.maxScrollExtent - pos.pixels >= _kLoadMoreLeadingPx) return;
+    if (_loadingMore) return;
+    final section = _resolveSection();
+    if (section == null || !section.hasMore || section.isLoadingMore) return;
+    _loadingMore = true;
+    ref
+        .read(fluxContinuProvider.notifier)
+        .loadMoreTheme(widget.sectionKeyValue)
+        .whenComplete(() => _loadingMore = false);
+  }
+
+  FeedThemeSection? _resolveSection() {
+    final state = ref.read(fluxContinuProvider).valueOrNull;
+    if (state == null) return widget.initialSection;
+    for (final s in state.sections) {
+      if (s is FeedThemeSection && sectionKey(s) == widget.sectionKeyValue) {
+        return s;
+      }
+    }
+    return widget.initialSection;
+  }
+
+  void _openArticle(BuildContext context, Content article) {
+    context.push(
+      '${RoutePaths.fluxContinu}/content/${article.id}',
+      extra: article,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    // Watch the provider so the page rebuilds when loadMoreTheme appends
+    // items. Falls back to [initialSection] until the provider has a value.
+    ref.watch(fluxContinuProvider);
+    final section = _resolveSection();
+    return Scaffold(
+      backgroundColor: colors.backgroundPrimary,
+      appBar: AppBar(
+        backgroundColor: colors.backgroundPrimary,
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: colors.textPrimary),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+        title: section == null
+            ? null
+            : Text(
+                section.label,
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 16,
+                ),
+              ),
+      ),
+      body: section == null
+          ? Center(
+              child: Text(
+                'Section introuvable',
+                style: TextStyle(color: colors.textSecondary),
+              ),
+            )
+          : CustomScrollView(
+              controller: _scroll,
+              physics: const AlwaysScrollableScrollPhysics(),
+              slivers: [
+                SliverToBoxAdapter(
+                  child: SectionBanner(
+                    title: section.label,
+                    accent: section.accent,
+                    blurb: section.blurb,
+                    illustrationAsset: section.illustrationAsset,
+                  ),
+                ),
+                SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) {
+                      final item = section.items[index];
+                      return FluxContinuArticleCard(
+                        article: item,
+                        onTap: () => _openArticle(context, item),
+                      );
+                    },
+                    childCount: section.items.length,
+                  ),
+                ),
+                SliverToBoxAdapter(
+                  child: _Footer(section: section),
+                ),
+                const SliverToBoxAdapter(
+                  child: SizedBox(height: 60),
+                ),
+              ],
+            ),
+    );
+  }
+}
+
+class _Footer extends StatelessWidget {
+  final FeedThemeSection section;
+
+  const _Footer({required this.section});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final String label;
+    if (section.isLoadingMore) {
+      label = 'Chargement…';
+    } else if (section.hasMore) {
+      label = '';
+    } else {
+      label = 'Plus rien à voir';
+    }
+    if (label.isEmpty) {
+      return const SizedBox(height: 32);
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (section.isLoadingMore) ...[
+            SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor:
+                    AlwaysStoppedAnimation<Color>(colors.textSecondary),
+              ),
+            ),
+            const SizedBox(width: 8),
+          ],
+          Text(
+            label,
+            style: TextStyle(
+              color: colors.textSecondary,
+              fontWeight: FontWeight.w500,
+              fontSize: 13,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
@@ -2,42 +2,37 @@ import 'package:flutter/material.dart';
 
 import '../../../config/theme.dart';
 
-/// In-place pagination button for [FeedThemeSection]s. Tapping appends
-/// the next 10 articles in the same section.
-class LoadMoreButton extends StatelessWidget {
+/// "Voir tout {thème}" — opens the dedicated theme page (slide-from-right)
+/// instead of paginating in-place. Visual cousin of [PlusDeButton] so the
+/// bottom-of-section CTA family stays consistent.
+class SeeAllSectionButton extends StatelessWidget {
   final String sectionLabel;
+  final int totalCount;
   final bool hasMore;
-  final bool isLoadingMore;
   final VoidCallback onTap;
 
-  const LoadMoreButton({
+  const SeeAllSectionButton({
     super.key,
     required this.sectionLabel,
+    required this.totalCount,
     required this.hasMore,
-    required this.isLoadingMore,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final String label;
-    if (isLoadingMore) {
-      label = 'Chargement…';
-    } else if (hasMore) {
-      label = 'Voir +10 de $sectionLabel';
-    } else {
-      label = 'Plus rien à voir';
-    }
-    final bool enabled = hasMore && !isLoadingMore;
+    final countSuffix = hasMore ? '+' : '';
+    final label = totalCount > 0
+        ? 'Voir tout $sectionLabel ($totalCount$countSuffix)'
+        : 'Voir tout $sectionLabel';
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
       child: Material(
-        color: colors.surfaceElevated
-            .withValues(alpha: enabled ? 0.5 : 0.25),
+        color: colors.surfaceElevated.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(12),
         child: InkWell(
-          onTap: enabled ? onTap : null,
+          onTap: onTap,
           borderRadius: BorderRadius.circular(12),
           child: Container(
             width: double.infinity,
@@ -45,27 +40,18 @@ class LoadMoreButton extends StatelessWidget {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                if (isLoadingMore) ...[
-                  SizedBox(
-                    width: 14,
-                    height: 14,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      valueColor: AlwaysStoppedAnimation<Color>(
-                        colors.textSecondary,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                ],
                 Text(
                   label,
                   style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                        color: enabled
-                            ? colors.textSecondary
-                            : colors.textSecondary.withValues(alpha: 0.5),
+                        color: colors.textSecondary,
                         fontWeight: FontWeight.w600,
                       ),
+                ),
+                const SizedBox(width: 6),
+                Icon(
+                  Icons.arrow_forward,
+                  color: colors.textSecondary,
+                  size: 16,
                 ),
               ],
             ),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -27,10 +27,10 @@ class SectionBlock extends StatelessWidget {
   final void Function(Object article, FluxSection section) onTapArticle;
   final ValueChanged<String>? onDismissArticle;
 
-  /// Append the next page of articles to a [FeedThemeSection]. Wired by the
-  /// flux_continu screen to `provider.loadMoreTheme(sectionKey)`. Ignored
-  /// for [DigestTopicSection] which keeps its legacy fold/expand button.
-  final VoidCallback? onLoadMore;
+  /// Opens the dedicated full-page view for a [FeedThemeSection]. Wired by
+  /// the flux_continu screen to push `/flux-continu/theme/:key`. Ignored
+  /// for [DigestTopicSection] which keeps its in-place fold/expand button.
+  final VoidCallback? onSeeAll;
 
   /// IDs of articles currently in the inline-feedback pending state. When
   /// non-empty, the matching cards are swapped for a [FeedbackInline] at the
@@ -68,7 +68,7 @@ class SectionBlock extends StatelessWidget {
     this.enableSwipeHintOnFirstCard = false,
     this.onSwipeHintComplete,
     this.onTapFavorite,
-    this.onLoadMore,
+    this.onSeeAll,
   });
 
   @override
@@ -78,12 +78,7 @@ class SectionBlock extends StatelessWidget {
     // viewport visually doesn't move. An animated transition here would defeat
     // the compensation by leaving the height in flux when the post-frame
     // callback measures it.
-    //
-    // [FeedThemeSection] never folds: it uses the in-place "Voir +10"
-    // pagination, so the fold UX of digest sections would conflict with
-    // that affordance. Only digest sections (essentiel / bonnes) fold.
-    final bool canFold = section is DigestTopicSection;
-    return (isFolded && canFold) ? _buildFolded() : _buildExpanded();
+    return isFolded ? _buildFolded() : _buildExpanded();
   }
 
   Widget _buildFolded() {
@@ -106,16 +101,16 @@ class SectionBlock extends StatelessWidget {
           accent: section.accent,
           blurb: section.blurb,
           illustrationAsset: section.illustrationAsset,
-          onTapFold: section is DigestTopicSection ? onFold : null,
+          onTapFold: onFold,
           onTapFavorite: onTapFavorite,
         ),
         ...cards,
-        if (section is FeedThemeSection)
-          LoadMoreButton(
+        if (section is FeedThemeSection && onSeeAll != null)
+          SeeAllSectionButton(
             sectionLabel: section.label,
+            totalCount: section.items.length,
             hasMore: section.hasMore,
-            isLoadingMore: section.isLoadingMore,
-            onTap: onLoadMore ?? () {},
+            onTap: onSeeAll!,
           )
         else if (section.hasOverflow)
           PlusDeButton(
@@ -177,9 +172,6 @@ class SectionBlock extends StatelessWidget {
               ),
         ];
       case FeedThemeSection(:final items):
-        // FeedThemeSection always renders the full accumulated list; the
-        // in-place LoadMoreButton appends +10 items at a time instead of
-        // hiding behind a fold/expand toggle.
         final visible = items;
         return [
           for (var i = 0; i < visible.length; i++)

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -2,33 +2,50 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import '../../../config/theme.dart';
-import '../models/flux_continu_models.dart';
+import '../../feed/widgets/feed_filter_bar.dart';
 import 'sticky_backdrop.dart';
+
+/// Lightweight descriptor for a sticky tab. Used by [StickyTabBar] so the
+/// sticky overlay can mix real Flux sections with virtual entries (e.g.
+/// "Explorer") without leaking widget-only state into the section sealed
+/// hierarchy.
+class StickyTab {
+  final String label;
+  final Color accent;
+
+  const StickyTab({required this.label, required this.accent});
+}
 
 /// Sticky tab bar revealed once the user scrolls past the AppBar threshold.
 ///
 /// Layout per V6 maquette :
 /// - parchment-tinted backdrop with a 14px blur (saturate 140%),
-/// - "sticky-head" row : zone title ("Les Actus du jour" in the editorial
-///   zone, "Explorer" in the Explorer zone),
+/// - "sticky-head" row : zone title ("Les Actus du jour" or "Explorer"),
 /// - horizontal tabs with section dot, label, done strike-through, and
 ///   an underline tinted with the active section's accent,
 /// - 4-px progress track with a 4-stop gradient fill (essentiel → bonnes
-///   → veille1 → veille2) and a soft accent glow.
+///   → veille1 → veille2) and a soft accent glow,
+/// - when [showFilterBar] is true (Explorer mode), [FeedFilterBar] is
+///   inserted below the tabs so the filter chips morph in under the same
+///   parchment surface rather than swapping the whole sticky.
 class StickyTabBar extends StatelessWidget {
-  final List<FluxSection> sections;
+  final List<StickyTab> tabs;
   final int activeIndex;
   final double progress;
   final ValueChanged<int> onTapTab;
   final ScrollController? tabsController;
+  final String title;
+  final bool showFilterBar;
 
   const StickyTabBar({
     super.key,
-    required this.sections,
+    required this.tabs,
     required this.activeIndex,
     required this.progress,
     required this.onTapTab,
     this.tabsController,
+    this.title = 'Les Actus du jour',
+    this.showFilterBar = false,
   });
 
   @override
@@ -38,9 +55,9 @@ class StickyTabBar extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const StickyHead(),
+          StickyHead(title: title),
           _TabsRow(
-            sections: sections,
+            tabs: tabs,
             activeIndex: activeIndex,
             onTapTab: onTapTab,
             controller: tabsController,
@@ -62,6 +79,17 @@ class StickyTabBar extends StatelessWidget {
               child: const SizedBox.expand(),
             ),
           ),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 180),
+            curve: Curves.easeOutCubic,
+            alignment: Alignment.topCenter,
+            child: showFilterBar
+                ? const Padding(
+                    padding: EdgeInsets.fromLTRB(16, 8, 16, 8),
+                    child: FeedFilterBar(),
+                  )
+                : const SizedBox(width: double.infinity),
+          ),
         ],
       ),
     );
@@ -69,10 +97,7 @@ class StickyTabBar extends StatelessWidget {
 }
 
 /// Top row of the sticky overlay — a single Fraunces label that names the
-/// current zone of the Flux Continu screen. Shared between the editorial
-/// sticky ([StickyTabBar]) and the Explorer sticky (`_ExplorerSticky` in
-/// `flux_continu_screen.dart`) so the two surfaces feel like the same bar
-/// changing its caption.
+/// current zone of the Flux Continu screen.
 class StickyHead extends StatelessWidget {
   final String title;
 
@@ -100,13 +125,13 @@ class StickyHead extends StatelessWidget {
 }
 
 class _TabsRow extends StatelessWidget {
-  final List<FluxSection> sections;
+  final List<StickyTab> tabs;
   final int activeIndex;
   final ValueChanged<int> onTapTab;
   final ScrollController? controller;
 
   const _TabsRow({
-    required this.sections,
+    required this.tabs,
     required this.activeIndex,
     required this.onTapTab,
     this.controller,
@@ -120,11 +145,11 @@ class _TabsRow extends StatelessWidget {
         controller: controller,
         scrollDirection: Axis.horizontal,
         padding: const EdgeInsets.fromLTRB(10, 4, 10, 8),
-        itemCount: sections.length,
+        itemCount: tabs.length,
         separatorBuilder: (_, __) => const SizedBox(width: 2),
         itemBuilder: (context, i) {
           return _Tab(
-            section: sections[i],
+            tab: tabs[i],
             isActive: i == activeIndex,
             isDone: i < activeIndex,
             onTap: () => onTapTab(i),
@@ -136,13 +161,13 @@ class _TabsRow extends StatelessWidget {
 }
 
 class _Tab extends StatelessWidget {
-  final FluxSection section;
+  final StickyTab tab;
   final bool isActive;
   final bool isDone;
   final VoidCallback onTap;
 
   const _Tab({
-    required this.section,
+    required this.tab,
     required this.isActive,
     required this.isDone,
     required this.onTap,
@@ -160,7 +185,7 @@ class _Tab extends StatelessWidget {
       labelColor = colors.textSecondary;
     }
     final dotColor = isActive
-        ? section.accent
+        ? tab.accent
         : (isDone ? colors.textTertiary : colors.textSecondary);
     return InkWell(
       onTap: onTap,
@@ -182,7 +207,7 @@ class _Tab extends StatelessWidget {
                   ),
                 ),
                 Text(
-                  section.label,
+                  tab.label,
                   style: GoogleFonts.dmSans(
                     fontSize: 12.5,
                     fontWeight: FontWeight.w600,
@@ -204,7 +229,7 @@ class _Tab extends StatelessWidget {
               height: 2,
               child: Container(
                 decoration: BoxDecoration(
-                  color: section.accent,
+                  color: tab.accent,
                   borderRadius: const BorderRadius.vertical(
                     top: Radius.circular(2),
                   ),


### PR DESCRIPTION
## Quoi
- "Voir tout {thème}" en bas d'une section FeedTheme ouvre une **page dédiée** (`ThemeSectionScreen`, slide-from-right) avec scroll infini, au lieu de paginer en place dans le feed principal.
- **Sticky bar unifié** : l'entrée *Explorer* devient un onglet virtuel à la fin de la barre d'onglets éditoriaux ; le `FeedFilterBar` morphe sous les tabs via `AnimatedSize` (même surface parchment) au lieu d'un swap complet du sticky.
- `FeedThemeSection` peut maintenant être fold/unfold (banner tap) comme les digest sections, vu qu'il n'y a plus de bouton "Voir +10" in-place qui rendait le fold ambigu.

## Pourquoi
Le bouton "Voir +10" empilait les articles indéfiniment dans le feed principal, cassait la lecture des sections suivantes et rendait le sticky-Explorer incohérent (deux barres se substituaient au lieu d'évoluer). La page dédiée donne un espace clair pour creuser un thème sans polluer la *Tournée du jour*.

## Comment ça a été vérifié
- [x] `flutter analyze` sur le diff — 0 nouveau warning
- [x] `flutter test test/features/flux_continu/` — 55/55 OK
- [ ] Suite complète : 36 échecs **pré-existants** (vérifié en stashant le diff), aucun causé par ce PR
- [x] `/simplify` passé — extraction const `_kExplorerLabel`/`_kExplorerAccent`, drop no-op `?? () {}`, guard `_scrollProgress.value`, trim commentaire narratif

## Zones à risque
- `flux_continu_screen.dart` : réordre du scroll listener (`_updateExploreMode` avant `_updateActiveSection`) pour que l'onglet *Explorer* prenne le focus au moment où la bannière est franchie
- `routes.dart` : nouvelle route `/flux-continu/theme/:key` avec la section passée via `extra` (clé encodée pour deep-link futur)
- `section_block.dart` : `FeedThemeSection` peut désormais être fold — vérifier que le PO valide le fold sur thèmes (auparavant exclusif aux digest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)