### PR TITLE
fix(mobile): Explorer feed sourcé depuis feedProvider + fix écran noir goNamed

### DIFF
--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -217,6 +217,33 @@ class FeedThemeSection extends FluxSection {
   }
 }
 
+/// Collects every content id already rendered above the Explorer continuation
+/// — digest leads, Essentiel hi-fi articles, theme/topic items. The screen
+/// passes this set as a filter when building the Explorer list so an article
+/// already shown in the Tournée du jour never reappears below the closing
+/// card.
+Set<String> renderedContentIds(List<FluxSection> sections) {
+  final seen = <String>{};
+  for (final section in sections) {
+    switch (section) {
+      case EssentielSection(:final articles):
+        for (final article in articles) {
+          seen.add(article.contentId);
+        }
+      case DigestTopicSection(:final topics):
+        for (final topic in topics) {
+          if (topic.articles.isEmpty) continue;
+          seen.add(pickTopicLead(topic).contentId);
+        }
+      case FeedThemeSection(:final items):
+        for (final item in items) {
+          seen.add(item.id);
+        }
+    }
+  }
+  return seen;
+}
+
 /// Picks the lead article for a digest topic.
 ///
 /// Priority — followed-source first (user-affinity bonus), otherwise the
@@ -233,17 +260,13 @@ DigestItem pickTopicLead(DigestTopic topic) {
 /// Snapshot of the Flux Continu screen state.
 ///
 /// `sections` is the **ordered** list to render (already accounting for the
-/// serein swap and any missing sections). `feedContinu` is the paginated feed
-/// rendered below the closing card; the provider dedupes it against the
-/// articles already shown above. `feedCarousels` are the editorial carousels
-/// (Plus tard c'est maintenant, Autres angles, Pépites…) returned by the
-/// feed API, intercalated at their backend-provided position inside the
-/// feedContinu list.
+/// serein swap and any missing sections). The Explorer continuation below the
+/// closing card is sourced from `feedProvider` directly (and filtered locally
+/// against `dismissedIds` + the ids already rendered in `sections`), so the
+/// filter chips of the Explorer sticky bar actually drive the list.
 @immutable
 class FluxContinuState {
   final List<FluxSection> sections;
-  final List<Content> feedContinu;
-  final List<FeedCarouselData> feedCarousels;
   final bool isSerene;
   // Per-section UI state keyed by [sectionKey]. String keys (rather than
   // `SectionKind`) so multiple theme sections (one per favorite, 0..3) keep
@@ -266,8 +289,6 @@ class FluxContinuState {
 
   const FluxContinuState({
     this.sections = const [],
-    this.feedContinu = const [],
-    this.feedCarousels = const [],
     this.isSerene = false,
     this.moreOpen = const {},
     this.folded = const {},
@@ -279,8 +300,6 @@ class FluxContinuState {
 
   FluxContinuState copyWith({
     List<FluxSection>? sections,
-    List<Content>? feedContinu,
-    List<FeedCarouselData>? feedCarousels,
     bool? isSerene,
     Map<String, bool>? moreOpen,
     Map<String, bool>? folded,
@@ -292,8 +311,6 @@ class FluxContinuState {
   }) {
     return FluxContinuState(
       sections: sections ?? this.sections,
-      feedContinu: feedContinu ?? this.feedContinu,
-      feedCarousels: feedCarousels ?? this.feedCarousels,
       isSerene: isSerene ?? this.isSerene,
       moreOpen: moreOpen ?? this.moreOpen,
       folded: folded ?? this.folded,

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -72,10 +72,12 @@ String _closingPrefsKey(DateTime day) =>
 
 /// Riverpod provider for the Flux Continu V1.8 home screen.
 ///
-/// Orchestrates three parallel API calls at mount, then up to three themed
-/// feed calls once the user's favorites have been resolved. Holds an ordered
-/// list of sections (already accounting for the serein swap) and a deduped
-/// feed continuation to render below the closing card.
+/// Orchestrates three parallel API calls at mount (digest, top-themes,
+/// essentiel) then up to three themed feed calls once the user's favorites
+/// have been resolved. Holds an ordered list of sections (already accounting
+/// for the serein swap). The Explorer continuation rendered below the closing
+/// card is sourced from `feedProvider` so the filter chips in the Explorer
+/// sticky bar actually shape the list.
 final fluxContinuProvider =
     AsyncNotifierProvider<FluxContinuNotifier, FluxContinuState>(
   FluxContinuNotifier.new,
@@ -96,12 +98,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   FluxSection? _bonnes;
   // Up to [_kMaxFavoriteSections] theme/topic sections, ordered to mirror
   // `userInterestsProvider.favorites`. Empty when the user has no favorites
-  // — the tournée then collapses to digest + feed continu only.
+  // — the tournée then collapses to digest only.
   List<FeedThemeSection> _themes = const [];
-  List<Content> _feedContinu = const [];
-  List<FeedCarouselData> _feedCarousels = const [];
-  bool _feedHasMore = false;
-  int _feedPage = 1;
   Map<String, bool> _moreOpen = const {};
   Map<String, bool> _folded = const {};
   bool _closingDismissed = false;
@@ -137,7 +135,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     });
 
     // React to favorite reorders / additions / removals without rebuilding
-    // the digest or feed continuation (those don't depend on favorites).
+    // the digest (the digest doesn't depend on favorites).
     ref.listen<AsyncValue<UserInterestsState>>(
       userInterestsProvider,
       (prev, next) {
@@ -165,10 +163,6 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         'getTopThemes',
         fallback: const <TopTheme>[],
       ),
-      _safe<FeedResponse>(
-        () => _feedRepo.getFeed(page: 1, limit: 20, serein: isSerene),
-        'getFeed (continuation)',
-      ),
       _safe<List<EssentielArticle>>(
         () async => (await _essentielRepo.fetch()) ?? const [],
         'fetchEssentiel',
@@ -177,9 +171,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     ]);
     final dual = results[0] as DualDigestResponse?;
     final topThemes = (results[1] as List<TopTheme>?) ?? const <TopTheme>[];
-    final feed = results[2] as FeedResponse?;
     final essentielArticles =
-        (results[3] as List<EssentielArticle>?) ?? const <EssentielArticle>[];
+        (results[2] as List<EssentielArticle>?) ?? const <EssentielArticle>[];
 
     // PR2 — la section "Essentiel" du haut du feed est désormais alimentée
     // par GET /api/essentiel (5 articles transversaux). Si l'endpoint n'a
@@ -214,10 +207,6 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     _lastFavorites = favorites;
     _themes = await _fetchThemeSections(favorites, isSerene);
 
-    _feedContinu = feed?.items ?? const [];
-    _feedCarousels = feed?.carousels ?? const [];
-    _feedHasMore = feed?.pagination.hasNext ?? false;
-    _feedPage = 1;
     _moreOpen = const {};
     _folded = await _loadFoldedForToday();
     _closingDismissed = await _loadClosingDismissedForToday();
@@ -266,8 +255,6 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
     return FluxContinuState(
       sections: _filterSections(ordered),
-      feedContinu: _filterFeed(_dedupFeed(_feedContinu, ordered)),
-      feedCarousels: _feedCarousels,
       isSerene: isSerene,
       moreOpen: _moreOpen,
       folded: _folded,
@@ -291,9 +278,11 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   }
 
   /// Purges the article from the local state — adds the id to the dismissed
-  /// set and re-emits filtered sections + feed. No API call (the hide was
-  /// already fired via [markHiddenRemote] at swipe time). Called when the
-  /// user resolves the inline feedback (chip / close / viewport-exit).
+  /// set and re-emits filtered sections. No API call (the hide was already
+  /// fired via [markHiddenRemote] at swipe time). The Explorer continuation
+  /// reads its items from `feedProvider`, so the screen layer applies the
+  /// same `dismissedIds` filter there. Called when the user resolves the
+  /// inline feedback (chip / close / viewport-exit).
   void confirmDismiss(String contentId) {
     if (contentId.isEmpty) return;
     if (_dismissedIds.contains(contentId)) return;
@@ -302,7 +291,6 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     if (current == null) return;
     state = AsyncData(current.copyWith(
       sections: _filterSections(current.sections),
-      feedContinu: _filterFeed(current.feedContinu),
       dismissedIds: Set.unmodifiable(_dismissedIds),
     ));
   }
@@ -372,11 +360,6 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             ),
         },
     ];
-  }
-
-  List<Content> _filterFeed(List<Content> feed) {
-    if (_dismissedIds.isEmpty) return feed;
-    return feed.where((c) => !_dismissedIds.contains(c.id)).toList();
   }
 
   /// Toggle the expand/collapse state of a section's "Plus de…" overflow.
@@ -646,28 +629,6 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     state = next;
   }
 
-  /// Append the next page of the feed continuation.
-  Future<void> loadMoreFeed() async {
-    if (!_feedHasMore) return;
-    final current = state.valueOrNull;
-    if (current == null) return;
-
-    final isSerene = ref.read(sereinToggleProvider).enabled;
-    final next = _feedPage + 1;
-    final page = await _safe<FeedResponse>(
-      () => _feedRepo.getFeed(page: next, limit: 20, serein: isSerene),
-      'getFeed page=$next',
-    );
-    if (page == null) return;
-
-    _feedPage = next;
-    _feedHasMore = page.pagination.hasNext;
-    _feedContinu = [..._feedContinu, ...page.items];
-    state = AsyncData(current.copyWith(
-      feedContinu: _dedupFeed(_feedContinu, current.sections),
-    ));
-  }
-
   /// Builds the v3 "L'Essentiel du jour" hi-fi section from the 5 articles
   /// returned by `GET /api/essentiel`. Returns `null` when the endpoint hasn't
   /// produced anything yet (202 preparing or transient failure) so the screen
@@ -886,8 +847,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   }
 
   /// Replays only the theme-section fetches against the new favorite list.
-  /// Saves the cost of refetching the digest and feed continuation, which
-  /// don't depend on favorites.
+  /// Saves the cost of refetching the digest, which doesn't depend on
+  /// favorites.
   Future<void> _refetchThemesOnly(List<FavoriteRef> nextFavorites) async {
     final isSerene = ref.read(sereinToggleProvider).enabled;
     final capped =
@@ -917,30 +878,6 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     if (key.startsWith('theme:')) return true;
     if (key.startsWith('topic:')) return true;
     return false;
-  }
-
-  /// Builds the set of content_ids already rendered in the sections (digest
-  /// leads + feed-theme items) and filters them out of the continuation.
-  List<Content> _dedupFeed(List<Content> feed, List<FluxSection> sections) {
-    final seen = <String>{};
-    for (final section in sections) {
-      switch (section) {
-        case EssentielSection(:final articles):
-          for (final article in articles) {
-            seen.add(article.contentId);
-          }
-        case DigestTopicSection(:final topics):
-          for (final topic in topics) {
-            if (topic.articles.isEmpty) continue;
-            seen.add(pickTopicLead(topic).contentId);
-          }
-        case FeedThemeSection(:final items):
-          for (final item in items) {
-            seen.add(item.id);
-          }
-      }
-    }
-    return feed.where((c) => !seen.contains(c.id)).toList();
   }
 
   Future<T?> _safe<T>(

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -661,10 +661,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       0,
       (sum, s) => sum + s.totalCount,
     );
-    // The Explorer continuation is filtered locally against (a) ids already
-    // rendered above (digest leads + Tournée items), and (b) the ids the user
-    // has swipe-dismissed during this session. The list itself is driven by
-    // `feedProvider` so the Explorer filter bar actually shapes what shows up.
     final exploreItems = _buildExploreItems(state, feedState);
     final exploreCarousels = feedState?.carousels ?? const <FeedCarouselData>[];
 

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -188,8 +188,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
         !_loadingMore) {
       _loadingMore = true;
       ref
-          .read(fluxContinuProvider.notifier)
-          .loadMoreFeed()
+          .read(feedProvider.notifier)
+          .loadMore()
           .whenComplete(() => _loadingMore = false);
     }
   }
