### PR TITLE
fix(lettres): align progression and refresh after saves

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -43,6 +43,7 @@ import '../../../core/nudges/widgets/nudge_inline_banner.dart';
 import '../../custom_topics/widgets/topic_chip.dart';
 import '../../digest/widgets/editorial_badge.dart';
 import '../../../core/ui/notification_service.dart';
+import '../../lettres/providers/letters_provider.dart';
 import '../../saved/widgets/collection_picker_sheet.dart';
 import '../../saved/providers/collections_provider.dart';
 import '../../../widgets/design/facteur_thumbnail.dart';
@@ -59,11 +60,7 @@ class ContentDetailScreen extends ConsumerStatefulWidget {
   final String contentId;
   final Content? content; // Passed via extra from GoRouter
 
-  const ContentDetailScreen({
-    super.key,
-    required this.contentId,
-    this.content,
-  });
+  const ContentDetailScreen({super.key, required this.contentId, this.content});
 
   @override
   ConsumerState<ContentDetailScreen> createState() =>
@@ -207,13 +204,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     );
     _bookmarkScaleAnimation = TweenSequence<double>([
       TweenSequenceItem(
-        tween: Tween<double>(begin: 1.0, end: 1.3)
-            .chain(CurveTween(curve: Curves.easeOut)),
+        tween: Tween<double>(
+          begin: 1.0,
+          end: 1.3,
+        ).chain(CurveTween(curve: Curves.easeOut)),
         weight: 30,
       ),
       TweenSequenceItem(
-        tween: Tween<double>(begin: 1.3, end: 1.0)
-            .chain(CurveTween(curve: Curves.bounceOut)),
+        tween: Tween<double>(
+          begin: 1.3,
+          end: 1.0,
+        ).chain(CurveTween(curve: Curves.bounceOut)),
         weight: 70,
       ),
     ]).animate(_bookmarkBounceController);
@@ -225,13 +226,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     );
     _likeScaleAnimation = TweenSequence<double>([
       TweenSequenceItem(
-        tween: Tween<double>(begin: 1.0, end: 1.3)
-            .chain(CurveTween(curve: Curves.easeOut)),
+        tween: Tween<double>(
+          begin: 1.0,
+          end: 1.3,
+        ).chain(CurveTween(curve: Curves.easeOut)),
         weight: 30,
       ),
       TweenSequenceItem(
-        tween: Tween<double>(begin: 1.3, end: 1.0)
-            .chain(CurveTween(curve: Curves.bounceOut)),
+        tween: Tween<double>(
+          begin: 1.3,
+          end: 1.0,
+        ).chain(CurveTween(curve: Curves.bounceOut)),
         weight: 70,
       ),
     ]).animate(_likeBounceController);
@@ -246,7 +251,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       vsync: this,
     );
     _footerAutoController.addListener(() {
-      _footerOffset.value = _footerAutoStart +
+      _footerOffset.value =
+          _footerAutoStart +
           (_footerAutoTarget - _footerAutoStart) * _footerAutoController.value;
     });
 
@@ -326,11 +332,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
     _webViewController = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..setNavigationDelegate(NavigationDelegate(
-        onPageFinished: (_) => _injectScrollBridgeScript(),
-      ))
-      ..addJavaScriptChannel('ScrollBridge',
-          onMessageReceived: _onScrollBridgeMessage)
+      ..setNavigationDelegate(
+        NavigationDelegate(onPageFinished: (_) => _injectScrollBridgeScript()),
+      )
+      ..addJavaScriptChannel(
+        'ScrollBridge',
+        onMessageReceived: _onScrollBridgeMessage,
+      )
       ..loadRequest(Uri.parse(content.url));
   }
 
@@ -606,7 +614,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (endBox == null || svBox == null) return;
     if (!_scrollController.hasClients) return;
     // content-coord of marker = screen Y of marker − screen Y of sv top + scroll offset
-    final extent = endBox.localToGlobal(Offset.zero).dy -
+    final extent =
+        endBox.localToGlobal(Offset.zero).dy -
         svBox.localToGlobal(Offset.zero).dy +
         _scrollController.offset;
     if (extent > 0) _articleContentExtent = extent;
@@ -666,8 +675,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     setState(() {
       final current = _perspectivesSelectedSegments;
       if (current.contains(key)) {
-        _perspectivesSelectedSegments =
-            current.length == 1 ? {} : (Set.from(current)..remove(key));
+        _perspectivesSelectedSegments = current.length == 1
+            ? {}
+            : (Set.from(current)..remove(key));
       } else {
         _perspectivesSelectedSegments = current.isEmpty || current.length == 3
             ? {key}
@@ -707,8 +717,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       // Drop the article subtree from the tree once the 300 ms fade-out is
       // done, so Flutter stops painting it under the scrolling WebView.
       _articleLayerUnmountTimer?.cancel();
-      _articleLayerUnmountTimer =
-          Timer(const Duration(milliseconds: 320), () {
+      _articleLayerUnmountTimer = Timer(const Duration(milliseconds: 320), () {
         if (mounted && _isWebViewActive && _articleLayerMounted) {
           setState(() => _articleLayerMounted = false);
         }
@@ -749,8 +758,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (_footerPermanent.value) return;
     final footerHeight =
         _kFooterContentHeight + MediaQuery.of(context).viewPadding.bottom;
-    _footerOffset.value =
-        (_footerOffset.value + delta / footerHeight).clamp(0.0, 1.0);
+    _footerOffset.value = (_footerOffset.value + delta / footerHeight).clamp(
+      0.0,
+      1.0,
+    );
   }
 
   /// Update footer offset based on a native scroll delta (in-app reader only).
@@ -837,10 +848,14 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           // Fixes cases where RSS provides longer htmlContent than the API
           // (e.g. Le Monde articles where enrichment returns a shorter version).
           final merged = content.copyWith(
-            description:
-                _pickLongest(content.description, _content?.description),
-            htmlContent:
-                _pickLongest(content.htmlContent, _content?.htmlContent),
+            description: _pickLongest(
+              content.description,
+              _content?.description,
+            ),
+            htmlContent: _pickLongest(
+              content.htmlContent,
+              _content?.htmlContent,
+            ),
             editorialBadge: content.editorialBadge ?? _content?.editorialBadge,
           );
           setState(() {
@@ -881,8 +896,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         } else {
           // Show error and pop if content not found
           setState(() => _contentResolved = true);
-          NotificationService.showError('Contenu introuvable',
-              context: context);
+          NotificationService.showError(
+            'Contenu introuvable',
+            context: context,
+          );
           context.pop();
         }
       }
@@ -914,10 +931,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       final supabase = Supabase.instance.client;
       final apiClient = ApiClient(supabase);
       final repository = FeedRepository(apiClient);
-      await repository.updateContentStatus(
-        content.id,
-        ContentStatus.consumed,
-      );
+      await repository.updateContentStatus(content.id, ContentStatus.consumed);
 
       // Silent update - no notification needed as this is tracked automatically
     } catch (e) {
@@ -948,6 +962,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           final colRepo = ref.read(collectionsRepositoryProvider);
           await colRepo.addToCollection(defaultCol.id, content.id);
           ref.invalidate(collectionsProvider);
+          unawaited(ref.read(lettersProvider.notifier).silentRefresh());
         }
         CollectionPickerSheet.show(
           context,
@@ -1114,8 +1129,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (response == null) return;
     if (response.perspectives.isEmpty || !response.shouldDisplay) return;
     _perspectivesCtaTriggered = true;
-    NudgeCounters.increment(NudgeCounters.articleWithPerspectivesCount)
-        .then((count) async {
+    NudgeCounters.increment(NudgeCounters.articleWithPerspectivesCount).then((
+      count,
+    ) async {
       if (!mounted) return;
       if (count < 2) return;
       final coordinator = ref.read(nudgeCoordinatorProvider);
@@ -1131,13 +1147,16 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       vsync: this,
       duration: const Duration(milliseconds: 600),
     );
-    _perspectivesPulseScale ??= TweenSequence<double>([
-      TweenSequenceItem(tween: Tween(begin: 1.0, end: 1.08), weight: 50),
-      TweenSequenceItem(tween: Tween(begin: 1.08, end: 1.0), weight: 50),
-    ]).animate(CurvedAnimation(
-      parent: _perspectivesPulseController!,
-      curve: Curves.easeOutCubic,
-    ));
+    _perspectivesPulseScale ??=
+        TweenSequence<double>([
+          TweenSequenceItem(tween: Tween(begin: 1.0, end: 1.08), weight: 50),
+          TweenSequenceItem(tween: Tween(begin: 1.08, end: 1.0), weight: 50),
+        ]).animate(
+          CurvedAnimation(
+            parent: _perspectivesPulseController!,
+            curve: Curves.easeOutCubic,
+          ),
+        );
     _perspectivesPulseController!.forward(from: 0).whenComplete(() async {
       if (!mounted) return;
       final coordinator = ref.read(nudgeCoordinatorProvider);
@@ -1165,24 +1184,16 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
         // Persist reading progress via status endpoint
         if (progressPct > 0) {
-          repository.updateContentStatusWithProgress(
-            _content!.id,
-            progressPct,
-          );
+          repository.updateContentStatusWithProgress(_content!.id, progressPct);
         }
 
         // Accumulate reading time on user_content_status for recommendation signal.
-        repository.updateContentStatusWithTimeSpent(
-          _content!.id,
-          duration,
-        );
+        repository.updateContentStatusWithTimeSpent(_content!.id, duration);
 
         // Track article read duration
-        ref.read(analyticsServiceProvider).trackArticleRead(
-              _content!.id,
-              _content!.source.id,
-              duration,
-            );
+        ref
+            .read(analyticsServiceProvider)
+            .trackArticleRead(_content!.id, _content!.source.id, duration);
       }
     } catch (e) {
       debugPrint('Error tracking on dispose: $e');
@@ -1330,7 +1341,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (contentId == null) return;
 
     setState(
-        () => _perspectivesAnalysisState = PerspectivesAnalysisState.loading);
+      () => _perspectivesAnalysisState = PerspectivesAnalysisState.loading,
+    );
 
     // Scroll to analysis zone so the user can see the progress
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -1360,7 +1372,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       debugPrint('Error requesting perspectives analysis: $e');
       if (!mounted) return;
       setState(
-          () => _perspectivesAnalysisState = PerspectivesAnalysisState.error);
+        () => _perspectivesAnalysisState = PerspectivesAnalysisState.error,
+      );
     }
   }
 
@@ -1384,16 +1397,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             onPressed: () => context.pop(),
           ),
         ),
-        body: Center(
-          child: CircularProgressIndicator(color: colors.primary),
-        ),
+        body: Center(child: CircularProgressIndicator(color: colors.primary)),
       );
     }
 
     // Premium source → redirect to external browser for authenticated access
     final userSources = ref.read(userSourcesProvider).valueOrNull ?? [];
-    final isPremiumSource =
-        userSources.any((s) => s.id == content.source.id && s.hasSubscription);
+    final isPremiumSource = userSources.any(
+      (s) => s.id == content.source.id && s.hasSubscription,
+    );
     if (isPremiumSource &&
         content.url.isNotEmpty &&
         !_premiumRedirectScheduled) {
@@ -1415,9 +1427,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
               const SizedBox(height: FacteurSpacing.space4),
               Text(
                 'Ouverture dans votre navigateur...',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: colors.textSecondary,
-                    ),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
               ),
             ],
           ),
@@ -1431,7 +1443,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     // Skip scroll-to-site for articles with too little content
     final articleText = content.htmlContent ?? content.description;
     final hasEnoughContent = plainTextLength(articleText) >= 100;
-    final useScrollToSite = content.hasInAppContent &&
+    final useScrollToSite =
+        content.hasInAppContent &&
         content.contentType == ContentType.article &&
         hasEnoughContent &&
         !_showWebView &&
@@ -1465,9 +1478,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
               const SizedBox(height: FacteurSpacing.space4),
               Text(
                 'Ouverture dans votre navigateur...',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: colors.textSecondary,
-                    ),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
               ),
             ],
           ),
@@ -1533,10 +1546,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 child: isVideoContent
                     ? _buildVideoContent(context, content)
                     : useScrollToSite
-                        ? _buildScrollToSiteContent(context, content)
-                        : useInAppReading
-                            ? _buildInAppContent(context, content)
-                            : _buildWebViewFallback(content),
+                    ? _buildScrollToSiteContent(context, content)
+                    : useInAppReading
+                    ? _buildInAppContent(context, content)
+                    : _buildWebViewFallback(content),
               ),
             ),
             // Header — pinned at the top of the screen; no scroll-driven
@@ -1558,9 +1571,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 top: MediaQuery.of(context).padding.top + _kHeaderVisualBottom,
                 left: 0,
                 right: 0,
-                child: RepaintBoundary(
-                  child: _buildReadingProgressBar(colors),
-                ),
+                child: RepaintBoundary(child: _buildReadingProgressBar(colors)),
               ),
             // Exit animation overlay — fade-to-white + scale-down
             if (_isExitAnimating)
@@ -1570,8 +1581,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   return Positioned.fill(
                     child: IgnorePointer(
                       child: ColoredBox(
-                        color: Colors.white
-                            .withValues(alpha: 0.6 * _exitAnimController.value),
+                        color: Colors.white.withValues(
+                          alpha: 0.6 * _exitAnimController.value,
+                        ),
                       ),
                     ),
                   );
