### PR TITLE
polish(perspectives): highlight contrast + intro pédagogique

### DIFF
--- a/apps/mobile/lib/features/feed/widgets/diff_title.dart
+++ b/apps/mobile/lib/features/feed/widgets/diff_title.dart
@@ -234,19 +234,32 @@ class _DiffTitleState extends State<DiffTitle>
             padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
             decoration: BoxDecoration(
               color: widget.biasColor
-                  .withValues(alpha: 0.22 * t * (chunk.weight ?? 1.0)),
+                  .withValues(alpha: _washAlpha(t, chunk.weight)),
               borderRadius: BorderRadius.circular(4),
             ),
             child: Text(
               chunk.text,
               style: widget.baseStyle.copyWith(
                 color: colors.textPrimary,
-                fontWeight: FontWeight.w400,
+                fontWeight: (chunk.weight ?? 0) >= 1.0
+                    ? FontWeight.w700
+                    : FontWeight.w400,
               ),
             ),
           ),
         );
     }
+  }
+
+  // weight=null (fallback spaCy hors digest) reste à 0.22 pour rétrocompat.
+  static double _washAlpha(double t, double? weight) {
+    if (weight == null) return 0.22 * t;
+    final base = switch (weight) {
+      >= 0.75 => 0.30,
+      >= 0.40 => 0.20,
+      _ => 0.12,
+    };
+    return base * t;
   }
 }
 

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -401,6 +401,16 @@ class _PerspectivesBottomSheetState
                           if (widget.comparisonQuality == 'low')
                             PerspectivesWarningBadge(
                                 colors: colors, textTheme: textTheme),
