### PR TITLE
feat(veille): curation premium par score + angle=sujet+grappe + fix navigation

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,31 +1,31 @@
-# PR 1 · Backend « La Grille du jour » (Story 24.1)
+# Veille — curation premium + config liée aux angles + fix navigation
 
-Fondation serveur du jeu **La Grille du jour** (Wordle postal Facteur). Le mobile (PR 2) consomme ce contrat — **cette PR merge en premier.**
+Refonte de la **veille** sur 3 axes (par impact) : curation par score (le « 90 % »), config où chaque angle porte sa grappe de mots-clés, et fix du bug « Créer ma veille » → feed.
 
-## Contenu
-- **Modèles** : `grille_puzzles` (puzzle global daté, mot secret serveur) + `grille_game_states` (1 partie/user/jour, unicité `(user_id, puzzle_date)`).
-- **Migration** `gr01_la_grille_du_jour` (additive, `down_revision = cl01_drop_daily_top3`, 1 head).
-- **Dictionnaire FR** embarqué (`app/data/grille_words_fr.txt`) chargé en `frozenset` au boot.
-- **Logique** (`grille_text` + `grille_service`) :
-  - `compute_tiles` à **comptage d'occurrences** (corrige la version simplifiée du proto, ne sur-colore plus les lettres doublées).
-  - Validation 100 % serveur : longueur / hors-dictionnaire (essai non consommé), rejeu interdit (409), `solved`/`failed`.
-  - Streak **dérivé** des parties (ne touche pas `UserStreak`).
-  - Classement quotidien : `distribution`, `percentile`, podium anonymisé (initiales via hash quotidien salé, `Toi` au rang du joueur).
-- **3 endpoints** sous `/api/grille` : `GET /today`, `POST /today/guess`, `GET /today/leaderboard`.
-- **Seed** : `app/data/grille_puzzles_seed.json` (≥ J+14) + `scripts/seed_grille_puzzles.py` (idempotent, assert word ∈ dico).
+## Part A — Curation premium (cœur)
+Remplace le filtre `OR` (où le **thème** suffisait à faire entrer tout l'article) par un pipeline **prefilter SQL axes forts → scoring piliers → seuil → tri par score**, en réutilisant le moteur de la Tournée (`PillarScoringEngine`).
+- `feed_filter.py` : `build_strong_predicate` (topics/sources/mots-clés ; **thème retiré du prédicat**) + fenêtre récence 168h + `CANDIDATE_CAP` 300 + `_score_and_rank` (seuil + tri score/récence). `matched_on` ne qualifie plus via `theme`.
+- `scoring_context.py` (nouveau) : adaptateur `VeilleAngleTopic` (duck-type de `_score_custom_topics`) + `build_veille_scoring_context` — thème = signal **faible** (`user_interests`), topics → `user_subtopics` (+45), angles → `user_custom_topics` (+25), sources → `followed_source_ids` (+35).
+- `scoring_config.py` : `VEILLE_RELEVANCE_THRESHOLD=40`, `VEILLE_CANDIDATE_CAP=300`, `VEILLE_RECENCY_HOURS=168` + log structuré (`max_score`/`pass_count`/`candidate_count`) pour calibrer en prod.
 
-## ⚠️ Note pour PR 2 (mobile)
-Les chemins réels sont préfixés `/api` (convention repo) : **`/api/grille/today`**, `/api/grille/today/guess`, `/api/grille/today/leaderboard` — et non `/grille/...`. Clés JSON = noms FR exacts (`dateAffichee`, `nbEssais`, `premiereLettre`, `prochainMotDansSec`, …). Le mot (`mot`) et le `pourquoi` ne sont jamais renvoyés tant que `statut == in_progress`.
+## Part B — Modèle : angle = sujet + grappe
+- `VeilleKeyword.veille_topic_id` (FK `veille_topics`, nullable = mot-clé global), index `ix_veille_keywords_topic`, unique relâché en `(config, topic_id, keyword)`.
+- Migration `vk01_link_keywords_to_topics` (`down_revision = dd01_franceinfo_dedup`, 1 head, downgrade symétrique).
 
-## Décisions (défauts confirmés par le PO au GO)
-- Préfixe API `/api/grille` (et non `/grille`).
-- Podium anonymisé via **hash quotidien salé** de `user_id` → 2 initiales non nominatives.
-- Ajout colonne `date_affichee` (absente du proto, requise par le masthead).
+## Part C — Config enrichie
+- `schemas` + `routers/veille.py` : `VeilleTopicSelection.keywords` persisté lié à l'angle ; `_hydrate_response` round-trip (grappes nichées, globaux à plat).
+- `angle_suggester.py` : prompt **8-12 angles** (au lieu de 5-8), `max_tokens` 2000, fallback étendu.
+- Sources : `/presets` 6 → 12 ; `_fetch_source_examples` **préfère** les articles matchant les mots-clés de la veille active (sinon récence brute).
+- Mobile : DTO round-trip des grappes ; brief introduit **une fois** au Step 1 (suppression du doublon Step 2).
+
+## Part D — Fix navigation « Créer ma veille » → feed (2 leviers)
+- `veille_config_provider.submit()` : `invalidate(userInterestsProvider)` après hydratation (lever racine).
+- `my_interests_screen.dart` : CTA masqué si veille active connue **ET** pas de `VeilleFavoriteRef` (défense en profondeur).
 
 ## Tests / VERIFY
-- `pytest tests/test_grille_logic.py tests/test_grille_api.py` → **24 passed**.
-- Suite complète backend → **1383 passed, 1 skipped, 2 xfailed** (aucune régression).
-- Alembic : `upgrade head` + `downgrade -1` + re-upgrade OK sur DB **vide**.
-- Seed rejoué → idempotent (0 créés / 15 maj).
+- Backend complet : **1408 passed, 1 skipped, 2 xfailed** (0 régression). Veille : 65 passed (scoring, thème-seul exclu, topic>keyword, source/keyword, frontière seuil, exclusions hidden/seen/inactive, pagination, persistance grappes round-trip, unique triplet).
+- Alembic : 1 head ; `upgrade head` + `downgrade -1` + re-upgrade OK sur DB **vide**.
+- Mobile : `flutter analyze` → 0 erreur (548 infos préexistantes).
 
-Story : `docs/stories/core/24.1.la-grille-du-jour-backend.md`.
+## Hors-scope (suite)
+Le fetch LLM `/suggest/angles` n'est pas encore branché dans l'écran suggestions mobile (il consomme aujourd'hui les preset topics statiques) ; le backend + le round-trip DTO sont prêts à l'accueillir → l'affichage éditable des chips de mots-clés par angle (C3 UI) suivra dans une PR mobile dédiée.

--- a/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
@@ -338,8 +338,11 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
               ),
             ),
             // CTA "Crée ta veille" — visible si aucun VeilleFavoriteRef dans
-            // les favoris. La veille devient le 3ᵉ type de favori (Story 23.2 PR-4).
-            if (interests.favorites.whereType<VeilleFavoriteRef>().isEmpty)
+            // les favoris ET aucune veille active connue. La double condition
+            // évite le faux CTA quand la liste des favoris est transitoirement
+            // périmée (sinon clic → VeilleConfigScreen redirige vers le feed).
+            if (interests.favorites.whereType<VeilleFavoriteRef>().isEmpty &&
+                ref.watch(veilleActiveConfigProvider).valueOrNull == null)
               _CreateVeilleCta(
                 onTap: () => context.pushNamed(RouteNames.veilleConfig),
               ),

