### PR TITLE
feat(nav): shell partagé onglets — header/footer fixes, body slide, scroll-to-top, footer glass premium

### DIFF
--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../shared/widgets/navigation/swipe_back_page.dart';
+import '../shared/widgets/navigation/main_shell.dart';
 
 import '../features/auth/screens/login_screen.dart';
 import '../features/auth/screens/splash_screen.dart';
@@ -44,43 +45,16 @@ import '../core/services/deep_link_service.dart';
 import '../core/ui/notification_service.dart';
 import '../shared/widgets/navigation/modal_bottom_sheet_page.dart';
 
-/// Onglet de bottom-nav affiché en dernier (Essentiel = 0, Flâner = 1).
+/// Clés de navigator des deux branches du shell principal (Essentiel / Flâner).
 ///
-/// Suivi au niveau module pour que la transition directionnelle entre onglets
-/// reste correcte quel que soit le chemin de navigation (tap footer, closing
-/// card, redirect, resume), et pas seulement sur un tap explicite du footer.
-int _lastMainTabIndex = 0;
-
-/// Construit la page d'un onglet principal avec une transition latérale
-/// directionnelle : l'onglet cible glisse depuis la gauche quand on avance vers
-/// la droite (Essentiel → Flâner) et depuis la droite quand on recule vers la
-/// gauche (Flâner → Essentiel). Sur le même onglet (delta nul) → simple fondu.
-CustomTransitionPage<void> _mainTabPage({
-  required LocalKey key,
-  required int tabIndex,
-  required Widget child,
-}) {
-  final delta = tabIndex - _lastMainTabIndex;
-  _lastMainTabIndex = tabIndex;
-  return CustomTransitionPage<void>(
-    key: key,
-    transitionDuration: const Duration(milliseconds: 260),
-    reverseTransitionDuration: const Duration(milliseconds: 260),
-    transitionsBuilder: (context, animation, secondaryAnimation, page) {
-      if (delta == 0) {
-        return FadeTransition(opacity: animation, child: page);
-      }
-      final begin = delta > 0 ? const Offset(-1, 0) : const Offset(1, 0);
-      return SlideTransition(
-        position: Tween<Offset>(begin: begin, end: Offset.zero).animate(
-          CurvedAnimation(parent: animation, curve: Curves.easeOutCubic),
-        ),
-        child: page,
-      );
-    },
-    child: child,
-  );
-}
+/// Chaque branche d'un `StatefulShellRoute` possède son propre navigator pour
+/// préserver son état (scroll, pile) quand on passe d'un onglet à l'autre. Le
+/// navigator *root* reste `NotificationService.navigatorKey` (cf. `GoRouter`
+/// plus bas) — c'est lui que ciblent les sous-routes article via
+/// `parentNavigatorKey` pour s'afficher plein écran au-dessus du footer.
+final _essentielBranchKey =
+    GlobalKey<NavigatorState>(debugLabel: 'essentielBranch');
+final _flanerBranchKey = GlobalKey<NavigatorState>(debugLabel: 'flanerBranch');
 
 /// Noms des routes
 class RouteNames {
@@ -297,87 +271,106 @@ final routerProvider = Provider<GoRouter>((ref) {
         builder: (context, state) => const ConclusionAnimationScreen(),
       ),
 
-      // Flux Continu V1.8 — nouvelle home post-auth (Story 21.1)
-      GoRoute(
-        path: RoutePaths.fluxContinu,
-        name: RouteNames.fluxContinu,
-        pageBuilder: (context, state) => _mainTabPage(
-          key: state.pageKey,
-          tabIndex: 0,
-          child: const Stack(children: [FluxContinuScreen(), NudgeHost()]),
+      // Shell principal des deux onglets (Essentiel / Flâner). Le shell pose un
+      // header + footer FIXES (MainShell) ; seul le body glisse au changement
+      // d'onglet (BranchPageView). Les sous-routes article s'échappent vers le
+      // navigator root via `parentNavigatorKey` pour s'afficher plein écran
+      // au-dessus du footer (swipe-back Cupertino conservé).
+      StatefulShellRoute(
+        builder: (context, state, navigationShell) =>
+            MainShell(navigationShell: navigationShell),
+        navigatorContainerBuilder: (context, navigationShell, children) =>
+            BranchPageView(
+          navigationShell: navigationShell,
+          children: children,
         ),
-        routes: [
-          GoRoute(
-            path: 'content/:id',
-            // Nom historique conservé pour que `context.pushNamed(contentDetail)`
-            // continue de fonctionner après la suppression de la route /feed.
-            name: RouteNames.contentDetail,
-            parentNavigatorKey: NotificationService.navigatorKey,
-            pageBuilder: (context, state) {
-              final contentId = state.pathParameters['id']!;
-              final content = state.extra as Content?;
-              return FullSwipeCupertinoPage(
-                child: ContentDetailScreen(
-                  contentId: contentId,
-                  content: content,
-                ),
-              );
-            },
+        branches: [
+          // Branche 0 — L'Essentiel (Flux Continu, home post-auth Story 21.1).
+          StatefulShellBranch(
+            navigatorKey: _essentielBranchKey,
+            routes: [
+              GoRoute(
+                path: RoutePaths.fluxContinu,
+                name: RouteNames.fluxContinu,
+                builder: (context, state) =>
+                    const Stack(children: [FluxContinuScreen(), NudgeHost()]),
+                routes: [
+                  GoRoute(
+                    path: 'content/:id',
+                    // Nom historique conservé pour que
+                    // `context.pushNamed(contentDetail)` fonctionne toujours.
+                    name: RouteNames.contentDetail,
+                    parentNavigatorKey: NotificationService.navigatorKey,
+                    pageBuilder: (context, state) {
+                      final contentId = state.pathParameters['id']!;
+                      final content = state.extra as Content?;
+                      return FullSwipeCupertinoPage(
+                        child: ContentDetailScreen(
+                          contentId: contentId,
+                          content: content,
+                        ),
+                      );
+                    },
+                  ),
+                  GoRoute(
+                    path: 'theme/:key',
+                    parentNavigatorKey: NotificationService.navigatorKey,
+                    pageBuilder: (context, state) {
+                      final key = state.pathParameters['key']!;
+                      final section = state.extra as FeedThemeSection?;
+                      return FullSwipeCupertinoPage(
+                        child: ThemeSectionScreen(
+                          sectionKeyValue: key,
+                          initialSection: section,
+                        ),
+                      );
+                    },
+                  ),
+                  GoRoute(
+                    path: 'section/:key',
+                    parentNavigatorKey: NotificationService.navigatorKey,
+                    pageBuilder: (context, state) {
+                      final key = state.pathParameters['key']!;
+                      final section = state.extra as DigestTopicSection?;
+                      return FullSwipeCupertinoPage(
+                        child: DigestSectionScreen(
+                          sectionKeyValue: key,
+                          initialSection: section,
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ],
           ),
-          GoRoute(
-            path: 'theme/:key',
-            parentNavigatorKey: NotificationService.navigatorKey,
-            pageBuilder: (context, state) {
-              final key = state.pathParameters['key']!;
-              final section = state.extra as FeedThemeSection?;
-              return FullSwipeCupertinoPage(
-                child: ThemeSectionScreen(
-                  sectionKeyValue: key,
-                  initialSection: section,
-                ),
-              );
-            },
-          ),
-          GoRoute(
-            path: 'section/:key',
-            parentNavigatorKey: NotificationService.navigatorKey,
-            pageBuilder: (context, state) {
-              final key = state.pathParameters['key']!;
-              final section = state.extra as DigestTopicSection?;
-              return FullSwipeCupertinoPage(
-                child: DigestSectionScreen(
-                  sectionKeyValue: key,
-                  initialSection: section,
-                ),
-              );
-            },
-          ),
-        ],
-      ),
-
-      // Flâner — feed autonome.
-      GoRoute(
-        path: RoutePaths.flaner,
-        name: RouteNames.flaner,
-        pageBuilder: (context, state) => _mainTabPage(
-          key: state.pageKey,
-          tabIndex: 1,
-          child: const Stack(children: [FlanerScreen(), NudgeHost()]),
-        ),
-        routes: [
-          GoRoute(
-            path: 'content/:id',
-            parentNavigatorKey: NotificationService.navigatorKey,
-            pageBuilder: (context, state) {
-              final contentId = state.pathParameters['id']!;
-              final content = state.extra as Content?;
-              return FullSwipeCupertinoPage(
-                child: ContentDetailScreen(
-                  contentId: contentId,
-                  content: content,
-                ),
-              );
-            },
+          // Branche 1 — Flâner (feed autonome).
+          StatefulShellBranch(
+            navigatorKey: _flanerBranchKey,
+            routes: [
+              GoRoute(
+                path: RoutePaths.flaner,
+                name: RouteNames.flaner,
+                builder: (context, state) =>
+                    const Stack(children: [FlanerScreen(), NudgeHost()]),
+                routes: [
+                  GoRoute(
+                    path: 'content/:id',
+                    parentNavigatorKey: NotificationService.navigatorKey,
+                    pageBuilder: (context, state) {
+                      final contentId = state.pathParameters['id']!;
+                      final content = state.extra as Content?;
+                      return FullSwipeCupertinoPage(
+                        child: ContentDetailScreen(
+                          contentId: contentId,
+                          content: content,
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ],
           ),
         ],
       ),

--- a/apps/mobile/lib/core/providers/navigation_providers.dart
+++ b/apps/mobile/lib/core/providers/navigation_providers.dart
@@ -1,4 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Provider to trigger scroll to top on the Feed tab
+/// Déclencheur de scroll-to-top pour l'onglet Flâner.
+///
+/// Incrémenté par le shell (`MainShell`) quand l'utilisateur re-tape l'onglet
+/// déjà actif ; `FlanerScreen` l'écoute via `ref.listen` et appelle son
+/// `_scrollToTop()`.
 final feedScrollTriggerProvider = StateProvider<int>((ref) => 0);
+
+/// Déclencheur de scroll-to-top pour l'onglet L'Essentiel (Flux Continu).
+///
+/// Miroir de [feedScrollTriggerProvider] : incrémenté par `MainShell` au re-tap
+/// de l'onglet actif, écouté par `FluxContinuScreen`.
+final essentielScrollTriggerProvider = StateProvider<int>((ref) => 0);

--- a/apps/mobile/lib/features/feed/screens/flaner_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/flaner_screen.dart
@@ -9,21 +9,17 @@ import 'package:visibility_detector/visibility_detector.dart';
 
 import '../../../config/routes.dart';
 import '../../../config/theme.dart';
+import '../../../core/providers/navigation_providers.dart';
 import '../../../shared/widgets/loaders/loading_view.dart';
-import '../../../shared/widgets/navigation/main_bottom_nav.dart';
 import '../../../widgets/article_preview_modal.dart';
-import '../../../widgets/design/facteur_logo.dart';
-import '../../app_update/providers/app_update_provider.dart';
 import '../../flux_continu/widgets/flux_continu_article_card.dart';
 import '../../flux_continu/widgets/section_banner.dart';
-import '../../gamification/widgets/streak_indicator.dart';
 import '../../sources/widgets/pepites_carousel.dart';
 import '../models/content_model.dart';
 import '../providers/feed_provider.dart';
 import '../widgets/feed_carousel.dart';
 import '../widgets/feed_filter_bar.dart';
 import '../widgets/follow_keyword_suggestion_card.dart';
-import '../widgets/profile_avatar_button.dart';
 
 const double _kLoadMoreLeadingPx = 800.0;
 const double _kScrollDirThreshold = 12.0;
@@ -124,12 +120,13 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
   Widget build(BuildContext context) {
     final async = ref.watch(feedProvider);
     final colors = context.facteurColors;
+    // Re-tap de l'onglet actif (depuis le shell) → remonter en haut.
+    ref.listen(feedScrollTriggerProvider, (_, __) => _scrollToTop());
     return Scaffold(
       backgroundColor: colors.backgroundPrimary,
-      bottomNavigationBar: const MainBottomNav(
-        current: MainBottomNavDestination.flaner,
-      ),
+      // Header & footer vivent désormais dans le shell partagé (MainShell).
       body: SafeArea(
+        top: false,
         bottom: false,
         child: Stack(
           children: [
@@ -174,7 +171,8 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
         controller: _scroll,
         physics: const AlwaysScrollableScrollPhysics(),
         slivers: [
-          const SliverToBoxAdapter(child: _Header()),
+          // NB : le header (logo · streak · réglages) vit dans le shell partagé
+          // (MainShell) — fixe, hors du scroll.
           const SliverToBoxAdapter(
             child: SectionBanner(
               title: 'Flâner',
@@ -267,67 +265,6 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
           ),
         );
       }, childCount: contents.length + intercalations.length),
-    );
-  }
-}
-
-class _Header extends ConsumerWidget {
-  const _Header();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = context.facteurColors;
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: FacteurSpacing.space6,
-        vertical: FacteurSpacing.space3,
-      ),
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          const FacteurLogo(size: 22, showIcon: false),
-          const Align(
-            alignment: Alignment.centerLeft,
-            child: StreakIndicator(),
-          ),
-          Align(
-            alignment: Alignment.centerRight,
-            child: Consumer(
-              builder: (context, ref, _) {
-                final hasUpdate =
-                    ref.watch(appUpdateProvider).valueOrNull?.updateAvailable ==
-                        true;
-                final settingsButton = ProfileAvatarButton(
-                  onTap: () => context.push(RoutePaths.settings),
-                );
-                if (!hasUpdate) return settingsButton;
-                return Stack(
-                  clipBehavior: Clip.none,
-                  children: [
-                    settingsButton,
-                    Positioned(
-                      top: -2,
-                      right: -2,
-                      child: Container(
-                        width: 12,
-                        height: 12,
-                        decoration: BoxDecoration(
-                          color: colors.error,
-                          shape: BoxShape.circle,
-                          border: Border.all(
-                            color: colors.backgroundPrimary,
-                            width: 2,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                );
-              },
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -14,16 +14,12 @@ import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../../core/orchestration/first_impression_orchestrator.dart';
 import '../../../core/providers/analytics_provider.dart';
-import '../../../widgets/design/facteur_logo.dart';
-import '../../../shared/widgets/navigation/main_bottom_nav.dart';
-import '../../app_update/providers/app_update_provider.dart';
+import '../../../core/providers/navigation_providers.dart';
 import '../../custom_topics/widgets/topic_chip.dart';
 import '../../digest/models/digest_models.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/providers/swipe_hint_provider.dart';
 import '../../feed/widgets/feedback_inline.dart';
-import '../../feed/widgets/profile_avatar_button.dart';
-import '../../gamification/widgets/streak_indicator.dart';
 import '../../lettres/widgets/lettres_notification_banner.dart';
 import '../../notifications/widgets/notification_renudge_banner.dart';
 import '../../well_informed/widgets/well_informed_prompt.dart';
@@ -592,12 +588,15 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(fluxContinuProvider);
+    // Re-tap de l'onglet actif (depuis le shell) → remonter en haut.
+    ref.listen(essentielScrollTriggerProvider, (_, __) => _scrollToTop());
     return Scaffold(
       backgroundColor: context.facteurColors.backgroundPrimary,
-      bottomNavigationBar: const MainBottomNav(
-        current: MainBottomNavDestination.essentiel,
-      ),
+      // Header & footer vivent désormais dans le shell partagé (MainShell) :
+      // l'écran ne fournit plus de bottomNavigationBar ni de header, et son top
+      // inset est déjà consommé par le header fixe du shell.
       body: SafeArea(
+        top: false,
         bottom: false,
         child: Stack(
           children: [
@@ -687,63 +686,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
         controller: _scroll,
         physics: const AlwaysScrollableScrollPhysics(),
         slivers: [
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: FacteurSpacing.space6,
-                vertical: FacteurSpacing.space3,
-              ),
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  const FacteurLogo(size: 22, showIcon: false),
-                  const Align(
-                    alignment: Alignment.centerLeft,
-                    child: StreakIndicator(),
-                  ),
-                  Align(
-                    alignment: Alignment.centerRight,
-                    child: Consumer(
-                      builder: (context, ref, _) {
-                        final hasUpdate =
-                            ref
-                                .watch(appUpdateProvider)
-                                .valueOrNull
-                                ?.updateAvailable ==
-                            true;
-                        final settingsButton = ProfileAvatarButton(
-                          onTap: () => context.push(RoutePaths.settings),
-                        );
-                        if (!hasUpdate) return settingsButton;
-                        return Stack(
-                          clipBehavior: Clip.none,
-                          children: [
-                            settingsButton,
-                            Positioned(
-                              top: -2,
-                              right: -2,
-                              child: Container(
-                                width: 12,
-                                height: 12,
-                                decoration: BoxDecoration(
-                                  color: colors.error,
-                                  shape: BoxShape.circle,
-                                  border: Border.all(
-                                    color: colors.backgroundPrimary,
-                                    width: 2,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        );
-                      },
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
+          // NB : le header (logo · streak · réglages) vit dans le shell partagé
+          // (MainShell) — fixe, hors du scroll.
           SliverToBoxAdapter(
             child: impressionSlot == FirstImpressionSlot.renudgeBanner
                 ? const NotificationRenudgeBanner()

--- a/apps/mobile/lib/shared/widgets/navigation/main_bottom_nav.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/main_bottom_nav.dart
@@ -1,67 +1,90 @@
 import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-import '../../../config/routes.dart';
 import '../../../config/theme.dart';
-
-enum MainBottomNavDestination { essentiel, flaner }
 
 /// Bottom nav persistante des deux onglets principaux (Essentiel / Flâner).
 ///
+/// Posée dans le shell partagé (`MainShell`) — elle ne navigue pas elle-même :
+/// elle remonte les taps via [onSelect] et c'est le shell qui décide (changement
+/// d'onglet vs scroll-to-top sur re-tap de l'onglet actif).
+///
 /// Style « point » historique de l'app (repris de `sticky_tab_bar.dart` `_Tab`)
-/// posé sur une surface glassmorphique (reprise de `_ScrollToTopButton` dans
-/// `flaner_screen.dart`) : aucune icône, juste un point orange sous l'onglet
-/// actif et un label. Le flou laisse transparaître le contenu qui défile
-/// derrière la barre.
+/// posé sur une surface glassmorphique premium : coins supérieurs arrondis, flou
+/// qui laisse transparaître le contenu défilant derrière, hairline + ombre douce.
 class MainBottomNav extends StatelessWidget {
-  final MainBottomNavDestination current;
+  /// Index de l'onglet actif (0 = L'Essentiel, 1 = Flâner).
+  final int currentIndex;
 
-  const MainBottomNav({super.key, required this.current});
+  /// Appelé au tap d'un onglet (actif ou non). Le shell arbitre la suite.
+  final ValueChanged<int> onSelect;
+
+  const MainBottomNav({
+    super.key,
+    required this.currentIndex,
+    required this.onSelect,
+  });
+
+  static const BorderRadius _topRadius = BorderRadius.vertical(
+    top: Radius.circular(20),
+  );
 
   @override
   Widget build(BuildContext context) {
-    final colors = context.facteurColors;
     final isDark = context.isDarkMode;
     final fillColor = isDark
-        ? colors.backgroundPrimary.withValues(alpha: 0.78)
-        : const Color.fromRGBO(242, 232, 213, 0.82);
+        ? context.facteurColors.backgroundPrimary.withValues(alpha: 0.80)
+        : const Color.fromRGBO(242, 232, 213, 0.86);
     final borderColor = isDark
-        ? Colors.white.withValues(alpha: 0.10)
+        ? Colors.white.withValues(alpha: 0.12)
         : const Color.fromRGBO(0, 0, 0, 0.08);
 
-    return ClipRect(
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
-        child: Container(
-          decoration: BoxDecoration(
-            color: fillColor,
-            border: Border(top: BorderSide(color: borderColor)),
+    return DecoratedBox(
+      // Ombre douce projetée vers le haut pour décoller la barre du contenu.
+      decoration: BoxDecoration(
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: isDark ? 0.32 : 0.10),
+            blurRadius: 18,
+            spreadRadius: -6,
+            offset: const Offset(0, -4),
           ),
-          child: SafeArea(
-            top: false,
-            child: SizedBox(
-              height: 50,
-              child: Row(
-                children: [
-                  Expanded(
-                    child: _FooterTab(
-                      label: 'L’Essentiel',
-                      selected:
-                          current == MainBottomNavDestination.essentiel,
-                      onTap: () => context.go(RoutePaths.fluxContinu),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: _topRadius,
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+          child: Container(
+            decoration: BoxDecoration(
+              color: fillColor,
+              borderRadius: _topRadius,
+              border: Border(top: BorderSide(color: borderColor)),
+            ),
+            child: SafeArea(
+              top: false,
+              child: SizedBox(
+                height: 50,
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: _FooterTab(
+                        label: 'L’Essentiel',
+                        selected: currentIndex == 0,
+                        onTap: () => onSelect(0),
+                      ),
                     ),
-                  ),
-                  Expanded(
-                    child: _FooterTab(
-                      label: 'Flâner',
-                      selected: current == MainBottomNavDestination.flaner,
-                      onTap: () => context.go(RoutePaths.flaner),
+                    Expanded(
+                      child: _FooterTab(
+                        label: 'Flâner',
+                        selected: currentIndex == 1,
+                        onTap: () => onSelect(1),
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),

--- a/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../config/routes.dart';
+import '../../../config/theme.dart';
+import '../../../core/providers/navigation_providers.dart';
+import '../../../features/app_update/providers/app_update_provider.dart';
+import '../../../features/feed/widgets/profile_avatar_button.dart';
+import '../../../features/gamification/widgets/streak_indicator.dart';
+import '../../../widgets/design/facteur_logo.dart';
+import 'main_bottom_nav.dart';
+
+/// Shell partagé des deux onglets principaux (L'Essentiel / Flâner).
+///
+/// C'est le `builder` du `StatefulShellRoute` : il pose un header **fixe** et un
+/// footer **fixe** (`MainBottomNav`), et confie le contenu central à
+/// [navigationShell] (rendu par [BranchPageView] via le `navigatorContainerBuilder`).
+/// Seul ce contenu glisse au changement d'onglet — header et footer restent
+/// immobiles.
+class MainShell extends ConsumerWidget {
+  final StatefulNavigationShell navigationShell;
+
+  const MainShell({super.key, required this.navigationShell});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      backgroundColor: context.facteurColors.backgroundPrimary,
+      // Le contenu passe sous le footer glassmorphique pour que le flou révèle
+      // les cartes qui défilent derrière (chaque écran réserve un padding bas).
+      extendBody: true,
+      bottomNavigationBar: MainBottomNav(
+        currentIndex: navigationShell.currentIndex,
+        onSelect: (index) {
+          if (index == navigationShell.currentIndex) {
+            // Re-tap de l'onglet actif → scroll-to-top, sans navigation (donc
+            // sans slide). L'écran concerné écoute son trigger.
+            final trigger = index == 0
+                ? essentielScrollTriggerProvider
+                : feedScrollTriggerProvider;
+            ref.read(trigger.notifier).state++;
+          } else {
+            navigationShell.goBranch(index);
+          }
+        },
+      ),
+      body: Column(
+        children: [
+          const _SharedTopHeader(),
+          Expanded(child: navigationShell),
+        ],
+      ),
+    );
+  }
+}
+
+/// Header partagé fixe : streak (gauche) · logo (centre) · avatar réglages
+/// (droite, avec pastille « mise à jour disponible »).
+///
+/// Repris du header historique de `FluxContinuScreen` afin de garder l'apparence
+/// identique tout en le sortant du scroll (il ne défile plus ni ne glisse).
+class _SharedTopHeader extends StatelessWidget {
+  const _SharedTopHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return SafeArea(
+      bottom: false,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: FacteurSpacing.space6,
+          vertical: FacteurSpacing.space3,
+        ),
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            const FacteurLogo(size: 22, showIcon: false),
+            const Align(
+              alignment: Alignment.centerLeft,
+              child: StreakIndicator(),
+            ),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Consumer(
+                builder: (context, ref, _) {
+                  final hasUpdate = ref
+                          .watch(appUpdateProvider)
+                          .valueOrNull
+                          ?.updateAvailable ==
+                      true;
+                  final settingsButton = ProfileAvatarButton(
+                    onTap: () => context.push(RoutePaths.settings),
+                  );
+                  if (!hasUpdate) return settingsButton;
+                  return Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      settingsButton,
+                      Positioned(
+                        top: -2,
+                        right: -2,
+                        child: Container(
+                          width: 12,
+                          height: 12,
+                          decoration: BoxDecoration(
+                            color: colors.error,
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: colors.backgroundPrimary,
+                              width: 2,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Conteneur des navigators de branche (le `navigatorContainerBuilder`).
+///
+/// Héberge les branches dans un [PageView] piloté programmatiquement : le
+/// changement d'onglet anime un slide horizontal directionnel (direction
+/// implicite via l'index de page), et le swipe utilisateur est désactivé
+/// (`NeverScrollableScrollPhysics`) pour ne pas entrer en conflit avec les
+/// carrousels horizontaux de Flâner.
+class BranchPageView extends StatefulWidget {
+  final StatefulNavigationShell navigationShell;
+  final List<Widget> children;
+
+  const BranchPageView({
+    super.key,
+    required this.navigationShell,
+    required this.children,
+  });
+
+  @override
+  State<BranchPageView> createState() => _BranchPageViewState();
+}
+
+class _BranchPageViewState extends State<BranchPageView> {
+  late final PageController _controller =
+      PageController(initialPage: widget.navigationShell.currentIndex);
+
+  @override
+  void didUpdateWidget(BranchPageView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!_controller.hasClients) return;
+    final target = widget.navigationShell.currentIndex;
+    final current = _controller.page?.round() ?? target;
+    if (target != current) {
+      _controller.animateToPage(
+        target,
+        duration: const Duration(milliseconds: 260),
+        curve: Curves.easeOutCubic,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PageView(
+      controller: _controller,
+      physics: const NeverScrollableScrollPhysics(),
+      children: [
+        for (final child in widget.children) _KeepAlive(child: child),
+      ],
+    );
+  }
+}
+
+/// Garde le navigator de la branche **inactive** monté dans le [PageView]
+/// (sinon perte du scroll et de la pile de navigation au changement d'onglet).
+class _KeepAlive extends StatefulWidget {
+  final Widget child;
+
+  const _KeepAlive({required this.child});
+
+  @override
+  State<_KeepAlive> createState() => _KeepAliveState();
+}
+
+class _KeepAliveState extends State<_KeepAlive>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.child;
+  }
+}

--- a/apps/mobile/test/shared/widgets/navigation/main_bottom_nav_test.dart
+++ b/apps/mobile/test/shared/widgets/navigation/main_bottom_nav_test.dart
@@ -1,0 +1,58 @@
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/shared/widgets/navigation/main_bottom_nav.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget wrap({
+    required int currentIndex,
+    required ValueChanged<int> onSelect,
+  }) {
+    return MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(
+        bottomNavigationBar: MainBottomNav(
+          currentIndex: currentIndex,
+          onSelect: onSelect,
+        ),
+      ),
+    );
+  }
+
+  group('MainBottomNav', () {
+    testWidgets('tap onglet inactif → onSelect(indexCible)', (tester) async {
+      final taps = <int>[];
+      await tester.pumpWidget(
+        wrap(currentIndex: 0, onSelect: taps.add),
+      );
+
+      await tester.tap(find.text('Flâner'));
+      await tester.pump();
+
+      expect(taps, [1]);
+    });
+
+    testWidgets('tap onglet actif → onSelect(indexCourant) (scroll-to-top géré '
+        'par le shell)', (tester) async {
+      final taps = <int>[];
+      await tester.pumpWidget(
+        wrap(currentIndex: 0, onSelect: taps.add),
+      );
+
+      await tester.tap(find.text('L’Essentiel'));
+      await tester.pump();
+
+      expect(taps, [0]);
+    });
+
+    testWidgets('reflète l\'onglet actif via la sémantique', (tester) async {
+      await tester.pumpWidget(
+        wrap(currentIndex: 1, onSelect: (_) {}),
+      );
+
+      final flaner = tester.getSemantics(find.text('Flâner'));
+      expect(flaner.hasFlag(SemanticsFlag.isSelected), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Quoi
Unifie les deux onglets principaux **L'Essentiel** (`/flux-continu`) et **Flâner** (`/flaner`) sous un **`StatefulShellRoute`** avec un **shell partagé** (`MainShell`) : header et footer **fixes**, seul le **body** glisse au changement d'onglet (slide directionnel bidirectionnel, **tap-only**). Le **re-tap de l'onglet actif** remonte la page courante en haut (scroll-to-top animé). Footer glassmorphique **plus premium** (coins arrondis, flou renforcé, hairline + ombre douce).

## Pourquoi
La transition précédente était au **niveau route** (`_mainTabPage`) et chaque écran portait son propre `Scaffold`+footer → tout glissait, header/footer inclus, sans conteneur persistant. Impossible de garder header/footer immobiles, et taper l'onglet déjà actif était un no-op.

## Comment
- `routes.dart` : 2 `GoRoute` `_mainTabPage` → **1 `StatefulShellRoute`** (2 branches, navigators dédiés). Sous-routes article conservées **dans** leur branche avec `parentNavigatorKey` root → plein écran au-dessus du footer, **swipe-back Cupertino intact**. Suppression de `_mainTabPage` / `_lastMainTabIndex`.
- **Nouveau** `main_shell.dart` : `MainShell` (header+footer fixes), `_SharedTopHeader` (streak · logo · avatar+badge update, **lifté** des 2 écrans), `BranchPageView` (`PageView` `NeverScrollableScrollPhysics` synchronisé sur `currentIndex`), `_KeepAlive` (préserve scroll/pile de la branche inactive).
- `MainBottomNav` : API `currentIndex` + `onSelect` (le shell arbitre nav vs scroll-to-top), restyle glass premium.
- Scroll-to-top via `essentielScrollTriggerProvider` + `feedScrollTriggerProvider` (le shell incrémente, les écrans écoutent → `_scrollToTop()`).

## Comment ça a été vérifié
- [x] `flutter analyze` — **0 erreur** (fichiers touchés clean ; le reste = lints `info` pré-existants en `test/`)
- [x] `flutter test test/core/services/deep_link_service_test.dart` — **13/13** (non-régression deep links / redirects legacy)
- [x] Nouveau widget test `MainBottomNav` — **3/3** (tap inactif → `onSelect(cible)` ; tap actif → `onSelect(courant)` ; sémantique `selected`)
- [x] Suite complète : **747 pass / 27 échecs pré-existants** (Hive/Supabase/Dio infra-mock, sans rapport) — aucune régression
- [x] `/simplify` passé (aucun changement requis ; findings = faux positifs / hors-scope)
- [ ] ⚠️ QA visuelle non automatisée : les onglets sont derrière l'auth Supabase, donc non pilotables headless ici. À valider via **`/validate-feature`** (Chrome 390x844) ou simulateur : slide body seul / header+footer immobiles, direction OK dans les 2 sens, re-tap actif = scroll-to-top, article plein écran + swipe-back, état préservé au switch.

## Zones à risque
- **Router** (zone LOCKED, cf. `safety-protocols`) : `routes.dart` refondu. Gating auth, scheme `io.supabase.facteur`, redirects `/feed` `/digest` `/progress`, et `name: content-detail` (unicité) **inchangés**. Clé root `NotificationService.navigatorKey` **préservée** (push notifs / main.dart).
