### PR TITLE
feat(api): filtre langue user-aware + Source.language (PR 1/2 curation FR-first)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,92 +1,98 @@
-## Quoi
+# PR 1 — Backend : Filtre par langue & `Source.language` (curation FR-first)
 
-PR 5 de la chaîne LLM bias annotation. Enrichit le contrat de
-`GET /contents/{id}/perspectives` pour exposer les annotations LLM
-(`weight` / `category` / `justification`) quand `semantic_equiv` est
-en base, sinon retourne le format spaCy actuel. Ajoute un header de
-debug `X-Bias-Annotation-Source: llm|spacy` et expose `language`
-sur chaque perspective.
+## Contexte
 
-## Pourquoi
+PR 1/2 du plan **language-aware curation**. Introduit la prise en compte
+de la langue de la source dans les pipelines Essentiel / feed / digest,
+contrôlée par une préférence user `hide_non_fr_sources` masquant les
+cartes des sources non-FR — sauf si la source est explicitement suivie.
 
-Les annotations LLM (`semantic_equiv.target_spans` pondérés + tooltips
-de justification) sont produites par le pipeline mergé en PR 4
-(#648), mais le contrat API actuel les ignore. Sans cette PR, le
-mobile (PR 6) ne peut pas afficher les poids ni les tooltips. Le
-champ `language` est requis par la future section « Couverture
-étrangère » pour regrouper les perspectives non-FR.
+La couche mobile + section "Couverture à l'étranger" (panel perspectives)
+arrivent en PR 2.
 
 ## Changements
 
-- **`Content.language`** : colonne `String(8)` nullable + index +
-  migration Alembic `lg01_add_language_to_contents` avec backfill
-  heuristique (`detect_language` = `looks_english` puis
-  `is_french_source`). Les nouveaux contents sont remplis à
-  l'ingestion (`sync_service._save_content`).
-- **`Perspective.language`** ajouté au dataclass, propagé depuis
-  `Content.language` dans `build_cluster_perspectives`. Les
-  perspectives Google News restent `None` (pas de row `Content`).
-- **`_attach_highlight_spans`** refactoré pour retourner
-  `tuple[dict | None, Literal["llm", "spacy"]]`. Si `semantic_equiv`
-  est rempli pour le cluster (filtré par `llm_version` +
-  `cluster_signature`), les target_spans LLM sont sérialisés tels
-  quels, avec `bias` injecté depuis `bias_stance` pour rétrocompat.
-  Sinon → fallback spaCy inchangé.
-- **Header `X-Bias-Annotation-Source`** posé via `Response` injecté
-  dans la signature FastAPI. Cache hit ré-attache le header via un
-  `_perspectives_source_cache` parallèle (sinon le header
-  disparaissait silencieusement après la 1ère requête).
-- **`detect_language`** factorisé dans
-  `app/services/ml/language_filter.py` — single source of truth pour
-  l'ingestion ET la migration de backfill.
+### Données
 
-## Comment ça a été vérifié
+- **Migration `lg02_source_language_user_pref`** (down_revision : `lg01`) :
+  - `sources.language String(8) NULL, indexed` ; backfill par langue
+    majoritaire (≥ 60 %) à partir de `Content.language`.
+  - `user_personalization.hide_non_fr_sources` (Boolean, default `true`).
+  - `user_personalization.language_filter_user_set` (Boolean, default
+    `false`) — flag "mode auto".
+  - Backfill `hide_non_fr_sources = false` pour les users qui suivent
+    déjà ≥ 1 source étrangère (respect du choix implicite).
 
-- [x] `pytest tests/routers/test_contents_perspectives_highlights.py`
-  — 13 OK (9 existants adaptés au tuple + 4 nouveaux : LLM enriched,
-  fallback spaCy, signature mismatch, language propagation).
-- [x] Suite complète backend : **1242 passed, 1 skipped, 2 xfailed**
-  (134 s).
-- [x] `alembic heads` → exactement 1 head
-  (`lg01_add_language_to_contents`).
-- [x] `alembic upgrade --sql` → DDL généré correctement
-  (`ALTER TABLE contents ADD COLUMN language VARCHAR(8)` +
-  `CREATE INDEX ix_contents_language`).
-- [x] `/simplify` passé : 5 fixes appliqués (factoriser
-  `detect_language`, bug header cache hit, dédupliquer `alt_tokens`,
-  hoister fixtures de tests, type `Literal`).
+### Services
 
-⚠️ **Round-trip migration live non testable localement** : le
-container Postgres test du workspace est dans un état désync (« Can't
-locate revision identified by 'b3c4d5e6f7a8' ») hérité d'un autre
-workspace. La migration sera testée pour de vrai par le `alembic
-upgrade head` du `Dockerfile` Railway au prochain boot.
+- `app/services/language_user_filter.py` (nouveau) :
+  - `is_foreign_source`, `get_hide_non_fr_pref`, `apply_language_filter`
+    (filtre Python), `language_filter_clause` (clause SQL partagée
+    digest_selector ↔ recommendation_service), `recompute_auto_pref`
+    (mode auto bascule sur follow/unfollow).
+- `essentiel_service` : `EssentielUserContext.hide_non_fr_sources` +
+  `_filter_articles_by_language` appliqué avant le scoring.
+- `recommendation_service._get_candidates` : filtre SQL équivalent
+  (followed sources jamais filtrées). Désactivé en mode "browse a
+  specific source" (exploration).
+- `digest_selector` : `DigestContext.hide_non_fr_sources` + filtre SQL
+  sur le pool curated (les articles des sources suivies passent par
+  `user_sources_query`, hors filtre par construction).
+- `source_service.{trust,untrust,create,delete}_source` : appellent
+  `recompute_auto_pref` après mutation.
 
-## Zones à risque
+### API
 
-- **Cache header** : nouveau dict `_perspectives_source_cache`
-  parallèle invalidé en même temps que `_perspectives_cache`
-  (`_perspectives_source_cache.pop` à côté de chaque
-  `_perspectives_cache.pop`). À surveiller : si une autre branche
-  oublie d'invalider l'un sans l'autre, le header pourrait diverger
-  du body.
-- **Backfill migration** : tourne dans une seule transaction
-  Alembic ; `env.py` désactive le `statement_timeout` via
-  `SET LOCAL statement_timeout = '0'`, donc pas de cap théorique.
-  Avec ~quelques 100k rows en prod, ça devrait passer en quelques
-  minutes. Idempotent (`WHERE language IS NULL`).
-- **Rétrocompat client** : confirmée par
-  `test_attach_highlight_spans_falls_back_to_spacy_when_no_semantic_equiv` —
-  les apps pre-PR-6 reçoivent le format spaCy historique.
-- **Stored snapshot path** : `language` est lu via
-  `getattr(p, "language", None)`, donc les snapshots déjà sérialisés
-  sans le champ tomberont à `null` (PR 6 traite `null` comme FR par
-  défaut).
+- `SourceMini.language: str | None` (forward-compat, propagé dans tous
+  les schemas qui l'embarquent).
+- `ContentResponse.language`, `DigestTopicArticle.language`,
+  `EssentielArticle.language` (forward-compat — utile au debug et label
+  éventuel côté mobile).
+- `GET /api/personalization` expose `hide_non_fr_sources` +
+  `language_filter_user_set`.
+- `POST /api/personalization/toggle-hide-non-fr-sources` : toute MAJ
+  flippe `language_filter_user_set = true` (gel du choix user).
 
-## Dette pré-existante (hors scope)
+### Background
 
-`tests/services/test_llm_bias_annotation_service.py` ne collecte pas
-sur `main` à cause d'un import circulaire via
-`app.services.editorial.__init__` → `pipeline` →
-`llm_bias_annotation_service`. Vérifié : présent avant cette PR.
-À traiter dans une PR follow-up.
+- `app/jobs/recompute_source_language.py` (nouveau) : recalcule
+  `sources.language` 1×/jour à partir de `Content.language` des 30
+  derniers jours (seuil majoritaire 60 %).
+- Scheduler : nouveau job `recompute_source_language` à 03h30 Paris.
+
+## Tests
+
+- `tests/services/test_language_user_filter.py` (nouveau) :
+  - 8 unit tests pure-Python.
+  - 6 tests DB pour `get_hide_non_fr_pref` + `recompute_auto_pref`
+    (mode auto / manuel, no-op sans personalization row).
+- Suite backend complète : **1285 passed, 1 skipped, 2 xfailed** sur DB
+  locale post-migration `lg02`.
+
+## Vérification
+
+```
+cd packages/api && python -m alembic heads          # → lg02_source_language_user_pref seule head
+cd packages/api && python -m alembic upgrade head   # DB vide → OK (jouée localement)
+cd packages/api && python -m pytest -q              # 1285 passed
+```
+
+## Points d'attention
+
+- **`Source.language=NULL` → traité comme FR** (rétro-compat avec le
+  client mobile et `editorial/writer.py:_looks_french`). Conséquence :
+  une source dont la langue n'est pas encore détectée ne sera pas
+  masquée.
+- **Filtre désactivé en exploration source** (`source_id` query param) :
+  on n'ampute pas le browse explicite.
+- **`recompute_auto_pref` flushe avant SELECT** : la nouvelle
+  UserSource doit être visible. Hooks placés après `db.flush()`.
+- **Mobile (PR 2)** reste à faire : toggle "Masquer sources non-FR" +
+  section "Couverture à l'étranger" dans le panel perspectives.
+
+## Follow-ups identifiés
+
+- La whitelist `is_french_source` peut mislabel certaines sources
+  (Story 7.7 — labellisation manuelle du catalogue). Acceptable pour PR 1.
+- Pas de migration côté Story 7.7 = on s'appuie sur le job daily pour
+  rattraper les nouvelles sources.

--- a/packages/api/alembic/versions/lg02_source_language_user_pref.py
+++ b/packages/api/alembic/versions/lg02_source_language_user_pref.py
@@ -1,0 +1,129 @@
+"""add Source.language and hide_non_fr_sources user prefs
+
+Suite directe de `lg01_add_language_to_contents` (qui a peuplé
+`Content.language`). Cette migration ajoute :
+
+1. `sources.language` (String(8), nullable, indexé) — backfill par langue
+   majoritaire des `Content.language` connus de la source (seuil ≥ 60%
+   des articles à langue connue, sinon NULL → traité comme FR par défaut
+   côté client, rétro-compat).
+2. `user_personalization.hide_non_fr_sources` (Boolean, default true) —
+   masque les cartes des sources non-FR dans Essentiel/feed/digest, sauf
+   les sources que l'utilisateur suit explicitement.
+3. `user_personalization.language_filter_user_set` (Boolean, default
+   false) — flag "mode auto" : tant qu'il est false, le toggle est
+   recalculé automatiquement à chaque follow/unfollow d'une source. Une
+   modification manuelle via l'API le passe à true (gel du choix user).
+
+Backfill du toggle : true uniquement pour les users qui ne suivent
+aucune source étrangère (`language NOT IN ('fr', NULL)`), false sinon
+— ainsi un user qui suit déjà des sources EN ne voit pas son feed
+amputé sans son consentement explicite.
+"""
+
+from collections import Counter
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "lg02_source_language_user_pref"
+down_revision: str | None = "lg01_add_language_to_contents"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+# Seuil au-delà duquel on considère une source comme "majoritairement X"
+# (sur l'échantillon des contents à langue connue). Sous le seuil →
+# language=NULL, traité comme FR par défaut (rétro-compat).
+_MAJORITY_THRESHOLD = 0.60
+
+
+def upgrade() -> None:
+    # --- 1. sources.language --------------------------------------------------
+    op.add_column(
+        "sources",
+        sa.Column("language", sa.String(length=8), nullable=True),
+    )
+    op.create_index("ix_sources_language", "sources", ["language"])
+
+    # --- 2. user_personalization.{hide_non_fr_sources, language_filter_user_set}
+    op.add_column(
+        "user_personalization",
+        sa.Column(
+            "hide_non_fr_sources",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+    op.add_column(
+        "user_personalization",
+        sa.Column(
+            "language_filter_user_set",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+    # Offline mode (`alembic upgrade --sql`) : DDL seul, pas de backfill.
+    if op.get_context().as_sql:
+        return
+
+    bind = op.get_bind()
+
+    # --- 3. Backfill sources.language ----------------------------------------
+    # Pour chaque source : compter les Content.language non-NULL, prendre
+    # la langue majoritaire si elle dépasse 60% — sinon laisser NULL.
+    rows = bind.execute(
+        sa.text(
+            "SELECT source_id, language, COUNT(*) AS n "
+            "FROM contents "
+            "WHERE language IS NOT NULL "
+            "GROUP BY source_id, language"
+        )
+    ).fetchall()
+
+    by_source: dict[str, Counter[str]] = {}
+    for row in rows:
+        by_source.setdefault(str(row.source_id), Counter())[row.language] = row.n
+
+    update_stmt = sa.text("UPDATE sources SET language = :language WHERE id = :id")
+    updates: list[dict[str, str]] = []
+    for source_id, counter in by_source.items():
+        total = sum(counter.values())
+        if total == 0:
+            continue
+        lang, n = counter.most_common(1)[0]
+        if n / total >= _MAJORITY_THRESHOLD:
+            updates.append({"id": source_id, "language": lang})
+
+    if updates:
+        bind.execute(update_stmt, updates)
+
+    # --- 4. Backfill user_personalization.hide_non_fr_sources -----------------
+    # Règle dynamique au moment de la migration : si le user suit déjà
+    # ≥1 source étrangère (language ∉ ('fr', NULL)), on désactive le
+    # toggle pour respecter son choix implicite. Sinon on l'active.
+    # `language_filter_user_set` reste à false (mode auto) — il ne passera
+    # à true que lors d'une interaction manuelle via l'API.
+    bind.execute(
+        sa.text(
+            "UPDATE user_personalization up "
+            "SET hide_non_fr_sources = false "
+            "WHERE EXISTS ("
+            "  SELECT 1 FROM user_sources us "
+            "  JOIN sources s ON s.id = us.source_id "
+            "  WHERE us.user_id = up.user_id "
+            "    AND s.language IS NOT NULL "
+            "    AND s.language <> 'fr'"
+            ")"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_personalization", "language_filter_user_set")
+    op.drop_column("user_personalization", "hide_non_fr_sources")
+    op.drop_index("ix_sources_language", table_name="sources")
+    op.drop_column("sources", "language")

--- a/packages/api/app/jobs/recompute_source_language.py
+++ b/packages/api/app/jobs/recompute_source_language.py
@@ -1,0 +1,118 @@
+"""Recalcul périodique de `Source.language` (langue majoritaire).
+
+Tourne 1×/jour. Pour chaque source ayant ≥1 Content à langue connue dans
+les 30 derniers jours, on calcule la langue majoritaire (seuil 60%). Les
+sources sans échantillon suffisant restent à `NULL` — traité comme FR par
+défaut côté curation (rétro-compat — cf. language_user_filter.py).
+
+Aligné avec le backfill initial de la migration `lg02` : un seul endroit
+décrit la règle, pas de drift entre cold-start et runtime.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import bindparam, text
+
+from app.database import safe_async_session
+
+logger = structlog.get_logger()
+
+# Seuil de majorité (sur l'échantillon des contents à langue connue).
+# Sous le seuil → on remet à NULL pour éviter de figer un fragile 51/49.
+_MAJORITY_THRESHOLD = 0.60
+
+# Fenêtre d'observation. Trop court (≤7j) → sensible aux pics de syndication
+# anglaise ; trop long (≥90j) → on rate les sources qui pivotent FR↔EN.
+_WINDOW_DAYS = 30
+
+
+async def recompute_source_language() -> dict[str, int]:
+    """Recalcule `sources.language` à partir des Content des 30 derniers jours.
+
+    Renvoie un dict de stats pour les logs (sources mises à jour, sources
+    sans signal suffisant, total examiné).
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=_WINDOW_DAYS)
+
+    updated = 0
+    unchanged = 0
+    reset_to_null = 0
+
+    async with safe_async_session() as session:
+        # Compteurs par (source_id, language) sur la fenêtre. Le tri par
+        # COUNT desc nous donne directement la langue majoritaire au LIMIT 1
+        # côté Python (cf. boucle plus bas).
+        rows = (
+            await session.execute(
+                text(
+                    "SELECT source_id, language, COUNT(*) AS n "
+                    "FROM contents "
+                    "WHERE language IS NOT NULL "
+                    "  AND published_at >= :cutoff "
+                    "GROUP BY source_id, language"
+                ),
+                {"cutoff": cutoff},
+            )
+        ).fetchall()
+
+        by_source: dict[str, Counter[str]] = {}
+        for row in rows:
+            by_source.setdefault(str(row.source_id), Counter())[row.language] = row.n
+
+        verdicts: dict[str, str | None] = {}
+        for source_id, counter in by_source.items():
+            total = sum(counter.values())
+            if total == 0:
+                continue
+            lang, n = counter.most_common(1)[0]
+            verdicts[source_id] = lang if (n / total) >= _MAJORITY_THRESHOLD else None
+
+        if not verdicts:
+            stats = {
+                "sources_updated": 0,
+                "sources_unchanged": 0,
+                "sources_reset_to_null": 0,
+                "total_examined": 0,
+            }
+            logger.info("recompute_source_language_done", **stats)
+            return stats
+
+        lookup_stmt = text(
+            "SELECT id::text AS id, language FROM sources WHERE id::text IN :ids"
+        ).bindparams(bindparam("ids", expanding=True))
+        current_rows = (
+            await session.execute(lookup_stmt, {"ids": list(verdicts)})
+        ).fetchall()
+        current_by_id = {r.id: r.language for r in current_rows}
+
+        params: list[dict[str, str | None]] = []
+        for source_id, verdict in verdicts.items():
+            if current_by_id.get(source_id) == verdict:
+                unchanged += 1
+                continue
+            params.append({"id": source_id, "lang": verdict})
+            if verdict is None:
+                reset_to_null += 1
+            else:
+                updated += 1
+
+        if params:
+            await session.execute(
+                text("UPDATE sources SET language = :lang WHERE id = :id"),
+                params,
+            )
+
+        await session.commit()
+
+    stats = {
+        "sources_updated": updated,
+        "sources_unchanged": unchanged,
+        "sources_reset_to_null": reset_to_null,
+        "total_examined": len(by_source),
+    }
+    logger.info("recompute_source_language_done", **stats)
+    return stats

--- a/packages/api/app/models/source.py
+++ b/packages/api/app/models/source.py
@@ -129,6 +129,14 @@ class Source(Base):
     # Values: "informative", "analytical", "humorous", "satirical", None
     tone: Mapped[str | None] = mapped_column(String(20), nullable=True, index=True)
 
+    # Langue majoritaire dénormalisée (re-calculée par job périodique à
+    # partir de Content.language des 30 derniers jours). NULL = source dont
+    # la langue n'a pas pu être déterminée (échantillon trop faible) →
+    # traitée comme FR par défaut côté curation (rétro-compat).
+    language: Mapped[str | None] = mapped_column(
+        String(8), nullable=True, index=True
+    )
+
     # Auto-include in serein mode even if user doesn't follow this source
     serein_default: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false"

--- a/packages/api/app/models/source.py
+++ b/packages/api/app/models/source.py
@@ -133,9 +133,7 @@ class Source(Base):
     # partir de Content.language des 30 derniers jours). NULL = source dont
     # la langue n'a pas pu être déterminée (échantillon trop faible) →
     # traitée comme FR par défaut côté curation (rétro-compat).
-    language: Mapped[str | None] = mapped_column(
-        String(8), nullable=True, index=True
-    )
+    language: Mapped[str | None] = mapped_column(String(8), nullable=True, index=True)
 
     # Auto-include in serein mode even if user doesn't follow this source
     serein_default: Mapped[bool] = mapped_column(

--- a/packages/api/app/models/user_personalization.py
+++ b/packages/api/app/models/user_personalization.py
@@ -47,6 +47,19 @@ class UserPersonalization(Base):
         Boolean, default=True, server_default="true"
     )
 
+    # Filtre langue : masque les cartes des sources non-FR (Source.language
+    # ∉ ('fr', NULL)) dans Essentiel/feed/digest. Les sources suivies
+    # explicitement par l'utilisateur ne sont JAMAIS masquées.
+    hide_non_fr_sources: Mapped[bool] = mapped_column(
+        Boolean, default=True, server_default="true"
+    )
+
+    # Mode du toggle ci-dessus. false = auto (recalculé à chaque
+    # follow/unfollow d'une source) ; true = figé par l'utilisateur via API.
+    language_filter_user_set: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false"
+    )
+
     # Story 13.2 — Carousel "Pépites" : rate-limit et cool-down dismiss
     pepite_carousel_dismissed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True

--- a/packages/api/app/routers/personalization.py
+++ b/packages/api/app/routers/personalization.py
@@ -50,12 +50,20 @@ class TogglePaidContentRequest(BaseModel):
     hide_paid: bool
 
 
+class ToggleHideNonFrSourcesRequest(BaseModel):
+    hide_non_fr: bool
+
+
 class PersonalizationResponse(BaseModel):
     muted_sources: list[UUID] = []
     muted_themes: list[str] = []
     muted_topics: list[str] = []
     muted_content_types: list[str] = []
     hide_paid_content: bool = True
+    hide_non_fr_sources: bool = True
+    # `true` quand l'utilisateur a touché manuellement au toggle ci-dessus —
+    # à partir de là, le recalcul auto sur follow/unfollow est gelé.
+    language_filter_user_set: bool = False
 
 
 # --- Endpoints ---
@@ -84,6 +92,10 @@ async def get_personalization(
         hide_paid_content=result.hide_paid_content
         if result.hide_paid_content is not None
         else True,
+        hide_non_fr_sources=result.hide_non_fr_sources
+        if result.hide_non_fr_sources is not None
+        else True,
+        language_filter_user_set=bool(result.language_filter_user_set),
     )
 
 
@@ -434,6 +446,67 @@ async def unmute_content_type(
         FEED_CACHE.invalidate(user_uuid)
 
     return {"message": f"Type de contenu '{ct_slug}' démuté"}
+
+
+@router.post("/toggle-hide-non-fr-sources")
+async def toggle_hide_non_fr_sources(
+    request: ToggleHideNonFrSourcesRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Active/désactive le masquage des sources non-FR.
+
+    Toute interaction utilisateur sur ce toggle gèle le mode auto
+    (`language_filter_user_set = true`) : le recalcul automatique sur
+    follow/unfollow d'une source non-FR ne touchera plus le toggle —
+    le choix explicite de l'utilisateur prévaut.
+    """
+    user_uuid = UUID(current_user_id)
+
+    user_service = UserService(db)
+    await user_service.get_or_create_profile(current_user_id)
+    await db.commit()
+
+    try:
+        stmt = (
+            pg_insert(UserPersonalization)
+            .values(
+                user_id=user_uuid,
+                hide_non_fr_sources=request.hide_non_fr,
+                language_filter_user_set=True,
+            )
+            .on_conflict_do_update(
+                index_elements=["user_id"],
+                set_={
+                    "hide_non_fr_sources": request.hide_non_fr,
+                    "language_filter_user_set": True,
+                    "updated_at": func.now(),
+                },
+            )
+        )
+
+        await db.execute(stmt)
+        await db.commit()
+        FEED_CACHE.invalidate(user_uuid)
+
+        return {
+            "message": (
+                f"Masquage sources non-FR "
+                f"{'activé' if request.hide_non_fr else 'désactivé'}"
+            ),
+            "hide_non_fr_sources": request.hide_non_fr,
+            "language_filter_user_set": True,
+        }
+
+    except Exception as e:
+        logger.error(
+            "toggle_hide_non_fr_sources_error", error=str(e), user_id=str(user_uuid)
+        )
+        await db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Erreur lors du changement de préférence: {str(e)}",
+        )
 
 
 @router.post("/toggle-paid-content")

--- a/packages/api/app/schemas/content.py
+++ b/packages/api/app/schemas/content.py
@@ -63,6 +63,9 @@ class SourceMini(BaseModel):
     bias_stance: BiasStance = BiasStance.UNKNOWN
     reliability_score: ReliabilityScore = ReliabilityScore.UNKNOWN
     bias_origin: BiasOrigin = BiasOrigin.UNKNOWN
+    # Langue majoritaire dénormalisée. `None` = inconnu (traité comme FR
+    # par défaut côté client, rétro-compat — cf. language_user_filter.py).
+    language: str | None = None
 
     class Config:
         from_attributes = True
@@ -115,6 +118,8 @@ class ContentResponse(BaseModel):
     note_text: str | None = None
     note_updated_at: datetime | None = None
     is_followed_source: bool = False
+    # Langue détectée du titre (forward-compat — label éventuel côté mobile).
+    language: str | None = None
 
     @field_serializer("topics", when_used="always")
     def serialize_topics(self, value: list[str] | None) -> list[str]:

--- a/packages/api/app/schemas/digest.py
+++ b/packages/api/app/schemas/digest.py
@@ -73,6 +73,8 @@ class DigestTopicArticle(BaseModel):
     is_saved: bool = False
     is_liked: bool = False
     is_dismissed: bool = False
+    # Langue détectée du titre (forward-compat — label éventuel mobile).
+    language: str | None = None
 
     @field_serializer("entities", when_used="always")
     def serialize_entities(self, value: list[str]) -> list[dict]:

--- a/packages/api/app/schemas/essentiel.py
+++ b/packages/api/app/schemas/essentiel.py
@@ -56,6 +56,8 @@ class EssentielArticle(BaseModel):
     is_saved: bool = False
     is_liked: bool = False
     is_dismissed: bool = False
+    # Langue détectée du titre (forward-compat).
+    language: str | None = None
 
     class Config:
         from_attributes = True

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -40,6 +40,7 @@ from app.models.source import Source, UserSource
 from app.models.user import UserProfile, UserSubtopic
 from app.schemas.digest import DigestScoreBreakdown
 from app.services.briefing.importance_detector import ImportanceDetector
+from app.services.language_user_filter import language_filter_clause
 from app.services.recommendation.filter_presets import (
     apply_ad_filter,
     apply_good_news_filter,
@@ -126,6 +127,10 @@ class DigestContext:
     muted_topics: set[str]
     muted_content_types: set[str]
     hide_paid_content: bool = True
+    # Filtre langue : masque les cartes des sources non-FR (sauf sources
+    # suivies). Default False : sécurité pour les call sites historiques
+    # qui n'instancient pas la pref.
+    hide_non_fr_sources: bool = False
     user_bias_stance: BiasStance | None = None
     source_affinity_scores: dict[UUID, float] = field(default_factory=dict)
     source_priority_multipliers: dict[UUID, float] = field(default_factory=dict)
@@ -657,6 +662,11 @@ class DigestSelector:
         if personalization and personalization.hide_paid_content is not None:
             hide_paid_content = personalization.hide_paid_content
 
+        # Language filter preference (hide non-FR sources non-suivies).
+        hide_non_fr_sources = True
+        if personalization and personalization.hide_non_fr_sources is not None:
+            hide_non_fr_sources = personalization.hide_non_fr_sources
+
         user_bias_stance = None
 
         # Compute source affinity from past interactions
@@ -691,6 +701,7 @@ class DigestSelector:
             muted_topics=muted_topics,
             muted_content_types=muted_content_types,
             hide_paid_content=hide_paid_content,
+            hide_non_fr_sources=hide_non_fr_sources,
             user_bias_stance=user_bias_stance,
             source_affinity_scores=source_affinity_scores,
             source_priority_multipliers=source_priority_multipliers,
@@ -867,6 +878,12 @@ class DigestSelector:
                 )
             else:
                 curated_query = curated_query.where(Content.is_paid.is_not(True))
+
+        # Pool curated = sources non-suivies par construction, donc pas de
+        # bypass à passer. `user_sources_query` (suivi explicite) bypasse
+        # naturellement le filtre.
+        if context.hide_non_fr_sources:
+            curated_query = curated_query.where(language_filter_clause())
 
         curated_query = apply_ad_filter(curated_query)
 

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -32,6 +32,10 @@ from app.models.source import UserSource
 from app.models.user import UserInterest, UserSubtopic
 from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
 from app.schemas.essentiel import EssentielArticle, EssentielKind, EssentielResponse
+from app.services.language_user_filter import (
+    get_hide_non_fr_pref,
+    is_foreign_source,
+)
 
 ESSENTIEL_MAX_ARTICLES = 5
 
@@ -56,6 +60,9 @@ class EssentielUserContext:
     followed_source_ids: frozenset[UUID] = field(default_factory=frozenset)
     source_priority_multipliers: dict[UUID, float] = field(default_factory=dict)
     topic_weights: dict[str, float] = field(default_factory=dict)
+    # Préférence langue : si True, on masque les articles des sources
+    # non-FR (sauf si la source est explicitement suivie).
+    hide_non_fr_sources: bool = False
 
 
 async def fetch_user_essentiel_context(
@@ -110,10 +117,13 @@ async def fetch_user_essentiel_context(
                 topic_weights.get(row.topic_slug, 0.0), float(row.weight or 1.0)
             )
 
+    hide_non_fr_sources = await get_hide_non_fr_pref(db, user_id)
+
     return EssentielUserContext(
         followed_source_ids=followed_source_ids,
         source_priority_multipliers=source_priority_multipliers,
         topic_weights=topic_weights,
+        hide_non_fr_sources=hide_non_fr_sources,
     )
 
 
@@ -162,6 +172,32 @@ def _score_article(
     return score
 
 
+def _filter_articles_by_language(
+    topics: list[DigestTopic],
+    ctx: EssentielUserContext,
+) -> list[DigestTopic]:
+    """Retire les articles de sources non-FR non-suivies si le toggle est ON.
+
+    Recopie chaque topic via `model_copy` pour ne pas muter la
+    `DigestResponse` source (la même instance peut être servie sur
+    plusieurs requêtes en cas de cache amont).
+    """
+    if not ctx.hide_non_fr_sources:
+        return topics
+
+    filtered: list[DigestTopic] = []
+    for topic in topics:
+        kept = [
+            a
+            for a in topic.articles
+            if a.source.id in ctx.followed_source_ids
+            or not is_foreign_source(a.source.language)
+        ]
+        if kept:
+            filtered.append(topic.model_copy(update={"articles": kept}))
+    return filtered
+
+
 def _pick_transversal_articles(
     topics: list[DigestTopic],
     ctx: EssentielUserContext,
@@ -175,6 +211,7 @@ def _pick_transversal_articles(
     - Round 2 (remplissage) : si <5, on complète avec les articles restants
       triés par score décroissant, dédupe par `content_id`.
     """
+    topics = _filter_articles_by_language(topics, ctx)
     eligible_topics = [t for t in topics if t.articles]
     if not eligible_topics:
         return []

--- a/packages/api/app/services/language_user_filter.py
+++ b/packages/api/app/services/language_user_filter.py
@@ -1,0 +1,152 @@
+"""Filtre langue user-aware appliqué à l'Essentiel, au feed et au digest.
+
+Le user a une préférence `hide_non_fr_sources` (UserPersonalization) qui,
+quand elle est activée, masque les cartes issues de sources non-FR — sauf
+quand la source est explicitement suivie par l'utilisateur.
+
+Le toggle a deux modes :
+
+- **Auto** (`language_filter_user_set = false`) : on recalcule la valeur
+  au follow/unfollow d'une source. Si l'utilisateur ne suit aucune source
+  étrangère → toggle ON ; sinon → OFF.
+- **Manuel** (`language_filter_user_set = true`) : on respecte le choix
+  user, le recalcul auto ne touche plus le toggle.
+
+Conventions :
+
+- `Source.language = None` est traité **comme `'fr'`** (rétro-compat) :
+  c'est l'alignement avec le client mobile et avec
+  `editorial/writer.py:_looks_french` qui ne rejettent pas les sources
+  dont la langue n'a pas pu être déterminée.
+- Le filtre est **binaire** : FR (ou unknown) vs. autres. Pas de
+  granularité par langue cible.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import ColumnElement
+
+from app.models.source import Source, UserSource
+from app.models.user_personalization import UserPersonalization
+
+# Langues considérées comme FR pour le filtre. `None` est ajouté
+# dynamiquement dans `is_foreign_source` — on ne peut pas le mettre dans
+# un set typé `str`.
+_NATIVE_LANGUAGES: frozenset[str] = frozenset({"fr"})
+
+
+def is_foreign_source(language: str | None) -> bool:
+    """True si la source doit être considérée comme étrangère.
+
+    `None` → False (rétro-compat : on ne masque pas les sources dont la
+    langue n'a pas pu être déterminée).
+    """
+    if language is None:
+        return False
+    return language not in _NATIVE_LANGUAGES
+
+
+def language_filter_clause(
+    followed_source_ids: set[UUID] | frozenset[UUID] | None = None,
+) -> ColumnElement[bool]:
+    """Clause SQL "garder cette source" pour le filtre langue.
+
+    `Source.language IS NULL` reste FR par défaut (rétro-compat). Les
+    sources explicitement suivies bypassent le filtre.
+    """
+    keep = or_(Source.language.is_(None), Source.language == "fr")
+    if followed_source_ids:
+        keep = or_(keep, Source.id.in_(list(followed_source_ids)))
+    return keep
+
+
+async def get_hide_non_fr_pref(db: AsyncSession, user_id: UUID) -> bool:
+    """Lit la préférence `hide_non_fr_sources` du user.
+
+    Si aucune row `UserPersonalization` n'existe encore → True (default
+    server_default cohérent avec la migration lg02).
+    """
+    row = await db.scalar(
+        select(UserPersonalization.hide_non_fr_sources).where(
+            UserPersonalization.user_id == user_id
+        )
+    )
+    if row is None:
+        return True
+    return bool(row)
+
+
+def apply_language_filter(
+    articles: list,
+    *,
+    hide_non_fr_sources: bool,
+    followed_source_ids: set[UUID] | frozenset[UUID],
+    source_language_of: callable,
+) -> list:
+    """Filtre une liste d'articles selon la préférence langue.
+
+    Polymorphe : `articles` peut contenir n'importe quel objet — on
+    s'appuie sur `source_language_of(article)` pour récupérer la langue
+    et sur `article.source.id` pour la comparaison avec
+    `followed_source_ids`. Cette approche permet de réutiliser le même
+    helper pour `DigestTopicArticle`, `EssentielArticle`, `Content`, etc.
+
+    Si `hide_non_fr_sources` est False → retourne `articles` sans toucher.
+    """
+    if not hide_non_fr_sources:
+        return list(articles)
+
+    kept = []
+    for article in articles:
+        source_id = article.source.id
+        if source_id in followed_source_ids:
+            kept.append(article)
+            continue
+        language = source_language_of(article)
+        if is_foreign_source(language):
+            continue
+        kept.append(article)
+    return kept
+
+
+async def recompute_auto_pref(db: AsyncSession, user_id: UUID) -> None:
+    """Recalcule `hide_non_fr_sources` en mode auto, no-op en mode manuel.
+
+    Appelée après tout follow/unfollow de source. Si l'utilisateur a déjà
+    touché manuellement au toggle (`language_filter_user_set = true`), on
+    ne fait rien — son choix est respecté.
+
+    Sinon, règle :
+
+    - true si l'utilisateur ne suit aucune source étrangère ;
+    - false sinon.
+
+    Ne commit pas : le caller orchestre la transaction.
+    """
+    pref = await db.scalar(
+        select(UserPersonalization).where(UserPersonalization.user_id == user_id)
+    )
+    if pref is None:
+        # Pas de personalization row → on n'en crée pas ici (la valeur par
+        # défaut côté ORM/DB est déjà `true`, donc cohérente avec la règle
+        # quand l'utilisateur n'a aucune source suivie).
+        return
+    if pref.language_filter_user_set:
+        return
+
+    follows_foreign = await db.scalar(
+        select(UserSource.source_id)
+        .join(Source, Source.id == UserSource.source_id)
+        .where(
+            UserSource.user_id == user_id,
+            Source.language.is_not(None),
+            Source.language != "fr",
+        )
+        .limit(1)
+    )
+
+    pref.hide_non_fr_sources = follows_foreign is None

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -144,6 +144,7 @@ def stratify_followed_first(
     return followed + others
 
 
+from app.services.language_user_filter import language_filter_clause
 from app.services.recommendation.filter_presets import (
     apply_entity_filter,
     apply_keyword_filter,
@@ -432,6 +433,14 @@ class RecommendationService:
         elif personalization and personalization.hide_paid_content is not None:
             hide_paid_content = personalization.hide_paid_content
 
+        # Language filter preference (hide non-FR sources non-suivies).
+        # Désactivé quand on browse explicitement une source (exploration).
+        hide_non_fr_sources = True
+        if source_id:
+            hide_non_fr_sources = False
+        elif personalization and personalization.hide_non_fr_sources is not None:
+            hide_non_fr_sources = personalization.hide_non_fr_sources
+
         # Convert source_id string to UUID if provided
         source_uuid = UUID(source_id) if source_id else None
 
@@ -466,6 +475,8 @@ class RecommendationService:
             keyword=keyword,
             # Paywall filter
             hide_paid_content=hide_paid_content,
+            # Language filter (hide non-FR sources non-suivies)
+            hide_non_fr_sources=hide_non_fr_sources,
             # Premium sources: allow paid content from subscribed sources
             subscribed_source_ids=subscribed_source_ids,
             # Source filter
@@ -2319,6 +2330,7 @@ class RecommendationService:
         digest_content_ids: list[UUID] = None,
         theme: str | None = None,
         hide_paid_content: bool = True,
+        hide_non_fr_sources: bool = False,
         subscribed_source_ids: set[UUID] = None,
         source_id: UUID | None = None,
         topic: str | None = None,
@@ -2490,6 +2502,9 @@ class RecommendationService:
                 )
             else:
                 query = query.where(Content.is_paid.is_not(True))
+
+        if hide_non_fr_sources:
+            query = query.where(language_filter_clause(followed_source_ids))
 
         # Apply serein content filter (orthogonal to mode — filters anxiety content)
         if serein and not source_id:

--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -13,6 +13,7 @@ from app.schemas.source import (
     SourceDetectResponse,
     SourceResponse,
 )
+from app.services.language_user_filter import recompute_auto_pref
 from app.services.rss_parser import RSSParser
 
 logger = structlog.get_logger()
@@ -351,6 +352,7 @@ class SourceService:
             self.db.add(user_source)
 
         await self.db.flush()
+        await recompute_auto_pref(self.db, user_uuid)
 
         return SourceResponse(
             id=source.id,
@@ -389,6 +391,7 @@ class SourceService:
 
         await self.db.delete(user_source)
         await self.db.flush()
+        await recompute_auto_pref(self.db, UUID(user_id))
 
         return True
 
@@ -440,6 +443,9 @@ class SourceService:
             ]
 
         await self.db.flush()
+        # Mode auto du filtre langue : si l'utilisateur n'a pas figé son
+        # toggle, le suivi d'une nouvelle source peut basculer la pref.
+        await recompute_auto_pref(self.db, UUID(user_id))
         return True
 
     async def update_source_subscription(
@@ -519,6 +525,7 @@ class SourceService:
 
         await self.db.delete(user_source)
         await self.db.flush()
+        await recompute_auto_pref(self.db, UUID(user_id))
         return True
 
     async def detect_source(self, url: str) -> SourceDetectResponse:

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -9,6 +9,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from app.config import get_settings
 from app.jobs.digest_generation_job import run_digest_generation
 from app.jobs.purge_deleted_users import purge_deleted_users
+from app.jobs.recompute_source_language import recompute_source_language
 from app.workers.rss_sync import sync_all_sources
 from app.workers.storage_cleanup import cleanup_old_articles
 from app.workers.top3_job import generate_daily_top3_job
@@ -240,6 +241,16 @@ def start_scheduler() -> None:
         replace_existing=True,
     )
 
+    # Recalcul `sources.language` à partir des Content des 30 derniers jours
+    # (3h30 Paris, après storage_cleanup pour partir d'un pool nettoyé).
+    scheduler.add_job(
+        recompute_source_language,
+        trigger=CronTrigger(hour=3, minute=30, timezone=_PARIS_TZ),
+        id="recompute_source_language",
+        name="Recompute Source.language (majoritaire 30j)",
+        replace_existing=True,
+    )
+
     # Zombie session sweeper — kill Supavisor sessions stuck in
     # `idle in transaction` > 5 min (filet de sécurité par-dessus le
     # timeout Postgres + le rollback() en finally de safe_async_session).
@@ -261,6 +272,7 @@ def start_scheduler() -> None:
             "digest_watchdog",
             "storage_cleanup",
             "purge_deleted_users",
+            "recompute_source_language",
             "zombie_session_sweeper",
         ],
         rss_interval_minutes=settings.rss_sync_interval_minutes,

--- a/packages/api/tests/services/test_language_user_filter.py
+++ b/packages/api/tests/services/test_language_user_filter.py
@@ -1,0 +1,242 @@
+"""Tests pour `app/services/language_user_filter.py`.
+
+Couvre :
+
+- `is_foreign_source` : règles FR/None/EN/autres.
+- `get_hide_non_fr_pref` : default (no row), lecture.
+- `apply_language_filter` : toggle ON/OFF, source suivie protégée, None
+  traité comme FR.
+- `recompute_auto_pref` : mode auto bascule, mode manuel gelé, no-op si
+  pas de personalization row.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from app.models.enums import SourceType
+from app.models.source import Source, UserSource
+from app.models.user import UserProfile
+from app.models.user_personalization import UserPersonalization
+from app.services.language_user_filter import (
+    apply_language_filter,
+    get_hide_non_fr_pref,
+    is_foreign_source,
+    recompute_auto_pref,
+)
+
+# ---- is_foreign_source --------------------------------------------------------
+
+
+def test_is_foreign_source_none_is_native():
+    """`None` = inconnu → traité comme FR (rétro-compat)."""
+    assert is_foreign_source(None) is False
+
+
+def test_is_foreign_source_fr_is_native():
+    assert is_foreign_source("fr") is False
+
+
+def test_is_foreign_source_en_is_foreign():
+    assert is_foreign_source("en") is True
+
+
+def test_is_foreign_source_other_is_foreign():
+    assert is_foreign_source("de") is True
+    assert is_foreign_source("es") is True
+
+
+# ---- apply_language_filter ----------------------------------------------------
+
+
+class _FakeSource:
+    def __init__(self, id, language):
+        self.id = id
+        self.language = language
+
+
+class _FakeArticle:
+    def __init__(self, source):
+        self.source = source
+
+
+def _lang_of(article):
+    return article.source.language
+
+
+def test_apply_filter_off_returns_articles_unchanged():
+    src1 = _FakeSource(uuid4(), "en")
+    src2 = _FakeSource(uuid4(), "fr")
+    articles = [_FakeArticle(src1), _FakeArticle(src2)]
+
+    out = apply_language_filter(
+        articles,
+        hide_non_fr_sources=False,
+        followed_source_ids=set(),
+        source_language_of=_lang_of,
+    )
+
+    assert len(out) == 2
+
+
+def test_apply_filter_on_removes_foreign_non_followed():
+    src_en = _FakeSource(uuid4(), "en")
+    src_fr = _FakeSource(uuid4(), "fr")
+    articles = [_FakeArticle(src_en), _FakeArticle(src_fr)]
+
+    out = apply_language_filter(
+        articles,
+        hide_non_fr_sources=True,
+        followed_source_ids=set(),
+        source_language_of=_lang_of,
+    )
+
+    assert len(out) == 1
+    assert out[0].source.language == "fr"
+
+
+def test_apply_filter_on_preserves_foreign_followed():
+    src_en = _FakeSource(uuid4(), "en")
+    articles = [_FakeArticle(src_en)]
+
+    out = apply_language_filter(
+        articles,
+        hide_non_fr_sources=True,
+        followed_source_ids={src_en.id},
+        source_language_of=_lang_of,
+    )
+
+    assert len(out) == 1
+    assert out[0].source.language == "en"
+
+
+def test_apply_filter_on_keeps_unknown_language():
+    """language=None doit être traité comme FR (rétro-compat)."""
+    src_unknown = _FakeSource(uuid4(), None)
+    articles = [_FakeArticle(src_unknown)]
+
+    out = apply_language_filter(
+        articles,
+        hide_non_fr_sources=True,
+        followed_source_ids=set(),
+        source_language_of=_lang_of,
+    )
+
+    assert len(out) == 1
+
+
+# ---- get_hide_non_fr_pref -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_hide_non_fr_pref_default_true_when_no_row(db_session):
+    """Aucune row personalization → default `True` (cohérent avec server_default)."""
+    user_id = uuid4()
+    assert await get_hide_non_fr_pref(db_session, user_id) is True
+
+
+@pytest.mark.asyncio
+async def test_get_hide_non_fr_pref_reads_stored_value(db_session):
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    db_session.add(
+        UserPersonalization(
+            user_id=user_id,
+            hide_non_fr_sources=False,
+            language_filter_user_set=True,
+        )
+    )
+    await db_session.commit()
+
+    assert await get_hide_non_fr_pref(db_session, user_id) is False
+
+
+# ---- recompute_auto_pref ------------------------------------------------------
+
+
+async def _make_user_with_pref(db_session, user_set: bool, current: bool = True):
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    db_session.add(
+        UserPersonalization(
+            user_id=user_id,
+            hide_non_fr_sources=current,
+            language_filter_user_set=user_set,
+        )
+    )
+    await db_session.commit()
+    return user_id
+
+
+async def _make_source(db_session, language: str | None):
+    src = Source(
+        id=uuid4(),
+        name=f"Test {language}",
+        url="https://example.test",
+        feed_url=f"https://example.test/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        language=language,
+    )
+    db_session.add(src)
+    await db_session.commit()
+    return src
+
+
+@pytest.mark.asyncio
+async def test_recompute_noop_in_manual_mode(db_session):
+    """Si l'utilisateur a touché le toggle, le recalcul ne change rien."""
+    user_id = await _make_user_with_pref(db_session, user_set=True, current=False)
+    en_source = await _make_source(db_session, language="en")
+    db_session.add(UserSource(user_id=user_id, source_id=en_source.id))
+    await db_session.commit()
+
+    await recompute_auto_pref(db_session, user_id)
+    await db_session.commit()
+
+    pref = await db_session.get(UserPersonalization, user_id)
+    assert pref.hide_non_fr_sources is False  # gelé
+
+
+@pytest.mark.asyncio
+async def test_recompute_auto_off_when_user_follows_foreign(db_session):
+    user_id = await _make_user_with_pref(db_session, user_set=False, current=True)
+    en_source = await _make_source(db_session, language="en")
+    db_session.add(UserSource(user_id=user_id, source_id=en_source.id))
+    await db_session.commit()
+
+    await recompute_auto_pref(db_session, user_id)
+    await db_session.commit()
+
+    pref = await db_session.get(UserPersonalization, user_id)
+    assert pref.hide_non_fr_sources is False
+
+
+@pytest.mark.asyncio
+async def test_recompute_auto_on_when_only_fr_sources(db_session):
+    """User suit seulement des sources FR (et unknown) → toggle = True."""
+    user_id = await _make_user_with_pref(db_session, user_set=False, current=False)
+    fr_source = await _make_source(db_session, language="fr")
+    unknown_source = await _make_source(db_session, language=None)
+    db_session.add(UserSource(user_id=user_id, source_id=fr_source.id))
+    db_session.add(UserSource(user_id=user_id, source_id=unknown_source.id))
+    await db_session.commit()
+
+    await recompute_auto_pref(db_session, user_id)
+    await db_session.commit()
+
+    pref = await db_session.get(UserPersonalization, user_id)
+    assert pref.hide_non_fr_sources is True
+
+
+@pytest.mark.asyncio
+async def test_recompute_noop_when_no_personalization_row(db_session):
+    """Pas de row personalization (user nouveau) → no-op, pas d'exception."""
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    await db_session.commit()
+
+    # Doit juste ne pas planter.
+    await recompute_auto_pref(db_session, user_id)
+    await db_session.commit()


### PR DESCRIPTION
# PR 1 — Backend : Filtre par langue & `Source.language` (curation FR-first)

## Contexte

PR 1/2 du plan **language-aware curation**. Introduit la prise en compte
de la langue de la source dans les pipelines Essentiel / feed / digest,
contrôlée par une préférence user `hide_non_fr_sources` masquant les
cartes des sources non-FR — sauf si la source est explicitement suivie.

La couche mobile + section "Couverture à l'étranger" (panel perspectives)
arrivent en PR 2.

## Changements

### Données

- **Migration `lg02_source_language_user_pref`** (down_revision : `lg01`) :
  - `sources.language String(8) NULL, indexed` ; backfill par langue
    majoritaire (≥ 60 %) à partir de `Content.language`.
  - `user_personalization.hide_non_fr_sources` (Boolean, default `true`).
  - `user_personalization.language_filter_user_set` (Boolean, default
    `false`) — flag "mode auto".
  - Backfill `hide_non_fr_sources = false` pour les users qui suivent
    déjà ≥ 1 source étrangère (respect du choix implicite).

### Services

- `app/services/language_user_filter.py` (nouveau) :
  - `is_foreign_source`, `get_hide_non_fr_pref`, `apply_language_filter`
    (filtre Python), `language_filter_clause` (clause SQL partagée
    digest_selector ↔ recommendation_service), `recompute_auto_pref`
    (mode auto bascule sur follow/unfollow).
- `essentiel_service` : `EssentielUserContext.hide_non_fr_sources` +
  `_filter_articles_by_language` appliqué avant le scoring.
- `recommendation_service._get_candidates` : filtre SQL équivalent
  (followed sources jamais filtrées). Désactivé en mode "browse a
  specific source" (exploration).
- `digest_selector` : `DigestContext.hide_non_fr_sources` + filtre SQL
  sur le pool curated (les articles des sources suivies passent par
  `user_sources_query`, hors filtre par construction).
- `source_service.{trust,untrust,create,delete}_source` : appellent
  `recompute_auto_pref` après mutation.

### API

- `SourceMini.language: str | None` (forward-compat, propagé dans tous
  les schemas qui l'embarquent).
- `ContentResponse.language`, `DigestTopicArticle.language`,
  `EssentielArticle.language` (forward-compat — utile au debug et label
  éventuel côté mobile).
- `GET /api/personalization` expose `hide_non_fr_sources` +
  `language_filter_user_set`.
- `POST /api/personalization/toggle-hide-non-fr-sources` : toute MAJ
  flippe `language_filter_user_set = true` (gel du choix user).

### Background

- `app/jobs/recompute_source_language.py` (nouveau) : recalcule
  `sources.language` 1×/jour à partir de `Content.language` des 30
  derniers jours (seuil majoritaire 60 %).
- Scheduler : nouveau job `recompute_source_language` à 03h30 Paris.

## Tests

- `tests/services/test_language_user_filter.py` (nouveau) :
  - 8 unit tests pure-Python.
  - 6 tests DB pour `get_hide_non_fr_pref` + `recompute_auto_pref`
    (mode auto / manuel, no-op sans personalization row).
- Suite backend complète : **1285 passed, 1 skipped, 2 xfailed** sur DB
  locale post-migration `lg02`.

## Vérification

```
cd packages/api && python -m alembic heads          # → lg02_source_language_user_pref seule head
cd packages/api && python -m alembic upgrade head   # DB vide → OK (jouée localement)
cd packages/api && python -m pytest -q              # 1285 passed
```

## Points d'attention

- **`Source.language=NULL` → traité comme FR** (rétro-compat avec le
  client mobile et `editorial/writer.py:_looks_french`). Conséquence :
  une source dont la langue n'est pas encore détectée ne sera pas
  masquée.
- **Filtre désactivé en exploration source** (`source_id` query param) :
  on n'ampute pas le browse explicite.
- **`recompute_auto_pref` flushe avant SELECT** : la nouvelle
  UserSource doit être visible. Hooks placés après `db.flush()`.
- **Mobile (PR 2)** reste à faire : toggle "Masquer sources non-FR" +
  section "Couverture à l'étranger" dans le panel perspectives.

## Follow-ups identifiés

- La whitelist `is_french_source` peut mislabel certaines sources
  (Story 7.7 — labellisation manuelle du catalogue). Acceptable pour PR 1.
- Pas de migration côté Story 7.7 = on s'appuie sur le job daily pour
  rattraper les nouvelles sources.