--- a/apps/mobile/lib/features/veille/models/veille_config_dto.dart
+++ b/apps/mobile/lib/features/veille/models/veille_config_dto.dart
@@ -19,6 +19,9 @@ class VeilleTopicDto {
   final String? reason;
   final int position;
 
+  /// Grappe de mots-clés de l'angle (round-trip avec le backend).
+  final List<String> keywords;
+
   const VeilleTopicDto({
     required this.id,
     required this.topicId,
@@ -26,6 +29,7 @@ class VeilleTopicDto {
     required this.kind,
     required this.reason,
     required this.position,
+    this.keywords = const [],
   });
 
   factory VeilleTopicDto.fromJson(Map<String, dynamic> json) {
@@ -36,6 +40,9 @@ class VeilleTopicDto {
       kind: json['kind'] as String,
       reason: json['reason'] as String?,
       position: (json['position'] as num?)?.toInt() ?? 0,
+      keywords: ((json['keywords'] as List?) ?? const [])
+          .map((e) => e as String)
+          .toList(),
     );
   }
 }
@@ -195,12 +202,16 @@ class VeilleTopicSelectionRequest {
   final String? reason;
   final int position;
 
+  /// Grappe de mots-clés de l'angle — pilote le scoring côté backend.
+  final List<String> keywords;
+
   const VeilleTopicSelectionRequest({
     required this.topicId,
     required this.label,
     required this.kind,
     this.reason,
     this.position = 0,
+    this.keywords = const [],
   });
 
   Map<String, dynamic> toJson() => {
@@ -209,6 +220,7 @@ class VeilleTopicSelectionRequest {
         'kind': kind,
         if (reason != null) 'reason': reason,
         'position': position,
+        'keywords': keywords,
       };
 }
 

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../my_interests/providers/user_interests_provider.dart';
 import '../models/veille_config.dart';
 import '../models/veille_config_dto.dart';
 import '../repositories/veille_repository.dart';
@@ -513,6 +514,11 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       _ref
           .read(veilleActiveConfigProvider.notifier)
           .hydrateFromServer(cfg);
+      // La veille est un favori d'intérêt : sans invalidation, la liste des
+      // favoris reste périmée (sans VeilleFavoriteRef) et le CTA « Créer ma
+      // veille » reste affiché → clic → redirection feed (bug navigation).
+      // Le chemin archivage le fait déjà (my_interests_screen.dart).
+      _ref.invalidate(userInterestsProvider);
       state = state.copyWith(isSubmitting: false);
     } on VeilleApiException catch (e) {
       state = state.copyWith(

--- a/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
@@ -74,8 +74,6 @@ class Step2SuggestionsScreen extends ConsumerWidget {
                 if (state.advancedMode) ...[
                   const SizedBox(height: 16),
                   _KeywordsSection(state: state, notifier: notifier),
-                  const SizedBox(height: 18),
-                  _BriefSection(state: state, notifier: notifier),
                 ],
               ],
             ),
@@ -484,44 +482,6 @@ class _AddKeywordButton extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-class _BriefSection extends StatelessWidget {
-  final VeilleConfigState state;
-  final VeilleConfigNotifier notifier;
-  const _BriefSection({required this.state, required this.notifier});
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'BRIEF ÉDITORIAL',
-          style: GoogleFonts.dmSans(
-            fontSize: 10,
-            fontWeight: FontWeight.w700,
-            letterSpacing: 0.8,
-            color: const Color(0xFF8B7E63),
-          ),
-        ),
-        const SizedBox(height: 6),
-        Text(
-          'Précise le format ou l\'angle (analyses long format, focus PME, etc.).',
-          style: GoogleFonts.dmSans(
-            fontSize: 12,
-            color: const Color(0xFF5D5B5A),
-            height: 1.4,
-          ),
-        ),
-        const SizedBox(height: 10),
-        VeilleEditorialBriefField(
-          value: state.editorialBrief,
-          onChanged: notifier.setEditorialBrief,
-        ),
-      ],
     );
   }
 }

