### PR TITLE
fix(api): sources — session DB ouverte après lock (idle-in-tx timeout fix)

### DIFF
--- a/docs/bugs/bug-onboarding-sources-idle-tx-timeout.md
+++ b/docs/bugs/bug-onboarding-sources-idle-tx-timeout.md
@@ -1,0 +1,117 @@
+# Bug : Erreur sources lors de l'onboarding — IdleInTransactionSessionTimeout
+
+**Date** : 2026-05-25
+**Statut** : Fix en cours
+**Sentry** : PYTHON-4R, PYTHON-3C, PYTHON-3H, PYTHON-3Z, PYTHON-3R, PYTHON-37, PYTHON-34
+**Impact** : Élevé — utilisateurs en onboarding bloqués à l'étape "Sélection des sources" avec erreur `sources_unavailable` (HTTP 503).
+
+---
+
+## Symptômes
+
+À l'étape sources de l'onboarding, le mobile appelle `GET /sources` et reçoit un HTTP 503 `sources_unavailable`. L'écran d'erreur Facteur s'affiche, bloquant la progression.
+
+Récurrent : plusieurs utilisateurs en onboarding touchés (confirmé par Sentry — PYTHON-4R encore actif le 2026-05-25).
+
+---
+
+## Chaîne causale
+
+```
+IdleInTransactionSessionTimeout (PYTHON-3C / 3H / 3Z / 3R / 37)
+  → session laissée en état invalide
+  → PendingRollbackError sur requête suivante (PYTHON-4R — actif aujourd'hui)
+  → retry_db_op() exhauste 3 tentatives
+  → HTTPException 503 sources_unavailable (PYTHON-34)
+  → mobile : erreur à l'étape sources
+```
+
+---
+
+## Cause racine
+
+### Partie 1 — Architectural (critique)
+
+`get_sources()` reçoit une session via `Depends(get_db)` qui **ouvre la transaction immédiatement** (`BEGIN; SET LOCAL idle_in_transaction_session_timeout=10000`). Ensuite l'handler acquiert `SOURCES_CACHE.lock(user_uuid)` pour éviter le thundering herd.
+
+**Problème** : si un autre request concurrent du même user tient le lock (ex. retry automatique de `userSourcesProvider`), le second request attend le lock avec sa transaction IDLE ouverte. Si l'attente dépasse 10 s → Postgres kill → `InternalError: IdleInTransactionSessionTimeout`.
+
+Les retries de `retry_db_op()` (3 tentatives) n'aident pas car ils se produisent APRÈS l'acquisition du lock — qui peut lui-même retomber dans le même état si le premier holder est lent.
+
+```
+Request 1 : acquiert lock → BEGIN; SET LOCAL idt=10s → 8 queries (lent)
+Request 2 : BEGIN; SET LOCAL idt=10s → attend lock ...
+             [10 s s'écoulent]
+             → InternalError: IdleInTransactionSessionTimeout
+             → retry × 3 (même séquence)
+             → HTTPException 503
+```
+
+### Partie 2 — Performance (N+1, aggravant)
+
+`get_all_sources()` appelle `get_curated_sources()` (5 queries) puis re-exécute 3 des mêmes queries pour les sources custom. Total : **8 queries avec 4 redondantes** (confirmé PYTHON-46 / PYTHON-1W "N+1 Query").
+
+Le lock holder met plus longtemps → fenêtre d'idle plus large pour les waiters.
+
+```
+get_all_sources() :
+  SELECT UserPersonalization         ← redondante (aussi dans get_curated_sources)
+  → get_curated_sources() :
+      SELECT Source (curated)
+      SELECT UserSource.source_id    ← redondante
+      SELECT UserSource.multiplier   ← redondante
+      SELECT UserSource.subscription ← redondante
+      SELECT UserPersonalization     ← redondante
+  SELECT UserSource.multiplier       ← re-exécuté
+  SELECT UserSource.subscription     ← re-exécuté
+  SELECT Source (custom, join UserSource)
+```
+
+---
+
+## Fix
+
+### Fix 1 — `packages/api/app/routers/sources.py`
+
+Supprimer `db: AsyncSession = Depends(get_db)` de `get_sources()`.  
+Ouvrir une `safe_async_session()` **à l'intérieur de l'handler, après l'acquisition du lock**.
+
+→ Le timer `idle_in_transaction_session_timeout` ne démarre qu'au moment où les queries commencent réellement. Plus de risque d'idle pendant l'attente de lock.
+
+### Fix 2 — `packages/api/app/services/source_service.py`
+
+Extraire un helper `_build_source_response()` (synchrone, pur).  
+Refactoriser `get_all_sources()` pour charger les données user en une seule passe :
+- 1 query UserSource combinée (source_id + multiplier + subscription)
+- 1 query UserPersonalization
+- 1 query Source curated
+- 1 query Source custom
+
+**4 queries au lieu de 8**, 0 redondance. `get_curated_sources()` aussi optimisée (3 queries au lieu de 5).
+
+---
+
+## Fichiers modifiés
+
+| Fichier | Modification |
+|---|---|
+| `packages/api/app/routers/sources.py` | Session ouverte après lock (Fix 1) |
+| `packages/api/app/services/source_service.py` | Élimination des queries redondantes (Fix 2) |
+
+---
+
+## Vérification
+
+```bash
+cd packages/api && pytest tests/test_sources.py -v
+cd packages/api && pytest -v
+
+# Test concurrence (thundering herd simulé)
+# Les 2 requests doivent réussir sans 503
+for i in 1 2; do
+  curl -s -H "Authorization: Bearer <jwt>" localhost:8080/api/sources &
+done
+wait
+```
+
+Sentry : PYTHON-4R, PYTHON-3C ne doivent plus apparaître après déploiement.

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -106,7 +106,6 @@ def _check_search_endpoint_rate(user_id: str) -> bool:
 @router.get("", response_model=SourceCatalogResponse)
 async def get_sources(
     user_id: str = Depends(get_current_user_id),
-    db: AsyncSession = Depends(get_db),
 ) -> SourceCatalogResponse:
     """Récupérer toutes les sources (curées + custom).
 
@@ -114,6 +113,14 @@ async def get_sources(
     (PYTHON-4 / PYTHON-26 — pool pressure). Returns 503 ``sources_unavailable``
     on persistent failure so the mobile FriendlyErrorView can render the
     "Petit souci de serveur" copy instead of a raw DioException.
+
+    Fix PYTHON-4R / PYTHON-3C (IdleInTransactionSessionTimeout lors de
+    l'onboarding) : la session DB est ouverte APRÈS l'acquisition du lock
+    SOURCES_CACHE, pas avant. Auparavant, ``Depends(get_db)`` ouvrait
+    ``BEGIN; SET LOCAL idle_in_transaction_session_timeout=10s`` avant même
+    d'avoir le lock — si un request concurrent tenait le lock plus de 10 s
+    (ex. retry mobile), Postgres tuait la transaction idle et le request
+    retombait en 503 après 3 retries exhaustés.
     """
     user_uuid = UUID(user_id)
 
