### PR TITLE
feat(api): contrat /perspectives enrichi (LLM bias) + Content.language (Phase 4 PR 5)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,51 +1,92 @@
-# PR — fix: restaure les favoris custom_topic + Sujets épinglés
+## Quoi
 
-## Summary
+PR 5 de la chaîne LLM bias annotation. Enrichit le contrat de
+`GET /contents/{id}/perspectives` pour exposer les annotations LLM
+(`weight` / `category` / `justification`) quand `semantic_equiv` est
+en base, sinon retourne le format spaCy actuel. Ajoute un header de
+debug `X-Bias-Annotation-Source: llm|spacy` et expose `language`
+sur chaque perspective.
 
-Annule partiellement la PR #636 (commit 8adc5d41) qui avait vidé la section **Explorer** en bloquant les favoris `custom_topic`. La PR ré-autorise l'état `favorite` côté backend, expose une section dédiée **« Sujets épinglés »** côté mobile (séparée du top 3 reorderable, label « Épinglé » au lieu de « Favori »), et restaure automatiquement les 62 favoris perdus pour 15 users via heuristique sur `priority_multiplier`.
+## Pourquoi
 
-- **Backend** : `set_state(custom_topic, favorite)` accepté ; `priority_multiplier` synchronisé à 2.0 sur favori (1.0 sinon) pour alimenter `feed.py:get_tab_counts`. Le top 3 reorderable reste réservé aux thèmes et veilles (nouvelle exception `CustomTopicNotReorderable` → 422 `custom_topic_not_reorderable` sur `/reorder` uniquement).
-- **Migration `23a4_restore_ct_favorites`** : exploite la signature `state=followed + priority_multiplier=2.0` (la migration 23a3 a oublié de reset le multiplier) pour ré-hydrater les rows perdues sans PITR Supabase. Idempotente, downgrade fonctionnel.
-- **Mobile** : `InterestStatePickerSheet` accepte un nouveau paramètre `favoriteSemantics` (theme vs pinnedTopic) qui change icône (étoile → punaise) + label (« Favori » → « Épinglé ») + description. Nouvelle section `_PinnedTopicsSection` dans « Mes intérêts » avec micro-copy expliquant le lien avec Explorer. `_StateChip` rend « Épinglé » + punaise pour les custom_topic.
+Les annotations LLM (`semantic_equiv.target_spans` pondérés + tooltips
+de justification) sont produites par le pipeline mergé en PR 4
+(#648), mais le contrat API actuel les ignore. Sans cette PR, le
+mobile (PR 6) ne peut pas afficher les poids ni les tooltips. Le
+champ `language` est requis par la future section « Couverture
+étrangère » pour regrouper les perspectives non-FR.
 
-## Décisions PM actées (avant code)
+## Changements
 
-| # | Décision |
-|---|---|
-| Backend | `state=favorite` autorisé pour custom_topic. Sémantique technique identique aux thèmes/veilles (pas de schema split). |
-| UX | Label « Épinglé » + icône punaise pour les sujets, distinct du « Favori » + étoile des thèmes. |
-| Top 3 | Reste réservé aux thèmes et veilles (sujets non-draggable). |
-| Bug `slug_parent` | **Hors scope**, PR séparée (Plongée → tous les sports). |
-| Recovery | Best-effort via heuristique multiplier — exploite l'oubli de la migration 23a3 (pas de PITR nécessaire). |
-| Veille CTA | Hors scope (attente refonte veille en cours). |
+- **`Content.language`** : colonne `String(8)` nullable + index +
+  migration Alembic `lg01_add_language_to_contents` avec backfill
+  heuristique (`detect_language` = `looks_english` puis
+  `is_french_source`). Les nouveaux contents sont remplis à
+  l'ingestion (`sync_service._save_content`).
+- **`Perspective.language`** ajouté au dataclass, propagé depuis
+  `Content.language` dans `build_cluster_perspectives`. Les
+  perspectives Google News restent `None` (pas de row `Content`).
+- **`_attach_highlight_spans`** refactoré pour retourner
+  `tuple[dict | None, Literal["llm", "spacy"]]`. Si `semantic_equiv`
+  est rempli pour le cluster (filtré par `llm_version` +
+  `cluster_signature`), les target_spans LLM sont sérialisés tels
+  quels, avec `bias` injecté depuis `bias_stance` pour rétrocompat.
+  Sinon → fallback spaCy inchangé.
+- **Header `X-Bias-Annotation-Source`** posé via `Response` injecté
+  dans la signature FastAPI. Cache hit ré-attache le header via un
+  `_perspectives_source_cache` parallèle (sinon le header
+  disparaissait silencieusement après la 1ère requête).
+- **`detect_language`** factorisé dans
+  `app/services/ml/language_filter.py` — single source of truth pour
+  l'ingestion ET la migration de backfill.
 
-## Test plan
+## Comment ça a été vérifié
 
-- [x] Backend : `pytest tests/routers/test_user_interests.py -v` → 12/12 OK (nouveaux : `test_patch_allows_favorite_for_custom_topic`, `test_patch_unfavorite_custom_topic_resets_multiplier` ; mis à jour : `test_reorder_rejects_custom_topic` → nouvelle erreur).
-- [x] Backend : `pytest tests/alembic/test_23a4_restore_ct_favorites.py -v` → 5/5 OK (promotion, ignore multiplier=1, append après favoris existants, idempotence, ordre par created_at).
-- [x] Backend : suite complète `pytest -q` → 1141 passed, 2 échecs NER pré-existants non liés.
-- [x] Mobile : `flutter test test/features/my_interests/` → 12/12 OK (nouveau : `pinnedTopic semantics renders "Épinglé" label`).
-- [x] Mobile : `flutter analyze` → aucun nouvel error.
-- [x] Alembic : single head `23a4_restore_ct_favorites`.
-- [ ] **Post-deploy DB** : `SELECT COUNT(*) FROM user_favorite_interests WHERE custom_topic_id IS NOT NULL` → attendu 62 rows réparties sur 15 users (snapshot prod 2026-05-20).
-- [ ] **Post-deploy DB** : `SELECT COUNT(*) FROM user_topic_profiles WHERE state='favorite'` → attendu 62.
-- [ ] **Manuel mobile** : créer un sujet → l'épingler → vérifier qu'il apparaît dans « Sujets épinglés » ET comme onglet dans Explorer ; tenter de drag vers top 3 → impossible ; désépingler → onglet Explorer disparaît.
+- [x] `pytest tests/routers/test_contents_perspectives_highlights.py`
+  — 13 OK (9 existants adaptés au tuple + 4 nouveaux : LLM enriched,
+  fallback spaCy, signature mismatch, language propagation).
+- [x] Suite complète backend : **1242 passed, 1 skipped, 2 xfailed**
+  (134 s).
+- [x] `alembic heads` → exactement 1 head
+  (`lg01_add_language_to_contents`).
+- [x] `alembic upgrade --sql` → DDL généré correctement
+  (`ALTER TABLE contents ADD COLUMN language VARCHAR(8)` +
+  `CREATE INDEX ix_contents_language`).
+- [x] `/simplify` passé : 5 fixes appliqués (factoriser
+  `detect_language`, bug header cache hit, dédupliquer `alt_tokens`,
+  hoister fixtures de tests, type `Literal`).
 
-## Hors scope (PR à venir)
-
-- Fix résolution `slug_parent` → keywords dans `feed.py:get_tab_counts` (Plongée → tous les sports).
-- CTA « Créer une Veille à partir de ce sujet » (attente refonte veille).
-- Refonte sémantique globale du mot « favori » dans le reste de l'app.
+⚠️ **Round-trip migration live non testable localement** : le
+container Postgres test du workspace est dans un état désync (« Can't
+locate revision identified by 'b3c4d5e6f7a8' ») hérité d'un autre
+workspace. La migration sera testée pour de vrai par le `alembic
+upgrade head` du `Dockerfile` Railway au prochain boot.
 
 ## Zones à risque
 
-- `services/user_interests_service.py` : mutation path favoris + sync `priority_multiplier`.
-- `alembic/versions/23a4_*` : migration data-only sur prod (62 rows à restaurer). Downgrade testé et fonctionnel.
-- `feed.py:get_tab_counts` continue de filtrer sur `priority_multiplier == 2.0` — le sync explicite dans `set_state` garantit que les onglets Explorer reflètent l'état déclaré en temps réel.
+- **Cache header** : nouveau dict `_perspectives_source_cache`
+  parallèle invalidé en même temps que `_perspectives_cache`
+  (`_perspectives_source_cache.pop` à côté de chaque
+  `_perspectives_cache.pop`). À surveiller : si une autre branche
+  oublie d'invalider l'un sans l'autre, le header pourrait diverger
+  du body.
+- **Backfill migration** : tourne dans une seule transaction
+  Alembic ; `env.py` désactive le `statement_timeout` via
+  `SET LOCAL statement_timeout = '0'`, donc pas de cap théorique.
+  Avec ~quelques 100k rows en prod, ça devrait passer en quelques
+  minutes. Idempotent (`WHERE language IS NULL`).
+- **Rétrocompat client** : confirmée par
+  `test_attach_highlight_spans_falls_back_to_spacy_when_no_semantic_equiv` —
+  les apps pre-PR-6 reçoivent le format spaCy historique.
+- **Stored snapshot path** : `language` est lu via
+  `getattr(p, "language", None)`, donc les snapshots déjà sérialisés
+  sans le champ tomberont à `null` (PR 6 traite `null` comme FR par
+  défaut).
 
-## Références
+## Dette pré-existante (hors scope)
 
-- Bug doc : `docs/bugs/bug-custom-topic-favori-regression.md`
-- Errata story : `docs/stories/core/23.3.read-only-custom-topics.md`
-- Migration source du problème : `packages/api/alembic/versions/23a3_custom_topic_fav_drop.py`
-- Snapshot recovery (2026-05-20) : 62 favoris perdus, 15 users, min 1, max 12 favoris par user, moyenne 4.13.
+`tests/services/test_llm_bias_annotation_service.py` ne collecte pas
+sur `main` à cause d'un import circulaire via
+`app.services.editorial.__init__` → `pipeline` →
+`llm_bias_annotation_service`. Vérifié : présent avant cette PR.
+À traiter dans une PR follow-up.

--- a/.github/workflows/alembic-smoke.yml
+++ b/.github/workflows/alembic-smoke.yml
@@ -53,6 +53,8 @@ jobs:
         env:
           DATABASE_URL: postgresql+psycopg://postgres:test@localhost:5432/facteur_test?sslmode=disable
         run: |
-          heads=$(alembic heads | wc -l)
+          # Filter to lines ending with "(head)" — structlog INFO lines on stdout
+          # would otherwise be counted by plain `wc -l`, yielding a false "3 heads".
+          heads=$(alembic heads | grep -c "(head)")
           echo "Heads: $heads"
           test "$heads" -eq 1

--- a/packages/api/alembic/versions/lg01_add_language_to_contents.py
+++ b/packages/api/alembic/versions/lg01_add_language_to_contents.py
@@ -7,8 +7,6 @@ du titre pour la section "Couverture étrangère" du panneau perspectives
 remplis à l'ingestion (sync_service.py).
 """
 
-from collections.abc import Iterator
-
 import sqlalchemy as sa
 
 from alembic import op
@@ -20,28 +18,6 @@ branch_labels: str | None = None
 depends_on: str | None = None
 
 _BATCH_SIZE = 500
-
-
-def _iter_batches(bind, query: str) -> Iterator[list]:
-    """Batch par keyset pagination (id > :last_id) — pas de curseurs server-side.
-
-    stream_results=True avec psycopg3 async fuit l'état curseur vers les
-    instructions suivantes sur la même connexion (dont l'UPDATE alembic_version
-    interne d'Alembic), qui se retrouvent emballées dans un DECLARE CURSOR FOR
-    UPDATE → SyntaxError PostgreSQL.
-
-    La query doit inclure :last_id et :limit comme paramètres nommés, et se
-    terminer par ORDER BY c.id LIMIT :limit.
-    """
-    last_id = 0
-    while True:
-        rows = bind.execute(
-            sa.text(query), {"last_id": last_id, "limit": _BATCH_SIZE}
-        ).fetchall()
-        if not rows:
-            break
-        yield rows
-        last_id = rows[-1].id
 
 
 def upgrade() -> None:
@@ -57,22 +33,33 @@ def upgrade() -> None:
         return
 
     bind = op.get_bind()
-    query = (
-        "SELECT c.id, c.title, s.name AS source_name "
-        "FROM contents c LEFT JOIN sources s ON s.id = c.source_id "
-        "WHERE c.language IS NULL AND c.id > :last_id "
-        "ORDER BY c.id LIMIT :limit"
-    )
+
+    # Fetch all rows to backfill in one query, then slice in Python.
+    # Avoids server-side cursors (stream_results=True) which leak cursor state
+    # in psycopg3 async — causing Alembic's subsequent UPDATE alembic_version
+    # to be wrapped in DECLARE CURSOR FOR UPDATE → SyntaxError PostgreSQL.
+    # Keyset pagination (id > :last_id) is also unsuitable because c.id is UUID
+    # and the initial sentinel 0 (smallint) triggers "operator does not exist:
+    # uuid > smallint". A single fetchall() is simpler and safe for a one-time
+    # migration where the result set fits in memory.
+    rows = bind.execute(
+        sa.text(
+            "SELECT c.id, c.title, s.name AS source_name "
+            "FROM contents c LEFT JOIN sources s ON s.id = c.source_id "
+            "WHERE c.language IS NULL"
+        )
+    ).fetchall()
+
     update_stmt = sa.text(
         "UPDATE contents SET language = :language WHERE id = :id"
     )
-    for batch in _iter_batches(bind, query):
-        updates = []
-        for row in batch:
-            lang = detect_language(row.title, row.source_name)
-            if lang is None:
-                continue
-            updates.append({"id": row.id, "language": lang})
+    for i in range(0, len(rows), _BATCH_SIZE):
+        batch = rows[i : i + _BATCH_SIZE]
+        updates = [
+            {"id": row.id, "language": lang}
+            for row in batch
+            if (lang := detect_language(row.title, row.source_name)) is not None
+        ]
         if updates:
             bind.execute(update_stmt, updates)
 

--- a/packages/api/alembic/versions/lg01_add_language_to_contents.py
+++ b/packages/api/alembic/versions/lg01_add_language_to_contents.py
@@ -1,0 +1,71 @@
+"""add language column to contents
+
+PR 5 (LLM bias annotation, contrat enrichi). Stocke la langue détectée
+du titre pour la section "Couverture étrangère" du panneau perspectives
+(consommée par PR 6 mobile). Backfill heuristique via
+`is_french_source` + `looks_english` ; les nouveaux contents sont
+remplis à l'ingestion (sync_service.py).
+"""
+
+from collections.abc import Iterator
+
+import sqlalchemy as sa
+
+from alembic import op
+from app.services.ml.language_filter import detect_language
+
+revision: str = "lg01_add_language_to_contents"
+down_revision: str | None = "23a4_restore_ct_favorites"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_BATCH_SIZE = 500
+
+
+def _iter_batches(bind, query: str) -> Iterator[list]:
+    result = bind.execution_options(stream_results=True).execute(sa.text(query))
+    batch: list = []
+    for row in result:
+        batch.append(row)
+        if len(batch) >= _BATCH_SIZE:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def upgrade() -> None:
+    op.add_column(
+        "contents",
+        sa.Column("language", sa.String(length=8), nullable=True),
+    )
+    op.create_index("ix_contents_language", "contents", ["language"])
+
+    # Offline mode (`alembic upgrade --sql`) has no live connection — emit
+    # the DDL only, skip the Python-driven backfill.
+    if op.get_context().as_sql:
+        return
+
+    bind = op.get_bind()
+    query = (
+        "SELECT c.id, c.title, s.name AS source_name "
+        "FROM contents c LEFT JOIN sources s ON s.id = c.source_id "
+        "WHERE c.language IS NULL"
+    )
+    update_stmt = sa.text(
+        "UPDATE contents SET language = :language WHERE id = :id"
+    )
+    for batch in _iter_batches(bind, query):
+        updates = []
+        for row in batch:
+            lang = detect_language(row.title, row.source_name)
+            if lang is None:
+                continue
+            updates.append({"id": row.id, "language": lang})
+        if updates:
+            bind.execute(update_stmt, updates)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_contents_language", table_name="contents")
+    op.drop_column("contents", "language")

--- a/packages/api/alembic/versions/lg01_add_language_to_contents.py
+++ b/packages/api/alembic/versions/lg01_add_language_to_contents.py
@@ -23,15 +23,25 @@ _BATCH_SIZE = 500
 
 
 def _iter_batches(bind, query: str) -> Iterator[list]:
-    result = bind.execution_options(stream_results=True).execute(sa.text(query))
-    batch: list = []
-    for row in result:
-        batch.append(row)
-        if len(batch) >= _BATCH_SIZE:
-            yield batch
-            batch = []
-    if batch:
-        yield batch
+    """Batch par keyset pagination (id > :last_id) — pas de curseurs server-side.
+
+    stream_results=True avec psycopg3 async fuit l'état curseur vers les
+    instructions suivantes sur la même connexion (dont l'UPDATE alembic_version
+    interne d'Alembic), qui se retrouvent emballées dans un DECLARE CURSOR FOR
+    UPDATE → SyntaxError PostgreSQL.
+
+    La query doit inclure :last_id et :limit comme paramètres nommés, et se
+    terminer par ORDER BY c.id LIMIT :limit.
+    """
+    last_id = 0
+    while True:
+        rows = bind.execute(
+            sa.text(query), {"last_id": last_id, "limit": _BATCH_SIZE}
+        ).fetchall()
+        if not rows:
+            break
+        yield rows
+        last_id = rows[-1].id
 
 
 def upgrade() -> None:
@@ -50,7 +60,8 @@ def upgrade() -> None:
     query = (
         "SELECT c.id, c.title, s.name AS source_name "
         "FROM contents c LEFT JOIN sources s ON s.id = c.source_id "
-        "WHERE c.language IS NULL"
+        "WHERE c.language IS NULL AND c.id > :last_id "
+        "ORDER BY c.id LIMIT :limit"
     )
     update_stmt = sa.text(
         "UPDATE contents SET language = :language WHERE id = :id"

--- a/packages/api/app/models/content.py
+++ b/packages/api/app/models/content.py
@@ -85,6 +85,11 @@ class Content(Base):
     # Thème inféré par ML à partir du titre/description (Phase 2 diversité feed)
     # Slug normalisé dérivé du top topic classifié (tech, society, etc.)
     theme: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    # Langue détectée du titre ("fr", "en", autre — NULL = non détecté). Sert
+    # au regroupement "Couverture étrangère" du panneau perspectives.
+    language: Mapped[str | None] = mapped_column(
+        String(8), nullable=True, index=True
+    )
     # Story 4.2-US-4: Named Entity Recognition
     entities: Mapped[list[str] | None] = mapped_column(ARRAY(Text), nullable=True)
     # Paywall detection: whether article is behind a paywall

--- a/packages/api/app/models/content.py
+++ b/packages/api/app/models/content.py
@@ -87,9 +87,7 @@ class Content(Base):
     theme: Mapped[str | None] = mapped_column(String(50), nullable=True)
     # Langue détectée du titre ("fr", "en", autre — NULL = non détecté). Sert
     # au regroupement "Couverture étrangère" du panneau perspectives.
-    language: Mapped[str | None] = mapped_column(
-        String(8), nullable=True, index=True
-    )
+    language: Mapped[str | None] = mapped_column(String(8), nullable=True, index=True)
     # Story 4.2-US-4: Named Entity Recognition
     entities: Mapped[list[str] | None] = mapped_column(ARRAY(Text), nullable=True)
     # Paywall detection: whether article is behind a paywall

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -950,8 +950,8 @@ async def get_perspectives(
     cached_response = _perspectives_cache.get(cache_key)
     if cached_response is not None:
         logger.info("perspectives_cache_hit", content_id=cache_key)
-        response.headers["X-Bias-Annotation-Source"] = (
-            _perspectives_source_cache.get(cache_key, "spacy")
+        response.headers["X-Bias-Annotation-Source"] = _perspectives_source_cache.get(
+            cache_key, "spacy"
         )
         return cached_response
 

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -1,10 +1,11 @@
 import asyncio
 import uuid
 from datetime import UTC, datetime
+from typing import Literal
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,6 +28,7 @@ from app.services.content_service import ContentService
 from app.services.feed_cache import FEED_CACHE
 from app.services.title_annotation_service import (
     ClusterAnnotations,
+    TitleAnnotationService,
     get_title_annotation_service,
 )
 
@@ -565,6 +567,10 @@ _analysis_cache: TTLCache = TTLCache(maxsize=256, ttl=7200)
 
 # In-memory cache for perspectives responses (TTL 2h, max 256 entries)
 _perspectives_cache: TTLCache = TTLCache(maxsize=256, ttl=7200)
+# Parallel cache keyed by content_id holding the `X-Bias-Annotation-Source`
+# value ("llm"/"spacy") for the cached body — so cache hits re-emit the
+# debug header instead of dropping it silently.
+_perspectives_source_cache: TTLCache = TTLCache(maxsize=256, ttl=7200)
 
 
 def _normalize_url_for_match(raw: str | None) -> str:
@@ -794,18 +800,23 @@ async def _attach_highlight_spans(
     db: AsyncSession,
     content: Content,
     perspectives_dicts: list[dict],
-) -> dict | None:
+) -> tuple[dict | None, Literal["llm", "spacy"]]:
     """Mutate `perspectives_dicts` in-place adding `highlight_spans` + `shared_tokens`.
 
-    Looks up cached strong_tokens for the cluster (computing & persisting if
-    missing), then diffs the reference article's tokens against each
-    perspective's. Perspectives that aren't part of any DB cluster
-    (pure Google News results) get their tokens computed in one batched
-    spaCy call. Any failure → every perspective gets empty lists.
+    Two sources possible per perspective :
+    - **LLM enriched** when `cluster_title_annotations.semantic_equiv` is
+      populated for the cluster (PR 4 pipeline). Each span carries
+      `{start, end, text, category, weight, justification}` + `bias`
+      injected from the perspective's `bias_stance` for backward compat.
+    - **spaCy fallback** otherwise (token diff between reference and
+      perspective titles). Shape : `{start, end, text, bias}`.
 
-    Returns the reference title's pivot verb span `{start, end, text}` or
-    `None` — the caller bubbles it up to the response root so the front can
-    wash the pivot in the `cm-ref-inline` block.
+    Returns `(reference_pivot, source)` where :
+    - `reference_pivot` = pivot verb span of the reference title `{start, end,
+      text}` or `None`.
+    - `source` = `"llm"` if at least one perspective was enriched via
+      `semantic_equiv`, otherwise `"spacy"`. Bubbled up to the response
+      header `X-Bias-Annotation-Source` for debugging.
     """
     try:
         svc = get_title_annotation_service()
@@ -822,6 +833,30 @@ async def _attach_highlight_spans(
             svc.compute_strong_tokens(content.title or "")
         )
 
+        # Look up LLM annotations once for the whole cluster. Filtered by
+        # both `llm_version` and `cluster_signature` — a composition change
+        # invalidates the cache and we fall back to spaCy until the
+        # pipeline re-annotates.
+        # Lazy import : `llm_bias_annotation_service` pulls in
+        # `app.services.editorial.__init__` which itself imports
+        # `editorial.pipeline` → `llm_bias_annotation_service`. Top-level
+        # import here would create a circular import at module load time.
+        from app.services.llm_bias_annotation_service import (
+            LLM_VERSION as _LLM_BIAS_VERSION,
+        )
+
+        llm_cache: dict = {}
+        if content.cluster_id and annotations.tokens_by_id:
+            cluster_signature = TitleAnnotationService.compute_cluster_signature(
+                list(annotations.tokens_by_id.keys())
+            )
+            llm_cache = await svc.get_llm_annotations(
+                db,
+                content.cluster_id,
+                _LLM_BIAS_VERSION,
+                cluster_signature,
+            )
+
         # Collect off-cluster perspective titles once and run a single
         # batched spaCy call instead of N synchronous invocations on the
         # event loop.
@@ -836,6 +871,7 @@ async def _attach_highlight_spans(
             zip(off_cluster_indices, off_cluster_tokens, strict=True)
         )
 
+        llm_used = 0
         for i, p in enumerate(perspectives_dicts):
             alt_id = annotations.id_by_url.get(p.get("url") or "")
             alt_tokens = (
@@ -843,14 +879,25 @@ async def _attach_highlight_spans(
                 if alt_id is not None
                 else tokens_by_index.get(i, [])
             )
-            p["highlight_spans"] = svc.diff_spans(
-                ref_tokens,
-                alt_tokens,
-                p.get("bias_stance") or BiasStance.UNKNOWN.value,
-            )
+            bias = p.get("bias_stance") or BiasStance.UNKNOWN.value
+
+            llm_payload = llm_cache.get(alt_id) if alt_id is not None else None
+            if llm_payload is not None:
+                # Inject `bias` per span for clients pre-PR-6 that read it
+                # alongside the new `weight`/`category`/`justification`.
+                p["highlight_spans"] = [
+                    {**span, "bias": bias}
+                    for span in llm_payload.get("target_spans") or []
+                ]
+                llm_used += 1
+            else:
+                p["highlight_spans"] = svc.diff_spans(ref_tokens, alt_tokens, bias)
             p["shared_tokens"] = svc.compute_shared_tokens(ref_tokens, alt_tokens)
 
-        return svc.compute_reference_pivot(ref_tokens)
+        return (
+            svc.compute_reference_pivot(ref_tokens),
+            "llm" if llm_used > 0 else "spacy",
+        )
     except Exception:
         logger.exception(
             "highlight_spans_failed",
@@ -860,12 +907,13 @@ async def _attach_highlight_spans(
         for p in perspectives_dicts:
             p.setdefault("highlight_spans", [])
             p.setdefault("shared_tokens", [])
-        return None
+        return (None, "spacy")
 
 
 @router.get("/{content_id}/perspectives", status_code=status.HTTP_200_OK)
 async def get_perspectives(
     content_id: UUID,
+    response: Response,
     db: AsyncSession = Depends(get_db),
     current_user_id: str = Depends(get_current_user_id),
 ):
@@ -902,6 +950,9 @@ async def get_perspectives(
     cached_response = _perspectives_cache.get(cache_key)
     if cached_response is not None:
         logger.info("perspectives_cache_hit", content_id=cache_key)
+        response.headers["X-Bias-Annotation-Source"] = (
+            _perspectives_source_cache.get(cache_key, "spacy")
+        )
         return cached_response
 
     logger.info(
@@ -1028,11 +1079,12 @@ async def get_perspectives(
         cached_row = analysis_result.scalars().first()
         cached_analysis = cached_row.analysis_text if cached_row else None
 
-        reference_pivot = await _attach_highlight_spans(
+        reference_pivot, bias_source = await _attach_highlight_spans(
             db, content, stored_perspectives
         )
+        response.headers["X-Bias-Annotation-Source"] = bias_source
 
-        response = {
+        response_body = {
             "content_id": cache_key,
             # Empty keywords: the snapshot was built without re-running the
             # Google News query path. Mobile uses keywords only as a hint
@@ -1047,7 +1099,8 @@ async def get_perspectives(
             "analysis_cached": cached_analysis is not None,
             "reference_pivot": reference_pivot,
         }
-        _perspectives_cache[cache_key] = response
+        _perspectives_cache[cache_key] = response_body
+        _perspectives_source_cache[cache_key] = bias_source
         logger.info(
             "perspectives_endpoint_stored_snapshot",
             content_id=cache_key,
@@ -1056,7 +1109,7 @@ async def get_perspectives(
             bias_groups=bias_groups,
             bias_sum=sum(stored_bias.values()),
         )
-        return response
+        return response_body
 
     # Live path (non-digest content_id, or stored snapshot missing).
     # Mirrors the editorial pipeline: include cluster's own sources so the
@@ -1195,12 +1248,16 @@ async def get_perspectives(
             "bias_stance": p.bias_stance,
             "published_at": p.published_at,
             "description": p.description,
+            "language": getattr(p, "language", None),
         }
         for p in perspectives
     ]
-    reference_pivot = await _attach_highlight_spans(db, content, perspectives_dicts)
+    reference_pivot, bias_source = await _attach_highlight_spans(
+        db, content, perspectives_dicts
+    )
+    response.headers["X-Bias-Annotation-Source"] = bias_source
 
-    response = {
+    response_body = {
         "content_id": cache_key,
         "keywords": keywords,
         "source_bias_stance": source_bias_stance,
@@ -1214,9 +1271,10 @@ async def get_perspectives(
     }
 
     # Store in cache (TTLCache handles expiration automatically)
-    _perspectives_cache[cache_key] = response
+    _perspectives_cache[cache_key] = response_body
+    _perspectives_source_cache[cache_key] = bias_source
 
-    return response
+    return response_body
 
 
 @router.post("/{content_id}/perspectives/analyze", status_code=status.HTTP_200_OK)
@@ -1328,5 +1386,6 @@ async def analyze_perspectives(
 
     # Invalidate perspectives cache so next get_perspectives includes the analysis
     _perspectives_cache.pop(cache_key, None)
+    _perspectives_source_cache.pop(cache_key, None)
 
     return response

--- a/packages/api/app/services/ml/language_filter.py
+++ b/packages/api/app/services/ml/language_filter.py
@@ -125,6 +125,20 @@ def is_french_source(source_name: str | None) -> bool:
     return any(token in needle for token in _FRENCH_SOURCE_TOKENS)
 
 
+def detect_language(title: str | None, source_name: str | None) -> str | None:
+    """Heuristique : "en" si le titre semble anglais, sinon "fr" si la source
+    est francophone connue, sinon None. Single source of truth partagée entre
+    le backfill (migration `lg01_add_language_to_contents`) et l'ingestion
+    (`sync_service._save_content`) — si la règle évolue ("on ajoute es"), les
+    deux call sites restent cohérents.
+    """
+    if looks_english(title):
+        return "en"
+    if is_french_source(source_name):
+        return "fr"
+    return None
+
+
 def looks_english(title: str | None) -> bool:
     """Renvoie True si le titre semble être en anglais.
 

--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -162,6 +162,11 @@ class Perspective:
     bias_stance: str  # left, center-left, center, center-right, right, unknown
     published_at: str | None = None
     description: str | None = None
+    # Langue détectée du titre ("fr", "en", autre — None = inconnu). Rempli
+    # côté cluster depuis `Content.language` ; les perspectives Google News
+    # restent None faute de row Content (le client traite null comme FR par
+    # défaut).
+    language: str | None = None
 
 
 STANCE_LABELS = {
@@ -761,6 +766,7 @@ class PerspectiveService:
                         else None
                     ),
                     description=getattr(content, "description", None),
+                    language=getattr(content, "language", None),
                 )
             )
         return result

--- a/packages/api/app/services/sync_service.py
+++ b/packages/api/app/services/sync_service.py
@@ -18,6 +18,7 @@ from app.models.content import Content
 from app.models.enums import ContentType, SourceType
 from app.models.source import Source, UserSource
 from app.services.content_extractor import ContentExtractor
+from app.services.ml.language_filter import detect_language
 from app.services.paywall_detector import detect_paywall
 
 logger = structlog.get_logger()
@@ -276,6 +277,7 @@ class SyncService:
             # Base content data
             content_data = {
                 "source_id": source.id,
+                "source_name": source.name,
                 "title": title,
                 "url": link,
                 "guid": guid,
@@ -646,6 +648,7 @@ class SyncService:
                 html_content=data.get("html_content"),
                 audio_url=data.get("audio_url"),
                 is_paid=data.get("is_paid", False),
+                language=detect_language(data["title"], data.get("source_name")),
                 created_at=datetime.datetime.utcnow(),
             )
 

--- a/packages/api/tests/routers/test_contents_perspectives_highlights.py
+++ b/packages/api/tests/routers/test_contents_perspectives_highlights.py
@@ -13,10 +13,13 @@ from uuid import uuid4
 import pytest
 import pytest_asyncio
 
+from app.models.cluster_title_annotation import ClusterTitleAnnotation
 from app.models.content import Content
 from app.models.enums import ContentType, SourceType
 from app.models.source import Source
 from app.routers.contents import _attach_highlight_spans
+from app.services.llm_bias_annotation_service import LLM_VERSION as LLM_BIAS_VERSION
+from app.services.title_annotation_service import TitleAnnotationService
 from tests.fixtures.fake_spacy import (
     FakeDoc,
     FakeEnt,
@@ -145,7 +148,7 @@ async def test_attach_highlight_spans_computes_for_content_without_cluster(db_se
         "app.routers.contents.get_title_annotation_service",
         return_value=fake_svc,
     ):
-        pivot = await _attach_highlight_spans(db_session, standalone, perspectives)
+        pivot, _ = await _attach_highlight_spans(db_session, standalone, perspectives)
 
     texts = {s["text"] for s in perspectives[0]["highlight_spans"]}
     assert "morts" in texts  # diverges from ref (lemma not in {Tsahal, frapper, Gaza})
@@ -357,7 +360,7 @@ async def test_attach_highlight_spans_returns_empty_when_nlp_unavailable(
         "app.routers.contents.get_title_annotation_service",
         return_value=fake_svc,
     ):
-        pivot = await _attach_highlight_spans(
+        pivot, _ = await _attach_highlight_spans(
             db_session, cluster_setup["ref"], perspectives
         )
 
@@ -383,7 +386,7 @@ async def test_attach_highlight_spans_swallows_exceptions(
         "app.routers.contents.get_title_annotation_service",
         return_value=BrokenService(),
     ):
-        pivot = await _attach_highlight_spans(
+        pivot, _ = await _attach_highlight_spans(
             db_session, cluster_setup["ref"], perspectives
         )
 
@@ -427,7 +430,7 @@ async def test_attach_highlight_spans_returns_reference_pivot_and_shared_tokens(
         "app.routers.contents.get_title_annotation_service",
         return_value=fake_svc,
     ):
-        pivot = await _attach_highlight_spans(
+        pivot, _ = await _attach_highlight_spans(
             db_session, cluster_setup["ref"], perspectives
         )
 
@@ -494,3 +497,273 @@ async def test_attach_highlight_spans_without_cluster_skips_db_scan(db_session):
     assert cluster_calls == []  # no DB scan on cluster_id IS NULL
     assert perspectives[0]["highlight_spans"] == []
     assert perspectives[0]["shared_tokens"] == []
+
+
+# --- PR 5 : LLM enriched contract -------------------------------------------
+
+# Shared fixtures for the LLM/spaCy branch tests. The Tsahal/Gaza pair is the
+# canonical example used across the calibration corpus.
+_REF_TOKENS_GAZA: list[dict] = [
+    {"start": 0, "end": 6, "text": "Tsahal", "lemma": "tsahal", "pos": "PROPN"},
+    {"start": 7, "end": 13, "text": "frappe", "lemma": "frapper", "pos": "VERB"},
+    {"start": 14, "end": 18, "text": "Gaza", "lemma": "gaza", "pos": "PROPN"},
+]
+_ALT_TOKENS_GAZA: list[dict] = [
+    {"start": 0, "end": 5, "text": "Armée", "lemma": "armée", "pos": "NOUN"},
+    {"start": 18, "end": 26, "text": "bombarde", "lemma": "bombarder", "pos": "VERB"},
+    {"start": 27, "end": 31, "text": "Gaza", "lemma": "gaza", "pos": "PROPN"},
+]
+
+
+async def _seed_strong_tokens_cache(
+    db_session, cluster_setup, ref_tokens, alt_tokens
+):
+    """Pré-peuple `cluster_title_annotations.strong_tokens` pour ref + alt_a.
+
+    Imite la sortie du pipeline spaCy déterministe (PR cta01) avant que la
+    couche LLM (PR 4) écrive `semantic_equiv`. Sans ces rows, l'appel
+    `get_or_compute_cluster_annotations` tomberait dans la branche
+    "compute_strong_tokens_batch" qui dépend du spaCy réel.
+    """
+    db_session.add_all(
+        [
+            ClusterTitleAnnotation(
+                cluster_id=cluster_setup["cluster_id"],
+                content_id=cluster_setup["ref"].id,
+                strong_tokens=ref_tokens,
+                model_version=TitleAnnotationService.MODEL_VERSION,
+            ),
+            ClusterTitleAnnotation(
+                cluster_id=cluster_setup["cluster_id"],
+                content_id=cluster_setup["alt_a"].id,
+                strong_tokens=alt_tokens,
+                model_version=TitleAnnotationService.MODEL_VERSION,
+            ),
+            ClusterTitleAnnotation(
+                cluster_id=cluster_setup["cluster_id"],
+                content_id=cluster_setup["alt_b"].id,
+                strong_tokens=ref_tokens,
+                model_version=TitleAnnotationService.MODEL_VERSION,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+
+def _cluster_signature(cluster_setup) -> str:
+    """Recompute the deterministic signature for the cluster_setup fixture."""
+    return TitleAnnotationService.compute_cluster_signature(
+        [
+            cluster_setup["ref"].id,
+            cluster_setup["alt_a"].id,
+            cluster_setup["alt_b"].id,
+        ]
+    )
+
+
+def _llm_payload(target_spans: list[dict], signature: str) -> dict:
+    """Mirror what `write_llm_annotations` persists for one variant."""
+    return {
+        "target_spans": target_spans,
+        "exclude_spans": [],
+        "notes": "test",
+        "confidence": 0.9,
+        "llm_version": LLM_BIAS_VERSION,
+        "annotated_at": "2026-05-23T12:00:00+00:00",
+        "cluster_signature": signature,
+    }
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_uses_llm_when_semantic_equiv_present(
+    db_session, cluster_setup
+):
+    """semantic_equiv populated → LLM target_spans surfaced verbatim
+    (weight/category/justification) with bias injected from the perspective."""
+    await _seed_strong_tokens_cache(
+        db_session, cluster_setup, _REF_TOKENS_GAZA, _ALT_TOKENS_GAZA
+    )
+
+    signature = _cluster_signature(cluster_setup)
+    llm_target_spans = [
+        {
+            "start": 18,
+            "end": 26,
+            "text": "bombarde",
+            "category": "editorial_angle",
+            "weight": 1.0,
+            "justification": "Verbe chargé qui dramatise l'action.",
+        }
+    ]
+    alt_row = await db_session.get(
+        ClusterTitleAnnotation,
+        (cluster_setup["cluster_id"], cluster_setup["alt_a"].id),
+    )
+    alt_row.semantic_equiv = _llm_payload(llm_target_spans, signature)
+    await db_session.commit()
+
+    fake_svc = service_with_nlp(FakeNlp({}))
+    perspectives = [
+        {
+            "title": "Armée israélienne bombarde Gaza",
+            "url": cluster_setup["alt_a"].url,
+            "bias_stance": "left",
+        }
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        pivot, source = await _attach_highlight_spans(
+            db_session, cluster_setup["ref"], perspectives
+        )
+
+    assert source == "llm"
+    spans = perspectives[0]["highlight_spans"]
+    assert len(spans) == 1
+    span = spans[0]
+    assert span["text"] == "bombarde"
+    assert span["category"] == "editorial_angle"
+    assert span["weight"] == 1.0
+    assert span["justification"] == "Verbe chargé qui dramatise l'action."
+    assert span["bias"] == "left"  # injected from p["bias_stance"] for compat
+    # Reference pivot still resolves via spaCy ref_tokens.
+    assert pivot == {"start": 7, "end": 13, "text": "frappe"}
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_falls_back_to_spacy_when_no_semantic_equiv(
+    db_session, cluster_setup
+):
+    """Cluster row exists but semantic_equiv IS NULL → spaCy fallback,
+    spans keep the legacy {start, end, text, bias} shape."""
+    await _seed_strong_tokens_cache(
+        db_session, cluster_setup, _REF_TOKENS_GAZA, _ALT_TOKENS_GAZA
+    )
+
+    fake_svc = service_with_nlp(FakeNlp({}))
+    perspectives = [
+        {
+            "title": "Armée israélienne bombarde Gaza",
+            "url": cluster_setup["alt_a"].url,
+            "bias_stance": "left",
+        }
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        _, source = await _attach_highlight_spans(
+            db_session, cluster_setup["ref"], perspectives
+        )
+
+    assert source == "spacy"
+    spans = perspectives[0]["highlight_spans"]
+    assert spans, "spaCy fallback must still produce spans"
+    for span in spans:
+        # Legacy contract: no LLM fields leak in.
+        assert set(span.keys()) == {"start", "end", "text", "bias"}
+        assert span["bias"] == "left"
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_invalidates_llm_on_cluster_signature_mismatch(
+    db_session, cluster_setup
+):
+    """semantic_equiv exists but cluster_signature is stale → cache ignored,
+    fallback to spaCy. End-to-end check of the versioning gate from PR 3."""
+    await _seed_strong_tokens_cache(
+        db_session, cluster_setup, _REF_TOKENS_GAZA, _ALT_TOKENS_GAZA
+    )
+
+    stale_payload = _llm_payload(
+        [
+            {
+                "start": 18,
+                "end": 26,
+                "text": "bombarde",
+                "category": "editorial_angle",
+                "weight": 1.0,
+                "justification": "stale",
+            }
+        ],
+        signature="deadbeefdeadbeef",  # not the real signature
+    )
+    alt_row = await db_session.get(
+        ClusterTitleAnnotation,
+        (cluster_setup["cluster_id"], cluster_setup["alt_a"].id),
+    )
+    alt_row.semantic_equiv = stale_payload
+    await db_session.commit()
+
+    fake_svc = service_with_nlp(FakeNlp({}))
+    perspectives = [
+        {
+            "title": "Armée israélienne bombarde Gaza",
+            "url": cluster_setup["alt_a"].url,
+            "bias_stance": "left",
+        }
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        _, source = await _attach_highlight_spans(
+            db_session, cluster_setup["ref"], perspectives
+        )
+
+    assert source == "spacy"
+    for span in perspectives[0]["highlight_spans"]:
+        assert "weight" not in span  # no LLM fields leaked through
+
+
+@pytest.mark.asyncio
+async def test_build_cluster_perspectives_propagates_content_language(db_session):
+    """`Perspective.language` mirrors `Content.language` so the endpoint
+    list-comp can expose it without an extra DB lookup."""
+    from app.services.perspective_service import PerspectiveService
+
+    source = Source(
+        id=uuid4(),
+        name="Reuters",  # not in is_french_source whitelist → simulate EN feed
+        url="https://reuters.com",
+        feed_url=f"https://reuters.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+    )
+    db_session.add(source)
+    await db_session.commit()
+    content_en = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title="Israel strikes Gaza after attacks",
+        url="https://reuters.com/article-en",
+        published_at=datetime.now(UTC),
+        content_type=ContentType.ARTICLE,
+        guid="en",
+        language="en",
+    )
+    content_fr = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title="Tsahal frappe Gaza",
+        url="https://reuters.com/article-fr",
+        published_at=datetime.now(UTC),
+        content_type=ContentType.ARTICLE,
+        guid="fr",
+        language="fr",
+    )
+    db_session.add_all([content_en, content_fr])
+    await db_session.commit()
+    # Reload so `content.source` relationship is populated.
+    await db_session.refresh(content_en, attribute_names=["source"])
+    await db_session.refresh(content_fr, attribute_names=["source"])
+
+    perspectives = await PerspectiveService(db_session).build_cluster_perspectives(
+        [content_en, content_fr]
+    )
+    # Single perspective per source_id — keep the one that landed first.
+    assert len(perspectives) == 1
+    assert perspectives[0].language == "en"


### PR DESCRIPTION
## Quoi

PR 5 de la chaîne LLM bias annotation. Enrichit le contrat de
`GET /contents/{id}/perspectives` pour exposer les annotations LLM
(`weight` / `category` / `justification`) quand `semantic_equiv` est
en base, sinon retourne le format spaCy actuel. Ajoute un header de
debug `X-Bias-Annotation-Source: llm|spacy` et expose `language`
sur chaque perspective.

## Pourquoi

Les annotations LLM (`semantic_equiv.target_spans` pondérés + tooltips
de justification) sont produites par le pipeline mergé en PR 4
(#648), mais le contrat API actuel les ignore. Sans cette PR, le
mobile (PR 6) ne peut pas afficher les poids ni les tooltips. Le
champ `language` est requis par la future section « Couverture
étrangère » pour regrouper les perspectives non-FR.

## Changements

- **`Content.language`** : colonne `String(8)` nullable + index +
  migration Alembic `lg01_add_language_to_contents` avec backfill
  heuristique (`detect_language` = `looks_english` puis
  `is_french_source`). Les nouveaux contents sont remplis à
  l'ingestion (`sync_service._save_content`).
- **`Perspective.language`** ajouté au dataclass, propagé depuis
  `Content.language` dans `build_cluster_perspectives`. Les
  perspectives Google News restent `None` (pas de row `Content`).
- **`_attach_highlight_spans`** refactoré pour retourner
  `tuple[dict | None, Literal["llm", "spacy"]]`. Si `semantic_equiv`
  est rempli pour le cluster (filtré par `llm_version` +
  `cluster_signature`), les target_spans LLM sont sérialisés tels
  quels, avec `bias` injecté depuis `bias_stance` pour rétrocompat.
  Sinon → fallback spaCy inchangé.
- **Header `X-Bias-Annotation-Source`** posé via `Response` injecté
  dans la signature FastAPI. Cache hit ré-attache le header via un
  `_perspectives_source_cache` parallèle (sinon le header
  disparaissait silencieusement après la 1ère requête).
- **`detect_language`** factorisé dans
  `app/services/ml/language_filter.py` — single source of truth pour
  l'ingestion ET la migration de backfill.

## Comment ça a été vérifié

- [x] `pytest tests/routers/test_contents_perspectives_highlights.py`
  — 13 OK (9 existants adaptés au tuple + 4 nouveaux : LLM enriched,
  fallback spaCy, signature mismatch, language propagation).
- [x] Suite complète backend : **1242 passed, 1 skipped, 2 xfailed**
  (134 s).
- [x] `alembic heads` → exactement 1 head
  (`lg01_add_language_to_contents`).
- [x] `alembic upgrade --sql` → DDL généré correctement
  (`ALTER TABLE contents ADD COLUMN language VARCHAR(8)` +
  `CREATE INDEX ix_contents_language`).
- [x] `/simplify` passé : 5 fixes appliqués (factoriser
  `detect_language`, bug header cache hit, dédupliquer `alt_tokens`,
  hoister fixtures de tests, type `Literal`).

⚠️ **Round-trip migration live non testable localement** : le
container Postgres test du workspace est dans un état désync (« Can't
locate revision identified by 'b3c4d5e6f7a8' ») hérité d'un autre
workspace. La migration sera testée pour de vrai par le `alembic
upgrade head` du `Dockerfile` Railway au prochain boot.

## Zones à risque

- **Cache header** : nouveau dict `_perspectives_source_cache`
  parallèle invalidé en même temps que `_perspectives_cache`
  (`_perspectives_source_cache.pop` à côté de chaque
  `_perspectives_cache.pop`). À surveiller : si une autre branche
  oublie d'invalider l'un sans l'autre, le header pourrait diverger
  du body.
- **Backfill migration** : tourne dans une seule transaction
  Alembic ; `env.py` désactive le `statement_timeout` via
  `SET LOCAL statement_timeout = '0'`, donc pas de cap théorique.
  Avec ~quelques 100k rows en prod, ça devrait passer en quelques
  minutes. Idempotent (`WHERE language IS NULL`).
- **Rétrocompat client** : confirmée par
  `test_attach_highlight_spans_falls_back_to_spacy_when_no_semantic_equiv` —
  les apps pre-PR-6 reçoivent le format spaCy historique.
- **Stored snapshot path** : `language` est lu via
  `getattr(p, "language", None)`, donc les snapshots déjà sérialisés
  sans le champ tomberont à `null` (PR 6 traite `null` comme FR par
  défaut).

## Dette pré-existante (hors scope)

`tests/services/test_llm_bias_annotation_service.py` ne collecte pas
sur `main` à cause d'un import circulaire via
`app.services.editorial.__init__` → `pipeline` →
`llm_bias_annotation_service`. Vérifié : présent avant cette PR.
À traiter dans une PR follow-up.