### PR TITLE
feat(essentiel): lead-slot Actu + diversité 2/source + is_read penalty + flags UI

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -103,6 +103,30 @@ lib/
 - **Titres** : Fraunces (serif)
 - **Corps** : DM Sans (sans-serif)
 
+## 🔦 Tester via Conductor Spotlight
+
+[Spotlight](https://www.conductor.build/docs/guides/spotlight-testing) synchronise les fichiers d'un workspace Conductor vers le repo root et déclenche le hot reload Flutter. Workflow en 3 étapes :
+
+**Prérequis :** `.env` au repo root renseigné (SUPABASE_ANON_KEY + API_BASE_URL) — déjà pré-rempli avec les valeurs par défaut.
+
+1. **Démarrer l'app depuis le repo root** (pas depuis le workspace) :
+   ```bash
+   # Depuis ~/Desktop/facteur (ou le chemin de ton repo root)
+   bash scripts/run-mobile-web.sh           # → prod Railway
+   bash scripts/run-mobile-web.sh --local   # → API locale uvicorn :8080
+   ```
+   Chrome s'ouvre sur `http://localhost:8081`.
+
+2. **Modifier du code** dans le workspace Conductor (ex. `mumbai`), puis cliquer **Spotlight** dans l'UI Conductor.
+
+3. Observer dans le terminal Flutter : `Reloaded N libraries` — la modif est visible dans Chrome sans rebuild complet.
+
+**Notes importantes :**
+- Le port `8081` est fixe : Spotlight peut taper la même URL d'une session à l'autre.
+- Changer une variable d'env (`.env`) nécessite un **restart** du script (compile-time, pas un hot reload).
+- Premier clic Spotlight = création du checkpoint git → peut prendre quelques secondes.
+- Si le hot reload ne se déclenche pas automatiquement, faire un **hot restart manuel** : taper `R` dans le terminal Flutter.
+
 ## 🧪 Tests
 
 ```bash

--- a/apps/mobile/lib/config/constants.dart
+++ b/apps/mobile/lib/config/constants.dart
@@ -39,14 +39,22 @@ class SupabaseConstants {
   SupabaseConstants._();
 
   /// URL Supabase (à configurer via env)
+  /// Fallback = URL du projet prod (publique, même valeur que .vscode/launch.json).
+  /// En CI ou build release, injecter via --dart-define=SUPABASE_URL=... pour
+  /// écraser ce fallback.
   static final String url = _validateAndCleanSupabaseUrl(
-    const String.fromEnvironment('SUPABASE_URL', defaultValue: ''),
+    const String.fromEnvironment(
+      'SUPABASE_URL',
+      defaultValue: 'https://ykuadtelnzavrqzbfdve.supabase.co',
+    ),
   );
 
   /// Clé anonyme Supabase (à configurer via env)
+  /// Fallback = clé anon publique (non-secrète, déjà présente dans launch.json).
+  /// En CI ou build release, injecter via --dart-define=SUPABASE_ANON_KEY=...
   static final String anonKey = _cleanEnvVar(const String.fromEnvironment(
     'SUPABASE_ANON_KEY',
-    defaultValue: '',
+    defaultValue: 'sb_publishable_0L_kPMbe0Pk9eBdzeEsIZg_0pogzm3k',
   ));
 
   static String _cleanEnvVar(String value) {

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -95,6 +95,11 @@ class EssentielArticle {
   final bool isSaved;
   final bool isLiked;
   final bool isDismissed;
+  // Signaux user-aware servis par /api/essentiel pour rendre la personnalisation
+  // et l'Actu du jour visibles côté carte (pastille, badges, avatar accent).
+  final bool isFollowedSource;
+  final bool isFollowedTopic;
+  final bool isActuDuJour;
 
   const EssentielArticle({
     required this.contentId,
@@ -113,6 +118,9 @@ class EssentielArticle {
     this.isSaved = false,
     this.isLiked = false,
     this.isDismissed = false,
+    this.isFollowedSource = false,
+    this.isFollowedTopic = false,
+    this.isActuDuJour = false,
   });
 }
 

--- a/apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart
+++ b/apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart
@@ -64,6 +64,9 @@ class EssentielRepository {
       isSaved: (json['is_saved'] as bool?) ?? false,
       isLiked: (json['is_liked'] as bool?) ?? false,
       isDismissed: (json['is_dismissed'] as bool?) ?? false,
+      isFollowedSource: (json['is_followed_source'] as bool?) ?? false,
+      isFollowedTopic: (json['is_followed_topic'] as bool?) ?? false,
+      isActuDuJour: (json['is_actu_du_jour'] as bool?) ?? false,
     );
   }
 

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -293,11 +293,16 @@ class _LeadTile extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              if (article.isActuDuJour) ...[
+                _ActuBadge(accent: chipAccent),
+                const SizedBox(height: FacteurSpacing.space2),
+              ],
               Row(
                 children: [
                   _SectionChip(
                     label: _sectionLabelFor(article),
                     accent: chipAccent,
+                    showFollowed: article.isFollowedTopic,
                   ),
                   const Spacer(),
                   if (article.perspectiveCount > 1)
@@ -309,19 +314,22 @@ class _LeadTile extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: FacteurSpacing.space2),
-              Text(
-                article.title,
-                maxLines: 3,
-                overflow: TextOverflow.ellipsis,
-                style: GoogleFonts.fraunces(
-                  fontSize: 17,
-                  fontWeight: FontWeight.w700,
-                  height: 1.3,
-                  color: colors.textPrimary,
+              Opacity(
+                opacity: article.isRead ? 0.7 : 1.0,
+                child: Text(
+                  article.title,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                  style: GoogleFonts.fraunces(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w700,
+                    height: 1.3,
+                    color: colors.textPrimary,
+                  ),
                 ),
               ),
               const SizedBox(height: FacteurSpacing.space2),
-              _SourceRow(article: article),
+              _SourceRow(article: article, accent: chipAccent),
             ],
           ),
         ),
@@ -355,6 +363,7 @@ class _MediumTile extends StatelessWidget {
                   _SectionChip(
                     label: _sectionLabelFor(article),
                     accent: themeAccent,
+                    showFollowed: article.isFollowedTopic,
                   ),
                   const SizedBox(width: FacteurSpacing.space2),
                   Flexible(
@@ -365,19 +374,34 @@ class _MediumTile extends StatelessWidget {
                       style: FacteurTypography.labelSmall(colors.textTertiary),
                     ),
                   ),
+                  if (article.perspectiveCount > 1) ...[
+                    const SizedBox(width: FacteurSpacing.space2),
+                    Text(
+                      '+${article.perspectiveCount}',
+                      style: FacteurTypography.labelSmall(colors.textTertiary),
+                    ),
+                  ],
                 ],
               ),
               const SizedBox(height: 4),
-              Text(
-                article.title,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-                style: GoogleFonts.fraunces(
-                  fontSize: 14.5,
-                  fontWeight: FontWeight.w600,
-                  height: 1.3,
-                  color: colors.textPrimary,
+              Opacity(
+                opacity: article.isRead ? 0.7 : 1.0,
+                child: Text(
+                  article.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: GoogleFonts.fraunces(
+                    fontSize: 14.5,
+                    fontWeight: FontWeight.w600,
+                    height: 1.3,
+                    color: colors.textPrimary,
+                  ),
                 ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                _relativeTime(article.publishedAt),
+                style: FacteurTypography.labelSmall(colors.textTertiary),
               ),
             ],
           ),
@@ -433,11 +457,14 @@ class _LightTile extends StatelessWidget {
               ),
               const SizedBox(width: FacteurSpacing.space2),
               Expanded(
-                child: Text(
-                  article.title,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: FacteurTypography.bodySmall(colors.textPrimary),
+                child: Opacity(
+                  opacity: article.isRead ? 0.7 : 1.0,
+                  child: Text(
+                    article.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: FacteurTypography.bodySmall(colors.textPrimary),
+                  ),
                 ),
               ),
             ],
@@ -451,8 +478,13 @@ class _LightTile extends StatelessWidget {
 class _SectionChip extends StatelessWidget {
   final String label;
   final Color accent;
+  final bool showFollowed;
 
-  const _SectionChip({required this.label, required this.accent});
+  const _SectionChip({
+    required this.label,
+    required this.accent,
+    this.showFollowed = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -462,14 +494,62 @@ class _SectionChip extends StatelessWidget {
         color: accent.withValues(alpha: 0.14),
         borderRadius: BorderRadius.circular(FacteurRadius.pill),
       ),
-      child: Text(
-        label,
-        style: GoogleFonts.dmSans(
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
-          letterSpacing: 0.2,
-          color: accent,
-        ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (showFollowed) ...[
+            Icon(Icons.bookmark_rounded, size: 11, color: accent),
+            const SizedBox(width: 3),
+          ],
+          Text(
+            label,
+            style: GoogleFonts.dmSans(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.2,
+              color: accent,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Pastille "Actu du jour" affichée au-dessus du lead quand l'article a été
+/// marqué Actu (topic trending/une ou badge="actu") par le pipeline du digest.
+class _ActuBadge extends StatelessWidget {
+  final Color accent;
+
+  const _ActuBadge({required this.accent});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: accent,
+        borderRadius: BorderRadius.circular(FacteurRadius.pill),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(
+            Icons.bolt_rounded,
+            size: 12,
+            color: Colors.white,
+          ),
+          const SizedBox(width: 3),
+          Text(
+            'Actu du jour',
+            style: GoogleFonts.dmSans(
+              fontSize: 10.5,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.4,
+              color: Colors.white,
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -477,12 +557,18 @@ class _SectionChip extends StatelessWidget {
 
 class _SourceRow extends StatelessWidget {
   final EssentielArticle article;
+  final Color accent;
 
-  const _SourceRow({required this.article});
+  const _SourceRow({required this.article, required this.accent});
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
+    final isFollowed = article.isFollowedSource;
+    final avatarBg =
+        isFollowed ? accent.withValues(alpha: 0.18) : colors.backgroundSecondary;
+    final avatarBorder = isFollowed ? accent : colors.border;
+    final avatarTextColor = isFollowed ? accent : colors.textSecondary;
     return Row(
       children: [
         Container(
@@ -490,16 +576,16 @@ class _SourceRow extends StatelessWidget {
           height: 20,
           alignment: Alignment.center,
           decoration: BoxDecoration(
-            color: colors.backgroundSecondary,
+            color: avatarBg,
             shape: BoxShape.circle,
-            border: Border.all(color: colors.border, width: 0.6),
+            border: Border.all(color: avatarBorder, width: 0.8),
           ),
           child: Text(
             article.sourceLetter,
             style: GoogleFonts.dmSans(
               fontSize: 10,
               fontWeight: FontWeight.w700,
-              color: colors.textSecondary,
+              color: avatarTextColor,
             ),
           ),
         ),
@@ -511,6 +597,11 @@ class _SourceRow extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
             style: FacteurTypography.labelSmall(colors.textTertiary),
           ),
+        ),
+        const SizedBox(width: FacteurSpacing.space2),
+        Text(
+          '·  ${_relativeTime(article.publishedAt)}',
+          style: FacteurTypography.labelSmall(colors.textTertiary),
         ),
       ],
     );
@@ -629,4 +720,16 @@ String _sectionLabelFor(EssentielArticle article) {
   final raw = article.sectionLabel.trim();
   if (raw.isNotEmpty) return raw;
   return 'Actus';
+}
+
+/// Horodatage relatif court pour la carte ("il y a 2h", "ce matin", "hier").
+/// Garde un format lisible et stable ; les valeurs sont des approximations
+/// (granularité heure pour <24h, jour au-delà).
+String _relativeTime(DateTime publishedAt) {
+  final delta = DateTime.now().difference(publishedAt);
+  if (delta.inMinutes < 1) return 'à l’instant';
+  if (delta.inMinutes < 60) return 'il y a ${delta.inMinutes} min';
+  if (delta.inHours < 24) return 'il y a ${delta.inHours}h';
+  if (delta.inDays < 2) return 'hier';
+  return 'il y a ${delta.inDays} j';
 }

--- a/packages/api/app/schemas/essentiel.py
+++ b/packages/api/app/schemas/essentiel.py
@@ -56,6 +56,10 @@ class EssentielArticle(BaseModel):
     is_saved: bool = False
     is_liked: bool = False
     is_dismissed: bool = False
+    # Signaux user-aware pour affichage mobile (badges "Tu suis", pastille "Actu du jour").
+    is_followed_source: bool = False
+    is_followed_topic: bool = False
+    is_actu_du_jour: bool = False
 
     class Config:
         from_attributes = True

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -1,25 +1,32 @@
-"""Service `essentiel` — top 5 articles transversaux du jour (Story 9.1).
+"""Service `essentiel` — top 5 articles transversaux du jour.
 
 Strictement read-only : consomme la `DigestResponse` déjà calculée par la cron
 nocturne via `read_digest_or_fallback`, et la projette en 5 articles cross-topic
 pour la carte hi-fi "L'Essentiel du jour" du feed mobile.
 
-Algorithme user-aware (fix bug-essentiel-user-prefs) :
-1. Charge le contexte user en read-only : sources suivies + multiplicateurs
-   de priorité, topics suivis + poids (union UserInterest ∪ UserSubtopic).
-2. Score chaque article candidat avec un scorer composite simple :
+Architecture :
+- Le `PillarScoringEngine` (services/recommendation/scoring_engine.py) et le
+  `digest_selector` ont déjà scoré + sélectionné les meilleurs articles par
+  topic en amont. On *réutilise* leurs signaux (`topic.is_trending`,
+  `topic.is_une`, `article.badge == "actu"`, `article.is_followed_source`)
+  plutôt que de re-scorer from scratch.
+- Les boosts d'Actu du jour s'alignent sur ceux du `Top3Selector` du briefing
+  pour cohérence cross-feature (`BOOST_UNE=30`, `BOOST_TRENDING=40`).
+
+Pipeline :
+1. Charge le contexte user (sources/topics suivis + multiplicateurs/poids).
+2. Score chaque article :
+   - bonus Actu (trending/une/badge actu) — aligné top3_selector,
    - bonus source suivie (×priority_multiplier),
    - bonus topic suivi (×weight),
-   - petit bonus perspective_count (transversal),
+   - bonus perspective_count,
+   - pénalité forte si `is_read` (l'écarte sauf si rien d'autre),
    - tie-break par rank.
-3. Round "diversité" : 1 article max par topic (le mieux scoré), dans l'ordre
-   des `topic.rank`, jusqu'à 5.
-4. Round "remplissage" : complète par les articles restants triés par score
-   décroissant si on n'a pas atteint 5.
-5. Déduplication par `content_id`.
+3. **Slot lead Actu** : si un article est Actu du jour, il occupe le rank=1.
+4. **Diversité dure** : max 2 articles d'une même source dans les 5.
+5. Round "diversité" (1/topic) + round "remplissage", déduplication content_id.
 
-Fallback sans préférences : le scorer dégénère en `+perspective_count - rank`,
-ce qui donne quasi le même résultat que l'ancien round-robin rank-driven.
+Fallback sans préférences : le scorer dégénère en `actu_boost + perspective − rank`.
 """
 
 from dataclasses import dataclass, field
@@ -34,15 +41,24 @@ from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
 from app.schemas.essentiel import EssentielArticle, EssentielKind, EssentielResponse
 
 ESSENTIEL_MAX_ARTICLES = 5
+ESSENTIEL_MAX_PER_SOURCE = 2  # Diversité dure : max 2 articles d'une même source.
 
-# Poids du scoring composite — réglés pour que chaque levier puisse l'emporter
-# isolément sans qu'aucun ne phagocyte les autres. Toute modif → ajouter un
-# test dans `test_essentiel_endpoint.py`.
+# Valeur de `DigestTopicArticle.badge` qui marque l'article comme "Actu du jour".
+# Le digest peut aussi tagger "pas_de_recul"/"pepite"/"coup_de_coeur" (cf.
+# schemas/digest.py) — seul "actu" déclenche le lead-slot ici.
+_BADGE_ACTU = "actu"
+
+# Poids alignés sur `Top3Selector` (briefing/top3_selector.py) pour cohérence
+# cross-feature. Toute modif → ajouter un test dans `test_essentiel_endpoint.py`.
+_W_TRENDING = 40.0  # `Top3Selector.BOOST_TRENDING` — topic.is_trending
+_W_UNE = 30.0  # `Top3Selector.BOOST_UNE` — topic.is_une
+_W_BADGE_ACTU = 25.0  # article.badge == _BADGE_ACTU (signal explicite du digest)
 _W_FOLLOWED_SOURCE = 100.0
 _W_FOLLOWED_SOURCE_FLAG = 50.0  # bonus moindre si on n'a que le flag du digest
 _W_TOPIC_WEIGHT = 50.0
 _W_PERSPECTIVE = 5.0
 _W_RANK_PENALTY = 0.5
+_W_READ_PENALTY = 1000.0  # Écarte les articles déjà lus sauf si rien d'autre.
 
 
 @dataclass(frozen=True)
@@ -66,7 +82,6 @@ async def fetch_user_essentiel_context(
     Aucune écriture, aucun pipeline LLM. 2 SELECTs courts, indexés sur
     `user_id`. Sans hit (utilisateur sans prefs) : retourne un contexte vide.
     """
-    # Sources suivies + multiplicateurs de priorité.
     src_rows = (
         await db.execute(
             select(UserSource.source_id, UserSource.priority_multiplier).where(
@@ -79,9 +94,6 @@ async def fetch_user_essentiel_context(
         row.source_id: float(row.priority_multiplier or 1.0) for row in src_rows
     }
 
-    # Topics suivis (slug → poids), union UserInterest ∪ UserSubtopic.
-    # En cas de doublon : on garde le max — c'est cohérent avec l'esprit
-    # "l'utilisateur a explicitement signalé son intérêt".
     topic_weights: dict[str, float] = {}
 
     interest_rows = (
@@ -125,6 +137,22 @@ def _source_letter(name: str) -> str:
     return "?"
 
 
+def _is_actu_du_jour(topic: DigestTopic, article: DigestTopicArticle) -> bool:
+    """Un article est "Actu du jour" si son topic est trending/une ou si
+    le digest l'a explicitement marqué d'un badge "actu"."""
+    return bool(topic.is_trending or topic.is_une or article.badge == _BADGE_ACTU)
+
+
+def _is_followed_topic(topic: DigestTopic, ctx: EssentielUserContext) -> bool:
+    return bool(topic.theme and topic.theme in ctx.topic_weights)
+
+
+def _is_followed_source(
+    article: DigestTopicArticle, ctx: EssentielUserContext
+) -> bool:
+    return article.source.id in ctx.followed_source_ids or article.is_followed_source
+
+
 def _score_article(
     topic: DigestTopic,
     article: DigestTopicArticle,
@@ -132,16 +160,22 @@ def _score_article(
 ) -> float:
     """Score composite user-aware d'un article candidat de l'Essentiel.
 
-    Détails dans le module docstring. Toujours positif sauf au fallback
-    no-prefs où on peut tomber légèrement négatif via le rank — c'est
-    voulu (l'ordre relatif est ce qui compte).
+    Réutilise les signaux déjà calculés par le digest (trending/une/badge actu/
+    is_followed_source) et leur applique des coefficients alignés sur ceux du
+    briefing (`Top3Selector`).
     """
     score = 0.0
 
-    # Bonus source : on préfère la jointure DB-fraîche (followed_source_ids).
-    # Si elle est vide mais que le digest a déjà tagué `is_followed_source`
-    # (cas où le digest a été généré avec un état UserSource différent), on
-    # garde un bonus moindre pour rester cohérent côté UI.
+    # Boost Actu du jour (aligné Top3Selector).
+    if topic.is_trending:
+        score += _W_TRENDING
+    if topic.is_une:
+        score += _W_UNE
+    if article.badge == _BADGE_ACTU:
+        score += _W_BADGE_ACTU
+
+    # Bonus source suivie : préfère la jointure DB-fraîche (followed_source_ids).
+    # Fallback sur le flag pré-calculé du digest si le contexte user est vide.
     if article.source.id in ctx.followed_source_ids:
         multiplier = ctx.source_priority_multipliers.get(article.source.id, 1.0)
         score += _W_FOLLOWED_SOURCE * multiplier
@@ -152,9 +186,13 @@ def _score_article(
     if topic.theme and topic.theme in ctx.topic_weights:
         score += _W_TOPIC_WEIGHT * ctx.topic_weights[topic.theme]
 
-    # Bonus "transversal" : un sujet couvert par plusieurs sources est
-    # plus à sa place dans l'Essentiel qu'un scoop isolé.
+    # Bonus "transversal" : un sujet couvert par plusieurs sources est plus à
+    # sa place dans l'Essentiel qu'un scoop isolé.
     score += _W_PERSPECTIVE * float(topic.perspective_count or 0)
+
+    # Pénalité is_read : écarte les articles déjà lus sauf si rien d'autre.
+    if article.is_read:
+        score -= _W_READ_PENALTY
 
     # Tie-break : un article rank=1 reste préféré à rank=2 à signaux égaux.
     score -= _W_RANK_PENALTY * float(article.rank)
@@ -168,12 +206,14 @@ def _pick_transversal_articles(
 ) -> list[tuple[DigestTopic, DigestTopicArticle]]:
     """Pioche jusqu'à 5 articles cross-topic, user-aware.
 
-    - Round 1 (diversité) : pour chaque topic, on prend l'article au meilleur
-      score (1 article max par topic), topics ordonnés d'abord par le meilleur
-      score de leur meilleur candidat (desc), puis par `topic.rank` (asc)
-      pour stabilité.
-    - Round 2 (remplissage) : si <5, on complète avec les articles restants
-      triés par score décroissant, dédupe par `content_id`.
+    1. **Slot lead Actu** : si un article est Actu du jour (trending/une/badge),
+       il prend la position 1 — quel que soit son score user. Le meilleur des
+       Actu gagne.
+    2. **Round diversité** (1 article max par topic), topics ordonnés par leur
+       meilleur score (desc), tie-break `topic.rank` (asc).
+    3. **Round remplissage** par score décroissant.
+    4. **Diversité dure** : max `ESSENTIEL_MAX_PER_SOURCE` (=2) articles d'une
+       même source à toutes les étapes.
     """
     eligible_topics = [t for t in topics if t.articles]
     if not eligible_topics:
@@ -187,7 +227,42 @@ def _pick_transversal_articles(
                 topic, article, ctx
             )
 
-    # Pour chaque topic, le meilleur candidat et son score.
+    picked: list[tuple[DigestTopic, DigestTopicArticle]] = []
+    seen_content_ids: set[UUID] = set()
+    used_topics: set[str] = set()
+    source_count: dict[UUID, int] = {}
+
+    def _try_pick(topic: DigestTopic, article: DigestTopicArticle) -> bool:
+        """Tente d'ajouter un article en respectant dédup + diversité source.
+
+        Renvoie True si ajouté, False sinon. Marque les ensembles.
+        """
+        if article.content_id in seen_content_ids:
+            return False
+        if source_count.get(article.source.id, 0) >= ESSENTIEL_MAX_PER_SOURCE:
+            return False
+        picked.append((topic, article))
+        seen_content_ids.add(article.content_id)
+        used_topics.add(topic.topic_id)
+        source_count[article.source.id] = source_count.get(article.source.id, 0) + 1
+        return True
+
+    # ─── Slot lead Actu ──────────────────────────────────────────────────
+    # Cherche le meilleur article Actu du jour (trending/une/badge=="actu").
+    # S'il existe, on le pose en rank=1 avant tout le reste.
+    actu_candidates: list[tuple[DigestTopic, DigestTopicArticle, float]] = []
+    for topic in eligible_topics:
+        for article in topic.articles:
+            if _is_actu_du_jour(topic, article):
+                actu_candidates.append(
+                    (topic, article, scored[(topic.topic_id, article.content_id)])
+                )
+    if actu_candidates:
+        actu_candidates.sort(key=lambda x: (-x[2], x[1].rank))
+        lead_topic, lead_article, _ = actu_candidates[0]
+        _try_pick(lead_topic, lead_article)
+
+    # ─── Round 1 : diversité (1 article max par topic, hors lead) ────────
     def _best_for_topic(
         topic: DigestTopic,
     ) -> tuple[DigestTopicArticle, float]:
@@ -201,26 +276,16 @@ def _pick_transversal_articles(
         return best_article, scored[(topic.topic_id, best_article.content_id)]
 
     topic_bests = [(t, *_best_for_topic(t)) for t in eligible_topics]
-
-    # Round 1 : 1 article max par topic, dans l'ordre du meilleur score
-    # de chaque topic (desc), tie-break `topic.rank` (asc).
     topic_bests_sorted = sorted(topic_bests, key=lambda tb: (-tb[2], tb[0].rank))
 
-    picked: list[tuple[DigestTopic, DigestTopicArticle]] = []
-    seen_content_ids: set[UUID] = set()
-    used_topics: set[str] = set()
-
     for topic, article, _ in topic_bests_sorted:
-        if article.content_id in seen_content_ids:
+        if topic.topic_id in used_topics:
             continue
-        picked.append((topic, article))
-        seen_content_ids.add(article.content_id)
-        used_topics.add(topic.topic_id)
+        _try_pick(topic, article)
         if len(picked) >= ESSENTIEL_MAX_ARTICLES:
             return picked
 
-    # Round 2 : remplir avec les meilleurs articles restants (tous topics
-    # confondus), triés par score décroissant, tie-break `article.rank` (asc).
+    # ─── Round 2 : remplissage (meilleurs articles restants) ─────────────
     remaining: list[tuple[DigestTopic, DigestTopicArticle, float]] = []
     for topic in eligible_topics:
         for article in topic.articles:
@@ -233,10 +298,7 @@ def _pick_transversal_articles(
     remaining.sort(key=lambda x: (-x[2], x[1].rank))
 
     for topic, article, _ in remaining:
-        if article.content_id in seen_content_ids:
-            continue
-        picked.append((topic, article))
-        seen_content_ids.add(article.content_id)
+        _try_pick(topic, article)
         if len(picked) >= ESSENTIEL_MAX_ARTICLES:
             break
 
@@ -247,6 +309,7 @@ def _to_essentiel_article(
     topic: DigestTopic,
     article: DigestTopicArticle,
     rank: int,
+    ctx: EssentielUserContext,
 ) -> EssentielArticle:
     return EssentielArticle(
         content_id=article.content_id,
@@ -265,6 +328,9 @@ def _to_essentiel_article(
         is_saved=article.is_saved,
         is_liked=article.is_liked,
         is_dismissed=article.is_dismissed,
+        is_followed_source=_is_followed_source(article, ctx),
+        is_followed_topic=_is_followed_topic(topic, ctx),
+        is_actu_du_jour=_is_actu_du_jour(topic, article),
     )
 
 
@@ -275,13 +341,12 @@ def build_essentiel_response(
     """Projette une `DigestResponse` en `EssentielResponse` (5 articles max).
 
     Si `user_context` est None, on utilise un contexte vide → fallback
-    no-prefs (le scorer dégénère en perspective+rank, comportement proche
-    du round-robin historique rank-driven).
+    no-prefs (le scorer dégénère en actu_boost + perspective − rank).
     """
     ctx = user_context or EssentielUserContext()
     picks = _pick_transversal_articles(digest.topics, ctx)
     articles = [
-        _to_essentiel_article(topic, article, rank=i + 1)
+        _to_essentiel_article(topic, article, rank=i + 1, ctx=ctx)
         for i, (topic, article) in enumerate(picks)
     ]
     return EssentielResponse(

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -157,9 +157,7 @@ def _is_followed_topic(topic: DigestTopic, ctx: EssentielUserContext) -> bool:
     return bool(topic.theme and topic.theme in ctx.topic_weights)
 
 
-def _is_followed_source(
-    article: DigestTopicArticle, ctx: EssentielUserContext
-) -> bool:
+def _is_followed_source(article: DigestTopicArticle, ctx: EssentielUserContext) -> bool:
     return article.source.id in ctx.followed_source_ids or article.is_followed_source
 
 

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -46,6 +46,8 @@ def _make_article(
     source_name: str = "Le Monde",
     source: SourceMini | None = None,
     is_followed_source: bool = False,
+    badge: str | None = None,
+    is_read: bool = False,
 ) -> DigestTopicArticle:
     return DigestTopicArticle(
         content_id=uuid4(),
@@ -56,6 +58,8 @@ def _make_article(
         rank=rank,
         reason="Test",
         is_followed_source=is_followed_source,
+        badge=badge,
+        is_read=is_read,
     )
 
 
@@ -66,6 +70,8 @@ def _make_topic(
     theme: str | None = "technologie",
     perspective_count: int = 3,
     n_articles: int = 1,
+    is_trending: bool = False,
+    is_une: bool = False,
 ) -> DigestTopic:
     return DigestTopic(
         topic_id=f"topic-{rank}",
@@ -74,6 +80,8 @@ def _make_topic(
         reason="Test",
         theme=theme,
         perspective_count=perspective_count,
+        is_trending=is_trending,
+        is_une=is_une,
         articles=[
             _make_article(rank=i + 1, title=f"{label} {i + 1}")
             for i in range(n_articles)
@@ -204,9 +212,15 @@ async def test_get_essentiel_returns_5_articles(auth_override: UUID):
     ]
     digest = _make_digest(topics)
 
-    with patch(
-        "app.routers.essentiel.read_digest_or_fallback",
-        new=AsyncMock(return_value=digest),
+    with (
+        patch(
+            "app.routers.essentiel.read_digest_or_fallback",
+            new=AsyncMock(return_value=digest),
+        ),
+        patch(
+            "app.routers.essentiel.fetch_user_essentiel_context",
+            new=AsyncMock(return_value=EssentielUserContext()),
+        ),
     ):
         async with _client() as client:
             resp = await client.get("/api/essentiel")
@@ -250,9 +264,15 @@ async def test_get_essentiel_propagates_stale_fallback(auth_override: UUID):
     topics = [_make_topic(rank=1, label="Tech", n_articles=5)]
     digest = _make_digest(topics, is_stale=True)
 
-    with patch(
-        "app.routers.essentiel.read_digest_or_fallback",
-        new=AsyncMock(return_value=digest),
+    with (
+        patch(
+            "app.routers.essentiel.read_digest_or_fallback",
+            new=AsyncMock(return_value=digest),
+        ),
+        patch(
+            "app.routers.essentiel.fetch_user_essentiel_context",
+            new=AsyncMock(return_value=EssentielUserContext()),
+        ),
     ):
         async with _client() as client:
             resp = await client.get("/api/essentiel")
@@ -468,6 +488,176 @@ def test_followed_source_flag_fallback_when_db_set_empty():
     response = build_essentiel_response(digest, user_context=ctx)
 
     assert response.articles[0].source.id == s_followed.id
+
+
+# ─── Tests Actu du jour / diversité dure / is_read / flags JSON ──────────
+
+
+def test_actu_trending_takes_lead_slot_over_strong_user_signal():
+    """Un topic `is_trending=True` doit fournir le lead, même si un autre
+    topic match plus fortement le profil user."""
+    actu_topic = _make_topic(
+        rank=5,
+        label="Actu",
+        theme="international",
+        is_trending=True,
+        n_articles=1,
+    )
+    followed_topic = _make_topic(
+        rank=1,
+        label="Tech",
+        theme="technologie",
+        n_articles=1,
+    )
+    digest = _make_digest([followed_topic, actu_topic])
+    # User suit fortement "technologie" (poids 3.0) → +150 sur Tech.
+    # Mais l'Actu a +40 (trending) — moins que 150 mais on a forcé le slot lead.
+    ctx = EssentielUserContext(topic_weights={"technologie": 3.0})
+
+    response = build_essentiel_response(digest, user_context=ctx)
+
+    assert response.articles[0].section_label == "Actu"
+    assert response.articles[0].is_actu_du_jour is True
+    assert response.articles[0].rank == 1
+
+
+def test_actu_une_or_badge_also_takes_lead_slot():
+    """Le slot lead Actu se déclenche aussi sur `is_une` ou `badge='actu'`."""
+    une_topic = DigestTopic(
+        topic_id="t-une",
+        label="Une du jour",
+        rank=3,
+        reason="Test",
+        theme="politique",
+        is_une=True,
+        perspective_count=4,
+        articles=[_make_article(rank=1, title="Une")],
+    )
+    regular_topic = _make_topic(rank=1, label="Régulier", n_articles=1)
+    digest = _make_digest([regular_topic, une_topic])
+
+    response = build_essentiel_response(digest)
+
+    assert response.articles[0].section_label == "Une du jour"
+    assert response.articles[0].is_actu_du_jour is True
+
+
+def test_diversity_hard_cap_max_2_articles_per_source():
+    """Pas plus de 2 articles d'une même `source.id` dans les 5."""
+    shared_source = _make_source("Le Monde")
+    # 5 articles tous depuis la même source, répartis sur 5 topics distincts
+    # (sinon le round diversité limiterait déjà à 1/topic).
+    topics = [
+        DigestTopic(
+            topic_id=f"t{i}",
+            label=f"T{i}",
+            rank=i + 1,
+            reason="Test",
+            theme=f"theme-{i}",
+            perspective_count=3,
+            articles=[_make_article(rank=1, title=f"T{i}-1", source=shared_source)],
+        )
+        for i in range(5)
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    # On a 5 topics, mais la diversité dure limite à 2 articles de la même source.
+    assert len(response.articles) == 2
+    assert all(a.source.id == shared_source.id for a in response.articles)
+
+
+def test_is_read_articles_are_deprioritized():
+    """Un article déjà lu est écarté tant qu'il existe un candidat non-lu."""
+    # 2 topics : T1 a un article DÉJÀ LU avec rank topic=1 (devrait gagner sans
+    # la pénalité), T2 a un article frais avec rank topic=2.
+    topics = [
+        DigestTopic(
+            topic_id="t1",
+            label="Lu",
+            rank=1,
+            reason="Test",
+            theme="politique",
+            perspective_count=3,
+            articles=[_make_article(rank=1, title="Déjà lu", is_read=True)],
+        ),
+        DigestTopic(
+            topic_id="t2",
+            label="Frais",
+            rank=2,
+            reason="Test",
+            theme="ecologie",
+            perspective_count=3,
+            articles=[_make_article(rank=1, title="Frais")],
+        ),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    # L'article frais doit passer en premier.
+    assert response.articles[0].section_label == "Frais"
+    assert response.articles[0].is_read is False
+    # L'article lu peut encore être présent (fallback si pas mieux) — vérifier
+    # qu'il est en position basse seulement.
+    read_positions = [
+        i for i, a in enumerate(response.articles) if a.is_read
+    ]
+    if read_positions:
+        assert min(read_positions) > 0
+
+
+def test_response_exposes_followed_and_actu_flags():
+    """La réponse JSON expose `is_followed_source`, `is_followed_topic`,
+    `is_actu_du_jour` calculés à la volée."""
+    followed_source = _make_source("Mediapart")
+    other_source = _make_source("Le Monde")
+    topics = [
+        DigestTopic(
+            topic_id="t-trend",
+            label="Trending",
+            rank=1,
+            reason="Test",
+            theme="politique",
+            is_trending=True,
+            perspective_count=4,
+            articles=[
+                _make_article(rank=1, title="Trend-1", source=followed_source)
+            ],
+        ),
+        DigestTopic(
+            topic_id="t-tech",
+            label="Tech",
+            rank=2,
+            reason="Test",
+            theme="technologie",
+            perspective_count=3,
+            articles=[
+                _make_article(rank=1, title="Tech-1", source=other_source)
+            ],
+        ),
+    ]
+    digest = _make_digest(topics)
+    ctx = EssentielUserContext(
+        followed_source_ids=frozenset({followed_source.id}),
+        source_priority_multipliers={followed_source.id: 1.0},
+        topic_weights={"technologie": 2.0},
+    )
+
+    response = build_essentiel_response(digest, user_context=ctx)
+
+    # Lead = Actu trending + source suivie.
+    lead = response.articles[0]
+    assert lead.is_actu_du_jour is True
+    assert lead.is_followed_source is True
+    assert lead.is_followed_topic is False  # theme="politique" pas dans topic_weights
+
+    # Article #2 = Tech, topic suivi mais pas source suivie ni actu.
+    tech = response.articles[1]
+    assert tech.is_actu_du_jour is False
+    assert tech.is_followed_source is False
+    assert tech.is_followed_topic is True
 
 
 @pytest.mark.asyncio

--- a/scripts/run-mobile-web.sh
+++ b/scripts/run-mobile-web.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# run-mobile-web.sh — Lance le mobile Flutter en Chrome avec dart-defines OK,
+# pour usage avec Conductor Spotlight (depuis le repo root).
+#
+# Usage:
+#   bash scripts/run-mobile-web.sh           # prod API (Railway)
+#   bash scripts/run-mobile-web.sh --local   # local API (uvicorn :8080)
+#   bash scripts/run-mobile-web.sh --clean   # flutter clean puis prod API
+#
+# Prérequis :
+#   - Flutter installé et dans le PATH (flutter doctor)
+#   - Chrome installé
+#   - .env au repo root renseigné (ou fallbacks publics utilisés)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# 1. Charge .env du repo root si présent
+if [ -f "$REPO_ROOT/.env" ]; then
+  set -a; source "$REPO_ROOT/.env"; set +a
+fi
+
+# 2. Fallbacks (mêmes valeurs que .vscode/launch.json — clés publiques anon)
+: "${SUPABASE_URL:=https://ykuadtelnzavrqzbfdve.supabase.co}"
+: "${SUPABASE_ANON_KEY:=sb_publishable_0L_kPMbe0Pk9eBdzeEsIZg_0pogzm3k}"
+
+# 3. Choix API et flags
+DO_CLEAN=false
+USE_LOCAL=false
+for arg in "$@"; do
+  case "$arg" in
+    --local) USE_LOCAL=true ;;
+    --clean) DO_CLEAN=true ;;
+  esac
+done
+
+if $USE_LOCAL; then
+  API_BASE_URL="http://localhost:8080/api/"
+  echo "→ Backend local (uvicorn :8080)"
+else
+  API_BASE_URL="${API_BASE_URL:-https://facteur-production.up.railway.app/api/}"
+  echo "→ Backend prod (Railway)"
+fi
+
+# 4. Garde-fou clé Supabase
+if [ -z "$SUPABASE_ANON_KEY" ]; then
+  echo "✗ SUPABASE_ANON_KEY vide — vérifie $REPO_ROOT/.env" >&2
+  exit 1
+fi
+
+echo "→ Supabase URL : $SUPABASE_URL"
+echo "→ API Base URL : $API_BASE_URL"
+echo "→ Port web fixe : 8081 (http://localhost:8081)"
+echo ""
+
+# 5. Nettoie le build si demandé OU si c'est la première fois qu'on passe
+#    des dart-defines (Flutter peut rater l'invalidation du cache dans ce cas).
+MOBILE_DIR="$REPO_ROOT/apps/mobile"
+DEFINES_STAMP="$MOBILE_DIR/.dart_tool/.dart_defines_stamp"
+CURRENT_DEFINES="${SUPABASE_URL}|${SUPABASE_ANON_KEY}|${API_BASE_URL}"
+
+if $DO_CLEAN; then
+  echo "→ flutter clean (demandé via --clean)…"
+  (cd "$MOBILE_DIR" && flutter clean)
+  rm -f "$DEFINES_STAMP"
+elif [ ! -f "$DEFINES_STAMP" ] || [ "$(cat "$DEFINES_STAMP" 2>/dev/null)" != "$CURRENT_DEFINES" ]; then
+  echo "→ Dart-defines changés — flutter clean automatique (évite le cache vide)…"
+  (cd "$MOBILE_DIR" && flutter clean)
+  echo "$CURRENT_DEFINES" > "$DEFINES_STAMP"
+fi
+
+echo ""
+echo "  Hot reload : r   |   Hot restart : R   |   Quitter : q"
+echo ""
+
+# 6. Lance Flutter (exec remplace le shell → Ctrl+C arrête bien Flutter)
+cd "$MOBILE_DIR"
+exec flutter run \
+  -d chrome \
+  --web-port=8081 \
+  --dart-define=API_BASE_URL="$API_BASE_URL" \
+  --dart-define=SUPABASE_URL="$SUPABASE_URL" \
+  --dart-define=SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY" \
+  --web-browser-flag \
+  --disable-web-security


### PR DESCRIPTION
## Quoi

Améliore la pertinence perçue de la carte « L'Essentiel du jour » sur 4 axes :

1. **Lead-slot Actu du jour** — si un topic est `is_trending`/`is_une` ou un article a `badge="actu"`, il prend la position 1, quel que soit le score user-aware. L'actu chaude domine toujours.
2. **Diversité dure 2/source** — max 2 articles d'une même source dans les 5, pour éviter l'effet « tout Le Monde ».
3. **Pénalité `is_read` (-1000)** — un article déjà lu n'apparaît que si aucun candidat frais n'existe.
4. **3 flags UI user-aware** — `is_followed_source`, `is_followed_topic`, `is_actu_du_jour` exposés en JSON et rendus côté carte (badge Actu, chip topic suivi, avatar source teinté).

Aligne les boosts (`BOOST_TRENDING=40`, `BOOST_UNE=30`) sur ceux du `Top3Selector` du briefing pour cohérence cross-feature.

## Pourquoi

Les recos de l'Essentiel étaient correctes statistiquement mais le user voyait parfois un sujet de fond en lead alors qu'une actu majeure était dans la pile. Et 3-4 articles d'une même source dans les 5 — courant — donnaient l'impression d'un digest mono-source. Le focus de cette PR : *vraiment pertinentes* > *statistiquement optimales*.

## Comment ça a été vérifié

- [x] `pytest tests/test_essentiel_endpoint.py -v` → **23/23 OK** (dont 5 nouveaux : lead-slot Actu trending/une/badge, cap 2/source, is_read deprioritized, flags JSON).
- [x] `pytest -v` suite complète : 1098 passed (174 errors = pré-existants, DB de test PG non montée dans ce workspace — non liés à cette PR).
- [x] `flutter analyze` sur `lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart` → **No issues found**.
- [x] `flutter test essentiel_hi_fi_card_test.dart` → 6/6 OK en isolation.
- [x] Simplify : suppression du double-dim (Opacity + textTertiary) sur les 3 tiles → opacity seule, cohérent avec `letter_row.dart`. Extraction d'une constante module-level `_BADGE_ACTU` pour le check stringly-typed `article.badge == "actu"`.

## Zones à risque

- `essentiel_service.py:_pick_transversal_articles` — cœur de l'algo, désormais avec un slot dédié au lead + un cap source + dédup. Bien couvert par tests.
- `EssentielArticle` schema : +3 champs `is_*` (forward-compatible — repo mobile lit avec `?? false`).
- `apps/mobile/lib/config/constants.dart` — fallbacks Supabase publics (mêmes valeurs que `.vscode/launch.json`). N'affecte que les builds sans `--dart-define`.

## Hors scope

- Extract `_relativeTime` dans `apps/mobile/lib/shared/utils/` (duplique partiellement `briefing_card._formatDuration`) — à faire dans une PR de housekeeping dédiée.
- Migrer `badge` vers un `Enum` Pydantic dans `schemas/digest.py` — risque de break la serialization du digest cron, hors scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)