### PR TITLE
fix(ui): restaurer labels polarisation Flux Continu + header Couverture Médiatique

### DIFF
--- a/apps/mobile/lib/features/digest/widgets/divergence_inline_badge.dart
+++ b/apps/mobile/lib/features/digest/widgets/divergence_inline_badge.dart
@@ -48,16 +48,7 @@ class DivergenceInlineBadge extends StatelessWidget {
   static _BadgeConfig? _configFor(String? level, FacteurColors colors) {
     switch (level) {
       case 'low':
-        return _BadgeConfig(
-          label: 'CONSENSUS',
-          dots: [
-            _Dot(11, 6, colors.textTertiary, 0.55),
-            _Dot(14, 6, colors.textTertiary, 0.55),
-            _Dot(17, 6, colors.textTertiary, 0.55),
-          ],
-          labelColor: colors.textTertiary,
-          bold: false,
-        );
+        return null;
       case 'medium':
         return _BadgeConfig(
           label: 'AVIS VARIÉS',

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -896,6 +896,7 @@ class _TopicSectionState extends ConsumerState<TopicSection>
         // action (e.g. analyzePerspectives) operates on the same content.
         contentId: pivotId,
         comparisonQuality: response.comparisonQuality,
+        divergenceLevel: widget.topic.divergenceLevel,
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -6,11 +6,12 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/theme.dart';
 import '../../../core/providers/analytics_provider.dart';
 import '../../../widgets/design/facteur_card.dart';
+import '../../digest/widgets/divergence_inline_badge.dart';
+import '../../digest/widgets/markdown_text.dart';
+import '../../digest/widgets/section_divider.dart';
 import '../../sources/models/source_model.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../../sources/widgets/source_detail_modal.dart';
-import '../../digest/widgets/markdown_text.dart';
-import '../../digest/widgets/section_divider.dart';
 import '../providers/feed_provider.dart';
 import '../repositories/feed_repository.dart' show HighlightSpan, TokenSpan;
 import '../screens/perspective_webview_screen.dart';
@@ -161,6 +162,7 @@ class PerspectivesBottomSheet extends ConsumerStatefulWidget {
   final String sourceName;
   final String contentId;
   final String comparisonQuality;
+  final String? divergenceLevel;
 
   const PerspectivesBottomSheet({
     super.key,
@@ -171,6 +173,7 @@ class PerspectivesBottomSheet extends ConsumerStatefulWidget {
     this.sourceBiasStance = 'unknown',
     this.sourceName = '',
     this.comparisonQuality = 'low',
+    this.divergenceLevel,
   });
 
   @override
@@ -401,6 +404,12 @@ class _PerspectivesBottomSheetState
                           if (widget.comparisonQuality == 'low')
                             PerspectivesWarningBadge(
                                 colors: colors, textTheme: textTheme),
+                          if (widget.divergenceLevel != null) ...[
+                            const SizedBox(height: 8),
+                            DivergenceInlineBadge(
+                                divergenceLevel: widget.divergenceLevel),
+                            const SizedBox(height: 4),
+                          ],
                           const SizedBox(height: 12),
                           Text(
                             'Le surlignage met en évidence les termes qui '

--- a/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
@@ -127,6 +127,7 @@ class _DigestSectionScreenState extends ConsumerState<DigestSectionScreen> {
                 isEssentiel: section.kind == SectionKind.essentiel,
                 pressReviewCount: topic.perspectiveCount,
                 perspectiveSources: topic.perspectiveSources,
+                divergenceLevel: topic.divergenceLevel,
                 onTap: () => _openArticle(context, lead),
               );
             },

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -8,6 +8,7 @@ import '../../../config/topic_labels.dart';
 import '../../../widgets/article_preview_modal.dart';
 import '../../../widgets/design/facteur_image.dart';
 import '../../digest/models/digest_models.dart';
+import '../../digest/widgets/divergence_inline_badge.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/widgets/swipe_to_open_card.dart';
 import '../../sources/models/source_model.dart';
@@ -101,6 +102,7 @@ class FluxContinuArticleCard extends StatefulWidget {
   final bool isEssentiel;
   final int pressReviewCount;
   final List<SourceMini> perspectiveSources;
+  final String? divergenceLevel;
 
   const FluxContinuArticleCard({
     super.key,
@@ -112,6 +114,7 @@ class FluxContinuArticleCard extends StatefulWidget {
     this.isEssentiel = false,
     this.pressReviewCount = 0,
     this.perspectiveSources = const [],
+    this.divergenceLevel,
   });
 
   @override
@@ -210,6 +213,7 @@ class _FluxContinuArticleCardState extends State<FluxContinuArticleCard> {
                                 widget.isEssentiel && widget.pressReviewCount > 0,
                             pressReviewCount: widget.pressReviewCount,
                             perspectiveSources: widget.perspectiveSources,
+                            divergenceLevel: widget.divergenceLevel,
                           ),
                         ],
                       ),
@@ -385,6 +389,7 @@ class _Footer extends StatelessWidget {
   final bool showPressReview;
   final int pressReviewCount;
   final List<SourceMini> perspectiveSources;
+  final String? divergenceLevel;
 
   const _Footer({
     required this.vm,
@@ -392,6 +397,7 @@ class _Footer extends StatelessWidget {
     required this.showPressReview,
     required this.pressReviewCount,
     required this.perspectiveSources,
+    this.divergenceLevel,
   });
 
   @override
@@ -461,6 +467,10 @@ class _Footer extends StatelessWidget {
             height: 1.4,
           ),
         ),
+        if (divergenceLevel != null) ...[
+          const SizedBox(width: 6),
+          DivergenceInlineBadge(divergenceLevel: divergenceLevel),
+        ],
         if (showPressReview) ...[
           const Spacer(),
           _PressReviewChip(

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -242,6 +242,7 @@ class SectionBlock extends StatelessWidget {
                 isEssentiel: isEssentiel,
                 pressReviewCount: visible[i].perspectiveCount,
                 perspectiveSources: visible[i].perspectiveSources,
+                divergenceLevel: visible[i].divergenceLevel,
                 onTap: () =>
                     onTapArticle(pickTopicLead(visible[i]), section),
                 onSwipeDismiss: onDismissArticle == null

--- a/apps/mobile/test/features/digest/widgets/divergence_inline_badge_test.dart
+++ b/apps/mobile/test/features/digest/widgets/divergence_inline_badge_test.dart
@@ -15,14 +15,22 @@ void main() {
   }
 
   group('DivergenceInlineBadge', () {
-    testWidgets('low → Consensus en text_tertiary (non bold)', (tester) async {
+    testWidgets('low → silence total (même comportement que null)',
+        (tester) async {
       await tester.pumpWidget(host('low'));
       await tester.pumpAndSettle();
 
-      expect(find.text('CONSENSUS'), findsOneWidget);
-      expect(find.byType(CustomPaint), findsWidgets);
-      final label = tester.widget<Text>(find.text('CONSENSUS'));
-      expect(label.style?.fontWeight, FontWeight.w500);
+      // Option A validée : 'low' = silence total, aucun badge affiché
+      expect(find.text('CONSENSUS'), findsNothing);
+      expect(find.text('AVIS VARIÉS'), findsNothing);
+      expect(find.text('POLARISÉ'), findsNothing);
+      expect(
+        find.descendant(
+          of: find.byType(DivergenceInlineBadge),
+          matching: find.byType(CustomPaint),
+        ),
+        findsNothing,
+      );
     });
 
     testWidgets('medium → Avis variés en text_tertiary (non bold)',


### PR DESCRIPTION
## Quoi

Restaure l'affichage du badge de polarisation (`DivergenceInlineBadge`) dans les cartes "Actus du jour" (Flux Continu) et dans le header de la bottom sheet "Couverture Médiatique". Le widget existait déjà (PR #620) mais n'était câblé que dans `topic_section.dart`.

## Pourquoi

- PR #683 a supprimé `DivergenceChip` (digest legacy) sans recâbler `DivergenceInlineBadge` dans les cartes Flux Continu
- Le backend retournait correctement `divergence_level` — problème 100% frontend
- `'low'` affichait encore CONSENSUS alors que l'Option A validée impose silence total

## Changements (7 fichiers)

| Fichier | Changement |
|---|---|
| `divergence_inline_badge.dart` | `'low'` → `null` (silence total, Option A) |
| `flux_continu_article_card.dart` | Prop `divergenceLevel` + badge dans le footer |
| `section_block.dart` | Passe `divergenceLevel` aux cartes `DigestTopicSection` |
| `digest_section_screen.dart` | Passe `divergenceLevel` dans la vue pleine page |
| `perspectives_bottom_sheet.dart` | Prop `divergenceLevel` + badge dans le header |
| `topic_section.dart` | Passe `widget.topic.divergenceLevel` à `PerspectivesBottomSheet` |
| `divergence_inline_badge_test.dart` | Mise à jour test `'low'` → aucun widget affiché |

## Comportement final

- **`null` / `'low'`** → rien (silence total)
- **`'medium'`** → 5 dots neutres + "AVIS VARIÉS" (tertiary)
- **`'high'`** → 2 dots rouge + 2 dots bleu + "POLARISÉ" (bold primary)

## Comment ça a été vérifié

- [x] `flutter test test/features/digest/widgets/divergence_inline_badge_test.dart` — 5/5 ✅
- [x] `flutter test` complet — 0 nouvelle régression (27 failures pre-existing, identiques sans mes changements)
- [x] `flutter analyze` — 0 erreur dans les fichiers modifiés
- [x] /simplify passé — 1 commentaire redondant supprimé

## Zones à risque

- `perspectives_bottom_sheet.dart` — widget large, changement localisé dans le header uniquement
- `flux_continu_article_card.dart` — footer Row : le null-guard évite un `SizedBox` fantôme quand `divergenceLevel` est absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)