@@ -1611,7 +1623,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (content == null) return;
     final articleText = content.htmlContent ?? content.description;
     final hasEnoughContent = plainTextLength(articleText) >= 100;
-    final isScrollToSite = content.hasInAppContent &&
+    final isScrollToSite =
+        content.hasInAppContent &&
         content.contentType == ContentType.article &&
         hasEnoughContent &&
         !_showWebView;
@@ -1641,18 +1654,22 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     // (htmlContent missing or too short — common race on Android). Reveal
     // the internal WebView instead of jumping straight to the external
     // browser, so the user stays inside the reader.
-    unawaited(Sentry.addBreadcrumb(Breadcrumb(
-      category: 'reader.cta',
-      message: 'fallback to internal webview',
-      level: SentryLevel.info,
-      data: {
-        'contentId': content.id,
-        'contentType': content.contentType.name,
-        'hasInAppContent': content.hasInAppContent,
-        'plainTextLen': plainTextLength(articleText),
-        'platform': defaultTargetPlatform.name,
-      },
-    )));
+    unawaited(
+      Sentry.addBreadcrumb(
+        Breadcrumb(
+          category: 'reader.cta',
+          message: 'fallback to internal webview',
+          level: SentryLevel.info,
+          data: {
+            'contentId': content.id,
+            'contentType': content.contentType.name,
+            'hasInAppContent': content.hasInAppContent,
+            'plainTextLen': plainTextLength(articleText),
+            'platform': defaultTargetPlatform.name,
+          },
+        ),
+      ),
+    );
     setState(() {
       _showWebView = true;
       _ctaTapped = true;
@@ -1671,9 +1688,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       style: OutlinedButton.styleFrom(
         backgroundColor: Colors.white.withValues(alpha: 0.5),
         foregroundColor: colors.textPrimary,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
-        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         side: BorderSide(color: colors.border.withValues(alpha: 0.5)),
         padding: const EdgeInsets.symmetric(horizontal: 12),
       ),
@@ -1745,7 +1760,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         color: colors.backgroundPrimary,
         border: Border(
           top: BorderSide(
-              color: colors.border.withValues(alpha: 0.5), width: 0.5),
+            color: colors.border.withValues(alpha: 0.5),
+            width: 0.5,
+          ),
         ),
         boxShadow: [
           BoxShadow(
@@ -1770,102 +1787,113 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   height: 53,
                   child: isArticle
                       ? ValueListenableBuilder<bool>(
-                    valueListenable: _footerPermanent,
-                    builder: (context, permanent, _) {
-                      final isWebViewMode = _ctaTapped || _isWebViewActive;
-                      // Primary orange ONLY when the user has reached the
-                      // bottom of the article (footer locked permanent) AND
-                      // the WebView hasn't been revealed yet.
-                      final usePrimary = permanent && !isWebViewMode;
+                          valueListenable: _footerPermanent,
+                          builder: (context, permanent, _) {
+                            final isWebViewMode =
+                                _ctaTapped || _isWebViewActive;
+                            // Primary orange ONLY when the user has reached the
+                            // bottom of the article (footer locked permanent) AND
+                            // the WebView hasn't been revealed yet.
+                            final usePrimary = permanent && !isWebViewMode;
 
-                      final label = isWebViewMode
-                          ? 'Lire via Navigateur'
-                          : 'Lire sur ${content.source.name}';
-                      final showLogo = !isWebViewMode;
-                      final iconData = isWebViewMode
-                          ? PhosphorIcons.arrowUpRight(
-                              PhosphorIconsStyle.regular)
-                          : PhosphorIcons.arrowDown(
-                              PhosphorIconsStyle.regular);
+                            final label = isWebViewMode
+                                ? 'Lire via Navigateur'
+                                : 'Lire sur ${content.source.name}';
+                            final showLogo = !isWebViewMode;
+                            final iconData = isWebViewMode
+                                ? PhosphorIcons.arrowUpRight(
+                                    PhosphorIconsStyle.regular,
+                                  )
+                                : PhosphorIcons.arrowDown(
+                                    PhosphorIconsStyle.regular,
+                                  );
 
-                      final children = <Widget>[
-                        if (showLogo) ...[
-                          SourceLogoAvatar(
-                            source: content.source,
-                            size: 28,
-                            radius: 8,
-                          ),
-                          const SizedBox(width: 6),
-                        ],
-                        Flexible(
-                          child: Text(
-                            label,
-                            style: textTheme.labelMedium?.copyWith(
-                              fontWeight: FontWeight.w600,
-                              color: usePrimary
-                                  ? Colors.white
-                                  : colors.textPrimary,
-                            ),
-                            overflow: TextOverflow.ellipsis,
-                            textAlign: TextAlign.left,
-                          ),
-                        ),
-                        const SizedBox(width: 4),
-                        Icon(
-                          iconData,
-                          size: 16,
-                          color: usePrimary
-                              ? Colors.white.withValues(alpha: 0.8)
-                              : colors.textSecondary,
-                        ),
-                      ];
-
-                      if (usePrimary) {
-                        return AnimatedBuilder(
-                          animation: _ctaPulseController,
-                          builder: (context, child) {
-                            // Subtle pop: 1.0 → 1.04 → 1.0 over 280ms.
-                            final t = _ctaPulseController.value;
-                            final scale = 1.0 + 0.04 * math.sin(t * math.pi);
-                            return Transform.scale(scale: scale, child: child);
-                          },
-                          child: FilledButton(
-                            onPressed: _onReadOnSiteTap,
-                            style: FilledButton.styleFrom(
-                              backgroundColor: colors.primary,
-                              foregroundColor: Colors.white,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16),
+                            final children = <Widget>[
+                              if (showLogo) ...[
+                                SourceLogoAvatar(
+                                  source: content.source,
+                                  size: 28,
+                                  radius: 8,
+                                ),
+                                const SizedBox(width: 6),
+                              ],
+                              Flexible(
+                                child: Text(
+                                  label,
+                                  style: textTheme.labelMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                    color: usePrimary
+                                        ? Colors.white
+                                        : colors.textPrimary,
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                  textAlign: TextAlign.left,
+                                ),
                               ),
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 12),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: children,
-                            ),
-                          ),
-                        );
-                      }
+                              const SizedBox(width: 4),
+                              Icon(
+                                iconData,
+                                size: 16,
+                                color: usePrimary
+                                    ? Colors.white.withValues(alpha: 0.8)
+                                    : colors.textSecondary,
+                              ),
+                            ];
 
-                      return OutlinedButton(
-                        onPressed: _onReadOnSiteTap,
-                        style: OutlinedButton.styleFrom(
-                          backgroundColor:
-                              Colors.white.withValues(alpha: 0.5),
-                          foregroundColor: colors.textPrimary,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(16),
-                          ),
-                          side: BorderSide(
-                              color: colors.border.withValues(alpha: 0.5)),
-                          padding:
-                              const EdgeInsets.symmetric(horizontal: 12),
-                        ),
-                        child: Row(children: children),
-                      );
-                    },
-                  )
+                            if (usePrimary) {
+                              return AnimatedBuilder(
+                                animation: _ctaPulseController,
+                                builder: (context, child) {
+                                  // Subtle pop: 1.0 → 1.04 → 1.0 over 280ms.
+                                  final t = _ctaPulseController.value;
+                                  final scale =
+                                      1.0 + 0.04 * math.sin(t * math.pi);
+                                  return Transform.scale(
+                                    scale: scale,
+                                    child: child,
+                                  );
+                                },
+                                child: FilledButton(
+                                  onPressed: _onReadOnSiteTap,
+                                  style: FilledButton.styleFrom(
+                                    backgroundColor: colors.primary,
+                                    foregroundColor: Colors.white,
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(16),
+                                    ),
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 12,
+                                    ),
+                                  ),
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: children,
+                                  ),
+                                ),
+                              );
+                            }
+
+                            return OutlinedButton(
+                              onPressed: _onReadOnSiteTap,
+                              style: OutlinedButton.styleFrom(
+                                backgroundColor: Colors.white.withValues(
+                                  alpha: 0.5,
+                                ),
+                                foregroundColor: colors.textPrimary,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                                side: BorderSide(
+                                  color: colors.border.withValues(alpha: 0.5),
+                                ),
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                ),
+                              ),
+                              child: Row(children: children),
+                            );
+                          },
+                        )
                       : _buildExternalCtaButton(context, content),
                 ),
               ),
@@ -1873,58 +1901,61 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-              // Sauvegarder (long-press → collection picker)
-              GestureDetector(
-                onLongPress: () {
-                  HapticFeedback.mediumImpact();
-                  CollectionPickerSheet.show(
-                    context,
-                    content.id,
-                    onAddNote: () => _openNoteSheet(),
-                  );
-                },
-                child: ScaleTransition(
-                  scale: _bookmarkScaleAnimation,
-                  child: IconButton(
-                    style: iconButtonStyle.copyWith(
-                      backgroundColor: content.isSaved
-                          ? WidgetStatePropertyAll(colors.primary)
-                          : null,
+                  // Sauvegarder (long-press → collection picker)
+                  GestureDetector(
+                    onLongPress: () {
+                      HapticFeedback.mediumImpact();
+                      CollectionPickerSheet.show(
+                        context,
+                        content.id,
+                        onAddNote: () => _openNoteSheet(),
+                      );
+                    },
+                    child: ScaleTransition(
+                      scale: _bookmarkScaleAnimation,
+                      child: IconButton(
+                        style: iconButtonStyle.copyWith(
+                          backgroundColor: content.isSaved
+                              ? WidgetStatePropertyAll(colors.primary)
+                              : null,
+                        ),
+                        onPressed: _toggleBookmark,
+                        icon: Icon(
+                          content.isSaved
+                              ? PhosphorIcons.bookmarkSimple(
+                                  PhosphorIconsStyle.fill,
+                                )
+                              : PhosphorIcons.bookmarkSimple(
+                                  PhosphorIconsStyle.regular,
+                                ),
+                          size: 28,
+                          color: content.isSaved
+                              ? Colors.white
+                              : colors.textSecondary,
+                        ),
+                        tooltip: 'Sauvegarder',
+                      ),
                     ),
-                    onPressed: _toggleBookmark,
-                    icon: Icon(
-                      content.isSaved
-                          ? PhosphorIcons.bookmarkSimple(
-                              PhosphorIconsStyle.fill)
-                          : PhosphorIcons.bookmarkSimple(
-                              PhosphorIconsStyle.regular),
-                      size: 28,
-                      color:
-                          content.isSaved ? Colors.white : colors.textSecondary,
-                    ),
-                    tooltip: 'Sauvegarder',
                   ),
-                ),
-              ),
 
-              // 🌻 Recommander
-              ScaleTransition(
-                scale: _likeScaleAnimation,
-                child: IconButton(
-                  style: iconButtonStyle.copyWith(
-                    backgroundColor: content.isLiked
-                        ? WidgetStatePropertyAll(colors.primary)
-                        : null,
+                  // 🌻 Recommander
+                  ScaleTransition(
+                    scale: _likeScaleAnimation,
+                    child: IconButton(
+                      style: iconButtonStyle.copyWith(
+                        backgroundColor: content.isLiked
+                            ? WidgetStatePropertyAll(colors.primary)
+                            : null,
+                      ),
+                      onPressed: _toggleLike,
+                      icon: SunflowerIcon(
+                        isActive: content.isLiked,
+                        size: 26,
+                        inactiveColor: colors.textSecondary,
+                      ),
+                      tooltip: 'Recommander',
+                    ),
                   ),
-                  onPressed: _toggleLike,
-                  icon: SunflowerIcon(
-                    isActive: content.isLiked,
-                    size: 26,
-                    inactiveColor: colors.textSecondary,
-                  ),
-                  tooltip: 'Recommander',
-                ),
-              ),
                 ],
               ),
             ],
@@ -1965,7 +1996,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   ? Container(
                       key: const ValueKey('nudge_visible'),
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 6),
+                        horizontal: 12,
+                        vertical: 6,
+                      ),
                       decoration: BoxDecoration(
                         color: const Color(0xFFFFF8E1).withValues(alpha: 0.5),
                         borderRadius: BorderRadius.circular(16),
@@ -1986,9 +2019,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         ),
                       ),
                     )
-                  : const SizedBox.shrink(
-                      key: ValueKey('nudge_hidden'),
-                    ),
+                  : const SizedBox.shrink(key: ValueKey('nudge_hidden')),
             ),
           ),
           footerContent,
@@ -2008,7 +2039,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     // Fallback to the article payload before the provider has loaded — avoids
     // a flash of the "Suivre +" chip on cold open when the source is already
     // followed server-side.
-    final InterestState effectiveState = liveState ??
+    final InterestState effectiveState =
+        liveState ??
         (content.isFollowedSource
             ? InterestState.followed
             : InterestState.unfollowed);
