### PR TITLE
feat(sticky-header): avatar button + earlier Flâner trigger

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -53,6 +53,10 @@ const double _kStickyThreshold = 60.0;
 /// behind the bar.
 const double _kStickyBarHeight = 100.0;
 
+/// Extra lookahead (px) before the Explorer banner reaches the sticky bottom
+/// at which we flip to Explorer mode — makes the "Flâner" tab activate earlier.
+const double _kExploreLeadPx = 120.0;
+
 /// Distance to the bottom (in px) before we trigger the next feed page.
 const double _kLoadMoreLeadingPx = 800.0;
 
@@ -250,7 +254,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     final box = ctx.findRenderObject();
     if (box is! RenderBox || !box.attached) return;
     final topY = box.localToGlobal(Offset.zero).dy;
-    final shouldExplore = topY < _kStickyBarHeight;
+    final shouldExplore = topY < _kStickyBarHeight + _kExploreLeadPx;
     if (_isInExploreMode.value != shouldExplore) {
       _isInExploreMode.value = shouldExplore;
     }

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../feed/providers/feed_provider.dart';
 import '../../feed/widgets/feed_filter_bar.dart';
+import '../../feed/widgets/profile_avatar_button.dart';
 import 'sticky_backdrop.dart';
 
 /// Lightweight descriptor for a sticky tab. Used by [StickyTabBar] so the
@@ -71,7 +74,7 @@ class StickyTabBar extends StatelessWidget {
             controller: tabsController,
           ),
           SizedBox(
-            height: 6,
+            height: 4,
             child: CustomPaint(
               painter: _ProgressPainter(
                 progress: progress.clamp(0.0, 1.0),
@@ -128,15 +131,15 @@ class _FeedRefreshIndicatorStrip extends ConsumerWidget {
   }
 }
 
-/// Top row of the sticky overlay — a single Fraunces label that names the
-/// current zone of the Flux Continu screen.
-class StickyHead extends StatelessWidget {
+/// Top row of the sticky overlay — a Fraunces label naming the current zone
+/// and a profile avatar button anchored to the right.
+class StickyHead extends ConsumerWidget {
   final String title;
 
   const StickyHead({super.key, this.title = 'Tournée du jour'});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 6),
@@ -149,6 +152,10 @@ class StickyHead extends StatelessWidget {
               fontWeight: FontWeight.w700,
               color: colors.textPrimary,
             ),
+          ),
+          const Spacer(),
+          ProfileAvatarButton(
+            onTap: () => context.push(RoutePaths.settings),
           ),
         ],
       ),


### PR DESCRIPTION
## What

Micro-ajustements du sticky header du Flux Continu : ajout d'un bouton avatar profil (→ settings) sur la droite du `StickyHead`, déclenchement anticipé du mode Flâner (+120 px de lookahead), et légère réduction de la barre de progression (6→4 px).

## Why

Améliore la navigabilité : l'accès aux settings est accessible depuis le header permanent, et la transition vers le mode Flâner s'active plus tôt pour une expérience plus fluide.

## Type

- [x] Feature

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)