### PR TITLE
feat(mobile): curation FR-first — toggle langue + couverture étrangère (PR 2/2)

### DIFF
--- a/apps/mobile/lib/features/custom_topics/providers/personalization_provider.dart
+++ b/apps/mobile/lib/features/custom_topics/providers/personalization_provider.dart
@@ -7,11 +7,15 @@ class UserPersonalization {
   final Set<String> mutedThemes;
   final Set<String> mutedTopics;
   final Set<String> mutedContentTypes;
+  final bool hideNonFrSources;
+  final bool languageFilterUserSet;
 
   const UserPersonalization({
     this.mutedThemes = const {},
     this.mutedTopics = const {},
     this.mutedContentTypes = const {},
+    this.hideNonFrSources = true,
+    this.languageFilterUserSet = false,
   });
 
   factory UserPersonalization.fromJson(Map<String, dynamic> json) {
@@ -19,6 +23,9 @@ class UserPersonalization {
       mutedThemes: _toStringSet(json['muted_themes']),
       mutedTopics: _toStringSet(json['muted_topics']),
       mutedContentTypes: _toStringSet(json['muted_content_types']),
+      hideNonFrSources: (json['hide_non_fr_sources'] as bool?) ?? true,
+      languageFilterUserSet:
+          (json['language_filter_user_set'] as bool?) ?? false,
     );
   }
 

--- a/apps/mobile/lib/features/feed/models/content_model.dart
+++ b/apps/mobile/lib/features/feed/models/content_model.dart
@@ -148,6 +148,11 @@ class Content {
   // Editorial badge from digest (actu, pas_de_recul, pepite, coup_de_coeur)
   final String? editorialBadge;
 
+  /// Langue ISO du contenu ("fr","en",...). `null` ⇒ traité comme `fr`
+  /// (convention back-end Phase 4). Forward-compat : non encore consommé
+  /// par l'UI.
+  final String? language;
+
   Content({
     required this.id,
     required this.title,
@@ -199,6 +204,7 @@ class Content {
     this.keywordOverflowSources = const [],
     this.keywordOverflowIsCustomTopic = false,
     this.editorialBadge,
+    this.language,
   });
 
   bool get isVideo => contentType == ContentType.youtube || contentType == ContentType.video;
@@ -286,6 +292,7 @@ class Content {
       keywordOverflowSources: keywordOverflowSources,
       keywordOverflowIsCustomTopic: keywordOverflowIsCustomTopic,
       editorialBadge: editorialBadge,
+      language: language,
     );
   }
 
@@ -338,6 +345,7 @@ class Content {
             ? DateTime.tryParse(json['note_updated_at'] as String)
             : null,
         isFollowedSource: (json['is_followed_source'] as bool?) ?? false,
+        language: json['language'] as String?,
       );
     } catch (e, stack) {
       // ignore: avoid_print
@@ -405,6 +413,7 @@ class Content {
     List<KeywordOverflowSource>? keywordOverflowSources,
     bool? keywordOverflowIsCustomTopic,
     String? editorialBadge,
+    String? language,
   }) {
     return Content(
       id: id ?? this.id,
@@ -471,6 +480,7 @@ class Content {
       keywordOverflowIsCustomTopic:
           keywordOverflowIsCustomTopic ?? this.keywordOverflowIsCustomTopic,
       editorialBadge: editorialBadge ?? this.editorialBadge,
+      language: language ?? this.language,
     );
   }
 

--- a/apps/mobile/lib/features/feed/repositories/personalization_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/personalization_repository.dart
@@ -93,6 +93,21 @@ class PersonalizationRepository {
     }
   }
 
+  Future<void> toggleHideNonFrSources(bool hideNonFr) async {
+    try {
+      await _apiClient.post(
+        'users/personalization/toggle-hide-non-fr-sources',
+        body: {'hide_non_fr': hideNonFr},
+      );
+    } on DioException catch (e) {
+      print('PersonalizationRepository.toggleHideNonFrSources failed:');
+      print('   Status: ${e.response?.statusCode}');
+      print('   Body sent: {hide_non_fr: $hideNonFr}');
+      print('   Response: ${e.response?.data}');
+      rethrow;
+    }
+  }
+
   Future<void> unmuteSource(String sourceId) async {
     try {
       await _apiClient.delete('users/personalization/unmute-source/$sourceId');

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -11,6 +11,7 @@ import '../../sources/models/source_model.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../../sources/widgets/source_detail_modal.dart';
 import '../../digest/widgets/markdown_text.dart';
+import '../../digest/widgets/section_divider.dart';
 import '../providers/feed_provider.dart';
 import '../repositories/feed_repository.dart' show HighlightSpan, TokenSpan;
 import 'coverage_spectrum_bar.dart';
@@ -193,11 +194,15 @@ class _PerspectivesBottomSheetState
     final opened = _openedAt;
     final elapsed =
         opened != null ? DateTime.now().difference(opened).inSeconds : 0;
-    ref.read(analyticsServiceProvider).trackPerspectiveComparisonClosed(
-          contentId: widget.contentId,
-          viewedArticles: _viewedPerspectiveIds.length,
-          openedSeconds: elapsed,
-        );
+    // En tests / teardown rapide, le ProviderScope peut être disposé avant
+    // ce widget — on ne veut pas crasher pour un event analytics.
+    try {
+      ref.read(analyticsServiceProvider).trackPerspectiveComparisonClosed(
+            contentId: widget.contentId,
+            viewedArticles: _viewedPerspectiveIds.length,
+            openedSeconds: elapsed,
+          );
+    } catch (_) {}
     super.dispose();
   }
 
@@ -271,6 +276,39 @@ class _PerspectivesBottomSheetState
       if (!mounted) return;
       setState(() => _analysisState = PerspectivesAnalysisState.error);
     }
+  }
+
+  /// Sépare FR (langue null ou `fr`) des couvertures étrangères et insère
+  /// un `SectionDivider` "Couverture à l'étranger" entre les deux blocs.
+  List<Widget> _buildPerspectiveCards(List<Perspective> perspectives) {
+    final fr = <Perspective>[];
+    final foreign = <Perspective>[];
+    for (final p in perspectives) {
+      if (p.language == null || p.language == 'fr') {
+        fr.add(p);
+      } else {
+        foreign.add(p);
+      }
+    }
+
+    Widget card(Perspective p, {bool dim = false}) {
+      final w = Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: _PerspectiveCard(
+          perspective: p,
+          onView: _onPerspectiveViewed,
+        ),
+      );
+      return dim ? Opacity(opacity: 0.92, child: w) : w;
+    }
+
+    return [
+      for (final p in fr) card(p),
+      if (foreign.isNotEmpty) ...[
+        const SectionDivider(label: "Couverture à l'étranger"),
+        for (final p in foreign) card(p, dim: true),
+      ],
+    ];
   }
 
   @override
