### PR TITLE
fix(tournee): aligner curation sections thématiques Tournée ↔ Flâner

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -955,6 +955,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             nextSectionAccent: i + 1 < state.sections.length
                 ? state.sections[i + 1].accent
                 : null,
+            nextSectionLabel: i + 1 < state.sections.length
+                ? state.sections[i + 1].label
+                : null,
             onNextSection: (section is EssentielSection ||
                     i >= state.sections.length - 1)
                 ? null

--- a/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
@@ -178,6 +178,13 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
     final scrollExhausted = !section.hasMore;
     final themeSlug = section.themeSlug;
 
+    // Pré-calcul des carrousels : permet de passer `hasThemeCarousels` à
+    // _buildDiscoverySection pour qu'elle décide si la carte "Vous êtes à
+    // jour" doit s'afficher (aucun carrousel ET aucun article de découverte).
+    final themeCarousels = (scrollExhausted && themeSlug != null)
+        ? _buildThemeCarousels(section, themeSlug)
+        : const <Widget>[];
+
     return CustomScrollView(
       controller: _scroll,
       physics: const AlwaysScrollableScrollPhysics(),
@@ -206,10 +213,13 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
           SliverToBoxAdapter(
             child: _LoadingMoreIndicator(visible: section.isLoadingMore),
           ),
+        ...themeCarousels,
         if (scrollExhausted && themeSlug != null)
-          ..._buildThemeCarousels(section, themeSlug),
-        if (scrollExhausted && themeSlug != null)
-          ..._buildDiscoverySection(section, themeSlug),
+          ..._buildDiscoverySection(
+            section,
+            themeSlug,
+            hasThemeCarousels: themeCarousels.isNotEmpty,
+          ),
         if (scrollExhausted) _buildFooterSliver(section),
         const SliverToBoxAdapter(child: SizedBox(height: 40)),
       ],
@@ -250,8 +260,9 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
 
   List<Widget> _buildDiscoverySection(
     FeedThemeSection section,
-    String themeSlug,
-  ) {
+    String themeSlug, {
+    bool hasThemeCarousels = false,
+  }) {
     final async = ref.watch(themeDiscoveryProvider(themeSlug));
     return async.when(
       data: (items) {
@@ -261,24 +272,38 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
                 !c.isFollowedSource && !alreadyShownIds.contains(c.id))
             .take(_kDiscoveryItemCap)
             .toList(growable: false);
-        if (discovery.isEmpty) return const <Widget>[];
-        return [
-          const SliverToBoxAdapter(
-            child: _BlockHeader(label: 'Explorer de nouvelles sources'),
-          ),
-          SliverList(
-            delegate: SliverChildBuilderDelegate(
-              (context, index) {
-                final article = discovery[index];
-                return FluxContinuArticleCard(
-                  article: article,
-                  onTap: () => _openArticle(context, article),
-                );
-              },
-              childCount: discovery.length,
+
+        if (discovery.isNotEmpty) {
+          return [
+            const SliverToBoxAdapter(
+              child: _BlockHeader(label: 'Explorer de nouvelles sources'),
             ),
-          ),
-        ];
+            SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final article = discovery[index];
+                  return FluxContinuArticleCard(
+                    article: article,
+                    onTap: () => _openArticle(context, article),
+                  );
+                },
+                childCount: discovery.length,
+              ),
+            ),
+          ];
+        }
+
+        // Rien à montrer après les articles personnalisés : ni carrousel
+        // éditorial, ni article de découverte → carte "Vous êtes à jour".
+        if (!hasThemeCarousels) {
+          return [
+            SliverToBoxAdapter(
+              child: _ThemeClosingCard(label: section.label),
+            ),
+          ];
+        }
+
+        return const <Widget>[];
       },
       loading: () => const [
         SliverToBoxAdapter(
@@ -388,6 +413,63 @@ class _DiscoverySkeleton extends StatelessWidget {
           ),
         );
       }),
