### PR TITLE
fix(ui): micro-ajustements swipe, article partiel, bouton Remonter pill, badge articles lus

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -2437,7 +2437,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   /// Inline "Article complet" button shown at the end of the body when the
   /// article is in partial mode — replaces the dismissible nudge for partial
   /// articles since reading-on-site is the only path to the full content.
-  Widget _buildPartialArticleInlineButton(BuildContext context, Content content) {
+  Widget _buildPartialArticleInlineButton(BuildContext context) {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
     return Padding(
@@ -2461,12 +2461,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              SourceLogoAvatar(
-                source: content.source,
-                size: 24,
-                radius: 6,
-              ),
-              const SizedBox(width: 6),
               Flexible(
                 child: Text(
                   'Article complet',
@@ -2726,7 +2720,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       ),
 
                       if (isPartial && _contentResolved)
-                        _buildPartialArticleInlineButton(context, content),
+                        _buildPartialArticleInlineButton(context),
 
                       // ZONE 3: Transparent spacer — only after CTA tap to enable scroll animation.
                       // _bridgeKey attached here so _computeScrollOffsets() can measure the bridge zone.
@@ -3258,7 +3252,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   children: [
                     articleWidget,
                     if (isPartial && _contentResolved)
-                      _buildPartialArticleInlineButton(context, content),
+                      _buildPartialArticleInlineButton(context),
                     if (_showReadOnSiteNudge) ...[
                       const SizedBox(height: FacteurSpacing.space4),
                       Padding(

--- a/apps/mobile/lib/features/feed/widgets/swipe_to_open_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/swipe_to_open_card.dart
@@ -180,26 +180,27 @@ class _SwipeToOpenCardState extends State<SwipeToOpenCard>
     final velocity = details.primaryVelocity ?? 0;
     final ratio = _dragExtent / screenWidth;
 
-    // Right swipe: open
+    // Right swipe: open. We deliberately skip _snapBack() — the parent
+    // pushes the article route immediately, so bouncing the card back to 0
+    // before the transition gave a "rebound" impression that the action
+    // wasn't firing.
     if (!_hasTriggered &&
         _dragExtent > 0 &&
         (ratio > _threshold || velocity > _flingVelocity)) {
       _hasTriggered = true;
       HapticFeedback.mediumImpact();
       widget.onSwipeOpen();
-      if (!mounted) return;
-      _snapBack();
       return;
     }
 
-    // Left swipe: snap back and fire callback (Epic 12: opens bottom sheet)
+    // Left swipe: fire callback (Epic 12: opens bottom sheet). Same rationale
+    // as above — let the bottom sheet take over instead of snapping back.
     if (!_hasTriggered &&
         _dragExtent < 0 &&
         widget.onSwipeDismiss != null &&
         (ratio < -_threshold || velocity < -_flingVelocity)) {
       _hasTriggered = true;
       HapticFeedback.mediumImpact();
-      _snapBack();
       widget.onSwipeDismiss!();
       return;
     }

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -1138,6 +1138,9 @@ class _ScrollToTopButton extends StatelessWidget {
 
   const _ScrollToTopButton({required this.onTap});
 
+  static const _kRadius =
+      BorderRadius.all(Radius.circular(22));
+
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
@@ -1152,20 +1155,20 @@ class _ScrollToTopButton extends StatelessWidget {
         : const Color.fromRGBO(0, 0, 0, 0.08);
 
     return ClipRRect(
-      borderRadius: BorderRadius.circular(22),
+      borderRadius: _kRadius,
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
         child: Material(
           color: Colors.transparent,
           child: InkWell(
-            borderRadius: BorderRadius.circular(22),
+            borderRadius: _kRadius,
             onTap: onTap,
             child: Container(
               height: 44,
               padding: const EdgeInsets.symmetric(horizontal: 14),
               decoration: BoxDecoration(
                 color: fillColor,
-                borderRadius: BorderRadius.circular(22),
+                borderRadius: _kRadius,
                 border: Border.all(color: borderColor, width: 1),
                 boxShadow: [
                   BoxShadow(

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 import 'dart:math' as math;
+import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/routes.dart';
@@ -1139,26 +1141,62 @@ class _ScrollToTopButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    return Material(
-      color: colors.backgroundPrimary,
-      shape: const CircleBorder(),
-      elevation: 4,
-      shadowColor: Colors.black26,
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        onTap: onTap,
-        child: Container(
-          width: 44,
-          height: 44,
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            border: Border.all(color: colors.border),
-          ),
-          alignment: Alignment.center,
-          child: Icon(
-            PhosphorIcons.caretUp(PhosphorIconsStyle.bold),
-            size: 18,
-            color: colors.textPrimary,
+    final isDark = context.isDarkMode;
+    // Same liquidglass mix as StickyBackdrop so the pill reads as part of the
+    // same surface family (parchment in light, dark-surface tint in dark).
+    final fillColor = isDark
+        ? colors.backgroundPrimary.withValues(alpha: 0.78)
+        : const Color.fromRGBO(242, 232, 213, 0.82);
+    final borderColor = isDark
+        ? Colors.white.withValues(alpha: 0.10)
+        : const Color.fromRGBO(0, 0, 0, 0.08);
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(22),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(22),
+            onTap: onTap,
+            child: Container(
+              height: 44,
+              padding: const EdgeInsets.symmetric(horizontal: 14),
+              decoration: BoxDecoration(
+                color: fillColor,
+                borderRadius: BorderRadius.circular(22),
+                border: Border.all(color: borderColor, width: 1),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.10),
+                    blurRadius: 12,
+                    spreadRadius: -4,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    PhosphorIcons.caretUp(PhosphorIconsStyle.bold),
+                    size: 16,
+                    color: colors.textPrimary,
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    'Remonter',
+                    style: GoogleFonts.dmSans(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      letterSpacing: -0.1,
+                      color: colors.textPrimary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ),
         ),
       ),

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -28,7 +28,6 @@ class FluxArticleVM {
   final DateTime? publishedAt;
   final bool isFollowedSource;
   final bool isRead;
-  final int readingProgress;
 
   const FluxArticleVM({
     required this.contentId,
@@ -42,10 +41,9 @@ class FluxArticleVM {
     this.publishedAt,
     this.isFollowedSource = false,
     this.isRead = false,
-    this.readingProgress = 0,
   });
 
-  bool get hasBeenRead => isRead || readingProgress > 0;
+  bool get hasBeenRead => isRead;
 
   factory FluxArticleVM.from(Object article) {
     if (article is DigestItem) {
@@ -80,7 +78,6 @@ class FluxArticleVM {
         isFollowedSource: article.isFollowedSource,
         isRead: article.status == ContentStatus.consumed ||
             article.readingProgress > 0,
-        readingProgress: article.readingProgress,
       );
     }
     throw ArgumentError('Unsupported article type: ${article.runtimeType}');
@@ -139,101 +136,98 @@ class _FluxContinuArticleCardState extends State<FluxContinuArticleCard> {
       padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
       child: Opacity(
         opacity: vm.hasBeenRead ? 0.6 : 1.0,
-        child: Material(
-          color: colors.surface,
-          borderRadius: BorderRadius.circular(12),
-          elevation: 0,
-          child: GestureDetector(
-            onLongPressStart: (_) => ArticlePreviewOverlay.show(
-                context, articleToContent(widget.article)),
-            onLongPressMoveUpdate: (details) =>
-                ArticlePreviewOverlay.updateScroll(
-                    details.localOffsetFromOrigin.dy),
-            onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
-            child: InkWell(
-              onTap: widget.onTap,
+        child: Stack(
+          children: [
+            Material(
+              color: colors.surface,
               borderRadius: BorderRadius.circular(12),
-              child: Ink(
-                decoration: BoxDecoration(
-                  color: colors.surface,
+              elevation: 0,
+              child: GestureDetector(
+                onLongPressStart: (_) => ArticlePreviewOverlay.show(
+                    context, articleToContent(widget.article)),
+                onLongPressMoveUpdate: (details) =>
+                    ArticlePreviewOverlay.updateScroll(
+                        details.localOffsetFromOrigin.dy),
+                onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
+                child: InkWell(
+                  onTap: widget.onTap,
                   borderRadius: BorderRadius.circular(12),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.05),
-                      blurRadius: 4,
-                      offset: const Offset(0, 2),
+                  child: Ink(
+                    decoration: BoxDecoration(
+                      color: colors.surface,
+                      borderRadius: BorderRadius.circular(12),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: 0.05),
+                          blurRadius: 4,
+                          offset: const Offset(0, 2),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(12, 14, 12, 14),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Row(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(12, 14, 12, 14),
+                      child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
                         children: [
-                          Expanded(
-                            child: Text(
-                              vm.title,
-                              style: GoogleFonts.dmSans(
-                                fontSize: 18.0,
-                                fontWeight: FontWeight.w600,
-                                height: 1.3,
-                                letterSpacing: -0.15,
-                                color: colors.textPrimary,
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  vm.title,
+                                  style: GoogleFonts.dmSans(
+                                    fontSize: 18.0,
+                                    fontWeight: FontWeight.w600,
+                                    height: 1.3,
+                                    letterSpacing: -0.15,
+                                    color: colors.textPrimary,
+                                  ),
+                                  maxLines: 4,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
                               ),
-                              maxLines: 4,
-                              overflow: TextOverflow.ellipsis,
-                            ),
+                              if (hasThumb) ...[
+                                const SizedBox(width: 12),
+                                _Thumbnail(
+                                  url: vm.thumbnailUrl!,
+                                  isVideo: _isVideo(vm.contentType),
+                                  accent: colors.primary,
+                                  onError: () {
+                                    if (mounted && !_thumbErrored) {
+                                      setState(() => _thumbErrored = true);
+                                    }
+                                  },
+                                ),
+                              ],
+                            ],
                           ),
-                          if (hasThumb) ...[
-                            const SizedBox(width: 12),
-                            _Thumbnail(
-                              url: vm.thumbnailUrl!,
-                              isVideo: _isVideo(vm.contentType),
-                              accent: colors.primary,
-                              onError: () {
-                                if (mounted && !_thumbErrored) {
-                                  setState(() => _thumbErrored = true);
-                                }
-                              },
-                            ),
-                          ],
+                          const SizedBox(height: 10),
+                          _Footer(
+                            vm: vm,
+                            colors: colors,
+                            showPressReview:
+                                widget.isEssentiel && widget.pressReviewCount > 0,
+                            pressReviewCount: widget.pressReviewCount,
+                            perspectiveSources: widget.perspectiveSources,
+                          ),
                         ],
                       ),
-                      const SizedBox(height: 10),
-                      _Footer(
-                        vm: vm,
-                        colors: colors,
-                        showPressReview:
-                            widget.isEssentiel && widget.pressReviewCount > 0,
-                        pressReviewCount: widget.pressReviewCount,
-                        perspectiveSources: widget.perspectiveSources,
-                      ),
-                    ],
+                    ),
                   ),
                 ),
               ),
             ),
-          ),
+            if (vm.hasBeenRead)
+              Positioned(
+                top: 4,
+                right: 4,
+                child: _ReadCheckBadge(color: colors.success),
+              ),
+          ],
         ),
       ),
     );
-
-    if (vm.hasBeenRead) {
-      card = Stack(
-        children: [
-          card,
-          Positioned(
-            top: 4,
-            right: 16,
-            child: _ReadCheckBadge(color: colors.success),
-          ),
-        ],
-      );
-    }
 
     if (widget.onTap != null) {
       card = SwipeToOpenCard(

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -27,6 +27,8 @@ class FluxArticleVM {
   final int? durationSeconds;
   final DateTime? publishedAt;
   final bool isFollowedSource;
+  final bool isRead;
+  final int readingProgress;
 
   const FluxArticleVM({
     required this.contentId,
@@ -39,7 +41,11 @@ class FluxArticleVM {
     this.durationSeconds,
     this.publishedAt,
     this.isFollowedSource = false,
+    this.isRead = false,
+    this.readingProgress = 0,
   });
+
+  bool get hasBeenRead => isRead || readingProgress > 0;
 
   factory FluxArticleVM.from(Object article) {
     if (article is DigestItem) {
@@ -57,6 +63,7 @@ class FluxArticleVM {
         durationSeconds: article.durationSeconds,
         publishedAt: article.publishedAt,
         isFollowedSource: article.isFollowedSource,
+        isRead: article.isRead,
       );
     }
     if (article is Content) {
@@ -71,6 +78,9 @@ class FluxArticleVM {
         durationSeconds: article.durationSeconds,
         publishedAt: article.publishedAt,
         isFollowedSource: article.isFollowedSource,
+        isRead: article.status == ContentStatus.consumed ||
+            article.readingProgress > 0,
+        readingProgress: article.readingProgress,
       );
     }
     throw ArgumentError('Unsupported article type: ${article.runtimeType}');
@@ -127,79 +137,83 @@ class _FluxContinuArticleCardState extends State<FluxContinuArticleCard> {
 
     Widget card = Padding(
       padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-      child: Material(
-        color: colors.surface,
-        borderRadius: BorderRadius.circular(12),
-        elevation: 0,
-        child: GestureDetector(
-          onLongPressStart: (_) => ArticlePreviewOverlay.show(
-              context, articleToContent(widget.article)),
-          onLongPressMoveUpdate: (details) => ArticlePreviewOverlay.updateScroll(
-              details.localOffsetFromOrigin.dy),
-          onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
-          child: InkWell(
-            onTap: widget.onTap,
-            borderRadius: BorderRadius.circular(12),
-            child: Ink(
-              decoration: BoxDecoration(
-                color: colors.surface,
-                borderRadius: BorderRadius.circular(12),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.05),
-                    blurRadius: 4,
-                    offset: const Offset(0, 2),
-                  ),
-                ],
-              ),
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(12, 14, 12, 14),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Expanded(
-                          child: Text(
-                            vm.title,
-                            style: GoogleFonts.dmSans(
-                              fontSize: 18.0,
-                              fontWeight: FontWeight.w600,
-                              height: 1.3,
-                              letterSpacing: -0.15,
-                              color: colors.textPrimary,
-                            ),
-                            maxLines: 4,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                        if (hasThumb) ...[
-                          const SizedBox(width: 12),
-                          _Thumbnail(
-                            url: vm.thumbnailUrl!,
-                            isVideo: _isVideo(vm.contentType),
-                            accent: colors.primary,
-                            onError: () {
-                              if (mounted && !_thumbErrored) {
-                                setState(() => _thumbErrored = true);
-                              }
-                            },
-                          ),
-                        ],
-                      ],
-                    ),
-                    const SizedBox(height: 10),
-                    _Footer(
-                      vm: vm,
-                      colors: colors,
-                      showPressReview:
-                          widget.isEssentiel && widget.pressReviewCount > 0,
-                      pressReviewCount: widget.pressReviewCount,
-                      perspectiveSources: widget.perspectiveSources,
+      child: Opacity(
+        opacity: vm.hasBeenRead ? 0.6 : 1.0,
+        child: Material(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(12),
+          elevation: 0,
+          child: GestureDetector(
+            onLongPressStart: (_) => ArticlePreviewOverlay.show(
+                context, articleToContent(widget.article)),
+            onLongPressMoveUpdate: (details) =>
+                ArticlePreviewOverlay.updateScroll(
+                    details.localOffsetFromOrigin.dy),
+            onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
+            child: InkWell(
+              onTap: widget.onTap,
+              borderRadius: BorderRadius.circular(12),
+              child: Ink(
+                decoration: BoxDecoration(
+                  color: colors.surface,
+                  borderRadius: BorderRadius.circular(12),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.05),
+                      blurRadius: 4,
+                      offset: const Offset(0, 2),
                     ),
                   ],
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 14, 12, 14),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Expanded(
+                            child: Text(
+                              vm.title,
+                              style: GoogleFonts.dmSans(
+                                fontSize: 18.0,
+                                fontWeight: FontWeight.w600,
+                                height: 1.3,
+                                letterSpacing: -0.15,
+                                color: colors.textPrimary,
+                              ),
+                              maxLines: 4,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          if (hasThumb) ...[
+                            const SizedBox(width: 12),
+                            _Thumbnail(
+                              url: vm.thumbnailUrl!,
+                              isVideo: _isVideo(vm.contentType),
+                              accent: colors.primary,
+                              onError: () {
+                                if (mounted && !_thumbErrored) {
+                                  setState(() => _thumbErrored = true);
+                                }
+                              },
+                            ),
+                          ],
+                        ],
+                      ),
+                      const SizedBox(height: 10),
+                      _Footer(
+                        vm: vm,
+                        colors: colors,
+                        showPressReview:
+                            widget.isEssentiel && widget.pressReviewCount > 0,
+                        pressReviewCount: widget.pressReviewCount,
+                        perspectiveSources: widget.perspectiveSources,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -207,6 +221,19 @@ class _FluxContinuArticleCardState extends State<FluxContinuArticleCard> {
         ),
       ),
     );
+
+    if (vm.hasBeenRead) {
+      card = Stack(
+        children: [
+          card,
+          Positioned(
+            top: 4,
+            right: 16,
+            child: _ReadCheckBadge(color: colors.success),
+          ),
+        ],
+      );
+    }
 
     if (widget.onTap != null) {
       card = SwipeToOpenCard(
@@ -618,6 +645,36 @@ class _PressReviewChip extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+class _ReadCheckBadge extends StatelessWidget {
+  final Color color;
+  const _ReadCheckBadge({required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 22,
+      height: 22,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.12),
+            blurRadius: 4,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      alignment: Alignment.center,
+      child: Icon(
+        PhosphorIcons.check(PhosphorIconsStyle.bold),
+        size: 12,
+        color: Colors.white,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Quoi

Quatre corrections UI indépendantes sur l'app mobile :

1. **Swipe sans rebond** — supprime `_snapBack()` après swipe droit/gauche dans `SwipeToOpenCard` ; le parent pousse la route immédiatement, le snap-back créait une impression de rebond avant la transition.
2. **Bouton « Article complet » simplifié** — retire le logo source du bouton inline dans `content_detail_screen`, aligne le style du bouton avec les autres CTA secondaires.
3. **Bouton « Remonter » pill glassmorphism** — remplace le cercle 44px par une pill avec `BackdropFilter` (blur 14px) cohérente avec la surface `StickyBackdrop` (même couleur parchement light / backgroundPrimary dark).
4. **Badge ✓ + opacité articles lus** — cartes Flux Continu lues affichées à 0.6 d'opacité avec un badge check vert (`_ReadCheckBadge`), nourri depuis `DigestItem.isRead` et `Content.status/readingProgress`.

## Pourquoi

Retours visuels identifiés sur le flux continu : swipe donne une impression « l'action n'a pas marché », le bouton article partiel trop chargé, le bouton Remonter qui tranche visuellement avec le reste de l'UI, et absence de signal visuel sur les articles déjà lus.

## Comment ça a été vérifié

- [x] `flutter test` — 668 tests OK, 27 échecs pré-existants non liés (Hive init dans smoke test)
- [x] `flutter analyze` — `No issues found` sur les fichiers modifiés
- [x] /simplify passé — `readingProgress` redondant supprimé, Stack conditionnel aplati en Positioned unique (pattern `feed_card.dart`), `BorderRadius.circular(22)` extrait en `const _kRadius`

## Zones à risque

- `swipe_to_open_card.dart` — comportement swipe global (feed + flux continu)
- `flux_continu_article_card.dart` — VM `FluxArticleVM` (breaking si quelqu'un passait `readingProgress` explicitement, mais aucun usage externe trouvé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)