### PR TITLE
feat(sources): connexion d'abonnement premium en WebView (login + article test)

### DIFF
--- a/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
+++ b/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
@@ -13,6 +13,7 @@ import '../../../core/ui/notification_service.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/repositories/personalization_repository.dart';
 import '../../my_interests/widgets/interest_state_pill.dart';
+import '../../sources/widgets/premium_source_connection.dart';
 import '../models/topic_models.dart';
 import '../providers/custom_topics_provider.dart';
 import '../providers/personalization_provider.dart';
@@ -89,8 +90,7 @@ class TopicChip extends StatelessWidget {
     bool highlightInitialSection = false,
   }) {
     final topicSlug = content.topics.isNotEmpty ? content.topics.first : '';
-    final topicLabel =
-        topicSlug.isNotEmpty ? getTopicLabel(topicSlug) : '';
+    final topicLabel = topicSlug.isNotEmpty ? getTopicLabel(topicSlug) : '';
     return showModalBottomSheet<void>(
       context: context,
       backgroundColor: Colors.transparent,
@@ -206,43 +206,43 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
 
               // ── Groupe 3: RECOMMANDATION ──
               if (reason != null && reason.breakdown.isNotEmpty) ...[
-              const SizedBox(height: FacteurSpacing.space3),
-              Divider(color: colors.textTertiary.withOpacity(0.2)),
-              const SizedBox(height: FacteurSpacing.space3),
-              Row(
-                children: [
-                  Text(
-                    'RECOMMANDATION',
-                    style: textTheme.labelSmall?.copyWith(
-                      color: colors.textTertiary,
-                      letterSpacing: 1.2,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  if (reason != null && reason.scoreTotal > 0) ...[
-                    const Spacer(),
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 10, vertical: 4),
-                      decoration: BoxDecoration(
-                        color: colors.primary.withOpacity(0.1),
-                        borderRadius: BorderRadius.circular(12),
+                const SizedBox(height: FacteurSpacing.space3),
+                Divider(color: colors.textTertiary.withOpacity(0.2)),
+                const SizedBox(height: FacteurSpacing.space3),
+                Row(
+                  children: [
+                    Text(
+                      'RECOMMANDATION',
+                      style: textTheme.labelSmall?.copyWith(
+                        color: colors.textTertiary,
+                        letterSpacing: 1.2,
+                        fontWeight: FontWeight.w600,
                       ),
-                      child: Text(
-                        '${reason.scoreTotal.toInt()} pts',
-                        style: TextStyle(
-                          color: colors.primary,
-                          fontSize: 14,
-                          fontWeight: FontWeight.bold,
+                    ),
+                    if (reason != null && reason.scoreTotal > 0) ...[
+                      const Spacer(),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 10, vertical: 4),
+                        decoration: BoxDecoration(
+                          color: colors.primary.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          '${reason.scoreTotal.toInt()} pts',
+                          style: TextStyle(
+                            color: colors.primary,
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ),
-                    ),
+                    ],
                   ],
-                ],
-              ),
-              const SizedBox(height: 12),
-              ..._buildBreakdownList(reason!, colors),
-              const SizedBox(height: FacteurSpacing.space2),
+                ),
+                const SizedBox(height: 12),
+                ..._buildBreakdownList(reason!, colors),
+                const SizedBox(height: FacteurSpacing.space2),
               ],
 
               const SizedBox(height: FacteurSpacing.space4),
@@ -320,8 +320,7 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
       ],
     ];
 
-    final sourceFirst =
-        widget.initialSection == ArticleSheetSection.source;
+    final sourceFirst = widget.initialSection == ArticleSheetSection.source;
 
     if (sourceFirst) {
       return [
@@ -468,10 +467,9 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
                 child: FilledButton.icon(
                   onPressed: () async {
                     try {
-                      await ref
-                          .read(customTopicsProvider.notifier)
-                          .followTopic(widget.topicLabel,
-                              slugParent: widget.topicSlug);
+                      await ref.read(customTopicsProvider.notifier).followTopic(
+                          widget.topicLabel,
+                          slugParent: widget.topicSlug);
                     } on DioException catch (e) {
                       if (context.mounted) {
                         final detail = e.response?.data;
@@ -488,7 +486,8 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
                       }
                     }
                   },
-                  icon: Icon(PhosphorIcons.plus(), size: 16, color: Colors.white),
+                  icon:
+                      Icon(PhosphorIcons.plus(), size: 16, color: Colors.white),
                   label: const Text(
                     'Suivre ce sujet',
                     style: TextStyle(
@@ -502,8 +501,7 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
                     foregroundColor: Colors.white,
                     padding: const EdgeInsets.symmetric(vertical: 14),
                     shape: RoundedRectangleBorder(
-                      borderRadius:
-                          BorderRadius.circular(FacteurRadius.medium),
+                      borderRadius: BorderRadius.circular(FacteurRadius.medium),
                     ),
                   ),
                 ),
@@ -599,9 +597,8 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
     return Builder(builder: (context) {
       final sourcesAsync = ref.watch(userSourcesProvider);
       final sourceMatch = sourcesAsync.whenOrNull(
-        data: (sources) => sources
-            .where((s) => s.id == widget.content.source.id)
-            .firstOrNull,
+        data: (sources) =>
+            sources.where((s) => s.id == widget.content.source.id).firstOrNull,
       );
       final isTrustedAndActive =
           sourceMatch?.isTrusted == true && sourceMatch?.isMuted != true;
@@ -719,7 +716,8 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
             Navigator.of(context).pop();
             context.pushNamed(RouteNames.sources);
           },
-          icon: Icon(PhosphorIcons.gear(), size: 14, color: colors.textSecondary),
+          icon:
+              Icon(PhosphorIcons.gear(), size: 14, color: colors.textSecondary),
           label: Text(
             'Gérer mes sources',
             style: textTheme.labelMedium?.copyWith(color: colors.textSecondary),
@@ -744,7 +742,8 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
                         .toggleTrust(widget.content.source.id, false);
                     ref.invalidate(userSourcesProvider);
                   },
-                  icon: Icon(PhosphorIcons.plus(), size: 16, color: Colors.white),
+                  icon:
+                      Icon(PhosphorIcons.plus(), size: 16, color: Colors.white),
                   label: const Text(
                     'Suivre cette source',
                     style: TextStyle(
@@ -814,38 +813,59 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
                     fillWidth: true,
                   ),
                 ),
-                Divider(color: _terracotta.withOpacity(0.15), height: 1),
-                const SizedBox(height: 8),
-                Row(
-                  children: [
-                    Icon(
-                      PhosphorIcons.link(PhosphorIconsStyle.regular),
-                      size: 18,
-                      color:
-                          isSubscribed ? colorScheme.primary : colors.textSecondary,
-                    ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Text(
-                        'Associer mon abonnement',
-                        style: textTheme.bodyMedium?.copyWith(
-                          color: colors.textPrimary,
-                          fontWeight: FontWeight.w500,
+                if (widget.content.source.premiumConnection != null ||
+                    isSubscribed) ...[
+                  Divider(color: _terracotta.withOpacity(0.15), height: 1),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Icon(
+                        isSubscribed
+                            ? PhosphorIcons.link(PhosphorIconsStyle.fill)
+                            : PhosphorIcons.link(PhosphorIconsStyle.regular),
+                        size: 18,
+                        color: isSubscribed
+                            ? colorScheme.primary
+                            : colors.textSecondary,
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: Text(
+                          isSubscribed
+                              ? 'Abonnement connecté'
+                              : 'Connecter mon abonnement',
+                          style: textTheme.bodyMedium?.copyWith(
+                            color: colors.textPrimary,
+                            fontWeight: FontWeight.w500,
+                          ),
                         ),
                       ),
-                    ),
-                    Switch.adaptive(
-                      value: isSubscribed,
-                      onChanged: (value) {
-                        ref
-                            .read(userSourcesProvider.notifier)
-                            .toggleSubscription(
-                                widget.content.source.id, isSubscribed);
-                      },
-                      activeTrackColor: colorScheme.primary,
-                    ),
-                  ],
-                ),
+                      TextButton(
+                        onPressed: () async {
+                          if (isSubscribed) {
+                            await ref
+                                .read(userSourcesProvider.notifier)
+                                .disconnectSubscription(
+                                    widget.content.source.id);
+                            return;
+                          }
+                          await Navigator.of(context).push<void>(
+                            MaterialPageRoute(
+                              builder: (_) => PremiumSourceConnection(
+                                source: widget.content.source,
+                                onConnected: () => ref
+                                    .read(userSourcesProvider.notifier)
+                                    .connectSubscription(
+                                        widget.content.source.id),
+                              ),
+                            ),
+                          );
+                        },
+                        child: Text(isSubscribed ? 'Dissocier' : 'Connecter'),
+                      ),
+                    ],
+                  ),
+                ],
               ],
             ),
           ),
@@ -870,8 +890,7 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
       mainAxisSize: MainAxisSize.min,
       children: widget.content.entities.map((entity) {
         final isEntityFollowed = topics.any(
-          (t) =>
-              t.canonicalName?.toLowerCase() == entity.text.toLowerCase(),
+          (t) => t.canonicalName?.toLowerCase() == entity.text.toLowerCase(),
         );
         final isMuted = mutedTopics.contains(entity.text.toLowerCase());
 
@@ -968,8 +987,8 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
                   },
                   behavior: HitTestBehavior.opaque,
                   child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 6, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
                     child: Icon(
                       PhosphorIcons.eyeSlash(PhosphorIconsStyle.regular),
                       size: 16,
@@ -1249,8 +1268,8 @@ class _PulseHighlightState extends State<_PulseHighlight>
         weight: 50,
       ),
       TweenSequenceItem(
-        tween: Tween(begin: 1.0, end: 0.0)
-            .chain(CurveTween(curve: Curves.easeIn)),
+        tween:
+            Tween(begin: 1.0, end: 0.0).chain(CurveTween(curve: Curves.easeIn)),
         weight: 50,
       ),
     ]).animate(_ctrl);

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -100,7 +100,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   bool _perspectivesCtaTriggered = false;
   bool _linkCopiedHeader = false;
   Timer? _linkCopiedHeaderTimer;
-  bool _premiumRedirectScheduled = false;
   bool _webFallbackRedirectScheduled = false;
   late DateTime _startTime;
   WebViewController? _webViewController;
@@ -251,8 +250,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       vsync: this,
     );
     _footerAutoController.addListener(() {
-      _footerOffset.value =
-          _footerAutoStart +
+      _footerOffset.value = _footerAutoStart +
           (_footerAutoTarget - _footerAutoStart) * _footerAutoController.value;
     });
 
@@ -614,8 +612,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (endBox == null || svBox == null) return;
     if (!_scrollController.hasClients) return;
     // content-coord of marker = screen Y of marker − screen Y of sv top + scroll offset
-    final extent =
-        endBox.localToGlobal(Offset.zero).dy -
+    final extent = endBox.localToGlobal(Offset.zero).dy -
         svBox.localToGlobal(Offset.zero).dy +
         _scrollController.offset;
     if (extent > 0) _articleContentExtent = extent;
@@ -675,9 +672,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     setState(() {
       final current = _perspectivesSelectedSegments;
       if (current.contains(key)) {
-        _perspectivesSelectedSegments = current.length == 1
-            ? {}
-            : (Set.from(current)..remove(key));
+        _perspectivesSelectedSegments =
+            current.length == 1 ? {} : (Set.from(current)..remove(key));
       } else {
         _perspectivesSelectedSegments = current.isEmpty || current.length == 3
             ? {key}
@@ -1147,16 +1143,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       vsync: this,
       duration: const Duration(milliseconds: 600),
     );
-    _perspectivesPulseScale ??=
-        TweenSequence<double>([
-          TweenSequenceItem(tween: Tween(begin: 1.0, end: 1.08), weight: 50),
-          TweenSequenceItem(tween: Tween(begin: 1.08, end: 1.0), weight: 50),
-        ]).animate(
-          CurvedAnimation(
-            parent: _perspectivesPulseController!,
-            curve: Curves.easeOutCubic,
-          ),
-        );
+    _perspectivesPulseScale ??= TweenSequence<double>([
+      TweenSequenceItem(tween: Tween(begin: 1.0, end: 1.08), weight: 50),
+      TweenSequenceItem(tween: Tween(begin: 1.08, end: 1.0), weight: 50),
+    ]).animate(
+      CurvedAnimation(
+        parent: _perspectivesPulseController!,
+        curve: Curves.easeOutCubic,
+      ),
+    );
     _perspectivesPulseController!.forward(from: 0).whenComplete(() async {
       if (!mounted) return;
       final coordinator = ref.read(nudgeCoordinatorProvider);
@@ -1401,56 +1396,26 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       );
     }
 
-    // Premium source → redirect to external browser for authenticated access
-    final userSources = ref.read(userSourcesProvider).valueOrNull ?? [];
-    final isPremiumSource = userSources.any(
-      (s) => s.id == content.source.id && s.hasSubscription,
-    );
-    if (isPremiumSource &&
-        content.url.isNotEmpty &&
-        !_premiumRedirectScheduled) {
-      _premiumRedirectScheduled = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) async {
-        final uri = Uri.tryParse(content.url);
-        if (uri != null) {
-          await launchUrl(uri, mode: LaunchMode.externalApplication);
-        }
-        if (mounted) context.pop();
-      });
-      return Scaffold(
-        backgroundColor: colors.backgroundPrimary,
-        body: Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              CircularProgressIndicator(color: colors.primary),
-              const SizedBox(height: FacteurSpacing.space4),
-              Text(
-                'Ouverture dans votre navigateur...',
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
     // Determine display mode:
     // - Articles with in-app content: progressive scroll-to-site
     // - Non-articles or explicit WebView toggle: old behavior
     // Skip scroll-to-site for articles with too little content
+    final userSources = ref.watch(userSourcesProvider).valueOrNull ?? [];
+    final isConnectedPremiumSource = userSources.any(
+      (s) => s.id == content.source.id && s.hasSubscription,
+    );
     final articleText = content.htmlContent ?? content.description;
     final hasEnoughContent = plainTextLength(articleText) >= 100;
-    final useScrollToSite =
+    final useScrollToSite = !isConnectedPremiumSource &&
         content.hasInAppContent &&
         content.contentType == ContentType.article &&
         hasEnoughContent &&
         !_showWebView &&
         !kIsWeb;
-    final useInAppReading =
-        content.hasInAppContent && !_showWebView && !useScrollToSite;
+    final useInAppReading = !isConnectedPremiumSource &&
+        content.hasInAppContent &&
+        !_showWebView &&
+        !useScrollToSite;
     final isVideoContent = content.isVideo;
 
     // Web: no WebView available — auto-redirect to original URL
@@ -1546,10 +1511,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 child: isVideoContent
                     ? _buildVideoContent(context, content)
                     : useScrollToSite
-                    ? _buildScrollToSiteContent(context, content)
-                    : useInAppReading
-                    ? _buildInAppContent(context, content)
-                    : _buildWebViewFallback(content),
+                        ? _buildScrollToSiteContent(context, content)
+                        : useInAppReading
+                            ? _buildInAppContent(context, content)
+                            : _buildWebViewFallback(content),
               ),
             ),
             // Header — pinned at the top of the screen; no scroll-driven
@@ -1623,8 +1588,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (content == null) return;
     final articleText = content.htmlContent ?? content.description;
     final hasEnoughContent = plainTextLength(articleText) >= 100;
-    final isScrollToSite =
-        content.hasInAppContent &&
+    final isScrollToSite = content.hasInAppContent &&
         content.contentType == ContentType.article &&
         hasEnoughContent &&
         !_showWebView;
@@ -2039,8 +2003,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     // Fallback to the article payload before the provider has loaded — avoids
     // a flash of the "Suivre +" chip on cold open when the source is already
     // followed server-side.
-    final InterestState effectiveState =
-        liveState ??
+    final InterestState effectiveState = liveState ??
         (content.isFollowedSource
             ? InterestState.followed
             : InterestState.unfollowed);
@@ -2125,9 +2088,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                               child: Container(
                                                 padding:
                                                     const EdgeInsets.symmetric(
-                                                      horizontal: 6,
-                                                      vertical: 2,
-                                                    ),
+                                                  horizontal: 6,
+                                                  vertical: 2,
+                                                ),
                                                 decoration: BoxDecoration(
                                                   color: Color.lerp(
                                                     colors.backgroundSecondary,
@@ -2141,11 +2104,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                                   content.source.name,
                                                   style: textTheme.labelMedium
                                                       ?.copyWith(
-                                                        fontWeight:
-                                                            FontWeight.bold,
-                                                        color:
-                                                            colors.textPrimary,
-                                                      ),
+                                                    fontWeight: FontWeight.bold,
+                                                    color: colors.textPrimary,
+                                                  ),
                                                   maxLines: 1,
                                                   overflow:
                                                       TextOverflow.ellipsis,
@@ -2186,12 +2147,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                             child: InkWell(
                                               onTap: () =>
                                                   TopicChip.showArticleSheet(
-                                                    context,
-                                                    content,
-                                                    initialSection:
-                                                        ArticleSheetSection
-                                                            .source,
-                                                  ),
+                                                context,
+                                                content,
+                                                initialSection:
+                                                    ArticleSheetSection.source,
+                                              ),
                                               child: Padding(
                                                 padding: const EdgeInsets.all(
                                                   3,
@@ -2227,11 +2187,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                                   locale: 'fr_short',
                                                 )
                                                 .replaceAll('il y a ', ''),
-                                            style: textTheme.bodySmall
-                                                ?.copyWith(
-                                                  color: colors.textTertiary,
-                                                  fontSize: 11,
-                                                ),
+                                            style:
+                                                textTheme.bodySmall?.copyWith(
+                                              color: colors.textTertiary,
+                                              fontSize: 11,
+                                            ),
                                           ),
                                         ],
                                       ),
@@ -2468,7 +2428,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           Colors.grey.shade400,
           colors.primary,
           clamped,
-        )!.withValues(alpha: alpha);
+        )!
+            .withValues(alpha: alpha);
         return TweenAnimationBuilder<double>(
           tween: Tween<double>(end: clamped),
           duration: const Duration(milliseconds: 300),
@@ -2850,9 +2811,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
     // Description text: prefer htmlContent (stripped), fallback to description
     final rawDescription = content.htmlContent ?? content.description;
-    final descriptionText = rawDescription != null
-        ? stripHtml(rawDescription).trim()
-        : null;
+    final descriptionText =
+        rawDescription != null ? stripHtml(rawDescription).trim() : null;
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -3017,8 +2977,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
                       // Bottom spacing — clears the persistent footer.
                       SizedBox(
-                        height:
-                            _kFooterContentHeight +
+                        height: _kFooterContentHeight +
                             MediaQuery.of(context).viewPadding.bottom,
                       ),
                     ],
@@ -3172,8 +3131,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
                     // Bottom spacing — clears the persistent footer.
                     SizedBox(
-                      height:
-                          _kFooterContentHeight +
+                      height: _kFooterContentHeight +
                           MediaQuery.of(context).viewPadding.bottom,
                     ),
                   ],
