### PR TITLE
feat(digest): projection éditoriale per-user (pool élargi + solo subjects)

### DIFF
--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -339,9 +339,7 @@ class DigestGenerationJob:
             select(UserSource.source_id)
             .where(
                 UserSource.user_id.in_(user_ids),
-                UserSource.state.in_(
-                    [InterestState.FOLLOWED, InterestState.FAVORITE]
-                ),
+                UserSource.state.in_([InterestState.FOLLOWED, InterestState.FAVORITE]),
             )
             .distinct()
         )
@@ -416,9 +414,7 @@ class DigestGenerationJob:
                 stmt = apply_ad_filter(stmt)
             return stmt.where(Content.published_at >= cutoff)
 
-        recency_stmt = (
-            _base_stmt().order_by(Content.published_at.desc()).limit(200)
-        )
+        recency_stmt = _base_stmt().order_by(Content.published_at.desc()).limit(200)
         try:
             result = await session.execute(recency_stmt)
             candidates = list(result.scalars().all())
@@ -445,9 +441,7 @@ class DigestGenerationJob:
         try:
             followed_result = await session.execute(followed_stmt)
             followed_articles = [
-                c
-                for c in followed_result.scalars().all()
-                if c.id not in seen_ids
+                c for c in followed_result.scalars().all() if c.id not in seen_ids
             ]
         except Exception as e:
             logger.error(

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -172,7 +172,18 @@ class DigestGenerationJob:
                     session, session_maker=safe_async_session
                 )
                 if pipeline.llm.is_ready and user_ids:
-                    global_candidates = await self._get_global_candidates(session)
+                    # P1 : union des sources réellement suivies du batch, pour
+                    # élargir le pool de clustering au-delà du top-200 récence.
+                    batch_followed_source_ids = (
+                        await self._get_batch_followed_source_ids(session, user_ids)
+                    )
+                    logger.info(
+                        "digest_generation_batch_followed_sources",
+                        count=len(batch_followed_source_ids),
+                    )
+                    global_candidates = await self._get_global_candidates(
+                        session, followed_source_ids=batch_followed_source_ids
+                    )
                     if global_candidates:
                         for mode in ("pour_vous", "serein"):
                             try:
@@ -184,7 +195,9 @@ class DigestGenerationJob:
                                     global_candidates
                                     if mode == "pour_vous"
                                     else await self._get_global_candidates(
-                                        session, mode="serein"
+                                        session,
+                                        mode="serein",
+                                        followed_source_ids=batch_followed_source_ids,
                                     )
                                 )
                                 if not mode_candidates:
@@ -299,10 +312,54 @@ class DigestGenerationJob:
             )
             raise
 
+    # Borne explicite sur la tranche "sources suivies" ajoutée au pool de
+    # clustering. Même ordre de grandeur que la tranche récence (200) pour
+    # garder un coût mémoire/LLM borné même si beaucoup de sources de niche
+    # sont suivies par le batch.
+    FOLLOWED_SLICE_LIMIT = 200
+
+    async def _get_batch_followed_source_ids(
+        self,
+        session: AsyncSession,
+        user_ids: list[UUID],
+    ) -> set[UUID]:
+        """Union des sources réellement suivies (followed/favorite) du batch.
+
+        Sert à élargir le pool de clustering éditorial pour que les sujets
+        adossés à des sources de niche suivies aient une chance d'être
+        clusterisés/sélectionnés (P1). Exclut HIDDEN/UNFOLLOWED.
+        """
+        if not user_ids:
+            return set()
+
+        from app.models.enums import InterestState
+        from app.models.source import UserSource
+
+        stmt = (
+            select(UserSource.source_id)
+            .where(
+                UserSource.user_id.in_(user_ids),
+                UserSource.state.in_(
+                    [InterestState.FOLLOWED, InterestState.FAVORITE]
+                ),
+            )
+            .distinct()
+        )
+        try:
+            result = await session.execute(stmt)
+            return {row[0] for row in result.all()}
+        except Exception as e:
+            logger.error(
+                "digest_generation_batch_followed_sources_failed",
+                error=str(e),
+            )
+            return set()
+
     async def _get_global_candidates(
         self,
         session: AsyncSession,
         mode: str = "pour_vous",
+        followed_source_ids: set[UUID] | None = None,
     ) -> list[Any]:
         """Fetch a user-agnostic global candidate pool for editorial context.
 
@@ -311,11 +368,19 @@ class DigestGenerationJob:
         Falls back to a broad recent-content query so the pipeline never
         cold-paths because of one unlucky user.
 
+        En plus de la tranche "top-200 par récence" (user-agnostique), on
+        unionne une tranche bornée d'articles récents des sources suivies du
+        batch (P1) : sans elle, les sources de niche sont systématiquement
+        évincées par les gros volumes mainstream et n'entrent jamais dans le
+        clustering. Les deux tranches passent les mêmes filtres ad/good-news.
+
         Args:
             session: Async SQLAlchemy session.
             mode: "pour_vous" (default, no filter) or "serein" (apply
-                ``apply_serein_filter`` so anxious articles are excluded
+                ``apply_good_news_filter`` so anxious articles are excluded
                 from the clustering pool).
+            followed_source_ids: Sources suivies du batch (P1). Si fourni et
+                non vide, leurs articles récents sont unionnés au pool.
         """
         from datetime import UTC, timedelta
 
@@ -327,34 +392,36 @@ class DigestGenerationJob:
         # Content.published_at is stored as tz-aware, so the comparison
         # value must also be tz-aware (and utcnow() is deprecated in 3.12).
         cutoff = datetime.datetime.now(UTC) - timedelta(hours=self.hours_lookback)
-        # Serein filter references Source.theme so we need an explicit join.
-        # The join is harmless for pour_vous (every Content has a Source) but
-        # we keep it behind the mode branch to match existing behaviour.
-        stmt = select(Content).options(selectinload(Content.source))
-        if mode == "serein":
-            # Mode "Bonnes nouvelles" : hard-filter is_good_news=True. Pool
-            # potentiellement plus restreint que l'ancien serein, c'est voulu.
-            from app.services.recommendation.filter_presets import (
-                apply_good_news_filter,
-            )
 
-            stmt = stmt.join(Source, Content.source_id == Source.id)
-            stmt = apply_good_news_filter(stmt)
-        else:
-            # Mode pour_vous : apply_good_news_filter inclut déjà apply_ad_filter,
-            # mais pour_vous n'y passe pas — sans ce filtre, les pubs Frandroid
-            # (is_ad=True) remontent dans le clustering éditorial.
-            from app.services.recommendation.filter_presets import apply_ad_filter
+        def _base_stmt():
+            # Serein filter references Source.theme so we need an explicit join.
+            # The join is harmless for pour_vous (every Content has a Source) but
+            # we keep it behind the mode branch to match existing behaviour.
+            stmt = select(Content).options(selectinload(Content.source))
+            if mode == "serein":
+                # Mode "Bonnes nouvelles" : hard-filter is_good_news=True. Pool
+                # potentiellement plus restreint que l'ancien serein, c'est voulu.
+                from app.services.recommendation.filter_presets import (
+                    apply_good_news_filter,
+                )
 
-            stmt = apply_ad_filter(stmt)
-        stmt = (
-            stmt.where(Content.published_at >= cutoff)
-            .order_by(Content.published_at.desc())
-            .limit(200)
+                stmt = stmt.join(Source, Content.source_id == Source.id)
+                stmt = apply_good_news_filter(stmt)
+            else:
+                # Mode pour_vous : apply_good_news_filter inclut déjà apply_ad_filter,
+                # mais pour_vous n'y passe pas — sans ce filtre, les pubs Frandroid
+                # (is_ad=True) remontent dans le clustering éditorial.
+                from app.services.recommendation.filter_presets import apply_ad_filter
+
+                stmt = apply_ad_filter(stmt)
+            return stmt.where(Content.published_at >= cutoff)
+
+        recency_stmt = (
+            _base_stmt().order_by(Content.published_at.desc()).limit(200)
         )
         try:
-            result = await session.execute(stmt)
-            return list(result.scalars().all())
+            result = await session.execute(recency_stmt)
+            candidates = list(result.scalars().all())
         except Exception as e:
             logger.error(
                 "digest_generation_global_candidates_failed",
@@ -362,6 +429,42 @@ class DigestGenerationJob:
                 error=str(e),
             )
             return []
+
+        if not followed_source_ids:
+            return candidates
+
+        # Tranche "sources suivies" : mêmes filtres + cutoff, bornée, puis
+        # dédupliquée contre la tranche récence (un article peut déjà y figurer).
+        seen_ids = {c.id for c in candidates}
+        followed_stmt = (
+            _base_stmt()
+            .where(Content.source_id.in_(followed_source_ids))
+            .order_by(Content.published_at.desc())
+            .limit(self.FOLLOWED_SLICE_LIMIT)
+        )
+        try:
+            followed_result = await session.execute(followed_stmt)
+            followed_articles = [
+                c
+                for c in followed_result.scalars().all()
+                if c.id not in seen_ids
+            ]
+        except Exception as e:
+            logger.error(
+                "digest_generation_followed_slice_failed",
+                mode=mode,
+                error=str(e),
+            )
+            followed_articles = []
+
+        if followed_articles:
+            logger.info(
+                "digest_generation_followed_slice_added",
+                mode=mode,
+                recency_count=len(candidates),
+                followed_added=len(followed_articles),
+            )
+        return candidates + followed_articles
 
     async def _prune_old_highlights(
         self,
@@ -583,8 +686,12 @@ class DigestGenerationJob:
                         )
                     )
 
