### PR TITLE
fix(youtube): re-land backend-served IFrame player (Error 153)

### DIFF
--- a/apps/mobile/lib/features/detail/widgets/youtube_player_widget.dart
+++ b/apps/mobile/lib/features/detail/widgets/youtube_player_widget.dart
@@ -3,21 +3,22 @@ import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../../config/constants.dart';
 import '../../../config/theme.dart';
 
 /// YouTube video player widget (Story 5.2)
 ///
-/// Uses flutter_inappwebview with the official YouTube IFrame Player API,
-/// loaded via `initialData` with `baseUrl: https://www.youtube.com`. This is
-/// the canonical fix for Android WebView Error 153 — YouTube checks the
-/// embed page origin, and pointing baseUrl at youtube.com makes the iframe
-/// think it lives on YouTube's own domain (where embedding is always allowed).
+/// Loads the YouTube IFrame Player API via a wrapper page served from our own
+/// backend (`/api/youtube/player?v=...`). Serving the wrapper from a real
+/// https origin gives the embedded YouTube iframe a valid Referer/Origin —
+/// the canonical fix for Android WebView Error 153. (Loading the embed
+/// directly, or via `loadDataWithBaseURL`, fails because Android WebView
+/// doesn't attach an Origin/Referer in those cases, so YouTube refuses the
+/// embed. This mirrors what the old corsproxy.io wrapper did, but self-hosted.)
 ///
