### PR TITLE
fix(grille): écran gris silencieux — seed auto au boot + .valueOrNull

### DIFF
--- a/apps/mobile/lib/features/grille/providers/grille_provider.dart
+++ b/apps/mobile/lib/features/grille/providers/grille_provider.dart
@@ -202,7 +202,11 @@ class GrilleNotifier extends AsyncNotifier<GrilleState> {
 /// État coloré du clavier, déduit des essais joués (pli `place>present>absent`).
 final grilleKeyboardStatesProvider = Provider<Map<String, TileState>>((ref) {
   final async = ref.watch(grilleProvider);
-  final today = async.value?.today;
+  // `.valueOrNull` (et non `.value`) : sur un état d'erreur `.value` re-lève
+  // l'exception (cf. docs/bugs/bug-grille-du-jour-crash.md). Chemin latent —
+  // ce provider n'est lu que dans la branche `data` de l'écran Grille — mais
+  // fermé par cohérence pour éviter tout futur crash en erreur/loading.
+  final today = async.valueOrNull?.today;
   if (today == null) return const {};
   return computeKeyboardStates(
     today.essais.map((e) => (mot: e.mot, etats: e.etats)),

--- a/apps/mobile/lib/features/grille/widgets/grille_cta_card.dart
+++ b/apps/mobile/lib/features/grille/widgets/grille_cta_card.dart
@@ -25,7 +25,13 @@ class _GrilleCtaCardState extends ConsumerState<GrilleCtaCard> {
 
   @override
   Widget build(BuildContext context) {
-    final today = ref.watch(grilleProvider).value?.today;
+    // `.valueOrNull` (et non `.value`) : sur un état d'erreur, `AsyncValue.value`
+    // **re-lève** l'exception (ici `GrilleNotFoundException` quand le serveur
+    // n'a pas de mot du jour) — elle s'échappait alors de `build()` et faisait
+    // tomber tout l'arbre de la Tournée (long écran gris, sans message). Cf.
+    // docs/bugs/bug-grille-du-jour-crash.md. `.valueOrNull` rend `null` en
+    // loading/erreur → la carte disparaît proprement, comme documenté ci-dessus.
+    final today = ref.watch(grilleProvider).valueOrNull?.today;
     if (today == null) return const SizedBox.shrink();
 
     final state = today.isFinished ? CarteCtaState.deja : CarteCtaState.neuf;

--- a/apps/mobile/test/features/grille/widgets/grille_cta_card_test.dart
+++ b/apps/mobile/test/features/grille/widgets/grille_cta_card_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/core/providers/analytics_provider.dart';
+import 'package:facteur/core/services/analytics_service.dart';
+import 'package:facteur/features/grille/models/grille_models.dart';
+import 'package:facteur/features/grille/providers/grille_provider.dart';
+import 'package:facteur/features/grille/repositories/grille_repository.dart';
+import 'package:facteur/features/grille/widgets/carte_cta.dart';
+import 'package:facteur/features/grille/widgets/grille_cta_card.dart';
+
+/// Repository pilotable : `getToday` peut lever ou rendre une partie.
+class _FakeGrilleRepository implements GrilleRepository {
+  _FakeGrilleRepository({this.error, this.today});
+
+  final Object? error;
+  final GrilleTodayResponse? today;
+
+  @override
+  Future<GrilleTodayResponse> getToday() async {
+    if (error != null) throw error!;
+    return today!;
+  }
+
+  @override
+  Future<GrilleGuessResponse> submitGuess(String mot) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<GrilleLeaderboardResponse> getLeaderboard() async =>
+      throw UnimplementedError();
+}
+
+GrilleTodayResponse _todayInProgress() => const GrilleTodayResponse(
+      date: '2026-05-31',
+      dateAffichee: 'Dimanche 31 mai',
+      dateCourt: 'Dim. 31 mai',
+      numero: 'N°144',
+      longueur: 6,
+      essaisMax: 6,
+      premiereLettre: 'B',
+      indice: 'indice',
+      theme: 'theme',
+      statut: 'in_progress',
+      essais: [],
+      nbEssais: 0,
+      streak: 0,
+      prochainMotDansSec: 1000,
+    );
+
+Widget _wrap(_FakeGrilleRepository repo) {
+  return ProviderScope(
+    overrides: [
+      grilleRepositoryProvider.overrideWithValue(repo),
+      analyticsServiceProvider.overrideWithValue(AnalyticsService.disabled()),
+    ],
+    child: MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: const Scaffold(body: GrilleCtaCard()),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets(
+    'erreur provider (GrilleNotFoundException) → rien rendu, aucun throw',
+    (t) async {
+      // Régression docs/bugs/bug-grille-du-jour-crash.md : `.value` re-levait
+      // l'exception hors de build() → écran gris. `.valueOrNull` doit absorber.
+      await t.pumpWidget(
+        _wrap(_FakeGrilleRepository(error: const GrilleNotFoundException())),
+      );
+      await t.pumpAndSettle();
+
+      expect(t.takeException(), isNull,
+          reason: 'aucune exception ne doit fuir de build()');
+      expect(find.byType(CarteCta), findsNothing);
+    },
+  );
+
+  testWidgets('loading → rien rendu (SizedBox.shrink)', (t) async {
+    await t.pumpWidget(
+      _wrap(_FakeGrilleRepository(today: _todayInProgress())),
+    );
+    // Premier frame : le build() async n'a pas encore résolu → loading.
+    await t.pump();
+    expect(find.byType(CarteCta), findsNothing);
+  });
+
+  testWidgets('data (partie neuve) → la carte CTA est rendue', (t) async {
+    await t.pumpWidget(
+      _wrap(_FakeGrilleRepository(today: _todayInProgress())),
+    );
+    await t.pumpAndSettle();
+    expect(find.byType(CarteCta), findsOneWidget);
+  });
+}

--- a/docs/bugs/bug-grille-du-jour-crash.md
+++ b/docs/bugs/bug-grille-du-jour-crash.md
@@ -1,0 +1,122 @@
+# Bug — La Grille du jour : écran gris silencieux en prod
+
+**Statut** : Corrigé (en attente de PR)
+**Branche** : `claude/grille-du-jour-crash-oDgO8`
+**Sévérité** : 🔴 Critique (prod — feature inutilisable + crash de l'onglet Essentiel)
+**Release impactée** : `beta-20260531-0230` (Story 24.2 — module mobile La Grille)
+**Plateforme remontée** : Android 16 (SM-A546E), Flutter 3.38.6 / Dart 3.10.7
+**Fichiers critiques** :
+- `apps/mobile/lib/features/grille/widgets/grille_cta_card.dart`
+- `apps/mobile/lib/features/grille/providers/grille_provider.dart`
+- `packages/api/app/main.py`
+- `packages/api/app/services/grille_seed.py` (nouveau)
+- `packages/api/scripts/seed_grille_puzzles.py`
+- `packages/api/app/data/grille_puzzles_seed.json`
+
+## Symptôme
+
+Le matin du 2026-05-31, La Grille du jour (« mot du jour »), tout juste mise en
+prod, ne fonctionne pas : l'onglet « L'Essentiel du jour » affiche un **très long
+écran gris**, sans aucun message d'erreur (cf. screenshot utilisateur).
+
+Sentry :
+
+```
+GrilleNotFoundException: GrilleNotFoundException
+  File "grille_cta_card.dart", line 28, in _GrilleCtaCardState.build
+  File "consumer.dart", line 539, in ConsumerStatefulElement.build
+  File "common.dart", line 495, in AsyncError.value
+handled = no · level = fatal · release = beta-20260531-0230
+```
+
+## Diagnostic — double cause, défaillance silencieuse
+
+### #1 — Cause racine (backend / données) : `grille_puzzles` vide en prod
+
+La migration `gr01_la_grille_du_jour` (jouée au boot Railway via le `Dockerfile`)
+crée la table `grille_puzzles` mais **ne seed aucune donnée** (DDL pure, conforme
+au principe « Alembic = schéma seulement »).
+
+Le seed des puzzles (`scripts/seed_grille_puzzles.py`) était **manuel uniquement**
+— absent du `Dockerfile`, du scheduler et du lifespan. Il n'a jamais été exécuté
+en prod. Vérification Supabase au moment de l'incident :
+
+```sql
+SELECT count(*) FROM grille_puzzles;          -- 0
+SELECT version_num FROM alembic_version;        -- gr01_la_grille_du_jour
+```
+
+Conséquence : `GET /api/grille/today` lève `PuzzleNotFound` →
+**HTTP 404 pour tous les utilisateurs** (`grille_service.get_today`, `grille.py`).
+
+### #2 — Amplificateur (frontend) : `.value` re-lève au lieu d'absorber
+
+`grille_cta_card.dart:28` (avant correctif) :
+
+```dart
+final today = ref.watch(grilleProvider).value?.today;
+if (today == null) return const SizedBox.shrink();
+```
+
+La docstring de la carte promet « en loading/erreur, ne rend **rien** ». Mais en
+Riverpod, `AsyncValue.value` **re-lève** l'exception quand le provider est en état
+erreur (seul `.valueOrNull` rend `null` sans lever) — c'est exactement la frame
+Sentry `common.dart:495 in AsyncError.value`.
+
+Le 404 (mappé en `GrilleNotFoundException` par `GrilleRepository.getToday`)
+s'échappait donc de `build()`. Non capturée, Flutter remplace le sous-arbre par
+l'`ErrorWidget` par défaut (en release : un **conteneur gris** plein écran). La
+carte CTA étant insérée comme sliver en bas de la Tournée
+(`flux_continu_screen.dart:829`), c'est **tout le corps de l'onglet Essentiel**
+qui s'effondre → long écran gris, sans message.
+
+**Pourquoi « ce matin » et pas avant** : tant qu'un puzzle existait, `getToday()`
+renvoyait des données et le bug restait latent. Le 31 mai, l'API renvoie 404 pour
+la première fois en prod → premier passage par le chemin `AsyncError` → crash.
+
+Un **second chemin latent** existait avec le même anti-pattern :
+`grilleKeyboardStatesProvider` (`grille_provider.dart:205`, `async.value?.today`).
+Non déclenché en prod (lu uniquement dans la branche `data` de l'écran Grille),
+mais corrigé par cohérence pour fermer le risque.
+
+## Correctifs
+
+### Immédiat — débloquer la prod (fait)
+
+Seed idempotent des 15 puzzles (30 mai → 13 juin) exécuté directement sur la DB
+prod (upsert `ON CONFLICT (puzzle_date)`). `GET /grille/today` repasse 200, La
+Grille refonctionne sans attendre un redéploiement de l'app.
+
+### Durable #1 — frontend : crash supprimé définitivement
+
+`grille_cta_card.dart:28` et `grille_provider.dart:205` (clavier) :
+`.value?.today` → `.valueOrNull?.today`. La carte redevient `SizedBox.shrink()`
+en erreur/loading comme documenté. **Robustifie l'app quel que soit l'état
+backend** : même si un jour le puzzle manque à nouveau, plus de crash de
+l'onglet — la carte disparaît simplement.
+
+### Durable #2 — backend : seed automatique au démarrage
+
+La logique d'upsert est extraite dans `app/services/grille_seed.py`
+(`seed_puzzles(db)`), réutilisée par :
+- `main.lifespan` (après le check migrations, best-effort, loggé + Sentry sur
+  échec) → une table vide ne peut plus passer en prod silencieusement ;
+- `scripts/seed_grille_puzzles.py` (devenu un simple wrapper d'exécution one-off).
+
+Idempotent (upsert par `puzzle_date`), garde-fou dictionnaire conservé
+(`SeedInvalidWord` si un `word` est hors `grille_words_fr.txt`).
+
+## Tests
+
+- `apps/mobile/test/features/grille/widgets/grille_cta_card_test.dart` :
+  provider en erreur (`GrilleNotFoundException`) → aucune exception ne fuit de
+  `build()`, `CarteCta` absente ; loading → rien ; data → carte rendue.
+- `packages/api/tests/test_grille_seed.py` : seed peuple la table, est
+  idempotent, calcule les dates affichées depuis le calendrier.
+
+## Prévention
+
+- Tout futur module à données seedées doit câbler son seed au démarrage (ou via
+  migration de données dédiée), jamais le laisser manuel-only.
+- Pattern Riverpod : dans un `build()` qui veut « disparaître » en erreur,
+  utiliser `.valueOrNull`, jamais `.value` (qui re-lève).

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -226,6 +226,27 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
                     "lifespan_startup_checks_skipped", reason="skip_startup_checks=True"
                 )
 
+            # SEED « La Grille du jour » : upsert idempotent des puzzles au boot.
+            # Le seed était manuel-only et n'avait jamais tourné en prod → table
+            # vide → GET /grille/today en 404 pour tous → crash silencieux côté
+            # mobile (écran gris). Cf. docs/bugs/bug-grille-du-jour-crash.md.
+            # Best-effort : un échec ici ne doit pas dégrader le reste de l'API.
+            try:
+                from app.database import safe_async_session
+                from app.services.grille_seed import seed_puzzles
+
+                async with safe_async_session() as _seed_db:
+                    created, updated = await seed_puzzles(_seed_db)
+                    await _seed_db.commit()
+                logger.info("lifespan_grille_seeded", created=created, updated=updated)
+            except Exception as seed_exc:
+                logger.error(
+                    "lifespan_grille_seed_failed",
+                    error=str(seed_exc),
+                    exc_info=True,
+                )
+                sentry_sdk.capture_exception(seed_exc)
+
         except Exception as e:
             logger.critical(
                 "lifespan_startup_db_error",

--- a/packages/api/app/services/grille_seed.py
+++ b/packages/api/app/services/grille_seed.py
@@ -1,0 +1,129 @@
+"""Seed idempotent des puzzles de « La Grille du jour ».
+
+Source de vérité : `app/data/grille_puzzles_seed.json` (committé). Upsert par
+`puzzle_date`. Les dates affichées (`date_affichee`, `date_court`, `cancel`)
+sont calculées depuis `date` pour éviter toute erreur de jour de semaine.
+
+Appelé à deux endroits :
+- au démarrage de l'app (`main.lifespan`) → garantit qu'une table vide ne
+  peut plus passer en prod silencieusement (cf. docs/bugs/bug-grille-du-jour-crash.md) ;
+- par `scripts/seed_grille_puzzles.py` (exécution manuelle / one-off).
+
+Invariant vérifié au seed : chaque `word` ∈ dictionnaire (grille_words_fr.txt).
+"""
+
+import json
+from datetime import date
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.grille_puzzle import GrillePuzzle
+from app.services.grille_dictionary import is_valid_word
+
+_SEED_PATH = (
+    Path(__file__).resolve().parent.parent / "data" / "grille_puzzles_seed.json"
+)
+
+_WEEKDAYS_LONG = [
+    "lundi",
+    "mardi",
+    "mercredi",
+    "jeudi",
+    "vendredi",
+    "samedi",
+    "dimanche",
+]
+_WEEKDAYS_SHORT = ["Lun.", "Mar.", "Mer.", "Jeu.", "Ven.", "Sam.", "Dim."]
+_MONTHS = [
+    "janvier",
+    "février",
+    "mars",
+    "avril",
+    "mai",
+    "juin",
+    "juillet",
+    "août",
+    "septembre",
+    "octobre",
+    "novembre",
+    "décembre",
+]
+
+
+class SeedInvalidWord(Exception):
+    """Un `word` du seed est absent du dictionnaire (grille_words_fr.txt)."""
+
+
+def _day_fr(d: date) -> str:
+    """« 30 » ou « 1er » (convention française pour le 1er du mois)."""
+    return "1er" if d.day == 1 else str(d.day)
+
+
+def format_date_affichee(d: date) -> str:
+    """« Samedi 30 mai » (masthead)."""
+    weekday = _WEEKDAYS_LONG[d.weekday()].capitalize()
+    return f"{weekday} {_day_fr(d)} {_MONTHS[d.month - 1]}"
+
+
+def format_date_court(d: date) -> str:
+    """« Sam. 30 mai » (pied de partage)."""
+    return f"{_WEEKDAYS_SHORT[d.weekday()]} {_day_fr(d)} {_MONTHS[d.month - 1]}"
+
+
+def format_cancel(d: date) -> str:
+    """« 30·05·26 » (cachet d'oblitération)."""
+    return f"{d.day:02d}·{d.month:02d}·{d.year % 100:02d}"
+
+
+def load_seed() -> tuple[str, list[dict]]:
+    """Charge l'indice par défaut + la liste des puzzles depuis le JSON seedé."""
+    data = json.loads(_SEED_PATH.read_text(encoding="utf-8"))
+    return data["indice_default"], data["puzzles"]
+
+
+async def seed_puzzles(db: AsyncSession) -> tuple[int, int]:
+    """Upsert idempotent des puzzles dans `db`. Retourne `(créés, mis_à_jour)`.
+
+    Ne commit pas : laisse la transaction au caller (parité avec `GrilleService`,
+    où `get_db` assure le commit). Lève [SeedInvalidWord] si un mot du jour est
+    hors dictionnaire — fail-fast plutôt que de servir un puzzle injouable.
+    """
+    indice_default, puzzles = load_seed()
+
+    invalid = [p["word"] for p in puzzles if not is_valid_word(p["word"])]
+    if invalid:
+        raise SeedInvalidWord(
+            f"Mots du jour absents du dictionnaire (grille_words_fr.txt) : {invalid}"
+        )
+
+    created = 0
+    updated = 0
+    for p in puzzles:
+        puzzle_date = date.fromisoformat(p["date"])
+        existing = await db.scalar(
+            select(GrillePuzzle).where(GrillePuzzle.puzzle_date == puzzle_date)
+        )
+        fields = {
+            "word": p["word"],
+            "length": p.get("longueur", 6),
+            "max_attempts": p.get("essaisMax", 6),
+            "indice": p.get("indice", indice_default),
+            "theme": p["theme"],
+            "pourquoi": p["pourquoi"],
+            "numero": p["numero"],
+            "date_affichee": format_date_affichee(puzzle_date),
+            "date_court": format_date_court(puzzle_date),
+            "cancel": format_cancel(puzzle_date),
+        }
+        if existing is None:
+            db.add(GrillePuzzle(puzzle_date=puzzle_date, **fields))
+            created += 1
+        else:
+            for key, value in fields.items():
+                setattr(existing, key, value)
+            updated += 1
+
+    await db.flush()
+    return created, updated

--- a/packages/api/scripts/seed_grille_puzzles.py
+++ b/packages/api/scripts/seed_grille_puzzles.py
@@ -1,10 +1,9 @@
 """Seed des puzzles de « La Grille du jour » (Story 24.1).
 
-Upsert idempotent par `puzzle_date` depuis `app/data/grille_puzzles_seed.json`.
-Les dates affichées (`date_affichee`, `date_court`, `cancel`) sont calculées
-depuis `date` pour éviter toute erreur de jour de semaine.
-
-Invariant vérifié au seed : chaque `word` ∈ dictionnaire (grille_words_fr.txt).
+Exécution manuelle / one-off. La logique d'upsert vit dans
+`app.services.grille_seed.seed_puzzles` (réutilisée au démarrage de l'app —
+cf. docs/bugs/bug-grille-du-jour-crash.md) ; ce script ne fait que l'invoquer
+sur une session dédiée et committer.
 
 Usage :
   cd packages/api && source venv/bin/activate
@@ -12,116 +11,16 @@ Usage :
 """
 
 import asyncio
-import json
-from datetime import date
-from pathlib import Path
-
-from sqlalchemy import select
 
 from app.database import async_session_maker
-from app.models.grille_puzzle import GrillePuzzle
-from app.services.grille_dictionary import is_valid_word
-
-_SEED_PATH = (
-    Path(__file__).resolve().parent.parent / "app" / "data" / "grille_puzzles_seed.json"
-)
-
-_WEEKDAYS_LONG = [
-    "lundi",
-    "mardi",
-    "mercredi",
-    "jeudi",
-    "vendredi",
-    "samedi",
-    "dimanche",
-]
-_WEEKDAYS_SHORT = ["Lun.", "Mar.", "Mer.", "Jeu.", "Ven.", "Sam.", "Dim."]
-_MONTHS = [
-    "janvier",
-    "février",
-    "mars",
-    "avril",
-    "mai",
-    "juin",
-    "juillet",
-    "août",
-    "septembre",
-    "octobre",
-    "novembre",
-    "décembre",
-]
-
-
-def _day_fr(d: date) -> str:
-    """« 30 » ou « 1er » (convention française pour le 1er du mois)."""
-    return "1er" if d.day == 1 else str(d.day)
-
-
-def format_date_affichee(d: date) -> str:
-    """« Samedi 30 mai » (masthead)."""
-    weekday = _WEEKDAYS_LONG[d.weekday()].capitalize()
-    return f"{weekday} {_day_fr(d)} {_MONTHS[d.month - 1]}"
-
-
-def format_date_court(d: date) -> str:
-    """« Sam. 30 mai » (pied de partage)."""
-    return f"{_WEEKDAYS_SHORT[d.weekday()]} {_day_fr(d)} {_MONTHS[d.month - 1]}"
-
-
-def format_cancel(d: date) -> str:
-    """« 30·05·26 » (cachet d'oblitération)."""
-    return f"{d.day:02d}·{d.month:02d}·{d.year % 100:02d}"
-
-
-def load_seed() -> tuple[str, list[dict]]:
-    data = json.loads(_SEED_PATH.read_text(encoding="utf-8"))
-    return data["indice_default"], data["puzzles"]
+from app.services.grille_seed import seed_puzzles
 
 
 async def main() -> None:
-    indice_default, puzzles = load_seed()
-
-    # Garde-fou : tous les mots du jour doivent être dans le dictionnaire.
-    invalid = [p["word"] for p in puzzles if not is_valid_word(p["word"])]
-    if invalid:
-        raise SystemExit(
-            f"Mots du jour absents du dictionnaire (grille_words_fr.txt) : {invalid}"
-        )
-
-    created = 0
-    updated = 0
     async with async_session_maker() as db:
-        for p in puzzles:
-            puzzle_date = date.fromisoformat(p["date"])
-            existing = await db.scalar(
-                select(GrillePuzzle).where(
-                    GrillePuzzle.puzzle_date == puzzle_date
-                )
-            )
-            fields = dict(
-                word=p["word"],
-                length=p.get("longueur", 6),
-                max_attempts=p.get("essaisMax", 6),
-                indice=p.get("indice", indice_default),
-                theme=p["theme"],
-                pourquoi=p["pourquoi"],
-                numero=p["numero"],
-                date_affichee=format_date_affichee(puzzle_date),
-                date_court=format_date_court(puzzle_date),
-                cancel=format_cancel(puzzle_date),
-            )
-            if existing is None:
-                db.add(GrillePuzzle(puzzle_date=puzzle_date, **fields))
-                created += 1
-                print(f"  + {p['date']} {p['numero']} {p['word']}")
-            else:
-                for key, value in fields.items():
-                    setattr(existing, key, value)
-                updated += 1
-                print(f"  ~ {p['date']} {p['numero']} {p['word']} (maj)")
+        created, updated = await seed_puzzles(db)
         await db.commit()
-
-    print(f"\nDone. {created} créés, {updated} mis à jour.")
+    print(f"Done. {created} créés, {updated} mis à jour.")
 
 
 if __name__ == "__main__":

--- a/packages/api/tests/test_grille_seed.py
+++ b/packages/api/tests/test_grille_seed.py
@@ -1,0 +1,74 @@
+"""Tests du seed idempotent des puzzles de « La Grille du jour ».
+
+Régression docs/bugs/bug-grille-du-jour-crash.md : la table `grille_puzzles`
+était vide en prod (seed manuel-only jamais exécuté) → 404 → écran gris mobile.
+Le seed est désormais joué au démarrage de l'app ; ces tests garantissent qu'il
+peuple bien la table et reste idempotent (upsert par `puzzle_date`).
+"""
+
+from datetime import date
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.grille_puzzle import GrillePuzzle
+from app.services.grille_seed import (
+    format_cancel,
+    format_date_affichee,
+    format_date_court,
+    load_seed,
+    seed_puzzles,
+)
+
+
+async def _count(db) -> int:
+    return await db.scalar(select(func.count()).select_from(GrillePuzzle))
+
+
+@pytest.mark.asyncio
+async def test_seed_populates_table(db_session):
+    created, updated = await seed_puzzles(db_session)
+    await db_session.commit()
+
+    _, puzzles = load_seed()
+    assert created == len(puzzles)
+    assert updated == 0
+    assert await _count(db_session) == len(puzzles)
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(db_session):
+    # 1er passage : tout créé.
+    created1, updated1 = await seed_puzzles(db_session)
+    await db_session.commit()
+    # 2e passage : tout mis à jour, rien de neuf, aucun doublon.
+    created2, updated2 = await seed_puzzles(db_session)
+    await db_session.commit()
+
+    _, puzzles = load_seed()
+    assert (created1, updated1) == (len(puzzles), 0)
+    assert (created2, updated2) == (0, len(puzzles))
+    assert await _count(db_session) == len(puzzles)
+
+
+@pytest.mark.asyncio
+async def test_seed_computes_display_dates_from_calendar(db_session):
+    await seed_puzzles(db_session)
+    await db_session.commit()
+
+    # 2026-05-30 est un samedi — vérifie que les dates affichées sont calculées
+    # depuis le calendrier (et non recopiées d'un champ JSON faillible).
+    p = await db_session.scalar(
+        select(GrillePuzzle).where(GrillePuzzle.puzzle_date == date(2026, 5, 30))
+    )
+    if p is not None:  # le seed peut évoluer ; on ne teste que si la date existe
+        assert p.date_affichee == "Samedi 30 mai"
+        assert p.date_court == "Sam. 30 mai"
+        assert p.cancel == "30·05·26"
+
+
+def test_format_helpers_french_conventions():
+    d = date(2026, 6, 1)  # lundi 1er juin
+    assert format_date_affichee(d) == "Lundi 1er juin"
+    assert format_date_court(d) == "Lun. 1er juin"
+    assert format_cancel(d) == "01·06·26"


### PR DESCRIPTION
La Grille du jour crashait tout l'onglet Essentiel (long écran gris, sans
message) en prod. Double cause :

1. Backend (cause racine) : la table grille_puzzles était vide. Le seed
   (scripts/seed_grille_puzzles.py) était manuel-only et n'avait jamais
   tourné en prod, alors que la migration gr01 ne crée que le schéma.
   GET /grille/today répondait donc 404 pour tous.

2. Frontend (amplificateur) : grille_cta_card.dart lisait
   ref.watch(grilleProvider).value?.today. En Riverpod, AsyncValue.value
   RE-LÈVE en état erreur (seul .valueOrNull est null-safe). Le 404 →
   GrilleNotFoundException s'échappait de build() et faisait tomber tout
   le sliver de la Tournée.

Correctifs :
- Front : .value?.today → .valueOrNull?.today dans grille_cta_card.dart
  et grilleKeyboardStatesProvider (2e chemin latent). La carte se masse
  proprement en erreur/loading, quel que soit l'état backend.
- Back : extraction de la logique d'upsert dans
  app/services/grille_seed.seed_puzzles(), câblée au lifespan (best-effort,
  loggée + Sentry). Une table vide ne peut plus passer silencieusement.
  Le script devient un wrapper one-off.

Tests : test_grille_seed.py (peuplement, idempotence, dates calendaires) ;
grille_cta_card_test.dart (erreur → rien rendu sans throw, loading → rien,
data → carte). Suite grille backend : 28 passed.

Note ops : prod seedée séparément (15 puzzles, 30 mai → 13 juin) pour
débloquer immédiatement les utilisateurs.

Cf. docs/bugs/bug-grille-du-jour-crash.md