### PR TITLE
feat(tournée): Sujet suivant + fix coreVisibleCount FeedThemeSection

### DIFF
--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -292,6 +292,10 @@ class FluxContinuState {
   // ids in this set are filtered out before render so the swipe-away feels
   // instant; the hide API call is fire-and-forget in the provider.
   final Set<String> dismissedIds;
+  // Section keys queued for fold at the next cold launch (via "Sujet
+  // suivant" or scroll-past detection). The section stays expanded on screen
+  // — only the in-session indicator on the "Sujet suivant" button flips.
+  final Set<String> markedForNextSession;
   final bool isLoading;
   final Object? error;
 
@@ -302,6 +306,7 @@ class FluxContinuState {
     this.folded = const {},
     this.closingDismissed = false,
     this.dismissedIds = const {},
+    this.markedForNextSession = const {},
     this.isLoading = true,
     this.error,
   });
@@ -313,6 +318,7 @@ class FluxContinuState {
     Map<String, bool>? folded,
     bool? closingDismissed,
     Set<String>? dismissedIds,
+    Set<String>? markedForNextSession,
     bool? isLoading,
     Object? error,
     bool clearError = false,
@@ -324,6 +330,8 @@ class FluxContinuState {
       folded: folded ?? this.folded,
       closingDismissed: closingDismissed ?? this.closingDismissed,
       dismissedIds: dismissedIds ?? this.dismissedIds,
+      markedForNextSession:
+          markedForNextSession ?? this.markedForNextSession,
       isLoading: isLoading ?? this.isLoading,
       error: clearError ? null : (error ?? this.error),
     );
@@ -334,6 +342,8 @@ class FluxContinuState {
   /// string-key encoding scheme.
   bool isOpen(FluxSection section) => moreOpen[sectionKey(section)] ?? false;
   bool isFolded(FluxSection section) => folded[sectionKey(section)] ?? false;
+  bool isMarkedForNextSession(FluxSection section) =>
+      markedForNextSession.contains(sectionKey(section));
 
   /// Slugs of the `FeedThemeSection`s that make up today's tournée — used by
   /// the Explorer filter bar to hide chips for themes the user has already

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -270,6 +270,16 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       _moreOpen = moreOpenFiltered;
     }
 
+    // Filter persistQueued against present sections to avoid stale keys
+    // surviving a compose (e.g. a favorite was removed).
+    final persistFiltered =
+        _persistQueued.where(keysPresent.contains).toSet();
+    if (persistFiltered.length != _persistQueued.length) {
+      _persistQueued
+        ..clear()
+        ..addAll(persistFiltered);
+    }
+
     return FluxContinuState(
       sections: _filterSections(ordered),
       isSerene: isSerene,
@@ -277,6 +287,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       folded: _folded,
       closingDismissed: _closingDismissed,
       dismissedIds: Set.unmodifiable(_dismissedIds),
+      markedForNextSession: Set.unmodifiable(_persistQueued),
       isLoading: false,
     );
   }
@@ -477,6 +488,12 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     if (_persistQueued.contains(key)) return;
     if (_folded[key] == true) return;
     _persistQueued.add(key);
+    final current = state.valueOrNull;
+    if (current != null) {
+      state = AsyncData(current.copyWith(
+        markedForNextSession: Set.unmodifiable(_persistQueued),
+      ));
+    }
     final combined = <String, bool>{
       ..._folded,
       for (final k in _persistQueued) k: true,
@@ -529,7 +546,11 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       return;
     }
     _folded = next;
-    state = AsyncData(current.copyWith(folded: next));
+    _persistQueued.removeAll(toPromote);
+    state = AsyncData(current.copyWith(
+      folded: next,
+      markedForNextSession: Set.unmodifiable(_persistQueued),
+    ));
   }
 
   /// Read-only snapshot of the sections queued for fold at next apply.
@@ -555,7 +576,14 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     if (wasFolded) {
       final next = Map<String, bool>.from(current.folded)..remove(key);
       _folded = next;
-      state = AsyncData(current.copyWith(folded: next));
+      state = AsyncData(current.copyWith(
+        folded: next,
+        markedForNextSession: Set.unmodifiable(_persistQueued),
+      ));
+    } else if (wasQueued) {
+      state = AsyncData(current.copyWith(
+        markedForNextSession: Set.unmodifiable(_persistQueued),
+      ));
     }
     // Rewrite the prefs blob with the new (live + still-queued) fold set so
     // the unfold survives a cold launch in the same tournée day.
