### PR TITLE
feat(mobile): tournée UI phase 2 — fold bug fix, compact hero, DigestSectionScreen, séparateur (#9.3)

### DIFF
--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -10,6 +10,7 @@ import '../features/onboarding/screens/onboarding_screen.dart';
 import '../features/onboarding/screens/conclusion_animation_screen.dart';
 import '../features/feed/screens/feed_screen.dart';
 import '../features/feed/models/content_model.dart';
+import '../features/flux_continu/screens/digest_section_screen.dart';
 import '../features/flux_continu/screens/flux_continu_screen.dart';
 import '../features/flux_continu/screens/theme_section_screen.dart';
 import '../features/flux_continu/models/flux_continu_models.dart';
@@ -279,6 +280,20 @@ final routerProvider = Provider<GoRouter>((ref) {
               final section = state.extra as FeedThemeSection?;
               return FullSwipeCupertinoPage(
                 child: ThemeSectionScreen(
+                  sectionKeyValue: key,
+                  initialSection: section,
+                ),
+              );
+            },
+          ),
+          GoRoute(
+            path: 'section/:key',
+            parentNavigatorKey: NotificationService.navigatorKey,
+            pageBuilder: (context, state) {
+              final key = state.pathParameters['key']!;
+              final section = state.extra as DigestTopicSection?;
+              return FullSwipeCupertinoPage(
+                child: DigestSectionScreen(
                   sectionKeyValue: key,
                   initialSection: section,
                 ),

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -62,7 +62,24 @@ const int _kMaxFavoriteSections = 3;
 const String _kFoldedPrefsKeyPrefix = 'flux_continu_folded_';
 const String _kClosingPrefsKeyPrefix = 'flux_continu_closing_dismissed_';
 
-String _dayKey(DateTime day) => day.toIso8601String().substring(0, 10);
+/// Boundary hour (local time) at which the "tournée day" flips. Aligned with
+/// the API digest cron at 07:30 Paris (`DIGEST_CRON_HOUR_PARIS`). Before this
+/// hour, the digest still reflects yesterday so the fold state must too —
+/// otherwise opening the app at 02:00 would wipe fold state while the
+/// content is unchanged.
+const int _kTourneeDayBoundaryHour = 7;
+const int _kTourneeDayBoundaryMinute = 30;
+
+/// Returns the canonical ISO day (`YYYY-MM-DD`) for the tournée at [now],
+/// using a 07:30-local boundary instead of midnight.
+String _dayKey(DateTime now) {
+  final shifted = (now.hour < _kTourneeDayBoundaryHour ||
+          (now.hour == _kTourneeDayBoundaryHour &&
+              now.minute < _kTourneeDayBoundaryMinute))
+      ? now.subtract(const Duration(days: 1))
+      : now;
+  return shifted.toIso8601String().substring(0, 10);
+}
 
 String _foldedPrefsKey(DateTime day) =>
     '$_kFoldedPrefsKeyPrefix${_dayKey(day)}';
@@ -537,17 +554,32 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   /// about to resize, so it can compensate the scroll offset.
   Set<String> persistQueuedSnapshot() => Set.unmodifiable(_persistQueued);
 
-  /// Re-expands a folded section in the current session only (not persisted).
-  /// Lets the user re-read a section they previously scrolled past without
-  /// disabling the auto-fold for tomorrow's tournée.
+  /// Re-expands a folded section. Also purges the section from
+  /// [_persistQueued] and from the day-scoped SharedPreferences blob so a
+  /// cold launch in the same day does not re-fold the section.
+  ///
+  /// Without the prefs purge, [markScrolledPastForNextSession] would have
+  /// persisted the fold immediately and [_loadFoldedForToday] would restore
+  /// it on next mount — leaving sections like "Actus du jour" stuck folded
+  /// forever once the user has scrolled past them once.
   void unfoldLocally(FluxSection section) {
     final current = state.valueOrNull;
     if (current == null) return;
     final key = sectionKey(section);
-    if (current.folded[key] != true) return;
-    final next = Map<String, bool>.from(current.folded)..remove(key);
-    _folded = next;
-    state = AsyncData(current.copyWith(folded: next));
+    final wasFolded = current.folded[key] == true;
+    final wasQueued = _persistQueued.remove(key);
+    if (!wasFolded && !wasQueued) return;
+    if (wasFolded) {
+      final next = Map<String, bool>.from(current.folded)..remove(key);
+      _folded = next;
+      state = AsyncData(current.copyWith(folded: next));
+    }
+    // Rewrite the prefs blob with the new (live + still-queued) fold set so
+    // the unfold survives a cold launch in the same tournée day.
+    unawaited(_persistFolded({
+      ..._folded,
+      for (final k in _persistQueued) k: true,
+    }));
   }
 
   /// Manually folds a section in the current session only (not persisted).
@@ -728,7 +760,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       blurb: _kThemeBlurb,
       accent: accent,
       illustrationAsset: _kVeilleIllustration,
-      coreVisibleCount: 3,
+      coreVisibleCount: 2,
       themeSlug: themeSlug,
       customTopicId: customTopicId,
       items: items,
@@ -867,7 +899,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       blurb: 'Les derniers articles de ta veille personnalisée.',
       accent: _kVeilleAccent,
       illustrationAsset: _kVeilleIllustration,
-      coreVisibleCount: 3,
+      coreVisibleCount: 2,
       items: items,
     );
   }

--- a/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../config/routes.dart';
+import '../../../config/theme.dart';
+import '../../digest/models/digest_models.dart';
+import '../models/flux_continu_models.dart';
+import '../providers/flux_continu_provider.dart';
+import '../widgets/flux_continu_article_card.dart';
+import '../widgets/section_banner.dart';
+
+/// Full-page view of a [DigestTopicSection] (Actus du jour, Bonnes Nouvelles).
+///
+/// Renders the section's hero banner and every topic's lead article. Mirrors
+/// [ThemeSectionScreen] visually so the dedicated-page UX is consistent
+/// across all Tournée sections. The digest payload is bounded (no infinite
+/// scroll) so we render the full list directly.
+class DigestSectionScreen extends ConsumerWidget {
+  final String sectionKeyValue;
+
+  /// Snapshot captured at navigation time. Used as the immediate render
+  /// source while [fluxContinuProvider] resolves, so the user doesn't see an
+  /// empty page during the slide-in transition.
+  final DigestTopicSection? initialSection;
+
+  const DigestSectionScreen({
+    super.key,
+    required this.sectionKeyValue,
+    this.initialSection,
+  });
+
+  DigestTopicSection? _resolveSection(WidgetRef ref) {
+    final state = ref.watch(fluxContinuProvider).valueOrNull;
+    if (state == null) return initialSection;
+    for (final s in state.sections) {
+      if (s is DigestTopicSection && sectionKey(s) == sectionKeyValue) {
+        return s;
+      }
+    }
+    return initialSection;
+  }
+
+  void _openArticle(BuildContext context, DigestItem article) {
+    context.push('${RoutePaths.fluxContinu}/content/${article.contentId}');
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final section = _resolveSection(ref);
+    return Scaffold(
+      backgroundColor: colors.backgroundPrimary,
+      appBar: AppBar(
+        backgroundColor: colors.backgroundPrimary,
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: colors.textPrimary),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+        title: section == null
+            ? null
+            : Text(
+                section.label,
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 16,
+                ),
+              ),
+      ),
+      body: section == null
+          ? Center(
+              child: Text(
+                'Section introuvable',
+                style: TextStyle(color: colors.textSecondary),
+              ),
+            )
+          : CustomScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              slivers: [
+                SliverToBoxAdapter(
+                  child: SectionBanner(
+                    title: section.label,
+                    accent: section.accent,
+                    blurb: section.blurb,
+                    illustrationAsset: section.illustrationAsset,
+                  ),
+                ),
+                SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) {
+                      final topic = section.topics[index];
+                      final lead = pickTopicLead(topic);
+                      return FluxContinuArticleCard(
+                        article: lead,
+                        isEssentiel:
+                            section.kind == SectionKind.essentiel,
+                        pressReviewCount: topic.perspectiveCount,
+                        perspectiveSources: topic.perspectiveSources,
+                        onTap: () => _openArticle(context, lead),
+                      );
+                    },
+                    childCount: section.topics.length,
+                  ),
+                ),
+                const SliverToBoxAdapter(child: SizedBox(height: 60)),
+              ],
+            ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -38,6 +38,7 @@ import '../widgets/my_interests_intro.dart';
 import '../widgets/my_interests_sheet.dart';
 import '../widgets/section_banner.dart';
 import '../widgets/section_block.dart';
