### PR TITLE
fix(serein): persistance du mode serein + indicateur visuel (profil vert + lotus)

### DIFF
--- a/apps/mobile/lib/features/digest/providers/serein_toggle_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/serein_toggle_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/auth/auth_state.dart';
 import 'digest_provider.dart';
 
 /// Global serein toggle state — shared between Digest and Feed.
@@ -23,6 +24,12 @@ class SereinToggleState {
 
 final sereinToggleProvider =
     StateNotifierProvider<SereinToggleNotifier, SereinToggleState>((ref) {
+  // Rebuild a fresh notifier (back to isLoading:true) whenever the
+  // authenticated user changes — logout, then a different account on the same
+  // device. Otherwise the initFromApi guard below would block the next user's
+  // server preference from ever applying and they'd inherit the previous
+  // user's toggle.
+  ref.watch(authStateProvider.select((s) => s.user?.id));
   return SereinToggleNotifier(ref);
 });
 
@@ -31,8 +38,14 @@ class SereinToggleNotifier extends StateNotifier<SereinToggleState> {
 
   SereinToggleNotifier(this._ref) : super(const SereinToggleState());
 
-  /// Called once when /digest/both returns to sync with server preference.
+  /// Sync with the server preference returned by /digest/both.
+  ///
+  /// Only syncs on the FIRST load (while still [isLoading]). Once the toggle
+  /// has stabilised, a digest re-fetch (scroll, navigation to Actus du jour,
+  /// stale-fallback refresh) must NEVER overwrite the user's current choice —
+  /// otherwise serein silently flips back OFF mid-session.
   void initFromApi(bool sereinEnabled) {
+    if (!state.isLoading) return;
     state = SereinToggleState(enabled: sereinEnabled, isLoading: false);
   }
 

--- a/apps/mobile/lib/features/feed/widgets/profile_avatar_button.dart
+++ b/apps/mobile/lib/features/feed/widgets/profile_avatar_button.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../digest/providers/serein_toggle_provider.dart';
 import '../../lettres/providers/letters_provider.dart';
 import '../../lettres/widgets/ring_avatar.dart';
 import '../../settings/providers/user_profile_provider.dart';
@@ -21,6 +22,7 @@ class ProfileAvatarButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final displayName = ref.watch(userProfileProvider).displayName;
     final lettersAsync = ref.watch(lettersProvider);
+    final serein = ref.watch(sereinToggleProvider.select((s) => s.enabled));
 
     final progress = lettersAsync.maybeWhen(
       data: (state) {
@@ -32,7 +34,7 @@ class ProfileAvatarButton extends ConsumerWidget {
       orElse: () => null,
     );
 
-    final avatar = RingAvatar.fromName(displayName, progress);
+    final avatar = RingAvatar.fromName(displayName, progress, serein: serein);
 
     if (onTap == null) return avatar;
 

--- a/apps/mobile/lib/features/lettres/widgets/ring_avatar.dart
+++ b/apps/mobile/lib/features/lettres/widgets/ring_avatar.dart
@@ -2,27 +2,37 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+import '../../../config/serein_colors.dart';
 import '../../../config/theme.dart';
 
 class RingAvatar extends StatelessWidget {
   final String initials;
   final double? progress;
 
+  /// When true the avatar adopts the serein identity: sage-green fill/ring and
+  /// a small lotus badge — the persistent visual cue that serein mode is ON.
+  final bool serein;
+
   const RingAvatar({
     super.key,
     required this.initials,
     this.progress,
+    this.serein = false,
   });
 
-  factory RingAvatar.fromName(String? fullName, double? progress) {
+  factory RingAvatar.fromName(
+    String? fullName,
+    double? progress, {
+    bool serein = false,
+  }) {
     final raw = fullName?.trim() ?? '';
     if (raw.isEmpty) {
-      return RingAvatar(initials: 'F', progress: progress);
+      return RingAvatar(initials: 'F', progress: progress, serein: serein);
     }
     final parts = raw.split(RegExp(r'\s+')).where((s) => s.isNotEmpty);
     final letters =
         parts.take(2).map((p) => p.characters.first.toUpperCase()).join();
-    return RingAvatar(initials: letters, progress: progress);
+    return RingAvatar(initials: letters, progress: progress, serein: serein);
   }
 
   @override
@@ -36,7 +46,7 @@ class RingAvatar extends StatelessWidget {
       height: 35,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        color: colors.textPrimary,
+        color: serein ? SereinColors.sereinColor : colors.textPrimary,
       ),
       alignment: Alignment.center,
       child: Text(
@@ -51,18 +61,11 @@ class RingAvatar extends StatelessWidget {
       ),
     );
 
+    final Widget inner;
     if (!hasRing) {
-      return SizedBox(
-        width: 42,
-        height: 42,
-        child: Center(child: avatar),
-      );
-    }
-
-    return SizedBox(
-      width: 42,
-      height: 42,
-      child: TweenAnimationBuilder<double>(
+      inner = Center(child: avatar);
+    } else {
+      inner = TweenAnimationBuilder<double>(
         duration: const Duration(milliseconds: 400),
         curve: Curves.easeOutCubic,
         tween: Tween(begin: 0, end: clamped),
@@ -70,12 +73,46 @@ class RingAvatar extends StatelessWidget {
           return CustomPaint(
             painter: _RingPainter(
               progress: value,
-              progressColor: colors.textSecondary,
+              progressColor:
+                  serein ? SereinColors.sereinColor : colors.textSecondary,
             ),
             child: child,
           );
         },
         child: Center(child: avatar),
+      );
+    }
+
+    // Non-serein render is left byte-identical to the original tree so the
+    // existing golden snapshots keep passing — only serein adds the Stack.
+    if (!serein) {
+      return SizedBox(width: 42, height: 42, child: inner);
+    }
+
+    return SizedBox(
+      width: 42,
+      height: 42,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned.fill(child: inner),
+          Positioned(
+            right: -1,
+            bottom: -1,
+            child: Container(
+              padding: const EdgeInsets.all(1.5),
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: colors.backgroundPrimary,
+              ),
+              child: Icon(
+                SereinColors.sereinIcon,
+                size: 12,
+                color: SereinColors.sereinColor,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
@@ -344,6 +344,7 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
                 onTap: () => context.pushNamed(RouteNames.veilleConfig),
               ),
           ],
+          if (sereinMode) const _SereinSettingsHeader(),
           ...macroThemeOrder.map((macroLabel) {
             final themeSlug = macroThemeToApiSlug[macroLabel] ?? macroLabel;
             return _ThemeBlock(
@@ -559,6 +560,69 @@ class _SereinToggleTile extends StatelessWidget {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// En-tête qui encadre la configuration du mode serein (cases à cocher des
+/// sujets) pour la distinguer visuellement du toggle d'activation au-dessus.
+class _SereinSettingsHeader extends StatelessWidget {
+  const _SereinSettingsHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        FacteurSpacing.space4,
+        FacteurSpacing.space2,
+        FacteurSpacing.space4,
+        FacteurSpacing.space2,
+      ),
+      child: Container(
+        padding: const EdgeInsets.all(FacteurSpacing.space3),
+        decoration: BoxDecoration(
+          color: SereinColors.sereinColor.withOpacity(0.08),
+          borderRadius: BorderRadius.circular(FacteurRadius.large),
+          border: Border.all(
+            color: SereinColors.sereinColor.withOpacity(0.25),
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              SereinColors.sereinIcon,
+              color: SereinColors.sereinColor,
+              size: 18,
+            ),
+            const SizedBox(width: FacteurSpacing.space2),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Paramètres du mode serein',
+                    style: textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      color: colors.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'Contenu à garder dans vos bonnes nouvelles. '
+                    'Décochez un sujet pour le mettre de côté.',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colors.textSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/apps/mobile/lib/features/onboarding/providers/conclusion_notifier.dart
+++ b/apps/mobile/lib/features/onboarding/providers/conclusion_notifier.dart
@@ -11,6 +11,7 @@ import '../../../models/user_profile.dart';
 import '../../../features/sources/providers/sources_providers.dart';
 import '../../custom_topics/providers/custom_topics_provider.dart';
 import '../../custom_topics/providers/personalization_provider.dart';
+import '../../digest/providers/serein_toggle_provider.dart';
 import 'onboarding_provider.dart';
 
 /// État de l'animation de conclusion
@@ -113,6 +114,14 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
 
       if (result.success) {
         await _saveProfileLocally(result.profile!);
+        // Pré-règle le mode serein dès l'entrée dans le feed depuis le choix
+        // d'onboarding, sans attendre /digest/both. La préférence est déjà
+        // persistée côté serveur (save_onboarding ⇒ serein_enabled='true'), et
+        // initFromApi reste idempotent (sync uniquement au 1er chargement), donc
+        // ce pré-réglage n'est jamais écrasé au scroll / refetch.
+        if (answers.digestMode == 'serein') {
+          _ref.read(sereinToggleProvider.notifier).setEnabledLocal(true);
+        }
         // Trust sources en parallèle avec timeout (important pour le digest)
         await _trustSelectedSourcesWithTimeout(answers.preferredSources);
         await _ref.read(onboardingProvider.notifier).clearSavedData();

--- a/apps/mobile/test/features/digest/serein_toggle_provider_test.dart
+++ b/apps/mobile/test/features/digest/serein_toggle_provider_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+import 'package:facteur/core/auth/auth_state.dart' as app_auth;
+import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
+
+app_auth.AuthState _authState(String? userId) {
+  if (userId == null) return const app_auth.AuthState();
+  return app_auth.AuthState(
+    user: supabase.User(
+      id: userId,
+      appMetadata: const {},
+      userMetadata: const {},
+      aud: 'authenticated',
+      createdAt: '2023-01-01',
+    ),
+  );
+}
+
+/// Controllable fake so tests can flip the signed-in user at will.
+class _FakeAuthNotifier extends StateNotifier<app_auth.AuthState>
+    implements app_auth.AuthStateNotifier {
+  _FakeAuthNotifier(String? userId) : super(_authState(userId));
+
+  void setUser(String? userId) => state = _authState(userId);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+ProviderContainer _container(_FakeAuthNotifier auth) {
+  final container = ProviderContainer(
+    overrides: [
+      app_auth.authStateProvider.overrideWith((ref) => auth),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('SereinToggleNotifier.initFromApi idempotency', () {
+    test('first call syncs with the server value and clears loading', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+      expect(container.read(sereinToggleProvider).isLoading, isTrue);
+
+      container.read(sereinToggleProvider.notifier).initFromApi(true);
+
+      final state = container.read(sereinToggleProvider);
+      expect(state.enabled, isTrue);
+      expect(state.isLoading, isFalse);
+    });
+
+    test('subsequent calls never overwrite the stabilised choice', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+      final notifier = container.read(sereinToggleProvider.notifier);
+
+      notifier.initFromApi(true); // first load → enabled, no longer loading
+      // A digest re-fetch returns the (stale) default — must be ignored.
+      notifier.initFromApi(false);
+
+      expect(container.read(sereinToggleProvider).enabled, isTrue);
+    });
+
+    test('setEnabledLocal keeps isLoading so the first sync still confirms', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+      final notifier = container.read(sereinToggleProvider.notifier);
+
+      // Pré-réglage post-onboarding avant que /digest/both ait répondu.
+      notifier.setEnabledLocal(true);
+      expect(container.read(sereinToggleProvider).enabled, isTrue);
+      expect(container.read(sereinToggleProvider).isLoading, isTrue);
+
+      // /digest/both confirme la préférence serveur.
+      notifier.initFromApi(true);
+      expect(container.read(sereinToggleProvider).enabled, isTrue);
+      expect(container.read(sereinToggleProvider).isLoading, isFalse);
+    });
+  });
+
+  group('SereinToggleNotifier auth lifecycle', () {
+    test('resets to a fresh loading state when the user changes', () {
+      final auth = _FakeAuthNotifier('userA');
+      final container = _container(auth);
+
+      // User A: serein synced ON, stabilised.
+      container.read(sereinToggleProvider.notifier).initFromApi(true);
+      expect(container.read(sereinToggleProvider).enabled, isTrue);
+      expect(container.read(sereinToggleProvider).isLoading, isFalse);
+
+      // Logout then a different account on the same device.
+      auth.setUser(null);
+      auth.setUser('userB');
+
+      // The notifier is rebuilt fresh → the guard no longer blocks the new
+      // user's sync, so userB's OFF preference applies correctly.
+      final fresh = container.read(sereinToggleProvider);
+      expect(fresh.isLoading, isTrue);
+      expect(fresh.enabled, isFalse);
+
+      container.read(sereinToggleProvider.notifier).initFromApi(false);
+      expect(container.read(sereinToggleProvider).enabled, isFalse);
+    });
+  });
+}

--- a/apps/mobile/test/features/lettres/widgets/ring_avatar_test.dart
+++ b/apps/mobile/test/features/lettres/widgets/ring_avatar_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import 'package:facteur/config/serein_colors.dart';
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/lettres/widgets/ring_avatar.dart';
 
@@ -44,6 +45,24 @@ void main() {
 
     test('lowercase input is uppercased', () {
       expect(RingAvatar.fromName('laurin boujon', null).initials, 'LB');
+    });
+  });
+
+  group('RingAvatar serein indicator', () {
+    testWidgets('shows the lotus badge when serein is true', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const RingAvatar(initials: 'LB', progress: null, serein: true),
+      ));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(SereinColors.sereinIcon), findsOneWidget);
+    });
+
+    testWidgets('hides the lotus badge when serein is false', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const RingAvatar(initials: 'LB', progress: 0.5),
+      ));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(SereinColors.sereinIcon), findsNothing);
     });
   });
 


### PR DESCRIPTION
## Lot de bugs « Mode Serein » (cluster A — PR 1/2)

Corrige A1 + A2 : le mode serein **rebascule OFF** pendant le scroll / la navigation Actus du jour, et le choix « Oui » de l'onboarding n'est pas reflété à l'entrée dans le feed.

### Cause racine
`initFromApi()` réécrivait le toggle serein **à chaque** re-fetch de `/digest/both`. Comme `digest_provider` watch le toggle et `flux_continu_provider` se ré-invalide dessus, n'importe quel re-fetch (scroll, navigation, stale-refresh) repassait serein sur la valeur serveur par défaut.

### Changements
- **`serein_toggle_provider.dart`** — `initFromApi` devient **idempotent** : il ne synchronise qu'au **premier** chargement (`isLoading`). Un re-fetch ne peut plus écraser le choix utilisateur. Le provider est **recréé quand l'utilisateur authentifié change** (logout → autre compte sur le même appareil), sinon le garde `isLoading` bloquerait la synchro du nouvel utilisateur (il hériterait du toggle du précédent).
- **`conclusion_notifier.dart`** — pré-règle le toggle (`setEnabledLocal(true)`) dès l'entrée dans le feed depuis `digest_mode == 'serein'`, sans attendre `/digest/both`.
- **Indicateur visuel** — `RingAvatar` gagne un paramètre `serein` : avatar **vert sauge** + **badge lotus** quand serein ON, watché dans `ProfileAvatarButton`. Le rendu **non-serein est laissé identique** → les goldens existants passent sans régénération.
- **Clarification réglages** (`my_interests_screen.dart`) — en-tête encadré **« Paramètres du mode serein »** pour distinguer la config (cases à cocher) du toggle d'activation.

### Note backend
La persistance serveur (`serein_enabled='true'` à l'onboarding) **existait déjà** (`user_service.save_onboarding`) — **aucun changement backend** dans cette PR.

### Tests
- `serein_toggle_provider_test.dart` (nouveau) : idempotence du garde, non-écrasement après stabilisation, **reset au changement de compte**, cohérence `setEnabledLocal` + sync.
- `ring_avatar_test.dart` : badge lotus présent ssi `serein` ; goldens inchangés.
- `flutter analyze` : pas de nouvelle erreur. Suite mobile : seuls les échecs environnementaux pré-existants (Hive/Supabase non init, réseau) subsistent — confirmés identiques sur tronc propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)