### PR TITLE
fix(tournee): curation sections thématiques — scoring intégral + fenêtre adaptative

### DIFF
--- a/docs/bugs/bug-curation-qualite-sections-thematiques.md
+++ b/docs/bugs/bug-curation-qualite-sections-thematiques.md
@@ -1,0 +1,217 @@
+# Bug — Qualité de curation des sections thématiques (Tournée du jour)
+
+## Symptôme (PO)
+
+Le PO reste **très insatisfait** de la qualité du contenu curé dans les sections
+thématiques de la Tournée (« Technologie », « Sciences », « Environnement »…),
+malgré les PR précédentes qui ont résolu la *quantité* (3 → 10+ articles) et
+l'affichage du bloc de clôture.
+
+Compte de référence : `fd6b9d0b-4c16-422b-9688-bae34d63f41c`.
+
+## Diagnostic (deep-dive 2026-06-01)
+
+### Cause racine : le tri chronologique pur ignore toute notion de qualité
+
+Il existe **3 chemins** dans `RecommendationService.get_personalized_feed`
+(`recommendation_service.py`) :
+
+1. **Chrono pur** (early-return L574) — aucun scoring, aucune compression.
+2. **Chrono diversifié** (L600-710) — compression lourde : diversification par
+   source + `entity_regroupement` + `keyword_regroupement` + `source_safety_net`.
+   C'est le feed **Flâner home**.
+3. **Scoré** (L712-918) — `PillarScoringEngine` (4 piliers), tri par score,
+   source-fatigue decay, `stratify_followed_first`. **Aucune compression.**
+
+Historique :
+- **Story 21.2** (`767c4023`) voulait router `personalized_theme_mode` vers le
+  chemin **scoré (3)**. Mais elle a sorti le mode de l'early-return *sans*
+  garder la condition L600. Les appels Tournée arrivent avec `mode=None`
+  (le mobile appelle `/api/feed/?theme=X&personalized=true`, sans `mode`) →
+  ils tombaient donc dans le chemin **chrono diversifié (2)** → la compression
+  collapsait 40+ candidats à 2-3 articles. **Story 21.2 a routé vers la
+  compression en croyant router vers le scoring.**
+- **Fix 3a4ccd9c** (PR #706) a « corrigé » en remettant `personalized_theme_mode`
+  dans l'early-return **chrono pur (1)** → supprime la compression **mais aussi
+  tout le scoring**. La section devient un dump anti-chronologique brut.
+
+### Conséquence mesurée sur le compte (fenêtre 24h, sources suivies)
+
+Pool **tech** = 21 articles. En tri chronologique pur :
+- **12 / 21 ont `content_quality='none'`** → non lisibles in-app (teasers
+  Le Monde / BDM / Courrier Int. / Mediapart, souvent paywall). « Lire plus »
+  ouvre un contenu vide.
+- Un teaser Le Monde `none` + sans image se classe **au-dessus** d'articles
+  Next.ink `full` + image, uniquement parce qu'il est plus récent.
+- **4 brèves « ☕️ » Next.ink** (ex. « Paint.NET récupère son domaine ») au même
+  niveau que les articles de fond.
+- Un **post Reddit en anglais** (« I fired my SEO agency ») dans la section FR.
+- **Theme bleed** : Mediapart « blanchiment 500 M€ » et Le Monde « encyclique du
+  pape sur l'IA » classés `tech` ; Le Monde « guerre de l'IA sur France 5 » =
+  grille TV.
+
+Le **boost subtopic** (seul levier de perso restant) est **quasi inerte** :
+presque tous les articles tech ont `ai`/`tech` dans `topics`, et le user a
+`tech=3.0`, `ai=2.89` → l'`overlap` est `True` presque partout → dégénère en
+chronologique pur. Le boost est binaire (match / pas match), pas pondéré.
+
+### Le problème généralise à tous les thèmes (24h, sources suivies)
+
+| thème | candidats | `full` lisible | `none` teaser | sans image |
+|---|---|---|---|---|
+| society | 36 | 6 | 29 | 19 |
+| international | 35 | 5 | 30 | 21 |
+| tech | 21 | 9 | 12 | 6 |
+| culture | 20 | 3 | 16 | 13 |
+| economy | 20 | 3 | 17 | 15 |
+| environment | 12 | 5 | 5 | 2 |
+| **science** | **4** | **0** | 3 | 3 |
+
+Deux problèmes distincts :
+- **(A) Ranking** — partout, la majorité des candidats sont des teasers
+  `none` non lisibles, noyant les rares articles riches. Le chrono pur ne
+  les distingue pas.
+- **(B) Rareté** — pour les thèmes à faible fréquence (science : 4 candidats,
+  0 lisible), 24h + sources-suivies-seulement donne une section quasi vide.
+  Les sources science du user (Hygiène Mentale, Science Étonnante… = chaînes
+  YouTube) publient peu par jour. Perçu comme « mauvaise curation » alors que
+  c'est une rareté de contenu.
+
+### Bonus : mauvais classements source-level (upstream)
+
+Au passage : Fireship / Underscore_ / Cybernetica (contenu tech) sont rangés
+`theme='society'` ; Socialter (société/environnement) est rangé `theme='tech'`.
+Ça pollue le matching source-level de `apply_theme_focus_filter` (Path 2).
+Hors-scope code, mais à corriger côté données sources.
+
+## Plan technique proposé
+
+### Fix #1 (PRIMAIRE, fort impact, faible risque) — Router vers le PillarScoringEngine
+
+Faire ce que Story 21.2 **voulait** faire, correctement :
+
+1. `recommendation_service.py` — retirer `personalized_theme_mode` de la
+   condition d'early-return chrono pur (L574-581).
+2. Ajouter le garde manquant à L600 :
+   `if (mode is None or mode == FeedFilterMode.CHRONOLOGICAL) and not personalized_theme_mode:`
+   → les sections thématiques **sautent la compression** et tombent dans le
+   chemin **scoré (3)**.
+3. **Neutraliser le source-fatigue decay agressif** (`decay_factor=0.70`,
+   L832) pour `personalized_theme_mode` : sur une section mono-thème où le user
+   suit délibérément ~10 sources, 0.70^n enterre ses meilleures sources
+   (Next.ink = 7/21 articles tech → 0.70^6 ≈ 0.12×). Remplacer par un
+   **interleaving doux** (réutiliser `_apply_source_interleaving`, L650 — pas de
+   pénalité de score, évite juste les murs de même source).
+
+Effet : la section est classée par les 4 piliers déjà éprouvés sur POUR_VOUS :
+- **Qualité (15%)** : `content_quality=full` (+10) + thumbnail (+12) + curated
+  (+10) → lève les articles riches au-dessus des teasers `none`. **Le plus gros
+  gain** vu la table ci-dessus.
+- **Source (25%)** : sources suivies + curated/reliability + **affinity apprise**
+  + **priority_multiplier** (préférences « plus/moins » du user) → Next.ink /
+  Le Monde > Reddit / BDM.
+- **Pertinence (40%)** : matching subtopic **pondéré** (`user_subtopic_weights`)
+  au lieu du boost binaire actuel → un article `ai`+`tech` passe devant un
+  `religion`.
+- **Fraîcheur (20%)** : récence, bornée par la fenêtre 24h.
+
+Réutilise tout le système de scoring testé. Randomisation déjà désactivée pour
+`personalized_theme_mode` (L850) → pagination stable. `stratify_followed_first`
+devient un no-op (tous les candidats sont déjà des sources suivies).
+
+### Fix #2 (SECONDAIRE, rareté — décision PO requise) — Fenêtre adaptative
+
+Quand le pool 24h + sources-suivies est sous un seuil (ex. `< 8`), élargir la
+fenêtre à 48h (puis 72h) **avant** de tomber sur la section quasi vide. Garde le
+« frais d'abord » mais évite la section science à 4 items. **Touche la règle
+« rester <24h » → à valider avec le PO** avant implémentation.
+
+### Hors-scope / follow-ups notés
+
+- Détection des brèves « ☕️ » (pas de signal propre aujourd'hui).
+- Filtre langue : le post Reddit EN passe (`language=null`) — pré-existant.
+- Theme bleed (classification ML) + mauvais `theme` source-level → côté données.
+
+## Vérification prévue (phase CODE)
+
+- **Preuve empirique avant/après** : script one-off qui fait tourner le vrai
+  `PillarScoringEngine` sur les 21 candidats tech du compte fd6b9d0b et imprime
+  le reclassement (articles `full` remontés, teasers `none` descendus, Reddit EN
+  en bas).
+- `pytest` : nouveau test « personalized_theme_mode → chemin scoré, pas de
+  compression, decay neutralisé ».
+- Tests de non-régression existants (`test_personalized_theme_mode.py`).
+- Comparaison cardinalité : la section doit garder ~10 items/page (pas de
+  ré-introduction de la compression).
+
+## Résultats (phase CODE — 2026-06-01)
+
+### Décision PO & base de travail
+
+Entre le diagnostic initial et l'implémentation, `main` avait reçu `#710`
+(promotion **top-3 « essentiel-grade »** en tête + reste chronologique). Le PO a
+tranché : cette variante **ne satisfait pas** la qualité de curation perçue. On
+**supersede `#710`** — la section thématique passe désormais ENTIÈREMENT par le
+PillarScoringEngine. Travail repris sur une branche propre depuis `main` (hérite
+du filtre langue `#658` et du bonus coverage du pilier Pertinence). La méthode
+`_curate_thematic_top_n` (`#710`), devenue sans appelant, est retirée.
+
+### Fixes implémentés
+
+- [x] **Fix #1** — `personalized_theme_mode` routé vers le PillarScoringEngine :
+  - retiré de l'early-return chrono pur (gardé par `and not personalized_theme_mode`)
+    et **suppression du bloc top-3 `#710`** qui y vivait ;
+  - garde ajouté sur la branche chrono-diversifié → saute la compression ;
+  - source-fatigue decay `0.70` neutralisé pour ce mode, remplacé par
+    `_apply_source_interleaving` (interleaving doux, sans pénalité de score) ;
+  - méthode morte `_curate_thematic_top_n` (`#710`) retirée.
+- [x] **Fix #2** — fenêtre de fraîcheur adaptative dans `_get_candidates` :
+  24h → 48h → 72h, n'élargit que si le pool < `THEMATIC_MIN_POOL_SIZE` (8) ;
+  ne relance la requête que si nécessaire. Constantes nommées dans
+  `ScoringWeights` (`THEMATIC_WINDOW_TIERS_HOURS`, `THEMATIC_MIN_POOL_SIZE`).
+
+### Fichiers modifiés
+
+- `packages/api/app/services/recommendation_service.py`
+- `packages/api/app/services/recommendation/scoring_config.py`
+- `packages/api/tests/test_thematic_curation.py` (nouveau — Fix #1 + Fix #2)
+- `packages/api/tests/test_personalized_theme_mode.py` (commentaires/docstrings MAJ)
+- `packages/api/scripts/prove_thematic_scoring.py` (nouveau — preuve empirique)
+
+### Preuve empirique (vrai PillarScoringEngine, 20 candidats tech réels)
+
+`PYTHONPATH=. python scripts/prove_thematic_scoring.py`
+
+```
+full+image — rang moyen : 8.5 → 7.6  (plus bas = mieux)
+full+image dans le top 5 : 2 → 3 / 5
+teasers 'none' — rang moyen : 11.2 → 13.1  (plus haut = mieux)
+teasers 'none' dans le top 5 : 3 → 1 / 5
+```
+
+- L'article riche **« Génération IA » (Le Grand Continent, favori, full+image)**
+  passe du rang **16 → 1**.
+- Les **4 teasers `none` de Le Monde** (priority_multiplier 0.2) tombent tous en
+  bas (rangs **17-20**).
+- Les teasers `none` dans le top 5 passent de **3 → 1**.
+
+> **Note sur les signaux de détection.** Ces métriques (full+image, `none`) sont
+> des **proxys provisoires** de qualité, pas une vérité produit. Exemple : le
+> post EN « I fired my SEO agency » remonte (le compte a mis
+> `priority_multiplier=2.0` + souscription sur cette source — le pilier Source
+> l'honore), ce qui n'est **pas** en soi un défaut de curation. Définir des
+> signaux de qualité *tranchés* (lisibilité, langue, fraîcheur, coverage…) sur un
+> **jeu de données annoté manuellement** est l'objet du hand-off QA
+> (`.context/qa-handoff-curation-scoring.md`).
+
+### Tests
+
+- Suite backend complète : **1416 passed**, 1 skipped (le seul échec,
+  `test_notification_preferences::test_patch_increments_refusal_count`, est
+  pré-existant et environnemental — sérialisation TZ `+02:00` ; échoue aussi sur
+  `origin/main`, hors-scope).
+- `test_thematic_curation.py` : fenêtre adaptative (élargit / reste 24h) +
+  scoring qualité (full+image > teaser none) — vert.
+- `test_personalized_theme_mode.py` (11 tests) : vert.
+- Cardinalité : aucune compression réintroduite (le chemin scoré ne compresse
+  pas) → la section garde son volume de candidats.

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -75,6 +75,15 @@ class ScoringWeights:
     # Article ancien (< 168h): +1 pt
     RECENT_OLD_BONUS = 1.0
 
+    # --- THEMATIC SECTION ADAPTIVE FRESHNESS WINDOW (rareté de contenu) ---
+    # Sections thématiques de la Tournée (personalized_theme_mode) : la fenêtre
+    # 24h + sources-suivies-seulement peut rendre une section quasi vide pour les
+    # thèmes à faible fréquence (ex. science = 4 candidats/24h). On élargit la
+    # fenêtre par paliers UNIQUEMENT quand le pool 24h est sous le seuil ; le
+    # scoring Fraîcheur continue de privilégier « le plus frais d'abord ».
+    THEMATIC_WINDOW_TIERS_HOURS = (24, 48, 72)  # paliers d'élargissement successifs
+    THEMATIC_MIN_POOL_SIZE = 8  # sous ce seuil → on tente le palier suivant
+
     # --- QUALITY LAYER (FQS - Facteur Quality Score) ---
 
     # Bonus léger pour les sources qualitatives (curées par Facteur).

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -556,59 +556,24 @@ class RecommendationService:
             source_uuid=source_uuid,
         )
 
-        # Explicit filter OR RECENT mode OR Tournée theme section: skip scoring,
+        # Explicit filter (exploration chip) OR RECENT mode : skip scoring,
         # return pure chronological order. Candidates are already sorted by
-        # published_at DESC (et boost user_subtopics pour personalized_theme_mode)
-        # from _get_candidates.
+        # published_at DESC from _get_candidates.
         #
-        # Note historique : Story 21.2 routait personalized_theme_mode vers le
-        # PillarScoringEngine + diversification + regroupement pour pondérer par
-        # weight_effective / source affinity / quality. En pratique cela
-        # compressait 40+ candidats à 2-3 articles visibles (cf. bug curation
-        # sections thématiques 2026-05-28) et créait un écart béant avec ce que
-        # Flâner thématique remontait sur les mêmes sources. On rebascule sur la
-        # même politique chronologique pure : « tout le contenu user récent
-        # (<24h) sur le thème, dans l'ordre publié » — la personnalisation reste
-        # exprimée via la restriction aux sources suivies + l'ordering boost
-        # user_subtopics appliqués dans _get_candidates.
+        # Note historique : les sections thématiques de la Tournée
+        # (personalized_theme_mode) ont oscillé — compression regroupement
+        # (Story 21.2), chrono pur (#706), puis promotion top-3 "essentiel-grade"
+        # + reste chronologique (#710). Décision PO 2026-06-01 : aucune de ces
+        # variantes ne satisfait la qualité de curation perçue. On route
+        # désormais la section ENTIÈRE par le PillarScoringEngine (chemin scoré
+        # ci-dessous) — classement qualité/source/pertinence/fraîcheur sur tous
+        # les candidats, sans compression ni promotion top-N. D'où le
+        # `and not personalized_theme_mode` : le mode saute cet early-return ET
+        # la compression chrono-diversifiée (garde plus bas) pour atterrir dans
+        # le chemin scoré (cf. bug curation sections thématiques + hand-off QA).
         if (
-            source_uuid
-            or theme
-            or topic
-            or entity
-            or mode == FeedFilterMode.RECENT
-            or personalized_theme_mode
-        ):
-            # Top3 thematic selection (PR 1) : sur Tournée du jour, on promeut
-            # 3 articles "essentiel-grade" en tête de section — multi-sources
-            # (coverage), filtrés qualité, diversifiés par cluster_id. Le reste
-            # reste en ordre chronologique pour préserver la cohérence de
-            # « Voir tout » et éviter la sur-compression de la version Story 21.2.
-            if personalized_theme_mode and len(candidates) > 3:
-                if not self.user_custom_topics:
-                    from app.models.user_topic_profile import UserTopicProfile
-
-                    custom_topics_stmt = select(UserTopicProfile).where(
-                        UserTopicProfile.user_id == user_id
-                    )
-                    async with safe_async_session(
-                        statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000
-                    ) as s:
-                        self.user_custom_topics = list(
-                            (await s.scalars(custom_topics_stmt)).all()
-                        )
-                candidates = await self._curate_thematic_top_n(
-                    candidates,
-                    user_interests=user_interests,
-                    user_interest_weights=user_interest_weights,
-                    user_interest_states=user_interest_states,
-                    user_subtopics=user_subtopics,
-                    user_subtopic_weights=user_subtopic_weights,
-                    followed_source_ids=followed_source_ids,
-                    user_prefs=user_prefs,
-                    user_profile=user_profile,
-                    top_n=3,
-                )
+            source_uuid or theme or topic or entity or mode == FeedFilterMode.RECENT
+        ) and not personalized_theme_mode:
             paginated = candidates[offset : offset + limit]
             await self._hydrate_user_status(paginated, user_id, followed_source_ids)
             return paginated
@@ -626,8 +591,12 @@ class RecommendationService:
         }
 
         # Epic 12: Chronological diversified mode (new default)
-        # mode=None means no chip selected → chronological diversified
-        if mode is None or mode == FeedFilterMode.CHRONOLOGICAL:
+        # mode=None means no chip selected → chronological diversified.
+        # personalized_theme_mode est exclu : il saute cette compression
+        # (regroupement + safety-net) et tombe dans le chemin scoré ci-dessous.
+        if (
+            mode is None or mode == FeedFilterMode.CHRONOLOGICAL
+        ) and not personalized_theme_mode:
             t3 = time.monotonic()
             logger.info(
                 "feed_phase2_candidates",
@@ -857,22 +826,32 @@ class RecommendationService:
         # 4b. Diversity Re-ranking (Source Fatigue)
         # Apply a cumulative penalty for multiple items from the same source
         # to ensure a diverse top-of-feed.
-        final_list = []
-        source_counts = {}
-        decay_factor = 0.70  # Each subsequent item from same source loses 30% score (Story diversity fix)
+        #
+        # personalized_theme_mode : decay NEUTRALISÉ. Sur une section mono-thème
+        # où le user suit délibérément ~10 sources, 0.70^n enterre ses meilleures
+        # sources suivies (ex. Next.ink = 7/21 candidats tech → 0.70^6 ≈ 0.12×).
+        # On conserve l'ordre par score ; les murs de même source seront évités
+        # par un interleaving doux (sans pénalité de score) juste avant la
+        # pagination (cf. étape 5).
+        if personalized_theme_mode:
+            final_list = scored_candidates
+        else:
+            final_list = []
+            source_counts = {}
+            decay_factor = 0.70  # Each subsequent item from same source loses 30% score (Story diversity fix)
 
-        for content, base_score in scored_candidates:
-            source_id = content.source_id
-            count = source_counts.get(source_id, 0)
+            for content, base_score in scored_candidates:
+                source_id = content.source_id
+                count = source_counts.get(source_id, 0)
 
-            # FinalScore = BaseScore * (decay_factor ^ count)
-            final_score = base_score * (decay_factor**count)
+                # FinalScore = BaseScore * (decay_factor ^ count)
+                final_score = base_score * (decay_factor**count)
 
-            final_list.append((content, final_score))
-            source_counts[source_id] = count + 1
+                final_list.append((content, final_score))
+                source_counts[source_id] = count + 1
 
-        # Sort again with diversity penalties applied to find the new Top-N
-        final_list.sort(key=lambda x: x[1], reverse=True)
+            # Sort again with diversity penalties applied to find the new Top-N
+            final_list.sort(key=lambda x: x[1], reverse=True)
 
         # 4c. Randomization (v2 only — Gumbel noise for discovery)
         # Story 21.2 — disabled on personalized_theme_mode so paginated "Plus de…"
@@ -901,15 +880,14 @@ class RecommendationService:
         if (theme or topic) and followed_source_ids:
             final_list = stratify_followed_first(final_list, followed_source_ids)
 
-        # 5. Paginate
-        scored_candidates = final_list
-        start = offset
-        end = offset + limit
-        # Check bounds
-        if start >= len(scored_candidates):
-            return []
-
-        result = [item[0] for item in scored_candidates[start:end]]
+        # 5. Paginate (le slice gère seul un offset hors-borne → [])
+        ordered = [item[0] for item in final_list]
+        if personalized_theme_mode:
+            # Interleaving doux sur la liste ordonnée complète : remplace le
+            # decay neutralisé en 4b (évite les murs de même source SANS
+            # pénalité de score). Pagination stable (slice déterministe).
+            ordered = self._apply_source_interleaving(ordered)
+        result = ordered[offset : offset + limit]
 
         # 5.5 Hydrate Recommendation Reason (Transparency)
         if use_pillars:
@@ -946,137 +924,6 @@ class RecommendationService:
             "feed_total", duration_ms=round((t_end - t0) * 1000), items=len(result)
         )
         return result
-
-    async def _curate_thematic_top_n(
-        self,
-        candidates: list[Content],
-        *,
-        user_interests: set[str],
-        user_interest_weights: dict[str, float],
-        user_interest_states: dict[str, InterestState],
-        user_subtopics: set[str],
-        user_subtopic_weights: dict[str, float],
-        followed_source_ids: set[UUID],
-        user_prefs: dict[str, Any],
-        user_profile: UserProfile | None,
-        top_n: int = 3,
-    ) -> list[Content]:
-        """Promeut N articles "essentiel-grade" en tête d'une section thématique.
-
-        Algorithme :
-        1. Calcule cluster_source_counts (24h) pour les N premiers candidats.
-        2. Score le pool via PillarScoringEngine — gagne le bonus coverage
-           dans Pertinence quand un cluster est multi-sources.
-        3. Applique un floor qualité (D2) : exclut les articles sans visuel,
-           sans contenu lisible et sans description suffisante.
-        4. Diversifie par cluster_id, fallback souple sur topic_slug, jusqu'à
-           obtenir N articles distincts en tête.
-        5. Retourne curated_top_N + reste chronologique (dedupe sur id).
-
-        En cas de pool trop pauvre (<N candidats après floor), on relâche
-        le floor pour ne jamais renvoyer une liste tronquée.
-        """
-        from app.services.recommendation.helpers import diversify
-
-        if len(candidates) <= top_n:
-            return candidates
-
-        # Pool restreint aux 50 plus récents (les candidats sont déjà triés
-        # par published_at DESC + boost subtopic). 50 est suffisant pour
-        # capter les sujets relayés du jour sans coût SQL prohibitif.
-        pool = candidates[:50]
-
-        now = datetime.datetime.now(datetime.UTC)
-
-        # 1. cluster_source_counts (24h, distinct sources per cluster_id)
-        cluster_ids = list({c.cluster_id for c in pool if c.cluster_id is not None})
-        cluster_source_counts: dict[UUID, int] = {}
-        if cluster_ids:
-            cutoff = now - datetime.timedelta(hours=24)
-            stmt = (
-                select(
-                    Content.cluster_id,
-                    func.count(func.distinct(Content.source_id)),
-                )
-                .where(
-                    Content.cluster_id.in_(cluster_ids),
-                    Content.published_at >= cutoff,
-                )
-                .group_by(Content.cluster_id)
-            )
-            rows = (await self.session.execute(stmt)).all()
-            cluster_source_counts = {row[0]: int(row[1]) for row in rows}
-
-        # 2. Build scoring context (minimal — pas d'impressions ni d'affinity
-        # pour rester léger ; les signaux clés Pertinence + Source + Coverage
-        # suffisent pour la promotion top N).
-        context = ScoringContext(
-            user_profile=user_profile,
-            user_interests=user_interests,
-            user_interest_weights=user_interest_weights,
-            followed_source_ids=followed_source_ids,
-            user_prefs=user_prefs,
-            now=now,
-            user_subtopics=user_subtopics,
-            user_subtopic_weights=user_subtopic_weights,
-            user_custom_topics=self.user_custom_topics,
-            user_interest_states=user_interest_states,
-            cluster_source_counts=cluster_source_counts,
-        )
-
-        scored: list[tuple[Content, float]] = []
-        for c in pool:
-            try:
-                result = self.pillar_engine.compute_score(c, context)
-                scored.append((c, result.final_score))
-            except Exception as exc:
-                logger.warning(
-                    "curate_thematic_top_score_failed",
-                    content_id=str(c.id),
-                    error=str(exc),
-                )
-                scored.append((c, 0.0))
-
-        scored.sort(key=lambda x: x[1], reverse=True)
-
-        # 3. Floor qualité (D2) — un article du top doit avoir un minimum
-        # de crédibilité visuelle/éditoriale. Exclut les rss bare-bones sans
-        # image, sans contenu in-app et avec un résumé < 100 caractères.
-        def _is_low_quality(c: Content) -> bool:
-            has_thumb = bool(c.thumbnail_url and c.thumbnail_url.strip())
-            has_content = getattr(c, "content_quality", None) in ("full", "partial")
-            desc_len = len(c.description or "")
-            return not has_thumb and not has_content and desc_len < 100
-
-        filtered = [pair for pair in scored if not _is_low_quality(pair[0])]
-        if len(filtered) < top_n:
-            # Pool insuffisant après floor — on dégrade gracieusement pour
-            # ne pas renvoyer un top tronqué (l'UI section a besoin de N).
-            filtered = scored
-
-        # 4. Diversification (souple) : 1 article max par cluster_id, sinon
-        # fallback topic_slug, sinon ordre score.
-        def _diversification_key(pair: tuple[Content, float]) -> Any:
-            c = pair[0]
-            if c.cluster_id is not None:
-                return ("cluster", c.cluster_id)
-            if c.topics:
-                return ("topic", c.topics[0].lower().strip())
-            return None
-
-        diversified = diversify(
-            filtered,
-            key_fn=_diversification_key,
-            target_size=top_n,
-            max_per_key=1,
-            fallback_ok=True,
-        )
-
-        curated_top = [pair[0] for pair in diversified[:top_n]]
-        curated_ids = {c.id for c in curated_top}
-
-        rest = [c for c in candidates if c.id not in curated_ids]
-        return curated_top + rest
 
     async def _hydrate_user_status(
         self,
@@ -2739,79 +2586,107 @@ class RecommendationService:
         if keyword and not source_id:
             query = apply_keyword_filter(query, keyword)
 
-        # Tournée du jour : fenêtre 24h sur les sections curées par thème/topic.
-        # Aligne le pool de candidats avec la notion de "fraîcheur du jour".
-        if personalized_theme_mode:
-            since_24h = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
-                hours=24
-            )
-            query = query.where(Content.published_at >= since_24h)
-
-        if _use_two_phase:
-            # Followed sources only — no curated enrichment in default feed.
-            # Curated enrichment is reserved for digest (digest_selector.py).
-            # In serein mode, also include serein_default sources (humorous/satirical).
-            if serein:
-                user_query = query.where(
-                    or_(
-                        Source.id.in_(list(followed_source_ids)),
-                        Source.serein_default == True,  # noqa: E712
+        async def _fetch_candidates(base_query) -> list[Content]:
+            """Exécute le fetch (two-phase ou simple) sur une `base_query` déjà
+            filtrée (thème/topic/fenêtre). Isolé pour pouvoir rejouer la requête
+            avec une fenêtre élargie (Tournée — rareté de contenu)."""
+            if _use_two_phase:
+                # Followed sources only — no curated enrichment in default feed.
+                # Curated enrichment is reserved for digest (digest_selector.py).
+                # In serein mode, also include serein_default sources (humorous/satirical).
+                if serein:
+                    user_query = base_query.where(
+                        or_(
+                            Source.id.in_(list(followed_source_ids)),
+                            Source.serein_default == True,  # noqa: E712
+                        )
                     )
-                )
-            else:
-                user_query = query.where(Source.id.in_(list(followed_source_ids)))
-            if personalized_theme_mode and user_subtopics:
-                # Soft boost via ORDER BY : articles matchant un user_subtopic
-                # remontent en tête, mais pas de section vide si l'intersection
-                # est nulle (`overlap` retourne False, on dégrade vers le tri
-                # chronologique pur).
-                user_query = user_query.order_by(
-                    Content.topics.overlap(list(user_subtopics)).desc(),
-                    Content.published_at.desc(),
-                ).limit(limit_candidates)
-            else:
-                user_query = user_query.order_by(Content.published_at.desc()).limit(
-                    limit_candidates
-                )
-            # The followed-only query on the default (unfiltered) view can
-            # hang under a bad plan when the user has many followed sources —
-            # other branches dodge it thanks to their `is_curated` narrowing.
-            # Bound the wait and degrade to the curated query on timeout so
-            # the client never gets stuck on a spinner. Cf.
-            # docs/bugs/bug-feed-default-hang.md
-            try:
-                user_result = await asyncio.wait_for(
-                    self.session.scalars(user_query),
-                    timeout=_FEED_TWO_PHASE_TIMEOUT_S,
-                )
-                candidates_list = list(user_result.all())
-            except TimeoutError:
-                await self.session.rollback()
-                logger.warning(
-                    "feed_two_phase_timeout_fallback_curated",
+                else:
+                    user_query = base_query.where(
+                        Source.id.in_(list(followed_source_ids))
+                    )
+                if personalized_theme_mode and user_subtopics:
+                    # Soft boost via ORDER BY : articles matchant un user_subtopic
+                    # remontent en tête, mais pas de section vide si l'intersection
+                    # est nulle (`overlap` retourne False, on dégrade vers le tri
+                    # chronologique pur).
+                    user_query = user_query.order_by(
+                        Content.topics.overlap(list(user_subtopics)).desc(),
+                        Content.published_at.desc(),
+                    ).limit(limit_candidates)
+                else:
+                    user_query = user_query.order_by(Content.published_at.desc()).limit(
+                        limit_candidates
+                    )
+                # The followed-only query on the default (unfiltered) view can
+                # hang under a bad plan when the user has many followed sources —
+                # other branches dodge it thanks to their `is_curated` narrowing.
+                # Bound the wait and degrade to the curated query on timeout so
+                # the client never gets stuck on a spinner. Cf.
+                # docs/bugs/bug-feed-default-hang.md
+                try:
+                    user_result = await asyncio.wait_for(
+                        self.session.scalars(user_query),
+                        timeout=_FEED_TWO_PHASE_TIMEOUT_S,
+                    )
+                    fetched = list(user_result.all())
+                except TimeoutError:
+                    await self.session.rollback()
+                    logger.warning(
+                        "feed_two_phase_timeout_fallback_curated",
+                        user_id=str(user_id),
+                        followed_source_count=len(followed_source_ids),
+                        timeout_seconds=_FEED_TWO_PHASE_TIMEOUT_S,
+                    )
+                    fallback_query = (
+                        base_query.where(
+                            Source.is_curated, Source.source_tier != "deep"
+                        )
+                        .order_by(Content.published_at.desc())
+                        .limit(limit_candidates)
+                    )
+                    fallback_result = await self.session.scalars(fallback_query)
+                    fetched = list(fallback_result.all())
+
+                logger.info(
+                    "feed_candidates_followed_only",
                     user_id=str(user_id),
                     followed_source_count=len(followed_source_ids),
-                    timeout_seconds=_FEED_TWO_PHASE_TIMEOUT_S,
+                    serein_default_included=serein,
+                    candidates=len(fetched),
                 )
-                fallback_query = (
-                    query.where(Source.is_curated, Source.source_tier != "deep")
-                    .order_by(Content.published_at.desc())
-                    .limit(limit_candidates)
-                )
-                fallback_result = await self.session.scalars(fallback_query)
-                candidates_list = list(fallback_result.all())
+                return fetched
 
+            simple_query = base_query.order_by(Content.published_at.desc()).limit(
+                limit_candidates
+            )
+            simple_result = await self.session.scalars(simple_query)
+            return list(simple_result.all())
+
+        if personalized_theme_mode:
+            # Tournée du jour : fenêtre de fraîcheur adaptative. On part de 24h
+            # (« fraîcheur du jour ») et on n'élargit (48h puis 72h) que si le
+            # pool reste sous THEMATIC_MIN_POOL_SIZE — évite la section quasi
+            # vide sur les thèmes rares sans dégrader les thèmes denses. On ne
+            # rejoue la requête que si nécessaire (pas 3 requêtes systématiques).
+            now_window = datetime.datetime.now(datetime.UTC)
+            for tier_hours in ScoringWeights.THEMATIC_WINDOW_TIERS_HOURS:
+                since = now_window - datetime.timedelta(hours=tier_hours)
+                candidates_list = await _fetch_candidates(
+                    query.where(Content.published_at >= since)
+                )
+                if len(candidates_list) >= ScoringWeights.THEMATIC_MIN_POOL_SIZE:
+                    break
+            # `tier_hours` reste le dernier palier essayé (tiers non vide).
             logger.info(
-                "feed_candidates_followed_only",
+                "feed_thematic_adaptive_window",
                 user_id=str(user_id),
-                followed_source_count=len(followed_source_ids),
-                serein_default_included=serein,
+                window_hours=tier_hours,
                 candidates=len(candidates_list),
+                threshold=ScoringWeights.THEMATIC_MIN_POOL_SIZE,
             )
         else:
-            query = query.order_by(Content.published_at.desc()).limit(limit_candidates)
-            candidates = await self.session.scalars(query)
-            candidates_list = list(candidates.all())
+            candidates_list = await _fetch_candidates(query)
 
         # Debug logging for mode filters
         if mode:

--- a/packages/api/scripts/prove_thematic_scoring.py
+++ b/packages/api/scripts/prove_thematic_scoring.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Preuve empirique avant/après — curation des sections thématiques (Tournée).
+
+Fait tourner le **vrai** `PillarScoringEngine` sur les candidats réels de la
+section « tech » du compte de référence `fd6b9d0b-4c16-422b-9688-bae34d63f41c`,
+et imprime le reclassement :
+
+  AVANT  = tri chronologique pur (comportement bugué : aucun scoring)
+  APRÈS  = tri par score des 4 piliers + interleaving doux (le fix)
+
+But (attendu par le PO) : montrer que les articles `content_quality='full'` +
+image remontent, que les teasers `none` (non lisibles in-app) descendent, et que
+le post Reddit EN tombe en bas — sur les données réelles du compte.
+
+Les données du fixture sont les 20 candidats tech réels (fenêtre 24h, sources
+suivies) extraits de la DB le 2026-06-01 10:09 UTC, avec les sous-thèmes pondérés
+et les signaux de source réels du compte. Les signaux *appris* (affinité de
+source, impressions) sont neutres ici — ils ne changent pas le reclassement
+qualité-vs-récence démontré. Le rôle PG read-only `claude_analytics_ro` n'expose
+pas `user_sources` / `contents` en SELECT direct, d'où le fixture (cf. hand-off).
+
+Usage :
+    cd packages/api && PYTHONPATH=. python scripts/prove_thematic_scoring.py
+"""
+
+import datetime
+import sys
+from pathlib import Path
+from uuid import UUID, uuid4
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+UTC = datetime.UTC
+NOW = datetime.datetime(2026, 6, 1, 10, 9, 0, tzinfo=UTC)
+
+# --- Sources réelles (flags du compte) -------------------------------------
+# name -> (is_curated, source_tier, reliability, priority_multiplier, subscribed)
+SOURCES = {
+    "Next.ink": (True, "deep", "high", 1.0, False),
+    "Flux général Developpez.com": (False, "mainstream", "unknown", 0.2, False),
+    "Le Monde": (True, "mainstream", "high", 0.2, False),
+    "BDM": (False, "mainstream", "unknown", 2.0, False),
+    "Mediapart": (True, "mainstream", "high", 1.0, False),
+    "Courrier International": (True, "deep", "high", 2.0, False),
+    "Le Grand Continent": (True, "deep", "high", 2.0, False),
+    "Reddit's Startup Community": (False, "mainstream", "unknown", 2.0, True),
+}
+
+# --- 20 candidats tech réels (ordre chronologique DESC) ---------------------
+# (titre, source, topics, content_quality, has_image, minutes_avant_now)
+CANDIDATES = [
+    (
+        "SoftBank investit 75 Md€ pour 5 GW d'infra IA en France",
+        "Next.ink",
+        ["ai", "economy"],
+        "full",
+        True,
+        51,
+    ),
+    (
+        "Les LLM continuent de croire à des affirmations fausses…",
+        "Flux général Developpez.com",
+        ["ai"],
+        "full",
+        True,
+        69,
+    ),
+    (
+        "Nvidia lance ses propres processeurs pour PC Windows",
+        "Le Monde",
+        ["tech", "ai"],
+        "none",
+        False,
+        98,
+    ),
+    (
+        "IA : les meilleurs modèles pour le code en juin 2026",
+        "BDM",
+        ["ai", "tech"],
+        "none",
+        True,
+        99,
+    ),
+    (
+        "Instagram intègre un prompteur pour les Reels",
+        "BDM",
+        ["tech"],
+        "none",
+        True,
+        115,
+    ),
+    (
+        "☕️ Canonical s'occupe désormais de Flutter Desktop",
+        "Next.ink",
+        ["tech"],
+        "none",
+        False,
+        121,
+    ),
+    (
+        "Harvard : l'orateur fustige l'IA, « détruisez l'IA »",
+        "Flux général Developpez.com",
+        ["ai"],
+        "full",
+        True,
+        144,
+    ),
+    (
+        "Windows 11 : la barre des tâches redevient libre",
+        "Next.ink",
+        ["tech"],
+        "none",
+        True,
+        151,
+    ),
+    (
+        "☕️ Microsoft voudrait ranger tous ses Copilot dans une app",
+        "Next.ink",
+        ["ai", "tech"],
+        "full",
+        True,
+        196,
+    ),
+    (
+        "☕️ Paint.NET dispose enfin du domaine paint.net",
+        "Next.ink",
+        ["tech"],
+        "full",
+        True,
+        218,
+    ),
+    (
+        "Censés « vivre ensemble », 50 % des agents IA s'entretuent",
+        "Next.ink",
+        ["ai", "tech"],
+        "full",
+        True,
+        242,
+    ),
+    (
+        "☕️ Brûler des tokens n'est pas travailler : Amazon ferme…",
+        "Next.ink",
+        ["ai", "tech"],
+        "full",
+        True,
+        277,
+    ),
+    (
+        "Facebook a-t-il encore sa place en social media ?",
+        "BDM",
+        ["tech", "media"],
+        "none",
+        True,
+        308,
+    ),
+    (
+        "Enquête blanchiment 500 M€ vise la société Wise",
+        "Mediapart",
+        ["cybersecurity", "finance"],
+        "none",
+        True,
+        310,
+    ),
+    (
+        "« L'alerte de l'encyclique du pape sur l'IA »",
+        "Le Monde",
+        ["ai", "religion"],
+        "none",
+        False,
+        368,
+    ),
+    ("Génération IA", "Le Grand Continent", ["ai"], "full", True, 369),
+    (
+        "Choose France : la course au gigantisme des datacenters IA",
+        "Le Monde",
+        ["ai", "tech"],
+        "none",
+        False,
+        383,
+    ),
+    (
+        "« L'IA a été créée par un petit groupe d'hommes blancs »",
+        "Courrier International",
+        ["ai", "science"],
+        "none",
+        True,
+        428,
+    ),
+    (
+        "I fired my SEO agency after 4 years. The weird thing…",
+        "Reddit's Startup Community",
+        ["ai", "startups"],
+        "full",
+        False,
+        608,
+    ),
+    (
+        "« Chine – États-Unis, la guerre de l'IA » sur France 5",
+        "Le Monde",
+        ["ai", "geopolitics"],
+        "none",
+        False,
+        1089,
+    ),
+]
+
+# --- Sous-thèmes pondérés réels du compte (extrait) -------------------------
+USER_SUBTOPIC_WEIGHTS = {
+    "ai": 3.0,
+    "environment": 3.0,
+    "tech": 3.0,
+    "science": 2.99,
+    "politics": 2.88,
+    "media": 2.69,
+    "privacy": 2.44,
+    "inequality": 2.32,
+    "economy": 2.28,
+    "climate": 2.22,
+    "startups": 2.19,
+    "geopolitics": 1.12,
+    "cybersecurity": 1.12,
+    "finance": 1.24,
+    "religion": 1.03,
+}
+
+
+def _build():
+    from app.models.content import Content
+    from app.models.enums import ContentType, ReliabilityScore
+    from app.models.source import Source
+
+    src_objs: dict[str, Source] = {}
+    src_ids: dict[str, UUID] = {}
+    for name, (curated, tier, rel, _mult, _sub) in SOURCES.items():
+        sid = uuid4()
+        src_ids[name] = sid
+        src_objs[name] = Source(
+            id=sid,
+            name=name,
+            theme="tech",
+            is_curated=curated,
+            source_tier=tier,
+            reliability_score=ReliabilityScore(rel),
+            secondary_themes=[],
+            tone=None,
+        )
+
+    contents = []
+    for title, sname, topics, quality, has_img, mins in CANDIDATES:
+        contents.append(
+            Content(
+                id=uuid4(),
+                title=title,
+                theme="tech",
+                topics=topics,
+                content_quality=quality,
+                thumbnail_url="https://img" if has_img else None,
+                language=None,  # comme en DB — le post Reddit EN passe (language=null)
+                published_at=NOW - datetime.timedelta(minutes=mins),
+                source_id=src_ids[sname],
+                source=src_objs[sname],
+                description="",
+                content_type=ContentType.ARTICLE,
+                duration_seconds=None,
+                entities=[],
+            )
+        )
+    return contents, src_ids
+
+
+def _context(src_ids):
+    from app.models.enums import InterestState
+    from app.services.recommendation.scoring_engine import ScoringContext
+
+    priority = {src_ids[n]: SOURCES[n][3] for n in SOURCES}
+    subscribed = {src_ids[n] for n in SOURCES if SOURCES[n][4]}
+    followed = set(src_ids.values())
+    return ScoringContext(
+        user_profile=None,
+        user_interests={"tech", "science", "environment"},
+        user_interest_weights={"tech": 3.0, "science": 2.99, "environment": 3.0},
+        followed_source_ids=followed,
+        user_prefs={},
+        now=NOW,
+        user_subtopics=set(USER_SUBTOPIC_WEIGHTS),
+        user_subtopic_weights=USER_SUBTOPIC_WEIGHTS,
+        source_priority_multipliers=priority,
+        subscribed_source_ids=subscribed,
+        user_interest_states={"tech": InterestState.FAVORITE},
+    )
+
+
+def _flag(c) -> str:
+    q = (getattr(c, "content_quality", None) or "none")[:4].ljust(4)
+    img = "IMG" if (c.thumbnail_url or "").strip() else " · "
+    return f"{q} {img}"
+
+
+def main() -> int:
+    from app.services.recommendation.scoring_engine import PillarScoringEngine
+    from app.services.recommendation_service import RecommendationService
+
+    contents, src_ids = _build()
+    context = _context(src_ids)
+    engine = PillarScoringEngine()
+    scores = {c.id: engine.compute_score(c, context) for c in contents}
+
+    before = sorted(contents, key=lambda c: c.published_at, reverse=True)
+    after = RecommendationService._apply_source_interleaving(
+        sorted(contents, key=lambda c: scores[c.id].final_score, reverse=True)
+    )
+
+    print(
+        f"\n{'=' * 92}\nSection « tech » — {len(contents)} candidats réels (compte fd6b9d0b)\n{'=' * 92}"
+    )
+    print("\n--- AVANT (chronologique pur — bug actuel) ---")
+    print(f"{'#':>2}  qual img  {'source':<22} titre")
+    for i, c in enumerate(before, 1):
+        print(f"{i:>2}  {_flag(c)} {(c.source.name):<22} {c.title[:50]}")
+
+    print("\n--- APRÈS (PillarScoringEngine + interleaving — fix) ---")
+    print(f"{'#':>2}  score qual img  {'source':<22} titre")
+    for i, c in enumerate(after, 1):
+        print(
+            f"{i:>2}  {scores[c.id].final_score:>5.1f} {_flag(c)} {(c.source.name):<22} {c.title[:46]}"
+        )
+
+    _verdict(before, after)
+    return 0
+
+
+def _verdict(before, after) -> None:
+    def rank(lst, pred):
+        return [i for i, c in enumerate(lst, 1) if pred(c)]
+
+    def avg(rs):
+        return sum(rs) / len(rs) if rs else 0.0
+
+    def is_rich(c):
+        return c.content_quality == "full" and bool((c.thumbnail_url or "").strip())
+
+    def is_none(c):
+        return c.content_quality == "none"
+
+    def is_reddit(c):
+        return "reddit" in c.source.name.lower()
+
+    rb, ra = rank(before, is_rich), rank(after, is_rich)
+    nb, na = rank(before, is_none), rank(after, is_none)
+    n = len(after)
+    print(f"\n{'=' * 92}\nVERDICT\n{'=' * 92}")
+    print(
+        f"full+image — rang moyen : {avg(rb):.1f} → {avg(ra):.1f}  (plus bas = mieux)"
+    )
+    print(
+        f"full+image dans le top 5 : {len([r for r in rb if r <= 5])} → {len([r for r in ra if r <= 5])} / 5"
+    )
+    print(
+        f"teasers 'none' — rang moyen : {avg(nb):.1f} → {avg(na):.1f}  (plus haut = mieux)"
+    )
+    print(
+        f"teasers 'none' dans le top 5 : {len([r for r in nb if r <= 5])} → {len([r for r in na if r <= 5])} / 5"
+    )
+    # Observation, PAS un KPI qualité : le post EN remonte car la source a
+    # priority_multiplier=2.0 + souscription (pilier Source). À trancher dans le
+    # travail QA (filtre langue ? préférence source ?), pas via ce proxy.
+    print(
+        f"[obs] post EN (source priorisée+abonnée) — rang : "
+        f"{rank(before, is_reddit)} → {rank(after, is_reddit)}  (sur {n})"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/api/tests/test_personalized_theme_mode.py
+++ b/packages/api/tests/test_personalized_theme_mode.py
@@ -2,7 +2,8 @@
 
 When `?personalized=true` is combined with `?theme=` or `?topic=` on
 `/api/feed/`, `_get_candidates` must:
-  1. restrict the candidate pool to articles published in the last 24h,
+  1. restrict the candidate pool to articles published in the last 24h
+     (fenêtre élargie à 48h/72h si le pool est trop maigre — Fix #2),
   2. restrict sources to the user's followed sources (with the existing
      two-phase + curated fallback path on empty follow set), and
   3. boost articles whose `Content.topics` overlap `user_subtopics` via a
@@ -240,12 +241,14 @@ async def test_personalized_theme_relaxes_seen_consumed_filter():
 
 
 # ---------------------------------------------------------------------------
-# `is_personalized_theme_mode` flag : utilisé pour activer la fenêtre 24h, la
-# restriction aux sources suivies et le boost ORDER BY user_subtopics dans
-# `_get_candidates`. Depuis le bug curation 2026-05-28, ce mode NE route plus
-# vers PillarScoringEngine (Story 21.2 inversée) — il prend le même chemin
-# chronologique court-circuité que Flâner thématique pour éviter la compression
-# regroupement/diversification qui collapsait 40+ candidats à 2-3 articles.
+# `is_personalized_theme_mode` flag : utilisé pour activer la fenêtre de
+# fraîcheur (adaptative 24/48/72h — Fix #2), la restriction aux sources suivies
+# et le boost ORDER BY user_subtopics dans `_get_candidates`. Décision PO
+# 2026-06-01 : ce mode route vers le PillarScoringEngine (chemin scoré) — il
+# saute l'early-return chrono pur ET la compression regroupement/diversification.
+# Supersede l'approche top-3 "essentiel-grade" (#710). Le routage et le
+# reclassement sont couverts par tests/test_thematic_curation.py +
+# scripts/prove_thematic_scoring.py.
 # ---------------------------------------------------------------------------
 
 

--- a/packages/api/tests/test_thematic_curation.py
+++ b/packages/api/tests/test_thematic_curation.py
@@ -1,0 +1,199 @@
+"""Tests pour la curation des sections thématiques de la Tournée.
+
+Couvre les deux fixes du bug « qualité de curation des sections thématiques »
+(docs/bugs/bug-curation-qualite-sections-thematiques.md) :
+
+- **Fix #2 — fenêtre de fraîcheur adaptative** (`_get_candidates`) : quand le
+  pool 24h des sources suivies est sous le seuil, la fenêtre s'élargit (48h puis
+  72h) ; sinon elle reste à 24h sans requête superflue. Testé bout-à-bout contre
+  la DB via `_get_candidates` (même véhicule que test_feed_chronological_refresh).
+
+- **Fix #1 — routage vers le PillarScoringEngine** : le moteur de scoring (vers
+  lequel `personalized_theme_mode` est désormais routé) classe un article riche
+  (`content_quality='full'` + image) au-dessus d'un teaser `none` à thème égal.
+  C'est exactement le reclassement que le fix introduit (cf. la preuve empirique
+  end-to-end dans scripts/prove_thematic_scoring.py).
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.models.content import Content
+from app.models.enums import ContentType, ReliabilityScore
+from app.models.source import Source, SourceType
+from app.services.recommendation.scoring_config import ScoringWeights
+from app.services.recommendation.scoring_engine import (
+    PillarScoringEngine,
+    ScoringContext,
+)
+from app.services.recommendation_service import RecommendationService
+
+
+@pytest.fixture
+def user_id() -> UUID:
+    return uuid4()
+
+
+@pytest.fixture
+async def followed_tech_source(db_session):
+    source = Source(
+        id=uuid4(),
+        name="Tech Test Source",
+        url="https://tech-test.com",
+        feed_url=f"https://tech-test.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="tech",
+        is_active=True,
+        is_curated=True,
+    )
+    db_session.add(source)
+    await db_session.commit()
+    return source
+
+
+async def _add_tech_contents(db_session, source_id: UUID, count: int, hours_ago: float):
+    """Insert `count` tech articles published `hours_ago` hours before now."""
+    published = datetime.now(UTC) - timedelta(hours=hours_ago)
+    ids = []
+    for _ in range(count):
+        cid = uuid4()
+        ids.append(cid)
+        db_session.add(
+            Content(
+                id=cid,
+                source_id=source_id,
+                title=f"Tech article {cid}",
+                url=f"https://example.com/{cid}",
+                guid=f"guid-{cid}",
+                published_at=published,
+                content_type=ContentType.ARTICLE,
+                theme="tech",
+                topics=["tech", "ai"],
+                content_quality="full",
+            )
+        )
+    await db_session.commit()
+    return set(ids)
+
+
+# --------------------------------------------------------------------------
+# Fix #2 — fenêtre de fraîcheur adaptative
+# --------------------------------------------------------------------------
+
+
+async def test_adaptive_window_widens_when_24h_pool_below_threshold(
+    db_session, followed_tech_source, user_id
+):
+    """Pool 24h sous le seuil → la fenêtre s'élargit pour récupérer du contenu
+    plus ancien (48h) plutôt que de rendre une section quasi vide."""
+    assert ScoringWeights.THEMATIC_MIN_POOL_SIZE == 8  # garde-fou du test
+    in_24h = await _add_tech_contents(
+        db_session, followed_tech_source.id, count=3, hours_ago=10
+    )
+    in_48h = await _add_tech_contents(
+        db_session, followed_tech_source.id, count=10, hours_ago=36
+    )
+
+    service = RecommendationService(db_session)
+    candidates = await service._get_candidates(
+        user_id=user_id,
+        limit_candidates=100,
+        theme="tech",
+        personalized=True,
+        followed_source_ids={followed_tech_source.id},
+        user_subtopics={"tech", "ai"},
+    )
+
+    ids = {c.id for c in candidates}
+    # 3 < 8 → on élargit à 48h et on récupère les 10 articles de 36h.
+    assert len(candidates) >= ScoringWeights.THEMATIC_MIN_POOL_SIZE
+    assert in_24h <= ids
+    assert in_48h & ids, "la fenêtre élargie doit inclure les articles de 36h"
+
+
+async def test_adaptive_window_stays_24h_when_pool_sufficient(
+    db_session, followed_tech_source, user_id
+):
+    """Pool 24h suffisant → on reste à 24h, sans aller chercher le contenu plus
+    ancien (pas d'élargissement superflu)."""
+    in_24h = await _add_tech_contents(
+        db_session, followed_tech_source.id, count=10, hours_ago=10
+    )
+    older = await _add_tech_contents(
+        db_session, followed_tech_source.id, count=5, hours_ago=36
+    )
+
+    service = RecommendationService(db_session)
+    candidates = await service._get_candidates(
+        user_id=user_id,
+        limit_candidates=100,
+        theme="tech",
+        personalized=True,
+        followed_source_ids={followed_tech_source.id},
+        user_subtopics={"tech", "ai"},
+    )
+
+    ids = {c.id for c in candidates}
+    # 10 >= 8 → on s'arrête à 24h : les articles de 36h ne doivent PAS apparaître.
+    assert in_24h <= ids
+    assert not (older & ids), "le pool 24h suffit, pas d'élargissement à 48h"
+
+
+# --------------------------------------------------------------------------
+# Fix #1 — le PillarScoringEngine privilégie la qualité (article riche > teaser)
+# --------------------------------------------------------------------------
+
+
+def _content(quality: str, has_image: bool, source: Source) -> Content:
+    return Content(
+        id=uuid4(),
+        source_id=source.id,
+        source=source,
+        title="Article",
+        theme="tech",
+        topics=["tech", "ai"],
+        content_quality=quality,
+        thumbnail_url="https://img" if has_image else None,
+        language=None,
+        published_at=datetime.now(UTC),
+        content_type=ContentType.ARTICLE,
+        description="",
+        duration_seconds=None,
+        entities=[],
+    )
+
+
+def test_pillar_engine_ranks_rich_article_above_none_teaser():
+    """À thème/sous-thèmes/source égaux, un article full+image score plus haut
+    qu'un teaser none sans contenu lisible — c'est ce que le routage de Fix #1
+    fait remonter (vs le tri chronologique pur qui les ignore)."""
+    source = Source(
+        id=uuid4(),
+        name="Src",
+        theme="tech",
+        is_curated=True,
+        source_tier="deep",
+        reliability_score=ReliabilityScore.HIGH,
+        secondary_themes=[],
+        tone=None,
+    )
+    rich = _content("full", True, source)
+    teaser = _content("none", False, source)
+
+    context = ScoringContext(
+        user_profile=None,
+        user_interests={"tech"},
+        user_interest_weights={"tech": 3.0},
+        followed_source_ids={source.id},
+        user_prefs={},
+        now=datetime.now(UTC),
+        user_subtopics={"tech", "ai"},
+        user_subtopic_weights={"tech": 3.0, "ai": 3.0},
+    )
+    engine = PillarScoringEngine()
+
+    rich_score = engine.compute_score(rich, context).final_score
+    teaser_score = engine.compute_score(teaser, context).final_score
+    assert rich_score > teaser_score


