### PR TITLE
fix(tabs): polish Essentiel/Flâner — preload, banner, nav, transitions

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -9,6 +9,7 @@ import 'core/auth/auth_state.dart';
 import 'core/providers/analytics_provider.dart';
 import 'core/services/deep_link_service.dart';
 import 'core/services/widget_service.dart';
+import 'features/feed/providers/feed_preload_provider.dart';
 import 'features/feed/providers/feed_provider.dart';
 import 'features/flux_continu/providers/flux_continu_preload_provider.dart';
 import 'features/flux_continu/services/tournee_progress_service.dart';
@@ -134,6 +135,11 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
     // GoRouter's splash → /flux-continu redirect. Cuts ~1-2s off the cold
     // open path.
     ref.watch(fluxContinuPreloadProvider);
+
+    // Idem pour l'onglet Flâner (feedProvider) — sans ce watch le feed n'était
+    // jamais préchargé, d'où une ouverture lente du tab. Le provider est
+    // fire-and-forget et gardé par l'âge du cache (cf. feed_preload_provider).
+    ref.watch(feedPreloadProvider);
 
     // Active la re-sync automatique de l'onboarding quand la session devient
     // authentifiée (best-effort, silencieux) — voir onboarding_sync_provider.dart.

--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -41,6 +41,44 @@ import '../core/services/deep_link_service.dart';
 import '../core/ui/notification_service.dart';
 import '../shared/widgets/navigation/modal_bottom_sheet_page.dart';
 