--- a/packages/api/alembic/versions/vk01_link_keywords_to_topics.py
+++ b/packages/api/alembic/versions/vk01_link_keywords_to_topics.py
@@ -1,0 +1,76 @@
+"""Veille : lier chaque mot-clé à son angle (grappe) — angle = sujet + keywords.
+
+Part B de la refonte curation veille :
+- ADD veille_keywords.veille_topic_id (UUID, nullable, FK veille_topics.id
+  ondelete CASCADE) — null = mot-clé global de la config.
+- INDEX ix_veille_keywords_topic.
+- Relâche l'unique de (veille_config_id, keyword) vers
+  (veille_config_id, veille_topic_id, keyword) pour autoriser la même clé
+  sous deux angles.
+
+Ops explicites (style vf01, pas d'autogenerate aveugle). `downgrade` symétrique
+(supprime d'abord les keywords rattachés à un angle pour ne pas violer l'ancien
+unique au moment du recreate).
+
+Revision ID: vk01_link_keywords_to_topics
+Revises: dd01_franceinfo_dedup
+Create Date: 2026-05-31
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "vk01_link_keywords_to_topics"
+down_revision: str | None = "dd01_franceinfo_dedup"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "veille_keywords",
+        sa.Column(
+            "veille_topic_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "fk_veille_keywords_topic",
+        "veille_keywords",
+        "veille_topics",
+        ["veille_topic_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index(
+        "ix_veille_keywords_topic", "veille_keywords", ["veille_topic_id"]
+    )
+
+    op.drop_constraint("uq_veille_keywords", "veille_keywords", type_="unique")
+    op.create_unique_constraint(
+        "uq_veille_keywords",
+        "veille_keywords",
+        ["veille_config_id", "veille_topic_id", "keyword"],
+    )
+
+
+def downgrade() -> None:
+    # Les keywords rattachés à un angle peuvent dupliquer (config, keyword) ;
+    # on les retire avant de restaurer l'ancien unique plus strict.
+    op.execute("DELETE FROM veille_keywords WHERE veille_topic_id IS NOT NULL")
+
+    op.drop_constraint("uq_veille_keywords", "veille_keywords", type_="unique")
+    op.create_unique_constraint(
+        "uq_veille_keywords",
+        "veille_keywords",
+        ["veille_config_id", "keyword"],
+    )
+
+    op.drop_index("ix_veille_keywords_topic", table_name="veille_keywords")
+    op.drop_constraint(
+        "fk_veille_keywords_topic", "veille_keywords", type_="foreignkey"
+    )
+    op.drop_column("veille_keywords", "veille_topic_id")

--- a/packages/api/app/models/veille.py
+++ b/packages/api/app/models/veille.py
@@ -151,12 +151,24 @@ class VeilleSource(Base):
 
 
 class VeilleKeyword(Base):
-    """Mot-clé/angle rattaché à une veille_config — matché ILIKE sur title+desc."""
+    """Mot-clé/angle rattaché à une veille_config — matché ILIKE sur title+desc.
+
+    Chaque mot-clé peut être rattaché à un angle (`veille_topic_id`) — c'est
+    alors la grappe de cet angle — ou rester **global** à la config
+    (`veille_topic_id IS NULL`). L'unique sur le triplet autorise la même clé
+    sous deux angles distincts (dédoublonnage fonctionnel géré côté API).
+    """
 
     __tablename__ = "veille_keywords"
     __table_args__ = (
-        UniqueConstraint("veille_config_id", "keyword", name="uq_veille_keywords"),
+        UniqueConstraint(
+            "veille_config_id",
+            "veille_topic_id",
+            "keyword",
+            name="uq_veille_keywords",
+        ),
         Index("ix_veille_keywords_config", "veille_config_id"),
+        Index("ix_veille_keywords_topic", "veille_topic_id"),
     )
 
     id: Mapped[UUID] = mapped_column(
@@ -166,6 +178,11 @@ class VeilleKeyword(Base):
         PGUUID(as_uuid=True),
         ForeignKey("veille_configs.id", ondelete="CASCADE"),
         nullable=False,
+    )
+    veille_topic_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("veille_topics.id", ondelete="CASCADE"),
+        nullable=True,
     )
     keyword: Mapped[str] = mapped_column(String(80), nullable=False)
     position: Mapped[int] = mapped_column(

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -306,7 +306,7 @@ async def upsert_config(
     # Un seul flush matérialise tous les topic.id, puis on rattache les grappes.
     if topic_rows:
         await db.flush()
-    for topic, t in zip(topic_rows, body.topics):
+    for topic, t in zip(topic_rows, body.topics, strict=True):
         for kpos, kw in enumerate(t.keywords):
             db.add(
                 VeilleKeyword(

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -9,7 +9,7 @@ import sentry_sdk
 import structlog
 from cachetools import TTLCache
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import delete, select
+from sqlalchemy import case, delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.data.veille_presets import get_presets
@@ -47,7 +47,7 @@ from app.schemas.veille import (
 from app.services.rss_parser import RSSParser
 from app.services.source_service import SourceService
 from app.services.user_interests_service import ensure_veille_favorite
-from app.services.veille.feed_filter import fetch_veille_feed
+from app.services.veille.feed_filter import fetch_veille_feed, load_veille_filters
 from app.services.veille.llm import get_angle_suggester, get_source_suggester
 
 logger = structlog.get_logger()
@@ -123,6 +123,13 @@ async def _hydrate_response(
         ):
             sources_by_id[src.id] = src
 
+    # Split mots-clés : globaux (veille_topic_id NULL) vs grappes d'angles.
+    global_keywords = [kw for kw in keywords_rows if kw.veille_topic_id is None]
+    keywords_by_topic: dict[UUID, list[str]] = {}
+    for kw in keywords_rows:
+        if kw.veille_topic_id is not None:
+            keywords_by_topic.setdefault(kw.veille_topic_id, []).append(kw.keyword)
+
     return VeilleConfigResponse(
         id=cfg.id,
         user_id=cfg.user_id,
@@ -142,6 +149,7 @@ async def _hydrate_response(
                 kind=t.kind,  # type: ignore[arg-type]
                 reason=t.reason,
                 position=t.position,
+                keywords=keywords_by_topic.get(t.id, []),
             )
             for t in topics_rows
         ],
@@ -158,7 +166,7 @@ async def _hydrate_response(
         ],
         keywords=[
             VeilleKeywordResponse(id=kw.id, keyword=kw.keyword, position=kw.position)
-            for kw in keywords_rows
+            for kw in global_keywords
         ],
     )
 
@@ -282,17 +290,32 @@ async def upsert_config(
         delete(VeilleKeyword).where(VeilleKeyword.veille_config_id == cfg.id)
     )
 
-    for idx, t in enumerate(body.topics):
-        db.add(
-            VeilleTopic(
-                veille_config_id=cfg.id,
-                topic_id=t.topic_id,
-                label=t.label,
-                kind=t.kind,
-                reason=t.reason,
-                position=idx,
-            )
+    topic_rows = [
+        VeilleTopic(
+            veille_config_id=cfg.id,
+            topic_id=t.topic_id,
+            label=t.label,
+            kind=t.kind,
+            reason=t.reason,
+            position=idx,
         )
+        for idx, t in enumerate(body.topics)
+    ]
+    for topic in topic_rows:
+        db.add(topic)
+    # Un seul flush matérialise tous les topic.id, puis on rattache les grappes.
+    if topic_rows:
+        await db.flush()
+    for topic, t in zip(topic_rows, body.topics):
+        for kpos, kw in enumerate(t.keywords):
+            db.add(
+                VeilleKeyword(
+                    veille_config_id=cfg.id,
+                    veille_topic_id=topic.id,
+                    keyword=kw,
+                    position=kpos,
+                )
+            )
 
     seen_source_ids: set[UUID] = set()
     for idx, sel in enumerate(body.source_selections):
@@ -436,7 +459,7 @@ async def list_presets(db: AsyncSession = Depends(get_db)):
                         Source.is_active.is_(True),
                     )
                     .order_by(Source.name)
-                    .limit(6)
+                    .limit(12)
                 )
             )
             .scalars()
@@ -462,28 +485,44 @@ async def list_presets(db: AsyncSession = Depends(get_db)):
 
 
 async def _fetch_source_examples(
-    db: AsyncSession, source_id: UUID
+    db: AsyncSession,
+    source_id: UUID,
+    keywords: list[str] | None = None,
 ) -> list[VeilleSourceExample]:
-    """Renvoie jusqu'à 2 exemples récents d'une source. Cache TTL 24 h."""
-    cache_key = str(source_id)
+    """Renvoie jusqu'à 2 exemples récents d'une source. Cache TTL 24 h.
+
+    Si `keywords` (issus de la config en cours) sont fournis, on **préfère**
+    les articles de la source qui matchent l'un d'eux (title/description) —
+    les exemples illustrent alors vraiment ce que la veille remontera, plutôt
+    que les 2 derniers articles bruts.
+    """
+    norm_keywords = sorted({k.lower().strip() for k in (keywords or []) if k.strip()})
+    cache_key = f"{source_id}|{'|'.join(norm_keywords)}"
     if cache_key in _SOURCE_EXAMPLES_CACHE:
         return _SOURCE_EXAMPLES_CACHE[cache_key]
 
     cutoff = datetime.now(UTC) - timedelta(days=_SOURCE_EXAMPLES_LOOKBACK_DAYS)
-    contents = (
-        (
-            await db.execute(
-                select(Content)
-                .where(
-                    Content.source_id == source_id,
-                    Content.published_at >= cutoff,
-                )
-                .order_by(Content.published_at.desc())
-                .limit(_SOURCE_EXAMPLES_LIMIT)
-            )
+    base_query = select(Content).where(
+        Content.source_id == source_id,
+        Content.published_at >= cutoff,
+    )
+    if norm_keywords:
+        match_expr = or_(
+            *[
+                Content.title.ilike(f"%{kw}%") | Content.description.ilike(f"%{kw}%")
+                for kw in norm_keywords
+            ]
         )
-        .scalars()
-        .all()
+        # Boost les articles matchant un mot-clé, puis tri par récence.
+        base_query = base_query.order_by(
+            case((match_expr, 1), else_=0).desc(),
+            Content.published_at.desc(),
+        )
+    else:
+        base_query = base_query.order_by(Content.published_at.desc())
+
+    contents = (
+        (await db.execute(base_query.limit(_SOURCE_EXAMPLES_LIMIT))).scalars().all()
     )
     if contents:
         examples = [
@@ -562,9 +601,18 @@ async def get_source_examples(
     db: AsyncSession = Depends(get_db),
     current_user_id: str = Depends(get_current_user_id),
 ):
-    """Renvoie un aperçu (≤2 articles) pour rassurer l'utilisateur au Step 3."""
-    UUID(current_user_id)
-    return await _fetch_source_examples(db, source_id)
+    """Renvoie un aperçu (≤2 articles) pour rassurer l'utilisateur au Step 3.
+
+    Si l'utilisateur a déjà une veille active, on préfère les articles de la
+    source qui matchent ses mots-clés (globaux + grappes d'angles).
+    """
+    user_uuid = UUID(current_user_id)
+    keywords: list[str] = []
+    cfg = await _get_active_config(db, user_uuid)
+    if cfg is not None:
+        filters = await load_veille_filters(db, cfg)
+        keywords = filters.all_keywords
+    return await _fetch_source_examples(db, source_id, keywords=keywords)
 
 
 # ─── Suggesters LLM (Story 23.3) ─────────────────────────────────────────────
@@ -575,7 +623,7 @@ async def suggest_angles(
     body: VeilleSuggestAnglesRequest,
     current_user_id: str = Depends(get_current_user_id),
 ):
-    """Renvoie 5-8 angles + mots-clés explicites pour un thème + brief.
+    """Renvoie 8-12 angles + mots-clés explicites pour un thème + brief.
 
     Appel synchrone Mistral (~10-15s), cache TTL 24h sur (theme + brief).
     Mobile affiche un HaloLoader pendant l'appel.

--- a/packages/api/app/schemas/veille.py
+++ b/packages/api/app/schemas/veille.py
@@ -36,6 +36,8 @@ class VeilleTopicResponse(BaseModel):
     kind: Literal["preset", "suggested", "custom"]
     reason: str | None = None
     position: int = 0
+    # Grappe de mots-clés de l'angle (round-trip avec VeilleTopicSelection).
+    keywords: list[str] = Field(default_factory=list)
 
 
 class VeilleSourceLite(BaseModel):
@@ -95,6 +97,21 @@ class VeilleTopicSelection(BaseModel):
     kind: Literal["preset", "suggested", "custom"]
     reason: str | None = Field(default=None, max_length=500)
     position: int = Field(default=0, ge=0)
+    # Grappe de mots-clés de l'angle — normalisés lowercase, dédupliqués.
+    # Ces mots-clés pilotent le scoring (custom-topic) en plus du slug.
+    keywords: list[str] = Field(default_factory=list, max_length=10)
+
+    @field_validator("keywords")
+    @classmethod
+    def _normalize_cluster(cls, v: list[str]) -> list[str]:
+        seen: set[str] = set()
+        out: list[str] = []
+        for raw in v:
+            kw = _normalize_keyword(raw)
+            if kw and 1 <= len(kw) <= 80 and kw not in seen:
+                seen.add(kw)
+                out.append(kw)
+        return out
 
 
 class VeilleNicheCandidate(BaseModel):

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -286,6 +286,24 @@ class ScoringWeights:
     # Scoring engine version: "layers_v1" (legacy) or "pillars_v1" (new).
     SCORING_VERSION = "pillars_v1"
 