+    );
+  }
+}
+
+/// Carte de clôture affichée sur la page dédiée d'un thème quand le feed
+/// personnalisé est épuisé ET qu'il n'y a ni carrousel éditorial ni article
+/// de découverte de sources non-suivies. Signale à l'utilisateur qu'il a
+/// tout lu sur ce thème pour le moment.
+class _ThemeClosingCard extends StatelessWidget {
+  final String label;
+
+  const _ThemeClosingCard({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 24, 16, 8),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: Colors.black.withValues(alpha: 0.05),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.check_circle_outline_rounded,
+            color: colors.textSecondary,
+            size: 28,
+          ),
+          const SizedBox(height: 10),
+          Text(
+            'Vous êtes à jour sur $label',
+            textAlign: TextAlign.center,
+            style: GoogleFonts.fraunces(
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+              height: 1.2,
+              color: colors.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Aucun autre article disponible pour le moment.',
+            textAlign: TextAlign.center,
+            style: GoogleFonts.dmSans(
+              fontSize: 13,
+              height: 1.5,
+              color: colors.textSecondary,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
@@ -118,11 +118,17 @@ class NextSectionButton extends StatefulWidget {
   final Color? nextAccent;
   final VoidCallback? onTap;
 
+  /// Nom de la section suivante, ex : « Technologie » ou « Bonnes Nouvelles ».
+  /// Quand fourni, le bouton affiche « {nextSectionLabel} ↓ » au lieu du
+  /// générique « Section suivante ».
+  final String? nextSectionLabel;
+
   const NextSectionButton({
     super.key,
     required this.isMarked,
     required this.onTap,
     this.nextAccent,
+    this.nextSectionLabel,
   });
 
   @override
@@ -184,7 +190,11 @@ class _NextSectionButtonState extends State<NextSectionButton>
     final colors = context.facteurColors;
     final marked = widget.isMarked || _localMarked;
     final accent = widget.nextAccent ?? colors.primary;
-    final label = marked ? 'Passé' : 'Section suivante';
+    final label = marked
+        ? 'Passé'
+        : (widget.nextSectionLabel != null
+            ? widget.nextSectionLabel!
+            : 'Section suivante');
     final foreground =
         marked ? colors.textSecondary : accent;
     final background = marked

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -81,6 +81,11 @@ class SectionBlock extends StatelessWidget {
   /// Null on the last Tournée section (the button is hidden anyway).
   final Color? nextSectionAccent;
 
+  /// Label de la section suivante (ex : « Technologie », « Bonnes Nouvelles »).
+  /// Quand fourni, le bouton [NextSectionButton] affiche ce nom au lieu du
+  /// générique « Section suivante ».
+  final String? nextSectionLabel;
+
   const SectionBlock({
     super.key,
     required this.section,
@@ -104,6 +109,7 @@ class SectionBlock extends StatelessWidget {
     this.onNextSection,
     this.isMarkedForNextSession = false,
     this.nextSectionAccent,
+    this.nextSectionLabel,
   });
 
   @override
@@ -165,6 +171,7 @@ class SectionBlock extends StatelessWidget {
               ? NextSectionButton(
                   isMarked: isMarkedForNextSession,
                   nextAccent: nextSectionAccent,
+                  nextSectionLabel: nextSectionLabel,
                   onTap: isMarkedForNextSession ? null : onNextSection,
                 )
               : null,

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -2376,8 +2376,8 @@ class RecommendationService:
 
         explicit_filter = (
             source_id is not None
-            or theme is not None       # inclut personalized_theme_mode
-            or topic is not None       # inclut personalized_theme_mode
+            or theme is not None  # inclut personalized_theme_mode
+            or topic is not None  # inclut personalized_theme_mode
             or entity is not None
             or keyword is not None
         )

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -2376,8 +2376,8 @@ class RecommendationService:
 
         explicit_filter = (
             source_id is not None
-            or (theme is not None and not personalized_theme_mode)
-            or (topic is not None and not personalized_theme_mode)
+            or theme is not None       # inclut personalized_theme_mode
+            or topic is not None       # inclut personalized_theme_mode
             or entity is not None
             or keyword is not None
         )

--- a/packages/api/tests/test_personalized_theme_mode.py
+++ b/packages/api/tests/test_personalized_theme_mode.py
@@ -196,6 +196,53 @@ async def test_explicit_filter_unchanged_when_personalized_false():
     )
 
 
+@pytest.mark.asyncio
+async def test_personalized_theme_relaxes_seen_consumed_filter():
+    """Régression : personalized=True + theme ne doit PAS re-filtrer les
+    articles seen/consumed — il doit tomber dans la branche explicit_filter=True
+    (identique à Flâner thème) et n'exclure que is_hidden.
+
+    Avant le fix : personalized_theme_mode=True → explicit_filter=False
+    → les articles seen/consumed disparaissaient des sections thématiques
+    de la Tournée alors qu'ils restaient visibles dans le Flâner filtré.
+    Après le fix : theme is not None → explicit_filter=True toujours.
+    """
+    service, session = _make_service()
+    captured: list[str] = []
+    session.scalars, _ = _stub_scalars(captured)
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            theme="tech",
+            personalized=True,
+            followed_source_ids={uuid4()},
+        ),
+        timeout=5.0,
+    )
+
+    assert captured, "expected at least one SQL statement"
+    sql = captured[0].lower()
+
+    # La branche explicit_filter=True n'inclut ni is_saved, ni
+    # last_impressed_at, ni manually_impressed dans le NOT EXISTS.
+    # Ces colonnes n'apparaissent que dans la branche default (explicit_filter=False).
+    assert "is_saved" not in sql, (
+        "personalized_theme_mode doit utiliser explicit_filter=True : "
+        "is_saved ne doit pas apparaître dans le NOT EXISTS.\n"
+        f"SQL:\n{captured[0]}"
+    )
+    assert "last_impressed_at" not in sql, (
+        "personalized_theme_mode ne doit pas filtrer last_impressed_at.\n"
+        f"SQL:\n{captured[0]}"
+    )
+    assert "manually_impressed" not in sql, (
+        "personalized_theme_mode ne doit pas filtrer manually_impressed.\n"
+        f"SQL:\n{captured[0]}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Story 21.2 — Tournée du jour favorite-theme sections fall through to the
 # PillarScoringEngine branch instead of the chronological short-circuit.


### PR DESCRIPTION
## Contexte

Sur la Tournée du jour, les sections thématiques (« Technologie », « Sciences »…) affichaient 2 articles alors que le feed Flâner filtré sur le même thème montrait 10+ articles des mêmes sources suivies publiés aujourd'hui. Ce ticket corrige la cause racine et améliore l'UX de clôture de la page dédiée.

## Cause racine

```python
# AVANT (bugué)
explicit_filter = (
    source_id is not None
    or (theme is not None and not personalized_theme_mode)  # ← excluait Tournée
    or (topic is not None and not personalized_theme_mode)  # ← excluait Tournée
    ...
)
```

Quand `personalized_theme_mode=True`, `explicit_filter=False` → la requête tombait dans la branche default qui excluait seen + consumed + impressed. Résultat : articles déjà vus filtrés de la Tournée thématique mais pas du Flâner.

## Changements

### 1. Backend — `recommendation_service.py`

`explicit_filter` inclut désormais `theme is not None` et `topic is not None` inconditionnellement. La section Tournée garde son contrat (sources suivies + fenêtre 24h + boost subtopiques) mais n'exclut plus les articles seen/consumed — parité exacte avec Flâner thème.

`digest_content_ids` continue d'exclure les articles du digest éditorial du jour (comportement intentionnel et inchangé).

### 2. Test backend — `test_personalized_theme_mode.py`

Nouveau test `test_personalized_theme_relaxes_seen_consumed_filter` : vérifie que les colonnes `is_saved`, `last_impressed_at`, `manually_impressed` n'apparaissent pas dans le NOT EXISTS quand `personalized=True + theme=tech`.

### 3. Frontend — Bouton « Section suivante » nommé

`NextSectionButton` accepte un nouveau champ optionnel `nextSectionLabel: String?`. Quand fourni, le label affiche le nom réel (ex : « Technologie ») au lieu du générique « Section suivante ». Propagé depuis `flux_continu_screen.dart` via `state.sections[i+1].label`.

### 4. Frontend — Carte « Vous êtes à jour » sur la page dédiée

Sur `ThemeSectionScreen` (page « Lire plus »), quand :
- le feed personnalisé est épuisé (`!section.hasMore`)
- aucun carrousel éditorial ne matche le thème
- `themeDiscoveryProvider` retourne 0 article non-suivi

→ un widget `_ThemeClosingCard` s'insère avant le `ThemeDetailFooter` avec le texte « Vous êtes à jour sur {label} ».

## Tests

- Backend : `pytest tests/test_personalized_theme_mode.py -v` → **11/11 ✅**
- Flutter analyze (flux_continu) → **0 erreur ✅**
- `flutter test test/features/flux_continu/` → **96/96 ✅**
- Les 10 failures dans `test/features/feed/` (perspectives, diff_title) sont pre-existantes et hors-scope.

## Vérification manuelle recommandée

1. Ouvrir la Tournée → section « Technologie » → vérifier ≥5 articles (vs 2 avant)
2. Tapper « Lire plus » → page dédiée → scroll jusqu'en bas → vérifier carte « Vous êtes à jour sur Technologie » si aucun contenu de découverte
3. Sur la Tournée principale, vérifier que le bouton en bas de chaque section affiche le nom de la section suivante (ex : « Bonnes Nouvelles ») au lieu de « Section suivante »

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)