+/// Onglet de bottom-nav affiché en dernier (Essentiel = 0, Flâner = 1).
+///
+/// Suivi au niveau module pour que la transition directionnelle entre onglets
+/// reste correcte quel que soit le chemin de navigation (tap footer, closing
+/// card, redirect, resume), et pas seulement sur un tap explicite du footer.
+int _lastMainTabIndex = 0;
+
+/// Construit la page d'un onglet principal avec une transition latérale
+/// directionnelle : l'onglet cible glisse depuis la gauche quand on avance vers
+/// la droite (Essentiel → Flâner) et depuis la droite quand on recule vers la
+/// gauche (Flâner → Essentiel). Sur le même onglet (delta nul) → simple fondu.
+CustomTransitionPage<void> _mainTabPage({
+  required LocalKey key,
+  required int tabIndex,
+  required Widget child,
+}) {
+  final delta = tabIndex - _lastMainTabIndex;
+  _lastMainTabIndex = tabIndex;
+  return CustomTransitionPage<void>(
+    key: key,
+    transitionDuration: const Duration(milliseconds: 260),
+    reverseTransitionDuration: const Duration(milliseconds: 260),
+    transitionsBuilder: (context, animation, secondaryAnimation, page) {
+      if (delta == 0) {
+        return FadeTransition(opacity: animation, child: page);
+      }
+      final begin = delta > 0 ? const Offset(-1, 0) : const Offset(1, 0);
+      return SlideTransition(
+        position: Tween<Offset>(begin: begin, end: Offset.zero).animate(
+          CurvedAnimation(parent: animation, curve: Curves.easeOutCubic),
+        ),
+        child: page,
+      );
+    },
+    child: child,
+  );
+}
+
 /// Noms des routes
 class RouteNames {
   RouteNames._();
@@ -254,8 +292,11 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: RoutePaths.fluxContinu,
         name: RouteNames.fluxContinu,
-        builder: (context, state) =>
-            const Stack(children: [FluxContinuScreen(), NudgeHost()]),
+        pageBuilder: (context, state) => _mainTabPage(
+          key: state.pageKey,
+          tabIndex: 0,
+          child: const Stack(children: [FluxContinuScreen(), NudgeHost()]),
+        ),
         routes: [
           GoRoute(
             path: 'content/:id',
@@ -309,8 +350,11 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: RoutePaths.flaner,
         name: RouteNames.flaner,
-        builder: (context, state) =>
-            const Stack(children: [FlanerScreen(), NudgeHost()]),
+        pageBuilder: (context, state) => _mainTabPage(
+          key: state.pageKey,
+          tabIndex: 1,
+          child: const Stack(children: [FlanerScreen(), NudgeHost()]),
+        ),
         routes: [
           GoRoute(
             path: 'content/:id',

--- a/apps/mobile/lib/features/feed/screens/flaner_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/flaner_screen.dart
@@ -15,6 +15,7 @@ import '../../../widgets/article_preview_modal.dart';
 import '../../../widgets/design/facteur_logo.dart';
 import '../../app_update/providers/app_update_provider.dart';
 import '../../flux_continu/widgets/flux_continu_article_card.dart';
+import '../../flux_continu/widgets/section_banner.dart';
 import '../../gamification/widgets/streak_indicator.dart';
 import '../../sources/widgets/pepites_carousel.dart';
 import '../models/content_model.dart';
@@ -174,6 +175,15 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
         physics: const AlwaysScrollableScrollPhysics(),
         slivers: [
           const SliverToBoxAdapter(child: _Header()),
+          const SliverToBoxAdapter(
+            child: SectionBanner(
+              title: 'Flâner',
+              blurb:
+                  'Tous les articles de tes sources triés par récence, à consulter à ton rythme',
+              accent: Color(0xFF5D4037),
+              illustrationAsset: 'assets/notifications/facteur_bike.png',
+            ),
+          ),
           const SliverPersistentHeader(
             pinned: true,
             delegate: _FilterHeaderDelegate(child: _FilterSurface()),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -48,8 +48,8 @@ class SectionBanner extends StatelessWidget {
     const topRadius = BorderRadius.vertical(top: Radius.circular(10));
     final container = Container(
       width: double.infinity,
-      margin: const EdgeInsets.fromLTRB(0, 4, 0, 6),
-      constraints: const BoxConstraints(minHeight: 96),
+      margin: const EdgeInsets.fromLTRB(0, 3, 0, 5),
+      constraints: const BoxConstraints(minHeight: 84),
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
         borderRadius: topRadius,
@@ -99,7 +99,7 @@ class SectionBanner extends StatelessWidget {
               ),
             ),
           Padding(
-            padding: const EdgeInsets.fromLTRB(20, 12, 14, 14),
+            padding: const EdgeInsets.fromLTRB(20, 10, 14, 11),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
@@ -126,7 +126,7 @@ class SectionBanner extends StatelessWidget {
                                     ),
                                   ],
                             style: GoogleFonts.fraunces(
-                              fontSize: 21,
+                              fontSize: 20,
                               fontWeight: FontWeight.w700,
                               height: 1.06,
                               letterSpacing: -0.4,
@@ -150,8 +150,8 @@ class SectionBanner extends StatelessWidget {
                 if (illustrationAsset != null) ...[
                   const SizedBox(width: 12),
                   SizedBox(
-                    width: 78,
-                    height: 78,
+                    width: 70,
+                    height: 70,
                     child: IgnorePointer(
                       child: ShaderMask(
                         blendMode: BlendMode.dstIn,
@@ -165,10 +165,10 @@ class SectionBanner extends StatelessWidget {
                           opacity: 0.72,
                           child: Image.asset(
                             illustrationAsset!,
-                            height: 78,
+                            height: 70,
                             // Source PNGs are 1024² — decode at 2× display
                             // height to keep texture memory bounded.
-                            cacheHeight: 156,
+                            cacheHeight: 140,
                             fit: BoxFit.contain,
                             errorBuilder: (_, __, ___) =>
                                 const SizedBox.shrink(),

--- a/apps/mobile/lib/features/settings/providers/user_profile_provider.dart
+++ b/apps/mobile/lib/features/settings/providers/user_profile_provider.dart
@@ -37,7 +37,11 @@ class UserProfileNotifier extends StateNotifier<UserProfile> {
     _loadProfile();
   }
 
-  final _supabase = Supabase.instance.client;
+  // Lazy access so simply constructing the notifier doesn't assert on an
+  // uninitialized Supabase instance — this lets widget tests pump a tree
+  // containing the profile avatar. In production Supabase is always
+  // initialized before any provider is read, so behaviour is unchanged.
+  SupabaseClient get _supabase => Supabase.instance.client;
   static const String _boxName = 'user_profile';
   static const String _displayNameKey = 'display_name';
 
@@ -53,10 +57,10 @@ class UserProfileNotifier extends StateNotifier<UserProfile> {
     }
 
     // 2. Fetch from Supabase
-    final userId = _supabase.auth.currentUser?.id;
-    if (userId == null) return;
-
     try {
+      final userId = _supabase.auth.currentUser?.id;
+      if (userId == null) return;
+
       final response = await _supabase
           .from('user_profiles')
           .select('display_name')
@@ -69,7 +73,8 @@ class UserProfileNotifier extends StateNotifier<UserProfile> {
         await box.put(_displayNameKey, state.displayName);
       }
     } catch (e) {
-      // Silently fail and use cached data
+      // Silently fail and use cached data (also covers test environments
+      // where Supabase isn't initialized).
     }
   }
 

--- a/apps/mobile/lib/shared/widgets/navigation/main_bottom_nav.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/main_bottom_nav.dart
@@ -1,11 +1,21 @@
+import 'dart:ui' show ImageFilter;
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 import '../../../config/routes.dart';
+import '../../../config/theme.dart';
 
 enum MainBottomNavDestination { essentiel, flaner }
 
+/// Bottom nav persistante des deux onglets principaux (Essentiel / Flâner).
+///
+/// Style « point » historique de l'app (repris de `sticky_tab_bar.dart` `_Tab`)
+/// posé sur une surface glassmorphique (reprise de `_ScrollToTopButton` dans
+/// `flaner_screen.dart`) : aucune icône, juste un point orange sous l'onglet
+/// actif et un label. Le flou laisse transparaître le contenu qui défile
+/// derrière la barre.
 class MainBottomNav extends StatelessWidget {
   final MainBottomNavDestination current;
 
@@ -13,29 +23,99 @@ class MainBottomNav extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BottomNavigationBar(
-      currentIndex: current.index,
-      onTap: (index) {
-        final destination = MainBottomNavDestination.values[index];
-        switch (destination) {
-          case MainBottomNavDestination.essentiel:
-            context.go(RoutePaths.fluxContinu);
-          case MainBottomNavDestination.flaner:
-            context.go(RoutePaths.flaner);
-        }
-      },
-      items: [
-        BottomNavigationBarItem(
-          icon: Icon(PhosphorIcons.newspaper()),
-          activeIcon: Icon(PhosphorIcons.newspaper(PhosphorIconsStyle.fill)),
-          label: 'L’Essentiel',
+    final colors = context.facteurColors;
+    final isDark = context.isDarkMode;
+    final fillColor = isDark
+        ? colors.backgroundPrimary.withValues(alpha: 0.78)
+        : const Color.fromRGBO(242, 232, 213, 0.82);
+    final borderColor = isDark
+        ? Colors.white.withValues(alpha: 0.10)
+        : const Color.fromRGBO(0, 0, 0, 0.08);
+
+    return ClipRect(
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
+        child: Container(
+          decoration: BoxDecoration(
+            color: fillColor,
+            border: Border(top: BorderSide(color: borderColor)),
+          ),
+          child: SafeArea(
+            top: false,
+            child: SizedBox(
+              height: 56,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: _FooterTab(
+                      label: 'L’Essentiel',
+                      selected:
+                          current == MainBottomNavDestination.essentiel,
+                      onTap: () => context.go(RoutePaths.fluxContinu),
+                    ),
+                  ),
+                  Expanded(
+                    child: _FooterTab(
+                      label: 'Flâner',
+                      selected: current == MainBottomNavDestination.flaner,
+                      onTap: () => context.go(RoutePaths.flaner),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
         ),
-        BottomNavigationBarItem(
-          icon: Icon(PhosphorIcons.compass()),
-          activeIcon: Icon(PhosphorIcons.compass(PhosphorIconsStyle.fill)),
-          label: 'Flâner',
+      ),
+    );
+  }
+}
+
+class _FooterTab extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _FooterTab({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: label,
+      child: InkWell(
+        onTap: onTap,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              width: 9,
+              height: 9,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: selected ? colors.primary : Colors.transparent,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              label,
+              style: GoogleFonts.dmSans(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: selected ? colors.primary : colors.textSecondary,
+              ),
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
 }

--- a/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
@@ -1,7 +1,10 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/flux_continu/widgets/sticky_tab_bar.dart';
@@ -33,8 +36,21 @@ const _tabs = [
 ];
 
 void main() {
-  setUpAll(() {
+  late Directory tempDir;
+
+  setUpAll(() async {
     GoogleFonts.config.allowRuntimeFetching = false;
+    // StickyHead renders a ProfileAvatarButton, which reads providers backed
+    // by Hive (user profile cache). Initialize Hive against a temp dir so the
+    // avatar can build; Supabase stays uninitialized and is handled gracefully
+    // by the providers (auth-less → default/empty state).
+    tempDir = await Directory.systemTemp.createTemp('sticky_tab_bar_test_');
+    Hive.init(tempDir.path);
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
   });
 
   group('StickyTabBar', () {


### PR DESCRIPTION
## What

Polish et corrections sur les deux onglets principaux :
- Bug : Flâner n'était pas préchargé au démarrage (ouverture lente)
- Feature : nouvelle `MainBottomNav` glassmorphique avec indicateur dot (cohérent avec `sticky_tab_bar`)
- Feature : `SectionBanner` ajouté sur Flâner (parité visuelle avec Essentiel)
- Feature : transitions directionnelles entre onglets via `pageBuilder`
- Fix test : init Hive dans `setUpAll` pour `sticky_three_state_bar_test`

## Why

L'onglet Flâner manquait de polish visuel et de cohérence avec Essentiel.
La nav bottom était générique (icons Flutter stock), sans le style "dot" déjà établi dans l'app.
Le preload manquant causait une ouverture lente de l'onglet Flâner.

## Type

- [x] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)