### PR TITLE
fix(onboarding): rendre observable l'enregistrement des sources (fin du silent fail)

### DIFF
--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -261,6 +261,29 @@ class AnalyticsService {
     await _logEvent('source_remove', {'source_id': sourceId});
   }
 
+  /// Issue de l'enregistrement des sources en fin d'onboarding.
+  ///
+  /// Rend OBSERVABLE en production l'écart "sources demandées → enregistrées".
+  /// Avant, un échec n'était qu'un `debugPrint` (invisible en release) → classe
+  /// de bug "enregistrement silencieux". `failed` = l'appel onboarding lui-même
+  /// n'a pas abouti (tous les retries KO).
+  Future<void> trackOnboardingSourcesRegistered({
+    required int requested,
+    required int created,
+    bool failed = false,
+  }) async {
+    final props = {
+      'session_id': _sessionId,
+      'requested': requested,
+      'created': created,
+      // signal clé pour l'alerting : des sources demandées mais 0 enregistrée
+      'missing': failed ? requested : (requested - created).clamp(0, requested),
+      'failed': failed,
+    };
+    await _logEvent('onboarding_sources_registered', props);
+    await _capturePostHog('onboarding_sources_registered', props);
+  }
+
   // ──────────────────────────────────────────────────────────────
   // Sprint 2 — feature-by-feature events (PR1)
   // ──────────────────────────────────────────────────────────────

--- a/apps/mobile/lib/features/onboarding/providers/conclusion_notifier.dart
+++ b/apps/mobile/lib/features/onboarding/providers/conclusion_notifier.dart
@@ -6,6 +6,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
+import '../../../core/providers/analytics_provider.dart';
 import '../../../models/onboarding_result.dart';
 import '../../../models/user_profile.dart';
 import '../../../features/sources/providers/sources_providers.dart';
@@ -68,6 +69,18 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
       // automatique au prochain lancement, puis afficher le fallback.
       _minAnimationTimer?.cancel();
       await _saveProfileLocallyDegraded();
+      // Échec de transport tracé (jamais silencieux) si des sources étaient demandées.
+      final requestedSources =
+          _ref.read(onboardingProvider).answers.preferredSources?.length ?? 0;
+      if (requestedSources > 0) {
+        unawaited(
+          _ref.read(analyticsServiceProvider).trackOnboardingSourcesRegistered(
+                requested: requestedSources,
+                created: 0,
+                failed: true,
+              ),
+        );
+      }
       state = ConclusionError(e.toString());
     }
   }
@@ -128,13 +141,24 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
           'Sources: ${result.sourcesCreated}',
         );
 
-        // Alerte si l'utilisateur avait sélectionné des sources mais aucune n'a été créée
-        if ((answers.preferredSources?.isNotEmpty ?? false) &&
-            (result.sourcesCreated ?? 0) == 0) {
-          debugPrint(
-            '⚠️ ATTENTION: ${answers.preferredSources!.length} sources sélectionnées '
-            'mais 0 créées côté serveur !',
+        // Observabilité : rendre l'issue de l'enregistrement des sources visible
+        // EN PRODUCTION (télémétrie), et plus seulement via un debugPrint avalé
+        // en release → fin de la classe de bug "enregistrement silencieux".
+        final requestedSources = answers.preferredSources?.length ?? 0;
+        if (requestedSources > 0) {
+          final created = result.sourcesCreated ?? 0;
+          unawaited(
+            _ref.read(analyticsServiceProvider).trackOnboardingSourcesRegistered(
+                  requested: requestedSources,
+                  created: created,
+                ),
           );
+          if (created == 0) {
+            debugPrint(
+              '⚠️ ATTENTION: $requestedSources sources sélectionnées '
+              'mais 0 créées côté serveur !',
+            );
+          }
         }
         return; // Succès, on sort
       }


### PR DESCRIPTION
## Contexte

Suite à l'analyse du bug récurrent « sources sélectionnées non enregistrées en fin d'onboarding » (silent error). En vérifiant le **vrai** tronc `main`, le gros du correctif **est déjà présent** :

- `save_onboarding` filtre déjà `Source.is_active` + détecte les sources manquantes + réconciliation (`sources_removed`) ;
- `UserSource.state` est mappé (enum `InterestState`, défaut `followed` → visible dans le feed) ;
- mode dégradé `pending_sync` + `answers_backup` re-synchronisé par le bootstrap ;
- tests `test_onboarding_sources.py`.

(La PR #724, basée par erreur sur `staging` — ~432 commits de retard — a été fermée : conflits + redondante.)

## Le seul angle mort restant : l'observabilité

Côté mobile, un écart « sources demandées → enregistrées » n'était signalé que par un `debugPrint` — **invisible en release**. Donc si la classe de bug réapparaissait, personne ne le verrait. Cette PR le rend **alertable en production**.

## Changements (2 fichiers, +53/−6)

- **`analytics_service.dart`** : `trackOnboardingSourcesRegistered({requested, created, missing, failed})`, émis vers le backend analytics **et** PostHog (même pattern que les autres events).
- **`conclusion_notifier.dart`** :
  - succès → émet la télémétrie de l'issue d'enregistrement (remplace le `debugPrint` avalé) ;
  - échec de transport (tous les retries KO) → émet `failed: true`.

Un échec d'enregistrement de sources n'est donc **plus jamais silencieux**.

## Tests

⚠️ Non exécutables dans le sandbox (Flutter absent). Changement additif et isolé (télémétrie best-effort via `unawaited`, ne bloque jamais le flux). À valider par `flutter analyze` / `flutter test` en CI.

## Suivi possible (hors scope)

La *trust loop* cliente (`_trustSelectedSourcesWithTimeout`) est désormais redondante avec l'enregistrement serveur atomique — candidate à suppression dans un second temps (après confirmation qu'aucun effet de bord `trustSource`, ex. auto-unmute, n'est requis).

https://claude.ai/code/session_01WPkN2i5wwfyix7TS4kntnk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPkN2i5wwfyix7TS4kntnk)_