### PR TITLE
feat(flaner): séparer thèmes (Tournée) et sujets épinglés (onglets Flâner)

### DIFF
--- a/apps/mobile/lib/features/custom_topics/widgets/entity_add_sheet.dart
+++ b/apps/mobile/lib/features/custom_topics/widgets/entity_add_sheet.dart
@@ -25,12 +25,22 @@ class EntityAddSheet extends ConsumerStatefulWidget {
   /// historique (simple suivi) inchangé pour les autres appelants.
   final bool pinOnFollow;
 
-  const EntityAddSheet({super.key, this.themeSlug, this.pinOnFollow = false});
+  /// Pré-remplit le champ de saisie (ex : depuis la recherche de la modale
+  /// d'épinglage, quand aucun sujet existant ne matche → « Créer le sujet ... »).
+  final String? initialQuery;
+
+  const EntityAddSheet({
+    super.key,
+    this.themeSlug,
+    this.pinOnFollow = false,
+    this.initialQuery,
+  });
 
   static void show(
     BuildContext context, {
     String? themeSlug,
     bool pinOnFollow = false,
+    String? initialQuery,
   }) {
     showModalBottomSheet<void>(
       context: context,
@@ -42,7 +52,11 @@ class EntityAddSheet extends ConsumerStatefulWidget {
         child: Padding(
           padding:
               EdgeInsets.only(bottom: MediaQuery.of(ctx).viewInsets.bottom),
-          child: EntityAddSheet(themeSlug: themeSlug, pinOnFollow: pinOnFollow),
+          child: EntityAddSheet(
+            themeSlug: themeSlug,
+            pinOnFollow: pinOnFollow,
+            initialQuery: initialQuery,
+          ),
         ),
       ),
     );
@@ -57,6 +71,17 @@ class _EntityAddSheetState extends ConsumerState<EntityAddSheet> {
   bool _loading = false;
   List<DisambiguationSuggestion>? _suggestions;
   int? _followingIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = widget.initialQuery?.trim() ?? '';
+    if (initial.isNotEmpty) {
+      _controller.text = initial;
+      _controller.selection =
+          TextSelection.collapsed(offset: _controller.text.length);
+    }
+  }
 
   @override
   void dispose() {

--- a/apps/mobile/lib/features/custom_topics/widgets/entity_add_sheet.dart
+++ b/apps/mobile/lib/features/custom_topics/widgets/entity_add_sheet.dart
@@ -7,6 +7,8 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
 import '../../../core/ui/notification_service.dart';
+import '../../my_interests/models/user_interests_state.dart';
+import '../../my_interests/providers/user_interests_provider.dart';
 import '../models/topic_models.dart';
 import '../providers/custom_topics_provider.dart';
 import 'disambiguation_suggestion_tile.dart';
@@ -17,9 +19,19 @@ const Color _terracotta = Color(0xFFE07A5F);
 class EntityAddSheet extends ConsumerStatefulWidget {
   final String? themeSlug;
 
-  const EntityAddSheet({super.key, this.themeSlug});
+  /// Quand `true`, le sujet créé est immédiatement épinglé en favori
+  /// (`CustomTopicFavoriteRef` → favorite) → il apparaît comme onglet dans
+  /// Flâner. Utilisé par la modale d'épinglage. Défaut `false` : comportement
+  /// historique (simple suivi) inchangé pour les autres appelants.
+  final bool pinOnFollow;
 
-  static void show(BuildContext context, {String? themeSlug}) {
+  const EntityAddSheet({super.key, this.themeSlug, this.pinOnFollow = false});
+
+  static void show(
+    BuildContext context, {
+    String? themeSlug,
+    bool pinOnFollow = false,
+  }) {
     showModalBottomSheet<void>(
       context: context,
       backgroundColor: Colors.transparent,
@@ -30,7 +42,7 @@ class EntityAddSheet extends ConsumerStatefulWidget {
         child: Padding(
           padding:
               EdgeInsets.only(bottom: MediaQuery.of(ctx).viewInsets.bottom),
-          child: EntityAddSheet(themeSlug: themeSlug),
+          child: EntityAddSheet(themeSlug: themeSlug, pinOnFollow: pinOnFollow),
         ),
       ),
     );
@@ -72,9 +84,10 @@ class _EntityAddSheetState extends ConsumerState<EntityAddSheet> {
           await _followSuggestion(suggestions[0], 0);
         } else {
           // Fallback: follow as plain topic
-          await ref
+          final created = await ref
               .read(customTopicsProvider.notifier)
               .followTopic(name, slugParent: widget.themeSlug);
+          await _maybePin(created);
           if (mounted) {
             Navigator.of(context).pop();
             NotificationService.showInfo('"$name" ajouté à vos intérêts');
@@ -108,7 +121,9 @@ class _EntityAddSheetState extends ConsumerState<EntityAddSheet> {
   ) async {
     setState(() => _followingIndex = index);
     try {
-      await ref.read(customTopicsProvider.notifier).followSuggestion(s);
+      final created =
+          await ref.read(customTopicsProvider.notifier).followSuggestion(s);
+      await _maybePin(created);
       if (mounted) {
         Navigator.of(context).pop();
         NotificationService.showInfo(
@@ -127,6 +142,21 @@ class _EntityAddSheetState extends ConsumerState<EntityAddSheet> {
       }
     } finally {
       if (mounted) setState(() => _followingIndex = null);
+    }
+  }
+
+  /// Épingle le sujet fraîchement créé si la sheet a été ouverte en mode
+  /// [EntityAddSheet.pinOnFollow]. Best-effort : un échec d'épinglage ne doit
+  /// pas casser le flow de suivi (le sujet est déjà créé).
+  Future<void> _maybePin(UserTopicProfile? created) async {
+    if (!widget.pinOnFollow || created == null) return;
+    try {
+      await ref.read(userInterestsProvider.notifier).setInterestState(
+            CustomTopicFavoriteRef(id: created.id),
+            InterestState.favorite,
+          );
+    } catch (_) {
+      // Le suivi a réussi ; l'épinglage pourra être refait depuis la modale.
     }
   }
 

--- a/apps/mobile/lib/features/feed/screens/flaner_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/flaner_screen.dart
@@ -20,6 +20,7 @@ import '../providers/feed_provider.dart';
 import '../widgets/feed_carousel.dart';
 import '../widgets/feed_filter_bar.dart';
 import '../widgets/follow_keyword_suggestion_card.dart';
+import '../widgets/pin_subjects_sheet.dart';
 
 const double _kLoadMoreLeadingPx = 800.0;
 const double _kScrollDirThreshold = 12.0;
@@ -187,6 +188,7 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
             pinned: true,
             delegate: _FilterHeaderDelegate(child: _FilterSurface()),
           ),
+          const SliverToBoxAdapter(child: PinSubjectsBanner()),
           SliverToBoxAdapter(
             child: (keyword == null || keyword.trim().isEmpty)
                 ? const SizedBox.shrink()
@@ -284,7 +286,7 @@ class _FilterSurface extends ConsumerWidget {
         children: [
           const Padding(
             padding: EdgeInsets.fromLTRB(16, 8, 16, 8),
-            child: FeedFilterBar(excludedThemeSlugs: <String>[]),
+            child: FeedFilterBar(),
           ),
           SizedBox(
             height: 2,

--- a/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
+++ b/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
-import '../../../config/topic_labels.dart';
 import '../../custom_topics/models/topic_models.dart';
 import '../../custom_topics/providers/custom_topics_provider.dart';
 import '../../my_interests/models/user_interests_state.dart';
@@ -43,10 +42,6 @@ class FavoriteTopicTabs extends ConsumerStatefulWidget {
   final VoidCallback onTapActiveTab;
   final VoidCallback onTapActiveTabRefresh;
   final VoidCallback onAddFavorite;
-  /// API slugs (macro themes) to omit from the tab list. Used by the Flux
-  /// Continu Explorer filter bar to hide themes already covered by the day's
-  /// tournée — avoiding the "double serving" of the same theme.
-  final List<String> excludedThemeSlugs;
 
   const FavoriteTopicTabs({
     super.key,
@@ -59,7 +54,6 @@ class FavoriteTopicTabs extends ConsumerStatefulWidget {
     required this.onTapActiveTab,
     required this.onTapActiveTabRefresh,
     required this.onAddFavorite,
-    this.excludedThemeSlugs = const [],
   });
 
   @override
@@ -128,7 +122,6 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
       selectedTopicSlug: widget.selectedTopicSlug,
       selectedThemeSlug: widget.selectedThemeSlug,
       selectedEntitySlug: widget.selectedEntitySlug,
-      excludedThemeSlugs: widget.excludedThemeSlugs,
     );
 
     _activeKey = null;
@@ -186,10 +179,6 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
   }
 }
 
-final Map<String, String> _apiSlugToMacroLabel = {
-  for (final e in macroThemeToApiSlug.entries) e.value: e.key,
-};
-
 @visibleForTesting
 List<FavoriteTabModel> buildFavoriteTabModelsForTest({
   required List<UserTopicProfile> topics,
@@ -199,7 +188,6 @@ List<FavoriteTabModel> buildFavoriteTabModelsForTest({
   String? selectedTopicSlug,
   String? selectedThemeSlug,
   String? selectedEntitySlug,
-  List<String> excludedThemeSlugs = const [],
 }) =>
     _buildTabModels(
       topics: topics,
@@ -209,9 +197,11 @@ List<FavoriteTabModel> buildFavoriteTabModelsForTest({
       selectedTopicSlug: selectedTopicSlug,
       selectedThemeSlug: selectedThemeSlug,
       selectedEntitySlug: selectedEntitySlug,
-      excludedThemeSlugs: excludedThemeSlugs,
     );
 
+/// Onglets Flâner = uniquement les *sujets épinglés* (custom topics + entités
+/// favoris). Les *thèmes/veille* pilotent la Tournée du jour et ne sont donc
+/// pas rendus en onglet ici — ils restent filtrables via la chip thème.
 List<FavoriteTabModel> _buildTabModels({
   required List<UserTopicProfile> topics,
   required List<FavoriteRef> favorites,
@@ -220,17 +210,12 @@ List<FavoriteTabModel> _buildTabModels({
   String? selectedTopicSlug,
   String? selectedThemeSlug,
   String? selectedEntitySlug,
-  List<String> excludedThemeSlugs = const [],
 }) {
   final useServer = serverCounts != null && serverCounts.total > 0;
 
   final favoriteCustomIds = <String>{
     for (final f in favorites)
       if (f is CustomTopicFavoriteRef) f.id,
-  };
-  final favoriteThemeSlugs = <String>{
-    for (final f in favorites)
-      if (f is ThemeFavoriteRef) f.slug,
   };
 
   final entitySubjects = topics
@@ -243,11 +228,6 @@ List<FavoriteTabModel> _buildTabModels({
           t.entityType == null && favoriteCustomIds.contains(t.id))
       .toList()
     ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
-
-  final favoriteThemes = macroThemeOrder
-      .where((label) =>
-          favoriteThemeSlugs.contains(macroThemeToApiSlug[label]))
-      .toList();
 
   final cutoff = DateTime.now().subtract(const Duration(hours: 48));
   final tabs = <FavoriteTabModel>[];
@@ -267,9 +247,8 @@ List<FavoriteTabModel> _buildTabModels({
         selectedEntitySlug == null,
   ));
 
-  // 2. Onglets favoris (entités, topics, thèmes) fusionnés et triés
-  // par nombre d'articles disponibles décroissant. Pas de hiérarchie
-  // Sujet > Thème : seul le volume d'actu disponible compte.
+  // 2. Onglets favoris (entités + sujets épinglés) triés par nombre
+  // d'articles disponibles décroissant.
   final favoriteTabs = <FavoriteTabModel>[];
 
   for (final entity in entitySubjects) {
@@ -302,23 +281,6 @@ List<FavoriteTabModel> _buildTabModels({
     ));
   }
 
-  for (final label in favoriteThemes) {
-    final apiSlug = macroThemeToApiSlug[label];
-    if (apiSlug == null) continue;
-    if (excludedThemeSlugs.contains(apiSlug)) continue;
-    favoriteTabs.add(FavoriteTabModel(
-      kind: FavoriteTabKind.theme,
-      slug: apiSlug,
-      label: label,
-      emoji: getMacroThemeEmoji(label),
-      count: useServer
-          ? (serverCounts.themes[apiSlug] ?? 0)
-          : _countUnreadRecent(items,
-              cutoff: cutoff, kind: FavoriteTabKind.theme, slug: apiSlug),
-      active: selectedThemeSlug != null && selectedThemeSlug == apiSlug,
-    ));
-  }
-
   favoriteTabs.sort((a, b) {
     final byCount = b.count.compareTo(a.count);
     if (byCount != 0) return byCount;
@@ -346,11 +308,9 @@ int _countUnreadRecent(
         final lower = slug.toLowerCase();
         return c.entities.any((e) => e.text.toLowerCase() == lower);
       case FavoriteTabKind.theme:
-        if (slug == null) return false;
-        final label = _apiSlugToMacroLabel[slug];
-        if (label == null) return false;
-        final themeSlugs = getSlugsForMacroTheme(label);
-        return c.topics.any(themeSlugs.contains);
+        // Les thèmes ne sont plus rendus en onglet Flâner (ils pilotent la
+        // Tournée). Valeur conservée dans l'enum pour la chip thème.
+        return false;
     }
   }
 

--- a/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
@@ -11,7 +11,7 @@ import 'compact_source_chip.dart';
 import 'compact_theme_chip.dart';
 import 'favorite_topic_tabs.dart';
 import 'filter_collapsible_panel.dart';
-import 'interest_filter_sheet.dart';
+import 'pin_subjects_sheet.dart';
 import 'search_filter_sheet.dart';
 
 /// Compact, self-contained version of `FeedScreen._buildFilterBar`, intended
@@ -26,12 +26,10 @@ import 'search_filter_sheet.dart';
 /// them here behind optional callbacks rather than duplicating the logic.
 class FeedFilterBar extends ConsumerStatefulWidget {
   final VoidCallback? onAfterChange;
-  final List<String> excludedThemeSlugs;
 
   const FeedFilterBar({
     super.key,
     this.onAfterChange,
-    this.excludedThemeSlugs = const [],
   });
 
   @override
@@ -63,7 +61,6 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
         selectedTopicSlug: selection.topic,
         selectedThemeSlug: selection.theme,
         selectedEntitySlug: selection.entity,
-        excludedThemeSlugs: widget.excludedThemeSlugs,
         onTabTap: (kind, slug) async {
           // Sheet owns this override ; clear it so the chip label rebuilds
           // from the tapped tab's name on next layout.
@@ -93,32 +90,11 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
           HapticFeedback.mediumImpact();
           widget.onAfterChange?.call();
         },
+        // Le « + » des onglets épingle des sujets précis (custom topics) —
+        // le filtrage par thème/source reste assuré par les chips ci-dessous.
         onAddFavorite: () {
           HapticFeedback.mediumImpact();
-          InterestFilterSheet.show(
-            context,
-            currentTopicSlug:
-                selection.topic ?? selection.theme ?? selection.entity,
-            currentIsTheme: selection.theme != null,
-            onInterestSelected: (
-              slug,
-              name, {
-              bool isTheme = false,
-              bool isEntity = false,
-            }) async {
-              setState(() {
-                _selectedInterestNameOverride = name;
-              });
-              if (isTheme) {
-                await notifier.setTheme(slug);
-              } else if (isEntity) {
-                await notifier.setEntity(slug);
-              } else {
-                await notifier.setTopic(slug);
-              }
-              widget.onAfterChange?.call();
-            },
-          );
+          showPinSubjectsSheet(context);
         },
       ),
       leadingTrigger: _SearchTrigger(

--- a/apps/mobile/lib/features/feed/widgets/pin_subjects_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/pin_subjects_sheet.dart
@@ -10,10 +10,11 @@ import '../../../core/ui/notification_service.dart';
 import '../../custom_topics/widgets/entity_add_sheet.dart';
 import '../../my_interests/models/user_interests_state.dart';
 import '../../my_interests/providers/user_interests_provider.dart';
+import '../../veille/providers/veille_themes_provider.dart';
 
 /// Nombre de sujets épinglés en-dessous duquel on incite l'utilisateur à en
 /// épingler davantage (carte CTA + sous-titre). Aligné sur la promesse
-/// « épingle 3-4 sujets pour une veille de qualité ».
+/// « 3-4 sujets suffisent ».
 const int kPinSubjectsTarget = 3;
 
 int _pinnedCount(UserInterestsState? interests) {
@@ -89,7 +90,7 @@ class PinSubjectsBanner extends ConsumerWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        'Épingle tes sujets de veille',
+                        'Épingle tes sujets',
                         style: Theme.of(context)
                             .textTheme
                             .titleSmall
@@ -100,8 +101,8 @@ class PinSubjectsBanner extends ConsumerWidget {
                       ),
                       const SizedBox(height: 2),
                       Text(
-                        'Épingle 3-4 sujets pour une veille de qualité — '
-                        'ils deviennent tes onglets ici.',
+                        '3-4 sujets suffisent — ils deviennent tes onglets '
+                        'dans Flâner.',
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                               color: colors.textSecondary,
                               height: 1.35,
@@ -125,14 +126,48 @@ class PinSubjectsBanner extends ConsumerWidget {
   }
 }
 
-class _PinSubjectsContent extends ConsumerWidget {
+/// Emoji du thème parent d'un sujet (sert d'icône de thématique). Fallback
+/// 📰 pour un slug hors des 9 thèmes Facteur (cf. [kVeilleFacteurThemes]).
+String _themeEmoji(String slugParent) {
+  for (final t in kVeilleFacteurThemes) {
+    if (t.slug == slugParent) return t.emoji;
+  }
+  return '📰';
+}
+
+/// Normalise une chaîne pour la recherche : minuscules + accents retirés.
+String _normalize(String input) {
+  final lower = input.toLowerCase();
+  const from = 'àâäáãéèêëíìîïóòôöõúùûüçñ';
+  const to = 'aaaaaeeeeiiiiooooouuuucn';
+  final buffer = StringBuffer();
+  for (final rune in lower.runes) {
+    final char = String.fromCharCode(rune);
+    final idx = from.indexOf(char);
+    buffer.write(idx == -1 ? char : to[idx]);
+  }
+  return buffer.toString();
+}
+
+class _PinSubjectsContent extends ConsumerStatefulWidget {
   const _PinSubjectsContent();
 
-  Future<void> _setState(
-    WidgetRef ref,
-    String topicId,
-    InterestState state,
-  ) async {
+  @override
+  ConsumerState<_PinSubjectsContent> createState() =>
+      _PinSubjectsContentState();
+}
+
+class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
+  final _searchController = TextEditingController();
+  String _query = '';
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _setState(String topicId, InterestState state) async {
     try {
       await ref.read(userInterestsProvider.notifier).setInterestState(
             CustomTopicFavoriteRef(id: topicId),
@@ -143,20 +178,63 @@ class _PinSubjectsContent extends ConsumerWidget {
     }
   }
 
+  bool _matches(CustomTopicInterest t, String normalizedQuery) {
+    if (normalizedQuery.isEmpty) return true;
+    return _normalize(t.topicName).contains(normalizedQuery);
+  }
+
+  /// Groupe les sujets par thème parent, dans l'ordre canonique des thèmes
+  /// Facteur (les thèmes inconnus en dernier), sujets triés alpha dans chaque
+  /// groupe.
+  List<MapEntry<String, List<CustomTopicInterest>>> _groupByTheme(
+    List<CustomTopicInterest> subjects,
+  ) {
+    final groups = <String, List<CustomTopicInterest>>{};
+    for (final t in subjects) {
+      groups.putIfAbsent(t.slugParent, () => []).add(t);
+    }
+    for (final list in groups.values) {
+      list.sort((a, b) =>
+          a.topicName.toLowerCase().compareTo(b.topicName.toLowerCase()));
+    }
+    final order = {
+      for (var i = 0; i < kVeilleFacteurThemes.length; i++)
+        kVeilleFacteurThemes[i].slug: i,
+    };
+    final entries = groups.entries.toList()
+      ..sort((a, b) {
+        final ia = order[a.key] ?? kVeilleFacteurThemes.length;
+        final ib = order[b.key] ?? kVeilleFacteurThemes.length;
+        if (ia != ib) return ia.compareTo(ib);
+        return a.key.compareTo(b.key);
+      });
+    return entries;
+  }
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
     final interests = ref.watch(userInterestsProvider).valueOrNull;
     final topics = interests?.customTopics ?? const <CustomTopicInterest>[];
 
-    final pinned =
-        topics.where((t) => t.state == InterestState.favorite).toList();
-    final pinnable = topics
-        .where((t) => t.state != InterestState.favorite)
+    final normalizedQuery = _normalize(_query.trim());
+    final hasQuery = normalizedQuery.isNotEmpty;
+
+    final pinned = topics
+        .where((t) =>
+            t.state == InterestState.favorite && _matches(t, normalizedQuery))
         .toList()
       ..sort((a, b) =>
           a.topicName.toLowerCase().compareTo(b.topicName.toLowerCase()));
+    final pinnable = topics
+        .where((t) =>
+            t.state != InterestState.favorite && _matches(t, normalizedQuery))
+        .toList();
+    final pinnableGroups = _groupByTheme(pinnable);
+
+    final hasAnyTopic = topics.isNotEmpty;
+    final noMatch = pinned.isEmpty && pinnable.isEmpty;
 
     return SafeArea(
       top: false,
@@ -206,6 +284,21 @@ class _PinSubjectsContent extends ConsumerWidget {
                 ),
                 const SizedBox(height: FacteurSpacing.space4),
 
+                // Barre de recherche — filtre les sujets ; fallback « créer »
+                // quand aucun ne matche.
+                if (hasAnyTopic)
+                  _SearchField(
+                    controller: _searchController,
+                    colors: colors,
+                    onChanged: (value) => setState(() => _query = value),
+                    onClear: () => setState(() {
+                      _searchController.clear();
+                      _query = '';
+                    }),
+                  ),
+                if (hasAnyTopic)
+                  const SizedBox(height: FacteurSpacing.space4),
+
                 // Sujets déjà épinglés → tap pour dé-épingler.
                 if (pinned.isNotEmpty) ...[
                   _SectionLabel(label: 'SUJETS ÉPINGLÉS', colors: colors),
@@ -214,33 +307,59 @@ class _PinSubjectsContent extends ConsumerWidget {
                     _SubjectRow(
                       key: ValueKey('pinned_${t.id}'),
                       label: t.topicName,
+                      emoji: _themeEmoji(t.slugParent),
                       pinned: true,
                       colors: colors,
-                      onTap: () =>
-                          _setState(ref, t.id, InterestState.unfollowed),
+                      onTap: () => _setState(t.id, InterestState.unfollowed),
                     ),
                   const SizedBox(height: FacteurSpacing.space4),
                 ],
 
-                // Sujets suivis non épinglés → 1 tap pour épingler.
+                // Sujets suivis non épinglés → groupés par thématique,
+                // 1 tap pour épingler.
                 if (pinnable.isNotEmpty) ...[
                   _SectionLabel(
                     label: 'ÉPINGLER UN SUJET SUIVI',
                     colors: colors,
                   ),
                   const SizedBox(height: 8),
-                  for (final t in pinnable)
-                    _SubjectRow(
-                      key: ValueKey('pinnable_${t.id}'),
-                      label: t.topicName,
-                      pinned: false,
+                  for (final group in pinnableGroups) ...[
+                    _ThemeGroupHeader(
+                      emoji: _themeEmoji(group.key),
+                      label: veilleThemeLabelForSlug(group.key),
                       colors: colors,
-                      onTap: () => _setState(ref, t.id, InterestState.favorite),
                     ),
+                    const SizedBox(height: 6),
+                    for (final t in group.value)
+                      _SubjectRow(
+                        key: ValueKey('pinnable_${t.id}'),
+                        label: t.topicName,
+                        emoji: _themeEmoji(t.slugParent),
+                        pinned: false,
+                        colors: colors,
+                        onTap: () => _setState(t.id, InterestState.favorite),
+                      ),
+                    const SizedBox(height: 10),
+                  ],
+                  const SizedBox(height: FacteurSpacing.space2),
+                ],
+
+                // Aucun sujet ne matche la recherche → proposer de le créer.
+                if (hasQuery && noMatch) ...[
+                  _CreateSubjectTile(
+                    query: _query.trim(),
+                    colors: colors,
+                    onTap: () => EntityAddSheet.show(
+                      context,
+                      pinOnFollow: true,
+                      initialQuery: _query.trim(),
+                    ),
+                  ),
                   const SizedBox(height: FacteurSpacing.space4),
                 ],
 
-                if (pinned.isEmpty && pinnable.isEmpty) ...[
+                // Aucun sujet du tout (et pas de recherche en cours).
+                if (!hasQuery && !hasAnyTopic) ...[
                   Text(
                     'Aucun sujet pour le moment. Crée ton premier sujet '
                     'à suivre ci-dessous.',
@@ -293,6 +412,163 @@ class _PinSubjectsContent extends ConsumerWidget {
   }
 }
 
+class _SearchField extends StatelessWidget {
+  final TextEditingController controller;
+  final FacteurColors colors;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onClear;
+
+  const _SearchField({
+    required this.controller,
+    required this.colors,
+    required this.onChanged,
+    required this.onClear,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      onChanged: onChanged,
+      textInputAction: TextInputAction.search,
+      style: TextStyle(color: colors.textPrimary, fontSize: 14),
+      decoration: InputDecoration(
+        isDense: true,
+        hintText: 'Rechercher un sujet…',
+        hintStyle: TextStyle(color: colors.textTertiary, fontSize: 14),
+        prefixIcon: Icon(
+          PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
+          size: 18,
+          color: colors.textTertiary,
+        ),
+        suffixIcon: controller.text.isEmpty
+            ? null
+            : IconButton(
+                icon: Icon(
+                  PhosphorIcons.x(PhosphorIconsStyle.regular),
+                  size: 16,
+                  color: colors.textTertiary,
+                ),
+                onPressed: onClear,
+              ),
+        filled: true,
+        fillColor: colors.surface,
+        contentPadding: const EdgeInsets.symmetric(vertical: 12),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(FacteurRadius.medium),
+          borderSide: BorderSide(color: colors.border),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(FacteurRadius.medium),
+          borderSide: BorderSide(color: colors.border),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(FacteurRadius.medium),
+          borderSide: BorderSide(color: colors.primary),
+        ),
+      ),
+    );
+  }
+}
+
+class _ThemeGroupHeader extends StatelessWidget {
+  final String emoji;
+  final String label;
+  final FacteurColors colors;
+
+  const _ThemeGroupHeader({
+    required this.emoji,
+    required this.label,
+    required this.colors,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 2, bottom: 2),
+      child: Row(
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 13)),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: colors.textSecondary,
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CreateSubjectTile extends StatelessWidget {
+  final String query;
+  final FacteurColors colors;
+  final VoidCallback onTap;
+
+  const _CreateSubjectTile({
+    required this.query,
+    required this.colors,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () {
+          HapticFeedback.selectionClick();
+          onTap();
+        },
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+          decoration: BoxDecoration(
+            color: colors.primary.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: colors.primary.withValues(alpha: 0.3)),
+          ),
+          child: Row(
+            children: [
+              Icon(
+                PhosphorIcons.plus(PhosphorIconsStyle.bold),
+                size: 16,
+                color: colors.primary,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text.rich(
+                  TextSpan(
+                    text: 'Créer le sujet ',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: colors.textSecondary,
+                    ),
+                    children: [
+                      TextSpan(
+                        text: '« $query »',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w700,
+                          color: colors.textPrimary,
+                        ),
+                      ),
+                    ],
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _SectionLabel extends StatelessWidget {
   final String label;
   final FacteurColors colors;
@@ -314,6 +590,7 @@ class _SectionLabel extends StatelessWidget {
 
 class _SubjectRow extends StatelessWidget {
   final String label;
+  final String emoji;
   final bool pinned;
   final FacteurColors colors;
   final VoidCallback onTap;
@@ -321,6 +598,7 @@ class _SubjectRow extends StatelessWidget {
   const _SubjectRow({
     super.key,
     required this.label,
+    required this.emoji,
     required this.pinned,
     required this.colors,
     required this.onTap,
@@ -353,6 +631,8 @@ class _SubjectRow extends StatelessWidget {
             ),
             child: Row(
               children: [
+                Text(emoji, style: const TextStyle(fontSize: 14)),
+                const SizedBox(width: 10),
                 Expanded(
                   child: Text(
                     label,

--- a/apps/mobile/lib/features/feed/widgets/pin_subjects_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/pin_subjects_sheet.dart
@@ -1,0 +1,383 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../../../core/ui/notification_service.dart';
+import '../../custom_topics/widgets/entity_add_sheet.dart';
+import '../../my_interests/models/user_interests_state.dart';
+import '../../my_interests/providers/user_interests_provider.dart';
+
+/// Nombre de sujets épinglés en-dessous duquel on incite l'utilisateur à en
+/// épingler davantage (carte CTA + sous-titre). Aligné sur la promesse
+/// « épingle 3-4 sujets pour une veille de qualité ».
+const int kPinSubjectsTarget = 3;
+
+int _pinnedCount(UserInterestsState? interests) {
+  final favorites = interests?.favorites ?? const <FavoriteRef>[];
+  return favorites.whereType<CustomTopicFavoriteRef>().length;
+}
+
+/// Ouvre la modale d'épinglage de sujets précis (custom topics) — distincte des
+/// thèmes (qui pilotent la Tournée). Épingler un sujet le transforme en onglet
+/// dédié dans Flâner.
+Future<void> showPinSubjectsSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    barrierColor: Colors.black.withValues(alpha: 0.5),
+    builder: (ctx) => ClipRect(
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+        child: const _PinSubjectsContent(),
+      ),
+    ),
+  );
+}
+
+/// Carte proéminente (sliver) affichée en haut du feed Flâner tant que
+/// l'utilisateur a épinglé moins de [kPinSubjectsTarget] sujets. Sinon masquée.
+class PinSubjectsBanner extends ConsumerWidget {
+  const PinSubjectsBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Ne rebuild la bannière que lorsque le nombre de sujets épinglés change —
+    // pas sur chaque mutation d'intérêt (thèmes, veille, réordonnancement).
+    final pinnedCount = ref.watch(
+      userInterestsProvider.select((value) {
+        final interests = value.valueOrNull;
+        return interests == null ? null : _pinnedCount(interests);
+      }),
+    );
+    if (pinnedCount == null || pinnedCount >= kPinSubjectsTarget) {
+      return const SizedBox.shrink();
+    }
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(FacteurRadius.large),
+          onTap: () {
+            HapticFeedback.mediumImpact();
+            showPinSubjectsSheet(context);
+          },
+          child: Container(
+            padding: const EdgeInsets.all(FacteurSpacing.space4),
+            decoration: BoxDecoration(
+              color: colors.primary.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(FacteurRadius.large),
+              border:
+                  Border.all(color: colors.primary.withValues(alpha: 0.25)),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  PhosphorIcons.pushPin(PhosphorIconsStyle.fill),
+                  size: 22,
+                  color: colors.primary,
+                ),
+                const SizedBox(width: FacteurSpacing.space3),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Épingle tes sujets de veille',
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleSmall
+                            ?.copyWith(
+                              fontWeight: FontWeight.w700,
+                              color: colors.textPrimary,
+                            ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        'Épingle 3-4 sujets pour une veille de qualité — '
+                        'ils deviennent tes onglets ici.',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: colors.textSecondary,
+                              height: 1.35,
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: FacteurSpacing.space2),
+                Icon(
+                  PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
+                  size: 18,
+                  color: colors.primary,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PinSubjectsContent extends ConsumerWidget {
+  const _PinSubjectsContent();
+
+  Future<void> _setState(
+    WidgetRef ref,
+    String topicId,
+    InterestState state,
+  ) async {
+    try {
+      await ref.read(userInterestsProvider.notifier).setInterestState(
+            CustomTopicFavoriteRef(id: topicId),
+            state,
+          );
+    } catch (e) {
+      NotificationService.showError('Erreur : $e');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final interests = ref.watch(userInterestsProvider).valueOrNull;
+    final topics = interests?.customTopics ?? const <CustomTopicInterest>[];
+
+    final pinned =
+        topics.where((t) => t.state == InterestState.favorite).toList();
+    final pinnable = topics
+        .where((t) => t.state != InterestState.favorite)
+        .toList()
+      ..sort((a, b) =>
+          a.topicName.toLowerCase().compareTo(b.topicName.toLowerCase()));
+
+    return SafeArea(
+      top: false,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.82,
+        ),
+        child: Container(
+          decoration: BoxDecoration(
+            color: colors.backgroundSecondary,
+            borderRadius:
+                const BorderRadius.vertical(top: Radius.circular(20)),
+          ),
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: colors.textTertiary.withValues(alpha: 0.3),
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: FacteurSpacing.space4),
+                Text(
+                  'Épingler des sujets',
+                  style: textTheme.displaySmall?.copyWith(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w700,
+                    color: colors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Tes sujets précis deviennent des onglets dans Flâner. '
+                  'Les thèmes, eux, pilotent ta Tournée du jour.',
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colors.textTertiary,
+                    height: 1.4,
+                  ),
+                ),
+                const SizedBox(height: FacteurSpacing.space4),
+
+                // Sujets déjà épinglés → tap pour dé-épingler.
+                if (pinned.isNotEmpty) ...[
+                  _SectionLabel(label: 'SUJETS ÉPINGLÉS', colors: colors),
+                  const SizedBox(height: 8),
+                  for (final t in pinned)
+                    _SubjectRow(
+                      key: ValueKey('pinned_${t.id}'),
+                      label: t.topicName,
+                      pinned: true,
+                      colors: colors,
+                      onTap: () =>
+                          _setState(ref, t.id, InterestState.unfollowed),
+                    ),
+                  const SizedBox(height: FacteurSpacing.space4),
+                ],
+
+                // Sujets suivis non épinglés → 1 tap pour épingler.
+                if (pinnable.isNotEmpty) ...[
+                  _SectionLabel(
+                    label: 'ÉPINGLER UN SUJET SUIVI',
+                    colors: colors,
+                  ),
+                  const SizedBox(height: 8),
+                  for (final t in pinnable)
+                    _SubjectRow(
+                      key: ValueKey('pinnable_${t.id}'),
+                      label: t.topicName,
+                      pinned: false,
+                      colors: colors,
+                      onTap: () => _setState(ref, t.id, InterestState.favorite),
+                    ),
+                  const SizedBox(height: FacteurSpacing.space4),
+                ],
+
+                if (pinned.isEmpty && pinnable.isEmpty) ...[
+                  Text(
+                    'Aucun sujet pour le moment. Crée ton premier sujet '
+                    'à suivre ci-dessous.',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colors.textTertiary,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: FacteurSpacing.space4),
+                ],
+
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton.icon(
+                    onPressed: () => EntityAddSheet.show(
+                      context,
+                      pinOnFollow: true,
+                    ),
+                    icon: Icon(
+                      PhosphorIcons.plus(PhosphorIconsStyle.bold),
+                      size: 16,
+                      color: colors.primary,
+                    ),
+                    label: Text(
+                      'Créer un sujet',
+                      style: TextStyle(
+                        color: colors.primary,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 14,
+                      ),
+                    ),
+                    style: OutlinedButton.styleFrom(
+                      side: BorderSide(
+                        color: colors.primary.withValues(alpha: 0.5),
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius:
+                            BorderRadius.circular(FacteurRadius.medium),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String label;
+  final FacteurColors colors;
+
+  const _SectionLabel({required this.label, required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      label,
+      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+            color: colors.textTertiary,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 1.2,
+          ),
+    );
+  }
+}
+
+class _SubjectRow extends StatelessWidget {
+  final String label;
+  final bool pinned;
+  final FacteurColors colors;
+  final VoidCallback onTap;
+
+  const _SubjectRow({
+    super.key,
+    required this.label,
+    required this.pinned,
+    required this.colors,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: () {
+            HapticFeedback.selectionClick();
+            onTap();
+          },
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+            decoration: BoxDecoration(
+              color: pinned
+                  ? colors.primary.withValues(alpha: 0.06)
+                  : colors.surface,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: pinned
+                    ? colors.primary.withValues(alpha: 0.3)
+                    : colors.border,
+              ),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: colors.textPrimary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Icon(
+                  pinned
+                      ? PhosphorIcons.pushPin(PhosphorIconsStyle.fill)
+                      : PhosphorIcons.plus(PhosphorIconsStyle.bold),
+                  size: 16,
+                  color: pinned ? colors.primary : colors.textSecondary,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/my_interests_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/my_interests_sheet.dart
@@ -41,7 +41,11 @@ class _MyInterestsContent extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
     final interests = ref.watch(userInterestsProvider).valueOrNull;
-    final favorites = interests?.favorites ?? const <FavoriteRef>[];
+    // Cette modale ne gère que les thèmes/veille qui pilotent la Tournée.
+    // Les sujets précis (custom topics) se gèrent dans Flâner.
+    final favorites = (interests?.favorites ?? const <FavoriteRef>[])
+        .where((f) => f is! CustomTopicFavoriteRef)
+        .toList();
     final rows = <_FavoriteRow>[
       for (final fav in favorites)
         _FavoriteRow.fromRef(ref: fav, interests: interests),
@@ -105,11 +109,20 @@ class _MyInterestsContent extends ConsumerWidget {
                 ),
                 const SizedBox(height: 6),
                 Text(
-                  'Les intérêts qui pilotent ta tournée du jour.',
+                  'Les thèmes et la veille qui pilotent ta tournée du jour.',
                   style: GoogleFonts.dmSans(
                     fontSize: 13,
                     height: 1.45,
                     color: colors.textSecondary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Tes sujets précis se gèrent dans Flâner.',
+                  style: GoogleFonts.dmSans(
+                    fontSize: 12,
+                    height: 1.4,
+                    color: colors.textTertiary,
                   ),
                 ),
                 const SizedBox(height: 14),

--- a/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
@@ -6,9 +6,6 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/theme.dart';
 import '../../../core/providers/analytics_provider.dart';
 import '../../../core/ui/notification_service.dart';
-import '../../custom_topics/models/topic_models.dart';
-import '../../custom_topics/providers/custom_topics_provider.dart';
-import '../../custom_topics/widgets/disambiguation_suggestion_tile.dart';
 import '../../my_interests/models/user_interests_state.dart';
 import '../../my_interests/providers/user_sources_state_provider.dart';
 import '../models/smart_search_result.dart';
@@ -69,12 +66,6 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
   late final FocusNode _searchFocusNode;
   bool _searchActive = false;
 
-  // B1 — suggestions de sujets (« Donald » → « Donald Trump ») remontées en
-  // live dans la recherche via l'infra de désambiguïsation existante.
-  List<DisambiguationSuggestion> _topicSuggestions = const [];
-  String? _topicsForQuery;
-  int? _followingTopicIndex;
-
   @override
   void initState() {
     super.initState();
@@ -131,7 +122,6 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
       _currentQuery = value;
       _expanded = false;
     });
-    _fetchTopicSuggestions(value);
   }
 
   void _clearSearch() {
@@ -139,13 +129,11 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
     _resetSearchState();
   }
 
-  /// Remet l'état de recherche à zéro (query, résultats, suggestions de sujets).
+  /// Remet l'état de recherche à zéro (query, résultats).
   void _resetSearchState() {
     setState(() {
       _currentQuery = '';
       _expanded = false;
-      _topicSuggestions = const [];
-      _topicsForQuery = null;
     });
   }
 
@@ -378,8 +366,6 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        // B1 — sujets proposés (« Donald » → « Donald Trump ») en tête.
-        _buildTopicSuggestions(),
         _buildFilterChips(),
         const SizedBox(height: 12),
         searchAsync.when(
@@ -405,116 +391,10 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
     );
   }
 
-  /// Section « Sujets » : suggestions de désambiguïsation suivables, rendues
-  /// avec le tile partagé (réutilise le rendu de `EntityAddSheet`).
-  Widget _buildTopicSuggestions() {
-    if (_topicSuggestions.isEmpty) return const SizedBox.shrink();
-    final colors = context.facteurColors;
-    final textTheme = Theme.of(context).textTheme;
-    return Padding(
-      padding: const EdgeInsets.only(bottom: FacteurSpacing.space4),
-      child: Container(
-        padding: const EdgeInsets.all(FacteurSpacing.space3),
-        decoration: BoxDecoration(
-          color: colors.surface,
-          borderRadius: BorderRadius.circular(FacteurRadius.large),
-          border: Border.all(color: colors.border),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Icon(PhosphorIcons.tag(PhosphorIconsStyle.regular),
-                    size: 16, color: colors.primary),
-                const SizedBox(width: 6),
-                Text(
-                  'Sujets',
-                  style: textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w600,
-                    color: colors.textPrimary,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 2),
-            Text(
-              'Suivre un sujet d\'actualité dans vos intérêts',
-              style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
-            ),
-            const SizedBox(height: FacteurSpacing.space3),
-            ...List.generate(_topicSuggestions.length, (index) {
-              return DisambiguationSuggestionTile(
-                suggestion: _topicSuggestions[index],
-                isFollowing: _followingTopicIndex == index,
-                onFollow: _followingTopicIndex != null
-                    ? null
-                    : () =>
-                        _followTopicSuggestion(_topicSuggestions[index], index),
-              );
-            }),
-          ],
-        ),
-      ),
-    );
-  }
-
   void _onExampleTap(String text) {
     _searchController.text = text;
     setState(() => _currentQuery = text);
     ref.read(analyticsServiceProvider).trackAddSourceExampleTap(text);
-    _fetchTopicSuggestions(text);
-  }
-
-  /// B1 — interroge `/personalization/topics/disambiguate` en parallèle de la
-  /// recherche de sources et alimente la section « Sujets ». URLs et tokens
-  /// trop courts sont ignorés (la désambiguïsation vise des mots-sujets).
-  Future<void> _fetchTopicSuggestions(String query) async {
-    final trimmed = query.trim();
-    final looksLikeUrl = trimmed.startsWith('http') ||
-        trimmed.contains('://') ||
-        trimmed.contains('@');
-    if (trimmed.length < 2 || looksLikeUrl) {
-      setState(() {
-        _topicSuggestions = const [];
-        _topicsForQuery = null;
-      });
-      return;
-    }
-    // Évite un appel LLM (quota Mistral) redondant pour une requête déjà
-    // résolue ou en cours — la recherche est explicite et peut se rejouer.
-    if (_topicsForQuery == trimmed) return;
-    setState(() => _topicsForQuery = trimmed);
-    try {
-      final suggestions =
-          await ref.read(topicRepositoryProvider).disambiguate(trimmed);
-      if (!mounted || _topicsForQuery != trimmed) return; // stale guard
-      setState(() => _topicSuggestions = suggestions);
-    } catch (_) {
-      if (!mounted || _topicsForQuery != trimmed) return;
-      setState(() => _topicSuggestions = const []);
-    }
-  }
-
-  Future<void> _followTopicSuggestion(
-    DisambiguationSuggestion s,
-    int index,
-  ) async {
-    setState(() => _followingTopicIndex = index);
-    try {
-      await ref.read(customTopicsProvider.notifier).followSuggestion(s);
-      if (!mounted) return;
-      NotificationService.showSuccess(
-          '« ${s.canonicalName} » ajouté à vos intérêts');
-      // Retire le sujet suivi de la liste (les autres restent proposés).
-      final updated = [..._topicSuggestions]..removeAt(index);
-      setState(() => _topicSuggestions = updated);
-    } catch (e) {
-      if (mounted)
-        NotificationService.showError('Erreur lors de l\'ajout : $e');
-    } finally {
-      if (mounted) setState(() => _followingTopicIndex = null);
-    }
   }
 
   Widget _buildEmptyState() {

--- a/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
+++ b/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
@@ -66,8 +66,9 @@ void main() {
       expect(tabs.first.active, isTrue);
     });
 
-    test('2 sujets + 1 thème → 4 tabs sorted by count desc (alpha tie-break)',
-        () {
+    test(
+        '2 sujets + 1 thème favori → seuls les sujets sont des onglets '
+        '(le thème pilote la Tournée, pas un onglet Flâner)', () {
       final topics = [
         _topic(
           id: 't1',
@@ -93,19 +94,17 @@ void main() {
         items: const [],
       );
 
-      // All counts are 0 here, so the tie-break is alphabetical on label
-      // (lowercased): environnement < ia santé < trump.
+      // Le thème favori (environment) ne produit PLUS d'onglet : seuls
+      // « Tous » + les 2 sujets épinglés sont présents. Counts à 0 → tri
+      // alphabétique : ia santé < trump.
       expect(tabs.map((t) => t.kind).toList(), [
         FavoriteTabKind.tous,
-        FavoriteTabKind.theme,
         FavoriteTabKind.subjectTopic,
         FavoriteTabKind.subjectEntity,
       ]);
-      expect(tabs[1].label, 'Environnement');
-      expect(tabs[1].slug, 'environment');
-      expect(tabs[1].emoji, isNotEmpty);
-      expect(tabs[2].label, 'IA santé');
-      expect(tabs[3].label, 'Trump');
+      expect(tabs.any((t) => t.kind == FavoriteTabKind.theme), isFalse);
+      expect(tabs[1].label, 'IA santé');
+      expect(tabs[2].label, 'Trump');
     });
 
     test('topic not in favorites → excluded', () {

--- a/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
+++ b/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/widgets/pin_subjects_sheet.dart';
+import 'package:facteur/features/my_interests/models/user_interests_state.dart';
+import 'package:facteur/features/my_interests/providers/user_interests_provider.dart';
+
+/// Fake notifier: serves a fixed state and applies setInterestState locally
+/// (no repository), recording each call so tests can assert on pin/unpin.
+class _FakeUserInterestsNotifier extends UserInterestsNotifier {
+  _FakeUserInterestsNotifier(this._initial);
+
+  final UserInterestsState _initial;
+  final List<(FavoriteRef, InterestState)> calls = [];
+
+  @override
+  Future<UserInterestsState> build() async => _initial;
+
+  @override
+  Future<void> setInterestState(
+    FavoriteRef refTarget,
+    InterestState newState,
+  ) async {
+    calls.add((refTarget, newState));
+    final current = state.value;
+    if (current == null) return;
+    final topics = [
+      for (final t in current.customTopics)
+        if (t.id == refTarget.targetId)
+          t.copyWith(state: newState)
+        else
+          t,
+    ];
+    final favorites = [
+      for (final f in current.favorites)
+        if (f != refTarget) f,
+      if (newState == InterestState.favorite) refTarget,
+    ];
+    state = AsyncData(current.copyWith(
+      customTopics: topics,
+      favorites: favorites,
+      favoriteCount: favorites.length,
+    ));
+  }
+}
+
+CustomTopicInterest _topic(String id, String name, InterestState state) {
+  return CustomTopicInterest(
+    id: id,
+    topicName: name,
+    slugParent: 'tech',
+    state: state,
+    priorityMultiplier: state == InterestState.favorite ? 2.0 : 1.0,
+  );
+}
+
+UserInterestsState _state({
+  required List<CustomTopicInterest> topics,
+}) {
+  final favorites = <FavoriteRef>[
+    for (final t in topics)
+      if (t.state == InterestState.favorite) CustomTopicFavoriteRef(id: t.id),
+  ];
+  return UserInterestsState(
+    themes: const [],
+    customTopics: topics,
+    favorites: favorites,
+    favoriteCount: favorites.length,
+    favoriteCap: 3,
+  );
+}
+
+Widget _host(
+  UserInterestsState interests,
+  Widget child, {
+  _FakeUserInterestsNotifier? notifier,
+}) {
+  return ProviderScope(
+    overrides: [
+      userInterestsProvider.overrideWith(
+        () => notifier ?? _FakeUserInterestsNotifier(interests),
+      ),
+    ],
+    child: MaterialApp(
+      theme: ThemeData(extensions: [FacteurPalettes.light]),
+      home: Scaffold(body: child),
+    ),
+  );
+}
+
+void main() {
+  group('PinSubjectsBanner', () {
+    testWidgets('visible when fewer than 3 subjects are pinned',
+        (tester) async {
+      final st = _state(topics: [
+        _topic('t1', 'Sujet A', InterestState.favorite),
+      ]);
+      await tester.pumpWidget(_host(st, const PinSubjectsBanner()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Épingle tes sujets de veille'), findsOneWidget);
+    });
+
+    testWidgets('hidden when 3 or more subjects are pinned', (tester) async {
+      final st = _state(topics: [
+        _topic('t1', 'Sujet A', InterestState.favorite),
+        _topic('t2', 'Sujet B', InterestState.favorite),
+        _topic('t3', 'Sujet C', InterestState.favorite),
+      ]);
+      await tester.pumpWidget(_host(st, const PinSubjectsBanner()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Épingle tes sujets de veille'), findsNothing);
+    });
+  });
+
+  group('showPinSubjectsSheet', () {
+    testWidgets('pins a followed subject in one tap', (tester) async {
+      final st = _state(topics: [
+        _topic('t1', 'Climat', InterestState.followed),
+      ]);
+      final notifier = _FakeUserInterestsNotifier(st);
+
+      await tester.pumpWidget(_host(
+        st,
+        Builder(
+          builder: (ctx) => Center(
+            child: ElevatedButton(
+              onPressed: () => showPinSubjectsSheet(ctx),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+        notifier: notifier,
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      // Le sujet suivi est proposé à l'épinglage.
+      expect(find.text('ÉPINGLER UN SUJET SUIVI'), findsOneWidget);
+      expect(find.text('Climat'), findsOneWidget);
+
+      await tester.tap(find.text('Climat'));
+      await tester.pumpAndSettle();
+
+      expect(notifier.calls, hasLength(1));
+      expect(notifier.calls.first.$1, const CustomTopicFavoriteRef(id: 't1'));
+      expect(notifier.calls.first.$2, InterestState.favorite);
+      // Après épinglage il bascule dans la section « SUJETS ÉPINGLÉS ».
+      expect(find.text('SUJETS ÉPINGLÉS'), findsOneWidget);
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
+++ b/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
@@ -46,11 +46,16 @@ class _FakeUserInterestsNotifier extends UserInterestsNotifier {
   }
 }
 
-CustomTopicInterest _topic(String id, String name, InterestState state) {
+CustomTopicInterest _topic(
+  String id,
+  String name,
+  InterestState state, {
+  String slugParent = 'tech',
+}) {
   return CustomTopicInterest(
     id: id,
     topicName: name,
-    slugParent: 'tech',
+    slugParent: slugParent,
     state: state,
     priorityMultiplier: state == InterestState.favorite ? 2.0 : 1.0,
   );
@@ -100,7 +105,7 @@ void main() {
       await tester.pumpWidget(_host(st, const PinSubjectsBanner()));
       await tester.pumpAndSettle();
 
-      expect(find.text('Épingle tes sujets de veille'), findsOneWidget);
+      expect(find.text('Épingle tes sujets'), findsOneWidget);
     });
 
     testWidgets('hidden when 3 or more subjects are pinned', (tester) async {
@@ -112,7 +117,7 @@ void main() {
       await tester.pumpWidget(_host(st, const PinSubjectsBanner()));
       await tester.pumpAndSettle();
 
-      expect(find.text('Épingle tes sujets de veille'), findsNothing);
+      expect(find.text('Épingle tes sujets'), findsNothing);
     });
   });
 
@@ -152,6 +157,90 @@ void main() {
       expect(notifier.calls.first.$2, InterestState.favorite);
       // Après épinglage il bascule dans la section « SUJETS ÉPINGLÉS ».
       expect(find.text('SUJETS ÉPINGLÉS'), findsOneWidget);
+    });
+
+    testWidgets('search filters the followed subjects', (tester) async {
+      final st = _state(topics: [
+        _topic('t1', 'Climat', InterestState.followed),
+        _topic('t2', 'Intelligence artificielle', InterestState.followed),
+      ]);
+
+      await tester.pumpWidget(_host(
+        st,
+        Builder(
+          builder: (ctx) => Center(
+            child: ElevatedButton(
+              onPressed: () => showPinSubjectsSheet(ctx),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      // Recherche insensible aux accents/casse.
+      await tester.enterText(find.byType(TextField), 'clim');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Climat'), findsOneWidget);
+      expect(find.text('Intelligence artificielle'), findsNothing);
+    });
+
+    testWidgets('offers to create a subject when no match', (tester) async {
+      final st = _state(topics: [
+        _topic('t1', 'Climat', InterestState.followed),
+      ]);
+
+      await tester.pumpWidget(_host(
+        st,
+        Builder(
+          builder: (ctx) => Center(
+            child: ElevatedButton(
+              onPressed: () => showPinSubjectsSheet(ctx),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'Zélande');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Climat'), findsNothing);
+      // La tuile « Créer le sujet » reprend la requête entre guillemets.
+      expect(find.textContaining('Créer le sujet « Zélande »'), findsOneWidget);
+    });
+
+    testWidgets('groups followed subjects by theme', (tester) async {
+      final st = _state(topics: [
+        _topic('t1', 'Climat', InterestState.followed,
+            slugParent: 'environment'),
+        _topic('t2', 'IA', InterestState.followed, slugParent: 'tech'),
+      ]);
+
+      await tester.pumpWidget(_host(
+        st,
+        Builder(
+          builder: (ctx) => Center(
+            child: ElevatedButton(
+              onPressed: () => showPinSubjectsSheet(ctx),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      // En-têtes de groupe par thématique (labels canoniques Facteur).
+      expect(find.text('Technologie'), findsOneWidget);
+      expect(find.text('Environnement'), findsOneWidget);
     });
   });
 }

--- a/apps/mobile/test/features/flux_continu/widgets/my_interests_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/my_interests_sheet_test.dart
@@ -70,7 +70,8 @@ void main() {
   });
 
   group('showMyInterestsBottomSheet', () {
-    testWidgets('lists the favorite themes/topics and the primary CTA',
+    testWidgets(
+        'lists only theme/veille favorites (custom topics excluded) + CTA',
         (tester) async {
       await tester.pumpWidget(_openerHost(_stateWithFavorites()));
 
@@ -78,13 +79,16 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Mes intérêts'), findsOneWidget);
-      expect(find.text('2 FAVORIS'), findsOneWidget);
-      // Custom topic name resolved from interests.customTopics
-      expect(find.text('IA & éducation'), findsOneWidget);
+      // Le sujet précis (custom topic) est exclu : seul le thème compte.
+      expect(find.text('1 FAVORIS'), findsOneWidget);
+      expect(find.text('IA & éducation'), findsNothing);
       // Theme slug → canonical visual label
       expect(find.text('Environnement'), findsOneWidget);
       expect(find.text('01'), findsOneWidget);
-      expect(find.text('02'), findsOneWidget);
+      expect(find.text('02'), findsNothing);
+      // Copie clarifiant la séparation thèmes ↔ sujets.
+      expect(find.text('Tes sujets précis se gèrent dans Flâner.'),
+          findsOneWidget);
       expect(find.text('Gérer mes intérêts'), findsOneWidget);
       expect(find.text('Fermer'), findsOneWidget);
     });

--- a/docs/stories/core/10.1.sujets-epingles-flaner.md
+++ b/docs/stories/core/10.1.sujets-epingles-flaner.md
@@ -1,0 +1,49 @@
+# Story 10.1 — Clarifier thèmes (Tournée) vs sujets épinglés (Flâner)
+
+**Type** : Feature · **Statut** : Implémenté · **Scope** : Mobile/UX uniquement (aucune modif backend)
+
+## Problème
+
+Les utilisateurs ne distinguent pas deux mécaniques que l'UI mélange :
+
+- **Thèmes / veille** (gros sujets, haut-niveau) → pilotent la **Tournée du jour** (top 3).
+- **Sujets épinglés** (custom topics précis) → doivent créer des **onglets dédiés dans Flâner**.
+
+Le modèle de données sépare déjà proprement les deux (`FavoriteRef` = `ThemeFavoriteRef` |
+`CustomTopicFavoriteRef` | `VeilleFavoriteRef`) et le backend n'a pas de cap dur sur les
+custom topics. Tout le travail est donc mobile/UX.
+
+## Les 4 axes
+
+### Axe 1 — Onglets Flâner = seulement les sujets épinglés
+`feed/widgets/favorite_topic_tabs.dart` ne construit plus d'onglet `FavoriteTabKind.theme`.
+Les onglets = `Tous` + entités (`subjectEntity`) + sujets (`subjectTopic`). La valeur
+`FavoriteTabKind.theme` reste dans l'enum (filtrage via la chip thème conservé) ; le
+paramètre `excludedThemeSlugs` (devenu inutile) est supprimé de `FavoriteTopicTabs`,
+`FeedFilterBar` et `flaner_screen.dart`.
+
+### Axe 2 — CTA + modale d'épinglage dans Flâner
+- **2a** `PinSubjectsBanner` (sliver) en haut du feed, visible tant que `< 3` sujets épinglés.
+- **2b** `pin_subjects_sheet.dart` (`showPinSubjectsSheet`) : sections « Sujets épinglés »
+  (tap = dé-épingler) et « Épingler un sujet suivi » (1 tap = épingler), + bouton
+  « Créer un sujet ». Aucun thème dans cette modale.
+- **2c** `EntityAddSheet` reçoit un flag `pinOnFollow` (défaut `false`) : quand `true`, le
+  sujet créé est immédiatement épinglé en favori. Le « + » des onglets ouvre désormais
+  `showPinSubjectsSheet` au lieu de `InterestFilterSheet`.
+
+### Axe 3 — Modale « GÉRER » Tournée = thèmes/veille uniquement
+`flux_continu/widgets/my_interests_sheet.dart` exclut les `CustomTopicFavoriteRef` (liste +
+compteur) et clarifie la copie (« Tes sujets précis se gèrent dans Flâner »).
+
+### Axe 4 — Supprimer la reco de sujets dans Ajout de sources
+`sources/widgets/source_add_panel.dart` : suppression de la section « Sujets » (B1) et de
+toute sa logique (`_buildTopicSuggestions`, `_fetchTopicSuggestions`,
+`_followTopicSuggestion`, état associé).
+
+## Vérification
+
+- `test/features/feed/widgets/favorite_topic_tabs_test.dart` — plus d'onglet thème.
+- `test/features/flux_continu/widgets/my_interests_sheet_test.dart` — modale = thèmes/veille.
+- `test/features/feed/widgets/pin_subjects_sheet_test.dart` (nouveau) — banner conditionnel,
+  épinglage 1-tap.
+- `flutter analyze` propre sur les fichiers modifiés.


### PR DESCRIPTION
## Quoi

Clarifie deux mécaniques que l'UI mélangeait, sans aucune modif backend (le modèle `FavoriteRef` sépare déjà thèmes / custom topics / veille) :

- **Thèmes / veille** → pilotent la **Tournée du jour**
- **Sujets précis** (custom topics) → **onglets dédiés dans Flâner**

**Axe 1 — Onglets Flâner.** `favorite_topic_tabs.dart` ne construit plus d'onglet thème ; onglets = `Tous` + entités + sujets épinglés. `FavoriteTabKind.theme` reste dans l'enum (filtrage via la chip thème conservé). Le paramètre devenu inutile `excludedThemeSlugs` est retiré (`FeedFilterBar`, `flaner_screen`).

**Axe 2 — CTA + modale d'épinglage.** `PinSubjectsBanner` (sliver en haut du feed, visible tant que < 3 sujets épinglés) + nouveau `pin_subjects_sheet.dart` (`showPinSubjectsSheet` : sections « Sujets épinglés » / « Épingler un sujet suivi » en 1 tap, bouton « Créer un sujet »). Le « + » des onglets ouvre désormais cette modale. `EntityAddSheet` reçoit un flag `pinOnFollow` (défaut `false` → comportement historique inchangé).

**Axe 3 — Modale « GÉRER » Tournée.** `my_interests_sheet.dart` exclut les `CustomTopicFavoriteRef` (liste + compteur) et clarifie la copie (« Tes sujets précis se gèrent dans Flâner »).

**Axe 4 — Ajout de sources.** `source_add_panel.dart` : suppression de la reco « Sujets » et de toute sa logique.

## Pourquoi

Les utilisateurs ne distinguaient pas thèmes (veille haut-niveau) et sujets précis ; les onglets Flâner affichaient à tort les thèmes favoris (déjà servis dans la Tournée), et il manquait un CTA clair pour épingler des sujets.

## Comment ça a été vérifié

- [x] `flutter analyze` propre sur les 7 fichiers touchés (0 erreur, 0 nouvel issue)
- [x] Tests ciblés OK : `favorite_topic_tabs_test`, `my_interests_sheet_test` (mis à jour) + `pin_subjects_sheet_test` (nouveau) — 13/13
- [x] Suite complète : 760 pass / 45 fail, **les 45 échecs prouvés pré-existants** (baseline identique après `git stash`) — réseau/Hive/Supabase hors périmètre, CI = backend pytest only
- [x] `/simplify` passé (1 fix appliqué : `.select()` sur la bannière pour éviter les rebuilds inutiles)

## Zones à risque

- `favorite_topic_tabs.dart` / `feed_filter_bar.dart` : rendu des onglets Flâner et de l'Explorer (changement global assumé : thèmes = Tournée).
- `entity_add_sheet.dart` : le flag `pinOnFollow` est opt-in, les autres appelants (My Interests) restent inchangés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)