### PR TITLE
feat(feed): fin de tournée button + Tout lire CTA + UX polish

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -342,24 +342,35 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
 
   void _alignTabsToActive(int index) {
     if (!_tabsScroll.hasClients) return;
-    final maxExtent = _tabsScroll.position.maxScrollExtent;
     // Explorer is the virtual tab appended after every real section; pin it
     // to the right edge so the sticky bar visibly bottoms out instead of
     // leaving trailing whitespace when the user reaches the last zone.
     final bool isLastTab = index >= _sectionKeys.length;
-    final double target;
-    if (isLastTab) {
-      target = maxExtent;
-    } else {
-      const double estimatedTabWidth = 140.0;
-      const double leftPadding = 12.0;
-      target = (index * estimatedTabWidth - leftPadding).clamp(0.0, maxExtent);
+    void doScroll() {
+      if (!_tabsScroll.hasClients) return;
+      final maxExtent = _tabsScroll.position.maxScrollExtent;
+      final double target;
+      if (isLastTab) {
+        target = maxExtent;
+      } else {
+        const double estimatedTabWidth = 140.0;
+        const double leftPadding = 12.0;
+        target =
+            (index * estimatedTabWidth - leftPadding).clamp(0.0, maxExtent);
+      }
+      _tabsScroll.animateTo(
+        target,
+        duration: const Duration(milliseconds: 220),
+        curve: Curves.easeOutCubic,
+      );
     }
-    _tabsScroll.animateTo(
-      target,
-      duration: const Duration(milliseconds: 220),
-      curve: Curves.easeOutCubic,
-    );
+    doScroll();
+    if (isLastTab) {
+      // Second pass after layout — covers the case where the sticky bar has
+      // just appeared and `maxScrollExtent` hadn't been computed yet, so the
+      // first `animateTo(maxExtent)` resolved against a stale extent.
+      WidgetsBinding.instance.addPostFrameCallback((_) => doScroll());
+    }
   }
 
   Future<void> _scrollToSection(int index) async {
@@ -1032,6 +1043,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
                     i >= state.sections.length - 1)
                 ? null
                 : () => _advanceToNextSection(section, i),
+            onEndOfTournee: (section is! EssentielSection &&
+                    i == state.sections.length - 1)
+                ? _endOfTournee
+                : null,
           ),
         ),
       ));
@@ -1041,17 +1056,46 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
 
   /// "Sujet suivant" tap handler for in-Tournée progression. Marks the
   /// current section as consumed for the next session (without folding it
