### PR TITLE
fix(pipeline): déduplication domaines RSS + filtre singletons podcast

### DIFF
--- a/packages/api/alembic/versions/dd01_dedup_franceinfo_vrai_ou_fake.py
+++ b/packages/api/alembic/versions/dd01_dedup_franceinfo_vrai_ou_fake.py
@@ -1,0 +1,30 @@
+"""data: désactiver France Info — Vrai ou Fake (doublon francetvinfo.fr).
+
+La source 'France Info — Vrai ou Fake' (feed vrai-ou-fake.rss) est un sous-flux
+du même domaine que 'France Info' (feed titres.rss). Avec les deux curated,
+source_ids est artificiellement gonflé dans le clustering et les perspectives
+affichent des doublons (même domaine, titres similaires).
+
+Fix: is_curated=false — la source principale France Info reste active.
+"""
+
+from alembic import op
+
+revision: str = "dd01_dedup_franceinfo_vrai_ou_fake"
+down_revision: str | None = "gr01_la_grille_du_jour"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_SOURCE_ID = "b71e6b5f-4995-43e3-990a-5674c719c737"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"UPDATE sources SET is_curated = false WHERE id = '{_SOURCE_ID}'"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        f"UPDATE sources SET is_curated = true WHERE id = '{_SOURCE_ID}'"
+    )

--- a/packages/api/alembic/versions/dd01_franceinfo_dedup.py
+++ b/packages/api/alembic/versions/dd01_franceinfo_dedup.py
@@ -10,7 +10,7 @@ Fix: is_curated=false — la source principale France Info reste active.
 
 from alembic import op
 
-revision: str = "dd01_dedup_franceinfo_vrai_ou_fake"
+revision: str = "dd01_franceinfo_dedup"
 down_revision: str | None = "gr01_la_grille_du_jour"
 branch_labels: str | None = None
 depends_on: str | None = None

--- a/packages/api/app/services/briefing/importance_detector.py
+++ b/packages/api/app/services/briefing/importance_detector.py
@@ -14,6 +14,7 @@ bruts et produit des clusters/flags d'importance utilisés par TopicSelector et 
 
 from collections import Counter
 from dataclasses import dataclass, field
+from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
 import structlog
@@ -35,6 +36,20 @@ from app.services.text_similarity import (
 # primaire ET un share Reddit du même sujet, on ne compte pas Reddit comme
 # une "couverture média" distincte. Cf. bug-digest-pipeline-fallbacks.md C4.
 _AGGREGATOR_SOURCE_TYPES: frozenset[SourceType] = frozenset({SourceType.REDDIT})
+
+
+def _extract_domain(url: str) -> str:
+    """Extrait le domaine canonique depuis une URL d'article.
+
+    Deux feeds du même site (ex: francetvinfo.fr/titres.rss et
+    francetvinfo.fr/vrai-ou-fake.rss) retournent le même domaine, évitant
+    qu'ils soient comptés comme deux sources distinctes dans le clustering.
+    """
+    try:
+        host = urlparse(str(url)).netloc
+        return (host or str(url)).removeprefix("www.")
+    except Exception:
+        return str(url)
 
 
 def _is_aggregator(content: Content) -> bool:
@@ -69,17 +84,18 @@ class TopicCluster:
     tokens: set[str]
     contents: list[Content] = field(default_factory=list)
     source_ids: set[UUID] = field(default_factory=set)
+    source_domains: set[str] = field(default_factory=set)
     theme: str | None = None  # Thème dominant du cluster
 
     @property
     def is_trending(self) -> bool:
-        """Cluster couvert par ≥3 sources distinctes."""
-        return len(self.source_ids) >= 3
+        """Cluster couvert par ≥3 domaines distincts."""
+        return len(self.source_domains) >= 3
 
     @property
     def is_multi_source(self) -> bool:
-        """Cluster couvert par ≥2 sources distinctes."""
-        return len(self.source_ids) >= 2
+        """Cluster couvert par ≥2 domaines distincts."""
+        return len(self.source_domains) >= 2
 
 
 class ImportanceDetector:
@@ -204,12 +220,18 @@ class ImportanceDetector:
             # repris uniquement par r/france mérite encore d'exister.
             primary_source_ids: set[UUID] = set()
             aggregator_source_ids: set[UUID] = set()
+            primary_source_domains: set[str] = set()
+            aggregator_source_domains: set[str] = set()
             for c in cluster_contents:
+                domain = _extract_domain(c.url)
                 if _is_aggregator(c):
                     aggregator_source_ids.add(c.source_id)
+                    aggregator_source_domains.add(domain)
                 else:
                     primary_source_ids.add(c.source_id)
+                    primary_source_domains.add(domain)
             source_ids = primary_source_ids or aggregator_source_ids
+            source_domains = primary_source_domains or aggregator_source_domains
 
             # Thème dominant : mode de content.theme, fallback source.theme
             themes: list[str] = []
@@ -228,6 +250,7 @@ class ImportanceDetector:
                     tokens=raw["tokens"],
                     contents=cluster_contents,
                     source_ids=source_ids,
+                    source_domains=source_domains,
                     theme=theme,
                 )
             )