+    # --- VEILLE (feed temps-réel curé par score) ---
+
+    # Seuil de pertinence (score final piliers, échelle ~0-100) en-deçà duquel
+    # un article candidat est élagué du feed veille. Dérivé analytiquement :
+    # un article "thème seul" score ~47 (mais ne peut de toute façon pas entrer
+    # car le thème est absent du prédicat SQL), "thème + topic" ~66,
+    # "thème + mot-clé d'angle" ~55, "source suivie seule" ~37-45.
+    # 40 passe topic/mot-clé largement ; la source-seule reste limite.
+    # Point de calibration à figer via les logs de prod (max_score/pass_count).
+    VEILLE_RELEVANCE_THRESHOLD = 40.0
+
+    # Plafond du pool de candidats scorés par fetch (borne le coût ILIKE +
+    # scoring sur un feed curé ; offsets au-delà renvoient vide — acceptable).
+    VEILLE_CANDIDATE_CAP = 300
+
+    # Fenêtre de récence (heures) du prédicat veille — aligné sur le digest.
+    VEILLE_RECENCY_HOURS = 168
+
     # --- TOPIC-AWARE FEED DIVERSIFICATION (Phase 2 — Budget Neutre) ---
 
     # Floor ratio: minimum fraction of neutral articles kept visible (discovery).

--- a/packages/api/app/services/veille/feed_filter.py
+++ b/packages/api/app/services/veille/feed_filter.py
@@ -1,16 +1,20 @@
-"""Service de filtre temps-réel pour /api/veille/feed (Story 23.1).
+"""Feed veille curé par score (refonte curation).
 