@@ -395,15 +433,10 @@ class _PerspectivesBottomSheetState
                         ],
                       ),
                     ),
-                    ...filtered.map(
-                      (p) => Padding(
-                        padding: const EdgeInsets.only(bottom: 8),
-                        child: _PerspectiveCard(
-                          perspective: p,
-                          onView: _onPerspectiveViewed,
-                        ),
-                      ),
-                    ),
+                    // Split FR ("language" null ou "fr") des couvertures
+                    // étrangères. Le panel reste pluraliste : insensible au
+                    // toggle "Masquer les sources non françaises" (PO).
+                    ..._buildPerspectiveCards(filtered),
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
                       child: PerspectivesAnalysisZone(

--- a/apps/mobile/lib/features/settings/providers/language_preference_provider.dart
+++ b/apps/mobile/lib/features/settings/providers/language_preference_provider.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../custom_topics/providers/personalization_provider.dart';
+import '../../digest/providers/digest_provider.dart';
+import '../../feed/providers/feed_provider.dart';
+import '../../feed/repositories/personalization_repository.dart';
+import '../../flux_continu/providers/flux_continu_provider.dart';
+
+/// État du filtre langue (PR 6.1 — couverture FR-first).
+///
+/// `hideNonFr` : masque les sources non-FR (sauf sources suivies).
+/// `userSet` : `true` dès que l'utilisateur a touché manuellement au toggle —
+/// gèle le recalcul auto serveur sur follow/unfollow.
+/// `synced` : `true` une fois la phase Hive + sync backend terminée (succès
+/// ou échec). Évite les flashs d'état par défaut au boot.
+@immutable
+class LanguagePreferenceState {
+  final bool hideNonFr;
+  final bool userSet;
+  final bool synced;
+
+  const LanguagePreferenceState({
+    this.hideNonFr = true,
+    this.userSet = false,
+    this.synced = false,
+  });
+
+  LanguagePreferenceState copyWith({
+    bool? hideNonFr,
+    bool? userSet,
+    bool? synced,
+  }) {
+    return LanguagePreferenceState(
+      hideNonFr: hideNonFr ?? this.hideNonFr,
+      userSet: userSet ?? this.userSet,
+      synced: synced ?? this.synced,
+    );
+  }
+}
+
+/// Pilote le toggle "Masquer les sources non françaises" + son alignement
+/// auto (refresh) après follow/unfollow tant que `userSet = false`.
+///
+/// Hive = cache pour first-paint ; backend = source of truth.
+class LanguagePreferenceNotifier
+    extends StateNotifier<LanguagePreferenceState> {
+  LanguagePreferenceNotifier(this._ref)
+      : super(const LanguagePreferenceState()) {
+    unawaited(_bootstrap());
+  }
+
+  final Ref _ref;
+
+  static const _boxName = 'settings';
+  static const _kHideNonFr = 'hide_non_fr_sources';
+  static const _kLanguageUserSet = 'language_filter_user_set';
+
+  Future<Box<dynamic>> _box() => Hive.openBox<dynamic>(_boxName);
+
+  Future<void> _bootstrap() async {
+    await _loadFromHive();
+    try {
+      await _syncFromBackend();
+    } finally {
+      if (mounted) state = state.copyWith(synced: true);
+    }
+  }
+
+  Future<void> _loadFromHive() async {
+    final box = await _box();
+    if (!mounted) return;
+    state = LanguagePreferenceState(
+      hideNonFr: box.get(_kHideNonFr, defaultValue: true) as bool,
+      userSet: box.get(_kLanguageUserSet, defaultValue: false) as bool,
+    );
+  }
+
+  Future<void> _persist(LanguagePreferenceState s) async {
+    final box = await _box();
+    await box.putAll({
+      _kHideNonFr: s.hideNonFr,
+      _kLanguageUserSet: s.userSet,
+    });
+  }
+
+  Future<void> _syncFromBackend() async {
+    try {
+      _ref.invalidate(personalizationProvider);
+      final perso = await _ref.read(personalizationProvider.future);
+      if (!mounted) return;
+      final fresh = state.copyWith(
+        hideNonFr: perso.hideNonFrSources,
+        userSet: perso.languageFilterUserSet,
+      );
+      state = fresh;
+      await _persist(fresh);
+    } catch (e) {
+      debugPrint('LanguagePreference: backend sync failed: $e');
+    }
+  }
+
+  /// Optimistic toggle : met à jour le state + Hive immédiatement, puis POST.
+  /// Sur erreur, rollback + retourne `false` pour que l'UI affiche une snackbar.
+  Future<bool> toggle(bool value) async {
+    final previous = state;
+    state = state.copyWith(hideNonFr: value, userSet: true);
+    await _persist(state);
+
+    try {
+      final repo = _ref.read(personalizationRepositoryProvider);
+      await repo.toggleHideNonFrSources(value);
+      _ref.invalidate(feedProvider);
+      _ref.invalidate(digestProvider);
+      _ref.invalidate(fluxContinuProvider);
+      return true;
+    } catch (e) {
+      debugPrint('LanguagePreference.toggle failed: $e');
+      if (mounted) {
+        state = previous;
+        await _persist(previous);
+      }
+      return false;
+    }
+  }
+
+  /// Resync depuis `/personalization` — appelé après follow/unfollow puisque
+  /// le serveur peut basculer auto `hideNonFr` tant que `userSet = false`.
+  /// No-op si `userSet = true` (le serveur ne touche plus la valeur, donc
+  /// inutile de payer N round-trips pendant un onboarding bulk).
+  Future<void> refresh() async {
+    if (state.userSet) return;
+    await _syncFromBackend();
+  }
+}
+
+final languagePreferenceProvider = StateNotifierProvider<
+    LanguagePreferenceNotifier, LanguagePreferenceState>(
+  (ref) => LanguagePreferenceNotifier(ref),
+);

--- a/apps/mobile/lib/features/settings/screens/account_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/account_screen.dart
@@ -8,6 +8,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/theme.dart';
 import '../../../core/auth/auth_state.dart';
 import '../../../core/services/widget_service.dart';
+import '../providers/language_preference_provider.dart';
 import '../providers/user_profile_provider.dart';
 import 'package:facteur/core/ui/notification_service.dart';
 
@@ -164,6 +165,9 @@ class AccountScreen extends ConsumerWidget {
               ),
             ],
 
