### PR TITLE
perf(mobile): boot parallélisé + préchargement Flux Continu (cold start <1s, round 1)

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -9,6 +9,7 @@ import 'core/services/deep_link_service.dart';
 import 'core/services/widget_service.dart';
 import 'features/feed/providers/feed_preload_provider.dart';
 import 'features/feed/providers/feed_provider.dart';
+import 'features/flux_continu/providers/flux_continu_preload_provider.dart';
 import 'features/my_interests/services/interests_sync_service.dart';
 import 'features/onboarding/providers/onboarding_sync_provider.dart';
 import 'features/settings/providers/theme_provider.dart';
@@ -116,6 +117,12 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
     // watches auth state and kicks off `feedProvider.future` in the
     // background so the Feed tab renders instantly on first tap.
     ref.watch(feedPreloadProvider);
+
+    // Same pattern for the home screen (Flux Continu) — kicks off the 4
+    // endpoints in parallel as soon as auth is confirmed, in parallel with
+    // GoRouter's splash → /flux-continu redirect. Cuts ~1-2s off the cold
+    // open path.
+    ref.watch(fluxContinuPreloadProvider);
 
     // Active la re-sync automatique de l'onboarding quand la session devient
     // authentifiée (best-effort, silencieux) — voir onboarding_sync_provider.dart.

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_preload_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_preload_provider.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/auth/auth_state.dart';
+import 'flux_continu_provider.dart';
+
+/// Kicks off `fluxContinuProvider.future` in the background as soon as the
+/// user is authenticated, email-confirmed and past onboarding — so by the
+/// time GoRouter has finished its redirect to `/flux-continu`, the four
+/// underlying endpoints (digest/both, top-themes, feed page 1, essentiel)
+/// are already in-flight or resolved.
+///
+/// Mirrors the pattern of `feedPreloadProvider` but targets the home screen.
+/// The provider exposes no state — it's a pure side-effect trigger meant to
+/// be watched from the top-level widget tree (`FacteurApp`) so it stays
+/// active for the entire authenticated session.
+///
+/// Idempotency: [Ref.read] on an [AsyncNotifierProvider.future] while a build
+/// is already in flight returns the pending future instead of starting a new
+/// one, so re-triggering on auth state changes is safe.
+final fluxContinuPreloadProvider = Provider<void>((ref) {
+  final authState = ref.watch(authStateProvider);
+
+  final shouldPreload = authState.isAuthenticated &&
+      authState.isEmailConfirmed &&
+      !authState.needsOnboarding;
+
+  if (!shouldPreload) return;
+
+  // Fire-and-forget. If a fetch fails, the user will get the normal error
+  // flow when they actually land on /flux-continu.
+  // ignore: unused_result
+  ref.read(fluxContinuProvider.future);
+});

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -49,18 +49,11 @@ Future<void> main() async {
 }
 
 Future<void> _bootstrap() async {
+  final bootSw = Stopwatch()..start();
 
-  // Initialiser timeago
   timeago.setLocaleMessages('fr', fr_messages.FrMessages());
   timeago.setLocaleMessages('fr_short', FrCompactMessages());
 
-  // Orientation portrait uniquement
-  await SystemChrome.setPreferredOrientations([
-    DeviceOrientation.portraitUp,
-    DeviceOrientation.portraitDown,
-  ]);
-
-  // Status bar style
   SystemChrome.setSystemUIOverlayStyle(
     const SystemUiOverlayStyle(
       statusBarColor: Colors.transparent,
@@ -69,24 +62,26 @@ Future<void> _bootstrap() async {
     ),
   );
 
-  // Initialiser Hive (storage local)
+  // Orientation : doit être résolu avant 1ère frame, sinon flash rotation
+  // sur devices qui lancent en landscape.
+  await SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+    DeviceOrientation.portraitDown,
+  ]);
+
   await Hive.initFlutter();
 
