### PR TITLE
fix(serene): propagate serein pref to essentiel digest + fix section order

### DIFF
--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -246,11 +246,11 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   FluxContinuState _compose(bool isSerene) {
     final ordered = <FluxSection>[];
     if (isSerene) {
-      // Mode sérène — Bonnes Nouvelles d'abord, puis les thèmes,
-      // puis la carte hi-fi v3 et la section "Actus du jour" en fin de page.
+      // Mode sérène — "L'Essentiel du jour" reste en tête (parité avec le
+      // mode normal), puis Bonnes Nouvelles, thèmes favoris, "Actus du jour".
+      if (_essentiel != null) ordered.add(_essentiel!);
       if (_bonnes != null) ordered.add(_bonnes!);
       ordered.addAll(_themes);
-      if (_essentiel != null) ordered.add(_essentiel!);
       if (_actusDuJour != null) ordered.add(_actusDuJour!);
     } else {
       // Mode normal — carte hi-fi v3 ("L'Essentiel du jour"),

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -260,7 +260,7 @@ async def get_both_digests(
         return _preparing_response()
 
     service = DigestService(db)
-    serein_enabled = await service._get_user_serein_enabled(user_uuid)
+    serein_enabled = await service.get_user_serein_enabled(user_uuid)
 
     if normal is not None:
         normal = await _enrich_community_carousel(db, user_uuid, normal)

--- a/packages/api/app/routers/essentiel.py
+++ b/packages/api/app/routers/essentiel.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.schemas.essentiel import EssentielResponse
-from app.services.digest_service import read_digest_or_fallback
+from app.services.digest_service import DigestService, read_digest_or_fallback
 from app.services.essentiel_service import (
     build_essentiel_response,
     fetch_user_essentiel_context,
@@ -60,8 +60,10 @@ async def get_essentiel(
     effective_date = target_date or today_paris()
     start = time.monotonic()
 
+    service = DigestService(db)
+    serein_enabled = await service.get_user_serein_enabled(user_uuid)
     digest = await read_digest_or_fallback(
-        db, user_uuid, effective_date, is_serene=False
+        db, user_uuid, effective_date, is_serene=serein_enabled
     )
     if digest is None:
         return _preparing_response()
@@ -78,6 +80,7 @@ async def get_essentiel(
         elapsed_ms=round((time.monotonic() - start) * 1000, 1),
         articles_count=len(response.articles),
         is_stale_fallback=response.is_stale_fallback,
+        serein_enabled=serein_enabled,
         followed_sources_count=len(user_context.followed_source_ids),
         topic_weights_count=len(user_context.topic_weights),
     )

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -2831,7 +2831,7 @@ class DigestService:
             "message": message,
         }
 
-    async def _get_user_serein_enabled(self, user_id: UUID) -> bool:
+    async def get_user_serein_enabled(self, user_id: UUID) -> bool:
         """Lit la préférence serein_enabled depuis user_preferences."""
         from app.models.user import UserPreference, UserProfile
 

--- a/packages/api/tests/test_digest_readonly_hotpath.py
+++ b/packages/api/tests/test_digest_readonly_hotpath.py
@@ -535,7 +535,7 @@ async def test_get_both_returns_200_with_one_variant_present():
         with (
             patch("app.routers.digest.read_digest_or_fallback", new=fake_resolver),
             patch(
-                "app.routers.digest.DigestService._get_user_serein_enabled",
+                "app.routers.digest.DigestService.get_user_serein_enabled",
                 new=AsyncMock(return_value=False),
             ),
             patch(

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -227,6 +227,10 @@ async def test_get_essentiel_returns_5_articles(auth_override: UUID):
             "app.routers.essentiel.fetch_user_essentiel_context",
             new=AsyncMock(return_value=EssentielUserContext()),
         ),
+        patch(
+            "app.routers.essentiel.DigestService.get_user_serein_enabled",
+            new=AsyncMock(return_value=False),
+        ),
     ):
         async with _client() as client:
             resp = await client.get("/api/essentiel")
@@ -242,9 +246,15 @@ async def test_get_essentiel_returns_5_articles(auth_override: UUID):
 
 @pytest.mark.asyncio
 async def test_get_essentiel_returns_202_when_no_digest(auth_override: UUID):
-    with patch(
-        "app.routers.essentiel.read_digest_or_fallback",
-        new=AsyncMock(return_value=None),
+    with (
+        patch(
+            "app.routers.essentiel.read_digest_or_fallback",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.routers.essentiel.DigestService.get_user_serein_enabled",
+            new=AsyncMock(return_value=False),
+        ),
     ):
         async with _client() as client:
             resp = await client.get("/api/essentiel")
@@ -278,6 +288,10 @@ async def test_get_essentiel_propagates_stale_fallback(auth_override: UUID):
         patch(
             "app.routers.essentiel.fetch_user_essentiel_context",
             new=AsyncMock(return_value=EssentielUserContext()),
+        ),
+        patch(
+            "app.routers.essentiel.DigestService.get_user_serein_enabled",
+            new=AsyncMock(return_value=False),
         ),
     ):
         async with _client() as client:
@@ -681,10 +695,14 @@ async def test_get_essentiel_uses_user_context_from_router(auth_override: UUID):
         patch(
             "app.routers.essentiel.read_digest_or_fallback",
             new=AsyncMock(return_value=digest),
-        ),
+        ) as mock_read,
         patch(
             "app.routers.essentiel.fetch_user_essentiel_context",
             new=AsyncMock(return_value=fake_ctx),
+        ),
+        patch(
+            "app.routers.essentiel.DigestService.get_user_serein_enabled",
+            new=AsyncMock(return_value=False),
         ),
     ):
         async with _client() as client:
@@ -694,6 +712,36 @@ async def test_get_essentiel_uses_user_context_from_router(auth_override: UUID):
     body = resp.json()
     assert body["articles"][0]["source"]["name"] == "Mediapart"
     assert body["articles"][0]["rank"] == 1
+    assert mock_read.await_args.kwargs["is_serene"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_essentiel_serein_user_fetches_serein_digest(
+    auth_override: UUID,
+):
+    """serein_enabled=True propagates is_serene=True to read_digest_or_fallback."""
+    topics = [_make_topic(rank=1, label="Tech", n_articles=3)]
+    digest = _make_digest(topics)
+
+    with (
+        patch(
+            "app.routers.essentiel.read_digest_or_fallback",
+            new=AsyncMock(return_value=digest),
+        ) as mock_read,
+        patch(
+            "app.routers.essentiel.fetch_user_essentiel_context",
+            new=AsyncMock(return_value=EssentielUserContext()),
+        ),
+        patch(
+            "app.routers.essentiel.DigestService.get_user_serein_enabled",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        async with _client() as client:
+            resp = await client.get("/api/essentiel")
+
+    assert resp.status_code == 200
+    assert mock_read.await_args.kwargs["is_serene"] is True
 
 
 # ─── Story 9.4 — Durcissement des filtres ────────────────────────────────


### PR DESCRIPTION
## Quoi

Deux bugs liés au mode sérène :
1. **Backend** : `GET /api/essentiel` hardcodait `is_serene=False`, ignorant la préférence utilisateur
2. **Mobile** : en mode sérène, `_compose()` plaçait "L'Essentiel du jour" après "Bonnes Nouvelles" au lieu de le garder en tête (comme en mode normal)

## Pourquoi

Les utilisateurs ayant activé le mode sérène recevaient le digest normal (non filtré) et voyaient "L'Essentiel du jour" repositionné en milieu de feed, cassant la parité visuelle avec le mode normal.

## Comment ça a été vérifié

- [x] pytest — 44 tests essentiel OK (dont nouveau test `test_get_essentiel_serein_user_fetches_serein_digest`)
- [x] flutter test — 22 tests flux_continu_provider OK
- [x] flutter analyze — aucun nouvel avertissement dans les fichiers modifiés
- [x] /simplify passé — `_get_user_serein_enabled` rendu public, commentaires parasites supprimés

## Zones à risque

- `DigestService.get_user_serein_enabled` : méthode renommée de privée → publique (les mocks de test mis à jour)
- `read_digest_or_fallback` : reçoit maintenant `is_serene` dynamique au lieu de `False` hardcodé