### PR TITLE
feat(tournee): top 3 « essentiel-grade » sur sections thématiques

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,109 +1,62 @@
-# fix(perspectives): strip source suffix backend + intro inline + clamp legacy spans
+# PR — Top 3 "essentiel-grade" sur sections thématiques (Tournée du jour)
 
-## Contexte
+## Pourquoi
 
-Trois symptômes en prod sur la feature « Diff Highlighting » (Story 7.4) :
+Sur Tournée du jour, chaque section thématique affichait 3 articles en pur ordre chronologique (Story 21.2 avait désactivé tout scoring pour éviter une sur-compression). Conséquence : le top 3 était souvent "plat" — 3 articles récents mais sans le bénéfice des signaux forts disponibles (cluster multi-sources, custom topics, qualité éditoriale). L'objectif est de promouvoir 3 articles vraiment "essentiels" sans casser la sémantique « Voir tout » chronologique.
 
-1. **Tout au même alpha** — pas de niveau de surlignage différencié visible.
-2. **Aucun texte d'intro** dans la vue inline « Couverture médiatique » du
-   reader d'article (seul le modal en avait un).
-3. **Noms de journaux surlignés à tort** (`« - Le Monde »`, `« | Libération »`)
-   et un strip client fragile qui décalait les positions.
+## Ce qui change
 
-Diagnostic SQL prod confirmé avant code :
+### Cœur de la PR (Axes A1 + A3 + B3 + D2 du plan)
 
-| | Résultat |
-|---|---|
-| `cluster_title_annotations` (LLM) | **0 rows** |
-| `contents.cluster_id` 7j | **0 / 13 532** |
-| `MISTRAL_API_KEY` Railway | présent (autres uses-cases du matin OK) |
+**Coverage bonus (A1)** : `PertinencePillar` lit `cluster_source_counts` depuis le contexte et applique un bonus log-calibré `min(30, 12·log2(n))` pour les articles dont le cluster est couvert par plusieurs sources distinctes dans les 24h. Un scoop isolé ne reçoit rien ; un sujet à 5 médias récupère ~28 pts.
 
-→ Symptôme 1 est ops : `_persist_content_cluster_ids` ne produit pas en prod
-malgré Sprint 3 mergé. À traiter hors PR — cette PR couvre uniquement les
-symptômes 2 + 3 et prépare le terrain pour quand les annotations LLM
-arriveront enfin.
+**Diversification (A3)** : passe finale `diversify()` par `cluster_id` (fallback `topic_slug`) sur le top 3 des sections thématiques personnalisées. Mode "souple" — si on n'a pas 3 clusters distincts, on relâche pour ne jamais retourner moins de 3 cartes.
 
-## Changements
+**Custom topic boost (B3)** : `CUSTOM_TOPIC_BASE_BONUS` 15 → 25. Le signal d'intention le plus précis dont on dispose pèse maintenant ~50 pts max (multiplier 2.0), au niveau d'un `TRUSTED_SOURCE`.
 
-### Backend
+**Quality floor (D2)** : avant la diversification top 3, on exclut les articles sans visuel + sans contenu in-app + résumé < 100 caractères. Fallback gracieux si le pool devient trop pauvre.
 
-- **`perspective_service.py`** : nouveau `_strip_source_suffix(title,
-  source_name)` appliqué à l'ingestion RSS Google News. Path primaire = match
-  exact contre `<source>` (100% safe). Fallback regex restrictive
-  `\s+[-–|]\s+[A-ZÀ-Ý][A-Za-zÀ-ÿ0-9\s'.&-]{0,40}\s*$` : 7,3% des titres prod
-  matchent un séparateur, mais l'échantillon de 30 montre que la regex large
-  initialement proposée aurait massacré des titres légitimes
-  (`« Flipper One - Le Linux de poche qui terrifie ses propres créateurs »`,
-  `« Etats-Unis – Iran : Finkielkraut espère »`, suffixes
-  `« - 26/05 »`). La regex restreinte (uppercase initial, pas de `:`,
-  ≤ 40 chars) les préserve. Dedup `title.split(" - ")[0]` retirée — devenue
-  redondante puisque le titre stocké est déjà clean.
+### Mutualisation (partie B + C du plan)
 
-- **`routers/contents.py` `_attach_highlight_spans`** : clamp défensif des
-  spans LLM lus depuis `semantic_equiv` (`0 <= start < end <= len(title)`).
-  Protège la mise en page Flutter contre les rows historiques calculés sur
-  les titres bruts pré-strip.
+Helpers partagés (nouveaux) :
+- `packages/api/app/services/recommendation/helpers/coverage_score.py` → `compute_coverage_score(n)`
+- `packages/api/app/services/recommendation/helpers/diversification.py` → `diversify(items, key_fn, ...)`
 
-- **`llm_bias_annotation_service.py`** : prompt enrichi — la catégorie
-  `exclude_spans.noise` mentionne explicitement les suffixes médias résiduels.
-  `LLM_VERSION` → `mistral-medium-latest-v2`, snapshot regénéré (anti-dérive
-  silencieuse). Safe : 0 annotations existantes en prod à invalider.
+Consolidation `scoring_config.py` :
+- `COVERAGE_BASE = 12.0`, `COVERAGE_CAP = 30.0` (canoniques)
+- Aliases rétrocompat : `ESSENTIEL_PERSPECTIVE_BASE/CAP`
+- Aliases canoniques : `TOPIC_IS_TRENDING_BONUS = TOPIC_TRENDING_BONUS = 50`, `TOPIC_IS_UNE_BONUS = TOPIC_UNE_BONUS = 35`
 
