### PR TITLE
feat(flux-continu): CTA fin de page Thème + refactor closing card

### DIFF
--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -252,6 +252,22 @@ Set<String> renderedContentIds(List<FluxSection> sections) {
   return seen;
 }
 
+/// Returns the section that follows [currentKey] in [sections] (the ordered
+/// Tournée du jour list), ignoring `EssentielSection` (no "Voir + de") and the
+/// current section itself. Returns `null` when the current section is the
+/// last one — used by the theme/digest detail screens to decide whether to
+/// show the "Sujet suivant" CTA or fall back to "Retour à la Tournée".
+FluxSection? nextSectionAfter(List<FluxSection> sections, String currentKey) {
+  final ordered = sections.whereType<FluxSection>().where((s) {
+    if (s is EssentielSection) return false;
+    return true;
+  }).toList(growable: false);
+  final currentIndex = ordered.indexWhere((s) => sectionKey(s) == currentKey);
+  if (currentIndex == -1) return null;
+  if (currentIndex + 1 >= ordered.length) return null;
+  return ordered[currentIndex + 1];
+}
+
 /// Picks the lead article for a digest topic.
 ///
 /// Priority — followed-source first (user-affinity bonus), otherwise the

--- a/apps/mobile/lib/features/flux_continu/providers/theme_discovery_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/theme_discovery_provider.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../feed/models/content_model.dart';
+import '../../feed/providers/feed_provider.dart';
+
+/// Fetches today's articles for [themeSlug] including sources the user does
+/// **not** follow yet — backs the "Explorer de nouvelles sources" block at
+/// the bottom of [ThemeSectionScreen].
+///
+/// The filtering (`isFollowedSource == false`) and dedup against the section
+/// already on screen happens in the UI layer: this keeps the provider
+/// stateless and trivial to test, and avoids coupling it to the current
+/// `fluxContinuProvider` snapshot.
+final themeDiscoveryProvider =
+    FutureProvider.family.autoDispose<List<Content>, String>(
+  (ref, themeSlug) async {
+    final repo = ref.watch(feedRepositoryProvider);
+    final resp = await repo.getFeed(
+      theme: themeSlug,
+      includeUnfollowed: true,
+      page: 1,
+      limit: 20,
+    );
+    return resp.items;
+  },
+);

--- a/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
@@ -9,14 +9,16 @@ import '../models/flux_continu_models.dart';
 import '../providers/flux_continu_provider.dart';
 import '../widgets/flux_continu_article_card.dart';
 import '../widgets/section_banner.dart';
+import '../widgets/theme_detail_footer.dart';
 
 /// Full-page view of a [DigestTopicSection] (Actus du jour, Bonnes Nouvelles).
 ///
 /// Renders the section's hero banner and every topic's lead article. Mirrors
 /// [ThemeSectionScreen] visually so the dedicated-page UX is consistent
 /// across all Tournée sections. The digest payload is bounded (no infinite