@@ -2026,8 +2058,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             right: FacteurSpacing.space2,
           ),
           child: Padding(
-            padding:
-                const EdgeInsets.symmetric(horizontal: FacteurSpacing.space2),
+            padding: const EdgeInsets.symmetric(
+              horizontal: FacteurSpacing.space2,
+            ),
             child: Row(
               children: [
                 // Discreet Back Button (reduced icon, maintained hitbox)
@@ -2092,14 +2125,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                               child: Container(
                                                 padding:
                                                     const EdgeInsets.symmetric(
-                                                        horizontal: 6,
-                                                        vertical: 2),
+                                                      horizontal: 6,
+                                                      vertical: 2,
+                                                    ),
                                                 decoration: BoxDecoration(
                                                   color: Color.lerp(
-                                                      colors
-                                                          .backgroundSecondary,
-                                                      Colors.black,
-                                                      0.003)!,
+                                                    colors.backgroundSecondary,
+                                                    Colors.black,
+                                                    0.003,
+                                                  )!,
                                                   borderRadius:
                                                       BorderRadius.circular(8),
                                                 ),
@@ -2107,9 +2141,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                                   content.source.name,
                                                   style: textTheme.labelMedium
                                                       ?.copyWith(
-                                                    fontWeight: FontWeight.bold,
-                                                    color: colors.textPrimary,
-                                                  ),
+                                                        fontWeight:
+                                                            FontWeight.bold,
+                                                        color:
+                                                            colors.textPrimary,
+                                                      ),
                                                   maxLines: 1,
                                                   overflow:
                                                       TextOverflow.ellipsis,
@@ -2150,18 +2186,20 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                             child: InkWell(
                                               onTap: () =>
                                                   TopicChip.showArticleSheet(
-                                                context,
-                                                content,
-                                                initialSection:
-                                                    ArticleSheetSection.source,
-                                              ),
+                                                    context,
+                                                    content,
+                                                    initialSection:
+                                                        ArticleSheetSection
+                                                            .source,
+                                                  ),
                                               child: Padding(
-                                                padding:
-                                                    const EdgeInsets.all(3),
+                                                padding: const EdgeInsets.all(
+                                                  3,
+                                                ),
                                                 child: Icon(
                                                   PhosphorIcons.gear(
-                                                      PhosphorIconsStyle
-                                                          .regular),
+                                                    PhosphorIconsStyle.regular,
+                                                  ),
                                                   size: 11,
                                                   color: colors.textTertiary,
                                                 ),
@@ -2176,21 +2214,24 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                         children: [
                                           Icon(
                                             PhosphorIcons.clock(
-                                                PhosphorIconsStyle.regular),
+                                              PhosphorIconsStyle.regular,
+                                            ),
                                             size: 11,
                                             color: colors.textTertiary,
                                           ),
                                           const SizedBox(width: 3),
                                           Text(
                                             timeago
-                                                .format(content.publishedAt,
-                                                    locale: 'fr_short')
+                                                .format(
+                                                  content.publishedAt,
+                                                  locale: 'fr_short',
+                                                )
                                                 .replaceAll('il y a ', ''),
-                                            style:
-                                                textTheme.bodySmall?.copyWith(
-                                              color: colors.textTertiary,
-                                              fontSize: 11,
-                                            ),
+                                            style: textTheme.bodySmall
+                                                ?.copyWith(
+                                                  color: colors.textTertiary,
+                                                  fontSize: 11,
+                                                ),
                                           ),
                                         ],
                                       ),
@@ -2253,8 +2294,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     );
   }
 
-  double _measureChipWidth(String text, TextStyle? style,
-      {bool isEntity = false}) {
+  double _measureChipWidth(
+    String text,
+    TextStyle? style, {
+    bool isEntity = false,
+  }) {
     const chipHPad = 16.0;
     const followIconExtra = 13.0; // icon 10px + gap 3px
     final tp = TextPainter(
@@ -2292,8 +2336,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
   /// Builds a 2-line-max Wrap of article chips: Aperçu (if partial) + topic
   /// chips + entity chips, followed by a +X overflow chip if needed.
-  Widget _buildTagsWrap(BuildContext context, Content content,
-      {bool isPartial = false}) {
+  Widget _buildTagsWrap(
+    BuildContext context,
+    Content content, {
+    bool isPartial = false,
+  }) {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
     final labelStyle = textTheme.labelSmall;
@@ -2348,57 +2395,64 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
     if (chips.isEmpty) return const SizedBox.shrink();
 
-    return LayoutBuilder(builder: (context, constraints) {
-      const spacing = 6.0;
-      final availWidth = constraints.maxWidth;
-      final widths = chips.map((c) => c.width).toList();
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const spacing = 6.0;
+        final availWidth = constraints.maxWidth;
+        final widths = chips.map((c) => c.width).toList();
 
-      // How many chips fit in 2 lines without any overflow chip?
-      int visibleCount = _simulateWrapVisible(widths, availWidth);
-      final total = chips.length;
+        // How many chips fit in 2 lines without any overflow chip?
+        int visibleCount = _simulateWrapVisible(widths, availWidth);
+        final total = chips.length;
 
-      if (visibleCount < total) {
-        // Need an overflow chip — find the largest visibleCount such that
-        // [visibleCount chips + overflow chip] all fit within 2 lines.
-        // Use the max possible overflow width for a stable estimate.
-        final overflowChipW = _measureChipWidth('+$total', labelStyle);
-        while (visibleCount > 0) {
-          final test = [...widths.take(visibleCount), overflowChipW];
-          if (_simulateWrapVisible(test, availWidth) == test.length) break;
-          visibleCount--;
+        if (visibleCount < total) {
+          // Need an overflow chip — find the largest visibleCount such that
+          // [visibleCount chips + overflow chip] all fit within 2 lines.
+          // Use the max possible overflow width for a stable estimate.
+          final overflowChipW = _measureChipWidth('+$total', labelStyle);
+          while (visibleCount > 0) {
+            final test = [...widths.take(visibleCount), overflowChipW];
+            if (_simulateWrapVisible(test, availWidth) == test.length) break;
+            visibleCount--;
+          }
         }
-      }
 
-      final overflow = total - visibleCount;
+        final overflow = total - visibleCount;
 
-      return Wrap(
-        spacing: spacing,
-        runSpacing: spacing,
-        children: [
-          ...chips.take(visibleCount).map((c) => c.widget),
-          if (overflow > 0)
-            GestureDetector(
-              onTap: () => TopicChip.showArticleSheet(context, content,
-                  initialSection: ArticleSheetSection.entities),
-              child: Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  color: colors.textTertiary.withValues(alpha: 0.12),
-                  borderRadius: BorderRadius.circular(8),
+        return Wrap(
+          spacing: spacing,
+          runSpacing: spacing,
+          children: [
+            ...chips.take(visibleCount).map((c) => c.widget),
+            if (overflow > 0)
+              GestureDetector(
+                onTap: () => TopicChip.showArticleSheet(
+                  context,
+                  content,
+                  initialSection: ArticleSheetSection.entities,
                 ),
-                child: Text(
-                  '+$overflow',
-                  style: labelStyle?.copyWith(
-                    color: colors.textTertiary,
-                    fontWeight: FontWeight.w500,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: colors.textTertiary.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    '+$overflow',
+                    style: labelStyle?.copyWith(
+                      color: colors.textTertiary,
+                      fontWeight: FontWeight.w500,
+                    ),
                   ),
                 ),
               ),
-            ),
-        ],
-      );
-    });
+          ],
+        );
+      },
+    );
   }
 
   Widget _buildReadingProgressBar(FacteurColors colors) {
@@ -2414,8 +2468,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           Colors.grey.shade400,
           colors.primary,
           clamped,
-        )!
-            .withValues(alpha: alpha);
+        )!.withValues(alpha: alpha);
         return TweenAnimationBuilder<double>(
           tween: Tween<double>(end: clamped),
           duration: const Duration(milliseconds: 300),
@@ -2561,178 +2614,198 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         // of the scrolling WebView.
         if (_articleLayerMounted)
           Positioned.fill(
-          child: AnimatedOpacity(
-            opacity: _isWebViewActive ? 0.0 : 1.0,
-            duration: const Duration(milliseconds: 300),
-            child: IgnorePointer(
-              ignoring: _isWebViewActive,
-              child: ColoredBox(
-                color: _isWebViewActive
-                    ? const Color(0x00000000)
-                    : colors.backgroundPrimary,
-                child: SingleChildScrollView(
-                  controller: _scrollController,
-                  physics: _isWebViewActive
-                      ? const NeverScrollableScrollPhysics()
-                      : const ClampingScrollPhysics(),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      // Spacer: scrolls with content, initially behind the header overlay
-                      SizedBox(height: headerHeight),
-                      // ZONE 1a: Top header (thumbnail / tags / title / reading-time)
-                      Container(
-                        color: colors.backgroundPrimary,
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: FacteurSpacing.space4),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            const SizedBox(height: FacteurSpacing.space2),
-                            if (content.thumbnailUrl != null) ...[
-                              ClipRRect(
-                                borderRadius: BorderRadius.circular(
-                                    FacteurRadius.large),
-                                child: FacteurThumbnail(
-                                  imageUrl: content.thumbnailUrl,
-                                  aspectRatio: 16 / 9,
+            child: AnimatedOpacity(
+              opacity: _isWebViewActive ? 0.0 : 1.0,
+              duration: const Duration(milliseconds: 300),
+              child: IgnorePointer(
+                ignoring: _isWebViewActive,
+                child: ColoredBox(
+                  color: _isWebViewActive
+                      ? const Color(0x00000000)
+                      : colors.backgroundPrimary,
+                  child: SingleChildScrollView(
+                    controller: _scrollController,
+                    physics: _isWebViewActive
+                        ? const NeverScrollableScrollPhysics()
+                        : const ClampingScrollPhysics(),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        // Spacer: scrolls with content, initially behind the header overlay
+                        SizedBox(height: headerHeight),
+                        // ZONE 1a: Top header (thumbnail / tags / title / reading-time)
+                        Container(
+                          color: colors.backgroundPrimary,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: FacteurSpacing.space4,
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const SizedBox(height: FacteurSpacing.space2),
+                              if (content.thumbnailUrl != null) ...[
+                                ClipRRect(
+                                  borderRadius: BorderRadius.circular(
+                                    FacteurRadius.large,
+                                  ),
+                                  child: FacteurThumbnail(
+                                    imageUrl: content.thumbnailUrl,
+                                    aspectRatio: 16 / 9,
+                                  ),
+                                ),
+                                const SizedBox(height: FacteurSpacing.space3),
+                              ],
+                              if (isPartial ||
+                                  content.entities.isNotEmpty ||
+                                  content.topics.isNotEmpty) ...[
+                                _buildTagsWrap(
+                                  context,
+                                  content,
+                                  isPartial: isPartial,
+                                ),
+                                const SizedBox(height: FacteurSpacing.space4),
+                              ],
+                              Text(
+                                content.title,
+                                style: textTheme.displayLarge?.copyWith(
+                                  fontSize: 24,
                                 ),
                               ),
-                              const SizedBox(height: FacteurSpacing.space3),
-                            ],
-                            if (isPartial ||
-                                content.entities.isNotEmpty ||
-                                content.topics.isNotEmpty) ...[
-                              _buildTagsWrap(context, content,
-                                  isPartial: isPartial),
+                              const SizedBox(height: FacteurSpacing.space2),
+                              if (readingTime != null) ...[
+                                Row(
+                                  children: [
+                                    Icon(
+                                      PhosphorIcons.timer(
+                                        PhosphorIconsStyle.regular,
+                                      ),
+                                      size: 14,
+                                      color: colors.textTertiary,
+                                    ),
+                                    const SizedBox(width: 4),
+                                    Text(
+                                      readingTime,
+                                      style: textTheme.bodySmall?.copyWith(
+                                        color: colors.textTertiary,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: FacteurSpacing.space3),
+                              ],
                               const SizedBox(height: FacteurSpacing.space4),
                             ],
-                            Text(
-                              content.title,
-                              style: textTheme.displayLarge
-                                  ?.copyWith(fontSize: 24),
-                            ),
-                            const SizedBox(height: FacteurSpacing.space2),
-                            if (readingTime != null) ...[
-                              Row(
-                                children: [
-                                  Icon(
-                                    PhosphorIcons.timer(
-                                        PhosphorIconsStyle.regular),
-                                    size: 14,
-                                    color: colors.textTertiary,
-                                  ),
-                                  const SizedBox(width: 4),
-                                  Text(
-                                    readingTime,
-                                    style: textTheme.bodySmall?.copyWith(
-                                        color: colors.textTertiary),
-                                  ),
-                                ],
-                              ),
-                              const SizedBox(height: FacteurSpacing.space3),
-                            ],
-                            const SizedBox(height: FacteurSpacing.space4),
-                          ],
-                        ),
-                      ),
-
-                      // ZONE 1b: Perspectives section, framed by dividers.
-                      if (_perspectivesResponse != null &&
-                          _perspectivesResponse!.perspectives.isNotEmpty) ...[
-                        Container(
-                          color: colors.backgroundPrimary,
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: FacteurSpacing.space4),
-                          child: Divider(color: colors.textTertiary.withValues(alpha: 0.3), height: 1, thickness: 1),
-                        ),
-                        Container(
-                          color: colors.backgroundPrimary,
-                          child: PerspectivesInlineSection(
-                            key: _perspectivesKey,
-                            perspectives: _perspectivesResponse!.perspectives
-                                .map(
-                                  (PerspectiveData p) => Perspective(
-                                    title: p.title,
-                                    url: p.url,
-                                    sourceName: p.sourceName,
-                                    sourceDomain: p.sourceDomain,
-                                    biasStance: p.biasStance,
-                                    publishedAt: p.publishedAt,
-                                    highlightSpans: p.highlightSpans,
-                                    sharedTokens: p.sharedTokens,
-                                  ),
-                                )
-                                .toList(),
-                            biasDistribution:
-                                _perspectivesResponse!.biasDistribution,
-                            keywords: _perspectivesResponse!.keywords,
-                            sourceBiasStance:
-                                _perspectivesResponse!.sourceBiasStance,
-                            sourceName: _content?.source.name ?? '',
-                            contentId: widget.contentId,
-                            comparisonQuality:
-                                _perspectivesResponse!.comparisonQuality,
-                            externalSelectedSegments:
-                                _perspectivesSelectedSegments,
-                            onSegmentTap: _onPerspectivesSegmentTap,
-                            onClearSegments: () {
-                              setState(() =>
-                                  _perspectivesSelectedSegments = {});
-                            },
-                            analysisState: _perspectivesAnalysisState,
-                            analysisText: _perspectivesAnalysisText,
-                            onRequestAnalysis: _requestPerspectivesAnalysis,
-                            analysisZoneKey: _analysisZoneKey,
-                            isExpanded: _perspectivesExpanded,
-                            onToggle: _onPerspectivesToggle,
-                            referenceTitle: _content?.title ?? '',
-                            referencePivot:
-                                _perspectivesResponse!.referencePivot,
                           ),
                         ),
+
+                        // ZONE 1b: Perspectives section, framed by dividers.
+                        if (_perspectivesResponse != null &&
+                            _perspectivesResponse!.perspectives.isNotEmpty) ...[
+                          Container(
+                            color: colors.backgroundPrimary,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: FacteurSpacing.space4,
+                            ),
+                            child: Divider(
+                              color: colors.textTertiary.withValues(alpha: 0.3),
+                              height: 1,
+                              thickness: 1,
+                            ),
+                          ),
+                          Container(
+                            color: colors.backgroundPrimary,
+                            child: PerspectivesInlineSection(
+                              key: _perspectivesKey,
+                              perspectives: _perspectivesResponse!.perspectives
+                                  .map(
+                                    (PerspectiveData p) => Perspective(
+                                      title: p.title,
+                                      url: p.url,
+                                      sourceName: p.sourceName,
+                                      sourceDomain: p.sourceDomain,
+                                      biasStance: p.biasStance,
+                                      publishedAt: p.publishedAt,
+                                      highlightSpans: p.highlightSpans,
+                                      sharedTokens: p.sharedTokens,
+                                    ),
+                                  )
+                                  .toList(),
+                              biasDistribution:
+                                  _perspectivesResponse!.biasDistribution,
+                              keywords: _perspectivesResponse!.keywords,
+                              sourceBiasStance:
+                                  _perspectivesResponse!.sourceBiasStance,
+                              sourceName: _content?.source.name ?? '',
+                              contentId: widget.contentId,
+                              comparisonQuality:
+                                  _perspectivesResponse!.comparisonQuality,
+                              externalSelectedSegments:
+                                  _perspectivesSelectedSegments,
+                              onSegmentTap: _onPerspectivesSegmentTap,
+                              onClearSegments: () {
+                                setState(
+                                  () => _perspectivesSelectedSegments = {},
+                                );
+                              },
+                              analysisState: _perspectivesAnalysisState,
+                              analysisText: _perspectivesAnalysisText,
+                              onRequestAnalysis: _requestPerspectivesAnalysis,
+                              analysisZoneKey: _analysisZoneKey,
+                              isExpanded: _perspectivesExpanded,
+                              onToggle: _onPerspectivesToggle,
+                              referenceTitle: _content?.title ?? '',
+                              referencePivot:
+                                  _perspectivesResponse!.referencePivot,
+                            ),
+                          ),
+                          Container(
+                            color: colors.backgroundPrimary,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: FacteurSpacing.space4,
+                            ),
+                            child: Divider(
+                              color: colors.textTertiary.withValues(alpha: 0.3),
+                              height: 1,
+                              thickness: 1,
+                            ),
+                          ),
+                          const SizedBox(height: FacteurSpacing.space4),
+                        ],
+
+                        // ZONE 2: Article body — _articleKey scopes scroll-bridge
+                        // measurement to the body, excluding header + perspectives.
                         Container(
+                          key: _articleKey,
                           color: colors.backgroundPrimary,
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: FacteurSpacing.space4),
-                          child: Divider(color: colors.textTertiary.withValues(alpha: 0.3), height: 1, thickness: 1),
+                          child: ArticleReaderWidget(
+                            htmlContent: content.htmlContent,
+                            description: content.description,
+                            title: content.title,
+                            shrinkWrap: true,
+                            onLinkTap: _animateAndLaunch,
+                            bodyPlaceholder: !_contentResolved
+                                ? _buildArticleBodySkeleton(colors)
+                                : null,
+                            footer: SizedBox(
+                              height: _kFooterContentHeight + bottomInset,
+                            ),
+                          ),
                         ),
-                        const SizedBox(height: FacteurSpacing.space4),
+
+                        if (isPartial && _contentResolved)
+                          _buildPartialArticleInlineButton(context),
+
+                        // ZONE 3: Transparent spacer — only after CTA tap to enable scroll animation.
+                        // _bridgeKey attached here so _computeScrollOffsets() can measure the bridge zone.
+                        if (_ctaTapped)
+                          SizedBox(key: _bridgeKey, height: availableHeight),
                       ],
-
-                      // ZONE 2: Article body — _articleKey scopes scroll-bridge
-                      // measurement to the body, excluding header + perspectives.
-                      Container(
-                        key: _articleKey,
-                        color: colors.backgroundPrimary,
-                        child: ArticleReaderWidget(
-                          htmlContent: content.htmlContent,
-                          description: content.description,
-                          title: content.title,
-                          shrinkWrap: true,
-                          onLinkTap: _animateAndLaunch,
-                          bodyPlaceholder: !_contentResolved
-                              ? _buildArticleBodySkeleton(colors)
-                              : null,
-                          footer: SizedBox(
-                              height: _kFooterContentHeight + bottomInset),
-                        ),
-                      ),
-
-                      if (isPartial && _contentResolved)
-                        _buildPartialArticleInlineButton(context),
-
-                      // ZONE 3: Transparent spacer — only after CTA tap to enable scroll animation.
-                      // _bridgeKey attached here so _computeScrollOffsets() can measure the bridge zone.
-                      if (_ctaTapped)
-                        SizedBox(key: _bridgeKey, height: availableHeight),
-                    ],
+                    ),
                   ),
                 ),
               ),
             ),
           ),
-        ),
       ],
     );
   }
