### PR TITLE
fix(flaner): stabilize refresh cache and auth rebuilds

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,31 +1,30 @@
-# Veille — curation premium + config liée aux angles + fix navigation
+# Fix Flâner refresh cache
 
-Refonte de la **veille** sur 3 axes (par impact) : curation par score (le « 90 % »), config où chaque angle porte sa grappe de mots-clés, et fix du bug « Créer ma veille » → feed.
+Corrige un ensemble de régressions mobiles autour de Flâner: refresh trop fréquent au retour premier plan, perte de filtres lors de rebuilds auth sans changement d'utilisateur, et collision potentielle entre caches `normal` / `serein`.
 
-## Part A — Curation premium (cœur)
-Remplace le filtre `OR` (où le **thème** suffisait à faire entrer tout l'article) par un pipeline **prefilter SQL axes forts → scoring piliers → seuil → tri par score**, en réutilisant le moteur de la Tournée (`PillarScoringEngine`).
-- `feed_filter.py` : `build_strong_predicate` (topics/sources/mots-clés ; **thème retiré du prédicat**) + fenêtre récence 168h + `CANDIDATE_CAP` 300 + `_score_and_rank` (seuil + tri score/récence). `matched_on` ne qualifie plus via `theme`.
-- `scoring_context.py` (nouveau) : adaptateur `VeilleAngleTopic` (duck-type de `_score_custom_topics`) + `build_veille_scoring_context` — thème = signal **faible** (`user_interests`), topics → `user_subtopics` (+45), angles → `user_custom_topics` (+25), sources → `followed_source_ids` (+35).
-- `scoring_config.py` : `VEILLE_RELEVANCE_THRESHOLD=40`, `VEILLE_CANDIDATE_CAP=300`, `VEILLE_RECENCY_HOURS=168` + log structuré (`max_score`/`pass_count`/`candidate_count`) pour calibrer en prod.
+## Quoi
+- extrait et teste la règle `shouldRefreshFlanerOnForeground()` avec un seuil de 30 minutes,
+- stabilise `feedProvider` pour ignorer les rebuilds liés à la seule rotation JWT et conserver les filtres pour le même utilisateur,
+- remet les filtres à zéro uniquement sur logout ou vrai changement d'utilisateur,
+- sépare le cache feed par variante `normal` / `serein` avec fallback legacy pour `normal`,
+- corrige `theme_provider_test.dart` pour l'API actuelle `AppThemeMode`.
 
-## Part B — Modèle : angle = sujet + grappe
-- `VeilleKeyword.veille_topic_id` (FK `veille_topics`, nullable = mot-clé global), index `ix_veille_keywords_topic`, unique relâché en `(config, topic_id, keyword)`.
-- Migration `vk01_link_keywords_to_topics` (`down_revision = dd01_franceinfo_dedup`, 1 head, downgrade symétrique).
+## Pourquoi
+- éviter des refresh Flâner inutiles en revenant rapidement dans l'app,
+- empêcher la perte de contexte filtre lors de rebuilds auth sans impact fonctionnel,
+- garantir qu'un cache `serein` ne pollue pas la vue normale, et inversement,
+- débloquer `flutter analyze` pour permettre une PR conforme.
 
-## Part C — Config enrichie
-- `schemas` + `routers/veille.py` : `VeilleTopicSelection.keywords` persisté lié à l'angle ; `_hydrate_response` round-trip (grappes nichées, globaux à plat).
-- `angle_suggester.py` : prompt **8-12 angles** (au lieu de 5-8), `max_tokens` 2000, fallback étendu.
-- Sources : `/presets` 6 → 12 ; `_fetch_source_examples` **préfère** les articles matchant les mots-clés de la veille active (sinon récence brute).
-- Mobile : DTO round-trip des grappes ; brief introduit **une fois** au Step 1 (suppression du doublon Step 2).
+## Comment ça a été vérifié
+- [x] Tests ciblés feed/lifecycle:
+  - `flutter test test/app_lifecycle_test.dart test/features/feed/feed_provider_auth_filter_test.dart test/features/feed/feed_cache_service_test.dart test/features/feed/feed_refresh_recovery_test.dart test/features/feed/personalization_logic_test.dart`
+- [ ] `flutter test`
+  - Bloqué par des échecs hors diff dans `test/features/custom_topics/widgets/topic_chip_test.dart` et `test/features/custom_topics/widgets/topic_explorer_screen_test.dart`
+- [ ] `flutter analyze`
+  - Le `undefined_method` de `theme_provider_test.dart` est corrigé, mais `flutter analyze` reste rouge à cause de centaines d'`info`/`warning` historiques hors périmètre
+- [x] Review finale du diff
 
-## Part D — Fix navigation « Créer ma veille » → feed (2 leviers)
-- `veille_config_provider.submit()` : `invalidate(userInterestsProvider)` après hydratation (lever racine).
-- `my_interests_screen.dart` : CTA masqué si veille active connue **ET** pas de `VeilleFavoriteRef` (défense en profondeur).
-
-## Tests / VERIFY
-- Backend complet : **1408 passed, 1 skipped, 2 xfailed** (0 régression). Veille : 65 passed (scoring, thème-seul exclu, topic>keyword, source/keyword, frontière seuil, exclusions hidden/seen/inactive, pagination, persistance grappes round-trip, unique triplet).
-- Alembic : 1 head ; `upgrade head` + `downgrade -1` + re-upgrade OK sur DB **vide**.
-- Mobile : `flutter analyze` → 0 erreur (548 infos préexistantes).
-
-## Hors-scope (suite)
-Le fetch LLM `/suggest/angles` n'est pas encore branché dans l'écran suggestions mobile (il consomme aujourd'hui les preset topics statiques) ; le backend + le round-trip DTO sont prêts à l'accueillir → l'affichage éditable des chips de mots-clés par angle (C3 UI) suivra dans une PR mobile dédiée.
+## Zones à risque
+- synchronisation différée via `scheduleMicrotask` entre owner/reset et provider de sélection,
+- UX potentiellement plus stale sur retour premier plan < 30 min, choix volontaire pour réduire les refresh inutiles,
+- persistance des filtres lors des rebuilds auth intermédiaires.

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -20,6 +20,13 @@ import 'features/settings/providers/theme_provider.dart';
 import 'core/api/api_client.dart' show ApiGoneNotifier;
 import 'core/ui/notification_service.dart';
 
+const flanerForegroundRefreshThreshold = Duration(minutes: 30);
+
+@visibleForTesting
+bool shouldRefreshFlanerOnForeground(Duration? elapsed) {
+  return elapsed == null || elapsed >= flanerForegroundRefreshThreshold;
+}
+
 /// Application principale Facteur
 class FacteurApp extends ConsumerStatefulWidget {
   const FacteurApp({super.key});
@@ -102,7 +109,7 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
         }
         if (ref.read(authStateProvider).isAuthenticated &&
             currentPath == RoutePaths.flaner &&
-            (elapsed == null || elapsed.inSeconds >= 60)) {
+            shouldRefreshFlanerOnForeground(elapsed)) {
           ref.read(feedProvider.notifier).refresh();
         }
       }

--- a/apps/mobile/lib/features/feed/providers/feed_preload_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_preload_provider.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/auth/auth_state.dart';
+import '../../digest/providers/serein_toggle_provider.dart';
+import '../services/feed_cache_service.dart';
 import 'feed_provider.dart';
 
 /// R5.1 — minimum age (seconds) of a cached default feed below which the
@@ -24,14 +26,24 @@ const int _preloadSkipIfCacheYoungerThanSeconds = 60;
 /// is already in flight returns the pending future instead of starting a new
 /// one, so re-triggering is safe.
 final feedPreloadProvider = Provider<void>((ref) {
-  final authState = ref.watch(authStateProvider);
+  final authGate = ref.watch(
+    authStateProvider.select(
+      (state) => (
+        userId: state.user?.id,
+        isAuthenticated: state.isAuthenticated,
+        isEmailConfirmed: state.isEmailConfirmed,
+        needsOnboarding: state.needsOnboarding,
+      ),
+    ),
+  );
 
   // Preload gates: authenticated + confirmed + past onboarding. The router
   // won't let an un-confirmed / onboarding user land on /feed anyway, so
   // fetching before these gates would be wasted work.
-  final shouldPreload = authState.isAuthenticated &&
-      authState.isEmailConfirmed &&
-      !authState.needsOnboarding;
+  final shouldPreload =
+      authGate.isAuthenticated &&
+      authGate.isEmailConfirmed &&
+      !authGate.needsOnboarding;
 
   if (!shouldPreload) return;
 
@@ -40,10 +52,14 @@ final feedPreloadProvider = Provider<void>((ref) {
   // `feedProvider` will paint instantly from cache, and we avoid hitting
   // `/api/feed/` for nothing. We only short-circuit on a clearly fresh
   // entry — anything older than the threshold proceeds to preload.
-  final userId = authState.user?.id;
+  final userId = authGate.userId;
   final cache = ref.read(feedCacheServiceProvider);
   if (userId != null && cache != null) {
-    final cached = cache.readRaw(userId);
+    final isSerein = ref.read(sereinToggleProvider).enabled;
+    final cached = cache.readRaw(
+      userId,
+      variant: isSerein ? FeedCacheVariant.serein : FeedCacheVariant.normal,
+    );
     if (cached != null) {
       final age = DateTime.now().difference(cached.savedAt).inSeconds;
       if (age < _preloadSkipIfCacheYoungerThanSeconds) {

--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -30,10 +30,7 @@ class FeedState {
   final List<Content> items;
   final List<FeedCarouselData> carousels;
 
-  FeedState({
-    required this.items,
-    this.carousels = const [],
-  });
+  FeedState({required this.items, this.carousels = const []});
 }
 
 /// Snapshot capturé juste avant un refresh, pour permettre l'undo.
@@ -53,9 +50,7 @@ class FeedSnapshot {
     required this.impressionsBackup,
   });
 
-  FeedSnapshot copyWith({
-    List<PreviousImpression>? impressionsBackup,
-  }) =>
+  FeedSnapshot copyWith({List<PreviousImpression>? impressionsBackup}) =>
       FeedSnapshot(
         items: items,
         carousels: carousels,
@@ -108,12 +103,14 @@ class FeedFilterSelection {
           keyword == other.keyword;
 
   @override
-  int get hashCode =>
-      Object.hash(sourceId, topic, theme, entity, keyword);
+  int get hashCode => Object.hash(sourceId, topic, theme, entity, keyword);
 }
 
-final feedFilterSelectionProvider =
-    StateProvider<FeedFilterSelection>((ref) => FeedFilterSelection.empty);
+final feedFilterSelectionProvider = StateProvider<FeedFilterSelection>(
+  (ref) => FeedFilterSelection.empty,
+);
+
+final _feedFilterSelectionOwnerProvider = StateProvider<String?>((ref) => null);
 
 /// `true` tant qu'un refresh feed est en vol (filter change, serein toggle,
 /// pull-to-refresh). Permet d'afficher un loader partagé sur les deux écrans
@@ -124,6 +121,45 @@ final feedRefreshingProvider = StateProvider<bool>((ref) => false);
 final feedProvider = AsyncNotifierProvider<FeedNotifier, FeedState>(() {
   return FeedNotifier();
 });
+
+class _FeedAuthGate {
+  final String? userId;
+  final bool isAuthenticated;
+  final bool isEmailConfirmed;
+  final bool needsOnboarding;
+
+  const _FeedAuthGate({
+    required this.userId,
+    required this.isAuthenticated,
+    required this.isEmailConfirmed,
+    required this.needsOnboarding,
+  });
+
+  factory _FeedAuthGate.fromAuthState(AuthState state) {
+    return _FeedAuthGate(
+      userId: state.user?.id,
+      isAuthenticated: state.isAuthenticated,
+      isEmailConfirmed: state.isEmailConfirmed,
+      needsOnboarding: state.needsOnboarding,
+    );
+  }
+
+  bool get canFetch =>
+      isAuthenticated && userId != null && isEmailConfirmed && !needsOnboarding;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _FeedAuthGate &&
+          userId == other.userId &&
+          isAuthenticated == other.isAuthenticated &&
+          isEmailConfirmed == other.isEmailConfirmed &&
+          needsOnboarding == other.needsOnboarding;
+
+  @override
+  int get hashCode =>
+      Object.hash(userId, isAuthenticated, isEmailConfirmed, needsOnboarding);
+}
 
 class FeedNotifier extends AsyncNotifier<FeedState> {
   // Internal state for pagination
@@ -176,8 +212,11 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
   List<Content> get globalItems => _globalItems;
 
   bool get _isUnfiltered =>
+      _selectedFilter == null &&
       _selectedTopic == null &&
       _selectedTheme == null &&
+      _selectedSourceId == null &&
+      _selectedKeyword == null &&
       _selectedEntity == null;
 
   @override
@@ -189,29 +228,42 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       _widgetPushDebounce?.cancel();
     });
 
-    // Watch auth state to handle logout/user change
-    final authState = ref.watch(authStateProvider);
+    // Watch only the auth identity/gates that can affect feed access.
+    // JWT rotations update AuthState.lastTokenRefreshAt, but must not rebuild
+    // this notifier because rebuilds preserve scroll/list context.
+    final authGate = ref.watch(
+      authStateProvider.select(_FeedAuthGate.fromAuthState),
+    );
 
-    if (!authState.isAuthenticated || authState.user == null) {
-      // R5.1 — drop the static repository-level dedupe state on logout
-      // so the next user (or the same user after re-login) can't see a
-      // stale payload from the previous session.
-      FeedRepository.clearDefaultViewCache();
+    final selectionOwner = ref.read(_feedFilterSelectionOwnerProvider);
+
+    if (!authGate.canFetch) {
+      if (authGate.userId == null) {
+        _resetFiltersToEmpty(syncSelectionProvider: true);
+        _setSelectionOwner(null);
+        FeedRepository.clearDefaultViewCache();
+      } else if (selectionOwner != null && selectionOwner != authGate.userId) {
+        _resetFiltersToEmpty(syncSelectionProvider: true);
+        _setSelectionOwner(authGate.userId);
+        FeedRepository.clearDefaultViewCache();
+      }
       return FeedState(items: []);
+    }
+
+    if (selectionOwner != null && selectionOwner != authGate.userId) {
+      FeedRepository.clearDefaultViewCache();
+      _resetFiltersToEmpty(syncSelectionProvider: true);
+      _setSelectionOwner(authGate.userId);
+    } else {
+      if (selectionOwner == null) {
+        _setSelectionOwner(authGate.userId);
+      }
+      _restoreFiltersFromSelection();
     }
 
     _page = 1;
     _hasNext = true;
     _isLoadingMore = false;
-    _selectedFilter = null; // Reset filter on build/rebuild
-    _selectedTheme = null;
-    _selectedTopic = null;
-    _selectedSourceId = null;
-    _selectedEntity = null;
-    _selectedKeyword = null;
-    // Riverpod interdit de muter un autre provider pendant le build : on
-    // diffère donc le reset au prochain microtick.
-    scheduleMicrotask(_syncSelectionProvider);
 
     // NB: serein toggle is observed in feed_screen.dart (which wraps the
     // refresh in a loading indicator). Listening here as well would cause
@@ -222,10 +274,11 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     // a silent refresh so the next frame is up-to-date. This is the main
     // lever for the "feed takes 4-5s on open" UX issue — subsequent opens in
     // the same 10-minute window become near-instant.
-    final userId = authState.user!.id;
+    final userId = authGate.userId!;
     final cache = ref.read(feedCacheServiceProvider);
     final isSerein = ref.read(sereinToggleProvider).enabled;
-    final cached = (!isSerein) ? cache?.readRaw(userId) : null;
+    final cacheVariant = _cacheVariantForSerein(isSerein);
+    final cached = cache?.readRaw(userId, variant: cacheVariant);
     if (cached != null && cached.isFresh) {
       try {
         final parsed = FeedRepository.parseFeedData(
@@ -246,13 +299,14 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         }
         _globalItems = parsed.items;
         print(
-            '[PERF] feedProvider.build(): cache hit (${parsed.items.length} items, age=${ageSeconds}s, silent_reval=${ageSeconds >= _silentRevalSkipSeconds})');
+          '[PERF] feedProvider.build(): cache hit (${parsed.items.length} items, age=${ageSeconds}s, silent_reval=${ageSeconds >= _silentRevalSkipSeconds})',
+        );
         unawaited(_prefetchForWidget(parsed.items));
         return FeedState(items: parsed.items, carousels: parsed.carousels);
       } catch (e) {
         // Corrupted cache or schema drift — drop silently and fall through.
         print('FeedNotifier: cached feed parse failed, evicting: $e');
-        await cache?.clearForUser(userId);
+        await cache?.clearForUser(userId, variant: cacheVariant);
       }
     }
 
@@ -260,7 +314,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     final sw = Stopwatch()..start();
     final response = await _fetchPage(page: 1);
     sw.stop();
-    print('[PERF] feedProvider.build(): ${sw.elapsedMilliseconds}ms (${response.items.length} items)');
+    print(
+      '[PERF] feedProvider.build(): ${sw.elapsedMilliseconds}ms (${response.items.length} items)',
+    );
 
     _globalItems = response.items;
     unawaited(_prefetchForWidget(response.items));
@@ -293,14 +349,17 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
           ...?(currentState?.items
               .where((c) => c.status == ContentStatus.consumed)
               .map((c) => c.id)),
-          ...?(currentState?.carousels.expand((carousel) => carousel.items
-              .where((c) => c.status == ContentStatus.consumed)
-              .map((c) => c.id))),
+          ...?(currentState?.carousels.expand(
+            (carousel) => carousel.items
+                .where((c) => c.status == ContentStatus.consumed)
+                .map((c) => c.id),
+          )),
         };
         if (consumedIds.isEmpty) {
           _globalItems = response.items;
           state = AsyncData(
-              FeedState(items: response.items, carousels: response.carousels));
+            FeedState(items: response.items, carousels: response.carousels),
+          );
           return;
         }
         Content preserve(Content c) => consumedIds.contains(c.id)
@@ -308,13 +367,17 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
             : c;
         final mergedItems = response.items.map(preserve).toList();
         _globalItems = mergedItems;
-        state = AsyncData(FeedState(
-          items: mergedItems,
-          carousels: response.carousels
-              .map((car) =>
-                  car.copyWith(items: car.items.map(preserve).toList()))
-              .toList(),
-        ));
+        state = AsyncData(
+          FeedState(
+            items: mergedItems,
+            carousels: response.carousels
+                .map(
+                  (car) =>
+                      car.copyWith(items: car.items.map(preserve).toList()),
+                )
+                .toList(),
+          ),
+        );
       } catch (e) {
         // Silent: user still sees the cached feed.
         print('FeedNotifier: silent revalidation failed: $e');
@@ -463,8 +526,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     await refresh();
   }
 
-  Future<void> setKeyword(String? keyword, {bool includeUnfollowed = false}) async {
-    if (_selectedKeyword == keyword && _includeUnfollowed == includeUnfollowed) {
+  Future<void> setKeyword(
+    String? keyword, {
+    bool includeUnfollowed = false,
+  }) async {
+    if (_selectedKeyword == keyword &&
+        _includeUnfollowed == includeUnfollowed) {
       return;
     }
     _selectedKeyword = keyword;
@@ -491,6 +558,41 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     await refresh();
   }
 
+  FeedCacheVariant _cacheVariantForSerein(bool isSerein) =>
+      isSerein ? FeedCacheVariant.serein : FeedCacheVariant.normal;
+
+  void _restoreFiltersFromSelection() {
+    final selection = ref.read(feedFilterSelectionProvider);
+    _selectedFilter = null;
+    _selectedSourceId = selection.sourceId;
+    _selectedTopic = selection.topic;
+    _selectedTheme = selection.theme;
+    _selectedEntity = selection.entity;
+    _selectedKeyword = selection.keyword;
+    _includeUnfollowed = false;
+  }
+
+  void _resetFiltersToEmpty({required bool syncSelectionProvider}) {
+    _selectedFilter = null;
+    _selectedTheme = null;
+    _selectedTopic = null;
+    _selectedSourceId = null;
+    _selectedEntity = null;
+    _selectedKeyword = null;
+    _includeUnfollowed = false;
+    if (syncSelectionProvider) {
+      // Riverpod interdit de muter un autre provider pendant le build : on
+      // diffère donc le reset au prochain microtick.
+      scheduleMicrotask(_syncSelectionProvider);
+    }
+  }
+
+  void _setSelectionOwner(String? userId) {
+    scheduleMicrotask(() {
+      ref.read(_feedFilterSelectionOwnerProvider.notifier).state = userId;
+    });
+  }
+
   /// Pushes the current filter selection into [feedFilterSelectionProvider]
   /// so listeners (chips, tabs, funnel badge) rebuild **immediately** on tap,
   /// without waiting for the refresh round-trip.
@@ -511,37 +613,14 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     final repository = ref.read(feedRepositoryProvider);
     final isSerein = ref.read(sereinToggleProvider).enabled;
 
-    // Only the page-1 "default" view (no filters, serein off) is cache-worthy:
-    // that's what the user lands on after cold-open or tab switch. Filtered
-    // views and paginated loads bypass the cache entirely.
-    final bool isDefaultView = page == 1 &&
-        !isSerein &&
-        _selectedFilter == null &&
-        _selectedTheme == null &&
-        _selectedTopic == null &&
-        _selectedSourceId == null &&
-        _selectedEntity == null &&
-        _selectedKeyword == null;
+    // Only the page-1 unfiltered view is cache-worthy: that's what the user
+    // lands on after cold-open or tab switch. Normal and serein variants have
+    // separate cache keys. Filtered views and paginated loads bypass the cache.
+    final bool isDefaultView = page == 1 && _isUnfiltered;
 
-    if (isDefaultView) {
+    final cache = ref.read(feedCacheServiceProvider);
+    if (isDefaultView && cache != null) {
       final result = await repository.getFeedWithRaw(
-          page: page,
-          limit: _limit,
-          mode: _selectedFilter,
-          theme: _selectedTheme,
-          topic: _selectedTopic,
-          sourceId: _selectedSourceId,
-          entity: _selectedEntity,
-          keyword: _selectedKeyword,
-          serein: isSerein,
-          forceFresh: forceFresh);
-      _hasNext = result.feed.pagination.hasNext && result.feed.items.isNotEmpty;
-      // Persist in the background — cache write failures never block the UI.
-      _persistDefaultFeedCache(result.raw);
-      return result.feed;
-    }
-
-    final response = await repository.getFeed(
         page: page,
         limit: _limit,
         mode: _selectedFilter,
@@ -550,8 +629,31 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         sourceId: _selectedSourceId,
         entity: _selectedEntity,
         keyword: _selectedKeyword,
-        includeUnfollowed: _includeUnfollowed,
-        serein: isSerein);
+        serein: isSerein,
+        forceFresh: forceFresh,
+      );
+      _hasNext = result.feed.pagination.hasNext && result.feed.items.isNotEmpty;
+      // Persist in the background — cache write failures never block the UI.
+      _persistDefaultFeedCache(
+        result.raw,
+        cache,
+        variant: _cacheVariantForSerein(isSerein),
+      );
+      return result.feed;
+    }
+
+    final response = await repository.getFeed(
+      page: page,
+      limit: _limit,
+      mode: _selectedFilter,
+      theme: _selectedTheme,
+      topic: _selectedTopic,
+      sourceId: _selectedSourceId,
+      entity: _selectedEntity,
+      keyword: _selectedKeyword,
+      includeUnfollowed: _includeUnfollowed,
+      serein: isSerein,
+    );
 
     // Hybrid pagination: trust the backend's `has_next` (based on the
     // total_candidates pool pre-diversification), but stop anyway if we got
@@ -564,14 +666,16 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
 
   /// Best-effort persistence of the default feed response for the current
   /// user. Silent on error (cache is a pure optimization).
-  void _persistDefaultFeedCache(dynamic rawData) {
+  void _persistDefaultFeedCache(
+    dynamic rawData,
+    FeedCacheService cache, {
+    required FeedCacheVariant variant,
+  }) {
     final authState = ref.read(authStateProvider);
     final userId = authState.user?.id;
     if (userId == null) return;
-    final cache = ref.read(feedCacheServiceProvider);
-    if (cache == null) return;
     // Fire-and-forget: a failed write must never surface to the UI.
-    unawaited(cache.saveRaw(userId, rawData));
+    unawaited(cache.saveRaw(userId, rawData, variant: variant));
   }
 
   Future<void> loadMore() async {
@@ -605,15 +709,18 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         // All items were duplicates — pagination is fully misaligned (e.g. stale
         // cache vs. heavily updated candidate pool). Stop paging to avoid a loop.
         print(
-            'FeedNotifier: loadMore page $nextPage fully deduplicated (${newItems.length} dupes), stopping pagination.');
+          'FeedNotifier: loadMore page $nextPage fully deduplicated (${newItems.length} dupes), stopping pagination.',
+        );
         _hasNext = false;
         return;
       }
 
-      state = AsyncData(FeedState(
-        items: [...currentItems, ...dedupedNewItems],
-        carousels: currentCarousels, // Keep page 1 carousels
-      ));
+      state = AsyncData(
+        FeedState(
+          items: [...currentItems, ...dedupedNewItems],
+          carousels: currentCarousels, // Keep page 1 carousels
+        ),
+      );
     } catch (e) {
       // Don't replace state with AsyncError — that would wipe the existing
       // feed items on a transient page 2+ failure. Log and stop paging; the
@@ -646,10 +753,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       if (_isUnfiltered) {
         _globalItems = response.items;
       }
-      state = AsyncData(FeedState(
-        items: response.items,
-        carousels: response.carousels,
-      ));
+      state = AsyncData(
+        FeedState(items: response.items, carousels: response.carousels),
+      );
     } catch (e, stack) {
       // Recovery policy : ne JAMAIS figer le provider en AsyncError si on a
       // déjà des items à l'écran. Un AsyncError wipe `state.value` → tous les
@@ -666,8 +772,7 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       final previous = state.valueOrNull;
       if (previous != null) {
         // ignore: avoid_print
-        print(
-            'FeedNotifier: refresh failed, keeping previous feed state: $e');
+        print('FeedNotifier: refresh failed, keeping previous feed state: $e');
         state = AsyncData(previous);
       } else {
         // Premier chargement jamais abouti : AsyncError est la bonne
@@ -687,7 +792,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
   /// Capture un snapshot de l'état UI + backup backend dans
   /// [feedUndoSnapshotProvider] pour permettre l'undo via [undoLastRefresh].
   /// Story 4.5b.
-  Future<void> refreshArticlesWithSnapshot(Set<String> visibleContentIds) async {
+  Future<void> refreshArticlesWithSnapshot(
+    Set<String> visibleContentIds,
+  ) async {
     // Single owner of the snapshot lifecycle: always drop any prior value at
     // the start. We'll either replace it below (happy path) or leave it null
     // (empty visible set, backend failure) — never leak a stale snapshot that
@@ -699,9 +806,11 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
 
     // Collect IDs from main feed items (non-consumed + visible)
     final mainIds = currentState.items
-        .where((c) =>
-            c.status != ContentStatus.consumed &&
-            visibleContentIds.contains(c.id))
+        .where(
+          (c) =>
+              c.status != ContentStatus.consumed &&
+              visibleContentIds.contains(c.id),
+        )
         .map((c) => c.id)
         .toSet();
 
@@ -740,10 +849,13 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       final backups = await repository.refreshFeed(allIds);
 
       // 3. Store enriched snapshot for undo (only on success)
-      ref.read(feedUndoSnapshotProvider.notifier).state =
-          snapshot.copyWith(impressionsBackup: backups);
+      ref.read(feedUndoSnapshotProvider.notifier).state = snapshot.copyWith(
+        impressionsBackup: backups,
+      );
     } catch (e) {
-      print('FeedNotifier: refreshArticlesWithSnapshot backend call failed: $e');
+      print(
+        'FeedNotifier: refreshArticlesWithSnapshot backend call failed: $e',
+      );
     }
 
     // 4. Refetch page 1 (always — keeps the gesture responsive even on error)
@@ -762,10 +874,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     // 1. Restore UI state optimistically
     _page = snapshot.page;
     _hasNext = snapshot.hasNext;
-    state = AsyncData(FeedState(
-      items: snapshot.items,
-      carousels: snapshot.carousels,
-    ));
+    state = AsyncData(
+      FeedState(items: snapshot.items, carousels: snapshot.carousels),
+    );
 
     // 2. Clear snapshot immediately so double-tap does nothing
     ref.read(feedUndoSnapshotProvider.notifier).state = null;
@@ -787,7 +898,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     // Optimistic remove from feed
     final updatedItems = List<Content>.from(currentState.items);
     updatedItems.removeWhere((c) => c.id == content.id);
-    state = AsyncData(FeedState(items: updatedItems, carousels: state.value?.carousels ?? const []));
+    state = AsyncData(
+      FeedState(
+        items: updatedItems,
+        carousels: state.value?.carousels ?? const [],
+      ),
+    );
 
     try {
       final repository = ref.read(feedRepositoryProvider);
@@ -854,7 +970,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     );
 
     // Mise à jour optimiste immédiate
-    state = AsyncData(FeedState(items: updatedItems, carousels: updatedCarousels));
+    state = AsyncData(
+      FeedState(items: updatedItems, carousels: updatedCarousels),
+    );
 
     try {
       final repository = ref.read(feedRepositoryProvider);
@@ -896,7 +1014,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     );
 
     // Optimistic update
-    state = AsyncData(FeedState(items: updatedItems, carousels: updatedCarousels));
+    state = AsyncData(
+      FeedState(items: updatedItems, carousels: updatedCarousels),
+    );
 
     try {
       final repository = ref.read(feedRepositoryProvider);
@@ -916,7 +1036,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     updatedItems.removeWhere((c) => c.id == content.id);
 
     // Optimistic remove
-    state = AsyncData(FeedState(items: updatedItems, carousels: state.value?.carousels ?? const []));
+    state = AsyncData(
+      FeedState(
+        items: updatedItems,
+        carousels: state.value?.carousels ?? const [],
+      ),
+    );
 
     try {
       final repository = ref.read(feedRepositoryProvider);
@@ -936,7 +1061,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     final updatedItems = List<Content>.from(currentState.items);
     updatedItems.removeWhere((c) => c.id == content.id);
 
-    state = AsyncData(FeedState(items: updatedItems, carousels: state.value?.carousels ?? const []));
+    state = AsyncData(
+      FeedState(
+        items: updatedItems,
+        carousels: state.value?.carousels ?? const [],
+      ),
+    );
 
     try {
       final repository = ref.read(feedRepositoryProvider);
@@ -959,10 +1089,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     if (currentState == null) return;
     final updatedItems = List<Content>.from(currentState.items)
       ..removeWhere((c) => c.id == contentId);
-    state = AsyncData(FeedState(
-      items: updatedItems,
-      carousels: currentState.carousels,
-    ));
+    state = AsyncData(
+      FeedState(items: updatedItems, carousels: currentState.carousels),
+    );
   }
 
   /// Undo a swipe-dismiss: re-insert article at original position.
@@ -974,7 +1103,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     final insertIndex = originalIndex.clamp(0, updatedItems.length);
     updatedItems.insert(insertIndex, content);
 
-    state = AsyncData(FeedState(items: updatedItems, carousels: state.value?.carousels ?? const []));
+    state = AsyncData(
+      FeedState(
+        items: updatedItems,
+        carousels: state.value?.carousels ?? const [],
+      ),
+    );
 
     try {
       final repository = ref.read(feedRepositoryProvider);
@@ -992,9 +1126,15 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     if (currentState == null) return;
 
     // Optimistic remove all from this source
-    final updatedItems =
-        currentState.items.where((c) => c.source.id != content.source.id).toList();
-    state = AsyncData(FeedState(items: updatedItems, carousels: state.value?.carousels ?? const []));
+    final updatedItems = currentState.items
+        .where((c) => c.source.id != content.source.id)
+        .toList();
+    state = AsyncData(
+      FeedState(
+        items: updatedItems,
+        carousels: state.value?.carousels ?? const [],
+      ),
+    );
 
     try {
       final repository = ref.read(feedRepositoryProvider);
@@ -1023,7 +1163,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       if (c.id == content.id) return false;
       return !c.topics.contains(topic);
     }).toList();
-    state = AsyncData(FeedState(items: updatedItems, carousels: state.value?.carousels ?? const []));
+    state = AsyncData(
+      FeedState(
+        items: updatedItems,
+        carousels: state.value?.carousels ?? const [],
+      ),
+    );
 
     try {
       final repository = ref.read(feedRepositoryProvider);
@@ -1053,7 +1198,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     // Optimistic remove of all content from this source
     final updatedItems =
         currentState.items.where((c) => c.source.id != sourceId).toList();
-    state = AsyncData(FeedState(items: updatedItems, carousels: state.value?.carousels ?? const []));
+    state = AsyncData(
+      FeedState(
+        items: updatedItems,
+        carousels: state.value?.carousels ?? const [],
+      ),
+    );
 
     try {
       final repo = ref.read(personalizationRepositoryProvider);
@@ -1072,7 +1222,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     // Optimistic remove of all content from this theme
     final updatedItems =
         currentState.items.where((c) => c.source.theme != theme).toList();
-    state = AsyncData(FeedState(items: updatedItems, carousels: state.value?.carousels ?? const []));
+    state = AsyncData(
+      FeedState(
+        items: updatedItems,
+        carousels: state.value?.carousels ?? const [],
+      ),
+    );
 
     try {
       final repo = ref.read(personalizationRepositoryProvider);
@@ -1093,7 +1248,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       return !c.topics.contains(topic);
     }).toList();
 
-    state = AsyncData(FeedState(items: updatedItems, carousels: state.value?.carousels ?? const []));
+    state = AsyncData(
+      FeedState(
+        items: updatedItems,
+        carousels: state.value?.carousels ?? const [],
+      ),
+    );
 
     try {
       final repo = ref.read(personalizationRepositoryProvider);
@@ -1137,7 +1297,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         .where((c) => c.contentType.name != contentType)
         .toList();
 
-    state = AsyncData(FeedState(items: updatedItems, carousels: state.value?.carousels ?? const []));
+    state = AsyncData(
+      FeedState(
+        items: updatedItems,
+        carousels: state.value?.carousels ?? const [],
+      ),
+    );
 
     try {
       final repo = ref.read(personalizationRepositoryProvider);
@@ -1182,8 +1347,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
 
     final updatedItems = List<Content>.from(currentState.items);
     if (feedIndex != -1) {
-      updatedItems[feedIndex] =
-          updatedItems[feedIndex].copyWith(status: ContentStatus.consumed);
+      updatedItems[feedIndex] = updatedItems[feedIndex].copyWith(
+        status: ContentStatus.consumed,
+      );
     }
 
     final updatedCarousels = _updateCarouselItem(
@@ -1192,17 +1358,34 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       (c) => c.copyWith(status: ContentStatus.consumed),
     );
 
-    state = AsyncData(FeedState(items: updatedItems, carousels: updatedCarousels));
+    state = AsyncData(
+      FeedState(items: updatedItems, carousels: updatedCarousels),
+    );
 
     try {
       final repository = ref.read(feedRepositoryProvider);
       await repository.updateContentStatus(content.id, ContentStatus.consumed);
-      // Invalidate in-memory dedupe + Hive cache so the next fetch (silent
-      // revalidation or cold start) returns fresh data with the correct status.
-      FeedRepository.clearDefaultViewCache();
       final userId = ref.read(authStateProvider).user?.id;
       if (userId != null) {
-        unawaited(ref.read(feedCacheServiceProvider)?.clearForUser(userId));
+        final cache = ref.read(feedCacheServiceProvider);
+        if (cache != null) {
+          unawaited(
+            cache.patchContentStatus(
+              userId,
+              content.id,
+              ContentStatus.consumed,
+              variant: FeedCacheVariant.normal,
+            ),
+          );
+          unawaited(
+            cache.patchContentStatus(
+              userId,
+              content.id,
+              ContentStatus.consumed,
+              variant: FeedCacheVariant.serein,
+            ),
+          );
+        }
       }
     } catch (e) {
       // Silent failure, state is already updated optimistically

--- a/apps/mobile/lib/features/feed/services/feed_cache_service.dart
+++ b/apps/mobile/lib/features/feed/services/feed_cache_service.dart
@@ -2,11 +2,16 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
+import '../models/content_model.dart';
+
+enum FeedCacheVariant { normal, serein }
+
 /// Local cache for the "default" feed (page 1, no filters) to enable
 /// stale-while-revalidate UX: instant paint on cold open + silent refetch.
 ///
 /// Storage: Hive `Box<String>` named `feed_cache` (opened in `main.dart`).
-/// Key shape: `feed:{userId}`.
+/// Key shape: `feed:{userId}:normal` / `feed:{userId}:serein`.
+/// Legacy normal entries at `feed:{userId}` are still readable.
 /// Value shape: JSON string `{"saved_at": <ms>, "data": <raw API response>}`.
 ///
 /// Why cache the raw API response (not a parsed model):
@@ -36,19 +41,26 @@ class FeedCacheService {
     return FeedCacheService(Hive.box<String>(boxName));
   }
 
-  String _key(String userId) => 'feed:$userId';
+  String _legacyKey(String userId) => 'feed:$userId';
+
+  String _key(String userId, FeedCacheVariant variant) =>
+      'feed:$userId:${variant.name}';
 
   /// Persist a raw feed response (decoded JSON) for [userId].
   ///
   /// The caller should only invoke this for page 1 with no filters active
   /// (default feed). No-op on serialization error.
-  Future<void> saveRaw(String userId, dynamic rawData) async {
+  Future<void> saveRaw(
+    String userId,
+    dynamic rawData, {
+    FeedCacheVariant variant = FeedCacheVariant.normal,
+  }) async {
     try {
       final payload = <String, dynamic>{
         'saved_at': DateTime.now().millisecondsSinceEpoch,
         'data': rawData,
       };
-      await _box.put(_key(userId), jsonEncode(payload));
+      await _box.put(_key(userId, variant), jsonEncode(payload));
     } catch (e) {
       if (kDebugMode) {
         debugPrint('FeedCacheService.saveRaw failed: $e');
@@ -58,10 +70,29 @@ class FeedCacheService {
 
   /// Read the cached raw feed response for [userId], or null if absent /
   /// corrupted. A corrupted entry is evicted on read.
-  CachedFeedRaw? readRaw(String userId) {
-    final key = _key(userId);
+  CachedFeedRaw? readRaw(
+    String userId, {
+    FeedCacheVariant variant = FeedCacheVariant.normal,
+  }) {
+    final entry = _readEncoded(userId, variant);
+    if (entry == null) return null;
+    final (key, encoded) = entry;
+    return _decodeEntry(key, encoded);
+  }
+
+  (String, String)? _readEncoded(String userId, FeedCacheVariant variant) {
+    final key = _key(userId, variant);
     final encoded = _box.get(key);
-    if (encoded == null) return null;
+    if (encoded != null) return (key, encoded);
+    if (variant == FeedCacheVariant.normal) {
+      final legacyKey = _legacyKey(userId);
+      final legacy = _box.get(legacyKey);
+      if (legacy != null) return (legacyKey, legacy);
+    }
+    return null;
+  }
+
+  CachedFeedRaw? _decodeEntry(String key, String encoded) {
     try {
       final decoded = jsonDecode(encoded);
       if (decoded is! Map<String, dynamic>) {
@@ -87,9 +118,101 @@ class FeedCacheService {
     }
   }
 
-  /// Remove the cache entry for [userId]. Use on logout or user switch.
-  Future<void> clearForUser(String userId) async {
-    await _box.delete(_key(userId));
+  /// Patch a single content status inside a cached raw payload.
+  ///
+  /// Supports the two raw shapes used by `FeedRepository.parseFeedData`:
+  /// a top-level List of content maps, or a Map with `items` and optional
+  /// `carousels[].items`. Returns false if no matching content exists or the
+  /// entry cannot be decoded.
+  Future<bool> patchContentStatus(
+    String userId,
+    String contentId,
+    ContentStatus status, {
+    FeedCacheVariant variant = FeedCacheVariant.normal,
+  }) async {
+    final entry = _readEncoded(userId, variant);
+    if (entry == null) return false;
+    final (key, encoded) = entry;
+    try {
+      final decoded = jsonDecode(encoded);
+      if (decoded is! Map<String, dynamic>) {
+        await _box.delete(key);
+        return false;
+      }
+      final savedAt = decoded['saved_at'];
+      final data = decoded['data'];
+      if (savedAt is! int || data == null) {
+        await _box.delete(key);
+        return false;
+      }
+      final patched = _patchStatusInData(data, contentId, status.name);
+      if (!patched) return false;
+      await _box.put(key, jsonEncode(decoded));
+      return true;
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('FeedCacheService.patchContentStatus failed: $e');
+      }
+      await _box.delete(key);
+      return false;
+    }
+  }
+
+  bool _patchStatusInData(dynamic data, String contentId, String status) {
+    var patched = false;
+
+    bool patchItem(dynamic item) {
+      if (item is! Map<String, dynamic>) return false;
+      if (item['id'] != contentId) return false;
+      item['status'] = status;
+      return true;
+    }
+
+    if (data is List) {
+      for (final item in data) {
+        patched = patchItem(item) || patched;
+      }
+      return patched;
+    }
+
+    if (data is Map<String, dynamic>) {
+      final items = data['items'];
+      if (items is List) {
+        for (final item in items) {
+          patched = patchItem(item) || patched;
+        }
+      }
+
+      final carousels = data['carousels'];
+      if (carousels is List) {
+        for (final carousel in carousels) {
+          if (carousel is! Map<String, dynamic>) continue;
+          final carouselItems = carousel['items'];
+          if (carouselItems is! List) continue;
+          for (final item in carouselItems) {
+            patched = patchItem(item) || patched;
+          }
+        }
+      }
+    }
+
+    return patched;
+  }
+
+  /// Remove cache entries for [userId]. Use on logout or user switch.
+  Future<void> clearForUser(String userId, {FeedCacheVariant? variant}) async {
+    if (variant != null) {
+      await _box.delete(_key(userId, variant));
+      if (variant == FeedCacheVariant.normal) {
+        await _box.delete(_legacyKey(userId));
+      }
+      return;
+    }
+    await _box.deleteAll([
+      _key(userId, FeedCacheVariant.normal),
+      _key(userId, FeedCacheVariant.serein),
+      _legacyKey(userId),
+    ]);
   }
 
   /// Wipe every cache entry. Use on global reset.
@@ -98,8 +221,11 @@ class FeedCacheService {
   }
 
   /// Whether [savedAt] is within the [ttl] window from [now].
-  static bool isFresh(DateTime savedAt,
-      {DateTime? now, Duration ttl = defaultTtl}) {
+  static bool isFresh(
+    DateTime savedAt, {
+    DateTime? now,
+    Duration ttl = defaultTtl,
+  }) {
     final reference = now ?? DateTime.now();
     return reference.difference(savedAt) < ttl;
   }

--- a/apps/mobile/test/app_lifecycle_test.dart
+++ b/apps/mobile/test/app_lifecycle_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/app.dart';
+
+void main() {
+  group('shouldRefreshFlanerOnForeground', () {
+    test('does not refresh before 30 minutes', () {
+      expect(
+        shouldRefreshFlanerOnForeground(
+          const Duration(minutes: 29, seconds: 59),
+        ),
+        isFalse,
+      );
+    });
+
+    test('refreshes at or after 30 minutes', () {
+      expect(
+        shouldRefreshFlanerOnForeground(const Duration(minutes: 30)),
+        isTrue,
+      );
+      expect(
+        shouldRefreshFlanerOnForeground(const Duration(minutes: 45)),
+        isTrue,
+      );
+    });
+
+    test('refreshes when elapsed time is unknown', () {
+      expect(shouldRefreshFlanerOnForeground(null), isTrue);
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/feed_cache_service_test.dart
+++ b/apps/mobile/test/features/feed/feed_cache_service_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
+import 'package:facteur/features/feed/models/content_model.dart';
 import 'package:facteur/features/feed/services/feed_cache_service.dart';
 
 /// Unit tests for FeedCacheService — the Hive-backed local cache powering
@@ -65,17 +66,118 @@ void main() {
       final cached = service.readRaw(userId);
 
       expect(cached, isNotNull);
-      expect(cached!.data, isA<List>());
-      expect((cached.data as List).length, 2);
+      expect(cached!.data, isA<List<dynamic>>());
+      expect((cached.data as List<dynamic>).length, 2);
     });
 
     test('reads are user-scoped: another user sees null', () async {
-      await service.saveRaw('user-A', {'items': []});
+      await service.saveRaw('user-A', {'items': <dynamic>[]});
       expect(service.readRaw('user-B'), isNull);
+    });
+
+    test('keeps normal and serein variants separated', () async {
+      await service.saveRaw('user-mode', {
+        'items': <Map<String, dynamic>>[
+          {'id': 'normal'},
+        ],
+      });
+      await service.saveRaw(
+          'user-mode',
+          {
+            'items': <Map<String, dynamic>>[
+              {'id': 'serein'},
+            ],
+          },
+          variant: FeedCacheVariant.serein);
+
+      final normal = service.readRaw('user-mode')!.data as Map;
+      final serein = service
+          .readRaw('user-mode', variant: FeedCacheVariant.serein)!
+          .data as Map;
+
+      expect((normal['items'] as List).first['id'], 'normal');
+      expect((serein['items'] as List).first['id'], 'serein');
+    });
+
+    test('normal reads fall back to legacy feed:userId key', () async {
+      await box.put(
+        'feed:legacy-user',
+        '{"saved_at":1760000000000,"data":{"items":[{"id":"legacy"}]}}',
+      );
+
+      final cached = service.readRaw('legacy-user');
+
+      expect(cached, isNotNull);
+      expect(((cached!.data as Map)['items'] as List).first['id'], 'legacy');
     });
 
     test('returns null when nothing has been saved', () {
       expect(service.readRaw('never-seen'), isNull);
+    });
+  });
+
+  group('FeedCacheService.patchContentStatus', () {
+    test('patches top-level List payloads', () async {
+      await service.saveRaw('user-list', [
+        {'id': 'a1', 'status': 'unseen'},
+        {'id': 'a2', 'status': 'unseen'},
+      ]);
+
+      final patched = await service.patchContentStatus(
+        'user-list',
+        'a2',
+        ContentStatus.consumed,
+      );
+      final data = service.readRaw('user-list')!.data as List;
+
+      expect(patched, isTrue);
+      expect(data[0]['status'], 'unseen');
+      expect(data[1]['status'], 'consumed');
+    });
+
+    test('patches Map items and carousel items', () async {
+      await service.saveRaw('user-map', {
+        'items': [
+          {'id': 'a1', 'status': 'unseen'},
+        ],
+        'carousels': [
+          {
+            'items': [
+              {'id': 'a2', 'status': 'unseen'},
+            ],
+          },
+        ],
+      });
+
+      final patched = await service.patchContentStatus(
+        'user-map',
+        'a2',
+        ContentStatus.consumed,
+      );
+      final data = service.readRaw('user-map')!.data as Map;
+      final carouselItems =
+          ((data['carousels'] as List).first as Map)['items'] as List;
+
+      expect(patched, isTrue);
+      expect((data['items'] as List).first['status'], 'unseen');
+      expect(carouselItems.first['status'], 'consumed');
+    });
+
+    test('returns false without clearing when content is absent', () async {
+      await service.saveRaw('user-absent', {
+        'items': [
+          {'id': 'a1', 'status': 'unseen'},
+        ],
+      });
+
+      final patched = await service.patchContentStatus(
+        'user-absent',
+        'missing',
+        ContentStatus.consumed,
+      );
+
+      expect(patched, isFalse);
+      expect(service.readRaw('user-absent'), isNotNull);
     });
   });
 
@@ -96,19 +198,25 @@ void main() {
       final now = DateTime(2026, 1, 1, 12, 0, 0);
       final savedAt = now.subtract(const Duration(seconds: 30));
       expect(
-        FeedCacheService.isFresh(savedAt,
-            now: now, ttl: const Duration(seconds: 10)),
+        FeedCacheService.isFresh(
+          savedAt,
+          now: now,
+          ttl: const Duration(seconds: 10),
+        ),
         isFalse,
       );
       expect(
-        FeedCacheService.isFresh(savedAt,
-            now: now, ttl: const Duration(minutes: 1)),
+        FeedCacheService.isFresh(
+          savedAt,
+          now: now,
+          ttl: const Duration(minutes: 1),
+        ),
         isTrue,
       );
     });
 
     test('cached.isFresh flag reflects recent save', () async {
-      await service.saveRaw('user-fresh', {'items': []});
+      await service.saveRaw('user-fresh', {'items': <dynamic>[]});
       final cached = service.readRaw('user-fresh');
       expect(cached!.isFresh, isTrue);
     });
@@ -137,8 +245,12 @@ void main() {
     });
 
     test('clearForUser removes only that user\'s entry', () async {
-      await service.saveRaw('keep-me', {'items': [1]});
-      await service.saveRaw('drop-me', {'items': [2]});
+      await service.saveRaw('keep-me', {
+        'items': [1],
+      });
+      await service.saveRaw('drop-me', {
+        'items': [2],
+      });
 
       await service.clearForUser('drop-me');
 
@@ -147,8 +259,8 @@ void main() {
     });
 
     test('clearAll wipes every entry', () async {
-      await service.saveRaw('user-a', {'items': []});
-      await service.saveRaw('user-b', {'items': []});
+      await service.saveRaw('user-a', {'items': <dynamic>[]});
+      await service.saveRaw('user-b', {'items': <dynamic>[]});
       await service.clearAll();
       expect(service.readRaw('user-a'), isNull);
       expect(service.readRaw('user-b'), isNull);

--- a/apps/mobile/test/features/feed/feed_provider_auth_filter_test.dart
+++ b/apps/mobile/test/features/feed/feed_provider_auth_filter_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+import 'package:facteur/core/auth/auth_state.dart' as app_auth;
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/feed/providers/feed_provider.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+
+class MockFeedRepository extends Mock implements FeedRepository {}
+
+class MockAuthStateNotifier extends StateNotifier<app_auth.AuthState>
+    implements app_auth.AuthStateNotifier {
+  MockAuthStateNotifier() : super(app_auth.AuthState(user: makeUser('u1')));
+
+  void setAuth(app_auth.AuthState next) {
+    state = next;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+supabase.User makeUser(String id) => supabase.User(
+      id: id,
+      appMetadata: const {},
+      userMetadata: const {},
+      aud: 'authenticated',
+      createdAt: '2023-01-01',
+      emailConfirmedAt: '2023-01-01',
+    );
+
+void main() {
+  late MockFeedRepository feedRepository;
+  late MockAuthStateNotifier authNotifier;
+  late ProviderContainer container;
+  late int feedCalls;
+
+  final source = Source(
+    id: 'source-1',
+    name: 'Source 1',
+    url: 'https://example.test',
+    type: SourceType.article,
+    theme: 'TECH',
+  );
+
+  Content content(String id) => Content(
+        id: id,
+        title: 'Title $id',
+        url: 'https://example.test/$id',
+        contentType: ContentType.article,
+        publishedAt: DateTime(2026, 1, 1),
+        source: source,
+      );
+
+  void stubFeed() {
+    when(
+      () => feedRepository.getFeed(
+        page: any(named: 'page'),
+        limit: any(named: 'limit'),
+        mode: any(named: 'mode'),
+        theme: any(named: 'theme'),
+        topic: any(named: 'topic'),
+        sourceId: any(named: 'sourceId'),
+        entity: any(named: 'entity'),
+        keyword: any(named: 'keyword'),
+        includeUnfollowed: any(named: 'includeUnfollowed'),
+        serein: any(named: 'serein'),
+      ),
+    ).thenAnswer((invocation) async {
+      feedCalls++;
+      final sourceId = invocation.namedArguments[#sourceId] as String?;
+      final theme = invocation.namedArguments[#theme] as String?;
+      final keyword = invocation.namedArguments[#keyword] as String?;
+      final suffix = sourceId ?? theme ?? keyword ?? 'default';
+      return FeedResponse(
+        items: [content(suffix)],
+        pagination: Pagination(page: 1, perPage: 20, total: 1, hasNext: false),
+      );
+    });
+  }
+
+  setUp(() {
+    feedRepository = MockFeedRepository();
+    authNotifier = MockAuthStateNotifier();
+    feedCalls = 0;
+    stubFeed();
+
+    container = ProviderContainer(
+      overrides: [
+        feedRepositoryProvider.overrideWithValue(feedRepository),
+        app_auth.authStateProvider.overrideWith((ref) => authNotifier),
+      ],
+    );
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  test('token refresh does not reset filters or refetch the feed', () async {
+    final notifier = container.read(feedProvider.notifier);
+    await container.read(feedProvider.future);
+
+    await notifier.setSource('source-1');
+    expect(notifier.selectedSourceId, 'source-1');
+    expect(container.read(feedFilterSelectionProvider).sourceId, 'source-1');
+
+    final callsBeforeTokenRefresh = feedCalls;
+
+    authNotifier.setAuth(
+      authNotifier.state.copyWith(lastTokenRefreshAt: DateTime(2026, 1, 1, 12)),
+    );
+    await container.pump();
+
+    expect(notifier.selectedSourceId, 'source-1');
+    expect(container.read(feedFilterSelectionProvider).sourceId, 'source-1');
+    expect(feedCalls, callsBeforeTokenRefresh);
+  });
+
+  test(
+    'same-user rebuild restores selection from feedFilterSelectionProvider',
+    () async {
+      final notifier = container.read(feedProvider.notifier);
+      await container.read(feedProvider.future);
+
+      await notifier.setKeyword('climat');
+      expect(notifier.selectedKeyword, 'climat');
+
+      authNotifier.setAuth(authNotifier.state.copyWith(needsOnboarding: true));
+      await container.read(feedProvider.future);
+      expect(container.read(feedProvider).value!.items, isEmpty);
+
+      authNotifier.setAuth(authNotifier.state.copyWith(needsOnboarding: false));
+      await container.read(feedProvider.future);
+
+      expect(container.read(feedProvider.notifier).selectedKeyword, 'climat');
+      expect(container.read(feedFilterSelectionProvider).keyword, 'climat');
+      expect(container.read(feedProvider).value!.items.single.id, 'climat');
+    },
+  );
+
+  test('provider recreation keeps same-user filter selection', () async {
+    final notifier = container.read(feedProvider.notifier);
+    await container.read(feedProvider.future);
+
+    await notifier.setTheme('TECH');
+    expect(container.read(feedFilterSelectionProvider).theme, 'TECH');
+
+    container.invalidate(feedProvider);
+    await container.read(feedProvider.future);
+
+    expect(container.read(feedProvider.notifier).selectedTheme, 'TECH');
+    expect(container.read(feedProvider).value!.items.single.id, 'TECH');
+  });
+
+  test('user change resets active filters', () async {
+    final notifier = container.read(feedProvider.notifier);
+    await container.read(feedProvider.future);
+
+    await notifier.setTheme('TECH');
+    expect(container.read(feedFilterSelectionProvider).theme, 'TECH');
+
+    authNotifier.setAuth(app_auth.AuthState(user: makeUser('u2')));
+    await container.read(feedProvider.future);
+    await container.pump();
+
+    expect(container.read(feedProvider.notifier).selectedTheme, isNull);
+    expect(
+      container.read(feedFilterSelectionProvider),
+      FeedFilterSelection.empty,
+    );
+  });
+}

--- a/apps/mobile/test/features/feed/feed_refresh_recovery_test.dart
+++ b/apps/mobile/test/features/feed/feed_refresh_recovery_test.dart
@@ -31,13 +31,18 @@ class MockPersonalizationRepository extends Mock
 class MockAuthStateNotifier extends StateNotifier<app_auth.AuthState>
     implements app_auth.AuthStateNotifier {
   MockAuthStateNotifier()
-      : super(const app_auth.AuthState(
-            user: supabase.User(
-                id: 'u1',
-                appMetadata: {},
-                userMetadata: {},
-                aud: 'authenticated',
-                createdAt: '2023-01-01')));
+    : super(
+        const app_auth.AuthState(
+          user: supabase.User(
+            id: 'u1',
+            appMetadata: {},
+            userMetadata: {},
+            aud: 'authenticated',
+            createdAt: '2023-01-01',
+            emailConfirmedAt: '2023-01-01',
+          ),
+        ),
+      );
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -58,13 +63,13 @@ void main() {
   );
 
   Content makeContent(String id) => Content(
-        id: id,
-        title: 'Title $id',
-        url: 'url',
-        contentType: ContentType.article,
-        publishedAt: DateTime.now(),
-        source: mockSource,
-      );
+    id: id,
+    title: 'Title $id',
+    url: 'url',
+    contentType: ContentType.article,
+    publishedAt: DateTime.now(),
+    source: mockSource,
+  );
 
   setUp(() {
     mockFeedRepo = MockFeedRepository();
@@ -104,21 +109,27 @@ void main() {
         final initialItems = [makeContent('a'), makeContent('b')];
 
         // First call (build): return 2 items.
-        when(() => mockFeedRepo.getFeed(
-              page: any(named: 'page'),
-              limit: any(named: 'limit'),
-              mode: any(named: 'mode'),
-              theme: any(named: 'theme'),
-              topic: any(named: 'topic'),
-              sourceId: any(named: 'sourceId'),
-              entity: any(named: 'entity'),
-              keyword: any(named: 'keyword'),
-              serein: any(named: 'serein'),
-            )).thenAnswer(
+        when(
+          () => mockFeedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            mode: any(named: 'mode'),
+            theme: any(named: 'theme'),
+            topic: any(named: 'topic'),
+            sourceId: any(named: 'sourceId'),
+            entity: any(named: 'entity'),
+            keyword: any(named: 'keyword'),
+            serein: any(named: 'serein'),
+          ),
+        ).thenAnswer(
           (_) async => FeedResponse(
             items: initialItems,
-            pagination:
-                Pagination(page: 1, perPage: 20, total: 2, hasNext: false),
+            pagination: Pagination(
+              page: 1,
+              perPage: 20,
+              total: 2,
+              hasNext: false,
+            ),
           ),
         );
 
@@ -127,30 +138,37 @@ void main() {
         expect(container.read(feedProvider).value!.items.length, 2);
 
         // Simulate the 2nd call (refresh) failing with 403 "Email not confirmed".
-        when(() => mockFeedRepo.getFeed(
-              page: any(named: 'page'),
-              limit: any(named: 'limit'),
-              mode: any(named: 'mode'),
-              theme: any(named: 'theme'),
-              topic: any(named: 'topic'),
-              sourceId: any(named: 'sourceId'),
-              entity: any(named: 'entity'),
-              keyword: any(named: 'keyword'),
-              serein: any(named: 'serein'),
-            )).thenThrow(_dioException(
-          statusCode: 403,
-          detail: 'Email not confirmed',
-        ));
+        when(
+          () => mockFeedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            mode: any(named: 'mode'),
+            theme: any(named: 'theme'),
+            topic: any(named: 'topic'),
+            sourceId: any(named: 'sourceId'),
+            entity: any(named: 'entity'),
+            keyword: any(named: 'keyword'),
+            serein: any(named: 'serein'),
+          ),
+        ).thenThrow(
+          _dioException(statusCode: 403, detail: 'Email not confirmed'),
+        );
 
         // Act : refresh fails. Must NOT rethrow and must NOT wipe items.
         await notifier.refresh();
 
         final asyncState = container.read(feedProvider);
-        expect(asyncState.hasError, isFalse,
-            reason: 'state must not be AsyncError when we have previous items');
+        expect(
+          asyncState.hasError,
+          isFalse,
+          reason: 'state must not be AsyncError when we have previous items',
+        );
         expect(asyncState.value, isNotNull);
-        expect(asyncState.value!.items.length, 2,
-            reason: 'previous items must be preserved on refresh failure');
+        expect(
+          asyncState.value!.items.length,
+          2,
+          reason: 'previous items must be preserved on refresh failure',
+        );
         expect(asyncState.value!.items.map((c) => c.id), ['a', 'b']);
       },
     );
@@ -162,24 +180,30 @@ void main() {
         final refreshedItems = [makeContent('x'), makeContent('y')];
         var callCount = 0;
 
-        when(() => mockFeedRepo.getFeed(
-              page: any(named: 'page'),
-              limit: any(named: 'limit'),
-              mode: any(named: 'mode'),
-              theme: any(named: 'theme'),
-              topic: any(named: 'topic'),
-              sourceId: any(named: 'sourceId'),
-              entity: any(named: 'entity'),
-              keyword: any(named: 'keyword'),
-              serein: any(named: 'serein'),
-            )).thenAnswer((_) async {
+        when(
+          () => mockFeedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            mode: any(named: 'mode'),
+            theme: any(named: 'theme'),
+            topic: any(named: 'topic'),
+            sourceId: any(named: 'sourceId'),
+            entity: any(named: 'entity'),
+            keyword: any(named: 'keyword'),
+            serein: any(named: 'serein'),
+          ),
+        ).thenAnswer((_) async {
           callCount++;
           if (callCount == 1) {
             // initial build
             return FeedResponse(
               items: initialItems,
-              pagination:
-                  Pagination(page: 1, perPage: 20, total: 1, hasNext: false),
+              pagination: Pagination(
+                page: 1,
+                perPage: 20,
+                total: 1,
+                hasNext: false,
+              ),
             );
           } else if (callCount == 2) {
             // first refresh → 500
@@ -188,8 +212,12 @@ void main() {
             // second refresh → success
             return FeedResponse(
               items: refreshedItems,
-              pagination:
-                  Pagination(page: 1, perPage: 20, total: 2, hasNext: false),
+              pagination: Pagination(
+                page: 1,
+                perPage: 20,
+                total: 2,
+                hasNext: false,
+              ),
             );
           }
         });
@@ -199,30 +227,37 @@ void main() {
         expect(container.read(feedProvider).value!.items.length, 1);
 
         await notifier.refresh(); // fails, items preserved
-        expect(container.read(feedProvider).value!.items.length, 1,
-            reason: 'items preserved after first failed refresh');
+        expect(
+          container.read(feedProvider).value!.items.length,
+          1,
+          reason: 'items preserved after first failed refresh',
+        );
 
         await notifier.refresh(); // succeeds
         expect(container.read(feedProvider).value!.items.length, 2);
-        expect(container.read(feedProvider).value!.items.map((c) => c.id),
-            ['x', 'y']);
+        expect(container.read(feedProvider).value!.items.map((c) => c.id), [
+          'x',
+          'y',
+        ]);
       },
     );
 
     test(
       'initial load failure (no previous items) → AsyncError is expected',
       () async {
-        when(() => mockFeedRepo.getFeed(
-              page: any(named: 'page'),
-              limit: any(named: 'limit'),
-              mode: any(named: 'mode'),
-              theme: any(named: 'theme'),
-              topic: any(named: 'topic'),
-              sourceId: any(named: 'sourceId'),
-              entity: any(named: 'entity'),
-              keyword: any(named: 'keyword'),
-              serein: any(named: 'serein'),
-            )).thenThrow(_dioException(statusCode: 500));
+        when(
+          () => mockFeedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            mode: any(named: 'mode'),
+            theme: any(named: 'theme'),
+            topic: any(named: 'topic'),
+            sourceId: any(named: 'sourceId'),
+            entity: any(named: 'entity'),
+            keyword: any(named: 'keyword'),
+            serein: any(named: 'serein'),
+          ),
+        ).thenThrow(_dioException(statusCode: 500));
 
         // Trigger build; it should surface as AsyncError since there's no
         // prior state to fall back to.

--- a/apps/mobile/test/features/feed/personalization_logic_test.dart
+++ b/apps/mobile/test/features/feed/personalization_logic_test.dart
@@ -18,13 +18,18 @@ class MockPersonalizationRepository extends Mock
 class MockAuthStateNotifier extends StateNotifier<app_auth.AuthState>
     implements app_auth.AuthStateNotifier {
   MockAuthStateNotifier()
-      : super(const app_auth.AuthState(
-            user: supabase.User(
-                id: 'u1',
-                appMetadata: {},
-                userMetadata: {},
-                aud: 'authenticated',
-                createdAt: '2023-01-01')));
+    : super(
+        const app_auth.AuthState(
+          user: supabase.User(
+            id: 'u1',
+            appMetadata: {},
+            userMetadata: {},
+            aud: 'authenticated',
+            createdAt: '2023-01-01',
+            emailConfirmedAt: '2023-01-01',
+          ),
+        ),
+      );
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -75,14 +80,18 @@ void main() {
     // 1. Setup Feed with one item
     final items = [mockContent];
 
-    when(() => mockFeedRepo.getFeed(
-            page: any(named: 'page'),
-            limit: any(named: 'limit'),
-            mode: any(named: 'mode')))
-        .thenAnswer((_) async => FeedResponse(
-            items: items,
-            pagination:
-                Pagination(page: 1, perPage: 20, total: 1, hasNext: false)));
+    when(
+      () => mockFeedRepo.getFeed(
+        page: any(named: 'page'),
+        limit: any(named: 'limit'),
+        mode: any(named: 'mode'),
+      ),
+    ).thenAnswer(
+      (_) async => FeedResponse(
+        items: items,
+        pagination: Pagination(page: 1, perPage: 20, total: 1, hasNext: false),
+      ),
+    );
 
     when(() => mockPersoRepo.muteSource(any())).thenAnswer((_) async {});
 
@@ -96,37 +105,51 @@ void main() {
     final muteFuture = notifier.muteSource(mockContent);
 
     // 3. Verification: Optimistic update should have removed the item IMMEDIATELY
-    expect(container.read(feedProvider).value!.items.length, 0,
-        reason: 'Item should be removed from state BEFORE API call completes');
+    expect(
+      container.read(feedProvider).value!.items.length,
+      0,
+      reason: 'Item should be removed from state BEFORE API call completes',
+    );
 
     await muteFuture; // Complete the API call
     verify(() => mockPersoRepo.muteSource('s1')).called(1);
   });
 
-  test('muteSourceById should work even if content is not in current state',
-      () async {
-    // 1. Setup Feed with one item
-    final items = [mockContent];
+  test(
+    'muteSourceById should work even if content is not in current state',
+    () async {
+      // 1. Setup Feed with one item
+      final items = [mockContent];
 
-    when(() => mockFeedRepo.getFeed(
-            page: any(named: 'page'),
-            limit: any(named: 'limit'),
-            mode: any(named: 'mode')))
-        .thenAnswer((_) async => FeedResponse(
-            items: items,
-            pagination:
-                Pagination(page: 1, perPage: 20, total: 1, hasNext: false)));
+      when(
+        () => mockFeedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          mode: any(named: 'mode'),
+        ),
+      ).thenAnswer(
+        (_) async => FeedResponse(
+          items: items,
+          pagination: Pagination(
+            page: 1,
+            perPage: 20,
+            total: 1,
+            hasNext: false,
+          ),
+        ),
+      );
 
-    when(() => mockPersoRepo.muteSource(any())).thenAnswer((_) async {});
+      when(() => mockPersoRepo.muteSource(any())).thenAnswer((_) async {});
 
-    final notifier = container.read(feedProvider.notifier);
-    await container.read(feedProvider.future);
+      final notifier = container.read(feedProvider.notifier);
+      await container.read(feedProvider.future);
 
-    // 2. Action: Mute Source by ID (simulate calling from Nudge where content might be just an ID)
-    await notifier.muteSourceById('s1');
+      // 2. Action: Mute Source by ID (simulate calling from Nudge where content might be just an ID)
+      await notifier.muteSourceById('s1');
 
-    // 3. Verification
-    expect(container.read(feedProvider).value!.items.length, 0);
-    verify(() => mockPersoRepo.muteSource('s1')).called(1);
-  });
+      // 3. Verification
+      expect(container.read(feedProvider).value!.items.length, 0);
+      verify(() => mockPersoRepo.muteSource('s1')).called(1);
+    },
+  );
 }

--- a/apps/mobile/test/features/settings/theme_provider_test.dart
+++ b/apps/mobile/test/features/settings/theme_provider_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
@@ -12,40 +11,43 @@ void main() {
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp();
     Hive.init(tempDir.path);
-    await Hive.openBox('settings');
+    await Hive.openBox<dynamic>('settings');
   });
 
   tearDown(() async {
     await Hive.deleteFromDisk();
   });
 
-  test('ThemeNotifier defaults to ThemeMode.light', () {
+  test('ThemeNotifier defaults to AppThemeMode.light', () {
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
     final themeMode = container.read(themeNotifierProvider);
-    expect(themeMode, ThemeMode.light);
+    expect(themeMode, AppThemeMode.light);
   });
 
-  test('ThemeNotifier persists ThemeMode', () async {
+  test('ThemeNotifier persists AppThemeMode', () async {
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
     // Initial state
-    expect(container.read(themeNotifierProvider), ThemeMode.light);
+    expect(container.read(themeNotifierProvider), AppThemeMode.light);
 
     // Change to dark
-    container.read(themeNotifierProvider.notifier).setThemeMode(ThemeMode.dark);
-    expect(container.read(themeNotifierProvider), ThemeMode.dark);
+    container.read(themeNotifierProvider.notifier).commitThemeMode(
+          initial: AppThemeMode.light,
+          chosen: AppThemeMode.dark,
+        );
+    expect(container.read(themeNotifierProvider), AppThemeMode.dark);
 
     // Verify persistence
-    final box = Hive.box('settings');
-    expect(box.get('theme_mode'), 'ThemeMode.dark');
+    final box = Hive.box<dynamic>('settings');
+    expect(box.get('theme_mode'), 'dark');
 
     // Recreate container to simulate app restart
     final container2 = ProviderContainer();
     addTearDown(container2.dispose);
     expect(container2.read(themeNotifierProvider),
-        ThemeMode.dark); // Should read from Hive
+        AppThemeMode.dark); // Should read from Hive
   });
 }

--- a/docs/bugs/bug-flaner-refresh-cache.md
+++ b/docs/bugs/bug-flaner-refresh-cache.md
@@ -1,0 +1,35 @@
+# Bug — Flâner refresh/cache auth rebuild regressions
+
+## Contexte
+- Le retour au premier plan sur l'onglet Flâner déclenchait un refresh trop agressif.
+- Les rebuilds du `feedProvider` liés à l'auth pouvaient réinitialiser des filtres sans changement réel d'utilisateur.
+- Le cache local du feed par défaut ne séparait pas explicitement toutes les variantes utiles du mode normal vs `serein`.
+- `flutter analyze` était en plus bloqué par un test thème obsolète, hors diff fonctionnel.
+
+## Décisions d'implémentation
+- Extraire la règle de refresh foreground de Flâner dans `shouldRefreshFlanerOnForeground()` avec un seuil de `30 minutes`, testée isolément.
+- Restreindre l'observation auth du `feedProvider` aux champs qui changent réellement l'accès au feed, pour éviter les rebuilds sur rotation JWT seule.
+- Préserver la sélection de filtres pour un même utilisateur, et la remettre à zéro uniquement sur logout ou vrai changement d'utilisateur.
+- Séparer le cache feed par variante `normal` / `serein`, en gardant la lecture legacy `feed:{userId}` pour le mode normal.
+- Corriger le test thème pour refléter l'API actuelle `AppThemeMode` / `commitThemeMode`.
+
+## Fichiers principaux
+- `apps/mobile/lib/app.dart`
+- `apps/mobile/lib/features/feed/providers/feed_preload_provider.dart`
+- `apps/mobile/lib/features/feed/providers/feed_provider.dart`
+- `apps/mobile/lib/features/feed/services/feed_cache_service.dart`
+- `apps/mobile/test/app_lifecycle_test.dart`
+- `apps/mobile/test/features/feed/feed_provider_auth_filter_test.dart`
+- `apps/mobile/test/features/settings/theme_provider_test.dart`
+
+## Vérification
+- Ciblé:
+  - `flutter test test/app_lifecycle_test.dart test/features/feed/feed_provider_auth_filter_test.dart test/features/feed/feed_cache_service_test.dart test/features/feed/feed_refresh_recovery_test.dart test/features/feed/personalization_logic_test.dart`
+- Global mobile à exécuter avant PR:
+  - `flutter test`
+  - `flutter analyze`
+
+## Risques revus
+- Race potentielle autour des `scheduleMicrotask` de sync Riverpod: acceptable tant que la mutation différée reste limitée au reset/owner sync.
+- Risque de stale UX sur Flâner: volontairement réduit via refresh au retour premier plan seulement si `elapsed == null` ou `>= 30 min`.
+- Risque de collision cache entre modes feed: couvert par les clés variantes + tests de séparation.


### PR DESCRIPTION
# Fix Flâner refresh cache

Corrige un ensemble de régressions mobiles autour de Flâner: refresh trop fréquent au retour premier plan, perte de filtres lors de rebuilds auth sans changement d'utilisateur, et collision potentielle entre caches `normal` / `serein`.

## Quoi
- extrait et teste la règle `shouldRefreshFlanerOnForeground()` avec un seuil de 30 minutes,
- stabilise `feedProvider` pour ignorer les rebuilds liés à la seule rotation JWT et conserver les filtres pour le même utilisateur,
- remet les filtres à zéro uniquement sur logout ou vrai changement d'utilisateur,
- sépare le cache feed par variante `normal` / `serein` avec fallback legacy pour `normal`,
- corrige `theme_provider_test.dart` pour l'API actuelle `AppThemeMode`.

## Pourquoi
- éviter des refresh Flâner inutiles en revenant rapidement dans l'app,
- empêcher la perte de contexte filtre lors de rebuilds auth sans impact fonctionnel,
- garantir qu'un cache `serein` ne pollue pas la vue normale, et inversement,
- débloquer `flutter analyze` pour permettre une PR conforme.

## Comment ça a été vérifié
- [x] Tests ciblés feed/lifecycle:
  - `flutter test test/app_lifecycle_test.dart test/features/feed/feed_provider_auth_filter_test.dart test/features/feed/feed_cache_service_test.dart test/features/feed/feed_refresh_recovery_test.dart test/features/feed/personalization_logic_test.dart`
- [ ] `flutter test`
  - Bloqué par des échecs hors diff dans `test/features/custom_topics/widgets/topic_chip_test.dart` et `test/features/custom_topics/widgets/topic_explorer_screen_test.dart`
- [ ] `flutter analyze`
  - Le `undefined_method` de `theme_provider_test.dart` est corrigé, mais `flutter analyze` reste rouge à cause de centaines d'`info`/`warning` historiques hors périmètre
- [x] Review finale du diff

## Zones à risque
- synchronisation différée via `scheduleMicrotask` entre owner/reset et provider de sélection,
- UX potentiellement plus stale sur retour premier plan < 30 min, choix volontaire pour réduire les refresh inutiles,
- persistance des filtres lors des rebuilds auth intermédiaires.
