### PR TITLE
feat(flux-continu): grouper les sections folded en toggle « Tournée du jour ✓ »

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -43,6 +43,7 @@ import '../widgets/section_block.dart';
 import '../widgets/section_divider_dotted.dart';
 import '../widgets/section_hairline.dart';
 import '../widgets/sticky_tab_bar.dart';
+import '../widgets/tournee_folded_group_card.dart';
 
 /// Scroll offset at which the AppBar is swapped with the sticky tab bar.
 const double _kStickyThreshold = 60.0;
@@ -74,13 +75,20 @@ class FluxContinuScreen extends ConsumerStatefulWidget {
   ConsumerState<FluxContinuScreen> createState() => _FluxContinuScreenState();
 }
 
-class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
+class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
+    with WidgetsBindingObserver {
   final ScrollController _scroll = ScrollController();
   final ScrollController _tabsScroll = ScrollController();
   final ValueNotifier<bool> _stickyVisible = ValueNotifier(false);
   final ValueNotifier<double> _scrollProgress = ValueNotifier(0);
   final ValueNotifier<int> _activeIndex = ValueNotifier(0);
   final ValueNotifier<bool> _isInExploreMode = ValueNotifier(false);
+
+  /// Controls whether the « Tournée du jour ✓ » group toggle is expanded.
+  /// Resets to [false] (collapsed) on app pause and when opening an article
+  /// from Flâner — per spec, the grouping re-appears on quit-and-return.
+  final ValueNotifier<bool> _tourneeGroupExpanded = ValueNotifier(false);
+
   final GlobalKey _closingKey = GlobalKey();
   final GlobalKey _explorerKey = GlobalKey();
   final List<GlobalKey> _sectionKeys = [];
@@ -108,10 +116,12 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   void initState() {
     super.initState();
     _scroll.addListener(_onScroll);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _scroll.removeListener(_onScroll);
     _scroll.dispose();
     _tabsScroll.dispose();
@@ -119,8 +129,22 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     _scrollProgress.dispose();
     _activeIndex.dispose();
     _isInExploreMode.dispose();
+    _tourneeGroupExpanded.dispose();
     _pullHintTimer?.cancel();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    // Collapse the « Tournée du jour ✓ » toggle when the app is backgrounded
+    // so the user always sees it grouped on return — per spec.
+    // `hidden` covers the moment the app becomes invisible on Android (Flutter
+    // 3.13+); `paused` is the fallback and the reliable signal on iOS.
+    if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden) {
+      _tourneeGroupExpanded.value = false;
+    }
   }
 
   void _onScroll() {
@@ -494,6 +518,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       return;
     }
     if (!mounted) return;
+    // When the article was opened from Flâner (fromSection == null), collapse
+    // the group toggle so the user sees the « Tournée du jour ✓ » row on
+    // return — per spec.
+    if (fromSection == null) _tourneeGroupExpanded.value = false;
     ref
         .read(fluxContinuProvider.notifier)
         .applyPendingFoldsToState(exceptKeys: exceptKeys);
@@ -739,6 +767,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     final exploreItems = _buildExploreItems(state, feedState);
     final exploreCarousels = feedState?.carousels ?? const <FeedCarouselData>[];
 
