### PR TITLE
fix(mobile): webview reader header — encart opaque + saccades scroll

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -375,6 +375,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           var dy = pendingDy;
           pendingDy = 0;
           if (Math.abs(dy) < 1) return;
+          // Cap per-frame delta to absorb rAF bursts caused by site CSS
+          // animations (e.g. Le Monde sticky-nav collapse). A real flick
+          // never exceeds ~150px in a single flush at 60fps.
+          if (dy >  150) dy =  150;
+          if (dy < -150) dy = -150;
           // Invert sign so positive = page-scroll-down-equivalent (hide chrome).
           ScrollBridge.postMessage('gesture_delta:' + (-dy));
         }
@@ -386,7 +391,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           pendingDy = 0;
           touchActive = true;
           ScrollBridge.postMessage('gesture_start');
-        }, { passive: true });
+        }, { passive: true, capture: true });
         document.addEventListener('touchmove', function(e) {
           if (!touchActive || e.touches.length > 1) return;
           var y = e.touches[0].clientY;
@@ -405,7 +410,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             rafScheduled = true;
             raf(flushGesture);
           }
-        }, { passive: true });
+        }, { passive: true, capture: true });
         document.addEventListener('touchend', function(e) {
           if (!touchActive) return;
           touchActive = false;
@@ -415,13 +420,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           // velocity is finger px/ms; invert sign (page-down equivalent) and
           // convert to px/s for the Dart snap heuristic.
           ScrollBridge.postMessage('gesture_end:' + (-velocity * 1000));
-        }, { passive: true });
+        }, { passive: true, capture: true });
         document.addEventListener('touchcancel', function(e) {
           if (!touchActive) return;
           touchActive = false;
           if (rafScheduled) flushGesture();
           ScrollBridge.postMessage('gesture_cancel');
-        }, { passive: true });
+        }, { passive: true, capture: true });
         // `window.scroll` is observed *only* for progress + scrollY mirroring.
         // It never drives the chrome offset.
         var lastProgress = 0;
@@ -2619,11 +2624,19 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       children: [
         // LAYER 0: WebView — fixed in viewport below the header, always rendered.
         // Painted first so it appears visually behind the scrollable content.
-        Positioned(
-          top: headerHeight,
-          left: 0,
-          right: 0,
-          bottom: 0,
+        // `top` follows _headerOffset so the WebView fills the gap as the
+        // header slides out (offset 0.0 → top=headerHeight, 1.0 → top=0).
+        // _buildWebViewLayer() is passed via `child` so the WebView controller
+        // is never rebuilt when the offset changes.
+        ValueListenableBuilder<double>(
+          valueListenable: _headerOffset,
+          builder: (_, offset, child) => Positioned(
+            top: headerHeight * (1.0 - offset),
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: child!,
+          ),
           child: _buildWebViewLayer(),
         ),
 


### PR DESCRIPTION
## What

Two regressive bugs fixed in the WebView scroll reader (scroll-to-site mode, used by Le Monde, Le Parisien, etc.):

1. **Encart opaque** : WebView `top` was hardcoded to `headerHeight`. Wrapped the `Positioned` in a `ValueListenableBuilder<double>` on `_headerOffset` so the top tracks the header slide-out (`top = headerHeight * (1.0 - offset)`). `_buildWebViewLayer()` passed via the `child` slot — WebView controller is never rebuilt on offset changes.

2. **Saccades (Le Monde, Le Parisien)** : JS scroll bridge listeners used bubble phase; sites calling `stopPropagation()` on their sticky nav staled `lastTouchY`, producing large erroneous `dy` spikes. Switched all 4 touch listeners to `{ passive: true, capture: true }`. Also capped `pendingDy` per rAF flush to ±150px to absorb CSS-animation bursts.

## Why

Both bugs previously fixed in PR #605 and PR #612 had regressed. Root causes addressed at the source this time.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`flutter test` — 36 pre-existing failures, 0 regressions introduced)
- [x] Linting passes (`flutter analyze` — 0 errors/warnings on modified lines)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)

> ⚠️ Test manuel iOS WKWebView requis avant merge (Chrome ne reproduit pas cette classe de bug).