### PR TITLE
feat(veille): angles LLM + chips de mots-clés éditables au Step 2 (Veille C3)

### DIFF
--- a/apps/mobile/lib/features/veille/models/veille_config_dto.dart
+++ b/apps/mobile/lib/features/veille/models/veille_config_dto.dart
@@ -6,9 +6,12 @@ import 'package:flutter/foundation.dart';
 /// `last_delivered_at`/`next_scheduled_at` (scheduler async drop) et ajouté
 /// `keywords[]` (angles libres saisis par l'utilisateur).
 ///
-/// PR-4 (Story 23.3) : suggesters LLM (`VeilleSuggestAngles*`,
-/// `VeilleSuggestSources*`, `VeilleAngleSuggestionDto`,
-/// `VeilleSourceSuggestionDto`) retirés — backend `/suggest/*` répond 410 Gone.
+/// PR-4 (Story 23.3) : suggesters LLM (`VeilleSuggestSources*`,
+/// `VeilleSourceSuggestionDto`) retirés — `/suggest/sources` répond 410 Gone.
+///
+/// Veille C3 (PR-3) : `VeilleAngleSuggestionDto` / `VeilleSuggestAnglesResponse`
+/// ré-introduits — `POST /veille/suggest/angles` est actif (suggestion d'angles
+/// LLM = titre + grappe de mots-clés éditable au Step 2).
 
 @immutable
 class VeilleTopicDto {
@@ -316,4 +319,50 @@ class VeilleConfigUpsertRequest {
         'editorial_brief': editorialBrief,
         'preset_id': presetId,
       };
+}
+
+// ─── Suggestion d'angles LLM (POST /veille/suggest/angles) ──────────────────
+
+/// Un angle suggéré par le LLM : un titre éditorial + sa grappe de mots-clés
+/// (pilote le scoring) + une raison courte. Miroir de `VeilleAngleSuggestion`
+/// (`packages/api/app/schemas/veille.py`).
+@immutable
+class VeilleAngleSuggestionDto {
+  final String title;
+  final List<String> keywords;
+  final String? reason;
+
+  const VeilleAngleSuggestionDto({
+    required this.title,
+    this.keywords = const [],
+    this.reason,
+  });
+
+  factory VeilleAngleSuggestionDto.fromJson(Map<String, dynamic> json) {
+    return VeilleAngleSuggestionDto(
+      title: json['title'] as String,
+      keywords: ((json['keywords'] as List?) ?? const [])
+          .map((e) => e as String)
+          .toList(),
+      reason: json['reason'] as String?,
+    );
+  }
+}
+
+/// Réponse de `POST /veille/suggest/angles`. Miroir de
+/// `VeilleSuggestAnglesResponse` côté backend.
+@immutable
+class VeilleSuggestAnglesResponse {
+  final List<VeilleAngleSuggestionDto> angles;
+
+  const VeilleSuggestAnglesResponse({this.angles = const []});
+
+  factory VeilleSuggestAnglesResponse.fromJson(Map<String, dynamic> json) {
+    return VeilleSuggestAnglesResponse(
+      angles: ((json['angles'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleAngleSuggestionDto.fromJson)
+          .toList(),
+    );
+  }
 }

--- a/apps/mobile/lib/features/veille/providers/veille_angles_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_angles_provider.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/veille_config_dto.dart';
+import 'veille_repository_provider.dart';
+
+/// Clé de cache de [veilleAnglesProvider] : thème + brief pilotent la
+/// suggestion LLM (le backend cache sur le triplet `theme_id`/`theme_label`/
+/// `brief` pendant 24 h).
+typedef VeilleAnglesQuery = ({String themeId, String themeLabel, String brief});
+
+/// Suggestion d'angles LLM pour le Step 2 (titre + grappe de mots-clés).
+///
+/// Délègue à `VeilleRepository.suggestAngles`, qui retourne `[]` en cas
+/// d'erreur/timeout — l'UI retombe alors sur les preset topics statiques,
+/// donc aucune régression si le LLM est KO. `autoDispose` : la suggestion est
+/// re-déclenchée à chaque entrée dans le Step 2 (le cache backend absorbe le
+/// coût des appels répétés).
+final veilleAnglesProvider = FutureProvider.autoDispose
+    .family<List<VeilleAngleSuggestionDto>, VeilleAnglesQuery>((ref, q) async {
+  final repo = ref.watch(veilleRepositoryProvider);
+  return repo.suggestAngles(
+    themeId: q.themeId,
+    themeLabel: q.themeLabel,
+    brief: q.brief,
+  );
+});

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -78,6 +78,12 @@ class VeilleConfigState {
   /// backend.
   final Set<String> keywords;
 
+  /// Grappe de mots-clés par angle LLM sélectionné (slug `angle-…` →
+  /// liste éditable). Seedée depuis la suggestion LLM à la sélection, puis
+  /// éditable (add/remove chip). Injectée dans `VeilleTopicSelection.keywords`
+  /// au submit pour les angles `suggested`. Vide = aucun angle activé.
+  final Map<String, List<String>> angleKeywords;
+
   /// Toggle "Configuration avancée" sur step2/step3. Quand `true`, révèle les
   /// champs free-text (keywords + brief éditorial step2, source URL step3).
   final bool advancedMode;
@@ -116,6 +122,7 @@ class VeilleConfigState {
     required this.topicLabels,
     required this.sourcesMeta,
     required this.keywords,
+    required this.angleKeywords,
     required this.advancedMode,
     required this.skippedStep2,
     required this.purpose,
@@ -138,6 +145,7 @@ class VeilleConfigState {
         topicLabels: {},
         sourcesMeta: {},
         keywords: <String>{},
+        angleKeywords: {},
         advancedMode: false,
         skippedStep2: false,
         purpose: null,
@@ -166,6 +174,7 @@ class VeilleConfigState {
     Map<String, String>? topicLabels,
     Map<String, VeilleSourceMeta>? sourcesMeta,
     Set<String>? keywords,
+    Map<String, List<String>>? angleKeywords,
     bool? advancedMode,
     bool? skippedStep2,
     Object? purpose = _Sentinel.value,
@@ -191,6 +200,7 @@ class VeilleConfigState {
         topicLabels: topicLabels ?? this.topicLabels,
         sourcesMeta: sourcesMeta ?? this.sourcesMeta,
         keywords: keywords ?? this.keywords,
+        angleKeywords: angleKeywords ?? this.angleKeywords,
         advancedMode: advancedMode ?? this.advancedMode,
         skippedStep2: skippedStep2 ?? this.skippedStep2,
         purpose:
@@ -228,6 +238,9 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
 
   /// Limite backend (`MAX_KEYWORDS_PER_CONFIG` dans `schemas/veille.py`).
   static const int maxKeywords = 20;
+
+  /// Limite backend par angle (`VeilleTopicSelection.keywords` max_length=10).
+  static const int maxAngleKeywords = 10;
 
   void selectTheme(String id) {
     // Changer de thème reset les topics pré-sélectionnés (les preset topics
@@ -299,7 +312,9 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     state = state.copyWith(customTopics: next, selectedTopics: selection);
   }
 
-  static String _slugifyCustom(String input) {
+  /// Slug normalisé (sans préfixe) : lowercase, diacritiques → ASCII, capé à
+  /// 60 chars (confort backend, max 80). Vide → "sujet".
+  static String _slugifyBase(String input) {
     final lowered = input.toLowerCase().trim();
     final cleaned = lowered
         .replaceAll(RegExp(r'[àâä]'), 'a')
@@ -313,9 +328,32 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
         .replaceAll(RegExp(r'-+'), '-');
     final trimmed = cleaned.replaceAll(RegExp(r'^-|-$'), '');
     final base = trimmed.isEmpty ? 'sujet' : trimmed;
-    // Cap à 60 chars pour rester confortable côté backend (max 80).
-    final capped = base.length > 60 ? base.substring(0, 60) : base;
-    return 'custom-$capped';
+    return base.length > 60 ? base.substring(0, 60) : base;
+  }
+
+  static String _slugifyCustom(String input) => 'custom-${_slugifyBase(input)}';
+
+  /// Slug d'un angle LLM (préfixe dédié `angle-`) — distinct des sujets custom
+  /// (`custom-`) pour ne pas collisionner dans `topicLabels`/`angleKeywords`.
+  static String angleSlug(String title) => 'angle-${_slugifyBase(title)}';
+
+  /// Normalise un mot-clé : trim + lowercase, longueur 2..60 sinon `null`.
+  static String? _normalizeKeyword(String raw) {
+    final kw = raw.trim().toLowerCase();
+    if (kw.length < 2 || kw.length > 60) return null;
+    return kw;
+  }
+
+  /// Normalise/dédupe une grappe d'angle, capée à `maxAngleKeywords`.
+  static List<String> _normalizeAngleKeywords(Iterable<String> raw) {
+    final out = <String>[];
+    for (final r in raw) {
+      final kw = _normalizeKeyword(r);
+      if (kw == null || out.contains(kw)) continue;
+      out.add(kw);
+      if (out.length >= maxAngleKeywords) break;
+    }
+    return out;
   }
 
   void toggleTopic(String id) =>
@@ -325,6 +363,62 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
         selectedSuggestions: _toggle(state.selectedSuggestions, id),
       );
 
+  // ─── Angles LLM (Step 2) ────────────────────────────────────────────────
+
+  /// Active / désactive un angle suggéré par le LLM (sélection opt-in). À
+  /// l'activation : l'angle entre dans `selectedSuggestions` (kind `suggested`),
+  /// son label est enregistré, et sa grappe est seedée dans `angleKeywords`
+  /// (préservée si déjà éditée → re-toggle ne perd pas les edits). À la
+  /// désactivation : retiré de `selectedSuggestions` (la grappe éditée reste
+  /// mémorisée mais n'est plus envoyée au submit).
+  void toggleAngle(VeilleAngleSuggestionDto angle) {
+    final slug = angleSlug(angle.title);
+    if (state.selectedSuggestions.contains(slug)) {
+      final nextSel = Set<String>.from(state.selectedSuggestions)..remove(slug);
+      state = state.copyWith(selectedSuggestions: nextSel);
+      return;
+    }
+    final nextLabels = Map<String, String>.from(state.topicLabels)
+      ..[slug] = angle.title;
+    final nextAngleKw = Map<String, List<String>>.from(state.angleKeywords);
+    nextAngleKw.putIfAbsent(
+      slug,
+      () => _normalizeAngleKeywords(angle.keywords),
+    );
+    state = state.copyWith(
+      selectedSuggestions: {...state.selectedSuggestions, slug},
+      topicLabels: nextLabels,
+      angleKeywords: nextAngleKw,
+    );
+  }
+
+  /// Remplace la grappe d'un angle (normalisée + capée).
+  void setAngleKeywords(String slug, List<String> keywords) {
+    final next = Map<String, List<String>>.from(state.angleKeywords)
+      ..[slug] = _normalizeAngleKeywords(keywords);
+    state = state.copyWith(angleKeywords: next);
+  }
+
+  /// Ajoute un mot-clé à la grappe d'un angle (dédupe, cap `maxAngleKeywords`).
+  void addAngleKeyword(String slug, String raw) {
+    final kw = _normalizeKeyword(raw);
+    if (kw == null) return;
+    final current = state.angleKeywords[slug] ?? const <String>[];
+    if (current.contains(kw) || current.length >= maxAngleKeywords) return;
+    final next = Map<String, List<String>>.from(state.angleKeywords)
+      ..[slug] = [...current, kw];
+    state = state.copyWith(angleKeywords: next);
+  }
+
+  /// Retire un mot-clé de la grappe d'un angle.
+  void removeAngleKeyword(String slug, String kw) {
+    final current = state.angleKeywords[slug];
+    if (current == null || !current.contains(kw)) return;
+    final next = Map<String, List<String>>.from(state.angleKeywords)
+      ..[slug] = current.where((k) => k != kw).toList();
+    state = state.copyWith(angleKeywords: next);
+  }
+
   void toggleSource(String id) => state = state.copyWith(
         selectedSourceIds: _toggle(state.selectedSourceIds, id),
       );
@@ -332,8 +426,8 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
   /// Ajoute un mot-clé / angle libre (step2 advanced). Normalise lowercase,
   /// dédupe, respecte la cap backend (`maxKeywords`).
   void addKeyword(String raw) {
-    final kw = raw.trim().toLowerCase();
-    if (kw.length < 2 || kw.length > 60) return;
+    final kw = _normalizeKeyword(raw);
+    if (kw == null) return;
     if (state.keywords.contains(kw)) return;
     if (state.keywords.length >= maxKeywords) return;
     state = state.copyWith(keywords: {...state.keywords, kw});
@@ -363,6 +457,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       skippedStep2: true,
       selectedSuggestions: const {},
       keywords: const {},
+      angleKeywords: const {},
       editorialBrief: null,
     );
   }
@@ -547,8 +642,10 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     final selectedSuggestions = <String>{};
     final customTopics = <VeilleTopic>[];
     final topicLabels = <String, String>{};
+    final angleKeywords = <String, List<String>>{};
     for (final t in cfg.topics) {
       topicLabels[t.topicId] = t.label;
+      if (t.keywords.isNotEmpty) angleKeywords[t.topicId] = t.keywords;
       switch (t.kind) {
         case 'custom':
           customTopics.add(
@@ -593,6 +690,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       selectedSourceIds: selectedSourceIds,
       sourcesMeta: sourcesMeta,
       keywords: keywords,
+      angleKeywords: angleKeywords,
       advancedMode: keywords.isNotEmpty || (cfg.editorialBrief?.isNotEmpty ?? false),
       purpose: cfg.purpose,
       editorialBrief: cfg.editorialBrief,
@@ -628,6 +726,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
           label: s.topicLabels[slug] ?? slug,
           kind: slug.startsWith('custom-') ? 'custom' : 'preset',
           position: pos++,
+          keywords: s.angleKeywords[slug] ?? const <String>[],
         ),
       );
     }
@@ -638,6 +737,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
           label: s.topicLabels[slug] ?? slug,
           kind: 'suggested',
           position: pos++,
+          keywords: s.angleKeywords[slug] ?? const <String>[],
         ),
       );
     }

--- a/apps/mobile/lib/features/veille/repositories/veille_repository.dart
+++ b/apps/mobile/lib/features/veille/repositories/veille_repository.dart
@@ -87,6 +87,36 @@ class VeilleRepository {
     }
   }
 
+  // ─── Suggestion d'angles LLM (Step 2) ──────────────────────────────────
+
+  /// `POST /api/veille/suggest/angles` — suggère des angles éditoriaux (titre +
+  /// grappe de mots-clés) pour un thème/brief via LLM (~10-15 s côté backend,
+  /// cache 24 h). Toute erreur/timeout → **liste vide** : l'UI retombe alors
+  /// sur les preset topics statiques, donc aucune régression si le LLM est KO.
+  Future<List<VeilleAngleSuggestionDto>> suggestAngles({
+    required String themeId,
+    required String themeLabel,
+    String brief = '',
+  }) async {
+    try {
+      final response = await _dio.post<dynamic>(
+        'veille/suggest/angles',
+        data: {
+          'theme_id': themeId,
+          'theme_label': themeLabel,
+          'brief': brief,
+        },
+      );
+      return VeilleSuggestAnglesResponse.fromJson(
+        response.data as Map<String, dynamic>,
+      ).angles;
+    } catch (_) {
+      // Erreur réseau/timeout (DioException) ou réponse inattendue/parsing :
+      // on dégrade en silence vers les preset topics statiques.
+      return const [];
+    }
+  }
+
   VeilleApiException _wrap(DioException e) {
     final code = e.response?.statusCode;
     final detail = e.response?.data is Map

--- a/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
@@ -4,18 +4,25 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../../config/theme.dart';
+import '../../../../shared/widgets/loaders/facteur_loader.dart';
 import '../../models/veille_config.dart';
+import '../../models/veille_config_dto.dart';
+import '../../providers/veille_angles_provider.dart';
 import '../../providers/veille_config_provider.dart';
 import '../../providers/veille_preset_topics_provider.dart';
+import '../../providers/veille_themes_provider.dart';
 import '../../widgets/veille_widgets.dart';
 
 /// Step 2 — choix des sujets pour la veille.
 ///
-/// PR-4 (Story 23.3) : la suggestion LLM des angles a été supprimée. L'écran
-/// affiche les sujets curés du thème (via `veillePresetTopicsProvider`) +
-/// les sujets custom déjà ajoutés ; l'user peut en ajouter d'autres ou tout
-/// passer. Un toggle "Configuration avancée" expose mots-clés libres + brief
-/// éditorial pour les power-users.
+/// Veille C3 (PR-3) : la suggestion LLM des angles est ré-introduite. À
+/// l'entrée du Step 2, on fetch `POST /veille/suggest/angles` (thème + brief)
+/// et on affiche chaque angle comme une carte « titre + grappe de mots-clés
+/// éditable » sélectionnable (opt-in). Les sujets curés du thème (via
+/// `veillePresetTopicsProvider`) + les sujets custom restent affichés en
+/// dessous. Si le LLM est KO, l'appel retourne `[]` → on retombe simplement
+/// sur les preset topics (aucune régression). Un toggle "Configuration
+/// avancée" expose les mots-clés libres pour les power-users.
 class Step2SuggestionsScreen extends ConsumerWidget {
   final VoidCallback onClose;
   const Step2SuggestionsScreen({super.key, required this.onClose});
@@ -29,7 +36,22 @@ class Step2SuggestionsScreen extends ConsumerWidget {
         ? const AsyncValue<List<VeilleTopic>>.data(<VeilleTopic>[])
         : ref.watch(veillePresetTopicsProvider(theme));
 
-    final hasSelection = state.selectedTopics.isNotEmpty;
+    final anglesAsync = theme == null
+        ? const AsyncValue<List<VeilleAngleSuggestionDto>>.data(
+            <VeilleAngleSuggestionDto>[])
+        : ref.watch(
+            veilleAnglesProvider((
+              themeId: theme,
+              themeLabel:
+                  state.resolvedThemeLabel(veilleThemeLabelForSlug(theme)),
+              brief: state.editorialBrief ?? '',
+            )),
+          );
+
+    // Un angle LLM sélectionné suffit à passer à l'étape suivante (les angles
+    // vivent dans `selectedSuggestions`, distincts des preset topics).
+    final hasSelection =
+        state.selectedTopics.isNotEmpty || state.selectedSuggestions.isNotEmpty;
 
     return Column(
       children: [
@@ -57,6 +79,11 @@ class Step2SuggestionsScreen extends ConsumerWidget {
                   ),
                 ),
                 const SizedBox(height: 22),
+                _AnglesSection(
+                  anglesAsync: anglesAsync,
+                  state: state,
+                  notifier: notifier,
+                ),
                 _TopicsList(
                   presetTopicsAsync: presetTopicsAsync,
                   state: state,
@@ -115,6 +142,216 @@ class _SkipButton extends StatelessWidget {
           fontWeight: FontWeight.w600,
           color: FacteurColors.veille,
         ),
+      ),
+    );
+  }
+}
+
+/// Bloc « Angles suggérés » (LLM). Affiché au-dessus des preset topics.
+/// Pendant le fetch (~10-15 s) : un [FacteurLoader]. Liste vide (LLM KO ou
+/// thème sans angle) → rien (on retombe sur les preset topics → pas de
+/// régression).
+class _AnglesSection extends StatelessWidget {
+  final AsyncValue<List<VeilleAngleSuggestionDto>> anglesAsync;
+  final VeilleConfigState state;
+  final VeilleConfigNotifier notifier;
+  const _AnglesSection({
+    required this.anglesAsync,
+    required this.state,
+    required this.notifier,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return anglesAsync.when(
+      loading: () => const _AnglesLoading(),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (angles) {
+        if (angles.isEmpty) return const SizedBox.shrink();
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'ANGLES SUGGÉRÉS',
+              style: GoogleFonts.dmSans(
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 0.8,
+                color: const Color(0xFF8B7E63),
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Des angles proposés pour ton thème. Touche pour en suivre un — '
+              'tu peux ajuster ses mots-clés.',
+              style: GoogleFonts.dmSans(
+                fontSize: 12,
+                color: const Color(0xFF5D5B5A),
+                height: 1.4,
+              ),
+            ),
+            const SizedBox(height: 12),
+            for (int i = 0; i < angles.length; i++) ...[
+              if (i > 0) const SizedBox(height: 8),
+              _AngleCard(
+                angle: angles[i],
+                state: state,
+                notifier: notifier,
+              ),
+            ],
+            const SizedBox(height: 22),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _AnglesLoading extends StatelessWidget {
+  const _AnglesLoading();
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 22),
+      child: Column(
+        children: [
+          const FacteurLoader(width: 64, height: 64),
+          const SizedBox(height: 8),
+          Text(
+            'Recherche d\'angles pour ton thème…',
+            style: GoogleFonts.dmSans(
+              fontSize: 12.5,
+              color: const Color(0xFF8B7E63),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Carte d'un angle LLM : en-tête tapable (checkbox + titre + raison) qui
+/// active/désactive l'angle (opt-in), puis la grappe de mots-clés. Les chips
+/// ne sont éditables (supprimables + ajout) qu'une fois l'angle sélectionné ;
+/// sinon ils s'affichent en aperçu statique.
+class _AngleCard extends StatelessWidget {
+  final VeilleAngleSuggestionDto angle;
+  final VeilleConfigState state;
+  final VeilleConfigNotifier notifier;
+  const _AngleCard({
+    required this.angle,
+    required this.state,
+    required this.notifier,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final slug = VeilleConfigNotifier.angleSlug(angle.title);
+    final selected = state.selectedSuggestions.contains(slug);
+    final keywords =
+        selected ? (state.angleKeywords[slug] ?? const <String>[]) : angle.keywords;
+    final showChips = keywords.isNotEmpty || selected;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: selected ? FacteurColors.veilleTint : Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: selected ? FacteurColors.veille : FacteurColors.veilleLineSoft,
+          width: 1.5,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Material(
+            color: Colors.transparent,
+            borderRadius: BorderRadius.circular(12),
+            child: InkWell(
+              borderRadius: BorderRadius.circular(12),
+              onTap: () => notifier.toggleAngle(angle),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      width: 18,
+                      height: 18,
+                      margin: const EdgeInsets.only(top: 1),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(5),
+                        color: selected ? FacteurColors.veille : Colors.white,
+                        border: Border.all(
+                          color: selected
+                              ? FacteurColors.veille
+                              : const Color(0xFFD2C9BB),
+                          width: 1.5,
+                        ),
+                      ),
+                      child: selected
+                          ? const Icon(Icons.check, size: 11, color: Colors.white)
+                          : null,
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            angle.title,
+                            style: GoogleFonts.dmSans(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                              height: 1.3,
+                              color: const Color(0xFF2C2A29),
+                            ),
+                          ),
+                          if (angle.reason != null &&
+                              angle.reason!.trim().isNotEmpty) ...[
+                            const SizedBox(height: 3),
+                            Text(
+                              angle.reason!,
+                              style: GoogleFonts.dmSans(
+                                fontSize: 11.5,
+                                height: 1.4,
+                                color: const Color(0xFF959392),
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          if (showChips)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+              child: Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: [
+                  for (final kw in keywords)
+                    _KeywordChip(
+                      label: kw,
+                      onRemove: selected
+                          ? () => notifier.removeAngleKeyword(slug, kw)
+                          : null,
+                    ),
+                  if (selected &&
+                      keywords.length < VeilleConfigNotifier.maxAngleKeywords)
+                    _AddKeywordButton(
+                      enabled: true,
+                      onTap: () =>
+                          _openAddAngleKeywordSheet(context, notifier, slug),
+                    ),
+                ],
+              ),
+            ),
+        ],
       ),
     );
   }
@@ -396,44 +633,47 @@ class _KeywordsSection extends StatelessWidget {
   }
 }
 
+/// Chip d'un mot-clé. `onRemove == null` → aperçu statique (pas d'icône X, pas
+/// de tap) ; sinon supprimable au tap.
 class _KeywordChip extends StatelessWidget {
   final String label;
-  final VoidCallback onRemove;
-  const _KeywordChip({required this.label, required this.onRemove});
+  final VoidCallback? onRemove;
+  const _KeywordChip({required this.label, this.onRemove});
 
   @override
   Widget build(BuildContext context) {
+    final chip = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FacteurColors.veilleLineSoft),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: GoogleFonts.dmSans(
+              fontSize: 12,
+              color: const Color(0xFF2C2A29),
+            ),
+          ),
+          if (onRemove != null) ...[
+            const SizedBox(width: 6),
+            Icon(PhosphorIcons.x(), size: 12, color: const Color(0xFF8B7E63)),
+          ],
+        ],
+      ),
+    );
+    if (onRemove == null) return chip;
     return Material(
-      color: Colors.white,
+      color: Colors.transparent,
       borderRadius: BorderRadius.circular(20),
       child: InkWell(
         onTap: onRemove,
         borderRadius: BorderRadius.circular(20),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(color: FacteurColors.veilleLineSoft),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                label,
-                style: GoogleFonts.dmSans(
-                  fontSize: 12,
-                  color: const Color(0xFF2C2A29),
-                ),
-              ),
-              const SizedBox(width: 6),
-              Icon(
-                PhosphorIcons.x(),
-                size: 12,
-                color: const Color(0xFF8B7E63),
-              ),
-            ],
-          ),
-        ),
+        child: chip,
       ),
     );
   }
@@ -574,10 +814,39 @@ Future<void> _openAddTopicSheet(
   if (result != null && result.isNotEmpty) notifier.addCustomTopic(result);
 }
 
+/// Mot-clé libre global (config avancée) → `notifier.addKeyword`.
 Future<void> _openAddKeywordSheet(
   BuildContext context,
   VeilleConfigNotifier notifier,
-) async {
+) =>
+    _showAddKeywordSheet(
+      context,
+      subtitle: 'Sera utilisé pour filtrer les articles (titre, description).',
+      hint: 'Ex : gpt-5',
+      onAdd: notifier.addKeyword,
+    );
+
+/// Mot-clé ajouté à la grappe d'un angle → `notifier.addAngleKeyword(slug, …)`.
+Future<void> _openAddAngleKeywordSheet(
+  BuildContext context,
+  VeilleConfigNotifier notifier,
+  String slug,
+) =>
+    _showAddKeywordSheet(
+      context,
+      subtitle: 'Affine cet angle — filtre les articles sur ce terme.',
+      hint: 'Ex : régulation',
+      onAdd: (kw) => notifier.addAngleKeyword(slug, kw),
+    );
+
+/// Bottom sheet partagé de saisie d'un mot-clé. `onAdd` reçoit le texte trimé
+/// non-vide ; la normalisation/dédupe est faite côté notifier.
+Future<void> _showAddKeywordSheet(
+  BuildContext context, {
+  required String subtitle,
+  required String hint,
+  required void Function(String) onAdd,
+}) async {
   final ctrl = TextEditingController();
   final result = await showModalBottomSheet<String>(
     context: context,
@@ -599,18 +868,18 @@ Future<void> _openAddKeywordSheet(
               style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
             ),
             const SizedBox(height: 4),
-            const Text(
-              'Sera utilisé pour filtrer les articles (titre, description).',
-              style: TextStyle(fontSize: 12, color: Color(0xFF8B7E63)),
+            Text(
+              subtitle,
+              style: const TextStyle(fontSize: 12, color: Color(0xFF8B7E63)),
             ),
             const SizedBox(height: 12),
             TextField(
               controller: ctrl,
               autofocus: true,
               maxLength: 60,
-              decoration: const InputDecoration(
-                border: OutlineInputBorder(),
-                hintText: 'Ex : gpt-5',
+              decoration: InputDecoration(
+                border: const OutlineInputBorder(),
+                hintText: hint,
                 counterText: '',
               ),
               onSubmitted: (_) => Navigator.of(ctx).pop(ctrl.text.trim()),
@@ -636,5 +905,5 @@ Future<void> _openAddKeywordSheet(
     },
   );
   ctrl.dispose();
-  if (result != null && result.isNotEmpty) notifier.addKeyword(result);
+  if (result != null && result.isNotEmpty) onAdd(result);
 }

--- a/apps/mobile/test/features/veille/models/veille_config_dto_test.dart
+++ b/apps/mobile/test/features/veille/models/veille_config_dto_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/veille/models/veille_config_dto.dart';
+
+/// Round-trip des DTO veille touchés par PR-3 : suggestion d'angles LLM
+/// (`VeilleAngleSuggestionDto` / `VeilleSuggestAnglesResponse`) + la grappe
+/// `keywords` sur les topics (contrat livré par #730, exercé ici côté angle).
+void main() {
+  group('VeilleAngleSuggestionDto.fromJson', () {
+    test('mappe title / keywords / reason', () {
+      final dto = VeilleAngleSuggestionDto.fromJson(const {
+        'title': 'IA générative',
+        'keywords': ['ia', 'llm', 'chatgpt'],
+        'reason': 'Impact workflows',
+      });
+      expect(dto.title, 'IA générative');
+      expect(dto.keywords, ['ia', 'llm', 'chatgpt']);
+      expect(dto.reason, 'Impact workflows');
+    });
+
+    test('keywords absents → liste vide ; reason absent → null', () {
+      final dto =
+          VeilleAngleSuggestionDto.fromJson(const {'title': 'Sans grappe'});
+      expect(dto.keywords, isEmpty);
+      expect(dto.reason, isNull);
+    });
+  });
+
+  group('VeilleSuggestAnglesResponse.fromJson', () {
+    test('mappe la liste d\'angles', () {
+      final res = VeilleSuggestAnglesResponse.fromJson(const {
+        'angles': [
+          {
+            'title': 'Régulation',
+            'keywords': ['ai act'],
+            'reason': null,
+          },
+          {'title': 'Open source', 'keywords': <String>[]},
+        ],
+      });
+      expect(res.angles.length, 2);
+      expect(res.angles.first.title, 'Régulation');
+      expect(res.angles.first.keywords, ['ai act']);
+      expect(res.angles[1].reason, isNull);
+    });
+
+    test('clé angles absente → liste vide (pas de crash)', () {
+      expect(
+          VeilleSuggestAnglesResponse.fromJson(const {}).angles, isEmpty);
+    });
+  });
+
+  group('VeilleTopicDto / VeilleTopicSelectionRequest — grappe keywords', () {
+    test('VeilleTopicDto.fromJson lit keywords (round-trip backend)', () {
+      final dto = VeilleTopicDto.fromJson(const {
+        'id': 't1',
+        'topic_id': 'angle-ia',
+        'label': 'IA',
+        'kind': 'suggested',
+        'reason': null,
+        'position': 0,
+        'keywords': ['llm', 'agents'],
+      });
+      expect(dto.keywords, ['llm', 'agents']);
+    });
+
+    test('keywords absents → liste vide par défaut', () {
+      final dto = VeilleTopicDto.fromJson(const {
+        'id': 't1',
+        'topic_id': 'preset-ai',
+        'label': 'IA',
+        'kind': 'preset',
+        'position': 0,
+      });
+      expect(dto.keywords, isEmpty);
+    });
+
+    test('VeilleTopicSelectionRequest.toJson sérialise keywords', () {
+      const req = VeilleTopicSelectionRequest(
+        topicId: 'angle-ia',
+        label: 'IA générative',
+        kind: 'suggested',
+        keywords: ['ia', 'llm'],
+      );
+      expect(req.toJson()['keywords'], ['ia', 'llm']);
+    });
+  });
+}

--- a/apps/mobile/test/features/veille/providers/veille_angles_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_angles_provider_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/veille/models/veille_config_dto.dart';
+import 'package:facteur/features/veille/providers/veille_angles_provider.dart';
+import 'package:facteur/features/veille/providers/veille_repository_provider.dart';
+import 'package:facteur/features/veille/repositories/veille_repository.dart';
+
+/// Repo factice : renvoie une liste d'angles fixe (ou `[]` pour simuler un LLM
+/// KO, ce que fait le vrai repo via try/catch). `suggestAngles` est la seule
+/// méthode exercée ici.
+class _FakeRepo implements VeilleRepository {
+  final List<VeilleAngleSuggestionDto> angles;
+  _FakeRepo(this.angles);
+
+  @override
+  Future<List<VeilleAngleSuggestionDto>> suggestAngles({
+    required String themeId,
+    required String themeLabel,
+    String brief = '',
+  }) async =>
+      angles;
+
+  @override
+  noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} non mocké');
+}
+
+void main() {
+  const query = (themeId: 'tech', themeLabel: 'Technologie', brief: '');
+
+  test('expose les angles renvoyés par le repo', () async {
+    final repo = _FakeRepo(const [
+      VeilleAngleSuggestionDto(title: 'IA', keywords: ['llm']),
+    ]);
+    final container = ProviderContainer(
+      overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+    );
+    addTearDown(container.dispose);
+
+    final angles = await container.read(veilleAnglesProvider(query).future);
+    expect(angles.single.title, 'IA');
+  });
+
+  test('LLM KO (repo → []) : provider renvoie une liste vide (fallback presets)',
+      () async {
+    final container = ProviderContainer(
+      overrides: [veilleRepositoryProvider.overrideWithValue(_FakeRepo(const []))],
+    );
+    addTearDown(container.dispose);
+
+    final angles = await container.read(veilleAnglesProvider(query).future);
+    expect(angles, isEmpty);
+  });
+}

--- a/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
@@ -1,8 +1,38 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:facteur/features/veille/models/veille_config_dto.dart';
 import 'package:facteur/features/veille/providers/veille_config_provider.dart';
+import 'package:facteur/features/veille/providers/veille_repository_provider.dart';
 import 'package:facteur/features/veille/providers/veille_themes_provider.dart';
+import 'package:facteur/features/veille/repositories/veille_repository.dart';
+
+/// Repo factice qui capture le body d'`upsertConfig` (pour tester le mapping
+/// `_buildUpsertRequest`). Toute autre méthode throw → instrumentation à fixer.
+class _CaptureRepo implements VeilleRepository {
+  VeilleConfigUpsertRequest? captured;
+
+  @override
+  Future<VeilleConfigDto> upsertConfig(VeilleConfigUpsertRequest body) async {
+    captured = body;
+    return VeilleConfigDto(
+      id: 'cfg-1',
+      userId: 'user-1',
+      themeId: body.themeId,
+      themeLabel: body.themeLabel,
+      status: 'active',
+      createdAt: DateTime(2024),
+      updatedAt: DateTime(2024),
+      topics: const [],
+      sources: const [],
+      keywords: const [],
+    );
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} non mocké');
+}
 
 /// Tests business-logic du `VeilleConfigNotifier` après le drop des suggesters
 /// LLM (PR-4, Story 23.3). On vérifie surtout les transitions d'état et le
@@ -135,5 +165,87 @@ void main() {
       url: 'https://lemonde.fr',
     );
     expect(container.read(veilleConfigProvider).realSelectedSourceCount, 1);
+  });
+
+  // ─── Angles LLM (PR-3) ──────────────────────────────────────────────────
+
+  const angle = VeilleAngleSuggestionDto(
+    title: 'IA générative',
+    keywords: ['IA Générative', 'llm', 'chatgpt'],
+    reason: 'Impact sur les workflows',
+  );
+
+  test('toggleAngle sélectionne (slug angle-, label, grappe normalisée seedée)',
+      () {
+    notifier.toggleAngle(angle);
+    final s = container.read(veilleConfigProvider);
+    final slug = VeilleConfigNotifier.angleSlug('IA générative');
+
+    expect(slug, 'angle-ia-generative');
+    expect(s.selectedSuggestions, {slug});
+    expect(s.topicLabels[slug], 'IA générative');
+    // Grappe normalisée : lowercase + dédupe (accents conservés, comme
+    // `addKeyword` — seul le slug strippe les diacritiques).
+    expect(s.angleKeywords[slug], ['ia générative', 'llm', 'chatgpt']);
+  });
+
+  test('toggleAngle re-toggle désélectionne mais conserve la grappe éditée', () {
+    notifier.toggleAngle(angle);
+    final slug = VeilleConfigNotifier.angleSlug(angle.title);
+    notifier.addAngleKeyword(slug, 'gpt-5');
+
+    notifier.toggleAngle(angle); // désélection
+    final s = container.read(veilleConfigProvider);
+    expect(s.selectedSuggestions, isEmpty);
+    expect(s.angleKeywords[slug], contains('gpt-5'),
+        reason: 'edits préservés pour un re-toggle');
+
+    // Re-sélection : la grappe éditée n'est PAS écrasée par le seed initial.
+    notifier.toggleAngle(angle);
+    expect(container.read(veilleConfigProvider).angleKeywords[slug],
+        contains('gpt-5'));
+  });
+
+  test('addAngleKeyword dédupe + cap maxAngleKeywords, removeAngleKeyword', () {
+    notifier.toggleAngle(
+      const VeilleAngleSuggestionDto(title: 'Vide', keywords: []),
+    );
+    final slug = VeilleConfigNotifier.angleSlug('Vide');
+
+    for (var i = 0; i < VeilleConfigNotifier.maxAngleKeywords + 5; i++) {
+      notifier.addAngleKeyword(slug, 'kw-$i');
+    }
+    expect(container.read(veilleConfigProvider).angleKeywords[slug]!.length,
+        VeilleConfigNotifier.maxAngleKeywords);
+
+    notifier.addAngleKeyword(slug, '  KW-0 '); // doublon normalisé
+    expect(container.read(veilleConfigProvider).angleKeywords[slug]!.length,
+        VeilleConfigNotifier.maxAngleKeywords);
+
+    notifier.removeAngleKeyword(slug, 'kw-0');
+    expect(container.read(veilleConfigProvider).angleKeywords[slug],
+        isNot(contains('kw-0')));
+  });
+
+  test('_buildUpsertRequest peuple keywords sur le topic suggested de l\'angle',
+      () async {
+    final repo = _CaptureRepo();
+    final c = ProviderContainer(
+      overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+    );
+    addTearDown(c.dispose);
+    final n = c.read(veilleConfigProvider.notifier);
+
+    n.selectTheme('tech');
+    n.toggleAngle(angle);
+    await n.submit();
+
+    final slug = VeilleConfigNotifier.angleSlug(angle.title);
+    final topic =
+        repo.captured!.topics.firstWhere((t) => t.topicId == slug);
+    expect(topic.kind, 'suggested');
+    expect(topic.keywords, ['ia générative', 'llm', 'chatgpt']);
+    final json = topic.toJson();
+    expect(json['keywords'], ['ia générative', 'llm', 'chatgpt']);
   });
 }


### PR DESCRIPTION
## Quoi

Rebranche la **suggestion d'angles LLM** (`POST /veille/suggest/angles`, réactivé en #730) dans le flux de config veille et rend la **grappe de mots-clés de chaque angle visible + éditable** au Step 2. Suite mobile de #730 (Veille C3 — la partie « Hors-scope » du handoff de #730).

## Pourquoi

#730 a livré le backend (scoring par grappe, contrat `topics[].keywords`) + le round-trip DTO, mais l'écran suggestions consommait encore uniquement les preset topics statiques. Cette PR branche enfin le fetch LLM et l'édition des grappes, sans régression si le LLM est indisponible.

## Comment

- **DTO** (`veille_config_dto.dart`) : ré-ajout de `VeilleAngleSuggestionDto {title, keywords[], reason}` + `VeilleSuggestAnglesResponse`.
- **Repository** (`veille_repository.dart`) : `suggestAngles({themeId, themeLabel, brief})` → **liste vide en cas d'erreur/timeout** (jamais d'exception remontée à l'UI).
- **Provider** (`veille_config_provider.dart`) : `Map<String,List<String>> angleKeywords` (slug→grappe), sélection **opt-in** (`toggleAngle`), édition `add/remove/setAngleKeyword` (cap 10), mapping dans `_buildUpsertRequest` → `VeilleTopicSelection.keywords` des angles `suggested`. Nouveau `FutureProvider.family veilleAnglesProvider` clé `(themeId, themeLabel, brief)`.
- **UI Step 2** (`step2_suggestions_screen.dart`) : `FacteurLoader` pendant le fetch (~10-15 s), cartes d'angles tapables (titre + raison + chips supprimables + champ d'ajout) **au-dessus** des preset topics qui restent affichés. Liste vide → fallback presets, **aucune régression** si LLM KO.

## Comment ça a été vérifié

- [x] `flutter test test/features/veille` → **42/42** (12 nouveaux : DTO round-trip, `toggleAngle`, edit/cap des chips, mapping upsert via repo factice, fallback liste vide)
- [x] `flutter analyze lib/features/veille` → **0 issue**
- [x] Suite mobile complète : 0 régression introduite (les échecs restants sont la baseline pré-existante Hive/Supabase, hors veille)
- [x] `/simplify` passé (unification `_KeywordChip`, fusion catch repo)
- [ ] Validation Chrome (`/validate-feature`) du flux Step 1→2→3 — à lancer si souhaité

## Zones à risque

- `veille_config_provider.dart` (`_buildUpsertRequest`, hydratation édition) — couvert par tests.
- Dépendait de #730 (mergée) ; rebasé sur `main` post-merge, diff réduit au seul delta veille.
