### PR TITLE
fix(essentiel): durcir filtres sport/podcast/bulletins + score perspectives log (Story 9.4)

### DIFF
--- a/docs/stories/core/9.4.essentiel-filters-hardening.md
+++ b/docs/stories/core/9.4.essentiel-filters-hardening.md
@@ -1,0 +1,87 @@
+# Story 9.4 — Durcissement des filtres Essentiel / Actus du jour
+
+## Statut
+En cours — auteur : Laurin (PO), implémentation Claude.
+
+## Contexte
+
+Le digest « Actus du jour » servi par l'écran *Essentiel* (mobile) doit refléter
+**les actualités chaudes traitées par la presse française aujourd'hui**.
+Trois pathologies remontées par le PO et confirmées par un audit Supabase sur
+les batchs 2026-05-12 → 2026-05-25 :
+
+1. **Sport en top 1-4** (règle : ≥ slot 5).
+2. **Bulletins radio (« JOURNAL DE 8H »), chroniques courtes, podcasts, posts
+   Reddit** apparaissent en top 5.
+3. **Articles sans relais** (1 source) devancent des sujets très relayés
+   (6+ médias) car `+5 / perspective` est trop faible face à
+   `BOOST_TRENDING=+40`, `BOOST_UNE=+30`, `BOOST_BADGE_ACTU=+25`.
+
+### Preuves DB (extraits)
+
+| Date | Rank | Titre | Source | Anomalie |
+|------|------|-------|--------|----------|
+| 2026-05-12 | 1 | Trophées UNFP. Dembélé… | Ouest-France | Sport en slot 1 |
+| 2026-05-23 | 2 | F1. Grand Prix Canada | Ouest-France | Sport en slot 2 |
+| 2026-05-23 | 3 | FC Barcelone - OL Lyonnes (Ligue des champions) | Ouest-France | Sport en slot 3 |
+| 2026-05-25 | 2 | Wembanyama, 33 points (Game 4) | TrashTalk | Sport (source.theme=society ❗) |
+| 2026-05-25 | 3 | « JOURNAL DE 8H du lundi 25 mai 2026 » | France Culture | Bulletin radio (content_type=article) |
+| 2026-05-25 | 5 | « Avec Sciences, chronique du… » (4 min) | La Science CQFD | Podcast / chronique |
+| 2026-05-22 | 1 | post r/france | Reddit | Agrégateur, pas une rédaction |
+| 2026-05-24 | — | source_count=1 avg_rank=5.00 vs source_count=2 avg_rank=7.32 | — | Signal perspectives inversé |
+
+Cas PO emblématique : podcast « Le Miocène Moyen » (1 perspective) en slot 5 vs
+« Guerre au Moyen-Orient — hauts responsables iraniens à Doha » (6+ médias) en
+slot 6.
+
+## Objectifs (critères d'acceptation)
+
+1. **Sport** : au plus 1 article sport par Essentiel ; jamais avant le slot 5.
+   Si le pool non-sport contient < 4 articles, le sport est exclu plutôt que
+   remonté en slot 4 ou avant.
+2. **Bulletins / podcasts / Reddit** : exclus de l'Essentiel.
+   - Tous les `content_type ∈ {PODCAST, YOUTUBE}` exclus.
+   - Toutes les `source.type = REDDIT` exclues.
+   - Titres matchant des patterns de bulletins/chroniques (`^JOURNAL DE \d`,
+     `Le 7/9`, `^.{0,30}chronique du`, `^JT (de|du) `, etc.) exclus.
+3. **Perspectives** : un article relayé par ≥ 3 médias doit pouvoir rivaliser
+   avec un signal trending ; un article isolé (1 source) ne doit pas devancer
+   un sujet à 6+ relais sans signal user.
+
+## Approche — 1 PR, 2 couches
+
+### Couche A — `DigestSelector` (batch nocturne)
+- **Renforcer la pénalité sport** : `DIGEST_SPORT_PENALTY` de -40 → -80.
+  La détection `is_sport_content(content)` couvre déjà `content.theme`,
+  `content.topics`, et keywords titre (TrashTalk est donc déjà attrapé
+  via `content.theme="sport"`), mais le poids était insuffisant.
+
+### Couche B — `EssentielService` (request-time)
+- **Pré-filtre** `_is_allowed_for_essentiel(article)` : rejette podcasts,
+  YouTube, Reddit, bulletins par pattern de titre.
+- **Sport hard-cap positionnel** : après les rounds de sélection, on relègue
+  au plus 1 article sport en slot 5+ ; on l'exclut si le pool non-sport < 4.
+- **Score perspectives non-linéaire** : `min(30, 12·log₂(n))` →
+  `1→0  2→+12  3→+19  4→+24  5→+28  6→+30 (cap)`.
+
+Pas de migration Alembic — implémentation purement code (patterns regex +
+constantes). Si faux-négatifs en prod, une PR-2 ajoutera un champ DB
+`Content.is_news_bulletin`.
+
+## Fichiers modifiés
+
+- `packages/api/app/services/recommendation/filter_presets.py` — ajout
+  `NEWS_BULLETIN_PATTERNS`, `is_news_bulletin_title()`.
+- `packages/api/app/services/recommendation/scoring_config.py` — `ESSENTIEL_*`
+  constantes + `DIGEST_SPORT_PENALTY` renforcé.
+- `packages/api/app/services/essentiel_service.py` — pré-filtre, contrainte
+  sport positionnelle, score perspectives log.
+- `packages/api/tests/test_essentiel_endpoint.py` — couverture nouvelle.
+- `packages/api/tests/test_digest_selector_sport_penalty.py` — régression
+  TrashTalk.
+
+## Validation
+
+- Tests unitaires (cf. fichiers de test).
+- Requête SQL post-déploiement sur les 14 derniers digests : zéro sport
+  en rank 1-4, zéro bulletin/podcast/reddit en Essentiel.

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -29,12 +29,14 @@ Pipeline :
 Fallback sans préférences : le scorer dégénère en `actu_boost + perspective − rank`.
 """
 
+import math
 from dataclasses import dataclass, field
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.enums import ContentType, SourceType
 from app.models.source import UserSource
 from app.models.user import UserInterest, UserSubtopic
 from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
@@ -43,6 +45,12 @@ from app.services.language_user_filter import (
     get_hide_non_fr_pref,
     is_foreign_source,
 )
+from app.services.recommendation.filter_presets import (
+    LOW_PRIORITY_SPORT_KEYWORDS,
+    LOW_PRIORITY_SPORT_THEMES,
+    is_news_bulletin_title,
+)
+from app.services.recommendation.scoring_config import ScoringWeights
 
 ESSENTIEL_MAX_ARTICLES = 5
 ESSENTIEL_MAX_PER_SOURCE = 2  # Diversité dure : max 2 articles d'une même source.
@@ -60,9 +68,12 @@ _W_BADGE_ACTU = 25.0  # article.badge == _BADGE_ACTU (signal explicite du digest
 _W_FOLLOWED_SOURCE = 100.0
 _W_FOLLOWED_SOURCE_FLAG = 50.0  # bonus moindre si on n'a que le flag du digest
 _W_TOPIC_WEIGHT = 50.0
-_W_PERSPECTIVE = 5.0
 _W_RANK_PENALTY = 0.5
 _W_READ_PENALTY = 1000.0  # Écarte les articles déjà lus sauf si rien d'autre.
+
+# Source types exclus du pool Essentiel — Reddit est un agrégateur, pas une
+# rédaction d'info.
+_EXCLUDED_SOURCE_TYPES: frozenset[SourceType] = frozenset({SourceType.REDDIT})
 
 
 @dataclass(frozen=True)
@@ -153,6 +164,78 @@ def _is_actu_du_jour(topic: DigestTopic, article: DigestTopicArticle) -> bool:
     return bool(topic.is_trending or topic.is_une or article.badge == _BADGE_ACTU)
 
 
+def _is_sport_pick(topic: DigestTopic, article: DigestTopicArticle) -> bool:
+    """Détecte un article sport (union de signaux).
+
+    Couvre le cas TrashTalk : `source.theme="society"` mais `content.theme="sport"`.
+    Cherche dans :
+    - `topic.theme` (signal éditorial du digest)
+    - `article.source.theme` (catégorisation source)
+    - `article.topics[]` (classification ML Mistral)
+    - keywords titre (NBA, Ligue des champions, F1, etc.)
+    """
+    candidates = {
+        (topic.theme or "").lower(),
+        (article.source.theme or "").lower(),
+    }
+    if candidates & LOW_PRIORITY_SPORT_THEMES:
+        return True
+    if article.topics and any(
+        isinstance(t, str) and t.lower() == "sport" for t in article.topics
+    ):
+        return True
+    text = (article.title or "").lower()
+    return any(kw in text for kw in LOW_PRIORITY_SPORT_KEYWORDS)
+
+
+def _is_allowed_for_essentiel(article: DigestTopicArticle) -> bool:
+    """Pré-filtre : un article passe-t-il les critères de l'Essentiel ?
+
+    Exclut (Story 9.4) :
+    - Podcasts et vidéos YouTube (content_type ∈ {PODCAST, YOUTUBE}).
+    - Sources Reddit (agrégateurs, pas une rédaction d'info).
+    - Bulletins radio + chroniques régulières par pattern de titre
+      (« JOURNAL DE 8H », « Avec Sciences, chronique du… »).
+    """
+    if article.content_type != ContentType.ARTICLE:
+        return False
+    if (article.source.type or "").lower() in _EXCLUDED_SOURCE_TYPES:
+        return False
+    if is_news_bulletin_title(article.title):
+        return False
+    return True
+
+
+def _filter_articles_allowed(topics: list[DigestTopic]) -> list[DigestTopic]:
+    """Recopie les topics en ne gardant que les articles autorisés.
+
+    Topics dont tous les articles sont exclus disparaissent. `model_copy`
+    évite de muter la `DigestResponse` source (potentiellement cachée).
+    """
+    filtered: list[DigestTopic] = []
+    for topic in topics:
+        kept = [a for a in topic.articles if _is_allowed_for_essentiel(a)]
+        if kept:
+            filtered.append(topic.model_copy(update={"articles": kept}))
+    return filtered
+
+
+def _perspective_score(perspective_count: int) -> float:
+    """Score non-linéaire des perspectives (Story 9.4).
+
+    `min(CAP, BASE * log2(n))` — 1→0, 2→+12, 3→+19, 4→+24, 5→+28, 6→+30 (cap).
+    Permet à un sujet à 6+ relais de rivaliser avec un BOOST_BADGE_ACTU (+25)
+    et d'égaler un BOOST_UNE (+30). Le linéaire `+5/perspective` d'origine
+    laissait passer des scoops isolés devant des sujets très relayés.
+    """
+    if perspective_count <= 1:
+        return 0.0
+    return min(
+        ScoringWeights.ESSENTIEL_PERSPECTIVE_CAP,
+        ScoringWeights.ESSENTIEL_PERSPECTIVE_BASE * math.log2(perspective_count),
+    )
+
+
 def _is_followed_topic(topic: DigestTopic, ctx: EssentielUserContext) -> bool:
     return bool(topic.theme and topic.theme in ctx.topic_weights)
 
@@ -194,9 +277,9 @@ def _score_article(
     if topic.theme and topic.theme in ctx.topic_weights:
         score += _W_TOPIC_WEIGHT * ctx.topic_weights[topic.theme]
 
-    # Bonus "transversal" : un sujet couvert par plusieurs sources est plus à
-    # sa place dans l'Essentiel qu'un scoop isolé.
-    score += _W_PERSPECTIVE * float(topic.perspective_count or 0)
+    # Bonus "transversal" log-calibré : un sujet à 6+ médias bat un signal
+    # trending faible, un scoop isolé n'a aucun bonus.
+    score += _perspective_score(int(topic.perspective_count or 0))
 
     # Pénalité is_read : écarte les articles déjà lus sauf si rien d'autre.
     if article.is_read:
@@ -250,6 +333,9 @@ def _pick_transversal_articles(
        même source à toutes les étapes.
     """
     topics = _filter_articles_by_language(topics, ctx)
+    # Story 9.4 : exclure podcasts/youtube/reddit/bulletins en tête de pipeline
+    # — ces contenus ne reflètent pas l'actualité chaude traitée par la presse.
+    topics = _filter_articles_allowed(topics)
     eligible_topics = [t for t in topics if t.articles]
     if not eligible_topics:
         return []
@@ -284,11 +370,12 @@ def _pick_transversal_articles(
 
     # ─── Slot lead Actu ──────────────────────────────────────────────────
     # Cherche le meilleur article Actu du jour (trending/une/badge=="actu").
-    # S'il existe, on le pose en rank=1 avant tout le reste.
+    # S'il existe, on le pose en rank=1 avant tout le reste. Le sport est
+    # exclu du lead-slot par construction (Story 9.4 : sport jamais < slot 5).
     actu_candidates: list[tuple[DigestTopic, DigestTopicArticle, float]] = []
     for topic in eligible_topics:
         for article in topic.articles:
-            if _is_actu_du_jour(topic, article):
+            if _is_actu_du_jour(topic, article) and not _is_sport_pick(topic, article):
                 actu_candidates.append(
                     (topic, article, scored[(topic.topic_id, article.content_id)])
                 )
@@ -318,7 +405,7 @@ def _pick_transversal_articles(
             continue
         _try_pick(topic, article)
         if len(picked) >= ESSENTIEL_MAX_ARTICLES:
-            return picked
+            return _enforce_sport_slot_constraint(picked)
 
     # ─── Round 2 : remplissage (meilleurs articles restants) ─────────────
     remaining: list[tuple[DigestTopic, DigestTopicArticle, float]] = []
@@ -337,7 +424,34 @@ def _pick_transversal_articles(
         if len(picked) >= ESSENTIEL_MAX_ARTICLES:
             break
 
-    return picked
+    return _enforce_sport_slot_constraint(picked)
+
+
+def _enforce_sport_slot_constraint(
+    picked: list[tuple[DigestTopic, DigestTopicArticle]],
+) -> list[tuple[DigestTopic, DigestTopicArticle]]:
+    """Force le sport à occuper le slot ≥ 5 (Story 9.4), avec au plus 1 sport.
+
+    Stratégie :
+    - Partitionne en non-sport et sport (max ESSENTIEL_MAX_SPORT_PER_DIGEST).
+    - Si on a ≥ (ESSENTIEL_SPORT_MIN_SLOT - 1) non-sport, on place le sport
+      après — il aboutit en slot 5 ou plus.
+    - Sinon le pool non-sport est trop petit pour placer le sport en slot 5+ :
+      on l'exclut plutôt que de le remonter en slot < 5.
+    """
+    non_sport: list[tuple[DigestTopic, DigestTopicArticle]] = []
+    sport: list[tuple[DigestTopic, DigestTopicArticle]] = []
+    for topic, article in picked:
+        if _is_sport_pick(topic, article):
+            sport.append((topic, article))
+        else:
+            non_sport.append((topic, article))
+
+    sport = sport[: ScoringWeights.ESSENTIEL_MAX_SPORT_PER_DIGEST]
+    min_non_sport = ScoringWeights.ESSENTIEL_SPORT_MIN_SLOT - 1
+    if len(non_sport) >= min_non_sport:
+        return (non_sport + sport)[:ESSENTIEL_MAX_ARTICLES]
+    return non_sport[:ESSENTIEL_MAX_ARTICLES]
 
 
 def _to_essentiel_article(

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -433,9 +433,58 @@ LOW_PRIORITY_SPORT_KEYWORDS = [
     " asm ",
     "mbappé",
     "mbappe",
+    # NBA / basket élargi (Story 9.4 — preuves DB : Wembanyama / TrashTalk / Thunder)
+    "nba",
+    "wembanyama",
+    "play-offs",
+    "playoffs",
 ]
 
 LOW_PRIORITY_SPORT_THEMES = {"sport", "sports"}
+
+
+# --- Constantes "bulletins / chroniques" ---
+#
+# Patterns regex matchant les titres de bulletins radio (« JOURNAL DE 8H… »),
+# tranches horaires (« Le 7/9 »), chroniques régulières (« Avec Sciences,
+# chronique du lundi 25 mai 2026 »), revues de presse. Ces contenus ne
+# constituent pas une actualité chaude éditoriale et doivent être exclus de
+# l'Essentiel — ils saturent les top slots avec du contenu daté/répétitif.
+#
+# Ancrage début de chaîne ou borné aux 30 premiers caractères pour éviter de
+# matcher un article analytique contenant « chronique » en milieu de phrase
+# (« Une chronique du conflit… »).
+NEWS_BULLETIN_PATTERNS = [
+    r"^\s*journal de \d{1,2}\s?h",  # JOURNAL DE 8H, Journal de 13h
+    r"^\s*le \d{1,2}\s?/\s?\d{1,2}\b",  # Le 7/9, Le 13/14, Le 18/20
+    # « Avec Sciences, chronique du… » → précédé de virgule/colon, ou en début
+    # de titre (« Chronique du soir »). Le « Une chronique du conflit » est
+    # exclu par construction (mot précédent = « Une », pas une ponctuation).
+    r"(^\s*|[,:]\s+)chronique du\b",
+    r"^\s*jt (de |du )",  # JT de 20h, JT du soir
+    r"^\s*les titres\b",  # Les titres de l'actualité
+    r"^\s*info (matin|soir)\b",
+    r"^\s*bulletin (info|météo|meteo)\b",
+    r"^\s*revue de presse\b",
+    r"^\s*flash (info|actu)\b",
+    r"^\s*le journal\b",  # Le journal de France Inter, Le Journal du week-end
+]
+
+_BULLETIN_RE = re.compile("|".join(NEWS_BULLETIN_PATTERNS), re.IGNORECASE)
+
+
+def is_news_bulletin_title(title: str | None) -> bool:
+    """True si le titre matche un pattern de bulletin radio / chronique régulière.
+
+    Utilisé pour exclure de l'Essentiel les contenus daté/répétitifs
+    (« JOURNAL DE 8H du lundi 25 mai 2026 », « Avec Sciences, chronique du… »)
+    qui passent à travers les autres filtres parce qu'ils sont publiés en
+    flux article (content_type=ARTICLE) sur certaines sources comme France
+    Culture.
+    """
+    if not title:
+        return False
+    return bool(_BULLETIN_RE.search(title))
 
 
 def _match_ratio(cluster: TopicCluster, keywords: list[str]) -> float:

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -137,9 +137,28 @@ class ScoringWeights:
     # --- DIGEST LOW-PRIORITY (Sport) ---
 
     # Pénalité appliquée aux articles Sport dans le scoring du digest (2 modes).
-    # Alignée sur MUTED_THEME_MALUS (-40) : un Sport fort (source suivie + topic
-    # ciblé + très récent) peut encore dépasser le seuil — pas d'exclusion dure.
-    DIGEST_SPORT_PENALTY = -40.0
+    # Renforcée de -40 → -80 (Story 9.4) : la pénalité d'origine était trop
+    # faible — un sport avec source suivie (+100) ou trending (+45) la battait
+    # systématiquement, d'où plusieurs cas observés en rank 1-3 (UNFP Dembélé,
+    # Wembanyama, F1, Ligue des champions). À -80 le sport ne passe en tête
+    # que s'il est éditorialement majeur ET suivi par l'user.
+    DIGEST_SPORT_PENALTY = -80.0
+
+    # --- ESSENTIEL (top 5 transversal — Story 9.4) ---
+
+    # Slot minimum autorisé pour un article sport dans l'Essentiel (1-indexed).
+    # Sport en rank < 5 = exclu via post-processing positionnel.
+    ESSENTIEL_SPORT_MIN_SLOT = 5
+
+    # Nombre maximum d'articles sport par Essentiel (5 articles total).
+    ESSENTIEL_MAX_SPORT_PER_DIGEST = 1
+
+    # Score perspectives non-linéaire (log2) : `min(CAP, BASE * log2(n))`.
+    # 1→0  2→+12  3→+19  4→+24  5→+28  6→+30 (cap)  8+→+30
+    # Permet à un sujet relayé par 3+ médias de rivaliser avec un BOOST_BADGE_ACTU
+    # (+25) et d'égaler un BOOST_UNE (+30). Un scoop isolé n'a aucun bonus.
+    ESSENTIEL_PERSPECTIVE_BASE = 12.0
+    ESSENTIEL_PERSPECTIVE_CAP = 30.0
 
     # --- DIGEST TRENDING/IMPORTANCE (Pour vous hybride) ---
 

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -19,11 +19,13 @@ from httpx import ASGITransport, AsyncClient
 
 from app.dependencies import get_current_user_id
 from app.main import app
+from app.models.enums import ContentType
 from app.schemas.content import SourceMini
 from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
 from app.services.essentiel_service import (
     ESSENTIEL_MAX_ARTICLES,
     EssentielUserContext,
+    _perspective_score,
     _source_letter,
     build_essentiel_response,
 )
@@ -713,3 +715,338 @@ async def test_get_essentiel_uses_user_context_from_router(auth_override: UUID):
     body = resp.json()
     assert body["articles"][0]["source"]["name"] == "Mediapart"
     assert body["articles"][0]["rank"] == 1
+
+
+# ─── Story 9.4 — Durcissement des filtres ────────────────────────────────
+
+
+def _src(
+    name: str = "Le Monde",
+    *,
+    type_: str = "article",
+    theme: str | None = None,
+) -> SourceMini:
+    return SourceMini(
+        id=uuid4(),
+        name=name,
+        logo_url=None,
+        type=type_,
+        theme=theme,
+    )
+
+
+def _art(
+    *,
+    title: str = "Article",
+    source: SourceMini | None = None,
+    content_type: ContentType = ContentType.ARTICLE,
+    topics: list[str] | None = None,
+    rank: int = 1,
+) -> DigestTopicArticle:
+    return DigestTopicArticle(
+        content_id=uuid4(),
+        title=title,
+        url=f"https://example.com/{title.lower().replace(' ', '-')[:30]}",
+        published_at=datetime.now(UTC),
+        source=source or _src(),
+        rank=rank,
+        reason="Test",
+        content_type=content_type,
+        topics=topics or [],
+    )
+
+
+def _topic(
+    label: str,
+    articles: list[DigestTopicArticle],
+    *,
+    theme: str | None = None,
+    is_trending: bool = False,
+    is_une: bool = False,
+    perspective_count: int = 2,
+    rank: int = 1,
+) -> DigestTopic:
+    return DigestTopic(
+        topic_id=f"t-{label.lower()}",
+        label=label,
+        rank=rank,
+        reason="Test",
+        theme=theme,
+        is_trending=is_trending,
+        is_une=is_une,
+        perspective_count=perspective_count,
+        articles=articles,
+    )
+
+
+def test_sport_relegated_to_slot_5_when_pool_has_4_non_sport():
+    """Sport doit aboutir en slot 5+ s'il y a 4 non-sport disponibles."""
+    sport_src = _src("Ouest-France", theme="sport")
+    sport_art = _art(
+        title="Trophées UNFP. Dembélé meilleur joueur de Ligue 1",
+        source=sport_src,
+        topics=["sport"],
+    )
+    topics = [
+        _topic("Sport", [sport_art], theme="sport", is_trending=True, perspective_count=4, rank=1),
+        _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
+        _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
+        _topic("Tech", [_art(title="T1")], theme="tech", rank=4),
+        _topic("Culture", [_art(title="Cul1")], theme="culture", rank=5),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert len(response.articles) == 5
+    # Sport doit être en rank 5 (dernier).
+    assert response.articles[-1].section_label == "Sport"
+    # Aucun article sport en rank 1-4.
+    for art in response.articles[:4]:
+        assert art.section_label != "Sport"
+
+
+def test_sport_excluded_when_pool_under_4_non_sport():
+    """Si le pool non-sport < 4 articles, le sport est exclu (pas remonté en slot 4)."""
+    sport_src = _src("Ouest-France", theme="sport")
+    sport_art = _art(title="F1 GP Canada", source=sport_src, topics=["sport"])
+    topics = [
+        _topic("Sport", [sport_art], theme="sport", is_trending=True, perspective_count=5, rank=1),
+        _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
+        _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    # On a 2 non-sport (< 4 = min) → sport exclu, résultat = 2 articles.
+    assert len(response.articles) == 2
+    assert all(a.section_label != "Sport" for a in response.articles)
+
+
+def test_sport_detected_via_content_topic_even_if_source_theme_is_society():
+    """Régression TrashTalk : source.theme="society" mais topics=["sport"]."""
+    trashtalk = _src("TrashTalk", theme="society")
+    nba_art = _art(
+        title="Victor Wembanyama, 33 points et un impact majeur",
+        source=trashtalk,
+        topics=["sport"],  # ML a bien classifié "sport"
+    )
+    topics = [
+        _topic("NBA", [nba_art], theme="sport", is_trending=True, perspective_count=2, rank=1),
+        _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
+        _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
+        _topic("Tech", [_art(title="T1")], theme="tech", rank=4),
+        _topic("Culture", [_art(title="Cul1")], theme="culture", rank=5),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    # NBA (TrashTalk) doit être en rank 5, pas en lead.
+    assert response.articles[-1].section_label == "NBA"
+
+
+def test_sport_detected_via_title_keyword_only():
+    """Sport détecté via keyword titre même sans theme/topics."""
+    src = _src("Europe 1", theme="society")
+    sport_art = _art(
+        title="Play-offs NBA : le Thunder répond aux Spurs de Wembanyama",
+        source=src,
+        topics=[],  # pas de ML
+    )
+    topics = [
+        _topic("Play-offs", [sport_art], theme="society", is_trending=True, perspective_count=2, rank=1),
+        _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
+        _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
+        _topic("Tech", [_art(title="T1")], theme="tech", rank=4),
+        _topic("Culture", [_art(title="Cul1")], theme="culture", rank=5),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert response.articles[-1].section_label == "Play-offs"
+
+
+def test_news_bulletin_journal_de_8h_excluded():
+    """« JOURNAL DE 8H du lundi 25 mai 2026 » exclu même si trending."""
+    france_culture = _src("France Culture", theme="culture")
+    bulletin = _art(
+        title="JOURNAL DE 8H du lundi 25 mai 2026",
+        source=france_culture,
+    )
+    topics = [
+        _topic("Bulletin", [bulletin], theme="culture", is_trending=True, perspective_count=2, rank=1),
+        _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
+        _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    titles = [a.title for a in response.articles]
+    assert "JOURNAL DE 8H du lundi 25 mai 2026" not in titles
+    assert len(response.articles) == 2  # Politique + Climat seulement
+
+
+def test_news_bulletin_chronique_du_excluded():
+    """« Avec Sciences, chronique du lundi… » (podcast court) exclu."""
+    src = _src("La Science CQFD", type_="podcast", theme="science")
+    chronique = _art(
+        title="Avec Sciences, chronique du lundi 25 mai 2026",
+        source=src,
+        content_type=ContentType.PODCAST,  # doublement exclu
+    )
+    topics = [
+        _topic("Chronique", [chronique], theme="science", perspective_count=2, rank=1),
+        _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert all(a.title != "Avec Sciences, chronique du lundi 25 mai 2026" for a in response.articles)
+
+
+def test_chronique_in_middle_of_title_not_excluded():
+    """Faux-positif à éviter : « chronique » en milieu de phrase reste éligible."""
+    src = _src("Mediapart")
+    art = _art(
+        title="Une chronique du conflit israélo-palestinien après deux ans",
+        source=src,
+    )
+    topics = [
+        _topic("MO", [art], theme="international", perspective_count=4, rank=1),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    # L'article doit passer (pattern ancré début, "chronique du" en milieu OK).
+    assert len(response.articles) == 1
+    assert "chronique du conflit" in response.articles[0].title
+
+
+def test_podcast_content_type_excluded():
+    """Tous les podcasts (content_type=PODCAST) sont exclus de l'Essentiel."""
+    src = _src("France Culture")
+    podcast = _art(
+        title="Le Miocène Moyen, le passé pour raconter notre climat",
+        source=src,
+        content_type=ContentType.PODCAST,
+    )
+    topics = [
+        _topic("Podcast", [podcast], theme="science", perspective_count=1, rank=1),
+        _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert all(a.content_id != podcast.content_id for a in response.articles)
+
+
+def test_youtube_content_type_excluded():
+    """Vidéos YouTube (content_type=YOUTUBE) exclues de l'Essentiel."""
+    src = _src("Hugo Décrypte", type_="youtube")
+    yt = _art(
+        title="Le récap du jour",
+        source=src,
+        content_type=ContentType.YOUTUBE,
+    )
+    topics = [
+        _topic("YouTube", [yt], theme="news", perspective_count=2, rank=1),
+        _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert all(a.content_id != yt.content_id for a in response.articles)
+
+
+def test_reddit_source_excluded():
+    """Posts de sources Reddit (r/france) exclus de l'Essentiel."""
+    reddit = _src("r/france", type_="reddit")
+    post = _art(
+        title="Quatre policiers de la BAC condamnés",
+        source=reddit,
+    )
+    topics = [
+        _topic("Reddit", [post], theme="society", is_trending=True, perspective_count=3, rank=1),
+        _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert all(a.source.name != "r/france" for a in response.articles)
+
+
+def test_perspective_score_log_curve():
+    """Vérifie la calibration log2 du score perspectives."""
+    assert _perspective_score(0) == 0.0
+    assert _perspective_score(1) == 0.0
+    # 12 * log2(2) = 12
+    assert _perspective_score(2) == pytest.approx(12.0)
+    # 12 * log2(4) = 24
+    assert _perspective_score(4) == pytest.approx(24.0)
+    # 12 * log2(6) ≈ 31 → capé à 30
+    assert _perspective_score(6) == pytest.approx(30.0)
+    assert _perspective_score(20) == pytest.approx(30.0)
+
+
+def test_six_perspectives_beats_one_perspective_scoop():
+    """Cas PO : sujet à 6 médias (sans signal éditorial) doit passer devant un
+    scoop isolé (1 perspective), sans aucune préférence user."""
+    pop_src = _src("Le Monde")
+    scoop_src = _src("Mediapart")
+    very_relayed = _art(
+        title="Hauts responsables iraniens à Doha pour discussions",
+        source=pop_src,
+    )
+    isolated = _art(
+        title="Le Miocène moyen : passé du climat à venir",
+        source=scoop_src,
+    )
+    topics = [
+        # Scoop isolé en rank topic 1 (avantage rank), 1 perspective.
+        _topic("Climat", [isolated], theme="science", perspective_count=1, rank=1),
+        # Sujet relayé en rank topic 2, 6 perspectives.
+        _topic("MO", [very_relayed], theme="international", perspective_count=6, rank=2),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    # Sans signal user, 6 perspectives (+30) > 1 perspective (0) +
+    # rank_penalty (-0.5 vs -1.0) → MO passe devant.
+    assert response.articles[0].section_label == "MO"
+    assert response.articles[1].section_label == "Climat"
+
+
+def test_actu_lead_slot_skips_sport_trending():
+    """Un sport trending ne décroche pas le lead-slot Actu (Story 9.4)."""
+    sport_src = _src("Ouest-France", theme="sport")
+    sport_actu = _art(
+        title="Coupe du monde 2026, finale historique",
+        source=sport_src,
+        topics=["sport"],
+    )
+    regular = _art(title="Politique-1", source=_src("Le Monde"))
+    topics = [
+        _topic("Sport", [sport_actu], theme="sport", is_trending=True, perspective_count=5, rank=1),
+        _topic("Politique", [regular], theme="politique", perspective_count=3, rank=2),
+        _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
+        _topic("Tech", [_art(title="T1")], theme="tech", rank=4),
+        _topic("Culture", [_art(title="Cul1")], theme="culture", rank=5),
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    # Lead-slot = pas sport.
+    assert response.articles[0].section_label != "Sport"
+    # Sport en queue.
+    assert response.articles[-1].section_label == "Sport"

--- a/packages/api/tests/test_low_priority_cap.py
+++ b/packages/api/tests/test_low_priority_cap.py
@@ -18,6 +18,7 @@ from uuid import UUID, uuid4
 from app.services.recommendation.filter_presets import (
     cap_low_priority_clusters,
     is_faits_divers_cluster,
+    is_news_bulletin_title,
     is_sport_cluster,
     is_sport_content,
 )
@@ -194,3 +195,47 @@ class TestCapLowPriorityClusters:
         sport_b = _make(theme="sport", titles=["b"])
         kept = cap_low_priority_clusters([sport_a, sport_b], max_sport=2)
         assert len(kept) == 2
+
+
+class TestIsNewsBulletinTitle:
+    """Story 9.4 — exclusion des bulletins radio / chroniques régulières."""
+
+    def test_journal_de_8h_uppercase(self):
+        assert is_news_bulletin_title("JOURNAL DE 8H du lundi 25 mai 2026")
+
+    def test_journal_de_8h_lowercase(self):
+        assert is_news_bulletin_title("Journal de 8h du lundi 25 mai 2026")
+
+    def test_journal_de_13h(self):
+        assert is_news_bulletin_title("Journal de 13h - édition du 24/05")
+
+    def test_le_7_9_tranche(self):
+        assert is_news_bulletin_title("Le 7/9 du 25 mai : invités politiques")
+
+    def test_le_18_20(self):
+        assert is_news_bulletin_title("Le 18/20 — points clés")
+
+    def test_chronique_du_at_start(self):
+        assert is_news_bulletin_title("Avec Sciences, chronique du lundi 25 mai 2026")
+
+    def test_jt_de_20h(self):
+        assert is_news_bulletin_title("JT de 20h du 24 mai")
+
+    def test_revue_de_presse(self):
+        assert is_news_bulletin_title("Revue de presse internationale")
+
+    def test_chronique_in_middle_not_bulletin(self):
+        """Faux-positif à éviter : « chronique du conflit » en milieu de phrase
+        n'est PAS un bulletin (le pattern est ancré début/30 premiers chars)."""
+        assert not is_news_bulletin_title(
+            "Une chronique du conflit israélo-palestinien après deux ans de guerre"
+        )
+
+    def test_regular_article_not_bulletin(self):
+        assert not is_news_bulletin_title(
+            "Macron annonce une réforme des retraites lundi"
+        )
+
+    def test_empty_or_none(self):
+        assert not is_news_bulletin_title(None)
+        assert not is_news_bulletin_title("")


### PR DESCRIPTION
## Quoi

Refonte des filtres de l'Essentiel (« Actus du jour ») pour corriger 3 pathologies observées sur les batchs 2026-05-12 → 2026-05-25 :

- **Sport en top 1-4** (UNFP Dembélé, F1, Wembanyama via TrashTalk…). Pénalité digest renforcée (-40 → -80) + hard-cap positionnel : au plus 1 sport, jamais avant le slot 5, exclu du lead-slot Actu. Détection multi-signaux (theme topic / theme source / content.topics / keywords titre) pour attraper TrashTalk (source.theme=society mais content.theme=sport).
- **Bulletins radio / podcasts / Reddit en top 5** (« JOURNAL DE 8H », « chronique du… », posts r/france). Pré-filtre `_is_allowed_for_essentiel` qui exclut `content_type ∈ {PODCAST, YOUTUBE}`, `source.type=reddit`, et les titres matchant 10 patterns de bulletins/chroniques régulières.
- **Scoops isolés devant des sujets très relayés**. Score perspectives passe de `+5·n` (linéaire) à `min(30, 12·log₂(n))` — `1→0, 2→+12, 3→+19, 4→+24, 5→+28, 6→+30 (cap)`. Un sujet à 6+ médias rivalise avec BOOST_BADGE_ACTU (+25), un scoop isolé n'a aucun bonus.

## Pourquoi

Cas PO emblématiques (cf. story 9.4) :
- « JOURNAL DE 8H du lundi 25 mai 2026 » en rank 3 (France Culture, content_type=article).
- Wembanyama 33 points en rank 2 (TrashTalk classé `society` au niveau source).
- Podcast « Le Miocène Moyen » (1 perspective) en slot 5 vs « hauts responsables iraniens à Doha » (6+ médias) en slot 6.

Pas de migration : implémentation purement code (patterns regex + constantes). Couvre la couche **DigestSelector** (batch) via `DIGEST_SPORT_PENALTY` et la couche **EssentielService** (request-time) via le pré-filtre, le cap positionnel et le score log.

## Comment ça a été vérifié

- [x] `pytest tests/test_essentiel_endpoint.py tests/test_low_priority_cap.py` — **65 passed** (dont 13 nouveaux tests sport/bulletin/perspective + 11 tests pattern bulletin)
- [x] Suite backend complète — **1130 passed**, 184 errors préexistants (DB locale Supabase non démarrée sur :54322, sans rapport)
- [x] Faux-positif évité : « Une chronique du conflit israélo-palestinien » reste éligible (pattern ancré début/30 premiers chars)
- [x] Régression TrashTalk : article NBA classé `society` au niveau source est bien détecté comme sport via `content.topics=["sport"]`
- [x] /simplify : enum `SourceType.REDDIT` au lieu de la chaîne brute, suppression de `NEWS_BULLETIN_REGEX_SQL` (dead code), comment trimming

## Zones à risque

- `essentiel_service._pick_transversal_articles` — ordre du pipeline modifié (lang → allowed → eligible)
- `scoring_config.DIGEST_SPORT_PENALTY` — un Sport fort (source suivie + trending) ne peut plus passer en tête sauf si éditorialement majeur ET suivi
- Pas d'impact sur le digest hors Essentiel : la `DigestResponse` source n'est pas mutée (`model_copy`)