### PR TITLE
micro(tournee): retirer checkmark du texte, chevron simple -> double

### DIFF
--- a/apps/mobile/lib/features/flux_continu/widgets/tournee_folded_group_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/tournee_folded_group_card.dart
@@ -12,7 +12,8 @@ import '../../../config/theme.dart';
 /// still be reopened.
 ///
 /// Layout mirrors [FoldedSectionCard] (same padding / hairline) but uses a
-/// larger Fraunces H1 weight and [Icons.expand_more] to signpost the action.
+/// larger Fraunces H1 weight and [Icons.unfold_more] (double chevron) to
+/// signpost the expand action.
 class TourneeFoldedGroupCard extends StatelessWidget {
   final VoidCallback onTap;
 
@@ -42,7 +43,7 @@ class TourneeFoldedGroupCard extends StatelessWidget {
               const SizedBox(width: 10),
               Expanded(
                 child: Text(
-                  'Tournée du jour ✓',
+                  'Tournée du jour',
                   style: GoogleFonts.fraunces(
                     fontSize: 21,
                     fontWeight: FontWeight.w700,
@@ -56,7 +57,7 @@ class TourneeFoldedGroupCard extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               Icon(
-                Icons.expand_more,
+                Icons.unfold_more,
                 size: 22,
                 color: colors.textPrimary.withValues(alpha: 0.45),
               ),

--- a/apps/mobile/test/features/flux_continu/widgets/tournee_folded_group_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/tournee_folded_group_card_test.dart
@@ -18,23 +18,23 @@ void main() {
   });
 
   group('TourneeFoldedGroupCard', () {
-    testWidgets('renders « Tournée du jour ✓ » title with Fraunces font',
+    testWidgets('renders « Tournée du jour » title with Fraunces font',
         (tester) async {
       await tester.pumpWidget(_wrap(
         TourneeFoldedGroupCard(onTap: () {}),
       ));
 
       // Title text is present
-      expect(find.text('Tournée du jour ✓'), findsOneWidget);
+      expect(find.text('Tournée du jour'), findsOneWidget);
     });
 
-    testWidgets('renders check icon and expand_more chevron', (tester) async {
+    testWidgets('renders check icon and double chevron', (tester) async {
       await tester.pumpWidget(_wrap(
         TourneeFoldedGroupCard(onTap: () {}),
       ));
 
       expect(find.byIcon(Icons.check), findsOneWidget);
-      expect(find.byIcon(Icons.expand_more), findsOneWidget);
+      expect(find.byIcon(Icons.unfold_more), findsOneWidget);
     });
 
     testWidgets('fires onTap callback when tapped', (tester) async {
@@ -56,7 +56,7 @@ void main() {
         TourneeFoldedGroupCard(onTap: () => taps++),
       ));
 
-      await tester.tap(find.text('Tournée du jour ✓'));
+      await tester.tap(find.text('Tournée du jour'));
       await tester.pump();
 
       expect(taps, 1);


### PR DESCRIPTION
## Quoi

Deux micro-ajustements UX sur le widget `TourneeFoldedGroupCard` (toggle « Tournée du jour » apparu dans #690) :

- **Texte** : « Tournée du jour ✓ » → « Tournée du jour » — le ✓ est redondant avec l'icône `Icons.check` déjà présente à gauche
- **Chevron** : `Icons.expand_more` (simple) → `Icons.unfold_more` (double) — signale mieux l'action d'expand

## Vérifié

- [x] `flutter test test/features/flux_continu/widgets/tournee_folded_group_card_test.dart` — 4/4 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)