### PR TITLE
feat(gamification): track streaks from app opens

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/ci-tests.yml'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -40,6 +42,7 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
     // is fully built and analyticsServiceProvider is readable.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _flushFluxScrollMetricIfAny();
+      _startAnalyticsSessionIfNeeded();
     });
     // Story 23.2 PR-4 : si un endpoint retiré répond 410, afficher un
     // snackbar global "Mise à jour requise". Le ApiClient intercepte tous
@@ -77,8 +80,10 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
     if (appState == AppLifecycleState.paused) {
       _wasBackgrounded = true;
       _backgroundedAt = DateTime.now();
+      _endAnalyticsSessionIfNeeded();
     } else if (appState == AppLifecycleState.resumed) {
       _flushFluxScrollMetricIfAny();
+      _startAnalyticsSessionIfNeeded();
       if (_wasBackgrounded) {
         _wasBackgrounded = false;
         final elapsed = _backgroundedAt != null
@@ -149,6 +154,11 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
     // pre-auth waits for sign-in before navigating.
     ref.listen<AuthState>(authStateProvider, (prev, next) {
       DeepLinkService.instance.setAuthenticated(next.isAuthenticated);
+      if (next.isAuthenticated) {
+        _startAnalyticsSessionIfNeeded();
+      } else if (prev?.isAuthenticated == true) {
+        _endAnalyticsSessionIfNeeded();
+      }
     });
     // Initial sync (the listen above only fires on changes).
     DeepLinkService.instance.setAuthenticated(
@@ -168,5 +178,18 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
       // Router
       routerConfig: router,
     );
+  }
+
+  void _startAnalyticsSessionIfNeeded() {
+    if (!ref.read(authStateProvider).isAuthenticated) return;
+    final analytics = ref.read(analyticsServiceProvider);
+    if (analytics.hasActiveSession) return;
+    unawaited(analytics.startSession());
+  }
+
+  void _endAnalyticsSessionIfNeeded() {
+    final analytics = ref.read(analyticsServiceProvider);
+    if (!analytics.hasActiveSession) return;
+    unawaited(analytics.endSession());
   }
 }

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -52,11 +52,13 @@ class AnalyticsService {
   Future<void> startSession({bool isOrganic = true}) async {
     _sessionId = const Uuid().v4();
     _sessionStartTime = DateTime.now();
+    final localDate = _sessionStartTime!.toIso8601String().split('T').first;
 
     await _logEvent('session_start', {
       'session_id': _sessionId,
       'is_organic': isOrganic,
       'platform': defaultTargetPlatform.toString(),
+      'local_date': localDate,
       if (_appVersion != null) 'app_version': _appVersion,
     });
     // Story 14.1 — PostHog uses `app_open` as the conventional event name
@@ -65,6 +67,7 @@ class AnalyticsService {
       'session_id': _sessionId,
       'is_organic': isOrganic,
       'platform': defaultTargetPlatform.toString(),
+      'local_date': localDate,
       if (_appVersion != null) 'app_version': _appVersion,
     });
   }
