### PR TITLE
Add PolyForm Noncommercial license and align public messaging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Ce guide s'adresse aux développeurs (même débutants) souhaitant contribuer au projet Facteur. Il regroupe toutes les étapes pour configurer votre environnement, installer les dépendances et lancer les différentes briques du projet.
 
+## 📄 Licence des contributions
+
+Le code du dépôt est disponible sous licence `PolyForm Noncommercial 1.0.0` (voir [`LICENSE`](LICENSE)).
+
+En contribuant à Facteur, vous acceptez que votre contribution soit distribuée sous cette même licence. Les contributions au dépôt sont donc acceptées sur une base non commerciale.
+
 ---
 
 ## 🛠 1. Prérequis

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,70 @@
+PolyForm Noncommercial License 1.0.0
+https://polyformproject.org/licenses/noncommercial/1.0.0
+
+Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose. However, you may only distribute the software according to the Distribution License and make changes or new works based on the software according to the Changes and New Works License.
+
+Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software. Your license to distribute covers distributing the software with changes and new works permitted by the Changes and New Works License.
+
+Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software. For example:
+
+Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else. These terms do not imply any other licenses.
+
+Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice. Otherwise, all your licenses end immediately.
+
+No Liability
+
+As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.
+
+Definitions
+
+The licensor is the individual or entity offering these terms, and the software is the software the licensor makes available under these terms.
+
+You refers to the individual or entity agreeing to these terms.
+Your company is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization. Control means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise. Control can be direct or indirect.
+
+Your licenses are all the licenses granted to you for the software under these terms.
+Use means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Documentation complète de l'architecture data pour les ingénieurs data/backend
 - **Services** : Supabase (Auth/DB), RevenueCat (Paiements).
 - **Déploiement** : Railway.
 
+## 📄 Licence
+
+Le code de Facteur est disponible sous licence `PolyForm Noncommercial 1.0.0`.
+
+Tout usage commercial requiert un accord de licence séparé. Contact : `laurin_boujon@proton.me`.
+
 ---
 
 *Propulsé par la méthode BMAD.*

--- a/apps/landing/public/index.html
+++ b/apps/landing/public/index.html
@@ -200,9 +200,9 @@
                 <!-- Pilier 3 -->
                 <div class="pillar reveal">
                     <div class="pillar__text">
-                        <h3 class="pillar__title"><span class="highlight">Transparent</span> et open-source</h3>
+                        <h3 class="pillar__title"><span class="highlight">Transparent</span> et source disponible</h3>
                         <p class="pillar__desc">Vois pourquoi chaque contenu t'est recommandé. Garde le contrôle sur ton
-                            feed. Le tout dans une app open-source et qui le restera.</p>
+                            feed. Le tout dans une app au code source disponible sous licence non commerciale.</p>
                     </div>
                     <div class="pillar__visuals">
                         <div class="phone-mockup phone-mockup--small">
@@ -320,11 +320,14 @@
 
                     <div class="faq__item">
                         <button class="faq__question" type="button">
-                            Facteur est open-source ?
+                            Le code de Facteur est-il public ?
                             <span class="faq__icon"></span>
                         </button>
                         <div class="faq__answer">
-                            <p>Oui, et &ccedil;a le restera. Le code est ouvert sous licence libre.
+                            <p>Oui. Le code source est disponible sous licence non commerciale
+                                <code>PolyForm Noncommercial 1.0.0</code>.
+                                Tout usage commercial requiert un accord s&eacute;par&eacute; via
+                                <a href="mailto:laurin_boujon@proton.me">laurin_boujon@proton.me</a>.
                                 D&eacute;veloppeurs, designers, product managers &mdash; ou toute personne avec de
                                 bonnes id&eacute;es et l'envie de les porter &mdash; sont les bienvenus pour
                                 contribuer.</p>


### PR DESCRIPTION
## What

- add the official `PolyForm Noncommercial 1.0.0` license at the repo root
- add license guidance to `README.md` and `CONTRIBUTING.md`
- replace public `open-source` / `licence libre` wording on the landing page with accurate non-commercial language
- point commercial licensing requests to `laurin_boujon@proton.me`

## Why

The repository had no published software license while the landing page already described the project as open-source. This PR makes the legal position explicit and aligns the public messaging with the chosen non-commercial licensing model.

## Type

- [ ] Feature
- [ ] Bug fix
- [x] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)