-Compose la config veille de l'utilisateur (thèmes/topics/sources/keywords) en
-une clause `OR` SQL appliquée live sur `contents`. Boost les articles dont la
-source matche la config (priorité dans le tri). Aucun appel LLM — pur SQL.
+Pipeline : **prefilter SQL (axes forts) → scoring piliers → seuil → tri par
+score**, en réutilisant le moteur de la Tournée (`PillarScoringEngine`). Le
+thème macro est retiré du prédicat : un article « thème seul » ne peut donc
+jamais entrer dans le pool de candidats. Les axes forts sont les topics/angles,
+les sources suivies et les mots-clés (globaux + grappes d'angles).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import case, exists, or_, select
+import structlog
+from sqlalchemy import exists, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -28,19 +32,60 @@ from app.services.recommendation.filter_presets import (
     apply_serein_filter,
     load_serein_preferences,
 )
+from app.services.recommendation.scoring_config import ScoringWeights
+from app.services.recommendation.scoring_engine import PillarScoringEngine
+from app.services.veille.scoring_context import build_veille_scoring_context
+
+logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class VeilleAngle:
+    """Un angle = sujet (`topic_id`) + sa grappe de mots-clés."""
+
+    topic_id: str
+    label: str
+    keywords: list[str] = field(default_factory=list)
 
 
 @dataclass
 class VeilleFilters:
-    """Filtres chargés depuis une VeilleConfig active."""
+    """Filtres chargés depuis une VeilleConfig active.
 
-    themes: list[str] = field(default_factory=list)
-    topic_slugs: list[str] = field(default_factory=list)
+    `theme_id` est un signal faible (scoring uniquement, jamais dans le
+    prédicat). Les axes forts qui peuplent le pool de candidats sont
+    `angles` (topics + grappes), `source_ids` et `global_keywords`.
+    """
+
+    theme_id: str | None = None
+    angles: list[VeilleAngle] = field(default_factory=list)
     source_ids: list[UUID] = field(default_factory=list)
-    keywords: list[str] = field(default_factory=list)
+    global_keywords: list[str] = field(default_factory=list)
 
-    def has_any(self) -> bool:
-        return bool(self.themes or self.topic_slugs or self.source_ids or self.keywords)
+    @property
+    def topic_slugs(self) -> list[str]:
+        return [a.topic_id for a in self.angles]
+
+    @property
+    def all_keywords(self) -> list[str]:
+        """Mots-clés globaux + grappes d'angles, dédupliqués (ordre stable)."""
+        seen: set[str] = set()
+        out: list[str] = []
+        for kw in self.global_keywords:
+            low = kw.lower().strip()
+            if low and low not in seen:
+                seen.add(low)
+                out.append(low)
+        for angle in self.angles:
+            for kw in angle.keywords:
+                low = kw.lower().strip()
+                if low and low not in seen:
+                    seen.add(low)
+                    out.append(low)
+        return out
+
+    def has_strong_axis(self) -> bool:
+        return bool(self.topic_slugs or self.source_ids or self.all_keywords)
 
 
 async def _get_active_config(
@@ -56,18 +101,45 @@ async def _get_active_config(
 async def load_veille_filters(
     session: AsyncSession, config: VeilleConfig
 ) -> VeilleFilters:
-    """Charge topics/sources/keywords liés à la config en 3 SELECT indexés."""
-    topics = (
-        (
-            await session.execute(
-                select(VeilleTopic.topic_id).where(
-                    VeilleTopic.veille_config_id == config.id
-                )
-            )
+    """Charge angles (topics + grappes), sources et mots-clés globaux.
+
+    Les `VeilleKeyword` rattachés à un angle (`veille_topic_id`) forment la
+    grappe de cet angle ; ceux sans rattachement (`veille_topic_id IS NULL`)
+    sont des mots-clés globaux de la config.
+    """
+    topic_rows = (
+        await session.execute(
+            select(VeilleTopic.id, VeilleTopic.topic_id, VeilleTopic.label)
+            .where(VeilleTopic.veille_config_id == config.id)
+            .order_by(VeilleTopic.position, VeilleTopic.created_at)
         )
-        .scalars()
-        .all()
-    )
+    ).all()
+
+    keyword_rows = (
+        await session.execute(
+            select(VeilleKeyword.keyword, VeilleKeyword.veille_topic_id)
+            .where(VeilleKeyword.veille_config_id == config.id)
+            .order_by(VeilleKeyword.position)
+        )
+    ).all()
+
+    keywords_by_topic: dict[UUID, list[str]] = {}
+    global_keywords: list[str] = []
+    for keyword, topic_id in keyword_rows:
+        if topic_id is None:
+            global_keywords.append(keyword)
+        else:
+            keywords_by_topic.setdefault(topic_id, []).append(keyword)
+
+    angles = [
+        VeilleAngle(
+            topic_id=topic_id,
+            label=label,
+            keywords=keywords_by_topic.get(row_id, []),
+        )
+        for row_id, topic_id, label in topic_rows
+    ]
+
     sources = (
         (
             await session.execute(
@@ -79,66 +151,97 @@ async def load_veille_filters(
         .scalars()
         .all()
     )
-    keywords = (
-        (
-            await session.execute(
-                select(VeilleKeyword.keyword)
-                .where(VeilleKeyword.veille_config_id == config.id)
-                .order_by(VeilleKeyword.position)
-            )
-        )
-        .scalars()
-        .all()
-    )
+
     return VeilleFilters(
-        themes=[config.theme_id] if config.theme_id else [],
-        topic_slugs=list(topics),
+        theme_id=config.theme_id or None,
+        angles=angles,
         source_ids=list(sources),
-        keywords=list(keywords),
+        global_keywords=global_keywords,
     )
 
 
-def build_or_predicate(filters: VeilleFilters):
-    """Construit la clause `OR` SQL combinant les 4 axes du filtre.
+def build_strong_predicate(filters: VeilleFilters):
+    """Clause `OR` SQL sur les axes **forts uniquement** (jamais le thème).
 
-    - `theme` : Content.theme IN (themes) — index ix_contents_theme_published
     - `topic` : Content.topics && topic_slugs — index GIN ix_contents_topics
     - `source` : Content.source_id IN (source_ids) — index ix_contents_source_id
-    - `keyword` : title ILIKE OR description ILIKE — pas d'index trigramme V1,
-      benchmark requis (cf. R1 Story 23.1).
+    - `keyword` : title ILIKE OR description ILIKE (globaux + grappes d'angles)
+
+    Renvoie `None` si aucun axe fort (p.ex. thème seul) → exclusion voulue.
     """
     clauses = []
-    if filters.themes:
-        clauses.append(Content.theme.in_(filters.themes))
     if filters.topic_slugs:
         clauses.append(Content.topics.overlap(filters.topic_slugs))
     if filters.source_ids:
         clauses.append(Content.source_id.in_(filters.source_ids))
-    if filters.keywords:
-        for kw in filters.keywords:
-            pattern = f"%{kw}%"
-            clauses.append(Content.title.ilike(pattern))
-            clauses.append(Content.description.ilike(pattern))
+    for kw in filters.all_keywords:
+        pattern = f"%{kw}%"
+        clauses.append(Content.title.ilike(pattern))
+        clauses.append(Content.description.ilike(pattern))
     return or_(*clauses) if clauses else None
 
 
-def _matched_axes(content: Content, filters: VeilleFilters) -> list[str]:
-    """Calcule sur quels axes l'article matche (info exposée au front)."""
+def _matched_axes(
+    content: Content,
+    topic_slugs: set[str],
+    source_ids: set[UUID],
+    keywords: list[str],
+) -> list[str]:
+    """Axes **qualifiants** sur lesquels l'article matche (exposés au front).
+
+    Le thème n'est plus un axe qualifiant : l'inclusion est gérée par le
+    prédicat fort + le seuil de score. On garde topic/source/keyword. Les
+    collections sont pré-calculées par l'appelant (hot path : ~CANDIDATE_CAP
+    appels par fetch).
+    """
     axes: list[str] = []
-    if filters.themes and content.theme in filters.themes:
-        axes.append("theme")
-    if filters.topic_slugs and content.topics:
-        topic_set = set(filters.topic_slugs)
-        if any(t in topic_set for t in content.topics):
+    if topic_slugs and content.topics:
+        if any(t in topic_slugs for t in content.topics):
             axes.append("topic")
-    if filters.source_ids and content.source_id in filters.source_ids:
+    if source_ids and content.source_id in source_ids:
         axes.append("source")
-    if filters.keywords:
+    if keywords:
         title_lower = (content.title or "").lower()
         desc_lower = (content.description or "").lower()
-        if any(kw in title_lower or kw in desc_lower for kw in filters.keywords):
+        if any(kw in title_lower or kw in desc_lower for kw in keywords):
             axes.append("keyword")
     return axes
+
+
+def _score_and_rank(
+    candidates: list[Content],
+    context,
+    filters: VeilleFilters,
+) -> list[tuple[Content, float, list[str]]]:
+    """Score chaque candidat, garde ≥ seuil, trie par (score, récence) desc."""
+    engine = PillarScoringEngine()
+    # Pré-calcul hors boucle : ces dérivations sont stables sur tout le fetch.
+    topic_slugs = set(filters.topic_slugs)
+    source_ids = set(filters.source_ids)
+    keywords = filters.all_keywords
+    passing: list[tuple[Content, float, list[str]]] = []
+    max_score = 0.0
+    for content in candidates:
+        result = engine.compute_score(content, context)
+        score = result.final_score
+        if score > max_score:
+            max_score = score
+        if score >= ScoringWeights.VEILLE_RELEVANCE_THRESHOLD:
+            axes = _matched_axes(content, topic_slugs, source_ids, keywords)
+            passing.append((content, score, axes))
+
+    _epoch = datetime.min.replace(tzinfo=UTC)
+    passing.sort(
+        key=lambda t: (t[1], t[0].published_at or _epoch),
+        reverse=True,
+    )
+    logger.info(
+        "veille.feed_scored",
+        candidate_count=len(candidates),
+        pass_count=len(passing),
+        max_score=round(max_score, 1),
+    )
+    return passing
 
 
 async def fetch_veille_feed(
@@ -149,25 +252,26 @@ async def fetch_veille_feed(
     offset: int = 0,
     serein: bool = False,
 ) -> tuple[list[tuple[Content, list[str]]], bool]:
-    """Récupère le feed veille filtré pour `user_id`.
+    """Récupère le feed veille curé pour `user_id`.
 
-    Returns (items_with_axes, has_more). `items_with_axes` est la liste paginée
-    de tuples (Content hydraté, axes matchés). `has_more` est dérivé d'un
-    fetch limit+1 pour éviter un COUNT séparé.
+    Returns (items_with_axes, has_more). Pipeline : prefilter SQL sur axes
+    forts (≤ CANDIDATE_CAP) → scoring piliers → seuil → tri par score, puis
+    pagination sur l'ensemble scoré. Contrat API (limit/offset/has_more)
+    inchangé.
 
-    Si aucune config active OU filtres vides → liste vide (200 OK avec items=[]).
+    Si aucune config active OU aucun axe fort (thème seul) → liste vide.
     """
     config = await _get_active_config(session, user_id)
     if config is None:
         return [], False
 
     filters = await load_veille_filters(session, config)
-    if not filters.has_any():
-        return [], False
-
-    predicate = build_or_predicate(filters)
+    predicate = build_strong_predicate(filters)
     if predicate is None:
         return [], False
+
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(hours=ScoringWeights.VEILLE_RECENCY_HOURS)
 
     exclude_user_status = exists().where(
         UserContentStatus.content_id == Content.id,
@@ -185,6 +289,7 @@ async def fetch_veille_feed(
         .where(~exclude_user_status)
         .where(predicate)
         .where(Source.is_active.is_(True))
+        .where(Content.published_at >= cutoff)
     )
 
     if serein:
@@ -195,17 +300,17 @@ async def fetch_veille_feed(
             excluded_topics=serein_prefs.excluded_topics,
         )
 
-    if filters.source_ids:
-        source_boost = case(
-            (Content.source_id.in_(filters.source_ids), 1), else_=0
-        ).desc()
-        query = query.order_by(source_boost, Content.published_at.desc())
-    else:
-        query = query.order_by(Content.published_at.desc())
-
-    rows = (
-        (await session.execute(query.limit(limit + 1).offset(offset))).scalars().all()
+    query = query.order_by(Content.published_at.desc()).limit(
+        ScoringWeights.VEILLE_CANDIDATE_CAP
     )
-    has_more = len(rows) > limit
-    items = rows[:limit]
-    return [(c, _matched_axes(c, filters)) for c in items], has_more
+
+    candidates = (await session.execute(query)).scalars().all()
+    if not candidates:
+        return [], False
+
+    context = await build_veille_scoring_context(session, config, filters, now)
+    scored = _score_and_rank(list(candidates), context, filters)
+
+    page = scored[offset : offset + limit]
+    has_more = len(scored) > offset + limit
+    return [(content, axes) for content, _score, axes in page], has_more

--- a/packages/api/app/services/veille/llm/angle_suggester.py
+++ b/packages/api/app/services/veille/llm/angle_suggester.py
@@ -44,7 +44,7 @@ class _LLMAngle(BaseModel):
 
 _SYSTEM_PROMPT = """Tu es un expert en curation éditoriale francophone, spécialisé en veille thématique.
 
-Tâche : pour un thème et un brief éditorial donnés, propose 5 à 8 ANGLES de veille pertinents. Chaque angle vient avec 3 à 5 mots-clés explicites qui serviront ensuite à filtrer des articles d'actualité.
+Tâche : pour un thème et un brief éditorial donnés, propose 8 à 12 ANGLES de veille pertinents. Chaque angle vient avec 3 à 5 mots-clés explicites qui serviront ensuite à filtrer des articles d'actualité.
 
 Format JSON strict :
 {
@@ -59,7 +59,7 @@ Format JSON strict :
 }
 
 Contraintes :
-- 5 à 8 angles distincts (pas de redondance).
+- 8 à 12 angles distincts (pas de redondance).
 - title : titre court (max 80 chars), explicite, complémentaire aux autres angles.
 - keywords : 3 à 5 mots ou expressions courtes (1-3 mots chacun), en français, en minuscules. Ce sont les mots qui doivent matcher dans les titres / descriptions des articles. Pense large (synonymes, variantes, noms propres pertinents) mais reste précis pour le sujet.
 - reason : 1 phrase max 200 chars qui explique l'intérêt de cet angle pour le thème + brief.
@@ -94,6 +94,21 @@ def _fallback_angles(theme_label: str) -> list[AngleSuggestion]:
             title="Initiatives et bonnes pratiques",
             keywords=["initiative", "bonne pratique", "retour d'expérience"],
             reason="Cas concrets et solutions testées",
+        ),
+        AngleSuggestion(
+            title="Acteurs et personnalités",
+            keywords=["interview", "portrait", "personnalité"],
+            reason="Les figures qui font bouger le domaine",
+        ),
+        AngleSuggestion(
+            title="Tendances de fond",
+            keywords=["tendance", "prospective", "futur"],
+            reason="Mouvements de long terme et signaux faibles",
+        ),
+        AngleSuggestion(
+            title="Réglementation et politique",
+            keywords=["réglementation", "loi", "politique"],
+            reason="Cadre légal et décisions publiques",
         ),
     ]
 
@@ -139,7 +154,7 @@ class AngleSuggester:
         user_message = (
             f"Thème : {theme_label} (slug: {theme_id})\n"
             f"Brief éditorial : {brief or '(aucun)'}\n\n"
-            f"Propose 5 à 8 angles avec leurs mots-clés explicites."
+            f"Propose 8 à 12 angles avec leurs mots-clés explicites."
         )
 
         raw = await self._llm.chat_json(
@@ -147,7 +162,7 @@ class AngleSuggester:
             user_message=user_message,
             model=self._model,
             temperature=0.3,
-            max_tokens=1200,
+            max_tokens=2000,
         )
 
         angles = self._parse(raw)

--- a/packages/api/app/services/veille/scoring_context.py
+++ b/packages/api/app/services/veille/scoring_context.py
@@ -1,0 +1,107 @@
+"""Construction d'un `ScoringContext` pour le feed veille (refonte curation).
+
+La veille réutilise **le moteur de scoring de la Tournée** (`PillarScoringEngine`,
+piliers Pertinence/Source/Fraîcheur/Qualité) au lieu d'un scoring parallèle. Ce
+module adapte une `VeilleConfig` + ses filtres en un `ScoringContext` :
+
+- thème → `user_interests` (signal **faible** : ne qualifie jamais seul, le
+  thème est même retiré du prédicat SQL côté `feed_filter`).
+- topics/angles canoniques → `user_subtopics` (+45/topic matché, signal fort).
+- angles (sujet + sa grappe de mots-clés) → `user_custom_topics` via
+  l'adaptateur `VeilleAngleTopic` (+25/angle matché par slug **ou** keyword).
+- sources suivies → `followed_source_ids` (+35 source de confiance).
+
+Aucune affinité/multiplicateur/mute en V1 — seuls ces 4 leviers pilotent le tri.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.enums import InterestState
+from app.models.user import UserProfile
+from app.services.recommendation.scoring_engine import ScoringContext
+
+if TYPE_CHECKING:  # éviter un import circulaire feed_filter ↔ scoring_context
+    from app.services.veille.feed_filter import VeilleFilters
+
+
+@dataclass(frozen=True)
+class VeilleAngleTopic:
+    """Adaptateur angle veille → custom-topic (duck-typing de `_score_custom_topics`).
+
+    `_score_custom_topics` (pertinence.py) attend `slug_parent`, `keywords`,
+    `priority_multiplier`, `state`, `topic_name`. Un angle matche si son
+    `slug_parent` est dans `content.topics` **ou** si l'un de ses `keywords`
+    apparaît dans le titre/description → +CUSTOM_TOPIC_BASE_BONUS (25).
+    """
+
+    slug_parent: str
+    keywords: list[str]
+    topic_name: str
+    priority_multiplier: float = 1.0
+    state: InterestState = InterestState.FOLLOWED
+
+
+async def build_veille_scoring_context(
+    session: AsyncSession,
+    config,
+    filters: VeilleFilters,
+    now: datetime,
+) -> ScoringContext:
+    """Construit le `ScoringContext` veille depuis la config + ses filtres.
+
+    Calqué sur la construction de contexte du digest (`digest_selector`), mais
+    sourcé depuis la config veille. Charge le `UserProfile` réel (select léger)
+    pour un contexte non-None ; retombe sur une instance transitoire si absent.
+    """
+    profile = (
+        (
+            await session.execute(
+                select(UserProfile).where(UserProfile.user_id == config.user_id)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if profile is None:
+        profile = UserProfile(user_id=config.user_id)
+
+    topic_slugs = {s.lower().strip() for s in filters.topic_slugs if s}
+
+    custom_topics: list[VeilleAngleTopic] = [
+        VeilleAngleTopic(
+            slug_parent=angle.topic_id.lower().strip(),
+            keywords=[k.lower().strip() for k in angle.keywords if k.strip()],
+            topic_name=angle.label,
+        )
+        for angle in filters.angles
+    ]
+    # Les mots-clés globaux (non rattachés à un angle) deviennent un custom-topic
+    # sans slug → ne matchent que par leur grappe, mais restent un signal fort
+    # (+25) au même titre qu'un angle.
+    if filters.global_keywords:
+        custom_topics.append(
+            VeilleAngleTopic(
+                slug_parent="",
+                keywords=[k.lower().strip() for k in filters.global_keywords if k.strip()],
+                topic_name="Mots-clés",
+            )
+        )
+
+    return ScoringContext(
+        user_profile=profile,
+        user_interests={config.theme_id} if config.theme_id else set(),
+        user_interest_weights={},
+        followed_source_ids=set(filters.source_ids),
+        user_prefs={},
+        now=now,
+        user_subtopics=topic_slugs,
+        user_subtopic_weights={},
+        user_custom_topics=custom_topics,
+    )

--- a/packages/api/app/services/veille/scoring_context.py
+++ b/packages/api/app/services/veille/scoring_context.py
@@ -89,7 +89,9 @@ async def build_veille_scoring_context(
         custom_topics.append(
             VeilleAngleTopic(
                 slug_parent="",
-                keywords=[k.lower().strip() for k in filters.global_keywords if k.strip()],
+                keywords=[
+                    k.lower().strip() for k in filters.global_keywords if k.strip()
+                ],
                 topic_name="Mots-clés",
             )
         )

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -7,7 +7,7 @@ Couvre les endpoints refondus en filtre temps-réel :
 """
 
 from datetime import UTC, datetime, timedelta
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -160,6 +160,52 @@ class TestConfigCRUD:
         assert len(data["sources"]) == 1
         assert len(data["keywords"]) == 2
         assert data["keywords"][0]["keyword"] == "intelligence artificielle"
+
+    async def test_post_config_persists_angle_keyword_clusters(
+        self, auth_user, curated_tech_source, db_session
+    ):
+        """Story curation : un angle `suggested` + sa grappe → VeilleKeyword liés."""
+        from app.models.veille import VeilleKeyword
+
+        payload = {
+            "theme_id": "tech",
+            "theme_label": "Tech",
+            "topics": [
+                {
+                    "topic_id": "ia-generative",
+                    "label": "IA générative",
+                    "kind": "suggested",
+                    "keywords": ["GPT-5", "Mistral", "gpt-5"],  # dédup attendu
+                }
+            ],
+            "keywords": [{"keyword": "souveraineté", "position": 0}],
+        }
+        async with _client() as c:
+            r = await c.post("/api/veille/config", json=payload)
+        assert r.status_code == 200, r.text
+        data = r.json()
+        # Round-trip : la grappe niche sous l'angle, le mot-clé global reste à plat.
+        assert len(data["topics"]) == 1
+        assert data["topics"][0]["keywords"] == ["gpt-5", "mistral"]
+        assert [k["keyword"] for k in data["keywords"]] == ["souveraineté"]
+
+        # En base : 2 keywords liés à l'angle + 1 global (veille_topic_id NULL).
+        rows = (
+            (
+                await db_session.execute(
+                    select(VeilleKeyword).where(
+                        VeilleKeyword.veille_config_id == UUID(data["id"])
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        linked = [r for r in rows if r.veille_topic_id is not None]
+        globals_ = [r for r in rows if r.veille_topic_id is None]
+        assert len(linked) == 2
+        assert len(globals_) == 1
+        assert globals_[0].keyword == "souveraineté"
 
     async def test_post_config_requires_at_least_one_axis(self, auth_user):
         payload = {
@@ -333,9 +379,14 @@ class TestFeed:
         assert r.status_code == 200
         assert r.json()["items"] == []
 
-    async def test_feed_matches_theme(
+    async def test_feed_source_axis_returns_all_but_theme_not_qualifying(
         self, auth_user, curated_tech_source, tech_content
     ):
+        """La source est un axe fort → ses 3 articles entrent dans le pool.
+
+        Contrat inversé : le thème n'est plus un axe **qualifiant** —
+        `matched_on` n'expose plus "theme" même quand content.theme == config.theme.
+        """
         payload = {
             "theme_id": "tech",
             "theme_label": "Tech",
@@ -348,12 +399,33 @@ class TestFeed:
             r = await c.get("/api/veille/feed?limit=20")
         assert r.status_code == 200
         data = r.json()
-        # 3 articles, mais la source matche pour les 3 → tous reviennent (source axe)
         assert len(data["items"]) == 3
-        # GPT-5 matche aussi theme=tech
         gpt = next(it for it in data["items"] if "GPT-5" in it["title"])
-        assert "theme" in gpt["matched_on"]
         assert "source" in gpt["matched_on"]
+        assert "theme" not in gpt["matched_on"]
+
+    async def test_feed_theme_only_article_excluded(
+        self, auth_user, curated_tech_source, tech_content
+    ):
+        """Config sur un topic précis → un article « thème macro seul » est exclu.
+
+        Le thème étant retiré du prédicat, GPT-5 (topics=["ai","openai"]) entre
+        via le topic "ai" mais l'article Bourse (theme=economy, hors topic, hors
+        source suivie, hors keyword) n'entre jamais dans le pool.
+        """
+        payload = {
+            "theme_id": "tech",
+            "theme_label": "Tech",
+            "topics": [{"topic_id": "ai", "label": "IA", "kind": "preset"}],
+        }
+        async with _client() as c:
+            await c.post("/api/veille/config", json=payload)
+            r = await c.get("/api/veille/feed?limit=20")
+        items = r.json()["items"]
+        titles = [it["title"] for it in items]
+        assert any("GPT-5" in t for t in titles)
+        assert not any("Bourse" in t for t in titles)
+        assert not any("Vélo" in t for t in titles)
 
     async def test_feed_matches_keyword(
         self, auth_user, curated_tech_source, tech_content
@@ -367,10 +439,11 @@ class TestFeed:
             await c.post("/api/veille/config", json=payload)
             r = await c.get("/api/veille/feed")
         items = r.json()["items"]
-        # Le keyword "vélo" matche l'article Vélo électrique, mais l'axe theme
-        # matche aussi GPT-5 (theme=tech). Donc 2 résultats.
-        assert len(items) == 2
-        velo = next(it for it in items if "Vélo" in it["title"])
+        # Seul l'article "Vélo électrique" matche le keyword. GPT-5 n'entre plus
+        # via le thème (retiré du prédicat) → 1 seul résultat (contrat inversé).
+        assert len(items) == 1
+        velo = items[0]
+        assert "Vélo" in velo["title"]
         assert "keyword" in velo["matched_on"]
 
 

--- a/packages/api/tests/services/test_veille_scoring.py
+++ b/packages/api/tests/services/test_veille_scoring.py
@@ -1,0 +1,284 @@
+"""Tests du feed veille curé par score (refonte curation).
+
+Couvre le pipeline `fetch_veille_feed` : prefilter axes forts → scoring piliers
+→ seuil → tri par score. Le thème macro est un signal faible (jamais dans le
+prédicat) → un article « thème seul » n'entre jamais dans le pool.
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentStatus, ContentType, ReliabilityScore, SourceType
+from app.models.source import Source
+from app.models.user import UserProfile
+from app.models.veille import (
+    VeilleConfig,
+    VeilleKeyword,
+    VeilleSource,
+    VeilleStatus,
+    VeilleTopic,
+)
+from app.services.veille.feed_filter import fetch_veille_feed
+
+pytestmark = pytest.mark.asyncio
+
+
+def _now():
+    return datetime.now(UTC)
+
+
+@pytest_asyncio.fixture
+async def user(db_session):
+    u = UserProfile(user_id=uuid4(), display_name="scoring", onboarding_completed=True)
+    db_session.add(u)
+    await db_session.commit()
+    return u
+
+
+@pytest_asyncio.fixture
+async def source(db_session):
+    s = Source(
+        id=uuid4(),
+        name="Curated Tech",
+        url="https://ct.example.com",
+        feed_url=f"https://ct.example.com/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="tech",
+        is_active=True,
+        is_curated=True,
+        reliability_score=ReliabilityScore.HIGH,
+    )
+    db_session.add(s)
+    await db_session.commit()
+    return s
+
+
+async def _add_content(
+    db_session,
+    source,
+    *,
+    title,
+    theme="tech",
+    topics=None,
+    description="",
+    hours=2,
+    reliability=None,
+):
+    c = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title=title,
+        url=f"https://ct.example.com/{uuid4()}",
+        description=description,
+        published_at=_now() - timedelta(hours=hours),
+        content_type=ContentType.ARTICLE,
+        guid=str(uuid4()),
+        theme=theme,
+        topics=topics or [],
+    )
+    db_session.add(c)
+    await db_session.commit()
+    return c
+
+
+async def _make_config(
+    db_session,
+    user,
+    *,
+    theme_id="tech",
+    topics=None,
+    source_ids=None,
+    global_keywords=None,
+):
+    """topics: list of (topic_id, label, [keywords]). source_ids/global_keywords lists."""
+    cfg = VeilleConfig(
+        id=uuid4(),
+        user_id=user.user_id,
+        theme_id=theme_id,
+        theme_label=theme_id.capitalize(),
+        status=VeilleStatus.ACTIVE.value,
+    )
+    db_session.add(cfg)
+    await db_session.flush()
+
+    for pos, (tid, label, kws) in enumerate(topics or []):
+        topic = VeilleTopic(
+            veille_config_id=cfg.id,
+            topic_id=tid,
+            label=label,
+            kind="suggested",
+            position=pos,
+        )
+        db_session.add(topic)
+        await db_session.flush()
+        for kpos, kw in enumerate(kws or []):
+            db_session.add(
+                VeilleKeyword(
+                    veille_config_id=cfg.id,
+                    veille_topic_id=topic.id,
+                    keyword=kw,
+                    position=kpos,
+                )
+            )
+
+    for sid in source_ids or []:
+        db_session.add(VeilleSource(veille_config_id=cfg.id, source_id=sid, kind="followed"))
+
+    for kpos, kw in enumerate(global_keywords or []):
+        db_session.add(
+            VeilleKeyword(veille_config_id=cfg.id, keyword=kw, position=kpos)
+        )
+
+    await db_session.commit()
+    return cfg
+
+
+async def _titles(db_session, user):
+    items, _ = await fetch_veille_feed(db_session, user.user_id, limit=20, offset=0)
+    return [c.title for c, _axes in items], items
+
+
+async def test_theme_only_article_never_enters_pool(db_session, user, source):
+    """Article matchant uniquement le thème macro → absent (prédicat sans thème)."""
+    await _add_content(db_session, source, title="Topic AI", topics=["ai"])
+    await _add_content(db_session, source, title="Theme Only", topics=["unrelated"])
+    await _make_config(db_session, user, topics=[("ai", "IA", [])])
+
+    titles, _ = await _titles(db_session, user)
+    assert "Topic AI" in titles
+    assert "Theme Only" not in titles
+
+
+async def test_topic_outranks_keyword(db_session, user, source):
+    """Thème + topic (>) thème + mot-clé : les deux présents, topic mieux classé."""
+    await _add_content(db_session, source, title="Topic Match", topics=["ai"])
+    await _add_content(
+        db_session,
+        source,
+        title="Keyword Match transformers",
+        topics=["other"],
+        description="modèle transformers",
+    )
+    await _make_config(
+        db_session,
+        user,
+        topics=[("ai", "IA", ["transformers"])],
+    )
+
+    titles, _ = await _titles(db_session, user)
+    assert "Topic Match" in titles
+    assert "Keyword Match transformers" in titles
+    assert titles.index("Topic Match") < titles.index("Keyword Match transformers")
+
+
+async def test_source_only_and_keyword_only_present(db_session, user, source):
+    """Source-seule présente ; mot-clé-seul présent (valide le seuil)."""
+    await _add_content(
+        db_session, source, title="From Source", theme="economy", topics=["markets"]
+    )
+    await _make_config(db_session, user, source_ids=[source.id])
+    titles, _ = await _titles(db_session, user)
+    assert "From Source" in titles
+
+
+async def test_keyword_only_present(db_session, user, source):
+    await _add_content(
+        db_session,
+        source,
+        title="Vélo électrique nouveau modèle",
+        theme="society",
+        topics=["mobility"],
+        description="test du nouveau VAE",
+    )
+    await _make_config(db_session, user, global_keywords=["vélo"])
+    titles, items = await _titles(db_session, user)
+    assert "Vélo électrique nouveau modèle" in titles
+    assert "keyword" in items[0][1]
+
+
+async def test_weak_candidate_below_threshold_excluded(db_session, user):
+    """Candidat faible (mot-clé, vieux, source basse fiabilité) < seuil → exclu."""
+    weak_src = Source(
+        id=uuid4(),
+        name="Low",
+        url="https://low.example.com",
+        feed_url=f"https://low.example.com/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="economy",
+        is_active=True,
+        is_curated=False,
+        reliability_score=ReliabilityScore.LOW,
+    )
+    db_session.add(weak_src)
+    await db_session.commit()
+    await _add_content(
+        db_session,
+        weak_src,
+        title="incident mineur vélo",
+        theme="economy",
+        topics=["misc"],
+        hours=160,
+    )
+    await _make_config(db_session, user, global_keywords=["vélo"])
+    titles, _ = await _titles(db_session, user)
+    assert titles == []
+
+
+async def test_excludes_hidden_seen_and_inactive(db_session, user, source):
+    """Exclusions hidden/seen + is_active=False."""
+    visible = await _add_content(db_session, source, title="Visible AI", topics=["ai"])
+    hidden = await _add_content(db_session, source, title="Hidden AI", topics=["ai"])
+    seen = await _add_content(db_session, source, title="Seen AI", topics=["ai"])
+
+    db_session.add(
+        UserContentStatus(
+            user_id=user.user_id, content_id=hidden.id, is_hidden=True
+        )
+    )
+    db_session.add(
+        UserContentStatus(
+            user_id=user.user_id,
+            content_id=seen.id,
+            status=ContentStatus.SEEN,
+        )
+    )
+    await db_session.commit()
+
+    await _make_config(db_session, user, topics=[("ai", "IA", [])])
+    titles, _ = await _titles(db_session, user)
+    assert "Visible AI" in titles
+    assert "Hidden AI" not in titles
+    assert "Seen AI" not in titles
+
+    # is_active=False sur la source → tout disparaît.
+    source.is_active = False
+    await db_session.commit()
+    titles2, _ = await _titles(db_session, user)
+    assert titles2 == []
+
+
+async def test_pagination_over_scored_set(db_session, user, source):
+    """Pagination sur l'ensemble scoré : has_more + tranches cohérentes."""
+    for i in range(5):
+        await _add_content(
+            db_session, source, title=f"AI article {i}", topics=["ai"], hours=i + 1
+        )
+    await _make_config(db_session, user, topics=[("ai", "IA", [])])
+
+    page1, has_more1 = await fetch_veille_feed(
+        db_session, user.user_id, limit=2, offset=0
+    )
+    page2, has_more2 = await fetch_veille_feed(
+        db_session, user.user_id, limit=2, offset=2
+    )
+    assert len(page1) == 2
+    assert has_more1 is True
+    assert len(page2) == 2
+    assert has_more2 is True
+    titles1 = {c.title for c, _ in page1}
+    titles2 = {c.title for c, _ in page2}
+    assert titles1.isdisjoint(titles2)

--- a/packages/api/tests/test_veille_models.py
+++ b/packages/api/tests/test_veille_models.py
@@ -234,18 +234,90 @@ class TestVeilleKeyword:
         assert rows[0].keyword == "ia générative"
 
     @pytest.mark.asyncio
-    async def test_keyword_unique_per_config(self, db_session, cfg):
+    async def test_keyword_unique_per_topic(self, db_session, cfg):
+        """Unique = (config, topic_id, keyword) — collision sous un même angle."""
+        topic = VeilleTopic(
+            veille_config_id=cfg.id,
+            topic_id="climat",
+            label="Climat",
+            kind=VeilleTopicKind.PRESET,
+            position=0,
+        )
+        db_session.add(topic)
+        await db_session.commit()
+        await db_session.refresh(topic)
+
         db_session.add(
-            VeilleKeyword(veille_config_id=cfg.id, keyword="climat", position=0)
+            VeilleKeyword(
+                veille_config_id=cfg.id,
+                veille_topic_id=topic.id,
+                keyword="climat",
+                position=0,
+            )
         )
         await db_session.commit()
 
         db_session.add(
-            VeilleKeyword(veille_config_id=cfg.id, keyword="climat", position=1)
+            VeilleKeyword(
+                veille_config_id=cfg.id,
+                veille_topic_id=topic.id,
+                keyword="climat",
+                position=1,
+            )
         )
         with pytest.raises(IntegrityError):
             await db_session.commit()
         await db_session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_same_keyword_allowed_under_two_angles(self, db_session, cfg):
+        """La même clé peut vivre sous deux angles distincts (triplet unique)."""
+        t1 = VeilleTopic(
+            veille_config_id=cfg.id,
+            topic_id="climat",
+            label="Climat",
+            kind=VeilleTopicKind.PRESET,
+            position=0,
+        )
+        t2 = VeilleTopic(
+            veille_config_id=cfg.id,
+            topic_id="energie",
+            label="Énergie",
+            kind=VeilleTopicKind.PRESET,
+            position=1,
+        )
+        db_session.add_all([t1, t2])
+        await db_session.commit()
+        await db_session.refresh(t1)
+        await db_session.refresh(t2)
+
+        db_session.add_all(
+            [
+                VeilleKeyword(
+                    veille_config_id=cfg.id, veille_topic_id=t1.id, keyword="co2"
+                ),
+                VeilleKeyword(
+                    veille_config_id=cfg.id, veille_topic_id=t2.id, keyword="co2"
+                ),
+                # + un mot-clé global (veille_topic_id NULL) identique : autorisé.
+                VeilleKeyword(veille_config_id=cfg.id, keyword="co2"),
+            ]
+        )
+        await db_session.commit()
+
+        rows = (
+            (
+                await db_session.execute(
+                    select(VeilleKeyword).where(
+                        VeilleKeyword.veille_config_id == cfg.id,
+                        VeilleKeyword.keyword == "co2",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 3
 
 
 class TestCascade:


### PR DESCRIPTION
# Veille — curation premium + config liée aux angles + fix navigation

Refonte de la **veille** sur 3 axes (par impact) : curation par score (le « 90 % »), config où chaque angle porte sa grappe de mots-clés, et fix du bug « Créer ma veille » → feed.

## Part A — Curation premium (cœur)
Remplace le filtre `OR` (où le **thème** suffisait à faire entrer tout l'article) par un pipeline **prefilter SQL axes forts → scoring piliers → seuil → tri par score**, en réutilisant le moteur de la Tournée (`PillarScoringEngine`).
- `feed_filter.py` : `build_strong_predicate` (topics/sources/mots-clés ; **thème retiré du prédicat**) + fenêtre récence 168h + `CANDIDATE_CAP` 300 + `_score_and_rank` (seuil + tri score/récence). `matched_on` ne qualifie plus via `theme`.
- `scoring_context.py` (nouveau) : adaptateur `VeilleAngleTopic` (duck-type de `_score_custom_topics`) + `build_veille_scoring_context` — thème = signal **faible** (`user_interests`), topics → `user_subtopics` (+45), angles → `user_custom_topics` (+25), sources → `followed_source_ids` (+35).
- `scoring_config.py` : `VEILLE_RELEVANCE_THRESHOLD=40`, `VEILLE_CANDIDATE_CAP=300`, `VEILLE_RECENCY_HOURS=168` + log structuré (`max_score`/`pass_count`/`candidate_count`) pour calibrer en prod.

## Part B — Modèle : angle = sujet + grappe
- `VeilleKeyword.veille_topic_id` (FK `veille_topics`, nullable = mot-clé global), index `ix_veille_keywords_topic`, unique relâché en `(config, topic_id, keyword)`.
- Migration `vk01_link_keywords_to_topics` (`down_revision = dd01_franceinfo_dedup`, 1 head, downgrade symétrique).

## Part C — Config enrichie
- `schemas` + `routers/veille.py` : `VeilleTopicSelection.keywords` persisté lié à l'angle ; `_hydrate_response` round-trip (grappes nichées, globaux à plat).
- `angle_suggester.py` : prompt **8-12 angles** (au lieu de 5-8), `max_tokens` 2000, fallback étendu.
- Sources : `/presets` 6 → 12 ; `_fetch_source_examples` **préfère** les articles matchant les mots-clés de la veille active (sinon récence brute).
- Mobile : DTO round-trip des grappes ; brief introduit **une fois** au Step 1 (suppression du doublon Step 2).

## Part D — Fix navigation « Créer ma veille » → feed (2 leviers)
- `veille_config_provider.submit()` : `invalidate(userInterestsProvider)` après hydratation (lever racine).
- `my_interests_screen.dart` : CTA masqué si veille active connue **ET** pas de `VeilleFavoriteRef` (défense en profondeur).

## Tests / VERIFY
- Backend complet : **1408 passed, 1 skipped, 2 xfailed** (0 régression). Veille : 65 passed (scoring, thème-seul exclu, topic>keyword, source/keyword, frontière seuil, exclusions hidden/seen/inactive, pagination, persistance grappes round-trip, unique triplet).
- Alembic : 1 head ; `upgrade head` + `downgrade -1` + re-upgrade OK sur DB **vide**.
- Mobile : `flutter analyze` → 0 erreur (548 infos préexistantes).

## Hors-scope (suite)
Le fetch LLM `/suggest/angles` n'est pas encore branché dans l'écran suggestions mobile (il consomme aujourd'hui les preset topics statiques) ; le backend + le round-trip DTO sont prêts à l'accueillir → l'affichage éditable des chips de mots-clés par angle (C3 UI) suivra dans une PR mobile dédiée.
