### PR TITLE
fix(mobile): hotfix 3 régressions front Essentiel v3 (PR #650 follow-up)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -21,9 +21,17 @@ enum SectionKind { essentiel, bonnes, theme, veille }
 /// id discriminates between multiple `kind == theme` instances; system
 /// sections collapse to just their kind name. La section veille collapse à
 /// `'veille'` (un seul par user à V1).
+///
+/// **Disambiguation Story 9.2 hotfix** : depuis la PR #650, deux sections
+/// peuvent porter `kind = SectionKind.essentiel` :
+///   - la nouvelle [EssentielSection] (carte hi-fi "L'Essentiel du jour")
+///     → mappée sur `'essentiel_v3'` ;
+///   - la [DigestTopicSection] legacy renommée "Actus du jour"
+///     → garde la clé historique `'essentiel'` afin que les prefs
+///     `flux_continu_folded_*` déjà écrites côté PO restent valides.
 String sectionKey(FluxSection section) {
   return switch (section) {
-    EssentielSection() => section.kind.name,
+    EssentielSection() => 'essentiel_v3',
     DigestTopicSection() => section.kind.name,
     FeedThemeSection(:final kind, :final themeSlug, :final customTopicId) =>
       kind == SectionKind.veille

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -21,6 +21,12 @@ import '../repositories/essentiel_repository.dart';
 import '../repositories/flux_continu_repository.dart';
 import '../utils/theme_color_mapping.dart';
 
+/// Accent applied to the legacy "Actus du jour" digest topic section
+/// (DigestTopicSection avec kind=essentiel). Distinct de l'accent
+/// `colors.sectionEssentiel` exposé via le thème car ce dernier dépend du
+/// BuildContext. Aligné avec `EssentielSection.accent` (carte hi-fi).
+const Color _kEssentielAccent = Color(0xFFB0470A);
+
 /// Accent applied to the Bonnes Nouvelles section banner.
 const Color _kBonnesAccent = Color(0xFF2E7D32);
 
@@ -38,6 +44,8 @@ const String _kVeilleIllustration = 'assets/notifications/facteur_veille.png';
 /// Blurbs rendered under each section title.
 const String _kEssentielBlurb =
     "L'essentiel des actus les plus couvertes en France aujourd'hui, en privilégiant tes sources.";
+const String _kActusDuJourBlurb =
+    'Les actus les plus couvertes du jour, regroupées par sujet.';
 const String _kBonnesBlurb = 'Un peu d\'amour, dans ce monde de brutes ?';
 const String _kThemeBlurb =
     "Les derniers articles sur les sujets que tu suis le plus.";
@@ -80,6 +88,11 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   late EssentielRepository _essentielRepo;
 
   FluxSection? _essentiel;
+  // Section "Actus du jour" : DigestTopicSection legacy (kind=essentiel)
+  // restaurée après le hotfix Story 9.2 — la nouvelle EssentielSection
+  // (carte hi-fi v3) occupe désormais le nom "L'Essentiel du jour" et
+  // celle-ci reprend les topics du digest sous le nouveau nom.
+  FluxSection? _actusDuJour;
   FluxSection? _bonnes;
   // Up to [_kMaxFavoriteSections] theme/topic sections, ordered to mirror
   // `userInterestsProvider.favorites`. Empty when the user has no favorites
@@ -171,9 +184,22 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // PR2 — la section "Essentiel" du haut du feed est désormais alimentée
     // par GET /api/essentiel (5 articles transversaux). Si l'endpoint n'a
     // rien servi (preparing/erreur), on ne rend pas la section : le digest
-    // legacy (kind=essentiel, accédé via "Voir plus de…") reste accessible
-    // ailleurs, et Bonnes Nouvelles n'est pas affectée.
+    // legacy reste affiché juste en dessous sous le nom "Actus du jour",
+    // et Bonnes Nouvelles n'est pas affectée.
     _essentiel = _buildEssentielSection(essentielArticles);
+    // Hotfix Story 9.2 — "Actus du jour" : DigestTopicSection legacy,
+    // alimentée par `dual.normal` (digest classique), avec le label
+    // historique "Actus du jour" (anciennement "L'Essentiel du jour" avant
+    // que la carte hi-fi v3 ne reprenne ce nom).
+    _actusDuJour = _buildDigestSection(
+      digest: dual?.normal,
+      kind: SectionKind.essentiel,
+      label: 'Actus du jour',
+      blurb: _kActusDuJourBlurb,
+      accent: _kEssentielAccent,
+      illustration: _kEssentielIllustration,
+      coreVisibleCount: 3,
+    );
     _bonnes = _buildDigestSection(
       digest: dual?.serein,
       kind: SectionKind.bonnes,
@@ -203,11 +229,18 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   FluxContinuState _compose(bool isSerene) {
     final ordered = <FluxSection>[];
     if (isSerene) {
+      // Mode sérène — Bonnes Nouvelles d'abord, puis les thèmes,
+      // puis la carte hi-fi v3 et la section "Actus du jour" en fin de page.
       if (_bonnes != null) ordered.add(_bonnes!);
       ordered.addAll(_themes);
       if (_essentiel != null) ordered.add(_essentiel!);
+      if (_actusDuJour != null) ordered.add(_actusDuJour!);
     } else {
+      // Mode normal — carte hi-fi v3 ("L'Essentiel du jour"),
+      // puis "Actus du jour" (digest legacy regroupé par sujet),
+      // puis les thèmes favoris, puis Bonnes Nouvelles.
       if (_essentiel != null) ordered.add(_essentiel!);
+      if (_actusDuJour != null) ordered.add(_actusDuJour!);
       ordered.addAll(_themes);
       if (_bonnes != null) ordered.add(_bonnes!);
     }

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -40,7 +40,6 @@ import '../widgets/section_banner.dart';
 import '../widgets/section_block.dart';
 import '../widgets/section_hairline.dart';
 import '../widgets/sticky_tab_bar.dart';
-import '../../feed/widgets/feed_filter_bar.dart';
 
 /// Scroll offset at which the AppBar is swapped with the sticky tab bar.
 const double _kStickyThreshold = 60.0;
@@ -74,11 +73,11 @@ class FluxContinuScreen extends ConsumerStatefulWidget {
 
 class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   final ScrollController _scroll = ScrollController();
+  final ScrollController _tabsScroll = ScrollController();
   final ValueNotifier<bool> _stickyVisible = ValueNotifier(false);
   final ValueNotifier<double> _scrollProgress = ValueNotifier(0);
   final ValueNotifier<int> _activeIndex = ValueNotifier(0);
-  final ValueNotifier<StickyMacroBloc> _currentMacroBloc =
-      ValueNotifier(StickyMacroBloc.essentiel);
+  final ValueNotifier<bool> _isInExploreMode = ValueNotifier(false);
   final GlobalKey _closingKey = GlobalKey();
   final GlobalKey _explorerKey = GlobalKey();
   final List<GlobalKey> _sectionKeys = [];
@@ -112,10 +111,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   void dispose() {
     _scroll.removeListener(_onScroll);
     _scroll.dispose();
+    _tabsScroll.dispose();
     _stickyVisible.dispose();
     _scrollProgress.dispose();
     _activeIndex.dispose();
-    _currentMacroBloc.dispose();
+    _isInExploreMode.dispose();
     _pullHintTimer?.cancel();
     super.dispose();
   }
@@ -129,11 +129,18 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       _stickyVisible.value = showSticky;
     }
     final max = pos.maxScrollExtent;
-    _scrollProgress.value = max > 0 ? (currentScroll / max).clamp(0.0, 1.0) : 0;
+    final nextProgress =
+        max > 0 ? (currentScroll / max).clamp(0.0, 1.0).toDouble() : 0.0;
+    if (_scrollProgress.value != nextProgress) {
+      _scrollProgress.value = nextProgress;
+    }
+    // Explore-mode flag must be refreshed before the active-section pass: the
+    // sticky's "Explorer" virtual tab is selected from that flag, and we want
+    // the same frame the user crosses the banner to swap to it.
+    _updateExploreMode();
     _updateActiveSection();
     _maybeFoldSections();
     _maybeDismissClosingCard();
-    _updateMacroBloc();
 
     if (currentScroll > _maxScrollDepthPx) {
       _maxScrollDepthPx = currentScroll;
@@ -187,43 +194,17 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     }
   }
 
-  /// Decides which macro-bloc the user is currently traversing — drives the
-  /// 3-state sticky bar (Essentiel / Par thème / Explorer).
-  ///
-  /// Boundaries :
-  /// - `essentiel` : user is on or above the first non-essentiel section.
-  /// - `parTheme`  : between the second section header and the Explorer banner.
-  /// - `explorer`  : Explorer banner top crossed `_kStickyBarHeight`.
-  void _updateMacroBloc() {
-    StickyMacroBloc bloc = StickyMacroBloc.essentiel;
-    final value = ref.read(fluxContinuProvider).valueOrNull;
-    if (value != null && _sectionKeys.length == value.sections.length) {
-      // First non-Essentiel section delimits the "par thème" zone.
-      for (var i = 0; i < value.sections.length; i++) {
-        if (value.sections[i] is EssentielSection) continue;
-        final ctx = _sectionKeys[i].currentContext;
-        if (ctx == null) break;
-        final box = ctx.findRenderObject();
-        if (box is! RenderBox || !box.attached) break;
-        final topY = box.localToGlobal(Offset.zero).dy;
-        if (topY < _kStickyBarHeight) {
-          bloc = StickyMacroBloc.parTheme;
-        }
-        break;
-      }
-    }
-    final explorerCtx = _explorerKey.currentContext;
-    if (explorerCtx != null) {
-      final box = explorerCtx.findRenderObject();
-      if (box is RenderBox && box.attached) {
-        final topY = box.localToGlobal(Offset.zero).dy;
-        if (topY < _kStickyBarHeight) {
-          bloc = StickyMacroBloc.explorer;
-        }
-      }
-    }
-    if (_currentMacroBloc.value != bloc) {
-      _currentMacroBloc.value = bloc;
+  /// Flips the sticky overlay from the editorial tab bar to the feed filter
+  /// bar once the user crosses the Explorer banner.
+  void _updateExploreMode() {
+    final ctx = _explorerKey.currentContext;
+    if (ctx == null) return;
+    final box = ctx.findRenderObject();
+    if (box is! RenderBox || !box.attached) return;
+    final topY = box.localToGlobal(Offset.zero).dy;
+    final shouldExplore = topY < _kStickyBarHeight;
+    if (_isInExploreMode.value != shouldExplore) {
+      _isInExploreMode.value = shouldExplore;
     }
   }
 
@@ -266,6 +247,18 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   }
 
   void _updateActiveSection() {
+    // Explorer is rendered as the last virtual tab in the sticky overlay.
+    // Once the user crosses the Explorer banner, that tab takes precedence
+    // over the editorial active-section measurement so the sticky reflects
+    // the zone the user is actually browsing.
+    if (_isInExploreMode.value) {
+      final exploreIndex = _sectionKeys.length;
+      if (_activeIndex.value != exploreIndex) {
+        _activeIndex.value = exploreIndex;
+        _alignTabsToActive(exploreIndex);
+      }
+      return;
+    }
     if (_sectionKeys.isEmpty) return;
     int activeAt = 0;
     for (var i = 0; i < _sectionKeys.length; i++) {
@@ -280,48 +273,31 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     }
     if (_activeIndex.value != activeAt) {
       _activeIndex.value = activeAt;
+      _alignTabsToActive(activeAt);
     }
   }
 
-  /// Tap on the sticky bar — scrolls back to the top of the current macro
-  /// bloc so the user can quickly re-orient.
-  Future<void> _onTapStickyBar() async {
-    final bloc = _currentMacroBloc.value;
-    final value = ref.read(fluxContinuProvider).valueOrNull;
-    if (value == null) return;
-    int? targetIndex;
-    switch (bloc) {
-      case StickyMacroBloc.essentiel:
-        await _scrollToTop();
-        return;
-      case StickyMacroBloc.parTheme:
-        for (var i = 0; i < value.sections.length; i++) {
-          if (value.sections[i] is! EssentielSection) {
-            targetIndex = i;
-            break;
-          }
-        }
-      case StickyMacroBloc.explorer:
-        // No section index — scroll to the Explorer key directly.
-        final ctx = _explorerKey.currentContext;
-        if (ctx != null) {
-          await Scrollable.ensureVisible(
-            ctx,
-            duration: const Duration(milliseconds: 350),
-            curve: Curves.easeInOut,
-            alignment: 0,
-          );
-        }
-        return;
-    }
-    if (targetIndex != null) {
-      await _scrollToSection(targetIndex);
-    }
+  void _alignTabsToActive(int index) {
+    if (!_tabsScroll.hasClients) return;
+    const double estimatedTabWidth = 140.0;
+    const double leftPadding = 12.0;
+    final target =
+        (index * estimatedTabWidth - leftPadding)
+            .clamp(0.0, _tabsScroll.position.maxScrollExtent);
+    _tabsScroll.animateTo(
+      target,
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeOutCubic,
+    );
   }
 
   Future<void> _scrollToSection(int index) async {
-    if (index < 0 || index >= _sectionKeys.length) return;
-    final ctx = _sectionKeys[index].currentContext;
+    if (index < 0) return;
+    // Last tab is the virtual "Explorer" entry — scrolls to its banner key.
+    final GlobalKey targetKey = index >= _sectionKeys.length
+        ? _explorerKey
+        : _sectionKeys[index];
+    final ctx = targetKey.currentContext;
     if (ctx == null) return;
     final box = ctx.findRenderObject();
     if (box is! RenderBox) return;
@@ -602,9 +578,12 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             ),
             _StickyHostOverlay(
               stickyVisible: _stickyVisible,
-              currentMacroBloc: _currentMacroBloc,
+              scrollProgress: _scrollProgress,
+              activeIndex: _activeIndex,
+              isInExploreMode: _isInExploreMode,
               stateProvider: fluxContinuProvider,
-              onTap: _onTapStickyBar,
+              onTapTab: _scrollToSection,
+              tabsController: _tabsScroll,
             ),
             // Floating "back to top" button — reveals on upward scroll above
             // the hide threshold, fades down on reverse / near top.
@@ -784,17 +763,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
               ),
             ),
           ),
-          const SliverToBoxAdapter(
-            child: Padding(
-              padding: EdgeInsets.fromLTRB(
-                FacteurSpacing.space4,
-                0,
-                FacteurSpacing.space4,
-                FacteurSpacing.space2,
-              ),
-              child: FeedFilterBar(),
-            ),
-          ),
           if (state.feedContinu.isNotEmpty) ...[
             _buildIntercalatedFeed(context, state),
             const SliverToBoxAdapter(child: SectionHairline()),
@@ -958,28 +926,40 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   }
 }
 
-/// Sticky overlay that hosts either the editorial tab bar (top of the
-/// screen) or the feed filter bar (once the user crosses the Explorer
-/// banner). The header itself lives inside the scroll view, so it simply
-/// disappears upward as content moves up.
+/// Sticky overlay shown at the top of the screen once the user scrolls past
+/// the AppBar threshold. Always hosts the editorial tab bar — the "Explorer"
+/// virtual tab is appended at the end so the same bar covers the whole
+/// screen instead of swapping out when the user crosses the Explorer banner.
+/// When the user is in Explorer mode, [FeedFilterBar] morphs in under the
+/// tabs (within the same parchment surface) so filtering stays available.
+const String _kExplorerLabel = 'Explorer';
+const Color _kExplorerAccent = Color(0xFF5D4037);
+
 class _StickyHostOverlay extends ConsumerWidget {
   final ValueNotifier<bool> stickyVisible;
-  final ValueNotifier<StickyMacroBloc> currentMacroBloc;
+  final ValueNotifier<double> scrollProgress;
+  final ValueNotifier<int> activeIndex;
+  final ValueNotifier<bool> isInExploreMode;
   final AsyncNotifierProvider<FluxContinuNotifier, FluxContinuState>
       stateProvider;
-  final VoidCallback onTap;
+  final ValueChanged<int> onTapTab;
+  final ScrollController tabsController;
 
   const _StickyHostOverlay({
     required this.stickyVisible,
-    required this.currentMacroBloc,
+    required this.scrollProgress,
+    required this.activeIndex,
+    required this.isInExploreMode,
     required this.stateProvider,
-    required this.onTap,
+    required this.onTapTab,
+    required this.tabsController,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(stateProvider).valueOrNull;
-    final sections = state?.sections ?? const <FluxSection>[];
+    final sections =
+        ref.watch(stateProvider).valueOrNull?.sections ??
+            const <FluxSection>[];
     return Positioned(
       top: 0,
       left: 0,
@@ -988,59 +968,35 @@ class _StickyHostOverlay extends ConsumerWidget {
         valueListenable: stickyVisible,
         builder: (context, visible, _) {
           final showSticky = visible && sections.isNotEmpty;
-          return AnimatedSwitcher(
-            duration: const Duration(milliseconds: 150),
-            child: !showSticky
-                ? const SizedBox.shrink(key: ValueKey('hidden'))
-                : ValueListenableBuilder<StickyMacroBloc>(
-                    key: const ValueKey('sticky'),
-                    valueListenable: currentMacroBloc,
-                    builder: (context, bloc, _) {
-                      final read = _readCountFor(bloc, state);
-                      final total = _totalFor(bloc, sections);
-                      return StickyThreeStateBar(
-                        bloc: bloc,
-                        read: read,
-                        total: total,
-                        remainingMin: ((total - read) * 2).clamp(0, 60),
-                        onTap: onTap,
-                      );
-                    },
-                  ),
+          if (!showSticky) {
+            return const SizedBox.shrink();
+          }
+          final tabs = <StickyTab>[
+            for (final s in sections)
+              StickyTab(label: s.label, accent: s.accent),
+            const StickyTab(label: _kExplorerLabel, accent: _kExplorerAccent),
+          ];
+          return ValueListenableBuilder<bool>(
+            valueListenable: isInExploreMode,
+            builder: (context, explore, _) => ValueListenableBuilder<int>(
+              valueListenable: activeIndex,
+              builder: (context, idx, _) => ValueListenableBuilder<double>(
+                valueListenable: scrollProgress,
+                builder: (context, progress, _) => StickyTabBar(
+                  tabs: tabs,
+                  activeIndex: idx.clamp(0, tabs.length - 1),
+                  progress: progress,
+                  onTapTab: onTapTab,
+                  tabsController: tabsController,
+                  title: explore ? _kExplorerLabel : 'Les Actus du jour',
+                  showFilterBar: explore,
+                ),
+              ),
+            ),
           );
         },
       ),
     );
-  }
-
-  static int _totalFor(StickyMacroBloc bloc, List<FluxSection> sections) {
-    switch (bloc) {
-      case StickyMacroBloc.essentiel:
-        return sections
-            .whereType<EssentielSection>()
-            .fold<int>(0, (sum, s) => sum + s.totalCount);
-      case StickyMacroBloc.parTheme:
-        return sections
-            .where((s) => s is! EssentielSection)
-            .fold<int>(0, (sum, s) => sum + s.totalCount);
-      case StickyMacroBloc.explorer:
-        return 0;
-    }
-  }
-
-  static int _readCountFor(StickyMacroBloc bloc, FluxContinuState? state) {
-    if (state == null) return 0;
-    switch (bloc) {
-      case StickyMacroBloc.essentiel:
-        return state.sections.whereType<EssentielSection>().fold<int>(
-              0,
-              (sum, s) =>
-                  sum + s.articles.where((a) => a.isRead).length,
-            );
-      case StickyMacroBloc.parTheme:
-      case StickyMacroBloc.explorer:
-        return 0;
-    }
   }
 }
 

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -116,13 +116,12 @@ class _Header extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
     final now = DateTime.now();
-    final dateLabel = _formatDateStamp(now);
     final dayLabel = _formatDayName(now).toUpperCase();
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _DateStamp(label: dateLabel, accent: accent),
+        _DateStamp(day: now.day, month: _monthAbbrev(now.month), accent: accent),
         const SizedBox(width: FacteurSpacing.space3),
         Expanded(
           child: Column(
@@ -131,6 +130,8 @@ class _Header extends StatelessWidget {
               Text(
                 'ÉDITION DU $dayLabel · 5 ACTUS À SUIVRE',
                 style: FacteurTypography.stamp(colors.textTertiary),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
               const SizedBox(height: 4),
               Text(
@@ -153,7 +154,9 @@ class _Header extends StatelessWidget {
     );
   }
 
-  static String _formatDateStamp(DateTime d) {
+  // Unused after the hotfix (the stamp now renders day/month on two lines),
+  // but kept for backwards reference. _formatDateStamp removed.
+  static String _monthAbbrev(int m) {
     const months = [
       'JAN',
       'FÉV',
@@ -168,8 +171,7 @@ class _Header extends StatelessWidget {
       'NOV',
       'DÉC',
     ];
-    final dd = d.day.toString().padLeft(2, '0');
-    return '$dd / ${months[d.month - 1]}';
+    return months[m - 1];
   }
 
   static String _formatDayName(DateTime d) {
@@ -187,34 +189,58 @@ class _Header extends StatelessWidget {
 }
 
 class _DateStamp extends StatelessWidget {
-  final String label;
+  final int day;
+  final String month;
   final Color accent;
 
-  const _DateStamp({required this.label, required this.accent});
+  const _DateStamp({
+    required this.day,
+    required this.month,
+    required this.accent,
+  });
 
   @override
   Widget build(BuildContext context) {
+    // Hotfix Story 9.2 — cachet rond ocre :
+    //   - diamètre 64 px (vs 56 légèrement trop discret),
+    //   - jour sur la 1re ligne (grand),
+    //   - mois sur la 2e ligne (petit, letterspacing élargi),
+    //   - fond plus saturé (alpha 0.16) et bordure 1.6 px pour ressortir.
     return Transform.rotate(
       angle: -0.05,
       child: Container(
-        width: 56,
-        height: 56,
+        width: 64,
+        height: 64,
         alignment: Alignment.center,
         decoration: BoxDecoration(
-          color: accent.withValues(alpha: 0.12),
+          color: accent.withValues(alpha: 0.16),
           shape: BoxShape.circle,
-          border: Border.all(color: accent, width: 1.2),
+          border: Border.all(color: accent, width: 1.6),
         ),
-        child: Text(
-          label,
-          textAlign: TextAlign.center,
-          style: GoogleFonts.courierPrime(
-            fontSize: 10,
-            fontWeight: FontWeight.w700,
-            height: 1.15,
-            letterSpacing: 0.3,
-            color: accent,
-          ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              day.toString().padLeft(2, '0'),
+              style: GoogleFonts.courierPrime(
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+                height: 1.0,
+                color: accent,
+              ),
+            ),
+            const SizedBox(height: 1),
+            Text(
+              month,
+              style: GoogleFonts.courierPrime(
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+                height: 1.0,
+                letterSpacing: 1.2,
+                color: accent,
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -282,7 +308,9 @@ class _LeadTile extends StatelessWidget {
             FacteurSpacing.space3,
           ),
           decoration: BoxDecoration(
-            color: themeAccent.withValues(alpha: 0.08),
+            // Hotfix Story 9.2 — fond teinté plus discret (0.06) pour que la
+            // couleur thématique suggère la section sans surligner.
+            color: themeAccent.withValues(alpha: 0.06),
             borderRadius: BorderRadius.circular(FacteurRadius.medium),
             border: Border(left: BorderSide(color: themeAccent, width: 3)),
           ),
@@ -291,7 +319,10 @@ class _LeadTile extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  _SectionChip(label: article.sectionLabel, accent: themeAccent),
+                  _SectionChip(
+                    label: _sectionLabelFor(article),
+                    accent: themeAccent,
+                  ),
                   const Spacer(),
                   if (article.perspectiveCount > 1)
                     Text(
@@ -345,7 +376,10 @@ class _MediumTile extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  _SectionChip(label: article.sectionLabel, accent: themeAccent),
+                  _SectionChip(
+                    label: _sectionLabelFor(article),
+                    accent: themeAccent,
+                  ),
                   const SizedBox(width: FacteurSpacing.space2),
                   Flexible(
                     child: Text(
@@ -407,7 +441,9 @@ class _LightTile extends StatelessWidget {
               ),
               const SizedBox(width: FacteurSpacing.space2),
               Text(
-                article.sectionLabel.toUpperCase(),
+                _sectionLabelFor(article).toUpperCase(),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
                 style: FacteurTypography.labelSmall(themeAccent).copyWith(
                   fontSize: 10.5,
                   fontWeight: FontWeight.w700,
@@ -511,7 +547,12 @@ class _Hairline extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
-    return Container(height: 0.6, color: colors.border);
+    // Hotfix Story 9.2 — opacité réduite (0.35) pour que le filet
+    // suggère la séparation sans dominer visuellement la carte.
+    return Container(
+      height: 0.6,
+      color: colors.border.withValues(alpha: 0.35),
+    );
   }
 }
 
@@ -521,6 +562,7 @@ class _DottedDivider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
+    final dotColor = colors.border.withValues(alpha: 0.35);
     return LayoutBuilder(
       builder: (context, constraints) {
         final dashCount = (constraints.maxWidth / 4).floor();
@@ -528,7 +570,7 @@ class _DottedDivider extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: List.generate(
             dashCount,
-            (_) => Container(width: 2, height: 1, color: colors.border),
+            (_) => Container(width: 2, height: 1, color: dotColor),
           ),
         );
       },
@@ -599,4 +641,22 @@ Color _accentFor(EssentielArticle article, Color fallback) {
     return themeMap[slug]!.accent;
   }
   return fallback;
+}
+
+/// Resolves the section label rendered next to each article in the hi-fi card.
+///
+/// The backend (`digest_selector.py:_build_topic_groups`) currently fills
+/// `topic.label` *after* the loop that assembles the EssentielArticle, so the
+/// payload often arrives with `section_label = ""`. Until the backend is fixed
+/// (tracked separately) we fall back to the theme name from [themeMap], or
+/// "Actus" if even the slug is unknown — strictly cosmetic, the article still
+/// opens correctly when tapped.
+String _sectionLabelFor(EssentielArticle article) {
+  final raw = article.sectionLabel.trim();
+  if (raw.isNotEmpty) return raw;
+  final slug = article.theme;
+  if (slug != null && themeMap.containsKey(slug)) {
+    return themeMap[slug]!.label;
+  }
+  return 'Actus';
 }

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -1,253 +1,291 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
+import '../../feed/widgets/feed_filter_bar.dart';
 import 'sticky_backdrop.dart';
 
-/// Macro-bloc the user is currently traversing.
-///
-/// Drives [StickyThreeStateBar] : each value swaps icon, accent and label.
-/// Story 9.2, composant 2.
-enum StickyMacroBloc { essentiel, parTheme, explorer }
+/// Lightweight descriptor for a sticky tab. Used by [StickyTabBar] so the
+/// sticky overlay can mix real Flux sections with virtual entries (e.g.
+/// "Explorer") without leaking widget-only state into the section sealed
+/// hierarchy.
+class StickyTab {
+  final String label;
+  final Color accent;
 
-/// Sticky bar v3 — 3-state contextual reminder of the macro zone.
-///
-/// Layout (~64 px) :
-/// - Row 1 : 40×40 rounded square with `--k-tint` background + Phosphor icon,
-///   Fraunces 15px/w600 title, mono "~N min" hint pinned right.
-/// - Row 2 : N progress plots (lu = filled accent + check / current = ring /
-///   upcoming = grey disc) + "read/total" ratio.
-///
-/// Transition between blocs : container stays in place, only the inner
-/// content crossfades over 200 ms via [AnimatedSwitcher].
-class StickyThreeStateBar extends StatelessWidget {
-  final StickyMacroBloc bloc;
-  final int read;
-  final int total;
-  final int remainingMin;
-  final VoidCallback? onTap;
+  const StickyTab({required this.label, required this.accent});
+}
 
-  const StickyThreeStateBar({
+/// Sticky tab bar revealed once the user scrolls past the AppBar threshold.
+///
+/// Layout per V6 maquette :
+/// - parchment-tinted backdrop with a 14px blur (saturate 140%),
+/// - "sticky-head" row : zone title ("Les Actus du jour" or "Explorer"),
+/// - horizontal tabs with section dot, label, a check icon when the tab is
+///   done (replaces the legacy strike-through, per PO feedback hotfix
+///   2026-05-23 — "lu = checked, pas barré"), and an underline tinted with
+///   the active section's accent,
+/// - 4-px progress track with a 4-stop gradient fill (essentiel → bonnes
+///   → veille1 → veille2) and a soft accent glow,
+/// - when [showFilterBar] is true (Explorer mode), [FeedFilterBar] is
+///   inserted below the tabs so the filter chips morph in under the same
+///   parchment surface rather than swapping the whole sticky.
+class StickyTabBar extends StatelessWidget {
+  final List<StickyTab> tabs;
+  final int activeIndex;
+  final double progress;
+  final ValueChanged<int> onTapTab;
+  final ScrollController? tabsController;
+  final String title;
+  final bool showFilterBar;
+
+  const StickyTabBar({
     super.key,
-    required this.bloc,
-    required this.read,
-    required this.total,
-    required this.remainingMin,
-    this.onTap,
+    required this.tabs,
+    required this.activeIndex,
+    required this.progress,
+    required this.onTapTab,
+    this.tabsController,
+    this.title = 'Les Actus du jour',
+    this.showFilterBar = false,
   });
 
   @override
   Widget build(BuildContext context) {
     return StickyBackdrop(
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: onTap,
-          child: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 200),
-            child: _StickyContent(
-              key: ValueKey(bloc),
-              bloc: bloc,
-              read: read,
-              total: total,
-              remainingMin: remainingMin,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          StickyHead(title: title),
+          _TabsRow(
+            tabs: tabs,
+            activeIndex: activeIndex,
+            onTapTab: onTapTab,
+            controller: tabsController,
+          ),
+          SizedBox(
+            height: 4,
+            child: CustomPaint(
+              painter: _ProgressPainter(
+                progress: progress.clamp(0.0, 1.0),
+                gradient: const [
+                  Color(0xFFD35400),
+                  Color(0xFFC2185B),
+                  Color(0xFF2C3E50),
+                  Color(0xFF6C3483),
+                ],
+                glow: const Color.fromRGBO(211, 84, 0, 0.35),
+                trackColor: const Color.fromRGBO(0, 0, 0, 0.06),
+              ),
+              child: const SizedBox.expand(),
             ),
           ),
-        ),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 180),
+            curve: Curves.easeOutCubic,
+            alignment: Alignment.topCenter,
+            child: showFilterBar
+                ? const Padding(
+                    padding: EdgeInsets.fromLTRB(16, 8, 16, 8),
+                    child: FeedFilterBar(),
+                  )
+                : const SizedBox(width: double.infinity),
+          ),
+        ],
       ),
     );
   }
 }
 
-class _StickyContent extends StatelessWidget {
-  final StickyMacroBloc bloc;
-  final int read;
-  final int total;
-  final int remainingMin;
+/// Top row of the sticky overlay — a single Fraunces label that names the
+/// current zone of the Flux Continu screen.
+class StickyHead extends StatelessWidget {
+  final String title;
 
-  const _StickyContent({
-    super.key,
-    required this.bloc,
-    required this.read,
-    required this.total,
-    required this.remainingMin,
+  const StickyHead({super.key, this.title = 'Les Actus du jour'});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Row(
+        children: [
+          Text(
+            title,
+            style: GoogleFonts.fraunces(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: colors.textPrimary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TabsRow extends StatelessWidget {
+  final List<StickyTab> tabs;
+  final int activeIndex;
+  final ValueChanged<int> onTapTab;
+  final ScrollController? controller;
+
+  const _TabsRow({
+    required this.tabs,
+    required this.activeIndex,
+    required this.onTapTab,
+    this.controller,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 44,
+      child: ListView.separated(
+        controller: controller,
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.fromLTRB(10, 4, 10, 8),
+        itemCount: tabs.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 2),
+        itemBuilder: (context, i) {
+          return _Tab(
+            tab: tabs[i],
+            isActive: i == activeIndex,
+            isDone: i < activeIndex,
+            onTap: () => onTapTab(i),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _Tab extends StatelessWidget {
+  final StickyTab tab;
+  final bool isActive;
+  final bool isDone;
+  final VoidCallback onTap;
+
+  const _Tab({
+    required this.tab,
+    required this.isActive,
+    required this.isDone,
+    required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final accent = _accentFor(colors, bloc);
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        FacteurSpacing.space4,
-        FacteurSpacing.space2,
-        FacteurSpacing.space4,
-        FacteurSpacing.space2,
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
+    final Color labelColor;
+    if (isActive) {
+      labelColor = colors.textPrimary;
+    } else if (isDone) {
+      labelColor = colors.textTertiary;
+    } else {
+      labelColor = colors.textSecondary;
+    }
+    final dotColor = isActive
+        ? tab.accent
+        : (isDone ? colors.textTertiary : colors.textSecondary);
+    return InkWell(
+      onTap: onTap,
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+      child: Stack(
         children: [
-          _IconBadge(accent: accent, bloc: bloc),
-          const SizedBox(width: FacteurSpacing.space3),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 7, 12, 9),
+            child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  _titleFor(bloc),
-                  style: GoogleFonts.fraunces(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w600,
-                    height: 1.2,
-                    color: colors.textPrimary,
+                Container(
+                  width: 6,
+                  height: 6,
+                  margin: const EdgeInsets.only(right: 6),
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: dotColor,
                   ),
                 ),
-                const SizedBox(height: 2),
-                _ProgressPlots(
-                  accent: accent,
-                  read: read.clamp(0, total),
-                  total: total,
+                Text(
+                  tab.label,
+                  style: GoogleFonts.dmSans(
+                    fontSize: 12.5,
+                    fontWeight: FontWeight.w600,
+                    color: labelColor,
+                  ),
                 ),
+                if (isDone) ...[
+                  const SizedBox(width: 4),
+                  Icon(
+                    Icons.check_rounded,
+                    size: 13,
+                    color: labelColor,
+                    semanticLabel: 'lu',
+                  ),
+                ],
               ],
             ),
           ),
-          const SizedBox(width: FacteurSpacing.space2),
-          Text(
-            '~$remainingMin min',
-            style: GoogleFonts.courierPrime(
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-              color: colors.textTertiary,
+          if (isActive)
+            Positioned(
+              left: 8,
+              right: 8,
+              bottom: 0,
+              height: 2,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: tab.accent,
+                  borderRadius: const BorderRadius.vertical(
+                    top: Radius.circular(2),
+                  ),
+                ),
+              ),
             ),
-          ),
         ],
       ),
     );
   }
-
-  static String _titleFor(StickyMacroBloc bloc) {
-    switch (bloc) {
-      case StickyMacroBloc.essentiel:
-        return 'L’Essentiel du jour';
-      case StickyMacroBloc.parTheme:
-        return 'L’Essentiel, par thème';
-      case StickyMacroBloc.explorer:
-        return 'Explorer';
-    }
-  }
-
-  static Color _accentFor(FacteurColors colors, StickyMacroBloc bloc) {
-    switch (bloc) {
-      case StickyMacroBloc.essentiel:
-        return colors.sectionEssentiel;
-      case StickyMacroBloc.parTheme:
-        return colors.sectionBonnes;
-      case StickyMacroBloc.explorer:
-        return colors.sectionVeille1;
-    }
-  }
 }
 
-class _IconBadge extends StatelessWidget {
-  final Color accent;
-  final StickyMacroBloc bloc;
+class _ProgressPainter extends CustomPainter {
+  final double progress;
+  final List<Color> gradient;
+  final Color glow;
+  final Color trackColor;
 
-  const _IconBadge({required this.accent, required this.bloc});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 40,
-      height: 40,
-      alignment: Alignment.center,
-      decoration: BoxDecoration(
-        color: accent.withValues(alpha: 0.14),
-        borderRadius: BorderRadius.circular(FacteurRadius.medium),
-      ),
-      child: Icon(_iconFor(bloc), color: accent, size: 20),
-    );
-  }
-
-  static IconData _iconFor(StickyMacroBloc bloc) {
-    switch (bloc) {
-      case StickyMacroBloc.essentiel:
-        return PhosphorIcons.envelopeSimple();
-      case StickyMacroBloc.parTheme:
-        return PhosphorIcons.stack();
-      case StickyMacroBloc.explorer:
-        return PhosphorIcons.compass();
-    }
-  }
-}
-
-class _ProgressPlots extends StatelessWidget {
-  final Color accent;
-  final int read;
-  final int total;
-
-  const _ProgressPlots({
-    required this.accent,
-    required this.read,
-    required this.total,
+  _ProgressPainter({
+    required this.progress,
+    required this.gradient,
+    required this.glow,
+    required this.trackColor,
   });
 
   @override
-  Widget build(BuildContext context) {
-    final colors = context.facteurColors;
-    if (total <= 0) {
-      return const SizedBox(height: 12);
-    }
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        for (var i = 0; i < total; i++) ...[
-          if (i > 0) const SizedBox(width: 4),
-          _plotFor(i, accent, colors),
-        ],
-        const SizedBox(width: 8),
-        Text(
-          '$read/$total',
-          style: GoogleFonts.dmSans(
-            fontSize: 11,
-            fontWeight: FontWeight.w500,
-            color: colors.textTertiary,
-          ),
-        ),
-      ],
-    );
+  void paint(Canvas canvas, Size size) {
+    final fullRect = Offset.zero & size;
+    final trackPaint = Paint()..color = trackColor;
+    canvas.drawRect(fullRect, trackPaint);
+
+    if (progress <= 0) return;
+    final clipped = Rect.fromLTWH(0, 0, size.width * progress, size.height);
+    final glowPaint = Paint()
+      ..color = glow
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 4);
+    canvas.drawRect(clipped, glowPaint);
+    final fillPaint = Paint()
+      ..shader = LinearGradient(
+        colors: gradient,
+        stops: const [0.0, 0.4, 0.7, 1.0],
+      ).createShader(fullRect);
+    canvas.drawRect(clipped, fillPaint);
   }
 
-  Widget _plotFor(int i, Color accent, FacteurColors colors) {
-    if (i < read) {
-      // Read
-      return Container(
-        width: 12,
-        height: 12,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(color: accent, shape: BoxShape.circle),
-        child: const Icon(Icons.check, size: 9, color: Colors.white),
-      );
-    }
-    if (i == read) {
-      // Current
-      return Container(
-        width: 12,
-        height: 12,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          border: Border.all(color: accent, width: 2),
-        ),
-      );
-    }
-    return Container(
-      width: 12,
-      height: 12,
-      decoration: BoxDecoration(
-        color: colors.textTertiary.withValues(alpha: 0.25),
-        shape: BoxShape.circle,
-      ),
-    );
-  }
+  @override
+  bool shouldRepaint(_ProgressPainter old) =>
+      old.progress != progress ||
+      old.gradient != gradient ||
+      old.glow != glow ||
+      old.trackColor != trackColor;
 }

--- a/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
+++ b/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
@@ -89,6 +89,19 @@ void main() {
       expect(sectionKey(digestSection(kind: SectionKind.bonnes)), 'bonnes');
     });
 
+    test('disambiguates EssentielSection from legacy "Actus du jour"', () {
+      // Story 9.2 hotfix — the v3 hi-fi card (EssentielSection) coexists
+      // with the legacy DigestTopicSection now labelled "Actus du jour".
+      // Both originally collapsed to 'essentiel'; we now route the v3 card
+      // to its own key so per-section prefs survive without collision.
+      const essentielV3 = EssentielSection(articles: []);
+      expect(sectionKey(essentielV3), 'essentiel_v3');
+      expect(
+        sectionKey(digestSection(kind: SectionKind.essentiel)),
+        'essentiel',
+      );
+    });
+
     test('uses theme:<slug> for theme favorites', () {
       expect(sectionKey(themeSection(slug: 'tech')), 'theme:tech');
       expect(sectionKey(themeSection(slug: 'science')), 'theme:science');

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -1,3 +1,5 @@
+import 'package:facteur/features/digest/models/digest_models.dart';
+import 'package:facteur/features/digest/models/dual_digest_response.dart';
 import 'package:facteur/features/digest/providers/digest_provider.dart';
 import 'package:facteur/features/digest/repositories/digest_repository.dart';
 import 'package:facteur/features/feed/models/content_model.dart';
@@ -650,4 +652,97 @@ void main() {
           ));
     });
   });
+
+  group('FluxContinuNotifier — Story 9.2 hotfix (Actus du jour)', () {
+    /// Stub Essentiel repo returning a single EssentielArticle so the v3
+    /// hi-fi section is built. Distinct from `_StubEssentielRepository`
+    /// (which returns an empty list) to drive the coexistence assertion.
+    final hiFiArticle = EssentielArticle(
+      contentId: 'hifi-1',
+      title: 'Hi-fi article',
+      url: 'https://x.test/hifi-1',
+      publishedAt: DateTime(2026, 1, 1),
+      sourceName: 'Source',
+      sourceLetter: 'S',
+      sectionLabel: 'Tech',
+      rank: 1,
+    );
+
+    test('EssentielSection (hi-fi) and "Actus du jour" coexist in sections',
+        () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      // Digest "normal" with two non-empty topics → builds the legacy
+      // "Actus du jour" DigestTopicSection.
+      final digest = DigestResponse(
+        digestId: 'd1',
+        userId: 'u1',
+        targetDate: DateTime(2026, 5, 23),
+        generatedAt: DateTime(2026, 5, 23),
+        topics: [
+          DigestTopic(
+            topicId: 't1',
+            label: 'Topic A',
+            articles: const [DigestItem(contentId: 'a1', title: 'A')],
+          ),
+          DigestTopic(
+            topicId: 't2',
+            label: 'Topic B',
+            articles: const [DigestItem(contentId: 'b1', title: 'B')],
+          ),
+        ],
+      );
+      when(() => digestRepo.fetchBothDigests()).thenAnswer(
+        (_) async => DualDigestResponse(normal: digest, sereinEnabled: false),
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          digestRepositoryProvider.overrideWithValue(digestRepo),
+          feedRepositoryProvider.overrideWithValue(feedRepo),
+          fluxContinuRepositoryProvider.overrideWithValue(fluxRepo),
+          essentielRepositoryProvider.overrideWithValue(
+            _OneArticleEssentielRepository(hiFiArticle),
+          ),
+          userInterestsProvider.overrideWith(
+            () => _StubUserInterestsNotifier(_interestsState()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final state = await container.read(fluxContinuProvider.future);
+
+      // Both must be present, with distinct sectionKeys.
+      final essentielV3 = state.sections.whereType<EssentielSection>().toList();
+      final actusDuJour = state.sections
+          .whereType<DigestTopicSection>()
+          .where((s) => s.kind == SectionKind.essentiel)
+          .toList();
+      expect(essentielV3, hasLength(1));
+      expect(actusDuJour, hasLength(1));
+      expect(actusDuJour.single.label, 'Actus du jour');
+      // Distinct keys — no collision in the folded/moreOpen maps.
+      expect(sectionKey(essentielV3.single), 'essentiel_v3');
+      expect(sectionKey(actusDuJour.single), 'essentiel');
+      // The dedup pass drops the lead article of "Actus du jour" if it ever
+      // overlaps with the hi-fi card — the legacy section must still
+      // survive composition though (it carries other topics).
+      expect(
+        state.sections.indexOf(essentielV3.single),
+        lessThan(state.sections.indexOf(actusDuJour.single)),
+        reason: 'Hi-fi card renders above the legacy "Actus du jour"',
+      );
+    });
+  });
+}
+
+/// Stub EssentielRepository returning exactly one [EssentielArticle] so the
+/// hi-fi section is built during the coexistence test.
+class _OneArticleEssentielRepository implements EssentielRepository {
+  _OneArticleEssentielRepository(this._article);
+  final EssentielArticle _article;
+
+  @override
+  Future<List<EssentielArticle>?> fetch() async => [_article];
 }

--- a/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
@@ -5,79 +5,101 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/flux_continu/widgets/sticky_tab_bar.dart';
 
+/// Tests cover the [StickyTabBar] restored by the Story 9.2 hotfix
+/// (PR follow-up to #650). The file name kept its historical name so the
+/// existing CI globs don't need an update.
 Widget _wrap(Widget child) {
   return MaterialApp(
     theme: ThemeData(extensions: [FacteurPalettes.light]),
-    home: Scaffold(body: child),
+    home: Scaffold(
+      // Sticky overlay is rendered at the very top of the screen in
+      // production via `Positioned(top:0, left:0, right:0)` — its inner
+      // Column sizes vertically to its children (mainAxisSize.min). Wrapping
+      // the test fixture in a top-aligned Align keeps the layout faithful
+      // and lets the FeedFilterBar variant compute its natural height
+      // without being stretched to fill the Scaffold body.
+      body: Align(alignment: Alignment.topCenter, child: child),
+    ),
   );
 }
+
+const _tabs = [
+  StickyTab(label: 'Essentiel', accent: Color(0xFFB0470A)),
+  StickyTab(label: 'Tech', accent: Color(0xFF2C3E50)),
+  StickyTab(label: 'Explorer', accent: Color(0xFF5D4037)),
+];
 
 void main() {
   setUpAll(() {
     GoogleFonts.config.allowRuntimeFetching = false;
   });
 
-  group('StickyThreeStateBar', () {
-    testWidgets('renders Essentiel state with title + ratio', (tester) async {
+  group('StickyTabBar', () {
+    testWidgets('renders the head title + every tab label', (tester) async {
       await tester.pumpWidget(_wrap(
-        const StickyThreeStateBar(
-          bloc: StickyMacroBloc.essentiel,
-          read: 2,
-          total: 5,
-          remainingMin: 6,
+        StickyTabBar(
+          tabs: _tabs,
+          activeIndex: 0,
+          progress: 0.2,
+          onTapTab: (_) {},
         ),
       ));
-      expect(find.text('L’Essentiel du jour'), findsOneWidget);
-      expect(find.text('2/5'), findsOneWidget);
-      expect(find.text('~6 min'), findsOneWidget);
-    });
-
-    testWidgets('swaps title when bloc changes to parTheme', (tester) async {
-      await tester.pumpWidget(_wrap(
-        const StickyThreeStateBar(
-          bloc: StickyMacroBloc.essentiel,
-          read: 0,
-          total: 5,
-          remainingMin: 10,
-        ),
-      ));
-      await tester.pumpWidget(_wrap(
-        const StickyThreeStateBar(
-          bloc: StickyMacroBloc.parTheme,
-          read: 0,
-          total: 8,
-          remainingMin: 16,
-        ),
-      ));
-      await tester.pumpAndSettle();
-      expect(find.text('L’Essentiel, par thème'), findsOneWidget);
-    });
-
-    testWidgets('shows Explorer label in explorer state', (tester) async {
-      await tester.pumpWidget(_wrap(
-        const StickyThreeStateBar(
-          bloc: StickyMacroBloc.explorer,
-          read: 0,
-          total: 0,
-          remainingMin: 0,
-        ),
-      ));
+      expect(find.text('Les Actus du jour'), findsOneWidget);
+      expect(find.text('Essentiel'), findsOneWidget);
+      expect(find.text('Tech'), findsOneWidget);
       expect(find.text('Explorer'), findsOneWidget);
     });
 
-    testWidgets('tap fires onTap', (tester) async {
-      var taps = 0;
+    testWidgets('shows a check icon next to done tabs (no strike-through)',
+        (tester) async {
+      // activeIndex = 2 → tabs 0 and 1 are done, tab 2 is active, no
+      // upcoming tabs in this fixture.
       await tester.pumpWidget(_wrap(
-        StickyThreeStateBar(
-          bloc: StickyMacroBloc.essentiel,
-          read: 0,
-          total: 5,
-          remainingMin: 10,
-          onTap: () => taps++,
+        StickyTabBar(
+          tabs: _tabs,
+          activeIndex: 2,
+          progress: 0.9,
+          onTapTab: (_) {},
         ),
       ));
-      await tester.tap(find.text('L’Essentiel du jour'));
-      expect(taps, 1);
+      // Two check icons (one per done tab).
+      expect(find.byIcon(Icons.check_rounded), findsNWidgets(2));
+      // No strike-through anywhere — we deliberately render labels without
+      // the lineThrough decoration since the hotfix.
+      final essentielText = tester.widget<Text>(find.text('Essentiel'));
+      expect(essentielText.style?.decoration, isNot(TextDecoration.lineThrough));
+    });
+
+    testWidgets('tapping a tab fires onTapTab with its index', (tester) async {
+      var lastTapped = -1;
+      await tester.pumpWidget(_wrap(
+        StickyTabBar(
+          tabs: _tabs,
+          activeIndex: 0,
+          progress: 0.0,
+          onTapTab: (i) => lastTapped = i,
+        ),
+      ));
+      await tester.tap(find.text('Tech'));
+      expect(lastTapped, 1);
+    });
+
+    testWidgets('switches head title to "Explorer" in Explorer mode',
+        (tester) async {
+      // `showFilterBar: false` here — we only assert on the head title
+      // swap. The full filter-bar variant pulls in Riverpod-backed feed
+      // providers, which is covered by the integration tests instead.
+      await tester.pumpWidget(_wrap(
+        StickyTabBar(
+          tabs: _tabs,
+          activeIndex: 2,
+          progress: 1.0,
+          onTapTab: (_) {},
+          title: 'Explorer',
+        ),
+      ));
+      // Head title becomes Explorer and the last tab keeps the same label.
+      expect(find.text('Explorer'), findsNWidgets(2));
     });
   });
 }

--- a/docs/bugs/bug-essentiel-front-regressions.md
+++ b/docs/bugs/bug-essentiel-front-regressions.md
@@ -1,0 +1,42 @@
+# Bug — Régressions front Story 9.2 (PR #650)
+
+**Date** : 2026-05-23
+**Auteur** : Laurin (PO)
+**Branch** : `boujonlaurin-dotcom/hotfix-essentiel-front-regressions`
+
+## Symptômes (3 régressions remontées par le PO)
+
+1. **Sticky bar** : PR #650 a remplacé la `StickyTabBar` à onglets (puce + label par section + soulignement + barre de progression dégradée) par un `StickyThreeStateBar` à 3 macro-blocs. Le PO veut la bar à onglets d'origine, mais avec une **icône check** à la place du `lineThrough` quand l'onglet est `isDone`.
+2. **« Actus du jour » supprimée** : PR #650 a remplacé la `DigestTopicSection(kind: essentiel)` legacy par la nouvelle carte hi-fi `EssentielSection`. Le PO voulait **garder les deux** — la carte hi-fi prend désormais le nom « L'Essentiel du jour », et la section legacy est renommée « Actus du jour » et placée juste en dessous.
+3. **UI de la carte hi-fi** : noms des thématiques vides (`article.sectionLabel == ""` côté backend), cachet de date trop discret, dividers trop sombres, fond du lead pas assez subtil.
+
+## Plan de correction (1 PR vers `main`)
+
+### Régression 1 — Sticky
+- Restaurer `StickyTabBar` + `StickyHead` + `_TabsRow` + `_ProgressPainter` depuis `d1463c05:apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart`.
+- Modifier `_Tab` : remplacer `decoration: TextDecoration.lineThrough` (quand `isDone`) par une `Icon(Icons.check, size: 12)` à droite du label.
+- Supprimer `StickyMacroBloc` enum, `StickyThreeStateBar`, `_currentMacroBloc`, `_updateMacroBloc`, `_onTapStickyBar` dans `flux_continu_screen.dart`.
+- Restaurer `_tabsScroll`, `_isInExploreMode`, `_updateExploreMode`, `_alignTabsToActive`, `_scrollToSection` (gère `_explorerKey` comme dernier tab virtuel).
+- Restaurer `_StickyHostOverlay` original (tabs + `tabsController` + `isInExploreMode` + `showFilterBar`).
+- Retirer la `FeedFilterBar` injectée dans le scroll sous le banner Explorer (PR #650) : elle reprend sa place dans la sticky via `showFilterBar: true`.
+
+### Régression 2 — « Actus du jour »
+- Restaurer la constante `_kEssentielAccent` + nouveau champ `_actusDuJour` dans `FluxContinuNotifier`.
+- Construire `_actusDuJour` via `_buildDigestSection(... kind: SectionKind.essentiel, label: "Actus du jour" ...)`.
+- Ordre dans `_compose` (normal) : `_essentiel` (hi-fi) → `_actusDuJour` (legacy) → thèmes → `_bonnes`. Mode sérène : `_bonnes` → thèmes → `_essentiel` → `_actusDuJour`.
+- **Collision de clé** : étendre `sectionKey()` pour matcher `EssentielSection` → `'essentiel_v3'` ; `DigestTopicSection(kind: essentiel)` reste sur `'essentiel'` (préserve les prefs `flux_continu_folded_*` existantes du PO).
+- Test provider : vérifier que `_essentiel` (hi-fi) et `_actusDuJour` (legacy) coexistent quand les deux payloads sont présents.
+
+### Régression 3 — Carte hi-fi
+- a. **Fallback theme label** : dans `essentiel_hi_fi_card.dart`, remplacer les usages de `article.sectionLabel` par `_sectionLabelFor(article)` qui retombe sur `themeMap[article.theme]?.label ?? 'Actus'` quand le backend renvoie vide.
+- b. **Pastille date** : diamètre 64 px, texte 2 lignes ("23" gros / "MAI" petit), fond `accent.withValues(alpha: 0.16)`, bordure 1.6 px.
+- c. **Dividers** : `_Hairline` et `_DottedDivider` → `colors.border.withValues(alpha: 0.35)`.
+- d. **Lead background** : `themeAccent.withValues(alpha: 0.06)`, bord gauche 3 px solide confirmé.
+- e. **Overflow safety** : ellipsis garantie sur les noms de sources / titres déjà couverts.
+
+> Bug backend séparé (à ouvrir) : `topic.label = ""` est rempli **après** la boucle dans `digest_selector.py:_build_topic_groups`. Tant qu'il n'est pas corrigé, le fallback front absorbe la régression visible.
+
+## Validation
+- `flutter pub get && flutter analyze` (0 erreur nouvelle).
+- `flutter test test/features/flux_continu/` vert (test étendu pour `Actus du jour`).
+- PR vers `main` avec body listant les 3 fixes.


### PR DESCRIPTION
## Contexte

PR #650 (Story 9.2 — carte hi-fi « L'Essentiel du jour » + sticky 3-états + repli) a été mergée mais le PO a remonté 3 régressions à corriger immédiatement. Ce hotfix les traite dans une seule PR.

## Régressions corrigées

### 1. Sticky bar — restauration des onglets

- `StickyThreeStateBar` (3 macro-blocs Essentiel/Par thème/Explorer) **supprimé** → la `StickyTabBar` à onglets est restaurée depuis `d1463c05` (puce colorée + label par section + soulignement actif + barre de progression dégradée 4-stops).
- **Modification ciblée** : les onglets `isDone` portent maintenant une icône `Icons.check_rounded` à droite du label (au lieu de `TextDecoration.lineThrough`). Spec « lu = checked, pas barré ».
- Au screen : `StickyMacroBloc`, `_currentMacroBloc`, `_onTapStickyBar`, `_updateMacroBloc` supprimés. `_tabsScroll`, `_isInExploreMode`, `_updateExploreMode`, `_alignTabsToActive`, `_StickyHostOverlay` (tabs + tabsController + showFilterBar) restaurés.
- La `FeedFilterBar` retrouve sa place dans la sticky en mode Explorer (`showFilterBar: true`) au lieu d'un sliver séparé sous le banner.

### 2. « Actus du jour » réintégrée

- Nouveau champ `_actusDuJour` dans `FluxContinuNotifier` — `DigestTopicSection(kind: essentiel, label: "Actus du jour")` alimentée par `dual.normal.topics`.
- Ordre `_compose` (normal) : `EssentielSection` (hi-fi) → `DigestTopicSection("Actus du jour")` → thèmes → Bonnes Nouvelles. Mode sérène : Bonnes Nouvelles → thèmes → EssentielSection → Actus du jour.
- **Collision de clé résolue** : `sectionKey()` mappe désormais `EssentielSection` → `'essentiel_v3'` ; `DigestTopicSection(kind: essentiel)` garde la clé legacy `'essentiel'` pour préserver les prefs `flux_continu_folded_*` historiques du PO.

### 3. UI de la carte hi-fi

- **Noms des thématiques** : fallback côté front via `_sectionLabelFor(article)` — utilise `themeMap[article.theme].label` puis `'Actus'` quand le backend renvoie `section_label = ""`. **Bug backend séparé à ouvrir** : `digest_selector.py:_build_topic_groups` remplit `topic.label` *après* la boucle qui construit les `EssentielArticle`, donc la valeur arrive vide. Le fallback front absorbe la régression en attendant.
- **Pastille « 23 mai »** : diamètre 64 px (vs 56), texte sur 2 lignes (« 23 » 20 px + « MAI » 10 px letterspacing 1.2), fond `accent @ alpha 0.16` (vs 0.12), bordure 1.6 px (vs 1.2). Rotation -3° préservée.
- **Dividers** : `_Hairline` et `_DottedDivider` passent à `colors.border.withValues(alpha: 0.35)` (suggère la séparation sans dominer).
- **Lead background** : `themeAccent @ alpha 0.06` (vs 0.08), bord gauche 3 px solide confirmé.
- **Overflow safety** : ellipsis ajoutée sur le kicker `ÉDITION DU…` et sur le label `_LightTile` pour éviter les débordements sur petits écrans.

## Tests

- `flutter analyze lib/features/flux_continu/` : 0 nouvelle erreur (1 lint info `prefer_single_quotes` pré-existant sur `_kThemeBlurb:51`, hors scope ; 1 warning sur `flux_continu_repository.dart:132` pré-existant).
- `flutter test test/features/flux_continu/` : **65 tests verts**.
  - Nouveau test `sectionKey` : disambiguation `EssentielSection` / `DigestTopicSection(essentiel)`.
  - Nouveau test provider : `EssentielSection` (hi-fi) et `DigestTopicSection("Actus du jour")` coexistent quand les deux payloads sont présents, dans le bon ordre, avec des clés distinctes.
  - Test sticky entièrement réécrit sur `StickyTabBar` (check icon visible quand `isDone`, no strike-through, `onTapTab` fired, title swap en mode Explorer).

> Les failures pré-existantes globales (`digest_completion_test.dart`, `topic_chip_test.dart`, etc.) sont confirmées présentes sur `main` (`acb6dbb8`) et hors scope.

## Note de design

Compromis assumé sur le cachet de date : la spec design parlait d'un « cachet rond ocre » sans visuel précis, j'ai appliqué les 4 ajustements suggérés (diamètre, 2 lignes, alpha 0.16, bordure 1.6). À itérer en validation visuelle si le rendu ne convient pas.

## Story doc

`docs/bugs/bug-essentiel-front-regressions.md` — résumé des 3 régressions et plan d'action (3 paragraphes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)