### PR TITLE
fix(essentiel): mutes appliqués + bulletins élargis + découplage trending/une

### DIFF
--- a/docs/maintenance/maintenance-essentiel-repasse-critique-1.md
+++ b/docs/maintenance/maintenance-essentiel-repasse-critique-1.md
@@ -1,0 +1,94 @@
+# Maintenance — Essentiel : repasse critique #1 (mutes, bulletins, trending/une)
+
+> **Date** : 2026-05-27
+> **Branche** : `boujonlaurin-dotcom/ton-essentiel-curation`
+> **PR ciblée** : `main`
+> **Type** : 3 bug fixes consolidés sur la carte « Ton Essentiel »
+> **Audit source** : [`.context/audit-essentiel-2026-05-27.md`](../../.context/audit-essentiel-2026-05-27.md)
+
+## Contexte
+
+Audit bout-en-bout d'« Essentiel » sur 3 profils réels × 3 jours (25-27 mai
+2026) = 9 audits. **6 constats critiques** remontés ; les 3 premiers sont
+livrés dans cette PR consolidée parce qu'ils sont **interdépendants côté
+qualité du pool** :
+
+- PR 2 (filtre bulletin élargi) et PR 3 (correction trending/une) compensent
+  partiellement le rétrécissement du pool causé par PR 1 (mutes appliqués).
+- Livrer les 3 ensemble évite une fenêtre où Essentiel passerait par un état
+  plus mince sans les compensations qualité.
+
+## Bugs adressés
+
+### #1 — `muted_themes` / `muted_topics` / `muted_sources` ignorés (criticité ⭐⭐⭐)
+
+`fetch_user_essentiel_context` (`packages/api/app/services/essentiel_service.py:104`)
+ne lit que `hide_non_fr_sources` depuis `user_personalization`. Les 3 listes
+de mutes existent en DB mais ne sont jamais consultées par la chaîne
+Essentiel.
+
+**Preuve.** Sylvie (`f95320a6-…`) mute `tech` / `international` / `sport`
+et reçoit Corée du Nord, Présidentielle 2027, Moyen-Orient dans son
+Essentiel des 2026-05-25 et 26.
+
+### #4 — Chroniques France Culture passent le filtre (criticité ⭐⭐)
+
+`is_news_bulletin_title` (`packages/api/app/services/recommendation/filter_presets.py:487`)
+laisse passer :
+
+- « L'humeur du jour, émission du mercredi 27 mai 2026 »
+- « La revue de presse internationale, émission du lundi 25 mai 2026 »
+
+Cause : les patterns existants ancrent au début (`^l['']émission`,
+`^revue de presse`) ; ici un préfixe descriptif précède le mot-clé.
+
+### #6 — `is_une` et `is_trending` lus depuis le même champ (criticité ⭐⭐)
+
+`_build_editorial_response` (`packages/api/app/services/digest_service.py:2343-2344`)
+alimente `is_trending` ET `is_une` depuis `subject["is_a_la_une"]`. Tout
+subject « à la une » reçoit `+_W_TRENDING (40) + _W_UNE (30) = +70` au lieu
+du +30 attendu pour `is_une` seul. Casse la sémantique documentée
+« trending = ≥3 sources couvrent le topic ».
+
+## Changements
+
+| Fichier | Modification |
+|---|---|
+| `packages/api/app/services/essentiel_service.py` | + 3 champs sur `EssentielUserContext` ; + 1 SELECT `UserPersonalization` dans `fetch_user_essentiel_context` ; + fonction `_filter_articles_by_mutes` ; appel en tête de `_pick_transversal_articles` |
+| `packages/api/app/services/recommendation/filter_presets.py` | + 3 patterns dans `NEWS_BULLETIN_PATTERNS` |
+| `packages/api/app/services/digest_service.py` | 1 ligne : `is_trending` ← `source_count >= 3` (et non `is_a_la_une`) |
+| `packages/api/tests/test_low_priority_cap.py` | + 7 tests `TestIsNewsBulletinTitle` (cas réels + régressions) |
+| `packages/api/tests/test_essentiel_endpoint.py` | + tests mutes (theme / source / topic / no-regression / fetch) + tests scoring découplé |
+
+**Pas de migration Alembic** — aucun changement schéma. Les champs
+`muted_*` existent déjà sur `user_personalization`.
+
+## Résultat attendu
+
+- Mutes respectés : 100 % (vs 0 % aujourd'hui)
+- 0 chronique radio en lead-slot Essentiel
+- `is_a_la_une=true` + `source_count=2` → +30 seul (pas +70)
+- `is_a_la_une=false` + `source_count=5` → +40 seul (trending légitime)
+
+## Risques
+
+- **Pool plus mince pour profils très-mutants** (Sylvie : 3 thèmes
+  + 2 topics + 0 sources). Bénéfice qualité > régression quantité ;
+  surveiller post-merge le taux d'Essentiels < 5 articles. Le hand-off
+  audit propose une « PR 5 » fallback robuste (non incluse ici) si
+  nécessaire.
+- **Patterns bulletin trop larges** : mitigé par listes fermées et tests
+  de non-régression (« Une chronique du conflit », « La revue d'un livre »).
+- **Pas de cache à invalider** : `_build_editorial_response` reconstruit
+  la réponse à chaque requête depuis le JSONB stocké.
+
+## Vérification
+
+```bash
+# Tests ciblés
+cd packages/api && pytest tests/test_low_priority_cap.py::TestIsNewsBulletinTitle -v -x
+cd packages/api && pytest tests/test_essentiel_endpoint.py -v -x
+
+# Suite complète (le hook stop-verify-tests.sh la rejouera)
+cd packages/api && pytest -v
+```

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -2340,7 +2340,14 @@ class DigestService:
                         label=subject.get("label", ""),
                         rank=subject.get("rank", 0),
                         reason=subject.get("selection_reason", ""),
-                        is_trending=subject.get("is_a_la_une", False),
+                        # `is_trending` = signal "≥3 sources couvrent le topic"
+                        # (le buzz multi-rédaction). `is_une` = décision
+                        # éditoriale "à la une". Deux leviers indépendants
+                        # dans le scoring Essentiel (_W_TRENDING + _W_UNE) —
+                        # historiquement mappés au même champ JSONB, ce qui
+                        # cumulait +70 sur tout subject "à la une" indépendamment
+                        # de sa couverture.
+                        is_trending=subject.get("source_count", 0) >= 3,
                         is_une=subject.get("is_a_la_une", False),
                         source_count=subject.get("source_count", 0),
                         theme=subject.get("theme"),

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -168,8 +168,12 @@ async def fetch_user_essentiel_context(
         )
     ).first()
     muted_themes = frozenset(perso_row.muted_themes or ()) if perso_row else frozenset()
-    muted_topic_slugs = frozenset(perso_row.muted_topics or ()) if perso_row else frozenset()
-    muted_source_ids = frozenset(perso_row.muted_sources or ()) if perso_row else frozenset()
+    muted_topic_slugs = (
+        frozenset(perso_row.muted_topics or ()) if perso_row else frozenset()
+    )
+    muted_source_ids = (
+        frozenset(perso_row.muted_sources or ()) if perso_row else frozenset()
+    )
 
     return EssentielUserContext(
         followed_source_ids=followed_source_ids,

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -41,6 +41,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.enums import ContentType, SourceType
 from app.models.source import UserSource
 from app.models.user import UserInterest, UserSubtopic
+from app.models.user_personalization import UserPersonalization
 from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
 from app.schemas.essentiel import EssentielArticle, EssentielKind, EssentielResponse
 from app.services.language_user_filter import (
@@ -99,6 +100,12 @@ class EssentielUserContext:
     # Préférence langue : si True, on masque les articles des sources
     # non-FR (sauf si la source est explicitement suivie).
     hide_non_fr_sources: bool = False
+    # Mutes (`user_personalization`) appliqués en tête de pipeline avant
+    # tout autre filtre — un article muté ne doit jamais devenir le fallback
+    # Tournée ni être proposé en lead Actu.
+    muted_themes: frozenset[str] = field(default_factory=frozenset)
+    muted_topic_slugs: frozenset[str] = field(default_factory=frozenset)
+    muted_source_ids: frozenset[UUID] = field(default_factory=frozenset)
 
 
 async def fetch_user_essentiel_context(
@@ -151,11 +158,27 @@ async def fetch_user_essentiel_context(
 
     hide_non_fr_sources = await get_hide_non_fr_pref(db, user_id)
 
+    perso_row = (
+        await db.execute(
+            select(
+                UserPersonalization.muted_themes,
+                UserPersonalization.muted_topics,
+                UserPersonalization.muted_sources,
+            ).where(UserPersonalization.user_id == user_id)
+        )
+    ).first()
+    muted_themes = frozenset(perso_row.muted_themes or ()) if perso_row else frozenset()
+    muted_topic_slugs = frozenset(perso_row.muted_topics or ()) if perso_row else frozenset()
+    muted_source_ids = frozenset(perso_row.muted_sources or ()) if perso_row else frozenset()
+
     return EssentielUserContext(
         followed_source_ids=followed_source_ids,
         source_priority_multipliers=source_priority_multipliers,
         topic_weights=topic_weights,
         hide_non_fr_sources=hide_non_fr_sources,
+        muted_themes=muted_themes,
+        muted_topic_slugs=muted_topic_slugs,
+        muted_source_ids=muted_source_ids,
     )
 
 
@@ -298,6 +321,40 @@ def _score_article(
     return score
 
 
+def _filter_articles_by_mutes(
+    topics: list[DigestTopic],
+    ctx: EssentielUserContext,
+) -> list[DigestTopic]:
+    """Retire les articles mutés par l'utilisateur (`user_personalization`).
+
+    Trois leviers :
+    - `muted_themes` (slugs macro comme "tech", "international") → topic entier
+      écarté si `topic.theme` est muté.
+    - `muted_source_ids` (UUID des sources) → article écarté.
+    - `muted_topic_slugs` (slugs granulaires ML) → article écarté si
+      `article.topics` intersecte la liste.
+
+    Appliqué *avant* tout autre filtre — un article muté ne doit jamais devenir
+    le fallback Tournée ni être proposé en lead Actu.
+    """
+    if not (ctx.muted_themes or ctx.muted_source_ids or ctx.muted_topic_slugs):
+        return topics
+
+    filtered: list[DigestTopic] = []
+    for topic in topics:
+        if topic.theme and topic.theme in ctx.muted_themes:
+            continue
+        kept = [
+            a
+            for a in topic.articles
+            if a.source.id not in ctx.muted_source_ids
+            and not (ctx.muted_topic_slugs.intersection(a.topics))
+        ]
+        if kept:
+            filtered.append(topic.model_copy(update={"articles": kept}))
+    return filtered
+
+
 def _filter_articles_by_language(
     topics: list[DigestTopic],
     ctx: EssentielUserContext,
@@ -368,6 +425,9 @@ def _pick_transversal_articles(
     4. **Diversité dure** : max `ESSENTIEL_MAX_PER_SOURCE` (=2) articles d'une
        même source à toutes les étapes.
     """
+    # Mutes utilisateur (`user_personalization`) — prime sur tous les autres
+    # filtres : un article muté ne doit jamais devenir le fallback Tournée.
+    topics = _filter_articles_by_mutes(topics, ctx)
     topics = _filter_articles_by_language(topics, ctx)
     # Story 9.4 : exclure podcasts/youtube/reddit/bulletins en tête de pipeline
     # — ces contenus ne reflètent pas l'actualité chaude traitée par la presse.

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -479,6 +479,16 @@ NEWS_BULLETIN_PATTERNS = [
     r"^\s*(ma|la|sa|notre)\s+chronique\b",
     # « Chronique: l'économie », « Chronique – bilan de semaine ».
     r"^\s*chronique\s*[:\-–—]",
+    # Préfixe descriptif avant « émission du <jour> » :
+    # « L'humeur du jour, émission du mercredi 27 mai 2026 »
+    # « La revue de presse internationale, émission du lundi 25 mai 2026 »
+    r",\s*émission du (lundi|mardi|mercredi|jeudi|vendredi|samedi|dimanche)\b",
+    # « La revue de presse », « La matinale », « L'invité » — liste fermée
+    # pour ne pas attraper « La revue d'un livre ».
+    r"^\s*(la|l[''’])\s*(revue de presse|humeur du jour|invité|matinale)\b",
+    # « L'humeur du jour », « L'idée du jour » — chronique matinale type
+    # France Culture / France Inter.
+    r"^\s*l[''’][a-zéèêàâîôûç]+ du jour\b",
 ]
 
 _BULLETIN_RE = re.compile("|".join(NEWS_BULLETIN_PATTERNS), re.IGNORECASE)

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -26,7 +26,10 @@ from app.services.essentiel_service import (
     ESSENTIEL_MAX_ARTICLES,
     EssentielUserContext,
     _perspective_score,
+    _score_article,
     _source_letter,
+    _W_TRENDING,
+    _W_UNE,
     build_essentiel_response,
 )
 
@@ -1026,3 +1029,164 @@ def test_actu_lead_slot_skips_sport_trending():
     assert response.articles[0].section_label != "Sport"
     # Sport en queue.
     assert response.articles[-1].section_label == "Sport"
+
+
+# ─── Repasse 2026-05-27 — mutes appliqués + scoring is_trending découplé ───
+
+
+def test_muted_theme_excludes_topic():
+    """Sylvie 2026-05-25/26 : mute `international` → topic de theme
+    international entièrement écarté (article Corée du Nord exclu)."""
+    international = _topic(
+        "International",
+        [_art(title="Corée du Nord tire un projectile")],
+        theme="international",
+        is_trending=True,
+        rank=1,
+    )
+    other = _topic("Société", [_art(title="Société-1")], theme="society", rank=2)
+    digest = _make_digest([international, other])
+    ctx = EssentielUserContext(muted_themes=frozenset({"international"}))
+
+    response = build_essentiel_response(digest, user_context=ctx)
+
+    labels = [a.section_label for a in response.articles]
+    assert "International" not in labels
+    assert labels == ["Société"]
+
+
+def test_muted_source_excludes_article():
+    """Article de source mutée écarté même si trending."""
+    muted_src = _src("Frandroid")
+    ok_src = _src("Le Monde")
+    same_topic = _topic(
+        "Tech",
+        [
+            _art(title="Article muted", source=muted_src),
+            _art(title="Article ok", source=ok_src),
+        ],
+        theme="tech",
+        is_trending=True,
+        rank=1,
+    )
+    digest = _make_digest([same_topic])
+    ctx = EssentielUserContext(muted_source_ids=frozenset({muted_src.id}))
+
+    response = build_essentiel_response(digest, user_context=ctx)
+
+    assert len(response.articles) == 1
+    assert response.articles[0].title == "Article ok"
+
+
+def test_muted_topic_slug_excludes_article():
+    """Sylvie : mute `space` → article taggué `topics=["space"]` exclu."""
+    src = _src("Le Monde")
+    topic = _topic(
+        "Sciences",
+        [
+            _art(title="Mission lunaire", source=src, topics=["space"]),
+            _art(title="Biologie marine", source=src, topics=["biology"]),
+        ],
+        theme="sciences",
+        rank=1,
+    )
+    digest = _make_digest([topic])
+    ctx = EssentielUserContext(muted_topic_slugs=frozenset({"space"}))
+
+    response = build_essentiel_response(digest, user_context=ctx)
+
+    titles = [a.title for a in response.articles]
+    assert "Mission lunaire" not in titles
+    assert "Biologie marine" in titles
+
+
+def test_no_mutes_no_regression():
+    """Sans mutes : comportement identique au comportement historique."""
+    topics = [
+        _make_topic(rank=i + 1, label=f"T{i + 1}", n_articles=1) for i in range(3)
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(
+        digest,
+        user_context=EssentielUserContext(),
+    )
+
+    assert [a.section_label for a in response.articles] == ["T1", "T2", "T3"]
+
+
+def test_muted_source_does_not_break_other_topics():
+    """Régression : muter une source d'un topic ne doit pas vider les
+    autres topics. Garantit que `_filter_articles_by_mutes` n'élague pas
+    trop large."""
+    muted = _src("Frandroid")
+    ok = _src("Le Monde")
+    topics = [
+        _topic("Tech", [_art(title="T1", source=muted)], theme="tech", rank=1),
+        _topic("Politique", [_art(title="P1", source=ok)], theme="politique", rank=2),
+    ]
+    digest = _make_digest(topics)
+    ctx = EssentielUserContext(muted_source_ids=frozenset({muted.id}))
+
+    response = build_essentiel_response(digest, user_context=ctx)
+
+    labels = [a.section_label for a in response.articles]
+    assert labels == ["Politique"]
+
+
+def test_trending_and_une_decoupled_in_scoring():
+    """Bug audit #6 : `is_une` et `is_trending` étaient lus du même champ
+    JSONB → tout subject à la une recevait +70 (40+30). Après découplage,
+    un subject avec `is_une=True` seul reçoit `+_W_UNE` (30) uniquement."""
+    topic_une_only = _topic(
+        "UneOnly",
+        [_art(title="A1")],
+        theme="theme-une",
+        is_trending=False,
+        is_une=True,
+        perspective_count=1,
+        rank=1,
+    )
+    topic_trending_only = _topic(
+        "TrendingOnly",
+        [_art(title="A2")],
+        theme="theme-trending",
+        is_trending=True,
+        is_une=False,
+        perspective_count=1,
+        rank=2,
+    )
+    ctx = EssentielUserContext()
+
+    une_score = _score_article(topic_une_only, topic_une_only.articles[0], ctx)
+    trending_score = _score_article(
+        topic_trending_only, topic_trending_only.articles[0], ctx
+    )
+
+    # `is_une` seul : +_W_UNE (30), `is_trending` seul : +_W_TRENDING (40).
+    # Tie-break par rank pénalisé (-0.5 * 1).
+    assert une_score == pytest.approx(_W_UNE - 0.5)
+    assert trending_score == pytest.approx(_W_TRENDING - 0.5)
+    # Le découplage doit produire des scores différents (avant le fix,
+    # is_une=true et is_trending=true étaient toujours cumulés → scores égaux
+    # ne se distinguaient jamais).
+    assert une_score != trending_score
+
+
+def test_une_and_trending_can_cumulate_when_both_set():
+    """Cumul `+70` toujours possible mais légitime — quand le subject est
+    à la fois à la une éditoriale (`is_une`) et couvert par ≥3 sources
+    (`is_trending`)."""
+    topic = _topic(
+        "Both",
+        [_art(title="A1")],
+        theme="t",
+        is_trending=True,
+        is_une=True,
+        perspective_count=1,
+        rank=1,
+    )
+
+    score = _score_article(topic, topic.articles[0], EssentielUserContext())
+
+    assert score == pytest.approx(_W_TRENDING + _W_UNE - 0.5)

--- a/packages/api/tests/test_low_priority_cap.py
+++ b/packages/api/tests/test_low_priority_cap.py
@@ -285,6 +285,48 @@ class TestIsNewsBulletinTitle:
             "Une nouvelle émission de Radio France pour les jeunes"
         )
 
+    # --- Repasse Essentiel 2026-05-27 : chroniques France Culture ---
+
+    def test_humeur_du_jour_emission_du_mercredi(self):
+        """« L'humeur du jour, émission du mercredi 27 mai 2026 » — chronique
+        quotidienne France Culture passée à travers le filtre avant repasse."""
+        assert is_news_bulletin_title(
+            "L'humeur du jour, émission du mercredi 27 mai 2026"
+        )
+
+    def test_revue_de_presse_internationale_emission_du_lundi(self):
+        """« La revue de presse internationale, émission du lundi 25 mai 2026 »
+        — chronique France Culture, non matchée par `^revue de presse` à cause
+        du préfixe « La ». Doit l'être désormais."""
+        assert is_news_bulletin_title(
+            "La revue de presse internationale, émission du lundi 25 mai 2026"
+        )
+
+    def test_humeur_du_jour_short(self):
+        """Forme courte sans suffixe d'édition — chronique matinale."""
+        assert is_news_bulletin_title("L'humeur du jour")
+
+    def test_idee_du_jour(self):
+        """Variante France Inter / France Culture."""
+        assert is_news_bulletin_title("L'idée du jour")
+
+    def test_la_matinale(self):
+        """« La matinale du 27 mai » — chronique régulière."""
+        assert is_news_bulletin_title("La matinale du 27 mai")
+
+    def test_revue_d_un_livre_not_matched(self):
+        """Régression : « La revue d'un livre… » n'est pas dans la liste
+        fermée (revue de presse / matinale / humeur du jour / invité) et
+        ne doit donc pas matcher."""
+        assert not is_news_bulletin_title("La revue d'un livre de Camus")
+
+    def test_l_emission_du_president(self):
+        """Régression : la forme « L'émission du <x> » reste matchée par le
+        pattern historique `^l['émission`."""
+        assert is_news_bulletin_title(
+            "L'émission du président qu'il faut écouter"
+        )
+
 
 class TestIsDenylistedEditorialSource:
     """Sources bloquées du top 10 éditorial."""


### PR DESCRIPTION
## Quoi

Repasse critique #1 sur la carte « Ton Essentiel » — 3 bugs interdépendants corrigés en une PR consolidée pour éviter une fenêtre où l'Essentiel serait plus mince sans les compensations qualité.

## Pourquoi

Audit bout-en-bout de 9 sessions (3 profils × 3 jours, 25-27 mai 2026) a remonté 6 constats critiques. Cette PR adresse les 3 premiers :

**#1 — Mutes ignorés (⭐⭐⭐)** : `muted_themes`/`muted_topics`/`muted_sources` existent en DB mais n'étaient jamais consultés par le pipeline Essentiel. Sylvie mute `tech`/`international`/`sport` → ces articles continuaient d'apparaître en lead.

**#2 — Bulletins radio non filtrés** : Des chroniques France Culture/Inter (`L'humeur du jour, émission du mercredi…`, `La revue de presse internationale…`) passaient à travers `NEWS_BULLETIN_PATTERNS` et polluaient le top 5.

**#3 — Découplage `is_trending`/`is_une` (⭐⭐)** : Les deux signaux étaient lus du même champ JSONB `is_a_la_une`, cumulant +70pts sur tout subject éditorial indépendamment de sa couverture réelle. `is_trending` est maintenant dérivé de `source_count >= 3` (buzz multi-rédaction).

## Comment ça a été vérifié

- [x] pytest : **96 tests OK** (tests modifiés + suite complète 1123 passed)
- [x] Erreurs DB pré-existantes confirmées non-régressives (git stash vérifié)
- [x] /simplify passé (frozenset if/else simplifié)

## Zones à risque

- `essentiel_service.py` : pipeline principal Essentiel — ajout filtre mutes en tête
- `digest_service.py` : mapping JSONB → `DigestTopic` (is_trending/is_une)
- `filter_presets.py` : regex bulletins (NEWS_BULLETIN_PATTERNS)