### PR TITLE
fix(filter-bar): sticky bar compact + reactive filter selection + dark mode backdrop

### DIFF
--- a/apps/mobile/lib/config/theme.dart
+++ b/apps/mobile/lib/config/theme.dart
@@ -540,4 +540,6 @@ extension FacteurThemeContext on BuildContext {
     }
     return colors;
   }
+
+  bool get isDarkMode => Theme.of(this).brightness == Brightness.dark;
 }

--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -69,6 +69,57 @@ class FeedSnapshot {
 /// `null` quand aucun undo n'est possible (pas de refresh récent ou undo déjà joué).
 final feedUndoSnapshotProvider = StateProvider<FeedSnapshot?>((ref) => null);
 
+/// Sélection de filtres en cours, exposée séparément du `feedProvider` pour que
+/// l'UI (chips, tabs, badge du funnel) puisse réagir **dès le tap** sans
+/// attendre la fin du refresh réseau. Les setters du [FeedNotifier] poussent
+/// ici avant `await refresh()`.
+class FeedFilterSelection {
+  final String? sourceId;
+  final String? topic;
+  final String? theme;
+  final String? entity;
+  final String? keyword;
+
+  const FeedFilterSelection({
+    this.sourceId,
+    this.topic,
+    this.theme,
+    this.entity,
+    this.keyword,
+  });
+
+  static const empty = FeedFilterSelection();
+
+  int get activeCount {
+    var c = 0;
+    if (sourceId != null) c++;
+    if (keyword != null && keyword!.isNotEmpty) c++;
+    return c;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FeedFilterSelection &&
+          sourceId == other.sourceId &&
+          topic == other.topic &&
+          theme == other.theme &&
+          entity == other.entity &&
+          keyword == other.keyword;
+
+  @override
+  int get hashCode =>
+      Object.hash(sourceId, topic, theme, entity, keyword);
+}
+
+final feedFilterSelectionProvider =
+    StateProvider<FeedFilterSelection>((ref) => FeedFilterSelection.empty);
+
+/// `true` tant qu'un refresh feed est en vol (filter change, serein toggle,
+/// pull-to-refresh). Permet d'afficher un loader partagé sur les deux écrans
+/// qui consomment `feedProvider` (FeedScreen + Explorer du FluxContinu).
+final feedRefreshingProvider = StateProvider<bool>((ref) => false);
+
 // Provider des données du feed (Infinite Scroll + Briefing)
 final feedProvider = AsyncNotifierProvider<FeedNotifier, FeedState>(() {
   return FeedNotifier();
@@ -158,6 +209,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     _selectedSourceId = null;
     _selectedEntity = null;
     _selectedKeyword = null;
+    // Riverpod interdit de muter un autre provider pendant le build : on
+    // diffère donc le reset au prochain microtick.
+    scheduleMicrotask(_syncSelectionProvider);
 
     // NB: serein toggle is observed in feed_screen.dart (which wraps the
     // refresh in a loading indicator). Listening here as well would cause
@@ -366,6 +420,7 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     _selectedEntity = null;
     _selectedKeyword = null;
     _includeUnfollowed = false;
+    _syncSelectionProvider();
     await refresh();
   }
 
@@ -378,6 +433,7 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     _selectedEntity = null;
     _selectedKeyword = null;
     _includeUnfollowed = false;
+    _syncSelectionProvider();
     await refresh();
   }
 
@@ -390,6 +446,7 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     _selectedEntity = null;
     _selectedKeyword = null;
     _includeUnfollowed = false;
+    _syncSelectionProvider();
     await refresh();
   }
 
@@ -402,6 +459,7 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     _selectedSourceId = null;
     _selectedKeyword = null;
     _includeUnfollowed = false;
+    _syncSelectionProvider();
     await refresh();
   }
 
@@ -416,6 +474,7 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     _selectedTopic = null;
     _selectedSourceId = null;
     _selectedEntity = null;
+    _syncSelectionProvider();
     await refresh();
   }
 
@@ -428,7 +487,21 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     _selectedEntity = null;
     _selectedKeyword = null;
     _includeUnfollowed = false;
+    _syncSelectionProvider();
     await refresh();