### PR DESCRIPTION
## Quoi

Les **sections thématiques de la Tournée** sont désormais classées **entièrement
par le `PillarScoringEngine`** (Qualité 15 % / Source 25 % / Pertinence 40 % /
Fraîcheur 20 %), sans compression ni promotion top-N.

- **Fix #1 — scoring intégral.** `personalized_theme_mode` est sorti de
  l'early-return chrono pur (le bloc **top-3 « essentiel-grade » de `#710` y est
  supprimé**, et la méthode morte `_curate_thematic_top_n` retirée) **et** de la
  compression chrono-diversifiée. Le decay source-fatigue `0.70` (qui enterrait
  les meilleures sources délibérément suivies sur une section mono-thème) est
  neutralisé pour ce mode, remplacé par un interleaving doux
  (`_apply_source_interleaving`, sans pénalité de score).
- **Fix #2 — fenêtre de fraîcheur adaptative** dans `_get_candidates` :
  24h → 48h → 72h, uniquement quand le pool des sources suivies est sous
  `THEMATIC_MIN_POOL_SIZE` (8). Évite la section quasi vide sur les thèmes rares.

## Pourquoi

`#710` (top-3 « essentiel-grade » + reste chronologique) **ne satisfait pas** la
qualité de curation perçue par le PO (constat fait sur le `main` incluant `#710`).
Décision PO 2026-06-01 : router toute la section par le scoring. Diagnostic
complet : `docs/bugs/bug-curation-qualite-sections-thematiques.md`.

