### PR TITLE
hotfix(flux-continu): badge articles lus — mise à jour in-memory après lecture

### DIFF
--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -401,6 +401,97 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     ];
   }
 
+  /// Marks a single article as read in-memory (same-session visual feedback).
+  ///
+  /// Called by [FluxContinuScreen._openArticle] after the reader route pops so
+  /// the card immediately shows the grey + check badge without waiting for a
+  /// pull-to-refresh. No API call — the reader already fires the status update
+  /// independently.
+  void markArticleRead(String contentId) {
+    if (contentId.isEmpty) return;
+    final current = state.valueOrNull;
+    if (current == null) return;
+    final updated = [
+      for (final s in current.sections)
+        switch (s) {
+          EssentielSection(:final articles) => EssentielSection(
+              articles: [
+                for (final a in articles)
+                  if (a.contentId == contentId)
+                    EssentielArticle(
+                      contentId: a.contentId,
+                      title: a.title,
+                      url: a.url,
+                      thumbnailUrl: a.thumbnailUrl,
+                      publishedAt: a.publishedAt,
+                      sourceName: a.sourceName,
+                      sourceLetter: a.sourceLetter,
+                      sectionLabel: a.sectionLabel,
+                      rank: a.rank,
+                      kind: a.kind,
+                      theme: a.theme,
+                      perspectiveCount: a.perspectiveCount,
+                      isRead: true,
+                      isSaved: a.isSaved,
+                      isLiked: a.isLiked,
+                      isDismissed: a.isDismissed,
+                      isFollowedSource: a.isFollowedSource,
+                      isFollowedTopic: a.isFollowedTopic,
+                      isActuDuJour: a.isActuDuJour,
+                    )
+                  else
+                    a,
+              ],
+              blurb: s.blurb,
+              illustrationAsset: s.illustrationAsset,
+            ),
+          DigestTopicSection(:final topics) => DigestTopicSection(
+              kind: s.kind,
+              label: s.label,
+              accent: s.accent,
+              coreVisibleCount: s.coreVisibleCount,
+              blurb: s.blurb,
+              illustrationAsset: s.illustrationAsset,
+              topics: [
+                for (final t in topics)
+                  t.copyWith(
+                    articles: [
+                      for (final a in t.articles)
+                        if (a.contentId == contentId)
+                          a.copyWith(isRead: true)
+                        else
+                          a,
+                    ],
+                  ),
+              ],
+            ),
+          FeedThemeSection(
+            :final items,
+            :final themeSlug,
+            :final customTopicId,
+          ) =>
+            FeedThemeSection(
+              kind: s.kind,
+              label: s.label,
+              accent: s.accent,
+              coreVisibleCount: s.coreVisibleCount,
+              blurb: s.blurb,
+              illustrationAsset: s.illustrationAsset,
+              themeSlug: themeSlug,
+              customTopicId: customTopicId,
+              items: [
+                for (final c in items)
+                  if (c.id == contentId)
+                    c.copyWith(status: ContentStatus.consumed)
+                  else
+                    c,
+              ],
+            ),
+        },
+    ];
+    state = AsyncData(current.copyWith(sections: updated));
+  }
+
   /// Toggle the expand/collapse state of a section's "Plus de…" overflow.
   void toggleMore(FluxSection section) {
     final current = state.valueOrNull;

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -479,21 +479,30 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
         ? const <String>{}
         : {sectionKey(fromSection)};
     final heightsBefore = _measureFoldCandidateHeights(exceptKeys);
+    String? openedContentId;
     if (article is DigestItem) {
+      openedContentId = article.contentId;
       await context
           .push('${RoutePaths.fluxContinu}/content/${article.contentId}');
     } else if (article is Content) {
+      openedContentId = article.id;
       await context.push(
         '${RoutePaths.fluxContinu}/content/${article.id}',
         extra: article,
       );
     } else if (article is EssentielArticle) {
+      openedContentId = article.contentId;
       await context
           .push('${RoutePaths.fluxContinu}/content/${article.contentId}');
     } else {
       return;
     }
     if (!mounted) return;
+    // Mark the article as read in local state so the card immediately
+    // shows the grey + check badge without waiting for a pull-to-refresh.
+    ref
+        .read(fluxContinuProvider.notifier)
+        .markArticleRead(openedContentId);
     ref
         .read(fluxContinuProvider.notifier)
         .applyPendingFoldsToState(exceptKeys: exceptKeys);


### PR DESCRIPTION
## Problème root cause

La PR #686 avait ajouté le traitement visuel (opacité 0.6 + badge ✓) sur `FluxContinuArticleCard`, mais le badge ne s'affichait jamais.

**Pourquoi** : `_openArticle()` attend le retour du reader (`await context.push`) mais ne mettait ensuite à jour **aucun état** de l'article. Or l'API feed exclut les articles `consumed`/`seen` de la prochaine requête (SQL filter) — la seule fenêtre où le badge peut s'afficher est donc **en session**, juste après le retour du reader.

## Fix

Ajout de `markArticleRead(String contentId)` dans `FluxContinuNotifier`, calqué sur le pattern `_filterSections` existant. Couvre les 3 types de sections :

- **FeedThemeSection** → `Content.copyWith(status: ContentStatus.consumed)`
- **DigestTopicSection** → `DigestItem.copyWith(isRead: true)` via `DigestTopic.copyWith`
- **EssentielSection** → `EssentielArticle` reconstruit avec `isRead: true`

Appelé immédiatement dans `_openArticle()` après le retour du push, avant `applyPendingFoldsToState`.

## Vérification

- `flutter analyze` : 0 erreur/warning nouveaux
- `flutter test test/features/flux_continu/` : **96/96 ✓**

🤖 Generated with [Claude Code](https://claude.com/claude-code)