@@ -126,13 +133,17 @@ async def get_sources(
         if cached is not None:
             return cached
 
-        service = SourceService(db)
+        # Session ouverte ICI — après le lock, juste avant les queries.
+        # Le timer idle_in_transaction_session_timeout ne démarre qu'à ce
+        # moment, éliminant le risque de timeout pendant l'attente de lock.
         try:
-            sources = await retry_db_op(
-                lambda: service.get_all_sources(user_id),
-                session=db,
-                op_name="sources.get_all",
-            )
+            async with safe_async_session() as db:
+                service = SourceService(db)
+                sources = await retry_db_op(
+                    lambda: service.get_all_sources(user_id),
+                    session=db,
+                    op_name="sources.get_all",
+                )
         except (SQLAlchemyError, DBAPIError) as e:
             logger.error(
                 "sources_endpoint_db_error",

--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -25,6 +25,31 @@ class SourceService:
         self.db = db
         self.rss_parser = RSSParser()
 
+    async def _load_user_source_context(
+        self, user_id: UUID
+    ) -> tuple[set[UUID], dict[UUID, float], dict[UUID, bool]]:
+        """Charge trusted_ids, multipliers et subscriptions en une seule query.
+
+        Remplace les trois appels séparés (_load_user_source_multipliers,
+        _load_user_source_subscriptions, SELECT source_id) par une unique
+        query combinée — réduit le nombre de round-trips DB de 3 à 1.
+        Fix partiel PYTHON-46 / PYTHON-1W (N+1 sur sources).
+        """
+        result = await self.db.execute(
+            select(
+                UserSource.source_id,
+                UserSource.priority_multiplier,
+                UserSource.has_subscription,
+            ).where(UserSource.user_id == user_id)
+        )
+        rows = result.all()
+        trusted_ids = {row.source_id for row in rows}
+        multipliers = {row.source_id: row.priority_multiplier for row in rows}
+        subscriptions = {row.source_id: row.has_subscription for row in rows}
+        return trusted_ids, multipliers, subscriptions
+
+    # Gardés pour rétro-compatibilité avec les appelants existants (trust_source,
+    # update_source_subscription, etc.) qui les utilisent dans des contextes isolés.
     async def _load_user_source_multipliers(self, user_id: UUID) -> dict[UUID, float]:
         """Load priority_multiplier for all user sources."""
         result = await self.db.execute(
@@ -43,27 +68,95 @@ class SourceService:
         )
         return {row.source_id: row.has_subscription for row in result.all()}
 
+    def _build_source_response(
+        self,
+        s: Source,
+        *,
+        is_curated: bool,
+        is_custom: bool,
+        is_trusted: bool,
+        muted_source_ids: set[UUID],
+        multipliers: dict[UUID, float],
+        subscriptions: dict[UUID, bool],
+        follower_count: int = 0,
+    ) -> SourceResponse:
+        """Construit un SourceResponse à partir d'un objet Source et du contexte user.
+
+        Helper synchrone pur — élimine la duplication du bloc SourceResponse(...)
+        présent dans get_all_sources, get_curated_sources, get_trending_sources, etc.
+        """
+        return SourceResponse(
+            id=s.id,
+            name=s.name,
+            url=s.url,
+            type=s.type,
+            theme=s.theme,
+            description=s.description,
+            logo_url=s.logo_url,
+            is_curated=is_curated,
+            is_custom=is_custom,
+            is_trusted=is_trusted,
+            is_muted=s.id in muted_source_ids,
+            priority_multiplier=multipliers.get(s.id, 1.0),
+            has_subscription=subscriptions.get(s.id, False),
+            content_count=0,  # TODO
+            follower_count=follower_count,
+            bias_stance=getattr(s.bias_stance, "value", "unknown"),
+            reliability_score=getattr(s.reliability_score, "value", "unknown"),
+            bias_origin=getattr(s.bias_origin, "value", "unknown"),
+            score_independence=s.score_independence,
+            score_rigor=s.score_rigor,
+            score_ux=s.score_ux,
+            recommended_by=getattr(s, "recommended_by", None),
+            recommendation_reason=getattr(s, "recommendation_reason", None),
+        )
+
     async def get_all_sources(self, user_id: str) -> SourceCatalogResponse:
-        """Récupère toutes les sources (curées + custom)."""
+        """Récupère toutes les sources (curées + custom).
+
+        Optimisé : 4 queries au lieu de 8 (fix PYTHON-46 / PYTHON-1W N+1).
+        Les données user (trusted_ids, multipliers, subscriptions, muted) sont
+        chargées une seule fois et partagées entre curated et custom, éliminant
+        les 4 queries redondantes de l'implémentation précédente qui appelait
+        get_curated_sources() puis re-chargeait les mêmes données.
+
+        Combiné avec le fix du router (session ouverte après lock), résout
+        l'IdleInTransactionSessionTimeout lors de l'onboarding (PYTHON-4R / 3C).
+        """
         user_uuid = UUID(user_id)
 
-        # Load muted sources for is_muted flag
-        muted_source_ids = set()
+        # 1 query combinée : trusted_ids + multipliers + subscriptions
+        trusted_source_ids, multipliers, subscriptions = (
+            await self._load_user_source_context(user_uuid)
+        )
+
+        # 1 query : muted sources via UserPersonalization
+        muted_source_ids: set[UUID] = set()
         personalization = await self.db.scalar(
             select(UserPersonalization).where(UserPersonalization.user_id == user_uuid)
         )
         if personalization and personalization.muted_sources:
             muted_source_ids = set(personalization.muted_sources)
 
-        # Sources curées
-        curated = await self.get_curated_sources(user_id)
+        # 1 query : sources curées
+        curated_result = await self.db.execute(
+            select(Source).where(Source.is_curated, Source.is_active)
+        )
+        curated = [
+            self._build_source_response(
+                s,
+                is_curated=True,
+                is_custom=False,
+                is_trusted=s.id in trusted_source_ids,
+                muted_source_ids=muted_source_ids,
+                multipliers=multipliers,
+                subscriptions=subscriptions,
+            )
+            for s in curated_result.scalars().all()
+        ]
 
-        # Load priority multipliers and subscriptions
-        multipliers = await self._load_user_source_multipliers(user_uuid)
-        subscriptions = await self._load_user_source_subscriptions(user_uuid)
-
-        # Sources custom de l'utilisateur (distinct au cas où doublons user_sources)
-        query = (
+        # 1 query : sources custom (distinct pour éviter doublons user_sources)
+        custom_result = await self.db.execute(
             select(Source)
             .join(UserSource)
             .where(
@@ -72,35 +165,17 @@ class SourceService:
             )
             .distinct()
         )
-        result = await self.db.execute(query)
-        custom_sources = result.scalars().all()
-
         custom = [
-            SourceResponse(
-                id=s.id,
-                name=s.name,
-                url=s.url,
-                type=s.type,
-                theme=s.theme,
-                description=s.description,
-                logo_url=s.logo_url,
+            self._build_source_response(
+                s,
                 is_curated=False,
                 is_custom=True,
-                is_trusted=True,
-                is_muted=s.id in muted_source_ids,
-                priority_multiplier=multipliers.get(s.id, 1.0),
-                has_subscription=subscriptions.get(s.id, False),
-                content_count=0,  # TODO
-                bias_stance=getattr(s.bias_stance, "value", "unknown"),
-                reliability_score=getattr(s.reliability_score, "value", "unknown"),
-                bias_origin=getattr(s.bias_origin, "value", "unknown"),
-                score_independence=s.score_independence,
-                score_rigor=s.score_rigor,
-                score_ux=s.score_ux,
-                recommended_by=getattr(s, "recommended_by", None),
-                recommendation_reason=getattr(s, "recommendation_reason", None),
+                is_trusted=True,  # les sources custom sont toujours trusted
+                muted_source_ids=muted_source_ids,
+                multipliers=multipliers,
+                subscriptions=subscriptions,
             )
-            for s in custom_sources
+            for s in custom_result.scalars().all()
         ]
 
         return SourceCatalogResponse(curated=curated, custom=custom)
@@ -108,26 +183,26 @@ class SourceService:
     async def get_curated_sources(
         self, user_id: str | None = None
     ) -> list[SourceResponse]:
-        """Récupère les sources curées."""
-        query = select(Source).where(Source.is_curated, Source.is_active)
-        result = await self.db.execute(query)
-        sources = result.scalars().all()
+        """Récupère les sources curées.
 
-        trusted_source_ids = set()
-        muted_source_ids = set()
+        Optimisé : 3 queries au lieu de 5 (trusted_ids + multipliers +
+        subscriptions chargés en une seule query via _load_user_source_context).
+        """
+        curated_result = await self.db.execute(
+            select(Source).where(Source.is_curated, Source.is_active)
+        )
+        sources = curated_result.scalars().all()
+
+        trusted_source_ids: set[UUID] = set()
+        muted_source_ids: set[UUID] = set()
         multipliers: dict[UUID, float] = {}
         subscriptions: dict[UUID, bool] = {}
+
         if user_id:
             user_uuid = UUID(user_id)
-            user_sources_query = select(UserSource.source_id).where(
-                UserSource.user_id == user_uuid
+            trusted_source_ids, multipliers, subscriptions = (
+                await self._load_user_source_context(user_uuid)
             )
-            user_sources_result = await self.db.execute(user_sources_query)
-            trusted_source_ids = set(user_sources_result.scalars().all())
-
-            multipliers = await self._load_user_source_multipliers(user_uuid)
-            subscriptions = await self._load_user_source_subscriptions(user_uuid)
-
             personalization = await self.db.scalar(
                 select(UserPersonalization).where(
                     UserPersonalization.user_id == user_uuid
@@ -137,29 +212,14 @@ class SourceService:
                 muted_source_ids = set(personalization.muted_sources)
 
         return [
-            SourceResponse(
-                id=s.id,
-                name=s.name,
-                url=s.url,
-                type=s.type,
-                theme=s.theme,
-                description=s.description,
-                logo_url=s.logo_url,
+            self._build_source_response(
+                s,
                 is_curated=True,
                 is_custom=False,
                 is_trusted=s.id in trusted_source_ids,
-                is_muted=s.id in muted_source_ids,
-                priority_multiplier=multipliers.get(s.id, 1.0),
-                has_subscription=subscriptions.get(s.id, False),
-                content_count=0,  # TODO
-                bias_stance=getattr(s.bias_stance, "value", "unknown"),
-                reliability_score=getattr(s.reliability_score, "value", "unknown"),
-                bias_origin=getattr(s.bias_origin, "value", "unknown"),
-                score_independence=s.score_independence,
-                score_rigor=s.score_rigor,
-                score_ux=s.score_ux,
-                recommended_by=getattr(s, "recommended_by", None),
-                recommendation_reason=getattr(s, "recommendation_reason", None),
+                muted_source_ids=muted_source_ids,
+                multipliers=multipliers,
+                subscriptions=subscriptions,
             )
             for s in sources
         ]

--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -48,25 +48,6 @@ class SourceService:
         subscriptions = {row.source_id: row.has_subscription for row in rows}
         return trusted_ids, multipliers, subscriptions
 
-    # Gardés pour rétro-compatibilité avec les appelants existants (trust_source,
-    # update_source_subscription, etc.) qui les utilisent dans des contextes isolés.
-    async def _load_user_source_multipliers(self, user_id: UUID) -> dict[UUID, float]:
-        """Load priority_multiplier for all user sources."""
-        result = await self.db.execute(
-            select(UserSource.source_id, UserSource.priority_multiplier).where(
-                UserSource.user_id == user_id
-            )
-        )
-        return {row.source_id: row.priority_multiplier for row in result.all()}
-
-    async def _load_user_source_subscriptions(self, user_id: UUID) -> dict[UUID, bool]:
-        """Load has_subscription for all user sources."""
-        result = await self.db.execute(
-            select(UserSource.source_id, UserSource.has_subscription).where(
-                UserSource.user_id == user_id
-            )
-        )
-        return {row.source_id: row.has_subscription for row in result.all()}
 
     def _build_source_response(
         self,
@@ -229,7 +210,7 @@ class SourceService:
     ) -> list[SourceResponse]:
         """Récupère les sources les plus populaires de la communauté."""
         count_col = func.count(UserSource.user_id).label("follower_count")
-        query = (
+        result = await self.db.execute(
             select(Source, count_col)
             .join(UserSource)
             .where(Source.is_active)
@@ -238,23 +219,14 @@ class SourceService:
             .order_by(count_col.desc())
             .limit(limit)
         )
-
-        result = await self.db.execute(query)
         rows = result.all()  # list of (Source, follower_count) tuples
 
-        # Check trusted & muted status for the current user
         user_uuid = UUID(user_id)
-
-        user_sources_query = select(UserSource.source_id).where(
-            UserSource.user_id == user_uuid
+        trusted_source_ids, multipliers, subscriptions = (
+            await self._load_user_source_context(user_uuid)
         )
-        user_sources_result = await self.db.execute(user_sources_query)
-        trusted_source_ids = set(user_sources_result.scalars().all())
 
-        multipliers = await self._load_user_source_multipliers(user_uuid)
-        subscriptions = await self._load_user_source_subscriptions(user_uuid)
-
-        muted_source_ids = set()
+        muted_source_ids: set[UUID] = set()
         personalization = await self.db.scalar(
             select(UserPersonalization).where(UserPersonalization.user_id == user_uuid)
         )
@@ -262,30 +234,15 @@ class SourceService:
             muted_source_ids = set(personalization.muted_sources)
 
         return [
-            SourceResponse(
-                id=s.id,
-                name=s.name,
-                url=s.url,
-                type=s.type,
-                theme=s.theme,
-                description=s.description,
-                logo_url=s.logo_url,
+            self._build_source_response(
+                s,
                 is_curated=s.is_curated,
                 is_custom=not s.is_curated,
                 is_trusted=s.id in trusted_source_ids,
-                is_muted=s.id in muted_source_ids,
-                priority_multiplier=multipliers.get(s.id, 1.0),
-                has_subscription=subscriptions.get(s.id, False),
-                content_count=0,
+                muted_source_ids=muted_source_ids,
+                multipliers=multipliers,
+                subscriptions=subscriptions,
                 follower_count=follower_count,
-                bias_stance=getattr(s.bias_stance, "value", "unknown"),
-                reliability_score=getattr(s.reliability_score, "value", "unknown"),
-                bias_origin=getattr(s.bias_origin, "value", "unknown"),
-                score_independence=s.score_independence,
-                score_rigor=s.score_rigor,
-                score_ux=s.score_ux,
-                recommended_by=getattr(s, "recommended_by", None),
-                recommendation_reason=getattr(s, "recommendation_reason", None),
             )
             for s, follower_count in rows
         ]
@@ -307,21 +264,15 @@ class SourceService:
         result = await self.db.execute(search_query)
         sources = result.scalars().all()
 
-        # Load user context for is_trusted / is_muted flags
-        trusted_source_ids = set()
-        muted_source_ids = set()
+        trusted_source_ids: set[UUID] = set()
+        muted_source_ids: set[UUID] = set()
         multipliers: dict[UUID, float] = {}
         subscriptions: dict[UUID, bool] = {}
         if user_id:
             user_uuid = UUID(user_id)
-            user_sources_result = await self.db.execute(
-                select(UserSource.source_id).where(UserSource.user_id == user_uuid)
+            trusted_source_ids, multipliers, subscriptions = (
+                await self._load_user_source_context(user_uuid)
             )
-            trusted_source_ids = set(user_sources_result.scalars().all())
-
-            multipliers = await self._load_user_source_multipliers(user_uuid)
-            subscriptions = await self._load_user_source_subscriptions(user_uuid)
-
             personalization = await self.db.scalar(
                 select(UserPersonalization).where(
                     UserPersonalization.user_id == user_uuid
@@ -331,29 +282,14 @@ class SourceService:
                 muted_source_ids = set(personalization.muted_sources)
 
         return [
-            SourceResponse(
-                id=s.id,
-                name=s.name,
-                url=s.url,
-                type=s.type,
-                theme=s.theme,
-                description=s.description,
-                logo_url=s.logo_url,
+            self._build_source_response(
+                s,
                 is_curated=s.is_curated,
                 is_custom=not s.is_curated,
                 is_trusted=s.id in trusted_source_ids,
-                is_muted=s.id in muted_source_ids,
-                priority_multiplier=multipliers.get(s.id, 1.0),
-                has_subscription=subscriptions.get(s.id, False),
-                content_count=0,
-                bias_stance=getattr(s.bias_stance, "value", "unknown"),
-                reliability_score=getattr(s.reliability_score, "value", "unknown"),
-                bias_origin=getattr(s.bias_origin, "value", "unknown"),
-                score_independence=s.score_independence,
-                score_rigor=s.score_rigor,
-                score_ux=s.score_ux,
-                recommended_by=getattr(s, "recommended_by", None),
-                recommendation_reason=getattr(s, "recommendation_reason", None),
+                muted_source_ids=muted_source_ids,
+                multipliers=multipliers,
+                subscriptions=subscriptions,
             )
             for s in sources
         ]

--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -48,7 +48,6 @@ class SourceService:
         subscriptions = {row.source_id: row.has_subscription for row in rows}
         return trusted_ids, multipliers, subscriptions
 
-
     def _build_source_response(
         self,
         s: Source,
@@ -107,9 +106,11 @@ class SourceService:
         user_uuid = UUID(user_id)
 
         # 1 query combinée : trusted_ids + multipliers + subscriptions
-        trusted_source_ids, multipliers, subscriptions = (
-            await self._load_user_source_context(user_uuid)
-        )
+        (
+            trusted_source_ids,
+            multipliers,
+            subscriptions,
+        ) = await self._load_user_source_context(user_uuid)
 
         # 1 query : muted sources via UserPersonalization
         muted_source_ids: set[UUID] = set()
@@ -181,9 +182,11 @@ class SourceService:
 
         if user_id:
             user_uuid = UUID(user_id)
-            trusted_source_ids, multipliers, subscriptions = (
-                await self._load_user_source_context(user_uuid)
-            )
+            (
+                trusted_source_ids,
+                multipliers,
+                subscriptions,
+            ) = await self._load_user_source_context(user_uuid)
             personalization = await self.db.scalar(
                 select(UserPersonalization).where(
                     UserPersonalization.user_id == user_uuid
@@ -222,9 +225,11 @@ class SourceService:
         rows = result.all()  # list of (Source, follower_count) tuples
 
         user_uuid = UUID(user_id)
-        trusted_source_ids, multipliers, subscriptions = (
-            await self._load_user_source_context(user_uuid)
-        )
+        (
+            trusted_source_ids,
+            multipliers,
+            subscriptions,
+        ) = await self._load_user_source_context(user_uuid)
 
         muted_source_ids: set[UUID] = set()
         personalization = await self.db.scalar(
@@ -270,9 +275,11 @@ class SourceService:
         subscriptions: dict[UUID, bool] = {}
         if user_id:
             user_uuid = UUID(user_id)
-            trusted_source_ids, multipliers, subscriptions = (
-                await self._load_user_source_context(user_uuid)
-            )
+            (
+                trusted_source_ids,
+                multipliers,
+                subscriptions,
+            ) = await self._load_user_source_context(user_uuid)
             personalization = await self.db.scalar(
                 select(UserPersonalization).where(
                     UserPersonalization.user_id == user_uuid

--- a/packages/api/tests/test_sources_resilience.py
+++ b/packages/api/tests/test_sources_resilience.py
@@ -173,22 +173,39 @@ class TestSourcesCache:
 # ─── get_sources router ────────────────────────────────────────────────
 
 
+def _make_mock_session_ctx(session: MagicMock) -> MagicMock:
+    """Crée un faux async context manager simulant safe_async_session().
+
+    Fix PYTHON-4R : get_sources() ouvre maintenant sa propre session APRÈS
+    le lock (via safe_async_session()), donc les tests doivent mocker
+    safe_async_session plutôt que de passer db= en argument.
+    """
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
 class TestGetSourcesEndpoint:
     @pytest.mark.asyncio
     async def test_returns_503_when_db_keeps_failing(self):
         from app.routers import sources as sources_mod
 
         user_id = str(uuid4())
-        db = MagicMock()
-        db.rollback = AsyncMock()
+        mock_session = MagicMock()
+        mock_session.rollback = AsyncMock()
 
         failing_service = MagicMock()
         failing_service.get_all_sources = AsyncMock(side_effect=_op_error("pool gone"))
 
+        mock_ctx = _make_mock_session_ctx(mock_session)
+
         with patch.object(
+            sources_mod, "safe_async_session", MagicMock(return_value=mock_ctx)
+        ), patch.object(
             sources_mod, "SourceService", MagicMock(return_value=failing_service)
         ), pytest.raises(HTTPException) as exc_info:
-            await sources_mod.get_sources(user_id=user_id, db=db)
+            await sources_mod.get_sources(user_id=user_id)
 
         assert exc_info.value.status_code == 503
         assert exc_info.value.detail == "sources_unavailable"
@@ -200,8 +217,8 @@ class TestGetSourcesEndpoint:
         from app.routers import sources as sources_mod
 
         user_id = str(uuid4())
-        db = MagicMock()
-        db.rollback = AsyncMock()
+        mock_session = MagicMock()
+        mock_session.rollback = AsyncMock()
 
         payload = SourceCatalogResponse(curated=[], custom=[])
         recovering_service = MagicMock()
@@ -209,10 +226,14 @@ class TestGetSourcesEndpoint:
             side_effect=[_op_error(), payload]
         )
 
+        mock_ctx = _make_mock_session_ctx(mock_session)
+
         with patch.object(
+            sources_mod, "safe_async_session", MagicMock(return_value=mock_ctx)
+        ), patch.object(
             sources_mod, "SourceService", MagicMock(return_value=recovering_service)
         ):
-            result = await sources_mod.get_sources(user_id=user_id, db=db)
+            result = await sources_mod.get_sources(user_id=user_id)
 
         assert result is payload
         assert recovering_service.get_all_sources.await_count == 2
@@ -226,15 +247,18 @@ class TestGetSourcesEndpoint:
         from app.routers import sources as sources_mod
 
         user_id = str(uuid4())
-        db = MagicMock()
         payload = SourceCatalogResponse(curated=[], custom=[])
         SOURCES_CACHE.put(UUID(user_id), payload)
 
         service_factory = MagicMock()
+        mock_safe_session = MagicMock()  # ne doit PAS être appelé (cache hit)
 
-        with patch.object(sources_mod, "SourceService", service_factory):
-            result = await sources_mod.get_sources(user_id=user_id, db=db)
+        with patch.object(
+            sources_mod, "safe_async_session", mock_safe_session
+        ), patch.object(sources_mod, "SourceService", service_factory):
+            result = await sources_mod.get_sources(user_id=user_id)
 
         assert result is payload
-        # Service must not even be instantiated
+        # Ni le service ni la session ne doivent être instanciés
         service_factory.assert_not_called()
+        mock_safe_session.assert_not_called()


### PR DESCRIPTION
## Quoi

Corrige le bug récurrent PYTHON-4R / PYTHON-3C où les utilisateurs en onboarding tombaient sur une erreur `sources_unavailable` (HTTP 503) à l'étape « Sélection des sources ».

Deux fixes complémentaires :
1. **Fix architectural** : la session DB n'est plus ouverte via `Depends(get_db)` — elle est ouverte à l'intérieur du handler, **après** acquisition du lock. Le timer `idle_in_transaction_session_timeout` ne démarre donc plus pendant l'attente du lock.
2. **Fix N+1** : `get_all_sources()` passait de 8 requêtes à 4 (4 redondantes éliminées via `_load_user_source_context()` + `_build_source_response()`). Le lock holder libère le lock plus vite, ce qui réduit aussi la fenêtre d'idle pour les waiters.

## Pourquoi

La chaîne causale documentée dans `docs/bugs/bug-onboarding-sources-idle-tx-timeout.md` :

```
Depends(get_db) ouvre session → BEGIN; SET LOCAL idle_in_transaction_session_timeout=10s
→ SOURCES_CACHE.lock() attend (requête concurrent mobile retry)
→ Timeout 10s → IdleInTransactionSessionTimeout (PYTHON-3C)
→ session invalide → PendingRollbackError (PYTHON-4R, actif le 2026-05-25)
→ retry_db_op() exhauste 3 tentatives → HTTP 503 sources_unavailable
→ onboarding bloqué
```

Le mobile a une logique de retry automatique (`userSourcesProvider`) qui génère naturellement des requêtes concurrentes pour le même user, amplifiant le lock contention.

## Comment ça a été vérifié

- [x] pytest 1271 tests passés (0 échec) — avant et après les modifications
- [x] `test_sources_resilience.py` — 10 tests dédiés au retry / cache / endpoint
- [x] `test_sources.py` — 23 tests existants validés
- [x] /simplify passé (get_trending_sources + search_sources aussi migrés vers les nouveaux helpers ; anciens helpers orphelins supprimés)

## Zones à risque

- `packages/api/app/routers/sources.py` — logique de lock + session ouverte inside handler
- `packages/api/app/services/source_service.py` — toutes les méthodes publiques refactorisées

## Sentry

Issues ciblées : PYTHON-4R, PYTHON-3C, PYTHON-3H, PYTHON-3Z, PYTHON-3R, PYTHON-37, PYTHON-34, PYTHON-46, PYTHON-1W

🤖 Generated with [Claude Code](https://claude.com/claude-code)