### PR TITLE
feat(feed): citation du jour disponible en mode normal + sérène

### DIFF
--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -312,6 +312,10 @@ class FluxContinuState {
   // suivant" or scroll-past detection). The section stays expanded on screen
   // — only the in-session indicator on the "Sujet suivant" button flips.
   final Set<String> markedForNextSession;
+  // Citation du jour — rendue comme clôture éditoriale juste avant
+  // ClosingCardV18 ("Fin de tournée"). Déterministe (seed = user_id + date)
+  // côté backend, disponible dans les deux modes normal + sérène.
+  final QuoteResponse? quote;
   final bool isLoading;
   final Object? error;
 
@@ -323,6 +327,7 @@ class FluxContinuState {
     this.closingDismissed = false,
     this.dismissedIds = const {},
     this.markedForNextSession = const {},
+    this.quote,
     this.isLoading = true,
     this.error,
   });
@@ -335,6 +340,7 @@ class FluxContinuState {
     bool? closingDismissed,
     Set<String>? dismissedIds,
     Set<String>? markedForNextSession,
+    QuoteResponse? quote,
     bool? isLoading,
     Object? error,
     bool clearError = false,
@@ -348,6 +354,7 @@ class FluxContinuState {
       dismissedIds: dismissedIds ?? this.dismissedIds,
       markedForNextSession:
           markedForNextSession ?? this.markedForNextSession,
+      quote: quote ?? this.quote,
       isLoading: isLoading ?? this.isLoading,
       error: clearError ? null : (error ?? this.error),
     );

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -131,6 +131,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   Map<String, bool> _moreOpen = const {};
   Map<String, bool> _folded = const {};
   bool _closingDismissed = false;
+  // Citation du jour servie par le backend (sérène ou normal — même pool
+  // YAML, sélection déterministe seed = user_id + date). Rendue avant
+  // ClosingCardV18 comme clôture éditoriale de la tournée.
+  QuoteResponse? _quote;
   final Set<String> _dismissedIds = <String>{};
 
   /// Sections marked as "consumed" during this session via the scroll-past
@@ -230,6 +234,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       illustration: _kBonnesIllustration,
       coreVisibleCount: isSerene ? 4 : 2,
     );
+    // Citation du jour — même pool dans les deux digests (déterministe par
+    // user/date), on prend le sérène par défaut et on retombe sur le normal
+    // si seul l'un des deux a réussi.
+    _quote = dual?.serein?.quote ?? dual?.normal?.quote;
 
     final favorites = _pickFavorites(topThemes);
     _lastFavorites = favorites;
@@ -299,6 +307,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       closingDismissed: _closingDismissed,
       dismissedIds: Set.unmodifiable(_dismissedIds),
       markedForNextSession: Set.unmodifiable(_persistQueued),
+      quote: _quote,
       isLoading: false,
     );
   }

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -34,6 +34,7 @@ import '../../well_informed/widgets/well_informed_prompt.dart';
 import '../../../shared/widgets/loaders/loading_view.dart';
 import '../models/flux_continu_models.dart';
 import '../providers/flux_continu_provider.dart';
+import '../widgets/citation_du_jour_card.dart';
 import '../widgets/closing_card_v18.dart';
 import '../widgets/flux_continu_article_card.dart';
 import '../widgets/my_interests_intro.dart';
