### PR TITLE
fix(curation): dédup sujet Essentiel + filtre thème sans fuite secondary_themes

### DIFF
--- a/docs/bugs/bug-essentials-curation-clustering-theme.md
+++ b/docs/bugs/bug-essentials-curation-clustering-theme.md
@@ -1,0 +1,143 @@
+# Bug: Curation Essentiels — doublons de sujet + sections thématiques hors-sujet
+
+**Date de découverte** : 2026-05-31 (prod / `main`)
+**Sévérité** : 🔥 CRITICAL (prod)
+**Status** : ✅ Corrigé (fix #1 + fix #2 implémentés + tests) — en attente CI/review
+**Surfaces** : Carte « L'Essentiel du jour », sections thématiques « Tournée du jour »
+
+---
+
+## Symptômes (rapportés + screenshots)
+
+1. **Bug 1 — même sujet 3× dans la carte Essentiel.** Le sujet « météore explose
+   au-dessus des États-Unis » apparaît 3 fois : Actu du jour (Home Fil actu) +
+   Ouest-France + Le Figaro.
+2. **Bug 2 — articles hors-thème dans le top 3 des sections.** Sous « Technologie »
+   **et** sous « Science », on retrouve les mêmes 2 articles Le Monde sans rapport :
+   « guerre en Ukraine : 229 drones » et « baleine échouée à l'île de Ré » (badgés
+   « Géopolitique »).
+
+---
+
+## Cause racine #1 — Doublons de sujet (PAS un bug de clustering)
+
+Le clustering **fonctionne** : les 3 articles météore partagent le même
+`content.cluster_id` (`a309ac1c-…`) et `content.theme = science` (vérifié en prod).
+
+Le défaut est dans la **projection Essentiel** :
+`app/services/essentiel_service.py` → `_pick_transversal_articles()`.
+
+L'Essentiel doit être « 5 articles **transversaux** » = 1 article max par sujet.
+Or la contrainte « 1 article par topic » n'est appliquée **qu'au Round 1
+(diversité)** :
+
+- **Slot lead Actu** (l.485-495) : pose l'article Actu en rank 1, marque le topic.
+- **Round 1 diversité** (l.513-518) : `if topic.topic_id in used_topics: continue` ✅
+- **Round 2 remplissage** (l.520-535) : appelle `_try_pick()` **sans** vérifier
+  `used_topics`. `_try_pick` ne contrôle que `content_id` (dédup) + max 2/source.
+
+Conséquence : quand un topic « revue de presse » contient plusieurs articles du
+**même** sujet (météore : 3 sources distinctes), le Round 2 ré-injecte les autres
+articles du topic déjà servi en lead → le même sujet ressort 2-3×.
+
+> Le filtre `ESSENTIEL_MAX_PER_SOURCE = 2` ne protège pas : les 3 articles
+> viennent de **sources différentes**.
+
+## Cause racine #2 — Sections thématiques hors-sujet
+
+Endpoint : `GET /api/feed?theme=<slug>&personalized=true` →
+`recommendation_service._get_candidates()` → `apply_theme_focus_filter()`
+(`app/services/recommendation/filter_presets.py` l.305-336).
+
+Le filtre admet un article via **2 chemins** :
+
+```python
+or_(
+    Content.theme == theme_slug,                       # (1) classifié ML
+    and_(
+        Content.source_id.in_(                          # (2) "bénéfice du doute"
+            sources WHERE source.theme == slug
+                 OR source.secondary_themes ANY slug),
+        Content.theme.is_(None),                        #     non encore classifié
+    ),
+)
+```
+
+Le **chemin (2)** est la fuite. Vérifié en prod :
+
+- Les 2 articles incriminés (Ukraine 229 drones 07h11, baleine 06h48) sont des
+  articles **Le Monde frais, non encore classifiés** : `content.theme = NULL`,
+  `topics = []`.
+- `Le Monde` : `theme = "international"`, `secondary_themes =
+  ["society","politics","economy","culture","tech","science"]`.
+
+Donc un article Le Monde non classifié matche le chemin (2) pour **tech ET
+science** (présents dans `secondary_themes`) → il apparaît dans la section
+Technologie **et** Science. Le badge affiché vient de `source.theme`
+(`international`) → « Géopolitique ». D'où l'effet « hors-sujet partout ».
+
+> Les articles classifiés (149/162 chez Le Monde sur 48 h) passent correctement
+> par le chemin (1). La fuite ne concerne que les articles **frais non classifiés**
+> de **sources généralistes à `secondary_themes` larges** — précisément la fenêtre
+> 24 h de la Tournée.
+
+---
+
+## Plan de correction (structurel, anti-overfitting)
+
+### Fix #1 — Invariant « 1 sujet max » dans l'Essentiel
+`app/services/essentiel_service.py` :
+1. Appliquer le guard `used_topics` au **Round 2** (remplissage), pas seulement
+   au Round 1 → un topic déjà représenté ne peut plus ré-entrer.
+2. Filet de sécurité **anti-doublon de titre** (couvre les clusters scindés et le
+   couple actu/deep d'un même sujet en format éditorial) : avant de retenir un
+   article, l'écarter si son titre normalisé a une similarité Jaccard ≥
+   `TOPIC_CLUSTER_THRESHOLD` avec un article déjà retenu. Réutilise
+   `app/services/text_similarity.py` (aucune nouvelle dépendance).
+3. Conséquence assumée : s'il existe < 5 sujets distincts, l'Essentiel rend < 5
+   articles plutôt que de dupliquer un sujet (cohérent avec « transversaux »).
+
+### Fix #2 — Resserrer le filtre thématique pour les articles non classifiés
+`app/services/recommendation/filter_presets.py` → `apply_theme_focus_filter()` :
+- Pour le chemin « bénéfice du doute » (`Content.theme IS NULL`), restreindre au
+  **thème principal** de la source (`Source.theme == theme_slug`) et **ne plus**
+  s'appuyer sur `secondary_themes`.
+- Rationale : `secondary_themes` n'a de sens que pour les articles classifiés —
+  or ceux-ci passent déjà par le chemin (1) via `content.theme`. S'appuyer sur
+  les `secondary_themes` larges des sources généralistes pour des articles **non
+  classifiés** est précisément ce qui déverse Le Monde dans toutes les sections.
+- Effet : un article Le Monde non classifié n'apparaît plus que dans sa section
+  principale (international/Géopolitique) jusqu'à classification ML (latence
+  courte). Aucune régression sur les articles classifiés.
+
+### Tests
+- `tests/test_essentiel_endpoint.py` : cas « 1 topic multi-sources (3 articles) →
+  le sujet n'apparaît qu'1 fois » + cas « 2 titres quasi-identiques sur 2 topics →
+  1 seul retenu ».
+- `tests/test_personalized_theme_mode.py` : cas « article `theme=NULL` d'une source
+  généraliste (`secondary_themes` contient le slug, mais `source.theme` ≠ slug) →
+  exclu de la section » + non-régression « article classifié → inclus ».
+- Test unitaire direct sur `apply_theme_focus_filter` (SQL compilé / fixtures).
+
+### Hors-scope (noté, non traité ici)
+- Latence de classification ML (déclencheur sous-jacent du bug 2) : le fix #2
+  corrige la **frontière** de manière défensive sans dépendre du timing ML.
+- Refonte de l'algo de clustering : inutile, le clustering regroupe correctement.
+
+---
+
+## Fichiers impactés
+- `app/services/essentiel_service.py` (fix #1)
+- `app/services/recommendation/filter_presets.py` (fix #2)
+- `tests/test_essentiel_endpoint.py`, `tests/test_personalized_theme_mode.py` (+ test filtre)
+
+## Preuves prod (read-only, Supabase)
+- 3 articles météore → même `cluster_id`, `theme=science`.
+- Ukraine/baleine → `content.theme=NULL`, `topics=[]`, `source.theme=international`.
+- `Le Monde.secondary_themes` ⊇ {tech, science}.
+- Tous les digests du jour : `format_version = editorial_v1`.
+
+## Note de branche
+Bugs présents sur `main` (feature « Tournée du jour » absente de `staging`). La
+branche de travail `claude/essentials-curation-bugs-ebgnc` a été rebasée sur
+`origin/main` (elle était une copie de `staging`, sans commit propre).

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -54,6 +54,7 @@ from app.services.recommendation.filter_presets import (
 )
 from app.services.recommendation.helpers import compute_coverage_score
 from app.services.recommendation.scoring_config import ScoringWeights
+from app.services.text_similarity import jaccard_similarity, normalize_title
 
 logger = logging.getLogger(__name__)
 
@@ -462,6 +463,31 @@ def _pick_transversal_articles(
     seen_content_ids: set[UUID] = set()
     used_topics: set[str] = set()
     source_count: dict[UUID, int] = {}
+    picked_title_tokens: list[set[str]] = []
+
+    def _is_duplicate_subject(topic: DigestTopic, article: DigestTopicArticle) -> bool:
+        """Un même sujet ne doit jamais occuper deux slots de l'Essentiel.
+
+        L'Essentiel est une sélection *transversale* (1 article par sujet). On
+        bloque sur deux niveaux complémentaires :
+        - `topic.topic_id` déjà servi → un topic « revue de presse » multi-sources
+          (ex: météore couvert par 3 médias) ne peut ré-entrer via un round de
+          remplissage.
+        - similarité de titre Jaccard ≥ `TOPIC_CLUSTER_THRESHOLD` → filet pour les
+          clusters scindés ou le couple actu/deep d'un même sujet, dont les titres
+          quasi-identiques tomberaient sinon sur des `topic_id` différents.
+        """
+        if topic.topic_id in used_topics:
+            return True
+        tokens = normalize_title(article.title)
+        if tokens:
+            for prev in picked_title_tokens:
+                if (
+                    jaccard_similarity(tokens, prev)
+                    >= ScoringWeights.TOPIC_CLUSTER_THRESHOLD
+                ):
+                    return True
+        return False
 
     def _try_pick(topic: DigestTopic, article: DigestTopicArticle) -> bool:
         """Tente d'ajouter un article en respectant dédup + diversité source.
@@ -472,10 +498,13 @@ def _pick_transversal_articles(
             return False
         if source_count.get(article.source.id, 0) >= ESSENTIEL_MAX_PER_SOURCE:
             return False
+        if _is_duplicate_subject(topic, article):
+            return False
         picked.append((topic, article))
         seen_content_ids.add(article.content_id)
         used_topics.add(topic.topic_id)
         source_count[article.source.id] = source_count.get(article.source.id, 0) + 1
+        picked_title_tokens.append(normalize_title(article.title))
         return True
 
     # ─── Slot lead Actu ──────────────────────────────────────────────────

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -308,28 +308,37 @@ def apply_theme_focus_filter(query, theme_slug: str):
     Optimisé : résout le matching source-level via subquery sur la petite
     table sources (~100 rows), puis utilise deux chemins indexés sur contents
     via BitmapOr :
-      1. Content.source_id IN (source IDs matchant le thème) → ix_contents_source_id
-      2. Content.theme = theme_slug → ix_contents_theme_published
+      1. Content.theme = theme_slug → ix_contents_theme_published
+      2. Content.source_id IN (sources dont le thème PRINCIPAL matche)
+         ET Content.theme IS NULL → ix_contents_source_id
 
     Utilisé par le mode THEME_FOCUS (digest) et le filtre thème (feed).
+
+    NOTE (fix bug curation 2026-05-31) : pour les articles non classifiés
+    (`Content.theme IS NULL`), on ne s'appuie QUE sur le thème **principal** de
+    la source — jamais sur ses `secondary_themes`. Les sources généralistes ont
+    des `secondary_themes` très larges (Le Monde → society/politics/economy/
+    culture/tech/science) : les utiliser pour des articles frais non classifiés
+    déversait chaque article du matin dans des sections sans rapport (un fil
+    « guerre en Ukraine » apparaissant sous Technologie ET Science). Les articles
+    classifiés, eux, passent toujours par le chemin (1) via `content.theme`, donc
+    `secondary_themes` n'apporte rien d'autre que la fuite.
     """
-    # Subquery : source IDs dont le thème principal ou secondaire matche
-    theme_source_ids_subq = select(Source.id).where(
-        or_(
-            Source.theme == theme_slug,
-            Source.secondary_themes.any(theme_slug),
-        )
+    # Subquery : source IDs dont le thème PRINCIPAL matche (pas les secondaires).
+    primary_theme_source_ids_subq = select(Source.id).where(
+        Source.theme == theme_slug
     )
     # Deux chemins indexés sur la même table (contents) :
     # 1. Articles classifiés ML dans ce thème → toujours inclus
-    # 2. Articles de sources matchant le thème MAIS pas encore classifiés
-    #    (Content.theme IS NULL) → bénéfice du doute
+    # 2. Articles d'une source dont le thème principal matche MAIS pas encore
+    #    classifiés (Content.theme IS NULL) → bénéfice du doute, borné à la
+    #    section principale de la source.
     # Exclut: articles de sources matchantes mais classifiés dans un AUTRE thème
     return query.where(
         or_(
             Content.theme == theme_slug,
             and_(
-                Content.source_id.in_(theme_source_ids_subq),
+                Content.source_id.in_(primary_theme_source_ids_subq),
                 Content.theme.is_(None),
             ),
         )

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -325,9 +325,7 @@ def apply_theme_focus_filter(query, theme_slug: str):
     `secondary_themes` n'apporte rien d'autre que la fuite.
     """
     # Subquery : source IDs dont le thème PRINCIPAL matche (pas les secondaires).
-    primary_theme_source_ids_subq = select(Source.id).where(
-        Source.theme == theme_slug
-    )
+    primary_theme_source_ids_subq = select(Source.id).where(Source.theme == theme_slug)
     # Deux chemins indexés sur la même table (contents) :
     # 1. Articles classifiés ML dans ce thème → toujours inclus
     # 2. Articles d'une source dont le thème principal matche MAIS pas encore

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -136,17 +136,21 @@ def test_build_essentiel_picks_one_article_per_topic():
         assert article.section_label == f"T{i + 1}"
 
 
-def test_build_essentiel_round_robin_when_few_topics():
+def test_build_essentiel_one_subject_per_topic_no_backfill():
+    """Invariant transversal : un topic (= 1 sujet) ne fournit qu'1 article.
+
+    Régression bug 2026-05-31 : un topic « revue de presse » multi-articles
+    (ex: météore couvert par 3 médias) remplissait l'Essentiel avec le même
+    sujet 3×. On préfère désormais rendre < 5 articles plutôt que dupliquer.
+    """
     topics = [_make_topic(rank=1, label="Tech", n_articles=5)]
     digest = _make_digest(topics)
 
     response = build_essentiel_response(digest)
 
-    assert len(response.articles) == ESSENTIEL_MAX_ARTICLES
-    # Tous viennent du même topic, ranks 1..5 de l'essentiel.
-    assert all(a.section_label == "Tech" for a in response.articles)
-    seen_ids = {a.content_id for a in response.articles}
-    assert len(seen_ids) == 5  # déduplication implicite OK
+    # 1 seul sujet disponible → 1 seul article (pas de remplissage intra-topic).
+    assert len(response.articles) == 1
+    assert response.articles[0].section_label == "Tech"
 
 
 def test_build_essentiel_handles_sparse_digest():
@@ -155,9 +159,9 @@ def test_build_essentiel_handles_sparse_digest():
 
     response = build_essentiel_response(digest)
 
-    assert len(response.articles) == 2
+    # Un topic = un sujet → 1 article, jamais 2 angles du même sujet.
+    assert len(response.articles) == 1
     assert response.articles[0].rank == 1
-    assert response.articles[1].rank == 2
 
 
 def test_build_essentiel_empty_when_no_topics():
@@ -175,8 +179,70 @@ def test_build_essentiel_skips_topics_without_articles():
 
     response = build_essentiel_response(digest)
 
-    assert len(response.articles) == 3
+    # Topic vide ignoré ; le topic Tech ne contribue qu'1 article (1 sujet).
+    assert len(response.articles) == 1
     assert all(a.section_label == "Tech" for a in response.articles)
+
+
+def test_build_essentiel_dedup_same_subject_multi_source_topic():
+    """Bug 1 reproduction : 1 topic multi-sources sur le MÊME sujet (météore
+    couvert par 3 médias distincts) ne doit apparaître qu'une fois."""
+    src_home = _make_source("Home Fil actu")
+    src_ouest = _make_source("Ouest-France")
+    src_figaro = _make_source("Le Figaro")
+    meteor = _make_topic(rank=1, label="Météore", theme="science", n_articles=0)
+    meteor.articles = [
+        _make_article(
+            rank=1,
+            title='"300 tonnes de TNT": un météore explose au-dessus des États-Unis',
+            source=src_home,
+            badge="actu",
+        ),
+        _make_article(
+            rank=2,
+            title="Un météore explose au-dessus des États-Unis et se fait entendre",
+            source=src_ouest,
+        ),
+        _make_article(
+            rank=3,
+            title="Un météore explose au-dessus des États-Unis, détonations",
+            source=src_figaro,
+        ),
+    ]
+    other = _make_topic(rank=2, label="Économie", theme="economy", n_articles=1)
+    digest = _make_digest([meteor, other])
+
+    response = build_essentiel_response(digest)
+
+    # Le sujet météore (même topic, 3 sources) n'apparaît qu'une fois.
+    meteor_articles = [a for a in response.articles if "météore" in a.title.lower()]
+    assert len(meteor_articles) == 1
+
+
+def test_build_essentiel_dedup_near_duplicate_titles_across_topics():
+    """Filet anti-doublon de titre : deux topics distincts couvrant le même
+    événement (titres quasi-identiques) ne produisent qu'un seul article."""
+    split_a = _make_topic(rank=1, label="Élection A", theme="politics", n_articles=0)
+    split_a.articles = [
+        _make_article(
+            rank=1,
+            title="Élection présidentielle : large victoire du candidat sortant annoncée",
+            source=_make_source("Le Monde"),
+        )
+    ]
+    split_b = _make_topic(rank=2, label="Élection B", theme="politics", n_articles=0)
+    split_b.articles = [
+        _make_article(
+            rank=1,
+            title="Élection présidentielle : victoire large du candidat sortant",
+            source=_make_source("Le Figaro"),
+        )
+    ]
+    digest = _make_digest([split_a, split_b])
+
+    response = build_essentiel_response(digest)
+
+    assert len(response.articles) == 1
 
 
 def test_build_essentiel_propagates_stale_flag():

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -23,13 +23,13 @@ from app.models.enums import ContentType
 from app.schemas.content import SourceMini
 from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
 from app.services.essentiel_service import (
+    _W_TRENDING,
+    _W_UNE,
     ESSENTIEL_MAX_ARTICLES,
     EssentielUserContext,
     _perspective_score,
     _score_article,
     _source_letter,
-    _W_TRENDING,
-    _W_UNE,
     build_essentiel_response,
 )
 
@@ -383,9 +383,7 @@ def test_followed_source_promoted_above_unfollowed_competitor():
             theme="politique",
             perspective_count=2,
             articles=[
-                _make_article(
-                    rank=1, title="P-1", source=other_source
-                ),
+                _make_article(rank=1, title="P-1", source=other_source),
             ],
         ),
         DigestTopic(
@@ -396,9 +394,7 @@ def test_followed_source_promoted_above_unfollowed_competitor():
             theme="ecologie",
             perspective_count=2,
             articles=[
-                _make_article(
-                    rank=1, title="C-1", source=followed_source
-                ),
+                _make_article(rank=1, title="C-1", source=followed_source),
             ],
         ),
     ]
@@ -587,9 +583,7 @@ def test_tournee_pool_filter_drops_article_older_than_24h():
             theme="politique",
             perspective_count=2,
             articles=[
-                _make_article(
-                    rank=1, title="S-1", source=followed, published_at=stale
-                ),
+                _make_article(rank=1, title="S-1", source=followed, published_at=stale),
             ],
         ),
         DigestTopic(
@@ -745,9 +739,7 @@ async def test_get_essentiel_uses_user_context_from_router(auth_override: UUID):
             reason="Test",
             theme="ecologie",
             perspective_count=2,
-            articles=[
-                _make_article(rank=1, title="C-1", source=followed_source)
-            ],
+            articles=[_make_article(rank=1, title="C-1", source=followed_source)],
         ),
     ]
     digest = _make_digest(topics)
@@ -881,7 +873,14 @@ def test_sport_relegated_to_slot_5_when_pool_has_4_non_sport():
         topics=["sport"],
     )
     topics = [
-        _topic("Sport", [sport_art], theme="sport", is_trending=True, perspective_count=4, rank=1),
+        _topic(
+            "Sport",
+            [sport_art],
+            theme="sport",
+            is_trending=True,
+            perspective_count=4,
+            rank=1,
+        ),
         _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
         _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
         _topic("Tech", [_art(title="T1")], theme="tech", rank=4),
@@ -904,7 +903,14 @@ def test_sport_excluded_when_pool_under_4_non_sport():
     sport_src = _src("Ouest-France", theme="sport")
     sport_art = _art(title="F1 GP Canada", source=sport_src, topics=["sport"])
     topics = [
-        _topic("Sport", [sport_art], theme="sport", is_trending=True, perspective_count=5, rank=1),
+        _topic(
+            "Sport",
+            [sport_art],
+            theme="sport",
+            is_trending=True,
+            perspective_count=5,
+            rank=1,
+        ),
         _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
         _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
     ]
@@ -926,7 +932,14 @@ def test_sport_detected_via_content_topic_even_if_source_theme_is_society():
         topics=["sport"],  # ML a bien classifié "sport"
     )
     topics = [
-        _topic("NBA", [nba_art], theme="sport", is_trending=True, perspective_count=2, rank=1),
+        _topic(
+            "NBA",
+            [nba_art],
+            theme="sport",
+            is_trending=True,
+            perspective_count=2,
+            rank=1,
+        ),
         _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
         _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
         _topic("Tech", [_art(title="T1")], theme="tech", rank=4),
@@ -949,7 +962,14 @@ def test_sport_detected_via_title_keyword_only():
         topics=[],  # pas de ML
     )
     topics = [
-        _topic("Play-offs", [sport_art], theme="society", is_trending=True, perspective_count=2, rank=1),
+        _topic(
+            "Play-offs",
+            [sport_art],
+            theme="society",
+            is_trending=True,
+            perspective_count=2,
+            rank=1,
+        ),
         _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
         _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
         _topic("Tech", [_art(title="T1")], theme="tech", rank=4),
@@ -970,7 +990,14 @@ def test_news_bulletin_journal_de_8h_excluded():
         source=france_culture,
     )
     topics = [
-        _topic("Bulletin", [bulletin], theme="culture", is_trending=True, perspective_count=2, rank=1),
+        _topic(
+            "Bulletin",
+            [bulletin],
+            theme="culture",
+            is_trending=True,
+            perspective_count=2,
+            rank=1,
+        ),
         _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
         _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
     ]
