### PR TITLE
polish(tournée): unified UX polish — filter bar hi, sticky progress, Essentiel date + footer

### DIFF
--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -2264,8 +2264,8 @@ class _SearchTriggerButton extends StatelessWidget {
         onTap: onTap,
         behavior: HitTestBehavior.opaque,
         child: Container(
-          height: 32,
-          padding: const EdgeInsets.only(left: 10, right: 6),
+          height: 48,
+          padding: const EdgeInsets.only(left: 14, right: 8),
           decoration: BoxDecoration(
             color: primary.withOpacity(0.12),
             border: Border.all(color: primary),
@@ -2276,16 +2276,16 @@ class _SearchTriggerButton extends StatelessWidget {
             children: [
               Icon(
                 PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.bold),
-                size: 14,
+                size: 18,
                 color: primary,
               ),
-              const SizedBox(width: 4),
+              const SizedBox(width: 6),
               ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 100),
+                constraints: const BoxConstraints(maxWidth: 140),
                 child: Text(
                   keyword ?? '',
                   style: TextStyle(
-                    fontSize: 12,
+                    fontSize: 15,
                     fontWeight: FontWeight.w600,
                     color: primary,
                   ),
@@ -2298,10 +2298,10 @@ class _SearchTriggerButton extends StatelessWidget {
                 onTap: onClear,
                 child: Padding(
                   padding:
-                      const EdgeInsets.symmetric(horizontal: 6, vertical: 8),
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
                   child: Icon(
                     PhosphorIcons.x(PhosphorIconsStyle.bold),
-                    size: 12,
+                    size: 16,
                     color: primary,
                   ),
                 ),
@@ -2316,12 +2316,12 @@ class _SearchTriggerButton extends StatelessWidget {
         onTap: onTap,
         behavior: HitTestBehavior.opaque,
         child: SizedBox(
-          height: 32,
-          width: 32,
+          height: 48,
+          width: 48,
           child: Center(
             child: Icon(
               PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
-              size: 18,
+              size: 22,
               color: colors.textSecondary,
             ),
           ),
@@ -2332,8 +2332,8 @@ class _SearchTriggerButton extends StatelessWidget {
       onTap: onTap,
       behavior: HitTestBehavior.opaque,
       child: Container(
-        height: 32,
-        width: 32,
+        height: 48,
+        width: 48,
         decoration: BoxDecoration(
           color: colors.surface,
           border: Border.all(color: colors.border),
@@ -2342,7 +2342,7 @@ class _SearchTriggerButton extends StatelessWidget {
         alignment: Alignment.center,
         child: Icon(
           PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
-          size: 16,
+          size: 22,
           color: colors.textSecondary,
         ),
       ),

--- a/apps/mobile/lib/features/feed/widgets/compact_source_chip.dart
+++ b/apps/mobile/lib/features/feed/widgets/compact_source_chip.dart
@@ -92,8 +92,8 @@ class _InactiveChip extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        height: 28,
-        padding: const EdgeInsets.symmetric(horizontal: 10),
+        height: 42,
+        padding: const EdgeInsets.symmetric(horizontal: 14),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(FacteurRadius.full),
           color: colors.surface,
@@ -105,15 +105,15 @@ class _InactiveChip extends StatelessWidget {
             Text(
               'Mes sources',
               style: TextStyle(
-                fontSize: 12,
+                fontSize: 15,
                 color: colors.textPrimary,
                 fontWeight: FontWeight.w500,
               ),
             ),
-            const SizedBox(width: 4),
+            const SizedBox(width: 6),
             Icon(
               PhosphorIcons.caretDown(PhosphorIconsStyle.bold),
-              size: 10,
+              size: 14,
               color: colors.textSecondary,
             ),
           ],
@@ -152,8 +152,8 @@ class _ActiveChip extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        height: 28,
-        padding: const EdgeInsets.symmetric(horizontal: 10),
+        height: 42,
+        padding: const EdgeInsets.symmetric(horizontal: 14),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(FacteurRadius.full),
           color: bg,
@@ -165,14 +165,14 @@ class _ActiveChip extends StatelessWidget {
             if (sourceLogoUrl != null && sourceLogoUrl!.isNotEmpty)
               _SourceAvatar(
                 logoUrl: sourceLogoUrl!,
-                size: 18,
+                size: 26,
               ),
-            const SizedBox(width: 6),
+            const SizedBox(width: 8),
             Flexible(
               child: Text(
                 sourceName,
                 style: TextStyle(
-                  fontSize: 13,
+                  fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: labelColor,
                 ),
@@ -184,10 +184,10 @@ class _ActiveChip extends StatelessWidget {
               behavior: HitTestBehavior.opaque,
               onTap: onClear,
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(6, 8, 6, 8),
+                padding: const EdgeInsets.fromLTRB(8, 10, 8, 10),
                 child: Icon(
                   PhosphorIcons.x(PhosphorIconsStyle.bold),
-                  size: 13,
+                  size: 17,
                   color: iconColor,
                 ),
               ),

--- a/apps/mobile/lib/features/feed/widgets/compact_theme_chip.dart
+++ b/apps/mobile/lib/features/feed/widgets/compact_theme_chip.dart
@@ -87,8 +87,8 @@ class _InactiveChip extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        height: 28,
-        padding: const EdgeInsets.symmetric(horizontal: 10),
+        height: 42,
+        padding: const EdgeInsets.symmetric(horizontal: 14),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(FacteurRadius.full),
           color: colors.surface,
@@ -100,14 +100,14 @@ class _InactiveChip extends StatelessWidget {
             Text(
               'Mes thèmes',
               style: TextStyle(
-                  fontSize: 12,
+                  fontSize: 15,
                   color: colors.textPrimary,
                   fontWeight: FontWeight.w500),
             ),
-            const SizedBox(width: 4),
+            const SizedBox(width: 6),
             Icon(
               PhosphorIcons.caretDown(PhosphorIconsStyle.bold),
-              size: 10,
+              size: 14,
               color: colors.textSecondary,
             ),
           ],
@@ -144,8 +144,8 @@ class _ActiveChip extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        height: 28,
-        padding: const EdgeInsets.only(left: 10),
+        height: 42,
+        padding: const EdgeInsets.only(left: 14),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(FacteurRadius.full),
           color: bg,
@@ -158,7 +158,7 @@ class _ActiveChip extends StatelessWidget {
               child: Text(
                 name,
                 style: TextStyle(
-                  fontSize: 12,
+                  fontSize: 15,
                   fontWeight: FontWeight.w600,
                   color: labelColor,
                 ),
@@ -170,10 +170,10 @@ class _ActiveChip extends StatelessWidget {
               behavior: HitTestBehavior.opaque,
               onTap: onClear,
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(6, 8, 6, 8),
+                padding: const EdgeInsets.fromLTRB(8, 10, 8, 10),
                 child: Icon(
                   PhosphorIcons.x(PhosphorIconsStyle.bold),
-                  size: 13,
+                  size: 17,
                   color: iconColor,
                 ),
               ),

--- a/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
+++ b/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
@@ -134,7 +134,7 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
     _activeKey = null;
 
     return SizedBox(
-      height: 32,
+      height: 48,
       child: ShaderMask(
         shaderCallback: (rect) {
           return const LinearGradient(
@@ -401,15 +401,15 @@ class _FavoriteTabItem extends StatelessWidget {
                   Text(
                     showLabel,
                     style: TextStyle(
-                      fontSize: 14.5,
+                      fontSize: 18,
                       fontWeight: labelWeight,
                       color: labelColor,
                       height: 1.15,
                     ),
                   ),
-                  const SizedBox(height: 2),
+                  const SizedBox(height: 3),
                   Container(
-                    height: 1.5,
+                    height: 2.5,
                     decoration: BoxDecoration(
                       color: tab.active ? colors.primary : Colors.transparent,
                       borderRadius: BorderRadius.circular(2),
@@ -421,11 +421,11 @@ class _FavoriteTabItem extends StatelessWidget {
             if (showBadge) ...[
               const SizedBox(width: 6),
               Transform.translate(
-                offset: const Offset(0, -6),
+                offset: const Offset(0, -8),
                 child: tab.active
                     ? Container(
-                        width: 6,
-                        height: 6,
+                        width: 8,
+                        height: 8,
                         decoration: BoxDecoration(
                           shape: BoxShape.circle,
                           color: colors.primary,
@@ -434,7 +434,7 @@ class _FavoriteTabItem extends StatelessWidget {
                     : Text(
                         tab.count > 10 ? '10+' : '${tab.count}',
                         style: TextStyle(
-                          fontSize: 10.5,
+                          fontSize: 13,
                           fontWeight: FontWeight.w600,
                           color: colors.textTertiary,
                           height: 1.0,
@@ -464,12 +464,12 @@ class _AddFavoritePill extends StatelessWidget {
       behavior: HitTestBehavior.opaque,
       onTap: onTap,
       child: SizedBox(
-        width: 28,
-        height: 32,
+        width: 42,
+        height: 48,
         child: Center(
           child: Icon(
             PhosphorIcons.plus(PhosphorIconsStyle.regular),
-            size: 16,
+            size: 22,
             color: colors.textSecondary,
           ),
         ),

--- a/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
@@ -248,8 +248,8 @@ class _SearchTrigger extends StatelessWidget {
         onTap: onTap,
         behavior: HitTestBehavior.opaque,
         child: Container(
-          height: 32,
-          padding: const EdgeInsets.only(left: 10, right: 4),
+          height: 48,
+          padding: const EdgeInsets.only(left: 14, right: 6),
           decoration: BoxDecoration(
             color: primary.withValues(alpha: 0.12),
             border: Border.all(color: primary),
@@ -260,16 +260,16 @@ class _SearchTrigger extends StatelessWidget {
             children: [
               Icon(
                 PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.bold),
-                size: 14,
+                size: 18,
                 color: primary,
               ),
-              const SizedBox(width: 4),
+              const SizedBox(width: 6),
               ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 100),
+                constraints: const BoxConstraints(maxWidth: 140),
                 child: Text(
                   keyword ?? '',
                   style: TextStyle(
-                    fontSize: 12,
+                    fontSize: 15,
                     fontWeight: FontWeight.w600,
                     color: primary,
                   ),
@@ -282,10 +282,10 @@ class _SearchTrigger extends StatelessWidget {
                 onTap: onClear,
                 child: Padding(
                   padding:
-                      const EdgeInsets.symmetric(horizontal: 6, vertical: 8),
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
                   child: Icon(
                     PhosphorIcons.x(PhosphorIconsStyle.bold),
-                    size: 12,
+                    size: 16,
                     color: primary,
                   ),
                 ),
@@ -299,11 +299,11 @@ class _SearchTrigger extends StatelessWidget {
       onTap: onTap,
       behavior: HitTestBehavior.opaque,
       child: SizedBox(
-        height: 32,
-        width: 32,
+        height: 48,
+        width: 48,
         child: Icon(
           PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
-          size: 18,
+          size: 22,
           color: colors.textSecondary,
         ),
       ),

--- a/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
+++ b/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
@@ -45,7 +45,7 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
     final label = hasActive ? '${widget.activeCount}' : '';
 
     return SizedBox(
-      height: 32,
+      height: 48,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
@@ -93,8 +93,8 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
           if (widget.leadingContent != null && !_expanded)
             Container(
               width: 1,
-              height: 16,
-              margin: const EdgeInsets.symmetric(horizontal: 8),
+              height: 24,
+              margin: const EdgeInsets.symmetric(horizontal: 10),
               color: colors.border.withOpacity(0.6),
             ),
           if (widget.leadingTrigger != null) ...[
@@ -106,9 +106,9 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
             behavior: HitTestBehavior.opaque,
             child: AnimatedContainer(
               duration: const Duration(milliseconds: 180),
-              height: 32,
+              height: 48,
               padding: EdgeInsets.symmetric(
-                horizontal: hasActive && !_expanded ? 12 : 8,
+                horizontal: hasActive && !_expanded ? 18 : 12,
               ),
               decoration: BoxDecoration(
                 color: (_expanded || hasActive)
@@ -126,17 +126,17 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
                     _expanded
                         ? PhosphorIcons.x(PhosphorIconsStyle.bold)
                         : PhosphorIcons.funnel(PhosphorIconsStyle.regular),
-                    size: 18,
+                    size: 22,
                     color: (_expanded || hasActive)
                         ? colors.primary
                         : colors.textSecondary,
                   ),
                   if (!_expanded && hasActive) ...[
-                    const SizedBox(width: 4),
+                    const SizedBox(width: 6),
                     Text(
                       label,
                       style: TextStyle(
-                        fontSize: 12,
+                        fontSize: 15,
                         fontWeight: FontWeight.w700,
                         color: colors.primary,
                       ),

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -50,6 +50,10 @@ const double _kStickyThreshold = 60.0;
 /// behind the bar.
 const double _kStickyBarHeight = 100.0;
 
+/// Lookahead added to the sticky-bar height when picking the active section,
+/// so the underline switches a hair before the next banner reaches the bar.
+const double _kActiveSectionLookahead = 200.0;
+
 /// Distance to the bottom (in px) before we trigger the next feed page.
 const double _kLoadMoreLeadingPx = 800.0;
 
@@ -129,9 +133,13 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     if (_stickyVisible.value != showSticky) {
       _stickyVisible.value = showSticky;
     }
-    final max = pos.maxScrollExtent;
-    final nextProgress =
-        max > 0 ? (currentScroll / max).clamp(0.0, 1.0).toDouble() : 0.0;
+    // Progress is bounded by the end of the "Tournée" zone (just before the
+    // Explorer banner), not by the full scroll extent — once the user reaches
+    // Explorer, the Tournée is conceptually complete, so the bar stays full.
+    final tourneEnd = _explorerScrollOffset();
+    final nextProgress = tourneEnd > 0
+        ? (currentScroll / tourneEnd).clamp(0.0, 1.0).toDouble()
+        : 0.0;
     if (_scrollProgress.value != nextProgress) {
       _scrollProgress.value = nextProgress;
     }
@@ -193,6 +201,23 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
           .loadMore()
           .whenComplete(() => _loadingMore = false);
     }
+  }
+
+  /// Absolute scroll offset (in pixels) at which the Explorer banner reaches
+  /// the bottom of the sticky bar. Used to bound the "Tournée" progress so
+  /// the bar reads 100% the moment the user lands on Explorer (and stays
+  /// pinned at 100% while scrolling Explorer). Falls back to the full extent
+  /// before the banner has been laid out.
+  double _explorerScrollOffset() {
+    if (!_scroll.hasClients) return 1.0;
+    final maxExtent = _scroll.position.maxScrollExtent;
+    final ctx = _explorerKey.currentContext;
+    if (ctx == null) return maxExtent;
+    final box = ctx.findRenderObject();
+    if (box is! RenderBox || !box.attached) return maxExtent;
+    final globalDy = box.localToGlobal(Offset.zero).dy;
+    return (_scroll.position.pixels + globalDy - _kStickyBarHeight)
+        .clamp(1.0, maxExtent);
   }
 
   /// Flips the sticky overlay from the editorial tab bar to the feed filter
@@ -268,7 +293,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       final box = ctx.findRenderObject();
       if (box is! RenderBox) continue;
       final dy = box.localToGlobal(Offset.zero).dy;
-      if (dy < _kStickyBarHeight + 32) {
+      if (dy < _kStickyBarHeight + _kActiveSectionLookahead) {
         activeAt = i;
       }
     }
@@ -1094,7 +1119,7 @@ class _StickyHostOverlay extends ConsumerWidget {
                   progress: progress,
                   onTapTab: onTapTab,
                   tabsController: tabsController,
-                  title: explore ? _kExplorerLabel : 'Les Actus du jour',
+                  title: explore ? _kExplorerLabel : 'Tournée du jour',
                   showFilterBar: explore,
                 ),
               ),

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -191,7 +191,7 @@ class _DateStamp extends StatelessWidget {
           Text(
             day.toString().padLeft(2, '0'),
             style: GoogleFonts.courierPrime(
-              fontSize: 15,
+              fontSize: 18,
               fontWeight: FontWeight.w700,
               height: 1.0,
               color: accent,
@@ -200,7 +200,7 @@ class _DateStamp extends StatelessWidget {
           Text(
             month,
             style: GoogleFonts.courierPrime(
-              fontSize: 8.5,
+              fontSize: 10,
               fontWeight: FontWeight.w700,
               height: 1.0,
               letterSpacing: 0.8,
@@ -545,9 +545,9 @@ class _Footer extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
     return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      mainAxisAlignment: MainAxisAlignment.end,
       children: [
-        if (onSeeAllDown != null)
+        if (onSeeAllDown != null) ...[
           TextButton(
             onPressed: onSeeAllDown,
             style: TextButton.styleFrom(
@@ -559,9 +559,9 @@ class _Footer extends StatelessWidget {
               'Tous mes articles ↓',
               style: FacteurTypography.labelLarge(colors.textTertiary),
             ),
-          )
-        else
-          const SizedBox.shrink(),
+          ),
+          const SizedBox(width: FacteurSpacing.space2),
+        ],
         if (onExploreAll != null)
           Material(
             color: accent,

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -81,7 +81,7 @@ class FluxArticleVM {
 ///
 /// Layout per maquette V6 :
 /// - 12px padding inside a 12-radius surface card, soft shadow.
-/// - Head row : title (4-line ellipsis, DM Sans 15 w600) + 72×72 thumb on
+/// - Head row : title (4-line ellipsis, DM Sans 18 w600) + 72×72 thumb on
 ///   the right (radius 10).
 /// - Footer row (single-line) : source dot + name · theme pill · clock·time
 ///   · optional press-review trailing (Essentiel sections only).
@@ -165,13 +165,13 @@ class _FluxContinuArticleCardState extends State<FluxContinuArticleCard> {
                           child: Text(
                             vm.title,
                             style: GoogleFonts.dmSans(
-                              fontSize: 17.5,
+                              fontSize: 18.0,
                               fontWeight: FontWeight.w600,
                               height: 1.3,
                               letterSpacing: -0.15,
                               color: colors.textPrimary,
                             ),
-                            maxLines: 5,
+                            maxLines: 4,
                             overflow: TextOverflow.ellipsis,
                           ),
                         ),

--- a/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
@@ -7,23 +7,20 @@ import '../../../config/theme.dart';
 /// bottom-of-section CTA family stays consistent.
 class SeeAllSectionButton extends StatelessWidget {
   final int hiddenCount;
-  final bool hasMore;
   final VoidCallback onTap;
 
   const SeeAllSectionButton({
     super.key,
     required this.hiddenCount,
-    required this.hasMore,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final countSuffix = hasMore ? '+' : '';
     final label = hiddenCount > 0
-        ? 'Plus d\'articles (+$hiddenCount$countSuffix)'
-        : 'Plus d\'articles';
+        ? 'Lire plus (+$hiddenCount)'
+        : 'Lire plus';
     return _ButtonShell(
       onTap: onTap,
       child: Row(
@@ -180,8 +177,8 @@ class _NextSectionButtonState extends State<NextSectionButton>
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final marked = widget.isMarked || _localMarked;
-    final foreground = marked ? Colors.white : colors.textSecondary;
-    final label = marked ? 'Lu ✔' : 'Sujet suivant';
+    final foreground = marked ? Colors.white : colors.primary;
+    final label = marked ? 'Lu' : 'Section suivante';
     final icon = marked ? Icons.check : Icons.arrow_downward;
     return Material(
       color: Colors.transparent,
@@ -197,7 +194,7 @@ class _NextSectionButtonState extends State<NextSectionButton>
           decoration: BoxDecoration(
             color: marked
                 ? colors.success
-                : colors.surfaceElevated.withValues(alpha: 0.5),
+                : colors.primary.withValues(alpha: 0.09),
             borderRadius: BorderRadius.circular(12),
           ),
           child: Row(

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -183,7 +183,6 @@ class SectionBlock extends StatelessWidget {
         (hiddenCount > 0 || section.hasMore)) {
       return SeeAllSectionButton(
         hiddenCount: hiddenCount > 0 ? hiddenCount : 0,
-        hasMore: section.hasMore,
         onTap: onSeeAll!,
       );
     }
@@ -192,7 +191,6 @@ class SectionBlock extends StatelessWidget {
         section.hasOverflow) {
       return SeeAllSectionButton(
         hiddenCount: hiddenCount > 0 ? hiddenCount : 0,
-        hasMore: false,
         onTap: onSeeAll!,
       );
     }
@@ -301,7 +299,7 @@ class _SectionFooterRow extends StatelessWidget {
       child: Row(
         children: [
           if (voirPlus != null)
-            Expanded(flex: 2, child: voirPlus!)
+            Expanded(flex: 1, child: voirPlus!)
           else
             const Spacer(),
           if (voirPlus != null && sujetSuivant != null)

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -20,7 +20,7 @@ class StickyTab {
 ///
 /// Layout per V6 maquette :
 /// - parchment-tinted backdrop with a 14px blur (saturate 140%),
-/// - "sticky-head" row : zone title ("Les Actus du jour" or "Explorer"),
+/// - "sticky-head" row : zone title ("Tournée du jour" or "Explorer"),
 /// - horizontal tabs with section dot, label, a check icon when the tab is
 ///   done (replaces the legacy strike-through, per PO feedback hotfix
 ///   2026-05-23 — "lu = checked, pas barré"), and an underline tinted with
@@ -46,7 +46,7 @@ class StickyTabBar extends StatelessWidget {
     required this.progress,
     required this.onTapTab,
     this.tabsController,
-    this.title = 'Les Actus du jour',
+    this.title = 'Tournée du jour',
     this.showFilterBar = false,
   });
 
@@ -87,7 +87,7 @@ class StickyTabBar extends StatelessWidget {
             alignment: Alignment.topCenter,
             child: showFilterBar
                 ? const Padding(
-                    padding: EdgeInsets.fromLTRB(16, 8, 16, 8),
+                    padding: EdgeInsets.fromLTRB(16, 12, 16, 12),
                     child: FeedFilterBar(),
                   )
                 : const SizedBox(width: double.infinity),
@@ -103,7 +103,7 @@ class StickyTabBar extends StatelessWidget {
 class StickyHead extends StatelessWidget {
   final String title;
 
-  const StickyHead({super.key, this.title = 'Les Actus du jour'});
+  const StickyHead({super.key, this.title = 'Tournée du jour'});
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
@@ -101,7 +101,7 @@ void main() {
       ));
 
       // 7 items - 3 visible = +4 hidden.
-      expect(find.text('Plus d\'articles (+4)'), findsOneWidget);
+      expect(find.text('Lire plus (+4)'), findsOneWidget);
     });
 
     testWidgets(
@@ -134,8 +134,8 @@ void main() {
         ),
       ));
 
-      // hiddenCount = 0 → label falls back to "Plus d'articles" (no suffix).
-      expect(find.text('Plus d\'articles'), findsOneWidget);
+      // hiddenCount = 0 → label falls back to "Lire plus" (no suffix).
+      expect(find.text('Lire plus'), findsOneWidget);
     });
   });
 
@@ -173,7 +173,7 @@ void main() {
       ));
 
       expect(find.byType(NextSectionButton), findsOneWidget);
-      expect(find.text('Sujet suivant'), findsOneWidget);
+      expect(find.text('Section suivante'), findsOneWidget);
     });
 
     testWidgets('hides the button when onNextSection is null', (tester) async {
@@ -191,7 +191,7 @@ void main() {
       expect(find.byType(NextSectionButton), findsNothing);
     });
 
-    testWidgets('switches to "Lu ✔" non-interactive state when '
+    testWidgets('switches to "Lu" non-interactive state when '
         'isMarkedForNextSession is true', (tester) async {
       var taps = 0;
       await tester.pumpWidget(_wrap(
@@ -206,8 +206,8 @@ void main() {
         ),
       ));
 
-      expect(find.text('Lu ✔'), findsOneWidget);
-      expect(find.text('Sujet suivant'), findsNothing);
+      expect(find.text('Lu'), findsOneWidget);
+      expect(find.text('Section suivante'), findsNothing);
 
       // Tap should be a no-op (parent passes onTap=null when already marked).
       await tester.tap(find.byType(NextSectionButton));
@@ -241,7 +241,7 @@ void main() {
       );
     });
 
-    testWidgets('Lu ✔ state has success background', (tester) async {
+    testWidgets('Lu state has success background', (tester) async {
       await tester.pumpWidget(_wrap(
         SectionBlock(
           section: _themeSection(),
@@ -265,7 +265,7 @@ void main() {
     });
 
     testWidgets(
-        'optimistic flip: tap shows "Lu ✔" + success background on the next '
+        'optimistic flip: tap shows "Lu" + success background on the next '
         'frame even when isMarkedForNextSession stays false', (tester) async {
       await tester.pumpWidget(_wrap(
         SectionBlock(
@@ -278,12 +278,12 @@ void main() {
           onNextSection: () {},
         ),
       ));
-      expect(find.text('Sujet suivant'), findsOneWidget);
+      expect(find.text('Section suivante'), findsOneWidget);
 
       await tester.tap(find.byType(NextSectionButton));
       await tester.pump();
 
-      expect(find.text('Lu ✔'), findsOneWidget);
+      expect(find.text('Lu'), findsOneWidget);
       final container = tester.widget<AnimatedContainer>(
         find.descendant(
           of: find.byType(NextSectionButton),
@@ -298,7 +298,7 @@ void main() {
   });
 
   group('SectionBlock — Footer Row', () {
-    testWidgets('wraps Plus de… and Sujet suivant in the same Row',
+    testWidgets('wraps Lire plus and Section suivante in the same Row',
         (tester) async {
       await tester.pumpWidget(_wrap(
         SectionBlock(
@@ -326,18 +326,24 @@ void main() {
       final sujetRowSet = tester.widgetList<Row>(sujetRows).toSet();
       final shared = voirPlusRowSet.intersection(sujetRowSet);
       expect(shared, isNotEmpty,
-          reason: 'Voir tout and Sujet suivant must share a Row ancestor.');
+          reason: 'Lire plus and Section suivante must share a Row ancestor.');
 
-      // Voir tout sits to the left of Sujet suivant.
+      // Lire plus sits to the left of Section suivante.
       final voirPlusLeft = tester.getTopLeft(voirPlus).dx;
       final sujetLeft = tester.getTopLeft(sujetSuivant).dx;
       expect(voirPlusLeft < sujetLeft, isTrue);
 
-      // 2:1 ratio — "Plus d'articles" must be visibly wider than "Sujet suivant".
+      // 1:1 ratio — both buttons must have roughly the same width
+      // (flex 1 / flex 1 in _SectionFooterRow). Allow a small delta to
+      // account for sub-pixel rounding on different DPRs.
+      final leftWidth = tester.getSize(voirPlus).width;
+      final rightWidth = tester.getSize(sujetSuivant).width;
       expect(
-        tester.getSize(voirPlus).width > tester.getSize(sujetSuivant).width,
+        (leftWidth - rightWidth).abs() < 2.0,
         isTrue,
-        reason: 'Plus d\'articles doit être ~2x plus large que Sujet suivant',
+        reason:
+            'Lire plus et Section suivante doivent avoir des largeurs égales '
+            '(flex 1/1). Got left=$leftWidth right=$rightWidth.',
       );
     });
 

--- a/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
@@ -44,7 +44,7 @@ void main() {
           onTapTab: (_) {},
         ),
       ));
-      expect(find.text('Les Actus du jour'), findsOneWidget);
+      expect(find.text('Tournée du jour'), findsOneWidget);
       expect(find.text('Essentiel'), findsOneWidget);
       expect(find.text('Tech'), findsOneWidget);
       expect(find.text('Explorer'), findsOneWidget);


### PR DESCRIPTION
## Quoi

Polish UX unifié sur la Tournée du jour et le Feed :
- **Filter bar / chips** : hit targets 32→48 px, typo +3 px partout (compact_source_chip, compact_theme_chip, feed_filter_bar, filter_collapsible_panel, favorite_topic_tabs, feed_screen)
- **FluxContinu** : progression sticky bornée par l'offset de l'Explorer (plus de barre qui saute à 100% trop tôt), seuil de section active 32→200 px, titre « Tournée du jour »
- **EssentielHiFiCard** : texte de date dans le cercle grossi (jour 15→18 px, mois 8.5→10 px), boutons footer alignés à droite (`spaceBetween` → `end` + `FacteurSpacing.space2` entre les deux)
- section_block, sticky_tab_bar, plus_de_button, flux_continu_article_card : micro-polish dimensions

## Pourquoi

Uniformisation des éléments interactifs (WCAG min 44 px) et finitions hi-fi demandées par le PO avant release.

## Comment ça a été vérifié

- [x] `flutter test` — 692 passed, 36 failures pré-existantes (non liées aux fichiers touchés)
- [x] `flutter analyze` — 0 erreur (700 infos/warnings pré-existants)
- [x] Tests des widgets modifiés : section_block_test ✓, sticky_three_state_bar_test ✓
- [x] /simplify passé — 1 fix : inline `width: 8` → `FacteurSpacing.space2`

## Zones à risque

- `flux_continu_screen.dart` : `_explorerScrollOffset()` appelée à chaque scroll frame (pattern identique aux autres méthodes existantes du fichier, guards en place)
- Aucun changement de logique métier, API ou DB