### PR TITLE
feat(mobile): UI cleanup titres perspectives + plumbing weight forward-compat (PR 6)

### DIFF
--- a/apps/mobile/lib/features/feed/repositories/feed_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/feed_repository.dart
@@ -1015,18 +1015,27 @@ class PerspectivesResponse {
 }
 
 /// Span de surlignage colorisé selon le bord de la source.
-/// Renvoyé par le back via `highlight_spans: [{start,end,text,bias}]`.
+/// Renvoyé par le back via `highlight_spans: [{start,end,text,bias,
+/// weight?,category?,justification?}]`. Les 3 derniers champs sont optionnels,
+/// présents uniquement quand l'annotation LLM (Phase 4) a couvert le span ;
+/// absents en mode fallback spaCy.
 class HighlightSpan {
   final int start;
   final int end;
   final String text;
   final String bias;
+  final double? weight;
+  final String? category;
+  final String? justification;
 
   const HighlightSpan({
     required this.start,
     required this.end,
     required this.text,
     required this.bias,
+    this.weight,
+    this.category,
+    this.justification,
   });
 
   factory HighlightSpan.fromJson(Map<String, dynamic> json) {
@@ -1035,6 +1044,9 @@ class HighlightSpan {
       end: (json['end'] as num?)?.toInt() ?? 0,
       text: (json['text'] as String?) ?? '',
       bias: (json['bias'] as String?) ?? 'unknown',
+      weight: (json['weight'] as num?)?.toDouble(),
+      category: json['category'] as String?,
+      justification: json['justification'] as String?,
     );
   }
 }