@@ -72,16 +75,22 @@ class AnalyticsService {
   Future<void> endSession() async {
     if (_sessionStartTime == null) return;
 
-    final duration = DateTime.now().difference(_sessionStartTime!).inSeconds;
+    final sessionStartTime = _sessionStartTime!;
+    final sessionId = _sessionId;
+    final duration = DateTime.now().difference(sessionStartTime).inSeconds;
 
-    await _logEvent('session_end', {
-      'session_id': _sessionId,
-      'duration_seconds': duration,
-    });
-
+    // Clear the in-memory session before awaiting I/O so a quick
+    // pause→resume cycle can start a fresh session immediately.
     _sessionId = null;
     _sessionStartTime = null;
+
+    await _logEvent('session_end', {
+      'session_id': sessionId,
+      'duration_seconds': duration,
+    });
   }
+
+  bool get hasActiveSession => _sessionStartTime != null;
 
   // ──────────────────────────────────────────────────────────────
   // Unified content interaction methods (GAFAM-aligned)
@@ -409,7 +418,6 @@ class AnalyticsService {
     await _capturePostHog('preference_changed', props);
   }
 
-
   Future<void> trackAddSourceThemeTap(String themeSlug) async {
     await _logEvent('add_source_theme_tap', {'theme_slug': themeSlug});
   }
@@ -423,10 +431,9 @@ class AnalyticsService {
   }
 
   Future<void> trackAddSourceContentTypeFilter(String contentType) async {
-    await _logEvent(
-      'add_source_content_type_filter',
-      {'content_type': contentType},
-    );
+    await _logEvent('add_source_content_type_filter', {
+      'content_type': contentType,
+    });
   }
 
   Future<void> trackAddSourceExpand(String query) async {
@@ -441,20 +448,14 @@ class AnalyticsService {
   Future<void> trackWellInformedPromptShown({
     String context = 'digest_inline',
   }) async {
-    final props = {
-      'session_id': _sessionId,
-      'context': context,
-    };
+    final props = {'session_id': _sessionId, 'context': context};
     await _logEvent('well_informed_prompt_shown', props);
   }
 
   Future<void> trackWellInformedPromptSkipped({
     String context = 'digest_inline',
   }) async {
-    final props = {
-      'session_id': _sessionId,
-      'context': context,
-    };
+    final props = {'session_id': _sessionId, 'context': context};
     await _logEvent('well_informed_prompt_skipped', props);
     await _capturePostHog('well_informed_prompt_skipped', props);
   }
@@ -558,9 +559,8 @@ class AnalyticsService {
     required int totalCount,
     DateTime? at,
   }) async {
-    final scrollPct = totalCount > 0
-        ? ((maxPosition + 1) / totalCount).clamp(0.0, 1.0)
-        : 0.0;
+    final scrollPct =
+        totalCount > 0 ? ((maxPosition + 1) / totalCount).clamp(0.0, 1.0) : 0.0;
     final props = <String, dynamic>{
       'session_id': _sessionId,
       'max_position': maxPosition,
@@ -574,19 +574,25 @@ class AnalyticsService {
 
   // ── Notifications activation events (brief §7) ──────────────────────
 
-  Future<void> trackModalNotifShown({required ActivationTrigger trigger}) async {
+  Future<void> trackModalNotifShown({
+    required ActivationTrigger trigger,
+  }) async {
     final props = <String, dynamic>{'trigger': trigger.name};
     await _logEvent('modal_notif_shown', props);
     await _capturePostHog('modal_notif_shown', props);
   }
 
-  Future<void> trackModalNotifPresetChanged({required NotifPreset preset}) async {
+  Future<void> trackModalNotifPresetChanged({
+    required NotifPreset preset,
+  }) async {
     final props = <String, dynamic>{'preset': preset.wire};
     await _logEvent('modal_notif_preset_changed', props);
     await _capturePostHog('modal_notif_preset_changed', props);
   }
 
-  Future<void> trackModalNotifTimeChanged({required NotifTimeSlot timeSlot}) async {
+  Future<void> trackModalNotifTimeChanged({
+    required NotifTimeSlot timeSlot,
+  }) async {
     final props = <String, dynamic>{'time': timeSlot.wire};
     await _logEvent('modal_notif_time_changed', props);
     await _capturePostHog('modal_notif_time_changed', props);
@@ -701,7 +707,7 @@ class AnalyticsService {
     try {
       if (_deviceId == null) await init();
 
-      await client.dio.post(
+      await client.dio.post<dynamic>(
         'analytics/events',
         data: {
           'event_type': eventType,

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -21,10 +21,11 @@ final digestRepositoryProvider = Provider<DigestRepository>((ref) {
 });
 
 // Digest state provider
-final digestProvider =
-    AsyncNotifierProvider<DigestNotifier, DigestResponse?>(() {
-  return DigestNotifier();
-});
+final digestProvider = AsyncNotifierProvider<DigestNotifier, DigestResponse?>(
+  () {
+    return DigestNotifier();
+  },
+);
 
 /// Read-only snapshot of the dual digest cache (both Essentiel + Lecture
 /// apaisée variants). Re-emits when [digestProvider] changes. Falls back to
@@ -32,11 +33,11 @@ final digestProvider =
 /// yet — keeps the feed carousel resilient before /digest/both lands.
 final dualDigestPreviewProvider =
     Provider<({DigestResponse? normal, DigestResponse? serein})>((ref) {
-  final state = ref.watch(digestProvider);
-  final notifier = ref.read(digestProvider.notifier);
-  final normal = notifier.normalDigest ?? state.valueOrNull;
-  return (normal: normal, serein: notifier.sereinDigest);
-});
+      final state = ref.watch(digestProvider);
+      final notifier = ref.read(digestProvider.notifier);
+      final normal = notifier.normalDigest ?? state.valueOrNull;
+      return (normal: normal, serein: notifier.sereinDigest);
+    });
 
 class DigestNotifier extends AsyncNotifier<DigestResponse?> {
   bool _isCompleting = false;
@@ -141,7 +142,9 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
 
     for (var attempt = 0; attempt <= _digestMaxRetries; attempt++) {
       try {
-        final dual = await repository.fetchBothDigests(date: date).timeout(
+        final dual = await repository
+            .fetchBothDigests(date: date)
+            .timeout(
               const Duration(seconds: 45),
               onTimeout: () => throw TimeoutException(
                 'Le chargement a pris trop de temps. Verifiez votre connexion et reessayez.',
@@ -166,7 +169,8 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
         if (attempt < _digestMaxRetries) {
           // ignore: avoid_print
           print(
-              'DigestNotifier: 202 preparing, retry ${attempt + 1}/$_digestMaxRetries...');
+            'DigestNotifier: 202 preparing, retry ${attempt + 1}/$_digestMaxRetries...',
+          );
           await Future<void>.delayed(_digestRetryDelays[attempt]);
           continue;
         }
@@ -179,7 +183,8 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
         if (attempt < 1) {
           // ignore: avoid_print
           print(
-              'DigestNotifier: 503 digest_generation_timeout, 1 retry only (attempt ${attempt + 1})...');
+            'DigestNotifier: 503 digest_generation_timeout, 1 retry only (attempt ${attempt + 1})...',
+          );
           await Future<void>.delayed(const Duration(seconds: 15));
           continue;
         }
@@ -193,7 +198,8 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
         if (attempt < maxGenerationRetries) {
           // ignore: avoid_print
           print(
-              'DigestNotifier: 503 error, retry ${attempt + 1}/$maxGenerationRetries...');
+            'DigestNotifier: 503 error, retry ${attempt + 1}/$maxGenerationRetries...',
+          );
           await Future<void>.delayed(_digestRetryDelays[attempt]);
           continue;
         }
@@ -350,7 +356,8 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
   /// polling rather than spin forever. The counter resets as soon as a
   /// fresh (non-stale) response arrives or on manual cache clear.
   void _maybeScheduleStaleFallbackRefetch() {
-    final isStale = (_normalDigest?.isStaleFallback ?? false) ||
+    final isStale =
+        (_normalDigest?.isStaleFallback ?? false) ||
         (_sereinDigest?.isStaleFallback ?? false);
     _staleFallbackRefetchTimer?.cancel();
     if (!isStale) {
@@ -366,8 +373,11 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
       _staleFallbackRefetchTimer = null;
       return;
     }
-    final delay = _staleFallbackBackoff[
-        _staleFallbackAttempts.clamp(0, _staleFallbackBackoff.length - 1)];
+    final delay =
+        _staleFallbackBackoff[_staleFallbackAttempts.clamp(
+          0,
+          _staleFallbackBackoff.length - 1,
+        )];
     _staleFallbackAttempts++;
     _staleFallbackRefetchTimer = Timer(delay, () async {
       // Only auto-refetch if still authenticated and same day, and the
@@ -431,11 +441,13 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
     }).toList();
 
     // Also update pepite/coup_de_coeur if contentId matches (editorial_v1)
-    final updatedPepite = currentDigest.pepite != null &&
+    final updatedPepite =
+        currentDigest.pepite != null &&
             currentDigest.pepite!.contentId == contentId
         ? _applyActionToPepite(currentDigest.pepite!, action)
         : currentDigest.pepite;
-    final updatedCoupDeCoeur = currentDigest.coupDeCoeur != null &&
+    final updatedCoupDeCoeur =
+        currentDigest.coupDeCoeur != null &&
             currentDigest.coupDeCoeur!.contentId == contentId
         ? _applyActionToCoupDeCoeur(currentDigest.coupDeCoeur!, action)
         : currentDigest.coupDeCoeur;
@@ -491,8 +503,11 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
   }
 
   /// Sync a digest item's state from the detail screen (local only, no API).
-  void syncItemFromDetail(String contentId,
-      {required bool isSaved, String? noteText}) {
+  void syncItemFromDetail(
+    String contentId, {
+    required bool isSaved,
+    String? noteText,
+  }) {
     final currentDigest = state.value;
     if (currentDigest == null) return;
 
@@ -509,11 +524,13 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
     }).toList();
 
     // Also sync pepite/coup_de_coeur
-    final updatedPepite = currentDigest.pepite != null &&
+    final updatedPepite =
+        currentDigest.pepite != null &&
             currentDigest.pepite!.contentId == contentId
         ? currentDigest.pepite!.copyWith(isSaved: isSaved)
         : currentDigest.pepite;
-    final updatedCoupDeCoeur = currentDigest.coupDeCoeur != null &&
+    final updatedCoupDeCoeur =
+        currentDigest.coupDeCoeur != null &&
             currentDigest.coupDeCoeur!.contentId == contentId
         ? currentDigest.coupDeCoeur!.copyWith(isSaved: isSaved)
         : currentDigest.coupDeCoeur;
@@ -534,25 +551,29 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
   }
 
   /// Complete the digest
-  Future<void> completeDigest() async {
+  Future<DigestCompletionResponse?> completeDigest() async {
     final currentDigest = state.value;
-    if (currentDigest == null || currentDigest.isCompleted || _isCompleting) {
-      return;
+    if (currentDigest == null || _isCompleting) {
+      return null;
     }
 
     _isCompleting = true;
+    final alreadyCompleted = currentDigest.isCompleted;
 
     try {
       final repository = ref.read(digestRepositoryProvider);
-      await repository.completeDigest(currentDigest.digestId);
+      final completionData = await repository.completeDigest(
+        currentDigest.digestId,
+      );
 
-      // Trigger celebratory haptic
-      await HapticFeedback.heavyImpact();
+      if (!alreadyCompleted) {
+        await HapticFeedback.heavyImpact();
+      }
 
       // Update local state and cache
       final completedDigest = currentDigest.copyWith(
         isCompleted: true,
-        completedAt: DateTime.now(),
+        completedAt: completionData.completedAt ?? DateTime.now(),
       );
       state = AsyncData(completedDigest);
       _updateActiveCache(completedDigest);
@@ -560,12 +581,15 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
       // Push completed state to home screen widget
       _syncWidget();
 
-      // Show completion notification
-      NotificationService.showSuccess('Briefing terminé !');
+      if (!alreadyCompleted) {
+        NotificationService.showSuccess('Briefing terminé !');
+      }
+      return completionData;
     } catch (e) {
       // ignore: avoid_print
       print('DigestNotifier: completeDigest failed: $e');
       // Don't rethrow - completion failure shouldn't block UI
+      return null;
     } finally {
       _isCompleting = false;
     }
@@ -588,7 +612,11 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
         return item.copyWith(isDismissed: true, isRead: false);
       case 'undo':
         return item.copyWith(
-            isRead: false, isSaved: false, isLiked: false, isDismissed: false);
+          isRead: false,
+          isSaved: false,
+          isLiked: false,
+          isDismissed: false,
+        );
       default:
         return item;
     }
@@ -611,7 +639,11 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
         return p.copyWith(isDismissed: true, isRead: false);
       case 'undo':
         return p.copyWith(
-            isRead: false, isSaved: false, isLiked: false, isDismissed: false);
+          isRead: false,
+          isSaved: false,
+          isLiked: false,
+          isDismissed: false,
+        );
       default:
         return p;
     }
@@ -619,7 +651,9 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
 
   /// Apply an action mutation to a CoupDeCoeurResponse's flags.
   CoupDeCoeurResponse _applyActionToCoupDeCoeur(
-      CoupDeCoeurResponse c, String action) {
+    CoupDeCoeurResponse c,
+    String action,
+  ) {
     switch (action) {
       case 'like':
         return c.copyWith(isLiked: true);
@@ -635,7 +669,11 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
         return c.copyWith(isDismissed: true, isRead: false);
       case 'undo':
         return c.copyWith(
-            isRead: false, isSaved: false, isLiked: false, isDismissed: false);
+          isRead: false,
+          isSaved: false,
+          isLiked: false,
+          isDismissed: false,
+        );
       default:
         return c;
     }
@@ -739,7 +777,9 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
     final timeSpentSeconds = _readingTimers.consume(item.contentId, action);
 
     try {
-      ref.read(analyticsServiceProvider).trackContentInteraction(
+      ref
+          .read(analyticsServiceProvider)
+          .trackContentInteraction(
             action: analyticsAction,
             surface: 'digest',
             contentId: item.contentId,
@@ -808,17 +848,22 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
   }
 
   /// Update a specific item's state locally (for optimistic updates)
-  void updateItemState(String contentId,
-      {bool? isRead, bool? isSaved, bool? isLiked, bool? isDismissed}) {
+  void updateItemState(
+    String contentId, {
+    bool? isRead,
+    bool? isSaved,
+    bool? isLiked,
+    bool? isDismissed,
+  }) {
     final currentDigest = state.value;
     if (currentDigest == null) return;
 
     DigestItem applyFlags(DigestItem item) => item.copyWith(
-          isRead: isRead ?? item.isRead,
-          isSaved: isSaved ?? item.isSaved,
-          isLiked: isLiked ?? item.isLiked,
-          isDismissed: isDismissed ?? item.isDismissed,
-        );
+      isRead: isRead ?? item.isRead,
+      isSaved: isSaved ?? item.isSaved,
+      isLiked: isLiked ?? item.isLiked,
+      isDismissed: isDismissed ?? item.isDismissed,
+    );
 
     final updatedItems = currentDigest.items.map((item) {
       return item.contentId == contentId ? applyFlags(item) : item;
@@ -832,7 +877,8 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
     }).toList();
 
     // Also update pepite/coup_de_coeur
-    final updatedPepite = currentDigest.pepite != null &&
+    final updatedPepite =
+        currentDigest.pepite != null &&
             currentDigest.pepite!.contentId == contentId
         ? currentDigest.pepite!.copyWith(
             isRead: isRead ?? currentDigest.pepite!.isRead,
@@ -841,7 +887,8 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
             isDismissed: isDismissed ?? currentDigest.pepite!.isDismissed,
           )
         : currentDigest.pepite;
-    final updatedCoupDeCoeur = currentDigest.coupDeCoeur != null &&
+    final updatedCoupDeCoeur =
+        currentDigest.coupDeCoeur != null &&
             currentDigest.coupDeCoeur!.contentId == contentId
         ? currentDigest.coupDeCoeur!.copyWith(
             isRead: isRead ?? currentDigest.coupDeCoeur!.isRead,

--- a/apps/mobile/lib/features/digest/repositories/digest_repository.dart
+++ b/apps/mobile/lib/features/digest/repositories/digest_repository.dart
@@ -27,14 +27,15 @@ class DigestGenerationException implements Exception {
 /// Cf. docs/bugs/bug-infinite-load-requests.md.
 class DigestTimeoutException extends DigestGenerationException {
   DigestTimeoutException()
-      : super('Le serveur a mis trop de temps à générer le briefing.');
+    : super('Le serveur a mis trop de temps à générer le briefing.');
 }
 
 /// Exception thrown when digest is being prepared (202)
 class DigestPreparingException implements Exception {
   final String message;
-  DigestPreparingException(
-      [this.message = 'Votre briefing est en cours de préparation']);
+  DigestPreparingException([
+    this.message = 'Votre briefing est en cours de préparation',
+  ]);
   @override
   String toString() => message;
 }
@@ -55,7 +56,8 @@ class DigestRepository {
 
       // ignore: avoid_print
       print(
-          'DigestRepository: GET digest ${queryParams.isNotEmpty ? queryParams : ""}');
+        'DigestRepository: GET digest ${queryParams.isNotEmpty ? queryParams : ""}',
+      );
 
       final response = await _apiClient.dio.get<dynamic>(
         'digest', // Removed trailing slash to match FastAPI exactly
@@ -70,12 +72,16 @@ class DigestRepository {
         // ignore: avoid_print
         print('DigestRepository: Received data keys: ${data.keys}');
         // ignore: avoid_print
-        print('DigestRepository: format_version=${data['format_version']}, topics_count=${(data['topics'] as List?)?.length ?? 0}, items_count=${(data['items'] as List?)?.length ?? 0}');
+        print(
+          'DigestRepository: format_version=${data['format_version']}, topics_count=${(data['topics'] as List?)?.length ?? 0}, items_count=${(data['items'] as List?)?.length ?? 0}',
+        );
 
         try {
           final digest = DigestResponse.fromJson(data);
           // ignore: avoid_print
-          print('DigestRepository: Parsed → usesTopics=${digest.usesTopics}, topics=${digest.topics.length}, items=${digest.items.length}');
+          print(
+            'DigestRepository: Parsed → usesTopics=${digest.usesTopics}, topics=${digest.topics.length}, items=${digest.items.length}',
+          );
           return digest;
         } catch (e, stack) {
           // ignore: avoid_print
@@ -106,9 +112,7 @@ class DigestRepository {
   /// Get a digest by its ID
   Future<DigestResponse> getDigestById(String digestId) async {
     try {
-      final response = await _apiClient.dio.get<dynamic>(
-        'digest/$digestId',
-      );
+      final response = await _apiClient.dio.get<dynamic>('digest/$digestId');
 
       if (response.statusCode == 200 && response.data != null) {
         final data = response.data as Map<String, dynamic>;
@@ -130,7 +134,7 @@ class DigestRepository {
     required String digestId,
     required String contentId,
     required String
-        action, // 'read', 'save', 'like', 'unlike', 'not_interested', 'undo', 'unsave'
+    action, // 'read', 'save', 'like', 'unlike', 'not_interested', 'undo', 'unsave'
   }) async {
     try {
       // Handle unsave as save with is_saved=false for API compatibility
@@ -156,11 +160,19 @@ class DigestRepository {
   }
 
   /// Complete a digest (mark as finished)
-  Future<void> completeDigest(String digestId) async {
+  Future<DigestCompletionResponse> completeDigest(String digestId) async {
     try {
-      await _apiClient.dio.post<dynamic>(
+      final response = await _apiClient.dio.post<dynamic>(
         'digest/$digestId/complete',
       );
+
+      if (response.statusCode == 200 && response.data != null) {
+        return DigestCompletionResponse.fromJson(
+          response.data as Map<String, dynamic>,
+        );
+      }
+
+      throw Exception('Failed to complete digest: ${response.statusCode}');
     } on DioException catch (e) {
       if (e.response?.data != null) {
         throw Exception('API Error: ${e.response?.data}');
@@ -174,9 +186,7 @@ class DigestRepository {
   /// Generate a new digest on-demand
   Future<DigestResponse> generateDigest() async {
     try {
-      final response = await _apiClient.dio.post<dynamic>(
-        'digest/generate',
-      );
+      final response = await _apiClient.dio.post<dynamic>('digest/generate');
 
       if (response.statusCode == 200 && response.data != null) {
         final data = response.data as Map<String, dynamic>;
@@ -199,7 +209,9 @@ class DigestRepository {
       if (response.statusCode == 200 && response.data != null) {
         final data = response.data as Map<String, dynamic>;
         // ignore: avoid_print
-        print('DigestRepository.forceRegenerate: format_version=${data['format_version']}, topics_count=${(data['topics'] as List?)?.length ?? 0}');
+        print(
+          'DigestRepository.forceRegenerate: format_version=${data['format_version']}, topics_count=${(data['topics'] as List?)?.length ?? 0}',
+        );
         return DigestResponse.fromJson(data);
       }
       throw Exception('Failed to regenerate digest: ${response.statusCode}');
@@ -209,14 +221,9 @@ class DigestRepository {
   }
 
   /// Regenerate digest with a specific mode
-  Future<DigestResponse> regenerateWithMode({
-    required String mode,
-  }) async {
+  Future<DigestResponse> regenerateWithMode({required String mode}) async {
     try {
-      final queryParams = <String, dynamic>{
-        'force': 'true',
-        'mode': mode,
-      };
+      final queryParams = <String, dynamic>{'force': 'true', 'mode': mode};
 
       final response = await _apiClient.dio.post<dynamic>(
         'digest/generate',
@@ -299,9 +306,7 @@ class DigestRepository {
 
   /// Report an article as not serene (misclassified)
   Future<void> reportNotSerene(String contentId) async {
-    await _apiClient.dio.post<dynamic>(
-      'contents/$contentId/report-not-serene',
-    );
+    await _apiClient.dio.post<dynamic>('contents/$contentId/report-not-serene');
   }
 
   /// Update a user preference (key-value)
@@ -320,10 +325,13 @@ class DigestRepository {
     final response = await _apiClient.dio.get<dynamic>('users/preferences');
     final data = response.data as List<dynamic>;
     return data
-        .map((item) => {
-              'preference_key': (item as Map<String, dynamic>)['preference_key'] as String,
-              'preference_value': item['preference_value'] as String,
-            })
+        .map(
+          (item) => {
+            'preference_key':
+                (item as Map<String, dynamic>)['preference_key'] as String,
+            'preference_value': item['preference_value'] as String,
+          },
+        )
         .toList();
   }
 }

--- a/apps/mobile/lib/features/digest/screens/closure_screen.dart
+++ b/apps/mobile/lib/features/digest/screens/closure_screen.dart
@@ -20,10 +20,7 @@ import '../../saved/providers/saved_summary_provider.dart';
 class ClosureScreen extends ConsumerStatefulWidget {
   final String digestId;
 
-  const ClosureScreen({
-    super.key,
-    required this.digestId,
-  });
+  const ClosureScreen({super.key, required this.digestId});
 
   @override
   ConsumerState<ClosureScreen> createState() => _ClosureScreenState();
@@ -76,10 +73,8 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
     _headlineOpacityAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
       CurvedAnimation(parent: _headlineController, curve: Curves.easeOut),
     );
-    _headlineSlideAnimation = Tween<Offset>(
-      begin: const Offset(0, 0.2),
-      end: Offset.zero,
-    ).animate(
+    _headlineSlideAnimation =
+        Tween<Offset>(begin: const Offset(0, 0.2), end: Offset.zero).animate(
       CurvedAnimation(parent: _headlineController, curve: Curves.easeOut),
     );
 
@@ -87,10 +82,8 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
     _summaryOpacityAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
       CurvedAnimation(parent: _summaryController, curve: Curves.easeOut),
     );
-    _summarySlideAnimation = Tween<Offset>(
-      begin: const Offset(0, 0.2),
-      end: Offset.zero,
-    ).animate(
+    _summarySlideAnimation =
+        Tween<Offset>(begin: const Offset(0, 0.2), end: Offset.zero).animate(
       CurvedAnimation(parent: _summaryController, curve: Curves.easeOut),
     );
 
@@ -98,10 +91,8 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
     _buttonsOpacityAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
       CurvedAnimation(parent: _buttonsController, curve: Curves.easeOut),
     );
-    _buttonsSlideAnimation = Tween<Offset>(
-      begin: const Offset(0, 0.2),
-      end: Offset.zero,
-    ).animate(
+    _buttonsSlideAnimation =
+        Tween<Offset>(begin: const Offset(0, 0.2), end: Offset.zero).animate(
       CurvedAnimation(parent: _buttonsController, curve: Curves.easeOut),
     );
   }
@@ -123,35 +114,18 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
 
   Future<void> _loadCompletionData() async {
     // Get completion data from provider or API
-    // For now, we'll calculate it from the digest state
-    final digest = ref.read(digestProvider).value;
-    if (digest != null) {
-      // Complete the digest to get the response
+    final initialDigest = ref.read(digestProvider).value;
+    if (initialDigest != null) {
+      DigestCompletionResponse? completionData;
       try {
-        await ref.read(digestProvider.notifier).completeDigest();
-      } catch (e) {
-        // Ignore errors - completion may have already happened
+        completionData =
+            await ref.read(digestProvider.notifier).completeDigest();
+      } catch (_) {
+        // Best-effort: we still show the closure summary from local state.
       }
 
-      // Calculate stats from items
-      final items = digest.items;
-      final readCount = items.where((item) => item.isRead).length;
-      final savedCount = items.where((item) => item.isSaved).length;
-      final dismissedCount = items.where((item) => item.isDismissed).length;
-
-      // Get streak info from provider or use defaults
-      // In a real implementation, this would come from the API response
-      final completionData = DigestCompletionResponse(
-        success: true,
-        digestId: widget.digestId,
-        completedAt: DateTime.now(),
-        articlesRead: readCount,
-        articlesSaved: savedCount,
-        articlesDismissed: dismissedCount,
-        closureTimeSeconds: null, // Would come from API
-        closureStreak: 1, // Would come from streak provider
-        streakMessage: null, // Would come from API
-      );
+      final digest = ref.read(digestProvider).value ?? initialDigest;
+      completionData ??= _buildFallbackCompletionData(digest);
 
       setState(() {
         _completionData = completionData;
@@ -165,6 +139,25 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
         _isLoadingCompletion = false;
       });
     }
+  }
+
+  DigestCompletionResponse _buildFallbackCompletionData(DigestResponse digest) {
+    final items = digest.items;
+    final readCount = items.where((item) => item.isRead).length;
+    final savedCount = items.where((item) => item.isSaved).length;
+    final dismissedCount = items.where((item) => item.isDismissed).length;
+
+    return DigestCompletionResponse(
+      success: true,
+      digestId: widget.digestId,
+      completedAt: DateTime.now(),
+      articlesRead: readCount,
+      articlesSaved: savedCount,
+      articlesDismissed: dismissedCount,
+      closureTimeSeconds: null,
+      closureStreak: 1,
+      streakMessage: null,
+    );
   }
 
   /// Fire a digest_session analytics event once per closure.
@@ -297,18 +290,17 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
                 onTap: () async {
                   final uri = Uri.parse(ExternalLinks.feedbackFormUrl);
                   if (await canLaunchUrl(uri)) {
-                    await launchUrl(
-                      uri,
-                      mode: LaunchMode.externalApplication,
-                    );
+                    await launchUrl(uri, mode: LaunchMode.externalApplication);
                   }
                 },
                 child: Container(
                   margin: const EdgeInsets.symmetric(horizontal: 32),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 10,
+                  ),
                   decoration: BoxDecoration(
-                    color: colors.textSecondary.withOpacity(0.10),
+                    color: colors.textSecondary.withValues(alpha: 0.10),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Row(
@@ -317,7 +309,8 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
                     children: [
                       Icon(
                         PhosphorIcons.chatCircleDots(
-                            PhosphorIconsStyle.regular),
+                          PhosphorIconsStyle.regular,
+                        ),
                         size: 16,
                         color: colors.textSecondary,
                       ),
@@ -336,59 +329,65 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
             ),
 
             // Saved articles nudge
-            Builder(builder: (context) {
-              final savedSummary = ref.watch(savedSummaryProvider).valueOrNull;
-              if (savedSummary == null || savedSummary.recentCount7d < 3) {
-                return const SizedBox.shrink();
-              }
-              final count = savedSummary.recentCount7d;
-              return Padding(
-                padding: const EdgeInsets.only(top: FacteurSpacing.space3),
-                child: GestureDetector(
-                  onTap: () => _goAndDismiss(RoutePaths.saved),
-                  child: Container(
-                    margin: const EdgeInsets.symmetric(horizontal: 32),
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 14, vertical: 10),
-                    decoration: BoxDecoration(
-                      color: colors.primary.withOpacity(0.08),
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          PhosphorIcons.bookmarkSimple(
-                              PhosphorIconsStyle.regular),
-                          size: 16,
-                          color: colors.primary,
-                        ),
-                        const SizedBox(width: 8),
-                        Flexible(
-                          child: Text(
-                            '$count article${count > 1 ? 's' : ''} sauvegardé${count > 1 ? 's' : ''} cette semaine',
+            Builder(
+              builder: (context) {
+                final savedSummary =
+                    ref.watch(savedSummaryProvider).valueOrNull;
+                if (savedSummary == null || savedSummary.recentCount7d < 3) {
+                  return const SizedBox.shrink();
+                }
+                final count = savedSummary.recentCount7d;
+                return Padding(
+                  padding: const EdgeInsets.only(top: FacteurSpacing.space3),
+                  child: GestureDetector(
+                    onTap: () => _goAndDismiss(RoutePaths.saved),
+                    child: Container(
+                      margin: const EdgeInsets.symmetric(horizontal: 32),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 10,
+                      ),
+                      decoration: BoxDecoration(
+                        color: colors.primary.withValues(alpha: 0.08),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            PhosphorIcons.bookmarkSimple(
+                              PhosphorIconsStyle.regular,
+                            ),
+                            size: 16,
+                            color: colors.primary,
+                          ),
+                          const SizedBox(width: 8),
+                          Flexible(
+                            child: Text(
+                              '$count article${count > 1 ? 's' : ''} sauvegardé${count > 1 ? 's' : ''} cette semaine',
+                              style: textTheme.bodySmall?.copyWith(
+                                color: colors.primary,
+                                fontWeight: FontWeight.w500,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            'Voir',
                             style: textTheme.bodySmall?.copyWith(
                               color: colors.primary,
-                              fontWeight: FontWeight.w500,
+                              fontWeight: FontWeight.w600,
                             ),
-                            textAlign: TextAlign.center,
                           ),
-                        ),
-                        const SizedBox(width: 4),
-                        Text(
-                          'Voir',
-                          style: textTheme.bodySmall?.copyWith(
-                            color: colors.primary,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
-                ),
-              );
-            }),
+                );
+              },
+            ),
 
             // Note nudge (always visible)
             Padding(
@@ -397,10 +396,12 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
                 onTap: () => context.go(RoutePaths.saved),
                 child: Container(
                   margin: const EdgeInsets.symmetric(horizontal: 32),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 10,
+                  ),
                   decoration: BoxDecoration(
-                    color: colors.primary.withOpacity(0.08),
+                    color: colors.primary.withValues(alpha: 0.08),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Row(
@@ -458,8 +459,9 @@ class _ClosureScreenState extends ConsumerState<ClosureScreen>
                             foregroundColor: Colors.white,
                             padding: const EdgeInsets.symmetric(vertical: 16),
                             shape: RoundedRectangleBorder(
-                              borderRadius:
-                                  BorderRadius.circular(FacteurRadius.medium),
+                              borderRadius: BorderRadius.circular(
+                                FacteurRadius.medium,
+                              ),
                             ),
                           ),
                         ),

--- a/apps/mobile/lib/features/gamification/models/streak_activity_model.dart
+++ b/apps/mobile/lib/features/gamification/models/streak_activity_model.dart
@@ -1,0 +1,53 @@
+class StreakActivityDay {
+  final DateTime date;
+  final bool opened;
+  final int? articlesRead;
+
+  const StreakActivityDay({
+    required this.date,
+    required this.opened,
+    this.articlesRead,
+  });
+
+  factory StreakActivityDay.fromJson(Map<String, dynamic> json) {
+    return StreakActivityDay(
+      date: DateTime.parse(json['date'] as String),
+      opened: json['opened'] as bool? ?? false,
+      articlesRead: (json['articles_read'] as num?)?.toInt(),
+    );
+  }
+}
+
+class StreakActivityModel {
+  final int currentStreak;
+  final int longestStreak;
+  final DateTime? lastActivityDate;
+  final List<StreakActivityDay> days;
+
+  const StreakActivityModel({
+    required this.currentStreak,
+    required this.longestStreak,
+    this.lastActivityDate,
+    required this.days,
+  });
+
+  factory StreakActivityModel.fromJson(Map<String, dynamic> json) {
+    return StreakActivityModel(
+      currentStreak: json['current_streak'] as int? ?? 0,
+      longestStreak: json['longest_streak'] as int? ?? 0,
+      lastActivityDate: json['last_activity_date'] != null
+          ? DateTime.tryParse(json['last_activity_date'] as String)
+          : null,
+      days: (json['days'] as List<dynamic>? ?? const <dynamic>[])
+          .whereType<Map<String, dynamic>>()
+          .map(StreakActivityDay.fromJson)
+          .toList(),
+    );
+  }
+
+  const StreakActivityModel.empty()
+    : currentStreak = 0,
+      longestStreak = 0,
+      lastActivityDate = null,
+      days = const <StreakActivityDay>[];
+}

--- a/apps/mobile/lib/features/gamification/models/streak_model.dart
+++ b/apps/mobile/lib/features/gamification/models/streak_model.dart
@@ -6,7 +6,7 @@ class StreakModel {
   final int weeklyGoal;
   final double weeklyProgress;
 
-  StreakModel({
+  const StreakModel({
     required this.currentStreak,
     required this.longestStreak,
     this.lastActivityDate,

--- a/apps/mobile/lib/features/gamification/providers/gamification_preference_provider.dart
+++ b/apps/mobile/lib/features/gamification/providers/gamification_preference_provider.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../../core/api/providers.dart';
+import '../../../core/api/user_api_service.dart';
+import '../../../models/user_profile.dart' as app_model;
+
+class GamificationPreferenceRepository {
+  GamificationPreferenceRepository(this._userApiService);
+
+  final UserApiService _userApiService;
+  static const _boxName = 'user_profile';
+  static const _profileKey = 'profile';
+  static const _gamificationKey = 'gamification_enabled';
+
+  Future<bool> load() async {
+    final cached = await _readCachedValue();
+
+    try {
+      final profile = await _userApiService.getProfile();
+      if (profile != null) {
+        await _writeCache(profile);
+        return profile.gamificationEnabled;
+      }
+    } catch (_) {
+      // Best-effort: keep using the cached value when the profile call fails.
+    }
+
+    return cached ?? true;
+  }
+
+  Future<bool?> _readCachedValue() async {
+    final box = await Hive.openBox<dynamic>(_boxName);
+    final cachedFlag = box.get(_gamificationKey);
+    if (cachedFlag is bool) return cachedFlag;
+
+    final cachedProfile = box.get(_profileKey);
+    if (cachedProfile is Map) {
+      final profile = app_model.UserProfile.fromJson(
+        Map<String, dynamic>.from(cachedProfile),
+      );
+      return profile.gamificationEnabled;
+    }
+
+    return null;
+  }
+
+  Future<void> _writeCache(app_model.UserProfile profile) async {
+    final box = await Hive.openBox<dynamic>(_boxName);
+    await box.put(_profileKey, profile.toJson());
+    await box.put(_gamificationKey, profile.gamificationEnabled);
+  }
+}
+
+final gamificationPreferenceRepositoryProvider =
+    Provider<GamificationPreferenceRepository>((ref) {
+  return GamificationPreferenceRepository(
+    ref.watch(userApiServiceProvider),
+  );
+});
+
+final gamificationPreferenceProvider = FutureProvider<bool>((ref) async {
+  final repository = ref.watch(gamificationPreferenceRepositoryProvider);
+  return repository.load();
+});

--- a/apps/mobile/lib/features/gamification/providers/streak_activity_provider.dart
+++ b/apps/mobile/lib/features/gamification/providers/streak_activity_provider.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/streak_activity_model.dart';
+import 'gamification_preference_provider.dart';
+import 'streak_provider.dart';
+
+final streakActivityProvider = FutureProvider.autoDispose<StreakActivityModel>((
+  ref,
+) async {
+  final enabled = await ref.watch(gamificationPreferenceProvider.future);
+  if (!enabled) return const StreakActivityModel.empty();
+
+  final repository = ref.watch(streakRepositoryProvider);
+  return repository.getActivity(days: 14);
+});

--- a/apps/mobile/lib/features/gamification/providers/streak_animation_provider.dart
+++ b/apps/mobile/lib/features/gamification/providers/streak_animation_provider.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'gamification_preference_provider.dart';
+
+typedef StreakAnimationClock = DateTime Function();
+
+final streakAnimationClockProvider = Provider<StreakAnimationClock>((ref) {
+  return DateTime.now;
+});
+
+class StreakDailyAnimationGate {
+  StreakDailyAnimationGate({
+    required StreakAnimationClock now,
+    Future<SharedPreferences> Function()? prefsFactory,
+  }) : _now = now,
+       _prefsFactory = prefsFactory ?? SharedPreferences.getInstance;
+
+  static const _prefsKey = 'streak_indicator_last_animation_date';
+  final StreakAnimationClock _now;
+  final Future<SharedPreferences> Function() _prefsFactory;
+
+  Future<bool> shouldAnimateToday() async {
+    final prefs = await _prefsFactory();
+    return prefs.getString(_prefsKey) != _todayKey();
+  }
+
+  Future<void> markAnimatedForToday() async {
+    final prefs = await _prefsFactory();
+    await prefs.setString(_prefsKey, _todayKey());
+  }
+
+  String _todayKey() => _now().toIso8601String().split('T').first;
+}
+
+final streakDailyAnimationGateProvider = Provider<StreakDailyAnimationGate>((
+  ref,
+) {
+  return StreakDailyAnimationGate(now: ref.watch(streakAnimationClockProvider));
+});
+
+final streakDailyAnimationProvider = FutureProvider<bool>((ref) async {
+  final enabled = await ref.watch(gamificationPreferenceProvider.future);
+  if (!enabled) return false;
+
+  final gate = ref.watch(streakDailyAnimationGateProvider);
+  return gate.shouldAnimateToday();
+});

--- a/apps/mobile/lib/features/gamification/providers/streak_provider.dart
+++ b/apps/mobile/lib/features/gamification/providers/streak_provider.dart
@@ -21,7 +21,7 @@ class StreakNotifier extends AsyncNotifier<StreakModel> {
   FutureOr<StreakModel> build() async {
     final authState = ref.watch(authStateProvider);
     if (!authState.isAuthenticated) {
-      return StreakModel(
+      return const StreakModel(
         currentStreak: 0,
         longestStreak: 0,
         weeklyCount: 0,
@@ -36,7 +36,7 @@ class StreakNotifier extends AsyncNotifier<StreakModel> {
     final repository = ref.read(streakRepositoryProvider);
     final streak = await repository.getStreak();
     // Push streak to home screen widget
-    WidgetService.updateWidget(streak: streak);
+    unawaited(WidgetService.updateWidget(streak: streak));
     return streak;
   }
 

--- a/apps/mobile/lib/features/gamification/repositories/streak_repository.dart
+++ b/apps/mobile/lib/features/gamification/repositories/streak_repository.dart
@@ -1,4 +1,5 @@
 import '../../../core/api/api_client.dart';
+import '../models/streak_activity_model.dart';
 import '../models/streak_model.dart';
 
 class StreakRepository {
@@ -8,15 +9,16 @@ class StreakRepository {
 
   Future<StreakModel> getStreak() async {
     try {
-      final response =
-          await _apiClient.dio.get<Map<String, dynamic>>('users/streak');
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        'users/streak',
+      );
 
       if (response.statusCode == 200 && response.data != null) {
         return StreakModel.fromJson(response.data!);
       }
 
       // Fallback default
-      return StreakModel(
+      return const StreakModel(
         currentStreak: 0,
         longestStreak: 0,
         weeklyCount: 0,
@@ -26,6 +28,25 @@ class StreakRepository {
     } catch (e) {
       // ignore: avoid_print
       print('StreakRepository: [ERROR] getStreak: $e');
+      rethrow;
+    }
+  }
+
+  Future<StreakActivityModel> getActivity({int days = 14}) async {
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        'streaks/activity',
+        queryParameters: {'days': days},
+      );
+
+      if (response.statusCode == 200 && response.data != null) {
+        return StreakActivityModel.fromJson(response.data!);
+      }
+
+      return const StreakActivityModel.empty();
+    } catch (e) {
+      // ignore: avoid_print
+      print('StreakRepository: [ERROR] getActivity: $e');
       rethrow;
     }
   }

--- a/apps/mobile/lib/features/gamification/widgets/streak_explainer_modal.dart
+++ b/apps/mobile/lib/features/gamification/widgets/streak_explainer_modal.dart
@@ -1,0 +1,353 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../models/streak_activity_model.dart';
+import '../providers/streak_activity_provider.dart';
+
+class StreakExplainerModal extends ConsumerWidget {
+  const StreakExplainerModal({super.key});
+
+  static Future<void> show(BuildContext context) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => const StreakExplainerModal(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final streakActivityAsync = ref.watch(streakActivityProvider);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.surfacePaper,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+          child: streakActivityAsync.when(
+            data: (activity) => _ExplainerBody(activity: activity),
+            loading: () => SizedBox(
+              height: 320,
+              child: Center(
+                child: CircularProgressIndicator(color: colors.primary),
+              ),
+            ),
+            error: (_, __) => SizedBox(
+              height: 220,
+              child: Center(
+                child: Text(
+                  'Impossible de charger la série pour le moment.',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ExplainerBody extends StatelessWidget {
+  const _ExplainerBody({required this.activity});
+
+  final StreakActivityModel activity;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final totalArticlesRead = activity.days.fold<int>(
+      0,
+      (sum, day) => sum + (day.articlesRead ?? 0),
+    );
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: colors.border,
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          const Center(child: _AnimatedFlameBadge()),
+          const SizedBox(height: 16),
+          Text(
+            'Ta série d\'ouverture',
+            style: textTheme.titleLarge?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: colors.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Elle avance chaque jour où tu ouvres Facteur. Si tu sautes une journée, elle repart à 1.',
+            style: textTheme.bodyMedium?.copyWith(
+              color: colors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 20),
+          Row(
+            children: [
+              Expanded(
+                child: _MetricTile(
+                  label: 'Actuelle',
+                  value: '${activity.currentStreak}',
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _MetricTile(
+                  label: 'Record',
+                  value: '${activity.longestStreak}',
+                ),
+              ),
+              if (totalArticlesRead > 0) ...[
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _MetricTile(label: 'Lus', value: '$totalArticlesRead'),
+                ),
+              ],
+            ],
+          ),
+          const SizedBox(height: 20),
+          Text(
+            '14 derniers jours',
+            style: textTheme.titleSmall?.copyWith(
+              color: colors.textPrimary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 12),
+          GridView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: activity.days.length,
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 7,
+              mainAxisSpacing: 8,
+              crossAxisSpacing: 8,
+              childAspectRatio: 0.86,
+            ),
+            itemBuilder: (context, index) {
+              return _DayTile(day: activity.days[index]);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetricTile extends StatelessWidget {
+  const _MetricTile({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+      decoration: BoxDecoration(
+        color: colors.backgroundSecondary.withValues(alpha: 0.35),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.border.withValues(alpha: 0.6)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            value,
+            style: textTheme.titleLarge?.copyWith(
+              color: colors.textPrimary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            label,
+            style: textTheme.bodySmall?.copyWith(color: colors.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DayTile extends StatelessWidget {
+  const _DayTile({required this.day});
+
+  final StreakActivityDay day;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final opened = day.opened;
+    final date = day.date;
+    final weekday = _weekdayLabel(date.weekday);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+      decoration: BoxDecoration(
+        color: opened
+            ? colors.primary.withValues(alpha: 0.10)
+            : colors.backgroundSecondary.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: opened
+              ? colors.primary.withValues(alpha: 0.25)
+              : colors.border.withValues(alpha: 0.5),
+        ),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            weekday,
+            style: textTheme.labelSmall?.copyWith(
+              color: colors.textSecondary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Icon(
+            opened
+                ? PhosphorIcons.fire(PhosphorIconsStyle.fill)
+                : PhosphorIcons.minus(PhosphorIconsStyle.bold),
+            size: 14,
+            color: opened
+                ? colors.primary.withValues(alpha: 0.85)
+                : colors.textTertiary,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '${date.day}',
+            style: textTheme.labelMedium?.copyWith(
+              color: colors.textPrimary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          if (day.articlesRead != null) ...[
+            const SizedBox(height: 2),
+            Text(
+              '${day.articlesRead}',
+              style: textTheme.labelSmall?.copyWith(
+                color: colors.textSecondary,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _weekdayLabel(int weekday) {
+    const labels = <int, String>{
+      DateTime.monday: 'L',
+      DateTime.tuesday: 'M',
+      DateTime.wednesday: 'M',
+      DateTime.thursday: 'J',
+      DateTime.friday: 'V',
+      DateTime.saturday: 'S',
+      DateTime.sunday: 'D',
+    };
+    return labels[weekday] ?? '';
+  }
+}
+
+class _AnimatedFlameBadge extends StatefulWidget {
+  const _AnimatedFlameBadge();
+
+  @override
+  State<_AnimatedFlameBadge> createState() => _AnimatedFlameBadgeState();
+}
+
+class _AnimatedFlameBadgeState extends State<_AnimatedFlameBadge>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scale;
+  late final Animation<double> _glow;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1400),
+    )..repeat(reverse: true);
+    _scale = Tween<double>(
+      begin: 0.96,
+      end: 1.06,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
+    _glow = Tween<double>(
+      begin: 0.18,
+      end: 0.36,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        return Container(
+          width: 72,
+          height: 72,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: colors.primary.withValues(alpha: 0.08),
+            boxShadow: [
+              BoxShadow(
+                color: colors.primary.withValues(alpha: _glow.value),
+                blurRadius: 18,
+                spreadRadius: 2,
+              ),
+            ],
+          ),
+          child: Transform.scale(
+            scale: _scale.value,
+            child: Icon(
+              PhosphorIcons.fire(PhosphorIconsStyle.fill),
+              color: colors.primary,
+              size: 34,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/apps/mobile/lib/features/gamification/widgets/streak_indicator.dart
+++ b/apps/mobile/lib/features/gamification/widgets/streak_indicator.dart
@@ -3,67 +3,190 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
+import '../providers/gamification_preference_provider.dart';
+import '../providers/streak_animation_provider.dart';
 import '../providers/streak_provider.dart';
+import 'streak_explainer_modal.dart';
 
-class StreakIndicator extends ConsumerWidget {
+class StreakIndicator extends ConsumerStatefulWidget {
   const StreakIndicator({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final streakAsync = ref.watch(streakProvider);
+  ConsumerState<StreakIndicator> createState() => _StreakIndicatorState();
+}
+
+class _StreakIndicatorState extends ConsumerState<StreakIndicator>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scale;
+  late final Animation<double> _glow;
+  bool _hasStartedDailyAnimation = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    );
+    _scale = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween<double>(
+          begin: 1.0,
+          end: 1.22,
+        ).chain(CurveTween(curve: Curves.easeOutBack)),
+        weight: 55,
+      ),
+      TweenSequenceItem(
+        tween: Tween<double>(
+          begin: 1.22,
+          end: 1.0,
+        ).chain(CurveTween(curve: Curves.easeOut)),
+        weight: 45,
+      ),
+    ]).animate(_controller);
+    _glow = Tween<double>(
+      begin: 0.0,
+      end: 0.30,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
+    final gamificationAsync = ref.watch(gamificationPreferenceProvider);
 
-    return streakAsync.when(
-      data: (streak) {
-        // if (streak.currentStreak == 0) return const SizedBox.shrink();
+    return gamificationAsync.when(
+      data: (enabled) {
+        if (!enabled) return const SizedBox.shrink();
 
-        final isActive = streak.currentStreak > 0;
-        final flameColor = colors.primary.withOpacity(isActive ? 0.75 : 0.35);
-        final textColor = isActive
-            ? colors.textPrimary
-            : colors.textSecondary.withOpacity(0.5);
+        final streakAsync = ref.watch(streakProvider);
+        final animateToday =
+            ref.watch(streakDailyAnimationProvider).valueOrNull ?? false;
+        _maybeStartDailyAnimation(animateToday);
 
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          decoration: BoxDecoration(
-            color: colors.primary.withOpacity(isActive ? 0.04 : 0.02),
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: colors.primary.withOpacity(0.10),
-              width: 1,
-            ),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                PhosphorIcons.fire(PhosphorIconsStyle.fill),
-                color: flameColor,
-                size: 16,
-              ),
-              const SizedBox(width: 4),
-              Text(
-                '${streak.currentStreak}',
-                style: textTheme.labelMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
-                  color: textColor,
+        return streakAsync.when(
+          data: (streak) {
+            final isActive = streak.currentStreak > 0;
+            final flameColor = colors.primary.withValues(
+              alpha: isActive ? 0.78 : 0.38,
+            );
+            final textColor = isActive
+                ? colors.textPrimary
+                : colors.textSecondary.withValues(alpha: 0.55);
+
+            return Semantics(
+              button: true,
+              label:
+                  'Serie actuelle : ${streak.currentStreak} jours. Ouvrir le detail.',
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(16),
+                  onTap: () => StreakExplainerModal.show(context),
+                  child: Container(
+                    constraints: const BoxConstraints(minHeight: 36),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 6,
+                    ),
+                    decoration: BoxDecoration(
+                      color: colors.primary.withValues(
+                        alpha: isActive ? 0.04 : 0.02,
+                      ),
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(
+                        color: colors.primary.withValues(alpha: 0.10),
+                        width: 1,
+                      ),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: AnimatedBuilder(
+                            animation: _controller,
+                            builder: (context, child) {
+                              return DecoratedBox(
+                                decoration: BoxDecoration(
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: colors.primary.withValues(
+                                        alpha: _glow.value,
+                                      ),
+                                      blurRadius: 12,
+                                      spreadRadius: 1,
+                                    ),
+                                  ],
+                                ),
+                                child: Transform.scale(
+                                  scale: _scale.value,
+                                  child: Icon(
+                                    PhosphorIcons.fire(PhosphorIconsStyle.fill),
+                                    color: flameColor,
+                                    size: 16,
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 6),
+                        Text(
+                          '${streak.currentStreak}',
+                          style: textTheme.labelMedium?.copyWith(
+                            fontWeight: FontWeight.w700,
+                            color: textColor,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
                 ),
               ),
-            ],
+            );
+          },
+          loading: () => Container(
+            constraints: const BoxConstraints(minHeight: 36, minWidth: 36),
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            child: Icon(
+              PhosphorIcons.fire(PhosphorIconsStyle.regular),
+              size: 16,
+              color: colors.primary.withValues(alpha: 0.3),
+            ),
           ),
+          error: (e, s) {
+            debugPrint('Streak Error: $e');
+            return const SizedBox.shrink();
+          },
         );
       },
-      loading: () => Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-        child: Icon(PhosphorIcons.fire(PhosphorIconsStyle.regular),
-            size: 16, color: colors.primary.withOpacity(0.3)),
-      ),
+      loading: () => const SizedBox.shrink(),
       error: (e, s) {
-        // Debugging: print error
-        debugPrint('Streak Error: $e');
+        debugPrint('Gamification Preference Error: $e');
         return const SizedBox.shrink();
       },
     );
+  }
+
+  void _maybeStartDailyAnimation(bool shouldAnimate) {
+    if (!shouldAnimate || _hasStartedDailyAnimation) return;
+    _hasStartedDailyAnimation = true;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
+      await ref.read(streakDailyAnimationGateProvider).markAnimatedForToday();
+      if (!mounted) return;
+      await _controller.forward(from: 0);
+    });
   }
 }

--- a/apps/mobile/test/core/services/analytics_service_dual_track_test.dart
+++ b/apps/mobile/test/core/services/analytics_service_dual_track_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -45,13 +47,9 @@ void main() {
     api = _MockApiClient();
     dio = _MockDio();
     when(() => api.dio).thenReturn(dio);
-    when(
-      () => dio.post(any(), data: any(named: 'data')),
-    ).thenAnswer(
-      (_) async => Response(
-        requestOptions: RequestOptions(path: ''),
-        statusCode: 201,
-      ),
+    when(() => dio.post(any(), data: any(named: 'data'))).thenAnswer(
+      (_) async =>
+          Response(requestOptions: RequestOptions(path: ''), statusCode: 201),
     );
     posthog = _RecordingPostHog();
   });
@@ -61,42 +59,82 @@ void main() {
     await service.startSession(isOrganic: true);
 
     expect(posthog.captured.map((e) => e.event), contains('app_open'));
-    // Backend logging still happens.
-    verify(
-      () => dio.post('analytics/events', data: any(named: 'data')),
-    ).called(1);
+    final capturedCalls = verify(
+      () => dio.post('analytics/events', data: captureAny(named: 'data')),
+    ).captured;
+    expect(capturedCalls, hasLength(1));
+    final captured = capturedCalls.single as Map<String, dynamic>;
+    expect(
+      captured['event_data']['local_date'],
+      matches(RegExp(r'^\d{4}-\d{2}-\d{2}$')),
+    );
   });
 
-  test('content_interaction read >30s emits article_read + article_completed',
+  test('endSession clears active state before awaiting the backend call',
       () async {
     final service = AnalyticsService(api, posthog: posthog);
-    await service.trackContentInteraction(
-      action: 'read',
-      surface: 'digest',
-      contentId: 'c1',
-      sourceId: 's1',
-      timeSpentSeconds: 45,
-    );
+    final endSessionCompleter = Completer<Response<dynamic>>();
+    var callCount = 0;
 
-    final events = posthog.captured.map((e) => e.event).toList();
-    expect(events, containsAll(<String>['article_read', 'article_completed']));
+    when(() => dio.post(any(), data: any(named: 'data'))).thenAnswer((_) {
+      callCount++;
+      if (callCount == 1) {
+        return Future.value(
+          Response(requestOptions: RequestOptions(path: ''), statusCode: 201),
+        );
+      }
+      return endSessionCompleter.future;
+    });
+
+    await service.startSession();
+    expect(service.hasActiveSession, isTrue);
+
+    final endFuture = service.endSession();
+    expect(service.hasActiveSession, isFalse);
+
+    endSessionCompleter.complete(
+      Response(requestOptions: RequestOptions(path: ''), statusCode: 201),
+    );
+    await endFuture;
   });
 
-  test('content_interaction read <30s emits article_read but NOT completed',
-      () async {
-    final service = AnalyticsService(api, posthog: posthog);
-    await service.trackContentInteraction(
-      action: 'read',
-      surface: 'digest',
-      contentId: 'c1',
-      sourceId: 's1',
-      timeSpentSeconds: 12,
-    );
+  test(
+    'content_interaction read >30s emits article_read + article_completed',
+    () async {
+      final service = AnalyticsService(api, posthog: posthog);
+      await service.trackContentInteraction(
+        action: 'read',
+        surface: 'digest',
+        contentId: 'c1',
+        sourceId: 's1',
+        timeSpentSeconds: 45,
+      );
 
-    final events = posthog.captured.map((e) => e.event).toList();
-    expect(events, contains('article_read'));
-    expect(events, isNot(contains('article_completed')));
-  });
+      final events = posthog.captured.map((e) => e.event).toList();
+      expect(
+        events,
+        containsAll(<String>['article_read', 'article_completed']),
+      );
+    },
+  );
+
+  test(
+    'content_interaction read <30s emits article_read but NOT completed',
+    () async {
+      final service = AnalyticsService(api, posthog: posthog);
+      await service.trackContentInteraction(
+        action: 'read',
+        surface: 'digest',
+        contentId: 'c1',
+        sourceId: 's1',
+        timeSpentSeconds: 12,
+      );
+
+      final events = posthog.captured.map((e) => e.event).toList();
+      expect(events, contains('article_read'));
+      expect(events, isNot(contains('article_completed')));
+    },
+  );
 
   test('save action does not emit article_read', () async {
     final service = AnalyticsService(api, posthog: posthog);
@@ -114,10 +152,7 @@ void main() {
     final service = AnalyticsService(api, posthog: posthog);
     await service.trackSourceAdd('source-42');
 
-    expect(
-      posthog.captured.map((e) => e.event),
-      contains('source_added'),
-    );
+    expect(posthog.captured.map((e) => e.event), contains('source_added'));
   });
 
   test('trackComparisonViewed fires comparison_viewed on PostHog', () async {
@@ -150,18 +185,23 @@ void main() {
     ).called(2);
   });
 
-  test('trackArticleRead mirrors article_read + article_completed when >=30s',
-      () async {
-    // Story 14.1 — feed/detail surfaces still call the legacy
-    // trackArticleRead, so it must mirror to PostHog with the same
-    // threshold logic as trackContentInteraction. Otherwise
-    // article_completed would never fire from real reading flows.
-    final service = AnalyticsService(api, posthog: posthog);
-    await service.trackArticleRead('c1', 's1', 45);
+  test(
+    'trackArticleRead mirrors article_read + article_completed when >=30s',
+    () async {
+      // Story 14.1 — feed/detail surfaces still call the legacy
+      // trackArticleRead, so it must mirror to PostHog with the same
+      // threshold logic as trackContentInteraction. Otherwise
+      // article_completed would never fire from real reading flows.
+      final service = AnalyticsService(api, posthog: posthog);
+      await service.trackArticleRead('c1', 's1', 45);
 
-    final events = posthog.captured.map((e) => e.event).toList();
-    expect(events, containsAll(<String>['article_read', 'article_completed']));
-  });
+      final events = posthog.captured.map((e) => e.event).toList();
+      expect(
+        events,
+        containsAll(<String>['article_read', 'article_completed']),
+      );
+    },
+  );
 
   test('trackArticleRead <30s emits article_read but NOT completed', () async {
     final service = AnalyticsService(api, posthog: posthog);
@@ -173,8 +213,9 @@ void main() {
   });
 
   test('backend failure does not crash analytics layer', () async {
-    when(() => dio.post(any(), data: any(named: 'data')))
-        .thenThrow(DioException(requestOptions: RequestOptions(path: '')));
+    when(
+      () => dio.post(any(), data: any(named: 'data')),
+    ).thenThrow(DioException(requestOptions: RequestOptions(path: '')));
 
     final service = AnalyticsService(api, posthog: posthog);
     // Must not throw

--- a/apps/mobile/test/features/gamification/models/streak_activity_model_test.dart
+++ b/apps/mobile/test/features/gamification/models/streak_activity_model_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/gamification/models/streak_activity_model.dart';
+
+void main() {
+  test('parses streak activity payload', () {
+    final model = StreakActivityModel.fromJson({
+      'current_streak': 4,
+      'longest_streak': 9,
+      'last_activity_date': '2026-05-26',
+      'days': [
+        {'date': '2026-05-25', 'opened': true, 'articles_read': 2},
+        {'date': '2026-05-26', 'opened': false},
+      ],
+    });
+
+    expect(model.currentStreak, 4);
+    expect(model.longestStreak, 9);
+    expect(model.lastActivityDate, DateTime(2026, 5, 26));
+    expect(model.days, hasLength(2));
+    expect(model.days.first.opened, isTrue);
+    expect(model.days.first.articlesRead, 2);
+    expect(model.days.last.articlesRead, isNull);
+  });
+}

--- a/apps/mobile/test/features/gamification/providers/streak_animation_provider_test.dart
+++ b/apps/mobile/test/features/gamification/providers/streak_animation_provider_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:facteur/features/gamification/providers/gamification_preference_provider.dart';
+import 'package:facteur/features/gamification/providers/streak_animation_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('daily animation only triggers once per local date', () async {
+    final container = ProviderContainer(
+      overrides: [
+        gamificationPreferenceProvider.overrideWith((ref) async => true),
+        streakAnimationClockProvider.overrideWithValue(
+          () => DateTime(2026, 5, 26, 9),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(await container.read(streakDailyAnimationProvider.future), isTrue);
+
+    await container
+        .read(streakDailyAnimationGateProvider)
+        .markAnimatedForToday();
+    container.invalidate(streakDailyAnimationProvider);
+
+    expect(await container.read(streakDailyAnimationProvider.future), isFalse);
+
+    final nextDayContainer = ProviderContainer(
+      overrides: [
+        gamificationPreferenceProvider.overrideWith((ref) async => true),
+        streakAnimationClockProvider.overrideWithValue(
+          () => DateTime(2026, 5, 27, 9),
+        ),
+      ],
+    );
+    addTearDown(nextDayContainer.dispose);
+
+    expect(
+      await nextDayContainer.read(streakDailyAnimationProvider.future),
+      isTrue,
+    );
+  });
+}

--- a/apps/mobile/test/features/gamification/widgets/streak_indicator_test.dart
+++ b/apps/mobile/test/features/gamification/widgets/streak_indicator_test.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/gamification/models/streak_activity_model.dart';
+import 'package:facteur/features/gamification/models/streak_model.dart';
+import 'package:facteur/features/gamification/providers/gamification_preference_provider.dart';
+import 'package:facteur/features/gamification/providers/streak_activity_provider.dart';
+import 'package:facteur/features/gamification/providers/streak_animation_provider.dart';
+import 'package:facteur/features/gamification/providers/streak_provider.dart';
+import 'package:facteur/features/gamification/widgets/streak_indicator.dart';
+
+class _FakeStreakNotifier extends StreakNotifier {
+  _FakeStreakNotifier(this._model);
+
+  final StreakModel _model;
+
+  @override
+  FutureOr<StreakModel> build() => _model;
+}
+
+Widget _wrap(List<Override> overrides) {
+  return ProviderScope(
+    overrides: overrides,
+    child: MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: const Scaffold(body: Center(child: StreakIndicator())),
+    ),
+  );
+}
+
+void main() {
+  final streak = StreakModel(
+    currentStreak: 5,
+    longestStreak: 8,
+    weeklyCount: 2,
+    weeklyGoal: 5,
+    weeklyProgress: 0.4,
+  );
+  final activity = StreakActivityModel.fromJson({
+    'current_streak': 5,
+    'longest_streak': 8,
+    'last_activity_date': '2026-05-26',
+    'days': List.generate(
+      14,
+      (index) => {
+        'date': DateTime(
+          2026,
+          5,
+          13 + index,
+        ).toIso8601String().split('T').first,
+        'opened': index.isEven,
+      },
+    ),
+  });
+
+  testWidgets('streak indicator is tappable and opens the explainer modal', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap([
+        gamificationPreferenceProvider.overrideWith((ref) async => true),
+        streakDailyAnimationProvider.overrideWith((ref) async => false),
+        streakActivityProvider.overrideWith((ref) async => activity),
+        streakProvider.overrideWith(() => _FakeStreakNotifier(streak)),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('5'), findsOneWidget);
+
+    await tester.tap(find.text('5'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('Ta série d\'ouverture'), findsOneWidget);
+    expect(find.text('14 derniers jours'), findsOneWidget);
+  });
+
+  testWidgets('streak indicator is hidden when gamification is disabled', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap([
+        gamificationPreferenceProvider.overrideWith((ref) async => false),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('5'), findsNothing);
+    expect(find.byType(InkWell), findsNothing);
+  });
+}

--- a/packages/api/app/routers/analytics.py
+++ b/packages/api/app/routers/analytics.py
@@ -1,6 +1,6 @@
 """Router pour les analytics."""
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Header
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
 from app.services.analytics_service import AnalyticsService
+from app.services.streak_service import StreakService
 
 router = APIRouter(tags=["Analytics"])
 
@@ -57,6 +58,21 @@ async def log_event(
         event_data=event.event_data,
         device_id=event.device_id,
     )
+
+    if event.event_type == "session_start":
+        local_date: date | None = None
+        raw_local_date = event.event_data.get("local_date")
+        if isinstance(raw_local_date, str):
+            try:
+                local_date = date.fromisoformat(raw_local_date)
+            except ValueError:
+                local_date = None
+
+        await StreakService(db).record_session_start(
+            str(user_id),
+            local_date=local_date,
+        )
+        await db.commit()
 
     # Update per-user version tracking on session_start or when header is present.
     # Priority: explicit header > event_data field.

--- a/packages/api/app/routers/streaks.py
+++ b/packages/api/app/routers/streaks.py
@@ -3,12 +3,12 @@
 import time
 
 import structlog
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.dependencies import get_current_user_id
-from app.schemas.streak import StreakResponse
+from app.schemas.streak import StreakActivityResponse, StreakResponse
 from app.services.streak_service import StreakService
 
 router = APIRouter()
@@ -31,3 +31,14 @@ async def get_streak(
     )
 
     return streak
+
+
+@router.get("/activity", response_model=StreakActivityResponse)
+async def get_streak_activity(
+    days: int = Query(14, ge=1, le=31),
+    user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> StreakActivityResponse:
+    """Récupérer l'activité récente d'ouverture d'app pour le streak."""
+    service = StreakService(db)
+    return await service.get_activity(user_id, days=days)

--- a/packages/api/app/schemas/streak.py
+++ b/packages/api/app/schemas/streak.py
@@ -17,3 +17,20 @@ class StreakResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class StreakActivityDayResponse(BaseModel):
+    """État d'ouverture d'app pour un jour donné."""
+
+    date: date
+    opened: bool
+    articles_read: int | None = None
+
+
+class StreakActivityResponse(BaseModel):
+    """Réponse d'activité streak pour le calendrier d'ouverture."""
+
+    current_streak: int
+    longest_streak: int
+    last_activity_date: date | None
+    days: list[StreakActivityDayResponse]

--- a/packages/api/app/services/streak_service.py
+++ b/packages/api/app/services/streak_service.py
@@ -96,7 +96,9 @@ class StreakService:
         await self.db.flush()
         return streak
 
-    async def get_activity(self, user_id: str, days: int = 14) -> StreakActivityResponse:
+    async def get_activity(
+        self, user_id: str, days: int = 14
+    ) -> StreakActivityResponse:
         """Construit l'activité d'ouverture d'app sur les N derniers jours."""
         streak = await self._get_or_create_streak(user_id)
         user_uuid = UUID(user_id)
@@ -137,7 +139,9 @@ class StreakService:
             # Reading implies the app was opened, even for historical days
             # recorded before `session_start` became the streak source.
             opened_dates.add(event_date)
-            articles_read_by_day[event_date] = articles_read_by_day.get(event_date, 0) + 1
+            articles_read_by_day[event_date] = (
+                articles_read_by_day.get(event_date, 0) + 1
+            )
 
         activity_days = [
             StreakActivityDayResponse(
@@ -149,9 +153,7 @@ class StreakService:
                     else None
                 ),
             )
-            for day in (
-                start_date + timedelta(days=offset) for offset in range(days)
-            )
+            for day in (start_date + timedelta(days=offset) for offset in range(days))
         ]
 
         return StreakActivityResponse(

--- a/packages/api/app/services/streak_service.py
+++ b/packages/api/app/services/streak_service.py
@@ -3,11 +3,16 @@
 from datetime import date, timedelta
 from uuid import UUID, uuid4
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.analytics import AnalyticsEvent
 from app.models.user import UserProfile, UserStreak
-from app.schemas.streak import StreakResponse
+from app.schemas.streak import (
+    StreakActivityDayResponse,
+    StreakActivityResponse,
+    StreakResponse,
+)
 
 
 class StreakService:
@@ -34,9 +39,10 @@ class StreakService:
 
     async def increment_consumption(self, user_id: str) -> UserStreak:
         """
-        Incrémente le compteur de consommation.
+        Incrémente le compteur hebdomadaire de lecture.
 
-        Met à jour le streak quotidien et le compteur hebdomadaire.
+        Le streak quotidien est désormais piloté par `session_start` :
+        cette méthode conserve uniquement le suivi de progression hebdo.
         """
         streak = await self._get_or_create_streak(user_id)
         today = date.today()
@@ -50,31 +56,110 @@ class StreakService:
         # Incrémenter le compteur hebdo
         streak.weekly_count += 1
 
-        # Gérer le streak quotidien
-        if streak.last_activity_date:
-            days_since = (today - streak.last_activity_date).days
+        await self.db.flush()
+        return streak
 
+    async def record_session_start(
+        self,
+        user_id: str,
+        *,
+        local_date: date | None = None,
+    ) -> UserStreak | None:
+        """Met à jour le streak d'ouverture d'app, idempotent par jour."""
+        profile = await self._get_profile(user_id)
+        if not profile or not profile.gamification_enabled:
+            return None
+
+        streak = await self._get_or_create_streak(user_id)
+        activity_date = local_date or date.today()
+
+        if streak.last_activity_date:
+            if activity_date < streak.last_activity_date:
+                return streak
+
+            days_since = (activity_date - streak.last_activity_date).days
             if days_since == 0:
-                # Déjà actif aujourd'hui, ne pas incrémenter le streak
-                pass
-            elif days_since == 1:
-                # Jour consécutif, incrémenter le streak
-                streak.current_streak += 1
+                return streak
+            if days_since == 1:
+                streak.current_streak = (
+                    streak.current_streak + 1 if streak.current_streak > 0 else 1
+                )
             else:
-                # Streak cassé, reset à 1
                 streak.current_streak = 1
         else:
-            # Premier jour d'activité
             streak.current_streak = 1
 
-        streak.last_activity_date = today
-
-        # Mettre à jour le record
+        streak.last_activity_date = activity_date
         if streak.current_streak > streak.longest_streak:
             streak.longest_streak = streak.current_streak
 
         await self.db.flush()
         return streak
+
+    async def get_activity(self, user_id: str, days: int = 14) -> StreakActivityResponse:
+        """Construit l'activité d'ouverture d'app sur les N derniers jours."""
+        streak = await self._get_or_create_streak(user_id)
+        user_uuid = UUID(user_id)
+        today = date.today()
+        start_date = today - timedelta(days=days - 1)
+        since_date = start_date - timedelta(days=1)
+
+        query = (
+            select(AnalyticsEvent)
+            .where(
+                AnalyticsEvent.user_id == user_uuid,
+                AnalyticsEvent.event_type.in_(
+                    ["session_start", "content_interaction", "article_read"]
+                ),
+                func.date(AnalyticsEvent.created_at) >= since_date,
+            )
+            .order_by(AnalyticsEvent.created_at.asc())
+        )
+        result = await self.db.execute(query)
+        events = result.scalars().all()
+
+        opened_dates: set[date] = set()
+        articles_read_by_day: dict[date, int] = {}
+
+        for event in events:
+            event_date = self._event_local_date(event)
+            if event_date < start_date or event_date > today:
+                continue
+
+            if event.event_type == "session_start":
+                opened_dates.add(event_date)
+                continue
+
+            if event.event_type == "content_interaction":
+                if event.event_data.get("action") != "read":
+                    continue
+
+            # Reading implies the app was opened, even for historical days
+            # recorded before `session_start` became the streak source.
+            opened_dates.add(event_date)
+            articles_read_by_day[event_date] = articles_read_by_day.get(event_date, 0) + 1
+
+        activity_days = [
+            StreakActivityDayResponse(
+                date=day,
+                opened=day in opened_dates,
+                articles_read=(
+                    articles_read_by_day[day]
+                    if articles_read_by_day.get(day, 0) > 0
+                    else None
+                ),
+            )
+            for day in (
+                start_date + timedelta(days=offset) for offset in range(days)
+            )
+        ]
+
+        return StreakActivityResponse(
+            current_streak=streak.current_streak,
+            longest_streak=streak.longest_streak,
+            last_activity_date=streak.last_activity_date,
+            days=activity_days,
+        )
 
     async def _get_or_create_streak(self, user_id: str) -> UserStreak:
         """Récupère ou crée le streak d'un utilisateur."""
@@ -98,3 +183,14 @@ class StreakService:
         query = select(UserProfile).where(UserProfile.user_id == UUID(user_id))
         result = await self.db.execute(query)
         return result.scalar_one_or_none()
+
+    @staticmethod
+    def _event_local_date(event: AnalyticsEvent) -> date:
+        """Utilise `event_data.local_date` si disponible, sinon `created_at`."""
+        raw_local_date = event.event_data.get("local_date")
+        if isinstance(raw_local_date, str):
+            try:
+                return date.fromisoformat(raw_local_date)
+            except ValueError:
+                pass
+        return event.created_at.date()

--- a/packages/api/tests/test_streak_activity.py
+++ b/packages/api/tests/test_streak_activity.py
@@ -1,0 +1,243 @@
+from datetime import date, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.analytics import AnalyticsEvent
+from app.models.user import UserProfile, UserStreak
+
+
+def _override_db(session):
+    async def _fake_db():
+        yield session
+
+    return _fake_db
+
+
+def _override_user(user_id: str):
+    async def _fake_user():
+        return user_id
+
+    return _fake_user
+
+
+async def _create_profile(db_session, user_id, *, gamification_enabled: bool):
+    profile = UserProfile(
+        user_id=user_id,
+        gamification_enabled=gamification_enabled,
+        onboarding_completed=True,
+        weekly_goal=5,
+    )
+    db_session.add(profile)
+    await db_session.commit()
+    return profile
+
+
+@pytest.mark.asyncio
+async def test_session_start_same_local_date_is_idempotent(db_session):
+    user_id = uuid4()
+    await _create_profile(db_session, user_id, gamification_enabled=True)
+
+    app.dependency_overrides[get_current_user_id] = _override_user(str(user_id))
+    app.dependency_overrides[get_db] = _override_db(db_session)
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            for _ in range(2):
+                response = await ac.post(
+                    "/api/analytics/events",
+                    json={
+                        "event_type": "session_start",
+                        "event_data": {"local_date": "2026-05-26"},
+                    },
+                )
+                assert response.status_code == 201
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    streak = await db_session.scalar(
+        select(UserStreak).where(UserStreak.user_id == user_id)
+    )
+    assert streak is not None
+    assert streak.current_streak == 1
+    assert streak.longest_streak == 1
+    assert streak.last_activity_date == date(2026, 5, 26)
+
+    events = (
+        await db_session.execute(
+            select(AnalyticsEvent).where(AnalyticsEvent.user_id == user_id)
+        )
+    ).scalars().all()
+    assert len(events) == 2
+
+
+@pytest.mark.asyncio
+async def test_session_start_consecutive_days_then_gap_resets_streak(db_session):
+    user_id = uuid4()
+    await _create_profile(db_session, user_id, gamification_enabled=True)
+
+    app.dependency_overrides[get_current_user_id] = _override_user(str(user_id))
+    app.dependency_overrides[get_db] = _override_db(db_session)
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            for local_date in ("2026-05-24", "2026-05-25", "2026-05-27"):
+                response = await ac.post(
+                    "/api/analytics/events",
+                    json={
+                        "event_type": "session_start",
+                        "event_data": {"local_date": local_date},
+                    },
+                )
+                assert response.status_code == 201
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    streak = await db_session.scalar(
+        select(UserStreak).where(UserStreak.user_id == user_id)
+    )
+    assert streak is not None
+    assert streak.current_streak == 1
+    assert streak.longest_streak == 2
+    assert streak.last_activity_date == date(2026, 5, 27)
+
+
+@pytest.mark.asyncio
+async def test_session_start_logs_analytics_but_skips_streak_when_gamification_disabled(
+    db_session,
+):
+    user_id = uuid4()
+    await _create_profile(db_session, user_id, gamification_enabled=False)
+
+    app.dependency_overrides[get_current_user_id] = _override_user(str(user_id))
+    app.dependency_overrides[get_db] = _override_db(db_session)
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/analytics/events",
+                json={
+                    "event_type": "session_start",
+                    "event_data": {"local_date": "2026-05-26"},
+                },
+            )
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 201
+    event = await db_session.scalar(
+        select(AnalyticsEvent).where(AnalyticsEvent.user_id == user_id)
+    )
+    assert event is not None
+    assert event.event_type == "session_start"
+
+    streak = await db_session.scalar(
+        select(UserStreak).where(UserStreak.user_id == user_id)
+    )
+    assert streak is None
+
+
+@pytest.mark.asyncio
+async def test_streak_activity_endpoint_returns_opened_days_and_articles_read(
+    db_session,
+):
+    user_id = uuid4()
+    today = date.today()
+    day_1 = today - timedelta(days=3)
+    day_2 = today - timedelta(days=2)
+    day_3 = today - timedelta(days=1)
+    await _create_profile(db_session, user_id, gamification_enabled=True)
+
+    db_session.add_all(
+        [
+            UserStreak(
+                user_id=user_id,
+                current_streak=2,
+                longest_streak=3,
+                last_activity_date=today,
+            ),
+            AnalyticsEvent(
+                user_id=user_id,
+                event_type="session_start",
+                event_data={"local_date": day_1.isoformat()},
+                created_at=datetime.combine(day_1, datetime.min.time()).replace(hour=8),
+            ),
+            AnalyticsEvent(
+                user_id=user_id,
+                event_type="article_read",
+                event_data={"local_date": day_2.isoformat()},
+                created_at=datetime.combine(day_2, datetime.min.time()).replace(hour=7),
+            ),
+            AnalyticsEvent(
+                user_id=user_id,
+                event_type="session_start",
+                event_data={"local_date": day_3.isoformat()},
+                created_at=datetime.combine(day_3, datetime.min.time()).replace(hour=8),
+            ),
+            AnalyticsEvent(
+                user_id=user_id,
+                event_type="content_interaction",
+                event_data={"action": "save", "local_date": day_2.isoformat()},
+                created_at=datetime.combine(day_2, datetime.min.time()).replace(hour=7, minute=30),
+            ),
+            AnalyticsEvent(
+                user_id=user_id,
+                event_type="session_start",
+                event_data={"local_date": today.isoformat()},
+                created_at=datetime.combine(today, datetime.min.time()).replace(hour=8),
+            ),
+            AnalyticsEvent(
+                user_id=user_id,
+                event_type="content_interaction",
+                event_data={"action": "read", "local_date": day_3.isoformat()},
+                created_at=datetime.combine(day_3, datetime.min.time()).replace(hour=9),
+            ),
+            AnalyticsEvent(
+                user_id=user_id,
+                event_type="article_read",
+                event_data={"local_date": today.isoformat()},
+                created_at=datetime.combine(today, datetime.min.time()).replace(hour=9),
+            ),
+            AnalyticsEvent(
+                user_id=user_id,
+                event_type="content_interaction",
+                event_data={"action": "save", "local_date": today.isoformat()},
+                created_at=datetime.combine(today, datetime.min.time()).replace(hour=9, minute=5),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    app.dependency_overrides[get_current_user_id] = _override_user(str(user_id))
+    app.dependency_overrides[get_db] = _override_db(db_session)
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/api/streaks/activity?days=4")
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["current_streak"] == 2
+    assert body["longest_streak"] == 3
+    assert body["last_activity_date"] == today.isoformat()
+    assert body["days"] == [
+        {"date": day_1.isoformat(), "opened": True, "articles_read": None},
+        {"date": day_2.isoformat(), "opened": True, "articles_read": 1},
+        {"date": day_3.isoformat(), "opened": True, "articles_read": 1},
+        {"date": today.isoformat(), "opened": True, "articles_read": 1},
+    ]


### PR DESCRIPTION
## Summary
- move streak progression from digest completion side effects to app-open `session_start` analytics events
- add streak activity API/mobile modal UI, daily indicator animation gating, and gamification preference gating
- return digest completion payload to the closure screen and clean up session lifecycle handling to avoid pause/resume races

## Verification
- `flutter test test/features/gamification/models/streak_activity_model_test.dart test/features/gamification/providers/streak_animation_provider_test.dart test/features/gamification/widgets/streak_indicator_test.dart test/core/services/analytics_service_dual_track_test.dart`
- `python -m ruff check app/routers/analytics.py app/routers/streaks.py app/schemas/streak.py app/services/streak_service.py tests/test_streak_activity.py` from `packages/api`
- `python -m compileall app/routers/analytics.py app/routers/streaks.py app/schemas/streak.py app/services/streak_service.py tests/test_streak_activity.py` from `packages/api`

## Notes
- `python -m pytest tests/test_streak_activity.py` is blocked in this workspace because the local Postgres test credentials at `localhost:54322` fail authentication for user `postgres`.
