### PR TITLE
fix(pipeline): filtrer bulletins, chroniques et pubs Frandroid du top 10 éditorial

### DIFF
--- a/docs/bugs/bug-pipeline-non-editorial-articles.md
+++ b/docs/bugs/bug-pipeline-non-editorial-articles.md
@@ -1,0 +1,57 @@
+# Bug — Articles non-éditoriaux + publicités Frandroid passent dans le top 10
+
+## Date
+
+2026-05-27
+
+## Symptôme
+
+Deux familles de faux positifs observées dans la pipeline « Actus du jour » :
+
+1. **Bulletins / chroniques régulières** remontent comme actu du jour :
+   - « Journal RTL du 25 mai 2026 » (pas catché — pattern « Le journal » exige
+     l'article défini)
+   - « L'émission politique de France 2 »
+   - « La chronique de Nicolas »
+2. **Publicités Frandroid** : « Bouygues fête ses 30 ans… » remonte parce que
+   `apply_ad_filter` tolère `is_ad=NULL` (articles non encore classifiés) et
+   parce que `apply_ad_filter` n'était même pas appliqué au pool `pour_vous`
+   du clustering éditorial.
+
+## Cause racine
+
+- `NEWS_BULLETIN_PATTERNS` incomplet : 4 variantes manquantes (`Journal RTL`,
+  `L'émission`, `Ma/La/Sa/Notre chronique`, `Chronique:`).
+- `is_news_bulletin_title()` était **uniquement** appelé dans
+  `essentiel_service.py` (les 5 cartes finales) — pas dans
+  `actu_matcher.py:_find_best_article*()` qui sélectionne les actus dans le
+  top 10 éditorial. Les bulletins remontaient donc dans le clustering en
+  amont.
+- Pool `pour_vous` de `digest_generation_job._get_global_candidates()` ne
+  passait pas par `apply_ad_filter`, contrairement à `serein` qui transite
+  par `apply_good_news_filter` (lequel l'inclut).
+
+## Correctif
+
+- `filter_presets.py` : +4 patterns ancrés début (`^\s*`), ajout
+  `EDITORIAL_SOURCE_DENYLIST` (`{"frandroid"}`) + helper
+  `is_denylisted_editorial_source()`.
+- `actu_matcher.py` : appel de `is_news_bulletin_title()` +
+  `is_denylisted_editorial_source()` dans les 3 méthodes de sélection
+  (`_find_best_article`, `_find_best_article_global`,
+  `_find_extra_articles_global`).
+- `digest_generation_job.py` : `apply_ad_filter` appliqué au pool
+  `pour_vous` dans `_get_global_candidates()`.
+
+## Tests
+
+- `tests/test_low_priority_cap.py::TestIsNewsBulletinTitle` — 11 nouveaux
+  cas (patterns + faux positifs « Une chronique du conflit »).
+- `tests/test_low_priority_cap.py::TestIsDenylistedEditorialSource` —
+  5 cas (Frandroid match + variations de casse + Le Monde non bloqué).
+
+## Vérification manuelle
+
+Régénération de la pipeline du 27 mai 2026 après merge pour confirmer
+disparition des bulletins RTL/émissions et des pubs Frandroid des actus
+du jour.

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -340,6 +340,13 @@ class DigestGenerationJob:
 
             stmt = stmt.join(Source, Content.source_id == Source.id)
             stmt = apply_good_news_filter(stmt)
+        else:
+            # Mode pour_vous : apply_good_news_filter inclut déjà apply_ad_filter,
+            # mais pour_vous n'y passe pas — sans ce filtre, les pubs Frandroid
+            # (is_ad=True) remontent dans le clustering éditorial.
+            from app.services.recommendation.filter_presets import apply_ad_filter
+
+            stmt = apply_ad_filter(stmt)
         stmt = (
             stmt.where(Content.published_at >= cutoff)
             .order_by(Content.published_at.desc())

--- a/packages/api/app/services/editorial/actu_matcher.py
+++ b/packages/api/app/services/editorial/actu_matcher.py
@@ -13,6 +13,10 @@ import structlog
 
 from app.services.briefing.importance_detector import TopicCluster
 from app.services.editorial.schemas import EditorialSubject, MatchedActuArticle
+from app.services.recommendation.filter_presets import (
+    is_denylisted_editorial_source,
+    is_news_bulletin_title,
+)
 
 logger = structlog.get_logger()
 
@@ -259,6 +263,10 @@ class ActuMatcher:
                 continue
             if content.is_paid:
                 continue
+            if is_news_bulletin_title(content.title):
+                continue
+            if is_denylisted_editorial_source(content):
+                continue
             if _is_non_text(content):
                 # Les "extra actus" affichés sous la carte sont aussi de la
                 # revue de presse texte ; les vidéos seraient redondantes
@@ -320,6 +328,10 @@ class ActuMatcher:
                 continue
             if content.is_paid:
                 continue
+            if is_news_bulletin_title(content.title):
+                continue
+            if is_denylisted_editorial_source(content):
+                continue
             if not allow_non_text and _is_non_text(content):
                 continue
             if content.published_at.replace(tzinfo=UTC) < cutoff:
@@ -373,6 +385,10 @@ class ActuMatcher:
             if content.id in excluded_ids:
                 continue
             if content.is_paid:
+                continue
+            if is_news_bulletin_title(content.title):
+                continue
+            if is_denylisted_editorial_source(content):
                 continue
             if _is_non_text(content):
                 continue

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -468,6 +468,17 @@ NEWS_BULLETIN_PATTERNS = [
     r"^\s*revue de presse\b",
     r"^\s*flash (info|actu)\b",
     r"^\s*le journal\b",  # Le journal de France Inter, Le Journal du week-end
+    # « Journal RTL », « Journal RFI » sans déterminant — pas catché par
+    # « Le journal » ni « Journal de Xh ».
+    r"^\s*journal (rtl|rfi|bfm|europe|france|rmc|lcp|i-?t[eé]l[eé])\b",
+    # « L'émission politique », « L'Émission du soir » — apostrophe droite
+    # ou typographique.
+    r"^\s*l[''’]\s*[ée]mission\b",
+    # « Ma chronique », « La chronique de Nicolas », « Sa chronique du lundi »
+    # — ancré sur possessif/déterminant pour éviter « Une chronique du conflit ».
+    r"^\s*(ma|la|sa|notre)\s+chronique\b",
+    # « Chronique: l'économie », « Chronique – bilan de semaine ».
+    r"^\s*chronique\s*[:\-–—]",
 ]
 
 _BULLETIN_RE = re.compile("|".join(NEWS_BULLETIN_PATTERNS), re.IGNORECASE)
@@ -485,6 +496,29 @@ def is_news_bulletin_title(title: str | None) -> bool:
     if not title:
         return False
     return bool(_BULLETIN_RE.search(title))
+
+
+# Sources dont les articles ne peuvent pas être sélectionnés comme actu dans
+# le top 10 éditorial. Match par sous-chaîne casefold sur Source.name — tolère
+# variations (« Frandroid », « FRANDROID », « frandroid.com »).
+EDITORIAL_SOURCE_DENYLIST: frozenset[str] = frozenset(
+    {
+        # Publie du contenu sponsorisé non systématiquement tagué is_ad
+        # (« Bouygues fête ses 30 ans… »).
+        "frandroid",
+    }
+)
+
+
+def is_denylisted_editorial_source(content) -> bool:  # type: ignore[no-untyped-def]
+    """True si la source du contenu est dans EDITORIAL_SOURCE_DENYLIST."""
+    source = getattr(content, "source", None)
+    if source is None:
+        return False
+    name = (getattr(source, "name", None) or "").casefold()
+    if not name:
+        return False
+    return any(token in name for token in EDITORIAL_SOURCE_DENYLIST)
 
 
 def _match_ratio(cluster: TopicCluster, keywords: list[str]) -> float:

--- a/packages/api/tests/test_low_priority_cap.py
+++ b/packages/api/tests/test_low_priority_cap.py
@@ -17,6 +17,7 @@ from uuid import UUID, uuid4
 
 from app.services.recommendation.filter_presets import (
     cap_low_priority_clusters,
+    is_denylisted_editorial_source,
     is_faits_divers_cluster,
     is_news_bulletin_title,
     is_sport_cluster,
@@ -239,3 +240,90 @@ class TestIsNewsBulletinTitle:
     def test_empty_or_none(self):
         assert not is_news_bulletin_title(None)
         assert not is_news_bulletin_title("")
+
+    # --- Patterns ajoutés pour bug-pipeline-non-editorial-articles ---
+
+    def test_journal_rtl_without_le(self):
+        assert is_news_bulletin_title("Journal RTL du 25 mai 2026")
+
+    def test_journal_rfi(self):
+        assert is_news_bulletin_title("Journal RFI - édition de 12h")
+
+    def test_journal_bfm(self):
+        assert is_news_bulletin_title("Journal BFM : les titres du jour")
+
+    def test_l_emission_apostrophe(self):
+        assert is_news_bulletin_title("L'émission politique de France 2")
+
+    def test_l_emission_typographic_apostrophe(self):
+        assert is_news_bulletin_title("L’Émission du soir")
+
+    def test_ma_chronique(self):
+        assert is_news_bulletin_title("Ma chronique du lundi")
+
+    def test_la_chronique_de(self):
+        assert is_news_bulletin_title("La chronique de Nicolas Demorand")
+
+    def test_notre_chronique(self):
+        assert is_news_bulletin_title("Notre chronique éco du matin")
+
+    def test_chronique_colon(self):
+        assert is_news_bulletin_title("Chronique: l'économie de la semaine")
+
+    def test_chronique_em_dash(self):
+        assert is_news_bulletin_title("Chronique – bilan de semaine")
+
+    def test_une_chronique_du_conflit_not_matched(self):
+        """« Une » n'est pas un possessif → ne doit pas matcher le pattern."""
+        assert not is_news_bulletin_title(
+            "Une chronique du conflit israélo-palestinien après deux ans de guerre"
+        )
+
+    def test_emission_in_middle_not_matched(self):
+        """« émission » en milieu de phrase n'est pas un bulletin."""
+        assert not is_news_bulletin_title(
+            "Une nouvelle émission de Radio France pour les jeunes"
+        )
+
+
+class TestIsDenylistedEditorialSource:
+    """Sources bloquées du top 10 éditorial."""
+
+    @dataclass
+    class _FakeSource:
+        name: str | None = None
+
+    @dataclass
+    class _FakeContentWithSource:
+        title: str | None = None
+        source: object | None = None
+
+    def test_frandroid_source_denylisted(self):
+        content = self._FakeContentWithSource(
+            title="Bouygues fête ses 30 ans",
+            source=self._FakeSource(name="Frandroid"),
+        )
+        assert is_denylisted_editorial_source(content)
+
+    def test_frandroid_casing_variations(self):
+        for name in ("FRANDROID", "frandroid", "Frandroid.com"):
+            content = self._FakeContentWithSource(
+                title="x", source=self._FakeSource(name=name)
+            )
+            assert is_denylisted_editorial_source(content), f"failed for {name}"
+
+    def test_le_monde_not_denylisted(self):
+        content = self._FakeContentWithSource(
+            title="x", source=self._FakeSource(name="Le Monde")
+        )
+        assert not is_denylisted_editorial_source(content)
+
+    def test_no_source_returns_false(self):
+        content = self._FakeContentWithSource(title="x", source=None)
+        assert not is_denylisted_editorial_source(content)
+
+    def test_source_with_none_name(self):
+        content = self._FakeContentWithSource(
+            title="x", source=self._FakeSource(name=None)
+        )
+        assert not is_denylisted_editorial_source(content)


### PR DESCRIPTION
## Quoi

Deux familles d'articles non pertinents remontaient dans le top 10 éditorial :

1. **Bulletins / chroniques** (« Journal RTL », « L'émission politique », « La chronique de Nicolas ») — patterns manquants ET `is_news_bulletin_title()` jamais appelé dans `actu_matcher.py` (seulement dans `essentiel_service.py` en aval).
2. **Publicités Frandroid** (« Bouygues fête ses 30 ans… ») — `apply_ad_filter` n'était pas appliqué au pool `pour_vous`, et `is_ad=NULL` est toléré, donc les pubs non taguées passaient.

## Pourquoi

Faux positifs visibles en prod le 27 mai (cf. plan dans `.context/attachments/pW4svb/plan.md`). Bug doc : `docs/bugs/bug-pipeline-non-editorial-articles.md`.

## Correctif

- `filter_presets.py` : +4 patterns regex ancrés début (`^\s*journal (rtl|rfi|...)`, `^\s*l[''’][ée]mission`, `^\s*(ma|la|sa|notre)\s+chronique`, `^\s*chronique\s*[:\-–—]`) + `EDITORIAL_SOURCE_DENYLIST = frozenset({"frandroid"})` + helper `is_denylisted_editorial_source()`.
- `actu_matcher.py` : appel des 2 filtres dans `_find_best_article`, `_find_best_article_global`, `_find_extra_articles_global`.
- `digest_generation_job.py` : `apply_ad_filter` sur le pool `pour_vous` dans `_get_global_candidates()`.

## Comment ça a été vérifié

- [x] `pytest tests/test_low_priority_cap.py` → 46/46 PASS (16 nouveaux cas)
- [x] `pytest tests/editorial/test_actu_matcher.py` → 16/16 PASS
- [x] `pytest` suite ciblée digest+essentiel+filter_presets → 43/43 PASS
- [x] `pytest` complet → 1108 passed, 204 errors **environnementaux** (auth Supabase locale, pré-existants — vérifié par `git stash`)
- [x] `simplify` passé : findings sont scope-creep (helper DRY pour 3 lignes), pas d'action

## Zones à risque

Pipeline « Actus du jour » (sélection éditoriale). Pas de changement de schéma DB. Les patterns regex utilisent `^\s*` pour éviter les faux positifs (« Une chronique du conflit » ne match pas).