@@ -922,6 +923,23 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
           if (state.sections.isEmpty)
             SliverToBoxAdapter(
               child: _EmptySectionsHint(onRetry: notifier.refresh),
+            ),
+          // Citation du jour — clôture éditoriale juste avant "Fin de
+          // tournée". Liée au même flag closingDismissed pour rester
+          // cohérente avec le "moment de fermeture". Quand la tournée est
+          // entièrement repliée et que le `TourneeFoldedGroupCard` se
+          // présente seul, on masque aussi la citation pour ne pas
+          // apparaître au-dessus de ce toggle compact.
+          if (state.quote != null && !state.closingDismissed)
+            SliverToBoxAdapter(
+              child: allFolded
+                  ? ValueListenableBuilder<bool>(
+                      valueListenable: _tourneeGroupExpanded,
+                      builder: (_, expanded, __) => expanded
+                          ? CitationDuJourCard(quote: state.quote!)
+                          : const SizedBox.shrink(),
+                    )
+                  : CitationDuJourCard(quote: state.quote!),
             ),
           SliverToBoxAdapter(
             child: state.closingDismissed

--- a/apps/mobile/lib/features/flux_continu/widgets/citation_du_jour_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/citation_du_jour_card.dart
@@ -1,0 +1,104 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../../digest/models/digest_models.dart';
+
+/// Citation du jour — clôture éditoriale de la Tournée du jour, rendue juste
+/// avant `ClosingCardV18`. Pool YAML curé côté backend, sélection
+/// déterministe seed = user_id + date (même citation toute la journée).
+///
+/// Style aligné sur `ClosingCardV18` (surface, radius 16, shadow alpha 0.06)
+/// mais nettement plus sobre : tampon brun chaud distinct du vert "fin de
+/// tournée", pas de CTA, pas d'illustration.
+class CitationDuJourCard extends StatelessWidget {
+  final QuoteResponse quote;
+
+  const CitationDuJourCard({super.key, required this.quote});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    const stampColor = Color(0xFF8D6E63);
+    return Container(
+      margin: const EdgeInsets.fromLTRB(18, 24, 18, 8),
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.06),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(22, 22, 22, 22),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Transform.rotate(
+              angle: -2 * math.pi / 180,
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  border: Border.all(color: stampColor, width: 1.5),
+                ),
+                child: Text(
+                  'CITATION DU JOUR',
+                  style: GoogleFonts.courierPrime(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w700,
+                    color: stampColor,
+                    letterSpacing: 2.0,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 320),
+              child: Text(
+                '« ${quote.text} »',
+                textAlign: TextAlign.center,
+                style: GoogleFonts.fraunces(
+                  fontSize: 18,
+                  fontStyle: FontStyle.italic,
+                  height: 1.45,
+                  color: colors.textPrimary,
+                ),
+              ),
+            ),
+            const SizedBox(height: 14),
+            Container(
+              height: 1,
+              width: 24,
+              color: colors.textPrimary.withValues(alpha: 0.08),
+            ),
+            const SizedBox(height: 10),
+            Text(
+              _attribution(quote),
+              textAlign: TextAlign.center,
+              style: GoogleFonts.dmSans(
+                fontSize: 12,
+                height: 1.4,
+                color: colors.textSecondary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _attribution(QuoteResponse q) {
+    final source = q.source;
+    if (source == null || source.isEmpty) return '— ${q.author}';
+    return '— ${q.author}, $source';
+  }
+}

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -2379,16 +2379,16 @@ class DigestService:
                     label=subject.get("label", ""),
                 )
 
-        # Quote for serein digest only
+        # Citation du jour — disponible dans les deux modes (normal + sérène),
+        # rendue côté mobile comme clôture éditoriale avant "Fin de tournée".
         quote_response = None
-        if digest.is_serene:
-            q = _select_daily_quote(str(digest.user_id), str(digest.target_date))
-            if q:
-                quote_response = QuoteResponse(
-                    text=q["text"],
-                    author=q["author"],
-                    source=q.get("source"),
-                )
+        q = _select_daily_quote(str(digest.user_id), str(digest.target_date))
+        if q:
+            quote_response = QuoteResponse(
+                text=q["text"],
+                author=q["author"],
+                source=q.get("source"),
+            )
 
         # Sans ce plafond, la barre de progression mobile exigerait
         # l'épuisement des 10 sujets backend même quand la pref user en
@@ -2580,16 +2580,15 @@ class DigestService:
                 )
             )
 
-        # Quote for serein digest only
+        # Citation du jour — disponible dans les deux modes (normal + sérène).
         quote_response = None
-        if digest.is_serene:
-            q = _select_daily_quote(str(digest.user_id), str(digest.target_date))
-            if q:
-                quote_response = QuoteResponse(
-                    text=q["text"],
-                    author=q["author"],
-                    source=q.get("source"),
-                )
+        q = _select_daily_quote(str(digest.user_id), str(digest.target_date))
+        if q:
+            quote_response = QuoteResponse(
+                text=q["text"],
+                author=q["author"],
+                source=q.get("source"),
+            )
 
         return DigestResponse(
             digest_id=digest.id,


### PR DESCRIPTION
## What

Extends the "citation du jour" feature from serene digest mode to both normal and serene modes. Adds a new  widget rendered as an editorial closing card just before "Fin de tournée" in the flux continu feed.

## Why

All users now receive the same daily curated quote regardless of their reading mode preference. The quote uses the same deterministic YAML pool (seed = user_id + date), ensuring consistency across both digest variants.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)