+  }
+
+  /// Pushes the current filter selection into [feedFilterSelectionProvider]
+  /// so listeners (chips, tabs, funnel badge) rebuild **immediately** on tap,
+  /// without waiting for the refresh round-trip.
+  void _syncSelectionProvider() {
+    ref.read(feedFilterSelectionProvider.notifier).state = FeedFilterSelection(
+      sourceId: _selectedSourceId,
+      topic: _selectedTopic,
+      theme: _selectedTheme,
+      entity: _selectedEntity,
+      keyword: _selectedKeyword,
+    );
   }
 
   Future<FeedResponse> _fetchPage({
@@ -560,6 +633,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
 
     // Ne pas émettre AsyncLoading — ça détruit le SliverList dans le screen
     // et reset la position de scroll. Le RefreshIndicator gère déjà le feedback visuel.
+    // À la place : feedRefreshingProvider signale qu'un fetch est en vol →
+    // sticky filter bar + écran legacy partagent le même LinearProgressIndicator.
+    ref.read(feedRefreshingProvider.notifier).state = true;
 
     try {
       // R5.1 — pull-to-refresh / explicit refresh always bypasses the
@@ -600,6 +676,8 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         print('FeedNotifier: refresh failed with no previous state: $e');
         state = AsyncError(e, stack);
       }
+    } finally {
+      ref.read(feedRefreshingProvider.notifier).state = false;
     }
   }
 

--- a/apps/mobile/lib/features/feed/screens/feed_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/feed_screen.dart
@@ -124,9 +124,6 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
   // Dynamic progressions map: ContentID -> Topic
   final Map<String, String> _activeProgressions = {};
 
-  // Feed loading state: true while any filter change or serein toggle refreshes
-  bool _isFeedRefreshing = false;
-
   // Story 4.5b: Show the undo banner after a viewport-aware pull-to-refresh.
   bool _showUndoBanner = false;
 
@@ -169,15 +166,6 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
   Timer? _idlePhaseTimer;
   bool _firstPaintTracked = false;
   bool _digestVisibleTracked = false;
-
-  Future<void> _withFeedLoading(Future<void> Function() action) async {
-    if (mounted) setState(() => _isFeedRefreshing = true);
-    try {
-      await action();
-    } finally {
-      if (mounted) setState(() => _isFeedRefreshing = false);
-    }
-  }
 
   // Interest filter: store selected name & type to avoid re-derivation bugs
   String? _selectedInterestName;
@@ -567,24 +555,25 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
         selectedThemeSlug: notifier.selectedTheme,
         selectedEntitySlug: notifier.selectedEntity,
         onTabTap: (kind, slug) {
-          _withFeedLoading(() async {
-            switch (kind) {
-              case FavoriteTabKind.tous:
-                await notifier.setTopic(null);
-                await notifier.setTheme(null);
-                await notifier.setEntity(null);
-                break;
-              case FavoriteTabKind.subjectTopic:
-                await notifier.setTopic(slug);
-                break;
-              case FavoriteTabKind.subjectEntity:
-                await notifier.setEntity(slug);
-                break;
-              case FavoriteTabKind.theme:
-                await notifier.setTheme(slug);
-                break;
-            }
-          });
+          // FeedNotifier.refresh() pilote feedRefreshingProvider — pas besoin
+          // de wrapper local : le LinearProgressIndicator partagé apparaît
+          // tout seul.
+          switch (kind) {
+            case FavoriteTabKind.tous:
+              notifier.setTopic(null);
+              notifier.setTheme(null);
+              notifier.setEntity(null);
+              break;
+            case FavoriteTabKind.subjectTopic:
+              notifier.setTopic(slug);
+              break;
+            case FavoriteTabKind.subjectEntity:
+              notifier.setEntity(slug);
+              break;
+            case FavoriteTabKind.theme:
+              notifier.setTheme(slug);
+              break;
+          }
           if (mounted) {
             setState(() {
               _selectedInterestName = null;
@@ -613,15 +602,13 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                 _selectedInterestName = name;
                 _selectedIsTheme = isTheme;
               });
-              _withFeedLoading(() async {
-                if (isTheme) {
-                  await notifier.setTheme(slug);
-                } else if (isEntity) {
-                  await notifier.setEntity(slug);
-                } else {
-                  await notifier.setTopic(slug);
-                }
-              });
+              if (isTheme) {
+                notifier.setTheme(slug);
+              } else if (isEntity) {
+                notifier.setEntity(slug);
+              } else {
+                notifier.setTopic(slug);
+              }
               _scrollToTop();
             },
           );
@@ -637,17 +624,17 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
             context,
             currentKeyword: notifier.selectedKeyword,
             onSearchSubmitted: (keyword, {bool fromTrending = false}) {
-              _withFeedLoading(() => notifier.setKeyword(
-                    keyword,
-                    includeUnfollowed: fromTrending,
-                  ));
+              notifier.setKeyword(
+                keyword,
+                includeUnfollowed: fromTrending,
+              );
               _scrollToTop();
             },
           );
         },
         onClear: () {
           HapticFeedback.mediumImpact();
-          _withFeedLoading(() => notifier.setKeyword(null));
+          notifier.setKeyword(null);
           _scrollToTop();
         },
       ),
