### PR TITLE
feat(grille): module mobile « La Grille du jour » (Story 24.2)

### DIFF
--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -32,6 +32,9 @@ import '../features/subscription/screens/paywall_screen.dart';
 import '../features/veille/screens/veille_config_screen.dart';
 import '../features/lettres/screens/courrier_screen.dart';
 import '../features/lettres/screens/open_letter_screen.dart';
+import '../features/grille/screens/grille_screen.dart';
+import '../features/grille/screens/grille_leaderboard_screen.dart';
+import '../features/grille/screens/grille_share_screen.dart';
 import '../features/saved/screens/saved_screen.dart';
 import '../features/saved/screens/saved_all_screen.dart';
 import '../features/saved/screens/collection_detail_screen.dart';
@@ -112,6 +115,9 @@ class RouteNames {
   static const String veilleConfig = 'veille-config';
   static const String lettres = 'lettres';
   static const String openLetter = 'open-letter';
+  static const String grille = 'grille';
+  static const String grilleLeaderboard = 'grille-leaderboard';
+  static const String grilleShare = 'grille-share';
 }
 
 /// Chemins des routes
@@ -144,6 +150,9 @@ class RoutePaths {
   static const String veilleConfig = '/veille/config';
   static const String lettres = '/lettres';
   static const String openLetter = '/lettres/:id';
+  static const String grille = '/grille';
+  static const String grilleLeaderboard = '/grille/leaderboard';
+  static const String grilleShare = '/grille/share';
 }
 
 final routerProvider = Provider<GoRouter>((ref) {
@@ -537,6 +546,29 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: RoutePaths.digest,
         name: RouteNames.digest,
         redirect: (context, state) => RoutePaths.fluxContinu,
+      ),
+
+      // La Grille du jour — route top-level (hors transition main-tab) +
+      // sous-routes classement / partage, toutes en FullSwipeCupertinoPage.
+      GoRoute(
+        path: RoutePaths.grille,
+        name: RouteNames.grille,
+        pageBuilder: (context, state) =>
+            const FullSwipeCupertinoPage(child: GrilleScreen()),
+        routes: [
+          GoRoute(
+            path: 'leaderboard',
+            name: RouteNames.grilleLeaderboard,
+            pageBuilder: (context, state) =>
+                const FullSwipeCupertinoPage(child: GrilleLeaderboardScreen()),
+          ),
+          GoRoute(
+            path: 'share',
+            name: RouteNames.grilleShare,
+            pageBuilder: (context, state) =>
+                const FullSwipeCupertinoPage(child: GrilleShareScreen()),
+          ),
+        ],
       ),
 
       // Topic Explorer (outside ShellRoute to hide bottom nav)

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -698,6 +698,81 @@ class AnalyticsService {
     await prefs.setBool('has_launched_before', true);
   }
 
+  // ──────────────────────────────────────────────────────────────
+  // La Grille du jour (Story 24.2)
+  // ──────────────────────────────────────────────────────────────
+
+  Future<void> trackGrilleOpened({String? numero, required String statut}) async {
+    final props = {
+      'session_id': _sessionId,
+      'numero': numero,
+      'statut': statut,
+    };
+    await _logEvent('grille_opened', props);
+    await _capturePostHog('grille_opened', props);
+  }
+
+  Future<void> trackGrilleGuessSubmitted({
+    String? numero,
+    required int essai,
+    required bool valide,
+    String? raison,
+  }) async {
+    await _logEvent('grille_guess_submitted', {
+      'session_id': _sessionId,
+      'numero': numero,
+      'essai': essai,
+      'valide': valide,
+      'raison': raison,
+    });
+  }
+
+  Future<void> trackGrilleCompleted({
+    String? numero,
+    required String statut,
+    required int nbEssais,
+  }) async {
+    final props = {
+      'session_id': _sessionId,
+      'numero': numero,
+      'statut': statut,
+      'nb_essais': nbEssais,
+    };
+    await _logEvent('grille_completed', props);
+    await _capturePostHog('grille_completed', props);
+  }
+
+  /// `medium` ∈ `texte | lien`.
+  Future<void> trackGrilleShared({String? numero, required String medium}) async {
+    final props = {
+      'session_id': _sessionId,
+      'numero': numero,
+      'medium': medium,
+    };
+    await _logEvent('grille_shared', props);
+    await _capturePostHog('grille_shared', props);
+  }
+
+  Future<void> trackGrilleLeaderboardOpened({String? numero}) async {
+    await _logEvent('grille_leaderboard_opened', {
+      'session_id': _sessionId,
+      'numero': numero,
+    });
+  }
+
+  Future<void> trackGrilleCtaShown({required String state}) async {
+    await _logEvent('grille_cta_shown', {
+      'session_id': _sessionId,
+      'state': state,
+    });
+  }
+
+  Future<void> trackGrilleCtaTapped({required String state}) async {
+    final props = {'session_id': _sessionId, 'state': state};
+    await _logEvent('grille_cta_tapped', props);
+    await _capturePostHog('grille_cta_tapped', props);
+  }
+
   Future<void> _logEvent(
     String eventType,
     Map<String, dynamic> eventData,

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -38,6 +38,7 @@ import '../widgets/my_interests_sheet.dart';
 import '../widgets/section_block.dart';
 import '../widgets/sticky_tab_bar.dart';
 import '../widgets/tournee_folded_group_card.dart';
+import '../../grille/widgets/grille_cta_card.dart';
 
 /// Scroll offset at which the AppBar is swapped with the sticky tab bar.
 const double _kStickyThreshold = 60.0;
@@ -816,6 +817,17 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
                           : const SizedBox.shrink(),
                     )
                   : CitationDuJourCard(quote: state.quote!),
+            ),
+          // La Grille du jour — récompense de fin de Tournée. Sliver additif
+          // au-dessus de ClosingCardV18 (cette dernière n'est pas modifiée :
+          // zéro régression, revert trivial). La carte se câble seule au
+          // grilleProvider et ne rend rien tant que `GET today` n'a pas répondu.
+          if (!state.closingDismissed)
+            const SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.fromLTRB(16, 22, 16, 0),
+                child: GrilleCtaCard(),
+              ),
             ),
           SliverToBoxAdapter(
             child: state.closingDismissed

--- a/apps/mobile/lib/features/grille/grille_constants.dart
+++ b/apps/mobile/lib/features/grille/grille_constants.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+/// Constantes du module « La Grille du jour ».
+///
+/// Centralise les valeurs **hors-token** explicitement validées dans le design
+/// (`.context/attachments/0rGiaa/grille.css`) — celles qui n'existent pas dans
+/// `FacteurPalettes`/`FacteurRadius` — ainsi que les dimensions et timings
+/// d'animation. Toute valeur qui EXISTE déjà comme token doit passer par le
+/// thème (`context.facteurColors`, `FacteurRadius`, `FacteurSpacing`), jamais
+/// être redéclarée ici.
+class GrilleConstants {
+  GrilleConstants._();
+
+  // ── Couleurs hors-token (validées dans grille.css) ──────────────────────
+  /// Tuile « absente » : charbon chaud — « n'habite pas ici ». (`.mt-tile.s-absent`)
+  static const Color absentGrille = Color(0xFF837A6D);
+
+  /// Touche clavier « absente » : gris plus clair. (`.kb-key.s-absent`)
+  static const Color absentClavier = Color(0xFFBBB1A1);
+
+  /// Bouton « steel » (footer Défier un·e ami·e). (`.g-btn.steel`)
+  static const Color steel = Color(0xFF34495E);
+
+  /// Jauge de distribution (barres remplies hors « moi »). (`.gl-dist .row .fill`)
+  static const Color gauge = Color(0xFFCDBFA6);
+
+  /// Fond d'avatar fallback (illustration Facteur). (`background: #F0E6D2`)
+  static const Color avatarFallback = Color(0xFFF0E6D2);
+
+  // ── Rayons custom hors FacteurRadius ────────────────────────────────────
+  /// Rayon d'une tuile de jeu. (`.mt-tile { border-radius: 6px }`)
+  static const double tileRadius = 6;
+
+  /// Rayon d'un carré de partage. (`.msg-cell { border-radius: 4px }`)
+  static const double shareCellRadius = 4;
+
+  /// Rayon d'une touche de clavier. (`.kb-key { border-radius: 7px }`)
+  static const double keyRadius = 7;
+
+  // ── Dimensions de jeu ───────────────────────────────────────────────────
+  /// Côté d'une tuile sur l'écran de jeu. (`.mot-grid { --tile: 50px }`)
+  static const double tileSize = 50;
+
+  /// Côté d'une tuile sur l'écran résultat. (`.mot-grid.v-resultat { --tile: 44px }`)
+  static const double tileSizeResult = 44;
+
+  /// Espace entre tuiles (jeu). (`--gap: 6px`)
+  static const double tileGap = 6;
+
+  /// Espace entre tuiles (résultat). (`.v-resultat { --gap: 5px }`)
+  static const double tileGapResult = 5;
+
+  /// Hauteur d'une touche de clavier. (`.kb-key { height: 50px }`)
+  static const double keyHeight = 50;
+
+  /// Côté d'un carré de partage. (`.msg-cell { width/height: 24px }`)
+  static const double shareCellSize = 24;
+
+  /// Côté d'une mini-tuile (carte d'entrée). (`.mt-mini { width/height: 18px }`)
+  static const double miniTileSize = 18;
+
+  // ── Animations ──────────────────────────────────────────────────────────
+  /// Durée du flip de révélation d'une tuile. (`@keyframes mt-flip { 420ms }`)
+  static const Duration flipDuration = Duration(milliseconds: 420);
+
+  /// Décalage du flip par colonne. (`animation-delay: calc(var(--i) * 95ms)`)
+  static const Duration flipStagger = Duration(milliseconds: 95);
+
+  /// Durée du shake d'un mot invalide. (contrôleur séparé, ~250ms)
+  static const Duration shakeDuration = Duration(milliseconds: 250);
+
+  // ── Lien de partage ─────────────────────────────────────────────────────
+  /// Base de lien de partage (sans spoiler). Le deep-link entrant est hors MVP.
+  static const String shareBaseUrl = 'https://facteur.app/grille';
+}

--- a/apps/mobile/lib/features/grille/models/grille_models.dart
+++ b/apps/mobile/lib/features/grille/models/grille_models.dart
@@ -1,0 +1,146 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'grille_models.freezed.dart';
+part 'grille_models.g.dart';
+
+/// Modèles de « La Grille du jour » (mobile, Story 24.2).
+///
+/// ⚠️ Contrat **byte-exact** avec `packages/api/app/schemas/grille.py` : les
+/// noms de champs portent **directement** les clés JSON camelCase FR — aucun
+/// `@JsonKey(name:)` de renommage, aucun `field_rename` dans `build.yaml`.
+/// `numero` est une **String** (`"N°143"`). Les champs `score`/`monScore`
+/// peuvent valoir un entier OU la chaîne `"X"` (raté) côté serveur : on
+/// normalise en `String` + getter `int? scoreInt`.
+
+/// Convertit une valeur d'union `int | "X"` en `String` stable.
+String _scoreToString(Object? value) => value?.toString() ?? 'X';
+
+/// Une proposition jouée et ses états par case (`place|present|absent`).
+@freezed
+class GrilleEssai with _$GrilleEssai {
+  const factory GrilleEssai({
+    required String mot,
+    required List<String> etats,
+  }) = _GrilleEssai;
+
+  factory GrilleEssai.fromJson(Map<String, dynamic> json) =>
+      _$GrilleEssaiFromJson(json);
+}
+
+/// Réponse de `GET grille/today`.
+///
+/// `mot`/`pourquoi` restent `null` tant que `statut == in_progress` (le mot
+/// n'est jamais exposé avant la fin de partie).
+@freezed
+class GrilleTodayResponse with _$GrilleTodayResponse {
+  const GrilleTodayResponse._();
+
+  const factory GrilleTodayResponse({
+    required String date,
+    required String dateAffichee,
+    required String dateCourt,
+    required String numero,
+    required int longueur,
+    required int essaisMax,
+    required String premiereLettre,
+    required String indice,
+    required String theme,
+    required String statut,
+    required List<GrilleEssai> essais,
+    required int nbEssais,
+    String? mot,
+    String? pourquoi,
+    required int streak,
+    required int prochainMotDansSec,
+  }) = _GrilleTodayResponse;
+
+  factory GrilleTodayResponse.fromJson(Map<String, dynamic> json) =>
+      _$GrilleTodayResponseFromJson(json);
+
+  bool get isInProgress => statut == 'in_progress';
+  bool get isSolved => statut == 'solved';
+  bool get isFailed => statut == 'failed';
+  bool get isFinished => isSolved || isFailed;
+}
+
+/// Réponse de `POST grille/today/guess`.
+///
+/// En cas de refus (`valide == false`), seul `raison` est renseigné et l'essai
+/// **n'est pas consommé**. En cas d'acceptation, `etats`/`statut`/`nbEssais`
+/// sont renseignés ; `mot`/`pourquoi` uniquement sur `solved`/`failed`.
+@freezed
+class GrilleGuessResponse with _$GrilleGuessResponse {
+  const GrilleGuessResponse._();
+
+  const factory GrilleGuessResponse({
+    required bool valide,
+    String? raison,
+    List<String>? etats,
+    String? statut,
+    int? nbEssais,
+    String? mot,
+    String? pourquoi,
+  }) = _GrilleGuessResponse;
+
+  factory GrilleGuessResponse.fromJson(Map<String, dynamic> json) =>
+      _$GrilleGuessResponseFromJson(json);
+
+  bool get isSolved => statut == 'solved';
+  bool get isFailed => statut == 'failed';
+  bool get isFinished => isSolved || isFailed;
+}
+
+/// Part (%) des joueurs pour un nombre d'essais donné (`score` ou `"X"`).
+@freezed
+class GrilleDistributionItem with _$GrilleDistributionItem {
+  const GrilleDistributionItem._();
+
+  const factory GrilleDistributionItem({
+    @JsonKey(fromJson: _scoreToString) required String score,
+    required int pct,
+  }) = _GrilleDistributionItem;
+
+  factory GrilleDistributionItem.fromJson(Map<String, dynamic> json) =>
+      _$GrilleDistributionItemFromJson(json);
+
+  /// `null` si raté (`"X"`), sinon le nombre d'essais.
+  int? get scoreInt => int.tryParse(score);
+}
+
+/// Une ligne du podium anonymisé (`moi == true` pour le joueur courant).
+@freezed
+class GrilleQuartierItem with _$GrilleQuartierItem {
+  const GrilleQuartierItem._();
+
+  const factory GrilleQuartierItem({
+    required String initiales,
+    @JsonKey(fromJson: _scoreToString) required String score,
+    required int rang,
+    @Default(false) bool moi,
+  }) = _GrilleQuartierItem;
+
+  factory GrilleQuartierItem.fromJson(Map<String, dynamic> json) =>
+      _$GrilleQuartierItemFromJson(json);
+
+  int? get scoreInt => int.tryParse(score);
+}
+
+/// Réponse de `GET grille/today/leaderboard` (partie terminée requise).
+@freezed
+class GrilleLeaderboardResponse with _$GrilleLeaderboardResponse {
+  const GrilleLeaderboardResponse._();
+
+  const factory GrilleLeaderboardResponse({
+    required int percentile,
+    required int joueurs,
+    @JsonKey(fromJson: _scoreToString) required String monScore,
+    required List<GrilleDistributionItem> distribution,
+    required List<GrilleQuartierItem> quartier,
+    required int streak,
+  }) = _GrilleLeaderboardResponse;
+
+  factory GrilleLeaderboardResponse.fromJson(Map<String, dynamic> json) =>
+      _$GrilleLeaderboardResponseFromJson(json);
+
+  int? get monScoreInt => int.tryParse(monScore);
+}

--- a/apps/mobile/lib/features/grille/models/grille_models.freezed.dart
+++ b/apps/mobile/lib/features/grille/models/grille_models.freezed.dart
@@ -1,0 +1,1585 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'grille_models.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+GrilleEssai _$GrilleEssaiFromJson(Map<String, dynamic> json) {
+  return _GrilleEssai.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GrilleEssai {
+  String get mot => throw _privateConstructorUsedError;
+  List<String> get etats => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GrilleEssaiCopyWith<GrilleEssai> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GrilleEssaiCopyWith<$Res> {
+  factory $GrilleEssaiCopyWith(
+          GrilleEssai value, $Res Function(GrilleEssai) then) =
+      _$GrilleEssaiCopyWithImpl<$Res, GrilleEssai>;
+  @useResult
+  $Res call({String mot, List<String> etats});
+}
+
+/// @nodoc
+class _$GrilleEssaiCopyWithImpl<$Res, $Val extends GrilleEssai>
+    implements $GrilleEssaiCopyWith<$Res> {
+  _$GrilleEssaiCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? mot = null,
+    Object? etats = null,
+  }) {
+    return _then(_value.copyWith(
+      mot: null == mot
+          ? _value.mot
+          : mot // ignore: cast_nullable_to_non_nullable
+              as String,
+      etats: null == etats
+          ? _value.etats
+          : etats // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$GrilleEssaiImplCopyWith<$Res>
+    implements $GrilleEssaiCopyWith<$Res> {
+  factory _$$GrilleEssaiImplCopyWith(
+          _$GrilleEssaiImpl value, $Res Function(_$GrilleEssaiImpl) then) =
+      __$$GrilleEssaiImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String mot, List<String> etats});
+}
+
+/// @nodoc
+class __$$GrilleEssaiImplCopyWithImpl<$Res>
+    extends _$GrilleEssaiCopyWithImpl<$Res, _$GrilleEssaiImpl>
+    implements _$$GrilleEssaiImplCopyWith<$Res> {
+  __$$GrilleEssaiImplCopyWithImpl(
+      _$GrilleEssaiImpl _value, $Res Function(_$GrilleEssaiImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? mot = null,
+    Object? etats = null,
+  }) {
+    return _then(_$GrilleEssaiImpl(
+      mot: null == mot
+          ? _value.mot
+          : mot // ignore: cast_nullable_to_non_nullable
+              as String,
+      etats: null == etats
+          ? _value._etats
+          : etats // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GrilleEssaiImpl implements _GrilleEssai {
+  const _$GrilleEssaiImpl(
+      {required this.mot, required final List<String> etats})
+      : _etats = etats;
+
+  factory _$GrilleEssaiImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GrilleEssaiImplFromJson(json);
+
+  @override
+  final String mot;
+  final List<String> _etats;
+  @override
+  List<String> get etats {
+    if (_etats is EqualUnmodifiableListView) return _etats;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_etats);
+  }
+
+  @override
+  String toString() {
+    return 'GrilleEssai(mot: $mot, etats: $etats)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GrilleEssaiImpl &&
+            (identical(other.mot, mot) || other.mot == mot) &&
+            const DeepCollectionEquality().equals(other._etats, _etats));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, mot, const DeepCollectionEquality().hash(_etats));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GrilleEssaiImplCopyWith<_$GrilleEssaiImpl> get copyWith =>
+      __$$GrilleEssaiImplCopyWithImpl<_$GrilleEssaiImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GrilleEssaiImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _GrilleEssai implements GrilleEssai {
+  const factory _GrilleEssai(
+      {required final String mot,
+      required final List<String> etats}) = _$GrilleEssaiImpl;
+
+  factory _GrilleEssai.fromJson(Map<String, dynamic> json) =
+      _$GrilleEssaiImpl.fromJson;
+
+  @override
+  String get mot;
+  @override
+  List<String> get etats;
+  @override
+  @JsonKey(ignore: true)
+  _$$GrilleEssaiImplCopyWith<_$GrilleEssaiImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+GrilleTodayResponse _$GrilleTodayResponseFromJson(Map<String, dynamic> json) {
+  return _GrilleTodayResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GrilleTodayResponse {
+  String get date => throw _privateConstructorUsedError;
+  String get dateAffichee => throw _privateConstructorUsedError;
+  String get dateCourt => throw _privateConstructorUsedError;
+  String get numero => throw _privateConstructorUsedError;
+  int get longueur => throw _privateConstructorUsedError;
+  int get essaisMax => throw _privateConstructorUsedError;
+  String get premiereLettre => throw _privateConstructorUsedError;
+  String get indice => throw _privateConstructorUsedError;
+  String get theme => throw _privateConstructorUsedError;
+  String get statut => throw _privateConstructorUsedError;
+  List<GrilleEssai> get essais => throw _privateConstructorUsedError;
+  int get nbEssais => throw _privateConstructorUsedError;
+  String? get mot => throw _privateConstructorUsedError;
+  String? get pourquoi => throw _privateConstructorUsedError;
+  int get streak => throw _privateConstructorUsedError;
+  int get prochainMotDansSec => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GrilleTodayResponseCopyWith<GrilleTodayResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GrilleTodayResponseCopyWith<$Res> {
+  factory $GrilleTodayResponseCopyWith(
+          GrilleTodayResponse value, $Res Function(GrilleTodayResponse) then) =
+      _$GrilleTodayResponseCopyWithImpl<$Res, GrilleTodayResponse>;
+  @useResult
+  $Res call(
+      {String date,
+      String dateAffichee,
+      String dateCourt,
+      String numero,
+      int longueur,
+      int essaisMax,
+      String premiereLettre,
+      String indice,
+      String theme,
+      String statut,
+      List<GrilleEssai> essais,
+      int nbEssais,
+      String? mot,
+      String? pourquoi,
+      int streak,
+      int prochainMotDansSec});
+}
+
+/// @nodoc
+class _$GrilleTodayResponseCopyWithImpl<$Res, $Val extends GrilleTodayResponse>
+    implements $GrilleTodayResponseCopyWith<$Res> {
+  _$GrilleTodayResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? date = null,
+    Object? dateAffichee = null,
+    Object? dateCourt = null,
+    Object? numero = null,
+    Object? longueur = null,
+    Object? essaisMax = null,
+    Object? premiereLettre = null,
+    Object? indice = null,
+    Object? theme = null,
+    Object? statut = null,
+    Object? essais = null,
+    Object? nbEssais = null,
+    Object? mot = freezed,
+    Object? pourquoi = freezed,
+    Object? streak = null,
+    Object? prochainMotDansSec = null,
+  }) {
+    return _then(_value.copyWith(
+      date: null == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as String,
+      dateAffichee: null == dateAffichee
+          ? _value.dateAffichee
+          : dateAffichee // ignore: cast_nullable_to_non_nullable
+              as String,
+      dateCourt: null == dateCourt
+          ? _value.dateCourt
+          : dateCourt // ignore: cast_nullable_to_non_nullable
+              as String,
+      numero: null == numero
+          ? _value.numero
+          : numero // ignore: cast_nullable_to_non_nullable
+              as String,
+      longueur: null == longueur
+          ? _value.longueur
+          : longueur // ignore: cast_nullable_to_non_nullable
+              as int,
+      essaisMax: null == essaisMax
+          ? _value.essaisMax
+          : essaisMax // ignore: cast_nullable_to_non_nullable
+              as int,
+      premiereLettre: null == premiereLettre
+          ? _value.premiereLettre
+          : premiereLettre // ignore: cast_nullable_to_non_nullable
+              as String,
+      indice: null == indice
+          ? _value.indice
+          : indice // ignore: cast_nullable_to_non_nullable
+              as String,
+      theme: null == theme
+          ? _value.theme
+          : theme // ignore: cast_nullable_to_non_nullable
+              as String,
+      statut: null == statut
+          ? _value.statut
+          : statut // ignore: cast_nullable_to_non_nullable
+              as String,
+      essais: null == essais
+          ? _value.essais
+          : essais // ignore: cast_nullable_to_non_nullable
+              as List<GrilleEssai>,
+      nbEssais: null == nbEssais
+          ? _value.nbEssais
+          : nbEssais // ignore: cast_nullable_to_non_nullable
+              as int,
+      mot: freezed == mot
+          ? _value.mot
+          : mot // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pourquoi: freezed == pourquoi
+          ? _value.pourquoi
+          : pourquoi // ignore: cast_nullable_to_non_nullable
+              as String?,
+      streak: null == streak
+          ? _value.streak
+          : streak // ignore: cast_nullable_to_non_nullable
+              as int,
+      prochainMotDansSec: null == prochainMotDansSec
+          ? _value.prochainMotDansSec
+          : prochainMotDansSec // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$GrilleTodayResponseImplCopyWith<$Res>
+    implements $GrilleTodayResponseCopyWith<$Res> {
+  factory _$$GrilleTodayResponseImplCopyWith(_$GrilleTodayResponseImpl value,
+          $Res Function(_$GrilleTodayResponseImpl) then) =
+      __$$GrilleTodayResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String date,
+      String dateAffichee,
+      String dateCourt,
+      String numero,
+      int longueur,
+      int essaisMax,
+      String premiereLettre,
+      String indice,
+      String theme,
+      String statut,
+      List<GrilleEssai> essais,
+      int nbEssais,
+      String? mot,
+      String? pourquoi,
+      int streak,
+      int prochainMotDansSec});
+}
+
+/// @nodoc
+class __$$GrilleTodayResponseImplCopyWithImpl<$Res>
+    extends _$GrilleTodayResponseCopyWithImpl<$Res, _$GrilleTodayResponseImpl>
+    implements _$$GrilleTodayResponseImplCopyWith<$Res> {
+  __$$GrilleTodayResponseImplCopyWithImpl(_$GrilleTodayResponseImpl _value,
+      $Res Function(_$GrilleTodayResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? date = null,
+    Object? dateAffichee = null,
+    Object? dateCourt = null,
+    Object? numero = null,
+    Object? longueur = null,
+    Object? essaisMax = null,
+    Object? premiereLettre = null,
+    Object? indice = null,
+    Object? theme = null,
+    Object? statut = null,
+    Object? essais = null,
+    Object? nbEssais = null,
+    Object? mot = freezed,
+    Object? pourquoi = freezed,
+    Object? streak = null,
+    Object? prochainMotDansSec = null,
+  }) {
+    return _then(_$GrilleTodayResponseImpl(
+      date: null == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as String,
+      dateAffichee: null == dateAffichee
+          ? _value.dateAffichee
+          : dateAffichee // ignore: cast_nullable_to_non_nullable
+              as String,
+      dateCourt: null == dateCourt
+          ? _value.dateCourt
+          : dateCourt // ignore: cast_nullable_to_non_nullable
+              as String,
+      numero: null == numero
+          ? _value.numero
+          : numero // ignore: cast_nullable_to_non_nullable
+              as String,
+      longueur: null == longueur
+          ? _value.longueur
+          : longueur // ignore: cast_nullable_to_non_nullable
+              as int,
+      essaisMax: null == essaisMax
+          ? _value.essaisMax
+          : essaisMax // ignore: cast_nullable_to_non_nullable
+              as int,
+      premiereLettre: null == premiereLettre
+          ? _value.premiereLettre
+          : premiereLettre // ignore: cast_nullable_to_non_nullable
+              as String,
+      indice: null == indice
+          ? _value.indice
+          : indice // ignore: cast_nullable_to_non_nullable
+              as String,
+      theme: null == theme
+          ? _value.theme
+          : theme // ignore: cast_nullable_to_non_nullable
+              as String,
+      statut: null == statut
+          ? _value.statut
+          : statut // ignore: cast_nullable_to_non_nullable
+              as String,
+      essais: null == essais
+          ? _value._essais
+          : essais // ignore: cast_nullable_to_non_nullable
+              as List<GrilleEssai>,
+      nbEssais: null == nbEssais
+          ? _value.nbEssais
+          : nbEssais // ignore: cast_nullable_to_non_nullable
+              as int,
+      mot: freezed == mot
+          ? _value.mot
+          : mot // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pourquoi: freezed == pourquoi
+          ? _value.pourquoi
+          : pourquoi // ignore: cast_nullable_to_non_nullable
+              as String?,
+      streak: null == streak
+          ? _value.streak
+          : streak // ignore: cast_nullable_to_non_nullable
+              as int,
+      prochainMotDansSec: null == prochainMotDansSec
+          ? _value.prochainMotDansSec
+          : prochainMotDansSec // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GrilleTodayResponseImpl extends _GrilleTodayResponse {
+  const _$GrilleTodayResponseImpl(
+      {required this.date,
+      required this.dateAffichee,
+      required this.dateCourt,
+      required this.numero,
+      required this.longueur,
+      required this.essaisMax,
+      required this.premiereLettre,
+      required this.indice,
+      required this.theme,
+      required this.statut,
+      required final List<GrilleEssai> essais,
+      required this.nbEssais,
+      this.mot,
+      this.pourquoi,
+      required this.streak,
+      required this.prochainMotDansSec})
+      : _essais = essais,
+        super._();
+
+  factory _$GrilleTodayResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GrilleTodayResponseImplFromJson(json);
+
+  @override
+  final String date;
+  @override
+  final String dateAffichee;
+  @override
+  final String dateCourt;
+  @override
+  final String numero;
+  @override
+  final int longueur;
+  @override
+  final int essaisMax;
+  @override
+  final String premiereLettre;
+  @override
+  final String indice;
+  @override
+  final String theme;
+  @override
+  final String statut;
+  final List<GrilleEssai> _essais;
+  @override
+  List<GrilleEssai> get essais {
+    if (_essais is EqualUnmodifiableListView) return _essais;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_essais);
+  }
+
+  @override
+  final int nbEssais;
+  @override
+  final String? mot;
+  @override
+  final String? pourquoi;
+  @override
+  final int streak;
+  @override
+  final int prochainMotDansSec;
+
+  @override
+  String toString() {
+    return 'GrilleTodayResponse(date: $date, dateAffichee: $dateAffichee, dateCourt: $dateCourt, numero: $numero, longueur: $longueur, essaisMax: $essaisMax, premiereLettre: $premiereLettre, indice: $indice, theme: $theme, statut: $statut, essais: $essais, nbEssais: $nbEssais, mot: $mot, pourquoi: $pourquoi, streak: $streak, prochainMotDansSec: $prochainMotDansSec)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GrilleTodayResponseImpl &&
+            (identical(other.date, date) || other.date == date) &&
+            (identical(other.dateAffichee, dateAffichee) ||
+                other.dateAffichee == dateAffichee) &&
+            (identical(other.dateCourt, dateCourt) ||
+                other.dateCourt == dateCourt) &&
+            (identical(other.numero, numero) || other.numero == numero) &&
+            (identical(other.longueur, longueur) ||
+                other.longueur == longueur) &&
+            (identical(other.essaisMax, essaisMax) ||
+                other.essaisMax == essaisMax) &&
+            (identical(other.premiereLettre, premiereLettre) ||
+                other.premiereLettre == premiereLettre) &&
+            (identical(other.indice, indice) || other.indice == indice) &&
+            (identical(other.theme, theme) || other.theme == theme) &&
+            (identical(other.statut, statut) || other.statut == statut) &&
+            const DeepCollectionEquality().equals(other._essais, _essais) &&
+            (identical(other.nbEssais, nbEssais) ||
+                other.nbEssais == nbEssais) &&
+            (identical(other.mot, mot) || other.mot == mot) &&
+            (identical(other.pourquoi, pourquoi) ||
+                other.pourquoi == pourquoi) &&
+            (identical(other.streak, streak) || other.streak == streak) &&
+            (identical(other.prochainMotDansSec, prochainMotDansSec) ||
+                other.prochainMotDansSec == prochainMotDansSec));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      date,
+      dateAffichee,
+      dateCourt,
+      numero,
+      longueur,
+      essaisMax,
+      premiereLettre,
+      indice,
+      theme,
+      statut,
+      const DeepCollectionEquality().hash(_essais),
+      nbEssais,
+      mot,
+      pourquoi,
+      streak,
+      prochainMotDansSec);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GrilleTodayResponseImplCopyWith<_$GrilleTodayResponseImpl> get copyWith =>
+      __$$GrilleTodayResponseImplCopyWithImpl<_$GrilleTodayResponseImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GrilleTodayResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _GrilleTodayResponse extends GrilleTodayResponse {
+  const factory _GrilleTodayResponse(
+      {required final String date,
+      required final String dateAffichee,
+      required final String dateCourt,
+      required final String numero,
+      required final int longueur,
+      required final int essaisMax,
+      required final String premiereLettre,
+      required final String indice,
+      required final String theme,
+      required final String statut,
+      required final List<GrilleEssai> essais,
+      required final int nbEssais,
+      final String? mot,
+      final String? pourquoi,
+      required final int streak,
+      required final int prochainMotDansSec}) = _$GrilleTodayResponseImpl;
+  const _GrilleTodayResponse._() : super._();
+
+  factory _GrilleTodayResponse.fromJson(Map<String, dynamic> json) =
+      _$GrilleTodayResponseImpl.fromJson;
+
+  @override
+  String get date;
+  @override
+  String get dateAffichee;
+  @override
+  String get dateCourt;
+  @override
+  String get numero;
+  @override
+  int get longueur;
+  @override
+  int get essaisMax;
+  @override
+  String get premiereLettre;
+  @override
+  String get indice;
+  @override
+  String get theme;
+  @override
+  String get statut;
+  @override
+  List<GrilleEssai> get essais;
+  @override
+  int get nbEssais;
+  @override
+  String? get mot;
+  @override
+  String? get pourquoi;
+  @override
+  int get streak;
+  @override
+  int get prochainMotDansSec;
+  @override
+  @JsonKey(ignore: true)
+  _$$GrilleTodayResponseImplCopyWith<_$GrilleTodayResponseImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+GrilleGuessResponse _$GrilleGuessResponseFromJson(Map<String, dynamic> json) {
+  return _GrilleGuessResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GrilleGuessResponse {
+  bool get valide => throw _privateConstructorUsedError;
+  String? get raison => throw _privateConstructorUsedError;
+  List<String>? get etats => throw _privateConstructorUsedError;
+  String? get statut => throw _privateConstructorUsedError;
+  int? get nbEssais => throw _privateConstructorUsedError;
+  String? get mot => throw _privateConstructorUsedError;
+  String? get pourquoi => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GrilleGuessResponseCopyWith<GrilleGuessResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GrilleGuessResponseCopyWith<$Res> {
+  factory $GrilleGuessResponseCopyWith(
+          GrilleGuessResponse value, $Res Function(GrilleGuessResponse) then) =
+      _$GrilleGuessResponseCopyWithImpl<$Res, GrilleGuessResponse>;
+  @useResult
+  $Res call(
+      {bool valide,
+      String? raison,
+      List<String>? etats,
+      String? statut,
+      int? nbEssais,
+      String? mot,
+      String? pourquoi});
+}
+
+/// @nodoc
+class _$GrilleGuessResponseCopyWithImpl<$Res, $Val extends GrilleGuessResponse>
+    implements $GrilleGuessResponseCopyWith<$Res> {
+  _$GrilleGuessResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? valide = null,
+    Object? raison = freezed,
+    Object? etats = freezed,
+    Object? statut = freezed,
+    Object? nbEssais = freezed,
+    Object? mot = freezed,
+    Object? pourquoi = freezed,
+  }) {
+    return _then(_value.copyWith(
+      valide: null == valide
+          ? _value.valide
+          : valide // ignore: cast_nullable_to_non_nullable
+              as bool,
+      raison: freezed == raison
+          ? _value.raison
+          : raison // ignore: cast_nullable_to_non_nullable
+              as String?,
+      etats: freezed == etats
+          ? _value.etats
+          : etats // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      statut: freezed == statut
+          ? _value.statut
+          : statut // ignore: cast_nullable_to_non_nullable
+              as String?,
+      nbEssais: freezed == nbEssais
+          ? _value.nbEssais
+          : nbEssais // ignore: cast_nullable_to_non_nullable
+              as int?,
+      mot: freezed == mot
+          ? _value.mot
+          : mot // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pourquoi: freezed == pourquoi
+          ? _value.pourquoi
+          : pourquoi // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$GrilleGuessResponseImplCopyWith<$Res>
+    implements $GrilleGuessResponseCopyWith<$Res> {
+  factory _$$GrilleGuessResponseImplCopyWith(_$GrilleGuessResponseImpl value,
+          $Res Function(_$GrilleGuessResponseImpl) then) =
+      __$$GrilleGuessResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {bool valide,
+      String? raison,
+      List<String>? etats,
+      String? statut,
+      int? nbEssais,
+      String? mot,
+      String? pourquoi});
+}
+
+/// @nodoc
+class __$$GrilleGuessResponseImplCopyWithImpl<$Res>
+    extends _$GrilleGuessResponseCopyWithImpl<$Res, _$GrilleGuessResponseImpl>
+    implements _$$GrilleGuessResponseImplCopyWith<$Res> {
+  __$$GrilleGuessResponseImplCopyWithImpl(_$GrilleGuessResponseImpl _value,
+      $Res Function(_$GrilleGuessResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? valide = null,
+    Object? raison = freezed,
+    Object? etats = freezed,
+    Object? statut = freezed,
+    Object? nbEssais = freezed,
+    Object? mot = freezed,
+    Object? pourquoi = freezed,
+  }) {
+    return _then(_$GrilleGuessResponseImpl(
+      valide: null == valide
+          ? _value.valide
+          : valide // ignore: cast_nullable_to_non_nullable
+              as bool,
+      raison: freezed == raison
+          ? _value.raison
+          : raison // ignore: cast_nullable_to_non_nullable
+              as String?,
+      etats: freezed == etats
+          ? _value._etats
+          : etats // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      statut: freezed == statut
+          ? _value.statut
+          : statut // ignore: cast_nullable_to_non_nullable
+              as String?,
+      nbEssais: freezed == nbEssais
+          ? _value.nbEssais
+          : nbEssais // ignore: cast_nullable_to_non_nullable
+              as int?,
+      mot: freezed == mot
+          ? _value.mot
+          : mot // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pourquoi: freezed == pourquoi
+          ? _value.pourquoi
+          : pourquoi // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GrilleGuessResponseImpl extends _GrilleGuessResponse {
+  const _$GrilleGuessResponseImpl(
+      {required this.valide,
+      this.raison,
+      final List<String>? etats,
+      this.statut,
+      this.nbEssais,
+      this.mot,
+      this.pourquoi})
+      : _etats = etats,
+        super._();
+
+  factory _$GrilleGuessResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GrilleGuessResponseImplFromJson(json);
+
+  @override
+  final bool valide;
+  @override
+  final String? raison;
+  final List<String>? _etats;
+  @override
+  List<String>? get etats {
+    final value = _etats;
+    if (value == null) return null;
+    if (_etats is EqualUnmodifiableListView) return _etats;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  final String? statut;
+  @override
+  final int? nbEssais;
+  @override
+  final String? mot;
+  @override
+  final String? pourquoi;
+
+  @override
+  String toString() {
+    return 'GrilleGuessResponse(valide: $valide, raison: $raison, etats: $etats, statut: $statut, nbEssais: $nbEssais, mot: $mot, pourquoi: $pourquoi)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GrilleGuessResponseImpl &&
+            (identical(other.valide, valide) || other.valide == valide) &&
+            (identical(other.raison, raison) || other.raison == raison) &&
+            const DeepCollectionEquality().equals(other._etats, _etats) &&
+            (identical(other.statut, statut) || other.statut == statut) &&
+            (identical(other.nbEssais, nbEssais) ||
+                other.nbEssais == nbEssais) &&
+            (identical(other.mot, mot) || other.mot == mot) &&
+            (identical(other.pourquoi, pourquoi) ||
+                other.pourquoi == pourquoi));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      valide,
+      raison,
+      const DeepCollectionEquality().hash(_etats),
+      statut,
+      nbEssais,
+      mot,
+      pourquoi);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GrilleGuessResponseImplCopyWith<_$GrilleGuessResponseImpl> get copyWith =>
+      __$$GrilleGuessResponseImplCopyWithImpl<_$GrilleGuessResponseImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GrilleGuessResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _GrilleGuessResponse extends GrilleGuessResponse {
+  const factory _GrilleGuessResponse(
+      {required final bool valide,
+      final String? raison,
+      final List<String>? etats,
+      final String? statut,
+      final int? nbEssais,
+      final String? mot,
+      final String? pourquoi}) = _$GrilleGuessResponseImpl;
+  const _GrilleGuessResponse._() : super._();
+
+  factory _GrilleGuessResponse.fromJson(Map<String, dynamic> json) =
+      _$GrilleGuessResponseImpl.fromJson;
+
+  @override
+  bool get valide;
+  @override
+  String? get raison;
+  @override
+  List<String>? get etats;
+  @override
+  String? get statut;
+  @override
+  int? get nbEssais;
+  @override
+  String? get mot;
+  @override
+  String? get pourquoi;
+  @override
+  @JsonKey(ignore: true)
+  _$$GrilleGuessResponseImplCopyWith<_$GrilleGuessResponseImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+GrilleDistributionItem _$GrilleDistributionItemFromJson(
+    Map<String, dynamic> json) {
+  return _GrilleDistributionItem.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GrilleDistributionItem {
+  @JsonKey(fromJson: _scoreToString)
+  String get score => throw _privateConstructorUsedError;
+  int get pct => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GrilleDistributionItemCopyWith<GrilleDistributionItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GrilleDistributionItemCopyWith<$Res> {
+  factory $GrilleDistributionItemCopyWith(GrilleDistributionItem value,
+          $Res Function(GrilleDistributionItem) then) =
+      _$GrilleDistributionItemCopyWithImpl<$Res, GrilleDistributionItem>;
+  @useResult
+  $Res call({@JsonKey(fromJson: _scoreToString) String score, int pct});
+}
+
+/// @nodoc
+class _$GrilleDistributionItemCopyWithImpl<$Res,
+        $Val extends GrilleDistributionItem>
+    implements $GrilleDistributionItemCopyWith<$Res> {
+  _$GrilleDistributionItemCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? score = null,
+    Object? pct = null,
+  }) {
+    return _then(_value.copyWith(
+      score: null == score
+          ? _value.score
+          : score // ignore: cast_nullable_to_non_nullable
+              as String,
+      pct: null == pct
+          ? _value.pct
+          : pct // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$GrilleDistributionItemImplCopyWith<$Res>
+    implements $GrilleDistributionItemCopyWith<$Res> {
+  factory _$$GrilleDistributionItemImplCopyWith(
+          _$GrilleDistributionItemImpl value,
+          $Res Function(_$GrilleDistributionItemImpl) then) =
+      __$$GrilleDistributionItemImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({@JsonKey(fromJson: _scoreToString) String score, int pct});
+}
+
+/// @nodoc
+class __$$GrilleDistributionItemImplCopyWithImpl<$Res>
+    extends _$GrilleDistributionItemCopyWithImpl<$Res,
+        _$GrilleDistributionItemImpl>
+    implements _$$GrilleDistributionItemImplCopyWith<$Res> {
+  __$$GrilleDistributionItemImplCopyWithImpl(
+      _$GrilleDistributionItemImpl _value,
+      $Res Function(_$GrilleDistributionItemImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? score = null,
+    Object? pct = null,
+  }) {
+    return _then(_$GrilleDistributionItemImpl(
+      score: null == score
+          ? _value.score
+          : score // ignore: cast_nullable_to_non_nullable
+              as String,
+      pct: null == pct
+          ? _value.pct
+          : pct // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GrilleDistributionItemImpl extends _GrilleDistributionItem {
+  const _$GrilleDistributionItemImpl(
+      {@JsonKey(fromJson: _scoreToString) required this.score,
+      required this.pct})
+      : super._();
+
+  factory _$GrilleDistributionItemImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GrilleDistributionItemImplFromJson(json);
+
+  @override
+  @JsonKey(fromJson: _scoreToString)
+  final String score;
+  @override
+  final int pct;
+
+  @override
+  String toString() {
+    return 'GrilleDistributionItem(score: $score, pct: $pct)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GrilleDistributionItemImpl &&
+            (identical(other.score, score) || other.score == score) &&
+            (identical(other.pct, pct) || other.pct == pct));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, score, pct);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GrilleDistributionItemImplCopyWith<_$GrilleDistributionItemImpl>
+      get copyWith => __$$GrilleDistributionItemImplCopyWithImpl<
+          _$GrilleDistributionItemImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GrilleDistributionItemImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _GrilleDistributionItem extends GrilleDistributionItem {
+  const factory _GrilleDistributionItem(
+      {@JsonKey(fromJson: _scoreToString) required final String score,
+      required final int pct}) = _$GrilleDistributionItemImpl;
+  const _GrilleDistributionItem._() : super._();
+
+  factory _GrilleDistributionItem.fromJson(Map<String, dynamic> json) =
+      _$GrilleDistributionItemImpl.fromJson;
+
+  @override
+  @JsonKey(fromJson: _scoreToString)
+  String get score;
+  @override
+  int get pct;
+  @override
+  @JsonKey(ignore: true)
+  _$$GrilleDistributionItemImplCopyWith<_$GrilleDistributionItemImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+GrilleQuartierItem _$GrilleQuartierItemFromJson(Map<String, dynamic> json) {
+  return _GrilleQuartierItem.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GrilleQuartierItem {
+  String get initiales => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _scoreToString)
+  String get score => throw _privateConstructorUsedError;
+  int get rang => throw _privateConstructorUsedError;
+  bool get moi => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GrilleQuartierItemCopyWith<GrilleQuartierItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GrilleQuartierItemCopyWith<$Res> {
+  factory $GrilleQuartierItemCopyWith(
+          GrilleQuartierItem value, $Res Function(GrilleQuartierItem) then) =
+      _$GrilleQuartierItemCopyWithImpl<$Res, GrilleQuartierItem>;
+  @useResult
+  $Res call(
+      {String initiales,
+      @JsonKey(fromJson: _scoreToString) String score,
+      int rang,
+      bool moi});
+}
+
+/// @nodoc
+class _$GrilleQuartierItemCopyWithImpl<$Res, $Val extends GrilleQuartierItem>
+    implements $GrilleQuartierItemCopyWith<$Res> {
+  _$GrilleQuartierItemCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? initiales = null,
+    Object? score = null,
+    Object? rang = null,
+    Object? moi = null,
+  }) {
+    return _then(_value.copyWith(
+      initiales: null == initiales
+          ? _value.initiales
+          : initiales // ignore: cast_nullable_to_non_nullable
+              as String,
+      score: null == score
+          ? _value.score
+          : score // ignore: cast_nullable_to_non_nullable
+              as String,
+      rang: null == rang
+          ? _value.rang
+          : rang // ignore: cast_nullable_to_non_nullable
+              as int,
+      moi: null == moi
+          ? _value.moi
+          : moi // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$GrilleQuartierItemImplCopyWith<$Res>
+    implements $GrilleQuartierItemCopyWith<$Res> {
+  factory _$$GrilleQuartierItemImplCopyWith(_$GrilleQuartierItemImpl value,
+          $Res Function(_$GrilleQuartierItemImpl) then) =
+      __$$GrilleQuartierItemImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String initiales,
+      @JsonKey(fromJson: _scoreToString) String score,
+      int rang,
+      bool moi});
+}
+
+/// @nodoc
+class __$$GrilleQuartierItemImplCopyWithImpl<$Res>
+    extends _$GrilleQuartierItemCopyWithImpl<$Res, _$GrilleQuartierItemImpl>
+    implements _$$GrilleQuartierItemImplCopyWith<$Res> {
+  __$$GrilleQuartierItemImplCopyWithImpl(_$GrilleQuartierItemImpl _value,
+      $Res Function(_$GrilleQuartierItemImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? initiales = null,
+    Object? score = null,
+    Object? rang = null,
+    Object? moi = null,
+  }) {
+    return _then(_$GrilleQuartierItemImpl(
+      initiales: null == initiales
+          ? _value.initiales
+          : initiales // ignore: cast_nullable_to_non_nullable
+              as String,
+      score: null == score
+          ? _value.score
+          : score // ignore: cast_nullable_to_non_nullable
+              as String,
+      rang: null == rang
+          ? _value.rang
+          : rang // ignore: cast_nullable_to_non_nullable
+              as int,
+      moi: null == moi
+          ? _value.moi
+          : moi // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GrilleQuartierItemImpl extends _GrilleQuartierItem {
+  const _$GrilleQuartierItemImpl(
+      {required this.initiales,
+      @JsonKey(fromJson: _scoreToString) required this.score,
+      required this.rang,
+      this.moi = false})
+      : super._();
+
+  factory _$GrilleQuartierItemImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GrilleQuartierItemImplFromJson(json);
+
+  @override
+  final String initiales;
+  @override
+  @JsonKey(fromJson: _scoreToString)
+  final String score;
+  @override
+  final int rang;
+  @override
+  @JsonKey()
+  final bool moi;
+
+  @override
+  String toString() {
+    return 'GrilleQuartierItem(initiales: $initiales, score: $score, rang: $rang, moi: $moi)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GrilleQuartierItemImpl &&
+            (identical(other.initiales, initiales) ||
+                other.initiales == initiales) &&
+            (identical(other.score, score) || other.score == score) &&
+            (identical(other.rang, rang) || other.rang == rang) &&
+            (identical(other.moi, moi) || other.moi == moi));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, initiales, score, rang, moi);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GrilleQuartierItemImplCopyWith<_$GrilleQuartierItemImpl> get copyWith =>
+      __$$GrilleQuartierItemImplCopyWithImpl<_$GrilleQuartierItemImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GrilleQuartierItemImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _GrilleQuartierItem extends GrilleQuartierItem {
+  const factory _GrilleQuartierItem(
+      {required final String initiales,
+      @JsonKey(fromJson: _scoreToString) required final String score,
+      required final int rang,
+      final bool moi}) = _$GrilleQuartierItemImpl;
+  const _GrilleQuartierItem._() : super._();
+
+  factory _GrilleQuartierItem.fromJson(Map<String, dynamic> json) =
+      _$GrilleQuartierItemImpl.fromJson;
+
+  @override
+  String get initiales;
+  @override
+  @JsonKey(fromJson: _scoreToString)
+  String get score;
+  @override
+  int get rang;
+  @override
+  bool get moi;
+  @override
+  @JsonKey(ignore: true)
+  _$$GrilleQuartierItemImplCopyWith<_$GrilleQuartierItemImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+GrilleLeaderboardResponse _$GrilleLeaderboardResponseFromJson(
+    Map<String, dynamic> json) {
+  return _GrilleLeaderboardResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GrilleLeaderboardResponse {
+  int get percentile => throw _privateConstructorUsedError;
+  int get joueurs => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _scoreToString)
+  String get monScore => throw _privateConstructorUsedError;
+  List<GrilleDistributionItem> get distribution =>
+      throw _privateConstructorUsedError;
+  List<GrilleQuartierItem> get quartier => throw _privateConstructorUsedError;
+  int get streak => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GrilleLeaderboardResponseCopyWith<GrilleLeaderboardResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GrilleLeaderboardResponseCopyWith<$Res> {
+  factory $GrilleLeaderboardResponseCopyWith(GrilleLeaderboardResponse value,
+          $Res Function(GrilleLeaderboardResponse) then) =
+      _$GrilleLeaderboardResponseCopyWithImpl<$Res, GrilleLeaderboardResponse>;
+  @useResult
+  $Res call(
+      {int percentile,
+      int joueurs,
+      @JsonKey(fromJson: _scoreToString) String monScore,
+      List<GrilleDistributionItem> distribution,
+      List<GrilleQuartierItem> quartier,
+      int streak});
+}
+
+/// @nodoc
+class _$GrilleLeaderboardResponseCopyWithImpl<$Res,
+        $Val extends GrilleLeaderboardResponse>
+    implements $GrilleLeaderboardResponseCopyWith<$Res> {
+  _$GrilleLeaderboardResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? percentile = null,
+    Object? joueurs = null,
+    Object? monScore = null,
+    Object? distribution = null,
+    Object? quartier = null,
+    Object? streak = null,
+  }) {
+    return _then(_value.copyWith(
+      percentile: null == percentile
+          ? _value.percentile
+          : percentile // ignore: cast_nullable_to_non_nullable
+              as int,
+      joueurs: null == joueurs
+          ? _value.joueurs
+          : joueurs // ignore: cast_nullable_to_non_nullable
+              as int,
+      monScore: null == monScore
+          ? _value.monScore
+          : monScore // ignore: cast_nullable_to_non_nullable
+              as String,
+      distribution: null == distribution
+          ? _value.distribution
+          : distribution // ignore: cast_nullable_to_non_nullable
+              as List<GrilleDistributionItem>,
+      quartier: null == quartier
+          ? _value.quartier
+          : quartier // ignore: cast_nullable_to_non_nullable
+              as List<GrilleQuartierItem>,
+      streak: null == streak
+          ? _value.streak
+          : streak // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$GrilleLeaderboardResponseImplCopyWith<$Res>
+    implements $GrilleLeaderboardResponseCopyWith<$Res> {
+  factory _$$GrilleLeaderboardResponseImplCopyWith(
+          _$GrilleLeaderboardResponseImpl value,
+          $Res Function(_$GrilleLeaderboardResponseImpl) then) =
+      __$$GrilleLeaderboardResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int percentile,
+      int joueurs,
+      @JsonKey(fromJson: _scoreToString) String monScore,
+      List<GrilleDistributionItem> distribution,
+      List<GrilleQuartierItem> quartier,
+      int streak});
+}
+
+/// @nodoc
+class __$$GrilleLeaderboardResponseImplCopyWithImpl<$Res>
+    extends _$GrilleLeaderboardResponseCopyWithImpl<$Res,
+        _$GrilleLeaderboardResponseImpl>
+    implements _$$GrilleLeaderboardResponseImplCopyWith<$Res> {
+  __$$GrilleLeaderboardResponseImplCopyWithImpl(
+      _$GrilleLeaderboardResponseImpl _value,
+      $Res Function(_$GrilleLeaderboardResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? percentile = null,
+    Object? joueurs = null,
+    Object? monScore = null,
+    Object? distribution = null,
+    Object? quartier = null,
+    Object? streak = null,
+  }) {
+    return _then(_$GrilleLeaderboardResponseImpl(
+      percentile: null == percentile
+          ? _value.percentile
+          : percentile // ignore: cast_nullable_to_non_nullable
+              as int,
+      joueurs: null == joueurs
+          ? _value.joueurs
+          : joueurs // ignore: cast_nullable_to_non_nullable
+              as int,
+      monScore: null == monScore
+          ? _value.monScore
+          : monScore // ignore: cast_nullable_to_non_nullable
+              as String,
+      distribution: null == distribution
+          ? _value._distribution
+          : distribution // ignore: cast_nullable_to_non_nullable
+              as List<GrilleDistributionItem>,
+      quartier: null == quartier
+          ? _value._quartier
+          : quartier // ignore: cast_nullable_to_non_nullable
+              as List<GrilleQuartierItem>,
+      streak: null == streak
+          ? _value.streak
+          : streak // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GrilleLeaderboardResponseImpl extends _GrilleLeaderboardResponse {
+  const _$GrilleLeaderboardResponseImpl(
+      {required this.percentile,
+      required this.joueurs,
+      @JsonKey(fromJson: _scoreToString) required this.monScore,
+      required final List<GrilleDistributionItem> distribution,
+      required final List<GrilleQuartierItem> quartier,
+      required this.streak})
+      : _distribution = distribution,
+        _quartier = quartier,
+        super._();
+
+  factory _$GrilleLeaderboardResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GrilleLeaderboardResponseImplFromJson(json);
+
+  @override
+  final int percentile;
+  @override
+  final int joueurs;
+  @override
+  @JsonKey(fromJson: _scoreToString)
+  final String monScore;
+  final List<GrilleDistributionItem> _distribution;
+  @override
+  List<GrilleDistributionItem> get distribution {
+    if (_distribution is EqualUnmodifiableListView) return _distribution;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_distribution);
+  }
+
+  final List<GrilleQuartierItem> _quartier;
+  @override
+  List<GrilleQuartierItem> get quartier {
+    if (_quartier is EqualUnmodifiableListView) return _quartier;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_quartier);
+  }
+
+  @override
+  final int streak;
+
+  @override
+  String toString() {
+    return 'GrilleLeaderboardResponse(percentile: $percentile, joueurs: $joueurs, monScore: $monScore, distribution: $distribution, quartier: $quartier, streak: $streak)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GrilleLeaderboardResponseImpl &&
+            (identical(other.percentile, percentile) ||
+                other.percentile == percentile) &&
+            (identical(other.joueurs, joueurs) || other.joueurs == joueurs) &&
+            (identical(other.monScore, monScore) ||
+                other.monScore == monScore) &&
+            const DeepCollectionEquality()
+                .equals(other._distribution, _distribution) &&
+            const DeepCollectionEquality().equals(other._quartier, _quartier) &&
+            (identical(other.streak, streak) || other.streak == streak));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      percentile,
+      joueurs,
+      monScore,
+      const DeepCollectionEquality().hash(_distribution),
+      const DeepCollectionEquality().hash(_quartier),
+      streak);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GrilleLeaderboardResponseImplCopyWith<_$GrilleLeaderboardResponseImpl>
+      get copyWith => __$$GrilleLeaderboardResponseImplCopyWithImpl<
+          _$GrilleLeaderboardResponseImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GrilleLeaderboardResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _GrilleLeaderboardResponse extends GrilleLeaderboardResponse {
+  const factory _GrilleLeaderboardResponse(
+      {required final int percentile,
+      required final int joueurs,
+      @JsonKey(fromJson: _scoreToString) required final String monScore,
+      required final List<GrilleDistributionItem> distribution,
+      required final List<GrilleQuartierItem> quartier,
+      required final int streak}) = _$GrilleLeaderboardResponseImpl;
+  const _GrilleLeaderboardResponse._() : super._();
+
+  factory _GrilleLeaderboardResponse.fromJson(Map<String, dynamic> json) =
+      _$GrilleLeaderboardResponseImpl.fromJson;
+
+  @override
+  int get percentile;
+  @override
+  int get joueurs;
+  @override
+  @JsonKey(fromJson: _scoreToString)
+  String get monScore;
+  @override
+  List<GrilleDistributionItem> get distribution;
+  @override
+  List<GrilleQuartierItem> get quartier;
+  @override
+  int get streak;
+  @override
+  @JsonKey(ignore: true)
+  _$$GrilleLeaderboardResponseImplCopyWith<_$GrilleLeaderboardResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/apps/mobile/lib/features/grille/models/grille_models.g.dart
+++ b/apps/mobile/lib/features/grille/models/grille_models.g.dart
@@ -1,0 +1,147 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'grille_models.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$GrilleEssaiImpl _$$GrilleEssaiImplFromJson(Map<String, dynamic> json) =>
+    _$GrilleEssaiImpl(
+      mot: json['mot'] as String,
+      etats: (json['etats'] as List<dynamic>).map((e) => e as String).toList(),
+    );
+
+Map<String, dynamic> _$$GrilleEssaiImplToJson(_$GrilleEssaiImpl instance) =>
+    <String, dynamic>{
+      'mot': instance.mot,
+      'etats': instance.etats,
+    };
+
+_$GrilleTodayResponseImpl _$$GrilleTodayResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GrilleTodayResponseImpl(
+      date: json['date'] as String,
+      dateAffichee: json['dateAffichee'] as String,
+      dateCourt: json['dateCourt'] as String,
+      numero: json['numero'] as String,
+      longueur: (json['longueur'] as num).toInt(),
+      essaisMax: (json['essaisMax'] as num).toInt(),
+      premiereLettre: json['premiereLettre'] as String,
+      indice: json['indice'] as String,
+      theme: json['theme'] as String,
+      statut: json['statut'] as String,
+      essais: (json['essais'] as List<dynamic>)
+          .map((e) => GrilleEssai.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      nbEssais: (json['nbEssais'] as num).toInt(),
+      mot: json['mot'] as String?,
+      pourquoi: json['pourquoi'] as String?,
+      streak: (json['streak'] as num).toInt(),
+      prochainMotDansSec: (json['prochainMotDansSec'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$GrilleTodayResponseImplToJson(
+        _$GrilleTodayResponseImpl instance) =>
+    <String, dynamic>{
+      'date': instance.date,
+      'dateAffichee': instance.dateAffichee,
+      'dateCourt': instance.dateCourt,
+      'numero': instance.numero,
+      'longueur': instance.longueur,
+      'essaisMax': instance.essaisMax,
+      'premiereLettre': instance.premiereLettre,
+      'indice': instance.indice,
+      'theme': instance.theme,
+      'statut': instance.statut,
+      'essais': instance.essais,
+      'nbEssais': instance.nbEssais,
+      'mot': instance.mot,
+      'pourquoi': instance.pourquoi,
+      'streak': instance.streak,
+      'prochainMotDansSec': instance.prochainMotDansSec,
+    };
+
+_$GrilleGuessResponseImpl _$$GrilleGuessResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GrilleGuessResponseImpl(
+      valide: json['valide'] as bool,
+      raison: json['raison'] as String?,
+      etats:
+          (json['etats'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      statut: json['statut'] as String?,
+      nbEssais: (json['nbEssais'] as num?)?.toInt(),
+      mot: json['mot'] as String?,
+      pourquoi: json['pourquoi'] as String?,
+    );
+
+Map<String, dynamic> _$$GrilleGuessResponseImplToJson(
+        _$GrilleGuessResponseImpl instance) =>
+    <String, dynamic>{
+      'valide': instance.valide,
+      'raison': instance.raison,
+      'etats': instance.etats,
+      'statut': instance.statut,
+      'nbEssais': instance.nbEssais,
+      'mot': instance.mot,
+      'pourquoi': instance.pourquoi,
+    };
+
+_$GrilleDistributionItemImpl _$$GrilleDistributionItemImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GrilleDistributionItemImpl(
+      score: _scoreToString(json['score']),
+      pct: (json['pct'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$GrilleDistributionItemImplToJson(
+        _$GrilleDistributionItemImpl instance) =>
+    <String, dynamic>{
+      'score': instance.score,
+      'pct': instance.pct,
+    };
+
+_$GrilleQuartierItemImpl _$$GrilleQuartierItemImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GrilleQuartierItemImpl(
+      initiales: json['initiales'] as String,
+      score: _scoreToString(json['score']),
+      rang: (json['rang'] as num).toInt(),
+      moi: json['moi'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$$GrilleQuartierItemImplToJson(
+        _$GrilleQuartierItemImpl instance) =>
+    <String, dynamic>{
+      'initiales': instance.initiales,
+      'score': instance.score,
+      'rang': instance.rang,
+      'moi': instance.moi,
+    };
+
+_$GrilleLeaderboardResponseImpl _$$GrilleLeaderboardResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GrilleLeaderboardResponseImpl(
+      percentile: (json['percentile'] as num).toInt(),
+      joueurs: (json['joueurs'] as num).toInt(),
+      monScore: _scoreToString(json['monScore']),
+      distribution: (json['distribution'] as List<dynamic>)
+          .map(
+              (e) => GrilleDistributionItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      quartier: (json['quartier'] as List<dynamic>)
+          .map((e) => GrilleQuartierItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      streak: (json['streak'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$GrilleLeaderboardResponseImplToJson(
+        _$GrilleLeaderboardResponseImpl instance) =>
+    <String, dynamic>{
+      'percentile': instance.percentile,
+      'joueurs': instance.joueurs,
+      'monScore': instance.monScore,
+      'distribution': instance.distribution,
+      'quartier': instance.quartier,
+      'streak': instance.streak,
+    };

--- a/apps/mobile/lib/features/grille/models/tile_state.dart
+++ b/apps/mobile/lib/features/grille/models/tile_state.dart
@@ -1,0 +1,89 @@
+/// État d'une case de la grille « Le mot du jour ».
+///
+/// Trois états sont **renvoyés par le serveur** (métaphore postale) :
+///   - [place]   🟩 bien placée  → bonne adresse (livrée)
+///   - [present] 🟧 mal placée   → bon quartier, mauvaise rue
+///   - [absent]  ⬛ absente       → n'habite pas ici
+///
+/// Trois états sont **client-only** (jamais renvoyés par l'API) :
+///   - [empty]  case vide
+///   - [filled] lettre tapée, en attente de validation
+///   - [hint]   première lettre offerte (cadeau de départ)
+///
+/// Fichier **pur** (aucune dépendance Flutter/modèle) pour rester testable et
+/// réutilisable par les widgets, providers et utilitaires de partage.
+enum TileState { empty, filled, hint, place, present, absent }
+
+extension TileStateX on TileState {
+  /// Parse un état **serveur** (`place|present|absent`). Toute autre valeur est
+  /// traitée comme [absent] par défaut (le serveur ne renvoie jamais autre
+  /// chose, mais on dégrade sans crash).
+  static TileState fromServer(String raw) {
+    switch (raw) {
+      case 'place':
+        return TileState.place;
+      case 'present':
+        return TileState.present;
+      case 'absent':
+        return TileState.absent;
+      default:
+        return TileState.absent;
+    }
+  }
+
+  /// Vrai pour les états révélés par le serveur (colorés).
+  bool get isRevealed =>
+      this == TileState.place ||
+      this == TileState.present ||
+      this == TileState.absent;
+
+  /// Emoji de partage sans spoiler (façon Wordle).
+  /// Les états non révélés n'ont pas d'emoji → chaîne vide.
+  String get shareEmoji {
+    switch (this) {
+      case TileState.place:
+        return '🟩';
+      case TileState.present:
+        return '🟧';
+      case TileState.absent:
+        return '⬛';
+      default:
+        return '';
+    }
+  }
+}
+
+/// Rang d'absorption d'un état pour le clavier : `place > present > absent`.
+/// (un état plus fort écrase un état plus faible pour une même lettre).
+const Map<TileState, int> kTileStateRank = {
+  TileState.absent: 0,
+  TileState.present: 1,
+  TileState.place: 2,
+};
+
+/// Une proposition jouée, réduite à ce dont le clavier a besoin : la chaîne
+/// devinée et la liste d'états serveur alignée case par case.
+typedef GuessLike = ({String mot, List<String> etats});
+
+/// Replie l'ensemble des essais en un état coloré par lettre du clavier.
+///
+/// Pour chaque lettre rencontrée, on garde l'état de rang le plus élevé
+/// ([place] > [present] > [absent]) — exactement la logique `keyboardStates`
+/// du design (`fKkZuc/grille-mot.jsx`). Pur : prend les essais déjà résolus
+/// par le serveur, ne recalcule rien depuis la réponse (jamais exposée).
+Map<String, TileState> computeKeyboardStates(Iterable<GuessLike> guesses) {
+  final result = <String, TileState>{};
+  for (final guess in guesses) {
+    final mot = guess.mot.toUpperCase();
+    for (var i = 0; i < mot.length && i < guess.etats.length; i++) {
+      final letter = mot[i];
+      final state = TileStateX.fromServer(guess.etats[i]);
+      final existing = result[letter];
+      if (existing == null ||
+          (kTileStateRank[state] ?? 0) > (kTileStateRank[existing] ?? 0)) {
+        result[letter] = state;
+      }
+    }
+  }
+  return result;
+}

--- a/apps/mobile/lib/features/grille/providers/grille_leaderboard_provider.dart
+++ b/apps/mobile/lib/features/grille/providers/grille_leaderboard_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/grille_models.dart';
+import 'grille_provider.dart';
+
+/// Classement du jour. `autoDispose` → rechargé à chaque ouverture de l'écran.
+///
+/// Lève [GrilleGameInProgressException] (409) tant que la partie n'est pas
+/// terminée : l'écran de classement n'est atteignable qu'après le Résultat.
+final grilleLeaderboardProvider =
+    FutureProvider.autoDispose<GrilleLeaderboardResponse>((ref) async {
+  final repo = ref.watch(grilleRepositoryProvider);
+  return repo.getLeaderboard();
+});

--- a/apps/mobile/lib/features/grille/providers/grille_provider.dart
+++ b/apps/mobile/lib/features/grille/providers/grille_provider.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/providers.dart';
+import '../models/grille_models.dart';
+import '../models/tile_state.dart';
+import '../repositories/grille_repository.dart';
+
+/// État composite de la partie en cours côté UI.
+///
+/// [today] est la source de vérité serveur (essais joués, statut, mot/pourquoi
+/// une fois finie). [draft] est la ligne en cours de saisie (client-only).
+/// [justFinished] est un flag **transitoire** posé par [GrilleNotifier.submitGuess]
+/// quand la partie vient de se terminer : il aiguille l'écran vers le Résultat
+/// (vs Déjà-joué au cold-load) et est consommé une fois lu.
+@immutable
+class GrilleState {
+  const GrilleState({
+    required this.today,
+    this.draft = '',
+    this.justFinished = false,
+    this.submitting = false,
+    this.invalidNonce = 0,
+    this.invalidReason,
+    this.revealRow = -1,
+  });
+
+  final GrilleTodayResponse today;
+
+  /// Ligne en cours de saisie, en MAJUSCULES (longueur ≤ `today.longueur`).
+  final String draft;
+
+  /// Vrai uniquement pour la transition « la partie vient de finir ».
+  final bool justFinished;
+
+  /// Un POST `guess` est en vol.
+  final bool submitting;
+
+  /// Incrémenté à chaque essai **refusé** → déclenche le shake de la ligne.
+  final int invalidNonce;
+
+  /// Raison du dernier refus (`longueur` | `hors_dictionnaire`) ou `null`.
+  final String? invalidReason;
+
+  /// Index de la ligne fraîchement révélée (flip), `-1` si aucune.
+  final int revealRow;
+
+  GrilleState copyWith({
+    GrilleTodayResponse? today,
+    String? draft,
+    bool? justFinished,
+    bool? submitting,
+    int? invalidNonce,
+    Object? invalidReason = _sentinel,
+    int? revealRow,
+  }) {
+    return GrilleState(
+      today: today ?? this.today,
+      draft: draft ?? this.draft,
+      justFinished: justFinished ?? this.justFinished,
+      submitting: submitting ?? this.submitting,
+      invalidNonce: invalidNonce ?? this.invalidNonce,
+      invalidReason: invalidReason == _sentinel
+          ? this.invalidReason
+          : invalidReason as String?,
+      revealRow: revealRow ?? this.revealRow,
+    );
+  }
+
+  static const Object _sentinel = Object();
+}
+
+/// Repository provider.
+final grilleRepositoryProvider = Provider<GrilleRepository>((ref) {
+  final apiClient = ref.watch(apiClientProvider);
+  return GrilleRepository(apiClient);
+});
+
+/// Provider principal : charge `today` puis pilote saisie + essais.
+final grilleProvider =
+    AsyncNotifierProvider<GrilleNotifier, GrilleState>(GrilleNotifier.new);
+
+class GrilleNotifier extends AsyncNotifier<GrilleState> {
+  GrilleRepository get _repo => ref.read(grilleRepositoryProvider);
+
+  @override
+  Future<GrilleState> build() async {
+    final today = await _repo.getToday();
+    return GrilleState(today: today);
+  }
+
+  GrilleState? get _current => state.value;
+
+  /// Ajoute une lettre à la ligne en cours (no-op si partie finie / pleine).
+  void addLetter(String letter) {
+    final s = _current;
+    if (s == null || s.today.isFinished || s.submitting) return;
+    if (s.draft.length >= s.today.longueur) return;
+    final clean = letter.toUpperCase();
+    if (clean.length != 1) return;
+    // Une nouvelle frappe efface l'éventuel état d'erreur précédent.
+    state = AsyncData(s.copyWith(draft: s.draft + clean, invalidReason: null));
+  }
+
+  /// Efface la dernière lettre saisie.
+  void removeLetter() {
+    final s = _current;
+    if (s == null || s.draft.isEmpty || s.submitting) return;
+    state = AsyncData(
+      s.copyWith(
+        draft: s.draft.substring(0, s.draft.length - 1),
+        invalidReason: null,
+      ),
+    );
+  }
+
+  /// Soumet la ligne en cours.
+  ///
+  /// - longueur incomplète → refus local (shake), aucun appel réseau.
+  /// - `valide == false` → refus serveur (shake), **essai non consommé**.
+  /// - `valide == true` → essai ajouté à `today`, draft vidé, flip de la
+  ///   nouvelle ligne, `justFinished` posé si la partie se termine.
+  Future<void> submitGuess() async {
+    final s = _current;
+    if (s == null || s.today.isFinished || s.submitting) return;
+
+    if (s.draft.length != s.today.longueur) {
+      state = AsyncData(
+        s.copyWith(
+          invalidReason: 'longueur',
+          invalidNonce: s.invalidNonce + 1,
+        ),
+      );
+      return;
+    }
+
+    state = AsyncData(s.copyWith(submitting: true));
+    final mot = s.draft;
+    try {
+      final res = await _repo.submitGuess(mot);
+      final after = _current ?? s;
+
+      if (!res.valide) {
+        // Essai refusé : on ne consomme rien, on signale le shake.
+        state = AsyncData(
+          after.copyWith(
+            submitting: false,
+            invalidReason: res.raison ?? 'hors_dictionnaire',
+            invalidNonce: after.invalidNonce + 1,
+          ),
+        );
+        return;
+      }
+
+      final newEssai = GrilleEssai(mot: mot, etats: res.etats ?? const []);
+      final essais = [...after.today.essais, newEssai];
+      final updatedToday = after.today.copyWith(
+        essais: essais,
+        statut: res.statut ?? after.today.statut,
+        nbEssais: res.nbEssais ?? essais.length,
+        mot: res.mot ?? after.today.mot,
+        pourquoi: res.pourquoi ?? after.today.pourquoi,
+      );
+
+      state = AsyncData(
+        after.copyWith(
+          today: updatedToday,
+          draft: '',
+          submitting: false,
+          invalidReason: null,
+          revealRow: essais.length - 1,
+          justFinished: res.isFinished,
+        ),
+      );
+    } on GrilleAlreadyFinishedException {
+      // Le serveur considère la partie finie : on resynchronise.
+      await refresh();
+    } catch (e) {
+      final after = _current ?? s;
+      state = AsyncData(after.copyWith(submitting: false));
+      rethrow;
+    }
+  }
+
+  /// Consomme le flag transitoire `justFinished` (après aiguillage écran).
+  void consumeJustFinished() {
+    final s = _current;
+    if (s == null || !s.justFinished) return;
+    state = AsyncData(s.copyWith(justFinished: false));
+  }
+
+  /// Recharge `today` depuis le serveur.
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      final today = await _repo.getToday();
+      return GrilleState(today: today);
+    });
+  }
+}
+
+/// État coloré du clavier, déduit des essais joués (pli `place>present>absent`).
+final grilleKeyboardStatesProvider = Provider<Map<String, TileState>>((ref) {
+  final async = ref.watch(grilleProvider);
+  final today = async.value?.today;
+  if (today == null) return const {};
+  return computeKeyboardStates(
+    today.essais.map((e) => (mot: e.mot, etats: e.etats)),
+  );
+});

--- a/apps/mobile/lib/features/grille/repositories/grille_repository.dart
+++ b/apps/mobile/lib/features/grille/repositories/grille_repository.dart
@@ -1,0 +1,94 @@
+import 'package:dio/dio.dart';
+
+import '../../../core/api/api_client.dart';
+import '../models/grille_models.dart';
+
+/// Aucun mot du jour disponible (404 `Aucun mot du jour disponible`).
+class GrilleNotFoundException implements Exception {
+  const GrilleNotFoundException();
+  @override
+  String toString() => 'GrilleNotFoundException';
+}
+
+/// La partie est déjà terminée — un nouvel essai est refusé (409 `deja_termine`).
+class GrilleAlreadyFinishedException implements Exception {
+  const GrilleAlreadyFinishedException();
+  @override
+  String toString() => 'GrilleAlreadyFinishedException';
+}
+
+/// Le classement n'est accessible qu'une fois la partie finie
+/// (409 `partie_en_cours`).
+class GrilleGameInProgressException implements Exception {
+  const GrilleGameInProgressException();
+  @override
+  String toString() => 'GrilleGameInProgressException';
+}
+
+/// Accès réseau à « La Grille du jour ».
+///
+/// Base URL du client finit déjà par `/api/` → chemins relatifs `grille/...`.
+/// Un essai refusé (`valide == false`) est une **donnée** ([GrilleGuessResponse]),
+/// pas une exception : seuls les vrais codes d'erreur HTTP lèvent.
+class GrilleRepository {
+  GrilleRepository(this._apiClient);
+
+  final ApiClient _apiClient;
+
+  /// `GET grille/today`.
+  Future<GrilleTodayResponse> getToday() async {
+    try {
+      final response = await _apiClient.dio.get<dynamic>('grille/today');
+      return GrilleTodayResponse.fromJson(
+        response.data as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        throw const GrilleNotFoundException();
+      }
+      rethrow;
+    }
+  }
+
+  /// `POST grille/today/guess` — un refus (`valide == false`) revient en data.
+  Future<GrilleGuessResponse> submitGuess(String mot) async {
+    try {
+      final response = await _apiClient.dio.post<dynamic>(
+        'grille/today/guess',
+        data: {'mot': mot},
+      );
+      return GrilleGuessResponse.fromJson(
+        response.data as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      final code = e.response?.statusCode;
+      if (code == 409) {
+        throw const GrilleAlreadyFinishedException();
+      }
+      if (code == 404) {
+        throw const GrilleNotFoundException();
+      }
+      rethrow;
+    }
+  }
+
+  /// `GET grille/today/leaderboard` (partie terminée requise).
+  Future<GrilleLeaderboardResponse> getLeaderboard() async {
+    try {
+      final response =
+          await _apiClient.dio.get<dynamic>('grille/today/leaderboard');
+      return GrilleLeaderboardResponse.fromJson(
+        response.data as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      final code = e.response?.statusCode;
+      if (code == 409) {
+        throw const GrilleGameInProgressException();
+      }
+      if (code == 404) {
+        throw const GrilleNotFoundException();
+      }
+      rethrow;
+    }
+  }
+}

--- a/apps/mobile/lib/features/grille/screens/grille_leaderboard_screen.dart
+++ b/apps/mobile/lib/features/grille/screens/grille_leaderboard_screen.dart
@@ -1,0 +1,199 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../../../core/providers/analytics_provider.dart';
+import '../../../shared/widgets/loaders/editorial_loader_card.dart';
+import '../../../shared/widgets/states/friendly_error_view.dart';
+import '../models/grille_models.dart';
+import '../providers/grille_leaderboard_provider.dart';
+import '../providers/grille_provider.dart';
+import '../utils/grille_share_text.dart';
+import '../widgets/g_app_bar.dart';
+import '../widgets/grille_button.dart';
+import '../widgets/leaderboard_distribution.dart';
+import '../widgets/leaderboard_hero.dart';
+import '../widgets/leaderboard_podium.dart';
+
+/// Écran Classement du jour (`GClassement`) : hero percentile, podium du
+/// quartier, distribution des essais, streak.
+class GrilleLeaderboardScreen extends ConsumerStatefulWidget {
+  const GrilleLeaderboardScreen({super.key});
+
+  @override
+  ConsumerState<GrilleLeaderboardScreen> createState() =>
+      _GrilleLeaderboardScreenState();
+}
+
+class _GrilleLeaderboardScreenState
+    extends ConsumerState<GrilleLeaderboardScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final numero = ref.read(grilleProvider).value?.today.numero;
+      ref.read(analyticsServiceProvider).trackGrilleLeaderboardOpened(numero: numero);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    final async = ref.watch(grilleLeaderboardProvider);
+
+    return Scaffold(
+      backgroundColor: c.backgroundPrimary,
+      body: SafeArea(
+        child: Column(
+          children: [
+            const GAppBar(showBack: true),
+            Expanded(
+              child: async.when(
+                loading: () => const Center(child: EditorialLoaderCard()),
+                error: (e, _) => FriendlyErrorView(
+                  error: e,
+                  onRetry: () => ref.invalidate(grilleLeaderboardProvider),
+                ),
+                data: (l) => _buildContent(context, l),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, GrilleLeaderboardResponse l) {
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(16, 6, 16, 18),
+            child: Column(
+              children: [
+                LeaderboardHero(leaderboard: l),
+                const SizedBox(height: 22),
+                LeaderboardPodium(quartier: l.quartier),
+                const SizedBox(height: 24),
+                LeaderboardDistribution(
+                  distribution: l.distribution,
+                  monScore: l.monScore,
+                ),
+                const SizedBox(height: 22),
+                _StreakStrip(streak: l.streak),
+              ],
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 18),
+          child: GrilleButton(
+            label: 'Défier un·e ami·e',
+            style: GrilleButtonStyle.steel,
+            icon: PhosphorIcons.shareNetwork(),
+            onPressed: () => _defier(context),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _defier(BuildContext context) async {
+    final today = ref.read(grilleProvider).value?.today;
+    if (today == null) return;
+    final messenger = ScaffoldMessenger.of(context);
+    await Clipboard.setData(ClipboardData(text: buildGrilleShareLink(today)));
+    unawaited(ref.read(analyticsServiceProvider).trackGrilleShared(
+          numero: today.numero,
+          medium: 'lien',
+        ));
+    messenger.showSnackBar(
+      const SnackBar(content: Text('Lien copié — défie un·e ami·e !')),
+    );
+  }
+}
+
+/// Bande de streak (`.gl-streak`) : flamme, compteur, 7 pastilles.
+class _StreakStrip extends StatelessWidget {
+  const _StreakStrip({required this.streak});
+  final int streak;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    return Container(
+      decoration: BoxDecoration(
+        color: c.surface,
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        boxShadow: const [
+          BoxShadow(color: Color(0x1A000000), blurRadius: 4, offset: Offset(0, 2)),
+        ],
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      child: Row(
+        children: [
+          Container(
+            width: 46,
+            height: 46,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: c.primary.withValues(alpha: 0.10),
+            ),
+            child: Icon(
+              PhosphorIcons.fire(PhosphorIconsStyle.fill),
+              size: 24,
+              color: c.primary,
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '$streak jours d’affilée',
+                  style: GoogleFonts.fraunces(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                    color: c.textPrimary,
+                  ),
+                ),
+                Text(
+                  'Reviens demain pour tenir la série',
+                  style: FacteurTypography.bodySmall(c.textSecondary)
+                      .copyWith(fontSize: 12.5),
+                ),
+              ],
+            ),
+          ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (var i = 0; i < 7; i++) ...[
+                Container(
+                  width: 16,
+                  height: 16,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: i < streak ? c.primary : Colors.transparent,
+                    border: Border.all(
+                      color: i < streak ? c.primary : c.border,
+                      width: 1.5,
+                    ),
+                  ),
+                ),
+                if (i < 6) const SizedBox(width: 5),
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/screens/grille_screen.dart
+++ b/apps/mobile/lib/features/grille/screens/grille_screen.dart
@@ -1,0 +1,243 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/routes.dart';
+import '../../../config/theme.dart';
+import '../../../core/providers/analytics_provider.dart';
+import '../../../shared/widgets/loaders/editorial_loader_card.dart';
+import '../../../shared/widgets/states/friendly_error_view.dart';
+import '../models/grille_models.dart';
+import '../providers/grille_provider.dart';
+import '../repositories/grille_repository.dart';
+import '../widgets/azerty_keyboard.dart';
+import '../widgets/g_app_bar.dart';
+import '../widgets/grille_button.dart';
+import '../widgets/grille_deja_joue_view.dart';
+import '../widgets/grille_masthead.dart';
+import '../widgets/grille_result_view.dart';
+import '../widgets/grille_status_line.dart';
+import '../widgets/mot_grid.dart';
+
+/// Écran principal de La Grille — aiguille entre Jeu, Résultat et Déjà-joué
+/// selon le statut serveur et le flag transitoire `justFinished`.
+class GrilleScreen extends ConsumerStatefulWidget {
+  const GrilleScreen({super.key});
+
+  @override
+  ConsumerState<GrilleScreen> createState() => _GrilleScreenState();
+}
+
+class _GrilleScreenState extends ConsumerState<GrilleScreen> {
+  /// « Revoir ma grille » depuis l'écran Déjà-joué.
+  bool _reviewing = false;
+  bool _openTracked = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    final async = ref.watch(grilleProvider);
+
+    ref.listen<AsyncValue<GrilleState>>(grilleProvider, (prev, next) {
+      final data = next.value;
+      if (data != null && !_openTracked) {
+        _openTracked = true;
+        ref.read(analyticsServiceProvider).trackGrilleOpened(
+              numero: data.today.numero,
+              statut: data.today.statut,
+            );
+      }
+      final wasFinished = prev?.value?.justFinished ?? false;
+      if (data != null && data.justFinished && !wasFinished) {
+        ref.read(analyticsServiceProvider).trackGrilleCompleted(
+              numero: data.today.numero,
+              statut: data.today.statut,
+              nbEssais: data.today.nbEssais,
+            );
+      }
+    });
+
+    return Scaffold(
+      backgroundColor: c.backgroundPrimary,
+      body: SafeArea(
+        child: async.when(
+          loading: () => const Center(child: EditorialLoaderCard()),
+          error: (e, _) => _buildError(context, e),
+          data: (state) => _buildContent(context, state),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildError(BuildContext context, Object error) {
+    if (error is GrilleNotFoundException) {
+      final c = context.facteurColors;
+      return Column(
+        children: [
+          GAppBar(showBack: true, onBack: () => Navigator.of(context).maybePop()),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 28),
+              child: Center(
+                child: Text(
+                  'Pas de grille aujourd’hui — je t’en poste une toute neuve demain matin.',
+                  textAlign: TextAlign.center,
+                  style: FacteurTypography.bodyLarge(c.textSecondary),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+    return FriendlyErrorView(
+      error: error,
+      onRetry: () => ref.read(grilleProvider.notifier).refresh(),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, GrilleState state) {
+    final today = state.today;
+    if (!today.isFinished) {
+      return _buildJeu(context, state);
+    }
+    final showResult = state.justFinished || _reviewing;
+    if (showResult) {
+      return _buildResult(context, state);
+    }
+    return _buildDejaJoue(context, today);
+  }
+
+  // ── Phase Jeu ────────────────────────────────────────────────────────────
+  Widget _buildJeu(BuildContext context, GrilleState state) {
+    final today = state.today;
+    final notifier = ref.read(grilleProvider.notifier);
+    final keyboardStates = ref.watch(grilleKeyboardStatesProvider);
+
+    return Column(
+      children: [
+        GAppBar(showBack: true, streak: today.streak),
+        GrilleMasthead(
+          numero: today.numero,
+          date: today.dateAffichee,
+          longueur: today.longueur,
+          premiereLettre: today.premiereLettre,
+          essaisMax: today.essaisMax,
+          essai: today.nbEssais + 1,
+        ),
+        Expanded(
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: MotGrid(
+                longueur: today.longueur,
+                essaisMax: today.essaisMax,
+                premiereLettre: today.premiereLettre,
+                essais: today.essais,
+                draft: state.draft,
+                revealRow: state.revealRow,
+                shakeNonce: state.invalidNonce,
+              ),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(8, 0, 8, 14),
+          child: Column(
+            children: [
+              GrilleStatusLine(
+                message: _statusMessage(state),
+                isError: state.invalidReason != null,
+              ),
+              const SizedBox(height: 10),
+              AzertyKeyboard(
+                states: keyboardStates,
+                enabled: !state.submitting,
+                onKey: notifier.addLetter,
+                onBackspace: notifier.removeLetter,
+                onEnter: () {
+                  final essai = today.nbEssais + 1;
+                  notifier.submitGuess().then((_) {
+                    final after = ref.read(grilleProvider).value;
+                    ref.read(analyticsServiceProvider).trackGrilleGuessSubmitted(
+                          numero: today.numero,
+                          essai: essai,
+                          valide: after?.invalidReason == null,
+                          raison: after?.invalidReason,
+                        );
+                  });
+                },
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _statusMessage(GrilleState state) {
+    switch (state.invalidReason) {
+      case 'longueur':
+        return 'Tape les ${state.today.longueur} lettres.';
+      case 'hors_dictionnaire':
+        return 'Ce mot n’est pas distribué — essaie un autre.';
+      default:
+        return 'Première lettre offerte. Tape un mot de ${state.today.longueur} lettres.';
+    }
+  }
+
+  // ── Phase Résultat ───────────────────────────────────────────────────────
+  Widget _buildResult(BuildContext context, GrilleState state) {
+    return Column(
+      children: [
+        GAppBar(showBack: true, streak: state.today.streak),
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+            child: GrilleResultView(
+              today: state.today,
+              animateReveal: state.justFinished,
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 18),
+          child: Column(
+            children: [
+              GrilleButton(
+                label: 'Partager ma grille',
+                icon: PhosphorIcons.shareNetwork(),
+                onPressed: () => context.pushNamed(RouteNames.grilleShare),
+              ),
+              const SizedBox(height: 4),
+              GrilleButton(
+                label: 'Voir le classement du jour',
+                style: GrilleButtonStyle.ghost,
+                onPressed: () => context.pushNamed(RouteNames.grilleLeaderboard),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ── Phase Déjà-joué ──────────────────────────────────────────────────────
+  Widget _buildDejaJoue(BuildContext context, GrilleTodayResponse today) {
+    return Column(
+      children: [
+        GAppBar(showBack: true, streak: today.streak),
+        Expanded(child: GrilleDejaJoueView(today: today)),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 18),
+          child: GrilleButton(
+            label: 'Revoir ma grille du jour',
+            style: GrilleButtonStyle.ghost,
+            onPressed: () => setState(() => _reviewing = true),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/screens/grille_share_screen.dart
+++ b/apps/mobile/lib/features/grille/screens/grille_share_screen.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../../../core/providers/analytics_provider.dart';
+import '../models/grille_models.dart';
+import '../providers/grille_provider.dart';
+import '../utils/grille_share_text.dart';
+import '../widgets/g_app_bar.dart';
+import '../widgets/grille_button.dart';
+import '../widgets/grille_share_card.dart';
+
+/// Écran de partage (`GMotPartage`). MVP : **texte + lien via Clipboard**
+/// (built-in, aucune dépendance `share_plus`). La feuille reste affichée à
+/// l'écran ; l'export image (chip « Image ») est différé en follow-up.
+class GrilleShareScreen extends ConsumerWidget {
+  const GrilleShareScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final c = context.facteurColors;
+    final today = ref.watch(grilleProvider).value?.today;
+
+    return Scaffold(
+      backgroundColor: c.backgroundPrimary,
+      body: SafeArea(
+        child: Column(
+          children: [
+            const GAppBar(showBack: true),
+            Expanded(
+              child: today == null
+                  ? const SizedBox.shrink()
+                  : _buildBody(context, ref, today),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(
+      BuildContext context, WidgetRef ref, GrilleTodayResponse today) {
+    final c = context.facteurColors;
+    final score = grilleShareScore(today);
+
+    return Column(
+      children: [
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      PhosphorIcons.frameCorners(),
+                      size: 14,
+                      color: c.textTertiary,
+                    ),
+                    const SizedBox(width: 7),
+                    Text(
+                      'VOICI L’IMAGE PARTAGÉE',
+                      style: GoogleFonts.courierPrime(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w700,
+                        letterSpacing: 1.4,
+                        color: c.textTertiary,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                GrilleShareCard(
+                  numero: today.numero,
+                  dateCourt: today.dateCourt,
+                  score: score,
+                  essais: today.essais,
+                ),
+                const SizedBox(height: 20),
+                _targets(context, ref, today),
+              ],
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 18),
+          child: Column(
+            children: [
+              GrilleButton(
+                label: 'Partager',
+                icon: PhosphorIcons.shareNetwork(),
+                onPressed: () => _shareText(context, ref, today),
+              ),
+              const SizedBox(height: 4),
+              GrilleButton(
+                label: 'Défier un·e ami·e',
+                style: GrilleButtonStyle.ghost,
+                onPressed: () => _shareLink(context, ref, today),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Chips de partage. « Image » est masquée (export différé) → Texte · Lien.
+  Widget _targets(BuildContext context, WidgetRef ref, GrilleTodayResponse today) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _chip(
+          context,
+          icon: PhosphorIcons.textT(),
+          label: 'Texte',
+          onTap: () => _shareText(context, ref, today),
+        ),
+        const SizedBox(width: 10),
+        _chip(
+          context,
+          icon: PhosphorIcons.link(),
+          label: 'Lien',
+          onTap: () => _shareLink(context, ref, today),
+        ),
+      ],
+    );
+  }
+
+  Widget _chip(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+  }) {
+    final c = context.facteurColors;
+    return Material(
+      color: c.surface,
+      borderRadius: BorderRadius.circular(FacteurRadius.pill),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(FacteurRadius.pill),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 9),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 15, color: c.textSecondary),
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: FacteurTypography.labelLarge(c.textSecondary)
+                    .copyWith(fontSize: 12.5, fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _shareText(
+      BuildContext context, WidgetRef ref, GrilleTodayResponse today) async {
+    final messenger = ScaffoldMessenger.of(context);
+    await Clipboard.setData(ClipboardData(text: buildGrilleShareText(today)));
+    unawaited(ref.read(analyticsServiceProvider).trackGrilleShared(
+          numero: today.numero,
+          medium: 'texte',
+        ));
+    messenger.showSnackBar(
+      const SnackBar(content: Text('Grille copiée — colle-la où tu veux !')),
+    );
+  }
+
+  Future<void> _shareLink(
+      BuildContext context, WidgetRef ref, GrilleTodayResponse today) async {
+    final messenger = ScaffoldMessenger.of(context);
+    await Clipboard.setData(ClipboardData(text: buildGrilleShareLink(today)));
+    unawaited(ref.read(analyticsServiceProvider).trackGrilleShared(
+          numero: today.numero,
+          medium: 'lien',
+        ));
+    messenger.showSnackBar(
+      const SnackBar(content: Text('Lien copié — défie un·e ami·e !')),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/utils/grille_format.dart
+++ b/apps/mobile/lib/features/grille/utils/grille_format.dart
@@ -1,0 +1,21 @@
+/// Espace insécable (NBSP) — colle l'unité à son nombre (« 13 h 20 », « 5 min »).
+const String nbsp = ' ';
+
+/// Formate un compte à rebours (secondes) en libellé court avec NBSP.
+///
+/// Exemples (séparateurs = NBSP) : `13 h 20`, `13 h`, `45 min`, `30 s`.
+/// - ≥ 1 h : `{h} h {mm}` (les minutes sont omises si nulles → `{h} h`).
+/// - ≥ 1 min : `{m} min`.
+/// - sinon : `{s} s`.
+String formatCountdown(int totalSeconds) {
+  final seconds = totalSeconds < 0 ? 0 : totalSeconds;
+  final hours = seconds ~/ 3600;
+  final minutes = (seconds % 3600) ~/ 60;
+
+  if (hours > 0) {
+    if (minutes == 0) return '$hours${nbsp}h';
+    return '$hours${nbsp}h$nbsp$minutes';
+  }
+  if (minutes > 0) return '$minutes${nbsp}min';
+  return '$seconds${nbsp}s';
+}

--- a/apps/mobile/lib/features/grille/utils/grille_share_text.dart
+++ b/apps/mobile/lib/features/grille/utils/grille_share_text.dart
@@ -1,0 +1,45 @@
+import '../grille_constants.dart';
+import '../models/grille_models.dart';
+import '../models/tile_state.dart';
+
+/// Construit le **texte de partage sans spoiler** d'une grille terminée.
+///
+/// Format (façon Wordle, voix Facteur) :
+/// ```
+/// La Grille du jour N°143 · Ven. 30 mai · 3/6
+/// 🟧⬛⬛🟧⬛🟧
+/// 🟩🟩⬛🟧⬛🟩
+/// 🟩🟩🟩🟩🟩🟩
+///
+/// https://facteur.app/grille
+/// ```
+/// Les carrés ne révèlent jamais les lettres → on peut partager sans gâcher.
+String buildGrilleShareText(GrilleTodayResponse today) {
+  final score = grilleShareScore(today);
+  final header =
+      'La Grille du jour ${today.numero} · ${today.dateCourt} · $score';
+  final grid = buildGrilleEmojiGrid(today.essais);
+  return '$header\n$grid\n\n${buildGrilleShareLink(today)}';
+}
+
+/// Score d'affichage : `N/essaisMax` si trouvé, `X/essaisMax` sinon.
+String grilleShareScore(GrilleTodayResponse today) {
+  final base = today.isSolved ? '${today.nbEssais}' : 'X';
+  return '$base/${today.essaisMax}';
+}
+
+/// La grille d'emojis seule (lignes séparées par `\n`).
+String buildGrilleEmojiGrid(List<GrilleEssai> essais) {
+  return essais
+      .map(
+        (e) => e.etats
+            .map((etat) => TileStateX.fromServer(etat).shareEmoji)
+            .join(),
+      )
+      .join('\n');
+}
+
+/// Lien de partage (sans spoiler). Le deep-link entrant est hors MVP, donc on
+/// pointe vers la page publique de la Grille.
+String buildGrilleShareLink(GrilleTodayResponse today) =>
+    GrilleConstants.shareBaseUrl;

--- a/apps/mobile/lib/features/grille/widgets/azerty_keyboard.dart
+++ b/apps/mobile/lib/features/grille/widgets/azerty_keyboard.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+
+import '../../../config/theme.dart';
+import '../grille_constants.dart';
+import '../models/tile_state.dart';
+
+/// Disposition AZERTY (`fKkZuc/grille-mot.jsx`).
+const List<List<String>> _azertyRows = [
+  ['A', 'Z', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P'],
+  ['Q', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L', 'M'],
+  ['↵', 'W', 'X', 'C', 'V', 'B', 'N', '⌫'],
+];
+
+/// Clavier AZERTY coloré façon Wordle (`.mot-clavier`).
+///
+/// Les touches se teintent selon [states] (pli des essais joués) :
+/// `place` (vert), `present` (ocre), `absent` (gris clair). `↵` valide,
+/// `⌫` efface ; ces deux touches sont larges.
+class AzertyKeyboard extends StatelessWidget {
+  const AzertyKeyboard({
+    super.key,
+    required this.states,
+    required this.onKey,
+    required this.onEnter,
+    required this.onBackspace,
+    this.enabled = true,
+  });
+
+  final Map<String, TileState> states;
+  final ValueChanged<String> onKey;
+  final VoidCallback onEnter;
+  final VoidCallback onBackspace;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (var r = 0; r < _azertyRows.length; r++) ...[
+          Row(
+            children: [
+              for (var k = 0; k < _azertyRows[r].length; k++) ...[
+                _buildKey(context, _azertyRows[r][k]),
+                if (k < _azertyRows[r].length - 1) const SizedBox(width: 5),
+              ],
+            ],
+          ),
+          if (r < _azertyRows.length - 1) const SizedBox(height: 7),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildKey(BuildContext context, String key) {
+    final c = context.facteurColors;
+    final isEnter = key == '↵';
+    final isBackspace = key == '⌫';
+    final isWide = isEnter || isBackspace;
+    final state = states[key];
+
+    Color background;
+    Color foreground;
+    List<BoxShadow>? shadow = const [
+      BoxShadow(color: Color(0x14000000), blurRadius: 2, offset: Offset(0, 1)),
+    ];
+
+    switch (state) {
+      case TileState.place:
+        background = c.success;
+        foreground = Colors.white;
+      case TileState.present:
+        background = c.primary;
+        foreground = Colors.white;
+      case TileState.absent:
+        background = GrilleConstants.absentClavier;
+        foreground = Colors.white;
+        shadow = null;
+      default:
+        background = c.surface;
+        foreground = c.textPrimary;
+    }
+
+    final label = isEnter ? 'Entrée' : key;
+
+    return Expanded(
+      flex: isWide ? 17 : 10,
+      child: Semantics(
+        button: true,
+        label: isEnter
+            ? 'Valider'
+            : isBackspace
+                ? 'Effacer'
+                : key,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: enabled
+              ? () {
+                  if (isEnter) {
+                    onEnter();
+                  } else if (isBackspace) {
+                    onBackspace();
+                  } else {
+                    onKey(key);
+                  }
+                }
+              : null,
+          child: Container(
+            height: GrilleConstants.keyHeight,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: background,
+              borderRadius: BorderRadius.circular(GrilleConstants.keyRadius),
+              boxShadow: shadow,
+            ),
+            child: Text(
+              label,
+              style: FacteurTypography.labelLarge(foreground).copyWith(
+                fontSize: isWide ? 11 : 15,
+                fontWeight: FontWeight.w700,
+                letterSpacing: isWide ? 0.5 : 0,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/carte_cta.dart
+++ b/apps/mobile/lib/features/grille/widgets/carte_cta.dart
@@ -1,0 +1,287 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../grille_constants.dart';
+import '../models/grille_models.dart';
+import '../models/tile_state.dart';
+import 'grille_button.dart';
+import 'grille_countdown.dart';
+
+/// État visuel de la carte d'invitation.
+enum CarteCtaState { neuf, deja }
+
+/// Mini-grille de la carte d'entrée (`.mot-grid.v-mini`) : 3 lignes de mini
+/// tuiles 18 px. `teaser` → seule la 1re lettre (offerte) est affichée ;
+/// sinon, on montre les essais déjà joués.
+class MiniMotGrid extends StatelessWidget {
+  const MiniMotGrid({
+    super.key,
+    required this.longueur,
+    required this.premiereLettre,
+    this.essais = const [],
+    this.teaser = false,
+  });
+
+  final int longueur;
+  final String premiereLettre;
+  final List<GrilleEssai> essais;
+  final bool teaser;
+
+  static const int _rows = 3;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (var r = 0; r < _rows; r++) ...[
+          _row(context, r),
+          if (r < _rows - 1) const SizedBox(height: 4),
+        ],
+      ],
+    );
+  }
+
+  Widget _row(BuildContext context, int r) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (var i = 0; i < longueur; i++) ...[
+          _cell(context, r, i),
+          if (i < longueur - 1) const SizedBox(width: 4),
+        ],
+      ],
+    );
+  }
+
+  Widget _cell(BuildContext context, int r, int i) {
+    final c = context.facteurColors;
+    if (r < essais.length) {
+      final etat = i < essais[r].etats.length ? essais[r].etats[i] : 'absent';
+      final state = TileStateX.fromServer(etat);
+      Color color;
+      switch (state) {
+        case TileState.place:
+          color = c.success;
+        case TileState.present:
+          color = c.primary;
+        default:
+          color = GrilleConstants.absentGrille;
+      }
+      return _box(color: color, border: color);
+    }
+    final isHint = teaser && r == 0 && i == 0;
+    if (isHint) {
+      return _box(
+        color: c.surfacePaper,
+        border: c.primary,
+        child: Text(
+          premiereLettre,
+          style: GoogleFonts.fraunces(
+            fontSize: 10,
+            fontWeight: FontWeight.w700,
+            color: c.primary,
+          ),
+        ),
+      );
+    }
+    return _box(color: c.surfacePaper, border: c.border);
+  }
+
+  Widget _box({
+    required Color color,
+    required Color border,
+    Widget? child,
+  }) {
+    return Container(
+      width: GrilleConstants.miniTileSize,
+      height: GrilleConstants.miniTileSize,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(3),
+        border: Border.all(color: border, width: 1.5),
+      ),
+      child: child,
+    );
+  }
+}
+
+/// La carte d'invitation « La Grille du jour » (`.cta-card`).
+///
+/// Présentationnel pur. Le câblage provider/analytics se fait dans
+/// `GrilleCtaCard` (cf. `screens/`), inséré comme sliver additif au-dessus de
+/// `ClosingCardV18` (zéro modification de la carte de clôture).
+class CarteCta extends StatelessWidget {
+  const CarteCta({
+    super.key,
+    required this.state,
+    required this.today,
+    required this.onOpen,
+  });
+
+  final CarteCtaState state;
+  final GrilleTodayResponse today;
+  final VoidCallback onOpen;
+
+  bool get _deja => state == CarteCtaState.deja;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: c.surface,
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        boxShadow: const [
+          BoxShadow(color: Color(0x1A000000), blurRadius: 4, offset: Offset(0, 2)),
+        ],
+      ),
+      padding: const EdgeInsets.fromLTRB(18, 20, 18, 18),
+      child: Column(
+        children: [
+          _stamp(context),
+          const SizedBox(height: 16),
+          MiniMotGrid(
+            longueur: today.longueur,
+            premiereLettre: today.premiereLettre,
+            essais: _deja ? today.essais : const [],
+            teaser: !_deja,
+          ),
+          if (!_deja) ...[
+            const SizedBox(height: 14),
+            Text(
+              'La Grille du jour',
+              style: GoogleFonts.fraunces(
+                fontSize: 23,
+                fontWeight: FontWeight.w700,
+                height: 1.1,
+                letterSpacing: -0.5,
+                color: c.textPrimary,
+              ),
+            ),
+          ],
+          const SizedBox(height: 10),
+          Text(
+            _intro(),
+            textAlign: TextAlign.center,
+            style: GoogleFonts.fraunces(
+              fontSize: 14.5,
+              fontStyle: FontStyle.italic,
+              height: 1.5,
+              color: c.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 14),
+          if (_deja) _dejaFoot(context) else _meta(context),
+          const SizedBox(height: 16),
+          GrilleButton(
+            label: _deja ? 'Revoir ma grille' : 'Ouvrir la grille',
+            style: _deja ? GrilleButtonStyle.ghost : GrilleButtonStyle.primary,
+            onPressed: onOpen,
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _intro() {
+    if (_deja) {
+      final n = today.nbEssais;
+      return '« Trouvé en $n essai${n > 1 ? 's' : ''} aujourd’hui — joli flair. '
+          'Je te poste un mot tout neuf demain matin. »';
+    }
+    return '« Ta tournée est faite. J’ai caché un mot dans l’actu d’aujourd’hui '
+        '— six lettres, six essais. »';
+  }
+
+  Widget _stamp(BuildContext context) {
+    final c = context.facteurColors;
+    final color = _deja ? c.success : c.textStamp;
+    return Transform.rotate(
+      angle: -2 * math.pi / 180,
+      child: Container(
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: _deja ? 0.07 : 0.06),
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: color, width: 1.5),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 3),
+        child: Text(
+          _deja ? 'DÉJÀ JOUÉE' : 'APRÈS TA TOURNÉE',
+          style: GoogleFonts.courierPrime(
+            fontSize: 10,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 1.4,
+            color: color,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _meta(BuildContext context) {
+    final c = context.facteurColors;
+    final base = FacteurTypography.bodySmall(c.textTertiary)
+        .copyWith(fontSize: 12.5);
+    final bold = base.copyWith(
+      color: c.textSecondary,
+      fontWeight: FontWeight.w700,
+    );
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text.rich(TextSpan(style: base, children: [
+          TextSpan(text: '${today.longueur}', style: bold),
+          const TextSpan(text: ' lettres'),
+        ])),
+        _dot(c),
+        Text.rich(TextSpan(style: base, children: [
+          TextSpan(text: '<2', style: bold),
+          const TextSpan(text: ' min'),
+        ])),
+        _dot(c),
+        Icon(PhosphorIcons.fire(PhosphorIconsStyle.fill), size: 13, color: c.primary),
+        const SizedBox(width: 4),
+        Text.rich(TextSpan(style: base, children: [
+          TextSpan(text: '${today.streak}', style: bold),
+          const TextSpan(text: ' j'),
+        ])),
+      ],
+    );
+  }
+
+  Widget _dejaFoot(BuildContext context) {
+    final c = context.facteurColors;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Flexible(
+          child: GrilleCountdown(
+            initialSeconds: today.prochainMotDansSec,
+            fontSize: 11,
+            iconSize: 12,
+          ),
+        ),
+        _dot(c),
+        Icon(PhosphorIcons.fire(PhosphorIconsStyle.fill), size: 13, color: c.primary),
+        const SizedBox(width: 4),
+        Text(
+          '${today.streak} jours',
+          style: FacteurTypography.bodySmall(c.textSecondary)
+              .copyWith(fontSize: 12, fontWeight: FontWeight.w700),
+        ),
+      ],
+    );
+  }
+
+  Widget _dot(FacteurColors c) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        child: Text('·', style: TextStyle(color: c.textTertiary)),
+      );
+}

--- a/apps/mobile/lib/features/grille/widgets/dashed_border.dart
+++ b/apps/mobile/lib/features/grille/widgets/dashed_border.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+/// Peintre d'un rectangle arrondi à bord **pointillé** (tirets).
+///
+/// Maison (≈ pas de dépendance `dotted_border`) pour un contrôle pixel exact :
+/// utilisé pour le filet du masthead, le liseré du sceau (`mt-seal`), la feuille
+/// de partage et le contour des pastilles de streak. Déterministe → goldens
+/// stables.
+class DashedRRectPainter extends CustomPainter {
+  const DashedRRectPainter({
+    required this.color,
+    this.strokeWidth = 1.5,
+    this.radius = 0,
+    this.dashLength = 4,
+    this.gapLength = 3,
+    this.inset = 0,
+  });
+
+  /// Couleur du tiret.
+  final Color color;
+
+  /// Épaisseur du trait.
+  final double strokeWidth;
+
+  /// Rayon des coins du rectangle.
+  final double radius;
+
+  /// Longueur d'un tiret.
+  final double dashLength;
+
+  /// Longueur d'un espace entre deux tirets.
+  final double gapLength;
+
+  /// Marge intérieure du tracé par rapport aux bords (utile pour le liseré
+  /// `mt-seal` qui s'inscrit à l'intérieur de la tuile).
+  final double inset;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = strokeWidth
+      ..style = PaintingStyle.stroke;
+
+    final rect = Rect.fromLTWH(
+      inset,
+      inset,
+      size.width - inset * 2,
+      size.height - inset * 2,
+    );
+    final rrect = RRect.fromRectAndRadius(rect, Radius.circular(radius));
+
+    final path = Path()..addRRect(rrect);
+    canvas.drawPath(_dashPath(path), paint);
+  }
+
+  /// Reconstruit [source] en n'en gardant que des segments de [dashLength]
+  /// espacés de [gapLength], le long de toutes ses métriques.
+  Path _dashPath(Path source) {
+    final dest = Path();
+    for (final metric in source.computeMetrics()) {
+      var distance = 0.0;
+      var draw = true;
+      while (distance < metric.length) {
+        final len = draw ? dashLength : gapLength;
+        if (draw) {
+          dest.addPath(
+            metric.extractPath(distance, distance + len),
+            Offset.zero,
+          );
+        }
+        distance += len;
+        draw = !draw;
+      }
+    }
+    return dest;
+  }
+
+  @override
+  bool shouldRepaint(DashedRRectPainter oldDelegate) {
+    return color != oldDelegate.color ||
+        strokeWidth != oldDelegate.strokeWidth ||
+        radius != oldDelegate.radius ||
+        dashLength != oldDelegate.dashLength ||
+        gapLength != oldDelegate.gapLength ||
+        inset != oldDelegate.inset;
+  }
+}
+
+/// Filet horizontal pointillé (masthead `.rule`, clôture `.tf-closure-rule`).
+class DashedLinePainter extends CustomPainter {
+  const DashedLinePainter({
+    required this.color,
+    this.strokeWidth = 2,
+    this.dashLength = 5,
+    this.gapLength = 4,
+  });
+
+  final Color color;
+  final double strokeWidth;
+  final double dashLength;
+  final double gapLength;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = strokeWidth
+      ..style = PaintingStyle.stroke;
+    final y = size.height / 2;
+    var x = 0.0;
+    while (x < size.width) {
+      canvas.drawLine(Offset(x, y), Offset(x + dashLength, y), paint);
+      x += dashLength + gapLength;
+    }
+  }
+
+  @override
+  bool shouldRepaint(DashedLinePainter oldDelegate) {
+    return color != oldDelegate.color ||
+        strokeWidth != oldDelegate.strokeWidth ||
+        dashLength != oldDelegate.dashLength ||
+        gapLength != oldDelegate.gapLength;
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/g_app_bar.dart
+++ b/apps/mobile/lib/features/grille/widgets/g_app_bar.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+
+/// Barre supérieure de La Grille (`.g-appbar`) : back · wordmark · streak.
+class GAppBar extends StatelessWidget {
+  const GAppBar({
+    super.key,
+    this.showBack = true,
+    this.streak = 0,
+    this.title = 'Facteur',
+    this.onBack,
+  });
+
+  final bool showBack;
+  final int streak;
+  final String title;
+  final VoidCallback? onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 6, 16, 4),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 36,
+            height: 36,
+            child: showBack
+                ? IconButton(
+                    padding: EdgeInsets.zero,
+                    onPressed: onBack ?? () => Navigator.of(context).maybePop(),
+                    icon: Icon(
+                      PhosphorIcons.arrowLeft(),
+                      size: 19,
+                      color: c.textSecondary,
+                    ),
+                  )
+                : null,
+          ),
+          Expanded(
+            child: Center(
+              child: Text(
+                title,
+                style: GoogleFonts.fraunces(
+                  fontSize: 19,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: -0.5,
+                  color: c.textPrimary,
+                ),
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 36,
+            child: streak > 0
+                ? Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Icon(
+                        PhosphorIcons.fire(PhosphorIconsStyle.fill),
+                        size: 16,
+                        color: c.primary,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        '$streak',
+                        style: FacteurTypography.bodySmall(c.textSecondary)
+                            .copyWith(fontWeight: FontWeight.w700),
+                      ),
+                    ],
+                  )
+                : null,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/grille_button.dart
+++ b/apps/mobile/lib/features/grille/widgets/grille_button.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import '../../../config/theme.dart';
+import '../grille_constants.dart';
+
+/// Style d'un bouton de pied d'écran (`.g-btn`).
+enum GrilleButtonStyle { primary, ghost, steel }
+
+/// Bouton de pied d'écran de La Grille (`.g-btn` / `.ghost` / `.steel`).
+///
+/// - `primary` : plein ocre, 16 px w700, rayon `FacteurRadius.medium` (12).
+/// - `ghost` : transparent, 14 px w600, texte secondaire.
+/// - `steel` : plein acier (#34495e) — « Défier un·e ami·e ».
+class GrilleButton extends StatelessWidget {
+  const GrilleButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.style = GrilleButtonStyle.primary,
+    this.icon,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+  final GrilleButtonStyle style;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    final isGhost = style == GrilleButtonStyle.ghost;
+
+    Color background;
+    Color foreground;
+    switch (style) {
+      case GrilleButtonStyle.primary:
+        background = c.primary;
+        foreground = Colors.white;
+      case GrilleButtonStyle.steel:
+        background = GrilleConstants.steel;
+        foreground = Colors.white;
+      case GrilleButtonStyle.ghost:
+        background = Colors.transparent;
+        foreground = c.textSecondary;
+    }
+
+    return SizedBox(
+      width: double.infinity,
+      child: Material(
+        color: background,
+        borderRadius: BorderRadius.circular(FacteurRadius.medium),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(FacteurRadius.medium),
+          onTap: onPressed,
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: isGhost ? 10 : 15),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (icon != null) ...[
+                  Icon(icon, size: 18, color: foreground),
+                  const SizedBox(width: 8),
+                ],
+                Flexible(
+                  child: Text(
+                    label,
+                    textAlign: TextAlign.center,
+                    style: FacteurTypography.bodyLarge(foreground).copyWith(
+                      fontSize: isGhost ? 14 : 16,
+                      fontWeight: isGhost ? FontWeight.w600 : FontWeight.w700,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/grille_countdown.dart
+++ b/apps/mobile/lib/features/grille/widgets/grille_countdown.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../utils/grille_format.dart';
+
+/// Compte à rebours **live** « Nouveau mot dans {durée} » (`.gd-next`).
+///
+/// Décrémente chaque seconde et reformate avec NBSP (« 13 h 20 »). La valeur de
+/// temps est en ocre, le libellé en gris ; mono, majuscules.
+class GrilleCountdown extends StatefulWidget {
+  const GrilleCountdown({
+    super.key,
+    required this.initialSeconds,
+    this.fontSize = 12,
+    this.iconSize = 14,
+  });
+
+  final int initialSeconds;
+  final double fontSize;
+  final double iconSize;
+
+  @override
+  State<GrilleCountdown> createState() => _GrilleCountdownState();
+}
+
+class _GrilleCountdownState extends State<GrilleCountdown> {
+  late int _remaining;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _remaining = widget.initialSeconds;
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!mounted) return;
+      if (_remaining <= 0) {
+        _timer?.cancel();
+        return;
+      }
+      setState(() => _remaining -= 1);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    final base = GoogleFonts.courierPrime(
+      fontSize: widget.fontSize,
+      letterSpacing: 1,
+      color: c.textTertiary,
+    );
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(PhosphorIcons.clock(), size: widget.iconSize, color: c.textTertiary),
+        const SizedBox(width: 7),
+        Text.rich(
+          TextSpan(
+            style: base,
+            children: [
+              const TextSpan(text: 'NOUVEAU MOT DANS '),
+              TextSpan(
+                text: formatCountdown(_remaining),
+                style: base.copyWith(
+                  color: c.primary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/grille_cta_card.dart
+++ b/apps/mobile/lib/features/grille/widgets/grille_cta_card.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../config/routes.dart';
+import '../../../core/providers/analytics_provider.dart';
+import '../providers/grille_provider.dart';
+import 'carte_cta.dart';
+
+/// Carte d'entrée de La Grille câblée au provider — à insérer en fin de Tournée.
+///
+/// `ConsumerStatefulWidget` autonome : watch `grilleProvider` (pré-warm du
+/// `GET today`), choisit l'état visuel (neuf / déjà-joué), émet
+/// `trackGrilleCtaShown/Tapped` et pousse `/grille`. En loading/erreur, ne rend
+/// **rien** (`SizedBox.shrink`) pour ne pas perturber la carte de clôture.
+class GrilleCtaCard extends ConsumerStatefulWidget {
+  const GrilleCtaCard({super.key});
+
+  @override
+  ConsumerState<GrilleCtaCard> createState() => _GrilleCtaCardState();
+}
+
+class _GrilleCtaCardState extends ConsumerState<GrilleCtaCard> {
+  String? _shownState;
+
+  @override
+  Widget build(BuildContext context) {
+    final today = ref.watch(grilleProvider).value?.today;
+    if (today == null) return const SizedBox.shrink();
+
+    final state = today.isFinished ? CarteCtaState.deja : CarteCtaState.neuf;
+    final stateLabel = state == CarteCtaState.deja ? 'deja' : 'neuf';
+
+    // Émet « shown » une fois par état affiché.
+    if (_shownState != stateLabel) {
+      _shownState = stateLabel;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          ref.read(analyticsServiceProvider).trackGrilleCtaShown(state: stateLabel);
+        }
+      });
+    }
+
+    return CarteCta(
+      state: state,
+      today: today,
+      onOpen: () {
+        ref.read(analyticsServiceProvider).trackGrilleCtaTapped(state: stateLabel);
+        context.pushNamed(RouteNames.grille);
+      },
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/grille_deja_joue_view.dart
+++ b/apps/mobile/lib/features/grille/widgets/grille_deja_joue_view.dart
@@ -1,0 +1,128 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../models/grille_models.dart';
+import 'dashed_border.dart';
+import 'grille_countdown.dart';
+
+/// Écran « Déjà joué aujourd'hui » (`GDejaJoue`) : sceau, message et compte à
+/// rebours live jusqu'au prochain mot. Affiché au cold-load d'une partie déjà
+/// terminée (vs Résultat juste après la fin).
+class GrilleDejaJoueView extends StatelessWidget {
+  const GrilleDejaJoueView({super.key, required this.today});
+
+  final GrilleTodayResponse today;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    final solved = today.isSolved;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 28),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          _Seal(solved: solved),
+          const SizedBox(height: 22),
+          Text(
+            solved ? 'Mot du jour trouvé.' : 'Mot du jour manqué.',
+            textAlign: TextAlign.center,
+            style: GoogleFonts.fraunces(
+              fontSize: 26,
+              fontWeight: FontWeight.w700,
+              letterSpacing: -0.5,
+              color: c.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            _subtitle(solved),
+            textAlign: TextAlign.center,
+            style: GoogleFonts.fraunces(
+              fontSize: 15,
+              fontStyle: FontStyle.italic,
+              height: 1.55,
+              color: c.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 22),
+          GrilleCountdown(initialSeconds: today.prochainMotDansSec),
+        ],
+      ),
+    );
+  }
+
+  String _subtitle(bool solved) {
+    if (solved) {
+      final n = today.nbEssais;
+      return '« Tu as bouclé la grille d’aujourd’hui — $n essai${n > 1 ? 's' : ''}, '
+          'bien joué. Je te poste un mot tout neuf demain matin. »';
+    }
+    final mot = today.mot ?? '';
+    return '« Le mot du jour était « $mot ». Pas grave — il était sous tes yeux '
+        'toute la tournée. Je te poste un mot tout neuf demain matin. »';
+  }
+}
+
+/// Sceau circulaire « Trouvé / Raté » (`.gd-seal`).
+class _Seal extends StatelessWidget {
+  const _Seal({required this.solved});
+  final bool solved;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    final color = c.textStamp;
+    return Transform.rotate(
+      angle: -7 * math.pi / 180,
+      child: Container(
+        width: 116,
+        height: 116,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(color: color, width: 2.5),
+        ),
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            Positioned.fill(
+              child: Padding(
+                padding: const EdgeInsets.all(6),
+                child: CustomPaint(
+                  painter: DashedRRectPainter(
+                    color: color.withValues(alpha: 0.4),
+                    strokeWidth: 1.5,
+                    radius: 999,
+                  ),
+                ),
+              ),
+            ),
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  solved ? '✓' : '✕',
+                  style: TextStyle(fontSize: 30, color: color, height: 1),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  solved ? 'TROUVÉ' : 'RATÉ',
+                  style: GoogleFonts.courierPrime(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 1.5,
+                    color: color,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/grille_masthead.dart
+++ b/apps/mobile/lib/features/grille/widgets/grille_masthead.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import 'dashed_border.dart';
+
+/// Masthead de l'écran de jeu (`.mot-mast`) : kicker daté, titre serif, filet
+/// pointillé, puce d'indice et compteur d'essai.
+class GrilleMasthead extends StatelessWidget {
+  const GrilleMasthead({
+    super.key,
+    required this.numero,
+    required this.date,
+    required this.longueur,
+    required this.premiereLettre,
+    required this.essaisMax,
+    this.essai,
+  });
+
+  final String numero;
+  final String date;
+  final int longueur;
+  final String premiereLettre;
+  final int essaisMax;
+
+  /// Numéro de l'essai courant (`n / essaisMax`). `null` → compteur masqué.
+  final int? essai;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    final mono = GoogleFonts.courierPrime(
+      fontSize: 10,
+      fontWeight: FontWeight.w700,
+      letterSpacing: 1.5,
+      color: c.textTertiary,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(22, 6, 22, 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('$numero · $date'.toUpperCase(), style: mono),
+          const SizedBox(height: 6),
+          Text(
+            'La Grille du jour',
+            style: GoogleFonts.fraunces(
+              fontSize: 27,
+              fontWeight: FontWeight.w700,
+              height: 1.1,
+              letterSpacing: -0.6,
+              color: c.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 9),
+          SizedBox(
+            height: 2,
+            width: double.infinity,
+            child: CustomPaint(
+              painter: DashedLinePainter(color: c.border, strokeWidth: 2),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Flexible(child: _hintChip(context)),
+              if (essai != null)
+                Text(
+                  'Essai $essai / $essaisMax',
+                  style: GoogleFonts.courierPrime(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 1,
+                    color: c.textTertiary,
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _hintChip(BuildContext context) {
+    final c = context.facteurColors;
+    return Container(
+      decoration: BoxDecoration(
+        color: c.primary.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(FacteurRadius.pill),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 5),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            PhosphorIcons.envelopeSimple(),
+            size: 13,
+            color: c.textStamp,
+          ),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              '$longueur lettres · commence par $premiereLettre'.toUpperCase(),
+              overflow: TextOverflow.ellipsis,
+              style: GoogleFonts.courierPrime(
+                fontSize: 10.5,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 0.6,
+                color: c.textStamp,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/grille_result_view.dart
+++ b/apps/mobile/lib/features/grille/widgets/grille_result_view.dart
@@ -1,0 +1,219 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../grille_constants.dart';
+import '../models/grille_models.dart';
+import 'dashed_border.dart';
+import 'mot_grid.dart';
+
+/// Vue de résultat (`GMotResultat`, sans `CartePlusLoin`) : cachet de verdict,
+/// titre, sous-titre, grille révélée et carte « pourquoi » (voix Facteur).
+class GrilleResultView extends StatelessWidget {
+  const GrilleResultView({
+    super.key,
+    required this.today,
+    this.animateReveal = false,
+  });
+
+  final GrilleTodayResponse today;
+
+  /// Joue le flip de la dernière ligne (arrivée fraîche depuis le jeu).
+  final bool animateReveal;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    final solved = today.isSolved;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        _Cachet(solved: solved),
+        const SizedBox(height: 16),
+        Text(
+          solved ? 'Mot livré.' : 'Mot non distribué.',
+          style: GoogleFonts.fraunces(
+            fontSize: 24,
+            fontWeight: FontWeight.w700,
+            letterSpacing: -0.4,
+            color: c.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 5),
+        _subtitle(context, solved),
+        const SizedBox(height: 20),
+        MotGrid(
+          longueur: today.longueur,
+          essaisMax: today.essaisMax,
+          premiereLettre: today.premiereLettre,
+          essais: today.essais,
+          variant: MotGridVariant.resultat,
+          revealRow:
+              animateReveal && solved ? today.essais.length - 1 : -1,
+        ),
+        const SizedBox(height: 18),
+        if (today.pourquoi != null) _pourquoi(context),
+      ],
+    );
+  }
+
+  Widget _subtitle(BuildContext context, bool solved) {
+    final c = context.facteurColors;
+    final base = FacteurTypography.bodyMedium(c.textSecondary)
+        .copyWith(fontSize: 14);
+    final bold = base.copyWith(
+      color: c.textPrimary,
+      fontWeight: FontWeight.w700,
+    );
+    if (solved) {
+      final n = today.nbEssais;
+      return Text.rich(
+        TextSpan(
+          style: base,
+          children: [
+            const TextSpan(text: 'Trouvé en '),
+            TextSpan(text: '$n', style: bold),
+            TextSpan(text: ' essai${n > 1 ? 's' : ''} sur ${today.essaisMax}.'),
+          ],
+        ),
+        textAlign: TextAlign.center,
+      );
+    }
+    return Text.rich(
+      TextSpan(
+        style: base,
+        children: [
+          const TextSpan(text: 'Le mot du jour était '),
+          TextSpan(text: today.mot ?? '', style: bold),
+          const TextSpan(text: '.'),
+        ],
+      ),
+      textAlign: TextAlign.center,
+    );
+  }
+
+  Widget _pourquoi(BuildContext context) {
+    final c = context.facteurColors;
+    return Container(
+      decoration: BoxDecoration(
+        color: c.surfaceElevated,
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x1A000000),
+            blurRadius: 4,
+            offset: Offset(0, 2),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 36,
+            height: 36,
+            decoration: const BoxDecoration(
+              color: GrilleConstants.avatarFallback,
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  today.mot ?? '',
+                  style: GoogleFonts.fraunces(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 1,
+                    color: c.primary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '« ${today.pourquoi} »',
+                  style: GoogleFonts.fraunces(
+                    fontSize: 14,
+                    fontStyle: FontStyle.italic,
+                    height: 1.5,
+                    color: c.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Cachet circulaire de verdict (`.mv-cachet`) — ✓ Livré / ✕ Manqué.
+class _Cachet extends StatelessWidget {
+  const _Cachet({required this.solved});
+  final bool solved;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    final color = solved ? c.success : c.error;
+    return Transform.rotate(
+      angle: -9 * math.pi / 180,
+      child: Container(
+        width: 84,
+        height: 84,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(color: color, width: 2.5),
+        ),
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            Positioned.fill(
+              child: Padding(
+                padding: const EdgeInsets.all(5),
+                child: CustomPaint(
+                  painter: DashedRRectPainter(
+                    color: color.withValues(alpha: 0.45),
+                    strokeWidth: 1.5,
+                    radius: 999,
+                  ),
+                ),
+              ),
+            ),
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  solved ? '✓' : '✕',
+                  style: TextStyle(
+                    fontSize: 26,
+                    height: 1,
+                    color: color,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  solved ? 'LIVRÉ' : 'MANQUÉ',
+                  style: GoogleFonts.courierPrime(
+                    fontSize: 9,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 1.5,
+                    color: color,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/grille_share_card.dart
+++ b/apps/mobile/lib/features/grille/widgets/grille_share_card.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../models/grille_models.dart';
+import 'dashed_border.dart';
+import 'mot_share_grid.dart';
+
+/// La feuille de partage capturable (`.gp-sheet.mot-share-sheet`).
+///
+/// Enveloppée dans un [RepaintBoundary] (clé [boundaryKey]) pour préparer
+/// l'export image en follow-up (`toImage`). En MVP on partage le **texte**.
+class GrilleShareCard extends StatelessWidget {
+  const GrilleShareCard({
+    super.key,
+    required this.numero,
+    required this.dateCourt,
+    required this.score,
+    required this.essais,
+    this.boundaryKey,
+  });
+
+  final String numero;
+  final String dateCourt;
+
+  /// Score affiché (`3/6` ou `X/6`).
+  final String score;
+  final List<GrilleEssai> essais;
+  final GlobalKey? boundaryKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+
+    final sheet = Container(
+      decoration: BoxDecoration(
+        color: c.backgroundPrimary,
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x1A000000),
+            blurRadius: 4,
+            offset: Offset(0, 2),
+          ),
+        ],
+      ),
+      child: CustomPaint(
+        painter: DashedRRectPainter(
+          color: c.border,
+          strokeWidth: 1,
+          radius: FacteurRadius.large,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 26, 24, 26),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'La Grille du jour',
+                style: GoogleFonts.fraunces(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: -0.4,
+                  color: c.textPrimary,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '$numero · $dateCourt · $score'.toUpperCase(),
+                style: GoogleFonts.courierPrime(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 1.2,
+                  color: c.textTertiary,
+                ),
+              ),
+              const SizedBox(height: 16),
+              MotShareGrid(essais: essais),
+              const SizedBox(height: 16),
+              _wordmark(context),
+              const SizedBox(height: 2),
+              Text(
+                '— ta grille du jour, sans spoiler le mot',
+                textAlign: TextAlign.center,
+                style: GoogleFonts.courierPrime(
+                  fontSize: 9,
+                  letterSpacing: 0.8,
+                  color: c.textTertiary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    return RepaintBoundary(key: boundaryKey, child: sheet);
+  }
+
+  Widget _wordmark(BuildContext context) {
+    final c = context.facteurColors;
+    return Text.rich(
+      TextSpan(
+        style: GoogleFonts.fraunces(
+          fontSize: 16,
+          fontWeight: FontWeight.w700,
+          letterSpacing: -0.5,
+          color: c.textPrimary,
+        ),
+        children: [
+          TextSpan(text: 'F', style: TextStyle(color: c.primary)),
+          const TextSpan(text: 'acteur'),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/grille_status_line.dart
+++ b/apps/mobile/lib/features/grille/widgets/grille_status_line.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+import '../../../config/theme.dart';
+
+/// Ligne de statut sous la grille (`.mot-status`) — message d'aide ou d'erreur.
+class GrilleStatusLine extends StatelessWidget {
+  const GrilleStatusLine({
+    super.key,
+    required this.message,
+    this.isError = false,
+  });
+
+  final String message;
+  final bool isError;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    return SizedBox(
+      height: 26,
+      child: Center(
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+          style: FacteurTypography.bodySmall(
+            isError ? c.error : c.textTertiary,
+          ).copyWith(fontSize: 12.5),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/leaderboard_distribution.dart
+++ b/apps/mobile/lib/features/grille/widgets/leaderboard_distribution.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../grille_constants.dart';
+import '../models/grille_models.dart';
+
+/// Distribution des essais du quartier (`.gl-dist`) — une barre par nombre
+/// d'essais, la ligne du joueur (`score == monScore`) surlignée en ocre avec
+/// le suffixe « · toi ».
+class LeaderboardDistribution extends StatelessWidget {
+  const LeaderboardDistribution({
+    super.key,
+    required this.distribution,
+    required this.monScore,
+  });
+
+  final List<GrilleDistributionItem> distribution;
+  final String monScore;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '— EN COMBIEN D’ESSAIS LE QUARTIER A TROUVÉ —',
+          style: GoogleFonts.courierPrime(
+            fontSize: 10,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 1,
+            color: c.textTertiary,
+          ),
+        ),
+        const SizedBox(height: 12),
+        for (final d in distribution) _row(context, d),
+      ],
+    );
+  }
+
+  Widget _row(BuildContext context, GrilleDistributionItem d) {
+    final c = context.facteurColors;
+    final moi = d.score == monScore;
+    final factor = (d.pct * 2.5 / 100).clamp(0.0, 1.0);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 9),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 30,
+            child: Text(
+              d.score == 'X' ? 'Raté' : '${d.score} ess.',
+              style: GoogleFonts.courierPrime(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: c.textSecondary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(FacteurRadius.small),
+              child: Container(
+                height: 18,
+                color: c.backgroundSecondary,
+                alignment: Alignment.centerLeft,
+                child: FractionallySizedBox(
+                  widthFactor: factor,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: moi ? c.primary : GrilleConstants.gauge,
+                      borderRadius: BorderRadius.circular(FacteurRadius.small),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          SizedBox(
+            width: 44,
+            child: Text(
+              moi ? '${d.pct}% · toi' : '${d.pct}%',
+              textAlign: TextAlign.right,
+              style: GoogleFonts.courierPrime(
+                fontSize: 10,
+                color: c.textTertiary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/leaderboard_hero.dart
+++ b/apps/mobile/lib/features/grille/widgets/leaderboard_hero.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../models/grille_models.dart';
+
+/// En-tête du classement (`.gl-hero`) : badge percentile, grand chiffre, ligne
+/// « devant N% des Fact·eur·isses ».
+class LeaderboardHero extends StatelessWidget {
+  const LeaderboardHero({super.key, required this.leaderboard});
+
+  final GrilleLeaderboardResponse leaderboard;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.facteurColors;
+    final l = leaderboard;
+    final solved = l.monScoreInt != null;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: c.surface,
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        boxShadow: const [
+          BoxShadow(color: Color(0x1A000000), blurRadius: 4, offset: Offset(0, 2)),
+        ],
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 20),
+      child: Column(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              color: c.primary.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(FacteurRadius.pill),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  PhosphorIcons.medal(PhosphorIconsStyle.fill),
+                  size: 14,
+                  color: c.primary,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  'TOP ${l.percentile}% AUJOURD’HUI',
+                  style: GoogleFonts.courierPrime(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 1,
+                    color: c.primary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 14),
+          Text.rich(
+            TextSpan(
+              children: [
+                TextSpan(
+                  text: '${l.percentile}',
+                  style: GoogleFonts.fraunces(
+                    fontSize: 40,
+                    fontWeight: FontWeight.w700,
+                    height: 1,
+                    letterSpacing: -1,
+                    color: c.textPrimary,
+                  ),
+                ),
+                TextSpan(
+                  text: '%',
+                  style: GoogleFonts.fraunces(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w700,
+                    color: c.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 4),
+          _who(context, solved),
+        ],
+      ),
+    );
+  }
+
+  Widget _who(BuildContext context, bool solved) {
+    final c = context.facteurColors;
+    final base = FacteurTypography.bodyMedium(c.textSecondary)
+        .copyWith(fontSize: 14);
+    final bold =
+        base.copyWith(color: c.textPrimary, fontWeight: FontWeight.w700);
+    if (solved) {
+      return Text.rich(
+        TextSpan(
+          style: base,
+          children: [
+            const TextSpan(text: 'Trouvé en '),
+            TextSpan(text: '${leaderboard.monScore} essais', style: bold),
+            const TextSpan(text: ' — devant '),
+            TextSpan(text: '${100 - leaderboard.percentile}%', style: bold),
+            const TextSpan(text: ' des Fact·eur·isses'),
+          ],
+        ),
+        textAlign: TextAlign.center,
+      );
+    }
+    return Text(
+      'Pas trouvé aujourd’hui — mais tu étais dans la tournée. On remet ça demain.',
+      style: base,
+      textAlign: TextAlign.center,
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/leaderboard_podium.dart
+++ b/apps/mobile/lib/features/grille/widgets/leaderboard_podium.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../grille_constants.dart';
+import '../models/grille_models.dart';
+
+/// Podium du quartier (`.gl-podium`) — ordre visuel rang 2 · rang 1 · rang 3.
+/// L'avatar « Toi » est en ocre et légèrement plus grand.
+class LeaderboardPodium extends StatelessWidget {
+  const LeaderboardPodium({super.key, required this.quartier});
+
+  final List<GrilleQuartierItem> quartier;
+
+  GrilleQuartierItem? _byRank(int rank) {
+    for (final q in quartier) {
+      if (q.rang == rank) return q;
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rang1 = _byRank(1);
+    final rang2 = _byRank(2);
+    final rang3 = _byRank(3);
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Expanded(child: _col(context, rang2, 70)),
+        const SizedBox(width: 12),
+        Expanded(child: _col(context, rang1, 92)),
+        const SizedBox(width: 12),
+        Expanded(child: _col(context, rang3, 56)),
+      ],
+    );
+  }
+
+  Widget _col(BuildContext context, GrilleQuartierItem? p, double barHeight) {
+    if (p == null) return const SizedBox.shrink();
+    final c = context.facteurColors;
+    final moi = p.moi;
+    final label = moi ? 'Toi' : p.initiales;
+    final avatarSize = moi ? 54.0 : 46.0;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: avatarSize,
+          height: avatarSize,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: moi ? c.primary : GrilleConstants.steel,
+            border: Border.all(color: c.surface, width: 2),
+            boxShadow: moi
+                ? [
+                    BoxShadow(
+                      color: c.primary.withValues(alpha: 0.3),
+                      blurRadius: 8,
+                      offset: const Offset(0, 2),
+                    ),
+                  ]
+                : null,
+          ),
+          child: Text(
+            label,
+            style: FacteurTypography.labelLarge(
+              moi ? Colors.white : c.backgroundPrimary,
+            ).copyWith(fontSize: 13, fontWeight: FontWeight.w700),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          label,
+          style: FacteurTypography.bodySmall(
+            moi ? c.primary : c.textSecondary,
+          ).copyWith(
+            fontSize: 11.5,
+            fontWeight: moi ? FontWeight.w700 : FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          width: double.infinity,
+          height: barHeight,
+          alignment: Alignment.topCenter,
+          padding: const EdgeInsets.only(top: 7),
+          decoration: BoxDecoration(
+            color: moi ? c.primaryMuted : c.backgroundSecondary,
+            borderRadius: const BorderRadius.vertical(
+              top: Radius.circular(FacteurRadius.small),
+            ),
+          ),
+          child: Text(
+            p.score,
+            style: GoogleFonts.courierPrime(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: moi ? c.primary : c.textTertiary,
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          p.rang == 1 ? '1ᵉʳ' : '${p.rang}ᵉ',
+          style: GoogleFonts.courierPrime(
+            fontSize: 9,
+            letterSpacing: 1,
+            color: c.textTertiary,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/mot_grid.dart
+++ b/apps/mobile/lib/features/grille/widgets/mot_grid.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+
+import '../grille_constants.dart';
+import '../models/grille_models.dart';
+import '../models/tile_state.dart';
+import 'mot_grid_row.dart';
+
+/// Variante d'affichage de la grille.
+enum MotGridVariant { jeu, resultat }
+
+/// La grille de lettres complète (`.mot-grid`).
+///
+/// Compose des lignes révélées (essais joués), éventuellement la ligne en cours
+/// de saisie (variante [MotGridVariant.jeu]) et des lignes vides jusqu'au
+/// nombre d'essais max. Widget **pur** (aucune lecture de provider) → testable
+/// et golden-friendly.
+class MotGrid extends StatelessWidget {
+  const MotGrid({
+    super.key,
+    required this.longueur,
+    required this.essaisMax,
+    required this.premiereLettre,
+    required this.essais,
+    this.draft = '',
+    this.variant = MotGridVariant.jeu,
+    this.revealRow = -1,
+    this.shakeNonce = 0,
+  });
+
+  final int longueur;
+  final int essaisMax;
+  final String premiereLettre;
+  final List<GrilleEssai> essais;
+
+  /// Ligne en cours de saisie (variante jeu uniquement).
+  final String draft;
+  final MotGridVariant variant;
+
+  /// Index de la ligne à révéler par flip (`-1` = aucune).
+  final int revealRow;
+
+  /// Incrément de shake pour la ligne courante (essai refusé).
+  final int shakeNonce;
+
+  bool get _isJeu => variant == MotGridVariant.jeu;
+
+  double get _tileSize => _isJeu
+      ? GrilleConstants.tileSize
+      : GrilleConstants.tileSizeResult;
+  double get _gap =>
+      _isJeu ? GrilleConstants.tileGap : GrilleConstants.tileGapResult;
+
+  /// Nombre total de lignes : tous les essais en résultat, sinon `essaisMax`.
+  int get _totalRows => _isJeu ? essaisMax : essais.length;
+
+  List<MotCell> _revealedCells(GrilleEssai essai) {
+    return List.generate(longueur, (i) {
+      final letter = i < essai.mot.length ? essai.mot[i] : '';
+      final etat = i < essai.etats.length ? essai.etats[i] : 'absent';
+      return MotCell(TileStateX.fromServer(etat), letter);
+    });
+  }
+
+  List<MotCell> _currentCells() {
+    return List.generate(longueur, (i) {
+      if (i < draft.length) {
+        return MotCell(TileState.filled, draft[i]);
+      }
+      if (i == 0 && draft.isEmpty) {
+        return MotCell(TileState.hint, premiereLettre);
+      }
+      return const MotCell(TileState.empty, '');
+    });
+  }
+
+  List<MotCell> _emptyCells() =>
+      List.generate(longueur, (_) => const MotCell(TileState.empty, ''));
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = <Widget>[];
+    final currentRowIndex = essais.length;
+
+    for (var r = 0; r < _totalRows; r++) {
+      List<MotCell> cells;
+      var reveal = false;
+      var shake = 0;
+
+      if (r < essais.length) {
+        cells = _revealedCells(essais[r]);
+        reveal = r == revealRow;
+      } else if (_isJeu && r == currentRowIndex) {
+        cells = _currentCells();
+        shake = shakeNonce;
+      } else {
+        cells = _emptyCells();
+      }
+
+      rows.add(
+        MotGridRow(
+          key: ValueKey('grille-row-$r'),
+          cells: cells,
+          size: _tileSize,
+          gap: _gap,
+          reveal: reveal,
+          shakeNonce: shake,
+        ),
+      );
+      if (r < _totalRows - 1) {
+        rows.add(SizedBox(height: _gap));
+      }
+    }
+
+    return Column(mainAxisSize: MainAxisSize.min, children: rows);
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/mot_grid_row.dart
+++ b/apps/mobile/lib/features/grille/widgets/mot_grid_row.dart
@@ -1,0 +1,171 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../grille_constants.dart';
+import '../models/tile_state.dart';
+import 'mot_tile.dart';
+
+/// Une cellule de la ligne : état + lettre.
+class MotCell {
+  const MotCell(this.state, this.letter);
+  final TileState state;
+  final String letter;
+}
+
+/// Une ligne de la grille, porteuse des deux animations :
+///
+/// - **flip** de révélation (`@keyframes mt-flip`) : `rotateX 0 → -88° → 0`,
+///   420 ms `ease-out-cubic`, décalé de 95 ms par colonne. Joué une seule fois
+///   lorsque [reveal] passe à vrai.
+/// - **shake** d'un mot invalide (~250 ms) : translation horizontale amortie,
+///   rejouée à chaque incrément de [shakeNonce].
+///
+/// `MediaQuery.disableAnimations` (reduced-motion) → révélation directe, pas de
+/// shake.
+class MotGridRow extends StatefulWidget {
+  const MotGridRow({
+    super.key,
+    required this.cells,
+    this.size = GrilleConstants.tileSize,
+    this.gap = GrilleConstants.tileGap,
+    this.reveal = false,
+    this.shakeNonce = 0,
+  });
+
+  final List<MotCell> cells;
+  final double size;
+  final double gap;
+
+  /// Joue le flip de révélation une fois (ligne fraîchement validée).
+  final bool reveal;
+
+  /// Incrémenté pour déclencher un shake (essai refusé).
+  final int shakeNonce;
+
+  @override
+  State<MotGridRow> createState() => _MotGridRowState();
+}
+
+class _MotGridRowState extends State<MotGridRow>
+    with TickerProviderStateMixin {
+  late final AnimationController _flip;
+  late final AnimationController _shake;
+
+  static const double _maxTiltDeg = 88;
+  static const double _peakAt = 0.45; // 45 % de la durée
+
+  @override
+  void initState() {
+    super.initState();
+    final n = widget.cells.length;
+    _flip = AnimationController(
+      vsync: this,
+      duration: GrilleConstants.flipDuration +
+          GrilleConstants.flipStagger * (n > 0 ? n - 1 : 0),
+    );
+    _shake = AnimationController(
+      vsync: this,
+      duration: GrilleConstants.shakeDuration,
+    );
+    if (widget.reveal) {
+      // Joué après le 1er frame pour respecter disableAnimations du contexte.
+      WidgetsBinding.instance.addPostFrameCallback((_) => _maybePlayFlip());
+    }
+  }
+
+  @override
+  void didUpdateWidget(MotGridRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.reveal && !oldWidget.reveal) {
+      _maybePlayFlip();
+    }
+    if (widget.shakeNonce != oldWidget.shakeNonce) {
+      _maybeShake();
+    }
+  }
+
+  bool get _reducedMotion {
+    final mq = MediaQuery.maybeOf(context);
+    return mq?.disableAnimations ?? false;
+  }
+
+  void _maybePlayFlip() {
+    if (!mounted) return;
+    if (_reducedMotion) {
+      _flip.value = 1; // révélation directe
+      return;
+    }
+    _flip.forward(from: 0);
+  }
+
+  void _maybeShake() {
+    if (!mounted || _reducedMotion) return;
+    _shake.forward(from: 0);
+  }
+
+  @override
+  void dispose() {
+    _flip.dispose();
+    _shake.dispose();
+    super.dispose();
+  }
+
+  /// Angle (radians) d'une tuile à l'instant courant du contrôleur de flip.
+  double _tiltFor(int index) {
+    final total = _flip.duration!.inMilliseconds;
+    final elapsed = _flip.value * total;
+    final start = index * GrilleConstants.flipStagger.inMilliseconds;
+    final local =
+        ((elapsed - start) / GrilleConstants.flipDuration.inMilliseconds)
+            .clamp(0.0, 1.0);
+    double deg;
+    if (local <= _peakAt) {
+      deg = -_maxTiltDeg * (local / _peakAt);
+    } else {
+      deg = -_maxTiltDeg * (1 - (local - _peakAt) / (1 - _peakAt));
+    }
+    return deg * math.pi / 180;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tiles = <Widget>[];
+    for (var i = 0; i < widget.cells.length; i++) {
+      final cell = widget.cells[i];
+      final tile = MotTile(state: cell.state, letter: cell.letter, size: widget.size);
+      tiles.add(
+        AnimatedBuilder(
+          animation: _flip,
+          builder: (context, child) {
+            final matrix = Matrix4.identity()
+              ..setEntry(3, 2, 0.0015) // perspective
+              ..rotateX(_tiltFor(i));
+            return Transform(
+              alignment: Alignment.center,
+              transform: matrix,
+              child: child,
+            );
+          },
+          child: tile,
+        ),
+      );
+      if (i < widget.cells.length - 1) {
+        tiles.add(SizedBox(width: widget.gap));
+      }
+    }
+
+    final row = Row(mainAxisSize: MainAxisSize.min, children: tiles);
+
+    return AnimatedBuilder(
+      animation: _shake,
+      builder: (context, child) {
+        final t = _shake.value;
+        // Oscillation amortie : 4 allers-retours qui s'éteignent.
+        final dx = t == 0 ? 0.0 : math.sin(t * math.pi * 4) * 8 * (1 - t);
+        return Transform.translate(offset: Offset(dx, 0), child: child);
+      },
+      child: row,
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/mot_share_grid.dart
+++ b/apps/mobile/lib/features/grille/widgets/mot_share_grid.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+import '../../../config/theme.dart';
+import '../grille_constants.dart';
+import '../models/grille_models.dart';
+import '../models/tile_state.dart';
+
+/// Grille de partage (`.mot-share-grid`) : carrés de couleur **sans lettre**
+/// (façon Wordle) → partageable sans spoiler.
+class MotShareGrid extends StatelessWidget {
+  const MotShareGrid({super.key, required this.essais});
+
+  final List<GrilleEssai> essais;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (var r = 0; r < essais.length; r++) ...[
+          _row(context, essais[r]),
+          if (r < essais.length - 1) const SizedBox(height: 5),
+        ],
+      ],
+    );
+  }
+
+  Widget _row(BuildContext context, GrilleEssai essai) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (var i = 0; i < essai.etats.length; i++) ...[
+          _cell(context, TileStateX.fromServer(essai.etats[i])),
+          if (i < essai.etats.length - 1) const SizedBox(width: 5),
+        ],
+      ],
+    );
+  }
+
+  Widget _cell(BuildContext context, TileState state) {
+    final c = context.facteurColors;
+    Color color;
+    switch (state) {
+      case TileState.place:
+        color = c.success;
+      case TileState.present:
+        color = c.primary;
+      default:
+        color = GrilleConstants.absentGrille;
+    }
+    return Container(
+      width: GrilleConstants.shareCellSize,
+      height: GrilleConstants.shareCellSize,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(GrilleConstants.shareCellRadius),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/grille/widgets/mot_tile.dart
+++ b/apps/mobile/lib/features/grille/widgets/mot_tile.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../grille_constants.dart';
+import '../models/tile_state.dart';
+import 'dashed_border.dart';
+
+/// Couleurs résolues d'une tuile selon son [TileState] (tokens + hors-token).
+class _TileColors {
+  const _TileColors(this.background, this.border, this.foreground);
+  final Color background;
+  final Color border;
+  final Color foreground;
+
+  static _TileColors of(BuildContext context, TileState state) {
+    final c = context.facteurColors;
+    switch (state) {
+      case TileState.place:
+        return _TileColors(c.success, c.success, Colors.white);
+      case TileState.present:
+        return _TileColors(c.primary, c.primary, Colors.white);
+      case TileState.absent:
+        return const _TileColors(
+          GrilleConstants.absentGrille,
+          GrilleConstants.absentGrille,
+          Colors.white,
+        );
+      case TileState.hint:
+        return _TileColors(
+          c.primary.withValues(alpha: 0.04),
+          c.primary,
+          c.primary,
+        );
+      case TileState.filled:
+        return _TileColors(c.surfacePaper, c.textSecondary, c.textPrimary);
+      case TileState.empty:
+        return _TileColors(c.surfacePaper, c.border, c.textPrimary);
+    }
+  }
+}
+
+/// Une case de la grille « Le mot du jour ».
+///
+/// Géométrie fidèle à `.mt-tile` (grille.css) : rayon 6, bord 1.5, lettre serif
+/// `size*0.52`. La case `filled` grossit légèrement (`scale 1.02`), la `hint`
+/// a un bord pointillé primary, la `place` porte le sceau `mt-seal` (liseré
+/// pointillé blanc en retrait).
+class MotTile extends StatelessWidget {
+  const MotTile({
+    super.key,
+    required this.state,
+    this.letter = '',
+    this.size = GrilleConstants.tileSize,
+  });
+
+  final TileState state;
+  final String letter;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = _TileColors.of(context, state);
+    final isHint = state == TileState.hint;
+    final isFilled = state == TileState.filled;
+
+    final content = Container(
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: colors.background,
+        borderRadius: BorderRadius.circular(GrilleConstants.tileRadius),
+        border: isHint
+            ? null
+            : Border.all(color: colors.border, width: 1.5),
+      ),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          // Bord pointillé pour la case « première lettre offerte ».
+          if (isHint)
+            Positioned.fill(
+              child: CustomPaint(
+                painter: DashedRRectPainter(
+                  color: colors.border,
+                  strokeWidth: 1.5,
+                  radius: GrilleConstants.tileRadius,
+                ),
+              ),
+            ),
+          // Sceau « bonne adresse » sur les lettres livrées.
+          if (state == TileState.place)
+            Positioned.fill(
+              child: Padding(
+                padding: const EdgeInsets.all(4),
+                child: CustomPaint(
+                  painter: DashedRRectPainter(
+                    color: Colors.white.withValues(alpha: 0.45),
+                    strokeWidth: 1,
+                    radius: 3,
+                  ),
+                ),
+              ),
+            ),
+          Text(
+            letter.toUpperCase(),
+            style: GoogleFonts.fraunces(
+              fontSize: size * 0.52,
+              fontWeight: FontWeight.w700,
+              height: 1,
+              color: colors.foreground,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (isFilled) {
+      return Transform.scale(scale: 1.02, child: content);
+    }
+    return content;
+  }
+}

--- a/apps/mobile/test/features/grille/models/grille_models_test.dart
+++ b/apps/mobile/test/features/grille/models/grille_models_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/features/grille/models/grille_models.dart';
+
+void main() {
+  group('GrilleTodayResponse.fromJson', () {
+    test('lit les clés camelCase byte-exact, numero String, mot null', () {
+      final json = <String, dynamic>{
+        'date': '2026-05-30',
+        'dateAffichee': 'Vendredi 30 mai',
+        'dateCourt': 'Ven. 30 mai',
+        'numero': 'N°143',
+        'longueur': 6,
+        'essaisMax': 6,
+        'premiereLettre': 'C',
+        'indice': 'Le mot qui a traversé ta tournée',
+        'theme': 'Environnement',
+        'statut': 'in_progress',
+        'essais': [
+          {'mot': 'PLACER', 'etats': ['absent', 'present', 'absent', 'absent', 'absent', 'present']},
+        ],
+        'nbEssais': 1,
+        'mot': null,
+        'pourquoi': null,
+        'streak': 5,
+        'prochainMotDansSec': 47000,
+      };
+      final r = GrilleTodayResponse.fromJson(json);
+      expect(r.numero, 'N°143');
+      expect(r.numero, isA<String>());
+      expect(r.longueur, 6);
+      expect(r.nbEssais, 1);
+      expect(r.essais.single.mot, 'PLACER');
+      expect(r.essais.single.etats.length, 6);
+      expect(r.mot, isNull);
+      expect(r.pourquoi, isNull);
+      expect(r.prochainMotDansSec, 47000);
+      expect(r.isInProgress, isTrue);
+      expect(r.isFinished, isFalse);
+    });
+
+    test('statut solved expose le mot et les getters', () {
+      final r = GrilleTodayResponse.fromJson({
+        'date': '2026-05-30',
+        'dateAffichee': 'x',
+        'dateCourt': 'x',
+        'numero': 'N°143',
+        'longueur': 6,
+        'essaisMax': 6,
+        'premiereLettre': 'C',
+        'indice': 'x',
+        'theme': 'x',
+        'statut': 'solved',
+        'essais': const <Map<String, dynamic>>[],
+        'nbEssais': 3,
+        'mot': 'CLIMAT',
+        'pourquoi': 'parce que',
+        'streak': 5,
+        'prochainMotDansSec': 1000,
+      });
+      expect(r.isSolved, isTrue);
+      expect(r.isFinished, isTrue);
+      expect(r.mot, 'CLIMAT');
+    });
+  });
+
+  group('GrilleGuessResponse.fromJson', () {
+    test('refus: valide=false, raison seule, pas de crash sur nulls', () {
+      final r = GrilleGuessResponse.fromJson({
+        'valide': false,
+        'raison': 'hors_dictionnaire',
+        'etats': null,
+        'statut': null,
+        'nbEssais': null,
+        'mot': null,
+        'pourquoi': null,
+      });
+      expect(r.valide, isFalse);
+      expect(r.raison, 'hors_dictionnaire');
+      expect(r.etats, isNull);
+      expect(r.isFinished, isFalse);
+    });
+
+    test('acceptation solved', () {
+      final r = GrilleGuessResponse.fromJson({
+        'valide': true,
+        'raison': null,
+        'etats': ['place', 'place', 'place', 'place', 'place', 'place'],
+        'statut': 'solved',
+        'nbEssais': 3,
+        'mot': 'CLIMAT',
+        'pourquoi': 'parce que',
+      });
+      expect(r.valide, isTrue);
+      expect(r.isSolved, isTrue);
+      expect(r.etats!.length, 6);
+    });
+  });
+
+  group('Union int | "X" (monScore / score)', () {
+    test('leaderboard normalise les scores entiers et "X"', () {
+      final r = GrilleLeaderboardResponse.fromJson({
+        'percentile': 12,
+        'joueurs': 4218,
+        'monScore': 3,
+        'distribution': [
+          {'score': 1, 'pct': 4},
+          {'score': 'X', 'pct': 3},
+        ],
+        'quartier': [
+          {'initiales': 'A·M', 'score': 2, 'rang': 1, 'moi': false},
+          {'initiales': 'Toi', 'score': 3, 'rang': 2, 'moi': true},
+        ],
+        'streak': 5,
+      });
+      expect(r.monScore, '3');
+      expect(r.monScoreInt, 3);
+      expect(r.distribution[0].score, '1');
+      expect(r.distribution[0].scoreInt, 1);
+      expect(r.distribution[1].score, 'X');
+      expect(r.distribution[1].scoreInt, isNull);
+      expect(r.quartier[1].moi, isTrue);
+      expect(r.quartier[0].moi, isFalse);
+    });
+
+    test('monScore="X" (partie ratée)', () {
+      final r = GrilleLeaderboardResponse.fromJson({
+        'percentile': 50,
+        'joueurs': 100,
+        'monScore': 'X',
+        'distribution': const <Map<String, dynamic>>[],
+        'quartier': const <Map<String, dynamic>>[],
+        'streak': 0,
+      });
+      expect(r.monScore, 'X');
+      expect(r.monScoreInt, isNull);
+    });
+  });
+}

--- a/apps/mobile/test/features/grille/models/tile_state_test.dart
+++ b/apps/mobile/test/features/grille/models/tile_state_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/features/grille/models/tile_state.dart';
+
+void main() {
+  group('TileStateX.fromServer', () {
+    test('mappe les trois états serveur', () {
+      expect(TileStateX.fromServer('place'), TileState.place);
+      expect(TileStateX.fromServer('present'), TileState.present);
+      expect(TileStateX.fromServer('absent'), TileState.absent);
+    });
+
+    test('dégrade une valeur inconnue en absent (pas de crash)', () {
+      expect(TileStateX.fromServer('wat'), TileState.absent);
+      expect(TileStateX.fromServer(''), TileState.absent);
+    });
+  });
+
+  group('shareEmoji', () {
+    test('emoji sans spoiler pour les états révélés', () {
+      expect(TileState.place.shareEmoji, '🟩');
+      expect(TileState.present.shareEmoji, '🟧');
+      expect(TileState.absent.shareEmoji, '⬛');
+    });
+
+    test('états client-only sans emoji', () {
+      expect(TileState.empty.shareEmoji, '');
+      expect(TileState.filled.shareEmoji, '');
+      expect(TileState.hint.shareEmoji, '');
+    });
+  });
+
+  group('computeKeyboardStates (rang place > present > absent)', () {
+    test('garde le rang le plus fort par lettre', () {
+      // C en absent (essai 1) puis place (essai 2) → doit finir place.
+      final states = computeKeyboardStates([
+        (mot: 'PLACER', etats: ['absent', 'absent', 'absent', 'present', 'absent', 'present']),
+        (mot: 'CLIMAT', etats: ['place', 'place', 'absent', 'present', 'absent', 'place']),
+      ]);
+      expect(states['C'], TileState.place); // present→place gagne
+      expect(states['L'], TileState.place);
+      expect(states['R'], TileState.present); // present, jamais bien placé
+      expect(states['A'], TileState.absent); // absente dans les deux essais
+      expect(states['T'], TileState.place);
+      expect(states['P'], TileState.absent);
+    });
+
+    test('un present ne rétrograde jamais un place déjà acquis', () {
+      final states = computeKeyboardStates([
+        (mot: 'AA', etats: ['place', 'present']),
+      ]);
+      expect(states['A'], TileState.place);
+    });
+
+    test('minuscules normalisées en majuscules', () {
+      final states = computeKeyboardStates([
+        (mot: 'climat', etats: ['place', 'absent', 'absent', 'absent', 'absent', 'absent']),
+      ]);
+      expect(states.containsKey('C'), isTrue);
+      expect(states['C'], TileState.place);
+    });
+
+    test('aucune lettre pour une liste vide', () {
+      expect(computeKeyboardStates([]), isEmpty);
+    });
+  });
+}

--- a/apps/mobile/test/features/grille/providers/grille_provider_test.dart
+++ b/apps/mobile/test/features/grille/providers/grille_provider_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:facteur/features/grille/models/grille_models.dart';
+import 'package:facteur/features/grille/models/tile_state.dart';
+import 'package:facteur/features/grille/providers/grille_provider.dart';
+import 'package:facteur/features/grille/repositories/grille_repository.dart';
+
+/// Repository en mémoire — implémente le contrat sans réseau.
+class _FakeGrilleRepository implements GrilleRepository {
+  _FakeGrilleRepository(this.today, {this.guessResult});
+
+  GrilleTodayResponse today;
+  GrilleGuessResponse? guessResult;
+  int guessCalls = 0;
+
+  @override
+  Future<GrilleTodayResponse> getToday() async => today;
+
+  @override
+  Future<GrilleGuessResponse> submitGuess(String mot) async {
+    guessCalls++;
+    return guessResult ?? const GrilleGuessResponse(valide: false, raison: 'longueur');
+  }
+
+  @override
+  Future<GrilleLeaderboardResponse> getLeaderboard() async =>
+      throw UnimplementedError();
+}
+
+GrilleTodayResponse _todayInProgress() => const GrilleTodayResponse(
+      date: '2026-05-30',
+      dateAffichee: 'Vendredi 30 mai',
+      dateCourt: 'Ven. 30 mai',
+      numero: 'N°143',
+      longueur: 6,
+      essaisMax: 6,
+      premiereLettre: 'C',
+      indice: 'indice',
+      theme: 'theme',
+      statut: 'in_progress',
+      essais: [],
+      nbEssais: 0,
+      streak: 5,
+      prochainMotDansSec: 1000,
+    );
+
+Future<ProviderContainer> _container(_FakeGrilleRepository repo) async {
+  final c = ProviderContainer(
+    overrides: [grilleRepositoryProvider.overrideWithValue(repo)],
+  );
+  addTearDown(c.dispose);
+  // Laisse le build() async résoudre.
+  await c.read(grilleProvider.future);
+  return c;
+}
+
+void main() {
+  test('longueur incomplète : refus local, aucun appel réseau, draft préservé',
+      () async {
+    final repo = _FakeGrilleRepository(_todayInProgress());
+    final c = await _container(repo);
+    final notifier = c.read(grilleProvider.notifier);
+
+    for (final l in ['C', 'L', 'I']) {
+      notifier.addLetter(l);
+    }
+    await notifier.submitGuess();
+
+    final s = c.read(grilleProvider).value!;
+    expect(repo.guessCalls, 0, reason: 'pas de POST si longueur incomplète');
+    expect(s.invalidReason, 'longueur');
+    expect(s.invalidNonce, 1);
+    expect(s.draft, 'CLI', reason: 'la saisie est conservée');
+    expect(s.today.essais, isEmpty);
+  });
+
+  test('valide=false : essai NON consommé, shake, draft préservé', () async {
+    final repo = _FakeGrilleRepository(
+      _todayInProgress(),
+      guessResult: const GrilleGuessResponse(
+        valide: false,
+        raison: 'hors_dictionnaire',
+      ),
+    );
+    final c = await _container(repo);
+    final notifier = c.read(grilleProvider.notifier);
+
+    for (final l in 'PLACER'.split('')) {
+      notifier.addLetter(l);
+    }
+    await notifier.submitGuess();
+
+    final s = c.read(grilleProvider).value!;
+    expect(repo.guessCalls, 1);
+    expect(s.invalidReason, 'hors_dictionnaire');
+    expect(s.invalidNonce, 1);
+    expect(s.draft, 'PLACER', reason: 'essai non consommé → saisie conservée');
+    expect(s.today.essais, isEmpty);
+    expect(s.submitting, isFalse);
+  });
+
+  test('valide=true solved : essai ajouté, draft vidé, justFinished', () async {
+    final repo = _FakeGrilleRepository(
+      _todayInProgress(),
+      guessResult: const GrilleGuessResponse(
+        valide: true,
+        etats: ['place', 'place', 'place', 'place', 'place', 'place'],
+        statut: 'solved',
+        nbEssais: 1,
+        mot: 'CLIMAT',
+        pourquoi: 'parce que',
+      ),
+    );
+    final c = await _container(repo);
+    final notifier = c.read(grilleProvider.notifier);
+
+    for (final l in 'CLIMAT'.split('')) {
+      notifier.addLetter(l);
+    }
+    await notifier.submitGuess();
+
+    final s = c.read(grilleProvider).value!;
+    expect(s.today.essais.length, 1);
+    expect(s.today.essais.single.mot, 'CLIMAT');
+    expect(s.today.isSolved, isTrue);
+    expect(s.today.mot, 'CLIMAT');
+    expect(s.draft, isEmpty);
+    expect(s.justFinished, isTrue);
+    expect(s.revealRow, 0);
+
+    // Le clavier reflète les états après l'essai.
+    final kb = c.read(grilleKeyboardStatesProvider);
+    expect(kb['C'], TileState.place);
+    expect(kb['M'], TileState.place);
+
+    // consumeJustFinished éteint le flag transitoire.
+    notifier.consumeJustFinished();
+    expect(c.read(grilleProvider).value!.justFinished, isFalse);
+  });
+
+  test('addLetter borné à longueur ; removeLetter retire la dernière', () async {
+    final repo = _FakeGrilleRepository(_todayInProgress());
+    final c = await _container(repo);
+    final notifier = c.read(grilleProvider.notifier);
+
+    for (final l in 'CLIMATIQUE'.split('')) {
+      notifier.addLetter(l);
+    }
+    expect(c.read(grilleProvider).value!.draft, 'CLIMAT'); // borné à 6
+
+    notifier.removeLetter();
+    expect(c.read(grilleProvider).value!.draft, 'CLIMA');
+  });
+}

--- a/apps/mobile/test/features/grille/utils/grille_utils_test.dart
+++ b/apps/mobile/test/features/grille/utils/grille_utils_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/grille/models/grille_models.dart';
+import 'package:facteur/features/grille/utils/grille_format.dart';
+import 'package:facteur/features/grille/utils/grille_share_text.dart';
+
+void main() {
+  group('formatCountdown (NBSP)', () {
+    test('heures + minutes : « 13 h 20 » avec NBSP', () {
+      final s = formatCountdown(13 * 3600 + 20 * 60);
+      expect(s, '13${nbsp}h${nbsp}20');
+      expect(s, '13 h 20');
+      expect(s.contains(' '), isFalse, reason: 'aucun espace normal');
+    });
+
+    test('heures pleines : « 13 h »', () {
+      expect(formatCountdown(13 * 3600), '13${nbsp}h');
+    });
+
+    test('minutes seules : « 45 min »', () {
+      expect(formatCountdown(45 * 60), '45${nbsp}min');
+    });
+
+    test('secondes seules + valeurs négatives bornées à 0', () {
+      expect(formatCountdown(30), '30${nbsp}s');
+      expect(formatCountdown(-5), '0${nbsp}s');
+    });
+  });
+
+  group('grille emoji sans spoiler', () {
+    final today = GrilleTodayResponse.fromJson({
+      'date': '2026-05-30',
+      'dateAffichee': 'Vendredi 30 mai',
+      'dateCourt': 'Ven. 30 mai',
+      'numero': 'N°143',
+      'longueur': 6,
+      'essaisMax': 6,
+      'premiereLettre': 'C',
+      'indice': 'x',
+      'theme': 'x',
+      'statut': 'solved',
+      'essais': [
+        {'mot': 'PLACER', 'etats': ['absent', 'present', 'absent', 'absent', 'absent', 'present']},
+        {'mot': 'CLIMAT', 'etats': ['place', 'place', 'place', 'place', 'place', 'place']},
+      ],
+      'nbEssais': 2,
+      'mot': 'CLIMAT',
+      'pourquoi': 'parce que',
+      'streak': 5,
+      'prochainMotDansSec': 1000,
+    });
+
+    test('la grille emoji ne contient AUCUNE lettre (anti-spoiler)', () {
+      final grid = buildGrilleEmojiGrid(today.essais);
+      expect(grid, '⬛🟧⬛⬛⬛🟧\n🟩🟩🟩🟩🟩🟩');
+      // Aucune lettre A–Z (le mot ne fuite jamais).
+      expect(RegExp(r'[A-Za-z]').hasMatch(grid), isFalse);
+    });
+
+    test('texte de partage : en-tête + score N/6 + lien, sans le mot', () {
+      final text = buildGrilleShareText(today);
+      expect(text, contains('La Grille du jour N°143 · Ven. 30 mai · 2/6'));
+      expect(text, contains('🟩🟩🟩🟩🟩🟩'));
+      expect(text, contains(buildGrilleShareLink(today)));
+      expect(text.contains('CLIMAT'), isFalse, reason: 'le mot ne doit pas fuiter');
+    });
+
+    test('score raté = X/6', () {
+      final failed = today.copyWith(statut: 'failed', nbEssais: 6);
+      expect(grilleShareScore(failed), 'X/6');
+    });
+  });
+}

--- a/apps/mobile/test/features/grille/widgets/grille_widgets_test.dart
+++ b/apps/mobile/test/features/grille/widgets/grille_widgets_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/grille/models/grille_models.dart';
+import 'package:facteur/features/grille/models/tile_state.dart';
+import 'package:facteur/features/grille/widgets/azerty_keyboard.dart';
+import 'package:facteur/features/grille/widgets/mot_grid.dart';
+import 'package:facteur/features/grille/widgets/mot_share_grid.dart';
+import 'package:facteur/features/grille/widgets/leaderboard_podium.dart';
+import 'package:facteur/features/grille/widgets/leaderboard_distribution.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: FacteurTheme.lightTheme,
+    home: Scaffold(
+      backgroundColor: FacteurPalettes.light.backgroundPrimary,
+      body: Center(child: child),
+    ),
+  );
+}
+
+final _essais = [
+  const GrilleEssai(
+    mot: 'PLACER',
+    etats: ['absent', 'present', 'absent', 'absent', 'absent', 'present'],
+  ),
+  const GrilleEssai(
+    mot: 'CLIMAT',
+    etats: ['place', 'place', 'place', 'place', 'place', 'place'],
+  ),
+];
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('MotGrid (jeu) montre la 1re lettre offerte en hint', (t) async {
+    await t.pumpWidget(_wrap(const MotGrid(
+      longueur: 6,
+      essaisMax: 6,
+      premiereLettre: 'C',
+      essais: [],
+      draft: '',
+    )));
+    await t.pumpAndSettle();
+    // La lettre offerte « C » est visible sur la ligne courante.
+    expect(find.text('C'), findsWidgets);
+  });
+
+  testWidgets('MotGrid (résultat) rend les lettres révélées', (t) async {
+    await t.pumpWidget(_wrap(MotGrid(
+      longueur: 6,
+      essaisMax: 6,
+      premiereLettre: 'C',
+      essais: _essais,
+      variant: MotGridVariant.resultat,
+    )));
+    await t.pumpAndSettle();
+    expect(find.text('P'), findsWidgets);
+    expect(find.text('A'), findsWidgets);
+  });
+
+  testWidgets('MotShareGrid : carrés colorés SANS lettre', (t) async {
+    await t.pumpWidget(_wrap(MotShareGrid(essais: _essais)));
+    await t.pumpAndSettle();
+    // Aucune lettre ne doit apparaître (anti-spoiler).
+    expect(find.byType(Text), findsNothing);
+  });
+
+  testWidgets('Clavier : tap lettre/Entrée/Effacer câblés', (t) async {
+    final keys = <String>[];
+    var enter = 0;
+    var back = 0;
+    await t.pumpWidget(_wrap(AzertyKeyboard(
+      states: const {'C': TileState.place},
+      onKey: keys.add,
+      onEnter: () => enter++,
+      onBackspace: () => back++,
+    )));
+    await t.pumpAndSettle();
+
+    await t.tap(find.text('A'));
+    await t.tap(find.text('Entrée'));
+    expect(keys, ['A']);
+    expect(enter, 1);
+    expect(back, 0);
+  });
+
+  testWidgets('Clavier : une touche « place » est colorée en succès', (t) async {
+    await t.pumpWidget(_wrap(AzertyKeyboard(
+      states: const {'C': TileState.place},
+      onKey: (_) {},
+      onEnter: () {},
+      onBackspace: () {},
+    )));
+    await t.pumpAndSettle();
+    final success = FacteurPalettes.light.success;
+    final hasSuccessKey = t.widgetList<Container>(find.byType(Container)).any((w) {
+      final d = w.decoration;
+      return d is BoxDecoration && d.color == success;
+    });
+    expect(hasSuccessKey, isTrue);
+  });
+
+  testWidgets('Podium : « Toi » présent et avatar en ocre', (t) async {
+    final quartier = [
+      const GrilleQuartierItem(initiales: 'A·M', score: '2', rang: 1),
+      const GrilleQuartierItem(initiales: 'Toi', score: '3', rang: 2, moi: true),
+      const GrilleQuartierItem(initiales: 'L·B', score: '3', rang: 3),
+    ];
+    await t.pumpWidget(_wrap(LeaderboardPodium(quartier: quartier)));
+    await t.pumpAndSettle();
+    expect(find.text('Toi'), findsWidgets);
+
+    final primary = FacteurPalettes.light.primary;
+    final hasOcreAvatar = t.widgetList<Container>(find.byType(Container)).any((w) {
+      final d = w.decoration;
+      return d is BoxDecoration &&
+          d.color == primary &&
+          d.shape == BoxShape.circle;
+    });
+    expect(hasOcreAvatar, isTrue);
+  });
+
+  testWidgets('Distribution : la ligne du joueur porte « · toi »', (t) async {
+    await t.pumpWidget(_wrap(const LeaderboardDistribution(
+      distribution: [
+        GrilleDistributionItem(score: '2', pct: 19),
+        GrilleDistributionItem(score: '3', pct: 31),
+        GrilleDistributionItem(score: 'X', pct: 3),
+      ],
+      monScore: '3',
+    )));
+    await t.pumpAndSettle();
+    expect(find.textContaining('· toi'), findsOneWidget);
+    expect(find.text('Raté'), findsOneWidget);
+  });
+}

--- a/docs/stories/core/24.2.la-grille-du-jour-mobile.md
+++ b/docs/stories/core/24.2.la-grille-du-jour-mobile.md
@@ -1,0 +1,84 @@
+# Story 24.2 — Mobile « La Grille du jour » (Flutter, hi-fi)
+
+> **Type** : Feature · **Épic** : 24 (La Grille du jour) · **Branche** : `boujonlaurin-dotcom/grille-du-jour-mobile` → `main`
+> PR 1 (Story 24.1, commit `0cd2379f`) a livré le backend. Cette story construit le **module mobile Flutter** `features/grille/` qui consomme le contrat figé.
+
+## Objectif
+
+Brancher « le mot » (Wordle Facteur, 6 lettres, 1re lettre offerte) côté mobile : 6 surfaces MVP
+(Jeu, Résultat, Partage, Classement, Déjà-joué, CarteCTA) + l'entrée fin-de-Tournée, en haute
+fidélité au DS Facteur (thème/tokens existants), sans réinventer de couleurs/valeurs hors tokens
+(sauf hors-token explicitement listés dans le plan).
+
+## Périmètre
+
+**DANS le MVP** : `MotMasthead`, `MotGrid`/`MotGridRow`/`MotTile`/`mt-seal`, clavier AZERTY,
+`MotShareGrid`, `MiniMotGrid`, écran Jeu, écran Résultat, écran Partage (texte/lien via Clipboard),
+Classement, Déjà-joué, GAppBar, `CarteCTA` (version `mot`, 3 états).
+
+**HORS MVP** : toute la branche `questions` (vraifake/adresse/proportion), planche de timbres,
+`CarteQuestion`, `GCachet`, `GFacteurNote`, `GMasthead` (pips), `CartePlusLoin`, export image de
+partage (`RepaintBoundary→toImage` + chip « Image »), handler deep-link entrant `grille`.
+
+## Contrat backend (source de vérité — `packages/api/app/schemas/grille.py`)
+
+- `GET grille/today` → `GrilleTodayResponse`
+- `POST grille/today/guess` body `{ "mot": string }` → `GrilleGuessResponse` (`valide:false` = data, pas exception)
+- `GET grille/today/leaderboard` → `GrilleLeaderboardResponse` (409 `partie_en_cours`)
+- Clés JSON = camelCase FR **byte-exact, aucun alias_generator**. Côté mobile : noms de champs =
+  clés JSON (pas de `build.yaml`/`field_rename`). `numero` = `String`. Union `int|"X"` (monScore/score)
+  normalisée en `String` + getter `int?`.
+- États serveur : `place|present|absent`. États UI client-only : `empty|filled|hint`.
+
+## Décisions PO
+
+1. **1 seule PR** cohérente (`--base main`).
+2. **Partage** : pas de dépendance `share_plus`. Texte + lien via `Clipboard.setData` (built-in) +
+   toast « copié ». Feuille de partage affichée à l'écran ; export image + chip « Image » différés
+   (follow-up). Chips affichées : « Texte · Lien ».
+
+## Architecture — `apps/mobile/lib/features/grille/`
+
+```
+models/        tile_state.dart · grille_models.dart (+ générés)
+repositories/  grille_repository.dart
+providers/     grille_provider.dart · grille_leaderboard_provider.dart
+screens/       grille_screen.dart · grille_leaderboard_screen.dart · grille_share_screen.dart
+widgets/       grille_masthead · mot_grid · mot_grid_row · mot_tile · azerty_keyboard ·
+               grille_status_line · grille_result_view · grille_deja_joue_view · grille_countdown ·
+               mot_share_grid · grille_share_card · leaderboard_hero · leaderboard_podium ·
+               leaderboard_distribution · carte_cta · dashed_border
+utils/         grille_share_text.dart · grille_format.dart
+grille_constants.dart
+```
+
+## Tasks
+
+- [x] T0 — Story doc + relecture design source (`.context/attachments/`)
+- [x] T1 — `grille_constants.dart` + `dashed_border.dart`
+- [x] T2 — Modèles + `tile_state` + build_runner + unit tests
+- [x] T3 — Repository + exceptions typées
+- [x] T4 — Providers (notifier, draft, justFinished, leaderboard) + test invalide
+- [x] T5 — Widgets statiques + widget/golden tests
+- [x] T6 — Animations (flip + shake + reduced-motion)
+- [x] T7 — Écrans (dispatch + résultat + déjà-joué + leaderboard + partage)
+- [x] T8 — Routing (`/grille`, `/grille/leaderboard`, `/grille/share`)
+- [x] T9 — Analytics + câblage
+- [x] T10 — CarteCTA + insertion sliver dans `flux_continu_screen.dart`
+
+## Risques
+
+- Hypothèse camelCase-sans-alias (vérifiée via `.g.dart`).
+- Flip + swap mi-parcours + reduced-motion.
+- Union `int|"X"`.
+- Régression home/closing card (CarteCTA = sliver additif, `ClosingCardV18` non modifié).
+
+## Fichiers modifiés
+
+- Nouveau module `apps/mobile/lib/features/grille/**`
+- `apps/mobile/lib/config/routes.dart` (3 routes)
+- `apps/mobile/lib/core/services/analytics_service.dart` (méthodes `trackGrille*`)
+- `apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart` (sliver CarteCTA)
+- Tests sous `apps/mobile/test/features/grille/**`
+</content>
+</invoke>


### PR DESCRIPTION
# PR 2 · Mobile « La Grille du jour » (Story 24.2)

Module Flutter `features/grille/` — le jeu quotidien « Le mot du jour » (Wordle Facteur, 6 lettres,
1re lettre offerte). Consomme le contrat figé de la PR 1 (Story 24.1, backend). Cible `main`.

## Contenu

**Nouveau module** `apps/mobile/lib/features/grille/` (clean architecture calquée sur `digest/`) :
- **models** : `grille_models.dart` (freezed + json_serializable, clés camelCase **byte-exact sans
  alias**, `numero` String, union `int|"X"` normalisée + getter `scoreInt`), `tile_state.dart`
  (enum + parser serveur + pli clavier `place>present>absent`, pur).
- **repositories** : `grille_repository.dart` (3 endpoints, exceptions typées ; `valide:false` = data).
- **providers** : `grille_provider.dart` (`AsyncNotifier` : today + saisie draft + `justFinished` +
  shake nonce), `grille_leaderboard_provider.dart`, `grilleKeyboardStatesProvider` dérivé.
- **screens** : `grille_screen` (aiguille Jeu / Résultat / Déjà-joué), `grille_leaderboard_screen`,
  `grille_share_screen` (partage **texte/lien via `Clipboard`**, pas de `share_plus`).
- **widgets** : masthead, `mot_grid`/`mot_grid_row` (flip 420 ms + stagger 95 ms + shake +
  reduced-motion), `mot_tile` (hint + sceau `mt-seal`), clavier AZERTY, share grid/card
  (RepaintBoundary pour export différé), countdown live (NBSP), leaderboard hero/podium/distribution,
  CarteCTA + mini-grille, `dashed_border` (CustomPainter maison).
- **utils** : `grille_share_text` (emoji sans spoiler + lien), `grille_format` (NBSP).
- `grille_constants.dart` : hors-token validés (`#837A6D`, `#BBB1A1`, `#34495e`, `#cdbfa6`,
  `#F0E6D2`), rayons/dimensions, timings d'animation.

**Câblage** :
- `config/routes.dart` : `/grille`, `/grille/leaderboard`, `/grille/share` (top-level,
  `FullSwipeCupertinoPage`).
- `core/services/analytics_service.dart` : `trackGrille*` (opened, guess, completed, shared(medium),
  leaderboard, ctaShown/Tapped).
- `flux_continu_screen.dart` : **un seul sliver additif** `GrilleCtaCard` au-dessus de
  `ClosingCardV18` (carte de clôture **non modifiée** — zéro régression, revert trivial).

## Décisions

- **1 PR cohérente** ; partage **sans dépendance** (`Clipboard` built-in) + toast ; feuille affichée,
  export image + chip « Image » **différés** (follow-up). Chips visibles : « Texte · Lien ».
- Mapping tokens **par valeur** (design `--r-sm:12` → `FacteurRadius.medium`, `--r-md:16` → `large`).
- **Hors périmètre** : branche `questions` du design, planche de timbres, `CartePlusLoin`, deep-link
  entrant `grille`, export image.

## Vérification

- `cd apps/mobile && flutter test test/features/grille/` → **32/32 verts**.
- `dart analyze lib/features/grille test/features/grille` → **0 issue** ; `flutter analyze` n'introduit
  aucune issue nouvelle dans `lib/`.
- `flutter test test/features/flux_continu/` → **110/110 verts** (pas de régression de la clôture).
- Backend **inchangé**.
- **Restant** : validation visuelle des 6 surfaces (viewport 390×844) via `/validate-feature` ou
  simulateur ; goldens pixel différés (polices Google non bundlées → comme l'unique golden du repo,
  couverture par assertions structurelles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
