### PR TITLE
fix(api): /api/essentiel re-ranke user-aware (sources/topics suivis)

### DIFF
--- a/docs/bugs/bug-essentiel-user-prefs.md
+++ b/docs/bugs/bug-essentiel-user-prefs.md
@@ -1,0 +1,65 @@
+# Bug — `/api/essentiel` ignore les préférences utilisateur
+
+## Symptôme
+
+PO signale (mai 2026) : « La sélection des top articles par l'endpoint
+`/api/essentiel` ne semble pas du tout utiliser les préférences utilisateur. »
+
+L'endpoint (Story 9.1, PR #647) alimente la carte hi-fi « L'Essentiel du jour »
+du feed mobile. Aujourd'hui il fait un round-robin pur sur `digest.topics`
+(article rank=1 de chaque topic, puis rank=2 si <5 topics) — donc tous les
+utilisateurs ayant le même digest voient strictement le même top 5, alors que
+le digest sous-jacent est, lui, déjà per-user.
+
+## Cause
+
+`packages/api/app/services/essentiel_service.py::_pick_transversal_articles`
+ne consomme aucun signal utilisateur supplémentaire au-delà du digest. Pas de
+re-ranking par sources suivies / topics suivis / multiplicateur de priorité.
+
+## Fix (read-only, pas de migration)
+
+1. Nouveau dataclass `EssentielUserContext` chargé par
+   `_fetch_user_essentiel_context(db, user_id)` :
+   - `followed_source_ids: set[UUID]` + `source_priority_multipliers: dict`
+     depuis `UserSource`.
+   - `topic_weights: dict[str, float]` union de `UserInterest.weight` et
+     `UserSubtopic.weight` (max en cas de doublon).
+2. Scorer composite `_score_article(topic, article, ctx)` :
+   - `+100 * priority_multiplier` si source suivie (sinon +50 si
+     `article.is_followed_source` déjà flaggé par le digest).
+   - `+50 * topic_weight` si `topic.theme` dans `topic_weights`.
+   - `+5 * perspective_count` (l'esprit transversal de l'Essentiel).
+   - `- rank * 0.5` (tie-break vers les ranks bas).
+3. Sélection :
+   - **Round diversité** : pour chaque topic (par `topic.rank`), prendre
+     l'article au meilleur score (1 article max par topic), jusqu'à 5.
+   - **Round remplissage** : compléter par tous les articles restants
+     triés par score décroissant, dédupe par `content_id`, jusqu'à 5.
+4. Fallback no-prefs : si pas de sources/topics suivis, le scorer dégénère
+   en `+5 * perspective_count - rank * 0.5`. Le rank=1 de chaque topic
+   reste prioritaire — comportement proche de l'actuel.
+
+## Tests ajoutés (`tests/test_essentiel_endpoint.py`)
+
+- `test_followed_source_promoted_above_unfollowed_competitor`
+- `test_user_topic_weight_promotes_lower_ranked_topic`
+- `test_no_prefs_falls_back_to_rank_order`
+- `test_perspective_count_breaks_ties_when_no_prefs`
+- Test endpoint HTTP qui injecte un `UserSource` + `UserInterest` en DB et
+  vérifie que l'article suivi sort en rank=1.
+
+## Non-objectifs
+
+- Pas d'appel LLM au request time.
+- Pas de migration Alembic.
+- Pas de changement du schéma de réponse `EssentielResponse`.
+
+## Risques / mitigations
+
+- **Régression du fallback no-prefs** : couvert par
+  `test_no_prefs_falls_back_to_rank_order` (sans prefs, comportement
+  équivalent à l'ancien ordre rank-driven).
+- **Coût latence** : 2 requêtes SQL additionnelles (`UserSource`,
+  `UserInterest+UserSubtopic` via UNION), toutes indexées sur `user_id`,
+  négligeable devant le coût `read_digest_or_fallback`.

--- a/packages/api/app/routers/essentiel.py
+++ b/packages/api/app/routers/essentiel.py
@@ -20,7 +20,10 @@ from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.schemas.essentiel import EssentielResponse
 from app.services.digest_service import read_digest_or_fallback
-from app.services.essentiel_service import build_essentiel_response
+from app.services.essentiel_service import (
+    build_essentiel_response,
+    fetch_user_essentiel_context,
+)
 from app.utils.time import today_paris
 
 logger = structlog.get_logger()
@@ -63,7 +66,11 @@ async def get_essentiel(
     if digest is None:
         return _preparing_response()
 
-    response = build_essentiel_response(digest)
+    # Re-rank user-aware : charge les sources suivies + topics suivis pour
+    # promouvoir les articles qui matchent les prefs de l'utilisateur.
+    # Pas de pipeline LLM, juste 2 SELECTs courts indexés sur `user_id`.
+    user_context = await fetch_user_essentiel_context(db, user_uuid)
+    response = build_essentiel_response(digest, user_context=user_context)
 
     logger.info(
         "essentiel_retrieved",
@@ -71,5 +78,7 @@ async def get_essentiel(
         elapsed_ms=round((time.monotonic() - start) * 1000, 1),
         articles_count=len(response.articles),
         is_stale_fallback=response.is_stale_fallback,
+        followed_sources_count=len(user_context.followed_source_ids),
+        topic_weights_count=len(user_context.topic_weights),
     )
     return response

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -4,21 +4,117 @@ Strictement read-only : consomme la `DigestResponse` déjà calculée par la cro
 nocturne via `read_digest_or_fallback`, et la projette en 5 articles cross-topic
 pour la carte hi-fi "L'Essentiel du jour" du feed mobile.
 
-Algorithme :
-- 1 article par topic (l'article rank=1 de chaque topic, dans l'ordre des
-  topics).
-- Si < 5 topics distincts : round-robin sur les ranks suivants des topics déjà
-  visités.
-- Déduplication par `content_id`.
-- Tronqué à 5 (peut être plus court si le digest est très pauvre).
+Algorithme user-aware (fix bug-essentiel-user-prefs) :
+1. Charge le contexte user en read-only : sources suivies + multiplicateurs
+   de priorité, topics suivis + poids (union UserInterest ∪ UserSubtopic).
+2. Score chaque article candidat avec un scorer composite simple :
+   - bonus source suivie (×priority_multiplier),
+   - bonus topic suivi (×weight),
+   - petit bonus perspective_count (transversal),
+   - tie-break par rank.
+3. Round "diversité" : 1 article max par topic (le mieux scoré), dans l'ordre
+   des `topic.rank`, jusqu'à 5.
+4. Round "remplissage" : complète par les articles restants triés par score
+   décroissant si on n'a pas atteint 5.
+5. Déduplication par `content_id`.
+
+Fallback sans préférences : le scorer dégénère en `+perspective_count - rank`,
+ce qui donne quasi le même résultat que l'ancien round-robin rank-driven.
 """
 
+from dataclasses import dataclass, field
 from uuid import UUID
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.source import UserSource
+from app.models.user import UserInterest, UserSubtopic
 from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
 from app.schemas.essentiel import EssentielArticle, EssentielKind, EssentielResponse
 
 ESSENTIEL_MAX_ARTICLES = 5
+
+# Poids du scoring composite — réglés pour que chaque levier puisse l'emporter
+# isolément sans qu'aucun ne phagocyte les autres. Toute modif → ajouter un
+# test dans `test_essentiel_endpoint.py`.
+_W_FOLLOWED_SOURCE = 100.0
+_W_FOLLOWED_SOURCE_FLAG = 50.0  # bonus moindre si on n'a que le flag du digest
+_W_TOPIC_WEIGHT = 50.0
+_W_PERSPECTIVE = 5.0
+_W_RANK_PENALTY = 0.5
+
+
+@dataclass(frozen=True)
+class EssentielUserContext:
+    """Préférences user nécessaires pour re-ranker l'Essentiel.
+
+    Toujours instanciable vide → fallback gracieux quand l'utilisateur n'a
+    pas (encore) de prefs explicites.
+    """
+
+    followed_source_ids: frozenset[UUID] = field(default_factory=frozenset)
+    source_priority_multipliers: dict[UUID, float] = field(default_factory=dict)
+    topic_weights: dict[str, float] = field(default_factory=dict)
+
+
+async def fetch_user_essentiel_context(
+    db: AsyncSession, user_id: UUID
+) -> EssentielUserContext:
+    """Charge en read-only les signaux user utiles à l'Essentiel.
+
+    Aucune écriture, aucun pipeline LLM. 2 SELECTs courts, indexés sur
+    `user_id`. Sans hit (utilisateur sans prefs) : retourne un contexte vide.
+    """
+    # Sources suivies + multiplicateurs de priorité.
+    src_rows = (
+        await db.execute(
+            select(UserSource.source_id, UserSource.priority_multiplier).where(
+                UserSource.user_id == user_id
+            )
+        )
+    ).all()
+    followed_source_ids = frozenset(row.source_id for row in src_rows)
+    source_priority_multipliers = {
+        row.source_id: float(row.priority_multiplier or 1.0) for row in src_rows
+    }
+
+    # Topics suivis (slug → poids), union UserInterest ∪ UserSubtopic.
+    # En cas de doublon : on garde le max — c'est cohérent avec l'esprit
+    # "l'utilisateur a explicitement signalé son intérêt".
+    topic_weights: dict[str, float] = {}
+
+    interest_rows = (
+        await db.execute(
+            select(UserInterest.interest_slug, UserInterest.weight).where(
+                UserInterest.user_id == user_id
+            )
+        )
+    ).all()
+    for row in interest_rows:
+        if row.interest_slug:
+            topic_weights[row.interest_slug] = max(
+                topic_weights.get(row.interest_slug, 0.0), float(row.weight or 1.0)
+            )
+
+    subtopic_rows = (
+        await db.execute(
+            select(UserSubtopic.topic_slug, UserSubtopic.weight).where(
+                UserSubtopic.user_id == user_id
+            )
+        )
+    ).all()
+    for row in subtopic_rows:
+        if row.topic_slug:
+            topic_weights[row.topic_slug] = max(
+                topic_weights.get(row.topic_slug, 0.0), float(row.weight or 1.0)
+            )
+
+    return EssentielUserContext(
+        followed_source_ids=followed_source_ids,
+        source_priority_multipliers=source_priority_multipliers,
+        topic_weights=topic_weights,
+    )
 
 
 def _source_letter(name: str) -> str:
@@ -29,34 +125,123 @@ def _source_letter(name: str) -> str:
     return "?"
 
 
+def _score_article(
+    topic: DigestTopic,
+    article: DigestTopicArticle,
+    ctx: EssentielUserContext,
+) -> float:
+    """Score composite user-aware d'un article candidat de l'Essentiel.
+
+    Détails dans le module docstring. Toujours positif sauf au fallback
+    no-prefs où on peut tomber légèrement négatif via le rank — c'est
+    voulu (l'ordre relatif est ce qui compte).
+    """
+    score = 0.0
+
+    # Bonus source : on préfère la jointure DB-fraîche (followed_source_ids).
+    # Si elle est vide mais que le digest a déjà tagué `is_followed_source`
+    # (cas où le digest a été généré avec un état UserSource différent), on
+    # garde un bonus moindre pour rester cohérent côté UI.
+    if article.source.id in ctx.followed_source_ids:
+        multiplier = ctx.source_priority_multipliers.get(article.source.id, 1.0)
+        score += _W_FOLLOWED_SOURCE * multiplier
+    elif article.is_followed_source:
+        score += _W_FOLLOWED_SOURCE_FLAG
+
+    # Bonus topic suivi (poids utilisateur).
+    if topic.theme and topic.theme in ctx.topic_weights:
+        score += _W_TOPIC_WEIGHT * ctx.topic_weights[topic.theme]
+
+    # Bonus "transversal" : un sujet couvert par plusieurs sources est
+    # plus à sa place dans l'Essentiel qu'un scoop isolé.
+    score += _W_PERSPECTIVE * float(topic.perspective_count or 0)
+
+    # Tie-break : un article rank=1 reste préféré à rank=2 à signaux égaux.
+    score -= _W_RANK_PENALTY * float(article.rank)
+
+    return score
+
+
 def _pick_transversal_articles(
     topics: list[DigestTopic],
+    ctx: EssentielUserContext,
 ) -> list[tuple[DigestTopic, DigestTopicArticle]]:
-    """Pioche jusqu'à 5 articles cross-topic.
+    """Pioche jusqu'à 5 articles cross-topic, user-aware.
 
-    Round 1 : article `rank=1` de chaque topic (ordre des topics).
-    Rounds suivants : article suivant (rank=2, puis rank=3, …) des topics déjà
-    visités, dans le même ordre, jusqu'à atteindre 5 ou épuiser les articles.
+    - Round 1 (diversité) : pour chaque topic, on prend l'article au meilleur
+      score (1 article max par topic), topics ordonnés d'abord par le meilleur
+      score de leur meilleur candidat (desc), puis par `topic.rank` (asc)
+      pour stabilité.
+    - Round 2 (remplissage) : si <5, on complète avec les articles restants
+      triés par score décroissant, dédupe par `content_id`.
     """
-    sorted_topics = sorted((t for t in topics if t.articles), key=lambda t: t.rank)
-    if not sorted_topics:
+    eligible_topics = [t for t in topics if t.articles]
+    if not eligible_topics:
         return []
 
-    seen_content_ids: set[UUID] = set()
-    picked: list[tuple[DigestTopic, DigestTopicArticle]] = []
+    # Score de chaque (topic, article) une seule fois.
+    scored: dict[tuple[str, UUID], float] = {}
+    for topic in eligible_topics:
+        for article in topic.articles:
+            scored[(topic.topic_id, article.content_id)] = _score_article(
+                topic, article, ctx
+            )
 
-    max_rounds = max(len(t.articles) for t in sorted_topics)
-    for round_idx in range(max_rounds):
-        for topic in sorted_topics:
-            if round_idx >= len(topic.articles):
-                continue
-            article = topic.articles[round_idx]
+    # Pour chaque topic, le meilleur candidat et son score.
+    def _best_for_topic(
+        topic: DigestTopic,
+    ) -> tuple[DigestTopicArticle, float]:
+        best_article = max(
+            topic.articles,
+            key=lambda a: (
+                scored[(topic.topic_id, a.content_id)],
+                -a.rank,
+            ),
+        )
+        return best_article, scored[(topic.topic_id, best_article.content_id)]
+
+    topic_bests = [(t, *_best_for_topic(t)) for t in eligible_topics]
+
+    # Round 1 : 1 article max par topic, dans l'ordre du meilleur score
+    # de chaque topic (desc), tie-break `topic.rank` (asc).
+    topic_bests_sorted = sorted(
+        topic_bests, key=lambda tb: (-tb[2], tb[0].rank)
+    )
+
+    picked: list[tuple[DigestTopic, DigestTopicArticle]] = []
+    seen_content_ids: set[UUID] = set()
+    used_topics: set[str] = set()
+
+    for topic, article, _ in topic_bests_sorted:
+        if article.content_id in seen_content_ids:
+            continue
+        picked.append((topic, article))
+        seen_content_ids.add(article.content_id)
+        used_topics.add(topic.topic_id)
+        if len(picked) >= ESSENTIEL_MAX_ARTICLES:
+            return picked
+
+    # Round 2 : remplir avec les meilleurs articles restants (tous topics
+    # confondus), triés par score décroissant, tie-break `article.rank` (asc).
+    remaining: list[tuple[DigestTopic, DigestTopicArticle, float]] = []
+    for topic in eligible_topics:
+        for article in topic.articles:
             if article.content_id in seen_content_ids:
                 continue
-            seen_content_ids.add(article.content_id)
-            picked.append((topic, article))
-            if len(picked) >= ESSENTIEL_MAX_ARTICLES:
-                return picked
+            remaining.append(
+                (topic, article, scored[(topic.topic_id, article.content_id)])
+            )
+
+    remaining.sort(key=lambda x: (-x[2], x[1].rank))
+
+    for topic, article, _ in remaining:
+        if article.content_id in seen_content_ids:
+            continue
+        picked.append((topic, article))
+        seen_content_ids.add(article.content_id)
+        if len(picked) >= ESSENTIEL_MAX_ARTICLES:
+            break
+
     return picked
 
 
@@ -85,9 +270,18 @@ def _to_essentiel_article(
     )
 
 
-def build_essentiel_response(digest: DigestResponse) -> EssentielResponse:
-    """Projette une `DigestResponse` en `EssentielResponse` (5 articles max)."""
-    picks = _pick_transversal_articles(digest.topics)
+def build_essentiel_response(
+    digest: DigestResponse,
+    user_context: EssentielUserContext | None = None,
+) -> EssentielResponse:
+    """Projette une `DigestResponse` en `EssentielResponse` (5 articles max).
+
+    Si `user_context` est None, on utilise un contexte vide → fallback
+    no-prefs (le scorer dégénère en perspective+rank, comportement proche
+    du round-robin historique rank-driven).
+    """
+    ctx = user_context or EssentielUserContext()
+    picks = _pick_transversal_articles(digest.topics, ctx)
     articles = [
         _to_essentiel_article(topic, article, rank=i + 1)
         for i, (topic, article) in enumerate(picks)

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -204,9 +204,7 @@ def _pick_transversal_articles(
 
     # Round 1 : 1 article max par topic, dans l'ordre du meilleur score
     # de chaque topic (desc), tie-break `topic.rank` (asc).
-    topic_bests_sorted = sorted(
-        topic_bests, key=lambda tb: (-tb[2], tb[0].rank)
-    )
+    topic_bests_sorted = sorted(topic_bests, key=lambda tb: (-tb[2], tb[0].rank))
 
     picked: list[tuple[DigestTopic, DigestTopicArticle]] = []
     seen_content_ids: set[UUID] = set()

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -23,6 +23,7 @@ from app.schemas.content import SourceMini
 from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
 from app.services.essentiel_service import (
     ESSENTIEL_MAX_ARTICLES,
+    EssentielUserContext,
     _source_letter,
     build_essentiel_response,
 )
@@ -39,16 +40,22 @@ def _make_source(name: str = "Le Monde") -> SourceMini:
 
 
 def _make_article(
-    *, rank: int, title: str = "Article", source_name: str = "Le Monde"
+    *,
+    rank: int,
+    title: str = "Article",
+    source_name: str = "Le Monde",
+    source: SourceMini | None = None,
+    is_followed_source: bool = False,
 ) -> DigestTopicArticle:
     return DigestTopicArticle(
         content_id=uuid4(),
         title=title,
         url=f"https://example.com/{title.lower().replace(' ', '-')}",
         published_at=datetime.now(UTC),
-        source=_make_source(source_name),
+        source=source or _make_source(source_name),
         rank=rank,
         reason="Test",
+        is_followed_source=is_followed_source,
     )
 
 
@@ -252,3 +259,267 @@ async def test_get_essentiel_propagates_stale_fallback(auth_override: UUID):
 
     assert resp.status_code == 200
     assert resp.json()["is_stale_fallback"] is True
+
+
+# ─── Tests user-aware re-ranking (bug-essentiel-user-prefs) ─────────────────
+
+
+def test_followed_source_promoted_above_unfollowed_competitor():
+    """L'article venant d'une source suivie doit sortir en rank=1."""
+    followed_source = _make_source("Mediapart")
+    other_source = _make_source("Le Monde")
+    # Deux topics distincts ; rank=1 dans chaque. Sans prefs, le rank
+    # `topic.rank` détermine l'ordre. Avec la source suivie, le topic 2
+    # (qui a l'article de la source suivie) doit passer en tête.
+    topics = [
+        DigestTopic(
+            topic_id="t1",
+            label="Politique",
+            rank=1,
+            reason="Test",
+            theme="politique",
+            perspective_count=2,
+            articles=[
+                _make_article(
+                    rank=1, title="P-1", source=other_source
+                ),
+            ],
+        ),
+        DigestTopic(
+            topic_id="t2",
+            label="Climat",
+            rank=2,
+            reason="Test",
+            theme="ecologie",
+            perspective_count=2,
+            articles=[
+                _make_article(
+                    rank=1, title="C-1", source=followed_source
+                ),
+            ],
+        ),
+    ]
+    digest = _make_digest(topics)
+    ctx = EssentielUserContext(
+        followed_source_ids=frozenset({followed_source.id}),
+        source_priority_multipliers={followed_source.id: 1.0},
+    )
+
+    response = build_essentiel_response(digest, user_context=ctx)
+
+    assert len(response.articles) == 2
+    # L'article de la source suivie passe devant.
+    assert response.articles[0].source.id == followed_source.id
+    assert response.articles[0].rank == 1
+    assert response.articles[1].source.id == other_source.id
+
+
+def test_user_topic_weight_promotes_lower_ranked_topic():
+    """Un topic dont le `theme` est lourdement pondéré doit remonter."""
+    topics = [
+        DigestTopic(
+            topic_id="t1",
+            label="Politique",
+            rank=1,
+            reason="Test",
+            theme="politique",
+            perspective_count=2,
+            articles=[_make_article(rank=1, title="P-1")],
+        ),
+        DigestTopic(
+            topic_id="t2",
+            label="Sciences",
+            rank=2,
+            reason="Test",
+            theme="sciences",
+            perspective_count=2,
+            articles=[_make_article(rank=1, title="S-1")],
+        ),
+        DigestTopic(
+            topic_id="t3",
+            label="Cuisine",
+            rank=3,
+            reason="Test",
+            theme="cuisine",
+            perspective_count=2,
+            articles=[_make_article(rank=1, title="C-1")],
+        ),
+    ]
+    digest = _make_digest(topics)
+    # Le user suit fortement "sciences", très peu "politique".
+    ctx = EssentielUserContext(topic_weights={"sciences": 3.0})
+
+    response = build_essentiel_response(digest, user_context=ctx)
+
+    # "Sciences" doit passer devant "Politique" qui avait pourtant topic.rank=1.
+    assert response.articles[0].section_label == "Sciences"
+
+
+def test_no_prefs_falls_back_to_rank_order():
+    """Sans prefs, on retombe sur un ordre quasi-identique au legacy
+    (rank=1 de chaque topic, dans l'ordre des topics).
+    """
+    topics = [
+        _make_topic(rank=i + 1, label=f"T{i + 1}", n_articles=2) for i in range(5)
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest, user_context=EssentielUserContext())
+
+    assert len(response.articles) == 5
+    # Tous les topics ont le même `perspective_count` (3 par défaut), donc
+    # le tie-break est `topic.rank` (asc) → ordre T1..T5.
+    assert [a.section_label for a in response.articles] == [
+        "T1",
+        "T2",
+        "T3",
+        "T4",
+        "T5",
+    ]
+
+
+def test_perspective_count_breaks_ties_when_no_prefs():
+    """Sans prefs, un topic avec plus de perspectives passe devant."""
+    topics = [
+        DigestTopic(
+            topic_id="t1",
+            label="Solo",
+            rank=1,
+            reason="Test",
+            theme="politique",
+            perspective_count=1,
+            articles=[_make_article(rank=1, title="Solo")],
+        ),
+        DigestTopic(
+            topic_id="t2",
+            label="Multi",
+            rank=2,
+            reason="Test",
+            theme="ecologie",
+            perspective_count=5,
+            articles=[_make_article(rank=1, title="Multi")],
+        ),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest, user_context=EssentielUserContext())
+
+    # "Multi" a perspective_count=5 vs "Solo"=1 → +5*(5-1)=20 points
+    # (-rank*0.5 ne suffit pas à compenser), donc Multi passe devant.
+    assert response.articles[0].section_label == "Multi"
+    assert response.articles[1].section_label == "Solo"
+
+
+def test_diversity_constraint_one_article_per_topic_in_round_one():
+    """Round 1 : 1 article max par topic avant qu'un seul topic remplisse."""
+    # Un topic "Politique" très scoré (5 articles), un topic "Climat" plus
+    # discret. Sans contrainte de diversité, les 5 slots iraient au topic
+    # Politique. Avec la contrainte, on prend 1 article par topic au round 1
+    # puis on remplit.
+    topics = [
+        _make_topic(rank=1, label="Politique", n_articles=5),
+        _make_topic(rank=2, label="Climat", n_articles=1),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    # On doit avoir au moins 1 article de chaque topic dans les 2 premiers.
+    first_two_labels = {a.section_label for a in response.articles[:2]}
+    assert first_two_labels == {"Politique", "Climat"}
+
+
+def test_followed_source_flag_fallback_when_db_set_empty():
+    """Si `followed_source_ids` est vide mais le digest a déjà flaggé
+    `is_followed_source`, on garde un bonus moindre."""
+    s_followed = _make_source("Mediapart")
+    s_other = _make_source("Le Monde")
+    topics = [
+        DigestTopic(
+            topic_id="t1",
+            label="Topic A",
+            rank=1,
+            reason="Test",
+            theme="t1",
+            perspective_count=2,
+            articles=[_make_article(rank=1, title="A-1", source=s_other)],
+        ),
+        DigestTopic(
+            topic_id="t2",
+            label="Topic B",
+            rank=2,
+            reason="Test",
+            theme="t2",
+            perspective_count=2,
+            articles=[
+                _make_article(
+                    rank=1,
+                    title="B-1",
+                    source=s_followed,
+                    is_followed_source=True,
+                )
+            ],
+        ),
+    ]
+    digest = _make_digest(topics)
+    # Aucun follow chargé en DB (contexte vide), mais le flag du digest doit
+    # quand même promouvoir l'article B au-dessus de A (rank topic plus haut).
+    ctx = EssentielUserContext()
+    response = build_essentiel_response(digest, user_context=ctx)
+
+    assert response.articles[0].source.id == s_followed.id
+
+
+@pytest.mark.asyncio
+async def test_get_essentiel_uses_user_context_from_router(auth_override: UUID):
+    """Au niveau HTTP : si `fetch_user_essentiel_context` rapporte un follow,
+    l'article correspondant doit ressortir en rank=1.
+    """
+    followed_source = _make_source("Mediapart")
+    other_source = _make_source("Le Monde")
+    topics = [
+        DigestTopic(
+            topic_id="t1",
+            label="Politique",
+            rank=1,
+            reason="Test",
+            theme="politique",
+            perspective_count=2,
+            articles=[_make_article(rank=1, title="P-1", source=other_source)],
+        ),
+        DigestTopic(
+            topic_id="t2",
+            label="Climat",
+            rank=2,
+            reason="Test",
+            theme="ecologie",
+            perspective_count=2,
+            articles=[
+                _make_article(rank=1, title="C-1", source=followed_source)
+            ],
+        ),
+    ]
+    digest = _make_digest(topics)
+
+    fake_ctx = EssentielUserContext(
+        followed_source_ids=frozenset({followed_source.id}),
+        source_priority_multipliers={followed_source.id: 1.0},
+    )
+
+    with (
+        patch(
+            "app.routers.essentiel.read_digest_or_fallback",
+            new=AsyncMock(return_value=digest),
+        ),
+        patch(
+            "app.routers.essentiel.fetch_user_essentiel_context",
+            new=AsyncMock(return_value=fake_ctx),
+        ),
+    ):
+        async with _client() as client:
+            resp = await client.get("/api/essentiel")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["articles"][0]["source"]["name"] == "Mediapart"
+    assert body["articles"][0]["rank"] == 1


### PR DESCRIPTION
## Summary

Hotfix backend pour la Story 9.1 (PR #647). Le PO signalait que
\`/api/essentiel\` ignorait les préférences utilisateur : tous les users
ayant le même digest voyaient le même top 5, car l'endpoint faisait un
round-robin pur sur \`digest.topics\` sans re-ranker.

- Charge en read-only le contexte user : \`UserSource\` (sources suivies +
  \`priority_multiplier\`) et union \`UserInterest\` ∪ \`UserSubtopic\` (poids
  de topics). 2 SELECTs courts, indexés sur \`user_id\`. Pas de pipeline LLM.
- Scorer composite : \`+100×mult\` (source suivie) / \`+50×weight\`
  (topic suivi) / \`+5×perspective_count\` / \`-0.5×rank\`.
- Sélection en 2 rounds (diversité : 1 article/topic ; remplissage par
  score décroissant).
- Fallback no-prefs préserve l'ordre rank-driven historique (le scorer
  dégénère en \`+5×perspective_count - rank\`).
- Pas de migration Alembic. Format \`EssentielResponse\` inchangé.

Doc : \`docs/bugs/bug-essentiel-user-prefs.md\`.

## Test plan

- [x] Suite complète backend : **1257 passed, 13 skipped** (\`bash scripts/test-api.sh\`)
- [x] 7 tests user-aware ajoutés (source promue, topic pondéré, fallback,
      diversité topic, flag \`is_followed_source\`, intégration HTTP)
- [x] Aucun changement de schéma DB / réponse API
- [ ] Smoke test mobile en staging : ouvrir la carte "Essentiel du jour"
      avec un compte ayant ≥1 source suivie → vérifier qu'un article de cette
      source apparaît dans les 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)