-### Frontend
-
-- **`perspectives_bottom_sheet.dart`** :
-  - `kHighlightIntroText` extrait en constante partagée (single source of
-    truth pour modal + inline).
-  - `_PerspectiveCard.build()` : strip client `.replaceAll(RegExp(...))`
-    retiré, simple `.trim()` puisque l'API émet désormais des titres clean.
-  - `_buildExpandedBody` (vue inline « Couverture médiatique » expanded
-    dans le reader) : intro 2 lignes ajoutée en haut du groupe, une seule
-    fois, conditionnelle sur `variants.isNotEmpty`.
+Migration `essentiel_service.py` (fonctionnellement équivalent côté code mais ajustement de valeurs) :
+- `_perspective_score()` délègue à `compute_coverage_score()`
+- `_W_TRENDING` : 40 → 50 (= `TOPIC_IS_TRENDING_BONUS`)
+- `_W_UNE` : 30 → 35 (= `TOPIC_IS_UNE_BONUS`)
+- ⚠️ Trade-off documenté : on aligne sur les valeurs déjà en prod côté digest topics (plus largement déployées) plutôt que sur les valeurs historiques d'Essentiel.
 
 ## Tests
 
-- `tests/test_perspective_service.py` : 4 nouveaux tests
-  (`test_strip_source_suffix_*`) — primary path, fallback, préservation des
-  titres légitimes avec tirets, vides/whitespace. Fixture existante mise à
-  jour pour refléter le strip à l'ingestion.
-- `tests/routers/test_contents_perspectives_highlights.py` :
-  `test_attach_highlight_spans_clamps_out_of_bounds_llm_spans` — span valide
-  conservé, end > len(title) / start négatif / zero-width tous filtrés.
-- `tests/snapshots/llm_system_prompt.txt` : regénéré.
-- `apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart`
-  (nouveau) : intro présente en mode expanded avec perspectives, absente si
-  vide ou collapsé. Le widget test du modal existant continue à passer grâce
-  à la constante partagée.
+Nouveaux (`packages/api/tests/recommendation/`) :
+- `test_coverage_score.py` (4 tests) — monotonie log2, cap, singleton.
+- `test_diversification.py` (7 tests) — strict, souple, max_per_key=N, None-keys.
+- `test_pertinence_coverage.py` (5 tests) — bonus appliqué + label correct + stacking avec THEME_MATCH.
 
-### Résultats
+Suite existante :
+- `tests/test_essentiel_endpoint.py` : 33 tests passent (les valeurs `_W_TRENDING/UNE` sont importées comme symboles, pas codées en dur dans les assertions).
+- `tests/recommendation/` : pertinence existants OK.
+- `tests/test_feed_filters.py`, `tests/test_feed_followed_first_stratification.py`, `tests/test_digest_selector.py` : 46 tests OK.
+- `tests/test_custom_topics.py` (sous-classes non-DB) : 13 tests OK (assertion de calibration mise à jour).
 
-```
-472 passed  (pytest tests/routers/ tests/services/ tests/editorial/ tests/test_perspective_service.py)
-48  passed  (flutter test test/features/feed/widgets/)
-```
+## Hors scope (PR 2 / 3 du plan)
 
-`flutter analyze` : 0 nouvel issue sur les fichiers modifiés.
+- C1/C3 affinity (source × topic, save/like adjacency) — table matérialisée à venir.
+- B1 multiplicateur subtopic weight — déjà partiellement appliqué via `_score_subtopics`, à étendre.
+- Centralisation du filtrage mute (`mute_helpers.py`) — PR 3 dédiée (risque indépendant, scope trop large).
+- `is_une`/`is_trending` direct au feed — non exposés au niveau Content (calculés par `ImportanceDetector` côté digest). Le bonus de couverture (≥3 sources distinctes) capture l'équivalent `is_trending` opérationnel.
 
-## Test plan
+## Test plan QA
 