@@ -721,7 +749,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       blurb: _kThemeBlurb,
       accent: accent,
       illustrationAsset: _kVeilleIllustration,
-      coreVisibleCount: 2,
+      coreVisibleCount: 3,
       themeSlug: themeSlug,
       customTopicId: customTopicId,
       items: items,
@@ -860,7 +888,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       blurb: 'Les derniers articles de ta veille personnalisée.',
       accent: _kVeilleAccent,
       illustrationAsset: _kVeilleIllustration,
-      coreVisibleCount: 2,
+      coreVisibleCount: 3,
       items: items,
     );
   }

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -898,11 +898,28 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             onTapSeeAllDown: section is EssentielSection
                 ? () => _skipEssentielToExplorer(section)
                 : null,
+            isMarkedForNextSession: state.isMarkedForNextSession(section),
+            onNextSection: (section is EssentielSection ||
+                    i >= state.sections.length - 1)
+                ? null
+                : () => _advanceToNextSection(section, i),
           ),
         ),
       ));
     }
     return slivers;
+  }
+
+  /// "Sujet suivant" tap handler for in-Tournée progression. Marks the
+  /// current section as consumed for the next session (without folding it
+  /// visually) and smooth-scrolls to the next section banner.
+  Future<void> _advanceToNextSection(FluxSection section, int index) async {
+    unawaited(HapticFeedback.lightImpact());
+    unawaited(ref
+        .read(fluxContinuProvider.notifier)
+        .markScrolledPastForNextSession(section));
+    if (!mounted) return;
+    await _scrollToSection(index + 1);
   }
 
   /// Builds the Explorer feed list by reading from `feedProvider` and filtering