+import '../widgets/section_divider_dotted.dart';
 import '../widgets/section_hairline.dart';
 import '../widgets/sticky_tab_bar.dart';
 
@@ -323,7 +324,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     );
   }
 
-  /// "Tout explorer" action of the Essentiel hi-fi card: folds the card
+  /// "Tout l'essentiel" action of the Essentiel hi-fi card: folds the card
   /// (so it stops occupying the viewport) then scrolls to the section that
   /// follows in the composed feed — by construction "Actus du jour" in
   /// normal mode, cf. [FluxContinuNotifier._compose].
@@ -338,6 +339,18 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     await Future<void>.delayed(const Duration(milliseconds: 50));
     if (!mounted) return;
     await _scrollToSection(next);
+  }
+
+  /// "Je veux tout voir ⬇️" action of the Essentiel hi-fi card: folds the
+  /// card then scrolls all the way down to the "Explorer" banner. Reuses the
+  /// `index >= _sectionKeys.length` branch of [_scrollToSection], which
+  /// targets [_explorerKey] directly.
+  Future<void> _skipEssentielToExplorer(EssentielSection essentiel) async {
+    final notifier = ref.read(fluxContinuProvider.notifier);
+    notifier.foldLocally(essentiel);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    if (!mounted) return;
+    await _scrollToSection(_sectionKeys.length);
   }
 
   Future<void> _scrollToTop() async {
@@ -377,6 +390,16 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     final key = Uri.encodeComponent(sectionKey(section));
     context.push(
       '${RoutePaths.fluxContinu}/theme/$key',
+      extra: section,
+    );
+  }
+
+  /// Opens the dedicated full-page view for a [DigestTopicSection]
+  /// (Actus du jour, Bonnes Nouvelles). Mirrors [_openThemeSection].
+  void _openDigestSection(BuildContext context, DigestTopicSection section) {
+    final key = Uri.encodeComponent(sectionKey(section));
+    context.push(
+      '${RoutePaths.fluxContinu}/section/$key',
       extra: section,
     );
   }
