### PR TITLE
feat(nav): onglet Flâner — bottom nav + smart routing post-tournée

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -9,9 +9,9 @@ import 'core/auth/auth_state.dart';
 import 'core/providers/analytics_provider.dart';
 import 'core/services/deep_link_service.dart';
 import 'core/services/widget_service.dart';
-import 'features/feed/providers/feed_preload_provider.dart';
 import 'features/feed/providers/feed_provider.dart';
 import 'features/flux_continu/providers/flux_continu_preload_provider.dart';
+import 'features/flux_continu/services/tournee_progress_service.dart';
 import 'features/my_interests/services/interests_sync_service.dart';
 import 'features/onboarding/providers/onboarding_sync_provider.dart';
 import 'features/settings/providers/theme_provider.dart';
@@ -89,7 +89,18 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
         final elapsed = _backgroundedAt != null
             ? DateTime.now().difference(_backgroundedAt!)
             : null;
+        final router = ref.read(routerProvider);
+        final currentPath = router.routeInformationProvider.value.uri.path;
         if (ref.read(authStateProvider).isAuthenticated &&
+            currentPath == RoutePaths.fluxContinu &&
+            ref
+                .read(tourneeProgressServiceProvider)
+                .isClosingDismissedTodaySync()) {
+          router.go(RoutePaths.flaner);
+          return;
+        }
+        if (ref.read(authStateProvider).isAuthenticated &&
+            currentPath == RoutePaths.flaner &&
             (elapsed == null || elapsed.inSeconds >= 60)) {
           ref.read(feedProvider.notifier).refresh();
         }
@@ -117,11 +128,6 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
     debugPrint('FacteurApp: build() called');
     final router = ref.watch(routerProvider);
     final themeMode = ref.watch(themeNotifierProvider);
-
-    // Keep feed preloader alive for the entire authenticated session: it
-    // watches auth state and kicks off `feedProvider.future` in the
-    // background so the Feed tab renders instantly on first tap.
-    ref.watch(feedPreloadProvider);
 
     // Same pattern for the home screen (Flux Continu) — kicks off the 4
     // endpoints in parallel as soon as auth is confirmed, in parallel with

--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -9,10 +9,12 @@ import '../features/auth/screens/splash_screen.dart';
 import '../features/onboarding/screens/onboarding_screen.dart';
 import '../features/onboarding/screens/conclusion_animation_screen.dart';
 import '../features/feed/models/content_model.dart';
+import '../features/feed/screens/flaner_screen.dart';
 import '../features/flux_continu/screens/digest_section_screen.dart';
 import '../features/flux_continu/screens/flux_continu_screen.dart';
 import '../features/flux_continu/screens/theme_section_screen.dart';
 import '../features/flux_continu/models/flux_continu_models.dart';
+import '../features/flux_continu/services/tournee_progress_service.dart';
 import '../features/auth/screens/email_confirmation_screen.dart';
 import '../features/detail/screens/content_detail_screen.dart';
 
