### PR TITLE
fix(my-interests): réintroduire le CTA "Crée ta veille" supprimé par régression #639

### DIFF
--- a/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
@@ -337,6 +337,12 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
                 currentState: InterestState.favorite,
               ),
             ),
+            // CTA "Crée ta veille" — visible si aucun VeilleFavoriteRef dans
+            // les favoris. La veille devient le 3ᵉ type de favori (Story 23.2 PR-4).
+            if (interests.favorites.whereType<VeilleFavoriteRef>().isEmpty)
+              _CreateVeilleCta(
+                onTap: () => context.pushNamed(RouteNames.veilleConfig),
+              ),
           ],
           ...macroThemeOrder.map((macroLabel) {
             final themeSlug = macroThemeToApiSlug[macroLabel] ?? macroLabel;

--- a/apps/mobile/test/features/my_interests/screens/my_interests_screen_veille_cta_test.dart
+++ b/apps/mobile/test/features/my_interests/screens/my_interests_screen_veille_cta_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/custom_topics/providers/personalization_provider.dart';
+import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
+import 'package:facteur/features/my_interests/models/user_interests_state.dart';
+import 'package:facteur/features/my_interests/providers/user_interests_provider.dart';
+import 'package:facteur/features/my_interests/screens/my_interests_screen.dart';
+
+/// Régression #639 : le call site de `_CreateVeilleCta` avait été supprimé par
+/// mégarde dans `_buildBody()`, rendant la feature veille invisible pour tout
+/// user sans veille préexistante. Ces tests verrouillent la visibilité
+/// conditionnelle du CTA pour éviter une récidive.
+
+/// Stub qui renvoie un état figé sans toucher au repository.
+class _StubUserInterestsNotifier extends UserInterestsNotifier {
+  _StubUserInterestsNotifier(this._state);
+
+  final UserInterestsState _state;
+
+  @override
+  Future<UserInterestsState> build() async => _state;
+}
+
+/// Stub seedé sur l'état Serein voulu (sans appel réseau de persistance).
+class _StubSereinToggleNotifier extends SereinToggleNotifier {
+  _StubSereinToggleNotifier(super.ref, bool enabled) {
+    state = SereinToggleState(enabled: enabled, isLoading: false);
+  }
+}
+
+UserInterestsState _stateWithoutVeille() {
+  return const UserInterestsState(
+    themes: [],
+    customTopics: [],
+    favorites: [
+      ThemeFavoriteRef(slug: 'environment'),
+    ],
+    favoriteCount: 1,
+    favoriteCap: 3,
+  );
+}
+
+UserInterestsState _stateWithVeille() {
+  return const UserInterestsState(
+    themes: [],
+    customTopics: [],
+    favorites: [
+      ThemeFavoriteRef(slug: 'environment'),
+      VeilleFavoriteRef(id: 'veille-uuid'),
+    ],
+    favoriteCount: 2,
+    favoriteCap: 3,
+  );
+}
+
+Widget _host({
+  required UserInterestsState interests,
+  required bool sereinMode,
+}) {
+  return ProviderScope(
+    overrides: [
+      userInterestsProvider.overrideWith(
+        () => _StubUserInterestsNotifier(interests),
+      ),
+      sereinToggleProvider.overrideWith(
+        (ref) => _StubSereinToggleNotifier(ref, sereinMode),
+      ),
+      // Évite tout appel réseau du bloc "Types de contenu" (mode normal).
+      personalizationProvider.overrideWith(
+        (ref) async => const UserPersonalization(),
+      ),
+    ],
+    child: MaterialApp(
+      theme: ThemeData(extensions: [FacteurPalettes.light]),
+      home: const MyInterestsScreen(),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('MyInterestsScreen — CTA "Crée ta veille"', () {
+    testWidgets('visible quand aucune veille en favori et mode normal',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(interests: _stateWithoutVeille(), sereinMode: false),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Crée ta veille'), findsOneWidget);
+    });
+
+    testWidgets('masqué quand une veille existe déjà en favori',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(interests: _stateWithVeille(), sereinMode: false),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Crée ta veille'), findsNothing);
+    });
+
+    testWidgets('masqué en mode sérène même sans veille', (tester) async {
+      await tester.pumpWidget(
+        _host(interests: _stateWithoutVeille(), sereinMode: true),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Crée ta veille'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Contexte

PR #639 (`9fe3f166`, 23 mai) avait supprimé l'appel à `_CreateVeilleCta` dans `_buildBody()` (diff régressif de 5 lignes noyé dans 153 inserts / 15 deletes). Depuis 6 jours en prod, aucun user sans veille existante ne peut découvrir/créer la feature. Données prod : 81 users avec favoris, 0 veille créée depuis le merge PR #702 (28 mai). Diagnostic complet : `.context/qa-handoff-veille-visibility.md`.

## Changements

- Réintroduction du call site `_CreateVeilleCta` dans `_buildBody()` (condition `whereType<VeilleFavoriteRef>().isEmpty`, masqué en sérène).
- Widget test couvrant les 3 cas de visibilité pour éviter récidive.

## Test plan

- [x] `flutter test` vert sur le nouveau test (3/3 : CTA visible / masqué si veille présente / masqué en sérène).
- [x] `flutter analyze` clean (aucune nouvelle issue introduite).
- [ ] Vérif manuelle post-merge : compte test sans veille → CTA visible → tap → flow création → veille créée → CTA disparaît au refresh.

## Notes

- Diff minimal : 6 lignes de fix + 119 lignes de test. Pas de refactoring.
- La branche a été fast-forward sur `origin/main` (#708) pour compiler — le build du 28-05 (`onEndOfTournee`) était cassé sur la base et déjà corrigé sur main.
- Suite complète : 31 échecs **pré-existants** sur la base (auth/feed/digest/...), vérifiés identiques sur arbre propre — hors scope (ticket S2 séparé), non touchés par cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)