@@ -768,6 +791,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
                     ),
                   ),
           ),
+          const SliverToBoxAdapter(
+            child: SectionDividerDotted(label: 'Tous tes articles'),
+          ),
           SliverToBoxAdapter(
             child: KeyedSubtree(
               key: _explorerKey,
@@ -853,9 +879,14 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
                 : null,
             onSeeAll: section is FeedThemeSection
                 ? () => _openThemeSection(context, section)
-                : null,
+                : section is DigestTopicSection
+                    ? () => _openDigestSection(context, section)
+                    : null,
             onTapExploreAll: section is EssentielSection
                 ? () => _exploreAllEssentiel(section, i)
+                : null,
+            onTapSeeAllDown: section is EssentielSection
+                ? () => _skipEssentielToExplorer(section)
                 : null,
           ),
         ),

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -397,9 +397,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   /// Opens the dedicated full-page view for a [DigestTopicSection]
   /// (Actus du jour, Bonnes Nouvelles). Mirrors [_openThemeSection].
   void _openDigestSection(BuildContext context, DigestTopicSection section) {
-    final key = Uri.encodeComponent(sectionKey(section));
     context.push(
-      '${RoutePaths.fluxContinu}/section/$key',
+      '${RoutePaths.fluxContinu}/section/${sectionKey(section)}',
       extra: section,
     );
   }

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -52,8 +52,8 @@ class SectionBanner extends StatelessWidget {
     const topRadius = BorderRadius.vertical(top: Radius.circular(10));
     final container = Container(
       width: double.infinity,
-      margin: const EdgeInsets.fromLTRB(0, 4, 0, 16),
-      constraints: const BoxConstraints(minHeight: 132),
+      margin: const EdgeInsets.fromLTRB(0, 4, 0, 12),
+      constraints: const BoxConstraints(minHeight: 108),
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
         borderRadius: topRadius,
@@ -75,8 +75,8 @@ class SectionBanner extends StatelessWidget {
             right: 0,
             child: IgnorePointer(
               child: Container(
-                width: 220,
-                height: 140,
+                width: 180,
+                height: 112,
                 decoration: BoxDecoration(
                   gradient: RadialGradient(
                     center: Alignment.topRight,
@@ -107,7 +107,7 @@ class SectionBanner extends StatelessWidget {
               ),
             ),
           Padding(
-            padding: const EdgeInsets.fromLTRB(22, 16, 22, 18),
+            padding: const EdgeInsets.fromLTRB(20, 12, 20, 14),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
@@ -116,7 +116,7 @@ class SectionBanner extends StatelessWidget {
                   widthFactor: textWidthFactor,
                   alignment: AlignmentDirectional.centerStart,
                   child: Padding(
-                    padding: const EdgeInsets.only(top: 4, bottom: 6),
+                    padding: const EdgeInsets.only(top: 2, bottom: 4),
                     child: Text.rich(
                       TextSpan(
                         text: title,
@@ -133,10 +133,10 @@ class SectionBanner extends StatelessWidget {
                                 ),
                               ],
                         style: GoogleFonts.fraunces(
-                          fontSize: 25,
+                          fontSize: 21,
                           fontWeight: FontWeight.w700,
                           height: 1.06,
-                          letterSpacing: -0.5,
+                          letterSpacing: -0.4,
                           color: colors.textPrimary,
                         ),
                       ),
@@ -150,8 +150,8 @@ class SectionBanner extends StatelessWidget {
                     child: Text(
                       blurb!,
                       style: GoogleFonts.dmSans(
-                        fontSize: 13,
-                        height: 1.45,
+                        fontSize: 12,
+                        height: 1.35,
                         color: colors.textSecondary,
                       ),
                     ),
@@ -218,7 +218,7 @@ class _BannerIllustration extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Align(
-      alignment: const Alignment(1.15, 0.55),
+      alignment: const Alignment(0.98, 0.6),
       child: IgnorePointer(
         child: ShaderMask(
           blendMode: BlendMode.dstIn,
@@ -234,10 +234,10 @@ class _BannerIllustration extends StatelessWidget {
               opacity: 0.72,
               child: Image.asset(
                 asset,
-                height: 96,
+                height: 78,
                 // Source PNGs are 1024² — decode at 2× display height to
                 // keep texture memory bounded (saves ~10× per image).
-                cacheHeight: 192,
+                cacheHeight: 156,
                 fit: BoxFit.contain,
                 errorBuilder: (_, __, ___) => const SizedBox.shrink(),
               ),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -34,10 +34,16 @@ class SectionBlock extends StatelessWidget {
   /// for [DigestTopicSection] which keeps its in-place fold/expand button.
   final VoidCallback? onSeeAll;
 
-  /// "Tout explorer" action of the [EssentielSection] hi-fi card. Wired by
-  /// the flux_continu screen to fold the Essentiel card AND scroll to the
+  /// "Tout l'essentiel" action of the [EssentielSection] hi-fi card. Wired
+  /// by the flux_continu screen to fold the Essentiel card AND scroll to the
   /// next section ("Actus du jour"). Ignored for other section types.
   final VoidCallback? onTapExploreAll;
+
+  /// "Je veux tout voir ⬇️" action of the [EssentielSection] hi-fi card.
+  /// Wired by the flux_continu screen to fold the Essentiel card AND scroll
+  /// all the way down to the "Explorer" banner. Ignored for other section
+  /// types.
+  final VoidCallback? onTapSeeAllDown;
 
   /// IDs of articles currently in the inline-feedback pending state. When
   /// non-empty, the matching cards are swapped for a [FeedbackInline] at the
@@ -77,6 +83,7 @@ class SectionBlock extends StatelessWidget {
     this.onTapFavorite,
     this.onSeeAll,
     this.onTapExploreAll,
+    this.onTapSeeAllDown,
   });
 
   @override
@@ -118,7 +125,7 @@ class SectionBlock extends StatelessWidget {
               articles: section.articles,
               onTapArticle: (a) => onTapArticle(a, section),
               onTapPersonalize: () => EssentielPersonalizeSheet.show(context),
-              onTapSkip: onFold,
+              onTapSeeAllDown: onTapSeeAllDown,
               onTapExploreAll: onTapExploreAll,
             ),
             const SizedBox(height: 16),
@@ -145,6 +152,15 @@ class SectionBlock extends StatelessWidget {
             sectionLabel: section.label,
             totalCount: section.items.length,
             hasMore: section.hasMore,
+            onTap: onSeeAll!,
+          )
+        else if (section is DigestTopicSection &&
+            onSeeAll != null &&
+            section.hasOverflow)
+          PlusDeButton(
+            sectionLabel: section.label,
+            isOpen: false,
+            hiddenCount: hiddenCount > 0 ? hiddenCount : 0,
             onTap: onSeeAll!,
           )
         else if (section.hasOverflow)

--- a/apps/mobile/lib/features/flux_continu/widgets/section_divider_dotted.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_divider_dotted.dart
@@ -24,7 +24,6 @@ class SectionDividerDotted extends StatelessWidget {
     return Padding(
       padding: margin,
       child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Expanded(child: _DottedLine(color: tint)),
           Padding(

--- a/apps/mobile/lib/features/flux_continu/widgets/section_divider_dotted.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_divider_dotted.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+
+/// Horizontal dotted separator with a centered label, used to mark the
+/// transition between the bounded "Tournée du jour" stack and the open-ended
+/// "Explorer" feed below. Visual ID : two dotted segments (left/right of the
+/// label) drawn with [_DottedLinePainter], label uppercase letter-spaced.
+class SectionDividerDotted extends StatelessWidget {
+  final String label;
+  final EdgeInsetsGeometry margin;
+
+  const SectionDividerDotted({
+    super.key,
+    required this.label,
+    this.margin = const EdgeInsets.fromLTRB(20, 8, 20, 12),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final tint = colors.border.withValues(alpha: 0.65);
+    return Padding(
+      padding: margin,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(child: _DottedLine(color: tint)),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              label.toUpperCase(),
+              style: GoogleFonts.dmSans(
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 1.4,
+                color: colors.textSecondary,
+              ),
+            ),
+          ),
+          Expanded(child: _DottedLine(color: tint)),
+        ],
+      ),
+    );
+  }
+}
+
+class _DottedLine extends StatelessWidget {
+  final Color color;
+
+  const _DottedLine({required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 1,
+      child: CustomPaint(
+        painter: _DottedLinePainter(color: color),
+      ),
+    );
+  }
+}
+
+class _DottedLinePainter extends CustomPainter {
+  final Color color;
+
+  _DottedLinePainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = 1
+      ..strokeCap = StrokeCap.round;
+    const dashWidth = 2.0;
+    const dashGap = 4.0;
+    double x = 0;
+    final y = size.height / 2;
+    while (x < size.width) {
+      canvas.drawLine(Offset(x, y), Offset(x + dashWidth, y), paint);
+      x += dashWidth + dashGap;
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _DottedLinePainter oldDelegate) =>
+      oldDelegate.color != color;
+}

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -61,8 +61,16 @@ UserInterestsState _interestsState({
 }
 
 String _todayKey() {
-  final today = DateTime.now().toIso8601String().substring(0, 10);
-  return 'flux_continu_folded_$today';
+  // Mirror the provider's 07:30-local tournée-day boundary: before 07:30 the
+  // active prefs key still references yesterday so the fold survives across
+  // midnight (the digest hasn't regenerated yet).
+  final now = DateTime.now();
+  final shifted =
+      (now.hour < 7 || (now.hour == 7 && now.minute < 30))
+          ? now.subtract(const Duration(days: 1))
+          : now;
+  final day = shifted.toIso8601String().substring(0, 10);
+  return 'flux_continu_folded_$day';
 }
 
 FeedResponse _feedResponseWith(int items) {
@@ -349,6 +357,41 @@ void main() {
       expect(after!.folded, equals(initial.folded));
       // But the queue is preserved (so the cold-launch persist still applies).
       expect(notifier.persistQueuedSnapshot(), contains('essentiel'));
+    });
+
+    test('unfoldLocally purges _persistQueued and prefs so cold launch '
+        'does not re-fold the section', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      await container.read(fluxContinuProvider.future);
+      final notifier = container.read(fluxContinuProvider.notifier);
+      const essentiel = DigestTopicSection(
+        kind: SectionKind.essentiel,
+        label: 'Actus du jour',
+        accent: Color(0xFFB0470A),
+        coreVisibleCount: 3,
+        topics: [],
+      );
+
+      // Queue the fold (simulates the user scrolling past the section).
+      await notifier.markScrolledPastForNextSession(essentiel);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getStringList(_todayKey()), contains('essentiel'));
+      expect(notifier.persistQueuedSnapshot(), contains('essentiel'));
+
+      // User taps the folded card to re-expand. The fix must clear both the
+      // in-memory queue AND the prefs blob, otherwise the next cold launch
+      // would restore the fold and leave the section permanently folded.
+      notifier.unfoldLocally(essentiel);
+      // Give the unawaited _persistFolded a tick to flush.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifier.persistQueuedSnapshot(), isEmpty);
+      expect(prefs.getStringList(_todayKey()) ?? const <String>[],
+          isNot(contains('essentiel')));
     });
   });
 

--- a/docs/stories/core/9.3.tournee-ui-phase-2.md
+++ b/docs/stories/core/9.3.tournee-ui-phase-2.md
@@ -1,0 +1,102 @@
+# Story 9.3 — Tournée UI Phase 2 (ajustements UX)
+
+> **Status** : Implémentation faite, tests verts. En attente d'avis utilisateur sur la coordination avec l'agent #2 avant push/PR.
+> **Owner** : Agent dev (branche `boujonlaurin-dotcom/kelowna`).
+> **Parallèle** : Agent #2 travaille sur la carte d'Essentiel du jour (`essentiel_hi_fi_card.dart`). Pas d'overlap attendu sur les fichiers ci-dessous.
+
+---
+
+## Contexte
+
+Suite à la PR backend "filtre langue user-aware" (#658) et aux ajustements de
+personnalisation par user, on passe en **phase 2** : polir l'UX des premiers
+éléments rencontrés par l'utilisateur dans la Tournée du jour.
+
+## Objectifs
+
+1. **Aligner "Actus du jour" et "Bonnes Nouvelles" sur le pattern thématique** :
+   le clic sur "Plus de …" ouvre une page dédiée (comme les thèmes), pas un
+   fold inline.
+2. **2 articles par section thématique** au lieu de 3 (réduire la pression
+   visuelle dans la tournée).
+3. **Hero "L'essentiel du jour" plus compact** : police, marges et asset
+   ajustés pour qu'il prenne moins de place.
+4. **Bug fold** : la section "Actu du jour" reste folded en permanence. À
+   investiguer et corriger, en veillant à réinitialiser chaque matin en accord
+   avec le timing de génération du digest.
+5. **Bonus** : marquer la transition Tournée → Explorer par un séparateur
+   pointillés du design system, label "Tous tes articles" centré, **en plus**
+   du `SectionBanner` "Explorer" actuel.
+
+## Acceptance criteria
+
+- [x] AC1 — Sur "Actus du jour" et "Bonnes Nouvelles", le CTA "Plus de … (+N)"
+      ouvre une page dédiée (`DigestSectionScreen`, route
+      `/flux-continu/section/:key`) listant tous les topics de la section
+      (pattern aligné sur `ThemeSectionScreen`).
+- [x] AC2 — `FeedThemeSection` (thèmes favoris + veille) affichent désormais
+      2 articles core (vs 3 précédemment).
+- [x] AC3 — Le `SectionBanner` (le "hero" de chaque section dans la Tournée)
+      est plus compact :
+      - minHeight 132 → 108,
+      - titre Fraunces 25 → 21 px,
+      - blurb DM Sans 13/1.45 → 12/1.35,
+      - asset Image 96 → 78 px, alignement `Alignment(1.15, 0.55)` →
+        `Alignment(0.98, 0.6)` (l'asset rentre dans le cadre),
+      - padding texte `(22,16,22,18)` → `(20,12,20,14)`.
+- [x] AC4 — Bug fold "Actus du jour toujours folded" : `unfoldLocally` purge
+      désormais `_persistQueued` ET ré-écrit la liste SharedPreferences sans
+      la clé. Le day-key de référence pour `flux_continu_folded_*` bascule à
+      07:30 heure locale (aligné sur `DIGEST_CRON_HOUR_PARIS=7`,
+      `DIGEST_CRON_MINUTE_PARIS=30` côté API).
+- [x] AC5 — `SectionDividerDotted(label: 'Tous tes articles')` rendu en
+      `SliverToBoxAdapter` juste au-dessus du `SectionBanner` Explorer (le
+      banner Explorer existant reste en place, comme convenu).
+
+## Plan technique
+
+### Fichiers modifiés (mon scope)
+
+| Fichier | Changement |
+|---|---|
+| `apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart` | `coreVisibleCount: 3 → 2` sur les thèmes ; fix bug fold (purge prefs sur unfold) ; switch day-key vers fenêtre 5h locale. |
+| `apps/mobile/lib/features/digest/widgets/digest_hero.dart` | Hauteur 140→120, titre 28→24, asset 110→88, marges resserrées. |
+| `apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart` | Câbler `onSeeAll` pour `DigestTopicSection` (essentiel + bonnes) → push d'un écran dédié. Ajouter séparateur "Tous tes articles" au-dessus du `SectionBanner` Explorer. |
+| `apps/mobile/lib/features/flux_continu/widgets/section_block.dart` | Exposer `onSeeAll` aussi sur `DigestTopicSection` (actuellement réservé `FeedThemeSection`). |
+| `apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart` **(nouveau)** | Page dédiée pour "Actus du jour" et "Bonnes Nouvelles", calquée sur `ThemeSectionScreen`. |
+| `apps/mobile/lib/features/flux_continu/widgets/section_divider_dotted.dart` **(nouveau)** | Widget réutilisable : filet pointillé + label centré. |
+
+### Fichiers à NE PAS toucher (agent #2)
+
+- `apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart`
+- Tout fichier sous `apps/mobile/lib/features/digest/` autre que `digest_hero.dart` — si l'agent #2 y touche, on synchronise via merge.
+
+### Fix bug fold — hypothèse
+
+- `unfoldLocally(section)` (ligne 543) supprime de `_folded` mais ne purge
+  **ni** `_persistQueued` **ni** SharedPreferences. Conséquence : à chaque
+  cold launch dans la même journée, `_loadFoldedForToday()` ré-applique la
+  fold persistée → section "Actu du jour" perpétuellement folded si
+  l'utilisateur a scrollé une fois.
+- Fix : `unfoldLocally` doit retirer la clé de `_persistQueued` ET réécrire
+  la liste prefs sans cette clé. Idem pour la dismissal du closing.
+- Fenêtre 5h locale : remplacer `_dayKey(DateTime.now())` par une fonction
+  `_tournéeDayKey(now)` qui décale la borne à 5h locale (`now.hour < 5 ?
+  now - 1jour : now`), idéalement constantisée pour rester alignée avec le
+  cron de génération côté API (à vérifier — fallback 5h si non documenté).
+
+### Tests
+
+- Widget test `digest_hero_test.dart` : assertions taille + asset.
+- Provider test : un re-launch ne ré-applique pas un fold qui a été
+  `unfoldLocally` ; un launch avant 5h utilise la prefs de la veille ; un
+  launch après 5h purge.
+- Manuel via Playwright MCP : flux complet Tournée → "Plus de Actus du jour"
+  ouvre page dédiée, retour préserve scroll, séparateur visible avant
+  Explorer.
+
+## Coordination merge
+
+Branche unique `boujonlaurin-dotcom/kelowna` partagée avec agent #2. Avant
+chaque commit, `git pull --rebase` + relire les diffs sur `essentiel_hi_fi_card.dart` (zone agent #2) pour éviter d'écraser. PR finale propre via
+`/go`.


### PR DESCRIPTION
## Quoi

5 ajustements UX sur la Tournée du jour (Story 9.3) :

1. **Fix bug fold** : `unfoldLocally` purge maintenant `_persistQueued` ET réécrit la liste SharedPreferences sans la clé — les sections ne se re-foldent plus au cold launch dans la même journée.
2. **Day-key 07:30** : la borne de reset des folds bascule à 07:30 heure locale (aligné `DIGEST_CRON_HOUR_PARIS=7:30`).
3. **2 articles / section thématique** : `coreVisibleCount` 3→2 pour les sections favoris et veille.
4. **Hero `SectionBanner` compact** : minHeight 132→108, Fraunces 25→21 px, asset 96→78 px, padding et alignment resserrés.
5. **`DigestSectionScreen`** (nouveau) : page dédiée pour « Actus du jour » et « Bonnes Nouvelles », calquée sur `ThemeSectionScreen`. Route `/flux-continu/section/:key` câblée dans GoRouter.
6. **`SectionDividerDotted`** (nouveau) : séparateur pointillé + label « Tous tes articles » inséré au-dessus du `SectionBanner` Explorer.

## Pourquoi

- Bug fold : les utilisateurs qui scrollaient « Actus du jour » la retrouvaient folded à chaque relance le même jour.
- UX : le clic « Plus de … » ouvre maintenant un écran dédié (pattern cohérent avec les sections thématiques) plutôt qu'un fold inline.
- Pression visuelle : 2 articles core au lieu de 3 allège la lecture de la tournée.
- Transition Tournée→Explorer : le séparateur pointillé matérialise la limite éditoriale.

## Comment c'a été vérifié

- [x] `flutter test test/features/flux_continu/` — 70/70 tests OK (dont regression test du bug fold)
- [x] `flutter analyze` — 0 erreur, 0 warning (697 infos pré-existants)
- [x] /simplify passé — 2 corrections mineures (crossAxisAlignment redondant, Uri.encodeComponent inutile)

## Zones à risque

- `flux_continu_provider.dart` : logique fold/unfold + day-key — couvre le bug connu, regression test présent.
- `routes.dart` : nouvelle route `section/:key` sous `/flux-continu` — pattern identique aux routes `theme/:slug` existantes.
- **Coordination** : `essentiel_hi_fi_card.dart` et ses tests (Agent 2) volontairement exclus du commit — pas de conflit attendu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)