@@ -999,7 +1026,10 @@ def test_news_bulletin_chronique_du_excluded():
 
     response = build_essentiel_response(digest)
 
-    assert all(a.title != "Avec Sciences, chronique du lundi 25 mai 2026" for a in response.articles)
+    assert all(
+        a.title != "Avec Sciences, chronique du lundi 25 mai 2026"
+        for a in response.articles
+    )
 
 
 def test_chronique_in_middle_of_title_not_excluded():
@@ -1067,7 +1097,14 @@ def test_reddit_source_excluded():
         source=reddit,
     )
     topics = [
-        _topic("Reddit", [post], theme="society", is_trending=True, perspective_count=3, rank=1),
+        _topic(
+            "Reddit",
+            [post],
+            theme="society",
+            is_trending=True,
+            perspective_count=3,
+            rank=1,
+        ),
         _topic("Politique", [_art(title="P1")], theme="politique", rank=2),
     ]
     digest = _make_digest(topics)
@@ -1107,7 +1144,9 @@ def test_six_perspectives_beats_one_perspective_scoop():
         # Scoop isolé en rank topic 1 (avantage rank), 1 perspective.
         _topic("Climat", [isolated], theme="science", perspective_count=1, rank=1),
         # Sujet relayé en rank topic 2, 6 perspectives.