@@ -698,11 +685,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
             selectedSourceLogoUrl: selectedSourceLogoUrl,
             discreet: true,
             onSourceChanged: (sourceId) {
-              if (sourceId != null) {
-                _withFeedLoading(() => notifier.setSource(sourceId));
-              } else {
-                notifier.setSource(null);
-              }
+              notifier.setSource(sourceId);
               _scrollToTop();
             },
           ),
@@ -722,19 +705,17 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                 _selectedInterestName = name;
                 _selectedIsTheme = isTheme;
               });
-              _withFeedLoading(() async {
-                if (slug == null) {
-                  await notifier.setTopic(null);
-                  await notifier.setTheme(null);
-                  await notifier.setEntity(null);
-                } else if (isTheme) {
-                  await notifier.setTheme(slug);
-                } else if (isEntity) {
-                  await notifier.setEntity(slug);
-                } else {
-                  await notifier.setTopic(slug);
-                }
-              });
+              if (slug == null) {
+                notifier.setTopic(null);
+                notifier.setTheme(null);
+                notifier.setEntity(null);
+              } else if (isTheme) {
+                notifier.setTheme(slug);
+              } else if (isEntity) {
+                notifier.setEntity(slug);
+              } else {
+                notifier.setTopic(slug);
+              }
               _scrollToTop();
             },
           ),
@@ -746,6 +727,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
   @override
   Widget build(BuildContext context) {
     final feedAsync = ref.watch(feedProvider);
+    final isFeedRefreshing = ref.watch(feedRefreshingProvider);
     final colors = context.facteurColors;
     final loadPhase = ref.watch(feedLoadPhaseProvider);
 
@@ -787,10 +769,11 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
       });
     });
 
-    // Serein toggle: loading indicator tied to actual feed refresh
+    // Serein toggle: feedRefreshingProvider est piloté par refresh() lui-même,
+    // donc le LinearProgressIndicator partagé apparaît automatiquement.
     ref.listen(sereinToggleProvider.select((s) => s.enabled), (prev, next) {
       if (prev != next && mounted) {
-        _withFeedLoading(() => ref.read(feedProvider.notifier).refresh());
+        ref.read(feedProvider.notifier).refresh();
       }
     });
 
@@ -977,7 +960,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                     ),
                     const SliverToBoxAdapter(child: SizedBox(height: 16)),
                     // Brief loading indicator when serein toggle triggers feed refresh
