### PR TITLE
fix(mobile): Essentiel hi-fi card Vague 2 — aligne UI sur la maquette

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -323,6 +323,23 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     );
   }
 
+  /// "Tout explorer" action of the Essentiel hi-fi card: folds the card
+  /// (so it stops occupying the viewport) then scrolls to the section that
+  /// follows in the composed feed — by construction "Actus du jour" in
+  /// normal mode, cf. [FluxContinuNotifier._compose].
+  Future<void> _exploreAllEssentiel(
+    EssentielSection essentiel,
+    int essentielIndex,
+  ) async {
+    final notifier = ref.read(fluxContinuProvider.notifier);
+    notifier.foldLocally(essentiel);
+    final next = essentielIndex + 1;
+    if (next >= _sectionKeys.length) return;
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    if (!mounted) return;
+    await _scrollToSection(next);
+  }
+
   Future<void> _scrollToTop() async {
     if (!_scroll.hasClients) return;
     unawaited(HapticFeedback.lightImpact());
@@ -836,6 +853,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
                 : null,
             onSeeAll: section is FeedThemeSection
                 ? () => _openThemeSection(context, section)
+                : null,
+            onTapExploreAll: section is EssentielSection
+                ? () => _exploreAllEssentiel(section, i)
                 : null,
           ),
         ),

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -116,7 +116,6 @@ class _Header extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
     final now = DateTime.now();