+    // When every editorial section is folded, the individual pile of
+    // FoldedSectionCards is replaced by a single « Tournée du jour ✓ » toggle.
+    final allFolded = state.sections.isNotEmpty &&
+        state.sections.every((s) => state.isFolded(s));
+
     if (_sectionKeys.length != state.sections.length) {
       _sectionKeys
         ..clear()
@@ -833,11 +866,39 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
           // first user-favorite theme section (`theme1` / `theme2`). The
           // computed index handles both ordering modes (normal / sereine) by
           // tracking the actual position of the first favorite kind.
-          ..._buildSectionSlivers(
-            context: context,
-            state: state,
-            notifier: notifier,
-          ),
+          // When all sections are folded, collapse the pile into a single
+          // « Tournée du jour ✓ » toggle. Tapping expands it back to the
+          // individual FoldedSectionCards (each still re-openable).
+          if (allFolded)
+            SliverToBoxAdapter(
+              child: ValueListenableBuilder<bool>(
+                valueListenable: _tourneeGroupExpanded,
+                builder: (_, expanded, __) {
+                  if (!expanded) {
+                    return TourneeFoldedGroupCard(
+                      onTap: () => _tourneeGroupExpanded.value = true,
+                    );
+                  }
+                  // Expanded: flatten the individual section slivers into a
+                  // Column so they sit inside the single SliverToBoxAdapter.
+                  final sectionWidgets = _buildSectionSlivers(
+                    context: context,
+                    state: state,
+                    notifier: notifier,
+                  ).map((s) => s.child!).toList();
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: sectionWidgets,
+                  );
+                },
+              ),
+            )
+          else
+            ..._buildSectionSlivers(
+              context: context,
+              state: state,
+              notifier: notifier,
+            ),
           if (state.sections.isEmpty)
             SliverToBoxAdapter(
               child: _EmptySectionsHint(onRetry: notifier.refresh),
@@ -881,7 +942,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
 
   static bool _isFavoriteSection(FluxSection s) => s is FeedThemeSection;
 
-  List<Widget> _buildSectionSlivers({
+  List<SliverToBoxAdapter> _buildSectionSlivers({
     required BuildContext context,
     required FluxContinuState state,
     required FluxContinuNotifier notifier,
@@ -898,7 +959,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     final allFolded = state.sections.isNotEmpty &&
         state.sections.every((s) => state.isFolded(s));
 
-    final slivers = <Widget>[];
+    final slivers = <SliverToBoxAdapter>[];
     for (var i = 0; i < state.sections.length; i++) {
       // Inject the "Mes intérêts" intro once, right before the first
       // user-favorite section. Skipped when favorites are first (no system

--- a/apps/mobile/lib/features/flux_continu/widgets/tournee_folded_group_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/tournee_folded_group_card.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+
+/// Collapsed summary card shown when **every** editorial section of the day
+/// has been folded (the user has finished their Tournée).
+///
+/// Replaces the visual pile of individual [FoldedSectionCard]s with a single
+/// H1-weighted row that signals « mission accomplie » without cluttering the
+/// screen. Tapping it expands back to the individual stack so any section can
+/// still be reopened.
+///
+/// Layout mirrors [FoldedSectionCard] (same padding / hairline) but uses a
+/// larger Fraunces H1 weight and [Icons.expand_more] to signpost the action.
+class TourneeFoldedGroupCard extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const TourneeFoldedGroupCard({super.key, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.fromLTRB(22, 14, 18, 14),
+          decoration: BoxDecoration(
+            border: Border(
+              bottom: BorderSide(
+                color: colors.textPrimary.withValues(alpha: 0.08),
+                width: 0.5,
+              ),
+            ),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.check, size: 18, color: colors.success),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Tournée du jour ✓',
+                  style: GoogleFonts.fraunces(
+                    fontSize: 21,
+                    fontWeight: FontWeight.w700,
+                    height: 1.15,
+                    letterSpacing: -0.4,
+                    color: colors.textPrimary,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Icon(
+                Icons.expand_more,
+                size: 22,
+                color: colors.textPrimary.withValues(alpha: 0.45),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/flux_continu/widgets/tournee_folded_group_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/tournee_folded_group_card_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/flux_continu/widgets/tournee_folded_group_card.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [FacteurPalettes.light]),
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('TourneeFoldedGroupCard', () {
+    testWidgets('renders « Tournée du jour ✓ » title with Fraunces font',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        TourneeFoldedGroupCard(onTap: () {}),
+      ));
+
+      // Title text is present
+      expect(find.text('Tournée du jour ✓'), findsOneWidget);
+    });
+
+    testWidgets('renders check icon and expand_more chevron', (tester) async {
+      await tester.pumpWidget(_wrap(
+        TourneeFoldedGroupCard(onTap: () {}),
+      ));
+
+      expect(find.byIcon(Icons.check), findsOneWidget);
+      expect(find.byIcon(Icons.expand_more), findsOneWidget);
+    });
+
+    testWidgets('fires onTap callback when tapped', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_wrap(
+        TourneeFoldedGroupCard(onTap: () => taps++),
+      ));
+
+      await tester.tap(find.byType(TourneeFoldedGroupCard));
+      await tester.pump();
+
+      expect(taps, 1);
+    });
+
+    testWidgets('fires onTap callback when tapped on title text',
+        (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_wrap(
+        TourneeFoldedGroupCard(onTap: () => taps++),
+      ));
+
+      await tester.tap(find.text('Tournée du jour ✓'));
+      await tester.pump();
+
+      expect(taps, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Quoi

Quand toutes les sections éditoriales de la Tournée sont repliées (`allFolded == true`), la pile de 4-6 `FoldedSectionCard` est remplacée par un seul bloc toggle H1 Fraunces — « **Tournée du jour ✓** ». Tap sur le bloc → pile individuelle (chaque section reste ré-ouvrable). Re-collapse automatique sur :
- app mise en arrière-plan (iOS : `paused`, Android : `hidden` + `paused`)
- retour depuis un article ouvert via Flâner

## Pourquoi

Visuellement bruyant quand l'utilisateur a fini sa Tournée : une pile de 4-6 mini-cartes identiques encombre l'écran avant la closing card et le divider Flâner. Ce toggle réduit le bruit à une ligne qui signale « mission accomplie » sans sacrifier l'accès aux sections.

## Changements

- **Nouveau widget** `TourneeFoldedGroupCard` — stateless, `Material > InkWell`, Fraunces 21/700, `Icons.check` + `Icons.expand_more`, hairline bottom identique à `FoldedSectionCard`
- **`_FluxContinuScreenState`** : `ValueNotifier<bool> _tourneeGroupExpanded`, `WidgetsBindingObserver` (collapse sur paused + hidden), reset dans `_openArticle` si `fromSection == null`
- **`_buildSectionSlivers`** : return type promu de `List<Widget>` → `List<SliverToBoxAdapter>` (supprime le cast runtime `as SliverToBoxAdapter`)
- **4 tests widget** : titre, icônes, onTap

## Comment ça a été vérifié

- [x] `flutter test test/features/flux_continu/` — 100/100 OK
- [x] `flutter analyze` sur les fichiers modifiés — No issues found
- [x] /simplify passé : crossAxisAlignment redondant retiré, super.didChangeAppLifecycleState ajouté, AppLifecycleState.hidden ajouté, cast unsafe corrigé

## Zones à risque

- `_buildSectionSlivers` — type de retour changé, spread `...` dans la liste de slivers toujours fonctionnel (Dart accepte `List<SliverToBoxAdapter>` là où `List<Widget>` était attendu)
- `WidgetsBindingObserver` — coexiste avec l'observer global d'`app.dart`, le framework supporte plusieurs observers

🤖 Generated with [Claude Code](https://claude.com/claude-code)