@@ -3218,9 +3176,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           title: content.title,
           shrinkWrap: true,
           onLinkTap: _animateAndLaunch,
-          bodyPlaceholder: !_contentResolved
-              ? _buildArticleBodySkeleton(colors)
-              : null,
+          bodyPlaceholder:
+              !_contentResolved ? _buildArticleBodySkeleton(colors) : null,
         );
 
         return ScrollConfiguration(
@@ -3384,8 +3341,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 // ── Footer clearance ───────────────────────────────────────
                 const SizedBox(height: FacteurSpacing.space4),
                 SizedBox(
-                  height:
-                      _kFooterContentHeight +
+                  height: _kFooterContentHeight +
                       MediaQuery.of(context).viewPadding.bottom,
                 ),
               ],
@@ -3617,10 +3573,10 @@ class _FollowChip extends StatelessWidget {
               Text(
                 'Suivre',
                 style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  color: colors.textSecondary,
-                  fontWeight: FontWeight.w700,
-                  letterSpacing: 0.2,
-                ),
+                      color: colors.textSecondary,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0.2,
+                    ),
               ),
             ],
           ),

--- a/apps/mobile/lib/features/onboarding/screens/questions/sources_page2_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/sources_page2_question.dart
@@ -40,8 +40,7 @@ class _SourcesPage2QuestionState extends ConsumerState<SourcesPage2Question> {
     // Restore selections from Page 1
     final existingSources =
         ref.read(onboardingProvider).answers.preferredSources;
-    _selectedSourceIds =
-        existingSources != null ? existingSources.toSet() : {};
+    _selectedSourceIds = existingSources != null ? existingSources.toSet() : {};
 
     _searchController.addListener(() {
       setState(() {
@@ -108,17 +107,6 @@ class _SourcesPage2QuestionState extends ConsumerState<SourcesPage2Question> {
       backgroundColor: Colors.transparent,
       builder: (context) => PremiumSourcesSheet(
         allSources: allSources,
-        onDone: (subscribedIds) {
-          // Mark subscriptions via the sources provider
-          final sourcesNotifier = ref.read(userSourcesProvider.notifier);
-          for (final source in allSources.where((s) => s.isCurated)) {
-            final wasSubscribed = source.hasSubscription;
-            final isNowSubscribed = subscribedIds.contains(source.id);
-            if (wasSubscribed != isNowSubscribed) {
-              sourcesNotifier.toggleSubscription(source.id, wasSubscribed);
-            }
-          }
-        },
       ),
     );
   }
@@ -177,8 +165,7 @@ class _SourcesPage2QuestionState extends ConsumerState<SourcesPage2Question> {
             child: Text(
               _selectedSourceIds.isEmpty
                   ? OnboardingStrings.skipButton
-                  : OnboardingStrings.selectedCount(
-                      _selectedSourceIds.length),
+                  : OnboardingStrings.selectedCount(_selectedSourceIds.length),
             ),
           ),
         ),
@@ -280,8 +267,7 @@ class _SourcesPage2QuestionState extends ConsumerState<SourcesPage2Question> {
                 controller: _searchController,
                 decoration: InputDecoration(
                   hintText: OnboardingStrings.q9SearchHint,
-                  prefixIcon:
-                      Icon(Icons.search, color: colors.textSecondary),
+                  prefixIcon: Icon(Icons.search, color: colors.textSecondary),
                   filled: true,
                   fillColor: colors.surface,
                   contentPadding: const EdgeInsets.symmetric(
@@ -289,8 +275,7 @@ class _SourcesPage2QuestionState extends ConsumerState<SourcesPage2Question> {
                     vertical: FacteurSpacing.space3,
                   ),
                   border: OutlineInputBorder(
-                    borderRadius:
-                        BorderRadius.circular(FacteurRadius.full),
+                    borderRadius: BorderRadius.circular(FacteurRadius.full),
                     borderSide: BorderSide.none,
                   ),
                   hintStyle: TextStyle(color: colors.textSecondary),
@@ -306,8 +291,8 @@ class _SourcesPage2QuestionState extends ConsumerState<SourcesPage2Question> {
             if (_searchQuery.isNotEmpty &&
                 _filteredCatalog(reco.catalog).isEmpty)
               Padding(
-                padding: const EdgeInsets.symmetric(
-                    vertical: FacteurSpacing.space4),
+                padding:
+                    const EdgeInsets.symmetric(vertical: FacteurSpacing.space4),
                 child: Text(
                   OnboardingStrings.q9NoMatch,
                   style: TextStyle(color: colors.textSecondary),
@@ -352,8 +337,7 @@ class _SourcesPage2QuestionState extends ConsumerState<SourcesPage2Question> {
       final sources = grouped[themeSlug]!;
       final macroTheme = getTopicMacroTheme(themeSlug);
       final label = macroTheme ?? getTopicLabel(themeSlug);
-      final emoji =
-          macroTheme != null ? getMacroThemeEmoji(macroTheme) : '';
+      final emoji = macroTheme != null ? getMacroThemeEmoji(macroTheme) : '';
 
       // Mini-header for the theme group
       widgets.add(Padding(

--- a/apps/mobile/lib/features/onboarding/widgets/premium_sources_sheet.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/premium_sources_sheet.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../config/theme.dart';
 import '../../sources/models/source_model.dart';
+import '../../sources/providers/sources_providers.dart';
+import '../../sources/widgets/premium_source_connection.dart';
 import '../../../widgets/design/facteur_image.dart';
 import '../onboarding_strings.dart';
 
@@ -10,9 +13,9 @@ import '../onboarding_strings.dart';
 ///
 /// Shows all curated sources so the user can mark which ones they have
 /// a paid subscription to. Returns the set of subscribed source IDs via [onDone].
-class PremiumSourcesSheet extends StatefulWidget {
+class PremiumSourcesSheet extends ConsumerStatefulWidget {
   final List<Source> allSources;
-  final ValueChanged<Set<String>> onDone;
+  final ValueChanged<Set<String>>? onDone;
 
   const PremiumSourcesSheet({
     super.key,
@@ -21,10 +24,11 @@ class PremiumSourcesSheet extends StatefulWidget {
   });
 
   @override
-  State<PremiumSourcesSheet> createState() => _PremiumSourcesSheetState();
+  ConsumerState<PremiumSourcesSheet> createState() =>
+      _PremiumSourcesSheetState();
 }
 
-class _PremiumSourcesSheetState extends State<PremiumSourcesSheet> {
+class _PremiumSourcesSheetState extends ConsumerState<PremiumSourcesSheet> {
   late Set<String> _subscribed;
   final TextEditingController _searchController = TextEditingController();
   String _searchQuery = '';
@@ -50,7 +54,9 @@ class _PremiumSourcesSheetState extends State<PremiumSourcesSheet> {
 
   List<Source> get _filteredSources {
     var sources = widget.allSources
-        .where((s) => s.isCurated)
+        .where((s) =>
+            s.isCurated &&
+            (s.premiumConnection != null || _subscribed.contains(s.id)))
         .toList()
       ..sort((a, b) => a.name.compareTo(b.name));
 
@@ -146,22 +152,37 @@ class _PremiumSourcesSheetState extends State<PremiumSourcesSheet> {
           ),
           const SizedBox(height: FacteurSpacing.space3),
 
-          // Sources list
           Flexible(
-            child: ListView.separated(
-              shrinkWrap: true,
-              padding: const EdgeInsets.symmetric(
-                horizontal: FacteurSpacing.space6,
-              ),
-              itemCount: sources.length,
-              separatorBuilder: (_, __) =>
-                  const SizedBox(height: FacteurSpacing.space2),
-              itemBuilder: (context, index) {
-                final source = sources[index];
-                final isSubscribed = _subscribed.contains(source.id);
-                return _buildSourceTile(context, source, isSubscribed);
-              },
-            ),
+            child: sources.isEmpty
+                ? Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: FacteurSpacing.space6,
+                      vertical: FacteurSpacing.space4,
+                    ),
+                    child: Center(
+                      child: Text(
+                        'Aucun média premium connectable pour le moment.',
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: colors.textSecondary,
+                            ),
+                      ),
+                    ),
+                  )
+                : ListView.separated(
+                    shrinkWrap: true,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: FacteurSpacing.space6,
+                    ),
+                    itemCount: sources.length,
+                    separatorBuilder: (_, __) =>
+                        const SizedBox(height: FacteurSpacing.space2),
+                    itemBuilder: (context, index) {
+                      final source = sources[index];
+                      final isSubscribed = _subscribed.contains(source.id);
+                      return _buildSourceTile(context, source, isSubscribed);
+                    },
+                  ),
           ),
 
           // Done button
@@ -171,7 +192,7 @@ class _PremiumSourcesSheetState extends State<PremiumSourcesSheet> {
               width: double.infinity,
               child: ElevatedButton(
                 onPressed: () {
-                  widget.onDone(_subscribed);
+                  widget.onDone?.call(_subscribed);
                   Navigator.of(context).pop();
                 },
                 style: ElevatedButton.styleFrom(
@@ -196,7 +217,7 @@ class _PremiumSourcesSheetState extends State<PremiumSourcesSheet> {
 
     return Container(
       decoration: BoxDecoration(
-        color: colors.textPrimary.withOpacity(0.06),
+        color: colors.textPrimary.withValues(alpha: 0.06),
         borderRadius: BorderRadius.circular(8),
       ),
       alignment: Alignment.center,
@@ -230,7 +251,8 @@ class _PremiumSourcesSheetState extends State<PremiumSourcesSheet> {
                   ? FacteurImage(
                       imageUrl: source.logoUrl!,
                       fit: BoxFit.cover,
-                      errorWidget: (_) => _buildLogoFallback(colors, source.name),
+                      errorWidget: (_) =>
+                          _buildLogoFallback(colors, source.name),
                     )
                   : _buildLogoFallback(colors, source.name),
             ),
@@ -246,23 +268,46 @@ class _PremiumSourcesSheetState extends State<PremiumSourcesSheet> {
                   ),
             ),
           ),
-          // Switch
-          Switch.adaptive(
-            value: isSubscribed,
-            onChanged: (val) {
-              HapticFeedback.lightImpact();
-              setState(() {
-                if (val) {
-                  _subscribed.add(source.id);
-                } else {
-                  _subscribed.remove(source.id);
-                }
-              });
-            },
-            activeTrackColor: colors.primary,
+          TextButton(
+            onPressed: () => isSubscribed
+                ? _disconnectSource(source)
+                : _connectSource(context, source),
+            child: Text(isSubscribed ? 'Dissocier' : 'Connecter'),
           ),
         ],
       ),
     );
+  }
+
+  Future<void> _connectSource(BuildContext context, Source source) async {
+    if (source.premiumConnection == null) return;
+    final navigator = Navigator.of(context);
+    await HapticFeedback.lightImpact();
+    if (!mounted) return;
+    await navigator.push<void>(
+      MaterialPageRoute(
+        builder: (_) => PremiumSourceConnection(
+          source: source,
+          onConnected: () async {
+            await ref
+                .read(userSourcesProvider.notifier)
+                .connectSubscription(source.id);
+            if (mounted) {
+              setState(() => _subscribed.add(source.id));
+            }
+          },
+        ),
+      ),
+    );
+  }
+
+  Future<void> _disconnectSource(Source source) async {
+    await HapticFeedback.lightImpact();
+    await ref
+        .read(userSourcesProvider.notifier)
+        .disconnectSubscription(source.id);
+    if (mounted) {
+      setState(() => _subscribed.remove(source.id));
+    }
   }
 }

--- a/apps/mobile/lib/features/sources/models/source_model.dart
+++ b/apps/mobile/lib/features/sources/models/source_model.dart
@@ -8,6 +8,31 @@ enum SourceType {
   reddit,
 }
 
+class PremiumConnection {
+  final bool enabled;
+  final String loginUrl;
+  final String testUrl;
+  final String? displayHint;
+
+  const PremiumConnection({
+    this.enabled = true,
+    required this.loginUrl,
+    required this.testUrl,
+    this.displayHint,
+  });
+
+  factory PremiumConnection.fromJson(Map<String, dynamic> json) {
+    return PremiumConnection(
+      enabled: (json['enabled'] as bool?) ?? true,
+      loginUrl: (json['login_url'] as String?)?.trim() ?? '',
+      testUrl: (json['test_url'] as String?)?.trim() ?? '',
+      displayHint: (json['display_hint'] as String?)?.trim(),
+    );
+  }
+
+  bool get isUsable => enabled && loginUrl.isNotEmpty && testUrl.isNotEmpty;
+}
+
 class Source {
   final String id;
   final String name;
@@ -32,8 +57,10 @@ class Source {
   final int followerCount;
   final double priorityMultiplier;
   final bool hasSubscription;
+  final PremiumConnection? premiumConnection;
   final String? recommendedBy;
   final String? recommendationReason;
+
   /// Langue ISO de la source ("fr","en",...). `null` ⇒ traité comme `fr`
   /// (convention back-end Phase 4). Forward-compat : non encore consommé
   /// par l'UI, prêt pour Story 7.7 (label EN sur cartes).
@@ -63,6 +90,7 @@ class Source {
     this.followerCount = 0,
     this.priorityMultiplier = 1.0,
     this.hasSubscription = false,
+    this.premiumConnection,
     this.recommendedBy,
     this.recommendationReason,
     this.language,
@@ -92,6 +120,7 @@ class Source {
     int? followerCount,
     double? priorityMultiplier,
     bool? hasSubscription,
+    PremiumConnection? premiumConnection,
     String? recommendedBy,
     String? recommendationReason,
     String? language,
@@ -120,6 +149,7 @@ class Source {
       followerCount: followerCount ?? this.followerCount,
       priorityMultiplier: priorityMultiplier ?? this.priorityMultiplier,
       hasSubscription: hasSubscription ?? this.hasSubscription,
+      premiumConnection: premiumConnection ?? this.premiumConnection,
       recommendedBy: recommendedBy ?? this.recommendedBy,
       recommendationReason: recommendationReason ?? this.recommendationReason,
       language: language ?? this.language,
@@ -163,6 +193,7 @@ class Source {
         priorityMultiplier:
             (json['priority_multiplier'] as num?)?.toDouble() ?? 1.0,
         hasSubscription: (json['has_subscription'] as bool?) ?? false,
+        premiumConnection: _parsePremiumConnection(json['premium_connection']),
         recommendedBy: json['recommended_by'] as String?,
         recommendationReason: json['recommendation_reason'] as String?,
         language: json['language'] as String?,
@@ -170,6 +201,17 @@ class Source {
     } catch (e) {
       debugPrint('Source.fromJson: [ERROR] Failed to parse: $e');
       return Source.fallback();
+    }
+  }
+
+  static PremiumConnection? _parsePremiumConnection(dynamic value) {
+    if (value is! Map<String, dynamic>) return null;
+    try {
+      final connection = PremiumConnection.fromJson(value);
+      return connection.isUsable ? connection : null;
+    } catch (e) {
+      debugPrint('Source.fromJson: [WARNING] premium_connection ignored: $e');
+      return null;
     }
   }
 

--- a/apps/mobile/lib/features/sources/providers/sources_providers.dart
+++ b/apps/mobile/lib/features/sources/providers/sources_providers.dart
@@ -17,8 +17,9 @@ final sourcesRepositoryProvider = Provider<SourcesRepository>((ref) {
 
 typedef SmartSearchQuery = ({String query, String? contentType, bool expand});
 
-final smartSearchProvider = FutureProvider.family<SmartSearchResponse,
-    SmartSearchQuery>((ref, params) async {
+final smartSearchProvider =
+    FutureProvider.family<SmartSearchResponse, SmartSearchQuery>(
+        (ref, params) async {
   final trimmed = params.query.trim();
   if (trimmed.isEmpty) {
     return const SmartSearchResponse(queryNormalized: '', results: []);
@@ -36,8 +37,7 @@ final trendingSourcesProvider = FutureProvider<List<Source>>((ref) async {
   return repository.getTrendingSources(limit: 30);
 });
 
-final themesFollowedProvider =
-    FutureProvider<List<FollowedTheme>>((ref) async {
+final themesFollowedProvider = FutureProvider<List<FollowedTheme>>((ref) async {
   final repository = ref.watch(sourcesRepositoryProvider);
   return repository.getThemesFollowed();
 });
@@ -78,7 +78,6 @@ class PepitesNotifier extends AsyncNotifier<List<Source>> {
       print('PepitesNotifier: [ERROR] dismiss failed: $e\n$stack');
     }
   }
-
 }
 
 class UserSourcesNotifier extends AsyncNotifier<List<Source>> {
@@ -130,8 +129,19 @@ class UserSourcesNotifier extends AsyncNotifier<List<Source>> {
     }
   }
 
-  Future<void> toggleSubscription(
-      String sourceId, bool currentlySubscribed) async {
+  Future<void> connectSubscription(String sourceId) async {
+    await setSubscription(sourceId, true, rethrowOnError: true);
+  }
+
+  Future<void> disconnectSubscription(String sourceId) async {
+    await setSubscription(sourceId, false);
+  }
+
+  Future<void> setSubscription(
+    String sourceId,
+    bool hasSubscription, {
+    bool rethrowOnError = false,
+  }) async {
     final repository = ref.read(sourcesRepositoryProvider);
 
     // Optimistic Update
@@ -140,22 +150,25 @@ class UserSourcesNotifier extends AsyncNotifier<List<Source>> {
       state = AsyncValue.data([
         for (final source in state.value!)
           if (source.id == sourceId)
-            source.copyWith(hasSubscription: !currentlySubscribed)
+            source.copyWith(
+              hasSubscription: hasSubscription,
+              isTrusted: hasSubscription ? true : source.isTrusted,
+            )
           else
             source
       ]);
     }
 
     try {
-      await repository.updateSourceSubscription(
-          sourceId, !currentlySubscribed);
+      await repository.updateSourceSubscription(sourceId, hasSubscription);
       // Story 19.1 — repaint l'avancement Lettres si une action devient validée.
       unawaited(ref.read(lettersProvider.notifier).silentRefresh());
     } catch (e, stack) {
       // ignore: avoid_print
       print(
-          'UserSourcesNotifier: [ERROR] toggleSubscription failed: $e\n$stack');
+          'UserSourcesNotifier: [ERROR] setSubscription failed: $e\n$stack');
       state = previousState;
+      if (rethrowOnError) rethrow;
     }
   }
 

--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -304,8 +304,7 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                 const SizedBox(height: 12),
                 // Story 22.1 — section Favoris (drag-reorderable, cap 3).
                 _SourceFavoritesSection(
-                  favorites:
-                      sourcesStateAsync.value?.favorites ?? const [],
+                  favorites: sourcesStateAsync.value?.favorites ?? const [],
                   allSources: allSources,
                   onReorder: (reordered) async {
                     try {
@@ -316,8 +315,8 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                       if (!mounted) return;
                       ScaffoldMessenger.of(context).showSnackBar(
                         const SnackBar(
-                          content: Text(
-                              'Impossible de réordonner les favoris.'),
+                          content:
+                              Text('Impossible de réordonner les favoris.'),
                           duration: Duration(seconds: 3),
                         ),
                       );
@@ -540,11 +539,6 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
         ref
             .read(userSourcesProvider.notifier)
             .toggleMute(source.id, source.isMuted);
-      },
-      onToggleSubscription: () {
-        ref
-            .read(userSourcesProvider.notifier)
-            .toggleSubscription(source.id, source.hasSubscription);
       },
     );
   }

--- a/apps/mobile/lib/features/sources/widgets/premium_source_connection.dart
+++ b/apps/mobile/lib/features/sources/widgets/premium_source_connection.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../../../widgets/design/facteur_button.dart';
+import '../models/source_model.dart';
+import 'source_logo_avatar.dart';
+
+typedef PremiumWebViewBuilder = Widget Function(
+    BuildContext context, String url);
+
+class PremiumSourceConnection extends StatefulWidget {
+  final Source source;
+  final Future<void> Function() onConnected;
+  final VoidCallback? onFinished;
+  final PremiumWebViewBuilder? webViewBuilder;
+  final Future<void> Function(String url)? openExternal;
+
+  const PremiumSourceConnection({
+    super.key,
+    required this.source,
+    required this.onConnected,
+    this.onFinished,
+    this.webViewBuilder,
+    this.openExternal,
+  });
+
+  @override
+  State<PremiumSourceConnection> createState() =>
+      _PremiumSourceConnectionState();
+}
+
+class _PremiumSourceConnectionState extends State<PremiumSourceConnection> {
+  int _step = 0;
+  bool _saving = false;
+  String? _error;
+
+  PremiumConnection get _connection => widget.source.premiumConnection!;
+
+  Future<void> _openExternal(String url) async {
+    if (widget.openExternal != null) {
+      await widget.openExternal!(url);
+      return;
+    }
+    final uri = Uri.tryParse(url);
+    if (uri != null) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  Future<void> _confirm() async {
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+    try {
+      await widget.onConnected();
+      if (!mounted) return;
+      setState(() {
+        _saving = false;
+        _step = 3;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _saving = false;
+        _error = 'Impossible de connecter cet abonnement.';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Scaffold(
+      backgroundColor: colors.backgroundPrimary,
+      appBar: AppBar(
+        backgroundColor: colors.backgroundPrimary,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(PhosphorIcons.x(), color: colors.textPrimary),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: Text(
+          widget.source.name,
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                color: colors.textPrimary,
+                fontWeight: FontWeight.w700,
+              ),
+        ),
+      ),
+      body: SafeArea(child: _buildStep(context, colors)),
+    );
+  }
+
+  Widget _buildStep(BuildContext context, FacteurColors colors) {
+    switch (_step) {
+      case 1:
+        return _WebViewStep(
+          key: const ValueKey('premium-webview-login'),
+          title: 'Connexion',
+          url: _connection.loginUrl,
+          actionLabel: 'Continuer vers l\'article test',
+          webViewBuilder: widget.webViewBuilder,
+          onAction: () => setState(() => _step = 2),
+          onOpenExternal: () => _openExternal(_connection.loginUrl),
+        );
+      case 2:
+        return _WebViewStep(
+          key: const ValueKey('premium-webview-test'),
+          title: 'Article test',
+          url: _connection.testUrl,
+          actionLabel: 'L\'article s\'affiche correctement',
+          webViewBuilder: widget.webViewBuilder,
+          onAction: _saving ? null : _confirm,
+          onOpenExternal: () => _openExternal(_connection.testUrl),
+          isLoading: _saving,
+          error: _error,
+        );
+      case 3:
+        return Padding(
+          padding: const EdgeInsets.all(FacteurSpacing.space6),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Icon(
+                PhosphorIcons.checkCircle(PhosphorIconsStyle.fill),
+                size: 56,
+                color: colors.success,
+              ),
+              const SizedBox(height: FacteurSpacing.space4),
+              Text(
+                'Abonnement connecté',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      color: colors.textPrimary,
+                      fontWeight: FontWeight.w800,
+                    ),
+              ),
+              const SizedBox(height: FacteurSpacing.space2),
+              Text(
+                'Les articles de ${widget.source.name} s\'ouvriront dans Facteur tant que la session du média reste active.',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: colors.textSecondary,
+                      height: 1.4,
+                    ),
+              ),
+              const SizedBox(height: FacteurSpacing.space6),
+              FacteurButton(
+                label: 'Terminer',
+                type: FacteurButtonType.primary,
+                icon: PhosphorIcons.check(),
+                onPressed: () {
+                  widget.onFinished?.call();
+                  Navigator.of(context).pop();
+                },
+              ),
+            ],
+          ),
+        );
+      default:
+        return Padding(
+          padding: const EdgeInsets.all(FacteurSpacing.space6),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Spacer(),
+              Center(child: SourceLogoAvatar(source: widget.source, size: 72)),
+              const SizedBox(height: FacteurSpacing.space6),
+              Text(
+                'Connecter votre abonnement',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      color: colors.textPrimary,
+                      fontWeight: FontWeight.w800,
+                    ),
+              ),
+              const SizedBox(height: FacteurSpacing.space3),
+              Text(
+                _connection.displayHint ??
+                    'Connectez-vous dans la WebView du média, puis confirmez qu\'un article abonné s\'affiche correctement.',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: colors.textSecondary,
+                      height: 1.45,
+                    ),
+              ),
+              const Spacer(),
+              FacteurButton(
+                label: 'Commencer',
+                type: FacteurButtonType.primary,
+                icon: PhosphorIcons.link(),
+                onPressed: () => setState(() => _step = 1),
+              ),
+            ],
+          ),
+        );
+    }
+  }
+}
+
+class _WebViewStep extends StatefulWidget {
+  final String title;
+  final String url;
+  final String actionLabel;
+  final PremiumWebViewBuilder? webViewBuilder;
+  final VoidCallback? onAction;
+  final VoidCallback onOpenExternal;
+  final bool isLoading;
+  final String? error;
+
+  const _WebViewStep({
+    super.key,
+    required this.title,
+    required this.url,
+    required this.actionLabel,
+    required this.onAction,
+    required this.onOpenExternal,
+    this.webViewBuilder,
+    this.isLoading = false,
+    this.error,
+  });
+
+  @override
+  State<_WebViewStep> createState() => _WebViewStepState();
+}
+
+class _WebViewStepState extends State<_WebViewStep> {
+  WebViewController? _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.webViewBuilder == null) {
+      _controller = WebViewController()
+        ..setJavaScriptMode(JavaScriptMode.unrestricted)
+        ..loadRequest(Uri.parse(widget.url));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final webView = widget.webViewBuilder?.call(context, widget.url) ??
+        WebViewWidget(controller: _controller!);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            FacteurSpacing.space4,
+            FacteurSpacing.space2,
+            FacteurSpacing.space4,
+            FacteurSpacing.space3,
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  widget.title,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: colors.textPrimary,
+                        fontWeight: FontWeight.w700,
+                      ),
+                ),
+              ),
+              TextButton.icon(
+                onPressed: widget.onOpenExternal,
+                icon: Icon(PhosphorIcons.arrowSquareOut(), size: 18),
+                label: const Text('Navigateur'),
+              ),
+            ],
+          ),
+        ),
+        Expanded(child: webView),
+        if (widget.error != null)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
+            child: Text(
+              widget.error!,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: colors.error),
+            ),
+          ),
+        Padding(
+          padding: const EdgeInsets.all(FacteurSpacing.space4),
+          child: FacteurButton(
+            label: widget.isLoading ? 'Connexion...' : widget.actionLabel,
+            type: FacteurButtonType.primary,
+            icon: PhosphorIcons.arrowRight(),
+            onPressed: widget.onAction,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
@@ -155,9 +155,7 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
       _expanded = false;
     });
     if (value != null) {
-      ref
-          .read(analyticsServiceProvider)
-          .trackAddSourceContentTypeFilter(value);
+      ref.read(analyticsServiceProvider).trackAddSourceContentTypeFilter(value);
     }
   }
 
@@ -291,22 +289,6 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
         source: source,
         recentItems: recentItems,
         onToggleTrust: () => _toggleTrustSource(source),
-        onToggleSubscription: source.id.isNotEmpty
-            ? () {
-                final current = ref
-                        .read(userSourcesProvider)
-                        .valueOrNull
-                        ?.firstWhere(
-                          (s) => s.id == source.id,
-                          orElse: () => source,
-                        )
-                        .hasSubscription ??
-                    source.hasSubscription;
-                ref
-                    .read(userSourcesProvider.notifier)
-                    .toggleSubscription(source.id, current);
-              }
-            : null,
         onCopyFeedUrl: source.isCustom && (source.url?.isNotEmpty ?? false)
             ? () async {
                 await Clipboard.setData(ClipboardData(text: source.url!));
@@ -346,8 +328,9 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
   }
 
   Widget _buildBreathingSearch(FacteurColors colors) {
-    final glow =
-        _searchActive ? colors.primary.withValues(alpha: 0.18) : Colors.transparent;
+    final glow = _searchActive
+        ? colors.primary.withValues(alpha: 0.18)
+        : Colors.transparent;
     return AnimatedContainer(
       duration: const Duration(milliseconds: 320),
       curve: Curves.easeOut,
@@ -488,8 +471,9 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
   /// trop courts sont ignorés (la désambiguïsation vise des mots-sujets).
   Future<void> _fetchTopicSuggestions(String query) async {
     final trimmed = query.trim();
-    final looksLikeUrl =
-        trimmed.startsWith('http') || trimmed.contains('://') || trimmed.contains('@');
+    final looksLikeUrl = trimmed.startsWith('http') ||
+        trimmed.contains('://') ||
+        trimmed.contains('@');
     if (trimmed.length < 2 || looksLikeUrl) {
       setState(() {
         _topicSuggestions = const [];
@@ -526,7 +510,8 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
       final updated = [..._topicSuggestions]..removeAt(index);
       setState(() => _topicSuggestions = updated);
     } catch (e) {
-      if (mounted) NotificationService.showError('Erreur lors de l\'ajout : $e');
+      if (mounted)
+        NotificationService.showError('Erreur lors de l\'ajout : $e');
     } finally {
       if (mounted) setState(() => _followingTopicIndex = null);
     }

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -9,6 +9,7 @@ import '../models/smart_search_result.dart';
 import '../models/source_model.dart';
 import '../providers/sources_providers.dart';
 import '../../../widgets/design/facteur_button.dart';
+import 'premium_source_connection.dart';
 import 'source_logo_avatar.dart';
 
 class SourceDetailModal extends ConsumerWidget {
@@ -16,7 +17,6 @@ class SourceDetailModal extends ConsumerWidget {
   final VoidCallback onToggleTrust;
   final VoidCallback? onToggleMute;
   final VoidCallback? onCopyFeedUrl;
-  final VoidCallback? onToggleSubscription;
   final List<SmartSearchRecentItem>? recentItems;
 
   const SourceDetailModal({
@@ -25,7 +25,6 @@ class SourceDetailModal extends ConsumerWidget {
     required this.onToggleTrust,
     this.onToggleMute,
     this.onCopyFeedUrl,
-    this.onToggleSubscription,
     this.recentItems,
   });
 
@@ -124,8 +123,7 @@ class SourceDetailModal extends ConsumerWidget {
             decoration: BoxDecoration(
               color: colors.backgroundSecondary,
               borderRadius: BorderRadius.circular(16),
-              border:
-                  Border.all(color: colors.textTertiary.withOpacity(0.2)),
+              border: Border.all(color: colors.textTertiary.withOpacity(0.2)),
             ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -171,14 +169,12 @@ class SourceDetailModal extends ConsumerWidget {
               decoration: BoxDecoration(
                 color: colors.backgroundSecondary,
                 borderRadius: BorderRadius.circular(16),
-                border: Border.all(
-                    color: colors.textTertiary.withOpacity(0.2)),
+                border: Border.all(color: colors.textTertiary.withOpacity(0.2)),
               ),
               child: Row(
                 children: [
                   Icon(
-                    PhosphorIcons.slidersHorizontal(
-                        PhosphorIconsStyle.regular),
+                    PhosphorIcons.slidersHorizontal(PhosphorIconsStyle.regular),
                     size: 18,
                     color: colors.textSecondary,
                   ),
@@ -209,8 +205,7 @@ class SourceDetailModal extends ConsumerWidget {
               decoration: BoxDecoration(
                 color: colors.backgroundSecondary,
                 borderRadius: BorderRadius.circular(16),
-                border:
-                    Border.all(color: colors.textTertiary.withOpacity(0.2)),
+                border: Border.all(color: colors.textTertiary.withOpacity(0.2)),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -228,13 +223,11 @@ class SourceDetailModal extends ConsumerWidget {
                         child: Text(
                           'Recommandé par ${displaySource.recommendedBy} '
                           '— équipe Facteur',
-                          style: Theme.of(context)
-                              .textTheme
-                              .titleSmall
-                              ?.copyWith(
-                                color: colors.textPrimary,
-                                fontWeight: FontWeight.bold,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.titleSmall?.copyWith(
+                                    color: colors.textPrimary,
+                                    fontWeight: FontWeight.bold,
+                                  ),
                         ),
                       ),
                     ],
@@ -264,8 +257,7 @@ class SourceDetailModal extends ConsumerWidget {
             decoration: BoxDecoration(
               color: colors.surface,
               borderRadius: BorderRadius.circular(16),
-              border:
-                  Border.all(color: colors.textTertiary.withOpacity(0.2)),
+              border: Border.all(color: colors.textTertiary.withOpacity(0.2)),
             ),
             child: Text(
               source.description ??
@@ -366,18 +358,41 @@ class SourceDetailModal extends ConsumerWidget {
                 );
               }),
             ],
-            if (onToggleSubscription != null) ...[
+            if (displaySource.premiumConnection != null) ...[
               const SizedBox(height: 8),
               FacteurButton(
-                onPressed: () {
-                  onToggleSubscription!();
-                  Navigator.pop(context);
-                },
+                onPressed: () =>
+                    _openPremiumConnectionFlow(context, ref, displaySource),
                 label: displaySource.hasSubscription
-                    ? 'Dissocier mon abonnement'
-                    : 'Associer mon abonnement',
+                    ? 'Reconnecter cet abonnement'
+                    : 'Connecter mon abonnement',
                 type: FacteurButtonType.secondary,
                 icon: PhosphorIcons.link(PhosphorIconsStyle.regular),
+              ),
+            ],
+            if (displaySource.hasSubscription) ...[
+              const SizedBox(height: 8),
+              FacteurButton(
+                onPressed: () async {
+                  try {
+                    await ref
+                        .read(userSourcesProvider.notifier)
+                        .disconnectSubscription(displaySource.id);
+                    if (context.mounted) Navigator.pop(context);
+                  } catch (_) {
+                    if (!context.mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content:
+                            Text('Impossible de dissocier cet abonnement.'),
+                        duration: Duration(seconds: 3),
+                      ),
+                    );
+                  }
+                },
+                label: 'Dissocier mon abonnement',
+                type: FacteurButtonType.secondary,
+                icon: PhosphorIcons.linkBreak(PhosphorIconsStyle.regular),
               ),
             ],
             if (onToggleMute != null) ...[
@@ -405,6 +420,26 @@ class SourceDetailModal extends ConsumerWidget {
           ],
           SizedBox(height: MediaQuery.of(context).padding.bottom + 16),
         ],
+      ),
+    );
+  }
+
+  Future<void> _openPremiumConnectionFlow(
+    BuildContext context,
+    WidgetRef ref,
+    Source source,
+  ) async {
+    final navigator = Navigator.of(context);
+    navigator.pop();
+    await Future<void>.delayed(Duration.zero);
+    await navigator.push<void>(
+      MaterialPageRoute(
+        builder: (_) => PremiumSourceConnection(
+          source: source,
+          onConnected: () => ref
+              .read(userSourcesProvider.notifier)
+              .connectSubscription(source.id),
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/sources/widgets/source_list_item.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_list_item.dart
@@ -10,7 +10,7 @@ class SourceListItem extends StatelessWidget {
   final Source source;
   final VoidCallback? onTap;
   final VoidCallback? onToggleMute;
-  final VoidCallback? onToggleSubscription;
+
   /// Story 22.1 — ouvre le picker 4-états (callback optionnel).
   /// `true` → la source est actuellement en favori (étoile pleine).
   final VoidCallback? onPickInterestState;
@@ -21,7 +21,6 @@ class SourceListItem extends StatelessWidget {
     required this.source,
     this.onTap,
     this.onToggleMute,
-    this.onToggleSubscription,
     this.onPickInterestState,
     this.isFavorite = false,
   });
@@ -57,7 +56,6 @@ class SourceListItem extends StatelessWidget {
             source: source,
             onToggleTrust: onTap ?? () {},
             onToggleMute: onToggleMute,
-            onToggleSubscription: onToggleSubscription,
           ),
         );
       },
@@ -79,8 +77,7 @@ class SourceListItem extends StatelessWidget {
                 ? Border.all(color: Colors.transparent, width: 1.5)
                 : isTrusted
                     ? Border.all(
-                        color: colors.primary.withOpacity(0.3),
-                        width: 1.5)
+                        color: colors.primary.withOpacity(0.3), width: 1.5)
                     : Border.all(color: Colors.transparent, width: 1.5),
           ),
           child: Row(
@@ -129,8 +126,7 @@ class SourceListItem extends StatelessWidget {
                       const SizedBox(height: 2),
                       Row(
                         children: [
-                          Icon(_typeIcon,
-                              color: colors.textTertiary, size: 13),
+                          Icon(_typeIcon, color: colors.textTertiary, size: 13),
                           const SizedBox(width: 5),
                           Flexible(
                             child: Text(
@@ -157,7 +153,8 @@ class SourceListItem extends StatelessWidget {
                   onPressed: onPickInterestState,
                   padding: EdgeInsets.zero,
                   visualDensity: VisualDensity.compact,
-                  constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+                  constraints:
+                      const BoxConstraints(minWidth: 32, minHeight: 32),
                   icon: Icon(
                     isFavorite
                         ? PhosphorIcons.star(PhosphorIconsStyle.fill)

--- a/apps/mobile/test/features/sources/models/source_model_test.dart
+++ b/apps/mobile/test/features/sources/models/source_model_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+
+void main() {
+  group('Source.fromJson premiumConnection', () {
+    test('parses usable premium_connection', () {
+      final source = Source.fromJson({
+        'id': 'source-id',
+        'name': 'Premium Source',
+        'type': 'article',
+        'premium_connection': {
+          'enabled': true,
+          'login_url': ' https://example.com/login ',
+          'test_url': ' https://example.com/test ',
+          'display_hint': 'Connectez-vous',
+        },
+      });
+
+      expect(source.premiumConnection, isNotNull);
+      expect(source.premiumConnection!.loginUrl, 'https://example.com/login');
+      expect(source.premiumConnection!.testUrl, 'https://example.com/test');
+      expect(source.premiumConnection!.displayHint, 'Connectez-vous');
+    });
+
+    test('ignores malformed premium_connection defensively', () {
+      final source = Source.fromJson({
+        'id': 'source-id',
+        'name': 'Regular Source',
+        'type': 'article',
+        'premium_connection': ['not', 'a', 'map'],
+      });
+
+      expect(source.premiumConnection, isNull);
+    });
+
+    test('ignores incomplete premium_connection', () {
+      final source = Source.fromJson({
+        'id': 'source-id',
+        'name': 'Regular Source',
+        'type': 'article',
+        'premium_connection': {
+          'enabled': true,
+          'login_url': 'https://example.com/login',
+        },
+      });
+
+      expect(source.premiumConnection, isNull);
+    });
+  });
+}

--- a/apps/mobile/test/features/sources/widgets/premium_source_connection_test.dart
+++ b/apps/mobile/test/features/sources/widgets/premium_source_connection_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/widgets/premium_source_connection.dart';
+
+void main() {
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+            SystemChannels.platform, (call) async => null);
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  testWidgets('PremiumSourceConnection completes login test confirmation flow',
+      (tester) async {
+    var connected = false;
+    final source = Source(
+      id: 'source-id',
+      name: 'Premium Source',
+      type: SourceType.article,
+      premiumConnection: const PremiumConnection(
+        loginUrl: 'https://example.com/login',
+        testUrl: 'https://example.com/test',
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: PremiumSourceConnection(
+          source: source,
+          onConnected: () async {
+            connected = true;
+          },
+          webViewBuilder: (_, url) => Center(child: Text(url)),
+        ),
+      ),
+    );
+
+    expect(find.text('Connecter votre abonnement'), findsOneWidget);
+
+    await tester.ensureVisible(find.text('Commencer'));
+    await tester.tap(find.text('Commencer'));
+    await tester.pumpAndSettle();
+    expect(find.text('Connexion'), findsOneWidget);
+    expect(find.text('https://example.com/login'), findsOneWidget);
+
+    await tester.ensureVisible(find.text('Continuer vers l\'article test'));
+    await tester.tap(find.text('Continuer vers l\'article test'));
+    await tester.pumpAndSettle();
+    expect(find.text('Article test'), findsOneWidget);
+    expect(find.text('https://example.com/test'), findsOneWidget);
+
+    await tester.ensureVisible(find.text('L\'article s\'affiche correctement'));
+    await tester.tap(find.text('L\'article s\'affiche correctement'));
+    await tester.pumpAndSettle();
+
+    expect(connected, isTrue);
+    expect(find.text('Abonnement connecté'), findsOneWidget);
+  });
+}

--- a/packages/api/alembic/versions/pc01_premium_source_connection.py
+++ b/packages/api/alembic/versions/pc01_premium_source_connection.py
@@ -1,0 +1,41 @@
+"""premium source WebView connection config
+
+Revision ID: pc01_premium_source_connection
+Revises: vk01_link_keywords_to_topics
+Create Date: 2026-06-01
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "pc01_premium_source_connection"
+down_revision: str | None = "vk01_link_keywords_to_topics"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sources",
+        sa.Column("premium_connection_config", postgresql.JSONB(), nullable=True),
+    )
+    op.add_column(
+        "user_sources",
+        sa.Column("subscription_connected_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "user_sources",
+        sa.Column(
+            "subscription_last_verified_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_sources", "subscription_last_verified_at")
+    op.drop_column("user_sources", "subscription_connected_at")
+    op.drop_column("sources", "premium_connection_config")

--- a/packages/api/app/models/source.py
+++ b/packages/api/app/models/source.py
@@ -119,6 +119,10 @@ class Source(Base):
     # Paywall detection config (per-source patterns)
     paywall_config: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
+    # Premium source connection config. Credentials are never collected by
+    # Facteur; the mobile app only uses these URLs in its own WebView session.
+    premium_connection_config: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
     # Editorial digest: source tier (Story 10.22)
     # "mainstream" (default) or "deep" (fond/systémique sources for "pas de recul")
     source_tier: Mapped[str] = mapped_column(
@@ -189,6 +193,12 @@ class UserSource(Base):
     # Premium source: user declares they have a subscription to this source
     has_subscription: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false"
+    )
+    subscription_connected_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    subscription_last_verified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )
     state: Mapped[InterestState] = mapped_column(
         Enum(

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -18,6 +18,7 @@ from app.models.failed_source_attempt import FailedSourceAttempt
 from app.models.source import Source
 from app.models.user import UserInterest
 from app.schemas.source import (
+    PremiumConnectionResponse,
     SearchAbandonedRequest,
     SmartSearchRecentItem,
     SmartSearchRequest,
@@ -41,7 +42,7 @@ from app.services.search.smart_source_search import (
     SmartSourceSearchService,
     mark_search_abandoned,
 )
-from app.services.source_service import SourceService
+from app.services.source_service import PremiumConnectionNotEnabled, SourceService
 from app.services.sources_cache import SOURCES_CACHE
 from app.utils.db_retry import retry_db_op
 
@@ -257,6 +258,9 @@ def _source_to_response(
         score_ux=s.score_ux,
         recommended_by=getattr(s, "recommended_by", None),
         recommendation_reason=getattr(s, "recommendation_reason", None),
+        premium_connection=PremiumConnectionResponse.from_config(
+            getattr(s, "premium_connection_config", None)
+        ),
     )
 
 
@@ -600,9 +604,15 @@ async def update_source_subscription(
 ) -> SourceResponse:
     """Mettre à jour l'abonnement premium d'une source."""
     service = SourceService(db)
-    result = await service.update_source_subscription(
-        user_id, str(source_id), data.has_subscription
-    )
+    try:
+        result = await service.update_source_subscription(
+            user_id, str(source_id), data.has_subscription
+        )
+    except PremiumConnectionNotEnabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Premium connection is not enabled for this source",
+        ) from None
 
     if not result:
         raise HTTPException(

--- a/packages/api/app/schemas/source.py
+++ b/packages/api/app/schemas/source.py
@@ -39,9 +39,41 @@ class SourceResponse(BaseModel):
     score_ux: float | None = None
     recommended_by: str | None = None
     recommendation_reason: str | None = None
+    premium_connection: "PremiumConnectionResponse | None" = None
 
     class Config:
         from_attributes = True
+
+
+class PremiumConnectionResponse(BaseModel):
+    """Configuration mobile pour connecter une source payante en WebView."""
+
+    enabled: bool = True
+    login_url: str
+    test_url: str
+    display_hint: str | None = None
+
+    @classmethod
+    def from_config(cls, config: object) -> "PremiumConnectionResponse | None":
+        if not isinstance(config, dict) or config.get("enabled") is not True:
+            return None
+
+        login_url = config.get("login_url")
+        test_url = config.get("test_url")
+        if not isinstance(login_url, str) or not login_url.strip():
+            return None
+        if not isinstance(test_url, str) or not test_url.strip():
+            return None
+
+        display_hint = config.get("display_hint")
+        return cls(
+            enabled=True,
+            login_url=login_url.strip(),
+            test_url=test_url.strip(),
+            display_hint=display_hint.strip()
+            if isinstance(display_hint, str) and display_hint.strip()
+            else None,
+        )
 
 
 class SourceCreate(BaseModel):

--- a/packages/api/app/services/pepite_service.py
+++ b/packages/api/app/services/pepite_service.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.source import Source, UserSource
 from app.models.user import UserInterest
 from app.models.user_personalization import UserPersonalization
-from app.schemas.source import SourceResponse
+from app.schemas.source import PremiumConnectionResponse, SourceResponse
 
 logger = structlog.get_logger()
 
@@ -181,6 +181,9 @@ class PepiteService:
                 score_ux=s.score_ux,
                 recommended_by=getattr(s, "recommended_by", None),
                 recommendation_reason=getattr(s, "recommendation_reason", None),
+                premium_connection=PremiumConnectionResponse.from_config(
+                    getattr(s, "premium_connection_config", None)
+                ),
             )
             for s, follower_count in selected
         ]

--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -1,14 +1,17 @@
 """Service source."""
 
+from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 import structlog
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.enums import InterestState
 from app.models.source import Source, UserSource
 from app.models.user_personalization import UserPersonalization
 from app.schemas.source import (
+    PremiumConnectionResponse,
     SourceCatalogResponse,
     SourceDetectResponse,
     SourceResponse,
@@ -19,12 +22,22 @@ from app.services.rss_parser import RSSParser
 logger = structlog.get_logger()
 
 
+class PremiumConnectionNotEnabled(Exception):
+    """Raised when a source cannot be marked subscribed via WebView flow."""
+
+
 class SourceService:
     """Service pour la gestion des sources."""
 
     def __init__(self, db: AsyncSession):
         self.db = db
         self.rss_parser = RSSParser()
+
+    @staticmethod
+    def _premium_connection(s: Source) -> PremiumConnectionResponse | None:
+        return PremiumConnectionResponse.from_config(
+            getattr(s, "premium_connection_config", None)
+        )
 
     async def _load_user_source_context(
         self, user_id: UUID
@@ -90,6 +103,7 @@ class SourceService:
             score_ux=s.score_ux,
             recommended_by=getattr(s, "recommended_by", None),
             recommendation_reason=getattr(s, "recommendation_reason", None),
+            premium_connection=self._premium_connection(s),
         )
 
     async def get_all_sources(self, user_id: str) -> SourceCatalogResponse:
@@ -377,6 +391,7 @@ class SourceService:
             score_ux=source.score_ux,
             recommended_by=getattr(source, "recommended_by", None),
             recommendation_reason=getattr(source, "recommendation_reason", None),
+            premium_connection=self._premium_connection(source),
         )
 
     async def delete_custom_source(self, user_id: str, source_id: str) -> bool:
@@ -454,9 +469,21 @@ class SourceService:
     async def update_source_subscription(
         self, user_id: str, source_id: str, has_subscription: bool
     ) -> SourceResponse | None:
-        """Met à jour le has_subscription d'une source suivie."""
+        """Met à jour le has_subscription d'une source.
+
+        La connexion positive exige une config premium explicite côté source,
+        puis crée le lien UserSource si nécessaire. La dissociation reste
+        autorisée même si la config source a été retirée.
+        """
         user_uuid = UUID(user_id)
         source_uuid = UUID(source_id)
+
+        source = await self.db.scalar(select(Source).where(Source.id == source_uuid))
+        if not source:
+            return None
+
+        if has_subscription and self._premium_connection(source) is None:
+            raise PremiumConnectionNotEnabled
 
         user_source = await self.db.scalar(
             select(UserSource).where(
@@ -465,14 +492,28 @@ class SourceService:
             )
         )
         if not user_source:
-            return None
+            if not has_subscription:
+                return None
+            user_source = UserSource(
+                id=uuid4(),
+                user_id=user_uuid,
+                source_id=source_uuid,
+                is_custom=not source.is_curated,
+            )
+            self.db.add(user_source)
 
         user_source.has_subscription = has_subscription
-        await self.db.flush()
+        if has_subscription:
+            now = datetime.now(UTC)
+            user_source.state = InterestState.FOLLOWED
+            if user_source.subscription_connected_at is None:
+                user_source.subscription_connected_at = now
+            user_source.subscription_last_verified_at = now
+        else:
+            user_source.subscription_connected_at = None
+            user_source.subscription_last_verified_at = None
 
-        source = await self.db.scalar(select(Source).where(Source.id == source_uuid))
-        if not source:
-            return None
+        await self.db.flush()
 
         # Load muted status
         muted_source_ids = set()
@@ -512,6 +553,7 @@ class SourceService:
             score_ux=source.score_ux,
             recommended_by=getattr(source, "recommended_by", None),
             recommendation_reason=getattr(source, "recommendation_reason", None),
+            premium_connection=self._premium_connection(source),
         )
 
     async def untrust_source(self, user_id: str, source_id: str) -> bool:

--- a/packages/api/tests/test_premium_source_connection.py
+++ b/packages/api/tests/test_premium_source_connection.py
@@ -1,0 +1,182 @@
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.enums import InterestState, SourceType
+from app.models.source import Source, UserSource
+from app.schemas.source import PremiumConnectionResponse
+from app.services.source_service import PremiumConnectionNotEnabled, SourceService
+
+
+def test_premium_connection_response_requires_enabled_usable_urls():
+    assert PremiumConnectionResponse.from_config(None) is None
+    assert PremiumConnectionResponse.from_config({"enabled": False}) is None
+    assert (
+        PremiumConnectionResponse.from_config(
+            {"enabled": True, "login_url": "https://login.example.com"}
+        )
+        is None
+    )
+
+    response = PremiumConnectionResponse.from_config(
+        {
+            "enabled": True,
+            "login_url": " https://login.example.com ",
+            "test_url": " https://example.com/test ",
+            "display_hint": " Connectez-vous ",
+        }
+    )
+
+    assert response is not None
+    assert response.login_url == "https://login.example.com"
+    assert response.test_url == "https://example.com/test"
+    assert response.display_hint == "Connectez-vous"
+
+
+@pytest.mark.asyncio
+async def test_source_response_exposes_enabled_premium_config(
+    db_session: AsyncSession,
+):
+    source = Source(
+        id=uuid4(),
+        name="Premium Source",
+        url="https://example.com",
+        feed_url=f"https://example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_curated=True,
+        is_active=True,
+        premium_connection_config={
+            "enabled": True,
+            "login_url": "https://example.com/login",
+            "test_url": "https://example.com/premium-test",
+        },
+    )
+    hidden_source = Source(
+        id=uuid4(),
+        name="Hidden Premium Source",
+        url="https://hidden.example.com",
+        feed_url=f"https://hidden.example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_curated=True,
+        is_active=True,
+        premium_connection_config={
+            "enabled": True,
+            "login_url": "https://hidden.example.com/login",
+        },
+    )
+    db_session.add_all([source, hidden_source])
+    await db_session.flush()
+
+    responses = await SourceService(db_session).get_curated_sources()
+    by_id = {response.id: response for response in responses}
+
+    assert by_id[source.id].premium_connection is not None
+    assert by_id[source.id].premium_connection.login_url == "https://example.com/login"
+    assert by_id[hidden_source.id].premium_connection is None
+
+
+@pytest.mark.asyncio
+async def test_subscription_true_creates_user_source_and_timestamps(
+    db_session: AsyncSession,
+):
+    user_id = uuid4()
+    source = Source(
+        id=uuid4(),
+        name="Premium Source",
+        url="https://example.com",
+        feed_url=f"https://example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_curated=True,
+        is_active=True,
+        premium_connection_config={
+            "enabled": True,
+            "login_url": "https://example.com/login",
+            "test_url": "https://example.com/premium-test",
+        },
+    )
+    db_session.add(source)
+    await db_session.flush()
+
+    response = await SourceService(db_session).update_source_subscription(
+        str(user_id), str(source.id), True
+    )
+
+    user_source = await db_session.scalar(
+        select(UserSource).where(
+            UserSource.user_id == user_id,
+            UserSource.source_id == source.id,
+        )
+    )
+    assert response is not None
+    assert response.has_subscription is True
+    assert response.is_trusted is True
+    assert user_source is not None
+    assert user_source.has_subscription is True
+    assert user_source.state == InterestState.FOLLOWED
+    assert user_source.subscription_connected_at is not None
+    assert user_source.subscription_last_verified_at is not None
+
+
+@pytest.mark.asyncio
+async def test_subscription_false_clears_timestamps(db_session: AsyncSession):
+    user_id = uuid4()
+    source = Source(
+        id=uuid4(),
+        name="Premium Source",
+        url="https://example.com",
+        feed_url=f"https://example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_curated=True,
+        is_active=True,
+        premium_connection_config={
+            "enabled": True,
+            "login_url": "https://example.com/login",
+            "test_url": "https://example.com/premium-test",
+        },
+    )
+    user_source = UserSource(
+        user_id=user_id,
+        source=source,
+        has_subscription=True,
+    )
+    db_session.add_all([source, user_source])
+    await db_session.flush()
+
+    response = await SourceService(db_session).update_source_subscription(
+        str(user_id), str(source.id), False
+    )
+
+    assert response is not None
+    assert response.has_subscription is False
+    assert user_source.has_subscription is False
+    assert user_source.subscription_connected_at is None
+    assert user_source.subscription_last_verified_at is None
+
+
+@pytest.mark.asyncio
+async def test_subscription_true_rejects_non_allowlisted_source(
+    db_session: AsyncSession,
+):
+    source = Source(
+        id=uuid4(),
+        name="Regular Source",
+        url="https://example.com",
+        feed_url=f"https://example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_curated=True,
+        is_active=True,
+    )
+    db_session.add(source)
+    await db_session.flush()
+
+    with pytest.raises(PremiumConnectionNotEnabled):
+        await SourceService(db_session).update_source_subscription(
+            str(uuid4()), str(source.id), True
+        )


### PR DESCRIPTION
## Quoi
Connexion d'un **abonnement premium** à une source via un flux **WebView in-app** : intro → page de connexion du média → article test → confirmation. Une fois connectée, les articles de la source s'ouvrent directement dans Facteur (tant que la session du média reste active).

## Pourquoi
Les sources payantes étaient suivables mais leurs articles renvoyaient vers le web / paywall. Ce flux laisse l'utilisateur se connecter dans la WebView du média (Facteur ne collecte jamais d'identifiants) et marque l'abonnement comme connecté côté serveur.

## Comment
**Backend**
- `sources.premium_connection_config` (JSONB) + `user_sources.subscription_connected_at` / `subscription_last_verified_at` — migration `pc01_premium_source_connection` (1 head, downgrade symétrique).
- Schéma `PremiumConnectionResponse.from_config` (valide `enabled` + `login_url`/`test_url`) exposé sur `SourceResponse`.
- `update_source_subscription` : crée le lien `UserSource` au besoin, passe l'état à `FOLLOWED`, horodate, et **refuse une connexion positive sans config premium** (`PremiumConnectionNotEnabled` → HTTP 400).

**Mobile**
- Modèle `PremiumConnection` (parse défensif) + widget `PremiumSourceConnection`.
- Providers `connect/disconnect/setSubscription` ; entrée depuis la fiche source ; lecture in-app des sources premium connectées dans `content_detail`.

## Comment ça a été vérifié
- [x] `pytest` — **1422 passed**, 1 skipped, 2 xfailed (5 nouveaux tests premium ; 0 régression)
- [x] Alembic — 1 head ; `upgrade head` + `downgrade -1` + re-upgrade OK sur DB **vide**
- [x] App boot OK + `PremiumConnectionResponse` présent dans l'OpenAPI (forward-ref résolu)
- [x] `flutter analyze` — 0 erreur/warning sur les fichiers touchés (infos préexistantes only)
- [x] `flutter test` ciblé — modèle (`source_model_test`) + flow widget (`premium_source_connection_test`) OK
- [x] `/simplify` passé : suppression d'un wrapper mort (`toggleSubscription`) + clé par étape sur la WebView pour recharger l'URL au passage login → article test

## Zones à risque
- **DB schema** : nouvelle migration `pc01` (le `Dockerfile` rejoue `alembic upgrade head` au boot Railway — chaîne testée up/down sur DB vide).
- `source_service.update_source_subscription` : crée désormais le `UserSource` et bascule l'état à `FOLLOWED`.
- Router `PATCH /sources/{id}/subscription` : nouveau cas `400` (config premium absente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