-- [x] `pytest -q` backend sweep complet sur les zones touchées
-- [x] `flutter test test/features/feed/widgets/`
-- [x] `flutter analyze` sur `perspectives_bottom_sheet.dart`
-- [x] Échantillon prod (30 titres) confirme que la regex restrictive ne casse
-      pas les titres légitimes
-- [ ] **À faire post-merge** : ouvrir un article avec ≥ 2 perspectives,
-      vérifier (a) l'intro 2 lignes apparait en haut de la section
-      « Couverture médiatique » expanded, (b) aucun titre n'affiche
-      ` - Source` en clair, (c) `curl -D - .../perspectives | grep -i x-bias`
-      pour le header (restera `spacy` tant que ops n'a pas réparé le
-      pipeline LLM annotation — suivi séparé).
-
-## Suivi ops (hors PR)
-
-`with_llm=0` et `clustered=0/13532` indiquent que `_persist_content_cluster_ids`
-ne tourne pas en prod malgré Sprint 3 mergé ce matin (#698). La clé Mistral
-est fonctionnelle. Hypothèses à investiguer côté ops :
-
-- Le pipeline 07:30 a-t-il tourné depuis le merge de #698 ?
-- Si oui, regarder les logs Railway pour `editorial.llm_annotation.*` /
-  `editorial.persist_cluster_ids.*`.
+- [ ] Ouvrir Tournée du jour avec ≥1 thème suivi → vérifier que la section affiche 3 cartes
+- [ ] Vérifier que les 3 articles couvrent 3 clusters distincts (pas 3 reprises du même fait)
+- [ ] Vérifier qu'aucun article du top 3 n'est dépourvu d'image + de description < 100 chars
+- [ ] Snapshot offline (50 users) : comparer overlap top 3 actuel vs nouveau, source diversity, cluster diversity
+- [ ] Vérifier que « Voir tout » paginé fonctionne (offset > 0)

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -30,7 +30,6 @@ Fallback sans préférences : le scorer dégénère en `actu_boost + perspective
 """
 
 import logging
-import math
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
@@ -53,6 +52,7 @@ from app.services.recommendation.filter_presets import (
     LOW_PRIORITY_SPORT_THEMES,
     is_news_bulletin_title,
 )
+from app.services.recommendation.helpers import compute_coverage_score
 from app.services.recommendation.scoring_config import ScoringWeights
 
 logger = logging.getLogger(__name__)
@@ -72,8 +72,10 @@ _BADGE_ACTU = "actu"
 # Poids du scoring composite — réglés pour que chaque levier puisse l'emporter
 # isolément sans qu'aucun ne phagocyte les autres. Toute modif → ajouter un
 # test dans `test_essentiel_endpoint.py`.
-_W_TRENDING = 40.0  # `Top3Selector.BOOST_TRENDING` — topic.is_trending
-_W_UNE = 30.0  # `Top3Selector.BOOST_UNE` — topic.is_une
+# Source de vérité partagée avec le digest topics et le feed thématique
+# (`ScoringWeights.TOPIC_IS_TRENDING_BONUS` / `TOPIC_IS_UNE_BONUS`).
+_W_TRENDING = ScoringWeights.TOPIC_IS_TRENDING_BONUS  # 50 — topic.is_trending
+_W_UNE = ScoringWeights.TOPIC_IS_UNE_BONUS  # 35 — topic.is_une
 _W_BADGE_ACTU = 25.0  # article.badge == _BADGE_ACTU (signal explicite du digest)
 _W_FOLLOWED_SOURCE = 100.0
 _W_FOLLOWED_SOURCE_FLAG = 50.0  # bonus moindre si on n'a que le flag du digest
@@ -257,17 +259,10 @@ def _filter_articles_allowed(topics: list[DigestTopic]) -> list[DigestTopic]:
 def _perspective_score(perspective_count: int) -> float:
     """Score non-linéaire des perspectives (Story 9.4).
 
-    `min(CAP, BASE * log2(n))` — 1→0, 2→+12, 3→+19, 4→+24, 5→+28, 6→+30 (cap).
-    Permet à un sujet à 6+ relais de rivaliser avec un BOOST_BADGE_ACTU (+25)
-    et d'égaler un BOOST_UNE (+30). Le linéaire `+5/perspective` d'origine
-    laissait passer des scoops isolés devant des sujets très relayés.
+    Délègue à `helpers.compute_coverage_score` — source de vérité partagée
+    avec le feed thématique (`PertinencePillar._score_coverage`).
     """
-    if perspective_count <= 1:
-        return 0.0
-    return min(
-        ScoringWeights.ESSENTIEL_PERSPECTIVE_CAP,
-        ScoringWeights.ESSENTIEL_PERSPECTIVE_BASE * math.log2(perspective_count),
-    )
+    return compute_coverage_score(perspective_count)
 
 
 def _is_followed_topic(topic: DigestTopic, ctx: EssentielUserContext) -> bool:

--- a/packages/api/app/services/recommendation/helpers/__init__.py
+++ b/packages/api/app/services/recommendation/helpers/__init__.py
@@ -1,0 +1,11 @@
+"""Helpers partagés pour les surfaces de recommandation (feed, digest, essentiel).
+
+Centralise les primitives qui étaient dupliquées avec valeurs divergentes :
+- Score de couverture (perspectives multi-sources) : `compute_coverage_score`
+- Diversification générique 1-par-clé : `diversify`
+"""
+
+from app.services.recommendation.helpers.coverage_score import compute_coverage_score
+from app.services.recommendation.helpers.diversification import diversify
+
+__all__ = ["compute_coverage_score", "diversify"]

--- a/packages/api/app/services/recommendation/helpers/coverage_score.py
+++ b/packages/api/app/services/recommendation/helpers/coverage_score.py
@@ -1,0 +1,31 @@
+"""Score de couverture multi-sources d'un sujet.
+
+Un événement couvert par plusieurs médias distincts est plus probablement
+"l'essentiel du sujet du jour" qu'un scoop isolé. La formule log2 fait que
+le 5e relais apporte moins que le 2e — on rémunère la diversité initiale
+puis on plafonne.
+
+`1→0  2→+12  3→+19  4→+24  5→+28  6→+30 (cap)  8+→+30`
+
+Cette fonction est la source de vérité pour Essentiel, feed thématique et
+digest. Toute évolution des constantes passe par `ScoringWeights`.
+"""
+
+import math
+
+from app.services.recommendation.scoring_config import ScoringWeights
+
+
+def compute_coverage_score(cluster_size: int) -> float:
+    """Score non-linéaire de couverture d'un cluster.
+
+    `min(CAP, BASE × log2(max(cluster_size, 1)))`. Un cluster de taille 1
+    (scoop isolé) ne reçoit aucun bonus.
+    """
+    n = max(int(cluster_size or 0), 1)
+    if n <= 1:
+        return 0.0
+    return min(
+        ScoringWeights.COVERAGE_CAP,
+        ScoringWeights.COVERAGE_BASE * math.log2(n),
+    )

--- a/packages/api/app/services/recommendation/helpers/diversification.py
+++ b/packages/api/app/services/recommendation/helpers/diversification.py
@@ -1,0 +1,66 @@
+"""Diversification générique 1-(ou N)-par-clé.
+
+Sert à la fois :
+- au round 1 de l'Essentiel (1 article max par topic),
+- à la passe finale du feed thématique (top 3 sur 3 clusters distincts).
+
+L'algorithme préserve l'ordre d'entrée (déjà trié par score décroissant
+par les appelants) et bascule en mode "souple" si on n'a pas assez de
+clés distinctes : on autorise alors la réutilisation pour compléter au
+lieu de retourner une liste plus courte (l'UI top 3 doit toujours avoir
+3 cartes).
+"""
+
+from collections.abc import Callable, Hashable, Iterable
+
+
+def diversify[T](
+    items: Iterable[T],
+    key_fn: Callable[[T], Hashable | None],
+    *,
+    target_size: int | None = None,
+    max_per_key: int = 1,
+    fallback_ok: bool = True,
+) -> list[T]:
+    """Retourne `items` filtrés à au plus `max_per_key` éléments par clé.
+
+    Args:
+        items: itérable trié par score décroissant.
+        key_fn: extrait la clé de diversification (cluster_id, topic_slug…).
+            Une clé `None` est traitée comme "pas de groupement" — l'élément
+            est gardé sans compter dans aucun groupe.
+        target_size: si fourni et qu'on n'atteint pas cette taille en mode
+            strict, on bascule en mode souple (cf. `fallback_ok`).
+        max_per_key: nombre max d'éléments autorisés par clé en mode strict.
+        fallback_ok: si True et `target_size` non atteint, on rajoute les
+            éléments écartés par ordre original jusqu'à atteindre la cible.
+
+    Returns:
+        Liste filtrée. Ordre d'entrée préservé.
+    """
+    items_list = list(items)
+    if not items_list:
+        return []
+
+    counts: dict[Hashable, int] = {}
+    picked: list[T] = []
+    skipped: list[T] = []
+
+    for item in items_list:
+        key = key_fn(item)
+        if key is None:
+            picked.append(item)
+            continue
+        if counts.get(key, 0) < max_per_key:
+            picked.append(item)
+            counts[key] = counts.get(key, 0) + 1
+        else:
+            skipped.append(item)
+
+    if target_size is not None and fallback_ok and len(picked) < target_size:
+        for item in skipped:
+            picked.append(item)
+            if len(picked) >= target_size:
+                break
+
+    return picked

--- a/packages/api/app/services/recommendation/pillars/pertinence.py
+++ b/packages/api/app/services/recommendation/pillars/pertinence.py
@@ -6,6 +6,7 @@ Consolide : CoreLayer (theme), ArticleTopicLayer, BehavioralLayer,
 
 from app.models.content import Content
 from app.models.enums import ContentType, InterestState
+from app.services.recommendation.helpers import compute_coverage_score
 from app.services.recommendation.pillars.base import BasePillar, PillarContribution
 from app.services.recommendation.scoring_config import ScoringWeights
 from app.services.recommendation.scoring_engine import ScoringContext
@@ -155,6 +156,15 @@ class PertinencePillar(BasePillar):
         score += format_result[0]
         contributions.extend(format_result[1])
 
+        # --- 5b. Coverage Bonus (multi-sources sur même cluster) ---
+        # Un sujet relayé par plusieurs médias distincts dans les 24h dernières
+        # est plus probablement "l'essentiel" que les 3 articles standalone
+        # de la même section. Signal capé pour ne pas écraser la pertinence
+        # thématique (max +30 sur un base pertinence ~130).
+        coverage_result = self._score_coverage(content, context)
+        score += coverage_result[0]
+        contributions.extend(coverage_result[1])
+
         # --- 6. Theme Mismatch Malus ---
         # Léger désavantage pour les articles hors des thèmes/sous-thèmes suivis,
         # sans les exclure. Ne s'applique qu'aux utilisateurs ayant déclaré des
@@ -166,6 +176,32 @@ class PertinencePillar(BasePillar):
         contributions.extend(mismatch_result[1])
 
         return score, contributions
+
+    def _score_coverage(
+        self, content: Content, context: ScoringContext
+    ) -> tuple[float, list[PillarContribution]]:
+        """Bonus log-calibré pour les clusters multi-sources.
+
+        `cluster_source_counts` est rempli en mode thématique personnalisé ;
+        sinon (cold start, autres surfaces) on n'a aucun coût ni effet.
+        """
+        cluster_id = getattr(content, "cluster_id", None)
+        if cluster_id is None or not context.cluster_source_counts:
+            return 0.0, []
+
+        source_count = context.cluster_source_counts.get(cluster_id, 1)
+        bonus = compute_coverage_score(source_count)
+        if bonus <= 0:
+            return 0.0, []
+
+        # is_trending = ≥3 sources distinctes (définition partagée avec
+        # ImportanceDetector). On l'expose comme contribution dédiée pour
+        # l'explicabilité ; le bonus de couverture reste log-calibré.
+        if source_count >= 3:
+            label = f"Couvert par {source_count} sources"
+        else:
+            label = "Sujet relayé"
+        return bonus, [PillarContribution(label=label, points=bonus)]
 
     def _score_theme_mismatch(
         self,

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -49,8 +49,10 @@ class ScoringWeights:
     # --- CUSTOM TOPIC LAYER (Epic 11) ---
 
     # Base bonus when an article matches a user's custom topic.
-    # Calibrated: 15 * 2.0 max = 30pts (competes with THEME_MATCH=50 without dominating).
-    CUSTOM_TOPIC_BASE_BONUS = 15.0
+    # Top3 thematic selection: bumped 15→25 (B3) — un sujet perso précis est
+    # le signal d'intention le plus fort dont on dispose, il doit pouvoir
+    # peser autant qu'un TRUSTED_SOURCE (35) à multiplier max 2.0.
+    CUSTOM_TOPIC_BASE_BONUS = 25.0
 
     # --- DIGEST RECENCY BONUSES (Tiered) ---
     # Bonus de fraîcheur hiérarchisés pour l'algorithme de digest
@@ -157,8 +159,13 @@ class ScoringWeights:
     # 1→0  2→+12  3→+19  4→+24  5→+28  6→+30 (cap)  8+→+30
     # Permet à un sujet relayé par 3+ médias de rivaliser avec un BOOST_BADGE_ACTU
     # (+25) et d'égaler un BOOST_UNE (+30). Un scoop isolé n'a aucun bonus.
-    ESSENTIEL_PERSPECTIVE_BASE = 12.0
-    ESSENTIEL_PERSPECTIVE_CAP = 30.0
+    # Source de vérité unique partagée par Essentiel, feed thématique et digest
+    # via `helpers/coverage_score.py`.
+    COVERAGE_BASE = 12.0
+    COVERAGE_CAP = 30.0
+    # Anciens noms maintenus pour rétrocompat (essentiel_service avant migration).
+    ESSENTIEL_PERSPECTIVE_BASE = COVERAGE_BASE
+    ESSENTIEL_PERSPECTIVE_CAP = COVERAGE_CAP
 
     # --- DIGEST TRENDING/IMPORTANCE (Pour vous hybride) ---
 
@@ -181,10 +188,13 @@ class ScoringWeights:
     TOPIC_FOLLOWED_SOURCE_BONUS = 40.0
 
     # Bonus pour un topic trending (couvert par ≥3 sources distinctes).
+    # Source de vérité partagée avec Essentiel et feed thématique.
     TOPIC_TRENDING_BONUS = 50.0
+    TOPIC_IS_TRENDING_BONUS = TOPIC_TRENDING_BONUS  # alias canonique
 
     # Bonus pour un topic contenant ≥1 article "À la Une".
     TOPIC_UNE_BONUS = 35.0
+    TOPIC_IS_UNE_BONUS = TOPIC_UNE_BONUS  # alias canonique
 
     # Bonus pour un topic dont le thème dominant matche les intérêts user.
     TOPIC_THEME_MATCH_BONUS = 45.0

--- a/packages/api/app/services/recommendation/scoring_engine.py
+++ b/packages/api/app/services/recommendation/scoring_engine.py
@@ -44,6 +44,11 @@ class ScoringContext:
         # par interest_slug. Sujets (custom topics) portent leur state sur l'objet
         # ORM directement, pas dans cette dict.
         user_interest_states: dict[str, InterestState] | None = None,
+        # Top3 thematic selection: nombre de sources distinctes par cluster_id
+        # sur la fenêtre 24h. Permet à PertinencePillar d'attribuer un bonus
+        # de couverture multi-sources (cf. helpers.compute_coverage_score).
+        # Vide en cold start ou hors mode thématique personnalisé.
+        cluster_source_counts: dict[UUID, int] | None = None,
     ):
         self.user_profile = user_profile
         self.user_interests = user_interests
@@ -76,6 +81,9 @@ class ScoringContext:
 
         # Story 22.1: declared interest state per theme slug.
         self.user_interest_states = user_interest_states or {}
+
+        # Top3 thematic selection: cluster_id -> nb sources distinctes (24h).
+        self.cluster_source_counts = cluster_source_counts or {}
 
         # Diagnostics pour explicabilité
         self.reasons: dict[UUID, dict[str, Any]] = {}

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -579,6 +579,36 @@ class RecommendationService:
             or mode == FeedFilterMode.RECENT
             or personalized_theme_mode
         ):
+            # Top3 thematic selection (PR 1) : sur Tournée du jour, on promeut
+            # 3 articles "essentiel-grade" en tête de section — multi-sources
+            # (coverage), filtrés qualité, diversifiés par cluster_id. Le reste
+            # reste en ordre chronologique pour préserver la cohérence de
+            # « Voir tout » et éviter la sur-compression de la version Story 21.2.
+            if personalized_theme_mode and len(candidates) > 3:
+                if not self.user_custom_topics:
+                    from app.models.user_topic_profile import UserTopicProfile
+
+                    custom_topics_stmt = select(UserTopicProfile).where(
+                        UserTopicProfile.user_id == user_id
+                    )
+                    async with safe_async_session(
+                        statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000
+                    ) as s:
+                        self.user_custom_topics = list(
+                            (await s.scalars(custom_topics_stmt)).all()
+                        )
+                candidates = await self._curate_thematic_top_n(
+                    candidates,
+                    user_interests=user_interests,
+                    user_interest_weights=user_interest_weights,
+                    user_interest_states=user_interest_states,
+                    user_subtopics=user_subtopics,
+                    user_subtopic_weights=user_subtopic_weights,
+                    followed_source_ids=followed_source_ids,
+                    user_prefs=user_prefs,
+                    user_profile=user_profile,
+                    top_n=3,
+                )
             paginated = candidates[offset : offset + limit]
             await self._hydrate_user_status(paginated, user_id, followed_source_ids)
             return paginated
@@ -916,6 +946,137 @@ class RecommendationService:
             "feed_total", duration_ms=round((t_end - t0) * 1000), items=len(result)
         )
         return result
+
+    async def _curate_thematic_top_n(
+        self,
+        candidates: list[Content],
+        *,
+        user_interests: set[str],
+        user_interest_weights: dict[str, float],
+        user_interest_states: dict[str, InterestState],
+        user_subtopics: set[str],
+        user_subtopic_weights: dict[str, float],
+        followed_source_ids: set[UUID],
+        user_prefs: dict[str, Any],
+        user_profile: UserProfile | None,
+        top_n: int = 3,
+    ) -> list[Content]:
+        """Promeut N articles "essentiel-grade" en tête d'une section thématique.
+
+        Algorithme :
+        1. Calcule cluster_source_counts (24h) pour les N premiers candidats.
+        2. Score le pool via PillarScoringEngine — gagne le bonus coverage
+           dans Pertinence quand un cluster est multi-sources.
+        3. Applique un floor qualité (D2) : exclut les articles sans visuel,
+           sans contenu lisible et sans description suffisante.
+        4. Diversifie par cluster_id, fallback souple sur topic_slug, jusqu'à
+           obtenir N articles distincts en tête.
+        5. Retourne curated_top_N + reste chronologique (dedupe sur id).
+
+        En cas de pool trop pauvre (<N candidats après floor), on relâche
+        le floor pour ne jamais renvoyer une liste tronquée.
+        """
+        from app.services.recommendation.helpers import diversify
+
+        if len(candidates) <= top_n:
+            return candidates
+
+        # Pool restreint aux 50 plus récents (les candidats sont déjà triés
+        # par published_at DESC + boost subtopic). 50 est suffisant pour
+        # capter les sujets relayés du jour sans coût SQL prohibitif.
+        pool = candidates[:50]
+
+        now = datetime.datetime.now(datetime.UTC)
+
+        # 1. cluster_source_counts (24h, distinct sources per cluster_id)
+        cluster_ids = list({c.cluster_id for c in pool if c.cluster_id is not None})
+        cluster_source_counts: dict[UUID, int] = {}
+        if cluster_ids:
+            cutoff = now - datetime.timedelta(hours=24)
+            stmt = (
+                select(
+                    Content.cluster_id,
+                    func.count(func.distinct(Content.source_id)),
+                )
+                .where(
+                    Content.cluster_id.in_(cluster_ids),
+                    Content.published_at >= cutoff,
+                )
+                .group_by(Content.cluster_id)
+            )
+            rows = (await self.session.execute(stmt)).all()
+            cluster_source_counts = {row[0]: int(row[1]) for row in rows}
+
+        # 2. Build scoring context (minimal — pas d'impressions ni d'affinity
+        # pour rester léger ; les signaux clés Pertinence + Source + Coverage
+        # suffisent pour la promotion top N).
+        context = ScoringContext(
+            user_profile=user_profile,
+            user_interests=user_interests,
+            user_interest_weights=user_interest_weights,
+            followed_source_ids=followed_source_ids,
+            user_prefs=user_prefs,
+            now=now,
+            user_subtopics=user_subtopics,
+            user_subtopic_weights=user_subtopic_weights,
+            user_custom_topics=self.user_custom_topics,
+            user_interest_states=user_interest_states,
+            cluster_source_counts=cluster_source_counts,
+        )
+
+        scored: list[tuple[Content, float]] = []
+        for c in pool:
+            try:
+                result = self.pillar_engine.compute_score(c, context)
+                scored.append((c, result.final_score))
+            except Exception as exc:
+                logger.warning(
+                    "curate_thematic_top_score_failed",
+                    content_id=str(c.id),
+                    error=str(exc),
+                )
+                scored.append((c, 0.0))
+
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        # 3. Floor qualité (D2) — un article du top doit avoir un minimum
+        # de crédibilité visuelle/éditoriale. Exclut les rss bare-bones sans
+        # image, sans contenu in-app et avec un résumé < 100 caractères.
+        def _is_low_quality(c: Content) -> bool:
+            has_thumb = bool(c.thumbnail_url and c.thumbnail_url.strip())
+            has_content = getattr(c, "content_quality", None) in ("full", "partial")
+            desc_len = len(c.description or "")
+            return not has_thumb and not has_content and desc_len < 100
+
+        filtered = [pair for pair in scored if not _is_low_quality(pair[0])]
+        if len(filtered) < top_n:
+            # Pool insuffisant après floor — on dégrade gracieusement pour
+            # ne pas renvoyer un top tronqué (l'UI section a besoin de N).
+            filtered = scored
+
+        # 4. Diversification (souple) : 1 article max par cluster_id, sinon
+        # fallback topic_slug, sinon ordre score.
+        def _diversification_key(pair: tuple[Content, float]) -> Any:
+            c = pair[0]
+            if c.cluster_id is not None:
+                return ("cluster", c.cluster_id)
+            if c.topics:
+                return ("topic", c.topics[0].lower().strip())
+            return None
+
+        diversified = diversify(
+            filtered,
+            key_fn=_diversification_key,
+            target_size=top_n,
+            max_per_key=1,
+            fallback_ok=True,
+        )
+
+        curated_top = [pair[0] for pair in diversified[:top_n]]
+        curated_ids = {c.id for c in curated_top}
+
+        rest = [c for c in candidates if c.id not in curated_ids]
+        return curated_top + rest
 
     async def _hydrate_user_status(
         self,

--- a/packages/api/tests/recommendation/test_coverage_score.py
+++ b/packages/api/tests/recommendation/test_coverage_score.py
@@ -1,0 +1,35 @@
+"""Tests for the shared coverage_score helper."""
+
+import math
+
+import pytest
+
+from app.services.recommendation.helpers.coverage_score import compute_coverage_score
+from app.services.recommendation.scoring_config import ScoringWeights
+
+
+def test_singleton_cluster_no_bonus():
+    assert compute_coverage_score(0) == 0.0
+    assert compute_coverage_score(1) == 0.0
+
+
+def test_log2_progression():
+    assert compute_coverage_score(2) == pytest.approx(ScoringWeights.COVERAGE_BASE)
+    assert compute_coverage_score(3) == pytest.approx(
+        ScoringWeights.COVERAGE_BASE * math.log2(3)
+    )
+    assert compute_coverage_score(4) == pytest.approx(
+        ScoringWeights.COVERAGE_BASE * 2
+    )
+
+
+def test_capped_at_max():
+    assert compute_coverage_score(6) == pytest.approx(ScoringWeights.COVERAGE_CAP)
+    assert compute_coverage_score(50) == pytest.approx(ScoringWeights.COVERAGE_CAP)
+
+
+def test_monotone_increasing():
+    """Plus de sources → score >= ; jamais en régression."""
+    values = [compute_coverage_score(n) for n in range(1, 10)]
+    for prev, cur in zip(values, values[1:], strict=False):
+        assert cur >= prev

--- a/packages/api/tests/recommendation/test_diversification.py
+++ b/packages/api/tests/recommendation/test_diversification.py
@@ -1,0 +1,54 @@
+"""Tests for the shared diversify helper."""
+
+from app.services.recommendation.helpers.diversification import diversify
+
+
+def test_empty_input():
+    assert diversify([], key_fn=lambda x: x) == []
+
+
+def test_strict_dedup_one_per_key():
+    items = [("a", 1), ("a", 2), ("b", 3), ("c", 4), ("a", 5)]
+    out = diversify(items, key_fn=lambda x: x[0], target_size=None, max_per_key=1)
+    assert out == [("a", 1), ("b", 3), ("c", 4)]
+
+
+def test_souple_fallback_when_target_not_met():
+    """Si on n'a pas assez de clés distinctes, on rajoute des doublons par
+    ordre original pour atteindre la cible."""
+    items = [("a", 1), ("a", 2), ("a", 3), ("b", 4)]
+    out = diversify(
+        items, key_fn=lambda x: x[0], target_size=3, max_per_key=1, fallback_ok=True
+    )
+    assert out == [("a", 1), ("b", 4), ("a", 2)]
+
+
+def test_strict_no_fallback():
+    items = [("a", 1), ("a", 2), ("b", 3)]
+    out = diversify(
+        items,
+        key_fn=lambda x: x[0],
+        target_size=5,
+        max_per_key=1,
+        fallback_ok=False,
+    )
+    assert out == [("a", 1), ("b", 3)]
+
+
+def test_max_per_key_n():
+    items = [("a", 1), ("a", 2), ("a", 3), ("b", 4)]
+    out = diversify(items, key_fn=lambda x: x[0], max_per_key=2)
+    assert out == [("a", 1), ("a", 2), ("b", 4)]
+
+
+def test_none_keys_pass_through():
+    """Une clé None signifie 'pas de groupement' — l'élément n'est pas compté."""
+    items = [("a", 1), (None, 2), (None, 3), ("a", 4)]
+    out = diversify(items, key_fn=lambda x: x[0], max_per_key=1)
+    assert out == [("a", 1), (None, 2), (None, 3)]
+
+
+def test_preserves_input_order():
+    items = list(range(10))
+    out = diversify(items, key_fn=lambda x: x % 3, max_per_key=1)
+    assert out == [0, 1, 2]

--- a/packages/api/tests/recommendation/test_pertinence_coverage.py
+++ b/packages/api/tests/recommendation/test_pertinence_coverage.py
@@ -1,0 +1,122 @@
+"""Tests for the Coverage contribution inside PertinencePillar.
+
+Validates that an article belonging to a cluster covered by multiple
+sources in the past 24h gets a positive boost on top of theme/subtopic
+matching, while a scoop (cluster_size=1) gets nothing.
+"""
+
+import math
+from datetime import datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from app.services.recommendation.helpers.coverage_score import compute_coverage_score
+from app.services.recommendation.pillars.pertinence import PertinencePillar
+from app.services.recommendation.scoring_config import ScoringWeights
+from app.services.recommendation.scoring_engine import ScoringContext
+
+
+class _Source:
+    def __init__(self, theme=None):
+        self.id = uuid4()
+        self.theme = theme
+        self.secondary_themes = []
+        self.is_curated = True
+
+
+class _Content:
+    def __init__(self, theme=None, source_theme=None, topics=None, cluster_id=None):
+        self.id = uuid4()
+        self.title = "Test"
+        self.description = ""
+        self.theme = theme
+        self.topics = topics or []
+        self.source = _Source(theme=source_theme)
+        self.source_id = self.source.id
+        self.published_at = datetime.now()
+        self.content_type = None
+        self.duration_seconds = None
+        self.cluster_id = cluster_id
+
+
+def _context(*, cluster_source_counts=None, user_interests=None):
+    return ScoringContext(
+        user_profile=MagicMock(id=uuid4()),
+        user_interests=set(user_interests or []),
+        user_interest_weights={},
+        followed_source_ids=set(),
+        user_prefs={},
+        now=datetime.now(),
+        cluster_source_counts=cluster_source_counts or {},
+    )
+
+
+def test_no_cluster_no_bonus():
+    """Article sans cluster_id n'a pas de bonus coverage."""
+    content = _Content(cluster_id=None)
+    ctx = _context(cluster_source_counts={uuid4(): 5})
+
+    pillar = PertinencePillar()
+    raw, contribs = pillar.compute_raw(content, ctx)
+
+    assert not any(c.label.startswith("Couvert") for c in contribs)
+    assert not any(c.label == "Sujet relayé" for c in contribs)
+
+
+def test_singleton_cluster_no_bonus():
+    """cluster_size == 1 (scoop isolé) → 0 pt."""
+    cid = uuid4()
+    content = _Content(cluster_id=cid)
+    ctx = _context(cluster_source_counts={cid: 1})
+
+    pillar = PertinencePillar()
+    raw, _ = pillar.compute_raw(content, ctx)
+
+    # Pas de match thématique non plus → THEME_MISMATCH_MALUS s'applique
+    # uniquement si user_interests, mais ici set vide → 0.
+    assert raw == 0.0
+
+
+def test_trending_cluster_gets_label_and_bonus():
+    """≥3 sources → bonus log-calibré + label 'Couvert par N sources'."""
+    cid = uuid4()
+    content = _Content(cluster_id=cid)
+    ctx = _context(cluster_source_counts={cid: 5})
+
+    pillar = PertinencePillar()
+    raw, contribs = pillar.compute_raw(content, ctx)
+
+    coverage_contribs = [c for c in contribs if c.label.startswith("Couvert")]
+    assert len(coverage_contribs) == 1
+    expected = compute_coverage_score(5)
+    assert coverage_contribs[0].points == expected
+    assert raw == expected
+
+
+def test_small_cluster_gets_relayed_label():
+    """2 sources : bonus existe mais label moins fort que 'trending'."""
+    cid = uuid4()
+    content = _Content(cluster_id=cid)
+    ctx = _context(cluster_source_counts={cid: 2})
+
+    pillar = PertinencePillar()
+    raw, contribs = pillar.compute_raw(content, ctx)
+
+    contrib = next(c for c in contribs if c.label == "Sujet relayé")
+    assert contrib.points == ScoringWeights.COVERAGE_BASE
+
+
+def test_coverage_stacks_with_theme_match():
+    """Coverage s'ajoute à THEME_MATCH, sans le remplacer."""
+    cid = uuid4()
+    content = _Content(theme="tech", cluster_id=cid)
+    ctx = _context(
+        cluster_source_counts={cid: 4},
+        user_interests={"tech"},
+    )
+
+    pillar = PertinencePillar()
+    raw, _ = pillar.compute_raw(content, ctx)
+
+    expected = ScoringWeights.THEME_MATCH + ScoringWeights.COVERAGE_BASE * math.log2(4)
+    assert raw == expected

--- a/packages/api/tests/test_custom_topics.py
+++ b/packages/api/tests/test_custom_topics.py
@@ -601,9 +601,9 @@ class TestRecencyBaseAdjustment:
         """Verify recency_base has been raised to 100 (Epic 11)."""
         assert ScoringWeights.recency_base == 100.0
 
-    def test_custom_topic_base_bonus_is_15(self):
-        """Verify CUSTOM_TOPIC_BASE_BONUS is set."""
-        assert ScoringWeights.CUSTOM_TOPIC_BASE_BONUS == 15.0
+    def test_custom_topic_base_bonus_is_25(self):
+        """Verify CUSTOM_TOPIC_BASE_BONUS is set (bumped 15→25 for top3 thematic)."""
+        assert ScoringWeights.CUSTOM_TOPIC_BASE_BONUS == 25.0
 
 
 # ============================================================


### PR DESCRIPTION
# PR — Top 3 "essentiel-grade" sur sections thématiques (Tournée du jour)

## Pourquoi

Sur Tournée du jour, chaque section thématique affichait 3 articles en pur ordre chronologique (Story 21.2 avait désactivé tout scoring pour éviter une sur-compression). Conséquence : le top 3 était souvent "plat" — 3 articles récents mais sans le bénéfice des signaux forts disponibles (cluster multi-sources, custom topics, qualité éditoriale). L'objectif est de promouvoir 3 articles vraiment "essentiels" sans casser la sémantique « Voir tout » chronologique.

## Ce qui change

### Cœur de la PR (Axes A1 + A3 + B3 + D2 du plan)

**Coverage bonus (A1)** : `PertinencePillar` lit `cluster_source_counts` depuis le contexte et applique un bonus log-calibré `min(30, 12·log2(n))` pour les articles dont le cluster est couvert par plusieurs sources distinctes dans les 24h. Un scoop isolé ne reçoit rien ; un sujet à 5 médias récupère ~28 pts.

**Diversification (A3)** : passe finale `diversify()` par `cluster_id` (fallback `topic_slug`) sur le top 3 des sections thématiques personnalisées. Mode "souple" — si on n'a pas 3 clusters distincts, on relâche pour ne jamais retourner moins de 3 cartes.

**Custom topic boost (B3)** : `CUSTOM_TOPIC_BASE_BONUS` 15 → 25. Le signal d'intention le plus précis dont on dispose pèse maintenant ~50 pts max (multiplier 2.0), au niveau d'un `TRUSTED_SOURCE`.

**Quality floor (D2)** : avant la diversification top 3, on exclut les articles sans visuel + sans contenu in-app + résumé < 100 caractères. Fallback gracieux si le pool devient trop pauvre.

### Mutualisation (partie B + C du plan)

Helpers partagés (nouveaux) :
- `packages/api/app/services/recommendation/helpers/coverage_score.py` → `compute_coverage_score(n)`
- `packages/api/app/services/recommendation/helpers/diversification.py` → `diversify(items, key_fn, ...)`

Consolidation `scoring_config.py` :
- `COVERAGE_BASE = 12.0`, `COVERAGE_CAP = 30.0` (canoniques)
- Aliases rétrocompat : `ESSENTIEL_PERSPECTIVE_BASE/CAP`
- Aliases canoniques : `TOPIC_IS_TRENDING_BONUS = TOPIC_TRENDING_BONUS = 50`, `TOPIC_IS_UNE_BONUS = TOPIC_UNE_BONUS = 35`

Migration `essentiel_service.py` (fonctionnellement équivalent côté code mais ajustement de valeurs) :
- `_perspective_score()` délègue à `compute_coverage_score()`
- `_W_TRENDING` : 40 → 50 (= `TOPIC_IS_TRENDING_BONUS`)
- `_W_UNE` : 30 → 35 (= `TOPIC_IS_UNE_BONUS`)
- ⚠️ Trade-off documenté : on aligne sur les valeurs déjà en prod côté digest topics (plus largement déployées) plutôt que sur les valeurs historiques d'Essentiel.

## Tests

Nouveaux (`packages/api/tests/recommendation/`) :
- `test_coverage_score.py` (4 tests) — monotonie log2, cap, singleton.
- `test_diversification.py` (7 tests) — strict, souple, max_per_key=N, None-keys.
- `test_pertinence_coverage.py` (5 tests) — bonus appliqué + label correct + stacking avec THEME_MATCH.

Suite existante :
- `tests/test_essentiel_endpoint.py` : 33 tests passent (les valeurs `_W_TRENDING/UNE` sont importées comme symboles, pas codées en dur dans les assertions).
- `tests/recommendation/` : pertinence existants OK.
- `tests/test_feed_filters.py`, `tests/test_feed_followed_first_stratification.py`, `tests/test_digest_selector.py` : 46 tests OK.
- `tests/test_custom_topics.py` (sous-classes non-DB) : 13 tests OK (assertion de calibration mise à jour).

## Hors scope (PR 2 / 3 du plan)

- C1/C3 affinity (source × topic, save/like adjacency) — table matérialisée à venir.
- B1 multiplicateur subtopic weight — déjà partiellement appliqué via `_score_subtopics`, à étendre.
- Centralisation du filtrage mute (`mute_helpers.py`) — PR 3 dédiée (risque indépendant, scope trop large).
- `is_une`/`is_trending` direct au feed — non exposés au niveau Content (calculés par `ImportanceDetector` côté digest). Le bonus de couverture (≥3 sources distinctes) capture l'équivalent `is_trending` opérationnel.

## Test plan QA

- [ ] Ouvrir Tournée du jour avec ≥1 thème suivi → vérifier que la section affiche 3 cartes
- [ ] Vérifier que les 3 articles couvrent 3 clusters distincts (pas 3 reprises du même fait)
- [ ] Vérifier qu'aucun article du top 3 n'est dépourvu d'image + de description < 100 chars
- [ ] Snapshot offline (50 users) : comparer overlap top 3 actuel vs nouveau, source diversity, cluster diversity
- [ ] Vérifier que « Voir tout » paginé fonctionne (offset > 0)
