### PR TITLE
feat(mobile): Essentiel du jour v3 — carte hi-fi + sticky 3-états + repli (Story 9.2)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -23,6 +23,7 @@ enum SectionKind { essentiel, bonnes, theme, veille }
 /// `'veille'` (un seul par user à V1).
 String sectionKey(FluxSection section) {
   return switch (section) {
+    EssentielSection() => section.kind.name,
     DigestTopicSection() => section.kind.name,
     FeedThemeSection(:final kind, :final themeSlug, :final customTopicId) =>
       kind == SectionKind.veille
@@ -62,6 +63,68 @@ sealed class FluxSection {
 
   /// Whether some cards are hidden behind the "Plus de…" expand button.
   bool get hasOverflow => totalCount > coreVisibleCount;
+}
+
+/// One article inside the v3 "L'Essentiel du jour" hi-fi card.
+///
+/// Backed by `GET /api/essentiel` (Story 9.1) — 5 transversal articles
+/// cross-topic, projected from today's digest. Slot is decided by the rank:
+/// `rank=1` is the lead, `2..3` are mediums, `4..5` are lights.
+class EssentielArticle {
+  final String contentId;
+  final String title;
+  final String url;
+  final String? thumbnailUrl;
+  final DateTime publishedAt;
+  final String sourceName;
+  final String sourceLetter;
+  final SectionKind kind;
+  final String? theme;
+  final String sectionLabel;
+  final int perspectiveCount;
+  final int rank;
+  final bool isRead;
+  final bool isSaved;
+  final bool isLiked;
+  final bool isDismissed;
+
+  const EssentielArticle({
+    required this.contentId,
+    required this.title,
+    required this.url,
+    required this.publishedAt,
+    required this.sourceName,
+    required this.sourceLetter,
+    required this.sectionLabel,
+    required this.rank,
+    this.thumbnailUrl,
+    this.kind = SectionKind.theme,
+    this.theme,
+    this.perspectiveCount = 0,
+    this.isRead = false,
+    this.isSaved = false,
+    this.isLiked = false,
+    this.isDismissed = false,
+  });
+}
+
+/// Section v3 "L'Essentiel du jour" — single hi-fi card with 5 cross-topic
+/// articles. Distinct from [DigestTopicSection] which renders one card per
+/// digest topic. The card itself is built by `EssentielHiFiCard`; the section
+/// shell only carries the data and shares the fold/sticky infrastructure.
+class EssentielSection extends FluxSection {
+  final List<EssentielArticle> articles;
+
+  const EssentielSection({
+    required this.articles,
+    super.label = 'L’Essentiel du jour',
+    super.accent = const Color(0xFFB0470A),
+    super.blurb,
+    super.illustrationAsset,
+  }) : super(kind: SectionKind.essentiel, coreVisibleCount: 5);
+
+  @override
+  int get totalCount => articles.length;
 }
 
 /// Section backed by `digest.topics` (Essentiel, Bonnes Nouvelles). One

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -17,11 +17,9 @@ import '../../my_interests/models/user_interests_state.dart';
 import '../../my_interests/providers/user_interests_provider.dart';
 import '../../veille/providers/veille_active_config_provider.dart';
 import '../models/flux_continu_models.dart';
+import '../repositories/essentiel_repository.dart';
 import '../repositories/flux_continu_repository.dart';
 import '../utils/theme_color_mapping.dart';
-
-/// Accent applied to the Essentiel section banner.
-const Color _kEssentielAccent = Color(0xFFB0470A);
 
 /// Accent applied to the Bonnes Nouvelles section banner.
 const Color _kBonnesAccent = Color(0xFF2E7D32);
@@ -79,6 +77,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   late DigestRepository _digestRepo;
   late FeedRepository _feedRepo;
   late FluxContinuRepository _fluxRepo;
+  late EssentielRepository _essentielRepo;
 
   FluxSection? _essentiel;
   FluxSection? _bonnes;
@@ -116,6 +115,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     _digestRepo = ref.read(digestRepositoryProvider);
     _feedRepo = ref.read(feedRepositoryProvider);
     _fluxRepo = ref.read(fluxContinuRepositoryProvider);
+    _essentielRepo = ref.read(essentielRepositoryProvider);
 
     ref.listen<SereinToggleState>(sereinToggleProvider, (prev, next) {
       if (prev?.enabled != next.enabled && state.hasValue) {
@@ -156,20 +156,24 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         () => _feedRepo.getFeed(page: 1, limit: 20, serein: isSerene),
         'getFeed (continuation)',
       ),
+      _safe<List<EssentielArticle>>(
+        () async => (await _essentielRepo.fetch()) ?? const [],
+        'fetchEssentiel',
+        fallback: const <EssentielArticle>[],
+      ),
     ]);
     final dual = results[0] as DualDigestResponse?;
     final topThemes = (results[1] as List<TopTheme>?) ?? const <TopTheme>[];
     final feed = results[2] as FeedResponse?;
+    final essentielArticles =
+        (results[3] as List<EssentielArticle>?) ?? const <EssentielArticle>[];
 
-    _essentiel = _buildDigestSection(
-      digest: dual?.normal,
-      kind: SectionKind.essentiel,
-      label: "L'Essentiel du jour",
-      blurb: _kEssentielBlurb,
-      accent: _kEssentielAccent,
-      illustration: _kEssentielIllustration,
-      coreVisibleCount: isSerene ? 2 : 4,
-    );
+    // PR2 — la section "Essentiel" du haut du feed est désormais alimentée
+    // par GET /api/essentiel (5 articles transversaux). Si l'endpoint n'a
+    // rien servi (preparing/erreur), on ne rend pas la section : le digest
+    // legacy (kind=essentiel, accédé via "Voir plus de…") reste accessible
+    // ailleurs, et Bonnes Nouvelles n'est pas affectée.
+    _essentiel = _buildEssentielSection(essentielArticles);
     _bonnes = _buildDigestSection(
       digest: dual?.serein,
       kind: SectionKind.bonnes,
@@ -296,6 +300,13 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     return [
       for (final s in sections)
         switch (s) {
+          EssentielSection(:final articles) => EssentielSection(
+              articles: articles
+                  .where((a) => !_dismissedIds.contains(a.contentId))
+                  .toList(growable: false),
+              blurb: s.blurb,
+              illustrationAsset: s.illustrationAsset,
+            ),
           DigestTopicSection(:final topics) => DigestTopicSection(
               kind: s.kind,
               label: s.label,
@@ -624,6 +635,19 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     ));
   }
 
+  /// Builds the v3 "L'Essentiel du jour" hi-fi section from the 5 articles
+  /// returned by `GET /api/essentiel`. Returns `null` when the endpoint hasn't
+  /// produced anything yet (202 preparing or transient failure) so the screen
+  /// degrades gracefully — Bonnes Nouvelles + thèmes restent visibles.
+  FluxSection? _buildEssentielSection(List<EssentielArticle> articles) {
+    if (articles.isEmpty) return null;
+    return EssentielSection(
+      articles: articles,
+      illustrationAsset: _kEssentielIllustration,
+      blurb: _kEssentielBlurb,
+    );
+  }
+
   FluxSection? _buildDigestSection({
     required DigestResponse? digest,
     required SectionKind kind,
@@ -868,6 +892,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     final seen = <String>{};
     for (final section in sections) {
       switch (section) {
+        case EssentielSection(:final articles):
+          for (final article in articles) {
+            seen.add(article.contentId);
+          }
         case DigestTopicSection(:final topics):
           for (final topic in topics) {
             if (topic.articles.isEmpty) continue;

--- a/apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart
+++ b/apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart
@@ -1,0 +1,95 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/api_client.dart';
+import '../../../core/api/providers.dart';
+import '../models/flux_continu_models.dart';
+
+/// `GET /api/essentiel` — Story 9.1/9.2.
+///
+/// Renvoie jusqu'à 5 articles transversaux cross-topic pour alimenter la
+/// carte hi-fi "L'Essentiel du jour" en haut du feed. L'endpoint backend est
+/// strictement read-only (réutilise la chaîne de fallback de `/api/digest`),
+/// et peut renvoyer 202 `{"status":"preparing"}` quand aucun digest n'est
+/// encore prêt — le provider traite ce cas comme une liste vide et conserve
+/// son fallback construit depuis le digest classique.
+class EssentielRepository {
+  final ApiClient _apiClient;
+
+  EssentielRepository(this._apiClient);
+
+  /// Renvoie la liste des articles de l'Essentiel, ou `null` si l'endpoint
+  /// n'a rien servi (202 ou erreur réseau). Le provider décide alors s'il
+  /// veut fallback ou afficher une section vide.
+  Future<List<EssentielArticle>?> fetch() async {
+    try {
+      final response = await _apiClient.dio.get<dynamic>('essentiel');
+      if (response.statusCode == 202) {
+        return null;
+      }
+      if (response.statusCode != 200 || response.data is! Map) {
+        return null;
+      }
+      final data = response.data as Map<String, dynamic>;
+      final raw = (data['articles'] as List?) ?? const [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(_parseArticle)
+          .toList(growable: false);
+    } on DioException catch (e) {
+      // ignore: avoid_print
+      print('EssentielRepository: fetch failed: ${e.message}');
+      return null;
+    }
+  }
+
+  static EssentielArticle _parseArticle(Map<String, dynamic> json) {
+    final source = (json['source'] as Map?)?.cast<String, dynamic>() ?? const {};
+    final sourceName = (source['name'] as String?) ?? '';
+    return EssentielArticle(
+      contentId: (json['content_id'] as String?) ?? '',
+      title: (json['title'] as String?) ?? '',
+      url: (json['url'] as String?) ?? '',
+      thumbnailUrl: json['thumbnail_url'] as String?,
+      publishedAt: DateTime.tryParse(json['published_at'] as String? ?? '') ??
+          DateTime.now(),
+      sourceName: sourceName,
+      sourceLetter: (json['source_letter'] as String?) ?? _initial(sourceName),
+      kind: _parseKind(json['kind'] as String?),
+      theme: json['theme'] as String?,
+      sectionLabel: (json['section_label'] as String?) ?? '',
+      perspectiveCount: (json['perspective_count'] as num?)?.toInt() ?? 0,
+      rank: (json['rank'] as num?)?.toInt() ?? 0,
+      isRead: (json['is_read'] as bool?) ?? false,
+      isSaved: (json['is_saved'] as bool?) ?? false,
+      isLiked: (json['is_liked'] as bool?) ?? false,
+      isDismissed: (json['is_dismissed'] as bool?) ?? false,
+    );
+  }
+
+  static String _initial(String name) {
+    for (final ch in name.trim().split('')) {
+      if (ch.trim().isNotEmpty) return ch.toUpperCase();
+    }
+    return '?';
+  }
+
+  static SectionKind _parseKind(String? raw) {
+    switch (raw) {
+      case 'bonnes':
+        return SectionKind.bonnes;
+      case 'veille':
+        return SectionKind.veille;
+      case 'essentiel':
+        return SectionKind.essentiel;
+      case 'theme':
+      default:
+        return SectionKind.theme;
+    }
+  }
+}
+
+final essentielRepositoryProvider = Provider<EssentielRepository>((ref) {
+  final apiClient = ref.watch(apiClientProvider);
+  return EssentielRepository(apiClient);
+});

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -32,7 +32,6 @@ import '../../well_informed/widgets/well_informed_prompt.dart';
 import '../../../shared/widgets/loaders/loading_view.dart';
 import '../models/flux_continu_models.dart';
 import '../providers/flux_continu_provider.dart';
-import '../../feed/widgets/feed_filter_bar.dart';
 import '../widgets/closing_card_v18.dart';
 import '../widgets/flux_continu_article_card.dart';
 import '../widgets/my_interests_intro.dart';
@@ -40,8 +39,8 @@ import '../widgets/my_interests_sheet.dart';
 import '../widgets/section_banner.dart';
 import '../widgets/section_block.dart';
 import '../widgets/section_hairline.dart';
-import '../widgets/sticky_backdrop.dart';
 import '../widgets/sticky_tab_bar.dart';
+import '../../feed/widgets/feed_filter_bar.dart';
 
 /// Scroll offset at which the AppBar is swapped with the sticky tab bar.
 const double _kStickyThreshold = 60.0;
@@ -75,11 +74,11 @@ class FluxContinuScreen extends ConsumerStatefulWidget {
 
 class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   final ScrollController _scroll = ScrollController();
-  final ScrollController _tabsScroll = ScrollController();
   final ValueNotifier<bool> _stickyVisible = ValueNotifier(false);
   final ValueNotifier<double> _scrollProgress = ValueNotifier(0);
   final ValueNotifier<int> _activeIndex = ValueNotifier(0);
-  final ValueNotifier<bool> _isInExploreMode = ValueNotifier(false);
+  final ValueNotifier<StickyMacroBloc> _currentMacroBloc =
+      ValueNotifier(StickyMacroBloc.essentiel);
   final GlobalKey _closingKey = GlobalKey();
   final GlobalKey _explorerKey = GlobalKey();
   final List<GlobalKey> _sectionKeys = [];
@@ -113,11 +112,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   void dispose() {
     _scroll.removeListener(_onScroll);
     _scroll.dispose();
-    _tabsScroll.dispose();
     _stickyVisible.dispose();
     _scrollProgress.dispose();
     _activeIndex.dispose();
-    _isInExploreMode.dispose();
+    _currentMacroBloc.dispose();
     _pullHintTimer?.cancel();
     super.dispose();
   }
@@ -135,7 +133,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     _updateActiveSection();
     _maybeFoldSections();
     _maybeDismissClosingCard();
-    _updateExploreMode();
+    _updateMacroBloc();
 
     if (currentScroll > _maxScrollDepthPx) {
       _maxScrollDepthPx = currentScroll;
@@ -189,17 +187,43 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     }
   }
 
-  /// Flips the sticky overlay from the editorial tab bar to the feed filter
-  /// bar once the user crosses the Explorer banner.
-  void _updateExploreMode() {
-    final ctx = _explorerKey.currentContext;
-    if (ctx == null) return;
-    final box = ctx.findRenderObject();
-    if (box is! RenderBox || !box.attached) return;
-    final topY = box.localToGlobal(Offset.zero).dy;
-    final shouldExplore = topY < _kStickyBarHeight;
-    if (_isInExploreMode.value != shouldExplore) {
-      _isInExploreMode.value = shouldExplore;
+  /// Decides which macro-bloc the user is currently traversing — drives the
+  /// 3-state sticky bar (Essentiel / Par thème / Explorer).
+  ///
+  /// Boundaries :
+  /// - `essentiel` : user is on or above the first non-essentiel section.
+  /// - `parTheme`  : between the second section header and the Explorer banner.
+  /// - `explorer`  : Explorer banner top crossed `_kStickyBarHeight`.
+  void _updateMacroBloc() {
+    StickyMacroBloc bloc = StickyMacroBloc.essentiel;
+    final value = ref.read(fluxContinuProvider).valueOrNull;
+    if (value != null && _sectionKeys.length == value.sections.length) {
+      // First non-Essentiel section delimits the "par thème" zone.
+      for (var i = 0; i < value.sections.length; i++) {
+        if (value.sections[i] is EssentielSection) continue;
+        final ctx = _sectionKeys[i].currentContext;
+        if (ctx == null) break;
+        final box = ctx.findRenderObject();
+        if (box is! RenderBox || !box.attached) break;
+        final topY = box.localToGlobal(Offset.zero).dy;
+        if (topY < _kStickyBarHeight) {
+          bloc = StickyMacroBloc.parTheme;
+        }
+        break;
+      }
+    }
+    final explorerCtx = _explorerKey.currentContext;
+    if (explorerCtx != null) {
+      final box = explorerCtx.findRenderObject();
+      if (box is RenderBox && box.attached) {
+        final topY = box.localToGlobal(Offset.zero).dy;
+        if (topY < _kStickyBarHeight) {
+          bloc = StickyMacroBloc.explorer;
+        }
+      }
+    }
+    if (_currentMacroBloc.value != bloc) {
+      _currentMacroBloc.value = bloc;
     }
   }
 
@@ -256,22 +280,43 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     }
     if (_activeIndex.value != activeAt) {
       _activeIndex.value = activeAt;
-      _alignTabsToActive(activeAt);
     }
   }
 
-  void _alignTabsToActive(int index) {
-    if (!_tabsScroll.hasClients) return;
-    const double estimatedTabWidth = 140.0;
-    const double leftPadding = 12.0;
-    final target =
-        (index * estimatedTabWidth - leftPadding)
-            .clamp(0.0, _tabsScroll.position.maxScrollExtent);
-    _tabsScroll.animateTo(
-      target,
-      duration: const Duration(milliseconds: 220),
-      curve: Curves.easeOutCubic,
-    );
+  /// Tap on the sticky bar — scrolls back to the top of the current macro
+  /// bloc so the user can quickly re-orient.
+  Future<void> _onTapStickyBar() async {
+    final bloc = _currentMacroBloc.value;
+    final value = ref.read(fluxContinuProvider).valueOrNull;
+    if (value == null) return;
+    int? targetIndex;
+    switch (bloc) {
+      case StickyMacroBloc.essentiel:
+        await _scrollToTop();
+        return;
+      case StickyMacroBloc.parTheme:
+        for (var i = 0; i < value.sections.length; i++) {
+          if (value.sections[i] is! EssentielSection) {
+            targetIndex = i;
+            break;
+          }
+        }
+      case StickyMacroBloc.explorer:
+        // No section index — scroll to the Explorer key directly.
+        final ctx = _explorerKey.currentContext;
+        if (ctx != null) {
+          await Scrollable.ensureVisible(
+            ctx,
+            duration: const Duration(milliseconds: 350),
+            curve: Curves.easeInOut,
+            alignment: 0,
+          );
+        }
+        return;
+    }
+    if (targetIndex != null) {
+      await _scrollToSection(targetIndex);
+    }
   }
 
   Future<void> _scrollToSection(int index) async {
@@ -363,6 +408,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
         '${RoutePaths.fluxContinu}/content/${article.id}',
         extra: article,
       );
+    } else if (article is EssentielArticle) {
+      await context
+          .push('${RoutePaths.fluxContinu}/content/${article.contentId}');
     } else {
       return;
     }
@@ -505,6 +553,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     }
     for (final s in state.sections) {
       switch (s) {
+        case EssentielSection(:final articles):
+          for (final a in articles) {
+            if (a.contentId == contentId) return a;
+          }
         case DigestTopicSection(:final topics):
           for (final t in topics) {
             final lead = pickTopicLead(t);
@@ -539,12 +591,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             ),
             _StickyHostOverlay(
               stickyVisible: _stickyVisible,
-              scrollProgress: _scrollProgress,
-              activeIndex: _activeIndex,
-              isInExploreMode: _isInExploreMode,
+              currentMacroBloc: _currentMacroBloc,
               stateProvider: fluxContinuProvider,
-              onTapTab: _scrollToSection,
-              tabsController: _tabsScroll,
+              onTap: _onTapStickyBar,
             ),
             // Floating "back to top" button — reveals on upward scroll above
             // the hide threshold, fades down on reverse / near top.
@@ -724,6 +773,17 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
               ),
             ),
           ),
+          const SliverToBoxAdapter(
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(
+                FacteurSpacing.space4,
+                0,
+                FacteurSpacing.space4,
+                FacteurSpacing.space2,
+              ),
+              child: FeedFilterBar(),
+            ),
+          ),
           if (state.feedContinu.isNotEmpty) ...[
             _buildIntercalatedFeed(context, state),
             const SliverToBoxAdapter(child: SectionHairline()),
@@ -893,29 +953,22 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
 /// disappears upward as content moves up.
 class _StickyHostOverlay extends ConsumerWidget {
   final ValueNotifier<bool> stickyVisible;
-  final ValueNotifier<double> scrollProgress;
-  final ValueNotifier<int> activeIndex;
-  final ValueNotifier<bool> isInExploreMode;
+  final ValueNotifier<StickyMacroBloc> currentMacroBloc;
   final AsyncNotifierProvider<FluxContinuNotifier, FluxContinuState>
       stateProvider;
-  final ValueChanged<int> onTapTab;
-  final ScrollController tabsController;
+  final VoidCallback onTap;
 
   const _StickyHostOverlay({
     required this.stickyVisible,
-    required this.scrollProgress,
-    required this.activeIndex,
-    required this.isInExploreMode,
+    required this.currentMacroBloc,
     required this.stateProvider,
-    required this.onTapTab,
-    required this.tabsController,
+    required this.onTap,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final sections =
-        ref.watch(stateProvider).valueOrNull?.sections ??
-            const <FluxSection>[];
+    final state = ref.watch(stateProvider).valueOrNull;
+    final sections = state?.sections ?? const <FluxSection>[];
     return Positioned(
       top: 0,
       left: 0,
@@ -928,64 +981,55 @@ class _StickyHostOverlay extends ConsumerWidget {
             duration: const Duration(milliseconds: 150),
             child: !showSticky
                 ? const SizedBox.shrink(key: ValueKey('hidden'))
-                : ValueListenableBuilder<bool>(
+                : ValueListenableBuilder<StickyMacroBloc>(
                     key: const ValueKey('sticky'),
-                    valueListenable: isInExploreMode,
-                    builder: (context, explore, _) => AnimatedSwitcher(
-                      duration: const Duration(milliseconds: 120),
-                      child: explore
-                          ? const _ExplorerSticky(key: ValueKey('explore'))
-                          : ValueListenableBuilder<int>(
-                              key: const ValueKey('editorial'),
-                              valueListenable: activeIndex,
-                              builder: (context, idx, _) =>
-                                  ValueListenableBuilder<double>(
-                                valueListenable: scrollProgress,
-                                builder: (context, progress, _) => StickyTabBar(
-                                  sections: sections,
-                                  activeIndex:
-                                      idx.clamp(0, sections.length - 1),
-                                  progress: progress,
-                                  onTapTab: onTapTab,
-                                  tabsController: tabsController,
-                                ),
-                              ),
-                            ),
-                    ),
+                    valueListenable: currentMacroBloc,
+                    builder: (context, bloc, _) {
+                      final read = _readCountFor(bloc, state);
+                      final total = _totalFor(bloc, sections);
+                      return StickyThreeStateBar(
+                        bloc: bloc,
+                        read: read,
+                        total: total,
+                        remainingMin: ((total - read) * 2).clamp(0, 60),
+                        onTap: onTap,
+                      );
+                    },
                   ),
           );
         },
       ),
     );
   }
-}
 
-/// Sticky wrapper around [FeedFilterBar] sharing [StickyBackdrop] with
-/// [StickyTabBar] so the cross-fade between the two stickies feels like a
-/// single surface morphing rather than two distinct bars.
-class _ExplorerSticky extends StatelessWidget {
-  const _ExplorerSticky({super.key});
+  static int _totalFor(StickyMacroBloc bloc, List<FluxSection> sections) {
+    switch (bloc) {
+      case StickyMacroBloc.essentiel:
+        return sections
+            .whereType<EssentielSection>()
+            .fold<int>(0, (sum, s) => sum + s.totalCount);
+      case StickyMacroBloc.parTheme:
+        return sections
+            .where((s) => s is! EssentielSection)
+            .fold<int>(0, (sum, s) => sum + s.totalCount);
+      case StickyMacroBloc.explorer:
+        return 0;
+    }
+  }
 
-  @override
-  Widget build(BuildContext context) {
-    return const StickyBackdrop(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          StickyHead(title: 'Explorer'),
-          Padding(
-            padding: EdgeInsets.fromLTRB(
-              FacteurSpacing.space4,
+  static int _readCountFor(StickyMacroBloc bloc, FluxContinuState? state) {
+    if (state == null) return 0;
+    switch (bloc) {
+      case StickyMacroBloc.essentiel:
+        return state.sections.whereType<EssentielSection>().fold<int>(
               0,
-              FacteurSpacing.space4,
-              FacteurSpacing.space2,
-            ),
-            child: FeedFilterBar(),
-          ),
-        ],
-      ),
-    );
+              (sum, s) =>
+                  sum + s.articles.where((a) => a.isRead).length,
+            );
+      case StickyMacroBloc.parTheme:
+      case StickyMacroBloc.explorer:
+        return 0;
+    }
   }
 }
 

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -1,0 +1,602 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../models/flux_continu_models.dart';
+import '../utils/theme_color_mapping.dart';
+
+/// Carte hi-fi unique "L'Essentiel du jour" (Story 9.2, composant 1).
+///
+/// Présente jusqu'à 5 articles transversaux du jour :
+///   - `articles[0]` → lead (fond teinté, bord gauche accent)
+///   - `articles[1..2]` → médiums (filets fins)
+///   - `articles[3..4]` → lights (filet pointillé, une ligne tronquée)
+///
+/// Le bouton config en haut-droite ouvre la modal `EssentielPersonalizeSheet`
+/// pour rediriger vers `Mes intérêts` / `Mes sources` ; son tap est isolé
+/// (`InkWell`) pour ne pas déclencher l'ouverture d'un article par erreur.
+class EssentielHiFiCard extends StatelessWidget {
+  final List<EssentielArticle> articles;
+  final void Function(EssentielArticle article) onTapArticle;
+  final VoidCallback onTapPersonalize;
+  final VoidCallback? onTapSkip;
+  final VoidCallback? onTapExploreAll;
+
+  const EssentielHiFiCard({
+    super.key,
+    required this.articles,
+    required this.onTapArticle,
+    required this.onTapPersonalize,
+    this.onTapSkip,
+    this.onTapExploreAll,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<FacteurColors>()!;
+    final accent = colors.sectionEssentiel;
+
+    final lead = articles.isNotEmpty ? articles.first : null;
+    final mediums = articles.length > 1
+        ? articles.sublist(1, articles.length > 3 ? 3 : articles.length)
+        : const <EssentielArticle>[];
+    final lights = articles.length > 3
+        ? articles.sublist(3, articles.length > 5 ? 5 : articles.length)
+        : const <EssentielArticle>[];
+
+    return Container(
+      margin: const EdgeInsets.fromLTRB(
+        FacteurSpacing.space3,
+        FacteurSpacing.space2,
+        FacteurSpacing.space3,
+        FacteurSpacing.space4,
+      ),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        border: Border.all(color: colors.border, width: 0.6),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x14000000),
+            blurRadius: 14,
+            offset: Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          FacteurSpacing.space4,
+          FacteurSpacing.space4,
+          FacteurSpacing.space4,
+          FacteurSpacing.space3,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _Header(accent: accent, onTapPersonalize: onTapPersonalize),
+            const SizedBox(height: FacteurSpacing.space4),
+            if (lead != null)
+              _LeadTile(
+                article: lead,
+                accent: accent,
+                onTap: () => onTapArticle(lead),
+              ),
+            for (final m in mediums) ...[
+              const SizedBox(height: FacteurSpacing.space3),
+              const _Hairline(),
+              const SizedBox(height: FacteurSpacing.space3),
+              _MediumTile(article: m, onTap: () => onTapArticle(m)),
+            ],
+            for (final l in lights) ...[
+              const SizedBox(height: FacteurSpacing.space2),
+              const _DottedDivider(),
+              const SizedBox(height: FacteurSpacing.space2),
+              _LightTile(article: l, onTap: () => onTapArticle(l)),
+            ],
+            const SizedBox(height: FacteurSpacing.space4),
+            _Footer(
+              accent: accent,
+              onSkip: onTapSkip,
+              onExploreAll: onTapExploreAll,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  final Color accent;
+  final VoidCallback onTapPersonalize;
+
+  const _Header({required this.accent, required this.onTapPersonalize});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<FacteurColors>()!;
+    final now = DateTime.now();
+    final dateLabel = _formatDateStamp(now);
+    final dayLabel = _formatDayName(now).toUpperCase();
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _DateStamp(label: dateLabel, accent: accent),
+        const SizedBox(width: FacteurSpacing.space3),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'ÉDITION DU $dayLabel · 5 ACTUS À SUIVRE',
+                style: FacteurTypography.stamp(colors.textTertiary),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'L’Essentiel du jour',
+                style: GoogleFonts.fraunces(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  height: 1.2,
+                  color: colors.textPrimary,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: FacteurSpacing.space2),
+        _PersonalizeButton(onTap: onTapPersonalize),
+      ],
+    );
+  }
+
+  static String _formatDateStamp(DateTime d) {
+    const months = [
+      'JAN',
+      'FÉV',
+      'MAR',
+      'AVR',
+      'MAI',
+      'JUIN',
+      'JUIL',
+      'AOÛT',
+      'SEPT',
+      'OCT',
+      'NOV',
+      'DÉC',
+    ];
+    final dd = d.day.toString().padLeft(2, '0');
+    return '$dd / ${months[d.month - 1]}';
+  }
+
+  static String _formatDayName(DateTime d) {
+    const days = [
+      'lundi',
+      'mardi',
+      'mercredi',
+      'jeudi',
+      'vendredi',
+      'samedi',
+      'dimanche',
+    ];
+    return days[d.weekday - 1];
+  }
+}
+
+class _DateStamp extends StatelessWidget {
+  final String label;
+  final Color accent;
+
+  const _DateStamp({required this.label, required this.accent});
+
+  @override
+  Widget build(BuildContext context) {
+    return Transform.rotate(
+      angle: -0.05,
+      child: Container(
+        width: 56,
+        height: 56,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: accent.withValues(alpha: 0.12),
+          shape: BoxShape.circle,
+          border: Border.all(color: accent, width: 1.2),
+        ),
+        child: Text(
+          label,
+          textAlign: TextAlign.center,
+          style: GoogleFonts.courierPrime(
+            fontSize: 10,
+            fontWeight: FontWeight.w700,
+            height: 1.15,
+            letterSpacing: 0.3,
+            color: accent,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PersonalizeButton extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _PersonalizeButton({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<FacteurColors>()!;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(FacteurRadius.full),
+        child: Container(
+          width: 32,
+          height: 32,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(color: colors.border, width: 0.8),
+          ),
+          child: Icon(
+            Icons.tune_rounded,
+            size: 16,
+            color: colors.textSecondary,
+            semanticLabel: 'Personnaliser ton Essentiel',
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LeadTile extends StatelessWidget {
+  final EssentielArticle article;
+  final Color accent;
+  final VoidCallback onTap;
+
+  const _LeadTile({
+    required this.article,
+    required this.accent,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<FacteurColors>()!;
+    final themeAccent = _accentFor(article, accent);
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(FacteurRadius.medium),
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(
+            FacteurSpacing.space3,
+            FacteurSpacing.space3,
+            FacteurSpacing.space3,
+            FacteurSpacing.space3,
+          ),
+          decoration: BoxDecoration(
+            color: themeAccent.withValues(alpha: 0.08),
+            borderRadius: BorderRadius.circular(FacteurRadius.medium),
+            border: Border(left: BorderSide(color: themeAccent, width: 3)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  _SectionChip(label: article.sectionLabel, accent: themeAccent),
+                  const Spacer(),
+                  if (article.perspectiveCount > 1)
+                    Text(
+                      '+ ${article.perspectiveCount} sources',
+                      style:
+                          FacteurTypography.labelSmall(colors.textTertiary),
+                    ),
+                ],
+              ),
+              const SizedBox(height: FacteurSpacing.space2),
+              Text(
+                article.title,
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+                style: GoogleFonts.fraunces(
+                  fontSize: 17,
+                  fontWeight: FontWeight.w700,
+                  height: 1.3,
+                  color: colors.textPrimary,
+                ),
+              ),
+              const SizedBox(height: FacteurSpacing.space2),
+              _SourceRow(article: article),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MediumTile extends StatelessWidget {
+  final EssentielArticle article;
+  final VoidCallback onTap;
+
+  const _MediumTile({required this.article, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<FacteurColors>()!;
+    final themeAccent = _accentFor(article, colors.sectionEssentiel);
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(FacteurRadius.small),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  _SectionChip(label: article.sectionLabel, accent: themeAccent),
+                  const SizedBox(width: FacteurSpacing.space2),
+                  Flexible(
+                    child: Text(
+                      article.sourceName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: FacteurTypography.labelSmall(colors.textTertiary),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                article.title,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: GoogleFonts.fraunces(
+                  fontSize: 14.5,
+                  fontWeight: FontWeight.w600,
+                  height: 1.3,
+                  color: colors.textPrimary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LightTile extends StatelessWidget {
+  final EssentielArticle article;
+  final VoidCallback onTap;
+
+  const _LightTile({required this.article, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<FacteurColors>()!;
+    final themeAccent = _accentFor(article, colors.sectionEssentiel);
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(FacteurRadius.small),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Container(
+                width: 6,
+                height: 6,
+                decoration: BoxDecoration(
+                  color: themeAccent,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: FacteurSpacing.space2),
+              Text(
+                article.sectionLabel.toUpperCase(),
+                style: FacteurTypography.labelSmall(themeAccent).copyWith(
+                  fontSize: 10.5,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.6,
+                ),
+              ),
+              const SizedBox(width: FacteurSpacing.space2),
+              Text(
+                '·',
+                style: FacteurTypography.labelSmall(colors.textTertiary),
+              ),
+              const SizedBox(width: FacteurSpacing.space2),
+              Expanded(
+                child: Text(
+                  article.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: FacteurTypography.bodySmall(colors.textPrimary),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionChip extends StatelessWidget {
+  final String label;
+  final Color accent;
+
+  const _SectionChip({required this.label, required this.accent});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(FacteurRadius.pill),
+      ),
+      child: Text(
+        label,
+        style: GoogleFonts.dmSans(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.2,
+          color: accent,
+        ),
+      ),
+    );
+  }
+}
+
+class _SourceRow extends StatelessWidget {
+  final EssentielArticle article;
+
+  const _SourceRow({required this.article});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<FacteurColors>()!;
+    return Row(
+      children: [
+        Container(
+          width: 20,
+          height: 20,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: colors.backgroundSecondary,
+            shape: BoxShape.circle,
+            border: Border.all(color: colors.border, width: 0.6),
+          ),
+          child: Text(
+            article.sourceLetter,
+            style: GoogleFonts.dmSans(
+              fontSize: 10,
+              fontWeight: FontWeight.w700,
+              color: colors.textSecondary,
+            ),
+          ),
+        ),
+        const SizedBox(width: FacteurSpacing.space2),
+        Flexible(
+          child: Text(
+            article.sourceName,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: FacteurTypography.labelSmall(colors.textTertiary),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Hairline extends StatelessWidget {
+  const _Hairline();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<FacteurColors>()!;
+    return Container(height: 0.6, color: colors.border);
+  }
+}
+
+class _DottedDivider extends StatelessWidget {
+  const _DottedDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<FacteurColors>()!;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final dashCount = (constraints.maxWidth / 4).floor();
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: List.generate(
+            dashCount,
+            (_) => Container(width: 2, height: 1, color: colors.border),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _Footer extends StatelessWidget {
+  final Color accent;
+  final VoidCallback? onSkip;
+  final VoidCallback? onExploreAll;
+
+  const _Footer({required this.accent, this.onSkip, this.onExploreAll});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<FacteurColors>()!;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        if (onSkip != null)
+          TextButton(
+            onPressed: onSkip,
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              minimumSize: const Size(0, 32),
+              foregroundColor: colors.textTertiary,
+            ),
+            child: Text(
+              'Passer',
+              style: FacteurTypography.labelLarge(colors.textTertiary),
+            ),
+          )
+        else
+          const SizedBox.shrink(),
+        if (onExploreAll != null)
+          Material(
+            color: accent,
+            borderRadius: BorderRadius.circular(FacteurRadius.pill),
+            child: InkWell(
+              onTap: onExploreAll,
+              borderRadius: BorderRadius.circular(FacteurRadius.pill),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: FacteurSpacing.space4,
+                  vertical: 8,
+                ),
+                child: Text(
+                  'Tout explorer →',
+                  style: GoogleFonts.dmSans(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// Picks an accent color: theme slug first, then card-level kind fallback.
+Color _accentFor(EssentielArticle article, Color fallback) {
+  final slug = article.theme;
+  if (slug != null && themeMap.containsKey(slug)) {
+    return themeMap[slug]!.accent;
+  }
+  return fallback;
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_personalize_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_personalize_sheet.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../config/routes.dart';
+import '../../../config/theme.dart';
+
+/// Bottom sheet "Personnaliser ton Essentiel" (Story 9.2, composant 1 bis).
+///
+/// Affichée depuis le bouton config en haut-droite de la carte hi-fi
+/// `EssentielHiFiCard`. Propose deux choix :
+///   - "Tes intérêts" → `RouteNames.myInterests` (`/settings/interests`)
+///   - "Tes sources"  → `RouteNames.sources`     (`/settings/sources`)
+///
+/// Tap hors / `[×]` referme sans navigation.
+class EssentielPersonalizeSheet extends StatelessWidget {
+  const EssentielPersonalizeSheet({super.key});
+
+  /// Helper d'affichage aligné sur le pattern `InterestStatePickerSheet.show`.
+  static Future<void> show(BuildContext context) {
+    return showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => const EssentielPersonalizeSheet(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.backgroundSecondary,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              margin: const EdgeInsets.only(top: 12, bottom: 16),
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: colors.textTertiary.withValues(alpha: 0.3),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Personnaliser ton Essentiel',
+                      style: textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: colors.textPrimary,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    icon: Icon(Icons.close, color: colors.textTertiary),
+                    splashRadius: 20,
+                    tooltip: 'Fermer',
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 4),
+            _ChoiceTile(
+              icon: Icons.favorite_outline,
+              accent: colors.sectionEssentiel,
+              title: 'Tes intérêts',
+              subtitle: 'Choisis les thèmes qui guident ton Essentiel.',
+              onTap: () {
+                Navigator.of(context).pop();
+                context.goNamed(RouteNames.myInterests);
+              },
+            ),
+            _ChoiceTile(
+              icon: Icons.rss_feed,
+              accent: colors.sectionVeille1,
+              title: 'Tes sources',
+              subtitle: 'Suis ou masque les médias qui te parlent.',
+              onTap: () {
+                Navigator.of(context).pop();
+                context.goNamed(RouteNames.sources);
+              },
+            ),
+            const SizedBox(height: 12),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ChoiceTile extends StatelessWidget {
+  final IconData icon;
+  final Color accent;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  const _ChoiceTile({
+    required this.icon,
+    required this.accent,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+        child: Row(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: accent.withValues(alpha: 0.12),
+              ),
+              alignment: Alignment.center,
+              child: Icon(icon, color: accent, size: 22),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: textTheme.bodyLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: colors.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colors.textTertiary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Icon(Icons.chevron_right, color: colors.textTertiary, size: 18),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/folded_section_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/folded_section_card.dart
@@ -13,11 +13,17 @@ class FoldedSectionCard extends StatelessWidget {
   final int? articleCount;
   final VoidCallback? onTap;
 
+  /// When true, prefix the title with a small green check, matching the v3
+  /// spec for the folded "L'Essentiel du jour" ruban. Kept opt-in so the
+  /// existing digest sections (essentiel legacy, bonnes) stay unchanged.
+  final bool showCheck;
+
   const FoldedSectionCard({
     super.key,
     required this.title,
     this.articleCount,
     this.onTap,
+    this.showCheck = false,
   });
 
   @override
@@ -41,6 +47,10 @@ class FoldedSectionCard extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
+              if (showCheck) ...[
+                Icon(Icons.check, size: 16, color: colors.success),
+                const SizedBox(width: 6),
+              ],
               Expanded(
                 child: Text(
                   title,

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../../feed/widgets/feedback_inline.dart';
 import '../models/flux_continu_models.dart';
+import 'essentiel_hi_fi_card.dart';
+import 'essentiel_personalize_sheet.dart';
 import 'flux_continu_article_card.dart';
 import 'folded_section_card.dart';
 import 'plus_de_button.dart';
@@ -81,8 +83,10 @@ class SectionBlock extends StatelessWidget {
     //
     // [FeedThemeSection] never folds: it uses the in-place "Voir +10"
     // pagination, so the fold UX of digest sections would conflict with
-    // that affordance. Only digest sections (essentiel / bonnes) fold.
-    final bool canFold = section is DigestTopicSection;
+    // that affordance. Only digest sections (bonnes, "Actus du jour")
+    // and the v3 EssentielSection fold.
+    final bool canFold =
+        section is DigestTopicSection || section is EssentielSection;
     return (isFolded && canFold) ? _buildFolded() : _buildExpanded();
   }
 
@@ -91,12 +95,31 @@ class SectionBlock extends StatelessWidget {
       title: section.label,
       articleCount: section.totalCount,
       onTap: onUnfold,
+      showCheck: section is EssentielSection,
     );
   }
 
   Widget _buildExpanded() {
-    final cards = _buildCards();
     final section = this.section;
+    // EssentielSection is a fully self-contained hi-fi card — no banner,
+    // no "Plus de…" overflow.
+    if (section is EssentielSection) {
+      return Builder(
+        builder: (context) => Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            EssentielHiFiCard(
+              articles: section.articles,
+              onTapArticle: (a) => onTapArticle(a, section),
+              onTapPersonalize: () => EssentielPersonalizeSheet.show(context),
+              onTapSkip: onFold,
+            ),
+            const SizedBox(height: 16),
+          ],
+        ),
+      );
+    }
+    final cards = _buildCards();
     final hiddenCount = section.totalCount - section.coreVisibleCount;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -149,6 +172,10 @@ class SectionBlock extends StatelessWidget {
   List<Widget> _buildCards() {
     final isEssentiel = section.kind == SectionKind.essentiel;
     switch (section) {
+      case EssentielSection():
+        // _buildExpanded short-circuits to EssentielHiFiCard before reaching
+        // _buildCards, so this branch is unreachable in practice.
+        return const [];
       case DigestTopicSection(:final topics, :final coreVisibleCount):
         final visible =
             isOpen ? topics : topics.take(coreVisibleCount).toList();

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -1,259 +1,253 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
-import '../models/flux_continu_models.dart';
 import 'sticky_backdrop.dart';
 
-/// Sticky tab bar revealed once the user scrolls past the AppBar threshold.
+/// Macro-bloc the user is currently traversing.
 ///
-/// Layout per V6 maquette :
-/// - parchment-tinted backdrop with a 14px blur (saturate 140%),
-/// - "sticky-head" row : zone title ("Les Actus du jour" in the editorial
-///   zone, "Explorer" in the Explorer zone),
-/// - horizontal tabs with section dot, label, done strike-through, and
-///   an underline tinted with the active section's accent,
-/// - 4-px progress track with a 4-stop gradient fill (essentiel → bonnes
-///   → veille1 → veille2) and a soft accent glow.
-class StickyTabBar extends StatelessWidget {
-  final List<FluxSection> sections;
-  final int activeIndex;
-  final double progress;
-  final ValueChanged<int> onTapTab;
-  final ScrollController? tabsController;
+/// Drives [StickyThreeStateBar] : each value swaps icon, accent and label.
+/// Story 9.2, composant 2.
+enum StickyMacroBloc { essentiel, parTheme, explorer }
 
-  const StickyTabBar({
+/// Sticky bar v3 — 3-state contextual reminder of the macro zone.
+///
+/// Layout (~64 px) :
+/// - Row 1 : 40×40 rounded square with `--k-tint` background + Phosphor icon,
+///   Fraunces 15px/w600 title, mono "~N min" hint pinned right.
+/// - Row 2 : N progress plots (lu = filled accent + check / current = ring /
+///   upcoming = grey disc) + "read/total" ratio.
+///
+/// Transition between blocs : container stays in place, only the inner
+/// content crossfades over 200 ms via [AnimatedSwitcher].
+class StickyThreeStateBar extends StatelessWidget {
+  final StickyMacroBloc bloc;
+  final int read;
+  final int total;
+  final int remainingMin;
+  final VoidCallback? onTap;
+
+  const StickyThreeStateBar({
     super.key,
-    required this.sections,
-    required this.activeIndex,
-    required this.progress,
-    required this.onTapTab,
-    this.tabsController,
+    required this.bloc,
+    required this.read,
+    required this.total,
+    required this.remainingMin,
+    this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
     return StickyBackdrop(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          const StickyHead(),
-          _TabsRow(
-            sections: sections,
-            activeIndex: activeIndex,
-            onTapTab: onTapTab,
-            controller: tabsController,
-          ),
-          SizedBox(
-            height: 4,
-            child: CustomPaint(
-              painter: _ProgressPainter(
-                progress: progress.clamp(0.0, 1.0),
-                gradient: const [
-                  Color(0xFFD35400),
-                  Color(0xFFC2185B),
-                  Color(0xFF2C3E50),
-                  Color(0xFF6C3483),
-                ],
-                glow: const Color.fromRGBO(211, 84, 0, 0.35),
-                trackColor: const Color.fromRGBO(0, 0, 0, 0.06),
-              ),
-              child: const SizedBox.expand(),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 200),
+            child: _StickyContent(
+              key: ValueKey(bloc),
+              bloc: bloc,
+              read: read,
+              total: total,
+              remainingMin: remainingMin,
             ),
           ),
-        ],
+        ),
       ),
     );
   }
 }
 
-/// Top row of the sticky overlay — a single Fraunces label that names the
-/// current zone of the Flux Continu screen. Shared between the editorial
-/// sticky ([StickyTabBar]) and the Explorer sticky (`_ExplorerSticky` in
-/// `flux_continu_screen.dart`) so the two surfaces feel like the same bar
-/// changing its caption.
-class StickyHead extends StatelessWidget {
-  final String title;
+class _StickyContent extends StatelessWidget {
+  final StickyMacroBloc bloc;
+  final int read;
+  final int total;
+  final int remainingMin;
 
-  const StickyHead({super.key, this.title = 'Les Actus du jour'});
+  const _StickyContent({
+    super.key,
+    required this.bloc,
+    required this.read,
+    required this.total,
+    required this.remainingMin,
+  });
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
+    final accent = _accentFor(colors, bloc);
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      padding: const EdgeInsets.fromLTRB(
+        FacteurSpacing.space4,
+        FacteurSpacing.space2,
+        FacteurSpacing.space4,
+        FacteurSpacing.space2,
+      ),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Text(
-            title,
-            style: GoogleFonts.fraunces(
-              fontSize: 14,
-              fontWeight: FontWeight.w700,
-              color: colors.textPrimary,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _TabsRow extends StatelessWidget {
-  final List<FluxSection> sections;
-  final int activeIndex;
-  final ValueChanged<int> onTapTab;
-  final ScrollController? controller;
-
-  const _TabsRow({
-    required this.sections,
-    required this.activeIndex,
-    required this.onTapTab,
-    this.controller,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      height: 44,
-      child: ListView.separated(
-        controller: controller,
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.fromLTRB(10, 4, 10, 8),
-        itemCount: sections.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 2),
-        itemBuilder: (context, i) {
-          return _Tab(
-            section: sections[i],
-            isActive: i == activeIndex,
-            isDone: i < activeIndex,
-            onTap: () => onTapTab(i),
-          );
-        },
-      ),
-    );
-  }
-}
-
-class _Tab extends StatelessWidget {
-  final FluxSection section;
-  final bool isActive;
-  final bool isDone;
-  final VoidCallback onTap;
-
-  const _Tab({
-    required this.section,
-    required this.isActive,
-    required this.isDone,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.facteurColors;
-    final Color labelColor;
-    if (isActive) {
-      labelColor = colors.textPrimary;
-    } else if (isDone) {
-      labelColor = colors.textTertiary;
-    } else {
-      labelColor = colors.textSecondary;
-    }
-    final dotColor = isActive
-        ? section.accent
-        : (isDone ? colors.textTertiary : colors.textSecondary);
-    return InkWell(
-      onTap: onTap,
-      borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
-      child: Stack(
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(12, 7, 12, 9),
-            child: Row(
+          _IconBadge(accent: accent, bloc: bloc),
+          const SizedBox(width: FacteurSpacing.space3),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
               children: [
-                Container(
-                  width: 6,
-                  height: 6,
-                  margin: const EdgeInsets.only(right: 6),
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: dotColor,
+                Text(
+                  _titleFor(bloc),
+                  style: GoogleFonts.fraunces(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    height: 1.2,
+                    color: colors.textPrimary,
                   ),
                 ),
-                Text(
-                  section.label,
-                  style: GoogleFonts.dmSans(
-                    fontSize: 12.5,
-                    fontWeight: FontWeight.w600,
-                    color: labelColor,
-                    decoration: isDone
-                        ? TextDecoration.lineThrough
-                        : TextDecoration.none,
-                    decorationColor: labelColor,
-                  ),
+                const SizedBox(height: 2),
+                _ProgressPlots(
+                  accent: accent,
+                  read: read.clamp(0, total),
+                  total: total,
                 ),
               ],
             ),
           ),
-          if (isActive)
-            Positioned(
-              left: 8,
-              right: 8,
-              bottom: 0,
-              height: 2,
-              child: Container(
-                decoration: BoxDecoration(
-                  color: section.accent,
-                  borderRadius: const BorderRadius.vertical(
-                    top: Radius.circular(2),
-                  ),
-                ),
-              ),
+          const SizedBox(width: FacteurSpacing.space2),
+          Text(
+            '~$remainingMin min',
+            style: GoogleFonts.courierPrime(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: colors.textTertiary,
             ),
+          ),
         ],
       ),
     );
   }
+
+  static String _titleFor(StickyMacroBloc bloc) {
+    switch (bloc) {
+      case StickyMacroBloc.essentiel:
+        return 'L’Essentiel du jour';
+      case StickyMacroBloc.parTheme:
+        return 'L’Essentiel, par thème';
+      case StickyMacroBloc.explorer:
+        return 'Explorer';
+    }
+  }
+
+  static Color _accentFor(FacteurColors colors, StickyMacroBloc bloc) {
+    switch (bloc) {
+      case StickyMacroBloc.essentiel:
+        return colors.sectionEssentiel;
+      case StickyMacroBloc.parTheme:
+        return colors.sectionBonnes;
+      case StickyMacroBloc.explorer:
+        return colors.sectionVeille1;
+    }
+  }
 }
 
-class _ProgressPainter extends CustomPainter {
-  final double progress;
-  final List<Color> gradient;
-  final Color glow;
-  final Color trackColor;
+class _IconBadge extends StatelessWidget {
+  final Color accent;
+  final StickyMacroBloc bloc;
 
-  _ProgressPainter({
-    required this.progress,
-    required this.gradient,
-    required this.glow,
-    required this.trackColor,
+  const _IconBadge({required this.accent, required this.bloc});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 40,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(FacteurRadius.medium),
+      ),
+      child: Icon(_iconFor(bloc), color: accent, size: 20),
+    );
+  }
+
+  static IconData _iconFor(StickyMacroBloc bloc) {
+    switch (bloc) {
+      case StickyMacroBloc.essentiel:
+        return PhosphorIcons.envelopeSimple();
+      case StickyMacroBloc.parTheme:
+        return PhosphorIcons.stack();
+      case StickyMacroBloc.explorer:
+        return PhosphorIcons.compass();
+    }
+  }
+}
+
+class _ProgressPlots extends StatelessWidget {
+  final Color accent;
+  final int read;
+  final int total;
+
+  const _ProgressPlots({
+    required this.accent,
+    required this.read,
+    required this.total,
   });
 
   @override
-  void paint(Canvas canvas, Size size) {
-    final fullRect = Offset.zero & size;
-    final trackPaint = Paint()..color = trackColor;
-    canvas.drawRect(fullRect, trackPaint);
-
-    if (progress <= 0) return;
-    final clipped = Rect.fromLTWH(0, 0, size.width * progress, size.height);
-    final glowPaint = Paint()
-      ..color = glow
-      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 4);
-    canvas.drawRect(clipped, glowPaint);
-    final fillPaint = Paint()
-      ..shader = LinearGradient(
-        colors: gradient,
-        stops: const [0.0, 0.4, 0.7, 1.0],
-      ).createShader(fullRect);
-    canvas.drawRect(clipped, fillPaint);
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    if (total <= 0) {
+      return const SizedBox(height: 12);
+    }
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        for (var i = 0; i < total; i++) ...[
+          if (i > 0) const SizedBox(width: 4),
+          _plotFor(i, accent, colors),
+        ],
+        const SizedBox(width: 8),
+        Text(
+          '$read/$total',
+          style: GoogleFonts.dmSans(
+            fontSize: 11,
+            fontWeight: FontWeight.w500,
+            color: colors.textTertiary,
+          ),
+        ),
+      ],
+    );
   }
 
-  @override
-  bool shouldRepaint(_ProgressPainter old) =>
-      old.progress != progress ||
-      old.gradient != gradient ||
-      old.glow != glow ||
-      old.trackColor != trackColor;
+  Widget _plotFor(int i, Color accent, FacteurColors colors) {
+    if (i < read) {
+      // Read
+      return Container(
+        width: 12,
+        height: 12,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(color: accent, shape: BoxShape.circle),
+        child: const Icon(Icons.check, size: 9, color: Colors.white),
+      );
+    }
+    if (i == read) {
+      // Current
+      return Container(
+        width: 12,
+        height: 12,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(color: accent, width: 2),
+        ),
+      );
+    }
+    return Container(
+      width: 12,
+      height: 12,
+      decoration: BoxDecoration(
+        color: colors.textTertiary.withValues(alpha: 0.25),
+        shape: BoxShape.circle,
+      ),
+    );
+  }
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:facteur/features/feed/providers/feed_provider.dart';
 import 'package:facteur/features/feed/repositories/feed_repository.dart';
 import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
 import 'package:facteur/features/flux_continu/providers/flux_continu_provider.dart';
+import 'package:facteur/features/flux_continu/repositories/essentiel_repository.dart';
 import 'package:facteur/features/flux_continu/repositories/flux_continu_repository.dart';
 import 'package:facteur/features/my_interests/models/user_interests_state.dart';
 import 'package:facteur/features/my_interests/providers/user_interests_provider.dart';
@@ -21,6 +22,11 @@ class _MockFeedRepository extends Mock implements FeedRepository {}
 
 class _MockFluxContinuRepository extends Mock
     implements FluxContinuRepository {}
+
+class _StubEssentielRepository implements EssentielRepository {
+  @override
+  Future<List<EssentielArticle>?> fetch() async => const [];
+}
 
 /// Stub notifier that returns a fixed [UserInterestsState] synchronously,
 /// so the fluxContinuProvider's `ref.read(userInterestsProvider)` resolves
@@ -112,6 +118,8 @@ void main() {
         digestRepositoryProvider.overrideWithValue(digestRepo),
         feedRepositoryProvider.overrideWithValue(feedRepo),
         fluxContinuRepositoryProvider.overrideWithValue(fluxRepo),
+        essentielRepositoryProvider
+            .overrideWithValue(_StubEssentielRepository()),
         userInterestsProvider.overrideWith(
           () => _StubUserInterestsNotifier(interests ?? _interestsState()),
         ),

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
+import 'package:facteur/features/flux_continu/widgets/essentiel_hi_fi_card.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [FacteurPalettes.light]),
+    home: Scaffold(body: SingleChildScrollView(child: child)),
+  );
+}
+
+EssentielArticle _article({
+  required int rank,
+  String label = 'Tech',
+  String? theme = 'tech',
+  String source = 'Le Monde',
+}) {
+  return EssentielArticle(
+    contentId: 'c-$rank',
+    title: 'Titre $rank',
+    url: 'https://example.com/$rank',
+    publishedAt: DateTime(2026, 5, 23),
+    sourceName: source,
+    sourceLetter: source.substring(0, 1).toUpperCase(),
+    sectionLabel: label,
+    theme: theme,
+    rank: rank,
+    perspectiveCount: 3,
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('EssentielHiFiCard', () {
+    testWidgets('renders title, kicker and the lead article', (tester) async {
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [_article(rank: 1)],
+          onTapArticle: (_) {},
+          onTapPersonalize: () {},
+        ),
+      ));
+
+      expect(find.textContaining('L’Essentiel du jour'), findsOneWidget);
+      expect(find.textContaining('5 ACTUS À SUIVRE'), findsOneWidget);
+      expect(find.text('Titre 1'), findsOneWidget);
+    });
+
+    testWidgets('tap on the lead fires onTapArticle with the right article',
+        (tester) async {
+      EssentielArticle? tapped;
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [_article(rank: 1), _article(rank: 2)],
+          onTapArticle: (a) => tapped = a,
+          onTapPersonalize: () {},
+        ),
+      ));
+
+      await tester.tap(find.text('Titre 1'));
+      await tester.pumpAndSettle();
+      expect(tapped?.contentId, 'c-1');
+    });
+
+    testWidgets('tap on the personalize button fires the callback and not the '
+        'lead', (tester) async {
+      var personalizeTaps = 0;
+      var articleTaps = 0;
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [_article(rank: 1)],
+          onTapArticle: (_) => articleTaps++,
+          onTapPersonalize: () => personalizeTaps++,
+        ),
+      ));
+
+      await tester.tap(find.byIcon(Icons.tune_rounded));
+      await tester.pumpAndSettle();
+      expect(personalizeTaps, 1);
+      expect(articleTaps, 0,
+          reason: 'Personalize tap must not bubble to the lead InkWell.');
+    });
+
+    testWidgets('renders up to 5 articles (lead + 2 mediums + 2 lights)',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: List.generate(5, (i) => _article(rank: i + 1)),
+          onTapArticle: (_) {},
+          onTapPersonalize: () {},
+        ),
+      ));
+
+      for (var i = 1; i <= 5; i++) {
+        expect(find.text('Titre $i'), findsOneWidget);
+      }
+    });
+  });
+}

--- a/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/flux_continu/widgets/sticky_tab_bar.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [FacteurPalettes.light]),
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('StickyThreeStateBar', () {
+    testWidgets('renders Essentiel state with title + ratio', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const StickyThreeStateBar(
+          bloc: StickyMacroBloc.essentiel,
+          read: 2,
+          total: 5,
+          remainingMin: 6,
+        ),
+      ));
+      expect(find.text('L’Essentiel du jour'), findsOneWidget);
+      expect(find.text('2/5'), findsOneWidget);
+      expect(find.text('~6 min'), findsOneWidget);
+    });
+
+    testWidgets('swaps title when bloc changes to parTheme', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const StickyThreeStateBar(
+          bloc: StickyMacroBloc.essentiel,
+          read: 0,
+          total: 5,
+          remainingMin: 10,
+        ),
+      ));
+      await tester.pumpWidget(_wrap(
+        const StickyThreeStateBar(
+          bloc: StickyMacroBloc.parTheme,
+          read: 0,
+          total: 8,
+          remainingMin: 16,
+        ),
+      ));
+      await tester.pumpAndSettle();
+      expect(find.text('L’Essentiel, par thème'), findsOneWidget);
+    });
+
+    testWidgets('shows Explorer label in explorer state', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const StickyThreeStateBar(
+          bloc: StickyMacroBloc.explorer,
+          read: 0,
+          total: 0,
+          remainingMin: 0,
+        ),
+      ));
+      expect(find.text('Explorer'), findsOneWidget);
+    });
+
+    testWidgets('tap fires onTap', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_wrap(
+        StickyThreeStateBar(
+          bloc: StickyMacroBloc.essentiel,
+          read: 0,
+          total: 5,
+          remainingMin: 10,
+          onTap: () => taps++,
+        ),
+      ));
+      await tester.tap(find.text('L’Essentiel du jour'));
+      expect(taps, 1);
+    });
+  });
+}

--- a/docs/stories/core/9.2.essentiel-front.md
+++ b/docs/stories/core/9.2.essentiel-front.md
@@ -1,0 +1,46 @@
+# Story 9.2 — Front mobile « L'Essentiel du jour v3 »
+
+**Status:** 🚧 En cours
+**Dépend de :** Story 9.1 (backend `GET /api/essentiel`, mergée dans #647).
+
+## But
+
+Livrer côté mobile les trois composants de la refonte v3 du parcours d'ouverture du feed :
+
+1. **Carte hi-fi « L'Essentiel du jour »** — 5 articles transversaux (lead + 2 médiums + 2 lights), bouton config en haut-droite ouvrant une modal de personnalisation.
+2. **Sticky bar contextuelle 3-états** — Essentiel / Par thème / Explorer, crossfade 200 ms.
+3. **Repli auto de l'Essentiel** — même pattern que les sections digest classiques (`flux_continu_folded_YYYY-MM-DD`).
+
+## Décisions PO (récap)
+
+- Carte hi-fi alimentée par `GET /api/essentiel` (PR1 mergée).
+- Bonnes Nouvelles reste un `DigestTopicSection` inchangé.
+- « Actus du jour » = ancien topic « L'Essentiel du jour » du digest, accédé via *Voir plus de…* → renommage **libellé seul** (la clé interne `essentiel` reste intacte pour préserver les prefs `flux_continu_folded_*`).
+- Repli : **instant-swap** conservé (pas de 280 ms animé).
+
+## Fichiers créés
+
+- `apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart` — HTTP `GET /api/essentiel`.
+- `apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart` — Composant 1.
+- `apps/mobile/lib/features/flux_continu/widgets/essentiel_personalize_sheet.dart` — Modal `Personnaliser ton Essentiel`.
+
+## Fichiers modifiés
+
+- `apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart` — `EssentielSection`, `EssentielArticle`, `sectionKey()`.
+- `apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart` — `_buildEssentielSection(...)` + injection `EssentielRepository`, fallback digest si endpoint indisponible.
+- `apps/mobile/lib/features/flux_continu/widgets/section_block.dart` — dispatch `EssentielSection → EssentielHiFiCard`, `canFold` étendu.
+- `apps/mobile/lib/features/flux_continu/widgets/folded_section_card.dart` — paramètre optionnel `showCheck`.
+- `apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart` — refacto en `StickyThreeStateBar` (3 états, plots).
+- `apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart` — `_currentMacroBloc`, `_updateMacroBloc`, suppression du `_ExplorerSticky` redondant.
+
+## Vérification
+
+- `flutter test` — 0 régression, nouveaux widget tests verts.
+- `flutter analyze` — 0 warning nouveau.
+- Playwright/Chrome QA via `/validate-feature` après merge si nécessaire.
+
+## Hors scope
+
+- Refonte du feed Explorer / des sections thématiques.
+- Suppression du `FeedScreen` legacy (PR séparée à venir).
+- Animation 280 ms du repli.


### PR DESCRIPTION
## Summary

PR2 front de la refonte **L'Essentiel du jour v3**. Branche le mobile sur l'endpoint `GET /api/essentiel` livré en PR1 (#647) et refond l'ouverture du feed avec les 3 composants du plan :

1. **Carte hi-fi « L'Essentiel du jour »** (`EssentielHiFiCard`) en haut du feed — 5 articles transversaux (lead + 2 médiums + 2 lights), bouton config 32×32 qui ouvre la bottom sheet `EssentielPersonalizeSheet` → routes *Mes intérêts* / *Mes sources*. Tap config isolé (ne déclenche pas l'ouverture d'un article).
2. **Sticky bar contextuelle 3-états** (`StickyThreeStateBar`) — Essentiel / Par thème / Explorer, icône Phosphor + accent + titre Fraunces + plots de progression + temps restant, crossfade 200 ms entre états.
3. **Repli auto de l'Essentiel** — pattern fold day-scoped existant (`flux_continu_folded_YYYY-MM-DD`), instant-swap conservé (la compensation `correctBy` déjà en place côté screen).

Story doc : `docs/stories/core/9.2.essentiel-front.md`.

## Backward compat

- `/api/digest` inchangé.
- **Bonnes Nouvelles** reste un `DigestTopicSection` inchangé.
- L'écran **« Actus du jour »** (ex-topic *L'Essentiel du jour* du digest accédé via *Voir plus de…*) continue de fonctionner ; le renommage est libellé-only — la clé interne `essentiel` reste intacte pour préserver les prefs `flux_continu_folded_*`.
- `_ExplorerSticky` supprimé : la `FeedFilterBar` passe dans le scroll view sous le banner Explorer (l'état *explorer* du nouveau sticky prend le relais comme rappel contextuel).

## Fichiers

**Créés**

- `apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart`
- `apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart`
- `apps/mobile/lib/features/flux_continu/widgets/essentiel_personalize_sheet.dart`
- `apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart`
- `apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart`
- `docs/stories/core/9.2.essentiel-front.md`

**Modifiés**

- `apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart` — `EssentielSection`, `EssentielArticle`, `sectionKey()`.
- `apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart` — `_buildEssentielSection`, injection `EssentielRepository`.
- `apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart` — `_currentMacroBloc`, `_updateMacroBloc`, `_onTapStickyBar`, suppression `_ExplorerSticky`/`_tabsScroll`.
- `apps/mobile/lib/features/flux_continu/widgets/section_block.dart` — dispatch `EssentielSection`, `canFold` étendu.
- `apps/mobile/lib/features/flux_continu/widgets/folded_section_card.dart` — paramètre `showCheck` opt-in.
- `apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart` — refacto → `StickyThreeStateBar`.
- `apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart` — stub `EssentielRepository`.

## Test plan

- [x] `flutter test test/features/flux_continu/` → **63 PASS, 0 FAIL** (incl. 8 nouveaux widget tests + provider test mis à jour)
- [x] `flutter analyze` → 0 nouvelle erreur (warnings pré-existants, dont 1 `_kEssentielAccent` retiré)
- [ ] Smoke local : démarrer l'app, observer carte hi-fi top-feed + bottom sheet config + sticky 3-états
- [ ] `/validate-feature` (Chrome QA) post-merge si nécessaire
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)