-                    if (_isFeedRefreshing)
+                    if (isFeedRefreshing)
                       SliverToBoxAdapter(
                         child: Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -1167,7 +1150,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                         return SliverPadding(
                           padding: const EdgeInsets.symmetric(horizontal: 8),
                           sliver: SliverAnimatedOpacity(
-                            opacity: _isFeedRefreshing ? 0.3 : 1.0,
+                            opacity: isFeedRefreshing ? 0.3 : 1.0,
                             duration: const Duration(milliseconds: 200),
                             sliver: SliverList(
                               delegate: SliverChildBuilderDelegate(
@@ -1634,7 +1617,7 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                                                               _selectedInterestName = name;
                                                               _selectedIsTheme = false;
                                                             });
-                                                            _withFeedLoading(() => notifier.setEntity(key));
+                                                            notifier.setEntity(key);
                                                             _scrollToTop();
                                                           },
                                                         )

--- a/apps/mobile/lib/features/feed/widgets/compact_source_chip.dart
+++ b/apps/mobile/lib/features/feed/widgets/compact_source_chip.dart
@@ -92,8 +92,8 @@ class _InactiveChip extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        height: 42,
-        padding: const EdgeInsets.symmetric(horizontal: 14),
+        height: 34,
+        padding: const EdgeInsets.symmetric(horizontal: 11),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(FacteurRadius.full),
           color: colors.surface,
@@ -102,18 +102,22 @@ class _InactiveChip extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
-              'Mes sources',
-              style: TextStyle(
-                fontSize: 15,
-                color: colors.textPrimary,
-                fontWeight: FontWeight.w500,
+            Flexible(
+              child: Text(
+                'Mes sources',
+                style: TextStyle(
+                  fontSize: 12.5,
+                  color: colors.textPrimary,
+                  fontWeight: FontWeight.w500,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
             ),
-            const SizedBox(width: 6),
+            const SizedBox(width: 5),
             Icon(
               PhosphorIcons.caretDown(PhosphorIconsStyle.bold),
-              size: 14,
+              size: 11,
               color: colors.textSecondary,
             ),
           ],
@@ -152,8 +156,8 @@ class _ActiveChip extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        height: 42,
-        padding: const EdgeInsets.symmetric(horizontal: 14),
+        height: 34,
+        padding: const EdgeInsets.symmetric(horizontal: 11),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(FacteurRadius.full),
           color: bg,
@@ -165,14 +169,14 @@ class _ActiveChip extends StatelessWidget {
             if (sourceLogoUrl != null && sourceLogoUrl!.isNotEmpty)
               _SourceAvatar(
                 logoUrl: sourceLogoUrl!,
-                size: 26,
+                size: 20,
               ),
-            const SizedBox(width: 8),
+            const SizedBox(width: 6),
             Flexible(
               child: Text(
                 sourceName,
                 style: TextStyle(
-                  fontSize: 16,
+                  fontSize: 13,
                   fontWeight: FontWeight.w600,
                   color: labelColor,
                 ),
@@ -184,10 +188,10 @@ class _ActiveChip extends StatelessWidget {
               behavior: HitTestBehavior.opaque,
               onTap: onClear,
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(8, 10, 8, 10),
+                padding: const EdgeInsets.fromLTRB(6, 8, 6, 8),
                 child: Icon(
                   PhosphorIcons.x(PhosphorIconsStyle.bold),
-                  size: 17,
+                  size: 14,
                   color: iconColor,
                 ),
               ),

--- a/apps/mobile/lib/features/feed/widgets/compact_theme_chip.dart
+++ b/apps/mobile/lib/features/feed/widgets/compact_theme_chip.dart
@@ -87,8 +87,8 @@ class _InactiveChip extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        height: 42,
-        padding: const EdgeInsets.symmetric(horizontal: 14),
+        height: 34,
+        padding: const EdgeInsets.symmetric(horizontal: 11),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(FacteurRadius.full),
           color: colors.surface,
@@ -97,17 +97,21 @@ class _InactiveChip extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
-              'Mes thèmes',
-              style: TextStyle(
-                  fontSize: 15,
-                  color: colors.textPrimary,
-                  fontWeight: FontWeight.w500),
+            Flexible(
+              child: Text(
+                'Mes thèmes',
+                style: TextStyle(
+                    fontSize: 12.5,
+                    color: colors.textPrimary,
+                    fontWeight: FontWeight.w500),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
-            const SizedBox(width: 6),
+            const SizedBox(width: 5),
             Icon(
               PhosphorIcons.caretDown(PhosphorIconsStyle.bold),
-              size: 14,
+              size: 11,
               color: colors.textSecondary,
             ),
           ],
@@ -144,8 +148,8 @@ class _ActiveChip extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        height: 42,
-        padding: const EdgeInsets.only(left: 14),
+        height: 34,
+        padding: const EdgeInsets.only(left: 11),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(FacteurRadius.full),
           color: bg,
@@ -158,7 +162,7 @@ class _ActiveChip extends StatelessWidget {
               child: Text(
                 name,
                 style: TextStyle(
-                  fontSize: 15,
+                  fontSize: 12.5,
                   fontWeight: FontWeight.w600,
                   color: labelColor,
                 ),
@@ -170,10 +174,10 @@ class _ActiveChip extends StatelessWidget {
               behavior: HitTestBehavior.opaque,
               onTap: onClear,
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(8, 10, 8, 10),
+                padding: const EdgeInsets.fromLTRB(6, 8, 6, 8),
                 child: Icon(
                   PhosphorIcons.x(PhosphorIconsStyle.bold),
-                  size: 17,
+                  size: 14,
                   color: iconColor,
                 ),
               ),

--- a/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
+++ b/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
@@ -134,7 +134,7 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
     _activeKey = null;
 
     return SizedBox(
-      height: 48,
+      height: 38,
       child: ShaderMask(
         shaderCallback: (rect) {
           return const LinearGradient(
@@ -401,15 +401,15 @@ class _FavoriteTabItem extends StatelessWidget {
                   Text(
                     showLabel,
                     style: TextStyle(
-                      fontSize: 18,
+                      fontSize: 14.5,
                       fontWeight: labelWeight,
                       color: labelColor,
                       height: 1.15,
                     ),
                   ),
-                  const SizedBox(height: 3),
+                  const SizedBox(height: 2),
                   Container(
-                    height: 2.5,
+                    height: 2,
                     decoration: BoxDecoration(
                       color: tab.active ? colors.primary : Colors.transparent,
                       borderRadius: BorderRadius.circular(2),
@@ -419,13 +419,13 @@ class _FavoriteTabItem extends StatelessWidget {
               ),
             ),
             if (showBadge) ...[
-              const SizedBox(width: 6),
+              const SizedBox(width: 5),
               Transform.translate(
-                offset: const Offset(0, -8),
+                offset: const Offset(0, -6),
                 child: tab.active
                     ? Container(
-                        width: 8,
-                        height: 8,
+                        width: 6.5,
+                        height: 6.5,
                         decoration: BoxDecoration(
                           shape: BoxShape.circle,
                           color: colors.primary,
@@ -434,7 +434,7 @@ class _FavoriteTabItem extends StatelessWidget {
                     : Text(
                         tab.count > 10 ? '10+' : '${tab.count}',
                         style: TextStyle(
-                          fontSize: 13,
+                          fontSize: 11,
                           fontWeight: FontWeight.w600,
                           color: colors.textTertiary,
                           height: 1.0,
@@ -464,12 +464,12 @@ class _AddFavoritePill extends StatelessWidget {
       behavior: HitTestBehavior.opaque,
       onTap: onTap,
       child: SizedBox(
-        width: 42,
-        height: 48,
+        width: 34,
+        height: 38,
         child: Center(
           child: Icon(
             PhosphorIcons.plus(PhosphorIconsStyle.regular),
-            size: 22,
+            size: 18,
             color: colors.textSecondary,
           ),
         ),

--- a/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
@@ -35,25 +35,18 @@ class FeedFilterBar extends ConsumerStatefulWidget {
 }
 
 class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
-  String? _selectedInterestName;
-  bool _selectedIsTheme = false;
-
-  int _activeFilterCount() {
-    final notifier = ref.read(feedProvider.notifier);
-    var count = 0;
-    if (notifier.selectedSourceId != null) count++;
-    if (notifier.selectedKeyword != null &&
-        notifier.selectedKeyword!.isNotEmpty) {
-      count++;
-    }
-    return count;
-  }
+  /// Label affiché par la chip "thème/sujet" — défini quand la sélection vient
+  /// du sheet (`InterestFilterSheet`) qui connaît le `name`. Quand la
+  /// sélection vient d'un onglet [FavoriteTopicTabs], on ne le surcharge pas :
+  /// la chip retombe sur 'Thème' / 'Sujet' par défaut.
+  String? _selectedInterestNameOverride;
 
   @override
   Widget build(BuildContext context) {
     final notifier = ref.read(feedProvider.notifier);
-    final hasSearch = notifier.selectedKeyword != null &&
-        notifier.selectedKeyword!.isNotEmpty;
+    final selection = ref.watch(feedFilterSelectionProvider);
+    final hasSearch =
+        selection.keyword != null && selection.keyword!.isNotEmpty;
     final feedItems =
         ref.watch(feedProvider).valueOrNull?.items ?? const <dynamic>[];
     final serverCounts = ref.watch(tabCountsProvider).valueOrNull;
@@ -63,16 +56,21 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
             ?.tourneeThemeSlugs ??
         const <String>[];
     return FilterCollapsiblePanel(
-      activeCount: _activeFilterCount(),
-      chipsRow: _buildChipsRow(context),
+      activeCount: selection.activeCount,
+      chipsRow: _buildChipsRow(context, selection),
       leadingContent: FavoriteTopicTabs(
         items: feedItems.cast(),
         serverCounts: serverCounts,
-        selectedTopicSlug: notifier.selectedTopic,
-        selectedThemeSlug: notifier.selectedTheme,
-        selectedEntitySlug: notifier.selectedEntity,
+        selectedTopicSlug: selection.topic,
+        selectedThemeSlug: selection.theme,
+        selectedEntitySlug: selection.entity,
         excludedThemeSlugs: tourneeSlugs,
         onTabTap: (kind, slug) async {
+          // Sheet owns this override ; clear it so the chip label rebuilds
+          // from the tapped tab's name on next layout.
+          if (mounted) {
+            setState(() => _selectedInterestNameOverride = null);
+          }
           switch (kind) {
             case FavoriteTabKind.tous:
               await notifier.setTopic(null);
@@ -89,12 +87,6 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
               await notifier.setTheme(slug);
               break;
           }
-          if (mounted) {
-            setState(() {
-              _selectedInterestName = null;
-              _selectedIsTheme = kind == FavoriteTabKind.theme;
-            });
-          }
           widget.onAfterChange?.call();
         },
         onTapActiveTab: () => widget.onAfterChange?.call(),
@@ -106,15 +98,13 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
           HapticFeedback.mediumImpact();
           InterestFilterSheet.show(
             context,
-            currentTopicSlug: notifier.selectedTopic ??
-                notifier.selectedTheme ??
-                notifier.selectedEntity,
-            currentIsTheme: notifier.selectedTheme != null,
+            currentTopicSlug:
+                selection.topic ?? selection.theme ?? selection.entity,
+            currentIsTheme: selection.theme != null,
             onInterestSelected:
                 (slug, name, {bool isTheme = false, bool isEntity = false}) async {
               setState(() {
-                _selectedInterestName = name;
-                _selectedIsTheme = isTheme;
+                _selectedInterestNameOverride = name;
               });
               if (isTheme) {
                 await notifier.setTheme(slug);
@@ -130,12 +120,12 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
       ),
       leadingTrigger: _SearchTrigger(
         active: hasSearch,
-        keyword: notifier.selectedKeyword,
+        keyword: selection.keyword,
         onTap: () {
           HapticFeedback.mediumImpact();
           SearchFilterSheet.show(
             context,
-            currentKeyword: notifier.selectedKeyword,
+            currentKeyword: selection.keyword,
             onSearchSubmitted: (keyword, {bool fromTrending = false}) async {
               await notifier.setKeyword(
                 keyword,
@@ -154,24 +144,27 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
     );
   }
 
-  Widget _buildChipsRow(BuildContext context) {
+  Widget _buildChipsRow(BuildContext context, FeedFilterSelection selection) {
     final notifier = ref.read(feedProvider.notifier);
 
-    if (notifier.selectedTheme == null &&
-        notifier.selectedTopic == null &&
-        notifier.selectedEntity == null) {
-      _selectedInterestName = null;
-      _selectedIsTheme = false;
+    if (selection.theme == null &&
+        selection.topic == null &&
+        selection.entity == null) {
+      _selectedInterestNameOverride = null;
     }
 
     final allSources = ref.watch(userSourcesProvider).valueOrNull ?? [];
     final followedSources = allSources
         .where((s) => (s.isTrusted || s.isCustom) && !s.isMuted)
         .toList();
-    final selectedSourceId = notifier.selectedSourceId;
+    final selectedSourceId = selection.sourceId;
     final selectedSource = selectedSourceId != null
         ? followedSources.where((s) => s.id == selectedSourceId).firstOrNull
         : null;
+
+    final selectedInterestSlug =
+        selection.topic ?? selection.theme ?? selection.entity;
+    final selectedIsTheme = selection.theme != null;
 
     return Row(
       children: [
@@ -191,17 +184,14 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
         const SizedBox(width: 8),
         Flexible(
           child: CompactThemeChip(
-            selectedSlug: notifier.selectedTopic ??
-                notifier.selectedTheme ??
-                notifier.selectedEntity,
-            selectedName: _selectedInterestName,
-            selectedIsTheme: _selectedIsTheme,
+            selectedSlug: selectedInterestSlug,
+            selectedName: _selectedInterestNameOverride,
+            selectedIsTheme: selectedIsTheme,
             discreet: true,
             onInterestChanged: (slug, name,
                 {bool isTheme = false, bool isEntity = false}) async {
               setState(() {
-                _selectedInterestName = name;
-                _selectedIsTheme = isTheme;
+                _selectedInterestNameOverride = name;
               });
               if (slug == null) {
                 await notifier.setTopic(null);
@@ -248,8 +238,8 @@ class _SearchTrigger extends StatelessWidget {
         onTap: onTap,
         behavior: HitTestBehavior.opaque,
         child: Container(
-          height: 48,
-          padding: const EdgeInsets.only(left: 14, right: 6),
+          height: 38,
+          padding: const EdgeInsets.only(left: 12, right: 4),
           decoration: BoxDecoration(
             color: primary.withValues(alpha: 0.12),
             border: Border.all(color: primary),
@@ -260,16 +250,16 @@ class _SearchTrigger extends StatelessWidget {
             children: [
               Icon(
                 PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.bold),
-                size: 18,
+                size: 15,
                 color: primary,
               ),
-              const SizedBox(width: 6),
+              const SizedBox(width: 5),
               ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 140),
+                constraints: const BoxConstraints(maxWidth: 112),
                 child: Text(
                   keyword ?? '',
                   style: TextStyle(
-                    fontSize: 15,
+                    fontSize: 12.5,
                     fontWeight: FontWeight.w600,
                     color: primary,
                   ),
@@ -282,10 +272,10 @@ class _SearchTrigger extends StatelessWidget {
                 onTap: onClear,
                 child: Padding(
                   padding:
-                      const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 8),
                   child: Icon(
                     PhosphorIcons.x(PhosphorIconsStyle.bold),
-                    size: 16,
+                    size: 13,
                     color: primary,
                   ),
                 ),
@@ -299,11 +289,11 @@ class _SearchTrigger extends StatelessWidget {
       onTap: onTap,
       behavior: HitTestBehavior.opaque,
       child: SizedBox(
-        height: 48,
-        width: 48,
+        height: 38,
+        width: 38,
         child: Icon(
           PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
-          size: 22,
+          size: 18,
           color: colors.textSecondary,
         ),
       ),

--- a/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
+++ b/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
@@ -45,7 +45,7 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
     final label = hasActive ? '${widget.activeCount}' : '';
 
     return SizedBox(
-      height: 48,
+      height: 38,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
@@ -93,8 +93,8 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
           if (widget.leadingContent != null && !_expanded)
             Container(
               width: 1,
-              height: 24,
-              margin: const EdgeInsets.symmetric(horizontal: 10),
+              height: 18,
+              margin: const EdgeInsets.symmetric(horizontal: 8),
               color: colors.border.withOpacity(0.6),
             ),
           if (widget.leadingTrigger != null) ...[
@@ -106,9 +106,9 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
             behavior: HitTestBehavior.opaque,
             child: AnimatedContainer(
               duration: const Duration(milliseconds: 180),
-              height: 48,
+              height: 38,
               padding: EdgeInsets.symmetric(
-                horizontal: hasActive && !_expanded ? 18 : 12,
+                horizontal: hasActive && !_expanded ? 14 : 10,
               ),
               decoration: BoxDecoration(
                 color: (_expanded || hasActive)
@@ -126,17 +126,17 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
                     _expanded
                         ? PhosphorIcons.x(PhosphorIconsStyle.bold)
                         : PhosphorIcons.funnel(PhosphorIconsStyle.regular),
-                    size: 22,
+                    size: 18,
                     color: (_expanded || hasActive)
                         ? colors.primary
                         : colors.textSecondary,
                   ),
                   if (!_expanded && hasActive) ...[
-                    const SizedBox(width: 6),
+                    const SizedBox(width: 5),
                     Text(
                       label,
                       style: TextStyle(
-                        fontSize: 15,
+                        fontSize: 12.5,
                         fontWeight: FontWeight.w700,
                         color: colors.primary,
                       ),

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_backdrop.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_backdrop.dart
@@ -2,11 +2,15 @@ import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
 
+import '../../../config/theme.dart';
+
 /// Parchment-tinted backdrop shared by every sticky overlay on the Flux Continu
 /// screen — the editorial [StickyTabBar] and the Explorer sticky in
 /// `flux_continu_screen.dart`. Keeping the shell in one place locks the two
 /// surfaces to identical blur, colour, border and shadow so the cross-fade
 /// between them feels like one bar morphing rather than two distinct bars.
+///
+/// Adapts to dark mode: parchment overlay in light, dark-surface tint in dark.
 class StickyBackdrop extends StatelessWidget {
   final Widget child;
 
@@ -14,17 +18,22 @@ class StickyBackdrop extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = context.isDarkMode;
+    final backdropColor = isDark
+        ? context.facteurColors.backgroundPrimary.withValues(alpha: 0.92)
+        : const Color.fromRGBO(242, 232, 213, 0.92);
+    final borderColor = isDark
+        ? Colors.white.withValues(alpha: 0.08)
+        : const Color.fromRGBO(0, 0, 0, 0.06);
+
     return ClipRect(
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
         child: Container(
           decoration: BoxDecoration(
-            color: const Color.fromRGBO(242, 232, 213, 0.92),
-            border: const Border(
-              bottom: BorderSide(
-                color: Color.fromRGBO(0, 0, 0, 0.06),
-                width: 1,
-              ),
+            color: backdropColor,
+            border: Border(
+              bottom: BorderSide(color: borderColor, width: 1),
             ),
             boxShadow: [
               BoxShadow(

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import '../../../config/theme.dart';
+import '../../feed/providers/feed_provider.dart';
 import '../../feed/widgets/feed_filter_bar.dart';
 import 'sticky_backdrop.dart';
 
@@ -52,6 +54,10 @@ class StickyTabBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final trackColor = context.isDarkMode
+        ? const Color.fromRGBO(255, 255, 255, 0.08)
+        : const Color.fromRGBO(0, 0, 0, 0.06);
+
     return StickyBackdrop(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -76,7 +82,7 @@ class StickyTabBar extends StatelessWidget {
                   Color(0xFF6C3483),
                 ],
                 glow: const Color.fromRGBO(211, 84, 0, 0.35),
-                trackColor: const Color.fromRGBO(0, 0, 0, 0.06),
+                trackColor: trackColor,
               ),
               child: const SizedBox.expand(),
             ),
@@ -87,13 +93,37 @@ class StickyTabBar extends StatelessWidget {
             alignment: Alignment.topCenter,
             child: showFilterBar
                 ? const Padding(
-                    padding: EdgeInsets.fromLTRB(16, 12, 16, 12),
+                    padding: EdgeInsets.fromLTRB(16, 8, 16, 8),
                     child: FeedFilterBar(),
                   )
                 : const SizedBox(width: double.infinity),
           ),
+          const _FeedRefreshIndicatorStrip(),
         ],
       ),
+    );
+  }
+}
+
+/// 2 px progress strip wired to [feedRefreshingProvider]. Sits flush at the
+/// bottom of the sticky bar so the user gets immediate feedback that a
+/// filter / search change triggered a fetch in flight.
+class _FeedRefreshIndicatorStrip extends ConsumerWidget {
+  const _FeedRefreshIndicatorStrip();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final refreshing = ref.watch(feedRefreshingProvider);
+    final colors = context.facteurColors;
+    return SizedBox(
+      height: 2,
+      child: refreshing
+          ? LinearProgressIndicator(
+              minHeight: 2,
+              backgroundColor: Colors.transparent,
+              color: colors.primary,
+            )
+          : const SizedBox.shrink(),
     );
   }
 }

--- a/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -9,16 +10,18 @@ import 'package:facteur/features/flux_continu/widgets/sticky_tab_bar.dart';
 /// (PR follow-up to #650). The file name kept its historical name so the
 /// existing CI globs don't need an update.
 Widget _wrap(Widget child) {
-  return MaterialApp(
-    theme: ThemeData(extensions: [FacteurPalettes.light]),
-    home: Scaffold(
-      // Sticky overlay is rendered at the very top of the screen in
-      // production via `Positioned(top:0, left:0, right:0)` — its inner
-      // Column sizes vertically to its children (mainAxisSize.min). Wrapping
-      // the test fixture in a top-aligned Align keeps the layout faithful
-      // and lets the FeedFilterBar variant compute its natural height
-      // without being stretched to fill the Scaffold body.
-      body: Align(alignment: Alignment.topCenter, child: child),
+  return ProviderScope(
+    child: MaterialApp(
+      theme: ThemeData(extensions: [FacteurPalettes.light]),
+      home: Scaffold(
+        // Sticky overlay is rendered at the very top of the screen in
+        // production via `Positioned(top:0, left:0, right:0)` — its inner
+        // Column sizes vertically to its children (mainAxisSize.min).
+        // Wrapping the test fixture in a top-aligned Align keeps the layout
+        // faithful and lets the FeedFilterBar variant compute its natural
+        // height without being stretched to fill the Scaffold body.
+        body: Align(alignment: Alignment.topCenter, child: child),
+      ),
     ),
   );
 }


### PR DESCRIPTION
## Quoi

Réduit la hauteur de la sticky filter bar (48→38px) dans l'écran Explorer du Flux Continu, rend la sélection de filtres réactive côté UI sans attendre le refresh réseau, et ajoute un indicateur de progression partagé. Corrige aussi le dark mode sur le backdrop collant (couleur hardcodée → thème-aware).

## Pourquoi

- La filter bar à 48px prenait trop de place dans le sticky overlay en mode Explorer, masquant du contenu
- Les chips/tabs/badge du funnel rebuildaient seulement après le round-trip réseau → lag visuel perceptible au tap
- `StickyBackdrop` utilisait une couleur parchmin hardcodée (`RGBA(242,232,213)`) invisible en dark mode

## Comment ça a été vérifié

- [x] `flutter test` — 96/96 tests flux_continu OK, 697 total (36 failures pré-existantes sur `main` non liées)
- [x] `flutter analyze --no-pub` — 0 erreurs
- [x] /simplify passé : Builder inutile retiré, `==`/`hashCode` ajouté sur `FeedFilterSelection`, helper `isDarkMode` mutualisé dans `FacteurThemeContext`

## Changements clés

### feed_provider.dart
- `FeedFilterSelection` (nouveau) : value object exposant la sélection de filtres via `feedFilterSelectionProvider` — les chips/tabs/badge rebuild **immédiatement** au tap, sans attendre `refresh()`
- `feedRefreshingProvider` : booléen `true` pendant tout fetch — alimente la progress strip partagée
- `_syncSelectionProvider()` : appelé dans chaque setter avant `await refresh()`
- Equality (`==`/`hashCode`) sur `FeedFilterSelection` → Riverpod ne notifie que si les valeurs changent réellement

### feed_filter_bar.dart + feed_screen.dart
- `FeedFilterBar` lit depuis `feedFilterSelectionProvider` au lieu du notifier → reactive sans polling
- `_withFeedLoading()` supprimé de `FeedScreen` → `feedRefreshingProvider` prend le relais

### sticky_tab_bar.dart + sticky_backdrop.dart
- `_FeedRefreshIndicatorStrip` (2px linear progress) au bas du sticky bar
- Backdrop dark mode : parchmin → `backgroundPrimary@0.92`, bordure `black@0.06` → `white@0.08`
- `Builder` retiré du progress painter → `context.isDarkMode` appelé directement dans `build()`

### config/theme.dart
- `context.isDarkMode` : getter mutualisé dans `FacteurThemeContext`

## Zones à risque

- **FeedNotifier** : `_syncSelectionProvider()` appelé dans 6+ setters — à surveiller si un setter est ajouté sans l'appel
- **feedRefreshingProvider** : booléen (pas compteur) — si deux refreshes concurrent se terminent dans le mauvais ordre la strip peut disparaître prématurément (edge case mineur, refresh est sérialisé par `_isLoadingMore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)