> Remplace la PR #734 (branche tournée historique, devenue intenable : elle
> réintroduisait de vieilles versions de fichiers déjà dépassées sur `main`).
> Cette PR repart **propre depuis `main`** et hérite donc du filtre langue
> (`#658`) et du bonus coverage du pilier Pertinence.

## Comment ça a été vérifié

- [x] **pytest backend : 1416 passed** (1 skip, 2 xfail). Seul échec,
  `test_notification_preferences::test_patch_increments_refusal_count` :
  **pré-existant et environnemental** (sérialisation TZ `+02:00` ; échoue aussi
  sur `origin/main`, n'implique aucun fichier de cette PR).
- [x] **Tests dédiés** (`test_thematic_curation.py`) : fenêtre adaptative
  (élargit si < seuil / reste 24h sinon, vérifié bout-à-bout contre la DB) +
  scoring qualité (full+image > teaser none). `test_personalized_theme_mode.py` vert.
- [x] **Preuve empirique** (`scripts/prove_thematic_scoring.py`, vrai
  `PillarScoringEngine` sur 20 candidats tech réels) :
  ```
  full+image dans le top 5 : 2 → 3 / 5   (« Génération IA » Le Grand Continent : 16 → 1)
  teasers 'none' dans le top 5 : 3 → 1 / 5  (les 4 teasers none Le Monde tombent en 17-20)
  ```
- [x] `ruff check` + `ruff format` propres. Pas de migration Alembic.

### Sur les signaux de qualité (suite)

Les métriques ci-dessus sont des **proxys provisoires**, pas une vérité produit
(ex. un post EN remonte légitimement car la source a `priority×2`+abonnement).
Définir des signaux *tranchés* (lisibilité, langue, coverage, brèves…) sur un
**jeu de données annoté manuellement** est l'objet d'un **hand-off QA dédié**
(`.context/qa-handoff-curation-scoring.md`, local). Cette PR pose le routage ;
le tuning fin viendra après.

## Zones à risque

- `recommendation_service.py` — chemin scoré de `get_feed` (partagé avec
  POUR_VOUS) et `_get_candidates` (**hot path** feed). Toutes les branches
  ajoutées sont gardées par `personalized_theme_mode` → aucun changement pour les
  autres modes. Suppression de `_curate_thematic_top_n` (#710) : aucun appelant
  restant, aucun test ne le référençait.
