### PR TITLE
fix(perspectives): strip source suffix backend + intro inline + clamp legacy spans

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,98 +1,109 @@
-# PR 1 — Backend : Filtre par langue & `Source.language` (curation FR-first)
+# fix(perspectives): strip source suffix backend + intro inline + clamp legacy spans
 
 ## Contexte
 
-PR 1/2 du plan **language-aware curation**. Introduit la prise en compte
-de la langue de la source dans les pipelines Essentiel / feed / digest,
-contrôlée par une préférence user `hide_non_fr_sources` masquant les
-cartes des sources non-FR — sauf si la source est explicitement suivie.
+Trois symptômes en prod sur la feature « Diff Highlighting » (Story 7.4) :
 
-La couche mobile + section "Couverture à l'étranger" (panel perspectives)
-arrivent en PR 2.
+1. **Tout au même alpha** — pas de niveau de surlignage différencié visible.
+2. **Aucun texte d'intro** dans la vue inline « Couverture médiatique » du
+   reader d'article (seul le modal en avait un).
+3. **Noms de journaux surlignés à tort** (`« - Le Monde »`, `« | Libération »`)
+   et un strip client fragile qui décalait les positions.
+
+Diagnostic SQL prod confirmé avant code :
+
+| | Résultat |
+|---|---|
+| `cluster_title_annotations` (LLM) | **0 rows** |
+| `contents.cluster_id` 7j | **0 / 13 532** |
+| `MISTRAL_API_KEY` Railway | présent (autres uses-cases du matin OK) |
+
+→ Symptôme 1 est ops : `_persist_content_cluster_ids` ne produit pas en prod
+malgré Sprint 3 mergé. À traiter hors PR — cette PR couvre uniquement les
+symptômes 2 + 3 et prépare le terrain pour quand les annotations LLM
+arriveront enfin.
 
 ## Changements
 
-### Données
+### Backend
 
-- **Migration `lg02_source_language_user_pref`** (down_revision : `lg01`) :
-  - `sources.language String(8) NULL, indexed` ; backfill par langue
-    majoritaire (≥ 60 %) à partir de `Content.language`.
-  - `user_personalization.hide_non_fr_sources` (Boolean, default `true`).
-  - `user_personalization.language_filter_user_set` (Boolean, default
-    `false`) — flag "mode auto".
-  - Backfill `hide_non_fr_sources = false` pour les users qui suivent
-    déjà ≥ 1 source étrangère (respect du choix implicite).
+- **`perspective_service.py`** : nouveau `_strip_source_suffix(title,
+  source_name)` appliqué à l'ingestion RSS Google News. Path primaire = match
+  exact contre `<source>` (100% safe). Fallback regex restrictive
+  `\s+[-–|]\s+[A-ZÀ-Ý][A-Za-zÀ-ÿ0-9\s'.&-]{0,40}\s*$` : 7,3% des titres prod
+  matchent un séparateur, mais l'échantillon de 30 montre que la regex large
+  initialement proposée aurait massacré des titres légitimes
+  (`« Flipper One - Le Linux de poche qui terrifie ses propres créateurs »`,
+  `« Etats-Unis – Iran : Finkielkraut espère »`, suffixes
+  `« - 26/05 »`). La regex restreinte (uppercase initial, pas de `:`,
+  ≤ 40 chars) les préserve. Dedup `title.split(" - ")[0]` retirée — devenue
+  redondante puisque le titre stocké est déjà clean.
 
-### Services
+- **`routers/contents.py` `_attach_highlight_spans`** : clamp défensif des
+  spans LLM lus depuis `semantic_equiv` (`0 <= start < end <= len(title)`).
+  Protège la mise en page Flutter contre les rows historiques calculés sur
+  les titres bruts pré-strip.
 