-/// A standard Chrome mobile User-Agent is also set (no "wv" marker) so
-/// YouTube doesn't fall back to its WebView block.
-///
-/// The YT.Player JS API provides progress, play state, and playbackRate
-/// (long-press 2x speed boost). Falls back to "open in YouTube" on error.
+/// A standard Chrome mobile User-Agent is also set (no "wv" marker) as
+/// defense in depth. The YT.Player JS API drives progress, play state, and
+/// playbackRate (long-press 2x). Falls back to "open in YouTube" on error.
 class YouTubePlayerWidget extends StatefulWidget {
   final String videoUrl;
   final String title;
@@ -88,76 +89,11 @@ class _YouTubePlayerWidgetState extends State<YouTubePlayerWidget> {
     return null;
   }
 
-  // ---------------------------------------------------------------------------
-  // HTML page hosting the YouTube IFrame Player API.
-  // Loaded via initialData with baseUrl=https://www.youtube.com so the iframe
-  // origin matches youtube.com (bypasses Error 153).
-  // ---------------------------------------------------------------------------
-
-  String _buildPlayerHtml(String videoId) {
-    return '''
-<!DOCTYPE html>
-<html>
-<head>
-<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-<style>
-  html, body { margin: 0; padding: 0; background: #000; height: 100%; overflow: hidden; }
-  #player { width: 100%; height: 100%; }
-</style>
-</head>
-<body>
-<div id="player"></div>
-<script src="https://www.youtube.com/iframe_api"></script>
-<script>
-  var player;
-  var progressTimer;
-
-  function onYouTubeIframeAPIReady() {
-    player = new YT.Player('player', {
-      videoId: '$videoId',
-      width: '100%',
-      height: '100%',
-      playerVars: {
-        playsinline: 1,
-        rel: 0,
-        modestbranding: 1,
-        autoplay: 0,
-        controls: 1,
-        fs: 1
-      },
-      events: {
-        onReady: function() {
-          progressTimer = setInterval(function() {
-            try {
-              var d = player.getDuration();
-              if (d > 0) {
-                window.flutter_inappwebview.callHandler(
-                  'FlutterProgress', player.getCurrentTime() / d
-                );
-              }
-            } catch (e) {}
-          }, 1000);
-        },
-        onStateChange: function(e) {
-          // YT.PlayerState.PLAYING === 1
-          var isPlaying = e.data === 1 ? 1 : 0;
-          window.flutter_inappwebview.callHandler('FlutterPlayState', isPlaying);
-        },
-        onError: function(e) {
-          window.flutter_inappwebview.callHandler('FlutterError', e.data);
-        }
-      }
-    });
-  }
-
-  window.setPlaybackRate = function(rate) {
-    if (player && player.setPlaybackRate) player.setPlaybackRate(rate);
-  };
-</script>
-</body>
-</html>
-''';
-  }
+  /// URL of the backend-hosted IFrame Player wrapper page for [videoId].
+  /// Served from our real https origin so the YouTube embed gets a valid
+  /// Referer (bypasses Error 153). [ApiConstants.baseUrl] ends with `/`.
+  String _playerUrl(String videoId) =>
+      '${ApiConstants.baseUrl}youtube/player?v=$videoId';
 
   void _startSpeedBoost() {
     setState(() => _isSpeedBoosted = true);
@@ -199,6 +135,8 @@ class _YouTubePlayerWidgetState extends State<YouTubePlayerWidget> {
       );
     }
 
+    final apiHost = WebUri(ApiConstants.baseUrl).host;
+
     final settings = InAppWebViewSettings(
       javaScriptEnabled: true,
       mediaPlaybackRequiresUserGesture: false,
@@ -212,14 +150,9 @@ class _YouTubePlayerWidgetState extends State<YouTubePlayerWidget> {
     );
 
     final playerWidget = InAppWebView(
-      // baseUrl=youtube.com aligns the iframe origin with YouTube's own
-      // domain — the canonical fix for embed Error 153 in WebViews.
-      initialData: InAppWebViewInitialData(
-        data: _buildPlayerHtml(_videoId!),
-        baseUrl: WebUri('https://www.youtube.com'),
-        mimeType: 'text/html',
-        encoding: 'utf8',
-      ),
+      // Wrapper page served from our backend origin → the YouTube embed
+      // iframe gets a valid Referer → no Error 153.
+      initialUrlRequest: URLRequest(url: WebUri(_playerUrl(_videoId!))),
       initialSettings: settings,
       onWebViewCreated: (controller) {
         _controller = controller;
@@ -282,7 +215,8 @@ class _YouTubePlayerWidgetState extends State<YouTubePlayerWidget> {
         final uri = navigationAction.request.url;
         if (uri == null) return NavigationActionPolicy.CANCEL;
         final host = uri.host;
-        if (host.endsWith('youtube.com') ||
+        if (host == apiHost ||
+            host.endsWith('youtube.com') ||
             host.endsWith('youtube-nocookie.com') ||
             host.endsWith('ytimg.com') ||
             host.endsWith('googlevideo.com') ||

--- a/apps/mobile/lib/features/detail/widgets/youtube_player_widget.dart
+++ b/apps/mobile/lib/features/detail/widgets/youtube_player_widget.dart
@@ -44,6 +44,10 @@ class YouTubePlayerWidget extends StatefulWidget {
 }
 
 class _YouTubePlayerWidgetState extends State<YouTubePlayerWidget> {
+  /// Host of our backend origin — whitelisted in [shouldOverrideUrlLoading].
+  /// Derived once from the (constant) [ApiConstants.baseUrl].
+  static final String _apiHost = WebUri(ApiConstants.baseUrl).host;
+
   InAppWebViewController? _controller;
   String? _videoId;
   double _lastReportedProgress = -1.0;
@@ -135,8 +139,6 @@ class _YouTubePlayerWidgetState extends State<YouTubePlayerWidget> {
       );
     }
 
-    final apiHost = WebUri(ApiConstants.baseUrl).host;
-
     final settings = InAppWebViewSettings(
       javaScriptEnabled: true,
       mediaPlaybackRequiresUserGesture: false,
@@ -215,7 +217,7 @@ class _YouTubePlayerWidgetState extends State<YouTubePlayerWidget> {
         final uri = navigationAction.request.url;
         if (uri == null) return NavigationActionPolicy.CANCEL;
         final host = uri.host;
-        if (host == apiHost ||
+        if (host == _apiHost ||
             host.endsWith('youtube.com') ||
             host.endsWith('youtube-nocookie.com') ||
             host.endsWith('ytimg.com') ||

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -101,6 +101,7 @@ from app.routers import (
     waitlist,
     webhooks,
     well_informed,
+    youtube_player,
 )
 from app.workers.scheduler import start_scheduler, stop_scheduler
 
@@ -452,6 +453,7 @@ app.include_router(digest.router, prefix="/api/digest", tags=["Digest"])
 app.include_router(essentiel.router, prefix="/api/essentiel", tags=["Essentiel"])
 app.include_router(contents.router, prefix="/api/contents", tags=["Contents"])
 app.include_router(images.router, prefix="/api/images", tags=["Images"])
+app.include_router(youtube_player.router, prefix="/api/youtube", tags=["YouTube"])
 app.include_router(sources.router, prefix="/api/sources", tags=["Sources"])
 app.include_router(
     subscription.router, prefix="/api/subscription", tags=["Subscription"]

--- a/packages/api/app/routers/youtube_player.py
+++ b/packages/api/app/routers/youtube_player.py
@@ -1,0 +1,102 @@
+"""Page HTML hébergeant le YouTube IFrame Player API.
+
+Le WebView mobile charge cette page depuis une **vraie origine https**
+(api.facteur.app / Railway) au lieu d'un document `loadDataWithBaseURL`.
+
+Pourquoi : Android WebView ne propage PAS l'Origin/Referer du `baseUrl`
+aux sous-requêtes de l'iframe YouTube → YouTube refuse l'embed (Error 153).
+En servant le wrapper depuis notre propre origine, l'iframe YouTube reçoit
+un Referer valide et l'embed est autorisé — exactement la condition qui
+marchait avec le proxy corsproxy.io, mais self-hosted (pas de rate-limit,
+pas de dépendance tierce, cf. le pattern du proxy `routers/images.py`).
+
+Le bridge JS (`window.flutter_inappwebview.callHandler`) fonctionne quelle
+que soit l'origine de la page ; les gardes `if (window.flutter_inappwebview)`
+permettent aussi d'ouvrir la page dans un navigateur normal sans erreur.
+"""
+
+import re
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+# YouTube video IDs sont exactement 11 caractères [A-Za-z0-9_-]. Valider
+# strictement ferme tout vecteur d'injection HTML/JS dans le template.
+_VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+_CACHE_HEADERS = {"Cache-Control": "public, max-age=3600"}
+
+_PLAYER_HTML_TEMPLATE = """<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<style>
+  html, body { margin: 0; padding: 0; background: #000; height: 100%; overflow: hidden; }
+  #player { width: 100%; height: 100%; }
+</style>
+</head>
+<body>
+<div id="player"></div>
+<script src="https://www.youtube.com/iframe_api"></script>
+<script>
+  var player;
+  function onYouTubeIframeAPIReady() {
+    player = new YT.Player('player', {
+      videoId: '__VIDEO_ID__',
+      width: '100%',
+      height: '100%',
+      playerVars: {
+        playsinline: 1, rel: 0, modestbranding: 1,
+        autoplay: 0, controls: 1, fs: 1
+      },
+      events: {
+        onReady: function() {
+          setInterval(function() {
+            try {
+              var d = player.getDuration();
+              if (d > 0 && window.flutter_inappwebview) {
+                window.flutter_inappwebview.callHandler(
+                  'FlutterProgress', player.getCurrentTime() / d
+                );
+              }
+            } catch (e) {}
+          }, 1000);
+        },
+        onStateChange: function(e) {
+          // YT.PlayerState.PLAYING === 1
+          if (window.flutter_inappwebview) {
+            window.flutter_inappwebview.callHandler('FlutterPlayState', e.data === 1 ? 1 : 0);
+          }
+        },
+        onError: function(e) {
+          if (window.flutter_inappwebview) {
+            window.flutter_inappwebview.callHandler('FlutterError', e.data);
+          }
+        }
+      }
+    });
+  }
+  window.setPlaybackRate = function(rate) {
+    if (player && player.setPlaybackRate) player.setPlaybackRate(rate);
+  };
+</script>
+</body>
+</html>
+"""
+
+
+@router.get("/player", response_class=HTMLResponse)
+async def youtube_player(
+    v: str = Query(..., min_length=11, max_length=11),
+) -> HTMLResponse:
+    """Sert la page player IFrame pour un video_id YouTube donné.
+
+    Le WebView mobile charge cette URL (vraie origine https) pour contourner
+    l'Error 153 (embed refusé) dû à l'absence de Referer sous WebView Android.
+    """
+    if not _VIDEO_ID_RE.match(v):
+        raise HTTPException(status_code=400, detail="invalid_video_id")
+
+    html = _PLAYER_HTML_TEMPLATE.replace("__VIDEO_ID__", v)
+    return HTMLResponse(content=html, headers=_CACHE_HEADERS)

--- a/packages/api/tests/test_youtube_player.py
+++ b/packages/api/tests/test_youtube_player.py
@@ -1,0 +1,48 @@
+"""Tests pour la route player YouTube (page IFrame servie depuis notre origine)."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_player_returns_html_with_video_id():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/youtube/player", params={"v": "dQw4w9WgXcQ"})
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert resp.headers.get("cache-control") == "public, max-age=3600"
+    # Le video_id est injecté et l'API IFrame officielle est chargée.
+    assert "dQw4w9WgXcQ" in resp.text
+    assert "https://www.youtube.com/iframe_api" in resp.text
+    assert "onYouTubeIframeAPIReady" in resp.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "short",  # trop court (len != 11 → rejeté par Query min_length)
+        "twelvechars1",  # trop long (len != 11 → rejeté par Query max_length)
+    ],
+)
+async def test_player_rejects_wrong_length(bad_id: str):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/youtube/player", params={"v": bad_id})
+
+    assert resp.status_code == 422  # FastAPI Query validation
+
+
+@pytest.mark.asyncio
+async def test_player_rejects_injection_chars():
+    # 11 caractères mais avec des chars hors [A-Za-z0-9_-] → 400 (pas d'injection).
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/youtube/player", params={"v": "abc<script>"})
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "invalid_video_id"


### PR DESCRIPTION
# PR — Re-land backend-served YouTube player (Error 153)

## Pourquoi cette PR
PR #705 (mergée le 2026-05-28) a été **squash-mergée sur un commit périmé**.
Seul le widget mobile a atterri sur `main`, dans sa forme antérieure
`initialData` + `baseUrl=youtube.com` — l'approche que le QA handoff documente
comme **non-fonctionnelle** sous Android WebView (pas de Referer/Origin propagé
→ Error 153 → fallback systématique). Le commit final `eaa19e37` (page player
servie par le backend) n'a jamais atteint `main`, et la route backend n'a
jamais été mergée (`GET /api/youtube/player` renvoyait **404** en prod).

Conséquence terrain : fallback « Regarder sur YouTube » à chaque ouverture
d'une vidéo, sur device Android réel.

## Ce que fait cette PR
Rétablit le vrai fix par-dessus l'état actuel de `main` :
- **Nouvelle route** `GET /api/youtube/player?v=<id>` : sert la page IFrame
  Player API depuis notre propre origine https (Referer valide → embed
  autorisé). Validation stricte du `video_id` (regex 11 chars → anti-injection),
  `Cache-Control: public, max-age=3600`.
- **Widget mobile** : charge cette URL (`ApiConstants.baseUrl` → `…/api/youtube/player?v=…`)
  au lieu de `loadDataWithBaseURL`, et whiteliste l'`apiHost` dans
  `shouldOverrideUrlLoading`.

`main.py` est édité **chirurgicalement** (import + include uniquement) pour
préserver le router `grille` ajouté après la branche du fix (PR #715).

## Fichiers
- `packages/api/app/routers/youtube_player.py` (nouveau)
- `packages/api/tests/test_youtube_player.py` (nouveau, 4 tests)
- `packages/api/app/main.py` (+2 lignes : import + include)
- `apps/mobile/lib/features/detail/widgets/youtube_player_widget.dart`

## Vérifié
- Backend : `pytest tests/test_youtube_player.py` → **4 passed** (200/text-html/
  cache-control/body contient l'id ; rejet 422 longueur ; rejet 400 injection).
- Mobile : `flutter analyze` sur le widget → 0 erreur (3 `info withOpacity`
  pré-existants, hors-scope).
- Diff = exactement 4 fichiers ; `grille` préservé dans `main.py`.

## Après merge (gating — backend AVANT mobile, cf. QA handoff)
1. Laisser Railway redéployer, puis
   `curl -i https://facteur-production.up.railway.app/api/youtube/player?v=dQw4w9WgXcQ`
   → attendu **200 / text/html / body contient `dQw4w9WgXcQ`**.
2. Build mobile → validation device Android réel (lecture in-app sans Error 153).

## Aucune migration Alembic, aucun secret, aucune dépendance tierce.