@@ -1080,6 +1092,10 @@ class PerspectiveData {
   /// Spans partagés avec la référence — rendus en `text_tertiary` côté front
   /// pour faire ressortir les divergences. Liste vide en mode dégradé Mode 2.
   final List<TokenSpan> sharedTokens;
+  /// Langue ISO du titre ("fr","en",...). Optionnel — exposé par PR 5
+  /// (API enriched contract). Sert au regroupement "Couverture étrangère"
+  /// (PR 6.1) côté front.
+  final String? language;
 
   PerspectiveData({
     required this.title,
@@ -1090,6 +1106,7 @@ class PerspectiveData {
     this.publishedAt,
     this.highlightSpans = const [],
     this.sharedTokens = const [],
+    this.language,
   });
 
   factory PerspectiveData.fromJson(Map<String, dynamic> json) {
@@ -1112,6 +1129,7 @@ class PerspectiveData {
           : rawShared
               .map((e) => TokenSpan.fromJson(e as Map<String, dynamic>))
               .toList(),
+      language: json['language'] as String?,
     );
   }
 }

--- a/apps/mobile/lib/features/feed/widgets/diff_title.dart
+++ b/apps/mobile/lib/features/feed/widgets/diff_title.dart
@@ -118,7 +118,9 @@ class _DiffTitleState extends State<DiffTitle>
     for (final s in widget.highlightSpans) {
       final start = s.start.clamp(0, titleLen);
       final end = s.end.clamp(start, titleLen);
-      if (end > start) spans.add(_RawSpan(start, end, _ChunkType.key));
+      if (end > start) {
+        spans.add(_RawSpan(start, end, _ChunkType.key, weight: s.weight));
+      }
     }
     if (useSharedAsTertiary) {
       for (final s in widget.sharedTokens) {
@@ -147,6 +149,7 @@ class _DiffTitleState extends State<DiffTitle>
         text: title.substring(span.start, span.end),
         type: span.type,
         animIndex: animIndex,
+        weight: span.weight,
       ));
       animIndex++;
       cursor = span.end;
@@ -214,21 +217,13 @@ class _DiffTitleState extends State<DiffTitle>
   InlineSpan _buildInlineSpan(_Chunk chunk, FacteurColors colors) {
     switch (chunk.type) {
       case _ChunkType.plain:
+      case _ChunkType.dimmedFallback:
+      case _ChunkType.shared:
+        // Tous les chunks non-key partagent la même couleur textPrimary —
+        // seul le surlignage de fond (key) différencie visuellement.
         return TextSpan(
           text: chunk.text,
           style: TextStyle(color: colors.textPrimary, fontWeight: FontWeight.w400),
-        );
-      case _ChunkType.dimmedFallback:
-        return TextSpan(
-          text: chunk.text,
-          style: TextStyle(color: colors.textTertiary, fontWeight: FontWeight.w400),
-        );
-      case _ChunkType.shared:
-        final t = _easedProgressFor(chunk.animIndex);
-        final color = Color.lerp(colors.textPrimary, colors.textTertiary, t)!;
-        return TextSpan(
-          text: chunk.text,
-          style: TextStyle(color: color, fontWeight: FontWeight.w400),
         );
       case _ChunkType.key:
         final t = _easedProgressFor(chunk.animIndex);
@@ -238,7 +233,8 @@ class _DiffTitleState extends State<DiffTitle>
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
             decoration: BoxDecoration(
-              color: widget.biasColor.withValues(alpha: 0.22 * t),
+              color: widget.biasColor
+                  .withValues(alpha: 0.22 * t * (chunk.weight ?? 1.0)),
               borderRadius: BorderRadius.circular(4),
             ),
             child: Text(
@@ -260,12 +256,22 @@ class _Chunk {
   final String text;
   final _ChunkType type;
   final int animIndex;
-  const _Chunk({required this.text, required this.type, this.animIndex = -1});
+  /// LLM bias weight ∈ {0.25, 0.5, 1.0} ou null (fallback spaCy).
+  /// Module l'opacité du surlignage pour les chunks de type `key`.
+  /// null → traité comme 1.0 (comportement actuel).
+  final double? weight;
+  const _Chunk({
+    required this.text,
+    required this.type,
+    this.animIndex = -1,
+    this.weight,
+  });
 }
 
 class _RawSpan {
   final int start;
   final int end;
   final _ChunkType type;
-  const _RawSpan(this.start, this.end, this.type);
+  final double? weight;
+  const _RawSpan(this.start, this.end, this.type, {this.weight});
 }

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -28,6 +28,9 @@ class Perspective {
   final List<HighlightSpan> highlightSpans;
   /// Tokens partagés avec la référence (rendus en text_tertiary par DiffTitle).
   final List<TokenSpan> sharedTokens;
+  /// Langue ISO du titre ("fr","en",...). Optionnel — exposé par PR 5.
+  /// Réservé au regroupement "Couverture étrangère" (PR 6.1).
+  final String? language;
 
   Perspective({
     required this.title,
@@ -38,6 +41,7 @@ class Perspective {
     this.publishedAt,
     this.highlightSpans = const [],
     this.sharedTokens = const [],
+    this.language,
   });
 
   factory Perspective.fromJson(Map<String, dynamic> json) {
@@ -60,6 +64,7 @@ class Perspective {
           : rawShared
               .map((e) => TokenSpan.fromJson(e as Map<String, dynamic>))
               .toList(),
+      language: json['language'] as String?,
     );
   }
 
@@ -618,12 +623,12 @@ class _PerspectiveCard extends ConsumerWidget {
                           baseStyle: textTheme.bodyMedium?.copyWith(
                                 color: colors.textPrimary,
                                 fontSize:
-                                    (textTheme.bodyMedium?.fontSize ?? 14) + 1,
+                                    (textTheme.bodyMedium?.fontSize ?? 14) + 2,
                                 height: 1.35,
                               ) ??
                               TextStyle(
                                 color: colors.textPrimary,
-                                fontSize: 15,
+                                fontSize: 16,
                                 height: 1.35,
                               ),
                           maxLines: 4,
@@ -1689,8 +1694,8 @@ class _PivotedRefTitleState extends State<_PivotedRefTitle>
   }
 }
 
-/// Ligne variante (cm-vrow) — border-left 4 px couleur bias + head row
-/// (favicon + nom + bias label + arrow) + DiffTitle animé. Tap → launchUrl
+/// Ligne variante (cm-vrow) — border-left 4 px couleur bias + DiffTitle animé
+/// suivi d'une foot row (favicon + nom + bias label + arrow). Tap → launchUrl
 /// externe.
 class _VariantRow extends ConsumerWidget {
   final Perspective perspective;
@@ -1748,6 +1753,19 @@ class _VariantRow extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            DiffTitle(
+              title: perspective.title,
+              highlightSpans: perspective.highlightSpans,
+              sharedTokens: perspective.sharedTokens,
+              biasColor: biasColor,
+              baseStyle: textTheme.bodyMedium?.copyWith(
+                    fontSize: 15.5,
+                    height: 1.35,
+                    color: colors.textPrimary,
+                  ) ??
+                  TextStyle(fontSize: 15.5, color: colors.textPrimary),
+            ),
+            const SizedBox(height: 6),
             Row(
               children: [
                 if (perspective.sourceDomain.isNotEmpty)
@@ -1794,19 +1812,6 @@ class _VariantRow extends ConsumerWidget {
                   color: colors.textTertiary,
                 ),
               ],
-            ),
-            const SizedBox(height: 6),
-            DiffTitle(
-              title: perspective.title,
-              highlightSpans: perspective.highlightSpans,
-              sharedTokens: perspective.sharedTokens,
-              biasColor: biasColor,
-              baseStyle: textTheme.bodyMedium?.copyWith(
-                    fontSize: 14.5,
-                    height: 1.35,
-                    color: colors.textPrimary,
-                  ) ??
-                  TextStyle(fontSize: 14.5, color: colors.textPrimary),
             ),
           ],
         ),

--- a/apps/mobile/test/features/feed/widgets/diff_title_test.dart
+++ b/apps/mobile/test/features/feed/widgets/diff_title_test.dart
@@ -51,8 +51,11 @@ void main() {
       expect(combined.contains('réforme'), isTrue);
     });
 
-    testWidgets('fallback Mode 2 : sans sharedTokens → hors-key en tertiary',
+    testWidgets('Mode 2 : sans sharedTokens → titre reconstruit, wash sur key',
         (tester) async {
+      // PR 6 : la couleur uniforme textPrimary est désormais appliquée à tous
+      // les chunks (plain / dimmedFallback / shared). Seul le surlignage de
+      // fond du key span différencie visuellement.
       await tester.pumpWidget(host(DiffTitle(
         title: 'Tsahal frappe Gaza',
         highlightSpans: const [
@@ -65,9 +68,7 @@ void main() {
       )));
       await tester.pumpAndSettle();
 
-      // Mode 2 : le titre est toujours reconstruit, et le hors-key (Tsahal,
-      // Gaza) doit être en text_tertiary. On vérifie au moins que le widget
-      // a bien un wash (Container) pour le key span.
+      // Wash (Container) sur le key span.
       expect(find.byType(Container), findsWidgets);
       final combined = _richTextStrings(tester).join();
       expect(combined.contains('Tsahal'), isTrue);

--- a/apps/mobile/test/features/feed/widgets/diff_title_uniform_color_test.dart
+++ b/apps/mobile/test/features/feed/widgets/diff_title_uniform_color_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart';
+import 'package:facteur/features/feed/widgets/diff_title.dart';
+
+/// PR 6 — couleur uniforme textPrimary pour tous les chunks non-key.
+///
+/// Avant : tokens partagés / dimmedFallback étaient rendus en textTertiary,
+/// créant une différenciation typographique entre tokens partagés et
+/// divergents. PO a demandé : tous les textes des titres en même couleur.
+/// Seul le surlignage de fond du key span différencie désormais.
+void main() {
+  Color primary() =>
+      FacteurTheme.lightTheme.extension<FacteurColors>()!.textPrimary;
+  Color tertiary() =>
+      FacteurTheme.lightTheme.extension<FacteurColors>()!.textTertiary;
+
+  Widget host(DiffTitle child) {
+    return MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(body: Center(child: child)),
+    );
+  }
+
+  List<TextSpan> collectTextSpans(WidgetTester tester) {
+    final spans = <TextSpan>[];
+    for (final rt in tester.widgetList<RichText>(find.byType(RichText))) {
+      rt.text.visitChildren((span) {
+        if (span is TextSpan && (span.text?.isNotEmpty ?? false)) {
+          spans.add(span);
+        }
+        return true;
+      });
+    }
+    return spans;
+  }
+
+  group('DiffTitle — uniform textPrimary color', () {
+    testWidgets('Mode 3 (key + shared) : tous les TextSpan en textPrimary',
+        (tester) async {
+      await tester.pumpWidget(host(DiffTitle(
+        title: 'Macron annonce une réforme',
+        highlightSpans: const [
+          HighlightSpan(start: 7, end: 14, text: 'annonce', bias: 'right'),
+        ],
+        sharedTokens: const [
+          TokenSpan(start: 0, end: 6, text: 'Macron'),
+          TokenSpan(start: 19, end: 26, text: 'réforme'),
+        ],
+        biasColor: Colors.red,
+        baseStyle: const TextStyle(fontSize: 14),
+        animateIn: false,
+      )));
+      await tester.pumpAndSettle();
+
+      final spans = collectTextSpans(tester);
+      expect(spans, isNotEmpty);
+      for (final s in spans) {
+        // Le key span est rendu via WidgetSpan → texte enfant Text — récupéré
+        // aussi par visitChildren et doit également être textPrimary.
+        expect(s.style?.color, primary(),
+            reason: 'Tous les TextSpan doivent être en textPrimary, vu: '
+                '${s.text} → ${s.style?.color}');
+        expect(s.style?.color, isNot(tertiary()));
+      }
+    });
+
+    testWidgets('Mode 2 (sans shared) : pas de textTertiary sur le hors-key',
+        (tester) async {
+      await tester.pumpWidget(host(DiffTitle(
+        title: 'Tsahal frappe Gaza',
+        highlightSpans: const [
+          HighlightSpan(start: 7, end: 13, text: 'frappe', bias: 'left'),
+        ],
+        sharedTokens: const [],
+        biasColor: Colors.blue,
+        baseStyle: const TextStyle(fontSize: 14),
+        animateIn: false,
+      )));
+      await tester.pumpAndSettle();
+
+      final spans = collectTextSpans(tester);
+      expect(spans, isNotEmpty);
+      for (final s in spans) {
+        expect(s.style?.color, primary(),
+            reason: 'Mode 2 : hors-key doit être en textPrimary, pas tertiary');
+        expect(s.style?.color, isNot(tertiary()));
+      }
+    });
+
+    testWidgets('Mode shared en cours d\'animation : reste en textPrimary',
+        (tester) async {
+      // Avant PR 6 : la couleur des shared chunks était interpolée entre
+      // textPrimary et textTertiary par Color.lerp pendant la cascade. PR 6 :
+      // plus d'interpolation, couleur constante textPrimary à tous les frames.
+      await tester.pumpWidget(host(DiffTitle(
+        title: 'Macron annonce',
+        highlightSpans: const [
+          HighlightSpan(start: 7, end: 14, text: 'annonce', bias: 'right'),
+        ],
+        sharedTokens: const [TokenSpan(start: 0, end: 6, text: 'Macron')],
+        biasColor: Colors.red,
+        baseStyle: const TextStyle(fontSize: 14),
+        animateIn: true,
+      )));
+      // Pump à mi-animation
+      await tester.pump(const Duration(milliseconds: 380));
+      final spans = collectTextSpans(tester);
+      for (final s in spans) {
+        expect(s.style?.color, primary(),
+            reason:
+                'À tous les frames de la cascade, les TextSpan doivent rester '
+                'en textPrimary (plus d\'interpolation Color.lerp).');
+      }
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/widgets/diff_title_weight_test.dart
+++ b/apps/mobile/test/features/feed/widgets/diff_title_weight_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart';
+import 'package:facteur/features/feed/widgets/diff_title.dart';
+
+/// PR 6 — modulation d'opacité du surlignage par `weight` LLM.
+///
+/// Le surlignage du key span (Container avec BoxDecoration colorée) doit avoir
+/// une opacité = 0.22 * t * (weight ?? 1.0). animateIn=false → t=1.
+///
+/// Spec :
+///   weight = 1.0    → alpha = 0.22 (comportement actuel, max)
+///   weight = 0.5    → alpha = 0.11
+///   weight = 0.25   → alpha = 0.055
+///   weight = null   → alpha = 0.22 (fallback rétrocompat, sans modulation)
+void main() {
+  Widget host(DiffTitle child) {
+    return MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(body: Center(child: child)),
+    );
+  }
+
+  /// Récupère l'alpha appliqué à la couleur du Container du key span.
+  /// On suppose un seul Container dans l'arbre — c'est le wash du key.
+  double? keyWashAlpha(WidgetTester tester) {
+    final containers = tester.widgetList<Container>(find.byType(Container));
+    for (final c in containers) {
+      final dec = c.decoration;
+      if (dec is BoxDecoration && dec.color != null) {
+        final col = dec.color!;
+        // Le Container du wash a une couleur dérivée de biasColor (red ici).
+        // On le distingue des autres Container vides en filtrant sur "a une
+        // couleur non-transparente et un borderRadius".
+        if (dec.borderRadius != null) {
+          // alpha est dans [0,1] en double API moderne (Color.a) ou /255 sinon.
+          return col.a;
+        }
+      }
+    }
+    return null;
+  }
+
+  group('DiffTitle — weight modulation', () {
+    testWidgets('weight = 1.0 → alpha ≈ 0.22', (tester) async {
+      await tester.pumpWidget(host(DiffTitle(
+        title: 'Macron annonce une réforme',
+        highlightSpans: const [
+          HighlightSpan(
+            start: 7,
+            end: 14,
+            text: 'annonce',
+            bias: 'right',
+            weight: 1.0,
+          ),
+        ],
+        sharedTokens: const [],
+        biasColor: Colors.red,
+        baseStyle: const TextStyle(fontSize: 14),
+        animateIn: false,
+      )));
+      await tester.pumpAndSettle();
+
+      final alpha = keyWashAlpha(tester);
+      expect(alpha, isNotNull);
+      expect(alpha!, closeTo(0.22, 0.005));
+    });
+
+    testWidgets('weight = 0.5 → alpha ≈ 0.11', (tester) async {
+      await tester.pumpWidget(host(DiffTitle(
+        title: 'Macron annonce une réforme',
+        highlightSpans: const [
+          HighlightSpan(
+            start: 7,
+            end: 14,
+            text: 'annonce',
+            bias: 'right',
+            weight: 0.5,
+          ),
+        ],
+        sharedTokens: const [],
+        biasColor: Colors.red,
+        baseStyle: const TextStyle(fontSize: 14),
+        animateIn: false,
+      )));
+      await tester.pumpAndSettle();
+
+      final alpha = keyWashAlpha(tester);
+      expect(alpha, isNotNull);
+      expect(alpha!, closeTo(0.11, 0.005));
+    });
+
+    testWidgets('weight = 0.25 → alpha ≈ 0.055', (tester) async {
+      await tester.pumpWidget(host(DiffTitle(
+        title: 'Macron annonce une réforme',
+        highlightSpans: const [
+          HighlightSpan(
+            start: 7,
+            end: 14,
+            text: 'annonce',
+            bias: 'right',
+            weight: 0.25,
+          ),
+        ],
+        sharedTokens: const [],
+        biasColor: Colors.red,
+        baseStyle: const TextStyle(fontSize: 14),
+        animateIn: false,
+      )));
+      await tester.pumpAndSettle();
+
+      final alpha = keyWashAlpha(tester);
+      expect(alpha, isNotNull);
+      expect(alpha!, closeTo(0.055, 0.005));
+    });
+
+    testWidgets('weight = null → alpha ≈ 0.22 (rétrocompat)', (tester) async {
+      // C'est le cas pre-PR 5 : l'API ne renvoie pas weight. Le fallback (?? 1.0)
+      // garantit que le rendu est identique à l'avant-PR 6 (alpha = 0.22).
+      await tester.pumpWidget(host(DiffTitle(
+        title: 'Macron annonce une réforme',
+        highlightSpans: const [
+          HighlightSpan(start: 7, end: 14, text: 'annonce', bias: 'right'),
+        ],
+        sharedTokens: const [],
+        biasColor: Colors.red,
+        baseStyle: const TextStyle(fontSize: 14),
+        animateIn: false,
+      )));
+      await tester.pumpAndSettle();
+
+      final alpha = keyWashAlpha(tester);
+      expect(alpha, isNotNull);
+      expect(alpha!, closeTo(0.22, 0.005));
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/widgets/variant_row_source_below_test.dart
+++ b/apps/mobile/test/features/feed/widgets/variant_row_source_below_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart'
+    show HighlightSpan, TokenSpan;
+import 'package:facteur/features/feed/widgets/diff_title.dart';
+import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
+
+/// PR 6 — feedback PO : dans le mode inline (_VariantRow), la head row
+/// (favicon + source + bias label + arrow) doit passer SOUS le DiffTitle.
+/// Vérifie l'ordre vertical via les positions absolues des deux widgets.
+Perspective _persp(String name, String bias) => Perspective(
+      title: 'Titre court avec mot fort',
+      url: 'https://example.com/$name',
+      sourceName: name,
+      sourceDomain: '',
+      biasStance: bias,
+      highlightSpans: const [
+        HighlightSpan(start: 18, end: 22, text: 'fort', bias: 'left'),
+      ],
+      sharedTokens: const [TokenSpan(start: 0, end: 5, text: 'Titre')],
+    );
+
+Widget _harness() {
+  return ProviderScope(
+    child: MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: SizedBox(
+            width: 390,
+            child: PerspectivesInlineSection(
+              perspectives: [
+                _persp('Source-Gauche', 'left'),
+                _persp('Source-Droite', 'right'),
+              ],
+              biasDistribution: const {'left': 1, 'right': 1},
+              keywords: const [],
+              contentId: 'test',
+              externalSelectedSegments: null,
+              onSegmentTap: (_) {},
+              onClearSegments: () {},
+              onToggle: () {},
+              isExpanded: true,
+              referenceTitle: '',
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets(
+      '_VariantRow : DiffTitle est placé AU-DESSUS de la head row (favicon + arrow)',
+      (tester) async {
+    await tester.pumpWidget(_harness());
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    final diffTitles = find.byType(DiffTitle);
+    expect(diffTitles, findsWidgets,
+        reason: 'Au moins un DiffTitle doit être présent dans les variants.');
+
+    // L'icône arrowUpRight ne se trouve que dans la head row du _VariantRow.
+    final arrowIcons = find.byWidgetPredicate((w) =>
+        w is Icon &&
+        w.icon == PhosphorIcons.arrowUpRight(PhosphorIconsStyle.regular));
+    expect(arrowIcons, findsWidgets,
+        reason:
+            'L\'icône arrow-up-right est l\'ancre de la head row dans _VariantRow.');
+
+    // Compare la position verticale du premier DiffTitle vs le premier arrow :
+    // après PR 6, le DiffTitle doit être au-dessus (dy plus petit).
+    final firstDiffTitleY = tester.getTopLeft(diffTitles.first).dy;
+    final firstArrowY = tester.getTopLeft(arrowIcons.first).dy;
+
+    expect(firstDiffTitleY, lessThan(firstArrowY),
+        reason:
+            'Le DiffTitle doit être placé AU-DESSUS de la head row (favicon + '
+            'source + arrow). Position DiffTitle.dy=$firstDiffTitleY doit être '
+            '< position arrow.dy=$firstArrowY.');
+  });
+}


### PR DESCRIPTION
## Quoi

PR 6 partielle (plumbing forward-compat) + UI cleanup titres des perspectives.

Trois axes :
1. **UI cleanup titres** (feedback PO 2026-05-23) : couleur uniforme, taille augmentée, source déplacée sous le titre dans le mode inline.
2. **Plumbing forward-compat PR 5** : `HighlightSpan` (+`weight`/`category`/`justification`) et `Perspective`/`PerspectiveData` (+`language`) parsés en optional. Modulation alpha activée automatiquement dès que l'API expose `weight`.
3. **Hors-scope explicite** : section « Couverture étrangère » → PR 6.1 (dépend de `language` exposé par PR 5). Tap-to-justification → PR 7.

## Pourquoi

Le PO a demandé (2026-05-23) :
- Plus de différenciation typographique entre tokens partagés et divergents — seul le surlignage de fond doit différencier. Améliore la lisibilité.
- Titres légèrement plus grands sur les deux modes (inline + bottom-sheet) — harmonisation.
- Source / favicon / bias label sous le titre en mode inline (où ils étaient au-dessus) pour donner la primauté au titre.
- Préparer la consommation du contrat enrichi PR 5 sans bloquer PR 6 sur la merge backend.

Memory PO `[[project_perspectives_foreign_coverage]]` → reportée en PR 6.1.

## Comment ça a été vérifié

- [x] `flutter test` widget feed/ : 22/22 verts sur les fichiers touchés (3 nouveaux fichiers de test + non-régression `perspectives_inline_*`)
- [x] `flutter analyze` sur fichiers modifiés : 0 error, 0 warning
- [x] `flutter test` mobile complet : 654 verts, 36 échecs **pré-existants sur main** (refresh / mute / undo banner / digest completion — sans rapport avec PR 6, confirmé via `git stash` comparatif)
- [x] `simplify` skill : code clean, 0 modif suggérée actionnable
- [x] Grep analytics (`bias_chip_tapped`, `source_logo_tapped`) : aucun event ne dépend du parent layout modifié dans `_VariantRow`
- [ ] **À faire avant merge** : `/validate-feature` Chrome (viewport 390×844 + 360×640) — couverture programmatique assurée par les widget tests mais le visuel final (fontSize bump réel, ordre des éléments à l'œil nu) gagne à être confirmé par le PO. Skippé ici car nécessite démarrage de l'API local + flutter web + dataset cohérent.

### Nouveaux tests

- `diff_title_weight_test.dart` — 4 cas : weight 1.0 / 0.5 / 0.25 / null → alpha 0.22 / 0.11 / 0.055 / 0.22
- `diff_title_uniform_color_test.dart` — Mode 3, Mode 2, en cours d'animation : tous les `TextSpan` en `textPrimary`
- `variant_row_source_below_test.dart` — position dy : DiffTitle au-dessus de la head row

## Zones à risque

- `apps/mobile/lib/features/feed/widgets/diff_title.dart` — surlignage des titres (Mode 2 / Mode 3) ; comportement préservé pour articles non-digest (`weight == null` → alpha 0.22 comme avant)
- `apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart` — `_VariantRow` ré-ordonné ; aucun event analytics ne dépend du parent layout
- `apps/mobile/lib/features/feed/repositories/feed_repository.dart` — `HighlightSpan.fromJson` et `PerspectiveData.fromJson` parsent 3+1 champs optional ; si l'API ne les renvoie pas, comportement actuel inchangé

## Pour la suite

- **PR 6.1** : section « Couverture étrangère » (regroupe `language != "fr"`) + activation rendu de la modulation `weight` live, post-merge PR 5
- **PR 7** : Overlay positioned au tap pour afficher `HighlightSpan.justification` (champ déjà propagé dans `_Chunk` après PR 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)