### PR TITLE
fix(onboarding): PremiumSourcesSheet.onDone optionnel — débloque le build web Railway

### DIFF
--- a/apps/mobile/lib/features/onboarding/widgets/premium_sources_sheet.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/premium_sources_sheet.dart
@@ -20,7 +20,7 @@ class PremiumSourcesSheet extends ConsumerStatefulWidget {
   const PremiumSourcesSheet({
     super.key,
     required this.allSources,
-    required this.onDone,
+    this.onDone,
   });
 
   @override


### PR DESCRIPTION
## Quoi — Hotfix déploiement Railway
Rend `PremiumSourcesSheet.onDone` **optionnel** (suppression de `required`) pour débloquer le build web prod qui a échoué après le merge de #737.

## Pourquoi
Le déploiement prod de #737 (commit `ce5d058`) a **échoué** sur l'étape `flutter build web --release` :

```
sources_page2_question.dart:108: Error: Required named parameter 'onDone' must be provided.
      builder: (context) => PremiumSourcesSheet(
```

`onDone` était déclaré nullable (`ValueChanged<Set<String>>?`, appelé via `widget.onDone?.call(...)`) **et** `required` — contradiction. L'appelant `_openPremiumSheet` ne le passe pas. L'analyzer ne le remonte qu'en *warning* (`missing_required_argument`) et la CI ne compile jamais le web (pytest only), donc l'erreur n'a été visible qu'au build dart2js sur Railway.

## Comment ça a été vérifié
- [x] Reproduction locale de la commande exacte du Dockerfile : `flutter build web --release` → **✓ Built build/web**
- [x] `flutter analyze` sur le fichier touché : 0 erreur

## Zones à risque
Aucune — changement d'une seule contrainte de constructeur (callback optionnel par conception). N'affecte pas le service backend/alembic (déploiement séparé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