+                          const SizedBox(height: 12),
+                          Text(
+                            'Le surlignage met en évidence les termes qui '
+                            'marquent l\'angle éditorial : plus le surlignage '
+                            'est intense, plus le choix de mot est éditorialisé.',
+                            style: textTheme.bodySmall?.copyWith(
+                              color: colors.textSecondary,
+                              height: 1.4,
+                            ),
+                          ),
                           const SizedBox(height: 16),
                           PerspectivesBiasBar(
                             colors: colors,

--- a/apps/mobile/test/features/feed/widgets/diff_title_strong_editorial_test.dart
+++ b/apps/mobile/test/features/feed/widgets/diff_title_strong_editorial_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart';
+import 'package:facteur/features/feed/widgets/diff_title.dart';
+
+/// PR 6.1 — bump typo pour les key spans à `weight == 1.0`.
+///
+/// Le Text enfant du WidgetSpan d'un key chunk doit avoir
+/// `fontWeight = FontWeight.w700` quand `weight = 1.0`, et `FontWeight.w400`
+/// sinon (incluant null pour rétrocompat). animateIn=false → cascade
+/// terminée immédiatement.
+void main() {
+  Widget host(DiffTitle child) {
+    return MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(body: Center(child: child)),
+    );
+  }
+
+  /// Récupère le fontWeight du premier Text descendant du Container du wash.
+  /// On distingue le Container du wash via son borderRadius (signature du
+  /// key span dans DiffTitle).
+  FontWeight? keyTextFontWeight(WidgetTester tester) {
+    final containers = tester.widgetList<Container>(find.byType(Container));
+    for (final c in containers) {
+      final dec = c.decoration;
+      if (dec is BoxDecoration && dec.borderRadius != null) {
+        final textFinder = find.descendant(
+          of: find.byWidget(c),
+          matching: find.byType(Text),
+        );
+        if (textFinder.evaluate().isNotEmpty) {
+          return tester.widget<Text>(textFinder.first).style?.fontWeight;
+        }
+      }
+    }
+    return null;
+  }
+
+  DiffTitle buildDiff({double? weight}) => DiffTitle(
+        title: 'Macron annonce une réforme',
+        highlightSpans: [
+          HighlightSpan(
+            start: 7,
+            end: 14,
+            text: 'annonce',
+            bias: 'right',
+            weight: weight,
+          ),
+        ],
+        sharedTokens: const [],
+        biasColor: Colors.red,
+        baseStyle: const TextStyle(fontSize: 14),
+        animateIn: false,
+      );
+
+  group('DiffTitle — strong editorial fontWeight bump', () {
+    testWidgets('weight = 1.0 → fontWeight.w700', (tester) async {
+      await tester.pumpWidget(host(buildDiff(weight: 1.0)));
+      await tester.pumpAndSettle();
+      expect(keyTextFontWeight(tester), FontWeight.w700);
+    });
+
+    testWidgets('weight = 0.5 → fontWeight.w400 (pas de bump)', (tester) async {
+      await tester.pumpWidget(host(buildDiff(weight: 0.5)));
+      await tester.pumpAndSettle();
+      expect(keyTextFontWeight(tester), FontWeight.w400);
+    });
+
+    testWidgets('weight = 0.25 → fontWeight.w400', (tester) async {
+      await tester.pumpWidget(host(buildDiff(weight: 0.25)));
+      await tester.pumpAndSettle();
+      expect(keyTextFontWeight(tester), FontWeight.w400);
+    });
+
+    testWidgets('weight = null → fontWeight.w400 (rétrocompat)',
+        (tester) async {
+      await tester.pumpWidget(host(buildDiff(weight: null)));
+      await tester.pumpAndSettle();
+      expect(keyTextFontWeight(tester), FontWeight.w400);
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/widgets/diff_title_weight_test.dart
+++ b/apps/mobile/test/features/feed/widgets/diff_title_weight_test.dart
@@ -5,15 +5,16 @@ import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/feed/repositories/feed_repository.dart';
 import 'package:facteur/features/feed/widgets/diff_title.dart';
 
-/// PR 6 — modulation d'opacité du surlignage par `weight` LLM.
+/// PR 6.1 — re-mapping discret de l'opacité du surlignage par `weight` LLM.
 ///
-/// Le surlignage du key span (Container avec BoxDecoration colorée) doit avoir
-/// une opacité = 0.22 * t * (weight ?? 1.0). animateIn=false → t=1.
+/// Le surlignage du key span (Container avec BoxDecoration colorée) suit un
+/// mapping discret nettement contrasté, avec floor visible. animateIn=false
+/// → t=1.
 ///
 /// Spec :
-///   weight = 1.0    → alpha = 0.22 (comportement actuel, max)
-///   weight = 0.5    → alpha = 0.11
-///   weight = 0.25   → alpha = 0.055
+///   weight = 1.0    → alpha = 0.30 (max)
+///   weight = 0.5    → alpha = 0.20
+///   weight = 0.25   → alpha = 0.12 (floor lisible)
 ///   weight = null   → alpha = 0.22 (fallback rétrocompat, sans modulation)
 void main() {
   Widget host(DiffTitle child) {
@@ -44,7 +45,7 @@ void main() {
   }
 
   group('DiffTitle — weight modulation', () {
-    testWidgets('weight = 1.0 → alpha ≈ 0.22', (tester) async {
+    testWidgets('weight = 1.0 → alpha ≈ 0.30', (tester) async {
       await tester.pumpWidget(host(DiffTitle(
         title: 'Macron annonce une réforme',
         highlightSpans: const [
@@ -65,10 +66,10 @@ void main() {
 
       final alpha = keyWashAlpha(tester);
       expect(alpha, isNotNull);
-      expect(alpha!, closeTo(0.22, 0.005));
+      expect(alpha!, closeTo(0.30, 0.005));
     });
 
-    testWidgets('weight = 0.5 → alpha ≈ 0.11', (tester) async {
+    testWidgets('weight = 0.5 → alpha ≈ 0.20', (tester) async {
       await tester.pumpWidget(host(DiffTitle(
         title: 'Macron annonce une réforme',
         highlightSpans: const [
@@ -89,10 +90,10 @@ void main() {
 
       final alpha = keyWashAlpha(tester);
       expect(alpha, isNotNull);
-      expect(alpha!, closeTo(0.11, 0.005));
+      expect(alpha!, closeTo(0.20, 0.005));
     });
 
-    testWidgets('weight = 0.25 → alpha ≈ 0.055', (tester) async {
+    testWidgets('weight = 0.25 → alpha ≈ 0.12', (tester) async {
       await tester.pumpWidget(host(DiffTitle(
         title: 'Macron annonce une réforme',
         highlightSpans: const [
@@ -113,7 +114,7 @@ void main() {
 
       final alpha = keyWashAlpha(tester);
       expect(alpha, isNotNull);
-      expect(alpha!, closeTo(0.055, 0.005));
+      expect(alpha!, closeTo(0.12, 0.005));
     });
 
     testWidgets('weight = null → alpha ≈ 0.22 (rétrocompat)', (tester) async {

--- a/apps/mobile/test/features/feed/widgets/perspectives_bottom_sheet_intro_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_bottom_sheet_intro_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
+
+/// PR 6.1 — phrase d'intro pédagogique sous le titre « Couverture
+/// médiatique », au-dessus de la bias bar. Affichée uniquement quand
+/// `perspectives.isNotEmpty`.
+Perspective _persp(String name) => Perspective(
+      title: 'Titre pour $name',
+      url: 'https://example.com/$name',
+      sourceName: name,
+      sourceDomain: '',
+      biasStance: 'center',
+    );
+
+Future<void> _pumpSheet(
+  WidgetTester tester, {
+  required List<Perspective> perspectives,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(
+          body: SizedBox(
+            width: 390,
+            height: 844,
+            child: PerspectivesBottomSheet(
+              perspectives: perspectives,
+              biasDistribution: const {'center': 0},
+              keywords: const [],
+              contentId: 'test-content-id',
+              sourceBiasStance: 'center',
+              sourceName: 'Test',
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  const introSnippet = "marquent l'angle éditorial";
+
+  testWidgets('perspectives non vides → phrase d\'intro présente',
+      (tester) async {
+    await _pumpSheet(tester, perspectives: [_persp('Source-FR-1')]);
+
+    expect(find.textContaining(introSnippet), findsOneWidget);
+  });
+
+  testWidgets('perspectives vides → phrase d\'intro absente (empty state)',
+      (tester) async {
+    await _pumpSheet(tester, perspectives: const []);
+
+    expect(find.textContaining(introSnippet), findsNothing);
+  });
+}


### PR DESCRIPTION
## Quoi

Polish visuel de la bottom sheet Perspectives :
- **DiffTitle** : mapping d'opacité discret 3 niveaux (0.30 / 0.20 / 0.12) au lieu d'une multiplication continue par `weight`. Floor visible (0.12 au lieu de 0.055). Bump `fontWeight.w700` pour les key spans à `weight = 1.0`.
- **PerspectivesBottomSheet** : phrase d'intro pédagogique sous le titre « Couverture médiatique » (au-dessus de la bias bar) expliquant que l'intensité du surlignage reflète l'éditorialisation du choix de mot. Affichée uniquement quand `perspectives.isNotEmpty`.

## Pourquoi

Avant : les `weight = 0.25` (mots faiblement éditoriaux) étaient quasi invisibles (alpha 0.055). Après : 3 niveaux nettement contrastés, le plancher reste lisible, et le w700 sur les mots à fort score donne un signal typographique en plus du wash de couleur. L'intro contextualise la lecture pour les nouveaux users.

Rétrocompat : `weight = null` (fallback spaCy hors digest) reste à alpha 0.22 inchangé.

## Comment ça a été vérifié

- [x] `flutter test` ciblé sur les 3 fichiers de test : **10/10 OK**
  - `diff_title_weight_test.dart` (4 tests — alpha)
  - `diff_title_strong_editorial_test.dart` (4 tests — fontWeight, nouveau)
  - `perspectives_bottom_sheet_intro_test.dart` (2 tests — affichage conditionnel, nouveau)
- [x] Suite mobile complète : 703 passed. Les 36 échecs sont préexistants sur `origin/main` (digest_completion / bookmark / topic_chip / router — non liés à ce diff, baseline confirmée par checkout main).
- [x] `flutter analyze` : pas de nouveau warning sur les fichiers touchés.
- [x] /simplify passé : retiré une réf "PR 6 / PR 6.1" dans un commentaire.

## Zones à risque

- `DiffTitle` est rendu dans toutes les cartes du digest → vérifier sur device que le w700 ne crée pas de saut de baseline visible.
- L'intro ajoute ~3 lignes au-dessus de la bias bar → vérifier le scroll de la bottom sheet sur petit écran.

## Note sur le nom de branche

La branche s'appelle `pr-6.1-foreign-coverage` mais le diff ne touche pas au bloc « Couverture à l'étranger » (memory PO). Si c'est un changement de scope volontaire, ignorer ; sinon le bloc foreign coverage reste à faire dans une PR suivante.