-        _topic("MO", [very_relayed], theme="international", perspective_count=6, rank=2),
+        _topic(
+            "MO", [very_relayed], theme="international", perspective_count=6, rank=2
+        ),
     ]
     digest = _make_digest(topics)
 
@@ -1129,7 +1168,14 @@ def test_actu_lead_slot_skips_sport_trending():
     )
     regular = _art(title="Politique-1", source=_src("Le Monde"))
     topics = [
-        _topic("Sport", [sport_actu], theme="sport", is_trending=True, perspective_count=5, rank=1),
+        _topic(
+            "Sport",
+            [sport_actu],
+            theme="sport",
+            is_trending=True,
+            perspective_count=5,
+            rank=1,
+        ),
         _topic("Politique", [regular], theme="politique", perspective_count=3, rank=2),
         _topic("Climat", [_art(title="C1")], theme="ecologie", rank=3),
         _topic("Tech", [_art(title="T1")], theme="tech", rank=4),

--- a/packages/api/tests/test_personalized_theme_mode.py
+++ b/packages/api/tests/test_personalized_theme_mode.py
@@ -32,9 +32,7 @@ def _stub_scalars(captured: list):
     result.all.return_value = []
 
     async def _scalars(stmt):
-        captured.append(
-            stmt.compile(compile_kwargs={"literal_binds": False}).__str__()
-        )
+        captured.append(stmt.compile(compile_kwargs={"literal_binds": False}).__str__())
         return result
 
     return _scalars, result
@@ -186,13 +184,11 @@ async def test_explicit_filter_unchanged_when_personalized_false():
     )
     # No 24h window either.
     assert ">= " not in sql or "published_at" not in sql, (
-        "exploration must not add a 24h published_at filter. "
-        f"Got:\n{captured[0]}"
+        f"exploration must not add a 24h published_at filter. Got:\n{captured[0]}"
     )
     # No overlap-based ORDER BY.
     assert "overlap" not in sql and "&&" not in sql, (
-        "exploration must not add a subtopic overlap ORDER BY. "
-        f"Got:\n{captured[0]}"
+        f"exploration must not add a subtopic overlap ORDER BY. Got:\n{captured[0]}"
     )
 
 