@@ -270,7 +293,7 @@ class ImportanceDetector:
         trending_count = 0
 
         for cluster in clusters:
-            if len(cluster.source_ids) >= self.min_sources_for_trending:
+            if len(cluster.source_domains) >= self.min_sources_for_trending:
                 trending_count += 1
                 for content in cluster.contents:
                     trending_content_ids.add(content.id)

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -191,7 +191,9 @@ class EditorialPipelineService:
         # modes. Clusters are sorted by size desc so the largest — typically
         # the most trending — is kept. Skip the cap if the remaining non-
         # low-priority pool would be too small pour atteindre la cible sujets.
-        sorted_by_size = sorted(clusters, key=lambda c: len(c.source_domains), reverse=True)
+        sorted_by_size = sorted(
+            clusters, key=lambda c: len(c.source_domains), reverse=True
+        )
         capped = cap_low_priority_clusters(sorted_by_size)
         if len(capped) >= _read_target_subject_count():
             dropped = len(sorted_by_size) - len(capped)
@@ -251,9 +253,9 @@ class EditorialPipelineService:
                     trending=len(trending_clusters),
                 )
         elif a_la_une_pool:
-            top3 = sorted(a_la_une_pool, key=lambda c: len(c.source_domains), reverse=True)[
-                :3
-            ]
+            top3 = sorted(
+                a_la_une_pool, key=lambda c: len(c.source_domains), reverse=True
+            )[:3]
 
             if len(top3) == 1:
                 a_la_une_topic = _cluster_to_une_topic(top3[0])

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -27,6 +27,7 @@ from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.content import Content
+from app.models.enums import SourceType
 from app.models.source import Source
 from app.services.briefing.importance_detector import ImportanceDetector, TopicCluster
 from app.services.editorial.actu_matcher import ActuMatcher
@@ -50,6 +51,26 @@ from app.services.title_annotation_service import (
 )
 
 logger = structlog.get_logger()
+
+
+def _is_singleton_podcast(cluster: TopicCluster) -> bool:
+    """Vrai si le cluster n'est couvert que par un seul podcast.
+
+    Les épisodes de podcasts traitent de sujets thématiques spécifiques (ex:
+    Science CQFD) qui ne constituent pas de l'actualité multi-source. On les
+    exclut du pool LLM pour ne pas polluer le digest quotidien avec des sujets
+    de niche qui n'intéressent qu'une seule source.
+    Un cluster podcast + article reste inclus (is_multi_source=True).
+    """
+    if len(cluster.source_domains) > 1 or not cluster.contents:
+        return False
+    src = getattr(cluster.contents[0], "source", None)
+    src_type = getattr(src, "type", None) if src else None
+    try:
+        return bool(src_type) and SourceType(src_type) == SourceType.PODCAST
+    except (ValueError, TypeError):
+        return False
+
 
 # Curation oversample : on demande +buffer sujets de plus que la cible pour
 # absorber les échecs d'actu/deep matching. EDITORIAL_TARGET_SUBJECT_COUNT=5