@@ -517,7 +517,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     FluxFeedbackChip chip,
   ) async {
     final state = ref.read(fluxContinuProvider).valueOrNull;
-    final article = state == null ? null : _lookupArticle(state, contentId);
+    final feedItems =
+        ref.read(feedProvider).valueOrNull?.items ?? const <Content>[];
+    final article =
+        state == null ? null : _lookupArticle(state, feedItems, contentId);
     switch (chip) {
       case FluxFeedbackChip.source:
         _trackFeedbackSubmit(contentId, 'less_source');
@@ -548,11 +551,16 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   }
 
   /// Finds an article in the current state by its content id, looking
-  /// across digest leads, theme items and the feed continuation. Returns
-  /// the raw [DigestItem] or [Content] so the caller can route it through
-  /// [articleToContent] for the article sheet.
-  Object? _lookupArticle(FluxContinuState state, String contentId) {
-    for (final c in state.feedContinu) {
+  /// across digest leads, theme items and the Explorer continuation
+  /// (sourced from `feedProvider`). Returns the raw [DigestItem] or
+  /// [Content] so the caller can route it through [articleToContent] for
+  /// the article sheet.
+  Object? _lookupArticle(
+    FluxContinuState state,
+    List<Content> exploreItems,
+    String contentId,
+  ) {
+    for (final c in exploreItems) {
       if (c.id == contentId) return c;
     }
     for (final s in state.sections) {
@@ -647,11 +655,18 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     final notifier = ref.read(fluxContinuProvider.notifier);
     final colors = context.facteurColors;
     final impressionSlot = ref.watch(firstImpressionSlotProvider);
+    final feedState = ref.watch(feedProvider).valueOrNull;
     final keyword = ref.watch(feedProvider.notifier).selectedKeyword;
     final totalArticles = state.sections.fold<int>(
       0,
       (sum, s) => sum + s.totalCount,
     );
+    // The Explorer continuation is filtered locally against (a) ids already
+    // rendered above (digest leads + Tournée items), and (b) the ids the user
+    // has swipe-dismissed during this session. The list itself is driven by
+    // `feedProvider` so the Explorer filter bar actually shapes what shows up.
+    final exploreItems = _buildExploreItems(state, feedState);
+    final exploreCarousels = feedState?.carousels ?? const <FeedCarouselData>[];
 
     if (_sectionKeys.length != state.sections.length) {
       _sectionKeys
@@ -780,8 +795,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
               ),
             ),
           ),
-          if (state.feedContinu.isNotEmpty) ...[
-            _buildIntercalatedFeed(context, state),
+          if (exploreItems.isNotEmpty) ...[
+            _buildIntercalatedFeed(context, exploreItems, exploreCarousels),
             const SliverToBoxAdapter(child: SectionHairline()),
           ],
           const SliverToBoxAdapter(child: SizedBox(height: 60)),
@@ -864,11 +879,29 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     return slivers;
   }
 
+  /// Builds the Explorer feed list by reading from `feedProvider` and filtering
+  /// out (a) articles already rendered above and (b) ids swipe-dismissed
+  /// during this session. Keeps the Tournée / Explorer dedup invariant while
+  /// letting the filter chips drive the underlying list.
+  List<Content> _buildExploreItems(
+    FluxContinuState state,
+    FeedState? feedState,
+  ) {
+    final items = feedState?.items ?? const <Content>[];
+    if (items.isEmpty) return const [];
+    final rendered = renderedContentIds(state.sections);
+    final dismissed = state.dismissedIds;
+    if (rendered.isEmpty && dismissed.isEmpty) return items;
+    return items
+        .where((c) => !rendered.contains(c.id) && !dismissed.contains(c.id))
+        .toList(growable: false);
+  }
+
   Widget _buildIntercalatedFeed(
     BuildContext context,
-    FluxContinuState state,
+    List<Content> contents,
+    List<FeedCarouselData> carousels,
   ) {
-    final contents = state.feedContinu;
     final intercalations = <({int position, Widget Function() builder})>[];
 
     if (contents.length > 4) {
@@ -882,7 +915,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       ));
     }
 
-    for (final carousel in state.feedCarousels) {
+    for (final carousel in carousels) {
       if (carousel.items.isEmpty || carousel.position >= contents.length) {
         continue;
       }

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_personalize_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_personalize_sheet.dart
@@ -79,7 +79,7 @@ class EssentielPersonalizeSheet extends StatelessWidget {
               subtitle: 'Choisis les thèmes qui guident ton Essentiel.',
               onTap: () {
                 Navigator.of(context).pop();
-                context.goNamed(RouteNames.myInterests);
+                context.pushNamed(RouteNames.myInterests);
               },
             ),
             _ChoiceTile(
@@ -89,7 +89,7 @@ class EssentielPersonalizeSheet extends StatelessWidget {
               subtitle: 'Suis ou masque les médias qui te parlent.',
               onTap: () {
                 Navigator.of(context).pop();
-                context.goNamed(RouteNames.sources);
+                context.pushNamed(RouteNames.sources);
               },
             ),
             const SizedBox(height: 12),


### PR DESCRIPTION
## Quoi

- Branche l'Explorer (continuation sous la carte de fermeture) sur `feedProvider` au lieu de dupliquer le feed dans `FluxContinuState`
- Supprime `feedContinu`, `feedCarousels`, `loadMoreFeed()` et `_dedupFeed()` du `fluxContinuProvider`
- Extrait `renderedContentIds()` comme helper public dans `flux_continu_models.dart` (testable unitairement)
- Fix écran noir : `goNamed` → `pushNamed` dans `EssentielPersonalizeSheet` pour myInterests et sources

## Pourquoi

Les filter chips de l'Explorer (barre sticky) ne pilotaient pas la liste : le feed était fetché une fois au boot dans `fluxContinuProvider` indépendamment de `feedProvider`, donc changer de keyword/filtre ne rafraîchissait pas la continuation. En plus, `goNamed` depuis une bottom sheet remplaçait la route courante et provoquait un écran noir au retour.

## Comment ça a été vérifié

- [x] `flutter test test/features/flux_continu/` — 67 tests OK
- [x] `flutter analyze lib/features/flux_continu/` — 0 erreurs (2 warnings pré-existants)
- [x] /simplify passé — 1 commentaire inline redondant supprimé

## Zones à risque

- `flux_continu_screen.dart` : `_buildContent` regarde maintenant `feedProvider` (2 watches au lieu d'1) — Riverpod gère le dedup, pattern identique aux autres écrans
- `loadMore` délégué à `feedProvider.notifier` — pagination Explorer via la même interface que les autres tabs Feed