--- a/packages/api/tests/test_personalized_theme_mode.py
+++ b/packages/api/tests/test_personalized_theme_mode.py
@@ -305,3 +305,44 @@ class TestPersonalizedThemeModeDispatch:
             )
             is False
         )
+
+
+# ---------------------------------------------------------------------------
+# `apply_theme_focus_filter` — bug curation 2026-05-31.
+#
+# Un article frais NON classifié (`Content.theme IS NULL`) d'une source
+# généraliste (ex: Le Monde, theme="international", secondary_themes incluant
+# "tech"/"science") ne doit PAS apparaître dans les sections Technologie/Science.
+# Le chemin "bénéfice du doute" ne s'appuie désormais que sur le thème PRINCIPAL
+# de la source, jamais sur ses `secondary_themes`.
+# ---------------------------------------------------------------------------
+
+
+class TestThemeFocusFilterUnclassified:
+    """Le filtre thématique ne fuit plus via les `secondary_themes`."""
+
+    def _compiled_sql(self, theme_slug: str) -> str:
+        from sqlalchemy import select
+
+        from app.models.content import Content
+        from app.services.recommendation.filter_presets import (
+            apply_theme_focus_filter,
+        )
+
+        query = apply_theme_focus_filter(select(Content), theme_slug)
+        return str(query.compile(compile_kwargs={"literal_binds": False}))
+
+    def test_unclassified_path_uses_source_primary_theme_only(self):
+        sql = self._compiled_sql("tech")
+        # Chemin (1) : article classifié dans le thème.
+        assert "contents.theme = " in sql
+        # Chemin (2) : sous-requête sur le thème PRINCIPAL de la source.
+        assert "sources.theme = " in sql
+        # Garde la borne "non classifié" sur le chemin (2).
+        assert "contents.theme IS NULL" in sql
+
+    def test_secondary_themes_no_longer_referenced(self):
+        sql = self._compiled_sql("tech")
+        # Régression : les secondary_themes déversaient les articles non
+        # classifiés des sources généralistes dans des sections sans rapport.
+        assert "secondary_themes" not in sql


### PR DESCRIPTION
Bug 1 (Essentiel — même sujet 3×): le clustering regroupe correctement
(cluster_id partagé), mais _pick_transversal_articles n'appliquait l'invariant
"1 sujet = 1 article" qu'au Round 1. Le Round 2 (remplissage) ré-injectait
d'autres articles du même topic. Guard used_topics centralisé dans _try_pick
(tous les rounds) + filet anti-doublon de titre (Jaccard). Rend < 5 articles
plutôt que dupliquer un sujet.

Bug 2 (sections thématiques hors-sujet): apply_theme_focus_filter admettait
les articles non classifiés (content.theme IS NULL) dès qu'une source matchait
le thème via ses secondary_themes. Les sources généralistes (Le Monde →
tech/science/...) déversaient ainsi chaque article frais dans des sections sans
rapport. Le chemin "bénéfice du doute" ne s'appuie plus que sur le thème
PRINCIPAL de la source. Les articles classifiés (chemin 1) sont inchangés.

Tests: 3 tests d'ancien comportement réécrits, 5 nouveaux (dédup multi-sources,
dédup titres quasi-identiques, filtre thème non classifié).

https://claude.ai/code/session_01WReRhinLpJ7R9v2n5Sxnfo