### PR TITLE
hotfix(ui): mode iconOnly pour DivergenceInlineBadge dans Flux Continu

### DIFF
--- a/apps/mobile/lib/features/digest/widgets/divergence_inline_badge.dart
+++ b/apps/mobile/lib/features/digest/widgets/divergence_inline_badge.dart
@@ -17,20 +17,33 @@ import '../../../config/theme.dart';
 class DivergenceInlineBadge extends StatelessWidget {
   final String? divergenceLevel;
 
-  const DivergenceInlineBadge({super.key, this.divergenceLevel});
+  /// Mode compact pour les listes étroites (Flux Continu) : rend uniquement
+  /// les dots, sans le label texte. Opacité des dots `medium` boostée pour
+  /// compenser l'absence du label qui portait l'information sémantique.
+  final bool iconOnly;
+
+  const DivergenceInlineBadge({
+    super.key,
+    this.divergenceLevel,
+    this.iconOnly = false,
+  });
 
   @override
   Widget build(BuildContext context) {
-    final config = _configFor(divergenceLevel, context.facteurColors);
+    final config = _configFor(divergenceLevel, context.facteurColors, iconOnly);
     if (config == null) return const SizedBox.shrink();
+
+    final glyph = CustomPaint(
+      size: const Size(28, 12),
+      painter: _DivergenceGlyphPainter(config),
+    );
+
+    if (iconOnly) return glyph;
 
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        CustomPaint(
-          size: const Size(28, 12),
-          painter: _DivergenceGlyphPainter(config),
-        ),
+        glyph,
         const SizedBox(width: 4),
         Text(
           config.label,
@@ -45,19 +58,23 @@ class DivergenceInlineBadge extends StatelessWidget {
     );
   }
 
-  static _BadgeConfig? _configFor(String? level, FacteurColors colors) {
+  static _BadgeConfig? _configFor(
+      String? level, FacteurColors colors, bool iconOnly) {
     switch (level) {
       case 'low':
         return null;
       case 'medium':
+        // En iconOnly les dots portent tout le sens — on remonte l'opacité
+        // pour qu'ils restent lisibles sans le label.
+        final dotOpacity = iconOnly ? 0.85 : 0.5;
         return _BadgeConfig(
           label: 'AVIS VARIÉS',
           dots: [
-            _Dot(4, 6, colors.textTertiary, 0.5),
-            _Dot(10, 6, colors.textTertiary, 0.5),
-            _Dot(15, 6, colors.textTertiary, 0.5),
-            _Dot(20, 6, colors.textTertiary, 0.5),
-            _Dot(25, 6, colors.textTertiary, 0.5),
+            _Dot(4, 6, colors.textTertiary, dotOpacity),
+            _Dot(10, 6, colors.textTertiary, dotOpacity),
+            _Dot(15, 6, colors.textTertiary, dotOpacity),
+            _Dot(20, 6, colors.textTertiary, dotOpacity),
+            _Dot(25, 6, colors.textTertiary, dotOpacity),
           ],
           labelColor: colors.textTertiary,
           bold: false,

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -467,18 +467,20 @@ class _Footer extends StatelessWidget {
             height: 1.4,
           ),
         ),
+        if (showPressReview || divergenceLevel != null) const Spacer(),
         if (divergenceLevel != null) ...[
-          const SizedBox(width: 6),
-          DivergenceInlineBadge(divergenceLevel: divergenceLevel),
+          DivergenceInlineBadge(
+            divergenceLevel: divergenceLevel,
+            iconOnly: true,
+          ),
+          if (showPressReview) const SizedBox(width: 6),
         ],
-        if (showPressReview) ...[
-          const Spacer(),
+        if (showPressReview)
           _PressReviewChip(
             count: pressReviewCount,
             sources: perspectiveSources,
             colors: colors,
           ),
-        ],
       ],
     );
   }


### PR DESCRIPTION
## Quoi

Hotfix sur les cartes Flux Continu : le badge "AVIS VARIÉS" / "POLARISÉ" avec label complet faisait déborder les logos de sources. Affiche maintenant uniquement les dots, repositionnés à droite de la footer-row.

## Pourquoi

Ce changement avait déjà été préparé sur la PR #687 mais le squash-merge n'a pas inclus le hotfix (commit poussé après la merge). Comportement toujours présent en production.

## Changements

- `DivergenceInlineBadge` : nouvelle prop `iconOnly` (rend uniquement les dots, sans le label). Opacité des dots `medium` boostée de `0.5` → `0.85` pour compenser l'absence du label.
- `FluxContinuArticleCard._Footer` : badge déplacé du milieu de la row (après timestamp) vers la droite via `Spacer`, juste à gauche du `_PressReviewChip`. Utilisé en `iconOnly: true`.

Le mode label complet reste utilisé dans `feed_card.dart`, `topic_section.dart` et `perspectives_bottom_sheet.dart` où la largeur le permet.

## Nouveau layout du footer Flux Continu

```
[SourceDot] [SourceName] [+] [ThemePill] · [clock] [time]  ........  [dots] [+N logos]
```

## Comment ça a été vérifié

- [x] `flutter test test/features/digest/widgets/divergence_inline_badge_test.dart` — 5/5 ✅
- [x] `flutter analyze` propre sur les fichiers modifiés
- [x] Cherry-pick depuis le commit `c64166f7` qui avait été perdu dans le squash de #687

## Zones à risque

- Comportement par défaut de `DivergenceInlineBadge` inchangé (`iconOnly: false` par défaut) — pas de régression sur les autres usages

🤖 Generated with [Claude Code](https://claude.com/claude-code)