+            const SizedBox(height: FacteurSpacing.space6),
+            _LanguagePreferenceSection(),
+
             const Spacer(),
 
             // Bouton Déconnexion
@@ -280,6 +284,75 @@ class AccountScreen extends ConsumerWidget {
               Navigator.of(context).pop();
             },
             child: Text('Enregistrer', style: TextStyle(color: colors.primary)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Section "LANGUE & CONTENUS" — toggle masquage des sources non françaises.
+class _LanguagePreferenceSection extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final state = ref.watch(languagePreferenceProvider);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(
+        horizontal: FacteurSpacing.space4,
+        vertical: FacteurSpacing.space2,
+      ),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        border: Border.all(color: colors.surfaceElevated),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: FacteurSpacing.space2),
+            child: Text(
+              'LANGUE & CONTENUS',
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: colors.textTertiary,
+                    letterSpacing: 1.5,
+                  ),
+            ),
+          ),
+          SwitchListTile.adaptive(
+            contentPadding: EdgeInsets.zero,
+            title: Text(
+              'Masquer les sources non françaises',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(fontWeight: FontWeight.w500),
+            ),
+            subtitle: Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                'Les sources que tu suis restent toujours visibles.',
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(color: colors.textSecondary),
+              ),
+            ),
+            value: state.hideNonFr,
+            activeColor: colors.primary,
+            onChanged: (v) async {
+              final ok = await ref
+                  .read(languagePreferenceProvider.notifier)
+                  .toggle(v);
+              if (!ok) {
+                NotificationService.showError(
+                  'Impossible de mettre à jour ce réglage. Réessaye dans un instant.',
+                );
+              }
+            },
           ),
         ],
       ),