-- `app/services/language_user_filter.py` (nouveau) :
-  - `is_foreign_source`, `get_hide_non_fr_pref`, `apply_language_filter`
-    (filtre Python), `language_filter_clause` (clause SQL partagée
-    digest_selector ↔ recommendation_service), `recompute_auto_pref`
-    (mode auto bascule sur follow/unfollow).
-- `essentiel_service` : `EssentielUserContext.hide_non_fr_sources` +
-  `_filter_articles_by_language` appliqué avant le scoring.
-- `recommendation_service._get_candidates` : filtre SQL équivalent
-  (followed sources jamais filtrées). Désactivé en mode "browse a
-  specific source" (exploration).
-- `digest_selector` : `DigestContext.hide_non_fr_sources` + filtre SQL
-  sur le pool curated (les articles des sources suivies passent par
-  `user_sources_query`, hors filtre par construction).
-- `source_service.{trust,untrust,create,delete}_source` : appellent
-  `recompute_auto_pref` après mutation.
+- **`llm_bias_annotation_service.py`** : prompt enrichi — la catégorie
+  `exclude_spans.noise` mentionne explicitement les suffixes médias résiduels.
+  `LLM_VERSION` → `mistral-medium-latest-v2`, snapshot regénéré (anti-dérive
+  silencieuse). Safe : 0 annotations existantes en prod à invalider.
 
-### API
+### Frontend
 