--- a/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
@@ -7,14 +7,14 @@ import '../../../config/theme.dart';
 /// bottom-of-section CTA family stays consistent.
 class SeeAllSectionButton extends StatelessWidget {
   final String sectionLabel;
-  final int totalCount;
+  final int hiddenCount;
   final bool hasMore;
   final VoidCallback onTap;
 
   const SeeAllSectionButton({
     super.key,
     required this.sectionLabel,
-    required this.totalCount,
+    required this.hiddenCount,
     required this.hasMore,
     required this.onTap,
   });
@@ -23,8 +23,8 @@ class SeeAllSectionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final countSuffix = hasMore ? '+' : '';
-    final label = totalCount > 0
-        ? 'Voir tout $sectionLabel ($totalCount$countSuffix)'
+    final label = hiddenCount > 0
+        ? 'Voir tout $sectionLabel (+$hiddenCount$countSuffix)'
         : 'Voir tout $sectionLabel';
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
@@ -114,6 +114,70 @@ class PlusDeButton extends StatelessWidget {
                         fontWeight: FontWeight.w600,
                       ),
                 ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// "Sujet suivant →" — bottom-of-section CTA that marks the section as
+/// consumed for the next session and scrolls smoothly to the next section.
+/// When [isMarked] is true, the button switches to a non-interactive
+/// "Lu ✓" state showing the section has been validated in this session.
+///
+/// Visual variant: outlined/ghost (transparent fill with a 1px divider
+/// border) so it reads as a quieter cousin of [PlusDeButton] — the two
+/// can sit side by side without competing.
+class NextSectionButton extends StatelessWidget {
+  final bool isMarked;
+  final VoidCallback? onTap;
+
+  const NextSectionButton({
+    super.key,
+    required this.isMarked,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final foreground =
+        isMarked ? colors.success : colors.textSecondary;
+    final label = isMarked ? 'Lu' : 'Sujet suivant';
+    final icon = isMarked ? Icons.check : Icons.arrow_forward;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: colors.border,
+                width: 1,
+              ),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  label,
+                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                        color: foreground,
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+                const SizedBox(width: 6),
+                Icon(icon, color: foreground, size: 16),
               ],
             ),
           ),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -64,6 +64,18 @@ class SectionBlock extends StatelessWidget {
   /// null on system sections (`essentiel` / `bonnes`).
   final VoidCallback? onTapFavorite;
 
+  /// "Sujet suivant →" action shown in the section footer. Marks the section
+  /// as consumed for the next session and scrolls smoothly to the next
+  /// section. When null, the button is hidden (used for [EssentielSection]
+  /// which has its own progression CTAs, and for the last Tournée section
+  /// before Explorer).
+  final VoidCallback? onNextSection;
+
+  /// When true, the "Sujet suivant" button flips to the non-interactive
+  /// "Lu ✓" state — derived from the provider's queue of sections marked
+  /// for fold at the next cold launch.
+  final bool isMarkedForNextSession;
+
   const SectionBlock({
     super.key,
     required this.section,
@@ -84,6 +96,8 @@ class SectionBlock extends StatelessWidget {
     this.onSeeAll,
     this.onTapExploreAll,
     this.onTapSeeAllDown,
+    this.onNextSection,
+    this.isMarkedForNextSession = false,
   });
 
   @override
@@ -147,10 +161,12 @@ class SectionBlock extends StatelessWidget {
           onTapFavorite: onTapFavorite,
         ),
         ...cards,
-        if (section is FeedThemeSection && onSeeAll != null)
+        if (section is FeedThemeSection &&
+            onSeeAll != null &&
+            (hiddenCount > 0 || section.hasMore))
           SeeAllSectionButton(
             sectionLabel: section.label,
-            totalCount: section.items.length,
+            hiddenCount: hiddenCount > 0 ? hiddenCount : 0,
             hasMore: section.hasMore,
             onTap: onSeeAll!,
           )
@@ -169,6 +185,11 @@ class SectionBlock extends StatelessWidget {
             isOpen: isOpen,
             hiddenCount: hiddenCount > 0 ? hiddenCount : 0,
             onTap: onToggleMore,
+          ),
+        if (onNextSection != null)
+          NextSectionButton(
+            isMarked: isMarkedForNextSession,
+            onTap: isMarkedForNextSession ? null : onNextSection,
           ),
         const SizedBox(height: 16),
       ],
@@ -226,8 +247,8 @@ class SectionBlock extends StatelessWidget {
                         : null,
               ),
         ];
-      case FeedThemeSection(:final items):
-        final visible = items;
+      case FeedThemeSection(:final items, :final coreVisibleCount):
+        final visible = items.take(coreVisibleCount).toList();
         return [
           for (var i = 0; i < visible.length; i++)
             if (pendingFeedbackIds.contains(visible[i].id))

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -393,6 +393,99 @@ void main() {
       expect(prefs.getStringList(_todayKey()) ?? const <String>[],
           isNot(contains('essentiel')));
     });
