### PR TITLE
feat(mobile): ouvre les sources comparées dans une webview in-app

### DIFF
--- a/apps/mobile/lib/features/feed/screens/perspective_webview_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/perspective_webview_screen.dart
@@ -1,0 +1,263 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
+
+import '../../../config/theme.dart';
+
+/// Affiche une URL externe (typiquement un article d'une "autre source"
+/// proposée dans la carte de comparaisons) dans une webview in-app, plutôt
+/// que dans le navigateur système. Pousser cet écran via le **root navigator**
+/// pour qu'il s'empile au-dessus de la bottom sheet de perspectives sans la
+/// fermer ; un simple `Navigator.of(context).pop()` (ou swipe back iOS)
+/// ramène l'utilisateur sur la sheet, intacte.
+class PerspectiveWebViewScreen extends ConsumerStatefulWidget {
+  final String url;
+  final String sourceName;
+
+  const PerspectiveWebViewScreen({
+    super.key,
+    required this.url,
+    required this.sourceName,
+  });
+
+  @override
+  ConsumerState<PerspectiveWebViewScreen> createState() =>
+      _PerspectiveWebViewScreenState();
+}
+
+class _PerspectiveWebViewScreenState
+    extends ConsumerState<PerspectiveWebViewScreen> {
+  WebViewController? _controller;
+  int _loadingProgress = 0;
+  bool _hasError = false;
+  bool _isSupported = true;
+
+  @override
+  void initState() {
+    super.initState();
+
+    if (!kIsWeb &&
+        (Platform.isMacOS || Platform.isWindows || Platform.isLinux)) {
+      _isSupported = false;
+      return;
+    }
+
+    try {
+      late final PlatformWebViewControllerCreationParams params;
+      if (!kIsWeb && Platform.isIOS) {
+        params = WebKitWebViewControllerCreationParams(
+          allowsInlineMediaPlayback: true,
+        );
+      } else {
+        params = const PlatformWebViewControllerCreationParams();
+      }
+
+      _controller = WebViewController.fromPlatformCreationParams(params)
+        ..setJavaScriptMode(JavaScriptMode.unrestricted)
+        ..setBackgroundColor(const Color(0x00000000))
+        ..setNavigationDelegate(
+          NavigationDelegate(
+            onProgress: (int progress) {
+              if (mounted && _loadingProgress != progress) {
+                setState(() => _loadingProgress = progress);
+              }
+            },
+            onPageStarted: (_) {
+              if (mounted) {
+                setState(() {
+                  _loadingProgress = 0;
+                  _hasError = false;
+                });
+              }
+            },
+            onPageFinished: (_) {
+              if (mounted) setState(() => _loadingProgress = 100);
+            },
+            onWebResourceError: (_) {
+              if (mounted) setState(() => _hasError = true);
+            },
+          ),
+        )
+        ..loadRequest(Uri.parse(widget.url));
+    } catch (e) {
+      debugPrint('PerspectiveWebView init error: $e');
+      _isSupported = false;
+    }
+  }
+
+  Future<void> _openInBrowser() async {
+    final uri = Uri.tryParse(widget.url);
+    if (uri != null) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      backgroundColor: colors.backgroundPrimary,
+      appBar: AppBar(
+        backgroundColor: colors.backgroundPrimary,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(
+            PhosphorIcons.arrowLeft(PhosphorIconsStyle.regular),
+            color: colors.textPrimary,
+          ),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: Text(
+          widget.sourceName,
+          style: textTheme.titleMedium?.copyWith(
+            color: colors.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        actions: [
+          IconButton(
+            tooltip: 'Ouvrir dans le navigateur',
+            icon: Icon(
+              PhosphorIcons.arrowSquareOut(PhosphorIconsStyle.regular),
+              color: colors.textPrimary,
+            ),
+            onPressed: _openInBrowser,
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          if (_loadingProgress < 100 && !_hasError && _isSupported)
+            LinearProgressIndicator(
+              value: _loadingProgress / 100.0,
+              backgroundColor: colors.backgroundSecondary,
+              color: colors.primary,
+              minHeight: 2,
+            )
+          else
+            Divider(
+              height: 1,
+              thickness: 0.5,
+              color: colors.textTertiary.withValues(alpha: 0.3),
+            ),
+          Expanded(
+            child: Stack(
+              children: [
+                if (_isSupported && _controller != null)
+                  WebViewWidget(controller: _controller!)
+                else
+                  _UnsupportedView(onOpen: _openInBrowser),
+                if (_hasError)
+                  _ErrorView(
+                    onRetry: () {
+                      setState(() {
+                        _hasError = false;
+                        _loadingProgress = 0;
+                      });
+                      _controller?.reload();
+                    },
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _UnsupportedView extends StatelessWidget {
+  final VoidCallback onOpen;
+  const _UnsupportedView({required this.onOpen});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              PhosphorIcons.monitor(PhosphorIconsStyle.duotone),
+              size: 64,
+              color: colors.textSecondary.withValues(alpha: 0.5),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'WebView non supportée sur cette plateforme',
+              textAlign: TextAlign.center,
+              style: textTheme.titleMedium,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: onOpen,
+              icon: Icon(PhosphorIcons.browser(PhosphorIconsStyle.bold)),
+              label: const Text('Ouvrir dans le navigateur'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  final VoidCallback onRetry;
+  const _ErrorView({required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    return Container(
+      color: colors.backgroundPrimary,
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                PhosphorIcons.warningCircle(PhosphorIconsStyle.duotone),
+                size: 64,
+                color: colors.error,
+              ),
+              const SizedBox(height: 16),
+              Text('Erreur de chargement', style: textTheme.titleMedium),
+              const SizedBox(height: 8),
+              Text(
+                "Impossible de charger l'article. Vérifiez votre connexion ou réessayez plus tard.",
+                textAlign: TextAlign.center,
+                style: textTheme.bodySmall?.copyWith(
+                  color: colors.textSecondary,
+                ),
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: colors.primary,
+                  foregroundColor: Colors.white,
+                ),
+                onPressed: onRetry,
+                child: const Text('Réessayer'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../../config/theme.dart';
 import '../../../core/providers/analytics_provider.dart';
@@ -14,8 +13,22 @@ import '../../digest/widgets/markdown_text.dart';
 import '../../digest/widgets/section_divider.dart';
 import '../providers/feed_provider.dart';
 import '../repositories/feed_repository.dart' show HighlightSpan, TokenSpan;
+import '../screens/perspective_webview_screen.dart';
 import 'coverage_spectrum_bar.dart';
 import 'diff_title.dart';
+
+/// Pushed via the root navigator so the in-app webview stacks above the
+/// bottom sheet without dismissing it.
+void _openPerspectiveWebView(BuildContext context, Perspective p) {
+  Navigator.of(context, rootNavigator: true).push(
+    MaterialPageRoute<void>(
+      builder: (_) => PerspectiveWebViewScreen(
+        url: p.url,
+        sourceName: p.sourceName,
+      ),
+    ),
+  );
+}
 
 /// Model for a perspective from an external source
 class Perspective {
@@ -626,13 +639,12 @@ class _PerspectiveCard extends ConsumerWidget {
       child: FacteurCard(
         padding: EdgeInsets.zero,
         borderRadius: FacteurRadius.small,
-        onTap: () async {
+        onTap: () {
           final perspectiveId = perspective.sourceDomain.isNotEmpty
               ? perspective.sourceDomain
               : perspective.url;
           onView?.call(perspectiveId);
-          final uri = Uri.parse(perspective.url);
-          await launchUrl(uri, mode: LaunchMode.externalApplication);
+          _openPerspectiveWebView(context, perspective);
         },
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -669,8 +681,7 @@ class _PerspectiveCard extends ConsumerWidget {
                       ),
                       const SizedBox(width: 8),
                       Icon(
-                        PhosphorIcons.arrowSquareOut(
-                            PhosphorIconsStyle.regular),
+                        PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
                         size: 16,
                         color: colors.textTertiary,
                       ),
@@ -1728,8 +1739,7 @@ class _PivotedRefTitleState extends State<_PivotedRefTitle>
 }
 
 /// Ligne variante (cm-vrow) — border-left 4 px couleur bias + DiffTitle animé
-/// suivi d'une foot row (favicon + nom + bias label + arrow). Tap → launchUrl
-/// externe.
+/// suivi d'une foot row (favicon + nom + bias label + arrow).
 class _VariantRow extends ConsumerWidget {
   final Perspective perspective;
   final bool isLast;
@@ -1766,12 +1776,7 @@ class _VariantRow extends ConsumerWidget {
     final biasColor = perspective.getBiasColor(colors);
     return InkWell(
       key: firstCardKey,
-      onTap: () async {
-        final uri = Uri.tryParse(perspective.url);
-        if (uri != null) {
-          await launchUrl(uri, mode: LaunchMode.externalApplication);
-        }
-      },
+      onTap: () => _openPerspectiveWebView(context, perspective),
       child: Container(
         decoration: BoxDecoration(
           border: Border(
@@ -1840,7 +1845,7 @@ class _VariantRow extends ConsumerWidget {
                 ),
                 const Spacer(),
                 Icon(
-                  PhosphorIcons.arrowUpRight(PhosphorIconsStyle.regular),
+                  PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
                   size: 14,
                   color: colors.textTertiary,
                 ),

--- a/apps/mobile/test/features/feed/widgets/variant_row_source_below_test.dart
+++ b/apps/mobile/test/features/feed/widgets/variant_row_source_below_test.dart
@@ -65,13 +65,13 @@ void main() {
     expect(diffTitles, findsWidgets,
         reason: 'Au moins un DiffTitle doit être présent dans les variants.');
 
-    // L'icône arrowUpRight ne se trouve que dans la head row du _VariantRow.
+    // L'icône arrowRight ne se trouve que dans la head row du _VariantRow.
     final arrowIcons = find.byWidgetPredicate((w) =>
         w is Icon &&
-        w.icon == PhosphorIcons.arrowUpRight(PhosphorIconsStyle.regular));
+        w.icon == PhosphorIcons.arrowRight(PhosphorIconsStyle.regular));
     expect(arrowIcons, findsWidgets,
         reason:
-            'L\'icône arrow-up-right est l\'ancre de la head row dans _VariantRow.');
+            'L\'icône arrow-right est l\'ancre de la head row dans _VariantRow.');
 
     // Compare la position verticale du premier DiffTitle vs le premier arrow :
     // après PR 6, le DiffTitle doit être au-dessus (dy plus petit).


### PR DESCRIPTION
## Quoi

Le tap sur une carte "autre source" (bottom sheet de comparaisons / `_PerspectiveCard` et `_VariantRow`) pousse désormais un nouvel écran `PerspectiveWebViewScreen` au-dessus de la sheet via le **root navigator**, au lieu d'appeler `launchUrl` externe. Un swipe back / appui sur la flèche ramène l'utilisateur sur la bottom sheet intacte. Bouton "ouvrir dans le navigateur" disponible dans l'AppBar pour conserver l'option externe.

## Pourquoi

Quitter Facteur vers Safari/Chrome cassait le flux de lecture comparée — l'utilisateur perdait l'état de la sheet (sources lues, scroll, animation des `DiffTitle`) et devait re-naviguer pour revenir. La webview in-app garde la session de comparaison vivante tout en respectant la mise en page de la source.

## Comment ça a été vérifié

- [x] `flutter analyze` sur les fichiers touchés — `No issues found`
- [x] `flutter test test/features/feed/widgets/{variant_row_source_below,perspectives_bottom_sheet,perspectives_inline_animation}_test.dart` — 8/8 passés
- [x] Test ancre d'icône mis à jour : `arrowUpRight` → `arrowRight` (cohérent avec une navigation interne plutôt qu'une sortie externe)
- [x] Skill `simplify` exécutée : helper `_openPerspectiveWebView` extrait pour les 2 call sites, params morts (`sourceDomain`, `title`) supprimés, guard `no-op setState` sur `onProgress`

⚠️ Suite complète `flutter test` non re-lancée — 36 échecs préexistants sur `main` (topic_chip, router_redirection, notifications, smoke test, feed_refresh_recovery…), aucun ne touche les fichiers de cette PR.

## Zones à risque

- Plateformes desktop (macOS/Windows/Linux) : fallback `_UnsupportedView` avec CTA "ouvrir dans le navigateur"
- Navigation : utilisation explicite de `rootNavigator: true` pour empiler au-dessus de la `showModalBottomSheet`, à valider sur iOS swipe-back
- Pas de `dispose()` explicite sur `WebViewController` — l'API `webview_flutter` ne l'expose pas, le `WebViewWidget` gère le cycle de vie de la plateforme

🤖 Generated with [Claude Code](https://claude.com/claude-code)