-- `SourceMini.language: str | None` (forward-compat, propagé dans tous
-  les schemas qui l'embarquent).
-- `ContentResponse.language`, `DigestTopicArticle.language`,
-  `EssentielArticle.language` (forward-compat — utile au debug et label
-  éventuel côté mobile).
-- `GET /api/personalization` expose `hide_non_fr_sources` +
-  `language_filter_user_set`.
-- `POST /api/personalization/toggle-hide-non-fr-sources` : toute MAJ
-  flippe `language_filter_user_set = true` (gel du choix user).
-
-### Background
-
-- `app/jobs/recompute_source_language.py` (nouveau) : recalcule
-  `sources.language` 1×/jour à partir de `Content.language` des 30
-  derniers jours (seuil majoritaire 60 %).
-- Scheduler : nouveau job `recompute_source_language` à 03h30 Paris.
+- **`perspectives_bottom_sheet.dart`** :
+  - `kHighlightIntroText` extrait en constante partagée (single source of
+    truth pour modal + inline).
+  - `_PerspectiveCard.build()` : strip client `.replaceAll(RegExp(...))`
+    retiré, simple `.trim()` puisque l'API émet désormais des titres clean.
+  - `_buildExpandedBody` (vue inline « Couverture médiatique » expanded
+    dans le reader) : intro 2 lignes ajoutée en haut du groupe, une seule
+    fois, conditionnelle sur `variants.isNotEmpty`.
 
 ## Tests
 
-- `tests/services/test_language_user_filter.py` (nouveau) :
-  - 8 unit tests pure-Python.
-  - 6 tests DB pour `get_hide_non_fr_pref` + `recompute_auto_pref`
-    (mode auto / manuel, no-op sans personalization row).
-- Suite backend complète : **1285 passed, 1 skipped, 2 xfailed** sur DB
-  locale post-migration `lg02`.
+- `tests/test_perspective_service.py` : 4 nouveaux tests
+  (`test_strip_source_suffix_*`) — primary path, fallback, préservation des
+  titres légitimes avec tirets, vides/whitespace. Fixture existante mise à
+  jour pour refléter le strip à l'ingestion.
+- `tests/routers/test_contents_perspectives_highlights.py` :
+  `test_attach_highlight_spans_clamps_out_of_bounds_llm_spans` — span valide
+  conservé, end > len(title) / start négatif / zero-width tous filtrés.
+- `tests/snapshots/llm_system_prompt.txt` : regénéré.
+- `apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart`
+  (nouveau) : intro présente en mode expanded avec perspectives, absente si
+  vide ou collapsé. Le widget test du modal existant continue à passer grâce
+  à la constante partagée.
 
-## Vérification
+### Résultats
 
 ```
-cd packages/api && python -m alembic heads          # → lg02_source_language_user_pref seule head
-cd packages/api && python -m alembic upgrade head   # DB vide → OK (jouée localement)
-cd packages/api && python -m pytest -q              # 1285 passed
+472 passed  (pytest tests/routers/ tests/services/ tests/editorial/ tests/test_perspective_service.py)
+48  passed  (flutter test test/features/feed/widgets/)
 ```
 
-## Points d'attention
+`flutter analyze` : 0 nouvel issue sur les fichiers modifiés.
 
-- **`Source.language=NULL` → traité comme FR** (rétro-compat avec le
-  client mobile et `editorial/writer.py:_looks_french`). Conséquence :
-  une source dont la langue n'est pas encore détectée ne sera pas
-  masquée.
-- **Filtre désactivé en exploration source** (`source_id` query param) :
-  on n'ampute pas le browse explicite.
-- **`recompute_auto_pref` flushe avant SELECT** : la nouvelle
-  UserSource doit être visible. Hooks placés après `db.flush()`.
-- **Mobile (PR 2)** reste à faire : toggle "Masquer sources non-FR" +
-  section "Couverture à l'étranger" dans le panel perspectives.
+## Test plan
 
-## Follow-ups identifiés
+- [x] `pytest -q` backend sweep complet sur les zones touchées
+- [x] `flutter test test/features/feed/widgets/`
+- [x] `flutter analyze` sur `perspectives_bottom_sheet.dart`
+- [x] Échantillon prod (30 titres) confirme que la regex restrictive ne casse
+      pas les titres légitimes
+- [ ] **À faire post-merge** : ouvrir un article avec ≥ 2 perspectives,
+      vérifier (a) l'intro 2 lignes apparait en haut de la section
+      « Couverture médiatique » expanded, (b) aucun titre n'affiche
+      ` - Source` en clair, (c) `curl -D - .../perspectives | grep -i x-bias`
+      pour le header (restera `spacy` tant que ops n'a pas réparé le
+      pipeline LLM annotation — suivi séparé).
 
-- La whitelist `is_french_source` peut mislabel certaines sources
-  (Story 7.7 — labellisation manuelle du catalogue). Acceptable pour PR 1.
-- Pas de migration côté Story 7.7 = on s'appuie sur le job daily pour
-  rattraper les nouvelles sources.
+## Suivi ops (hors PR)
+
+`with_llm=0` et `clustered=0/13532` indiquent que `_persist_content_cluster_ids`
+ne tourne pas en prod malgré Sprint 3 mergé ce matin (#698). La clé Mistral
+est fonctionnelle. Hypothèses à investiguer côté ops :
+
+- Le pipeline 07:30 a-t-il tourné depuis le merge de #698 ?
+- Si oui, regarder les logs Railway pour `editorial.llm_annotation.*` /
+  `editorial.persist_cluster_ids.*`.

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -18,6 +18,14 @@ import 'article_viewer_modal.dart';
 import 'coverage_spectrum_bar.dart';
 import 'diff_title.dart';
 
+/// Texte d'introduction expliquant le surlignage. Affiché dans le bottom-sheet
+/// modal ET en tête du groupe inline de la section « Couverture médiatique »
+/// du reader d'article — single source of truth pour les deux vues.
+const String kHighlightIntroText =
+    'Le surlignage met en évidence les termes qui '
+    'marquent l\'angle éditorial : plus le surlignage '
+    'est intense, plus le choix de mot est éditorialisé.';
+
 /// Ouvre l'URL d'une perspective dans le même reader (modal webview) que
 /// pour un article interne. `useRootNavigator: true` empile la modal au-dessus
 /// de la sheet de comparaisons — la fermer ramène l'utilisateur sur la sheet
@@ -420,9 +428,7 @@ class _PerspectivesBottomSheetState
                           ],
                           const SizedBox(height: 12),
                           Text(
-                            'Le surlignage met en évidence les termes qui '
-                            'marquent l\'angle éditorial : plus le surlignage '
-                            'est intense, plus le choix de mot est éditorialisé.',
+                            kHighlightIntroText,
                             style: textTheme.bodySmall?.copyWith(
                               color: colors.textSecondary,
                               height: 1.4,
@@ -686,9 +692,7 @@ class _PerspectiveCard extends ConsumerWidget {
                     children: [
                       Expanded(
                         child: DiffTitle(
-                          title: perspective.title
-                              .replaceAll(RegExp(r'\s+[-–|]\s+[^-–|]+$'), '')
-                              .trim(),
+                          title: perspective.title.trim(),
                           highlightSpans: perspective.highlightSpans,
                           sharedTokens: perspective.sharedTokens,
                           biasColor: perspective.getBiasColor(colors),
@@ -1508,6 +1512,19 @@ class _PerspectivesInlineSectionState
               color: colors.textSecondary.withValues(alpha: 0.18),
             ),
           ],
+          if (variants.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 10, 16, 6),
+              child: Text(
+                kHighlightIntroText,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: textTheme.bodySmall?.copyWith(
+                  color: colors.textSecondary,
+                  height: 1.35,
+                ),
+              ),
+            ),
           for (var i = 0; i < variants.length; i++)
             _VariantRow(
               key: ValueKey('variant_${_animationGeneration}_$i'),

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
+
+Perspective _p(String name, {String bias = 'center'}) => Perspective(
+      title: 'Titre $name',
+      url: 'https://example.com/$name',
+      sourceName: name,
+      sourceDomain: '',
+      biasStance: bias,
+    );
+
+Future<void> _pumpInline(
+  WidgetTester tester, {
+  required List<Perspective> perspectives,
+  bool isExpanded = true,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SizedBox(
+              width: 390,
+              child: PerspectivesInlineSection(
+                perspectives: perspectives,
+                biasDistribution: const {'center': 0},
+                keywords: const [],
+                contentId: 'test-content-id',
+                sourceBiasStance: 'center',
+                sourceName: 'Test',
+                referenceTitle: 'Titre référence',
+                isExpanded: isExpanded,
+                onToggle: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  const introSnippet = "marquent l'angle éditorial";
+
+  testWidgets(
+    'inline expanded + perspectives non vides → intro rendue en haut du groupe',
+    (tester) async {
+      await _pumpInline(tester, perspectives: [_p('A'), _p('B', bias: 'left')]);
+
+      expect(find.textContaining(introSnippet), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'inline expanded + perspectives vides → pas d\'intro (rien à introduire)',
+    (tester) async {
+      await _pumpInline(tester, perspectives: const []);
+
+      expect(find.textContaining(introSnippet), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'inline collapsé → pas d\'intro (body non rendu)',
+    (tester) async {
+      await _pumpInline(
+        tester,
+        perspectives: [_p('A')],
+        isExpanded: false,
+      );
+
+      expect(find.textContaining(introSnippet), findsNothing);
+    },
+  );
+}

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -893,7 +893,7 @@ async def _attach_highlight_spans(
                 p["highlight_spans"] = [
                     {**span, "bias": bias}
                     for span in (llm_payload.get("target_spans") or [])
-                    if 0 <= span.get("start", 0)
+                    if span.get("start", 0) >= 0
                     and span.get("end", 0) <= title_len
                     and span.get("start", 0) < span.get("end", 0)
                 ]

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -885,9 +885,17 @@ async def _attach_highlight_spans(
             if llm_payload is not None:
                 # Inject `bias` per span for clients pre-PR-6 that read it
                 # alongside the new `weight`/`category`/`justification`.
+                # Clamp spans against the served title length: legacy rows
+                # stored positions on the raw RSS title before the source
+                # suffix was stripped at ingestion, so an end > len(title)
+                # would crash the Flutter DiffTitle layout.
+                title_len = len(p.get("title") or "")
                 p["highlight_spans"] = [
                     {**span, "bias": bias}
-                    for span in llm_payload.get("target_spans") or []
+                    for span in (llm_payload.get("target_spans") or [])
+                    if 0 <= span.get("start", 0)
+                    and span.get("end", 0) <= title_len
+                    and span.get("start", 0) < span.get("end", 0)
                 ]
                 llm_used += 1
             else:

--- a/packages/api/app/services/llm_bias_annotation_service.py
+++ b/packages/api/app/services/llm_bias_annotation_service.py
@@ -16,7 +16,7 @@ from app.services.editorial.llm_client import EditorialLLMClient
 
 logger = structlog.get_logger(__name__)
 
-LLM_VERSION = "mistral-medium-latest-v1"
+LLM_VERSION = "mistral-medium-latest-v2"
 DEFAULT_MODEL = "mistral-medium-latest"
 
 TARGET_CATEGORIES = frozenset(
@@ -98,7 +98,9 @@ Où :
       "désigne", "appelle").
     - entity_alias : nom propre alternatif ("Donald Trump" ⊂ "Trump").
     - geographic_alias : variante d'un lieu.
-    - noise : faits secondaires (titres de films, dates, noms de poste).
+    - noise : faits secondaires (titres de films, dates, noms de poste,
+      noms de médias résiduels comme « - Le Monde », « | Libération »,
+      « – BFMTV » qui auraient échappé au strip backend).
 
 RÈGLES IMPORTANTES :
 - Tes `start`/`end` doivent référer EXACTEMENT à des indices dans le titre

--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -62,6 +62,37 @@ def _parse_entity_names(
 # User-Agent to avoid being blocked by Google News
 USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 
+# Google News RSS titles end with " - Source Name" / " | Source" / " – Source".
+# Stripping at ingestion keeps the source name out of DiffTitle highlight spans
+# (spaCy would otherwise tag « Le Monde » as PROPN and surligher).
+# Primary path: exact match against the known source name from <source>.
+# Fallback regex stays restrictive — uppercase-initial, no colon, no internal
+# separator, ≤ 40 chars — to avoid eating legitimate dash-bearing titles
+# (« Foo - Le Linux de poche… », « Etats-Unis – Iran : … », « … - 26/05 »).
+_SOURCE_SUFFIX_FALLBACK_RE = re.compile(
+    r"\s+[-–|]\s+[A-ZÀ-Ý][A-Za-zÀ-ÿ0-9\s'.&-]{0,40}\s*$"
+)
+
+
+def _strip_source_suffix(title: str, source_name: str | None = None) -> str:
+    """Remove Google News' trailing source-name suffix from an RSS title."""
+    if not title:
+        return title
+    stripped = title.rstrip()
+    if source_name:
+        sn = source_name.strip()
+        if sn:
+            lower_title = stripped.lower()
+            lower_sn = sn.lower()
+            for sep in (" - ", " – ", " | "):
+                suffix = f"{sep}{lower_sn}"
+                if lower_title.endswith(suffix):
+                    return stripped[: -len(suffix)].rstrip()
+    match = _SOURCE_SUFFIX_FALLBACK_RE.search(stripped)
+    if match:
+        return stripped[: match.start()].rstrip()
+    return stripped
+
 # Bias mapping for major French news sources
 DOMAIN_BIAS_MAP = {
     # LEFT
@@ -892,23 +923,27 @@ class PerspectiveService:
                 if title_el is None or link_el is None:
                     continue
 
-                title = title_el.text or ""
+                raw_title = title_el.text or ""
                 link = link_el.text or ""
 
                 # 1. Filter out exact URL match
                 if exclude_url and link == exclude_url:
                     continue
 
-                # 2. Filter out very similar titles (simple exact match or contains for now)
-                # Google News titles often include " - Source Name" at the end
+                source_name = source_el.text if source_el is not None else "Unknown"
+                source_url = source_el.get("url", "") if source_el is not None else ""
+
+                # Strip Google News' "- Source" suffix once, at ingestion.
+                # All downstream consumers (dedup, DiffTitle, LLM annotation)
+                # see a clean title.
+                title = _strip_source_suffix(raw_title, source_name)
+
+                # 2. Filter out very similar titles vs. the reference article
                 if exclude_title:
-                    clean_title = title.split(" - ")[0].strip().lower()
+                    clean_title = title.lower()
                     clean_exclude = exclude_title.strip().lower()
                     if clean_title == clean_exclude or clean_exclude in clean_title:
                         continue
-
-                source_name = source_el.text if source_el is not None else "Unknown"
-                source_url = source_el.get("url", "") if source_el is not None else ""
 
                 # Extract domain from source URL
                 domain = self._extract_domain(source_url)
@@ -935,7 +970,7 @@ class PerspectiveService:
 
                 perspectives.append(
                     Perspective(
-                        title=title_el.text or "",
+                        title=title,
                         url=link_el.text or "",
                         source_name=source_name,
                         source_domain=domain,

--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -93,6 +93,7 @@ def _strip_source_suffix(title: str, source_name: str | None = None) -> str:
         return stripped[: match.start()].rstrip()
     return stripped
 
+
 # Bias mapping for major French news sources
 DOMAIN_BIAS_MAP = {
     # LEFT

--- a/packages/api/tests/routers/test_contents_perspectives_highlights.py
+++ b/packages/api/tests/routers/test_contents_perspectives_highlights.py
@@ -718,6 +718,84 @@ async def test_attach_highlight_spans_invalidates_llm_on_cluster_signature_misma
 
 
 @pytest.mark.asyncio
+async def test_attach_highlight_spans_clamps_out_of_bounds_llm_spans(
+    db_session, cluster_setup
+):
+    """Legacy semantic_equiv rows have positions computed on the raw RSS
+    title (before the source-suffix strip at ingestion). Once the served
+    title is shorter, any `end > len(title)` span must be dropped instead
+    of crashing the Flutter DiffTitle layout."""
+    await _seed_strong_tokens_cache(
+        db_session, cluster_setup, _REF_TOKENS_GAZA, _ALT_TOKENS_GAZA
+    )
+
+    served_title = "Armée israélienne bombarde Gaza"  # 31 chars
+    signature = _cluster_signature(cluster_setup)
+    legacy_spans = [
+        {  # in-bounds — must survive
+            "start": 18,
+            "end": 26,
+            "text": "bombarde",
+            "category": "editorial_angle",
+            "weight": 1.0,
+            "justification": "ok",
+        },
+        {  # end past served title length (stale, raw-title position)
+            "start": 32,
+            "end": 44,
+            "text": "- Le Monde",
+            "category": "noise",
+            "weight": 0.0,
+            "justification": "stale suffix span",
+        },
+        {  # negative start guard
+            "start": -1,
+            "end": 5,
+            "text": "junk",
+            "category": "noise",
+            "weight": 0.0,
+            "justification": "junk",
+        },
+        {  # zero-width
+            "start": 5,
+            "end": 5,
+            "text": "",
+            "category": "noise",
+            "weight": 0.0,
+            "justification": "empty",
+        },
+    ]
+    alt_row = await db_session.get(
+        ClusterTitleAnnotation,
+        (cluster_setup["cluster_id"], cluster_setup["alt_a"].id),
+    )
+    alt_row.semantic_equiv = _llm_payload(legacy_spans, signature)
+    await db_session.commit()
+
+    fake_svc = service_with_nlp(FakeNlp({}))
+    perspectives = [
+        {
+            "title": served_title,
+            "url": cluster_setup["alt_a"].url,
+            "bias_stance": "left",
+        }
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        _, source = await _attach_highlight_spans(
+            db_session, cluster_setup["ref"], perspectives
+        )
+
+    assert source == "llm"
+    spans = perspectives[0]["highlight_spans"]
+    assert len(spans) == 1, f"only the in-bounds span survives, got {spans}"
+    assert spans[0]["text"] == "bombarde"
+    assert spans[0]["end"] <= len(served_title)
+
+
+@pytest.mark.asyncio
 async def test_build_cluster_perspectives_propagates_content_language(db_session):
     """`Perspective.language` mirrors `Content.language` so the endpoint
     list-comp can expose it without an extra DB lookup."""

--- a/packages/api/tests/services/test_llm_bias_annotation_service.py
+++ b/packages/api/tests/services/test_llm_bias_annotation_service.py
@@ -34,7 +34,7 @@ SNAPSHOT_PATH = (
 
 def test_constants_locked():
     """Verrouille les contrats publics du module (cf. plan.md)."""
-    assert LLM_VERSION == "mistral-medium-latest-v1"
+    assert LLM_VERSION == "mistral-medium-latest-v2"
     assert DEFAULT_MODEL == "mistral-medium-latest"
     assert TARGET_CATEGORIES == {
         "editorial_angle",

--- a/packages/api/tests/snapshots/llm_system_prompt.txt
+++ b/packages/api/tests/snapshots/llm_system_prompt.txt
@@ -55,7 +55,9 @@ Où :
       "désigne", "appelle").
     - entity_alias : nom propre alternatif ("Donald Trump" ⊂ "Trump").
     - geographic_alias : variante d'un lieu.
-    - noise : faits secondaires (titres de films, dates, noms de poste).
+    - noise : faits secondaires (titres de films, dates, noms de poste,
+      noms de médias résiduels comme « - Le Monde », « | Libération »,
+      « – BFMTV » qui auraient échappé au strip backend).
 
 RÈGLES IMPORTANTES :
 - Tes `start`/`end` doivent référer EXACTEMENT à des indices dans le titre

--- a/packages/api/tests/test_perspective_service.py
+++ b/packages/api/tests/test_perspective_service.py
@@ -6,6 +6,7 @@ from app.services.perspective_service import (
     PERSPECTIVE_TITLE_JACCARD_MIN,
     Perspective,
     PerspectiveService,
+    _strip_source_suffix,
 )
 from app.services.text_similarity import normalize_title
 
@@ -36,23 +37,86 @@ async def test_perspective_filtering_logic():
     </channel>
     </rss>"""
 
-    # 1. Test without exclusion
+    # 1. Test without exclusion — titles are stripped at ingestion
     results = await service._parse_rss(mock_rss)
     assert len(results) == 3
+    assert [r.title for r in results] == [
+        "Article Original",
+        "Autre Article",
+        "Doublon Titre",
+    ]
 
     # 2. Test with URL exclusion
     results_url = await service._parse_rss(mock_rss, exclude_url="http://lemonde.fr/article1")
     assert len(results_url) == 2
-    assert results_url[0].title == "Autre Article - Figaro"
+    assert results_url[0].title == "Autre Article"
 
-    # 3. Test with Title exclusion (similarity check)
-    # The logic splits by " - " and compares
+    # 3. Test with Title exclusion (similarity check on stripped title)
     results_title = await service._parse_rss(mock_rss, exclude_title="Doublon Titre")
-    assert len(results_title) == 2
-    assert results_title[1].title == "Autre Article - Figaro"  # Order might change due to set, but here list
-    # Actually Liberation was the 3rd one.
     titles = [r.title for r in results_title]
-    assert "Doublon Titre - Libe" not in titles
+    assert "Doublon Titre" not in titles
+    assert len(results_title) == 2
+
+
+def test_strip_source_suffix_uses_known_source_name():
+    """Primary path: exact match against <source> element."""
+    assert (
+        _strip_source_suffix("Macron annonce une réforme - Le Monde", "Le Monde")
+        == "Macron annonce une réforme"
+    )
+    # Em-dash variant
+    assert (
+        _strip_source_suffix("Sujet brûlant – Libération", "Libération")
+        == "Sujet brûlant"
+    )
+    # Pipe variant
+    assert (
+        _strip_source_suffix("Headline | The Guardian", "The Guardian")
+        == "Headline"
+    )
+    # Case-insensitive
+    assert (
+        _strip_source_suffix("Foo - LE MONDE", "Le Monde") == "Foo"
+    )
+
+
+def test_strip_source_suffix_fallback_regex_when_source_mismatches():
+    """When <source> doesn't match (Google News localized variant), fallback."""
+    # `Figaro` doesn't equal `Le Figaro` exactly → fallback regex catches it.
+    assert (
+        _strip_source_suffix("Autre Article - Figaro", "Le Figaro")
+        == "Autre Article"
+    )
+
+
+def test_strip_source_suffix_preserves_legitimate_dash_titles():
+    """Hyphens in real titles must NOT trigger a strip."""
+    # Suffix too long (>40 chars after separator)
+    assert (
+        _strip_source_suffix(
+            "Flipper One - Le Linux de poche qui terrifie ses propres créateurs",
+            None,
+        )
+        == "Flipper One - Le Linux de poche qui terrifie ses propres créateurs"
+    )
+    # Contains a colon → not a source suffix
+    assert (
+        _strip_source_suffix(
+            "Accord États-Unis – Iran : Finkielkraut espère", None
+        )
+        == "Accord États-Unis – Iran : Finkielkraut espère"
+    )
+    # Numeric date suffix (Google News-style timestamp on radio shows)
+    assert (
+        _strip_source_suffix("Le Grand entretien - 26/05", None)
+        == "Le Grand entretien - 26/05"
+    )
+
+
+def test_strip_source_suffix_handles_empty_and_whitespace():
+    assert _strip_source_suffix("", "Le Monde") == ""
+    assert _strip_source_suffix("Foo - Le Monde  ", "Le Monde") == "Foo"
+    assert _strip_source_suffix("Foo", "Le Monde") == "Foo"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# fix(perspectives): strip source suffix backend + intro inline + clamp legacy spans

## Contexte

Trois symptômes en prod sur la feature « Diff Highlighting » (Story 7.4) :

1. **Tout au même alpha** — pas de niveau de surlignage différencié visible.
2. **Aucun texte d'intro** dans la vue inline « Couverture médiatique » du
   reader d'article (seul le modal en avait un).
3. **Noms de journaux surlignés à tort** (`« - Le Monde »`, `« | Libération »`)
   et un strip client fragile qui décalait les positions.

Diagnostic SQL prod confirmé avant code :

| | Résultat |
|---|---|
| `cluster_title_annotations` (LLM) | **0 rows** |
| `contents.cluster_id` 7j | **0 / 13 532** |
| `MISTRAL_API_KEY` Railway | présent (autres uses-cases du matin OK) |

→ Symptôme 1 est ops : `_persist_content_cluster_ids` ne produit pas en prod
malgré Sprint 3 mergé. À traiter hors PR — cette PR couvre uniquement les
symptômes 2 + 3 et prépare le terrain pour quand les annotations LLM
arriveront enfin.

## Changements

### Backend

- **`perspective_service.py`** : nouveau `_strip_source_suffix(title,
  source_name)` appliqué à l'ingestion RSS Google News. Path primaire = match
  exact contre `<source>` (100% safe). Fallback regex restrictive
  `\s+[-–|]\s+[A-ZÀ-Ý][A-Za-zÀ-ÿ0-9\s'.&-]{0,40}\s*$` : 7,3% des titres prod
  matchent un séparateur, mais l'échantillon de 30 montre que la regex large
  initialement proposée aurait massacré des titres légitimes
  (`« Flipper One - Le Linux de poche qui terrifie ses propres créateurs »`,
  `« Etats-Unis – Iran : Finkielkraut espère »`, suffixes
  `« - 26/05 »`). La regex restreinte (uppercase initial, pas de `:`,
  ≤ 40 chars) les préserve. Dedup `title.split(" - ")[0]` retirée — devenue
  redondante puisque le titre stocké est déjà clean.

- **`routers/contents.py` `_attach_highlight_spans`** : clamp défensif des
  spans LLM lus depuis `semantic_equiv` (`0 <= start < end <= len(title)`).
  Protège la mise en page Flutter contre les rows historiques calculés sur
  les titres bruts pré-strip.

- **`llm_bias_annotation_service.py`** : prompt enrichi — la catégorie
  `exclude_spans.noise` mentionne explicitement les suffixes médias résiduels.
  `LLM_VERSION` → `mistral-medium-latest-v2`, snapshot regénéré (anti-dérive
  silencieuse). Safe : 0 annotations existantes en prod à invalider.

### Frontend

- **`perspectives_bottom_sheet.dart`** :
  - `kHighlightIntroText` extrait en constante partagée (single source of
    truth pour modal + inline).
  - `_PerspectiveCard.build()` : strip client `.replaceAll(RegExp(...))`
    retiré, simple `.trim()` puisque l'API émet désormais des titres clean.
  - `_buildExpandedBody` (vue inline « Couverture médiatique » expanded
    dans le reader) : intro 2 lignes ajoutée en haut du groupe, une seule
    fois, conditionnelle sur `variants.isNotEmpty`.

## Tests

- `tests/test_perspective_service.py` : 4 nouveaux tests
  (`test_strip_source_suffix_*`) — primary path, fallback, préservation des
  titres légitimes avec tirets, vides/whitespace. Fixture existante mise à
  jour pour refléter le strip à l'ingestion.
- `tests/routers/test_contents_perspectives_highlights.py` :
  `test_attach_highlight_spans_clamps_out_of_bounds_llm_spans` — span valide
  conservé, end > len(title) / start négatif / zero-width tous filtrés.
- `tests/snapshots/llm_system_prompt.txt` : regénéré.
- `apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart`
  (nouveau) : intro présente en mode expanded avec perspectives, absente si
  vide ou collapsé. Le widget test du modal existant continue à passer grâce
  à la constante partagée.

### Résultats

```
472 passed  (pytest tests/routers/ tests/services/ tests/editorial/ tests/test_perspective_service.py)
48  passed  (flutter test test/features/feed/widgets/)
```

`flutter analyze` : 0 nouvel issue sur les fichiers modifiés.

## Test plan

- [x] `pytest -q` backend sweep complet sur les zones touchées
- [x] `flutter test test/features/feed/widgets/`
- [x] `flutter analyze` sur `perspectives_bottom_sheet.dart`
- [x] Échantillon prod (30 titres) confirme que la regex restrictive ne casse
      pas les titres légitimes
- [ ] **À faire post-merge** : ouvrir un article avec ≥ 2 perspectives,
      vérifier (a) l'intro 2 lignes apparait en haut de la section
      « Couverture médiatique » expanded, (b) aucun titre n'affiche
      ` - Source` en clair, (c) `curl -D - .../perspectives | grep -i x-bias`
      pour le header (restera `spacy` tant que ops n'a pas réparé le
      pipeline LLM annotation — suivi séparé).

## Suivi ops (hors PR)

`with_llm=0` et `clustered=0/13532` indiquent que `_persist_content_cluster_ids`
ne tourne pas en prod malgré Sprint 3 mergé ce matin (#698). La clé Mistral
est fonctionnelle. Hypothèses à investiguer côté ops :

- Le pipeline 07:30 a-t-il tourné depuis le merge de #698 ?
- Si oui, regarder les logs Railway pour `editorial.llm_annotation.*` /
  `editorial.persist_cluster_ids.*`.