@@ -170,7 +191,7 @@ class EditorialPipelineService:
         # modes. Clusters are sorted by size desc so the largest — typically
         # the most trending — is kept. Skip the cap if the remaining non-
         # low-priority pool would be too small pour atteindre la cible sujets.
-        sorted_by_size = sorted(clusters, key=lambda c: len(c.source_ids), reverse=True)
+        sorted_by_size = sorted(clusters, key=lambda c: len(c.source_domains), reverse=True)
         capped = cap_low_priority_clusters(sorted_by_size)
         if len(capped) >= _read_target_subject_count():
             dropped = len(sorted_by_size) - len(capped)
@@ -189,6 +210,18 @@ class EditorialPipelineService:
                 capped_size=len(capped),
             )
 
+        # Filtre singletons-podcast : épisodes thématiques d'une seule source
+        # (ex: Science CQFD) exclus du pool — pas de l'actu multi-source.
+        # Un cluster podcast + ≥1 autre source reste inclus.
+        filtered = [c for c in clusters if not _is_singleton_podcast(c)]
+        if dropped := len(clusters) - len(filtered):
+            logger.info(
+                "editorial_pipeline.singleton_podcast_filtered",
+                dropped=dropped,
+                remaining=len(filtered),
+            )
+        clusters = filtered
+
         # ÉTAPE 1B: Pré-sélection "À la Une" — cluster le plus couvert.
         # Cas standard : on prend parmi les clusters "trending" (≥3 sources).
         # Cas creux (week-end / jours fériés) : si aucun cluster ≥3, on
@@ -206,7 +239,7 @@ class EditorialPipelineService:
             if a_la_une_pool:
                 top3 = sorted(
                     a_la_une_pool,
-                    key=lambda c: len(c.source_ids),
+                    key=lambda c: len(c.source_domains),
                     reverse=True,
                 )[:3]
                 a_la_une_topic = await self.curation.select_bonne_nouvelle(top3)
@@ -218,7 +251,7 @@ class EditorialPipelineService:
                     trending=len(trending_clusters),
                 )
         elif a_la_une_pool:
-            top3 = sorted(a_la_une_pool, key=lambda c: len(c.source_ids), reverse=True)[
+            top3 = sorted(a_la_une_pool, key=lambda c: len(c.source_domains), reverse=True)[
                 :3
             ]
 

--- a/packages/api/tests/test_importance_detector.py
+++ b/packages/api/tests/test_importance_detector.py
@@ -156,6 +156,7 @@ class TestDetectTrendingClusters:
         mock.source_id = source_id or uuid.uuid4()
         mock.title = title
         mock.guid = str(uuid.uuid4())
+        mock.url = f"https://source-{mock.source_id}.fr/article"
         return mock
 
     def test_trending_with_3_sources(self):
@@ -374,6 +375,7 @@ class TestAggregatorFold:
         c.published_at = dt.now(UTC)
         c.entities = None
         c.theme = None
+        c.url = f"https://source-{c.source_id}.fr/article"
         c.source = MagicMock()
         c.source.type = source_type
         c.source.theme = "politique"

--- a/packages/api/tests/test_topic_selector.py
+++ b/packages/api/tests/test_topic_selector.py
@@ -55,12 +55,14 @@ def make_content(source=None, title=None, published_at=None, theme=None):
 def make_cluster(contents, theme=None, cluster_id=None):
     """Create a TopicCluster from a list of mock contents."""
     source_ids = set(c.source_id for c in contents)
+    source_domains = {f"source-{sid}.example.com" for sid in source_ids}
     return TopicCluster(
         cluster_id=cluster_id or str(uuid.uuid4()),
         label="",
         tokens={"test", "tokens"},
         contents=contents,
         source_ids=source_ids,
+        source_domains=source_domains,
         theme=theme,
     )
 

--- a/sources/sources_master.csv
+++ b/sources/sources_master.csv
@@ -60,7 +60,7 @@ La Croix — Analyses,https://www.la-croix.com/a-vif/,Site,society,CURATED,"Anal
 Courrier International — Analyses,https://www.courrierinternational.com/feed/all/,Site,international,CURATED,"Analyses et dossiers de Courrier International. Perspective mondiale par la traduction de la presse étrangère.",center,high,0.7,0.9,0.8,"[""geopolitics"", ""democracy""]",deep
 Slate FR — Explainers,https://www.slate.fr/explainers/,Site,culture,CURATED,"Articles explicatifs et analyses de Slate FR. Décryptage de l'actualité avec recul et profondeur.",center-left,high,0.7,0.8,0.8,"[""social-justice"", ""philosophy""]",deep
 Numerama — Décryptages,https://www.numerama.com/decryptage/,Site,tech,CURATED,"Décryptages tech et société numérique de Numerama. Analyses de fond sur le numérique et ses impacts.",center-left,high,0.7,0.8,0.8,"[""data-privacy"", ""regulation"", ""applied-science""]",deep
-France Info — Vrai ou Fake,https://www.francetvinfo.fr/vrai-ou-fake/,Site,society,CURATED,"Section fact-checking de France Info (Service Public). Vérification factuelle rigoureuse et pédagogique.",center,high,0.9,0.9,0.9,"[""democracy"", ""social-justice""]",deep
+France Info — Vrai ou Fake,https://www.francetvinfo.fr/vrai-ou-fake/,Site,society,INDEXED,"Section fact-checking de France Info (Service Public). Vérification factuelle rigoureuse et pédagogique.",center,high,0.9,0.9,0.9,"[""democracy"", ""social-justice""]",deep
 # --- 3. CANDIDATES (INDEXED) - Selection from sources_candidates.csv ---
 TF1 Info,https://www.tf1info.fr/,Site,society,INDEXED,"Information grand public du groupe TF1.",center-right,medium,,,,mainstream
 Public Sénat,https://www.publicsenat.fr/,Site,international,INDEXED,"Chaîne politique et parlementaire.",center,high,,,,mainstream


### PR DESCRIPTION
## Quoi

Deux fixes pour éliminer les doublons dans le digest et les perspectives :

1. **Quickwin** — désactivation de `France Info — Vrai ou Fake` (migration `dd01`) : ce sous-flux du même domaine `francetvinfo.fr` gonflait artificiellement `source_ids` dans le clustering et générait des titres en double dans les perspectives
2. **Domain-based counting** — `TopicCluster` acquiert un champ `source_domains: set[str]` ; `is_multi_source` et `is_trending` utilisent désormais le nombre de domaines distincts (pas d'UUID de sources). Deux feeds du même site comptent comme 1 source
3. **Filtre singleton-podcast** — les clusters couverts par un seul podcast (ex. Science CQFD épisodes thématiques) sont exclus du pool LLM avant la curation. Un cluster podcast + ≥1 autre source reste inclus

## Pourquoi

- Perspectives affichaient des doublons de titres (France Info × 2 = même contenu, même domaine)
- Le digest quotidien remontait chaque jour des articles Science CQFD sur des sujets de niche sans aucune couverture multi-source

## Comment ça a été vérifié

- [x] `pytest -v` — 166 tests OK (failures pré-existantes = connexion DB locale absente, non liées)
- [x] 1 head Alembic (`dd01_dedup_franceinfo_vrai_ou_fake`)
- [x] `/simplify` passé — 4 fixes appliqués (efficiency, simplification × 2, altitude)
- [x] `is_trending` / `is_multi_source` validés sur les cas same-source, 2-source, 3-source

## Zones à risque

- `TopicCluster` : nouveau champ `source_domains` — tout code qui crée des `TopicCluster` manuellement (tests) doit le peupler
- `detect_trending_clusters()` : utilise maintenant `source_domains` au lieu de `source_ids`
- Pipeline éditorial : le filtre singleton-podcast s'applique avant la curation LLM — si Sciences CQFD est le seul contenu sur un sujet trending, il disparaît du digest (comportement voulu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)