### PR TITLE
fix(perspectives): path absolu pour la route content-external (Page non trouvée)

### DIFF
--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -109,6 +109,7 @@ class RoutePaths {
   static const String flaner = '/flaner';
   static const String fluxContinu = '/flux-continu';
   static const String contentDetail = '/content/:id';
+  static const String contentExternal = '/content-external';
   static const String saved = '/saved';
   static const String sources = '/settings/sources'; // Moved to settings
   // static const String addSource = '/sources/add'; // Removed for V0
@@ -423,7 +424,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       // du site. Top-level sur le root navigator + swipe-back iOS : la sheet de
       // comparaisons (elle-même sur le root navigator) reste vivante dessous.
       GoRoute(
-        path: 'content-external',
+        path: RoutePaths.contentExternal,
         name: RouteNames.contentExternal,
         parentNavigatorKey: NotificationService.navigatorKey,
         pageBuilder: (context, state) {

--- a/apps/mobile/test/features/feed/widgets/perspective_opens_in_app_reader_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspective_opens_in_app_reader_test.dart
@@ -48,7 +48,11 @@ GoRouter _router(Widget home) {
     routes: [
       GoRoute(path: '/', builder: (_, __) => home),
       GoRoute(
-        path: '/content-external',
+        // Utilise la VRAIE constante de path (pas un littéral) pour que ce
+        // harness reflète le wiring de production — un path relatif au
+        // top-level (régression "Page non trouvée: /content-external")
+        // ferait alors échouer ces tests.
+        path: RoutePaths.contentExternal,
         name: RouteNames.contentExternal,
         builder: (_, state) {
           _routedPerspective = state.extra as Perspective?;
@@ -116,6 +120,26 @@ Widget _app(Widget home) {
 }
 
 void main() {
+  // Garde-fou direct contre la régression "Page non trouvée:
+  // /content-external" : une GoRoute top-level DOIT avoir un path absolu
+  // (commençant par '/'), sinon go_router ne sait pas résoudre la route nommée.
+  test('content-external : route top-level avec path absolu résolvable', () {
+    expect(RoutePaths.contentExternal.startsWith('/'), isTrue,
+        reason: 'Une GoRoute top-level doit avoir un path absolu.');
+    final router = GoRouter(
+      routes: [
+        GoRoute(path: '/', builder: (_, __) => const SizedBox()),
+        GoRoute(
+          path: RoutePaths.contentExternal,
+          name: RouteNames.contentExternal,
+          builder: (_, __) => const SizedBox(),
+        ),
+      ],
+    );
+    expect(router.namedLocation(RouteNames.contentExternal),
+        RoutePaths.contentExternal);
+  });
+
   setUp(() {
     _routedPerspective = null;
     // FacteurCard.onTap await `HapticFeedback.mediumImpact()` avant de


### PR DESCRIPTION
## Bug
`context.pushNamed(RouteNames.contentExternal)` aboutissait à **"Page non trouvée: /content-external"** : la GoRoute était enregistrée avec `path: 'content-external'` (relatif) alors que go_router exige un path absolu pour les routes top-level.

## Fix
- Ajoute `RoutePaths.contentExternal = '/content-external'` (suit la convention de tous les autres `RoutePaths.*`).
- La GoRoute utilise `RoutePaths.contentExternal` au lieu du littéral relatif.
- Le harness de test utilise désormais la vraie constante (plus de littéral masquant le bug).
- Nouveau test unitaire : assert que le path est absolu et que la route nommée est résolvable via `namedLocation`.

## Vérifié
- `flutter analyze lib/config/routes.dart` : No issues found.
- `flutter test test/features/feed/widgets/perspective_opens_in_app_reader_test.dart` : 3/3 (2 tests de navigation + 1 garde-fou).

Hotfix extrait de #739 (cherry-pick `393ea754`).