-  // Initialiser flutter_downloader (Android DownloadManager) pour la mise
-  // à jour APK : permet au téléchargement de continuer en arrière-plan.
-  try {
-    await FlutterDownloader.initialize(debug: false, ignoreSsl: false);
-  } catch (e) {
-    debugPrint('Main: FlutterDownloader init failed (non-critical): $e');
-  }
-
-  // Pré-ouvrir les boxes et vérifier leur contenu
-  // Try-catch avec fallback : si un box est corrompu, on le recrée vide
-  debugPrint('Main: Opening Hive boxes...');
-  await _openBoxSafe<dynamic>('settings');
-  final authBox = await _openBoxSafe<dynamic>('auth_prefs');
-  final supabaseBox = await _openBoxSafe<String>('supabase_auth_persistence');
-  await _openBoxSafe<String>('feed_cache');
+  final boxesSw = Stopwatch()..start();
+  final boxes = await Future.wait<Box<dynamic>>([
+    _openBoxSafe<dynamic>('settings'),
+    _openBoxSafe<dynamic>('auth_prefs'),
+    _openBoxSafe<String>('supabase_auth_persistence'),
+    _openBoxSafe<String>('feed_cache'),
+  ]);
+  final authBox = boxes[1];
+  final supabaseBox = boxes[2];
+  debugPrint(
+      '[PERF] boot.hive_boxes_ms=${boxesSw.elapsedMilliseconds} (4 boxes parallel)');
 
   debugPrint('Main: Hive auth_prefs keys: ${authBox.keys.toList()}');
   debugPrint(
@@ -104,26 +99,164 @@ Future<void> _bootstrap() async {
     debugPrint('Main: Hive supabase_session NOT FOUND in box.');
   }
 
-  // Initialiser les notifications push locales (sans forcer la permission)
+  // Validation Supabase config (sans ça, on crash plus tard)
+  if (SupabaseConstants.url.isEmpty || SupabaseConstants.anonKey.isEmpty) {
+    debugPrint('ERROR: Supabase URL or Anon Key is missing.');
+    _runErrorApp(
+      'Configuration Supabase manquante. Vérifiez vos paramètres --dart-define.',
+    );
+    return;
+  }
+
+  // Bind navigator key AVANT runApp : ref statique consommée par le plugin
+  // notifications lors de son init différé.
+  PushNotificationService.setNavigatorKey(NotificationService.navigatorKey);
+
+  // PushNotificationService.init() est différé post-runApp : la codebase
+  // n'appelle jamais getNotificationAppLaunchDetails, donc le tap depuis
+  // cold-launch n'est pas géré aujourd'hui — déférer l'init ne régresse rien
+  // et économise ~100-400ms (timezone DB load + platform channel).
+  final initsSw = Stopwatch()..start();
+  final posthog = PostHogService();
+  String? appVersion;
+  try {
+    await Future.wait<void>([
+      Supabase.initialize(
+        url: SupabaseConstants.url,
+        anonKey: SupabaseConstants.anonKey,
+        authOptions: FlutterAuthClientOptions(
+          localStorage: SupabaseHiveStorage(),
+        ),
+        headers: {
+          'X-Client-Info': 'supabase-flutter/2.5.0',
+        },
+      ).timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          debugPrint(
+              'Main: Supabase.initialize TIMEOUT 10s — throwing to catch block');
+          throw TimeoutException(
+              'Supabase.initialize timeout after 10 seconds');
+        },
+      ),
+      _initPosthogSafe(posthog),
+      _initDownloaderSafe(),
+      PackageInfo.fromPlatform().then((info) {
+        appVersion = '${info.version}+${info.buildNumber}';
+      }).catchError((Object _) {
+        // Best-effort — version tracking degrades gracefully
+      }),
+    ]);
+  } catch (e) {
+    debugPrint('ERROR: Failed to initialize Supabase: $e');
+    _runErrorApp(
+      'Erreur d\'initialisation Supabase. Vérifiez la validité de vos clés.',
+    );
+    return;
+  }
+  debugPrint('[PERF] boot.critical_inits_ms=${initsSw.elapsedMilliseconds}');
+
+  final hasSession = Supabase.instance.client.auth.currentSession != null;
+  debugPrint('Main: Supabase Session restored immediately: $hasSession');
+
+  // PostHog identify initial (fire-and-forget pour ne pas bloquer runApp)
+  if (hasSession) {
+    final user = Supabase.instance.client.auth.currentUser;
+    if (user != null) {
+      unawaited(posthog.identify(
+        userId: user.id,
+        properties: _userIdentifyProperties(user, appVersion: appVersion),
+      ));
+    }
+  }
+  Supabase.instance.client.auth.onAuthStateChange.listen((data) {
+    switch (data.event) {
+      case AuthChangeEvent.signedIn:
+      case AuthChangeEvent.tokenRefreshed:
+      case AuthChangeEvent.userUpdated:
+        final user = data.session?.user;
+        if (user != null) {
+          posthog.identify(
+            userId: user.id,
+            properties:
+                _userIdentifyProperties(user, appVersion: appVersion),
+          );
+        }
+        break;
+      case AuthChangeEvent.signedOut:
+        posthog.reset();
+        break;
+      default:
+        break;
+    }
+  });
+
+  debugPrint('[PERF] boot.pre_runapp_ms=${bootSw.elapsedMilliseconds}');
+
+  // Lancer l'app
+  runApp(const ProviderScope(child: FacteurApp()));
+
+  // Inits différés post-runApp : non bloquants pour la 1ère frame.
+  // - Notif scheduling (alarm, permissions, diagnostics)
+  // - Home Widget callback registration
+  unawaited(_initDeferredServices(posthog: posthog));
+}
+
+/// Init FlutterDownloader avec fallback silencieux (non-critique).
+Future<void> _initDownloaderSafe() async {
+  try {
+    await FlutterDownloader.initialize(debug: false, ignoreSsl: false);
+  } catch (e) {
+    debugPrint('Main: FlutterDownloader init failed (non-critical): $e');
+  }
+}
+
+/// Init PostHog avec fallback silencieux : la télémétrie ne doit jamais
+/// crasher le boot.
+Future<void> _initPosthogSafe(PostHogService posthog) async {
+  try {
+    await posthog.init();
+  } catch (e) {
+    debugPrint('Main: PostHog init failed (non-critical): $e');
+  }
+}
+
+/// Services lancés après [runApp] : aucun n'est requis pour la 1ère frame.
+///
+/// Inclut la planification de la notification quotidienne (system call lente),
+/// la vérification d'exact alarm permission, le diagnostic notifs, et
+/// l'enregistrement du callback Home Widget. Tout est fire-and-forget côté
+/// boot — si un service échoue, le démarrage de l'app n'est pas affecté.
+Future<void> _initDeferredServices({required PostHogService posthog}) async {
+  final sw = Stopwatch()..start();
+
+  try {
+    unawaited(
+        HomeWidget.registerInteractivityCallback(homeWidgetBackgroundCallback));
+  } catch (e) {
+    debugPrint('Main: Home Widget init failed (non-critical): $e');
+  }
+
   Map<String, dynamic>? bootNotifDiag;
   bool? bootPushEnabledHive;
   try {
-    debugPrint('Main: Initializing push notifications...');
     final pushNotificationService = PushNotificationService();
-    PushNotificationService.setNavigatorKey(NotificationService.navigatorKey);
+    // L'init plugin (timezone DB + platform channel) coûte ~100-400ms ;
+    // déférée car aucun consommateur du tap-callback ne s'active dans la
+    // 1ère seconde post-runApp.
     await pushNotificationService.init();
 
-    // Planifier uniquement si l'utilisateur a déjà autorisé les notifications
     final settingsBox = Hive.box<dynamic>('settings');
     final pushEnabled = settingsBox.get('push_notifications_enabled',
         defaultValue: true) as bool;
     bootPushEnabledHive = pushEnabled;
-    if (pushEnabled) {
-      // S'assurer que la permission exact alarm est toujours valide
-      // (peut être révoquée par une mise à jour Android ou un changement système)
-      await pushNotificationService.ensureExactAlarmPermission();
 
-      // Ne planifier la notification statique que si aucune n'existe déjà.
+    // Diagnostic + scheduling sont indépendants : collecter le diagnostic
+    // pendant la planification (alarms + permission). `pushEnabled=false`
+    // → on collecte quand même le diagnostic (cf. bug-notifications-stalled).
+    final diagFuture = pushNotificationService.getDiagnostics();
+    if (pushEnabled) {
+      await pushNotificationService.ensureExactAlarmPermission();
       // Si une notification personnalisée (avec les sujets du digest) a été
       // planifiée par DigestNotifier._updateNotificationWithTopics(), on la
       // préserve — écraser avec le corps statique régresserait la feature.
@@ -135,7 +268,6 @@ Future<void> _bootstrap() async {
         if (!scheduled) {
           debugPrint(
               'Main: WARNING — digest notification scheduling failed, retrying...');
-          // Retry après re-demande explicite de permission
           await pushNotificationService.requestExactAlarmPermission();
           final retryOk =
               await pushNotificationService.scheduleDailyDigestNotification();
@@ -146,133 +278,23 @@ Future<void> _bootstrap() async {
             'Main: Digest notification already scheduled — skipping static placeholder.');
       }
     }
-
-    // Toujours collecter le diagnostic — y compris quand pushEnabled=false —
-    // pour mesurer le parc côté télémétrie (cf. bug-notifications-stalled).
-    bootNotifDiag = await pushNotificationService.getDiagnostics();
-    debugPrint('Main: Push diagnostics: $bootNotifDiag');
-    debugPrint('Main: Push notifications initialized (enabled: $pushEnabled)');
+    bootNotifDiag = await diagFuture;
   } catch (e, s) {
-    debugPrint('ERROR: Failed to initialize push notifications: $e\n$s');
+    debugPrint(
+        'ERROR: Deferred push notifications init failed: $e\n$s');
   }
 
-  // Initialize Home Widget for Android home screen widget
-  try {
-    HomeWidget.registerInteractivityCallback(homeWidgetBackgroundCallback);
-    debugPrint('Main: Home Widget initialized.');
-  } catch (e) {
-    debugPrint('Main: Home Widget init failed (non-critical): $e');
-  }
-
-  // Validation Supabase avant initialisation
-  if (SupabaseConstants.url.isEmpty || SupabaseConstants.anonKey.isEmpty) {
-    debugPrint('ERROR: Supabase URL or Anon Key is missing.');
-    _runErrorApp(
-      'Configuration Supabase manquante. Vérifiez vos paramètres --dart-define.',
-    );
-    return;
-  }
-
-  // Initialisation Analytics
-  // Note: On le fait tôt pour choper le launch
-  // Mais on a besoin de Dio qui est dans le container...
-  // On va le faire via le provider plus tard ou ici si on instancie manuellement
-  // Pour l'instant on laisse le provider s'en occuper au premier build de FacteurApp
-
-  try {
-    final url = SupabaseConstants.url;
-    final key = SupabaseConstants.anonKey;
-
-    // Initialiser Supabase avec timeout de sécurité
-    debugPrint('Main: Initializing Supabase...');
-    debugPrint('Main: Supabase URL: ${SupabaseConstants.url}');
-    await Supabase.initialize(
-      url: url,
-      anonKey: key,
-      authOptions: FlutterAuthClientOptions(
-        localStorage: SupabaseHiveStorage(),
-      ),
-      headers: {
-        'X-Client-Info': 'supabase-flutter/2.5.0',
-      },
-    ).timeout(
-      const Duration(seconds: 15),
-      onTimeout: () {
-        debugPrint(
-            'Main: Supabase.initialize TIMEOUT - throwing to catch block');
-        throw TimeoutException('Supabase.initialize timeout after 15 seconds');
-      },
-    );
-    debugPrint('Main: Supabase initialized correctly.');
-    final hasSession = Supabase.instance.client.auth.currentSession != null;
-    debugPrint('Main: Supabase Session restored immediately: $hasSession');
-
-    // Story 14.1 — init PostHog after Supabase so we can piggyback on the
-    // auth state stream to identify/reset the distinct_id automatically.
-    final posthog = PostHogService();
-    await posthog.init();
-
-    String? appVersion;
-    try {
-      final info = await PackageInfo.fromPlatform();
-      appVersion = '${info.version}+${info.buildNumber}';
-    } catch (_) {
-      // Best-effort — version tracking degrades gracefully
-    }
-
-    // Émettre l'état des notifs locales collecté au boot (capture après init
-    // PostHog : avant, capture() est un no-op silencieux).
-    if (bootNotifDiag != null) {
-      final diagProps = <String, Object>{
-        'push_enabled_hive': bootPushEnabledHive ?? false,
-      };
-      bootNotifDiag.forEach((k, v) {
-        if (v != null) diagProps[k] = v as Object;
-      });
-      unawaited(posthog.capture(event: 'notif_diag', properties: diagProps));
-    }
-
-    if (hasSession) {
-      final user = Supabase.instance.client.auth.currentUser;
-      if (user != null) {
-        await posthog.identify(
-          userId: user.id,
-          properties: _userIdentifyProperties(user, appVersion: appVersion),
-        );
-      }
-    }
-    Supabase.instance.client.auth.onAuthStateChange.listen((data) {
-      switch (data.event) {
-        case AuthChangeEvent.signedIn:
-        case AuthChangeEvent.tokenRefreshed:
-        case AuthChangeEvent.userUpdated:
-          final user = data.session?.user;
-          if (user != null) {
-            posthog.identify(
-              userId: user.id,
-              properties: _userIdentifyProperties(user, appVersion: appVersion),
-            );
-          }
-          break;
-        case AuthChangeEvent.signedOut:
-          posthog.reset();
-          break;
-        default:
-          break;
-      }
+  if (bootNotifDiag != null) {
+    final diagProps = <String, Object>{
+      'push_enabled_hive': bootPushEnabledHive ?? false,
+    };
+    bootNotifDiag.forEach((k, v) {
+      if (v != null) diagProps[k] = v as Object;
     });
-  } catch (e) {
-    debugPrint('ERROR: Failed to initialize Supabase: $e');
-    _runErrorApp(
-      'Erreur d\'initialisation Supabase. Vérifiez la validité de vos clés.',
-    );
-    return;
+    unawaited(posthog.capture(event: 'notif_diag', properties: diagProps));
   }
 
-  // Lancer l'app
-  debugPrint('Main: Calling runApp...');
-  runApp(const ProviderScope(child: FacteurApp()));
-  debugPrint('Main: runApp called.');
+  debugPrint('[PERF] boot.deferred_inits_ms=${sw.elapsedMilliseconds}');
 }
 
 /// User properties pushed à chaque `$identify` PostHog. Permet de filtrer

--- a/docs/maintenance/maintenance-quick-start-boot-perf.md
+++ b/docs/maintenance/maintenance-quick-start-boot-perf.md
@@ -1,0 +1,68 @@
+# Maintenance — Quick Start : démarrage app < 1s
+
+## Status
+
+In Progress — PR1/3 (boot parallélisé)
+
+## Problème
+
+À l'arrivée sur l'app mobile, le temps perçu entre tap sur l'icône et contenu interactif est **>5s** (souvent 4.5–6.5s sur réseau correct, jusqu'à 20s+ si `/api/digest` renvoie 202 "preparing"). Objectif PO : **<1s perçu**.
+
+## Diagnostic (path critique séquentiel bloquant)
+
+```
+main() bootstrap : Hive ×4 + Supabase + PostHog + Notifs (SÉRIEL)   ~1.5–2.5s
+   ↓ runApp()
+Splash + auth refresh (router bloqué isLoading)                      ~0.5–1.5s
+   ↓ redirect /flux-continu
+FluxContinuScreen mount → LoadingView() plein écran
+   ↓ fluxContinuProvider._fetchAll() Future.wait 4 endpoints
+   ↓ tout doit revenir avant rendu
+[+ _fetchThemeSections() 3 appels SÉRIELS]
+```
+
+## Approche (3 PRs)
+
+### PR1 — Boot mobile parallélisé (gain attendu −0.5 à −1s, toutes ouvertures)
+
+- `Future.wait` sur les 4 `Hive.openBox` (était séquentiel)
+- `Future.wait` sur Supabase / PostHog / FlutterDownloader (indépendants)
+- Différer en post-runApp les services non-critiques pour la 1ère frame :
+  - `ensureExactAlarmPermission` (system call lent)
+  - `isDigestNotificationScheduled` + `scheduleDailyDigestNotification` (DB-backed alarm)
+  - `getDiagnostics` + capture PostHog `notif_diag`
+  - `HomeWidget.registerInteractivityCallback`
+- Conserver `PushNotificationService.init()` dans le path critique (rapide, et nécessaire pour les notifications cold-launch)
+- Réduire timeout Supabase 15s → 3s (au-delà, on continue avec la session Hive restaurée si dispo)
+- Logs `[PERF]` pour mesurer chaque étape
+
+### PR2 — SWR Flux Continu + preload + rendu progressif (gain : ré-ouvertures <100ms perçu, 1ère ouverture −1 à −2s)
+
+- `FluxContinuCacheService` (Hive `flux_continu_cache`, clé `flux_continu:{userId}:{date}`)
+- `fluxContinuPreloadProvider` watché dans `FacteurApp.build()`
+- Split `fluxContinuProvider._fetchAll` en sous-notifiers indépendants
+- Remplacement `LoadingView()` plein écran par skeleton par section
+- `Future.wait` sur les 3 themes (au lieu de série)
+
+### PR3 — Backend caches + fix retry 202
+
+- Cache in-memory 30s sur `/api/essentiel`, `/api/users/top-themes`, `/api/digest/both`
+- Retry 202 digest non-bloquant + polling background mobile
+
+## Fichiers touchés PR1
+
+- `apps/mobile/lib/main.dart` — refactor bootstrap
+
+## Vérification PR1
+
+- `cd apps/mobile && flutter analyze`
+- `cd apps/mobile && flutter test`
+- Profiling timeline DevTools : mesurer `main()` → premier `runApp` avant/après
+- Logs `[PERF] boot.*` dans la console pour validation
+
+## Non-Goals PR1
+
+- Pas de modification de l'écran d'arrivée (FluxContinuScreen) — PR2
+- Pas de cache local pour les endpoints — PR2
+- Pas de modification backend — PR3
+- Pas de réécriture du retry digest 202 — PR3


### PR DESCRIPTION
## Quoi

PR1 (boot parallélisé) + PR2a (préchargement Flux Continu) du chantier *cold start <1s perçu* (cf. `docs/maintenance/maintenance-quick-start-boot-perf.md`).

- 4 Hive boxes ouvertes en `Future.wait` (était sériel)
- Supabase + PostHog + FlutterDownloader + `PackageInfo.fromPlatform()` lancés en parallèle dans le path critique
- `PushNotificationService.init()` + scheduling + diagnostics **différés post-`runApp`** (init plugin coûte 100-400 ms, aucun consommateur du tap-callback dans la 1ère seconde)
- Timeout `Supabase.initialize` 15 s → 10 s
- PostHog init wrappé safe — la télémétrie ne doit jamais crasher le boot
- Nouveau `fluxContinuPreloadProvider` watché dans `FacteurApp` : déclenche les 4 endpoints du home screen dès `auth confirmed`, en parallèle du splash + redirect GoRouter (calque `feedPreloadProvider`)
- Logs `[PERF] boot.*` pour mesurer chaque étape (hive_boxes, critical_inits, pre_runapp, deferred_inits)

## Pourquoi

Cold start mesuré >5 s sur réseau correct (objectif PO : <1 s perçu). Diagnostic :

```
main() bootstrap (Hive ×4 sériel + Supabase + PostHog + Notifs sériels) ~1.5–2.5 s
   ↓ runApp()
Splash + auth refresh                                                  ~0.5–1.5 s
   ↓ redirect /flux-continu
FluxContinuScreen → LoadingView() plein écran → Future.wait 4 endpoints
```

**Gain attendu** : −0.5 à −1 s sur toutes les ouvertures (boot parallélisé), −1 à −2 s supplémentaires sur la 1ère ouverture (preload qui chevauche le splash). À confirmer sur device.

## Comment ça a été vérifié

- [x] `flutter analyze` : clean sur les 3 fichiers touchés (1 warning *pré-existant* `implementation_imports` sur timeago)
- [x] `flutter test` : 656 passed / 36 échecs **strictement pré-existants** (vérifié par stash/pop : même compte sur la branche sans les changements)
- [x] `flutter test test/core/services/ test/features/flux_continu/` : 125 tests, 100% pass
- [x] `/simplify` passé : 3 agents (reuse / quality / efficiency) → fixes appliqués (PostHog safe, PackageInfo parallèle, diagnostic parallèle au scheduling, comments trim)

## Zones à risque

- **Bootstrap path Android/iOS** : `setNavigatorKey` est bind **avant** `runApp` et l'init plugin est différée. Vérifié : `_navigatorKey` n'est lu que dans le tap-callback (jamais dans `init()`), donc race-free. À surveiller : si un futur callsite ajoute `getNotificationAppLaunchDetails`, le déférer cassera le cold-launch-from-notif (qui n'est pas géré aujourd'hui de toute façon).
- **Preload `fluxContinuProvider`** : lance 4 endpoints HTTP même si l'user va directement sur un deep-link (ex `/article/xxx`). Acceptable car preload idempotent et requis pour la 1ère ouverture warmupp. À revoir si signal métier sur surcoût battery.

## Suite

- **PR2** (suivante) : SWR snapshot du jour (`FluxContinuCacheService` Hive, clé `flux_continu:{userId}:{date}`) + rendu progressif (skeleton par section, themes en `Future.wait`)
- **PR3** : caches in-memory 30s backend (`/api/essentiel`, `/api/users/top-themes`, `/api/digest/both`) + fix retry 202 non-bloquant

🤖 Generated with [Claude Code](https://claude.com/claude-code)