-/// scroll) so we render the full list directly.
-class DigestSectionScreen extends ConsumerWidget {
+/// scroll) so we render the full list directly, then attach a
+/// [ThemeDetailFooter] with "Sujet suivant" / "Retour à la Tournée".
+class DigestSectionScreen extends ConsumerStatefulWidget {
   final String sectionKeyValue;
 
   /// Snapshot captured at navigation time. Used as the immediate render
@@ -30,25 +32,43 @@ class DigestSectionScreen extends ConsumerWidget {
     this.initialSection,
   });
 
-  DigestTopicSection? _resolveSection(WidgetRef ref) {
+  @override
+  ConsumerState<DigestSectionScreen> createState() =>
+      _DigestSectionScreenState();
+}
+
+class _DigestSectionScreenState extends ConsumerState<DigestSectionScreen> {
+  DigestTopicSection? _resolveSection() {
     final state = ref.watch(fluxContinuProvider).valueOrNull;
-    if (state == null) return initialSection;
+    if (state == null) return widget.initialSection;
     for (final s in state.sections) {
-      if (s is DigestTopicSection && sectionKey(s) == sectionKeyValue) {
+      if (s is DigestTopicSection && sectionKey(s) == widget.sectionKeyValue) {
         return s;
       }
     }
-    return initialSection;
+    return widget.initialSection;
   }
 
   void _openArticle(BuildContext context, DigestItem article) {
     context.push('${RoutePaths.fluxContinu}/content/${article.contentId}');
   }
 
+  void _onBackToTournee() {
+    Navigator.of(context).maybePop();
+  }
+
+  void _onTapNextSection(FluxSection next) {
+    final key = Uri.encodeComponent(sectionKey(next));
+    final path = next is FeedThemeSection
+        ? '${RoutePaths.fluxContinu}/theme/$key'
+        : '${RoutePaths.fluxContinu}/section/$key';
+    context.pushReplacement(path, extra: next);
+  }
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final section = _resolveSection(ref);
+    final section = _resolveSection();
     return Scaffold(
       backgroundColor: colors.backgroundPrimary,
       appBar: AppBar(
@@ -77,37 +97,53 @@ class DigestSectionScreen extends ConsumerWidget {
                 style: TextStyle(color: colors.textSecondary),
               ),
             )
-          : CustomScrollView(
-              physics: const AlwaysScrollableScrollPhysics(),
-              slivers: [
-                SliverToBoxAdapter(
-                  child: SectionBanner(
-                    title: section.label,
-                    accent: section.accent,
-                    blurb: section.blurb,
-                    illustrationAsset: section.illustrationAsset,
-                  ),
-                ),
-                SliverList(
-                  delegate: SliverChildBuilderDelegate(
-                    (context, index) {
-                      final topic = section.topics[index];
-                      final lead = pickTopicLead(topic);
-                      return FluxContinuArticleCard(
-                        article: lead,
-                        isEssentiel:
-                            section.kind == SectionKind.essentiel,
-                        pressReviewCount: topic.perspectiveCount,
-                        perspectiveSources: topic.perspectiveSources,
-                        onTap: () => _openArticle(context, lead),
-                      );
-                    },
-                    childCount: section.topics.length,
-                  ),
-                ),
-                const SliverToBoxAdapter(child: SizedBox(height: 60)),
-              ],
-            ),
+          : _buildBody(section),
+    );
+  }
+
+  Widget _buildBody(DigestTopicSection section) {
+    final state = ref.watch(fluxContinuProvider).valueOrNull;
+    final next = state == null
+        ? null
+        : nextSectionAfter(state.sections, widget.sectionKeyValue);
+    return CustomScrollView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      slivers: [
+        SliverToBoxAdapter(
+          child: SectionBanner(
+            title: section.label,
+            accent: section.accent,
+            blurb: section.blurb,
+            illustrationAsset: section.illustrationAsset,
+          ),
+        ),
+        SliverList(
+          delegate: SliverChildBuilderDelegate(
+            (context, index) {
+              final topic = section.topics[index];
+              final lead = pickTopicLead(topic);
+              return FluxContinuArticleCard(
+                article: lead,
+                isEssentiel: section.kind == SectionKind.essentiel,
+                pressReviewCount: topic.perspectiveCount,
+                perspectiveSources: topic.perspectiveSources,
+                onTap: () => _openArticle(context, lead),
+              );
+            },
+            childCount: section.topics.length,
+          ),
+        ),
+        SliverToBoxAdapter(
+          child: ThemeDetailFooter(
+            sectionLabel: section.label,
+            nextSection: next,
+            onTapBackToTournee: _onBackToTournee,
+            onTapNextSection:
+                next == null ? null : () => _onTapNextSection(next),
+          ),
+        ),
+        const SliverToBoxAdapter(child: SizedBox(height: 40)),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
@@ -1,26 +1,37 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../feed/models/content_model.dart';
+import '../../feed/providers/feed_provider.dart';
+import '../../feed/widgets/feed_carousel.dart';
 import '../models/flux_continu_models.dart';
 import '../providers/flux_continu_provider.dart';
+import '../providers/theme_discovery_provider.dart';
 import '../widgets/flux_continu_article_card.dart';
 import '../widgets/section_banner.dart';
+import '../widgets/theme_detail_footer.dart';
 
 /// Distance to the bottom (in px) at which we trigger the next page of
 /// articles for the current theme. Mirrors the threshold used on the main
 /// Flux Continu screen so the feel of the infinite scroll is identical.
 const double _kLoadMoreLeadingPx = 800.0;
 
+/// Cap on the number of "Explorer de nouvelles sources" articles surfaced.
+/// Past 6 the block stops being a discovery tease and starts to feel like a
+/// secondary feed — kept short on purpose.
+const int _kDiscoveryItemCap = 6;
+
 /// Full-page view of a Tournée du jour theme section (a `FeedThemeSection`).
 ///
 /// Surfaces the same hero banner as the inline section + the complete list of
-/// articles with infinite scroll. Reuses [fluxContinuProvider.loadMoreTheme]
-/// so any new article loaded here also propagates back to the main feed when
-/// the user returns.
+/// articles with infinite scroll. Once the personalized feed is exhausted
+/// (`!section.hasMore`), the page renders a closing block: theme-filtered
+/// editorial carousels, an "Explorer de nouvelles sources" discovery list,
+/// and a [ThemeDetailFooter] with "Sujet suivant" / "Retour à la Tournée".
 class ThemeSectionScreen extends ConsumerStatefulWidget {
   final String sectionKeyValue;
 
@@ -89,6 +100,41 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
     );
   }
 
+  void _onBackToTournee() {
+    Navigator.of(context).maybePop();
+  }
+
+  void _onTapNextSection(FluxSection next) {
+    final key = Uri.encodeComponent(sectionKey(next));
+    final path = next is FeedThemeSection
+        ? '${RoutePaths.fluxContinu}/theme/$key'
+        : '${RoutePaths.fluxContinu}/section/$key';
+    // pushReplacement so chaining "Sujet suivant" doesn't stack N detail pages.
+    // The back arrow always falls back to the Tournée.
+    context.pushReplacement(path, extra: next);
+  }
+
+  /// Builds a carousel restricted to items tagged with [themeSlug] (either
+  /// via [Content.topics] or via the source's macro-theme). Returns `null`
+  /// when fewer than 2 items match — single-item carousels feel like padding
+  /// in this context.
+  FeedCarouselData? _filterCarousel(FeedCarouselData carousel, String themeSlug) {
+    final filtered = <Content>[];
+    final filteredBadges = <CarouselItemBadge>[];
+    for (var i = 0; i < carousel.items.length; i++) {
+      final item = carousel.items[i];
+      final matches = item.topics.contains(themeSlug) ||
+          item.source.theme == themeSlug;
+      if (!matches) continue;
+      filtered.add(item);
+      if (i < carousel.badges.length) {
+        filteredBadges.add(carousel.badges[i]);
+      }
+    }
+    if (filtered.length < 2) return null;
+    return carousel.copyWith(items: filtered, badges: filteredBadges);
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
@@ -124,80 +170,168 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
                 style: TextStyle(color: colors.textSecondary),
               ),
             )
-          : CustomScrollView(
-              controller: _scroll,
-              physics: const AlwaysScrollableScrollPhysics(),
-              slivers: [
-                SliverToBoxAdapter(
-                  child: SectionBanner(
-                    title: section.label,
-                    accent: section.accent,
-                    blurb: section.blurb,
-                    illustrationAsset: section.illustrationAsset,
-                  ),
-                ),
-                SliverList(
-                  delegate: SliverChildBuilderDelegate(
-                    (context, index) {
-                      final item = section.items[index];
-                      return FluxContinuArticleCard(
-                        article: item,
-                        onTap: () => _openArticle(context, item),
-                      );
-                    },
-                    childCount: section.items.length,
-                  ),
-                ),
-                SliverToBoxAdapter(
-                  child: _Footer(section: section),
-                ),
-                const SliverToBoxAdapter(
-                  child: SizedBox(height: 60),
-                ),
-              ],
+          : _buildBody(section),
+    );
+  }
+
+  Widget _buildBody(FeedThemeSection section) {
+    final scrollExhausted = !section.hasMore;
+    final themeSlug = section.themeSlug;
+
+    return CustomScrollView(
+      controller: _scroll,
+      physics: const AlwaysScrollableScrollPhysics(),
+      slivers: [
+        SliverToBoxAdapter(
+          child: SectionBanner(
+            title: section.label,
+            accent: section.accent,
+            blurb: section.blurb,
+            illustrationAsset: section.illustrationAsset,
+          ),
+        ),
+        SliverList(
+          delegate: SliverChildBuilderDelegate(
+            (context, index) {
+              final item = section.items[index];
+              return FluxContinuArticleCard(
+                article: item,
+                onTap: () => _openArticle(context, item),
+              );
+            },
+            childCount: section.items.length,
+          ),
+        ),
+        if (!scrollExhausted)
+          SliverToBoxAdapter(
+            child: _LoadingMoreIndicator(visible: section.isLoadingMore),
+          ),
+        if (scrollExhausted && themeSlug != null)
+          ..._buildThemeCarousels(section, themeSlug),
+        if (scrollExhausted && themeSlug != null)
+          ..._buildDiscoverySection(section, themeSlug),
+        if (scrollExhausted) _buildFooterSliver(section),
+        const SliverToBoxAdapter(child: SizedBox(height: 40)),
+      ],
+    );
+  }
+
+  List<Widget> _buildThemeCarousels(
+    FeedThemeSection section,
+    String themeSlug,
+  ) {
+    final feed = ref.watch(feedProvider).valueOrNull;
+    final carousels = feed?.carousels ?? const <FeedCarouselData>[];
+    final filtered = <FeedCarouselData>[];
+    for (final c in carousels) {
+      final f = _filterCarousel(c, themeSlug);
+      if (f != null) filtered.add(f);
+    }
+    if (filtered.isEmpty) return const [];
+
+    return [
+      SliverToBoxAdapter(
+        child: _BlockHeader(label: 'À explorer dans ${section.label}'),
+      ),
+      SliverList(
+        delegate: SliverChildBuilderDelegate(
+          (context, index) => Padding(
+            padding: const EdgeInsets.only(bottom: 16),
+            child: FeedCarousel(
+              data: filtered[index],
+              onArticleTap: (c) => _openArticle(context, c),
             ),
+          ),
+          childCount: filtered.length,
+        ),
+      ),
+    ];
+  }
+
+  List<Widget> _buildDiscoverySection(
+    FeedThemeSection section,
+    String themeSlug,
+  ) {
+    final async = ref.watch(themeDiscoveryProvider(themeSlug));
+    return async.when(
+      data: (items) {
+        final alreadyShownIds = section.items.map((c) => c.id).toSet();
+        final discovery = items
+            .where((c) =>
+                !c.isFollowedSource && !alreadyShownIds.contains(c.id))
+            .take(_kDiscoveryItemCap)
+            .toList(growable: false);
+        if (discovery.isEmpty) return const <Widget>[];
+        return [
+          const SliverToBoxAdapter(
+            child: _BlockHeader(label: 'Explorer de nouvelles sources'),
+          ),
+          SliverList(
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                final article = discovery[index];
+                return FluxContinuArticleCard(
+                  article: article,
+                  onTap: () => _openArticle(context, article),
+                );
+              },
+              childCount: discovery.length,
+            ),
+          ),
+        ];
+      },
+      loading: () => const [
+        SliverToBoxAdapter(
+          child: _BlockHeader(label: 'Explorer de nouvelles sources'),
+        ),
+        SliverToBoxAdapter(child: _DiscoverySkeleton()),
+      ],
+      error: (_, __) => const <Widget>[],
+    );
+  }
+
+  Widget _buildFooterSliver(FeedThemeSection section) {
+    final state = ref.watch(fluxContinuProvider).valueOrNull;
+    final next = state == null
+        ? null
+        : nextSectionAfter(state.sections, widget.sectionKeyValue);
+    return SliverToBoxAdapter(
+      child: ThemeDetailFooter(
+        sectionLabel: section.label,
+        nextSection: next,
+        onTapBackToTournee: _onBackToTournee,
+        onTapNextSection: next == null ? null : () => _onTapNextSection(next),
+      ),
     );
   }
 }
 