@@ -2754,9 +2827,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       gestureRecognizers: _isWebViewActive
           ? {
               Factory<VerticalDragGestureRecognizer>(
-                  () => VerticalDragGestureRecognizer()),
+                () => VerticalDragGestureRecognizer(),
+              ),
               Factory<HorizontalDragGestureRecognizer>(
-                  () => HorizontalDragGestureRecognizer()),
+                () => HorizontalDragGestureRecognizer(),
+              ),
             }
           : const {},
     );
@@ -2775,47 +2850,210 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
     // Description text: prefer htmlContent (stripped), fallback to description
     final rawDescription = content.htmlContent ?? content.description;
-    final descriptionText =
-        rawDescription != null ? stripHtml(rawDescription).trim() : null;
+    final descriptionText = rawDescription != null
+        ? stripHtml(rawDescription).trim()
+        : null;
 
-    return LayoutBuilder(builder: (context, constraints) {
-      final maxHeight = constraints.maxHeight;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxHeight = constraints.maxHeight;
 
-      // --- Shorts: Column layout (no overlay on iframe → all buttons clickable) ---
-      if (isShort) {
-        // Reserve ~160px below the player for metadata (scrollable, same
-        // pattern as regular videos). FABs float over this Flutter text area
-        // (not an iframe) so they remain clickable.
-        final shortsPlayerHeight =
-            (maxHeight - headerHeight - 140).clamp(200.0, screenWidth * 16 / 9);
+        // --- Shorts: Column layout (no overlay on iframe → all buttons clickable) ---
+        if (isShort) {
+          // Reserve ~160px below the player for metadata (scrollable, same
+          // pattern as regular videos). FABs float over this Flutter text area
+          // (not an iframe) so they remain clickable.
+          final shortsPlayerHeight = (maxHeight - headerHeight - 140).clamp(
+            200.0,
+            screenWidth * 16 / 9,
+          );
+
+          return Column(
+            children: [
+              // Spacer for the pinned header overlay.
+              SizedBox(height: headerHeight),
+
+              // Centered player — bounded height, narrower than screen width
+              SizedBox(
+                height: shortsPlayerHeight,
+                width: screenWidth,
+                child: Center(
+                  child: YouTubePlayerWidget(
+                    videoUrl: content.url,
+                    title: content.title,
+                    aspectRatio: 9 / 16,
+                    onProgressChanged: _onVideoProgressChanged,
+                    onPlayStateChanged: _onVideoPlayStateChanged,
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: FacteurSpacing.space3),
+
+              // Scrollable metadata — same design as regular video
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: FacteurSpacing.space4,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Video Title
+                      Text(
+                        content.title,
+                        style: textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                        maxLines: 3,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: FacteurSpacing.space2),
+
+                      // Published date
+                      Text(
+                        timeago.format(content.publishedAt, locale: 'fr_short'),
+                        style: textTheme.bodySmall?.copyWith(
+                          color: colors.textSecondary,
+                        ),
+                      ),
+                      const SizedBox(height: FacteurSpacing.space3),
+
+                      // Channel row: avatar + name + optional theme chip
+                      Row(
+                        children: [
+                          if (content.source.logoUrl != null)
+                            CircleAvatar(
+                              radius: 16,
+                              backgroundImage: CachedNetworkImageProvider(
+                                content.source.logoUrl!,
+                              ),
+                              backgroundColor: colors.surfaceElevated,
+                            )
+                          else
+                            CircleAvatar(
+                              radius: 16,
+                              backgroundColor: colors.surfaceElevated,
+                              child: Icon(
+                                PhosphorIcons.user(PhosphorIconsStyle.regular),
+                                size: 16,
+                                color: colors.textTertiary,
+                              ),
+                            ),
+                          const SizedBox(width: FacteurSpacing.space3),
+                          Expanded(
+                            child: Text(
+                              content.source.name,
+                              style: textTheme.bodyMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          if (content.source.theme != null &&
+                              content.source.theme!.isNotEmpty) ...[
+                            const SizedBox(width: FacteurSpacing.space2),
+                            Opacity(
+                              opacity: 0.9,
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 3,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: colors.primary,
+                                  borderRadius: BorderRadius.circular(
+                                    FacteurRadius.pill,
+                                  ),
+                                ),
+                                child: Text(
+                                  content.source.getThemeLabel(),
+                                  style: textTheme.labelSmall?.copyWith(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+
+                      // Expandable description
+                      if (descriptionText != null &&
+                          descriptionText.isNotEmpty) ...[
+                        const SizedBox(height: FacteurSpacing.space3),
+                        Divider(color: colors.border, height: 1),
+                        const SizedBox(height: FacteurSpacing.space3),
+                        Text(
+                          descriptionText,
+                          style: textTheme.bodyMedium?.copyWith(
+                            color: colors.textSecondary,
+                            height: 1.5,
+                          ),
+                          maxLines: _isDescriptionExpanded ? null : 2,
+                          overflow: _isDescriptionExpanded
+                              ? TextOverflow.visible
+                              : TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: FacteurSpacing.space2),
+                        GestureDetector(
+                          onTap: () {
+                            setState(
+                              () => _isDescriptionExpanded =
+                                  !_isDescriptionExpanded,
+                            );
+                          },
+                          child: Text(
+                            _isDescriptionExpanded ? 'Voir moins' : 'Voir plus',
+                            style: textTheme.bodySmall?.copyWith(
+                              color: colors.primary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                      ],
+
+                      // Bottom spacing — clears the persistent footer.
+                      SizedBox(
+                        height:
+                            _kFooterContentHeight +
+                            MediaQuery.of(context).viewPadding.bottom,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          );
+        }
+
+        // --- Regular video: Column layout ---
+        final playerHeight = screenWidth * 9 / 16;
 
         return Column(
           children: [
-            // Spacer for the pinned header overlay.
+            // Push below the pinned header overlay.
             SizedBox(height: headerHeight),
 
-            // Centered player — bounded height, narrower than screen width
+            // Sticky player container
             SizedBox(
-              height: shortsPlayerHeight,
               width: screenWidth,
-              child: Center(
-                child: YouTubePlayerWidget(
-                  videoUrl: content.url,
-                  title: content.title,
-                  aspectRatio: 9 / 16,
-                  onProgressChanged: _onVideoProgressChanged,
-                  onPlayStateChanged: _onVideoPlayStateChanged,
-                ),
+              height: playerHeight,
+              child: YouTubePlayerWidget(
+                videoUrl: content.url,
+                title: content.title,
+                aspectRatio: 16 / 9,
+                onProgressChanged: _onVideoProgressChanged,
+                onPlayStateChanged: _onVideoPlayStateChanged,
               ),
             ),
 
-            const SizedBox(height: FacteurSpacing.space3),
-
-            // Scrollable metadata — same design as regular video
+            // Scrollable metadata below the player
             Expanded(
               child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: FacteurSpacing.space4),
+                padding: const EdgeInsets.all(FacteurSpacing.space4),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -2825,7 +3063,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       style: textTheme.headlineSmall?.copyWith(
                         fontWeight: FontWeight.bold,
                       ),
-                      maxLines: 3,
+                      maxLines: 4,
                       overflow: TextOverflow.ellipsis,
                     ),
                     const SizedBox(height: FacteurSpacing.space2),
@@ -2837,7 +3075,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         color: colors.textSecondary,
                       ),
                     ),
-                    const SizedBox(height: FacteurSpacing.space3),
+                    const SizedBox(height: FacteurSpacing.space4),
 
                     // Channel row: avatar + name + optional theme chip
                     Row(
@@ -2846,7 +3084,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           CircleAvatar(
                             radius: 16,
                             backgroundImage: CachedNetworkImageProvider(
-                                content.source.logoUrl!),
+                              content.source.logoUrl!,
+                            ),
                             backgroundColor: colors.surfaceElevated,
                           )
                         else
@@ -2873,24 +3112,22 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         if (content.source.theme != null &&
                             content.source.theme!.isNotEmpty) ...[
                           const SizedBox(width: FacteurSpacing.space2),
-                          Opacity(
-                            opacity: 0.9,
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 8,
-                                vertical: 3,
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 8,
+                              vertical: 3,
+                            ),
+                            decoration: BoxDecoration(
+                              color: colors.primary,
+                              borderRadius: BorderRadius.circular(
+                                FacteurRadius.pill,
                               ),
-                              decoration: BoxDecoration(
-                                color: colors.primary,
-                                borderRadius:
-                                    BorderRadius.circular(FacteurRadius.pill),
-                              ),
-                              child: Text(
-                                content.source.getThemeLabel(),
-                                style: textTheme.labelSmall?.copyWith(
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w600,
-                                ),
+                            ),
+                            child: Text(
+                              content.source.getThemeLabel(),
+                              style: textTheme.labelSmall?.copyWith(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w600,
                               ),
                             ),
                           ),
@@ -2901,16 +3138,16 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     // Expandable description
                     if (descriptionText != null &&
                         descriptionText.isNotEmpty) ...[
-                      const SizedBox(height: FacteurSpacing.space3),
+                      const SizedBox(height: FacteurSpacing.space4),
                       Divider(color: colors.border, height: 1),
-                      const SizedBox(height: FacteurSpacing.space3),
+                      const SizedBox(height: FacteurSpacing.space4),
                       Text(
                         descriptionText,
                         style: textTheme.bodyMedium?.copyWith(
                           color: colors.textSecondary,
                           height: 1.5,
                         ),
-                        maxLines: _isDescriptionExpanded ? null : 2,
+                        maxLines: _isDescriptionExpanded ? null : 3,
                         overflow: _isDescriptionExpanded
                             ? TextOverflow.visible
                             : TextOverflow.ellipsis,
@@ -2918,8 +3155,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       const SizedBox(height: FacteurSpacing.space2),
                       GestureDetector(
                         onTap: () {
-                          setState(() =>
-                              _isDescriptionExpanded = !_isDescriptionExpanded);
+                          setState(
+                            () => _isDescriptionExpanded =
+                                !_isDescriptionExpanded,
+                          );
                         },
                         child: Text(
                           _isDescriptionExpanded ? 'Voir moins' : 'Voir plus',
@@ -2933,7 +3172,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
                     // Bottom spacing — clears the persistent footer.
                     SizedBox(
-                      height: _kFooterContentHeight +
+                      height:
+                          _kFooterContentHeight +
                           MediaQuery.of(context).viewPadding.bottom,
                     ),
                   ],
@@ -2942,157 +3182,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             ),
           ],
         );
-      }
-
-      // --- Regular video: Column layout ---
-      final playerHeight = screenWidth * 9 / 16;
-
-      return Column(
-        children: [
-          // Push below the pinned header overlay.
-          SizedBox(height: headerHeight),
-
-          // Sticky player container
-          SizedBox(
-            width: screenWidth,
-            height: playerHeight,
-            child: YouTubePlayerWidget(
-              videoUrl: content.url,
-              title: content.title,
-              aspectRatio: 16 / 9,
-              onProgressChanged: _onVideoProgressChanged,
-              onPlayStateChanged: _onVideoPlayStateChanged,
-            ),
-          ),
-
-          // Scrollable metadata below the player
-          Expanded(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.all(FacteurSpacing.space4),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Video Title
-                  Text(
-                    content.title,
-                    style: textTheme.headlineSmall?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                    maxLines: 4,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: FacteurSpacing.space2),
-
-                  // Published date
-                  Text(
-                    timeago.format(content.publishedAt, locale: 'fr_short'),
-                    style: textTheme.bodySmall?.copyWith(
-                      color: colors.textSecondary,
-                    ),
-                  ),
-                  const SizedBox(height: FacteurSpacing.space4),
-
-                  // Channel row: avatar + name + optional theme chip
-                  Row(
-                    children: [
-                      if (content.source.logoUrl != null)
-                        CircleAvatar(
-                          radius: 16,
-                          backgroundImage: CachedNetworkImageProvider(
-                              content.source.logoUrl!),
-                          backgroundColor: colors.surfaceElevated,
-                        )
-                      else
-                        CircleAvatar(
-                          radius: 16,
-                          backgroundColor: colors.surfaceElevated,
-                          child: Icon(
-                            PhosphorIcons.user(PhosphorIconsStyle.regular),
-                            size: 16,
-                            color: colors.textTertiary,
-                          ),
-                        ),
-                      const SizedBox(width: FacteurSpacing.space3),
-                      Expanded(
-                        child: Text(
-                          content.source.name,
-                          style: textTheme.bodyMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                      if (content.source.theme != null &&
-                          content.source.theme!.isNotEmpty) ...[
-                        const SizedBox(width: FacteurSpacing.space2),
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 8,
-                            vertical: 3,
-                          ),
-                          decoration: BoxDecoration(
-                            color: colors.primary,
-                            borderRadius:
-                                BorderRadius.circular(FacteurRadius.pill),
-                          ),
-                          child: Text(
-                            content.source.getThemeLabel(),
-                            style: textTheme.labelSmall?.copyWith(
-                              color: Colors.white,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
-
-                  // Expandable description
-                  if (descriptionText != null &&
-                      descriptionText.isNotEmpty) ...[
-                    const SizedBox(height: FacteurSpacing.space4),
-                    Divider(color: colors.border, height: 1),
-                    const SizedBox(height: FacteurSpacing.space4),
-                    Text(
-                      descriptionText,
-                      style: textTheme.bodyMedium?.copyWith(
-                        color: colors.textSecondary,
-                        height: 1.5,
-                      ),
-                      maxLines: _isDescriptionExpanded ? null : 3,
-                      overflow: _isDescriptionExpanded
-                          ? TextOverflow.visible
-                          : TextOverflow.ellipsis,
-                    ),
-                    const SizedBox(height: FacteurSpacing.space2),
-                    GestureDetector(
-                      onTap: () {
-                        setState(() =>
-                            _isDescriptionExpanded = !_isDescriptionExpanded);
-                      },
-                      child: Text(
-                        _isDescriptionExpanded ? 'Voir moins' : 'Voir plus',
-                        style: textTheme.bodySmall?.copyWith(
-                          color: colors.primary,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    ),
-                  ],
-
-                  // Bottom spacing — clears the persistent footer.
-                  SizedBox(
-                    height: _kFooterContentHeight +
-                        MediaQuery.of(context).viewPadding.bottom,
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
-      );
-    }); // LayoutBuilder
+      },
+    ); // LayoutBuilder
   }
 
   Widget _buildInAppContent(BuildContext context, Content content) {
@@ -3127,8 +3218,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           title: content.title,
           shrinkWrap: true,
           onLinkTap: _animateAndLaunch,
-          bodyPlaceholder:
-              !_contentResolved ? _buildArticleBodySkeleton(colors) : null,
+          bodyPlaceholder: !_contentResolved
+              ? _buildArticleBodySkeleton(colors)
+              : null,
         );
 
         return ScrollConfiguration(
@@ -3147,15 +3239,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 // ── Top section: thumbnail → chips → title → reading time ─
                 Padding(
                   padding: const EdgeInsets.symmetric(
-                      horizontal: FacteurSpacing.space4),
+                    horizontal: FacteurSpacing.space4,
+                  ),
                   child: Column(
                     spacing: 12,
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       if (content.thumbnailUrl != null)
                         ClipRRect(
-                          borderRadius:
-                              BorderRadius.circular(FacteurRadius.large),
+                          borderRadius: BorderRadius.circular(
+                            FacteurRadius.large,
+                          ),
                           child: FacteurThumbnail(
                             imageUrl: content.thumbnailUrl,
                             aspectRatio: 16 / 9,
@@ -3180,8 +3274,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             const SizedBox(width: 4),
                             Text(
                               readingTime,
-                              style: textTheme.bodySmall
-                                  ?.copyWith(color: colors.textTertiary),
+                              style: textTheme.bodySmall?.copyWith(
+                                color: colors.textTertiary,
+                              ),
                             ),
                           ],
                         ),
@@ -3195,8 +3290,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   const SizedBox(height: FacteurSpacing.space4),
                   Padding(
                     padding: const EdgeInsets.symmetric(
-                        horizontal: FacteurSpacing.space4),
-                    child: Divider(color: colors.textTertiary.withValues(alpha: 0.3), height: 1, thickness: 1),
+                      horizontal: FacteurSpacing.space4,
+                    ),
+                    child: Divider(
+                      color: colors.textTertiary.withValues(alpha: 0.3),
+                      height: 1,
+                      thickness: 1,
+                    ),
                   ),
                   PerspectivesInlineSection(
                     key: _perspectivesKey,
@@ -3219,8 +3319,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     sourceBiasStance: _perspectivesResponse!.sourceBiasStance,
                     sourceName: _content?.source.name ?? '',
                     contentId: widget.contentId,
-                    comparisonQuality:
-                        _perspectivesResponse!.comparisonQuality,
+                    comparisonQuality: _perspectivesResponse!.comparisonQuality,
                     externalSelectedSegments: _perspectivesSelectedSegments,
                     onSegmentTap: _onPerspectivesSegmentTap,
                     onClearSegments: () {
@@ -3237,8 +3336,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   ),
                   Padding(
                     padding: const EdgeInsets.symmetric(
-                        horizontal: FacteurSpacing.space4),
-                    child: Divider(color: colors.textTertiary.withValues(alpha: 0.3), height: 1, thickness: 1),
+                      horizontal: FacteurSpacing.space4,
+                    ),
+                    child: Divider(
+                      color: colors.textTertiary.withValues(alpha: 0.3),
+                      height: 1,
+                      thickness: 1,
+                    ),
                   ),
                 ],
 
@@ -3257,7 +3361,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       const SizedBox(height: FacteurSpacing.space4),
                       Padding(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: FacteurSpacing.space4),
+                          horizontal: FacteurSpacing.space4,
+                        ),
                         child: NudgeInlineBanner(
                           body:
                               "Préférez l'expérience du site original ? Ouvrez l'article dans votre navigateur.",
@@ -3279,7 +3384,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 // ── Footer clearance ───────────────────────────────────────
                 const SizedBox(height: FacteurSpacing.space4),
                 SizedBox(
-                  height: _kFooterContentHeight +
+                  height:
+                      _kFooterContentHeight +
                       MediaQuery.of(context).viewPadding.bottom,
                 ),
               ],
@@ -3336,19 +3442,19 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     // Legacy web fallback — unreachable since build() auto-redirects
     // and footer CTA opens externally on web. Kept as safety net.
     if (kIsWeb) {
-      return Center(
-        child: CircularProgressIndicator(color: colors.primary),
-      );
+      return Center(child: CircularProgressIndicator(color: colors.primary));
     }
 
     // Mobile: Use native WebView with ScrollBridge for progress + auto-hide
     _webViewController ??= WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..setNavigationDelegate(NavigationDelegate(
-        onPageFinished: (_) => _injectScrollBridgeScript(),
-      ))
-      ..addJavaScriptChannel('ScrollBridge',
-          onMessageReceived: _onScrollBridgeMessage)
+      ..setNavigationDelegate(
+        NavigationDelegate(onPageFinished: (_) => _injectScrollBridgeScript()),
+      )
+      ..addJavaScriptChannel(
+        'ScrollBridge',
+        onMessageReceived: _onScrollBridgeMessage,
+      )
       ..loadRequest(Uri.parse(content.url));
 
     final topInset = MediaQuery.of(context).padding.top;
@@ -3361,7 +3467,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         if (content.entities.isNotEmpty || content.topics.isNotEmpty)
           Padding(
             padding: const EdgeInsets.symmetric(
-                horizontal: FacteurSpacing.space4, vertical: 6),
+              horizontal: FacteurSpacing.space4,
+              vertical: 6,
+            ),
             child: _buildTagsWrap(context, content),
           ),
         Expanded(child: WebViewWidget(controller: _webViewController!)),
@@ -3395,8 +3503,11 @@ class _SourceFollowAction extends ConsumerStatefulWidget {
 class _SourceFollowActionState extends ConsumerState<_SourceFollowAction> {
   bool _busy = false;
 
-  Future<void> _apply(InterestState next, {required String successMessage,
-      required String errorMessage}) async {
+  Future<void> _apply(
+    InterestState next, {
+    required String successMessage,
+    required String errorMessage,
+  }) async {
     if (_busy) return;
     setState(() => _busy = true);
     HapticFeedback.lightImpact();
@@ -3506,10 +3617,10 @@ class _FollowChip extends StatelessWidget {
               Text(
                 'Suivre',
                 style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                      color: colors.textSecondary,
-                      fontWeight: FontWeight.w700,
-                      letterSpacing: 0.2,
-                    ),
+                  color: colors.textSecondary,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.2,
+                ),
               ),
             ],
           ),
@@ -3659,10 +3770,7 @@ class _ShimmerSkeletonState extends State<_ShimmerSkeleton>
     return AnimatedBuilder(
       animation: _controller,
       builder: (context, child) {
-        return Opacity(
-          opacity: 0.3 + 0.4 * _controller.value,
-          child: child,
-        );
+        return Opacity(opacity: 0.3 + 0.4 * _controller.value, child: child);
       },
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -3742,10 +3850,7 @@ class _FadeScrollRowState extends State<_FadeScrollRow> {
               child: SingleChildScrollView(
                 controller: _controller,
                 scrollDirection: Axis.horizontal,
-                child: Row(
-                  spacing: 6,
-                  children: widget.children,
-                ),
+                child: Row(spacing: 6, children: widget.children),
               ),
             ),
           ),

--- a/apps/mobile/lib/features/lettres/providers/letters_provider.dart
+++ b/apps/mobile/lib/features/lettres/providers/letters_provider.dart
@@ -34,17 +34,12 @@ class LettersNotifier extends AsyncNotifier<LetterProgressState> {
   }
 
   Future<void> refreshLetterStatus(String letterId) async {
-    final updated =
-        await ref.read(lettersRepositoryProvider).refreshStatus(letterId);
-    final current = state.valueOrNull ?? const LetterProgressState.empty();
-    final next = current.letters
-        .map((l) => l.id == letterId ? updated : l)
-        .toList(growable: false);
-    state = AsyncData(LetterProgressState(letters: next));
+    await ref.read(lettersRepositoryProvider).refreshStatus(letterId);
+    await silentRefresh();
   }
 }
 
 final lettersProvider =
     AsyncNotifierProvider<LettersNotifier, LetterProgressState>(
-  LettersNotifier.new,
-);
+      LettersNotifier.new,
+    );

--- a/apps/mobile/lib/features/lettres/widgets/progress_toast.dart
+++ b/apps/mobile/lib/features/lettres/widgets/progress_toast.dart
@@ -30,7 +30,6 @@ void showProgressToast(
   _currentDismiss?.call();
 
   late OverlayEntry entry;
-  late void Function() dismiss;
   bool removed = false;
 
   void onDismissed() {
@@ -43,6 +42,8 @@ void showProgressToast(
     entry.remove();
   }
 
+  VoidCallback dismiss = onDismissed;
+
   entry = OverlayEntry(
     builder: (_) => _ProgressToast(
       level: level,
@@ -54,14 +55,17 @@ void showProgressToast(
       stepTitle: stepTitle,
       onOpen: onOpen,
       onDismissed: onDismissed,
-      onRequestClose: (cb) => dismiss = cb,
+      onRequestClose: (cb) {
+        dismiss = cb;
+        if (identical(entry, _currentEntry)) {
+          _currentDismiss = cb;
+        }
+      },
     ),
   );
 
   _currentEntry = entry;
-  _currentDismiss = () {
-    dismiss();
-  };
+  _currentDismiss = dismiss;
 
   overlay.insert(entry);
 
@@ -197,8 +201,7 @@ class _ProgressToastState extends State<_ProgressToast>
 
     final body = switch (widget.level) {
       ProgressToastLevel.micro => _MicroBody(accent: accent, toast: widget),
-      ProgressToastLevel.section =>
-        _SectionBody(accent: accent, toast: widget),
+      ProgressToastLevel.section => _SectionBody(accent: accent, toast: widget),
       ProgressToastLevel.step => _StepBody(toast: widget),
     };
 
@@ -327,11 +330,7 @@ class _MicroBody extends StatelessWidget {
             const SizedBox(height: 6),
             Padding(
               padding: const EdgeInsets.only(left: 26),
-              child: _Segments(
-                current: current,
-                total: total,
-                accent: accent,
-              ),
+              child: _Segments(current: current, total: total, accent: accent),
             ),
           ],
         ),
@@ -456,8 +455,7 @@ class _SegmentState extends State<_Segment>
                 builder: (_, __) => Align(
                   alignment: Alignment.centerLeft,
                   child: FractionallySizedBox(
-                    widthFactor:
-                        Curves.easeOutCubic.transform(_fill.value),
+                    widthFactor: Curves.easeOutCubic.transform(_fill.value),
                     child: Container(color: widget.accent),
                   ),
                 ),
@@ -983,10 +981,7 @@ class _CachetStampState extends State<_CachetStamp>
                       height: 54,
                       decoration: BoxDecoration(
                         shape: BoxShape.circle,
-                        border: Border.all(
-                          color: widget.accent,
-                          width: 1.5,
-                        ),
+                        border: Border.all(color: widget.accent, width: 1.5),
                       ),
                     ),
                   ),
@@ -1136,8 +1131,11 @@ class _DashedTopBorder extends CustomPainter {
     const gap = 3.0;
     double x = 0;
     while (x < size.width) {
-      canvas.drawLine(Offset(x, 0), Offset((x + dash).clamp(0, size.width), 0),
-          paint);
+      canvas.drawLine(
+        Offset(x, 0),
+        Offset((x + dash).clamp(0, size.width), 0),
+        paint,
+      );
       x += dash + gap;
     }
   }

--- a/apps/mobile/lib/features/saved/widgets/collection_picker_sheet.dart
+++ b/apps/mobile/lib/features/saved/widgets/collection_picker_sheet.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
+import '../../lettres/providers/letters_provider.dart';
 import '../models/collection_model.dart';
 import '../providers/collections_provider.dart';
 
@@ -28,10 +31,8 @@ class CollectionPickerSheet extends ConsumerStatefulWidget {
       context: context,
       backgroundColor: Colors.transparent,
       isScrollControlled: true,
-      builder: (_) => CollectionPickerSheet(
-        contentId: contentId,
-        onAddNote: onAddNote,
-      ),
+      builder: (_) =>
+          CollectionPickerSheet(contentId: contentId, onAddNote: onAddNote),
     );
   }
 
@@ -40,8 +41,7 @@ class CollectionPickerSheet extends ConsumerStatefulWidget {
       _CollectionPickerSheetState();
 }
 
-class _CollectionPickerSheetState
-    extends ConsumerState<CollectionPickerSheet>
+class _CollectionPickerSheetState extends ConsumerState<CollectionPickerSheet>
     with SingleTickerProviderStateMixin {
   final Set<String> _selectedIds = {};
   bool _isCreating = false;
@@ -54,15 +54,16 @@ class _CollectionPickerSheetState
   @override
   void initState() {
     super.initState();
-    _noteButtonAnimController = AnimationController(
-      duration: const Duration(milliseconds: 120),
-      vsync: this,
-      lowerBound: 0.93,
-      upperBound: 1.0,
-      value: 1.0,
-    )..addListener(() {
-        setState(() => _noteButtonScale = _noteButtonAnimController.value);
-      });
+    _noteButtonAnimController =
+        AnimationController(
+          duration: const Duration(milliseconds: 120),
+          vsync: this,
+          lowerBound: 0.93,
+          upperBound: 1.0,
+          value: 1.0,
+        )..addListener(() {
+          setState(() => _noteButtonScale = _noteButtonAnimController.value);
+        });
   }
 
   @override
@@ -194,8 +195,10 @@ class _CollectionPickerSheetState
               ),
               error: (_, __) => Padding(
                 padding: const EdgeInsets.all(24),
-                child: Text('Erreur de chargement',
-                    style: TextStyle(color: colors.textSecondary)),
+                child: Text(
+                  'Erreur de chargement',
+                  style: TextStyle(color: colors.textSecondary),
+                ),
               ),
             ),
 
@@ -217,7 +220,9 @@ class _CollectionPickerSheetState
                   child: Text(
                     'Confirmer (${_selectedIds.length})',
                     style: const TextStyle(
-                        fontWeight: FontWeight.w600, fontSize: 15),
+                      fontWeight: FontWeight.w600,
+                      fontSize: 15,
+                    ),
                   ),
                 ),
               ),
@@ -234,8 +239,11 @@ class _CollectionPickerSheetState
       onTap: () => setState(() => _isCreating = true),
       child: Row(
         children: [
-          Icon(PhosphorIcons.plus(PhosphorIconsStyle.regular),
-              color: colors.primary, size: 20),
+          Icon(
+            PhosphorIcons.plus(PhosphorIconsStyle.regular),
+            color: colors.primary,
+            size: 20,
+          ),
           const SizedBox(width: 12),
           Text(
             'Nouvelle collection',
@@ -265,8 +273,10 @@ class _CollectionPickerSheetState
               hintStyle: TextStyle(color: colors.textTertiary),
               counterText: '',
               isDense: true,
-              contentPadding:
-                  const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 12,
+                vertical: 10,
+              ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(8),
                 borderSide: BorderSide(color: colors.border),
@@ -289,8 +299,11 @@ class _CollectionPickerSheetState
             _isCreating = false;
             _createController.clear();
           }),
-          icon: Icon(PhosphorIcons.x(PhosphorIconsStyle.regular),
-              size: 18, color: colors.textTertiary),
+          icon: Icon(
+            PhosphorIcons.x(PhosphorIconsStyle.regular),
+            size: 18,
+            color: colors.textTertiary,
+          ),
           padding: EdgeInsets.zero,
           constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
         ),
@@ -299,7 +312,9 @@ class _CollectionPickerSheetState
   }
 
   Widget _buildCollectionsList(
-      List<Collection> collections, FacteurColors colors) {
+    List<Collection> collections,
+    FacteurColors colors,
+  ) {
     if (collections.isEmpty) {
       return Padding(
         padding: const EdgeInsets.symmetric(vertical: 24),
@@ -348,9 +363,7 @@ class _CollectionPickerSheetState
                             : colors.textTertiary,
                         width: isSelected ? 2 : 1.5,
                       ),
-                      color: isSelected
-                          ? colors.primary
-                          : Colors.transparent,
+                      color: isSelected ? colors.primary : Colors.transparent,
                     ),
                     child: isSelected
                         ? Icon(
@@ -376,10 +389,7 @@ class _CollectionPickerSheetState
                   ),
                   Text(
                     '${col.itemCount}',
-                    style: TextStyle(
-                      color: colors.textTertiary,
-                      fontSize: 13,
-                    ),
+                    style: TextStyle(color: colors.textTertiary, fontSize: 13),
                   ),
                 ],
               ),
@@ -419,6 +429,7 @@ class _CollectionPickerSheetState
 
     // Refresh collections to update counts
     ref.invalidate(collectionsProvider);
+    unawaited(ref.read(lettersProvider.notifier).silentRefresh());
 
     if (mounted) Navigator.pop(context);
     HapticFeedback.mediumImpact();

--- a/apps/mobile/test/features/lettres/providers/letters_provider_test.dart
+++ b/apps/mobile/test/features/lettres/providers/letters_provider_test.dart
@@ -14,7 +14,8 @@ class MockLettersRepository extends Mock implements LettersRepository {}
 class _AuthNotifier extends StateNotifier<app_auth.AuthState>
     implements app_auth.AuthStateNotifier {
   _AuthNotifier()
-      : super(const app_auth.AuthState(
+    : super(
+        const app_auth.AuthState(
           user: supabase.User(
             id: 'u1',
             appMetadata: {},
@@ -22,7 +23,8 @@ class _AuthNotifier extends StateNotifier<app_auth.AuthState>
             aud: 'authenticated',
             createdAt: '2026-01-01',
           ),
-        ));
+        ),
+      );
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -37,53 +39,53 @@ class _UnauthNotifier extends StateNotifier<app_auth.AuthState>
 }
 
 Map<String, dynamic> _l0Json() => {
-      'id': 'letter_0',
-      'num': '00',
-      'title': 'Bienvenue',
-      'message': 'msg',
-      'signature': 'Le Facteur',
-      'actions': <Map<String, dynamic>>[],
-      'status': 'archived',
-      'completed_actions': <String>[],
-      'progress': 1.0,
-      'started_at': null,
-      'archived_at': '2026-05-02T10:00:00Z',
-    };
+  'id': 'letter_0',
+  'num': '00',
+  'title': 'Bienvenue',
+  'message': 'msg',
+  'signature': 'Le Facteur',
+  'actions': <Map<String, dynamic>>[],
+  'status': 'archived',
+  'completed_actions': <String>[],
+  'progress': 1.0,
+  'started_at': null,
+  'archived_at': '2026-05-02T10:00:00Z',
+};
 
 Map<String, dynamic> _l1Json({List<String> completed = const []}) => {
-      'id': 'letter_1',
-      'num': '01',
-      'title': 'Tes premières sources',
-      'message': 'msg',
-      'signature': 'Le Facteur',
-      'actions': [
-        {'id': 'define_editorial_line', 'label': 'L1', 'help': 'h1'},
-        {'id': 'add_5_sources', 'label': 'L2', 'help': 'h2'},
-        {'id': 'add_2_personal_sources', 'label': 'L3', 'help': 'h3'},
-        {'id': 'first_perspectives_open', 'label': 'L4', 'help': 'h4'},
-      ],
-      'status': 'active',
-      'completed_actions': completed,
-      'progress': completed.length / 4,
-      'started_at': '2026-05-02T10:00:00Z',
-      'archived_at': null,
-    };
+  'id': 'letter_1',
+  'num': '01',
+  'title': 'Tes premières sources',
+  'message': 'msg',
+  'signature': 'Le Facteur',
+  'actions': [
+    {'id': 'define_editorial_line', 'label': 'L1', 'help': 'h1'},
+    {'id': 'add_5_sources', 'label': 'L2', 'help': 'h2'},
+    {'id': 'add_2_personal_sources', 'label': 'L3', 'help': 'h3'},
+    {'id': 'first_perspectives_open', 'label': 'L4', 'help': 'h4'},
+  ],
+  'status': 'active',
+  'completed_actions': completed,
+  'progress': completed.length / 4,
+  'started_at': '2026-05-02T10:00:00Z',
+  'archived_at': null,
+};
 
 Map<String, dynamic> _l2Json() => {
-      'id': 'letter_2',
-      'num': '02',
-      'title': 'Ton rythme idéal',
-      'message': 'msg',
-      'signature': 'Le Facteur',
-      'actions': [
-        {'id': 'set_frequency', 'label': 'X', 'help': 'h'},
-      ],
-      'status': 'upcoming',
-      'completed_actions': <String>[],
-      'progress': 0.0,
-      'started_at': null,
-      'archived_at': null,
-    };
+  'id': 'letter_2',
+  'num': '02',
+  'title': 'Ton rythme idéal',
+  'message': 'msg',
+  'signature': 'Le Facteur',
+  'actions': [
+    {'id': 'set_frequency', 'label': 'X', 'help': 'h'},
+  ],
+  'status': 'upcoming',
+  'completed_actions': <String>[],
+  'progress': 0.0,
+  'started_at': null,
+  'archived_at': null,
+};
 
 void main() {
   late MockLettersRepository mockRepo;
@@ -120,11 +122,13 @@ void main() {
   });
 
   test('build loads three letters and exposes activeLetter', () async {
-    when(() => mockRepo.getLetters()).thenAnswer((_) async => [
-          Letter.fromJson(_l0Json()),
-          Letter.fromJson(_l1Json()),
-          Letter.fromJson(_l2Json()),
-        ]);
+    when(() => mockRepo.getLetters()).thenAnswer(
+      (_) async => [
+        Letter.fromJson(_l0Json()),
+        Letter.fromJson(_l1Json()),
+        Letter.fromJson(_l2Json()),
+      ],
+    );
 
     final state = await container.read(lettersProvider.future);
 
@@ -137,49 +141,85 @@ void main() {
   });
 
   test('refresh re-fetches and updates state', () async {
-    when(() => mockRepo.getLetters())
-        .thenAnswer((_) async => [Letter.fromJson(_l1Json())]);
+    when(
+      () => mockRepo.getLetters(),
+    ).thenAnswer((_) async => [Letter.fromJson(_l1Json())]);
     await container.read(lettersProvider.future);
 
-    when(() => mockRepo.getLetters()).thenAnswer((_) async => [
-          Letter.fromJson(_l1Json(completed: ['define_editorial_line'])),
-        ]);
+    when(() => mockRepo.getLetters()).thenAnswer(
+      (_) async => [
+        Letter.fromJson(_l1Json(completed: ['define_editorial_line'])),
+      ],
+    );
     await container.read(lettersProvider.notifier).refresh();
 
     final state = container.read(lettersProvider).value!;
-    expect(state.letters.first.completedActions,
-        contains('define_editorial_line'));
+    expect(
+      state.letters.first.completedActions,
+      contains('define_editorial_line'),
+    );
     expect(state.letters.first.actions.first.status, LetterActionStatus.done);
   });
 
-  test('refreshLetterStatus updates only the target letter', () async {
-    when(() => mockRepo.getLetters()).thenAnswer((_) async => [
+  test(
+    'refreshLetterStatus reloads full state and exposes next active letter',
+    () async {
+      var fetchCount = 0;
+      when(() => mockRepo.getLetters()).thenAnswer((_) async {
+        fetchCount++;
+        if (fetchCount == 1) {
+          return [
+            Letter.fromJson(_l0Json()),
+            Letter.fromJson(_l1Json()),
+            Letter.fromJson(_l2Json()),
+          ];
+        }
+
+        final archivedL1 = _l1Json(
+          completed: [
+            'define_editorial_line',
+            'add_5_sources',
+            'add_2_personal_sources',
+            'first_perspectives_open',
+          ],
+        );
+        archivedL1['status'] = 'archived';
+        archivedL1['progress'] = 1.0;
+        archivedL1['archived_at'] = '2026-05-03T10:00:00Z';
+
+        final activeL2 = _l2Json();
+        activeL2['status'] = 'active';
+        activeL2['started_at'] = '2026-05-03T10:00:00Z';
+
+        return [
           Letter.fromJson(_l0Json()),
-          Letter.fromJson(_l1Json()),
-          Letter.fromJson(_l2Json()),
-        ]);
-    await container.read(lettersProvider.future);
+          Letter.fromJson(archivedL1),
+          Letter.fromJson(activeL2),
+        ];
+      });
+      await container.read(lettersProvider.future);
 
-    when(() => mockRepo.refreshStatus('letter_1')).thenAnswer(
-      (_) async =>
-          Letter.fromJson(_l1Json(completed: ['define_editorial_line'])),
-    );
-    await container
-        .read(lettersProvider.notifier)
-        .refreshLetterStatus('letter_1');
+      when(() => mockRepo.refreshStatus('letter_1')).thenAnswer(
+        (_) async =>
+            Letter.fromJson(_l1Json(completed: ['define_editorial_line'])),
+      );
+      await container
+          .read(lettersProvider.notifier)
+          .refreshLetterStatus('letter_1');
 
-    final state = container.read(lettersProvider).value!;
-    expect(state.letters.length, 3);
-    expect(state.letters[0].id, 'letter_0');
-    expect(
-        state.letters[1].completedActions, contains('define_editorial_line'));
-    expect(state.letters[2].id, 'letter_2');
-    verify(() => mockRepo.refreshStatus('letter_1')).called(1);
-  });
+      final state = container.read(lettersProvider).value!;
+      expect(state.letters.length, 3);
+      expect(state.letters[1].status, LetterStatus.archived);
+      expect(state.activeLetter?.id, 'letter_2');
+      verify(() => mockRepo.refreshStatus('letter_1')).called(1);
+      verify(() => mockRepo.getLetters()).called(2);
+    },
+  );
 
   test('build surfaces repository error as AsyncError', () async {
-    when(() => mockRepo.getLetters())
-        .thenThrow(const LettersApiException('boom', statusCode: 500));
+    when(
+      () => mockRepo.getLetters(),
+    ).thenThrow(const LettersApiException('boom', statusCode: 500));
 
     expect(
       () => container.read(lettersProvider.future),

--- a/apps/mobile/test/features/lettres/widgets/progress_toast_test.dart
+++ b/apps/mobile/test/features/lettres/widgets/progress_toast_test.dart
@@ -22,17 +22,20 @@ void main() {
     GoogleFonts.config.allowRuntimeFetching = false;
   });
 
-  testWidgets('niveau micro affiche le label + compteur puis disparaît',
-      (tester) async {
-    await tester.pumpWidget(_harness(
-      onReady: (ctx) => showProgressToast(
-        ctx,
-        level: ProgressToastLevel.micro,
-        current: 1,
-        total: 3,
-        label: 'Premier rendez-vous tenu.',
+  testWidgets('niveau micro affiche le label + compteur puis disparaît', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _harness(
+        onReady: (ctx) => showProgressToast(
+          ctx,
+          level: ProgressToastLevel.micro,
+          current: 1,
+          total: 3,
+          label: 'Premier rendez-vous tenu.',
+        ),
       ),
-    ));
+    );
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 400));
 
@@ -47,15 +50,17 @@ void main() {
 
   testWidgets('niveau étape est cliquable et invoque onOpen', (tester) async {
     var opened = 0;
-    await tester.pumpWidget(_harness(
-      onReady: (ctx) => showProgressToast(
-        ctx,
-        level: ProgressToastLevel.step,
-        stepNum: '01',
-        stepTitle: 'Tes premières sources',
-        onOpen: () => opened++,
+    await tester.pumpWidget(
+      _harness(
+        onReady: (ctx) => showProgressToast(
+          ctx,
+          level: ProgressToastLevel.step,
+          stepNum: '01',
+          stepTitle: 'Tes premières sources',
+          onOpen: () => opened++,
+        ),
       ),
-    ));
+    );
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 400));
 
@@ -69,19 +74,54 @@ void main() {
     expect(opened, 1);
   });
 
-  testWidgets('niveau section affiche titre Fraunces + sous-titre 100%',
-      (tester) async {
-    await tester.pumpWidget(_harness(
-      onReady: (ctx) => showProgressToast(
-        ctx,
-        level: ProgressToastLevel.section,
-        sectionTitle: 'Bonne nouvelle du jour',
+  testWidgets('niveau section affiche titre Fraunces + sous-titre 100%', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _harness(
+        onReady: (ctx) => showProgressToast(
+          ctx,
+          level: ProgressToastLevel.section,
+          sectionTitle: 'Bonne nouvelle du jour',
+        ),
       ),
-    ));
+    );
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 400));
 
     expect(find.text('Bonne nouvelle du jour'), findsOneWidget);
     expect(find.text('Lue de bout en bout · 100%'), findsOneWidget);
+  });
+
+  testWidgets('deux affichages rapprochés remplacent proprement le toast', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _harness(
+        onReady: (ctx) {
+          showProgressToast(
+            ctx,
+            level: ProgressToastLevel.micro,
+            current: 1,
+            total: 3,
+            label: 'Premier toast',
+          );
+          showProgressToast(
+            ctx,
+            level: ProgressToastLevel.micro,
+            current: 2,
+            total: 3,
+            label: 'Second toast',
+          );
+        },
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Premier toast'), findsNothing);
+    expect(find.text('Second toast'), findsOneWidget);
+    expect(find.text('2/3'), findsOneWidget);
   });
 }

--- a/apps/mobile/test/features/saved/widgets/collection_picker_sheet_test.dart
+++ b/apps/mobile/test/features/saved/widgets/collection_picker_sheet_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/core/auth/auth_state.dart' as app_auth;
+import 'package:facteur/features/lettres/providers/letters_repository_provider.dart';
+import 'package:facteur/features/lettres/repositories/letters_repository.dart';
+import 'package:facteur/features/saved/models/collection_model.dart';
+import 'package:facteur/features/saved/providers/collections_provider.dart';
+import 'package:facteur/features/saved/repositories/collections_repository.dart';
+import 'package:facteur/features/saved/widgets/collection_picker_sheet.dart';
+
+class MockCollectionsRepository extends Mock implements CollectionsRepository {}
+
+class MockLettersRepository extends Mock implements LettersRepository {}
+
+class _AuthNotifier extends StateNotifier<app_auth.AuthState>
+    implements app_auth.AuthStateNotifier {
+  _AuthNotifier()
+      : super(const app_auth.AuthState(
+          user: supabase.User(
+            id: 'u1',
+            appMetadata: {},
+            userMetadata: {},
+            aud: 'authenticated',
+            createdAt: '2026-01-01',
+          ),
+        ));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late MockCollectionsRepository mockCollectionsRepo;
+  late MockLettersRepository mockLettersRepo;
+
+  setUp(() {
+    mockCollectionsRepo = MockCollectionsRepository();
+    mockLettersRepo = MockLettersRepository();
+  });
+
+  testWidgets('confirm déclenche un silent refresh des lettres',
+      (tester) async {
+    final defaultCollection = Collection(
+      id: 'default-col',
+      name: 'Par défaut',
+      isDefault: true,
+      createdAt: DateTime.parse('2026-05-01T10:00:00Z'),
+    );
+
+    when(
+      () => mockCollectionsRepo.listCollections(),
+    ).thenAnswer((_) async => [defaultCollection]);
+    when(
+      () => mockCollectionsRepo.addToCollection('default-col', 'content-1'),
+    ).thenAnswer((_) async {});
+    when(() => mockLettersRepo.getLetters()).thenAnswer((_) async => []);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          collectionsRepositoryProvider.overrideWithValue(mockCollectionsRepo),
+          lettersRepositoryProvider.overrideWithValue(mockLettersRepo),
+          app_auth.authStateProvider.overrideWith((ref) => _AuthNotifier()),
+        ],
+        child: MaterialApp(
+          theme: ThemeData(extensions: [FacteurPalettes.light]),
+          home: const Scaffold(
+            body: CollectionPickerSheet(contentId: 'content-1'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Confirmer (1)'), findsOneWidget);
+
+    await tester.tap(find.text('Confirmer (1)'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    verify(
+      () => mockCollectionsRepo.addToCollection('default-col', 'content-1'),
+    ).called(1);
+    verify(() => mockLettersRepo.getLetters()).called(greaterThanOrEqualTo(1));
+  });
+}

--- a/packages/api/app/services/letters/catalog.py
+++ b/packages/api/app/services/letters/catalog.py
@@ -86,19 +86,22 @@ LETTER_2: dict = {
         },
         {
             "id": "read_3_long_articles",
-            "label": "Lire 3 articles jusqu'au bout",
-            "help": "Pas de scroll express. Prends le temps de finir.",
+            "label": "Lire 10 articles",
+            "help": "Dix articles distincts avec un vrai signal de lecture.",
             "completion_palier": (
-                "Trois lectures menées au bout. C'est ce qui te distingue déjà."
+                "Dix articles parcourus. Tu prends maintenant le rythme."
             ),
             "target_route": "/feed",
         },
         {
             "id": "read_first_video_podcast",
-            "label": "Écouter un podcast ou regarder une vidéo",
-            "help": "Au moins quatre minutes. Le temps que ça t'apporte quelque chose.",
+            "label": "Sauvegarder 3 articles dans vos collections",
+            "help": (
+                "Ajoute trois articles distincts dans tes collections, y compris "
+                "la collection par défaut."
+            ),
             "completion_palier": (
-                "Tu varies les formats. C'est comme ça qu'on s'enrichit."
+                "Trois articles mis de côté. Tu commences à te constituer un fonds."
             ),
             "target_route": "/feed",
         },

--- a/packages/api/app/services/letters/service.py
+++ b/packages/api/app/services/letters/service.py
@@ -14,11 +14,13 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 import structlog
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.analytics import AnalyticsEvent
+from app.models.collection import Collection, CollectionItem
 from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentStatus, ContentType
 from app.models.source import UserSource
 from app.models.user_letter_progress import UserLetterProgress
 from app.models.user_topic_profile import UserTopicProfile
@@ -100,34 +102,41 @@ _detect_read_first_bonnes_nouvelles = _first_event_detector("bonnes_nouvelles_op
 
 
 async def _detect_read_3_long_articles(user_id: UUID, db: AsyncSession) -> bool:
-    """≥3 contenus articles avec reading_progress≥90 et time_spent_seconds≥60."""
+    """≥10 articles distincts avec un signal minimal d'interaction."""
     stmt = (
         select(func.count(func.distinct(UserContentStatus.content_id)))
         .select_from(UserContentStatus)
         .join(Content, Content.id == UserContentStatus.content_id)
         .where(
             UserContentStatus.user_id == user_id,
-            UserContentStatus.reading_progress >= 90,
-            UserContentStatus.time_spent_seconds >= 60,
-            Content.content_type == "article",
+            Content.content_type == ContentType.ARTICLE,
+            or_(
+                UserContentStatus.time_spent_seconds > 0,
+                UserContentStatus.reading_progress > 0,
+                UserContentStatus.status.in_(
+                    [ContentStatus.SEEN, ContentStatus.CONSUMED]
+                ),
+                UserContentStatus.seen_at.is_not(None),
+            ),
         )
     )
-    return ((await db.execute(stmt)).scalar() or 0) >= 3
+    return ((await db.execute(stmt)).scalar() or 0) >= 10
 
 
 async def _detect_read_first_video_podcast(user_id: UUID, db: AsyncSession) -> bool:
-    """Au moins un contenu podcast/youtube avec time_spent_seconds≥240."""
+    """≥3 articles distincts ajoutés dans des collections utilisateur non likées."""
     stmt = (
-        select(UserContentStatus.id)
-        .join(Content, Content.id == UserContentStatus.content_id)
+        select(func.count(func.distinct(CollectionItem.content_id)))
+        .select_from(CollectionItem)
+        .join(Collection, Collection.id == CollectionItem.collection_id)
+        .join(Content, Content.id == CollectionItem.content_id)
         .where(
-            UserContentStatus.user_id == user_id,
-            UserContentStatus.time_spent_seconds >= 240,
-            Content.content_type.in_(["podcast", "youtube"]),
+            Collection.user_id == user_id,
+            Collection.is_liked_collection.is_(False),
+            Content.content_type == ContentType.ARTICLE,
         )
-        .limit(1)
     )
-    return (await db.execute(stmt)).scalar() is not None
+    return ((await db.execute(stmt)).scalar() or 0) >= 3
 
 
 async def _detect_recommend_first_article(user_id: UUID, db: AsyncSession) -> bool:

--- a/packages/api/tests/routers/test_letters_routes.py
+++ b/packages/api/tests/routers/test_letters_routes.py
@@ -21,8 +21,9 @@ from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.main import app
 from app.models.analytics import AnalyticsEvent
+from app.models.collection import Collection, CollectionItem
 from app.models.content import Content, UserContentStatus
-from app.models.enums import ContentType, SourceType
+from app.models.enums import ContentStatus, ContentType, SourceType
 from app.models.source import Source, UserSource
 from app.models.user import UserProfile
 from app.models.user_letter_progress import UserLetterProgress
@@ -184,10 +185,12 @@ async def _add_user_content_status(
     user_id: UUID,
     *,
     content_type: ContentType,
+    status: ContentStatus = ContentStatus.UNSEEN,
     reading_progress: int = 0,
     time_spent_seconds: int = 0,
     is_liked: bool = False,
-) -> None:
+    seen_at: datetime | None = None,
+) -> UUID:
     src = await _make_source(db_session)
     content = Content(
         id=uuid4(),
@@ -204,11 +207,55 @@ async def _add_user_content_status(
         UserContentStatus(
             user_id=user_id,
             content_id=content.id,
+            status=status,
             reading_progress=reading_progress,
             time_spent_seconds=time_spent_seconds,
             is_liked=is_liked,
+            seen_at=seen_at,
         )
     )
+    await db_session.commit()
+    return content.id
+
+
+async def _add_collection_items(
+    db_session,
+    user_id: UUID,
+    *,
+    content_types: list[ContentType],
+    is_default: bool = False,
+    is_liked_collection: bool = False,
+) -> None:
+    collection = Collection(
+        id=uuid4(),
+        user_id=user_id,
+        name=f"Collection {uuid4()}",
+        is_default=is_default,
+        is_liked_collection=is_liked_collection,
+    )
+    db_session.add(collection)
+    await db_session.flush()
+
+    for content_type in content_types:
+        src = await _make_source(db_session)
+        content = Content(
+            id=uuid4(),
+            source_id=src.id,
+            title="t",
+            url=f"https://x/{uuid4()}",
+            published_at=datetime.now(UTC),
+            content_type=content_type,
+            guid=str(uuid4()),
+        )
+        db_session.add(content)
+        await db_session.flush()
+        db_session.add(
+            CollectionItem(
+                collection_id=collection.id,
+                content_id=content.id,
+            )
+        )
+
     await db_session.commit()
 
 
@@ -500,42 +547,83 @@ class TestLetter2Detection:
 
         assert "read_first_bonnes_nouvelles" in resp.json()["completed_actions"]
 
-    async def test_read_3_long_articles_detected(self, auth_user, db_session):
+    async def test_read_10_articles_detected(self, auth_user, db_session):
         await _activate_l2(db_session, auth_user)
-        for _ in range(3):
-            await _add_user_content_status(
-                db_session,
-                auth_user,
-                content_type=ContentType.ARTICLE,
-                reading_progress=95,
-                time_spent_seconds=120,
-            )
+        for idx in range(10):
+            kwargs: dict = {"content_type": ContentType.ARTICLE}
+            match idx % 5:
+                case 0:
+                    kwargs["time_spent_seconds"] = 1
+                case 1:
+                    kwargs["reading_progress"] = 1
+                case 2:
+                    kwargs["status"] = ContentStatus.SEEN
+                case 3:
+                    kwargs["status"] = ContentStatus.CONSUMED
+                case _:
+                    kwargs["seen_at"] = datetime.now(UTC)
+            await _add_user_content_status(db_session, auth_user, **kwargs)
 
         async with _client() as ac:
             resp = await ac.post("/api/letters/letter_2/refresh-status")
 
         assert "read_3_long_articles" in resp.json()["completed_actions"]
 
-    async def test_read_3_long_articles_below_threshold_not_detected(
+    async def test_read_10_articles_below_threshold_not_detected(
         self, auth_user, db_session
     ):
         await _activate_l2(db_session, auth_user)
-        # 2 articles seulement → pas détecté
-        for _ in range(2):
+        for _ in range(9):
             await _add_user_content_status(
                 db_session,
                 auth_user,
                 content_type=ContentType.ARTICLE,
-                reading_progress=95,
-                time_spent_seconds=120,
+                time_spent_seconds=1,
             )
-        # 1 article avec time_spent insuffisant → ne doit pas compter
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert "read_3_long_articles" not in resp.json()["completed_actions"]
+
+    async def test_read_10_articles_non_articles_not_counted(
+        self, auth_user, db_session
+    ):
+        await _activate_l2(db_session, auth_user)
+        await _add_user_content_status(
+            db_session,
+            auth_user,
+            content_type=ContentType.PODCAST,
+            time_spent_seconds=1,
+        )
+        for _ in range(9):
+            await _add_user_content_status(
+                db_session,
+                auth_user,
+                content_type=ContentType.ARTICLE,
+                time_spent_seconds=1,
+            )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert "read_3_long_articles" not in resp.json()["completed_actions"]
+
+    async def test_read_10_articles_empty_interaction_not_counted(
+        self, auth_user, db_session
+    ):
+        await _activate_l2(db_session, auth_user)
+        for _ in range(9):
+            await _add_user_content_status(
+                db_session,
+                auth_user,
+                content_type=ContentType.ARTICLE,
+                time_spent_seconds=1,
+            )
         await _add_user_content_status(
             db_session,
             auth_user,
             content_type=ContentType.ARTICLE,
-            reading_progress=95,
-            time_spent_seconds=30,
         )
 
         async with _client() as ac:
@@ -543,19 +631,75 @@ class TestLetter2Detection:
 
         assert "read_3_long_articles" not in resp.json()["completed_actions"]
 
-    async def test_read_first_video_podcast_detected(self, auth_user, db_session):
+    async def test_saved_articles_detected(self, auth_user, db_session):
         await _activate_l2(db_session, auth_user)
-        await _add_user_content_status(
+        await _add_collection_items(
             db_session,
             auth_user,
-            content_type=ContentType.YOUTUBE,
-            time_spent_seconds=300,
+            content_types=[
+                ContentType.ARTICLE,
+                ContentType.ARTICLE,
+                ContentType.ARTICLE,
+            ],
+            is_default=True,
         )
 
         async with _client() as ac:
             resp = await ac.post("/api/letters/letter_2/refresh-status")
 
         assert "read_first_video_podcast" in resp.json()["completed_actions"]
+
+    async def test_saved_articles_below_threshold_not_detected(
+        self, auth_user, db_session
+    ):
+        await _activate_l2(db_session, auth_user)
+        await _add_collection_items(
+            db_session,
+            auth_user,
+            content_types=[ContentType.ARTICLE, ContentType.ARTICLE],
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert "read_first_video_podcast" not in resp.json()["completed_actions"]
+
+    async def test_saved_articles_in_liked_collection_not_counted(
+        self, auth_user, db_session
+    ):
+        await _activate_l2(db_session, auth_user)
+        await _add_collection_items(
+            db_session,
+            auth_user,
+            content_types=[
+                ContentType.ARTICLE,
+                ContentType.ARTICLE,
+                ContentType.ARTICLE,
+            ],
+            is_liked_collection=True,
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert "read_first_video_podcast" not in resp.json()["completed_actions"]
+
+    async def test_saved_non_articles_not_counted(self, auth_user, db_session):
+        await _activate_l2(db_session, auth_user)
+        await _add_collection_items(
+            db_session,
+            auth_user,
+            content_types=[
+                ContentType.ARTICLE,
+                ContentType.PODCAST,
+                ContentType.YOUTUBE,
+            ],
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_2/refresh-status")
+
+        assert "read_first_video_podcast" not in resp.json()["completed_actions"]
 
     async def test_recommend_first_article_detected(self, auth_user, db_session):
         await _activate_l2(db_session, auth_user)
@@ -606,19 +750,21 @@ class TestLetter2Idempotence:
         # Cocher toutes les actions
         await _add_event(db_session, auth_user, "digest_opened")
         await _add_event(db_session, auth_user, "bonnes_nouvelles_opened")
-        for _ in range(3):
+        for _ in range(10):
             await _add_user_content_status(
                 db_session,
                 auth_user,
                 content_type=ContentType.ARTICLE,
-                reading_progress=95,
-                time_spent_seconds=120,
+                time_spent_seconds=1,
             )
-        await _add_user_content_status(
+        await _add_collection_items(
             db_session,
             auth_user,
-            content_type=ContentType.PODCAST,
-            time_spent_seconds=300,
+            content_types=[
+                ContentType.ARTICLE,
+                ContentType.ARTICLE,
+                ContentType.ARTICLE,
+            ],
         )
         await _add_user_content_status(
             db_session,


### PR DESCRIPTION
## What

Update Lettre 2 progression rules to reward lightweight article engagement and saved articles, refresh letter state immediately after collection saves on mobile, and harden progress toast replacement behavior. This also adds mobile and API coverage for the new progression and refresh paths.

## Why

The previous level-2 milestones no longer matched the intended progression path, saved-article progress was not reflected immediately in the UI, and rapid toast replacement could leave overlay state inconsistent.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)
