### PR TITLE
fix(flux-continu): section folding applies to all sections + Paris TZ boundary + always-show check

### DIFF
--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/data/latest.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
 
 import '../../digest/models/digest_models.dart';
 import '../../digest/models/dual_digest_response.dart';
@@ -62,22 +64,33 @@ const int _kMaxFavoriteSections = 3;
 const String _kFoldedPrefsKeyPrefix = 'flux_continu_folded_';
 const String _kClosingPrefsKeyPrefix = 'flux_continu_closing_dismissed_';
 
-/// Boundary hour (local time) at which the "tournée day" flips. Aligned with
-/// the API digest cron at 07:30 Paris (`DIGEST_CRON_HOUR_PARIS`). Before this
-/// hour, the digest still reflects yesterday so the fold state must too —
-/// otherwise opening the app at 02:00 would wipe fold state while the
-/// content is unchanged.
+/// Boundary hour (Paris time) at which the "tournée day" flips. Aligned with
+/// the API digest cron at 07:30 Paris (`DIGEST_CRON_HOUR_PARIS`,
+/// `packages/api/app/workers/scheduler.py`). The boundary is computed against
+/// Europe/Paris — not the device's local timezone — so a user in Tokyo
+/// (UTC+9) at 02:00 local doesn't roll over to a fresh tournée hours before
+/// the backend has even generated tomorrow's digest.
 const int _kTourneeDayBoundaryHour = 7;
 const int _kTourneeDayBoundaryMinute = 30;
+const String _kTourneeDayBoundaryTz = 'Europe/Paris';
+
+tz.Location? _parisLocation;
+
+tz.Location _parisTz() {
+  if (_parisLocation != null) return _parisLocation!;
+  tz_data.initializeTimeZones();
+  return _parisLocation = tz.getLocation(_kTourneeDayBoundaryTz);
+}
 
 /// Returns the canonical ISO day (`YYYY-MM-DD`) for the tournée at [now],
-/// using a 07:30-local boundary instead of midnight.
+/// using a 07:30 Europe/Paris boundary instead of midnight.
 String _dayKey(DateTime now) {
-  final shifted = (now.hour < _kTourneeDayBoundaryHour ||
-          (now.hour == _kTourneeDayBoundaryHour &&
-              now.minute < _kTourneeDayBoundaryMinute))
-      ? now.subtract(const Duration(days: 1))
-      : now;
+  final paris = tz.TZDateTime.from(now, _parisTz());
+  final shifted = (paris.hour < _kTourneeDayBoundaryHour ||
+          (paris.hour == _kTourneeDayBoundaryHour &&
+              paris.minute < _kTourneeDayBoundaryMinute))
+      ? paris.subtract(const Duration(days: 1))
+      : paris;
   return shifted.toIso8601String().substring(0, 10);
 }
 

--- a/apps/mobile/lib/features/flux_continu/widgets/folded_section_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/folded_section_card.dart
@@ -4,26 +4,20 @@ import 'package:google_fonts/google_fonts.dart';
 import '../../../config/theme.dart';
 
 /// Compact "menu-list" version of [SectionBanner] used when the user has
-/// already consumed a section. Identity reduces to: section title, article
-/// count, chevron — over the bare parchment, with a hairline separator.
-/// No accent fill, no illustration: the card recedes to pure navigation
-/// once the day's content has been read.
+/// already consumed a section. Identity reduces to: green "Lu" check,
+/// section title, article count, chevron — over the bare parchment, with a
+/// hairline separator. No accent fill, no illustration: the card recedes to
+/// pure navigation once the day's content has been read.
 class FoldedSectionCard extends StatelessWidget {
   final String title;
   final int? articleCount;
   final VoidCallback? onTap;
-
-  /// When true, prefix the title with a small green check, matching the v3
-  /// spec for the folded "L'Essentiel du jour" ruban. Kept opt-in so the
-  /// existing digest sections (essentiel legacy, bonnes) stay unchanged.
-  final bool showCheck;
 
   const FoldedSectionCard({
     super.key,
     required this.title,
     this.articleCount,
     this.onTap,
-    this.showCheck = false,
   });
 
   @override
@@ -47,10 +41,8 @@ class FoldedSectionCard extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              if (showCheck) ...[
-                Icon(Icons.check, size: 16, color: colors.success),
-                const SizedBox(width: 6),
-              ],
+              Icon(Icons.check, size: 16, color: colors.success),
+              const SizedBox(width: 6),
               Expanded(
                 child: Text(
                   title,

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -107,14 +107,7 @@ class SectionBlock extends StatelessWidget {
     // viewport visually doesn't move. An animated transition here would defeat
     // the compensation by leaving the height in flux when the post-frame
     // callback measures it.
-    //
-    // [FeedThemeSection] never folds: it opens a dedicated ThemeSectionScreen
-    // (full-page slide), so the fold UX of digest sections would conflict
-    // with that affordance. Only digest sections (bonnes, "Actus du jour")
-    // and the v3 EssentielSection fold.
-    final bool canFold =
-        section is DigestTopicSection || section is EssentielSection;
-    return (isFolded && canFold) ? _buildFolded() : _buildExpanded();
+    return isFolded ? _buildFolded() : _buildExpanded();
   }
 
   Widget _buildFolded() {
@@ -122,7 +115,6 @@ class SectionBlock extends StatelessWidget {
       title: section.label,
       articleCount: section.totalCount,
       onTap: onUnfold,
-      showCheck: section is EssentielSection,
     );
   }
 


### PR DESCRIPTION
## Quoi

- Suppression du whitelist `canFold` (DigestTopicSection || EssentielSection) : toutes les sections se replient désormais quand `isFolded=true`, géré correctement par le provider
- Fix `_dayKey()` : la limite 07:30 est calculée en heure Europe/Paris (et non l'heure locale du device), pour éviter un rollover prématuré pour les utilisateurs hors France (ex. Tokyo à 02:00 local)
- `FoldedSectionCard` affiche toujours le check vert (suppression du param opt-in `showCheck`) : la carte n'est rendue que pour les sections déjà lues
- Simplification de la lazy-init timezone : suppression du bool `_tzInitialized` redondant, null-guard sur `_parisLocation` à la place

## Pourquoi

Le read state des sections repliées ne persistait pas correctement : la limite de jour 07:30 était calculée en heure locale, donc un utilisateur à Tokyo voyait son état de lecture effacé dès 02:00 heure locale alors que le backend n'avait pas encore généré le digest du lendemain. Par ailleurs, `FeedThemeSection` était arbitrairement exclu du repli alors que le provider gère correctement quelles sections ont `isFolded=true`.

## Comment ça a été vérifié

- [x] flutter test test/features/flux_continu/ → 96 tests OK
- [x] flutter analyze → aucun warning dans les fichiers modifiés
- [x] /simplify passé (suppression du bool redondant `_tzInitialized`)

## Zones à risque

- `flux_continu_provider.dart` : changement de timezone reference (local → Europe/Paris) pour la clé de persistance des prefs — les utilisateurs existants verront leur fold state réinitialisé une fois (les clés prefs ont un nouveau suffixe de date)
- `section_block.dart` : toutes les sections peuvent maintenant se replier (comportement étendu)