-class _Footer extends StatelessWidget {
-  final FeedThemeSection section;
+class _LoadingMoreIndicator extends StatelessWidget {
+  final bool visible;
 
-  const _Footer({required this.section});
+  const _LoadingMoreIndicator({required this.visible});
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final String label;
-    if (section.isLoadingMore) {
-      label = 'Chargement…';
-    } else if (section.hasMore) {
-      label = '';
-    } else {
-      label = 'Plus rien à voir';
-    }
-    if (label.isEmpty) {
-      return const SizedBox(height: 32);
-    }
+    if (!visible) return const SizedBox(height: 32);
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          if (section.isLoadingMore) ...[
-            SizedBox(
-              width: 14,
-              height: 14,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                valueColor:
-                    AlwaysStoppedAnimation<Color>(colors.textSecondary),
-              ),
+          SizedBox(
+            width: 14,
+            height: 14,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              valueColor:
+                  AlwaysStoppedAnimation<Color>(colors.textSecondary),
             ),
-            const SizedBox(width: 8),
-          ],
+          ),
+          const SizedBox(width: 8),
           Text(
-            label,
+            'Chargement…',
             style: TextStyle(
               color: colors.textSecondary,
               fontWeight: FontWeight.w500,
@@ -206,6 +340,54 @@ class _Footer extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _BlockHeader extends StatelessWidget {
+  final String label;
+
+  const _BlockHeader({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 12),
+      child: Text(
+        label,
+        style: GoogleFonts.dmSans(
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+          color: colors.textPrimary,
+        ),
+      ),
+    );
+  }
+}
+
+class _DiscoverySkeleton extends StatelessWidget {
+  const _DiscoverySkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Column(
+      children: List.generate(3, (_) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+          child: Container(
+            height: 88,
+            decoration: BoxDecoration(
+              color: colors.surface,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: Colors.black.withValues(alpha: 0.04),
+              ),
+            ),
+          ),
+        );
+      }),
     );
   }
 }

--- a/apps/mobile/lib/features/flux_continu/widgets/closing_card_v18.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/closing_card_v18.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import '../../../config/theme.dart';
+import 'tournee_cta_buttons.dart';
 
 /// Closing card displayed after the four Flux Continu sections.
 ///
@@ -107,7 +108,7 @@ class ClosingCardV18 extends StatelessWidget {
             const SizedBox(height: 20),
             SizedBox(
               width: double.infinity,
-              child: _PrimaryButton(
+              child: TourneePrimaryButton(
                 label: 'Continuer le feed',
                 onTap: onContinue,
               ),
@@ -116,7 +117,7 @@ class ClosingCardV18 extends StatelessWidget {
               const SizedBox(height: 8),
               SizedBox(
                 width: double.infinity,
-                child: _GhostButton(
+                child: TourneeGhostButton(
                   label: "Refermer pour aujourd'hui",
                   onTap: onClose,
                 ),
@@ -135,74 +136,3 @@ class ClosingCardV18 extends StatelessWidget {
   }
 }
 
-class _PrimaryButton extends StatelessWidget {
-  final String label;
-  final VoidCallback? onTap;
-
-  const _PrimaryButton({required this.label, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      color: const Color(0xFFD35400),
-      borderRadius: BorderRadius.circular(10),
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(10),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-          child: Center(
-            child: Text(
-              label,
-              style: GoogleFonts.dmSans(
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                color: Colors.white,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _GhostButton extends StatelessWidget {
-  final String label;
-  final VoidCallback? onTap;
-
-  const _GhostButton({required this.label, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.facteurColors;
-    return Material(
-      color: Colors.transparent,
-      borderRadius: BorderRadius.circular(10),
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(10),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(10),
-            border: Border.all(
-              color: Colors.black.withValues(alpha: 0.1),
-              width: 1.5,
-            ),
-          ),
-          child: Center(
-            child: Text(
-              label,
-              style: GoogleFonts.dmSans(
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                color: colors.textPrimary,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}

--- a/apps/mobile/lib/features/flux_continu/widgets/theme_detail_footer.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/theme_detail_footer.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../models/flux_continu_models.dart';
+import 'tournee_cta_buttons.dart';
+
+/// Closing block displayed at the very bottom of a Tournée detail screen
+/// (theme or digest "Voir + de…" page) once the scroll is fully exhausted.
+///
+/// Reuses the visual shell of [ClosingCardV18] — light surface card, 16px
+/// radius, subtle drop shadow, Fraunces 22 heading + DM Sans 13 sub — so the
+/// dedicated-page footers feel like a satellite of the main closing card
+/// instead of a foreign element.
+class ThemeDetailFooter extends StatelessWidget {
+  final String sectionLabel;
+  final FluxSection? nextSection;
+  final VoidCallback onTapBackToTournee;
+  final VoidCallback? onTapNextSection;
+
+  const ThemeDetailFooter({
+    super.key,
+    required this.sectionLabel,
+    required this.nextSection,
+    required this.onTapBackToTournee,
+    this.onTapNextSection,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final hasNext = nextSection != null;
+
+    return Container(
+      margin: const EdgeInsets.fromLTRB(18, 24, 18, 24),
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.06),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'Vous avez fait le tour de $sectionLabel',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.fraunces(
+                fontSize: 22,
+                fontWeight: FontWeight.w700,
+                height: 1.15,
+                letterSpacing: -0.4,
+                color: colors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Rien de nouveau dans vos sources aujourd’hui',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.dmSans(
+                fontSize: 13,
+                height: 1.5,
+                color: colors.textSecondary,
+              ),
+            ),
+            const SizedBox(height: 20),
+            TourneePrimaryButton(
+              label: hasNext
+                  ? 'Sujet suivant : ${nextSection!.label} →'
+                  : 'Retour à la Tournée',
+              onTap: hasNext ? onTapNextSection : onTapBackToTournee,
+            ),
+            if (hasNext) ...[
+              const SizedBox(height: 8),
+              TourneeGhostButton(
+                label: 'Retour à la Tournée',
+                onTap: onTapBackToTournee,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/tournee_cta_buttons.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/tournee_cta_buttons.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+
+/// Primary CTA used by the Tournée du jour closing surfaces.
+///
+/// Solid `#D35400` background, DM Sans 13 w600 white label, 10px radius — the
+/// shape pinned by [ClosingCardV18]'s "Continuer le feed" button. Shared so
+/// the new theme/digest detail footers stay visually aligned with the closing
+/// card without duplicating the styling.
+class TourneePrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onTap;
+
+  const TourneePrimaryButton({
+    super.key,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0xFFD35400),
+      borderRadius: BorderRadius.circular(10),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(10),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          child: Center(
+            child: Text(
+              label,
+              textAlign: TextAlign.center,
+              style: GoogleFonts.dmSans(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Outlined ghost CTA companion to [TourneePrimaryButton].
+class TourneeGhostButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onTap;
+
+  const TourneeGhostButton({
+    super.key,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(10),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(10),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: Colors.black.withValues(alpha: 0.1),
+              width: 1.5,
+            ),
+          ),
+          child: Center(
+            child: Text(
+              label,
+              textAlign: TextAlign.center,
+              style: GoogleFonts.dmSans(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: colors.textPrimary,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
+++ b/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
@@ -141,7 +141,7 @@ void main() {
     });
 
     test('isFolded reads from folded map keyed by sectionKey', () {
-      final state = FluxContinuState(folded: {'essentiel': true});
+      const state = FluxContinuState(folded: {'essentiel': true});
       expect(state.isFolded(digestSection(kind: SectionKind.essentiel)), isTrue);
       expect(state.isFolded(digestSection(kind: SectionKind.bonnes)), isFalse);
     });
@@ -262,6 +262,34 @@ void main() {
       const state = FluxContinuState(dismissedIds: {'x'});
       final updated = state.copyWith(isSerene: true);
       expect(updated.dismissedIds, {'x'});
+    });
+  });
+
+  group('nextSectionAfter', () {
+    test('returns the next section after the current one', () {
+      final a = themeSection(slug: 'tech');
+      final b = themeSection(slug: 'climat');
+      final result = nextSectionAfter([a, b], sectionKey(a));
+      expect(result, same(b));
+    });
+
+    test('skips EssentielSection between two theme sections', () {
+      final a = themeSection(slug: 'tech');
+      const essentiel = EssentielSection(articles: []);
+      final b = themeSection(slug: 'climat');
+      final result = nextSectionAfter([a, essentiel, b], sectionKey(a));
+      expect(result, same(b));
+    });
+
+    test('returns null when current section is the last one', () {
+      final a = themeSection(slug: 'tech');
+      final b = themeSection(slug: 'climat');
+      expect(nextSectionAfter([a, b], sectionKey(b)), isNull);
+    });
+
+    test('returns null for an unknown current key', () {
+      final a = themeSection(slug: 'tech');
+      expect(nextSectionAfter([a], 'theme:nope'), isNull);
     });
   });
 }

--- a/apps/mobile/test/features/flux_continu/providers/theme_discovery_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/theme_discovery_provider_test.dart
@@ -1,0 +1,68 @@
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/feed/providers/feed_provider.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart';
+import 'package:facteur/features/flux_continu/providers/theme_discovery_provider.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockFeedRepository extends Mock implements FeedRepository {}
+
+FeedResponse _resp(List<String> ids) {
+  return FeedResponse(
+    items: ids
+        .map((id) => Content(
+              id: id,
+              title: 'title-$id',
+              url: 'https://x.test/$id',
+              contentType: ContentType.article,
+              publishedAt: DateTime(2026, 1, 1),
+              source: Source(id: 's', name: 'S', type: SourceType.article),
+            ))
+        .toList(),
+    pagination: Pagination(page: 1, perPage: 20, total: 0, hasNext: false),
+    carousels: const [],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockFeedRepository feedRepo;
+
+  setUp(() {
+    feedRepo = _MockFeedRepository();
+  });
+
+  test(
+    'themeDiscoveryProvider calls getFeed(theme, includeUnfollowed: true, limit: 20)',
+    () async {
+      when(() => feedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            theme: any(named: 'theme'),
+            includeUnfollowed: any(named: 'includeUnfollowed'),
+          )).thenAnswer((_) async => _resp(['a', 'b']));
+
+      final container = ProviderContainer(
+        overrides: [
+          feedRepositoryProvider.overrideWithValue(feedRepo),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final items = await container.read(
+        themeDiscoveryProvider('tech').future,
+      );
+
+      expect(items.map((c) => c.id), ['a', 'b']);
+      verify(() => feedRepo.getFeed(
+            theme: 'tech',
+            includeUnfollowed: true,
+            page: 1,
+            limit: 20,
+          )).called(1);
+    },
+  );
+}

--- a/apps/mobile/test/features/flux_continu/widgets/theme_detail_footer_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/theme_detail_footer_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
+import 'package:facteur/features/flux_continu/widgets/theme_detail_footer.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [FacteurPalettes.light]),
+    home: Scaffold(body: child),
+  );
+}
+
+FeedThemeSection _section(String label) => FeedThemeSection(
+      kind: SectionKind.theme,
+      label: label,
+      accent: const Color(0xFF2C3E50),
+      coreVisibleCount: 2,
+      themeSlug: label.toLowerCase(),
+      items: const <Content>[],
+    );
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('ThemeDetailFooter', () {
+    testWidgets('without nextSection shows only the "Retour" primary CTA',
+        (tester) async {
+      var backTaps = 0;
+      await tester.pumpWidget(_wrap(
+        ThemeDetailFooter(
+          sectionLabel: 'Tech',
+          nextSection: null,
+          onTapBackToTournee: () => backTaps++,
+        ),
+      ));
+
+      expect(find.text('Vous avez fait le tour de Tech'), findsOneWidget);
+      expect(find.text('Retour à la Tournée'), findsOneWidget);
+      expect(find.textContaining('Sujet suivant'), findsNothing);
+
+      await tester.tap(find.text('Retour à la Tournée'));
+      expect(backTaps, 1);
+    });
+
+    testWidgets('with nextSection shows both CTAs and routes taps correctly',
+        (tester) async {
+      var backTaps = 0;
+      var nextTaps = 0;
+      final next = _section('Climat');
+
+      await tester.pumpWidget(_wrap(
+        ThemeDetailFooter(
+          sectionLabel: 'Tech',
+          nextSection: next,
+          onTapBackToTournee: () => backTaps++,
+          onTapNextSection: () => nextTaps++,
+        ),
+      ));
+
+      expect(find.text('Sujet suivant : Climat →'), findsOneWidget);
+      expect(find.text('Retour à la Tournée'), findsOneWidget);
+
+      await tester.tap(find.text('Sujet suivant : Climat →'));
+      expect(nextTaps, 1);
+      expect(backTaps, 0);
+
+      await tester.tap(find.text('Retour à la Tournée'));
+      expect(backTaps, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Quoi
Ajoute un footer de fermeture (`ThemeDetailFooter`) en bas des pages détail Thème + Digest ("Vous avez fait le tour de…" avec CTA "Sujet suivant" / "Retour à la Tournée").

- Extrait `ThemeDetailFooter`, `TourneePrimaryButton`, `TourneeGhostButton` depuis `closing_card_v18.dart` (style hérité : terracotta #D35400, radius 10, DM Sans 13).
- Ajoute `themeDiscoveryProvider` (FutureProvider.family.autoDispose) qui fetche les articles du thème en incluant les sources non-suivies — back du bloc "Explorer de nouvelles sources" sur la page Thème quand le feed perso est épuisé.
- Helper `nextSectionAfter(sections, currentKey)` ajouté dans `flux_continu_models.dart` pour décider si le CTA "Sujet suivant" est affiché.
- Refactor de `theme_section_screen.dart` (carrousels filtrés par thème + bloc discovery + footer) et `digest_section_screen.dart` (passage en `ConsumerStatefulWidget`, branchement du footer).

## Pourquoi
Permettre à l'utilisateur de continuer sa découverte depuis le bas d'une page Thème ou Digest (sujet suivant naturel ou retour Tournée) au lieu d'une fin abrupte, et capitaliser sur le pattern visuel déjà validé de `ClosingCardV18` sans le dupliquer.

## Comment ça a été vérifié
- [x] `flutter test test/features/flux_continu/` — 88/88 OK (dont 7 nouveaux tests : `theme_discovery_provider_test`, `theme_detail_footer_test`, et 2 cas `nextSectionAfter` dans `flux_continu_models_test`)
- [x] `flutter test` suite complète — 684 passés ; 36 échecs **pré-existants** sur `main` (placeholders `fail('Test not implemented')` dans `digest/`, `feed/`, et le smoke test `widget_test.dart` qui n'initialise pas Hive)
- [x] `flutter analyze lib/features/flux_continu/ test/features/flux_continu/` — pas de regression sur les fichiers touchés (lint `prefer_const_constructors` corrigé sur le test ajouté)
- [x] Skill `/simplify` passée — 3 reviewers (reuse / qualité / efficacité) ; findings examinés, code conservé tel quel (les boutons Tournée sont volontairement décorrélés des `PrimaryButton`/`SecondaryButton` partagés pour matcher le style hérité de `ClosingCardV18`)

## Zones à risque
- Refactor de `closing_card_v18.dart` (les anciens `_PrimaryButton` / `_GhostButton` privés sont remplacés par les nouveaux widgets partagés) — vérifier visuellement le rendu du moment de fermeture principal.
- Le `themeDiscoveryProvider` appelle `getFeed(theme: …, includeUnfollowed: true)` : s'assurer côté backend que ce param ne fait pas exploser la latence sur les thèmes avec beaucoup de sources non-suivies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)