@@ -49,6 +51,7 @@ class RouteNames {
   static const String onboardingConclusion = 'onboarding-conclusion';
   static const String digest = 'digest';
   static const String feed = 'feed';
+  static const String flaner = 'flaner';
   static const String fluxContinu = 'flux-continu';
   static const String contentDetail = 'content-detail';
   static const String saved = 'saved';
@@ -83,6 +86,7 @@ class RoutePaths {
   static const String onboardingConclusion = '/onboarding/conclusion';
   static const String digest = '/digest';
   static const String feed = '/feed';
+  static const String flaner = '/flaner';
   static const String fluxContinu = '/flux-continu';
   static const String contentDetail = '/content/:id';
   static const String saved = '/saved';
@@ -132,6 +136,12 @@ final routerProvider = Provider<GoRouter>((ref) {
       }
 
       final authState = ref.read(authStateProvider);
+      String postAuthHomePath() {
+        final tournee = ref.read(tourneeProgressServiceProvider);
+        return tournee.isClosingDismissedTodaySync()
+            ? RoutePaths.flaner
+            : RoutePaths.fluxContinu;
+      }
 
       // Attendre que l'auth state soit initialisé
       if (authState.isLoading) {
@@ -180,7 +190,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       if (isOnLoginPage || isOnEmailConfirmation || isOnSplash) {
         return authState.needsOnboarding
             ? RoutePaths.onboarding
-            : RoutePaths.fluxContinu;
+            : postAuthHomePath();
       }
 
       // 4. Onboarding : forcer si nécessaire
@@ -192,7 +202,7 @@ final routerProvider = Provider<GoRouter>((ref) {
 
       // 5. Onboarding : empêcher d'y retourner si fini → atterrissage flux continu
       if (!authState.needsOnboarding && isOnOnboarding) {
-        return RoutePaths.fluxContinu;
+        return postAuthHomePath();
       }
 
       return null;
@@ -244,12 +254,8 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: RoutePaths.fluxContinu,
         name: RouteNames.fluxContinu,
-        builder: (context, state) => const Stack(
-          children: [
-            FluxContinuScreen(),
-            NudgeHost(),
-          ],
-        ),
+        builder: (context, state) =>
+            const Stack(children: [FluxContinuScreen(), NudgeHost()]),
         routes: [
           GoRoute(
             path: 'content/:id',
@@ -299,13 +305,45 @@ final routerProvider = Provider<GoRouter>((ref) {
         ],
       ),
 
-      // Feed (legacy) — redirige vers FluxContinu pour préserver les deep
+      // Flâner — feed autonome.
+      GoRoute(
+        path: RoutePaths.flaner,
+        name: RouteNames.flaner,
+        builder: (context, state) =>
+            const Stack(children: [FlanerScreen(), NudgeHost()]),
+        routes: [
+          GoRoute(
+            path: 'content/:id',
+            parentNavigatorKey: NotificationService.navigatorKey,
+            pageBuilder: (context, state) {
+              final contentId = state.pathParameters['id']!;
+              final content = state.extra as Content?;
+              return FullSwipeCupertinoPage(
+                child: ContentDetailScreen(
+                  contentId: contentId,
+                  content: content,
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+
+      GoRoute(
+        path: '${RoutePaths.feed}/content/:id',
+        redirect: (context, state) {
+          final id = state.pathParameters['id']!;
+          return '${RoutePaths.flaner}/content/$id';
+        },
+      ),
+
+      // Feed (legacy) — redirige vers Flâner pour préserver les deep
       // links sortants en circulation (push notifs, partages, anciennes
       // versions de l'app). Voir cleanup post-unification du flux.
       GoRoute(
         path: RoutePaths.feed,
         name: RouteNames.feed,
-        redirect: (context, state) => RoutePaths.fluxContinu,
+        redirect: (context, state) => RoutePaths.flaner,
       ),
 
       // Saved (Sauvegardés)
@@ -317,9 +355,8 @@ final routerProvider = Provider<GoRouter>((ref) {
           GoRoute(
             path: 'all',
             name: RouteNames.savedAll,
-            pageBuilder: (context, state) => const FullSwipeCupertinoPage(
-              child: SavedAllScreen(),
-            ),
+            pageBuilder: (context, state) =>
+                const FullSwipeCupertinoPage(child: SavedAllScreen()),
           ),
           GoRoute(
             path: 'collection/:id',
@@ -351,30 +388,26 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: RoutePaths.settings,
         name: RouteNames.settings,
-        pageBuilder: (context, state) => const ModalBottomSheetPage(
-          child: SettingsSheet(),
-        ),
+        pageBuilder: (context, state) =>
+            const ModalBottomSheetPage(child: SettingsSheet()),
         routes: [
           GoRoute(
             path: 'profile', // /settings/profile
             name: RouteNames.profile,
-            pageBuilder: (context, state) => const FullSwipeCupertinoPage(
-              child: ProfileScreen(),
-            ),
+            pageBuilder: (context, state) =>
+                const FullSwipeCupertinoPage(child: ProfileScreen()),
           ),
           GoRoute(
             path: 'sources', // /settings/sources
             name: RouteNames.sources,
-            pageBuilder: (context, state) => const FullSwipeCupertinoPage(
-              child: SourcesScreen(),
-            ),
+            pageBuilder: (context, state) =>
+                const FullSwipeCupertinoPage(child: SourcesScreen()),
             routes: [
               GoRoute(
                 path: 'add', // /settings/sources/add
                 name: RouteNames.addSource,
-                pageBuilder: (context, state) => const FullSwipeCupertinoPage(
-                  child: AddSourceScreen(),
-                ),
+                pageBuilder: (context, state) =>
+                    const FullSwipeCupertinoPage(child: AddSourceScreen()),
               ),
               GoRoute(
                 path: 'theme/:slug', // /settings/sources/theme/:slug
@@ -395,23 +428,20 @@ final routerProvider = Provider<GoRouter>((ref) {
           GoRoute(
             path: 'account', // /settings/account
             name: RouteNames.account,
-            pageBuilder: (context, state) => const FullSwipeCupertinoPage(
-              child: AccountScreen(),
-            ),
+            pageBuilder: (context, state) =>
+                const FullSwipeCupertinoPage(child: AccountScreen()),
           ),
           GoRoute(
             path: 'notifications', // /settings/notifications
             name: RouteNames.notifications,
-            pageBuilder: (context, state) => const FullSwipeCupertinoPage(
-              child: NotificationsScreen(),
-            ),
+            pageBuilder: (context, state) =>
+                const FullSwipeCupertinoPage(child: NotificationsScreen()),
           ),
           GoRoute(
             path: 'about', // /settings/about
             name: RouteNames.about,
-            pageBuilder: (context, state) => const FullSwipeCupertinoPage(
-              child: AboutScreen(),
-            ),
+            pageBuilder: (context, state) =>
+                const FullSwipeCupertinoPage(child: AboutScreen()),
           ),
           GoRoute(
             path: 'interests', // /settings/interests
@@ -444,9 +474,8 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: RoutePaths.lettres,
         name: RouteNames.lettres,
-        pageBuilder: (context, state) => const FullSwipeCupertinoPage(
-          child: CourrierScreen(),
-        ),
+        pageBuilder: (context, state) =>
+            const FullSwipeCupertinoPage(child: CourrierScreen()),
         routes: [
           GoRoute(
             path: ':id',
@@ -489,18 +518,12 @@ final routerProvider = Provider<GoRouter>((ref) {
         pageBuilder: (context, state) => CustomTransitionPage(
           child: const PaywallScreen(),
           transitionsBuilder: (context, animation, secondaryAnimation, child) {
-            return FadeTransition(
-              opacity: animation,
-              child: child,
-            );
+            return FadeTransition(opacity: animation, child: child);
           },
         ),
       ),
     ],
-    errorBuilder: (context, state) => Scaffold(
-      body: Center(
-        child: Text('Page non trouvée: ${state.uri}'),
-      ),
-    ),
+    errorBuilder: (context, state) =>
+        Scaffold(body: Center(child: Text('Page non trouvée: ${state.uri}'))),
   );
 });

--- a/apps/mobile/lib/core/nudges/widgets/nudge_host.dart
+++ b/apps/mobile/lib/core/nudges/widgets/nudge_host.dart
@@ -17,7 +17,7 @@ import 'nudge_tooltip_bubble.dart';
 /// Les autres placements (inlineBanner, hintAnimation, tooltip intra-article)
 /// sont rendus en place par les feature widgets eux-mêmes — ce host ne fait
 /// que coordonner quand activer le spotlight et qu'il a les bonnes conditions
-/// (GlobalKey montée, route `/feed` courante).
+/// (GlobalKey montée, route feed courante).
 class NudgeHost extends ConsumerStatefulWidget {
   const NudgeHost({super.key});
 
@@ -65,9 +65,13 @@ class _NudgeHostState extends ConsumerState<NudgeHost> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      final currentLocation =
-          GoRouter.of(context).routerDelegate.currentConfiguration.uri.path;
-      if (!currentLocation.startsWith(RoutePaths.fluxContinu)) return;
+      final currentLocation = GoRouter.of(
+        context,
+      ).routerDelegate.currentConfiguration.uri.path;
+      if (!currentLocation.startsWith(RoutePaths.fluxContinu) &&
+          !currentLocation.startsWith(RoutePaths.flaner)) {
+        return;
+      }
 
       final anchor = _anchorFor(id);
       if (anchor?.currentContext == null) return;

--- a/apps/mobile/lib/core/services/deep_link_service.dart
+++ b/apps/mobile/lib/core/services/deep_link_service.dart
@@ -13,20 +13,18 @@ import 'analytics_service.dart';
 /// Supported URIs:
 /// - `io.supabase.facteur://digest` → `/digest`
 /// - `io.supabase.facteur://digest/<contentId>?pos=<n>&topicId=<id>`
-///   → `/feed/content/<contentId>` (article reader, Essentiel deep link)
-/// - `io.supabase.facteur://feed` → `/feed`
+///   → `/flux-continu/content/<contentId>` (article reader, Essentiel deep link)
+/// - `io.supabase.facteur://feed` → `/flaner`
 /// - `io.supabase.facteur://feed/content/<contentId>?pos=<n>&topicId=<id>`
-///   → `/feed/content/<contentId>` (article reader, Flux deep link)
+///   → `/flaner/content/<contentId>` (article reader, Flâner deep link)
 /// - `io.supabase.facteur://veille/dashboard` → `/veille/dashboard`
 ///
 /// `io.supabase.facteur://login-callback` is intentionally ignored — Supabase
 /// SDK intercepts it before it reaches us. Anything else falls through to
 /// GoRouter's `errorBuilder`, which is a safety net only.
 class DeepLinkService {
-  DeepLinkService._({
-    AppLinks? appLinks,
-    AnalyticsService? analytics,
-  })  : _appLinks = appLinks ?? AppLinks(),
+  DeepLinkService._({AppLinks? appLinks, AnalyticsService? analytics})
+      : _appLinks = appLinks ?? AppLinks(),
         _analytics = analytics;
 
   /// Test-only factory letting suites inject a fake AppLinks/Analytics.
@@ -73,10 +71,7 @@ class DeepLinkService {
   bool _authenticated = false;
 
   /// Bind the service to the running router and analytics. Idempotent.
-  void bind({
-    required GoRouter router,
-    AnalyticsService? analytics,
-  }) {
+  void bind({required GoRouter router, AnalyticsService? analytics}) {
     _router = router;
     if (analytics != null) {
       _analytics = analytics;
@@ -258,18 +253,18 @@ class DeepLinkService {
         if (articleId.isNotEmpty) {
           return WidgetDeepLinkAction(
             target: WidgetDeepLinkTarget.article,
-            route: '/flux-continu/content/$articleId',
+            route: '${RoutePaths.flaner}/content/$articleId',
             articleId: articleId,
             position: int.tryParse(uri.queryParameters['pos'] ?? ''),
             topicId: uri.queryParameters['topicId'],
           );
         }
       }
-      // FeedScreen a été supprimé lors du cleanup post-unification — on
-      // route vers le flux continu (la nouvelle home).
+      // FeedScreen historique — on route vers Flâner, désormais page feed
+      // autonome.
       return const WidgetDeepLinkAction(
         target: WidgetDeepLinkTarget.feed,
-        route: RoutePaths.fluxContinu,
+        route: RoutePaths.flaner,
       );
     }
 

--- a/apps/mobile/lib/features/feed/screens/flaner_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/flaner_screen.dart
@@ -1,0 +1,501 @@
+import 'dart:async';
+import 'dart:ui' show ImageFilter;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:visibility_detector/visibility_detector.dart';
+
+import '../../../config/routes.dart';
+import '../../../config/theme.dart';
+import '../../../shared/widgets/loaders/loading_view.dart';
+import '../../../shared/widgets/navigation/main_bottom_nav.dart';
+import '../../../widgets/article_preview_modal.dart';
+import '../../../widgets/design/facteur_logo.dart';
+import '../../app_update/providers/app_update_provider.dart';
+import '../../flux_continu/widgets/flux_continu_article_card.dart';
+import '../../gamification/widgets/streak_indicator.dart';
+import '../../sources/widgets/pepites_carousel.dart';
+import '../models/content_model.dart';
+import '../providers/feed_provider.dart';
+import '../widgets/feed_carousel.dart';
+import '../widgets/feed_filter_bar.dart';
+import '../widgets/follow_keyword_suggestion_card.dart';
+import '../widgets/profile_avatar_button.dart';
+
+const double _kLoadMoreLeadingPx = 800.0;
+const double _kScrollDirThreshold = 12.0;
+const double _kFabHideAboveScroll = 380.0;
+
+class FlanerScreen extends ConsumerStatefulWidget {
+  const FlanerScreen({super.key});
+
+  @override
+  ConsumerState<FlanerScreen> createState() => _FlanerScreenState();
+}
+
+class _FlanerScreenState extends ConsumerState<FlanerScreen> {
+  final ScrollController _scroll = ScrollController();
+  final Set<String> _visibleContentIds = <String>{};
+  bool _loadingMore = false;
+  bool _showScrollTopFab = false;
+  double _lastScrollPos = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _scroll.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scroll.removeListener(_onScroll);
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_scroll.hasClients) return;
+    final pos = _scroll.position;
+    final currentScroll = pos.pixels;
+
+    final delta = currentScroll - _lastScrollPos;
+    if (delta.abs() >= _kScrollDirThreshold) {
+      bool nextFab = _showScrollTopFab;
+      if (currentScroll < _kFabHideAboveScroll) {
+        nextFab = false;
+      } else if (delta < 0) {
+        nextFab = true;
+      } else if (delta > 0) {
+        nextFab = false;
+      }
+      if (nextFab != _showScrollTopFab) {
+        setState(() => _showScrollTopFab = nextFab);
+      }
+      _lastScrollPos = currentScroll;
+    }
+
+    if (pos.maxScrollExtent - currentScroll >= _kLoadMoreLeadingPx) return;
+    if (_loadingMore) return;
+    final notifier = ref.read(feedProvider.notifier);
+    if (!notifier.hasNext || notifier.isLoadingMore) return;
+    setState(() => _loadingMore = true);
+    unawaited(notifier.loadMore().whenComplete(() {
+      if (mounted) {
+        setState(() => _loadingMore = false);
+      } else {
+        _loadingMore = false;
+      }
+    }));
+  }
+
+  Future<void> _refresh() async {
+    final ids = Set<String>.from(_visibleContentIds);
+    _visibleContentIds.clear();
+    await ref.read(feedProvider.notifier).refreshArticlesWithSnapshot(ids);
+  }
+
+  Future<void> _openArticle(Content article) async {
+    await context.push(
+      '${RoutePaths.flaner}/content/${article.id}',
+      extra: article,
+    );
+    if (!mounted) return;
+    unawaited(ref.read(feedProvider.notifier).markContentAsConsumed(article));
+  }
+
+  Future<void> _scrollToTop() async {
+    if (!_scroll.hasClients) return;
+    unawaited(HapticFeedback.lightImpact());
+    await _scroll.animateTo(
+      0,
+      duration: const Duration(milliseconds: 700),
+      curve: Curves.easeInOutCubic,
+    );
+  }
+
+  void _markVisible(String contentId) {
+    if (contentId.isNotEmpty) _visibleContentIds.add(contentId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final async = ref.watch(feedProvider);
+    final colors = context.facteurColors;
+    return Scaffold(
+      backgroundColor: colors.backgroundPrimary,
+      bottomNavigationBar: const MainBottomNav(
+        current: MainBottomNavDestination.flaner,
+      ),
+      body: SafeArea(
+        bottom: false,
+        child: Stack(
+          children: [
+            async.when(
+              loading: () => const LoadingView(),
+              error: (e, _) => _ErrorView(
+                error: e,
+                onRetry: () => ref.read(feedProvider.notifier).refresh(),
+              ),
+              data: (state) => _buildContent(context, state),
+            ),
+            Positioned(
+              right: 16,
+              bottom: 24,
+              child: SafeArea(
+                child: AnimatedSlide(
+                  duration: const Duration(milliseconds: 220),
+                  curve: Curves.easeOutCubic,
+                  offset:
+                      _showScrollTopFab ? Offset.zero : const Offset(0, 1.6),
+                  child: AnimatedOpacity(
+                    duration: const Duration(milliseconds: 220),
+                    opacity: _showScrollTopFab ? 1.0 : 0.0,
+                    child: _ScrollToTopButton(onTap: _scrollToTop),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, FeedState state) {
+    final colors = context.facteurColors;
+    final keyword = ref.watch(feedProvider.notifier).selectedKeyword;
+    return RefreshIndicator(
+      onRefresh: _refresh,
+      color: colors.primary,
+      child: CustomScrollView(
+        controller: _scroll,
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          const SliverToBoxAdapter(child: _Header()),
+          const SliverPersistentHeader(
+            pinned: true,
+            delegate: _FilterHeaderDelegate(child: _FilterSurface()),
+          ),
+          SliverToBoxAdapter(
+            child: (keyword == null || keyword.trim().isEmpty)
+                ? const SizedBox.shrink()
+                : FollowKeywordSuggestionCard(keyword: keyword),
+          ),
+          if (state.items.length > 4)
+            const SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.only(bottom: 12),
+                child: PepitesCarousel(),
+              ),
+            ),
+          _buildFeedList(state),
+          if (_loadingMore)
+            const SliverToBoxAdapter(child: _LoadingMoreIndicator()),
+          const SliverToBoxAdapter(child: SizedBox(height: 92)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFeedList(FeedState state) {
+    final contents = state.items;
+    final carousels = state.carousels;
+    final intercalations = <({int position, Widget Function() builder})>[];
+
+    for (final carousel in carousels) {
+      if (carousel.items.isEmpty || carousel.position >= contents.length) {
+        continue;
+      }
+      intercalations.add((
+        position: carousel.position,
+        builder: () => Padding(
+              key: ValueKey('flaner_carousel_${carousel.carouselType}'),
+              padding: const EdgeInsets.only(bottom: 12),
+              child: FeedCarousel(
+                data: carousel,
+                onArticleTap: _openArticle,
+                onLongPressStart: (c, _) =>
+                    ArticlePreviewOverlay.show(context, c),
+                onLongPressMoveUpdate: (details) =>
+                    ArticlePreviewOverlay.updateScroll(
+                  details.localOffsetFromOrigin.dy,
+                ),
+                onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
+                onItemVisible: _markVisible,
+              ),
+            ),
+      ));
+    }
+
+    intercalations.sort((a, b) => a.position.compareTo(b.position));
+
+    return SliverList(
+      delegate: SliverChildBuilderDelegate((context, listIndex) {
+        int offset = 0;
+        for (final inter in intercalations) {
+          final effective = inter.position + offset;
+          if (listIndex == effective) return inter.builder();
+          if (listIndex > effective) offset++;
+        }
+        final articleIndex = listIndex - offset;
+        if (articleIndex < 0 || articleIndex >= contents.length) {
+          return null;
+        }
+        final article = contents[articleIndex];
+        return VisibilityDetector(
+          key: ValueKey('flaner_visible_${article.id}'),
+          onVisibilityChanged: (info) {
+            if (info.visibleFraction >= 0.9) _markVisible(article.id);
+          },
+          child: FluxContinuArticleCard(
+            article: article,
+            onTap: () => _openArticle(article),
+            onSwipeDismiss: () =>
+                ref.read(feedProvider.notifier).swipeDismiss(article),
+          ),
+        );
+      }, childCount: contents.length + intercalations.length),
+    );
+  }
+}
+
+class _Header extends ConsumerWidget {
+  const _Header();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: FacteurSpacing.space6,
+        vertical: FacteurSpacing.space3,
+      ),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          const FacteurLogo(size: 22, showIcon: false),
+          const Align(
+            alignment: Alignment.centerLeft,
+            child: StreakIndicator(),
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: Consumer(
+              builder: (context, ref, _) {
+                final hasUpdate =
+                    ref.watch(appUpdateProvider).valueOrNull?.updateAvailable ==
+                        true;
+                final settingsButton = ProfileAvatarButton(
+                  onTap: () => context.push(RoutePaths.settings),
+                );
+                if (!hasUpdate) return settingsButton;
+                return Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    settingsButton,
+                    Positioned(
+                      top: -2,
+                      right: -2,
+                      child: Container(
+                        width: 12,
+                        height: 12,
+                        decoration: BoxDecoration(
+                          color: colors.error,
+                          shape: BoxShape.circle,
+                          border: Border.all(
+                            color: colors.backgroundPrimary,
+                            width: 2,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FilterSurface extends ConsumerWidget {
+  const _FilterSurface();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final refreshing = ref.watch(feedRefreshingProvider);
+    return Material(
+      color: colors.backgroundPrimary,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 8, 16, 8),
+            child: FeedFilterBar(excludedThemeSlugs: <String>[]),
+          ),
+          SizedBox(
+            height: 2,
+            child: refreshing
+                ? LinearProgressIndicator(
+                    minHeight: 2,
+                    backgroundColor: Colors.transparent,
+                    color: colors.primary,
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FilterHeaderDelegate extends SliverPersistentHeaderDelegate {
+  final Widget child;
+
+  const _FilterHeaderDelegate({required this.child});
+
+  @override
+  double get minExtent => 56;
+
+  @override
+  double get maxExtent => 56;
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    return child;
+  }
+
+  @override
+  bool shouldRebuild(covariant _FilterHeaderDelegate oldDelegate) {
+    return oldDelegate.child != child;
+  }
+}
+
+class _LoadingMoreIndicator extends StatelessWidget {
+  const _LoadingMoreIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SizedBox(
+            width: 14,
+            height: 14,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              valueColor: AlwaysStoppedAnimation<Color>(colors.textSecondary),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            'Chargement…',
+            style: TextStyle(
+              color: colors.textSecondary,
+              fontWeight: FontWeight.w500,
+              fontSize: 13,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ScrollToTopButton extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _ScrollToTopButton({required this.onTap});
+
+  static const _kRadius = BorderRadius.all(Radius.circular(22));
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final isDark = context.isDarkMode;
+    final fillColor = isDark
+        ? colors.backgroundPrimary.withValues(alpha: 0.78)
+        : const Color.fromRGBO(242, 232, 213, 0.82);
+    final borderColor = isDark
+        ? Colors.white.withValues(alpha: 0.10)
+        : const Color.fromRGBO(0, 0, 0, 0.08);
+
+    return ClipRRect(
+      borderRadius: _kRadius,
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: _kRadius,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+              decoration: BoxDecoration(
+                color: fillColor,
+                borderRadius: _kRadius,
+                border: Border.all(color: borderColor),
+              ),
+              child: Icon(
+                Icons.keyboard_arrow_up_rounded,
+                color: colors.textPrimary,
+                size: 24,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  final Object error;
+  final VoidCallback onRetry;
+
+  const _ErrorView({required this.error, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Impossible de charger Flâner',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: colors.textPrimary,
+                fontWeight: FontWeight.w700,
+                fontSize: 18,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '$error',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: colors.textSecondary),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(onPressed: onRetry, child: const Text('Réessayer')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
-import '../../flux_continu/providers/flux_continu_provider.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../providers/feed_provider.dart';
 import '../providers/tab_counts_provider.dart';
@@ -27,8 +26,13 @@ import 'search_filter_sheet.dart';
 /// them here behind optional callbacks rather than duplicating the logic.
 class FeedFilterBar extends ConsumerStatefulWidget {
   final VoidCallback? onAfterChange;
+  final List<String> excludedThemeSlugs;
 
-  const FeedFilterBar({super.key, this.onAfterChange});
+  const FeedFilterBar({
+    super.key,
+    this.onAfterChange,
+    this.excludedThemeSlugs = const [],
+  });
 
   @override
   ConsumerState<FeedFilterBar> createState() => _FeedFilterBarState();
@@ -50,11 +54,6 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
     final feedItems =
         ref.watch(feedProvider).valueOrNull?.items ?? const <dynamic>[];
     final serverCounts = ref.watch(tabCountsProvider).valueOrNull;
-    final tourneeSlugs = ref
-            .watch(fluxContinuProvider)
-            .valueOrNull
-            ?.tourneeThemeSlugs ??
-        const <String>[];
     return FilterCollapsiblePanel(
       activeCount: selection.activeCount,
       chipsRow: _buildChipsRow(context, selection),
@@ -64,7 +63,7 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
         selectedTopicSlug: selection.topic,
         selectedThemeSlug: selection.theme,
         selectedEntitySlug: selection.entity,
-        excludedThemeSlugs: tourneeSlugs,
+        excludedThemeSlugs: widget.excludedThemeSlugs,
         onTabTap: (kind, slug) async {
           // Sheet owns this override ; clear it so the chip label rebuilds
           // from the tapped tab's name on next layout.
@@ -101,8 +100,12 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
             currentTopicSlug:
                 selection.topic ?? selection.theme ?? selection.entity,
             currentIsTheme: selection.theme != null,
-            onInterestSelected:
-                (slug, name, {bool isTheme = false, bool isEntity = false}) async {
+            onInterestSelected: (
+              slug,
+              name, {
+              bool isTheme = false,
+              bool isEntity = false,
+            }) async {
               setState(() {
                 _selectedInterestNameOverride = name;
               });
@@ -188,8 +191,12 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
             selectedName: _selectedInterestNameOverride,
             selectedIsTheme: selectedIsTheme,
             discreet: true,
-            onInterestChanged: (slug, name,
-                {bool isTheme = false, bool isEntity = false}) async {
+            onInterestChanged: (
+              slug,
+              name, {
+              bool isTheme = false,
+              bool isEntity = false,
+            }) async {
               setState(() {
                 _selectedInterestNameOverride = name;
               });
@@ -271,8 +278,10 @@ class _SearchTrigger extends StatelessWidget {
                 behavior: HitTestBehavior.opaque,
                 onTap: onClear,
                 child: Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 6, vertical: 8),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 8,
+                  ),
                   child: Icon(
                     PhosphorIcons.x(PhosphorIconsStyle.bold),
                     size: 13,

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -2,9 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:timezone/data/latest.dart' as tz_data;
-import 'package:timezone/timezone.dart' as tz;
 
 import '../../digest/models/digest_models.dart';
 import '../../digest/models/dual_digest_response.dart';
@@ -21,6 +18,7 @@ import '../../veille/providers/veille_active_config_provider.dart';
 import '../models/flux_continu_models.dart';
 import '../repositories/essentiel_repository.dart';
 import '../repositories/flux_continu_repository.dart';
+import '../services/tournee_progress_service.dart';
 import '../utils/theme_color_mapping.dart';
 
 /// Accent applied to the legacy "Actus du jour" digest topic section
@@ -63,48 +61,6 @@ const int _kMaxFavoriteSections = 3;
 /// pagination.hasNext (computed from a pre-compression candidate count) says.
 const int _kThemeSectionPageLimit = 10;
 
-/// Prefix for the day-scoped SharedPreferences key that stores which sections
-/// the user has already scrolled past today. Keys older than today are purged
-/// at startup so a new day starts with every section expanded.
-const String _kFoldedPrefsKeyPrefix = 'flux_continu_folded_';
-const String _kClosingPrefsKeyPrefix = 'flux_continu_closing_dismissed_';
-
-/// Boundary hour (Paris time) at which the "tournée day" flips. Aligned with
-/// the API digest cron at 07:30 Paris (`DIGEST_CRON_HOUR_PARIS`,
-/// `packages/api/app/workers/scheduler.py`). The boundary is computed against
-/// Europe/Paris — not the device's local timezone — so a user in Tokyo
-/// (UTC+9) at 02:00 local doesn't roll over to a fresh tournée hours before
-/// the backend has even generated tomorrow's digest.
-const int _kTourneeDayBoundaryHour = 7;
-const int _kTourneeDayBoundaryMinute = 30;
-const String _kTourneeDayBoundaryTz = 'Europe/Paris';
-
-tz.Location? _parisLocation;
-
-tz.Location _parisTz() {
-  if (_parisLocation != null) return _parisLocation!;
-  tz_data.initializeTimeZones();
-  return _parisLocation = tz.getLocation(_kTourneeDayBoundaryTz);
-}
-
-/// Returns the canonical ISO day (`YYYY-MM-DD`) for the tournée at [now],
-/// using a 07:30 Europe/Paris boundary instead of midnight.
-String _dayKey(DateTime now) {
-  final paris = tz.TZDateTime.from(now, _parisTz());
-  final shifted = (paris.hour < _kTourneeDayBoundaryHour ||
-          (paris.hour == _kTourneeDayBoundaryHour &&
-              paris.minute < _kTourneeDayBoundaryMinute))
-      ? paris.subtract(const Duration(days: 1))
-      : paris;
-  return shifted.toIso8601String().substring(0, 10);
-}
-
-String _foldedPrefsKey(DateTime day) =>
-    '$_kFoldedPrefsKeyPrefix${_dayKey(day)}';
-
-String _closingPrefsKey(DateTime day) =>
-    '$_kClosingPrefsKeyPrefix${_dayKey(day)}';
-
 /// Riverpod provider for the Flux Continu V1.8 home screen.
 ///
 /// Orchestrates three parallel API calls at mount (digest, top-themes,
@@ -115,8 +71,8 @@ String _closingPrefsKey(DateTime day) =>
 /// sticky bar actually shape the list.
 final fluxContinuProvider =
     AsyncNotifierProvider<FluxContinuNotifier, FluxContinuState>(
-  FluxContinuNotifier.new,
-);
+      FluxContinuNotifier.new,
+    );
 
 class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   late DigestRepository _digestRepo;
@@ -175,16 +131,16 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
     // React to favorite reorders / additions / removals without rebuilding
     // the digest (the digest doesn't depend on favorites).
-    ref.listen<AsyncValue<UserInterestsState>>(
-      userInterestsProvider,
-      (prev, next) {
-        final nextFavorites = next.valueOrNull?.favorites;
-        if (nextFavorites == null) return;
-        if (_favoriteListsEqual(_lastFavorites, nextFavorites)) return;
-        if (!state.hasValue) return;
-        unawaited(_refetchThemesOnly(nextFavorites));
-      },
-    );
+    ref.listen<AsyncValue<UserInterestsState>>(userInterestsProvider, (
+      prev,
+      next,
+    ) {
+      final nextFavorites = next.valueOrNull?.favorites;
+      if (nextFavorites == null) return;
+      if (_favoriteListsEqual(_lastFavorites, nextFavorites)) return;
+      if (!state.hasValue) return;
+      unawaited(_refetchThemesOnly(nextFavorites));
+    });
 
     return _fetchAll();
   }
@@ -298,8 +254,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
     // Filter persistQueued against present sections to avoid stale keys
     // surviving a compose (e.g. a favorite was removed).
-    final persistFiltered =
-        _persistQueued.where(keysPresent.contains).toSet();
+    final persistFiltered = _persistQueued.where(keysPresent.contains).toSet();
     if (persistFiltered.length != _persistQueued.length) {
       _persistQueued
         ..clear()
@@ -344,10 +299,12 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     _dismissedIds.add(contentId);
     final current = state.valueOrNull;
     if (current == null) return;
-    state = AsyncData(current.copyWith(
-      sections: _filterSections(current.sections),
-      dismissedIds: Set.unmodifiable(_dismissedIds),
-    ));
+    state = AsyncData(
+      current.copyWith(
+        sections: _filterSections(current.sections),
+        dismissedIds: Set.unmodifiable(_dismissedIds),
+      ),
+    );
   }
 
   /// Restores an article that was hidden remotely but not yet purged from
@@ -377,24 +334,25 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       for (final s in sections)
         switch (s) {
           EssentielSection(:final articles) => EssentielSection(
-              articles: articles
-                  .where((a) => !_dismissedIds.contains(a.contentId))
-                  .toList(growable: false),
-              blurb: s.blurb,
-              illustrationAsset: s.illustrationAsset,
-            ),
+            articles: articles
+                .where((a) => !_dismissedIds.contains(a.contentId))
+                .toList(growable: false),
+            blurb: s.blurb,
+            illustrationAsset: s.illustrationAsset,
+          ),
           DigestTopicSection(:final topics) => DigestTopicSection(
-              kind: s.kind,
-              label: s.label,
-              accent: s.accent,
-              coreVisibleCount: s.coreVisibleCount,
-              blurb: s.blurb,
-              illustrationAsset: s.illustrationAsset,
-              topics: topics
-                  .where((t) =>
-                      !_dismissedIds.contains(pickTopicLead(t).contentId))
-                  .toList(growable: false),
-            ),
+            kind: s.kind,
+            label: s.label,
+            accent: s.accent,
+            coreVisibleCount: s.coreVisibleCount,
+            blurb: s.blurb,
+            illustrationAsset: s.illustrationAsset,
+            topics: topics
+                .where(
+                  (t) => !_dismissedIds.contains(pickTopicLead(t).contentId),
+                )
+                .toList(growable: false),
+          ),
           FeedThemeSection(
             :final items,
             :final themeSlug,
@@ -431,56 +389,56 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       for (final s in current.sections)
         switch (s) {
           EssentielSection(:final articles) => EssentielSection(
-              articles: [
-                for (final a in articles)
-                  if (a.contentId == contentId)
-                    EssentielArticle(
-                      contentId: a.contentId,
-                      title: a.title,
-                      url: a.url,
-                      thumbnailUrl: a.thumbnailUrl,
-                      publishedAt: a.publishedAt,
-                      sourceName: a.sourceName,
-                      sourceLetter: a.sourceLetter,
-                      sectionLabel: a.sectionLabel,
-                      rank: a.rank,
-                      kind: a.kind,
-                      theme: a.theme,
-                      perspectiveCount: a.perspectiveCount,
-                      isRead: true,
-                      isSaved: a.isSaved,
-                      isLiked: a.isLiked,
-                      isDismissed: a.isDismissed,
-                      isFollowedSource: a.isFollowedSource,
-                      isFollowedTopic: a.isFollowedTopic,
-                      isActuDuJour: a.isActuDuJour,
-                    )
-                  else
-                    a,
-              ],
-              blurb: s.blurb,
-              illustrationAsset: s.illustrationAsset,
-            ),
+            articles: [
+              for (final a in articles)
+                if (a.contentId == contentId)
+                  EssentielArticle(
+                    contentId: a.contentId,
+                    title: a.title,
+                    url: a.url,
+                    thumbnailUrl: a.thumbnailUrl,
+                    publishedAt: a.publishedAt,
+                    sourceName: a.sourceName,
+                    sourceLetter: a.sourceLetter,
+                    sectionLabel: a.sectionLabel,
+                    rank: a.rank,
+                    kind: a.kind,
+                    theme: a.theme,
+                    perspectiveCount: a.perspectiveCount,
+                    isRead: true,
+                    isSaved: a.isSaved,
+                    isLiked: a.isLiked,
+                    isDismissed: a.isDismissed,
+                    isFollowedSource: a.isFollowedSource,
+                    isFollowedTopic: a.isFollowedTopic,
+                    isActuDuJour: a.isActuDuJour,
+                  )
+                else
+                  a,
+            ],
+            blurb: s.blurb,
+            illustrationAsset: s.illustrationAsset,
+          ),
           DigestTopicSection(:final topics) => DigestTopicSection(
-              kind: s.kind,
-              label: s.label,
-              accent: s.accent,
-              coreVisibleCount: s.coreVisibleCount,
-              blurb: s.blurb,
-              illustrationAsset: s.illustrationAsset,
-              topics: [
-                for (final t in topics)
-                  t.copyWith(
-                    articles: [
-                      for (final a in t.articles)
-                        if (a.contentId == contentId)
-                          a.copyWith(isRead: true)
-                        else
-                          a,
-                    ],
-                  ),
-              ],
-            ),
+            kind: s.kind,
+            label: s.label,
+            accent: s.accent,
+            coreVisibleCount: s.coreVisibleCount,
+            blurb: s.blurb,
+            illustrationAsset: s.illustrationAsset,
+            topics: [
+              for (final t in topics)
+                t.copyWith(
+                  articles: [
+                    for (final a in t.articles)
+                      if (a.contentId == contentId)
+                        a.copyWith(isRead: true)
+                      else
+                        a,
+                  ],
+                ),
+            ],
+          ),
           FeedThemeSection(
             :final items,
             :final themeSlug,
@@ -571,10 +529,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     if (response == null || response.items.isEmpty) {
       // Treat empty/error response as "no more" so the button settles into
       // the disabled "Plus rien à voir" state rather than spinning forever.
-      updated = afterTarget.copyWith(
-        isLoadingMore: false,
-        hasMore: false,
-      );
+      updated = afterTarget.copyWith(isLoadingMore: false, hasMore: false);
     } else {
       // Dedupe by content id — guards against a new article being published
       // between page 1 and page 2 and shifting the chronological cursor.
@@ -585,7 +540,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
           if (!existingIds.contains(item.id)) item,
       ];
       final hasMore = _themeHasMore(
-          response.pagination.hasNext, response.items.length);
+        response.pagination.hasNext,
+        response.items.length,
+      );
       updated = afterTarget.copyWith(
         items: appended,
         currentPage: nextPage,
@@ -610,9 +567,11 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     _persistQueued.add(key);
     final current = state.valueOrNull;
     if (current != null) {
-      state = AsyncData(current.copyWith(
-        markedForNextSession: Set.unmodifiable(_persistQueued),
-      ));
+      state = AsyncData(
+        current.copyWith(
+          markedForNextSession: Set.unmodifiable(_persistQueued),
+        ),
+      );
     }
     final combined = <String, bool>{
       ..._folded,
@@ -657,20 +616,19 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     if (current == null) return;
     final toPromote = _persistQueued.difference(exceptKeys);
     if (toPromote.isEmpty) return;
-    final next = <String, bool>{
-      ..._folded,
-      for (final k in toPromote) k: true,
-    };
+    final next = <String, bool>{..._folded, for (final k in toPromote) k: true};
     if (next.length == _folded.length &&
         next.entries.every((e) => _folded[e.key] == e.value)) {
       return;
     }
     _folded = next;
     _persistQueued.removeAll(toPromote);
-    state = AsyncData(current.copyWith(
-      folded: next,
-      markedForNextSession: Set.unmodifiable(_persistQueued),
-    ));
+    state = AsyncData(
+      current.copyWith(
+        folded: next,
+        markedForNextSession: Set.unmodifiable(_persistQueued),
+      ),
+    );
   }
 
   /// Read-only snapshot of the sections queued for fold at next apply.
@@ -696,21 +654,24 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     if (wasFolded) {
       final next = Map<String, bool>.from(current.folded)..remove(key);
       _folded = next;
-      state = AsyncData(current.copyWith(
-        folded: next,
-        markedForNextSession: Set.unmodifiable(_persistQueued),
-      ));
+      state = AsyncData(
+        current.copyWith(
+          folded: next,
+          markedForNextSession: Set.unmodifiable(_persistQueued),
+        ),
+      );
     } else if (wasQueued) {
-      state = AsyncData(current.copyWith(
-        markedForNextSession: Set.unmodifiable(_persistQueued),
-      ));
+      state = AsyncData(
+        current.copyWith(
+          markedForNextSession: Set.unmodifiable(_persistQueued),
+        ),
+      );
     }
     // Rewrite the prefs blob with the new (live + still-queued) fold set so
     // the unfold survives a cold launch in the same tournée day.
-    unawaited(_persistFolded({
-      ..._folded,
-      for (final k in _persistQueued) k: true,
-    }));
+    unawaited(
+      _persistFolded({..._folded, for (final k in _persistQueued) k: true}),
+    );
   }
 
   /// Manually folds a section in the current session only (not persisted).
@@ -726,75 +687,34 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   }
 
   Future<Map<String, bool>> _loadFoldedForToday() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final names = prefs.getStringList(_foldedPrefsKey(DateTime.now())) ??
-          const <String>[];
-      if (names.isEmpty) return const {};
-      // Parse tolerantly: legacy enum-style names (`essentiel`, `bonnes`) are
-      // still valid. Anything that doesn't match the new string-key shape
-      // (`essentiel` / `bonnes` / `theme:slug` / `topic:uuid`) — notably the
-      // dead `theme1` / `theme2` from the previous schema — is silently
-      // dropped. The day purge below will remove the prefs blob in <24h.
-      return {
-        for (final name in names)
-          if (_isLiveFoldedKey(name)) name: true,
-      };
-    } catch (e) {
-      debugPrint('FluxContinu: _loadFoldedForToday failed: $e');
-      return const {};
-    }
+    // Parse tolerantly: legacy enum-style names (`essentiel`, `bonnes`) are
+    // still valid. Anything that doesn't match the new string-key shape
+    // (`essentiel` / `bonnes` / `theme:slug` / `topic:uuid`) — notably the
+    // dead `theme1` / `theme2` from the previous schema — is silently
+    // dropped. The day purge below will remove the prefs blob in <24h.
+    return ref
+        .read(tourneeProgressServiceProvider)
+        .loadFoldedForToday(isLiveKey: _isLiveFoldedKey);
   }
 
   Future<void> _persistFolded(Map<String, bool> folded) async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final names =
-          folded.entries.where((e) => e.value).map((e) => e.key).toList();
-      await prefs.setStringList(_foldedPrefsKey(DateTime.now()), names);
-    } catch (e) {
-      debugPrint('FluxContinu: _persistFolded failed: $e');
-    }
+    await ref.read(tourneeProgressServiceProvider).persistFolded(folded);
   }
 
   Future<bool> _loadClosingDismissedForToday() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      return prefs.getBool(_closingPrefsKey(DateTime.now())) ?? false;
-    } catch (e) {
-      debugPrint('FluxContinu: _loadClosingDismissedForToday failed: $e');
-      return false;
-    }
+    return ref
+        .read(tourneeProgressServiceProvider)
+        .loadClosingDismissedForToday();
   }
 
   Future<void> _persistClosingDismissed(bool dismissed) async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_closingPrefsKey(DateTime.now()), dismissed);
-    } catch (e) {
-      debugPrint('FluxContinu: _persistClosingDismissed failed: $e');
-    }
+    await ref
+        .read(tourneeProgressServiceProvider)
+        .setClosingDismissedToday(dismissed);
   }
 
   Future<void> _purgeOldPrefsKeys() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final today = DateTime.now();
-      final foldedToday = _foldedPrefsKey(today);
-      final closingToday = _closingPrefsKey(today);
-      final stale = prefs.getKeys().where((k) {
-        if (k.startsWith(_kFoldedPrefsKeyPrefix) && k != foldedToday) {
-          return true;
-        }
-        if (k.startsWith(_kClosingPrefsKeyPrefix) && k != closingToday) {
-          return true;
-        }
-        return false;
-      }).toList();
-      await Future.wait(stale.map(prefs.remove));
-    } catch (e) {
-      debugPrint('FluxContinu: _purgeOldPrefsKeys failed: $e');
-    }
+    await ref.read(tourneeProgressServiceProvider).purgeOldPrefsKeys();
   }
 
   /// Pull-to-refresh: refetch all upstream calls from scratch.
@@ -831,7 +751,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     required String illustration,
     required int coreVisibleCount,
   }) {
-    final topics = digest?.topics
+    final topics =
+        digest?.topics
             .where((t) => t.articles.isNotEmpty)
             .toList(growable: false) ??
         const <DigestTopic>[];
@@ -867,7 +788,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     final items = feed?.items ?? const <Content>[];
     if (items.length < 2) return null;
     final hasMore = _themeHasMore(
-        feed?.pagination.hasNext ?? false, items.length);
+      feed?.pagination.hasNext ?? false,
+      items.length,
+    );
     return FeedThemeSection(
       kind: SectionKind.theme,
       label: label,
@@ -905,8 +828,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // Pad with canonical macro themes the user is missing — order: tech,
     // environment, science (matches the backend backfill list).
     const canonical = [fallbackTheme1, fallbackTheme2, 'science'];
-    final present =
-        valid.whereType<ThemeFavoriteRef>().map((r) => r.slug).toSet();
+    final present = valid
+        .whereType<ThemeFavoriteRef>()
+        .map((r) => r.slug)
+        .toSet();
     for (final slug in canonical) {
       if (valid.length >= _kMaxFavoriteSections) break;
       if (present.contains(slug)) continue;
@@ -934,17 +859,17 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       final feed = feeds[i];
       final section = switch (favRef) {
         ThemeFavoriteRef(:final slug) => _buildThemeSection(
-            feed: feed,
-            label: visualFor(slug).label,
-            accent: visualFor(slug).accent,
-            themeSlug: slug,
-          ),
+          feed: feed,
+          label: visualFor(slug).label,
+          accent: visualFor(slug).accent,
+          themeSlug: slug,
+        ),
         CustomTopicFavoriteRef(:final id) => _buildThemeSection(
-            feed: feed,
-            label: _customTopicLabel(interestsState, id),
-            accent: _customTopicAccent(interestsState, id),
-            customTopicId: id,
-          ),
+          feed: feed,
+          label: _customTopicLabel(interestsState, id),
+          accent: _customTopicAccent(interestsState, id),
+          customTopicId: id,
+        ),
         // Story 23.2 PR-4 : la veille devient une section Tournée dédiée
         // avec son propre accent et label, calculée séparément des thèmes.
         VeilleFavoriteRef() => _buildVeilleSection(feed),
@@ -960,39 +885,37 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // sections (vs. the unrestricted exploration mode used by feed chips).
     return switch (favRef) {
       ThemeFavoriteRef(:final slug) => _safe<FeedResponse>(
-          () => _feedRepo.getFeed(
-            page: 1,
-            limit: _kThemeSectionPageLimit,
-            theme: slug,
-            serein: isSerene,
-            personalized: true,
-          ),
-          'getFeed?theme=$slug&personalized=true',
+        () => _feedRepo.getFeed(
+          page: 1,
+          limit: _kThemeSectionPageLimit,
+          theme: slug,
+          serein: isSerene,
+          personalized: true,
         ),
+        'getFeed?theme=$slug&personalized=true',
+      ),
       // Backend `/api/feed` accepts a UUID stringified in the `topic` param
       // (story 22.1) — looked up against `user_topic_profiles` scoped on the
       // current user, so no cross-user leak.
       CustomTopicFavoriteRef(:final id) => _safe<FeedResponse>(
-          () => _feedRepo.getFeed(
-            page: 1,
-            limit: _kThemeSectionPageLimit,
-            topic: id,
-            serein: isSerene,
-            personalized: true,
-          ),
-          'getFeed?topic=$id&personalized=true',
+        () => _feedRepo.getFeed(
+          page: 1,
+          limit: _kThemeSectionPageLimit,
+          topic: id,
+          serein: isSerene,
+          personalized: true,
         ),
+        'getFeed?topic=$id&personalized=true',
+      ),
       // Story 23.2 PR-4 : la veille est résolue via `/api/veille/feed`,
       // exposée par FluxContinuRepository.getVeilleFeedItems (normalise la
       // réponse en FeedResponse Content-compatible).
       VeilleFavoriteRef() => _safe<FeedResponse>(
-          () =>
-              ref.read(fluxContinuRepositoryProvider).getVeilleFeedItems(
-                    limit: 10,
-                    serein: isSerene,
-                  ),
-          'getVeilleFeedItems',
-        ),
+        () => ref
+            .read(fluxContinuRepositoryProvider)
+            .getVeilleFeedItems(limit: 10, serein: isSerene),
+        'getVeilleFeedItems',
+      ),
     };
   }
 
@@ -1035,8 +958,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   /// favorites.
   Future<void> _refetchThemesOnly(List<FavoriteRef> nextFavorites) async {
     final isSerene = ref.read(sereinToggleProvider).enabled;
-    final capped =
-        nextFavorites.take(_kMaxFavoriteSections).toList(growable: false);
+    final capped = nextFavorites
+        .take(_kMaxFavoriteSections)
+        .toList(growable: false);
     final themes = await _fetchThemeSections(capped, isSerene);
     _lastFavorites = capped;
     _themes = themes;

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -14,19 +14,15 @@ import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../../core/orchestration/first_impression_orchestrator.dart';
 import '../../../core/providers/analytics_provider.dart';
-import '../../../widgets/article_preview_modal.dart';
 import '../../../widgets/design/facteur_logo.dart';
+import '../../../shared/widgets/navigation/main_bottom_nav.dart';
 import '../../app_update/providers/app_update_provider.dart';
 import '../../custom_topics/widgets/topic_chip.dart';
 import '../../digest/models/digest_models.dart';
 import '../../feed/models/content_model.dart';
-import '../../feed/providers/feed_provider.dart';
 import '../../feed/providers/swipe_hint_provider.dart';
-import '../../feed/widgets/feed_carousel.dart';
 import '../../feed/widgets/feedback_inline.dart';
-import '../../feed/widgets/follow_keyword_suggestion_card.dart';
 import '../../feed/widgets/profile_avatar_button.dart';
-import '../../sources/widgets/pepites_carousel.dart';
 import '../../gamification/widgets/streak_indicator.dart';
 import '../../lettres/widgets/lettres_notification_banner.dart';
 import '../../notifications/widgets/notification_renudge_banner.dart';
@@ -39,10 +35,7 @@ import '../widgets/closing_card_v18.dart';
 import '../widgets/flux_continu_article_card.dart';
 import '../widgets/my_interests_intro.dart';
 import '../widgets/my_interests_sheet.dart';
-import '../widgets/section_banner.dart';
 import '../widgets/section_block.dart';
-import '../widgets/section_divider_dotted.dart';
-import '../widgets/section_hairline.dart';
 import '../widgets/sticky_tab_bar.dart';
 import '../widgets/tournee_folded_group_card.dart';
 
@@ -53,13 +46,6 @@ const double _kStickyThreshold = 60.0;
 /// when scrolling a section into view so its banner doesn't disappear
 /// behind the bar.
 const double _kStickyBarHeight = 100.0;
-
-/// Extra lookahead (px) before the Explorer banner reaches the sticky bottom
-/// at which we flip to Explorer mode — makes the "Flâner" tab activate earlier.
-const double _kExploreLeadPx = 120.0;
-
-/// Distance to the bottom (in px) before we trigger the next feed page.
-const double _kLoadMoreLeadingPx = 800.0;
 
 /// Minimum delta (px) before the scroll-up FAB toggles, to avoid flicker
 /// on tiny inertia bounces. Matches the legacy FeedScreen behaviour.
@@ -87,17 +73,12 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   final ValueNotifier<bool> _stickyVisible = ValueNotifier(false);
   final ValueNotifier<double> _scrollProgress = ValueNotifier(0);
   final ValueNotifier<int> _activeIndex = ValueNotifier(0);
-  final ValueNotifier<bool> _isInExploreMode = ValueNotifier(false);
 
   /// Controls whether the « Tournée du jour ✓ » group toggle is expanded.
-  /// Resets to [false] (collapsed) on app pause and when opening an article
-  /// from Flâner — per spec, the grouping re-appears on quit-and-return.
+  /// Resets to [false] (collapsed) on app pause.
   final ValueNotifier<bool> _tourneeGroupExpanded = ValueNotifier(false);
 
-  final GlobalKey _closingKey = GlobalKey();
-  final GlobalKey _explorerKey = GlobalKey();
   final List<GlobalKey> _sectionKeys = [];
-  bool _loadingMore = false;
 
   /// Articles swipe-dismissed and replaced by a [FeedbackInline] banner at
   /// the same position. The hide API has already fired (via
@@ -133,7 +114,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     _stickyVisible.dispose();
     _scrollProgress.dispose();
     _activeIndex.dispose();
-    _isInExploreMode.dispose();
     _tourneeGroupExpanded.dispose();
     _pullHintTimer?.cancel();
     super.dispose();
@@ -160,23 +140,15 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     if (_stickyVisible.value != showSticky) {
       _stickyVisible.value = showSticky;
     }
-    // Progress is bounded by the end of the "Tournée" zone (just before the
-    // Explorer banner), not by the full scroll extent — once the user reaches
-    // Explorer, the Tournée is conceptually complete, so the bar stays full.
-    final tourneEnd = _explorerScrollOffset();
-    final nextProgress = tourneEnd > 0
-        ? (currentScroll / tourneEnd).clamp(0.0, 1.0).toDouble()
+    final maxExtent = pos.maxScrollExtent;
+    final nextProgress = maxExtent > 0
+        ? (currentScroll / maxExtent).clamp(0.0, 1.0).toDouble()
         : 0.0;
     if (_scrollProgress.value != nextProgress) {
       _scrollProgress.value = nextProgress;
     }
-    // Explore-mode flag must be refreshed before the active-section pass: the
-    // sticky's "Explorer" virtual tab is selected from that flag, and we want
-    // the same frame the user crosses the banner to swap to it.
-    _updateExploreMode();
     _updateActiveSection();
     _maybeFoldSections();
-    _maybeDismissClosingCard();
 
     if (currentScroll > _maxScrollDepthPx) {
       _maxScrollDepthPx = currentScroll;
@@ -203,8 +175,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
 
     // Pull-to-refresh hint pill — discoverability cue when the user scrolls
     // back to the very top after browsing deep. Never triggers a refresh.
-    final scrollingUp =
-        pos.userScrollDirection == ScrollDirection.forward;
+    final scrollingUp = pos.userScrollDirection == ScrollDirection.forward;
     if (scrollingUp &&
         currentScroll < 20 &&
         _maxScrollDepthPx >= _kPullHintMinDepthPx) {
@@ -219,46 +190,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
         });
       }
     }
-
-    if (pos.maxScrollExtent - currentScroll < _kLoadMoreLeadingPx &&
-        !_loadingMore) {
-      _loadingMore = true;
-      ref
-          .read(feedProvider.notifier)
-          .loadMore()
-          .whenComplete(() => _loadingMore = false);
-    }
-  }
-
-  /// Absolute scroll offset (in pixels) at which the Explorer banner reaches
-  /// the bottom of the sticky bar. Used to bound the "Tournée" progress so
-  /// the bar reads 100% the moment the user lands on Explorer (and stays
-  /// pinned at 100% while scrolling Explorer). Falls back to the full extent
-  /// before the banner has been laid out.
-  double _explorerScrollOffset() {
-    if (!_scroll.hasClients) return 1.0;
-    final maxExtent = _scroll.position.maxScrollExtent;
-    final ctx = _explorerKey.currentContext;
-    if (ctx == null) return maxExtent;
-    final box = ctx.findRenderObject();
-    if (box is! RenderBox || !box.attached) return maxExtent;
-    final globalDy = box.localToGlobal(Offset.zero).dy;
-    return (_scroll.position.pixels + globalDy - _kStickyBarHeight)
-        .clamp(1.0, maxExtent);
-  }
-
-  /// Flips the sticky overlay from the editorial tab bar to the feed filter
-  /// bar once the user crosses the Explorer banner.
-  void _updateExploreMode() {
-    final ctx = _explorerKey.currentContext;
-    if (ctx == null) return;
-    final box = ctx.findRenderObject();
-    if (box is! RenderBox || !box.attached) return;
-    final topY = box.localToGlobal(Offset.zero).dy;
-    final shouldExplore = topY < _kStickyBarHeight + _kExploreLeadPx;
-    if (_isInExploreMode.value != shouldExplore) {
-      _isInExploreMode.value = shouldExplore;
-    }
   }
 
   /// Records sections that have fully scrolled above the viewport, **without
@@ -266,10 +197,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   void _maybeFoldSections() {
     final value = ref.read(fluxContinuProvider).valueOrNull;
     if (value == null) return;
-    final count =
-        value.sections.length < _sectionKeys.length
-            ? value.sections.length
-            : _sectionKeys.length;
+    final count = value.sections.length < _sectionKeys.length
+        ? value.sections.length
+        : _sectionKeys.length;
     final notifier = ref.read(fluxContinuProvider.notifier);
     for (var i = 0; i < count; i++) {
       final section = value.sections[i];
@@ -286,32 +216,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     }
   }
 
-  void _maybeDismissClosingCard() {
-    final value = ref.read(fluxContinuProvider).valueOrNull;
-    if (value == null || value.closingDismissed) return;
-    final ctx = _closingKey.currentContext;
-    if (ctx == null) return;
-    final box = ctx.findRenderObject();
-    if (box is! RenderBox || !box.attached) return;
-    final bottom = box.localToGlobal(Offset.zero).dy + box.size.height;
-    if (bottom < -32) {
-      ref.read(fluxContinuProvider.notifier).markClosingDismissedForNextSession();
-    }
-  }
-
   void _updateActiveSection() {
-    // Explorer is rendered as the last virtual tab in the sticky overlay.
-    // Once the user crosses the Explorer banner, that tab takes precedence
-    // over the editorial active-section measurement so the sticky reflects
-    // the zone the user is actually browsing.
-    if (_isInExploreMode.value) {
-      final exploreIndex = _sectionKeys.length;
-      if (_activeIndex.value != exploreIndex) {
-        _activeIndex.value = exploreIndex;
-        _alignTabsToActive(exploreIndex);
-      }
-      return;
-    }
     if (_sectionKeys.isEmpty) return;
     // Active = section that occupies the most visible area below the sticky
     // bar. The previous heuristic ("last section whose top has crossed
@@ -320,7 +225,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     // dominance flips the active tab as soon as the next section becomes
     // majority-visible, which matches what the user is actually reading.
     const viewportTop = _kStickyBarHeight;
-    final viewportBottom = viewportTop +
+    final viewportBottom =
+        viewportTop +
         (_scroll.hasClients ? _scroll.position.viewportDimension : 0.0);
     int activeAt = 0;
     double bestVisible = -1;
@@ -347,49 +253,36 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
 
   void _alignTabsToActive(int index) {
     if (!_tabsScroll.hasClients) return;
-    // Explorer is the virtual tab appended after every real section; pin it
-    // to the right edge so the sticky bar visibly bottoms out instead of
-    // leaving trailing whitespace when the user reaches the last zone.
-    final bool isLastTab = index >= _sectionKeys.length;
     void doScroll() {
       if (!_tabsScroll.hasClients) return;
       final maxExtent = _tabsScroll.position.maxScrollExtent;
-      final double target;
-      if (isLastTab) {
-        target = maxExtent;
-      } else {
-        const double estimatedTabWidth = 140.0;
-        const double leftPadding = 12.0;
-        target =
-            (index * estimatedTabWidth - leftPadding).clamp(0.0, maxExtent);
-      }
+      const double estimatedTabWidth = 140.0;
+      const double leftPadding = 12.0;
+      final target = (index * estimatedTabWidth - leftPadding).clamp(
+        0.0,
+        maxExtent,
+      );
       _tabsScroll.animateTo(
         target,
         duration: const Duration(milliseconds: 220),
         curve: Curves.easeOutCubic,
       );
     }
+
     doScroll();
-    if (isLastTab) {
-      // Second pass after layout — covers the case where the sticky bar has
-      // just appeared and `maxScrollExtent` hadn't been computed yet, so the
-      // first `animateTo(maxExtent)` resolved against a stale extent.
-      WidgetsBinding.instance.addPostFrameCallback((_) => doScroll());
-    }
   }
 
   Future<void> _scrollToSection(int index) async {
     if (index < 0) return;
-    // Last tab is the virtual "Explorer" entry — scrolls to its banner key.
-    final GlobalKey targetKey = index >= _sectionKeys.length
-        ? _explorerKey
-        : _sectionKeys[index];
+    if (index >= _sectionKeys.length) return;
+    final targetKey = _sectionKeys[index];
     final ctx = targetKey.currentContext;
     if (ctx == null) return;
     final box = ctx.findRenderObject();
     if (box is! RenderBox) return;
-    final scrollBox = _scroll.position.context.notificationContext
-        ?.findRenderObject() as RenderBox?;
+    final scrollBox =
+        _scroll.position.context.notificationContext?.findRenderObject()
+            as RenderBox?;
     if (scrollBox == null) {
       await Scrollable.ensureVisible(
         ctx,
@@ -400,9 +293,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     }
     final delta =
         box.localToGlobal(Offset.zero, ancestor: scrollBox).dy -
-            _kStickyBarHeight;
-    final target = (_scroll.offset + delta)
-        .clamp(0.0, _scroll.position.maxScrollExtent);
+        _kStickyBarHeight;
+    final target = (_scroll.offset + delta).clamp(
+      0.0,
+      _scroll.position.maxScrollExtent,
+    );
     await _scroll.animateTo(
       target,
       duration: const Duration(milliseconds: 700),
@@ -413,8 +308,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   /// Folds the Essentiel card then scrolls to [targetIndex]. The 50ms delay
   /// lets the fold settle so the scroll target's measured position is the
   /// post-fold one. Used by both "Tout l'essentiel" (scroll to Actus du
-  /// jour) and "Tous mes articles ↓" (scroll to Explorer banner via the
-  /// `targetIndex == _sectionKeys.length` branch of [_scrollToSection]).
+  /// jour) and "Tous mes articles ↓".
   Future<void> _foldEssentielAndScroll(
     EssentielSection essentiel,
     int targetIndex,
@@ -435,15 +329,13 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   }
 
   /// "Tous mes articles ↓" action of the Essentiel hi-fi card: folds the
-  /// card then scrolls all the way down to the "Explorer" banner. Reuses the
-  /// `index >= _sectionKeys.length` branch of [_scrollToSection], which
-  /// targets [_explorerKey] directly.
+  /// card then opens Flâner.
   Future<void> _skipEssentielToExplorer(EssentielSection essentiel) async {
     final notifier = ref.read(fluxContinuProvider.notifier);
     notifier.foldLocally(essentiel);
     await Future<void>.delayed(const Duration(milliseconds: 50));
     if (!mounted) return;
-    await _scrollToSection(_sectionKeys.length);
+    context.go(RoutePaths.flaner);
   }
 
   Future<void> _scrollToTop() async {
@@ -468,11 +360,13 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
       setState(_pendingFeedback.clear);
     }
     if (_scroll.hasClients) {
-      unawaited(_scroll.animateTo(
-        0,
-        duration: const Duration(milliseconds: 350),
-        curve: Curves.easeOutCubic,
-      ));
+      unawaited(
+        _scroll.animateTo(
+          0,
+          duration: const Duration(milliseconds: 350),
+          curve: Curves.easeOutCubic,
+        ),
+      );
     }
   }
 
@@ -481,10 +375,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   /// the cached items immediately rather than waiting on the provider.
   void _openThemeSection(BuildContext context, FeedThemeSection section) {
     final key = Uri.encodeComponent(sectionKey(section));
-    context.push(
-      '${RoutePaths.fluxContinu}/theme/$key',
-      extra: section,
-    );
+    context.push('${RoutePaths.fluxContinu}/theme/$key', extra: section);
   }
 
   /// Opens the dedicated full-page view for a [DigestTopicSection]
@@ -522,8 +413,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     String? openedContentId;
     if (article is DigestItem) {
       openedContentId = article.contentId;
-      await context
-          .push('${RoutePaths.fluxContinu}/content/${article.contentId}');
+      await context.push(
+        '${RoutePaths.fluxContinu}/content/${article.contentId}',
+      );
     } else if (article is Content) {
       openedContentId = article.id;
       await context.push(
@@ -532,21 +424,16 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
       );
     } else if (article is EssentielArticle) {
       openedContentId = article.contentId;
-      await context
-          .push('${RoutePaths.fluxContinu}/content/${article.contentId}');
+      await context.push(
+        '${RoutePaths.fluxContinu}/content/${article.contentId}',
+      );
     } else {
       return;
     }
     if (!mounted) return;
-    // When the article was opened from Flâner (fromSection == null), collapse
-    // the group toggle so the user sees the « Tournée du jour ✓ » row on
-    // return — per spec.
-    if (fromSection == null) _tourneeGroupExpanded.value = false;
     // Mark the article as read in local state so the card immediately
     // shows the grey + check badge without waiting for a pull-to-refresh.
-    ref
-        .read(fluxContinuProvider.notifier)
-        .markArticleRead(openedContentId);
+    ref.read(fluxContinuProvider.notifier).markArticleRead(openedContentId);
     ref
         .read(fluxContinuProvider.notifier)
         .applyPendingFoldsToState(exceptKeys: exceptKeys);
@@ -556,8 +443,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
       final delta = heightsBefore - heightsAfter;
       if (delta <= 0.5) return;
       final position = _scroll.position;
-      final corrected =
-          (position.pixels - delta).clamp(0.0, position.maxScrollExtent);
+      final corrected = (position.pixels - delta).clamp(
+        0.0,
+        position.maxScrollExtent,
+      );
       position.correctBy(corrected - position.pixels);
     });
   }
@@ -568,8 +457,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   double _measureFoldCandidateHeights(Set<String> exceptKeys) {
     final value = ref.read(fluxContinuProvider).valueOrNull;
     if (value == null) return 0.0;
-    final queued =
-        ref.read(fluxContinuProvider.notifier).persistQueuedSnapshot();
+    final queued = ref
+        .read(fluxContinuProvider.notifier)
+        .persistQueuedSnapshot();
     if (queued.isEmpty) return 0.0;
     final count = math.min(value.sections.length, _sectionKeys.length);
     double sum = 0.0;
@@ -591,8 +481,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     final value = ref.read(fluxContinuProvider).valueOrNull;
     if (value == null) return;
     final notifier = ref.read(fluxContinuProvider.notifier);
-    final fromKey =
-        fromSection == null ? null : sectionKey(fromSection);
+    final fromKey = fromSection == null ? null : sectionKey(fromSection);
     if (fromKey == null) {
       for (final s in value.sections) {
         unawaited(notifier.markScrolledPastForNextSession(s));
@@ -631,7 +520,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
 
   void _trackFeedbackSubmit(String contentId, String feedbackType) {
     unawaited(
-      ref.read(analyticsServiceProvider).trackArticleFeedbackSubmitted(
+      ref
+          .read(analyticsServiceProvider)
+          .trackArticleFeedbackSubmitted(
             contentId: contentId,
             feedbackType: feedbackType,
             origin: 'flux_continu',
@@ -645,10 +536,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     FluxFeedbackChip chip,
   ) async {
     final state = ref.read(fluxContinuProvider).valueOrNull;
-    final feedItems =
-        ref.read(feedProvider).valueOrNull?.items ?? const <Content>[];
-    final article =
-        state == null ? null : _lookupArticle(state, feedItems, contentId);
+    final article = state == null ? null : _lookupArticle(state, contentId);
     switch (chip) {
       case FluxFeedbackChip.source:
         _trackFeedbackSubmit(contentId, 'less_source');
@@ -678,19 +566,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     }
   }
 
-  /// Finds an article in the current state by its content id, looking
-  /// across digest leads, theme items and the Explorer continuation
-  /// (sourced from `feedProvider`). Returns the raw [DigestItem] or
-  /// [Content] so the caller can route it through [articleToContent] for
-  /// the article sheet.
-  Object? _lookupArticle(
-    FluxContinuState state,
-    List<Content> exploreItems,
-    String contentId,
-  ) {
-    for (final c in exploreItems) {
-      if (c.id == contentId) return c;
-    }
+  /// Finds an article in the current state by its content id.
+  Object? _lookupArticle(FluxContinuState state, String contentId) {
     for (final s in state.sections) {
       switch (s) {
         case EssentielSection(:final articles):
@@ -716,6 +593,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     final state = ref.watch(fluxContinuProvider);
     return Scaffold(
       backgroundColor: context.facteurColors.backgroundPrimary,
+      bottomNavigationBar: const MainBottomNav(
+        current: MainBottomNavDestination.essentiel,
+      ),
       body: SafeArea(
         bottom: false,
         child: Stack(
@@ -724,8 +604,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
               loading: () => const LoadingView(),
               error: (e, _) => _ErrorView(
                 error: e,
-                onRetry: () =>
-                    ref.read(fluxContinuProvider.notifier).refresh(),
+                onRetry: () => ref.read(fluxContinuProvider.notifier).refresh(),
               ),
               data: (data) => _buildContent(context, data),
             ),
@@ -733,7 +612,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
               stickyVisible: _stickyVisible,
               scrollProgress: _scrollProgress,
               activeIndex: _activeIndex,
-              isInExploreMode: _isInExploreMode,
               stateProvider: fluxContinuProvider,
               onTapTab: _scrollToSection,
               tabsController: _tabsScroll,
@@ -747,8 +625,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
                 child: AnimatedSlide(
                   duration: const Duration(milliseconds: 220),
                   curve: Curves.easeOutCubic,
-                  offset:
-                      _showScrollTopFab ? Offset.zero : const Offset(0, 1.6),
+                  offset: _showScrollTopFab
+                      ? Offset.zero
+                      : const Offset(0, 1.6),
                   child: AnimatedOpacity(
                     duration: const Duration(milliseconds: 220),
                     opacity: _showScrollTopFab ? 1.0 : 0.0,
@@ -783,18 +662,15 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     final notifier = ref.read(fluxContinuProvider.notifier);
     final colors = context.facteurColors;
     final impressionSlot = ref.watch(firstImpressionSlotProvider);
-    final feedState = ref.watch(feedProvider).valueOrNull;
-    final keyword = ref.watch(feedProvider.notifier).selectedKeyword;
     final totalArticles = state.sections.fold<int>(
       0,
       (sum, s) => sum + s.totalCount,
     );
-    final exploreItems = _buildExploreItems(state, feedState);
-    final exploreCarousels = feedState?.carousels ?? const <FeedCarouselData>[];
 
     // When every editorial section is folded, the individual pile of
     // FoldedSectionCards is replaced by a single « Tournée du jour ✓ » toggle.
-    final allFolded = state.sections.isNotEmpty &&
+    final allFolded =
+        state.sections.isNotEmpty &&
         state.sections.every((s) => state.isFolded(s));
 
     if (_sectionKeys.length != state.sections.length) {
@@ -826,39 +702,42 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
                   ),
                   Align(
                     alignment: Alignment.centerRight,
-                    child: Consumer(builder: (context, ref, _) {
-                      final hasUpdate = ref
-                              .watch(appUpdateProvider)
-                              .valueOrNull
-                              ?.updateAvailable ==
-                          true;
-                      final settingsButton = ProfileAvatarButton(
-                        onTap: () => context.push(RoutePaths.settings),
-                      );
-                      if (!hasUpdate) return settingsButton;
-                      return Stack(
-                        clipBehavior: Clip.none,
-                        children: [
-                          settingsButton,
-                          Positioned(
-                            top: -2,
-                            right: -2,
-                            child: Container(
-                              width: 12,
-                              height: 12,
-                              decoration: BoxDecoration(
-                                color: colors.error,
-                                shape: BoxShape.circle,
-                                border: Border.all(
-                                  color: colors.backgroundPrimary,
-                                  width: 2,
+                    child: Consumer(
+                      builder: (context, ref, _) {
+                        final hasUpdate =
+                            ref
+                                .watch(appUpdateProvider)
+                                .valueOrNull
+                                ?.updateAvailable ==
+                            true;
+                        final settingsButton = ProfileAvatarButton(
+                          onTap: () => context.push(RoutePaths.settings),
+                        );
+                        if (!hasUpdate) return settingsButton;
+                        return Stack(
+                          clipBehavior: Clip.none,
+                          children: [
+                            settingsButton,
+                            Positioned(
+                              top: -2,
+                              right: -2,
+                              child: Container(
+                                width: 12,
+                                height: 12,
+                                decoration: BoxDecoration(
+                                  color: colors.error,
+                                  shape: BoxShape.circle,
+                                  border: Border.all(
+                                    color: colors.backgroundPrimary,
+                                    width: 2,
+                                  ),
                                 ),
                               ),
                             ),
-                          ),
-                        ],
-                      );
-                    }),
+                          ],
+                        );
+                      },
+                    ),
                   ),
                 ],
               ),
@@ -874,14 +753,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
                 ? const WellInformedPrompt()
                 : const SizedBox.shrink(),
           ),
-          const SliverToBoxAdapter(
-            child: LettresNotificationBanner(),
-          ),
-          SliverToBoxAdapter(
-            child: (keyword == null || keyword.trim().isEmpty)
-                ? const SizedBox.shrink()
-                : FollowKeywordSuggestionCard(keyword: keyword),
-          ),
+          const SliverToBoxAdapter(child: LettresNotificationBanner()),
           // One SliverToBoxAdapter per section. Sections never resize during
           // a session (folds are deferred to the next cold launch), so the
           // simpler non-lazy adapter is sufficient and keeps the GlobalKey
@@ -948,35 +820,16 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
           SliverToBoxAdapter(
             child: state.closingDismissed
                 ? const SizedBox.shrink()
-                : KeyedSubtree(
-                    key: _closingKey,
-                    child: ClosingCardV18(
-                      articleCount: totalArticles,
-                      onContinue: () => notifier.markClosingDismissed(),
-                      onClose: () => notifier.markClosingDismissed(),
-                    ),
+                : ClosingCardV18(
+                    articleCount: totalArticles,
+                    onContinue: () async {
+                      await notifier.markClosingDismissed();
+                      if (context.mounted) context.go(RoutePaths.flaner);
+                    },
+                    onClose: () => notifier.markClosingDismissed(),
                   ),
           ),
-          const SliverToBoxAdapter(
-            child: SectionDividerDotted(label: 'Tous tes articles'),
-          ),
-          SliverToBoxAdapter(
-            child: KeyedSubtree(
-              key: _explorerKey,
-              child: const SectionBanner(
-                title: 'Flâner',
-                blurb:
-                    'Tous les articles de tes sources triés par récence, à consulter à ton rythme',
-                accent: Color(0xFF5D4037),
-                illustrationAsset: 'assets/notifications/facteur_bike.png',
-              ),
-            ),
-          ),
-          if (exploreItems.isNotEmpty) ...[
-            _buildIntercalatedFeed(context, exploreItems, exploreCarousels),
-            const SliverToBoxAdapter(child: SectionHairline()),
-          ],
-          const SliverToBoxAdapter(child: SizedBox(height: 60)),
+          const SliverToBoxAdapter(child: SizedBox(height: 92)),
         ],
       ),
     );
@@ -989,16 +842,15 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     required FluxContinuState state,
     required FluxContinuNotifier notifier,
   }) {
-    final firstFavoriteIndex =
-        state.sections.indexWhere(_isFavoriteSection);
-    final favoriteCount =
-        state.sections.where(_isFavoriteSection).length;
+    final firstFavoriteIndex = state.sections.indexWhere(_isFavoriteSection);
+    final favoriteCount = state.sections.where(_isFavoriteSection).length;
     final swipeLeftHintSeen =
         ref.watch(swipeLeftHintSeenProvider).valueOrNull ?? true;
     // When the user has consumed every editorial section, the inline
     // "Mes intérêts" intro reads as residual chrome — hide it so the
     // folded stack collapses tightly into the closing card.
-    final allFolded = state.sections.isNotEmpty &&
+    final allFolded =
+        state.sections.isNotEmpty &&
         state.sections.every((s) => state.isFolded(s));
 
     final slivers = <SliverToBoxAdapter>[];
@@ -1008,67 +860,70 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
       // section above to separate from), absent altogether, or once every
       // section above has been folded (no editorial context left to break).
       if (i == firstFavoriteIndex && firstFavoriteIndex > 0 && !allFolded) {
-        slivers.add(SliverToBoxAdapter(
-          child: MyInterestsIntro(
-            favoriteCount: favoriteCount,
-            onTapManage: () => showMyInterestsBottomSheet(context),
+        slivers.add(
+          SliverToBoxAdapter(
+            child: MyInterestsIntro(
+              favoriteCount: favoriteCount,
+              onTapManage: () => showMyInterestsBottomSheet(context),
+            ),
           ),
-        ));
+        );
       }
       final section = state.sections[i];
       final isFavorite = _isFavoriteSection(section);
-      slivers.add(SliverToBoxAdapter(
-        child: KeyedSubtree(
-          key: _sectionKeys[i],
-          child: SectionBlock(
-            section: section,
-            isOpen: state.isOpen(section),
-            isFolded: state.isFolded(section),
-            onToggleMore: () => notifier.toggleMore(section),
-            onUnfold: () => notifier.unfoldLocally(section),
-            onFold: () => notifier.foldLocally(section),
-            onTapArticle: (a, s) =>
-                _openArticle(context, a, fromSection: s),
-            onDismissArticle: _onSwipeDismiss,
-            pendingFeedbackIds: _pendingFeedback,
-            onSelectFeedbackChip: (id, chip) =>
-                _onSelectFeedbackChip(context, id, chip),
-            onResolveFeedback: _resolveFeedback,
-            onUndoFeedback: _undoFeedback,
-            enableSwipeHintOnFirstCard: i == 0 && !swipeLeftHintSeen,
-            onSwipeHintComplete: () async {
-              await markSwipeLeftHintSeen();
-              if (mounted) ref.invalidate(swipeLeftHintSeenProvider);
-            },
-            onTapFavorite: isFavorite
-                ? () => showMyInterestsBottomSheet(context)
-                : null,
-            onSeeAll: section is FeedThemeSection
-                ? () => _openThemeSection(context, section)
-                : section is DigestTopicSection
-                    ? () => _openDigestSection(context, section)
-                    : null,
-            onTapExploreAll: section is EssentielSection
-                ? () => _exploreAllEssentiel(section, i)
-                : null,
-            onTapSeeAllDown: section is EssentielSection
-                ? () => _skipEssentielToExplorer(section)
-                : null,
-            isMarkedForNextSession: state.isMarkedForNextSession(section),
-            nextSectionAccent: i + 1 < state.sections.length
-                ? state.sections[i + 1].accent
-                : null,
-            nextSectionLabel: i + 1 < state.sections.length
-                ? state.sections[i + 1].label
-                : null,
-            onNextSection: (section is EssentielSection ||
-                    i >= state.sections.length - 1)
-                ? null
-                : () => _advanceToNextSection(section, i),
-
+      slivers.add(
+        SliverToBoxAdapter(
+          child: KeyedSubtree(
+            key: _sectionKeys[i],
+            child: SectionBlock(
+              section: section,
+              isOpen: state.isOpen(section),
+              isFolded: state.isFolded(section),
+              onToggleMore: () => notifier.toggleMore(section),
+              onUnfold: () => notifier.unfoldLocally(section),
+              onFold: () => notifier.foldLocally(section),
+              onTapArticle: (a, s) => _openArticle(context, a, fromSection: s),
+              onDismissArticle: _onSwipeDismiss,
+              pendingFeedbackIds: _pendingFeedback,
+              onSelectFeedbackChip: (id, chip) =>
+                  _onSelectFeedbackChip(context, id, chip),
+              onResolveFeedback: _resolveFeedback,
+              onUndoFeedback: _undoFeedback,
+              enableSwipeHintOnFirstCard: i == 0 && !swipeLeftHintSeen,
+              onSwipeHintComplete: () async {
+                await markSwipeLeftHintSeen();
+                if (mounted) ref.invalidate(swipeLeftHintSeenProvider);
+              },
+              onTapFavorite: isFavorite
+                  ? () => showMyInterestsBottomSheet(context)
+                  : null,
+              onSeeAll: section is FeedThemeSection
+                  ? () => _openThemeSection(context, section)
+                  : section is DigestTopicSection
+                  ? () => _openDigestSection(context, section)
+                  : null,
+              onTapExploreAll: section is EssentielSection
+                  ? () => _exploreAllEssentiel(section, i)
+                  : null,
+              onTapSeeAllDown: section is EssentielSection
+                  ? () => _skipEssentielToExplorer(section)
+                  : null,
+              isMarkedForNextSession: state.isMarkedForNextSession(section),
+              nextSectionAccent: i + 1 < state.sections.length
+                  ? state.sections[i + 1].accent
+                  : null,
+              nextSectionLabel: i + 1 < state.sections.length
+                  ? state.sections[i + 1].label
+                  : null,
+              onNextSection:
+                  (section is EssentielSection ||
+                      i >= state.sections.length - 1)
+                  ? null
+                  : () => _advanceToNextSection(section, i),
+            ),
           ),
         ),
-      ));
+      );
     }
     return slivers;
   }
@@ -1080,9 +935,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   /// expanded banner rather than a collapsed card.
   Future<void> _advanceToNextSection(FluxSection section, int index) async {
     unawaited(HapticFeedback.lightImpact());
-    unawaited(ref
-        .read(fluxContinuProvider.notifier)
-        .markScrolledPastForNextSession(section));
+    unawaited(
+      ref
+          .read(fluxContinuProvider.notifier)
+          .markScrolledPastForNextSession(section),
+    );
     final state = ref.read(fluxContinuProvider).valueOrNull;
     final nextIdx = index + 1;
     if (state != null && nextIdx < state.sections.length) {
@@ -1099,140 +956,14 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     if (!mounted) return;
     await _scrollToSection(nextIdx);
   }
-
-  /// "Fin de tournée — Flâner" tap handler for the last Tournée section.
-  /// Marks every editorial section as consumed for the next session and
-  /// smooth-scrolls to the Flâner banner.
-  Future<void> _endOfTournee() async {
-    unawaited(HapticFeedback.lightImpact());
-    final state = ref.read(fluxContinuProvider).valueOrNull;
-    if (state != null) {
-      final notifier = ref.read(fluxContinuProvider.notifier);
-      for (final s in state.sections) {
-        unawaited(notifier.markScrolledPastForNextSession(s));
-      }
-    }
-    await Future<void>.delayed(const Duration(milliseconds: 250));
-    if (!mounted) return;
-    await _scrollToSection(_sectionKeys.length);
-  }
-
-  /// Builds the Explorer feed list by reading from `feedProvider` and filtering
-  /// out (a) articles already rendered above and (b) ids swipe-dismissed
-  /// during this session. Keeps the Tournée / Explorer dedup invariant while
-  /// letting the filter chips drive the underlying list.
-  List<Content> _buildExploreItems(
-    FluxContinuState state,
-    FeedState? feedState,
-  ) {
-    final items = feedState?.items ?? const <Content>[];
-    if (items.isEmpty) return const [];
-    final rendered = renderedContentIds(state.sections);
-    final dismissed = state.dismissedIds;
-    if (rendered.isEmpty && dismissed.isEmpty) return items;
-    return items
-        .where((c) => !rendered.contains(c.id) && !dismissed.contains(c.id))
-        .toList(growable: false);
-  }
-
-  Widget _buildIntercalatedFeed(
-    BuildContext context,
-    List<Content> contents,
-    List<FeedCarouselData> carousels,
-  ) {
-    final intercalations = <({int position, Widget Function() builder})>[];
-
-    if (contents.length > 4) {
-      intercalations.add((
-        position: 4,
-        builder: () => const Padding(
-          key: ValueKey('flux_continu_pepites'),
-          padding: EdgeInsets.only(bottom: 12),
-          child: PepitesCarousel(),
-        ),
-      ));
-    }
-
-    for (final carousel in carousels) {
-      if (carousel.items.isEmpty || carousel.position >= contents.length) {
-        continue;
-      }
-      intercalations.add((
-        position: carousel.position,
-        builder: () => Padding(
-          key: ValueKey('flux_continu_carousel_${carousel.carouselType}'),
-          padding: const EdgeInsets.only(bottom: 12),
-          child: FeedCarousel(
-            data: carousel,
-            onArticleTap: (c) => _openArticle(context, c, fromSection: null),
-            onLongPressStart: (c, _) => ArticlePreviewOverlay.show(context, c),
-            onLongPressMoveUpdate: (details) =>
-                ArticlePreviewOverlay.updateScroll(
-                    details.localOffsetFromOrigin.dy),
-            onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
-          ),
-        ),
-      ));
-    }
-
-    intercalations.sort((a, b) => a.position.compareTo(b.position));
-
-    return SliverList(
-      delegate: SliverChildBuilderDelegate(
-        (context, listIndex) {
-          int offset = 0;
-          for (final inter in intercalations) {
-            final effective = inter.position + offset;
-            if (listIndex == effective) return inter.builder();
-            if (listIndex > effective) offset++;
-          }
-          final articleIndex = listIndex - offset;
-          if (articleIndex < 0 || articleIndex >= contents.length) return null;
-          final article = contents[articleIndex];
-          if (_pendingFeedback.contains(article.id)) {
-            return Padding(
-              key: ValueKey('flux_feedback_${article.id}'),
-              padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-              child: FeedbackInline(
-                onSelectSource: () => _onSelectFeedbackChip(
-                    context, article.id, FluxFeedbackChip.source),
-                onSelectTopic: () => _onSelectFeedbackChip(
-                    context, article.id, FluxFeedbackChip.topic),
-                onSelectAlreadySeen: () => _onSelectFeedbackChip(
-                    context, article.id, FluxFeedbackChip.alreadySeen),
-                onUndo: () => _undoFeedback(article.id),
-                onClose: () => _resolveFeedback(article.id),
-              ),
-            );
-          }
-          return FluxContinuArticleCard(
-            article: article,
-            onTap: () => _openArticle(context, article, fromSection: null),
-            onSwipeDismiss: () => _onSwipeDismiss(article.id),
-          );
-        },
-        childCount: contents.length + intercalations.length,
-      ),
-    );
-  }
 }
-
-/// Sticky overlay shown at the top of the screen once the user scrolls past
-/// the AppBar threshold. Always hosts the editorial tab bar — the "Explorer"
-/// virtual tab is appended at the end so the same bar covers the whole
-/// screen instead of swapping out when the user crosses the Explorer banner.
-/// When the user is in Explorer mode, [FeedFilterBar] morphs in under the
-/// tabs (within the same parchment surface) so filtering stays available.
-const String _kExplorerLabel = 'Flâner';
-const Color _kExplorerAccent = Color(0xFF5D4037);
 
 class _StickyHostOverlay extends ConsumerWidget {
   final ValueNotifier<bool> stickyVisible;
   final ValueNotifier<double> scrollProgress;
   final ValueNotifier<int> activeIndex;
-  final ValueNotifier<bool> isInExploreMode;
   final AsyncNotifierProvider<FluxContinuNotifier, FluxContinuState>
-      stateProvider;
+  stateProvider;
   final ValueChanged<int> onTapTab;
   final ScrollController tabsController;
 
@@ -1240,7 +971,6 @@ class _StickyHostOverlay extends ConsumerWidget {
     required this.stickyVisible,
     required this.scrollProgress,
     required this.activeIndex,
-    required this.isInExploreMode,
     required this.stateProvider,
     required this.onTapTab,
     required this.tabsController,
@@ -1249,8 +979,7 @@ class _StickyHostOverlay extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final sections =
-        ref.watch(stateProvider).valueOrNull?.sections ??
-            const <FluxSection>[];
+        ref.watch(stateProvider).valueOrNull?.sections ?? const <FluxSection>[];
     return Positioned(
       top: 0,
       left: 0,
@@ -1265,23 +994,19 @@ class _StickyHostOverlay extends ConsumerWidget {
           final tabs = <StickyTab>[
             for (final s in sections)
               StickyTab(label: s.label, accent: s.accent),
-            const StickyTab(label: _kExplorerLabel, accent: _kExplorerAccent),
           ];
-          return ValueListenableBuilder<bool>(
-            valueListenable: isInExploreMode,
-            builder: (context, explore, _) => ValueListenableBuilder<int>(
-              valueListenable: activeIndex,
-              builder: (context, idx, _) => ValueListenableBuilder<double>(
-                valueListenable: scrollProgress,
-                builder: (context, progress, _) => StickyTabBar(
-                  tabs: tabs,
-                  activeIndex: idx.clamp(0, tabs.length - 1),
-                  progress: progress,
-                  onTapTab: onTapTab,
-                  tabsController: tabsController,
-                  title: explore ? _kExplorerLabel : 'Tournée du jour',
-                  showFilterBar: explore,
-                ),
+          return ValueListenableBuilder<int>(
+            valueListenable: activeIndex,
+            builder: (context, idx, _) => ValueListenableBuilder<double>(
+              valueListenable: scrollProgress,
+              builder: (context, progress, _) => StickyTabBar(
+                tabs: tabs,
+                activeIndex: idx.clamp(0, tabs.length - 1),
+                progress: progress,
+                onTapTab: onTapTab,
+                tabsController: tabsController,
+                title: 'Tournée du jour',
+                showFilterBar: false,
               ),
             ),
           );
@@ -1296,8 +1021,7 @@ class _ScrollToTopButton extends StatelessWidget {
 
   const _ScrollToTopButton({required this.onTap});
 
-  static const _kRadius =
-      BorderRadius.all(Radius.circular(22));
+  static const _kRadius = BorderRadius.all(Radius.circular(22));
 
   @override
   Widget build(BuildContext context) {
@@ -1474,21 +1198,17 @@ class _ErrorView extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.cloud_off_rounded,
-                size: 48, color: colors.textTertiary),
+            Icon(Icons.cloud_off_rounded, size: 48, color: colors.textTertiary),
             const SizedBox(height: FacteurSpacing.space3),
             Text(
               'Le flux continu est indisponible.',
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: colors.textSecondary,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodyLarge?.copyWith(color: colors.textSecondary),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: FacteurSpacing.space4),
-            OutlinedButton(
-              onPressed: onRetry,
-              child: const Text('Réessayer'),
-            ),
+            OutlinedButton(onPressed: onRetry, child: const Text('Réessayer')),
           ],
         ),
       ),
@@ -1511,16 +1231,13 @@ class _EmptySectionsHint extends StatelessWidget {
           const SizedBox(height: 8),
           Text(
             'Pas encore de contenu pour la tournée du jour.',
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: colors.textSecondary,
-                ),
+            style: Theme.of(
+              context,
+            ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 12),
-          TextButton(
-            onPressed: onRetry,
-            child: const Text('Recharger'),
-          ),
+          TextButton(onPressed: onRetry, child: const Text('Recharger')),
         ],
       ),
     );

--- a/apps/mobile/lib/features/flux_continu/services/tournee_progress_service.dart
+++ b/apps/mobile/lib/features/flux_continu/services/tournee_progress_service.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/data/latest.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
+
+/// SharedPreferences instance injected by the app bootstrap.
+///
+/// Unit tests and providers that are allowed to await can omit the override:
+/// [TourneeProgressService] will lazily call [SharedPreferences.getInstance].
+final sharedPreferencesProvider = Provider<SharedPreferences?>((ref) => null);
+
+final tourneeProgressServiceProvider = Provider<TourneeProgressService>((ref) {
+  return TourneeProgressService(prefs: ref.watch(sharedPreferencesProvider));
+});
+
+const String kFoldedPrefsKeyPrefix = 'flux_continu_folded_';
+const String kClosingPrefsKeyPrefix = 'flux_continu_closing_dismissed_';
+
+/// Boundary hour (Paris time) at which the "tournée day" flips.
+const int kTourneeDayBoundaryHour = 7;
+const int kTourneeDayBoundaryMinute = 30;
+const String kTourneeDayBoundaryTz = 'Europe/Paris';
+
+tz.Location? _parisLocation;
+
+tz.Location _parisTz() {
+  if (_parisLocation != null) return _parisLocation!;
+  tz_data.initializeTimeZones();
+  return _parisLocation = tz.getLocation(kTourneeDayBoundaryTz);
+}
+
+class TourneeProgressService {
+  final SharedPreferences? _prefsOverride;
+
+  const TourneeProgressService({SharedPreferences? prefs})
+    : _prefsOverride = prefs;
+
+  Future<SharedPreferences> _prefs() async =>
+      _prefsOverride ?? await SharedPreferences.getInstance();
+
+  /// Returns the canonical ISO day (`YYYY-MM-DD`) for the tournée at [now],
+  /// using a 07:30 Europe/Paris boundary instead of midnight.
+  static String dayKey(DateTime now) {
+    final paris = tz.TZDateTime.from(now, _parisTz());
+    final shifted =
+        (paris.hour < kTourneeDayBoundaryHour ||
+            (paris.hour == kTourneeDayBoundaryHour &&
+                paris.minute < kTourneeDayBoundaryMinute))
+        ? paris.subtract(const Duration(days: 1))
+        : paris;
+    return shifted.toIso8601String().substring(0, 10);
+  }
+
+  static String foldedPrefsKey(DateTime day) =>
+      '$kFoldedPrefsKeyPrefix${dayKey(day)}';
+
+  static String closingPrefsKey(DateTime day) =>
+      '$kClosingPrefsKeyPrefix${dayKey(day)}';
+
+  bool isClosingDismissedTodaySync({DateTime? now}) {
+    final prefs = _prefsOverride;
+    if (prefs == null) return false;
+    return prefs.getBool(closingPrefsKey(now ?? DateTime.now())) ?? false;
+  }
+
+  Future<bool> loadClosingDismissedForToday({DateTime? now}) async {
+    try {
+      final prefs = await _prefs();
+      return prefs.getBool(closingPrefsKey(now ?? DateTime.now())) ?? false;
+    } catch (e) {
+      debugPrint('TourneeProgress: loadClosingDismissedForToday failed: $e');
+      return false;
+    }
+  }
+
+  Future<void> setClosingDismissedToday(bool dismissed, {DateTime? now}) async {
+    try {
+      final prefs = await _prefs();
+      await prefs.setBool(closingPrefsKey(now ?? DateTime.now()), dismissed);
+    } catch (e) {
+      debugPrint('TourneeProgress: setClosingDismissedToday failed: $e');
+    }
+  }
+
+  Future<Map<String, bool>> loadFoldedForToday({
+    DateTime? now,
+    bool Function(String key)? isLiveKey,
+  }) async {
+    try {
+      final prefs = await _prefs();
+      final names =
+          prefs.getStringList(foldedPrefsKey(now ?? DateTime.now())) ??
+          const <String>[];
+      if (names.isEmpty) return const {};
+      return {
+        for (final name in names)
+          if (isLiveKey == null || isLiveKey(name)) name: true,
+      };
+    } catch (e) {
+      debugPrint('TourneeProgress: loadFoldedForToday failed: $e');
+      return const {};
+    }
+  }
+
+  Future<void> persistFolded(Map<String, bool> folded, {DateTime? now}) async {
+    try {
+      final prefs = await _prefs();
+      final names = folded.entries
+          .where((e) => e.value)
+          .map((e) => e.key)
+          .toList();
+      await prefs.setStringList(foldedPrefsKey(now ?? DateTime.now()), names);
+    } catch (e) {
+      debugPrint('TourneeProgress: persistFolded failed: $e');
+    }
+  }
+
+  Future<void> purgeOldPrefsKeys({DateTime? now}) async {
+    try {
+      final prefs = await _prefs();
+      final today = now ?? DateTime.now();
+      final foldedToday = foldedPrefsKey(today);
+      final closingToday = closingPrefsKey(today);
+      final stale = prefs.getKeys().where((k) {
+        if (k.startsWith(kFoldedPrefsKeyPrefix) && k != foldedToday) {
+          return true;
+        }
+        if (k.startsWith(kClosingPrefsKeyPrefix) && k != closingToday) {
+          return true;
+        }
+        return false;
+      }).toList();
+      await Future.wait(stale.map(prefs.remove));
+    } catch (e) {
+      debugPrint('TourneeProgress: purgeOldPrefsKeys failed: $e');
+    }
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/closing_card_v18.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/closing_card_v18.dart
@@ -14,7 +14,7 @@ import 'tournee_cta_buttons.dart';
 /// - Heading "Vous êtes à jour" Fraunces 700 24px.
 /// - Description (DM Sans 13, line-height 1.5, max-w 280, centered) — "X
 ///   étape(s) parcourue(s)" or "Tournée terminée" when empty.
-/// - Primary CTA "Continuer le feed" (background #D35400) + ghost CTA
+/// - Primary CTA "Continuer sur Flâner" (background #D35400) + ghost CTA
 ///   "Refermer pour aujourd'hui" (border 1.5px rgba(0,0,0,0.1)).
 class ClosingCardV18 extends StatelessWidget {
   final int articleCount;
@@ -61,8 +61,7 @@ class ClosingCardV18 extends StatelessWidget {
             Transform.rotate(
               angle: -2 * math.pi / 180,
               child: Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
                   border: Border.all(
                     color: const Color(0xFF2E7D32),
@@ -109,7 +108,7 @@ class ClosingCardV18 extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: TourneePrimaryButton(
-                label: 'Continuer le feed',
+                label: 'Continuer sur Flâner',
                 onTap: onContinue,
               ),
             ),
@@ -135,4 +134,3 @@ class ClosingCardV18 extends StatelessWidget {
     return '$count étape$plural parcourue$plural';
   }
 }
-

--- a/apps/mobile/lib/features/lettres/screens/courrier_screen.dart
+++ b/apps/mobile/lib/features/lettres/screens/courrier_screen.dart
@@ -24,9 +24,11 @@ class CourrierScreen extends ConsumerWidget {
       backgroundColor: colors.backgroundPrimary,
       body: state.when(
         loading: () => const _Loader(),
-        error: (e, _) => _ErrorView(onRetry: () {
-          ref.read(lettersProvider.notifier).refresh();
-        }),
+        error: (e, _) => _ErrorView(
+          onRetry: () {
+            ref.read(lettersProvider.notifier).refresh();
+          },
+        ),
         data: (data) => _Body(state: data),
       ),
     );
@@ -209,7 +211,7 @@ class _TopBar extends StatelessWidget {
               if (Navigator.of(context).canPop()) {
                 Navigator.of(context).pop();
               } else {
-                context.go(RoutePaths.feed);
+                context.go(RoutePaths.flaner);
               }
             },
             tooltip: 'Retour',
@@ -255,10 +257,7 @@ class _SectionHeader extends StatelessWidget {
           ),
           const SizedBox(width: 8),
           Expanded(
-            child: Container(
-              height: 1,
-              color: Colors.black.withOpacity(0.08),
-            ),
+            child: Container(height: 1, color: Colors.black.withOpacity(0.08)),
           ),
         ],
       ),

--- a/apps/mobile/lib/features/onboarding/screens/conclusion_animation_screen.dart
+++ b/apps/mobile/lib/features/onboarding/screens/conclusion_animation_screen.dart
@@ -56,11 +56,11 @@ class _ConclusionAnimationScreenState
           ConclusionSuccess() =>
             const _LoadingView(), // Garde l'animation pendant la transition
           ConclusionError() => LaurinFallbackView(
-              title: OnboardingFallbackStrings.title,
-              subtitle: OnboardingFallbackStrings.subtitle,
-              onRetry: () =>
-                  ref.read(conclusionNotifierProvider.notifier).retry(),
-            ),
+            title: OnboardingFallbackStrings.title,
+            subtitle: OnboardingFallbackStrings.subtitle,
+            onRetry: () =>
+                ref.read(conclusionNotifierProvider.notifier).retry(),
+          ),
         },
       ),
     );
@@ -72,8 +72,9 @@ class _ConclusionAnimationScreenState
 
     // Capture la liste des customs échoués AVANT clearSavedData pour pouvoir
     // afficher le résumé utilisateur ("tu pourras les réajouter").
-    final failedCustomTopics =
-        List<String>.from(ref.read(onboardingProvider).failedCustomTopics);
+    final failedCustomTopics = List<String>.from(
+      ref.read(onboardingProvider).failedCustomTopics,
+    );
 
     // Effacer les données locales temporaires
     ref.read(onboardingProvider.notifier).clearSavedData();
@@ -118,7 +119,7 @@ class _ConclusionAnimationScreenState
     // context.go() remplace toute la stack pour bloquer le back vers
     // l'onboarding.
     if (mounted) {
-      context.go(RoutePaths.feed);
+      context.go(RoutePaths.fluxContinu);
     }
   }
 }
@@ -149,4 +150,3 @@ class _LoadingView extends StatelessWidget {
     );
   }
 }
-

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:home_widget/home_widget.dart';
@@ -19,6 +20,7 @@ import 'core/auth/supabase_storage.dart';
 import 'core/services/posthog_service.dart';
 import 'core/services/push_notification_service.dart';
 import 'core/ui/notification_service.dart';
+import 'features/flux_continu/services/tournee_progress_service.dart';
 
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:timeago/src/messages/fr_messages.dart'
@@ -32,20 +34,17 @@ Future<void> main() async {
   // pendant l'init. Si DSN absent (dev local sans clé), l'init est skip.
   // Cf. docs/bugs/bug-android-disconnect-race.md (P5 — instrumentation).
   if (SentryConstants.isEnabled) {
-    await SentryFlutter.init(
-      (options) {
-        options.dsn = SentryConstants.dsn;
-        options.environment = SentryConstants.environment;
-        if (SentryConstants.release.isNotEmpty) {
-          options.release = SentryConstants.release;
-        }
-        // Sample 100% des erreurs, pas de perf tracing pour le moment.
-        options.tracesSampleRate = 0.0;
-        // Ne pas envoyer les PII par défaut.
-        options.sendDefaultPii = false;
-      },
-      appRunner: _bootstrap,
-    );
+    await SentryFlutter.init((options) {
+      options.dsn = SentryConstants.dsn;
+      options.environment = SentryConstants.environment;
+      if (SentryConstants.release.isNotEmpty) {
+        options.release = SentryConstants.release;
+      }
+      // Sample 100% des erreurs, pas de perf tracing pour le moment.
+      options.tracesSampleRate = 0.0;
+      // Ne pas envoyer les PII par défaut.
+      options.sendDefaultPii = false;
+    }, appRunner: _bootstrap);
   } else {
     await _bootstrap();
   }
@@ -75,16 +74,20 @@ Future<void> _bootstrap() async {
   await Hive.initFlutter();
 
   final boxesSw = Stopwatch()..start();
-  final boxes = await Future.wait<Box<dynamic>>([
+  final initResults = await Future.wait<Object>([
     _openBoxSafe<dynamic>('settings'),
     _openBoxSafe<dynamic>('auth_prefs'),
     _openBoxSafe<String>('supabase_auth_persistence'),
     _openBoxSafe<String>('feed_cache'),
+    SharedPreferences.getInstance(),
   ]);
+  final boxes = initResults.take(4).cast<Box<dynamic>>().toList();
+  final sharedPreferences = initResults[4] as SharedPreferences;
   final authBox = boxes[1];
   final supabaseBox = boxes[2];
   debugPrint(
-      '[PERF] boot.hive_boxes_ms=${boxesSw.elapsedMilliseconds} (4 boxes parallel)');
+    '[PERF] boot.hive_boxes_ms=${boxesSw.elapsedMilliseconds} (4 boxes + prefs parallel)',
+  );
 
   debugPrint('Main: Hive auth_prefs keys: ${authBox.keys.toList()}');
   debugPrint(
@@ -130,16 +133,16 @@ Future<void> _bootstrap() async {
         authOptions: FlutterAuthClientOptions(
           localStorage: SupabaseHiveStorage(),
         ),
-        headers: {
-          'X-Client-Info': 'supabase-flutter/2.5.0',
-        },
+        headers: {'X-Client-Info': 'supabase-flutter/2.5.0'},
       ).timeout(
         const Duration(seconds: 10),
         onTimeout: () {
           debugPrint(
-              'Main: Supabase.initialize TIMEOUT 10s — throwing to catch block');
+            'Main: Supabase.initialize TIMEOUT 10s — throwing to catch block',
+          );
           throw TimeoutException(
-              'Supabase.initialize timeout after 10 seconds');
+            'Supabase.initialize timeout after 10 seconds',
+          );
         },
       ),
       _initPosthogSafe(posthog),
@@ -166,10 +169,12 @@ Future<void> _bootstrap() async {
   if (hasSession) {
     final user = Supabase.instance.client.auth.currentUser;
     if (user != null) {
-      unawaited(posthog.identify(
-        userId: user.id,
-        properties: _userIdentifyProperties(user, appVersion: appVersion),
-      ));
+      unawaited(
+        posthog.identify(
+          userId: user.id,
+          properties: _userIdentifyProperties(user, appVersion: appVersion),
+        ),
+      );
       unawaited(_loginRevenueCatSafe(user.id));
     }
   }
@@ -182,8 +187,7 @@ Future<void> _bootstrap() async {
         if (user != null) {
           posthog.identify(
             userId: user.id,
-            properties:
-                _userIdentifyProperties(user, appVersion: appVersion),
+            properties: _userIdentifyProperties(user, appVersion: appVersion),
           );
           unawaited(_loginRevenueCatSafe(user.id));
         }
@@ -200,7 +204,14 @@ Future<void> _bootstrap() async {
   debugPrint('[PERF] boot.pre_runapp_ms=${bootSw.elapsedMilliseconds}');
 
   // Lancer l'app
-  runApp(const ProviderScope(child: FacteurApp()));
+  runApp(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+      ],
+      child: const FacteurApp(),
+    ),
+  );
 
   // Inits différés post-runApp : non bloquants pour la 1ère frame.
   // - Notif scheduling (alarm, permissions, diagnostics)
@@ -282,7 +293,8 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
 
   try {
     unawaited(
-        HomeWidget.registerInteractivityCallback(homeWidgetBackgroundCallback));
+      HomeWidget.registerInteractivityCallback(homeWidgetBackgroundCallback),
+    );
   } catch (e) {
     debugPrint('Main: Home Widget init failed (non-critical): $e');
   }
@@ -317,7 +329,8 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
             await pushNotificationService.scheduleDailyDigestNotification();
         if (!scheduled) {
           debugPrint(
-              'Main: WARNING — digest notification scheduling failed, retrying...');
+            'Main: WARNING — digest notification scheduling failed, retrying...',
+          );
           await pushNotificationService.requestExactAlarmPermission();
           final retryOk =
               await pushNotificationService.scheduleDailyDigestNotification();
@@ -325,13 +338,13 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
         }
       } else {
         debugPrint(
-            'Main: Digest notification already scheduled — skipping static placeholder.');
+          'Main: Digest notification already scheduled — skipping static placeholder.',
+        );
       }
     }
     bootNotifDiag = await diagFuture;
   } catch (e, s) {
-    debugPrint(
-        'ERROR: Deferred push notifications init failed: $e\n$s');
+    debugPrint('ERROR: Deferred push notifications init failed: $e\n$s');
   }
 
   if (bootNotifDiag != null) {
@@ -386,7 +399,8 @@ Future<Box<T>> _openBoxSafe<T>(String name) async {
   } catch (e) {
     debugPrint('Main: Hive box "$name" corrupted, recreating: $e');
     debugPrint(
-        '[AUTH_TELEMETRY] event=hive_box_corrupted box_name=$name error=$e');
+      '[AUTH_TELEMETRY] event=hive_box_corrupted box_name=$name error=$e',
+    );
     await Hive.deleteBoxFromDisk(name);
     return await Hive.openBox<T>(name);
   }

--- a/apps/mobile/lib/shared/widgets/navigation/main_bottom_nav.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/main_bottom_nav.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/routes.dart';
+
+enum MainBottomNavDestination { essentiel, flaner }
+
+class MainBottomNav extends StatelessWidget {
+  final MainBottomNavDestination current;
+
+  const MainBottomNav({super.key, required this.current});
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      currentIndex: current.index,
+      onTap: (index) {
+        final destination = MainBottomNavDestination.values[index];
+        switch (destination) {
+          case MainBottomNavDestination.essentiel:
+            context.go(RoutePaths.fluxContinu);
+          case MainBottomNavDestination.flaner:
+            context.go(RoutePaths.flaner);
+        }
+      },
+      items: [
+        BottomNavigationBarItem(
+          icon: Icon(PhosphorIcons.newspaper()),
+          activeIcon: Icon(PhosphorIcons.newspaper(PhosphorIconsStyle.fill)),
+          label: 'L’Essentiel',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(PhosphorIcons.compass()),
+          activeIcon: Icon(PhosphorIcons.compass(PhosphorIconsStyle.fill)),
+          label: 'Flâner',
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/test/core/services/deep_link_service_test.dart
+++ b/apps/mobile/test/core/services/deep_link_service_test.dart
@@ -49,22 +49,22 @@ void main() {
       expect(action.route, '/flux-continu');
     });
 
-    test('feed host → flux continu (FeedScreen supprimé)', () {
+    test('feed host → flâner (FeedScreen supprimé)', () {
       final action = DeepLinkService.parse(
         Uri.parse('io.supabase.facteur://feed'),
       );
       expect(action.target, WidgetDeepLinkTarget.feed);
-      expect(action.route, '/flux-continu');
+      expect(action.route, '/flaner');
     });
 
-    test('feed/content/<id> → article reader (Flux deep link)', () {
+    test('feed/content/<id> → article reader (Flâner deep link)', () {
       final action = DeepLinkService.parse(
         Uri.parse(
           'io.supabase.facteur://feed/content/abc-123?pos=4&topicId=tech',
         ),
       );
       expect(action.target, WidgetDeepLinkTarget.article);
-      expect(action.route, '/flux-continu/content/abc-123');
+      expect(action.route, '/flaner/content/abc-123');
       expect(action.articleId, 'abc-123');
       expect(action.position, 4);
       expect(action.topicId, 'tech');
@@ -77,17 +77,17 @@ void main() {
         Uri.parse('io.supabase.facteur:///feed/content/abc-123?pos=7'),
       );
       expect(action.target, WidgetDeepLinkTarget.article);
-      expect(action.route, '/flux-continu/content/abc-123');
+      expect(action.route, '/flaner/content/abc-123');
       expect(action.articleId, 'abc-123');
       expect(action.position, 7);
     });
 
-    test('feed/content/ (id missing) falls back to flux continu', () {
+    test('feed/content/ (id missing) falls back to flâner', () {
       final action = DeepLinkService.parse(
         Uri.parse('io.supabase.facteur://feed/content/'),
       );
       expect(action.target, WidgetDeepLinkTarget.feed);
-      expect(action.route, '/flux-continu');
+      expect(action.route, '/flaner');
     });
 
     test('login-callback URI is ignored (handled by Supabase SDK)', () {


### PR DESCRIPTION
## What

Introduit **Flâner** comme onglet dédié dans la bottom navigation bar (L'Essentiel / Flâner). Ajoute un `FlanerScreen` avec feed infini, filtre par thème, et deep links. Extrait `TourneeProgressService` pour centraliser la persistance de la tournée et piloter un smart routing : si la closing card a déjà été dismissée aujourd'hui, l'app ouvre directement Flâner au lieu de Flux Continu.

## Why

Les utilisateurs qui ont fini leur tournée quotidienne n'avaient pas de destination claire. L'onglet Flâner donne un point d'entrée permanent pour continuer à lire librement.

## Type

- [x] Feature

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)