-                    # All users get editorial format — no per-user branching
-                    expected_version = "editorial_v1"
+                    # All users get editorial format — no per-user branching.
+                    # editorial_v2 = projection per-user (P2). Un digest caché
+                    # editorial_v1 est considéré stale et régénéré ci-dessous.
+                    from app.services.digest_service import EDITORIAL_FORMAT_VERSION
+
+                    expected_version = EDITORIAL_FORMAT_VERSION
 
                     stale_digest = None
                     if existing and existing.format_version != expected_version:

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -649,7 +649,7 @@ async def _load_cluster_articles_for_representative(
         select(DailyDigest)
         .where(
             DailyDigest.user_id == user_id,
-            DailyDigest.format_version == "editorial_v1",
+            DailyDigest.format_version.in_(("editorial_v1", "editorial_v2")),
         )
         .order_by(desc(DailyDigest.generated_at))
         .limit(4)  # up to 2 per day * 2 days (normal + serene)
@@ -747,7 +747,7 @@ async def _load_stored_perspectives_for_representative(
         select(DailyDigest)
         .where(
             DailyDigest.user_id == user_id,
-            DailyDigest.format_version == "editorial_v1",
+            DailyDigest.format_version.in_(("editorial_v1", "editorial_v2")),
         )
         .order_by(desc(DailyDigest.generated_at))
         .limit(4)

--- a/packages/api/app/services/digest_content_refs.py
+++ b/packages/api/app/services/digest_content_refs.py
@@ -46,7 +46,10 @@ def extract_content_ids(items: Any, format_version: str | None) -> set[UUID]:
 
     fmt = format_version or "flat_v1"
 
-    if fmt == "editorial_v1" and isinstance(items, dict):
+    # editorial_v1 et editorial_v2 partagent EXACTEMENT la même forme JSON
+    # (`items` = dict avec `subjects[]`) — seule la sémantique de sélection
+    # diffère. L'extraction des content_ids est donc identique.
+    if fmt in ("editorial_v1", "editorial_v2") and isinstance(items, dict):
         for subject in items.get("subjects") or []:
             if not isinstance(subject, dict):
                 continue

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -409,9 +409,7 @@ class DigestSelector:
                             # dérive un digest personnalisé (représentant source
                             # suivie + re-ranking intérêts + sujets solo) sans
                             # re-clustering ni LLM. Cf. _project_editorial_for_user.
-                            clusters = _get_cached_editorial_clusters(
-                                _cache_date, mode
-                            )
+                            clusters = _get_cached_editorial_clusters(_cache_date, mode)
                             if clusters is None:
                                 clusters = await self._rehydrate_editorial_clusters(
                                     global_ctx
@@ -1218,9 +1216,7 @@ class DigestSelector:
         score_inputs = rep_contents + solo_candidates
         if score_inputs:
             try:
-                scored = await self._score_candidates(
-                    score_inputs, context, mode=mode
-                )
+                scored = await self._score_candidates(score_inputs, context, mode=mode)
                 score_map = {c.id: sc for c, sc, _bd in scored}
             except Exception:
                 # Dégradation sûre : sans scoring on garde l'ordre run_for_user.

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -87,6 +87,48 @@ def _set_cached_editorial_ctx(
     logger.info("editorial_ctx_cache_set", target_date=str(target_date), mode=mode)
 
 
+# --- Rehydrated TopicCluster cache (P2) ---
+# `EditorialGlobalContext` only serializes cluster IDs (`cluster_data`); the
+# `TopicCluster` objects (with Content loaded) needed by the per-user actu
+# matching are discarded after `compute_global_context`. We rehydrate them
+# ONCE per (date, mode) — a single shared query — and reuse across all users
+# in the batch. Same date-based eviction as the ctx cache.
+_editorial_clusters_cache: dict[tuple, tuple[float, list]] = {}
+
+
+def _get_cached_editorial_clusters(
+    target_date: datetime.date, mode: str
+) -> list | None:
+    """Return cached rehydrated clusters for this (date, mode), else None."""
+    entry = _editorial_clusters_cache.get((target_date, mode))
+    if entry is not None:
+        return entry[1]
+    return None
+
+
+def _set_cached_editorial_clusters(
+    target_date: datetime.date, mode: str, clusters: list
+) -> None:
+    """Cache rehydrated clusters, clearing entries from previous dates."""
+    stale_keys = [k for k in _editorial_clusters_cache if k[0] != target_date]
+    for k in stale_keys:
+        del _editorial_clusters_cache[k]
+    _editorial_clusters_cache[(target_date, mode)] = (time.time(), clusters)
+
+
+# Seuil minimal (échelle pilier ~0-100) pour qu'un article de source suivie
+# non clusterisé en multi-sources devienne un "subject solo" per-user (P2).
+# Décision PO : pas de quota dur — on laisse le scoring (source suivie + fort
+# match intérêt + récence) franchir le gate. Configurable via env.
+def _read_solo_subject_min_score() -> float:
+    import os
+
+    try:
+        return float(os.environ.get("EDITORIAL_SOLO_SUBJECT_MIN_SCORE", ""))
+    except ValueError:
+        return 40.0
+
+
 @dataclass
 class DigestItem:
     """Représente un article sélectionné pour le digest.
@@ -362,31 +404,61 @@ class DigestSelector:
                             )
                             return None
                         else:
-                            # MVP V2: global digest — actu already matched
-                            # in compute_global_context(), no per-user phase
-                            from app.services.editorial.schemas import (
-                                EditorialPipelineResult,
+                            # P2 : projection editorial PER-USER. Le contexte
+                            # global (clusters/sujets) reste partagé ; on en
+                            # dérive un digest personnalisé (représentant source
+                            # suivie + re-ranking intérêts + sujets solo) sans
+                            # re-clustering ni LLM. Cf. _project_editorial_for_user.
+                            clusters = _get_cached_editorial_clusters(
+                                _cache_date, mode
                             )
+                            if clusters is None:
+                                clusters = await self._rehydrate_editorial_clusters(
+                                    global_ctx
+                                )
+                                _set_cached_editorial_clusters(
+                                    _cache_date, mode, clusters
+                                )
 
-                            actu_hits = sum(
-                                1
-                                for s in global_ctx.subjects
-                                if s.actu_article is not None
-                            )
-                            deep_hits = sum(
-                                1
-                                for s in global_ctx.subjects
-                                if s.deep_article is not None
-                            )
-                            result = EditorialPipelineResult(
-                                subjects=global_ctx.subjects,
-                                metadata={
-                                    "actu_hits": actu_hits,
-                                    "deep_hits": deep_hits,
-                                    "total_subjects": len(global_ctx.subjects),
-                                    "matching_ms": 0,
-                                },
-                            )
+                            if clusters:
+                                result = await self._project_editorial_for_user(
+                                    pipeline=pipeline,
+                                    global_ctx=global_ctx,
+                                    clusters=clusters,
+                                    context=context,
+                                    mode=mode,
+                                )
+                            else:
+                                # Réhydratation impossible (pool absent) :
+                                # repli sur le digest global verbatim plutôt
+                                # que de renvoyer vide.
+                                from app.services.editorial.schemas import (
+                                    EditorialPipelineResult,
+                                )
+
+                                logger.warning(
+                                    "digest_editorial_rehydrate_empty_fallback_global",
+                                    user_id=str(user_id),
+                                )
+                                result = EditorialPipelineResult(
+                                    subjects=global_ctx.subjects,
+                                    metadata={
+                                        "actu_hits": sum(
+                                            1
+                                            for s in global_ctx.subjects
+                                            if s.actu_article is not None
+                                        ),
+                                        "deep_hits": sum(
+                                            1
+                                            for s in global_ctx.subjects
+                                            if s.deep_article is not None
+                                        ),
+                                        "total_subjects": len(global_ctx.subjects),
+                                        "matching_ms": 0,
+                                        "per_user_projection": False,
+                                    },
+                                )
+
                             editorial_time = time.time() - step_start
                             total_time = time.time() - start_time
                             logger.info(
@@ -395,6 +467,10 @@ class DigestSelector:
                                 subjects=len(result.subjects),
                                 actu_hits=result.metadata.get("actu_hits", 0),
                                 deep_hits=result.metadata.get("deep_hits", 0),
+                                solo_added=result.metadata.get("solo_added", 0),
+                                followed_source_reps=result.metadata.get(
+                                    "followed_source_reps", 0
+                                ),
                                 editorial_ms=round(editorial_time * 1000, 2),
                                 total_ms=round(total_time * 1000, 2),
                             )
@@ -975,19 +1051,271 @@ class DigestSelector:
             )
             return []
 
+    async def _rehydrate_editorial_clusters(self, global_ctx: object) -> list:
+        """Reconstruit les `TopicCluster` (avec Content chargés) depuis `cluster_data`.
+
+        `EditorialGlobalContext` ne sérialise que les IDs (`cluster_data`) ; les
+        `TopicCluster` originaux sont jetés après `compute_global_context`. La
+        projection per-user (`match_for_user`) en a besoin (lit `contents` /
+        `source_ids` / `cluster_id`). On charge tous les Content concernés en UNE
+        requête partagée. `tokens` reste vide (non lu par le matching).
+        """
+        from app.services.briefing.importance_detector import TopicCluster
+
+        cluster_data = getattr(global_ctx, "cluster_data", None) or []
+
+        def _to_uuid(value: object) -> UUID | None:
+            try:
+                return UUID(str(value))
+            except (ValueError, AttributeError, TypeError):
+                return None
+
+        all_ids: set[UUID] = set()
+        for cd in cluster_data:
+            for cid in cd.get("content_ids", []):
+                u = _to_uuid(cid)
+                if u is not None:
+                    all_ids.add(u)
+        if not all_ids:
+            return []
+
+        stmt = (
+            select(Content)
+            .options(selectinload(Content.source))
+            .where(Content.id.in_(all_ids))
+        )
+        content_map: dict[UUID, Content] = {}
+        try:
+            if self.session_maker is not None:
+                async with self.session_maker() as session:
+                    result = await session.execute(stmt)
+                    for c in result.scalars().all():
+                        content_map[c.id] = c
+            else:
+                result = await self.session.execute(stmt)
+                for c in result.scalars().all():
+                    content_map[c.id] = c
+        except SQLAlchemyError:
+            logger.exception("editorial_clusters_rehydrate_failed")
+            return []
+
+        clusters: list = []
+        for cd in cluster_data:
+            contents = [
+                content_map[u]
+                for cid in cd.get("content_ids", [])
+                if (u := _to_uuid(cid)) is not None and u in content_map
+            ]
+            if not contents:
+                continue
+            source_ids = {
+                u
+                for sid in cd.get("source_ids", [])
+                if (u := _to_uuid(sid)) is not None
+            }
+            clusters.append(
+                TopicCluster(
+                    cluster_id=cd["cluster_id"],
+                    label=cd.get("label", ""),
+                    tokens=set(),
+                    contents=contents,
+                    source_ids=source_ids,
+                    theme=cd.get("theme"),
+                )
+            )
+        logger.info(
+            "editorial_clusters_rehydrated",
+            clusters=len(clusters),
+            contents=len(content_map),
+        )
+        return clusters
+
+    async def _project_editorial_for_user(
+        self,
+        *,
+        pipeline: object,
+        global_ctx: object,
+        clusters: list,
+        context: DigestContext,
+        mode: str,
+    ) -> object:
+        """Projection editorial per-user (P2 — le vrai levier de l'Essentiel).
+
+        À partir du contexte global PARTAGÉ (clusters/sujets identiques pour
+        tous), on dérive un digest personnalisé sans re-clustering ni LLM :
+
+        1. `run_for_user` choisit, par sujet, un représentant préférant une
+           source suivie (`is_user_source=True`) ; sinon conserve le
+           représentant global.
+        2. Re-ranking per-user : on score le représentant de chaque sujet via le
+           moteur de piliers (intérêts/subtopics×poids + source suivie + récence)
+           et on réordonne, en préservant « À la Une » au rang 1.
+        3. Sujets solo : un article d'une source suivie (<24h), non déjà
+           représenté et au score ≥ seuil, devient un sujet à lui seul
+           (gate cluster levé). Créés par-user → pas de fuite cross-user.
+        """
+        from app.services.editorial.pipeline import _read_target_subject_count
+        from app.services.editorial.schemas import (
+            EditorialPipelineResult,
+            EditorialSubject,
+            MatchedActuArticle,
+        )
+
+        target = _read_target_subject_count()
+
+        # 1. Matching actu per-user (représentant préférant les sources suivies).
+        per_user = pipeline.run_for_user(
+            global_ctx=global_ctx,
+            clusters=clusters,
+            user_source_ids=context.followed_source_ids,
+            excluded_content_ids=set(),
+        )
+        subjects = list(per_user.subjects)
+
+        # Lookup Content depuis le pool réhydraté.
+        content_by_id: dict[UUID, Content] = {}
+        for cl in clusters:
+            for c in cl.contents:
+                content_by_id[c.id] = c
+
+        represented_ids = {
+            s.actu_article.content_id for s in subjects if s.actu_article is not None
+        }
+
+        # Représentants à scorer.
+        rep_contents: list[Content] = []
+        seen: set[UUID] = set()
+        for s in subjects:
+            if s.actu_article is None:
+                continue
+            c = content_by_id.get(s.actu_article.content_id)
+            if c is not None and c.id not in seen:
+                rep_contents.append(c)
+                seen.add(c.id)
+
+        # Candidats solo : sources suivies, <24h, non représentés. 1 par source.
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=24)
+        solo_by_source: dict[UUID, Content] = {}
+        for c in content_by_id.values():
+            if c.source_id not in context.followed_source_ids:
+                continue
+            if c.id in represented_ids:
+                continue
+            pub = c.published_at
+            if pub.tzinfo is None:
+                pub = pub.replace(tzinfo=datetime.UTC)
+            if pub < cutoff:
+                continue
+            current = solo_by_source.get(c.source_id)
+            if current is None or pub > current.published_at.replace(
+                tzinfo=current.published_at.tzinfo or datetime.UTC
+            ):
+                solo_by_source[c.source_id] = c
+        solo_candidates = list(solo_by_source.values())
+
+        # 2. Scoring unifié (réutilise _score_candidates / pillar_engine).
+        score_map: dict[UUID, float] = {}
+        score_inputs = rep_contents + solo_candidates
+        if score_inputs:
+            try:
+                scored = await self._score_candidates(
+                    score_inputs, context, mode=mode
+                )
+                score_map = {c.id: sc for c, sc, _bd in scored}
+            except Exception:
+                # Dégradation sûre : sans scoring on garde l'ordre run_for_user.
+                logger.exception(
+                    "editorial_per_user_scoring_failed",
+                    user_id=str(context.user_id),
+                )
+
+        def subject_score(s: EditorialSubject) -> float:
+            if s.actu_article is None:
+                return float("-inf")
+            return score_map.get(s.actu_article.content_id, 0.0)
+
+        # 3. Sujets solo au-dessus du seuil.
+        threshold = _read_solo_subject_min_score()
+        solo_subjects: list[EditorialSubject] = []
+        for c in solo_candidates:
+            if score_map.get(c.id, 0.0) < threshold:
+                continue
+            solo_subjects.append(
+                EditorialSubject(
+                    rank=0,
+                    topic_id=f"solo-{c.id}",
+                    label=c.title,
+                    selection_reason="Source suivie",
+                    deep_angle=None,
+                    source_count=1,
+                    theme=c.theme or (c.source.theme if c.source else None),
+                    is_a_la_une=False,
+                    actu_article=MatchedActuArticle(
+                        content_id=c.id,
+                        title=c.title,
+                        source_name=c.source.name if c.source else "Source inconnue",
+                        source_id=c.source_id,
+                        is_user_source=True,
+                        published_at=c.published_at,
+                    ),
+                    extra_actu_articles=[],
+                )
+            )
+
+        # Re-ranking : « À la Une » reste rang 1 ; le reste trié par score desc.
+        une = [s for s in subjects if s.is_a_la_une]
+        rest = [s for s in subjects if not s.is_a_la_une] + solo_subjects
+        rest_sorted = sorted(rest, key=subject_score, reverse=True)
+        ordered = (une + rest_sorted)[:target]
+
+        renumbered: list[EditorialSubject] = []
+        for new_rank, s in enumerate(ordered, start=1):
+            renumbered.append(
+                s.model_copy(
+                    update={
+                        "rank": new_rank,
+                        "is_a_la_une": s.is_a_la_une and new_rank == 1,
+                    }
+                )
+            )
+
+        actu_hits = sum(1 for s in renumbered if s.actu_article is not None)
+        deep_hits = sum(1 for s in renumbered if s.deep_article is not None)
+        followed_reps = sum(
+            1
+            for s in renumbered
+            if s.actu_article is not None and s.actu_article.is_user_source
+        )
+        return EditorialPipelineResult(
+            subjects=renumbered,
+            metadata={
+                "actu_hits": actu_hits,
+                "deep_hits": deep_hits,
+                "total_subjects": len(renumbered),
+                "matching_ms": per_user.metadata.get("matching_ms", 0),
+                "solo_added": len(solo_subjects),
+                "followed_source_reps": followed_reps,
+                "per_user_projection": True,
+            },
+        )
+
     async def _score_candidates(
         self,
         candidates: list[Content],
         context: DigestContext,
         mode: str = "pour_vous",
     ) -> list[tuple[Content, float, list[DigestScoreBreakdown]]]:
-        """Score les candidats en utilisant le ScoringEngine existant avec bonus de fraîcheur.
+        """Score les candidats via le moteur de piliers unifié (PillarScoringEngine).
 
-        Cette méthode utilise le ScoringEngine configuré dans RecommendationService
-        et ajoute un bonus de fraîcheur hiérarchisé pour favoriser les articles
-        des sources suivies même s'ils sont plus anciens.
+        Le scoring (pertinence/source/fraîcheur/qualité + pénalités) est entièrement
+        délégué au `pillar_engine` — le même moteur que le Feed — pour une seule
+        source de vérité. La récence (FraicheurPillar) et le bonus source suivie
+        (SourcePillar) sont donc déjà comptés : aucun bonus manuel n'est ré-empilé
+        ici (anti double-comptage).
 
-        En mode PERSPECTIVE, ajoute un boost de +80 pts aux articles de biais opposé.
+        Seuls les ajustements digest-spécifiques sans équivalent pilier sont appliqués
+        en post-pilier : pénalité Sport (les deux modes) et boost "actu décalée" en
+        mode serein.
 
         Retourne les candidats avec leur score et un breakdown détaillé des contributions
         pour la transparence algorithmique.
@@ -1023,82 +1351,31 @@ class DigestSelector:
             breakdown: list[DigestScoreBreakdown] = []
 
             try:
-                # Get base score from ScoringEngine
-                base_score = self.rec_service.scoring_engine.compute_score(
+                # Moteur unifié : pertinence + source + fraîcheur + qualité,
+                # combinés et normalisés (~0-100), pénalités incluses. Une seule
+                # source de vérité partagée avec le Feed.
+                pillar_result = self.rec_service.pillar_engine.compute_score(
                     content, scoring_context
                 )
+                final_score = pillar_result.final_score
 
-                # Calculate recency bonus based on article age
-                # Defensive: Ensure both datetimes are timezone-aware
-                published = content.published_at
-                now = datetime.datetime.now(datetime.UTC)
-
-                if published.tzinfo is None:
-                    published = published.replace(tzinfo=datetime.UTC)
-                if now.tzinfo is None:
-                    now = now.replace(tzinfo=datetime.UTC)
-
-                hours_old = (now - published).total_seconds() / 3600
-
-                # Add recency contribution to breakdown
-                if hours_old < 6:
-                    recency_bonus = ScoringWeights.RECENT_VERY_BONUS  # +30
+                # Breakdown = contributions des piliers (déjà labellisées avec
+                # leur `pillar`). Récence et source suivie y figurent une seule
+                # fois — plus de ré-empilement manuel.
+                for contrib in pillar_result.contributions:
                     breakdown.append(
                         DigestScoreBreakdown(
-                            label="Article très récent (< 6h)",
-                            points=recency_bonus,
-                            is_positive=True,
+                            label=contrib["label"],
+                            points=contrib["points"],
+                            is_positive=contrib["is_positive"],
+                            pillar=contrib["pillar"],
                         )
                     )
-                elif hours_old < 24:
-                    recency_bonus = ScoringWeights.RECENT_BONUS  # +25
-                    breakdown.append(
-                        DigestScoreBreakdown(
-                            label="Article récent (< 24h)",
-                            points=recency_bonus,
-                            is_positive=True,
-                        )
-                    )
-                elif hours_old < 48:
-                    recency_bonus = ScoringWeights.RECENT_DAY_BONUS  # +15
-                    breakdown.append(
-                        DigestScoreBreakdown(
-                            label="Publié aujourd'hui",
-                            points=recency_bonus,
-                            is_positive=True,
-                        )
-                    )
-                elif hours_old < 72:
-                    recency_bonus = ScoringWeights.RECENT_YESTERDAY_BONUS  # +8
-                    breakdown.append(
-                        DigestScoreBreakdown(
-                            label="Publié hier", points=recency_bonus, is_positive=True
-                        )
-                    )
-                elif hours_old < 120:
-                    recency_bonus = ScoringWeights.RECENT_WEEK_BONUS  # +3
-                    breakdown.append(
-                        DigestScoreBreakdown(
-                            label="Article de la semaine",
-                            points=recency_bonus,
-                            is_positive=True,
-                        )
-                    )
-                elif hours_old < 168:
-                    recency_bonus = ScoringWeights.RECENT_OLD_BONUS  # +1
-                    breakdown.append(
-                        DigestScoreBreakdown(
-                            label="Article ancien",
-                            points=recency_bonus,
-                            is_positive=True,
-                        )
-                    )
-                else:
-                    recency_bonus = 0.0
 
-                final_score = base_score + recency_bonus
+                # --- Ajustements digest-spécifiques (post-pilier) ---
+                # Pas d'équivalent pilier : appliqués après la combinaison.
 
-                # Sport penalty (applied to both pour_vous and serein modes)
+                # Pénalité Sport (les deux modes).
                 if is_sport_content(content):
                     final_score += ScoringWeights.DIGEST_SPORT_PENALTY
                     breakdown.append(
@@ -1106,154 +1383,11 @@ class DigestSelector:
                             label="Sport (priorité réduite)",
                             points=ScoringWeights.DIGEST_SPORT_PENALTY,
                             is_positive=False,
+                            pillar="penalite",
                         )
                     )
 
-                # Capture CoreLayer contributions
-                # Theme match (3-tier: content.theme > source.theme > secondary)
-                _theme_breakdown_added = False
-                if (
-                    hasattr(content, "theme")
-                    and content.theme
-                    and content.theme in context.user_interests
-                ):
-                    breakdown.append(
-                        DigestScoreBreakdown(
-                            label=f"Thème article : {content.theme}",
-                            points=ScoringWeights.THEME_MATCH,
-                            is_positive=True,
-                        )
-                    )
-                    _theme_breakdown_added = True
-                elif content.source and content.source.theme in context.user_interests:
-                    breakdown.append(
-                        DigestScoreBreakdown(
-                            label=f"Thème matché : {content.source.theme}",
-                            points=ScoringWeights.THEME_MATCH,
-                            is_positive=True,
-                        )
-                    )
-                    _theme_breakdown_added = True
-                elif content.source and getattr(
-                    content.source, "secondary_themes", None
-                ):
-                    matched_sec = (
-                        set(content.source.secondary_themes) & context.user_interests
-                    )
-                    if matched_sec:
-                        sec_theme = sorted(matched_sec)[0]
-                        sec_pts = (
-                            ScoringWeights.THEME_MATCH
-                            * ScoringWeights.SECONDARY_THEME_FACTOR
-                        )
-                        breakdown.append(
-                            DigestScoreBreakdown(
-                                label=f"Thème secondaire : {sec_theme}",
-                                points=sec_pts,
-                                is_positive=True,
-                            )
-                        )
-                        _theme_breakdown_added = True
-
-                # Source followed
-                if content.source_id in context.followed_source_ids:
-                    breakdown.append(
-                        DigestScoreBreakdown(
-                            label="Source de confiance",
-                            points=ScoringWeights.TRUSTED_SOURCE,
-                            is_positive=True,
-                        )
-                    )
-
-                    # Digest-only additive boost: ensures an article from a
-                    # followed source outranks a comparable curated article in
-                    # the top-7 selection. base_score already counted the
-                    # standard TRUSTED_SOURCE via CoreLayer; this stacks on it
-                    # exclusively for the digest pipeline.
-                    final_score += ScoringWeights.DIGEST_TRUSTED_SOURCE_BONUS
-                    breakdown.append(
-                        DigestScoreBreakdown(
-                            label="Priorité source suivie (digest)",
-                            points=ScoringWeights.DIGEST_TRUSTED_SOURCE_BONUS,
-                            is_positive=True,
-                        )
-                    )
-
-                    # Custom source bonus
-                    if content.source_id in context.custom_source_ids:
-                        breakdown.append(
-                            DigestScoreBreakdown(
-                                label="Ta source personnalisée",
-                                points=ScoringWeights.CUSTOM_SOURCE_BONUS,
-                                is_positive=True,
-                            )
-                        )
-
-                # Capture ArticleTopicLayer contributions
-                if content.topics:
-                    matched_topics = 0
-                    for topic in content.topics:
-                        topic_lower = topic.lower()
-                        if topic_lower in context.user_subtopics and matched_topics < 2:
-                            w = context.user_subtopic_weights.get(topic_lower, 1.0)
-                            points = ScoringWeights.TOPIC_MATCH * w
-                            if w > 1.0:
-                                label = f"Renforcé par vos j'aime : {topic}"
-                            else:
-                                label = f"Sous-thème : {topic}"
-                            breakdown.append(
-                                DigestScoreBreakdown(
-                                    label=label, points=points, is_positive=True
-                                )
-                            )
-                            matched_topics += 1
-
-                    # Subtopic precision bonus if any topics matched
-                    if matched_topics > 0:
-                        breakdown.append(
-                            DigestScoreBreakdown(
-                                label="Précision thématique",
-                                points=ScoringWeights.SUBTOPIC_PRECISION_BONUS,
-                                is_positive=True,
-                            )
-                        )
-
-                # Capture StaticPreferenceLayer contributions
-                if content.content_type and context.user_prefs.get("preferred_format"):
-                    if content.content_type.value == context.user_prefs.get(
-                        "preferred_format"
-                    ):
-                        breakdown.append(
-                            DigestScoreBreakdown(
-                                label=f"Format préféré : {content.content_type.value}",
-                                points=15.0,  # Format preference weight
-                                is_positive=True,
-                            )
-                        )
-
-                # Capture QualityLayer contributions
-                if content.source and content.source.is_curated:
-                    breakdown.append(
-                        DigestScoreBreakdown(
-                            label="Source qualitative",
-                            points=ScoringWeights.CURATED_SOURCE,
-                            is_positive=True,
-                        )
-                    )
-
-                # Low reliability penalty (if applicable)
-                if content.source and hasattr(content.source, "reliability_score"):
-                    reliability = content.source.reliability_score
-                    if reliability and reliability.value == "low":
-                        breakdown.append(
-                            DigestScoreBreakdown(
-                                label="Fiabilité source faible",
-                                points=ScoringWeights.FQS_LOW_MALUS,
-                                is_positive=False,
-                            )
-                        )
-
-                # Serein mode: boost humorous/satirical sources x1.3
+                # Mode serein : boost sources humoristiques/satiriques x1.3.
                 if (
                     mode == "serein"
                     and content.source
@@ -1266,16 +1400,17 @@ class DigestSelector:
                             label="Actu décalée (mode serein)",
                             points=round(tone_boost, 1),
                             is_positive=True,
+                            pillar="pertinence",
                         )
                     )
 
                 logger.debug(
                     "digest_scoring_breakdown",
                     content_id=str(content.id),
-                    hours_old=round(hours_old, 2),
-                    base_score=round(base_score, 2),
-                    recency_bonus=recency_bonus,
                     final_score=round(final_score, 2),
+                    pillar_scores={
+                        k: round(v, 1) for k, v in pillar_result.pillar_scores.items()
+                    },
                     breakdown_count=len(breakdown),
                 )
 

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -169,7 +169,7 @@ def _schedule_background_regen(
                         user_id, target_date, is_serene=is_serene
                     )
                     if existing and existing.format_version in (
-                        "editorial_v1",
+                        EDITORIAL_FORMAT_VERSION,
                         "topics_v1",
                     ):
                         logger.info(
@@ -329,9 +329,21 @@ def _select_daily_quote(user_id: str, target_date: str) -> dict | None:
     return rng.choice(quotes)
 
 
+# Version courante du format editorial. Bumpée editorial_v1 -> editorial_v2 avec
+# la projection per-user (P2) : la FORME JSON est inchangée (toujours
+# `subjects[]`), mais la SÉMANTIQUE de sélection change (représentant source
+# suivie + re-ranking intérêts + sujets solo). Le bump force la régénération des
+# digests cachés `editorial_v1` (le cron les voit "stale") et évite de servir un
+# mix de sémantiques. Clé d'idempotence (user_id, target_date, is_serene)
+# inchangée.
+EDITORIAL_FORMAT_VERSION = "editorial_v2"
+# Tous les formats editorial rendus/clonables pendant la transition v1 -> v2.
+# Même forme JSON → `_build_editorial_response` les traite identiquement.
+_EDITORIAL_FORMATS: tuple[str, ...] = ("editorial_v1", "editorial_v2")
+
 # Format versions that the read-only hot path is willing to render. flat_v1
 # is legacy/expendable — never served from /digest or /digest/both.
-_READABLE_FORMATS: tuple[str, ...] = ("editorial_v1", "topics_v1")
+_READABLE_FORMATS: tuple[str, ...] = (*_EDITORIAL_FORMATS, "topics_v1")
 _HOTPATH_FALLBACK_DAYS = 7
 
 
@@ -443,7 +455,7 @@ async def read_digest_or_fallback(
                 DailyDigest.user_id != user_id,
                 DailyDigest.target_date == yesterday,
                 DailyDigest.is_serene == is_serene,
-                DailyDigest.format_version == "editorial_v1",
+                DailyDigest.format_version.in_(_EDITORIAL_FORMATS),
             )
         )
         .order_by(DailyDigest.generated_at.desc())
@@ -637,10 +649,10 @@ class DigestService:
         # 1a. Check format_version mismatch — stale cache from pre-editorial era
         expected_format = await self._get_user_digest_format(user_id)
         expected_version = {
-            "editorial": "editorial_v1",
+            "editorial": EDITORIAL_FORMAT_VERSION,
             "topics": "topics_v1",
             "flat": "flat_v1",
-        }.get(expected_format, "editorial_v1")
+        }.get(expected_format, EDITORIAL_FORMAT_VERSION)
 
         # Defer deletion of stale-format digest until AFTER the new digest is
         # successfully generated. This avoids a hole where we delete a valid
@@ -700,10 +712,7 @@ class DigestService:
                         digest_id=str(existing_digest.id),
                         format_version=existing_digest.format_version,
                     )
-                    if existing_digest.format_version in (
-                        "editorial_v1",
-                        "topics_v1",
-                    ):
+                    if existing_digest.format_version in _READABLE_FORMATS:
                         # Defer deletion, fall through to regeneration.
                         stale_format_digest = existing_digest
                         existing_digest = None
@@ -725,7 +734,13 @@ class DigestService:
             # pipeline (3-5 min), which exceeds both the /digest timeouts
             # and the mobile retry budget — the classic "spinner forever
             # after onboarding" symptom.
-            if expected_version == "editorial_v1":
+            # Cold-start fallback : depuis P2 le digest editorial est per-user,
+            # donc cloner la ligne d'un autre user n'est plus strictement
+            # "user-agnostic". On le garde quand même pour les nouveaux users
+            # arrivés après le batch : un digest frais et valide vaut mieux que
+            # le spinner cold-path LLM (3-5 min). La ligne clonée sera regénérée
+            # proprement (per-user) au prochain batch.
+            if expected_version == EDITORIAL_FORMAT_VERSION:
                 cloned = await self._try_clone_global_editorial_digest(
                     user_id=user_id,
                     target_date=target_date,
@@ -1610,7 +1625,7 @@ class DigestService:
                         DailyDigest.user_id != user_id,
                         DailyDigest.target_date == target_date,
                         DailyDigest.is_serene == is_serene,
-                        DailyDigest.format_version == "editorial_v1",
+                        DailyDigest.format_version.in_(_EDITORIAL_FORMATS),
                     )
                 )
                 .order_by(DailyDigest.generated_at.desc())
@@ -1645,7 +1660,9 @@ class DigestService:
             items=source.items,
             mode=source.mode or ("serein" if is_serene else "pour_vous"),
             is_serene=is_serene,
-            format_version="editorial_v1",
+            # Préserve la version de la source (le `items` JSONB embarque sa
+            # propre `format_version` — garder la ligne cohérente avec lui).
+            format_version=source.format_version,
             generated_at=source.generated_at,
         )
         self.session.add(cloned)
@@ -1848,7 +1865,7 @@ class DigestService:
         mode: str | None = None,
         is_serene: bool = False,
     ) -> DailyDigest | None:
-        """Create a new DailyDigest in editorial_v1 format."""
+        """Create a new DailyDigest in the current editorial format (editorial_v2)."""
         # Garde-fou: la pipeline trim déjà les sujets sans article (cf.
         # pipeline.py "ÉTAPE 3A-bis"). Ici on est défensif : si quelque chose
         # passe au travers, on logge en error (ce ne devrait plus arriver).
@@ -1868,7 +1885,7 @@ class DigestService:
         result = result.model_copy(update={"subjects": valid_subjects})
 
         items_json = {
-            "format_version": "editorial_v1",
+            "format_version": EDITORIAL_FORMAT_VERSION,
             "mode": mode or "pour_vous",
             "subjects": [
                 {
@@ -1929,7 +1946,7 @@ class DigestService:
             items=items_json,
             mode=mode or "pour_vous",
             is_serene=is_serene,
-            format_version="editorial_v1",
+            format_version=EDITORIAL_FORMAT_VERSION,
             generated_at=datetime.now(UTC),
         )
 
@@ -2015,7 +2032,7 @@ class DigestService:
         - topics_v1: grouped topics + flat items fallback
         - flat_v1 / None: legacy flat list
         """
-        if digest.format_version == "editorial_v1":
+        if digest.format_version in _EDITORIAL_FORMATS:
             return await self._build_editorial_response(digest, user_id)
         if digest.format_version == "topics_v1":
             return await self._build_topics_response(digest, user_id)
@@ -2403,7 +2420,8 @@ class DigestService:
             generated_at=digest.generated_at,
             mode=digest.mode or "pour_vous",
             is_serene=digest.is_serene,
-            format_version="editorial_v1",
+            # Reflète la version réelle de la ligne (v1 legacy ou v2 courant).
+            format_version=digest.format_version or EDITORIAL_FORMAT_VERSION,
             items=flat_items,
             topics=response_topics,
             completion_threshold=editorial_completion_threshold,

--- a/packages/api/app/services/recommendation/reason_builder.py
+++ b/packages/api/app/services/recommendation/reason_builder.py
@@ -4,7 +4,7 @@ Centralise la construction des labels pour "Pourquoi cet article ?".
 Utilisé par le Feed et le Digest pour une cohérence des labels.
 """
 
-from typing import Callable, TypeVar
+from collections.abc import Callable
 
 from app.schemas.content import RecommendationReason, ScoreContribution
 from app.schemas.digest import DigestRecommendationReason, DigestScoreBreakdown
@@ -13,13 +13,11 @@ from app.services.recommendation.scoring_engine import PillarScoreResult
 # Maximum de raisons affichées dans le breakdown
 MAX_BREAKDOWN_ITEMS = 6
 
-_BreakdownItem = TypeVar("_BreakdownItem", ScoreContribution, DigestScoreBreakdown)
 
-
-def _build_breakdown(
+def _build_breakdown[T: (ScoreContribution, DigestScoreBreakdown)](
     result: PillarScoreResult,
-    item_cls: Callable[..., _BreakdownItem],
-) -> list[_BreakdownItem]:
+    item_cls: Callable[..., T],
+) -> list[T]:
     """Map pillar contributions to breakdown items, sorted by |points| then capped.
 
     Shared by the feed (:class:`ScoreContribution`) and digest

--- a/packages/api/app/services/recommendation/reason_builder.py
+++ b/packages/api/app/services/recommendation/reason_builder.py
@@ -4,11 +4,40 @@ Centralise la construction des labels pour "Pourquoi cet article ?".
 Utilisé par le Feed et le Digest pour une cohérence des labels.
 """
 
+from typing import Callable, TypeVar
+
 from app.schemas.content import RecommendationReason, ScoreContribution
+from app.schemas.digest import DigestRecommendationReason, DigestScoreBreakdown
 from app.services.recommendation.scoring_engine import PillarScoreResult
 
 # Maximum de raisons affichées dans le breakdown
 MAX_BREAKDOWN_ITEMS = 6
+
+_BreakdownItem = TypeVar("_BreakdownItem", ScoreContribution, DigestScoreBreakdown)
+
+
+def _build_breakdown(
+    result: PillarScoreResult,
+    item_cls: Callable[..., _BreakdownItem],
+) -> list[_BreakdownItem]:
+    """Map pillar contributions to breakdown items, sorted by |points| then capped.
+
+    Shared by the feed (:class:`ScoreContribution`) and digest
+    (:class:`DigestScoreBreakdown`) builders — both schemas carry the same
+    fields (``label`` / ``points`` / ``is_positive`` / ``pillar``), so only the
+    target type differs.
+    """
+    breakdown = [
+        item_cls(
+            label=contrib["label"],
+            points=contrib["points"],
+            is_positive=contrib["is_positive"],
+            pillar=contrib["pillar"],
+        )
+        for contrib in result.contributions
+    ]
+    breakdown.sort(key=lambda x: abs(x.points), reverse=True)
+    return breakdown[:MAX_BREAKDOWN_ITEMS]
 
 
 def build_recommendation_reason(result: PillarScoreResult) -> RecommendationReason:
@@ -20,28 +49,41 @@ def build_recommendation_reason(result: PillarScoreResult) -> RecommendationReas
     Returns:
         RecommendationReason with label, score_total, and breakdown.
     """
-    # Build breakdown list from contributions
-    breakdown: list[ScoreContribution] = []
-    for contrib in result.contributions:
-        breakdown.append(
-            ScoreContribution(
-                label=contrib["label"],
-                points=contrib["points"],
-                is_positive=contrib["is_positive"],
-                pillar=contrib["pillar"],
-            )
-        )
-
-    # Sort by absolute contribution (highest first)
-    breakdown.sort(key=lambda x: abs(x.points), reverse=True)
-
-    # Limit to MAX_BREAKDOWN_ITEMS
-    breakdown = breakdown[:MAX_BREAKDOWN_ITEMS]
+    breakdown = _build_breakdown(result, ScoreContribution)
 
     # Compute top label
     label = _compute_top_label(result, breakdown)
 
     return RecommendationReason(
+        label=label,
+        score_total=result.final_score,
+        breakdown=breakdown,
+    )
+
+
+def build_digest_recommendation_reason(
+    result: PillarScoreResult,
+) -> DigestRecommendationReason:
+    """Build a DigestRecommendationReason from a PillarScoreResult.
+
+    Digest counterpart of :func:`build_recommendation_reason`. The digest
+    schemas (``DigestScoreBreakdown`` / ``DigestRecommendationReason``) carry
+    the exact same fields as the feed ones (``label`` / ``points`` /
+    ``is_positive`` / ``pillar``), so the mapping is identical — only the
+    target type differs. Centralising it here keeps the "Pourquoi cet
+    article ?" labels consistent between Feed and Digest.
+
+    ``score_total`` is the engine's combined ``final_score`` (the breakdown
+    is for transparency only and is not re-summed).
+    """
+    breakdown = _build_breakdown(result, DigestScoreBreakdown)
+
+    # `_compute_top_label` only reads `.pillar` / `.label` on the breakdown
+    # items and `result.pillar_scores`, so it works on DigestScoreBreakdown
+    # as-is.
+    label = _compute_top_label(result, breakdown)
+
+    return DigestRecommendationReason(
         label=label,
         score_total=result.final_score,
         breakdown=breakdown,

--- a/packages/api/tests/test_digest_generation_job.py
+++ b/packages/api/tests/test_digest_generation_job.py
@@ -266,3 +266,92 @@ class TestGlobalCandidatePool:
         compiled = str(stmt.compile(compile_kwargs={"literal_binds": False})).lower()
         # No good-news filter applied — historical behaviour preserved
         assert "is_good_news = true" not in compiled
+
+
+class TestFollowedSourceSlice:
+    """P1: followed sources are unioned into the clustering pool."""
+
+    @pytest.mark.asyncio
+    async def test_followed_slice_unioned_and_deduped(self, job):
+        """A followed-source article past the top-200 cut is added, deduped."""
+        from app.models.source import Source
+
+        followed_src = uuid4()
+        # recency slice: c1 (other source), c2 (followed, already present)
+        c1 = Mock(id=uuid4(), source_id=uuid4())
+        c2 = Mock(id=uuid4(), source_id=followed_src)
+        # followed slice query returns c2 (dup) + c3 (new, older niche article)
+        c3 = Mock(id=uuid4(), source_id=followed_src)
+
+        def _result(items):
+            scalars = MagicMock()
+            scalars.all = MagicMock(return_value=items)
+            res = MagicMock()
+            res.scalars = MagicMock(return_value=scalars)
+            return res
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(
+            side_effect=[_result([c1, c2]), _result([c2, c3])]
+        )
+
+        result = await job._get_global_candidates(
+            mock_session, followed_source_ids={followed_src}
+        )
+
+        ids = [c.id for c in result]
+        # c1, c2 from recency + c3 from followed slice (c2 deduped).
+        assert ids == [c1.id, c2.id, c3.id]
+        assert mock_session.execute.await_count == 2
+        # Second query (followed slice) filters on source_id and keeps cutoff.
+        followed_stmt = mock_session.execute.await_args_list[1].args[0]
+        compiled = str(
+            followed_stmt.compile(compile_kwargs={"literal_binds": False})
+        ).lower()
+        assert "contents.source_id in" in compiled
+        assert "contents.published_at >=" in compiled
+
+    @pytest.mark.asyncio
+    async def test_no_followed_slice_when_empty(self, job):
+        """Without followed sources, only the recency slice query runs."""
+        scalars = MagicMock()
+        scalars.all = MagicMock(return_value=[Mock(id=uuid4(), source_id=uuid4())])
+        res = MagicMock()
+        res.scalars = MagicMock(return_value=scalars)
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=res)
+
+        result = await job._get_global_candidates(
+            mock_session, followed_source_ids=set()
+        )
+        assert len(result) == 1
+        assert mock_session.execute.await_count == 1
+
+
+class TestBatchFollowedSourceIds:
+    """P1: the batch union of genuinely-followed source ids."""
+
+    @pytest.mark.asyncio
+    async def test_empty_user_ids_short_circuits(self, job):
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock()
+        result = await job._get_batch_followed_source_ids(mock_session, [])
+        assert result == set()
+        mock_session.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_filters_on_followed_and_favorite_state(self, job):
+        sid1, sid2 = uuid4(), uuid4()
+        res = MagicMock()
+        res.all = MagicMock(return_value=[(sid1,), (sid2,)])
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=res)
+
+        result = await job._get_batch_followed_source_ids(
+            mock_session, [uuid4(), uuid4()]
+        )
+        assert result == {sid1, sid2}
+        stmt = mock_session.execute.await_args.args[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+        assert "state in" in compiled
+        assert "'followed'" in compiled and "'favorite'" in compiled

--- a/packages/api/tests/test_digest_per_user_projection.py
+++ b/packages/api/tests/test_digest_per_user_projection.py
@@ -1,0 +1,300 @@
+"""Tests P2 — projection editorial per-user (DigestSelector).
+
+Couvre :
+- _rehydrate_editorial_clusters : cluster_data (IDs) -> TopicCluster consommable.
+- _project_editorial_for_user : deux users aux sources différentes -> ordres de
+  sujets différents depuis le MÊME EditorialGlobalContext (divergence), et sujet
+  solo créé pour le suiveur uniquement (contexte global reste partagé).
+"""
+
+import types
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services.digest_selector import DigestSelector, DigestContext
+from app.services.editorial.schemas import (
+    EditorialPipelineResult,
+    EditorialSubject,
+    MatchedActuArticle,
+)
+
+
+# ─── Factories ────────────────────────────────────────────────────────────────
+
+
+def _make_content(source_id, *, theme="tech", published_at=None, title="Article"):
+    c = MagicMock()
+    c.id = uuid4()
+    c.source_id = source_id
+    c.is_paid = False
+    c.content_type = None  # texte
+    c.theme = theme
+    c.topics = None
+    c.published_at = published_at or datetime.now(UTC)
+    c.title = title
+    c.thumbnail_url = None
+    c.source = MagicMock()
+    c.source.name = f"Source {source_id}"
+    c.source.theme = theme
+    c.source.is_curated = False
+    c.source.reliability_score = None
+    c.source.secondary_themes = []
+    return c
+
+
+def _make_topic_cluster(cluster_id, contents):
+    from app.services.briefing.importance_detector import TopicCluster
+
+    return TopicCluster(
+        cluster_id=cluster_id,
+        label="Cluster",
+        tokens=set(),
+        contents=contents,
+        source_ids={c.source_id for c in contents},
+        theme="tech",
+    )
+
+
+def _make_subject(topic_id, content, *, rank=1, is_a_la_une=False):
+    return EditorialSubject(
+        rank=rank,
+        topic_id=topic_id,
+        label=f"Sujet {topic_id}",
+        selection_reason="trending",
+        deep_angle=None,
+        is_a_la_une=is_a_la_une,
+        actu_article=MatchedActuArticle(
+            content_id=content.id,
+            title=content.title,
+            source_name=content.source.name,
+            source_id=content.source_id,
+            is_user_source=False,
+            published_at=content.published_at,
+        ),
+    )
+
+
+class _StubPipeline:
+    """Pipeline minimal : run_for_user délègue au vrai ActuMatcher."""
+
+    def run_for_user(
+        self, *, global_ctx, clusters, user_source_ids, excluded_content_ids
+    ):
+        from app.services.editorial.actu_matcher import ActuMatcher
+
+        subjects = ActuMatcher(actu_max_age_hours=24).match_for_user(
+            subjects=global_ctx.subjects,
+            clusters=clusters,
+            user_source_ids=user_source_ids,
+            excluded_content_ids=excluded_content_ids,
+        )
+        return EditorialPipelineResult(
+            subjects=subjects, metadata={"matching_ms": 0}
+        )
+
+
+class _FakeSessionMaker:
+    """async_sessionmaker stub renvoyant une session dont execute -> contents."""
+
+    def __init__(self, contents):
+        self._contents = contents
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        sess = AsyncMock()
+        scalars = MagicMock()
+        scalars.all = MagicMock(return_value=self._contents)
+        res = MagicMock()
+        res.scalars = MagicMock(return_value=scalars)
+        sess.execute = AsyncMock(return_value=res)
+        return sess
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _make_selector(session_maker=None):
+    from app.services.recommendation.scoring_engine import PillarScoringEngine
+
+    with patch("app.services.digest_selector.RecommendationService"):
+        sel = DigestSelector(AsyncMock(), session_maker=session_maker)
+    sel.rec_service = Mock()
+    sel.rec_service.fetch_impression_data = AsyncMock(return_value={})
+    sel.rec_service.pillar_engine = PillarScoringEngine()
+    return sel
+
+
+def _make_context(user_id, followed_source_ids, interests=None):
+    return DigestContext(
+        user_id=user_id,
+        user_profile=Mock(),
+        user_interests=interests or set(),
+        user_interest_weights={},
+        followed_source_ids=set(followed_source_ids),
+        custom_source_ids=set(),
+        user_prefs={},
+        user_subtopics=set(),
+        user_subtopic_weights={},
+        muted_sources=set(),
+        muted_themes=set(),
+        muted_topics=set(),
+        muted_content_types=set(),
+    )
+
+
+# ─── Tests: rehydration ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_clusters_from_cluster_data():
+    """cluster_data (IDs sérialisés) -> TopicCluster avec Content chargés."""
+    src = uuid4()
+    c1 = _make_content(src, title="A")
+    c2 = _make_content(src, title="B")
+    selector = _make_selector(session_maker=_FakeSessionMaker([c1, c2]))
+
+    global_ctx = types.SimpleNamespace(
+        cluster_data=[
+            {
+                "cluster_id": "cl-1",
+                "label": "Cluster 1",
+                "content_ids": [str(c1.id), str(c2.id)],
+                "source_ids": [str(src)],
+                "theme": "tech",
+            }
+        ],
+        subjects=[],
+    )
+
+    clusters = await selector._rehydrate_editorial_clusters(global_ctx)
+    assert len(clusters) == 1
+    assert clusters[0].cluster_id == "cl-1"
+    assert {c.id for c in clusters[0].contents} == {c1.id, c2.id}
+    assert clusters[0].source_ids == {src}
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_clusters_empty_when_no_data():
+    selector = _make_selector(session_maker=_FakeSessionMaker([]))
+    global_ctx = types.SimpleNamespace(cluster_data=[], subjects=[])
+    assert await selector._rehydrate_editorial_clusters(global_ctx) == []
+
+
+# ─── Tests: per-user projection divergence ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_two_users_diverge_on_followed_source_order():
+    """Même contexte global, sources suivies différentes -> ordres différents."""
+    srcA, srcB = uuid4(), uuid4()
+    now = datetime.now(UTC)
+    a1 = _make_content(srcA, published_at=now, title="Article A")
+    a2 = _make_content(srcB, published_at=now, title="Article B")
+
+    c1 = _make_topic_cluster("c1", [a1])
+    c2 = _make_topic_cluster("c2", [a2])
+    clusters = [c1, c2]
+
+    subjects = [
+        _make_subject("c1", a1, rank=1),
+        _make_subject("c2", a2, rank=2),
+    ]
+    global_ctx = types.SimpleNamespace(subjects=subjects, cluster_data=[])
+
+    selector = _make_selector()
+    pipeline = _StubPipeline()
+
+    # User A suit srcA.
+    ctx_a = _make_context(uuid4(), {srcA})
+    res_a = await selector._project_editorial_for_user(
+        pipeline=pipeline,
+        global_ctx=global_ctx,
+        clusters=clusters,
+        context=ctx_a,
+        mode="pour_vous",
+    )
+    order_a = [s.topic_id for s in res_a.subjects]
+
+    # User B suit srcB.
+    ctx_b = _make_context(uuid4(), {srcB})
+    res_b = await selector._project_editorial_for_user(
+        pipeline=pipeline,
+        global_ctx=global_ctx,
+        clusters=clusters,
+        context=ctx_b,
+        mode="pour_vous",
+    )
+    order_b = [s.topic_id for s in res_b.subjects]
+
+    # Le sujet adossé à la source suivie remonte en tête pour chaque user.
+    assert order_a[0] == "c1"
+    assert order_b[0] == "c2"
+    assert order_a != order_b
+    # Le représentant de la source suivie est marqué is_user_source.
+    top_a = res_a.subjects[0]
+    assert top_a.actu_article.is_user_source is True
+    # Les rangs sont renumérotés 1..n.
+    assert [s.rank for s in res_a.subjects] == list(
+        range(1, len(res_a.subjects) + 1)
+    )
+
+
+@pytest.mark.asyncio
+async def test_solo_subject_created_for_follower_only(monkeypatch):
+    """Un article de source suivie non représenté devient un sujet solo — pour
+    le suiveur seulement (le contexte global reste partagé)."""
+    # Seuil à 0 : tout article de source suivie récent franchit le gate.
+    monkeypatch.setenv("EDITORIAL_SOLO_SUBJECT_MIN_SCORE", "0")
+
+    srcA, srcB = uuid4(), uuid4()
+    now = datetime.now(UTC)
+    # c1 contient a1 (représentant, plus récent) + a3 (même source srcA, leftover).
+    a1 = _make_content(srcA, published_at=now, title="Rep A")
+    a3 = _make_content(
+        srcA, published_at=now - timedelta(hours=1), title="Solo A"
+    )
+    a2 = _make_content(srcB, published_at=now, title="Rep B")
+
+    c1 = _make_topic_cluster("c1", [a1, a3])
+    c2 = _make_topic_cluster("c2", [a2])
+    clusters = [c1, c2]
+    subjects = [
+        _make_subject("c1", a1, rank=1),
+        _make_subject("c2", a2, rank=2),
+    ]
+    global_ctx = types.SimpleNamespace(subjects=subjects, cluster_data=[])
+
+    selector = _make_selector()
+    pipeline = _StubPipeline()
+
+    # Suiveur de srcA : a3 (leftover, source suivie, récent) -> sujet solo.
+    ctx_follower = _make_context(uuid4(), {srcA})
+    res_follower = await selector._project_editorial_for_user(
+        pipeline=pipeline,
+        global_ctx=global_ctx,
+        clusters=clusters,
+        context=ctx_follower,
+        mode="pour_vous",
+    )
+    solo_ids = [s.topic_id for s in res_follower.subjects if s.topic_id.startswith("solo-")]
+    assert solo_ids, "le suiveur doit obtenir un sujet solo"
+    solo = next(s for s in res_follower.subjects if s.topic_id.startswith("solo-"))
+    assert solo.actu_article.content_id == a3.id
+    assert solo.actu_article.is_user_source is True
+
+    # Non-suiveur de srcA (suit srcB) : pas de sujet solo issu de a3.
+    ctx_other = _make_context(uuid4(), {srcB})
+    res_other = await selector._project_editorial_for_user(
+        pipeline=pipeline,
+        global_ctx=global_ctx,
+        clusters=clusters,
+        context=ctx_other,
+        mode="pour_vous",
+    )
+    other_solo = [s for s in res_other.subjects if s.topic_id.startswith("solo-")]
+    assert other_solo == [], "pas de fuite cross-user : aucun solo pour le non-suiveur"

--- a/packages/api/tests/test_digest_selector.py
+++ b/packages/api/tests/test_digest_selector.py
@@ -824,11 +824,25 @@ class TestGenerateReasonTrending:
         assert reason == "Thème : AI"
 
 
-# ─── Tests: Sport penalty in _score_candidates ───────────────────────────────
+# ─── Helpers: pillar engine ──────────────────────────────────────────────────
+
+
+def make_pillar_result(final_score=100.0, contributions=None):
+    """Construit un PillarScoreResult minimal pour mocker pillar_engine."""
+    from app.services.recommendation.scoring_engine import PillarScoreResult
+
+    return PillarScoreResult(
+        final_score=final_score,
+        pillar_scores={},
+        contributions=contributions or [],
+    )
+
+
+# ─── Tests: Sport penalty in _score_candidates (post-pilier) ──────────────────
 
 
 class TestScoreCandidatesSportPenalty:
-    """Pénalité Sport appliquée dans le scoring du digest (2 modes)."""
+    """Pénalité Sport appliquée en post-pilier dans le scoring du digest (2 modes)."""
 
     @pytest.fixture
     def context(self):
@@ -861,8 +875,11 @@ class TestScoreCandidatesSportPenalty:
 
         selector.rec_service = Mock()
         selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
-        selector.rec_service.scoring_engine = Mock()
-        selector.rec_service.scoring_engine.compute_score = Mock(return_value=100.0)
+        selector.rec_service.pillar_engine = Mock()
+        # Même score pilier pour les deux → seul le post-pilier sport diffère.
+        selector.rec_service.pillar_engine.compute_score = Mock(
+            return_value=make_pillar_result(final_score=100.0)
+        )
 
         scored = await selector._score_candidates(
             [sport_content, tech_content], context, mode="pour_vous"
@@ -877,6 +894,10 @@ class TestScoreCandidatesSportPenalty:
         )
         labels = [b.label for b in sport_breakdown]
         assert "Sport (priorité réduite)" in labels
+        sport_entry = next(
+            b for b in sport_breakdown if b.label == "Sport (priorité réduite)"
+        )
+        assert sport_entry.pillar == "penalite"
 
     @pytest.mark.asyncio
     async def test_sport_penalty_applies_in_serein_mode(self, selector, context):
@@ -889,8 +910,10 @@ class TestScoreCandidatesSportPenalty:
 
         selector.rec_service = Mock()
         selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
-        selector.rec_service.scoring_engine = Mock()
-        selector.rec_service.scoring_engine.compute_score = Mock(return_value=100.0)
+        selector.rec_service.pillar_engine = Mock()
+        selector.rec_service.pillar_engine.compute_score = Mock(
+            return_value=make_pillar_result(final_score=100.0)
+        )
 
         scored = await selector._score_candidates(
             [sport_content], context, mode="serein"
@@ -914,8 +937,10 @@ class TestScoreCandidatesSportPenalty:
 
         selector.rec_service = Mock()
         selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
-        selector.rec_service.scoring_engine = Mock()
-        selector.rec_service.scoring_engine.compute_score = Mock(return_value=100.0)
+        selector.rec_service.pillar_engine = Mock()
+        selector.rec_service.pillar_engine.compute_score = Mock(
+            return_value=make_pillar_result(final_score=100.0)
+        )
 
         scored = await selector._score_candidates([content], context, mode="pour_vous")
         _, _, breakdown = scored[0]
@@ -923,11 +948,17 @@ class TestScoreCandidatesSportPenalty:
         assert "Sport (priorité réduite)" in labels
 
 
-# ─── Tests: DIGEST_TRUSTED_SOURCE_BONUS ──────────────────────────────────────
+# ─── Tests: unified pillar scoring (P0) ───────────────────────────────────────
 
 
-class TestScoreCandidatesFollowedSourceBoost:
-    """Articles de sources suivies reçoivent un bonus exclusif au digest."""
+class TestScoreCandidatesUnifiedPillars:
+    """Le scoring digest est entièrement délégué au PillarScoringEngine.
+
+    On utilise le VRAI moteur de piliers (pas un mock) pour vérifier que :
+    - une source suivie reçoit une contribution `pillar='source'`,
+    - la récence n'est comptée qu'une fois (`pillar='fraicheur'`), sans
+      ré-empilement du bonus manuel legacy (anti double-comptage).
+    """
 
     @pytest.fixture
     def followed_src(self):
@@ -955,60 +986,49 @@ class TestScoreCandidatesFollowedSourceBoost:
             muted_content_types=set(),
         )
 
-    @pytest.mark.asyncio
-    async def test_followed_source_gets_digest_bonus(
-        self, selector, context, followed_src, other_src
-    ):
-        """Article d'une source suivie reçoit DIGEST_TRUSTED_SOURCE_BONUS en sus."""
-        from app.services.recommendation.scoring_config import ScoringWeights
-
-        now = datetime.now(timezone.utc)
-        followed_content = make_content(source=followed_src, theme="tech", published_at=now)
-        other_content = make_content(source=other_src, theme="tech", published_at=now)
+    def _wire_real_engine(self, selector):
+        from app.services.recommendation.scoring_engine import PillarScoringEngine
 
         selector.rec_service = Mock()
         selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
-        selector.rec_service.scoring_engine = Mock()
-        # CoreLayer's TRUSTED_SOURCE is already folded into base_score by
-        # compute_score in production; we mock it as a constant for both so
-        # the only differential measurable is the digest-specific bonus.
-        selector.rec_service.scoring_engine.compute_score = Mock(return_value=100.0)
+        selector.rec_service.pillar_engine = PillarScoringEngine()
+
+    @pytest.mark.asyncio
+    async def test_followed_source_gets_source_pillar_contribution(
+        self, selector, context, followed_src, other_src
+    ):
+        """Une source suivie reçoit une contribution mappée avec pillar='source'."""
+        self._wire_real_engine(selector)
+        now = datetime.now(timezone.utc)
+        followed_content = make_content(
+            source=followed_src, theme="tech", published_at=now
+        )
+        other_content = make_content(source=other_src, theme="tech", published_at=now)
 
         scored = await selector._score_candidates(
             [followed_content, other_content], context, mode="pour_vous"
         )
 
-        by_id = {c.id: (s, bd) for c, s, bd in scored}
-        followed_score, followed_breakdown = by_id[followed_content.id]
-        other_score, _ = by_id[other_content.id]
+        by_id = {c.id: bd for c, _, bd in scored}
+        followed_bd = by_id[followed_content.id]
+        other_bd = by_id[other_content.id]
 
-        assert followed_score - other_score == pytest.approx(
-            ScoringWeights.DIGEST_TRUSTED_SOURCE_BONUS
-        )
-        labels = [b.label for b in followed_breakdown]
-        assert "Priorité source suivie (digest)" in labels
+        source_contribs = [b for b in followed_bd if b.pillar == "source"]
+        assert any(b.label == "Source suivie" for b in source_contribs)
+        # La source non-suivie n'a pas de contribution "Source suivie".
+        assert not any(b.label == "Source suivie" for b in other_bd)
 
     @pytest.mark.asyncio
-    async def test_followed_outranks_curated_when_scores_close(
+    async def test_followed_source_outranks_equivalent_unfollowed(
         self, selector, context, followed_src, other_src
     ):
-        """Avec un base_score un peu inférieur, le followed gagne quand même."""
-        from app.services.recommendation.scoring_config import ScoringWeights
-
+        """Tout égal par ailleurs, l'article d'une source suivie score plus haut."""
+        self._wire_real_engine(selector)
         now = datetime.now(timezone.utc)
-        followed_content = make_content(source=followed_src, theme="tech", published_at=now)
+        followed_content = make_content(
+            source=followed_src, theme="tech", published_at=now
+        )
         other_content = make_content(source=other_src, theme="tech", published_at=now)
-
-        # Curated outscores by < bonus → followed should still win after stack.
-        gap = ScoringWeights.DIGEST_TRUSTED_SOURCE_BONUS - 5.0
-
-        def fake_compute(content, ctx):
-            return 100.0 if content.source_id == followed_src.id else 100.0 + gap
-
-        selector.rec_service = Mock()
-        selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
-        selector.rec_service.scoring_engine = Mock()
-        selector.rec_service.scoring_engine.compute_score = Mock(side_effect=fake_compute)
 
         scored = await selector._score_candidates(
             [followed_content, other_content], context, mode="pour_vous"
@@ -1018,48 +1038,44 @@ class TestScoreCandidatesFollowedSourceBoost:
         assert by_id[followed_content.id] > by_id[other_content.id]
 
     @pytest.mark.asyncio
-    async def test_followed_loses_when_curated_far_better(
-        self, selector, context, followed_src, other_src
+    async def test_recency_counted_once_no_legacy_double_count(
+        self, selector, context, followed_src
     ):
-        """Boost reste souple : un curated nettement meilleur passe devant."""
-        from app.services.recommendation.scoring_config import ScoringWeights
-
+        """La récence vient uniquement du FraicheurPillar, comptée une seule fois."""
+        self._wire_real_engine(selector)
         now = datetime.now(timezone.utc)
-        followed_content = make_content(source=followed_src, theme="tech", published_at=now)
-        other_content = make_content(source=other_src, theme="tech", published_at=now)
-
-        # Gap > bonus → curated wins, diversité préservée.
-        gap = ScoringWeights.DIGEST_TRUSTED_SOURCE_BONUS + 50.0
-
-        def fake_compute(content, ctx):
-            return 100.0 if content.source_id == followed_src.id else 100.0 + gap
-
-        selector.rec_service = Mock()
-        selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
-        selector.rec_service.scoring_engine = Mock()
-        selector.rec_service.scoring_engine.compute_score = Mock(side_effect=fake_compute)
+        content = make_content(source=followed_src, theme="tech", published_at=now)
 
         scored = await selector._score_candidates(
-            [followed_content, other_content], context, mode="pour_vous"
+            [content], context, mode="pour_vous"
         )
+        _, _, breakdown = scored[0]
 
-        by_id = {c.id: s for c, s, _ in scored}
-        assert by_id[other_content.id] > by_id[followed_content.id]
+        fraicheur_contribs = [b for b in breakdown if b.pillar == "fraicheur"]
+        # Exactement une contribution de récence (pas de préférence de récence
+        # dans user_prefs={} → un seul item fraicheur).
+        assert len(fraicheur_contribs) == 1
+        # Aucun label de récence manuel legacy ne doit subsister.
+        legacy_labels = {
+            "Article très récent (< 6h)",
+            "Article récent (< 24h)",
+            "Publié aujourd'hui",
+            "Publié hier",
+            "Article de la semaine",
+            "Article ancien",
+        }
+        assert not (legacy_labels & {b.label for b in breakdown})
 
     @pytest.mark.asyncio
-    async def test_no_bonus_when_source_not_followed(
+    async def test_no_source_contribution_when_not_followed(
         self, selector, context, other_src
     ):
-        """Aucun breakdown ni bonus si l'article n'est d'aucune source suivie."""
+        """Aucune contribution 'Source suivie' si l'article n'est d'aucune source suivie."""
+        self._wire_real_engine(selector)
         now = datetime.now(timezone.utc)
         content = make_content(source=other_src, theme="tech", published_at=now)
-
-        selector.rec_service = Mock()
-        selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
-        selector.rec_service.scoring_engine = Mock()
-        selector.rec_service.scoring_engine.compute_score = Mock(return_value=100.0)
 
         scored = await selector._score_candidates([content], context, mode="pour_vous")
         _, _, breakdown = scored[0]
         labels = [b.label for b in breakdown]
-        assert "Priorité source suivie (digest)" not in labels
+        assert "Source suivie" not in labels

--- a/packages/api/tests/test_scoring_v2.py
+++ b/packages/api/tests/test_scoring_v2.py
@@ -189,3 +189,40 @@ def test_personalization_layer_muted_topic(mock_content, base_context):
     score = layer.score(mock_content, base_context)
     assert score == -30.0
     assert "Tu vois moins de ai" in [r['details'] for r in base_context.reasons[mock_content.id]]
+
+
+# ─── P0: build_digest_recommendation_reason mapping ──────────────────────────
+
+
+def test_build_digest_recommendation_reason_maps_contributions():
+    """PillarScoreResult.contributions -> DigestScoreBreakdown (incl. pillar)."""
+    from app.services.recommendation.scoring_engine import PillarScoreResult
+    from app.services.recommendation.reason_builder import (
+        build_digest_recommendation_reason,
+    )
+
+    result = PillarScoreResult(
+        final_score=72.5,
+        pillar_scores={"source": 80.0, "pertinence": 50.0, "fraicheur": 40.0, "qualite": 10.0},
+        contributions=[
+            {"pillar": "source", "pillar_display": "Vos sources", "label": "Source suivie", "points": 35.0, "is_positive": True},
+            {"pillar": "fraicheur", "pillar_display": "Actualité", "label": "Récent", "points": 60.0, "is_positive": True},
+            {"pillar": "penalite", "pillar_display": "Pénalités", "label": "Source en sourdine", "points": -40.0, "is_positive": False},
+        ],
+    )
+
+    reason = build_digest_recommendation_reason(result)
+
+    # score_total est le final_score combiné, pas la somme du breakdown.
+    assert reason.score_total == 72.5
+    # Le pilier est conservé sur chaque contribution.
+    by_label = {b.label: b for b in reason.breakdown}
+    assert by_label["Source suivie"].pillar == "source"
+    assert by_label["Récent"].pillar == "fraicheur"
+    assert by_label["Source en sourdine"].pillar == "penalite"
+    assert by_label["Source en sourdine"].is_positive is False
+    # Tri par |points| décroissant : Récent (60) devant Source suivie (35).
+    labels = [b.label for b in reason.breakdown]
+    assert labels.index("Récent") < labels.index("Source suivie")
+    # Le label de tête reflète le pilier dominant (source ici, poids x score).
+    assert isinstance(reason.label, str) and reason.label


### PR DESCRIPTION
## Quoi

Rebâtit la sélection du digest autour d'une **projection par utilisateur** des sujets éditoriaux, au lieu d'un digest quasi-global identique pour tous.

- **`digest_generation_job`** : pool de candidats global élargi (slice récence + slice sources suivies via `_base_stmt`) pour alimenter la projection per-user.
- **`digest_selector`** : rehydratation des clusters éditoriaux mise en cache par `(date, mode)` ; projection per-user des subjects ; promotion de **« solo subjects »** (articles de sources suivies non clusterisés qui franchissent un seuil de score configurable `EDITORIAL_SOLO_SUBJECT_MIN_SCORE`, défaut 40 — pas de quota dur, décision PO).
- **`reason_builder`** : `build_digest_recommendation_reason` mutualise désormais le mapping `contributions → breakdown` avec le feed via un helper partagé `_build_breakdown` (sort par |points| + cap).
- **`digest_service` / `digest_content_refs` / `contents`** : câblage de la projection.

## Pourquoi

Le digest était quasi-global et cluster-gated → ~0 % de sources suivies remontaient pour l'utilisateur. La projection per-user réintroduit les signaux personnels (sources suivies, match intérêt, récence) dans la sélection éditoriale.

## Comment ça a été vérifié

- [x] `pytest` ciblé : `test_digest_per_user_projection` (nouveau, 300 l.), `test_digest_selector`, `test_digest_generation_job`, `test_scoring_v2` → **71 tests passés, 0 échec**
- [x] Suite backend complète : **1154 passed, 0 failed** (213 erreurs de *setup* = DB Postgres locale non démarrée, sur tests `veille`/`streak` hors diff — environnementales, passent en CI)
- [x] `/simplify` passé — 1 fix appliqué (factorisation `_build_breakdown`), reste skippé (faux positifs / décisions PO / micro-opts sur petites collections)
- [x] Rebasé sur `main` à jour ; le commit « top3 thématique » était déjà mergé dans `main` (skippé proprement au rebase), donc cette PR ne contient que la feature digest
- [ ] Pas de migration Alembic dans ce diff (1 head inchangé)

## Zones à risque

- Pipeline éditorial / sélection digest (`digest_selector`, `digest_generation_job`) — cœur de la génération quotidienne. Le seuil `EDITORIAL_SOLO_SUBJECT_MIN_SCORE` est configurable par env pour rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)