-  /// visually) and smooth-scrolls to the next section banner.
+  /// visually) and smooth-scrolls to the next section banner. If the target
+  /// section is currently folded, unfolds it first so the user lands on an
+  /// expanded banner rather than a collapsed card.
   Future<void> _advanceToNextSection(FluxSection section, int index) async {
     unawaited(HapticFeedback.lightImpact());
     unawaited(ref
         .read(fluxContinuProvider.notifier)
         .markScrolledPastForNextSession(section));
+    final state = ref.read(fluxContinuProvider).valueOrNull;
+    final nextIdx = index + 1;
+    if (state != null && nextIdx < state.sections.length) {
+      final next = state.sections[nextIdx];
+      if (state.isFolded(next)) {
+        ref.read(fluxContinuProvider.notifier).unfoldLocally(next);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        if (!mounted) return;
+      }
+    }
     // Let the "Terminé" pop play before the scroll kicks in, so the user
     // sees the green confirmation flash on its own frame.
-    await Future<void>.delayed(const Duration(milliseconds: 350));
+    await Future<void>.delayed(const Duration(milliseconds: 300));
     if (!mounted) return;
-    await _scrollToSection(index + 1);
+    await _scrollToSection(nextIdx);
+  }
+
+  /// "Fin de tournée — Flâner" tap handler for the last Tournée section.
+  /// Marks every editorial section as consumed for the next session and
+  /// smooth-scrolls to the Flâner banner.
+  Future<void> _endOfTournee() async {
+    unawaited(HapticFeedback.lightImpact());
+    final state = ref.read(fluxContinuProvider).valueOrNull;
+    if (state != null) {
+      final notifier = ref.read(fluxContinuProvider.notifier);
+      for (final s in state.sections) {
+        unawaited(notifier.markScrolledPastForNextSession(s));
+      }
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+    if (!mounted) return;
+    await _scrollToSection(_sectionKeys.length);
   }
 
   /// Builds the Explorer feed list by reading from `feedProvider` and filtering

--- a/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/plus_de_button.dart
@@ -19,8 +19,8 @@ class SeeAllSectionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final label = hiddenCount > 0
-        ? 'Lire plus (+$hiddenCount)'
-        : 'Lire plus';
+        ? 'Tout lire (+$hiddenCount)'
+        : 'Tout lire';
     return _ButtonShell(
       onTap: onTap,
       child: Row(
@@ -237,6 +237,60 @@ class _NextSectionButtonState extends State<NextSectionButton>
                   color: marked ? colors.success : foreground,
                   size: 16,
                 ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// "Fin de tournée — Flâner" — bottom-of-section CTA shown only on the last
+/// Tournée section. Visually similar to [NextSectionButton] (full-width
+/// pill, accent tint) but with a bolder label and forced brown accent
+/// matching the Flâner banner. One-shot: no "Passé" state, no flip.
+class EndOfTourneeButton extends StatelessWidget {
+  final VoidCallback? onTap;
+
+  const EndOfTourneeButton({super.key, required this.onTap});
+
+  static const Color _accent = Color(0xFF5D4037);
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          decoration: BoxDecoration(
+            color: _accent.withValues(alpha: 0.08),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Flexible(
+                child: Text(
+                  'Fin de tournée — Flâner',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                        color: _accent,
+                        fontWeight: FontWeight.w700,
+                      ),
+                ),
+              ),
+              const SizedBox(width: 6),
+              const Icon(
+                Icons.arrow_downward,
+                color: _accent,
+                size: 16,
               ),
             ],
           ),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -48,7 +48,7 @@ class SectionBanner extends StatelessWidget {
     const topRadius = BorderRadius.vertical(top: Radius.circular(10));
     final container = Container(
       width: double.infinity,
-      margin: const EdgeInsets.fromLTRB(0, 4, 0, 12),
+      margin: const EdgeInsets.fromLTRB(0, 4, 0, 6),
       constraints: const BoxConstraints(minHeight: 96),
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -86,6 +86,12 @@ class SectionBlock extends StatelessWidget {
   /// générique « Section suivante ».
   final String? nextSectionLabel;
 
+  /// "Fin de tournée — Flâner" action shown in the footer of the **last**
+  /// Tournée section in place of "Sujet suivant". When non-null, marks all
+  /// editorial sections as consumed for the next session and scrolls to the
+  /// Flâner banner. Mutually exclusive with [onNextSection].
+  final VoidCallback? onEndOfTournee;
+
   const SectionBlock({
     super.key,
     required this.section,
@@ -110,6 +116,7 @@ class SectionBlock extends StatelessWidget {
     this.isMarkedForNextSession = false,
     this.nextSectionAccent,
     this.nextSectionLabel,
+    this.onEndOfTournee,
   });
 
   @override
@@ -167,14 +174,17 @@ class SectionBlock extends StatelessWidget {
         ...cards,
         _SectionFooterRow(
           voirPlus: _buildVoirPlusButton(section, hiddenCount),
-          sujetSuivant: onNextSection != null
-              ? NextSectionButton(
-                  isMarked: isMarkedForNextSession,
-                  nextAccent: nextSectionAccent,
-                  nextSectionLabel: nextSectionLabel,
-                  onTap: isMarkedForNextSession ? null : onNextSection,
-                )
-              : null,
+          sujetSuivant: onEndOfTournee != null
+              ? EndOfTourneeButton(onTap: onEndOfTournee)
+              : onNextSection != null
+                  ? NextSectionButton(
+                      isMarked: isMarkedForNextSession,
+                      nextAccent: nextSectionAccent,
+                      nextSectionLabel: nextSectionLabel,
+                      onTap: isMarkedForNextSession ? null : onNextSection,
+                    )
+                  : null,
+          rightTakesMoreSpace: onEndOfTournee != null,
         ),
         const SizedBox(height: 16),
       ],
@@ -293,25 +303,33 @@ class SectionBlock extends StatelessWidget {
 class _SectionFooterRow extends StatelessWidget {
   final Widget? voirPlus;
   final Widget? sujetSuivant;
+  final bool rightTakesMoreSpace;
 
-  const _SectionFooterRow({this.voirPlus, this.sujetSuivant});
+  const _SectionFooterRow({
+    this.voirPlus,
+    this.sujetSuivant,
+    this.rightTakesMoreSpace = false,
+  });
 
   @override
   Widget build(BuildContext context) {
     if (voirPlus == null && sujetSuivant == null) {
       return const SizedBox.shrink();
     }
+    final int leftFlex = rightTakesMoreSpace ? 2 : 1;
+    final int rightFlex = rightTakesMoreSpace ? 3 : 1;
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
       child: Row(
         children: [
           if (voirPlus != null)
-            Expanded(flex: 1, child: voirPlus!)
+            Expanded(flex: leftFlex, child: voirPlus!)
           else
-            const Spacer(),
+            Spacer(flex: leftFlex),
           if (voirPlus != null && sujetSuivant != null)
             const SizedBox(width: 8),
-          if (sujetSuivant != null) Expanded(flex: 1, child: sujetSuivant!),
+          if (sujetSuivant != null)
+            Expanded(flex: rightFlex, child: sujetSuivant!),
         ],
       ),
     );

--- a/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
@@ -101,7 +101,7 @@ void main() {
       ));
 
       // 7 items - 3 visible = +4 hidden.
-      expect(find.text('Lire plus (+4)'), findsOneWidget);
+      expect(find.text('Tout lire (+4)'), findsOneWidget);
     });
 
     testWidgets(
@@ -134,8 +134,8 @@ void main() {
         ),
       ));
 
-      // hiddenCount = 0 → label falls back to "Lire plus" (no suffix).
-      expect(find.text('Lire plus'), findsOneWidget);
+      // hiddenCount = 0 → label falls back to "Tout lire" (no suffix).
+      expect(find.text('Tout lire'), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
## What

Adds the "Fin de tournée — Flâner" end-of-journey CTA on the last editorial section, renames "Lire plus" to "Tout lire" for consistency, auto-unfolds folded sections on navigation, fixes a sticky tab bar scroll edge case, and refines spacing.

## Why

Completes the feed UX flow so users have a clear, branded transition to the Flâner explorer after consuming all sections. Improves navigation responsiveness and visual hierarchy.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Changes

**flux_continu_screen.dart:**
- Added _endOfTournee() handler that marks all sections as consumed and scrolls to Flâner banner
- Wired onEndOfTournee callback to final section block
- Auto-unfold folded next section before scrolling in _advanceToNextSection
- Fixed Explorer tab scroll edge case by double-checking layout extent in _alignTabsToActive

**plus_de_button.dart:**
- Renamed "Lire plus" → "Tout lire" in SeeAllSectionButton (user-visible copy change)
- Added new EndOfTourneeButton widget with brown accent, down arrow, and bold styling

**section_banner.dart:**
- Reduced bottom margin from 12px to 6px for tighter spacing

**section_block.dart:**
- Added onEndOfTournee optional callback prop
- Substituted EndOfTourneeButton for NextSectionButton when end-of-tournée is triggered
- Adjusted _SectionFooterRow flex ratio (2:3) to give more space to "Fin de tournée" button
- Extended DigestTopicSection to use SeeAllSectionButton like theme sections

**section_block_test.dart:**
- Updated test assertions to match renamed "Tout lire" label

## Testing

- Tests in section_block_test.dart updated for "Tout lire" label
- No backend/API changes
- No database migrations
- Flutter analysis and tests pass locally