+
+    test('markScrolledPastForNextSession exposes the key in state', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      await container.read(fluxContinuProvider.future);
+      final notifier = container.read(fluxContinuProvider.notifier);
+      const tech = FeedThemeSection(
+        kind: SectionKind.theme,
+        label: 'Tech',
+        accent: Color(0xFF2C3E50),
+        coreVisibleCount: 3,
+        themeSlug: 'tech',
+        items: [],
+      );
+
+      await notifier.markScrolledPastForNextSession(tech);
+      final state = container.read(fluxContinuProvider).valueOrNull;
+
+      expect(state, isNotNull);
+      expect(state!.markedForNextSession, contains('theme:tech'));
+      expect(state.isMarkedForNextSession(tech), isTrue);
+    });
+
+    test('unfoldLocally removes the key from state.markedForNextSession',
+        () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      await container.read(fluxContinuProvider.future);
+      final notifier = container.read(fluxContinuProvider.notifier);
+      const essentiel = DigestTopicSection(
+        kind: SectionKind.essentiel,
+        label: 'Actus du jour',
+        accent: Color(0xFFB0470A),
+        coreVisibleCount: 3,
+        topics: [],
+      );
+
+      await notifier.markScrolledPastForNextSession(essentiel);
+      expect(
+        container.read(fluxContinuProvider).valueOrNull?.markedForNextSession,
+        contains('essentiel'),
+      );
+
+      notifier.unfoldLocally(essentiel);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.read(fluxContinuProvider).valueOrNull?.markedForNextSession,
+        isNot(contains('essentiel')),
+      );
+    });
+
+    test(
+        'applyPendingFoldsToState drops promoted keys from '
+        'markedForNextSession (but keeps excluded ones)', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      await container.read(fluxContinuProvider.future);
+      final notifier = container.read(fluxContinuProvider.notifier);
+      const essentiel = DigestTopicSection(
+        kind: SectionKind.essentiel,
+        label: 'Essentiel',
+        accent: Color(0xFFB0470A),
+        coreVisibleCount: 3,
+        topics: [],
+      );
+      const tech = FeedThemeSection(
+        kind: SectionKind.theme,
+        label: 'Tech',
+        accent: Color(0xFF2C3E50),
+        coreVisibleCount: 3,
+        themeSlug: 'tech',
+        items: [],
+      );
+      await notifier.markScrolledPastForNextSession(essentiel);
+      await notifier.markScrolledPastForNextSession(tech);
+
+      notifier.applyPendingFoldsToState(exceptKeys: {'theme:tech'});
+      final state = container.read(fluxContinuProvider).valueOrNull;
+
+      expect(state, isNotNull);
+      expect(state!.markedForNextSession, isNot(contains('essentiel')));
+      expect(state.markedForNextSession, contains('theme:tech'));
+    });
   });
 
   group('FluxContinuNotifier — favorites-driven theme sections', () {

--- a/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
+import 'package:facteur/features/flux_continu/widgets/flux_continu_article_card.dart';
+import 'package:facteur/features/flux_continu/widgets/plus_de_button.dart';
+import 'package:facteur/features/flux_continu/widgets/section_block.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [FacteurPalettes.light]),
+    home: Scaffold(body: SingleChildScrollView(child: child)),
+  );
+}
+
+Content _content(String id) {
+  return Content(
+    id: id,
+    title: 'title-$id',
+    url: 'https://x.test/$id',
+    contentType: ContentType.article,
+    publishedAt: DateTime(2026, 1, 1),
+    source: Source(id: 's', name: 'S', type: SourceType.article),
+  );
+}
+
+FeedThemeSection _themeSection({
+  int items = 7,
+  int coreVisibleCount = 3,
+  bool hasMore = false,
+}) {
+  return FeedThemeSection(
+    kind: SectionKind.theme,
+    label: 'Tech',
+    accent: const Color(0xFF2C3E50),
+    coreVisibleCount: coreVisibleCount,
+    themeSlug: 'tech',
+    items: List.generate(items, (i) => _content('c$i')),
+    hasMore: hasMore,
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('SectionBlock — coreVisibleCount slice', () {
+    testWidgets(
+        'FeedThemeSection renders only coreVisibleCount cards when closed',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(items: 7, coreVisibleCount: 3),
+          isOpen: false,
+          onToggleMore: () {},
+          onTapArticle: (_, __) {},
+          onSeeAll: () {},
+        ),
+      ));
+
+      expect(find.byType(FluxContinuArticleCard), findsNWidgets(3));
+    });
+
+    testWidgets(
+        'SeeAllSectionButton label uses (+N) where N = totalCount - '
+        'coreVisibleCount', (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(items: 7, coreVisibleCount: 3),
+          isOpen: false,
+          onToggleMore: () {},
+          onTapArticle: (_, __) {},
+          onSeeAll: () {},
+        ),
+      ));
+
+      // 7 items - 3 visible = +4 hidden.
+      expect(find.text('Voir tout Tech (+4)'), findsOneWidget);
+    });
+
+    testWidgets(
+        'SeeAllSectionButton hidden when nothing left to show (no overflow, '
+        'no hasMore)', (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(items: 2, coreVisibleCount: 3),
+          isOpen: false,
+          onToggleMore: () {},
+          onTapArticle: (_, __) {},
+          onSeeAll: () {},
+        ),
+      ));
+
+      expect(find.byType(SeeAllSectionButton), findsNothing);
+    });
+
+    testWidgets(
+        'SeeAllSectionButton appears with hasMore-suffix when backend has '
+        'more pages even if coreVisibleCount exhausts the local items',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(items: 3, coreVisibleCount: 3, hasMore: true),
+          isOpen: false,
+          onToggleMore: () {},
+          onTapArticle: (_, __) {},
+          onSeeAll: () {},
+        ),
+      ));
+
+      // hiddenCount = 0 → label falls back to "Voir tout Tech" (no suffix).
+      expect(find.text('Voir tout Tech'), findsOneWidget);
+    });
+  });
+
+  group('SectionBlock — Sujet suivant button', () {
+    testWidgets('renders the button when onNextSection is provided',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(),
+          isOpen: false,
+          onToggleMore: () {},
+          onTapArticle: (_, __) {},
+          onSeeAll: () {},
+          onNextSection: () {},
+        ),
+      ));
+
+      expect(find.byType(NextSectionButton), findsOneWidget);
+      expect(find.text('Sujet suivant'), findsOneWidget);
+    });
+
+    testWidgets('hides the button when onNextSection is null', (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(),
+          isOpen: false,
+          onToggleMore: () {},
+          onTapArticle: (_, __) {},
+          onSeeAll: () {},
+          // onNextSection deliberately omitted (null)
+        ),
+      ));
+
+      expect(find.byType(NextSectionButton), findsNothing);
+    });
+
+    testWidgets('switches to "Lu" non-interactive state when '
+        'isMarkedForNextSession is true', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(),
+          isOpen: false,
+          onToggleMore: () {},
+          onTapArticle: (_, __) {},
+          onSeeAll: () {},
+          isMarkedForNextSession: true,
+          onNextSection: () => taps++,
+        ),
+      ));
+
+      expect(find.text('Lu'), findsOneWidget);
+      expect(find.text('Sujet suivant'), findsNothing);
+
+      // Tap should be a no-op.
+      await tester.tap(find.byType(NextSectionButton));
+      await tester.pump();
+      expect(taps, 0);
+    });
+
+    testWidgets('tap fires onNextSection exactly once when not marked',
+        (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(),
+          isOpen: false,
+          onToggleMore: () {},
+          onTapArticle: (_, __) {},
+          onSeeAll: () {},
+          onNextSection: () => taps++,
+        ),
+      ));
+
+      await tester.tap(find.byType(NextSectionButton));
+      await tester.pump();
+      expect(taps, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Quoi

Deux follow-ups post-PR #663 (Story 9.3 — Tournée UI phase 2) :

1. **Bug fix** — `FeedThemeSection` affichait tous ses articles sur l'écran principal au lieu de respecter `coreVisibleCount`. Le label du CTA « Voir tout » affichait le total brut au lieu des articles cachés (+N). Défaut `coreVisibleCount` ajusté de 2 → **3** par décision PO.

2. **Feature « Sujet suivant »** — Nouveau bouton dans le footer de chaque section thématique et `DigestTopicSection`. Un tap marque la section comme consommée pour la prochaine session et smooth-scroll vers la section suivante. Absent sur Essentiel (qui gère sa propre progression) et sur la dernière section avant Explorer.

## Pourquoi

- Les sections thématiques rendaient tous leurs items plutôt que les 3 premiers → tournée illisible sur mobile.
- Le PO veut une progression linéaire rapide dans la tournée sans avoir à scroller manuellement.
- Pas de fold visuel pendant la session (pour éviter le content shift), mais état « Lu ✓ » visible immédiatement.

## Comment ça a été vérifié

- [x] `flutter test test/features/flux_continu/` — **79 tests OK** (dont 8 nouveaux `section_block_test` + 3 nouveaux provider)
- [x] `flutter analyze` — 0 erreur / 0 warning sur le code modifié
- [x] /simplify passé — fix double guard `isMarked` dans `NextSectionButton`

## Zones à risque

- `flux_continu_provider.dart` — `markScrolledPastForNextSession`, `applyPendingFoldsToState`, `unfoldLocally` ré-émettent maintenant `markedForNextSession` dans le state (nouveau champ)
- `_compose()` — filtre `_persistQueued` contre les sections présentes (même pattern que `foldedFiltered`/`moreOpenFiltered`)
- `section_block.dart` — slice des items `FeedThemeSection` : comportement visible change (3 cards max vs tous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)