-    final dayLabel = _formatDayName(now).toUpperCase();
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -128,19 +127,21 @@ class _Header extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                'ÉDITION DU $dayLabel · 5 ACTUS À SUIVRE',
-                style: FacteurTypography.stamp(colors.textTertiary),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              const SizedBox(height: 4),
-              Text(
                 'L’Essentiel du jour',
                 style: GoogleFonts.fraunces(
                   fontSize: 22,
                   fontWeight: FontWeight.w700,
                   height: 1.2,
                   color: colors.textPrimary,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Les 5 articles à ne pas manquer aujourd’hui, issus de tes préférences',
+                style: FacteurTypography.bodySmall(colors.textSecondary).copyWith(
+                  height: 1.35,
                 ),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
@@ -154,8 +155,6 @@ class _Header extends StatelessWidget {
     );
   }
 
-  // Unused after the hotfix (the stamp now renders day/month on two lines),
-  // but kept for backwards reference. _formatDateStamp removed.
   static String _monthAbbrev(int m) {
     const months = [
       'JAN',
@@ -173,19 +172,6 @@ class _Header extends StatelessWidget {
     ];
     return months[m - 1];
   }
-
-  static String _formatDayName(DateTime d) {
-    const days = [
-      'lundi',
-      'mardi',
-      'mercredi',
-      'jeudi',
-      'vendredi',
-      'samedi',
-      'dimanche',
-    ];
-    return days[d.weekday - 1];
-  }
 }
 
 class _DateStamp extends StatelessWidget {
@@ -201,47 +187,39 @@ class _DateStamp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Hotfix Story 9.2 — cachet rond ocre :
-    //   - diamètre 64 px (vs 56 légèrement trop discret),
-    //   - jour sur la 1re ligne (grand),
-    //   - mois sur la 2e ligne (petit, letterspacing élargi),
-    //   - fond plus saturé (alpha 0.16) et bordure 1.6 px pour ressortir.
-    return Transform.rotate(
-      angle: -0.05,
-      child: Container(
-        width: 64,
-        height: 64,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: accent.withValues(alpha: 0.16),
-          shape: BoxShape.circle,
-          border: Border.all(color: accent, width: 1.6),
-        ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(
-              day.toString().padLeft(2, '0'),
-              style: GoogleFonts.courierPrime(
-                fontSize: 20,
-                fontWeight: FontWeight.w700,
-                height: 1.0,
-                color: accent,
-              ),
+    return Container(
+      width: 64,
+      height: 64,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.16),
+        shape: BoxShape.circle,
+        border: Border.all(color: accent, width: 1.6),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            day.toString().padLeft(2, '0'),
+            style: GoogleFonts.courierPrime(
+              fontSize: 20,
+              fontWeight: FontWeight.w700,
+              height: 1.0,
+              color: accent,
             ),
-            const SizedBox(height: 1),
-            Text(
-              month,
-              style: GoogleFonts.courierPrime(
-                fontSize: 10,
-                fontWeight: FontWeight.w700,
-                height: 1.0,
-                letterSpacing: 1.2,
-                color: accent,
-              ),
+          ),
+          const SizedBox(height: 1),
+          Text(
+            month,
+            style: GoogleFonts.courierPrime(
+              fontSize: 10,
+              fontWeight: FontWeight.w700,
+              height: 1.0,
+              letterSpacing: 1.2,
+              color: accent,
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -294,7 +272,7 @@ class _LeadTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
-    final themeAccent = _accentFor(article, accent);
+    final chipAccent = _accentFor(article, accent);
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -308,11 +286,9 @@ class _LeadTile extends StatelessWidget {
             FacteurSpacing.space3,
           ),
           decoration: BoxDecoration(
-            // Hotfix Story 9.2 — fond teinté plus discret (0.06) pour que la
-            // couleur thématique suggère la section sans surligner.
-            color: themeAccent.withValues(alpha: 0.06),
+            color: accent.withValues(alpha: 0.06),
             borderRadius: BorderRadius.circular(FacteurRadius.medium),
-            border: Border(left: BorderSide(color: themeAccent, width: 3)),
+            border: Border(left: BorderSide(color: accent, width: 3)),
           ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -321,7 +297,7 @@ class _LeadTile extends StatelessWidget {
                 children: [
                   _SectionChip(
                     label: _sectionLabelFor(article),
-                    accent: themeAccent,
+                    accent: chipAccent,
                   ),
                   const Spacer(),
                   if (article.perspectiveCount > 1)
@@ -547,11 +523,9 @@ class _Hairline extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
-    // Hotfix Story 9.2 — opacité réduite (0.35) pour que le filet
-    // suggère la séparation sans dominer visuellement la carte.
     return Container(
       height: 0.6,
-      color: colors.border.withValues(alpha: 0.35),
+      color: colors.border.withValues(alpha: 0.20),
     );
   }
 }
@@ -562,7 +536,7 @@ class _DottedDivider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
-    final dotColor = colors.border.withValues(alpha: 0.35);
+    final dotColor = colors.border.withValues(alpha: 0.20);
     return LayoutBuilder(
       builder: (context, constraints) {
         final dashCount = (constraints.maxWidth / 4).floor();
@@ -645,18 +619,14 @@ Color _accentFor(EssentielArticle article, Color fallback) {
 
 /// Resolves the section label rendered next to each article in the hi-fi card.
 ///
-/// The backend (`digest_selector.py:_build_topic_groups`) currently fills
-/// `topic.label` *after* the loop that assembles the EssentielArticle, so the
-/// payload often arrives with `section_label = ""`. Until the backend is fixed
-/// (tracked separately) we fall back to the theme name from [themeMap], or
-/// "Actus" if even the slug is unknown — strictly cosmetic, the article still
-/// opens correctly when tapped.
+/// Prefers the stable client-side [themeMap] over the backend `section_label`,
+/// which is often empty or non-canonical (e.g. carries the source name).
 String _sectionLabelFor(EssentielArticle article) {
-  final raw = article.sectionLabel.trim();
-  if (raw.isNotEmpty) return raw;
   final slug = article.theme;
   if (slug != null && themeMap.containsKey(slug)) {
     return themeMap[slug]!.label;
   }
+  final raw = article.sectionLabel.trim();
+  if (raw.isNotEmpty) return raw;
   return 'Actus';
 }

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -34,6 +34,11 @@ class SectionBlock extends StatelessWidget {
   /// for [DigestTopicSection] which keeps its in-place fold/expand button.
   final VoidCallback? onSeeAll;
 
+  /// "Tout explorer" action of the [EssentielSection] hi-fi card. Wired by
+  /// the flux_continu screen to fold the Essentiel card AND scroll to the
+  /// next section ("Actus du jour"). Ignored for other section types.
+  final VoidCallback? onTapExploreAll;
+
   /// IDs of articles currently in the inline-feedback pending state. When
   /// non-empty, the matching cards are swapped for a [FeedbackInline] at the
   /// same position.
@@ -71,6 +76,7 @@ class SectionBlock extends StatelessWidget {
     this.onSwipeHintComplete,
     this.onTapFavorite,
     this.onSeeAll,
+    this.onTapExploreAll,
   });
 
   @override
@@ -113,6 +119,7 @@ class SectionBlock extends StatelessWidget {
               onTapArticle: (a) => onTapArticle(a, section),
               onTapPersonalize: () => EssentielPersonalizeSheet.show(context),
               onTapSkip: onFold,
+              onTapExploreAll: onTapExploreAll,
             ),
             const SizedBox(height: 16),
           ],

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -39,7 +39,7 @@ void main() {
   });
 
   group('EssentielHiFiCard', () {
-    testWidgets('renders title, kicker and the lead article', (tester) async {
+    testWidgets('renders title, subtitle and the lead article', (tester) async {
       await tester.pumpWidget(_wrap(
         EssentielHiFiCard(
           articles: [_article(rank: 1)],
@@ -49,7 +49,15 @@ void main() {
       ));
 
       expect(find.textContaining('L’Essentiel du jour'), findsOneWidget);
-      expect(find.textContaining('5 ACTUS À SUIVRE'), findsOneWidget);
+      expect(
+        find.textContaining('Les 5 articles à ne pas manquer'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('ÉDITION DU'),
+        findsNothing,
+        reason: 'Vague 2 hotfix: gray "ÉDITION DU [day]" banner removed.',
+      );
       expect(find.text('Titre 1'), findsOneWidget);
     });
 
@@ -101,6 +109,39 @@ void main() {
       for (var i = 1; i <= 5; i++) {
         expect(find.text('Titre $i'), findsOneWidget);
       }
+    });
+
+    testWidgets('"Tout explorer" button fires onTapExploreAll when wired',
+        (tester) async {
+      var exploreTaps = 0;
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [_article(rank: 1)],
+          onTapArticle: (_) {},
+          onTapPersonalize: () {},
+          onTapSkip: () {},
+          onTapExploreAll: () => exploreTaps++,
+        ),
+      ));
+
+      expect(find.text('Tout explorer →'), findsOneWidget);
+      await tester.tap(find.text('Tout explorer →'));
+      await tester.pumpAndSettle();
+      expect(exploreTaps, 1);
+    });
+
+    testWidgets('"Tout explorer" button is omitted when onTapExploreAll is null',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [_article(rank: 1)],
+          onTapArticle: (_) {},
+          onTapPersonalize: () {},
+          onTapSkip: () {},
+        ),
+      ));
+
+      expect(find.text('Tout explorer →'), findsNothing);
     });
   });
 }

--- a/docs/bugs/bug-essentiel-front-regressions.md
+++ b/docs/bugs/bug-essentiel-front-regressions.md
@@ -40,3 +40,38 @@
 - `flutter pub get && flutter analyze` (0 erreur nouvelle).
 - `flutter test test/features/flux_continu/` vert (test étendu pour `Actus du jour`).
 - PR vers `main` avec body listant les 3 fixes.
+
+---
+
+## Vague 2 — 2026-05-23
+
+Nouvelle remontée PO après le merge du hotfix #652 : l'UI reste éloignée de la maquette cible (`.context/attachments/ncGCVx/image.png`). Voir captures `.context/attachments/uzpxjS/image.png` (actuel) vs `.context/attachments/ncGCVx/image.png` (cible).
+
+### Symptômes
+
+1. Bandeau gris « ÉDITION DU [DAY] · 5 ACTUS À SUIVRE » au-dessus du titre — PO veut le remplacer par un sous-titre descriptif sous le titre.
+2. Pastille de date inclinée (-0.05 rad) — la maquette la montre droite.
+3. Fond du lead pris sur la couleur du THÈME de l'article (violet/bleu/etc selon le thème) — PO veut un ocre Essentiel uniforme.
+4. Filets (`_Hairline`, `_DottedDivider`) toujours trop visibles à 0.35 alpha.
+5. Noms thématiques absents ou parasités quand le backend renvoie un `section_label` non canonique (e.g. nom de source).
+6. Bouton « Tout explorer » présent dans la maquette mais invisible (callback non câblé dans `section_block.dart`).
+
+### Plan de correction (1 PR vers `main`)
+
+- a. **Header** (`_Header`) : supprimer le texte gris `ÉDITION DU $dayLabel · 5 ACTUS À SUIVRE`. Ajouter sous le titre un sous-titre `Les 5 articles à ne pas manquer aujourd'hui, issus de tes préférences` (`FacteurTypography.bodySmall` sur `textSecondary`, `height: 1.35`, max 2 lignes). Nettoyer `_formatDayName()` devenu inutile.
+- b. **Pastille date** (`_DateStamp`) : retirer `Transform.rotate(angle: -0.05, …)`. Le reste (diamètre 64, Courier Prime, 2 lignes, fond `accent@0.16`, bordure 1.6 px) reste identique.
+- c. **Lead background** (`_LeadTile`) : le fond et le bord gauche utilisent `accent` (`colors.sectionEssentiel` ocre uniforme) au lieu de `themeAccent`. La `_SectionChip` conserve `themeAccent` pour rester thématique.
+- d. **Dividers** (`_Hairline`, `_DottedDivider`) : opacité 0.35 → 0.20.
+- e. **Fallback label** (`_sectionLabelFor`) : priorité inversée — `themeMap[article.theme]?.label` d'abord, puis `article.sectionLabel.trim()` non-vide, puis `'Actus'`. Garantit que les noms thématiques (Technologie, Environnement…) s'affichent dès que le slug `theme` est reconnu, même si le backend renvoie un label parasite.
+- f. **Bouton « Tout explorer »** :
+  - `section_block.dart` : nouveau paramètre `onTapExploreAll: VoidCallback?`, passé au constructeur de `EssentielHiFiCard` (lignes ~111-116).
+  - `flux_continu_screen.dart` : nouvelle méthode `_exploreAllEssentiel(EssentielSection, int)` qui appelle `notifier.foldLocally(essentiel)` puis `_scrollToSection(essentielIndex + 1)` après un délai de 50 ms (laisse le fold se rendre). Wiring : `onTapExploreAll: section is EssentielSection ? () => _exploreAllEssentiel(section, i) : null`.
+
+### Validation
+- `flutter analyze` (0 warning nouveau).
+- `flutter test test/features/flux_continu/` vert (les tests #652 ne doivent pas casser).
+- E2E manuel Playwright MCP (390×844) : tap « Tout explorer » plie la carte ET scrolle vers « Actus du jour » ; tap « Passer » plie sans scroller.
+
+### Hors scope (toujours)
+- Backend `topic.label = ""` — fix backend séparé.
+- Page dédiée full-screen Essentiel — non retenue, scroll vers Actus du jour préféré par le PO.


### PR DESCRIPTION
## Quoi

Deuxième vague de hotfix sur la carte hi-fi *L'Essentiel du jour* (post #650 / #652). Le PO a comparé l'UI livrée à la maquette cible (`.context/attachments/ncGCVx/image.png`) et identifié 6 régressions visuelles + 1 wiring manquant — corrigées dans ce PR.

## Pourquoi

L'UI livrée par #650 puis ajustée par #652 reste éloignée de la maquette : bandeau gris parasite au-dessus du titre, cachet date incliné, fond de l'article principal teinté par le thème (couleurs incohérentes selon le sujet), filets trop opaques, labels thématiques parfois remplacés par le nom de la source, et bouton « Tout explorer » présent visuellement mais sans action.

## Changements

- **`_Header`** : supprime le bandeau « ÉDITION DU [day] · 5 ACTUS À SUIVRE ». Ajoute un sous-titre sous le titre : *« Les 5 articles à ne pas manquer aujourd'hui, issus de tes préférences »*. Nettoie `_formatDayName` devenu inutile.
- **`_DateStamp`** : retire `Transform.rotate(-0.05)`, cachet rendu droit.
- **`_LeadTile`** : fond + bord gauche utilisent l'accent ocre uniforme de la section (`accent`) ; la `_SectionChip` conserve la couleur du thème pour rester thématique.
- **`_Hairline` / `_DottedDivider`** : opacité 0.35 → 0.20.
- **`_sectionLabelFor`** : priorité inversée — `themeMap[article.theme].label` d'abord, puis `article.sectionLabel`, puis `'Actus'`. Garantit l'affichage du nom thématique stable même si le backend renvoie un libellé parasite.
- **Bouton « Tout explorer »** :
  - `section_block.dart` : nouveau paramètre `onTapExploreAll: VoidCallback?` (pattern identique à `onSeeAll`).
  - `flux_continu_screen.dart` : nouvelle méthode `_exploreAllEssentiel(EssentielSection, int)` qui plie la carte (`notifier.foldLocally`) puis scrolle vers la section suivante (par construction *Actus du jour*) après 50 ms.

## Comment ça a été vérifié

- [x] `flutter test test/features/flux_continu/` → **67/67 OK** (tests étendus pour le nouveau sous-titre, présence/absence du bouton « Tout explorer », et tirs de `onTapExploreAll`).
- [x] `flutter analyze lib/features/flux_continu/...` → **0 issue** sur les fichiers modifiés.
- [x] `flutter test` complet : pré-existant 36 échecs (smoke + feed_sources + feed_refresh_recovery, etc.) **non liés** — confirmés identiques sur `origin/main` sans ce PR.
- [x] Skill `simplify` passée : 2 commentaires resserrés (suppression d'un commentaire narratif sur `_LeadTile`, raccourci du docstring de `_sectionLabelFor`).

## Zones à risque

- `flux_continu/screens/flux_continu_screen.dart` : nouvelle interaction utilisateur (fold + scroll). Délai 50 ms volontaire pour laisser le fold s'animer avant le scroll ; `if (!mounted)` garde contre le scroll après dispose.
- `essentiel_hi_fi_card.dart::_sectionLabelFor` : appelé 3× par carte rendue. La nouvelle priorité ajoute un lookup `themeMap.containsKey()` (O(1) sur un `const Map`) avant le check backend — coût négligeable, gain de fiabilité.

## Hors scope

- Fix backend `topic.label = ""` dans `digest_selector.py:_build_topic_groups` (PR séparée).
- Couverture étrangère (bloc séparé EN/autres langues) — toujours en attente côté PO.