### PR TITLE
fix(mes-interets): topics display — invalidate userInterests on mutations + screen open

### DIFF
--- a/apps/mobile/lib/config/topic_labels.dart
+++ b/apps/mobile/lib/config/topic_labels.dart
@@ -146,6 +146,12 @@ const Map<String, String> _slugToMacroTheme = {
   'middleeast': 'Géopolitique',
   // Sport
   'sport': 'Sport',
+  // Macro-theme slugs (fallback si enrichissement retourne un slug macro)
+  'society': 'Société',
+  'society_climate': 'Société',
+  'culture': 'Culture',
+  'culture_ideas': 'Culture',
+  'international': 'Géopolitique',
 };
 
 /// Reverse mapping: macro-theme label → API theme slug.

--- a/apps/mobile/lib/features/custom_topics/providers/custom_topics_provider.dart
+++ b/apps/mobile/lib/features/custom_topics/providers/custom_topics_provider.dart
@@ -6,6 +6,7 @@ import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
 import '../../../core/providers/analytics_provider.dart';
 import '../../lettres/providers/letters_provider.dart';
+import '../../my_interests/providers/user_interests_provider.dart';
 import '../models/topic_models.dart';
 import '../repositories/topic_repository.dart';
 
@@ -111,6 +112,7 @@ class CustomTopicsNotifier extends AsyncNotifier<List<UserTopicProfile>> {
           ));
       // Story 19.1 — repaint l'avancement Lettres si une action devient validée.
       unawaited(ref.read(lettersProvider.notifier).silentRefresh());
+      ref.invalidate(userInterestsProvider);
       return created;
     } catch (e) {
       // Rollback
@@ -147,6 +149,7 @@ class CustomTopicsNotifier extends AsyncNotifier<List<UserTopicProfile>> {
               origin: 'custom_topics',
             ));
       }
+      ref.invalidate(userInterestsProvider);
     } catch (e) {
       state = previousState;
       rethrow;
@@ -249,6 +252,7 @@ class CustomTopicsNotifier extends AsyncNotifier<List<UserTopicProfile>> {
       }
       // Story 19.1 — repaint l'avancement Lettres si une action devient validée.
       unawaited(ref.read(lettersProvider.notifier).silentRefresh());
+      ref.invalidate(userInterestsProvider);
       return created;
     } catch (e) {
       state = previousState;

--- a/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
@@ -57,6 +57,7 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      ref.invalidate(userInterestsProvider);
       if (widget.forceSereinOn && !ref.read(sereinToggleProvider).enabled) {
         ref.read(sereinToggleProvider.notifier).setEnabledLocal(true);
       }


### PR DESCRIPTION
## Quoi

Correction de l'affichage des topics dans l'écran **Mes Intérêts** qui restait périmé après des actions (follow/unfollow) ou à la réouverture de l'écran.

## Pourquoi

`userInterestsProvider` n'était pas invalidé après les mutations dans `CustomTopicsNotifier`, ni à l'ouverture de `MyInterestsScreen`. Résultat : l'UI affichait des données stales issues du cache Riverpod.

## Changements

- **`custom_topics_provider.dart`** : `ref.invalidate(userInterestsProvider)` ajouté après `followTopic`, `unfollowTopic` et `followEntity` (success path uniquement, pas dans les catch de rollback)
- **`my_interests_screen.dart`** : `ref.invalidate(userInterestsProvider)` dans `initState` (via `addPostFrameCallback`) pour forcer des données fraîches à chaque ouverture
- **`topic_labels.dart`** : Extension de `_slugToMacroTheme` avec les slugs macro (`society`, `society_climate`, `culture`, `culture_ideas`, `international`) comme fallback quand l'enrichissement backend retourne un slug macro au lieu d'un slug fin

## Comment ça a été vérifié

- [x] `flutter test` — 692 tests, 36 échecs pré-existants (identiques sans nos changements, aucune régression)
- [x] `flutter analyze` — warnings/infos uniquement, tous pré-existants
- [x] /simplify passé — code propre, aucune modification nécessaire

## Zones à risque

- `CustomTopicsNotifier` : invalidation croisée vers `userInterestsProvider` (dépendance circulaire potentielle — vérifiée, OK car invalidation unidirectionnelle)
- `MyInterestsScreen.initState` : double fetch à l'ouverture (intentionnel pour le bug fix)