--- a/apps/mobile/lib/features/sources/models/source_model.dart
+++ b/apps/mobile/lib/features/sources/models/source_model.dart
@@ -34,6 +34,10 @@ class Source {
   final bool hasSubscription;
   final String? recommendedBy;
   final String? recommendationReason;
+  /// Langue ISO de la source ("fr","en",...). `null` ⇒ traité comme `fr`
+  /// (convention back-end Phase 4). Forward-compat : non encore consommé
+  /// par l'UI, prêt pour Story 7.7 (label EN sur cartes).
+  final String? language;
 
   Source({
     required this.id,
@@ -61,6 +65,7 @@ class Source {
     this.hasSubscription = false,
     this.recommendedBy,
     this.recommendationReason,
+    this.language,
   });
 
   Source copyWith({
@@ -89,6 +94,7 @@ class Source {
     bool? hasSubscription,
     String? recommendedBy,
     String? recommendationReason,
+    String? language,
   }) {
     return Source(
       id: id ?? this.id,
@@ -116,6 +122,7 @@ class Source {
       hasSubscription: hasSubscription ?? this.hasSubscription,
       recommendedBy: recommendedBy ?? this.recommendedBy,
       recommendationReason: recommendationReason ?? this.recommendationReason,
+      language: language ?? this.language,
     );
   }
 
@@ -158,6 +165,7 @@ class Source {
         hasSubscription: (json['has_subscription'] as bool?) ?? false,
         recommendedBy: json['recommended_by'] as String?,
         recommendationReason: json['recommendation_reason'] as String?,
+        language: json['language'] as String?,
       );
     } catch (e) {
       debugPrint('Source.fromJson: [ERROR] Failed to parse: $e');

--- a/apps/mobile/lib/features/sources/providers/sources_providers.dart
+++ b/apps/mobile/lib/features/sources/providers/sources_providers.dart
@@ -5,6 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../../core/api/api_client.dart';
 import '../../feed/repositories/personalization_repository.dart';
 import '../../lettres/providers/letters_provider.dart';
+import '../../settings/providers/language_preference_provider.dart';
 import '../models/smart_search_result.dart';
 import '../models/source_model.dart';
 import '../models/theme_source_model.dart';
@@ -115,6 +116,11 @@ class UserSourcesNotifier extends AsyncNotifier<List<Source>> {
 
       // ignore: avoid_print
       print('UserSourcesNotifier: Toggle success (persisted to DB)');
+      // Le backend peut basculer auto `hide_non_fr_sources` tant que
+      // `language_filter_user_set = false` — on resync sans bloquer l'UI.
+      unawaited(
+        ref.read(languagePreferenceProvider.notifier).refresh(),
+      );
       // No need to re-fetch entire list: optimistic update is sufficient and avoids race conditions
     } catch (e, stack) {
       // ignore: avoid_print

--- a/apps/mobile/test/features/feed/widgets/perspectives_bottom_sheet_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_bottom_sheet_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
+
+Perspective _persp(String name, {String? language}) => Perspective(
+      title: 'Titre pour $name',
+      url: 'https://example.com/$name',
+      sourceName: name,
+      sourceDomain: '',
+      biasStance: 'center',
+      language: language,
+    );
+
+Future<void> _pumpSheet(
+  WidgetTester tester, {
+  required List<Perspective> perspectives,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(
+          body: SizedBox(
+            width: 390,
+            height: 844,
+            child: PerspectivesBottomSheet(
+              perspectives: perspectives,
+              biasDistribution: const {'center': 0},
+              keywords: const [],
+              contentId: 'test-content-id',
+              sourceBiasStance: 'center',
+              sourceName: 'Test',
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+const _foreignDividerLabel = "Couverture à l'étranger";
+
+void main() {
+  testWidgets('mix FR + EN → divider + foreign cards under the divider',
+      (tester) async {
+    await _pumpSheet(tester, perspectives: [
+      _persp('Source-FR-1', language: 'fr'),
+      _persp('Source-EN-1', language: 'en'),
+      _persp('Source-FR-2'),
+    ]);
+
+    expect(find.text(_foreignDividerLabel), findsOneWidget);
+    expect(find.text('Source-FR-1'), findsOneWidget);
+    expect(find.text('Source-FR-2'), findsOneWidget);
+    expect(find.text('Source-EN-1'), findsOneWidget);
+  });
+
+  testWidgets('0 EN → no divider', (tester) async {
+    await _pumpSheet(tester, perspectives: [
+      _persp('Source-FR-1', language: 'fr'),
+      _persp('Source-FR-2', language: 'fr'),
+    ]);
+
+    expect(find.text(_foreignDividerLabel), findsNothing);
+  });
+
+  testWidgets('all language=null → no divider (null ≡ fr)', (tester) async {
+    await _pumpSheet(tester, perspectives: [
+      _persp('Source-A'),
+      _persp('Source-B'),
+    ]);
+
+    expect(find.text(_foreignDividerLabel), findsNothing);
+  });
+
+  testWidgets('100% EN → divider + foreign block', (tester) async {
+    await _pumpSheet(tester, perspectives: [
+      _persp('Source-EN-1', language: 'en'),
+      _persp('Source-EN-2', language: 'de'),
+    ]);
+
+    expect(find.text(_foreignDividerLabel), findsOneWidget);
+    expect(find.text('Source-EN-1'), findsOneWidget);
+    expect(find.text('Source-EN-2'), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/features/settings/language_toggle_test.dart
+++ b/apps/mobile/test/features/settings/language_toggle_test.dart
@@ -1,0 +1,153 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:facteur/features/custom_topics/providers/personalization_provider.dart';
+import 'package:facteur/features/feed/repositories/personalization_repository.dart';
+import 'package:facteur/features/settings/providers/language_preference_provider.dart';
+
+/// Fake repository — capture les appels et permet d'injecter une erreur.
+class _FakePersonalizationRepo implements PersonalizationRepository {
+  bool throwOnToggle = false;
+  bool? lastValue;
+  int callCount = 0;
+
+  @override
+  Future<void> toggleHideNonFrSources(bool hideNonFr) async {
+    callCount++;
+    lastValue = hideNonFr;
+    if (throwOnToggle) throw Exception('boom');
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+ProviderContainer _container({
+  required _FakePersonalizationRepo repo,
+  required UserPersonalization remote,
+}) {
+  return ProviderContainer(
+    overrides: [
+      personalizationRepositoryProvider.overrideWithValue(repo),
+      personalizationProvider.overrideWith((ref) async => remote),
+    ],
+  );
+}
+
+Future<void> _waitForSync(ProviderContainer container) async {
+  // Boot async : load Hive → sync backend → synced = true
+  while (!container.read(languagePreferenceProvider).synced) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    await Hive.openBox<dynamic>('settings');
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  test('toggle(true) persist Hive + POST repo + userSet=true', () async {
+    final repo = _FakePersonalizationRepo();
+    final container = _container(
+      repo: repo,
+      remote: const UserPersonalization(
+        hideNonFrSources: false,
+        languageFilterUserSet: false,
+      ),
+    );
+    addTearDown(container.dispose);
+
+    await _waitForSync(container);
+    expect(container.read(languagePreferenceProvider).hideNonFr, false);
+
+    final ok = await container
+        .read(languagePreferenceProvider.notifier)
+        .toggle(true);
+
+    expect(ok, true);
+    expect(repo.lastValue, true);
+    expect(repo.callCount, 1);
+    final state = container.read(languagePreferenceProvider);
+    expect(state.hideNonFr, true);
+    expect(state.userSet, true);
+
+    final box = Hive.box<dynamic>('settings');
+    expect(box.get('hide_non_fr_sources'), true);
+    expect(box.get('language_filter_user_set'), true);
+  });
+
+  test('toggle rollback on HTTP error → state revient + retour false',
+      () async {
+    final repo = _FakePersonalizationRepo()..throwOnToggle = true;
+    final container = _container(
+      repo: repo,
+      remote: const UserPersonalization(
+        hideNonFrSources: false,
+        languageFilterUserSet: false,
+      ),
+    );
+    addTearDown(container.dispose);
+
+    await _waitForSync(container);
+    final before = container.read(languagePreferenceProvider);
+    expect(before.hideNonFr, false);
+
+    final ok = await container
+        .read(languagePreferenceProvider.notifier)
+        .toggle(true);
+
+    expect(ok, false);
+    final after = container.read(languagePreferenceProvider);
+    expect(after.hideNonFr, false);
+    expect(after.userSet, false);
+  });
+
+  test('refresh() resync state depuis /personalization', () async {
+    final repo = _FakePersonalizationRepo();
+    final container = _container(
+      repo: repo,
+      remote: const UserPersonalization(
+        hideNonFrSources: true,
+        languageFilterUserSet: false,
+      ),
+    );
+    addTearDown(container.dispose);
+
+    await _waitForSync(container);
+    expect(container.read(languagePreferenceProvider).hideNonFr, true);
+
+    // Le backend a recalculé : maintenant hideNonFr=false.
+    container.updateOverrides([
+      personalizationRepositoryProvider.overrideWithValue(repo),
+      personalizationProvider.overrideWith(
+        (ref) async => const UserPersonalization(
+          hideNonFrSources: false,
+          languageFilterUserSet: false,
+        ),
+      ),
+    ]);
+
+    await container
+        .read(languagePreferenceProvider.notifier)
+        .refresh();
+
+    final state = container.read(languagePreferenceProvider);
+    expect(state.hideNonFr, false);
+    expect(state.userSet, false);
+
+    final box = Hive.box<dynamic>('settings');
+    expect(box.get('hide_non_fr_sources'), false);
+  });
+}


### PR DESCRIPTION
## What

Côté mobile de la curation FR-first (PR 2/2) : toggle « Masquer les sources non françaises » dans les réglages, séparation visuelle FR / couverture étrangère dans le panel Perspectives, et propagation des champs `language` sur `Source` et `Content` (forward-compat Phase 4).

## Why

Fait suite à PR #658 (filtre langue user-aware côté API). L'utilisateur peut maintenant épingler manuellement sa préférence langue depuis les Réglages. Le panel Perspectives reste pluraliste mais signale clairement les sources étrangères avec un bloc séparé.

## Type

- [x] Feature

## Checklist

- [x] Tests pass locally (`flutter test` — 7 nouveaux tests OK, 36 échecs pré-existants inchangés)
- [x] `flutter analyze` — aucun error/warning sur les fichiers touchés
- [x] /simplify passé (Padding redondant retiré, refresh() no-op quand userSet=true)
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed