### PR TITLE
polish(tournée): sticky tab bar, section footer, essentiel hi-fi card — pass 2

### DIFF
--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -59,4 +59,3 @@ app.*.map.json
 *.exe
 *.dmg
 .claude/scheduled_tasks.lock
-.claude/scheduled_tasks.lock

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -58,3 +58,5 @@ app.*.map.json
 *.AppImage
 *.exe
 *.dmg
+.claude/scheduled_tasks.lock
+.claude/scheduled_tasks.lock

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -48,7 +48,7 @@ const double _kStickyThreshold = 60.0;
 /// Vertical offset the sticky bar consumes — used as a landing buffer
 /// when scrolling a section into view so its banner doesn't disappear
 /// behind the bar.
-const double _kStickyBarHeight = 86.0;
+const double _kStickyBarHeight = 100.0;
 
 /// Distance to the bottom (in px) before we trigger the next feed page.
 const double _kLoadMoreLeadingPx = 800.0;
@@ -327,7 +327,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   /// Folds the Essentiel card then scrolls to [targetIndex]. The 50ms delay
   /// lets the fold settle so the scroll target's measured position is the
   /// post-fold one. Used by both "Tout l'essentiel" (scroll to Actus du
-  /// jour) and "Je veux tout voir ⬇️" (scroll to Explorer banner via the
+  /// jour) and "Tous mes articles ↓" (scroll to Explorer banner via the
   /// `targetIndex == _sectionKeys.length` branch of [_scrollToSection]).
   Future<void> _foldEssentielAndScroll(
     EssentielSection essentiel,
@@ -348,7 +348,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     await _foldEssentielAndScroll(essentiel, next);
   }
 
-  /// "Je veux tout voir ⬇️" action of the Essentiel hi-fi card: folds the
+  /// "Tous mes articles ↓" action of the Essentiel hi-fi card: folds the
   /// card then scrolls all the way down to the "Explorer" banner. Reuses the
   /// `index >= _sectionKeys.length` branch of [_scrollToSection], which
   /// targets [_explorerKey] directly.

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -79,9 +79,9 @@ class EssentielHiFiCard extends StatelessWidget {
                 onTap: () => onTapArticle(lead),
               ),
             for (final a in remaining) ...[
-              const SizedBox(height: FacteurSpacing.space3),
+              const SizedBox(height: FacteurSpacing.space2),
               const _Hairline(),
-              const SizedBox(height: FacteurSpacing.space3),
+              const SizedBox(height: FacteurSpacing.space2),
               _MediumTile(article: a, onTap: () => onTapArticle(a)),
             ],
             const SizedBox(height: FacteurSpacing.space4),
@@ -134,8 +134,6 @@ class _Header extends StatelessWidget {
                 style: FacteurTypography.bodySmall(colors.textSecondary).copyWith(
                   height: 1.35,
                 ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
               ),
             ],
           ),
@@ -344,7 +342,7 @@ class _MediumTile extends StatelessWidget {
         onTap: onTap,
         borderRadius: BorderRadius.circular(FacteurRadius.small),
         child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 4),
+          padding: const EdgeInsets.symmetric(vertical: 2),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -384,11 +382,6 @@ class _MediumTile extends StatelessWidget {
                   height: 1.3,
                   color: colors.textPrimary,
                 ),
-              ),
-              const SizedBox(height: 2),
-              Text(
-                _relativeTime(article.publishedAt),
-                style: FacteurTypography.labelSmall(colors.textTertiary),
               ),
             ],
           ),
@@ -523,11 +516,6 @@ class _SourceRow extends StatelessWidget {
             style: FacteurTypography.labelSmall(colors.textTertiary),
           ),
         ),
-        const SizedBox(width: FacteurSpacing.space2),
-        Text(
-          '·  ${_relativeTime(article.publishedAt)}',
-          style: FacteurTypography.labelSmall(colors.textTertiary),
-        ),
       ],
     );
   }
@@ -568,7 +556,7 @@ class _Footer extends StatelessWidget {
               foregroundColor: colors.textTertiary,
             ),
             child: Text(
-              'Je veux tout voir ⬇️',
+              'Tous mes articles ↓',
               style: FacteurTypography.labelLarge(colors.textTertiary),
             ),
           )
@@ -628,14 +616,3 @@ String _sectionLabelFor(EssentielArticle article) {
   return 'Actus';
 }
 
-/// Horodatage relatif court pour la carte ("il y a 2h", "ce matin", "hier").
-/// Garde un format lisible et stable ; les valeurs sont des approximations
-/// (granularité heure pour <24h, jour au-delà).
-String _relativeTime(DateTime publishedAt) {
-  final delta = DateTime.now().difference(publishedAt);
-  if (delta.inMinutes < 1) return 'à l’instant';
-  if (delta.inMinutes < 60) return 'il y a ${delta.inMinutes} min';
-  if (delta.inHours < 24) return 'il y a ${delta.inHours}h';
-  if (delta.inDays < 2) return 'hier';
-  return 'il y a ${delta.inDays} j';
-}

--- a/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
@@ -165,6 +165,17 @@ class _NextSectionButtonState extends State<NextSectionButton>
     super.dispose();
   }
 
+  void _handleTap() {
+    if (!_localMarked && !widget.isMarked) {
+      setState(() => _localMarked = true);
+      if (_ctrl.status != AnimationStatus.forward &&
+          _ctrl.status != AnimationStatus.completed) {
+        _ctrl.forward(from: 0);
+      }
+    }
+    widget.onTap?.call();
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
@@ -176,17 +187,7 @@ class _NextSectionButtonState extends State<NextSectionButton>
       color: Colors.transparent,
       borderRadius: BorderRadius.circular(12),
       child: InkWell(
-        onTap: widget.onTap == null
-            ? null
-            : () {
-                if (!_localMarked && !widget.isMarked) {
-                  setState(() => _localMarked = true);
-                  if (_ctrl.status != AnimationStatus.forward) {
-                    _ctrl.forward(from: 0);
-                  }
-                }
-                widget.onTap?.call();
-              },
+        onTap: widget.onTap == null ? null : _handleTap,
         borderRadius: BorderRadius.circular(12),
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 220),

--- a/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
@@ -2,18 +2,16 @@ import 'package:flutter/material.dart';
 
 import '../../../config/theme.dart';
 
-/// "Voir tout {thème}" — opens the dedicated theme page (slide-from-right)
+/// "Plus d'articles" — opens the dedicated theme page (slide-from-right)
 /// instead of paginating in-place. Visual cousin of [PlusDeButton] so the
 /// bottom-of-section CTA family stays consistent.
 class SeeAllSectionButton extends StatelessWidget {
-  final String sectionLabel;
   final int hiddenCount;
   final bool hasMore;
   final VoidCallback onTap;
 
   const SeeAllSectionButton({
     super.key,
-    required this.sectionLabel,
     required this.hiddenCount,
     required this.hasMore,
     required this.onTap,
@@ -24,8 +22,8 @@ class SeeAllSectionButton extends StatelessWidget {
     final colors = context.facteurColors;
     final countSuffix = hasMore ? '+' : '';
     final label = hiddenCount > 0
-        ? 'Voir tout $sectionLabel (+$hiddenCount$countSuffix)'
-        : 'Voir tout $sectionLabel';
+        ? 'Plus d\'articles (+$hiddenCount$countSuffix)'
+        : 'Plus d\'articles';
     return _ButtonShell(
       onTap: onTap,
       child: Row(
@@ -109,9 +107,11 @@ class PlusDeButton extends StatelessWidget {
 
 /// "Sujet suivant ↓" — bottom-of-section CTA that marks the section as
 /// consumed for the next session and scrolls smoothly to the next section.
-/// When [isMarked] is true, the button flips to a full-green "Terminé ✓"
+/// When [isMarked] is true, the button flips to a full-green "Lu ✔"
 /// state with a short scale-pop on the check icon (transition false→true
 /// only — restoring a marked session at cold start must not replay it).
+/// The flip is also applied optimistically the moment the user taps,
+/// before the provider propagates [isMarked].
 class NextSectionButton extends StatefulWidget {
   final bool isMarked;
   final VoidCallback? onTap;
@@ -130,6 +130,9 @@ class _NextSectionButtonState extends State<NextSectionButton>
     with SingleTickerProviderStateMixin {
   late final AnimationController _ctrl;
   late final Animation<double> _scale;
+  // Optimistic flip: tapping the button must show the "Lu ✔" state on the
+  // very next frame even if the provider takes a tick to propagate isMarked.
+  bool _localMarked = false;
 
   @override
   void initState() {
@@ -148,7 +151,11 @@ class _NextSectionButtonState extends State<NextSectionButton>
   void didUpdateWidget(covariant NextSectionButton old) {
     super.didUpdateWidget(old);
     if (!old.isMarked && widget.isMarked) {
-      _ctrl.forward(from: 0);
+      if (!_localMarked &&
+          _ctrl.status != AnimationStatus.forward &&
+          _ctrl.status != AnimationStatus.completed) {
+        _ctrl.forward(from: 0);
+      }
     }
   }
 
@@ -161,15 +168,25 @@ class _NextSectionButtonState extends State<NextSectionButton>
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final marked = widget.isMarked;
+    final marked = widget.isMarked || _localMarked;
     final foreground = marked ? Colors.white : colors.textSecondary;
-    final label = marked ? 'Terminé' : 'Sujet suivant';
+    final label = marked ? 'Lu ✔' : 'Sujet suivant';
     final icon = marked ? Icons.check : Icons.arrow_downward;
     return Material(
       color: Colors.transparent,
       borderRadius: BorderRadius.circular(12),
       child: InkWell(
-        onTap: widget.onTap,
+        onTap: widget.onTap == null
+            ? null
+            : () {
+                if (!_localMarked && !widget.isMarked) {
+                  setState(() => _localMarked = true);
+                  if (_ctrl.status != AnimationStatus.forward) {
+                    _ctrl.forward(from: 0);
+                  }
+                }
+                widget.onTap?.call();
+              },
         borderRadius: BorderRadius.circular(12),
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 220),
@@ -177,11 +194,10 @@ class _NextSectionButtonState extends State<NextSectionButton>
           width: double.infinity,
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
           decoration: BoxDecoration(
-            color: marked ? colors.success : Colors.transparent,
+            color: marked
+                ? colors.success
+                : colors.surfaceElevated.withValues(alpha: 0.5),
             borderRadius: BorderRadius.circular(12),
-            border: marked
-                ? null
-                : Border.all(color: colors.border, width: 1),
           ),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -39,7 +39,7 @@ class SectionBlock extends StatelessWidget {
   /// next section ("Actus du jour"). Ignored for other section types.
   final VoidCallback? onTapExploreAll;
 
-  /// "Je veux tout voir ⬇️" action of the [EssentielSection] hi-fi card.
+  /// "Tous mes articles ↓" action of the [EssentielSection] hi-fi card.
   /// Wired by the flux_continu screen to fold the Essentiel card AND scroll
   /// all the way down to the "Explorer" banner. Ignored for other section
   /// types.
@@ -182,7 +182,6 @@ class SectionBlock extends StatelessWidget {
         onSeeAll != null &&
         (hiddenCount > 0 || section.hasMore)) {
       return SeeAllSectionButton(
-        sectionLabel: section.label,
         hiddenCount: hiddenCount > 0 ? hiddenCount : 0,
         hasMore: section.hasMore,
         onTap: onSeeAll!,
@@ -191,10 +190,9 @@ class SectionBlock extends StatelessWidget {
     if (section is DigestTopicSection &&
         onSeeAll != null &&
         section.hasOverflow) {
-      return PlusDeButton(
-        sectionLabel: section.label,
-        isOpen: false,
+      return SeeAllSectionButton(
         hiddenCount: hiddenCount > 0 ? hiddenCount : 0,
+        hasMore: false,
         onTap: onSeeAll!,
       );
     }
@@ -302,10 +300,13 @@ class _SectionFooterRow extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
       child: Row(
         children: [
-          if (voirPlus != null) Flexible(child: voirPlus!) else const Spacer(),
+          if (voirPlus != null)
+            Expanded(flex: 2, child: voirPlus!)
+          else
+            const Spacer(),
           if (voirPlus != null && sujetSuivant != null)
             const SizedBox(width: 8),
-          if (sujetSuivant != null) Flexible(child: sujetSuivant!),
+          if (sujetSuivant != null) Expanded(flex: 1, child: sujetSuivant!),
         ],
       ),
     );

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -65,7 +65,7 @@ class StickyTabBar extends StatelessWidget {
             controller: tabsController,
           ),
           SizedBox(
-            height: 4,
+            height: 6,
             child: CustomPaint(
               painter: _ProgressPainter(
                 progress: progress.clamp(0.0, 1.0),
@@ -109,13 +109,13 @@ class StickyHead extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 6),
       child: Row(
         children: [
           Text(
             title,
             style: GoogleFonts.fraunces(
-              fontSize: 14,
+              fontSize: 21,
               fontWeight: FontWeight.w700,
               color: colors.textPrimary,
             ),
@@ -142,11 +142,11 @@ class _TabsRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: 44,
+      height: 56,
       child: ListView.separated(
         controller: controller,
         scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.fromLTRB(10, 4, 10, 8),
+        padding: const EdgeInsets.fromLTRB(12, 6, 12, 12),
         itemCount: tabs.length,
         separatorBuilder: (_, __) => const SizedBox(width: 2),
         itemBuilder: (context, i) {
@@ -200,9 +200,9 @@ class _Tab extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 Container(
-                  width: 6,
-                  height: 6,
-                  margin: const EdgeInsets.only(right: 6),
+                  width: 9,
+                  height: 9,
+                  margin: const EdgeInsets.only(right: 8),
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
                     color: dotColor,
@@ -211,7 +211,7 @@ class _Tab extends StatelessWidget {
                 Text(
                   tab.label,
                   style: GoogleFonts.dmSans(
-                    fontSize: 12.5,
+                    fontSize: 16,
                     fontWeight: FontWeight.w600,
                     color: labelColor,
                   ),
@@ -220,7 +220,7 @@ class _Tab extends StatelessWidget {
                   const SizedBox(width: 4),
                   Icon(
                     Icons.check_rounded,
-                    size: 13,
+                    size: 18,
                     color: labelColor,
                     semanticLabel: 'lu',
                   ),
@@ -230,10 +230,10 @@ class _Tab extends StatelessWidget {
           ),
           if (isActive)
             Positioned(
-              left: 8,
-              right: 8,
+              left: 10,
+              right: 10,
               bottom: 0,
-              height: 2,
+              height: 3,
               child: Container(
                 decoration: BoxDecoration(
                   color: tab.accent,
@@ -272,7 +272,7 @@ class _ProgressPainter extends CustomPainter {
     final clipped = Rect.fromLTWH(0, 0, size.width * progress, size.height);
     final glowPaint = Paint()
       ..color = glow
-      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 4);
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 5);
     canvas.drawRect(clipped, glowPaint);
     final fillPaint = Paint()
       ..shader = LinearGradient(

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -146,7 +146,7 @@ void main() {
       expect(find.text('Tout l’essentiel'), findsNothing);
     });
 
-    testWidgets('"Je veux tout voir ⬇️" button fires onTapSeeAllDown when wired',
+    testWidgets('"Tous mes articles ↓" button fires onTapSeeAllDown when wired',
         (tester) async {
       var seeAllDownTaps = 0;
       await tester.pumpWidget(_wrap(
@@ -159,8 +159,8 @@ void main() {
         ),
       ));
 
-      expect(find.text('Je veux tout voir ⬇️'), findsOneWidget);
-      await tester.tap(find.text('Je veux tout voir ⬇️'));
+      expect(find.text('Tous mes articles ↓'), findsOneWidget);
+      await tester.tap(find.text('Tous mes articles ↓'));
       await tester.pumpAndSettle();
       expect(seeAllDownTaps, 1);
     });

--- a/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/digest/models/digest_models.dart';
 import 'package:facteur/features/feed/models/content_model.dart';
 import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
 import 'package:facteur/features/flux_continu/widgets/flux_continu_article_card.dart';
@@ -25,6 +26,26 @@ Content _content(String id) {
     contentType: ContentType.article,
     publishedAt: DateTime(2026, 1, 1),
     source: Source(id: 's', name: 'S', type: SourceType.article),
+  );
+}
+
+DigestTopicSection _digestTopicSection({
+  int topics = 5,
+  int coreVisibleCount = 3,
+}) {
+  return DigestTopicSection(
+    kind: SectionKind.bonnes,
+    label: 'Actus du jour',
+    accent: const Color(0xFFD35400),
+    coreVisibleCount: coreVisibleCount,
+    topics: List.generate(
+      topics,
+      (i) => DigestTopic(
+        topicId: 't$i',
+        label: 'Topic $i',
+        articles: [DigestItem(contentId: 'c$i', title: 'A$i')],
+      ),
+    ),
   );
 }
 
@@ -80,7 +101,7 @@ void main() {
       ));
 
       // 7 items - 3 visible = +4 hidden.
-      expect(find.text('Voir tout Tech (+4)'), findsOneWidget);
+      expect(find.text('Plus d\'articles (+4)'), findsOneWidget);
     });
 
     testWidgets(
@@ -113,8 +134,27 @@ void main() {
         ),
       ));
 
-      // hiddenCount = 0 → label falls back to "Voir tout Tech" (no suffix).
-      expect(find.text('Voir tout Tech'), findsOneWidget);
+      // hiddenCount = 0 → label falls back to "Plus d'articles" (no suffix).
+      expect(find.text('Plus d\'articles'), findsOneWidget);
+    });
+  });
+
+  group('SectionBlock — DigestTopicSection CTA', () {
+    testWidgets(
+        'DigestTopicSection with onSeeAll uses SeeAllSectionButton (→) instead '
+        'of PlusDeButton (↓)', (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _digestTopicSection(topics: 5, coreVisibleCount: 3),
+          isOpen: false,
+          onToggleMore: () {},
+          onTapArticle: (_, __) {},
+          onSeeAll: () {},
+        ),
+      ));
+
+      expect(find.byType(SeeAllSectionButton), findsOneWidget);
+      expect(find.byType(PlusDeButton), findsNothing);
     });
   });
 
@@ -151,7 +191,7 @@ void main() {
       expect(find.byType(NextSectionButton), findsNothing);
     });
 
-    testWidgets('switches to "Terminé" non-interactive state when '
+    testWidgets('switches to "Lu ✔" non-interactive state when '
         'isMarkedForNextSession is true', (tester) async {
       var taps = 0;
       await tester.pumpWidget(_wrap(
@@ -166,11 +206,10 @@ void main() {
         ),
       ));
 
-      expect(find.text('Terminé'), findsOneWidget);
+      expect(find.text('Lu ✔'), findsOneWidget);
       expect(find.text('Sujet suivant'), findsNothing);
-      expect(find.text('Lu'), findsNothing);
 
-      // Tap should be a no-op.
+      // Tap should be a no-op (parent passes onTap=null when already marked).
       await tester.tap(find.byType(NextSectionButton));
       await tester.pump();
       expect(taps, 0);
@@ -202,7 +241,7 @@ void main() {
       );
     });
 
-    testWidgets('Terminé state has success background', (tester) async {
+    testWidgets('Lu ✔ state has success background', (tester) async {
       await tester.pumpWidget(_wrap(
         SectionBlock(
           section: _themeSection(),
@@ -223,6 +262,38 @@ void main() {
       );
       final decoration = container.decoration as BoxDecoration;
       expect(decoration.color, FacteurPalettes.light.success);
+    });
+
+    testWidgets(
+        'optimistic flip: tap shows "Lu ✔" + success background on the next '
+        'frame even when isMarkedForNextSession stays false', (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(),
+          isOpen: false,
+          onToggleMore: () {},
+          onTapArticle: (_, __) {},
+          onSeeAll: () {},
+          isMarkedForNextSession: false,
+          onNextSection: () {},
+        ),
+      ));
+      expect(find.text('Sujet suivant'), findsOneWidget);
+
+      await tester.tap(find.byType(NextSectionButton));
+      await tester.pump();
+
+      expect(find.text('Lu ✔'), findsOneWidget);
+      final container = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byType(NextSectionButton),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      expect(
+        (container.decoration as BoxDecoration).color,
+        FacteurPalettes.light.success,
+      );
     });
   });
 
@@ -261,6 +332,13 @@ void main() {
       final voirPlusLeft = tester.getTopLeft(voirPlus).dx;
       final sujetLeft = tester.getTopLeft(sujetSuivant).dx;
       expect(voirPlusLeft < sujetLeft, isTrue);
+
+      // 2:1 ratio — "Plus d'articles" must be visibly wider than "Sujet suivant".
+      expect(
+        tester.getSize(voirPlus).width > tester.getSize(sujetSuivant).width,
+        isTrue,
+        reason: 'Plus d\'articles doit être ~2x plus large que Sujet suivant',
+      );
     });
 
     testWidgets('tap fires onNextSection exactly once when not marked',


### PR DESCRIPTION
## Quoi

Deuxième passe de polish sur la Tournée / Flux Continu :
- **StickyTabBar** : police plus grande (14→21px titre, 12.5→16px tabs), dot 6→9px, underline 2→3px, hauteur row 44→56px, progress bar 4→6px
- **SeeAllSectionButton** : label unifié "Plus d'articles" (suppression du paramètre `sectionLabel`)
- **NextSectionButton** : flip optimiste "Lu ✔" dès le frame du tap (avant propagation Riverpod), extract `_handleTap()`, alignment status-check animation
- **EssentielHiFiCard** : suppression de l'horodatage relatif, espacement tiles medium resserré, texte CTA "Tous mes articles ↓"
- **SectionBlock** : `DigestTopicSection` utilise `SeeAllSectionButton` au lieu de `PlusDeButton`, footer row `Expanded(flex: 2:1)` au lieu de `Flexible`
- **_kStickyBarHeight** : 86→100px pour éviter que le scroll-to-section cache le banner

## Pourquoi

Pass 1 (#671) avait corrigé le scroll et uniformisé les tiles, mais la tab bar restait trop petite visuellement et le bouton "Sujet suivant" n'avait pas de feedback immédiat au tap. Le label "Voir tout {thème}" était redondant avec la navigation.

## Comment ça a été vérifié
- [x] flutter test flux_continu : 96/96 OK
- [x] flutter analyze : 0 erreur (3 warnings pré-existants hors scope)
- [x] Échecs pré-existants (digest/topics — "Test not implemented") confirmés sur `main` sans nos changements
- [x] /simplify passé : extract `_handleTap()`, align animation status check, dedup .gitignore

## Zones à risque
- `sticky_tab_bar.dart` : taille police augmentée — vérifier sur petits écrans (iPhone SE)
- `NextSectionButton` : optimistic state `_localMarked` jamais reset (voulu — évite un replay d'animation au rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
