### PR TITLE
feat(meteo): météo géolocalisée, plus présente et cliquable (Story 10.1)

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
+    <!-- Story 10.1 — météo géolocalisée : coarse suffit pour la météo -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <application
         android:label="Facteur"
         android:name="${applicationName}"

--- a/apps/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/apps/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -51,6 +51,11 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin flutter_timezone, net.wolverinebeach.flutter_timezone.FlutterTimezonePlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new com.baseflow.geolocator.GeolocatorPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin geolocator_android, com.baseflow.geolocator.GeolocatorPlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new io.achim.haptic_feedback.HapticFeedbackPlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin haptic_feedback, io.achim.haptic_feedback.HapticFeedbackPlugin", e);

--- a/apps/mobile/ios/Runner/GeneratedPluginRegistrant.m
+++ b/apps/mobile/ios/Runner/GeneratedPluginRegistrant.m
@@ -48,6 +48,12 @@
 @import flutter_timezone;
 #endif
 
+#if __has_include(<geolocator_apple/GeolocatorPlugin.h>)
+#import <geolocator_apple/GeolocatorPlugin.h>
+#else
+@import geolocator_apple;
+#endif
+
 #if __has_include(<haptic_feedback/HapticFeedbackPlugin.h>)
 #import <haptic_feedback/HapticFeedbackPlugin.h>
 #else
@@ -136,6 +142,7 @@
   [FlutterLocalNotificationsPlugin registerWithRegistrar:[registry registrarForPlugin:@"FlutterLocalNotificationsPlugin"]];
   [FlutterSecureStorageDarwinPlugin registerWithRegistrar:[registry registrarForPlugin:@"FlutterSecureStorageDarwinPlugin"]];
   [FlutterTimezonePlugin registerWithRegistrar:[registry registrarForPlugin:@"FlutterTimezonePlugin"]];
+  [GeolocatorPlugin registerWithRegistrar:[registry registrarForPlugin:@"GeolocatorPlugin"]];
   [HapticFeedbackPlugin registerWithRegistrar:[registry registrarForPlugin:@"HapticFeedbackPlugin"]];
   [HomeWidgetPlugin registerWithRegistrar:[registry registrarForPlugin:@"HomeWidgetPlugin"]];
   [JustAudioPlugin registerWithRegistrar:[registry registrarForPlugin:@"JustAudioPlugin"]];

--- a/apps/mobile/ios/Runner/Info.plist
+++ b/apps/mobile/ios/Runner/Info.plist
@@ -56,5 +56,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Pour afficher la météo de ta ville.</string>
 </dict>
 </plist>

--- a/apps/mobile/lib/core/orchestration/first_impression_orchestrator.dart
+++ b/apps/mobile/lib/core/orchestration/first_impression_orchestrator.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../auth/auth_state.dart';
 import '../web/web_perf.dart';
 import '../../features/notifications/providers/notification_renudge_provider.dart';
+import '../../features/flux_continu/providers/geoloc_prompt_provider.dart';
 import '../../features/onboarding/providers/ios_add_to_home_provider.dart';
 import '../../features/settings/providers/notifications_settings_provider.dart';
 import '../../features/well_informed/providers/well_informed_prompt_provider.dart';
@@ -18,6 +19,7 @@ enum FirstImpressionSlot {
   notifModal,
   renudgeBanner,
   wellInformed,
+  geolocPrompt,
 }
 
 /// Une fois la modal notif affichée dans la session, on ne déclenche aucun
@@ -38,6 +40,8 @@ final nudgeConsumedThisSessionProvider = StateProvider<bool>((_) => false);
 /// 4. Re-nudge éligible (cap, espacement, refus passé) ET aucun nudge déjà
 ///    consommé cette session → `renudgeBanner`.
 /// 5. Well-informed prompt dû ET aucun nudge déjà consommé → `wellInformed`.
+/// 6. Géoloc due (≥5 ouvertures, pas device, cap) ET aucun nudge consommé →
+///    `geolocPrompt` (priorité la plus basse).
 final firstImpressionSlotProvider = Provider<FirstImpressionSlot>((ref) {
   final auth = ref.watch(authStateProvider);
   final notif = ref.watch(notificationsSettingsProvider);
@@ -50,6 +54,8 @@ final firstImpressionSlotProvider = Provider<FirstImpressionSlot>((ref) {
       ref.watch(iosAddToHomeShouldShowProvider).valueOrNull ?? false;
   final iosAddToHomeConsumed =
       ref.watch(iosAddToHomeConsumedThisSessionProvider);
+  final geolocPromptShould =
+      ref.watch(geolocPromptShouldShowProvider).valueOrNull ?? false;
 
   if (!auth.isAuthenticated || !auth.isEmailConfirmed) {
     return FirstImpressionSlot.none;
@@ -73,6 +79,10 @@ final firstImpressionSlotProvider = Provider<FirstImpressionSlot>((ref) {
 
   if (!nudgeConsumed && wellInformedShould) {
     return FirstImpressionSlot.wellInformed;
+  }
+
+  if (!nudgeConsumed && geolocPromptShould) {
+    return FirstImpressionSlot.geolocPrompt;
   }
 
   return FirstImpressionSlot.none;

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -536,6 +536,30 @@ class AnalyticsService {
     await _capturePostHog('discover_disable_skipped', props);
   }
 
+  Future<void> trackGeolocPromptShown({required int displayCount}) async {
+    final props = {
+      'session_id': _sessionId,
+      'display_count': displayCount,
+    };
+    await _logEvent('geoloc_prompt_shown', props);
+    await _capturePostHog('geoloc_prompt_shown', props);
+  }
+
+  Future<void> trackGeolocPromptActivated({required bool granted}) async {
+    final props = {
+      'session_id': _sessionId,
+      'granted': granted,
+    };
+    await _logEvent('geoloc_prompt_activated', props);
+    await _capturePostHog('geoloc_prompt_activated', props);
+  }
+
+  Future<void> trackGeolocPromptDismissed() async {
+    final props = {'session_id': _sessionId};
+    await _logEvent('geoloc_prompt_dismissed', props);
+    await _capturePostHog('geoloc_prompt_dismissed', props);
+  }
+
   /// target: 'digest' | 'article' | 'feed'.
   /// Fired whenever a `io.supabase.facteur://` widget URI lands in the app.
   Future<void> trackWidgetAppOpened({

--- a/apps/mobile/lib/features/flux_continu/models/weather_location.dart
+++ b/apps/mobile/lib/features/flux_continu/models/weather_location.dart
@@ -1,0 +1,39 @@
+/// Localisation utilisée pour la météo. Stockée localement (Hive `settings`),
+/// jamais envoyée au backend — la météo reste 100 % client.
+class WeatherLocation {
+  final double lat;
+  final double lng;
+
+  /// Libellé affiché ("Paris" par défaut, "Ma position" si device).
+  final String label;
+
+  /// `true` quand les coordonnées viennent du GPS de l'appareil (vs. le défaut
+  /// Paris). Pilote l'affichage du CTA « Activer ma position » et la bannière.
+  final bool isDeviceLocation;
+
+  const WeatherLocation({
+    required this.lat,
+    required this.lng,
+    required this.label,
+    required this.isDeviceLocation,
+  });
+
+  /// Défaut hors géoloc : Paris.
+  static const WeatherLocation paris = WeatherLocation(
+    lat: 48.8566,
+    lng: 2.3522,
+    label: 'Paris',
+    isDeviceLocation: false,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      other is WeatherLocation &&
+      other.lat == lat &&
+      other.lng == lng &&
+      other.label == label &&
+      other.isDeviceLocation == isDeviceLocation;
+
+  @override
+  int get hashCode => Object.hash(lat, lng, label, isDeviceLocation);
+}

--- a/apps/mobile/lib/features/flux_continu/models/weather_snapshot.dart
+++ b/apps/mobile/lib/features/flux_continu/models/weather_snapshot.dart
@@ -36,18 +36,42 @@ WeatherCondition weatherConditionFromWmo(int code) {
   return WeatherCondition.cloudy;
 }
 
-class WeatherSnapshot {
+/// Une journée de prévision (today = `days[0]` dans [WeatherForecast]).
+class WeatherDay {
+  final DateTime date;
+  final WeatherCondition condition;
+  final int minC;
+  final int maxC;
+
+  const WeatherDay({
+    required this.date,
+    required this.condition,
+    required this.minC,
+    required this.maxC,
+  });
+}
+
+/// Prévision météo riche alimentant à la fois le badge du header (champs
+/// `condition` / `currentC` / `minC` / `maxC`) et la modal détaillée
+/// (`feelsLikeC` + [days] sur 5 jours). Un seul fetch sert les deux usages.
+class WeatherForecast {
   final WeatherCondition condition;
   final int currentC;
+  final int feelsLikeC;
   final int minC;
   final int maxC;
   final DateTime fetchedAt;
 
-  const WeatherSnapshot({
+  /// Prévision sur 5 jours, today inclus en `days[0]`.
+  final List<WeatherDay> days;
+
+  const WeatherForecast({
     required this.condition,
     required this.currentC,
+    required this.feelsLikeC,
     required this.minC,
     required this.maxC,
     required this.fetchedAt,
+    required this.days,
   });
 }

--- a/apps/mobile/lib/features/flux_continu/providers/geoloc_prompt_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/geoloc_prompt_provider.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../../core/nudges/nudge_counters.dart';
+import 'weather_location_provider.dart';
+
+/// Nombre d'ouvertures du feed requis avant de proposer la géoloc (jamais à
+/// l'onboarding — la météo doit d'abord être un repère quotidien).
+const int kGeolocPromptMinFeedOpens = 5;
+
+/// Cap dur : au plus 3 affichages de la bannière au total.
+const int kGeolocPromptMaxShown = 3;
+
+/// Persistance Hive (box `settings`) de l'état de la bannière géoloc, même
+/// pattern que les clés re-nudge notifications.
+class GeolocPromptController {
+  GeolocPromptController(this._ref);
+
+  final Ref _ref;
+
+  static const _boxName = 'settings';
+  static const kShownCount = 'geoloc_prompt_shown_count';
+  static const kLastAt = 'geoloc_prompt_last_at';
+  static const kDismissed = 'geoloc_prompt_dismissed';
+
+  Future<Box<dynamic>> _box() => Hive.openBox<dynamic>(_boxName);
+
+  /// Enregistre un affichage (incrémente le cap). Appelé une fois par affichage
+  /// effectif de la bannière. Retourne le numéro d'affichage (1-based) pour le
+  /// tracking analytics.
+  Future<int> recordShown() async {
+    final box = await _box();
+    final next = (box.get(kShownCount, defaultValue: 0) as int) + 1;
+    await box.putAll({
+      kShownCount: next,
+      kLastAt: DateTime.now().toIso8601String(),
+    });
+    _ref.invalidate(geolocPromptShouldShowProvider);
+    return next;
+  }
+
+  /// Coupe définitivement la bannière (option « ne plus afficher »). Non câblé
+  /// au bouton « Pas maintenant » (qui ne fait qu'un dismiss de session), mais
+  /// disponible si besoin.
+  Future<void> dismissPermanently() async {
+    final box = await _box();
+    await box.put(kDismissed, true);
+    _ref.invalidate(geolocPromptShouldShowProvider);
+  }
+}
+
+final geolocPromptControllerProvider =
+    Provider<GeolocPromptController>((ref) => GeolocPromptController(ref));
+
+/// `true` si la bannière de demande de géoloc doit s'afficher :
+/// ≥5 ouvertures du feed ET pas déjà en position device ET cap non atteint ET
+/// pas coupée définitivement.
+final geolocPromptShouldShowProvider = FutureProvider<bool>((ref) async {
+  final location = ref.watch(weatherLocationProvider);
+  if (location.isDeviceLocation) return false;
+
+  try {
+    final box = await Hive.openBox<dynamic>('settings');
+    if (box.get(GeolocPromptController.kDismissed, defaultValue: false)
+        as bool) {
+      return false;
+    }
+    final shownCount =
+        box.get(GeolocPromptController.kShownCount, defaultValue: 0) as int;
+    if (shownCount >= kGeolocPromptMaxShown) return false;
+  } catch (e) {
+    debugPrint('GeolocPrompt: Hive read failed: $e');
+    return false;
+  }
+
+  final feedOpens = await NudgeCounters.get(NudgeCounters.feedOpenCount);
+  return feedOpens >= kGeolocPromptMinFeedOpens;
+});

--- a/apps/mobile/lib/features/flux_continu/providers/weather_location_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/weather_location_provider.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/weather_location.dart';
+
+/// Source de vérité (locale) pour la localisation météo.
+///
+/// Défaut Paris. Charge/persiste dans la box Hive `settings`. La météo n'est
+/// jamais géolocalisée à l'onboarding : `useDeviceLocation()` est déclenché par
+/// la bannière in-feed (cf. `geoloc_prompt_provider.dart`). Le
+/// [weatherProvider] watch ce provider → refetch automatique au changement.
+class WeatherLocationNotifier extends Notifier<WeatherLocation> {
+  static const _boxName = 'settings';
+  static const _kLat = 'weather_loc_lat';
+  static const _kLng = 'weather_loc_lng';
+  static const _kLabel = 'weather_loc_label';
+  static const _kIsDevice = 'weather_loc_is_device';
+
+  @override
+  WeatherLocation build() {
+    unawaited(_loadFromHive());
+    return WeatherLocation.paris;
+  }
+
+  Future<void> _loadFromHive() async {
+    try {
+      final box = await Hive.openBox<dynamic>(_boxName);
+      final lat = box.get(_kLat);
+      final lng = box.get(_kLng);
+      if (lat is num && lng is num) {
+        state = WeatherLocation(
+          lat: lat.toDouble(),
+          lng: lng.toDouble(),
+          label: box.get(_kLabel, defaultValue: 'Ma position') as String,
+          isDeviceLocation: box.get(_kIsDevice, defaultValue: true) as bool,
+        );
+      }
+    } catch (e) {
+      // Hive peut ne pas être initialisé (tests) → on garde le défaut Paris.
+      debugPrint('WeatherLocation: load from Hive failed: $e');
+    }
+  }
+
+  /// Demande la permission de localisation puis bascule sur la position du
+  /// device. Retourne `true` si la position a été obtenue et persistée, `false`
+  /// si refus/erreur (l'état reste alors sur Paris).
+  Future<bool> useDeviceLocation() async {
+    try {
+      var permission = await Geolocator.checkPermission();
+      if (permission == LocationPermission.denied) {
+        permission = await Geolocator.requestPermission();
+      }
+      if (permission == LocationPermission.denied ||
+          permission == LocationPermission.deniedForever) {
+        return false;
+      }
+      final position = await Geolocator.getCurrentPosition(
+        locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.low,
+        ),
+      );
+      final location = WeatherLocation(
+        lat: position.latitude,
+        lng: position.longitude,
+        label: 'Ma position',
+        isDeviceLocation: true,
+      );
+      state = location;
+      await _persist(location);
+      return true;
+    } catch (e) {
+      debugPrint('WeatherLocation: useDeviceLocation failed: $e');
+      return false;
+    }
+  }
+
+  Future<void> _persist(WeatherLocation location) async {
+    final box = await Hive.openBox<dynamic>(_boxName);
+    await box.putAll({
+      _kLat: location.lat,
+      _kLng: location.lng,
+      _kLabel: location.label,
+      _kIsDevice: location.isDeviceLocation,
+    });
+  }
+}
+
+final weatherLocationProvider =
+    NotifierProvider<WeatherLocationNotifier, WeatherLocation>(
+  WeatherLocationNotifier.new,
+);

--- a/apps/mobile/lib/features/flux_continu/providers/weather_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/weather_provider.dart
@@ -2,24 +2,35 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/weather_snapshot.dart';
 import '../repositories/weather_repository.dart';
+import 'weather_location_provider.dart';
 
 const Duration _kWeatherTtl = Duration(minutes: 30);
 
-class WeatherNotifier extends AsyncNotifier<WeatherSnapshot> {
-  WeatherSnapshot? _cached;
+class WeatherNotifier extends AsyncNotifier<WeatherForecast> {
+  WeatherForecast? _cached;
+  String? _cachedKey;
 
   @override
-  Future<WeatherSnapshot> build() async {
+  Future<WeatherForecast> build() async {
+    // Refetch dès que la localisation change (Paris → device, etc.).
+    final location = ref.watch(weatherLocationProvider);
+    final key = '${location.lat},${location.lng}';
+
     final cached = _cached;
     if (cached != null &&
+        _cachedKey == key &&
         DateTime.now().difference(cached.fetchedAt) < _kWeatherTtl) {
       return cached;
     }
-    final fresh = await ref.read(weatherRepositoryProvider).fetchParis();
+
+    final fresh = await ref
+        .read(weatherRepositoryProvider)
+        .fetch(location.lat, location.lng);
     _cached = fresh;
+    _cachedKey = key;
     return fresh;
   }
 }
 
 final weatherProvider =
-    AsyncNotifierProvider<WeatherNotifier, WeatherSnapshot>(WeatherNotifier.new);
+    AsyncNotifierProvider<WeatherNotifier, WeatherForecast>(WeatherNotifier.new);

--- a/apps/mobile/lib/features/flux_continu/repositories/weather_repository.dart
+++ b/apps/mobile/lib/features/flux_continu/repositories/weather_repository.dart
@@ -3,22 +3,36 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/weather_snapshot.dart';
 
-/// Open-Meteo public endpoint. No API key required, lat/lng pinned to Paris
-/// for the MVP (no UI for city selection yet).
-const String _kOpenMeteoUrl =
-    'https://api.open-meteo.com/v1/forecast?latitude=48.8566&longitude=2.3522'
-    '&current=temperature_2m,weather_code'
-    '&daily=temperature_2m_max,temperature_2m_min'
-    '&timezone=Europe/Paris&forecast_days=1';
+/// Coordonnées de repli (Paris) utilisées quand l'utilisateur n'a pas (encore)
+/// partagé sa position. Mêmes valeurs que [WeatherLocation.paris].
+const double kParisLat = 48.8566;
+const double kParisLng = 2.3522;
 
 class WeatherRepository {
   final Dio _dio;
 
   WeatherRepository(this._dio);
 
-  Future<WeatherSnapshot> fetchParis() async {
+  /// Récupère la prévision Open-Meteo (sans clé API) pour des coordonnées
+  /// arbitraires : conditions courantes + ressenti + 5 jours.
+  ///
+  /// [timezone] = `'auto'` laisse Open-Meteo aligner les bornes journalières
+  /// sur le fuseau du point demandé (correct pour une position device).
+  Future<WeatherForecast> fetch(
+    double lat,
+    double lng, {
+    String timezone = 'auto',
+  }) async {
     final response = await _dio.get<Map<String, dynamic>>(
-      _kOpenMeteoUrl,
+      'https://api.open-meteo.com/v1/forecast',
+      queryParameters: {
+        'latitude': lat,
+        'longitude': lng,
+        'current': 'temperature_2m,apparent_temperature,weather_code',
+        'daily': 'weather_code,temperature_2m_max,temperature_2m_min',
+        'timezone': timezone,
+        'forecast_days': 5,
+      },
       options: Options(
         receiveTimeout: const Duration(seconds: 4),
         sendTimeout: const Duration(seconds: 4),
@@ -28,18 +42,43 @@ class WeatherRepository {
     if (data == null) {
       throw StateError('Open-Meteo returned an empty body');
     }
+    return parseForecast(data);
+  }
+
+  /// Parse exposé pour les tests : transforme le corps Open-Meteo en
+  /// [WeatherForecast]. `current` porte les conditions instantanées,
+  /// `daily` les bornes min/max et le code par jour (5 entrées).
+  static WeatherForecast parseForecast(Map<String, dynamic> data) {
     final current = (data['current'] as Map).cast<String, dynamic>();
     final daily = (data['daily'] as Map).cast<String, dynamic>();
+
     final currentC = (current['temperature_2m'] as num).round();
-    final code = (current['weather_code'] as num).toInt();
+    final feelsLikeC = (current['apparent_temperature'] as num).round();
+    final currentCode = (current['weather_code'] as num).toInt();
+
+    final dates = (daily['time'] as List).cast<String>();
+    final codes = (daily['weather_code'] as List).cast<num>();
     final maxList = (daily['temperature_2m_max'] as List).cast<num>();
     final minList = (daily['temperature_2m_min'] as List).cast<num>();
-    return WeatherSnapshot(
-      condition: weatherConditionFromWmo(code),
+
+    final days = <WeatherDay>[
+      for (var i = 0; i < dates.length; i++)
+        WeatherDay(
+          date: DateTime.parse(dates[i]),
+          condition: weatherConditionFromWmo(codes[i].toInt()),
+          minC: minList[i].round(),
+          maxC: maxList[i].round(),
+        ),
+    ];
+
+    return WeatherForecast(
+      condition: weatherConditionFromWmo(currentCode),
       currentC: currentC,
-      minC: minList.first.round(),
-      maxC: maxList.first.round(),
+      feelsLikeC: feelsLikeC,
+      minC: days.first.minC,
+      maxC: days.first.maxC,
       fetchedAt: DateTime.now(),
+      days: days,
     );
   }
 }

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -13,6 +13,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/routes.dart';
 import '../../../config/theme.dart';
+import '../../../core/nudges/nudge_counters.dart';
 import '../../../core/orchestration/first_impression_orchestrator.dart';
 import '../../../core/providers/analytics_provider.dart';
 import '../../../core/providers/navigation_providers.dart';
@@ -32,6 +33,7 @@ import '../widgets/closing_card_v18.dart';
 import '../widgets/flux_continu_article_card.dart';
 import '../widgets/my_interests_intro.dart';
 import '../widgets/my_interests_sheet.dart';
+import '../widgets/geoloc_prompt_banner.dart';
 import '../widgets/section_block.dart';
 import '../widgets/sticky_tab_bar.dart';
 import '../../grille/widgets/grille_cta_card.dart';
@@ -94,6 +96,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   void initState() {
     super.initState();
     _scroll.addListener(_onScroll);
+    // Compte une ouverture du feed par montage de l'écran. Alimente la bannière
+    // de demande de géoloc (déclenchée après 5 ouvertures, cf.
+    // geoloc_prompt_provider). Best-effort, n'impacte pas le rendu.
+    unawaited(NudgeCounters.increment(NudgeCounters.feedOpenCount));
   }
 
   @override
@@ -672,6 +678,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
           SliverToBoxAdapter(
             child: impressionSlot == FirstImpressionSlot.wellInformed
                 ? const WellInformedPrompt()
+                : const SizedBox.shrink(),
+          ),
+          SliverToBoxAdapter(
+            child: impressionSlot == FirstImpressionSlot.geolocPrompt
+                ? const GeolocPromptBanner()
                 : const SizedBox.shrink(),
           ),
           const SliverToBoxAdapter(child: LettresNotificationBanner()),

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -11,6 +11,7 @@ import '../models/flux_continu_models.dart';
 import '../models/weather_snapshot.dart';
 import '../providers/weather_provider.dart';
 import '../utils/theme_color_mapping.dart';
+import 'weather_detail_sheet.dart';
 
 /// Carte hi-fi unique "L'Essentiel du jour".
 ///
@@ -211,13 +212,13 @@ class _HeaderBadgeState extends ConsumerState<_HeaderBadge> {
 
     final Widget child;
     if (_showWeather) {
-      final snapshot = ref.watch(weatherProvider).valueOrNull;
-      if (snapshot != null) {
+      final forecast = ref.watch(weatherProvider).valueOrNull;
+      if (forecast != null) {
         child = GestureDetector(
           key: const ValueKey('weather'),
           behavior: HitTestBehavior.opaque,
-          onTap: () => setState(() => _showWeather = false),
-          child: _WeatherBadge(snapshot: snapshot),
+          onTap: () => showWeatherDetailSheet(context),
+          child: _WeatherBadge(forecast: forecast),
         );
       } else {
         child = GestureDetector(
@@ -244,10 +245,12 @@ class _HeaderBadgeState extends ConsumerState<_HeaderBadge> {
       );
     }
 
-    // Fixed slot: always 94×108 so the header never reflows when flipping.
+    // Fixed slot: always 100×120 so the header never reflows when flipping.
+    // Enlarged vs. the MVP (94×108) to give the accentuated weather block more
+    // presence; the date stamp (60×60) stays centered in the same slot.
     return SizedBox(
-      width: 94,
-      height: 108,
+      width: 100,
+      height: 120,
       child: AnimatedSwitcher(
         duration: const Duration(milliseconds: 320),
         switchInCurve: Curves.easeInOut,
@@ -280,10 +283,13 @@ class _HeaderBadgeState extends ConsumerState<_HeaderBadge> {
   }
 }
 
+/// Bloc météo accentué du header : température actuelle en gros, icône
+/// condition, min/max, et un indice visuel signalant qu'un tap ouvre la modal
+/// détaillée 5 jours.
 class _WeatherBadge extends StatelessWidget {
-  final WeatherSnapshot snapshot;
+  final WeatherForecast forecast;
 
-  const _WeatherBadge({required this.snapshot});
+  const _WeatherBadge({required this.forecast});
 
   @override
   Widget build(BuildContext context) {
@@ -291,11 +297,22 @@ class _WeatherBadge extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        SvgPicture.asset(
-          'assets/images/weather/${snapshot.condition.assetName}.svg',
-          width: 94,
-          height: 94,
+        Text(
+          '${forecast.currentC}°',
+          style: GoogleFonts.fraunces(
+            fontSize: 26,
+            fontWeight: FontWeight.w700,
+            height: 1.0,
+            color: colors.textPrimary,
+          ),
         ),
+        const SizedBox(height: 2),
+        SvgPicture.asset(
+          'assets/images/weather/${forecast.condition.assetName}.svg',
+          width: 56,
+          height: 56,
+        ),
+        const SizedBox(height: 2),
         RichText(
           text: TextSpan(
             style: GoogleFonts.courierPrime(
@@ -305,7 +322,7 @@ class _WeatherBadge extends StatelessWidget {
             ),
             children: [
               TextSpan(
-                text: '${snapshot.minC}°',
+                text: '${forecast.minC}°',
                 style: TextStyle(color: colors.info),
               ),
               TextSpan(
@@ -313,11 +330,18 @@ class _WeatherBadge extends StatelessWidget {
                 style: TextStyle(color: colors.textSecondary),
               ),
               TextSpan(
-                text: '${snapshot.maxC}°',
+                text: '${forecast.maxC}°',
                 style: TextStyle(color: colors.error),
               ),
             ],
           ),
+        ),
+        const SizedBox(height: 2),
+        Icon(
+          Icons.keyboard_arrow_down_rounded,
+          size: 14,
+          color: colors.textTertiary,
+          semanticLabel: 'Voir la météo détaillée',
         ),
       ],
     );

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -149,7 +149,8 @@ class _Header extends StatelessWidget {
               const SizedBox(height: 4),
               Text(
                 'Tes 5 articles du jour, basé sur tes préférences',
-                style: FacteurTypography.bodySmall(colors.textSecondary).copyWith(
+                style:
+                    FacteurTypography.bodySmall(colors.textSecondary).copyWith(
                   height: 1.35,
                 ),
               ),
@@ -245,12 +246,10 @@ class _HeaderBadgeState extends ConsumerState<_HeaderBadge> {
       );
     }
 
-    // Fixed slot: always 100×120 so the header never reflows when flipping.
-    // Enlarged vs. the MVP (94×108) to give the accentuated weather block more
-    // presence; the date stamp (60×60) stays centered in the same slot.
+    // Fixed slot: the header never reflows when flipping between date/weather.
     return SizedBox(
-      width: 100,
-      height: 120,
+      width: 90,
+      height: 108,
       child: AnimatedSwitcher(
         duration: const Duration(milliseconds: 320),
         switchInCurve: Curves.easeInOut,
@@ -260,8 +259,8 @@ class _HeaderBadgeState extends ConsumerState<_HeaderBadge> {
           children: [...previous, if (current != null) current],
         ),
         transitionBuilder: (Widget child, Animation<double> animation) {
-          final rotate = Tween<double>(begin: math.pi, end: 0.0)
-              .animate(animation);
+          final rotate =
+              Tween<double>(begin: math.pi, end: 0.0).animate(animation);
           return AnimatedBuilder(
             animation: rotate,
             builder: (context, c) {
@@ -283,9 +282,8 @@ class _HeaderBadgeState extends ConsumerState<_HeaderBadge> {
   }
 }
 
-/// Bloc météo accentué du header : température actuelle en gros, icône
-/// condition, min/max, et un indice visuel signalant qu'un tap ouvre la modal
-/// détaillée 5 jours.
+/// Bloc météo compact du header : icône condition, min/max, et un indice
+/// discret signalant qu'un tap ouvre la modal détaillée 5 jours.
 class _WeatherBadge extends StatelessWidget {
   final WeatherForecast forecast;
 
@@ -297,27 +295,17 @@ class _WeatherBadge extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Text(
-          '${forecast.currentC}°',
-          style: GoogleFonts.fraunces(
-            fontSize: 26,
-            fontWeight: FontWeight.w700,
-            height: 1.0,
-            color: colors.textPrimary,
-          ),
-        ),
-        const SizedBox(height: 2),
         SvgPicture.asset(
           'assets/images/weather/${forecast.condition.assetName}.svg',
-          width: 56,
-          height: 56,
+          width: 60,
+          height: 60,
         ),
-        const SizedBox(height: 2),
+        const SizedBox(height: 3),
         RichText(
           text: TextSpan(
             style: GoogleFonts.courierPrime(
-              fontSize: 13,
-              fontWeight: FontWeight.w600,
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
               height: 1.0,
             ),
             children: [
@@ -336,11 +324,11 @@ class _WeatherBadge extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 2),
+        const SizedBox(height: 1),
         Icon(
           Icons.keyboard_arrow_down_rounded,
-          size: 14,
-          color: colors.textTertiary,
+          size: 12,
+          color: colors.textTertiary.withValues(alpha: 0.7),
           semanticLabel: 'Voir la météo détaillée',
         ),
       ],
@@ -656,8 +644,9 @@ class _SourceRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
     final isFollowed = article.isFollowedSource;
-    final avatarBg =
-        isFollowed ? accent.withValues(alpha: 0.18) : colors.backgroundSecondary;
+    final avatarBg = isFollowed
+        ? accent.withValues(alpha: 0.18)
+        : colors.backgroundSecondary;
     final avatarBorder = isFollowed ? accent : colors.border;
     final avatarTextColor = isFollowed ? accent : colors.textSecondary;
     return Row(
@@ -788,4 +777,3 @@ String _sectionLabelFor(EssentielArticle article) {
   if (raw.isNotEmpty) return raw;
   return 'Actus';
 }
-

--- a/apps/mobile/lib/features/flux_continu/widgets/geoloc_prompt_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/geoloc_prompt_banner.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../../../core/orchestration/first_impression_orchestrator.dart';
+import '../../../core/providers/analytics_provider.dart';
+import '../providers/geoloc_prompt_provider.dart';
+import '../providers/weather_location_provider.dart';
+
+/// Bannière in-feed (format « notif de progression ») proposant d'activer la
+/// géolocalisation pour afficher la météo de la ville de l'utilisateur.
+///
+/// Miroir de `NotificationRenudgeBanner` : un seul nudge par session
+/// (anti-stacking via `nudgeConsumedThisSessionProvider`), cap dur persisté en
+/// Hive (`geoloc_prompt_shown_count`), dismiss de session sur « Pas maintenant ».
+class GeolocPromptBanner extends ConsumerStatefulWidget {
+  const GeolocPromptBanner({super.key});
+
+  @override
+  ConsumerState<GeolocPromptBanner> createState() => _GeolocPromptBannerState();
+}
+
+class _GeolocPromptBannerState extends ConsumerState<GeolocPromptBanner> {
+  /// Tracking analytics + incrément du cap au premier affichage.
+  bool _recordedShown = false;
+
+  /// Dismiss session-only : tant que l'écran vit, on ne ré-affiche pas après un
+  /// « Pas maintenant ». Au cold start suivant, le cap dur prend le relais.
+  bool _dismissedThisSession = false;
+
+  Future<void> _onActivate() async {
+    final granted =
+        await ref.read(weatherLocationProvider.notifier).useDeviceLocation();
+    unawaited(
+      ref
+          .read(analyticsServiceProvider)
+          .trackGeolocPromptActivated(granted: granted),
+    );
+    if (!mounted) return;
+    setState(() => _dismissedThisSession = true);
+  }
+
+  void _onDismiss() {
+    unawaited(ref.read(analyticsServiceProvider).trackGeolocPromptDismissed());
+    setState(() => _dismissedThisSession = true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dismissedThisSession) return const SizedBox.shrink();
+    final shouldShow =
+        ref.watch(geolocPromptShouldShowProvider).valueOrNull ?? false;
+    if (!shouldShow) return const SizedBox.shrink();
+
+    if (!_recordedShown) {
+      _recordedShown = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        if (!mounted) return;
+        // Marque le slot nudge comme consommé pour la session (anti-stacking).
+        ref.read(nudgeConsumedThisSessionProvider.notifier).state = true;
+        final displayCount =
+            await ref.read(geolocPromptControllerProvider).recordShown();
+        unawaited(
+          ref
+              .read(analyticsServiceProvider)
+              .trackGeolocPromptShown(displayCount: displayCount),
+        );
+      });
+    }
+
+    final colors = context.facteurColors;
+    final theme = Theme.of(context);
+
+    return Container(
+      margin: const EdgeInsets.symmetric(
+        horizontal: FacteurSpacing.space4,
+        vertical: FacteurSpacing.space3,
+      ),
+      padding: const EdgeInsets.all(FacteurSpacing.space4),
+      decoration: BoxDecoration(
+        color: colors.primary.withValues(alpha: 0.08),
+        border: Border.all(color: colors.primary.withValues(alpha: 0.25)),
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: colors.primary.withValues(alpha: 0.12),
+                ),
+                alignment: Alignment.center,
+                child: Icon(
+                  PhosphorIcons.mapPin(PhosphorIconsStyle.fill),
+                  color: colors.primary,
+                  size: 20,
+                ),
+              ),
+              const SizedBox(width: FacteurSpacing.space3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Active ta position pour la météo de ta ville',
+                      style: theme.textTheme.bodyMedium
+                          ?.copyWith(fontWeight: FontWeight.w600),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'On garde Paris par défaut. Ta position reste sur ton '
+                      'appareil.',
+                      style: theme.textTheme.bodySmall
+                          ?.copyWith(color: colors.textSecondary),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: FacteurSpacing.space3),
+          Row(
+            children: [
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: _onActivate,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: colors.primary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(FacteurRadius.medium),
+                    ),
+                  ),
+                  child: const Text('Activer'),
+                ),
+              ),
+              const SizedBox(width: FacteurSpacing.space2),
+              TextButton(
+                onPressed: _onDismiss,
+                child: Text(
+                  'Pas maintenant',
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: colors.textSecondary),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/weather_detail_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/weather_detail_sheet.dart
@@ -28,6 +28,16 @@ const List<String> _kWeekdaysShort = [
   'Dim',
 ];
 
+const List<String> _kWeekdaysFull = [
+  'Lundi',
+  'Mardi',
+  'Mercredi',
+  'Jeudi',
+  'Vendredi',
+  'Samedi',
+  'Dimanche',
+];
+
 const List<String> _kMonthsShort = [
   'janv.',
   'févr.',
@@ -44,6 +54,65 @@ const List<String> _kMonthsShort = [
 ];
 
 String _weekdayShort(DateTime d) => _kWeekdaysShort[d.weekday - 1];
+String _weekdayFull(DateTime d) => _kWeekdaysFull[d.weekday - 1];
+
+String weatherIntroLine(WeatherForecast forecast) {
+  final min = forecast.minC;
+  final max = forecast.maxC;
+
+  if (max >= 35) {
+    return 'Canicule en vue, mieux vaut garder le rythme léger.';
+  }
+  if (max >= 30) {
+    return 'Très chaud aujourd\'hui, pense à chercher l\'ombre.';
+  }
+  if (max <= 2) {
+    return 'Froid vif au programme, la journée demande une couche de plus.';
+  }
+  if (min <= 0) {
+    return 'Matinée glaciale, même si la journée peut s\'adoucir.';
+  }
+
+  switch (forecast.condition) {
+    case WeatherCondition.sunny:
+      if (max <= 9) {
+        return 'Beau soleil, mais l\'air reste frais.';
+      }
+      if (max >= 26) {
+        return 'Grand soleil, à savourer plutôt côté fraîcheur.';
+      }
+      return 'Grand soleil, la journée s\'annonce lumineuse.';
+    case WeatherCondition.partlyCloudy:
+      if (max >= 22) {
+        return 'Éclaircies et douceur, météo facile à vivre.';
+      }
+      if (max <= 10) {
+        return 'Quelques éclaircies, avec un fond d\'air encore frais.';
+      }
+      return 'Quelques éclaircies devraient rythmer la journée.';
+    case WeatherCondition.cloudy:
+      if (max >= 19) {
+        return 'Ciel couvert mais redoux sensible aujourd\'hui.';
+      }
+      if (max <= 9) {
+        return 'Ciel gris et air frais, ambiance calme aujourd\'hui.';
+      }
+      return 'Ciel couvert, une journée discrète côté météo.';
+    case WeatherCondition.rainy:
+      if (max <= 8) {
+        return 'Pluie froide aujourd\'hui, mieux vaut sortir couvert.';
+      }
+      if (max >= 22) {
+        return 'Averses possibles malgré la douceur, garde un oeil au ciel.';
+      }
+      return 'Journée humide, le parapluie mérite sa place.';
+    case WeatherCondition.snowy:
+      if (max <= 1) {
+        return 'Neige et froid installés, ambiance très hivernale.';
+      }
+      return 'Quelques flocons possibles, avec une météo bien fraîche.';
+  }
+}
 
 class _WeatherDetailSheet extends ConsumerWidget {
   const _WeatherDetailSheet();
@@ -55,7 +124,7 @@ class _WeatherDetailSheet extends ConsumerWidget {
     final weather = ref.watch(weatherProvider);
 
     return DraggableScrollableSheet(
-      initialChildSize: 0.6,
+      initialChildSize: 0.7,
       minChildSize: 0.4,
       maxChildSize: 0.92,
       expand: false,
@@ -172,39 +241,53 @@ class _Content extends ConsumerWidget {
             borderRadius: BorderRadius.circular(FacteurRadius.large),
             border: Border.all(color: colors.border, width: 0.6),
           ),
-          child: Row(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              SvgPicture.asset(
-                'assets/images/weather/${forecast.condition.assetName}.svg',
-                width: 72,
-                height: 72,
-              ),
-              const SizedBox(width: FacteurSpacing.space4),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      '${forecast.currentC}°',
-                      style: GoogleFonts.fraunces(
-                        fontSize: 40,
-                        fontWeight: FontWeight.w700,
-                        height: 1.0,
-                        color: colors.textPrimary,
-                      ),
+              Row(
+                children: [
+                  SvgPicture.asset(
+                    'assets/images/weather/${forecast.condition.assetName}.svg',
+                    width: 72,
+                    height: 72,
+                  ),
+                  const SizedBox(width: FacteurSpacing.space4),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '${forecast.currentC}°',
+                          style: GoogleFonts.fraunces(
+                            fontSize: 40,
+                            fontWeight: FontWeight.w700,
+                            height: 1.0,
+                            color: colors.textPrimary,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'Ressenti ${forecast.feelsLikeC}°',
+                          style:
+                              FacteurTypography.bodySmall(colors.textSecondary),
+                        ),
+                      ],
                     ),
-                    const SizedBox(height: 4),
-                    Text(
-                      'Ressenti ${forecast.feelsLikeC}°',
-                      style: FacteurTypography.bodySmall(colors.textSecondary),
-                    ),
-                  ],
-                ),
+                  ),
+                  _TempRange(
+                    minC: forecast.minC,
+                    maxC: forecast.maxC,
+                    fontSize: 17,
+                  ),
+                ],
               ),
-              _TempRange(
-                minC: forecast.minC,
-                maxC: forecast.maxC,
-                fontSize: 16,
+              const SizedBox(height: FacteurSpacing.space3),
+              Text(
+                weatherIntroLine(forecast),
+                style: FacteurTypography.bodySmall(colors.textSecondary)
+                    .copyWith(height: 1.3),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
               ),
             ],
           ),
@@ -255,9 +338,9 @@ class _DayRow extends StatelessWidget {
       child: Row(
         children: [
           SizedBox(
-            width: 64,
+            width: 96,
             child: Text(
-              isToday ? "Aujourd'hui" : _weekdayShort(day.date),
+              isToday ? "Aujourd'hui" : _weekdayFull(day.date),
               style: FacteurTypography.bodyMedium(colors.textPrimary).copyWith(
                 fontWeight: isToday ? FontWeight.w700 : FontWeight.w500,
               ),
@@ -266,11 +349,11 @@ class _DayRow extends StatelessWidget {
           const SizedBox(width: FacteurSpacing.space2),
           SvgPicture.asset(
             'assets/images/weather/${day.condition.assetName}.svg',
-            width: 32,
-            height: 32,
+            width: 40,
+            height: 40,
           ),
           const Spacer(),
-          _TempRange(minC: day.minC, maxC: day.maxC, fontSize: 14),
+          _TempRange(minC: day.minC, maxC: day.maxC, fontSize: 16),
         ],
       ),
     );

--- a/apps/mobile/lib/features/flux_continu/widgets/weather_detail_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/weather_detail_sheet.dart
@@ -1,0 +1,348 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../models/weather_snapshot.dart';
+import '../providers/weather_location_provider.dart';
+import '../providers/weather_provider.dart';
+
+/// Ouvre la modal météo détaillée (aujourd'hui + prévision 5 jours).
+Future<void> showWeatherDetailSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    builder: (_) => const _WeatherDetailSheet(),
+  );
+}
+
+const List<String> _kWeekdaysShort = [
+  'Lun',
+  'Mar',
+  'Mer',
+  'Jeu',
+  'Ven',
+  'Sam',
+  'Dim',
+];
+
+const List<String> _kMonthsShort = [
+  'janv.',
+  'févr.',
+  'mars',
+  'avr.',
+  'mai',
+  'juin',
+  'juil.',
+  'août',
+  'sept.',
+  'oct.',
+  'nov.',
+  'déc.',
+];
+
+String _weekdayShort(DateTime d) => _kWeekdaysShort[d.weekday - 1];
+
+class _WeatherDetailSheet extends ConsumerWidget {
+  const _WeatherDetailSheet();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final location = ref.watch(weatherLocationProvider);
+    final weather = ref.watch(weatherProvider);
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.6,
+      minChildSize: 0.4,
+      maxChildSize: 0.92,
+      expand: false,
+      builder: (context, scrollController) {
+        return Container(
+          decoration: BoxDecoration(
+            color: colors.backgroundPrimary,
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(20),
+              topRight: Radius.circular(20),
+            ),
+          ),
+          child: Column(
+            children: [
+              const SizedBox(height: 8),
+              Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: colors.border,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  controller: scrollController,
+                  padding: const EdgeInsets.fromLTRB(
+                    FacteurSpacing.space6,
+                    FacteurSpacing.space4,
+                    FacteurSpacing.space6,
+                    FacteurSpacing.space8,
+                  ),
+                  child: weather.when(
+                    data: (forecast) => _Content(
+                      forecast: forecast,
+                      locationLabel: location.label,
+                      isDeviceLocation: location.isDeviceLocation,
+                    ),
+                    loading: () => const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 48),
+                      child: Center(child: CircularProgressIndicator()),
+                    ),
+                    error: (_, __) => Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 48),
+                      child: Center(
+                        child: Text(
+                          'Météo indisponible pour le moment.',
+                          style: FacteurTypography.bodyMedium(
+                            colors.textSecondary,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _Content extends ConsumerWidget {
+  final WeatherForecast forecast;
+  final String locationLabel;
+  final bool isDeviceLocation;
+
+  const _Content({
+    required this.forecast,
+    required this.locationLabel,
+    required this.isDeviceLocation,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final now = DateTime.now();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // En-tête : libellé localisation + date du jour.
+        Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    locationLabel,
+                    style: FacteurTypography.serifTitle(colors.textPrimary)
+                        .copyWith(fontSize: 24, height: 1.15),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${_weekdayShort(now)} ${now.day} '
+                    '${_kMonthsShort[now.month - 1]}',
+                    style: FacteurTypography.bodySmall(colors.textSecondary),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: FacteurSpacing.space4),
+
+        // Bloc « aujourd'hui ».
+        Container(
+          padding: const EdgeInsets.all(FacteurSpacing.space4),
+          decoration: BoxDecoration(
+            color: colors.surface,
+            borderRadius: BorderRadius.circular(FacteurRadius.large),
+            border: Border.all(color: colors.border, width: 0.6),
+          ),
+          child: Row(
+            children: [
+              SvgPicture.asset(
+                'assets/images/weather/${forecast.condition.assetName}.svg',
+                width: 72,
+                height: 72,
+              ),
+              const SizedBox(width: FacteurSpacing.space4),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '${forecast.currentC}°',
+                      style: GoogleFonts.fraunces(
+                        fontSize: 40,
+                        fontWeight: FontWeight.w700,
+                        height: 1.0,
+                        color: colors.textPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'Ressenti ${forecast.feelsLikeC}°',
+                      style: FacteurTypography.bodySmall(colors.textSecondary),
+                    ),
+                  ],
+                ),
+              ),
+              _TempRange(
+                minC: forecast.minC,
+                maxC: forecast.maxC,
+                fontSize: 16,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: FacteurSpacing.space4),
+
+        // Prévision 5 jours.
+        Text(
+          'Prévisions',
+          style: FacteurTypography.labelLarge(colors.textSecondary),
+        ),
+        const SizedBox(height: FacteurSpacing.space2),
+        for (var i = 0; i < forecast.days.length; i++) ...[
+          _DayRow(day: forecast.days[i], isToday: i == 0),
+          if (i < forecast.days.length - 1)
+            Divider(height: 1, color: colors.border.withValues(alpha: 0.4)),
+        ],
+
+        if (!isDeviceLocation) ...[
+          const SizedBox(height: FacteurSpacing.space4),
+          _ActivateLocationCta(
+            onTap: () async {
+              final granted = await ref
+                  .read(weatherLocationProvider.notifier)
+                  .useDeviceLocation();
+              if (granted && context.mounted) {
+                await Navigator.of(context).maybePop();
+              }
+            },
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _DayRow extends StatelessWidget {
+  final WeatherDay day;
+  final bool isToday;
+
+  const _DayRow({required this.day, required this.isToday});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: FacteurSpacing.space3),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 64,
+            child: Text(
+              isToday ? "Aujourd'hui" : _weekdayShort(day.date),
+              style: FacteurTypography.bodyMedium(colors.textPrimary).copyWith(
+                fontWeight: isToday ? FontWeight.w700 : FontWeight.w500,
+              ),
+            ),
+          ),
+          const SizedBox(width: FacteurSpacing.space2),
+          SvgPicture.asset(
+            'assets/images/weather/${day.condition.assetName}.svg',
+            width: 32,
+            height: 32,
+          ),
+          const Spacer(),
+          _TempRange(minC: day.minC, maxC: day.maxC, fontSize: 14),
+        ],
+      ),
+    );
+  }
+}
+
+/// Affiche « min° / max° » en chiffres monospace (bleu / gris / rouge),
+/// partagé entre le bloc du jour et chaque ligne de prévision.
+class _TempRange extends StatelessWidget {
+  final int minC;
+  final int maxC;
+  final double fontSize;
+
+  const _TempRange({
+    required this.minC,
+    required this.maxC,
+    required this.fontSize,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return RichText(
+      text: TextSpan(
+        style: GoogleFonts.courierPrime(
+          fontSize: fontSize,
+          fontWeight: FontWeight.w600,
+        ),
+        children: [
+          TextSpan(text: '$minC°', style: TextStyle(color: colors.info)),
+          TextSpan(text: ' / ', style: TextStyle(color: colors.textSecondary)),
+          TextSpan(text: '$maxC°', style: TextStyle(color: colors.error)),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActivateLocationCta extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _ActivateLocationCta({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Material(
+      color: colors.primary.withValues(alpha: 0.08),
+      borderRadius: BorderRadius.circular(FacteurRadius.medium),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(FacteurRadius.medium),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: FacteurSpacing.space4,
+            vertical: FacteurSpacing.space3,
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.my_location_rounded, size: 18, color: colors.primary),
+              const SizedBox(width: FacteurSpacing.space2),
+              Expanded(
+                child: Text(
+                  'Activer ma position',
+                  style: FacteurTypography.bodyMedium(colors.primary)
+                      .copyWith(fontWeight: FontWeight.w600),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import flutter_inappwebview_macos
 import flutter_local_notifications
 import flutter_secure_storage_darwin
 import flutter_timezone
+import geolocator_apple
 import just_audio
 import package_info_plus
 import path_provider_foundation
@@ -29,6 +30,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
+  GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -640,6 +640,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.0"
+  geolocator:
+    dependency: "direct main"
+    description:
+      name: geolocator
+      sha256: f62bcd90459e63210bbf9c35deb6a51c521f992a78de19a1fe5c11704f9530e2
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.4"
+  geolocator_android:
+    dependency: transitive
+    description:
+      name: geolocator_android
+      sha256: fcb1760a50d7500deca37c9a666785c047139b5f9ee15aa5469fae7dbbe3170d
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.2"
+  geolocator_apple:
+    dependency: transitive
+    description:
+      name: geolocator_apple
+      sha256: dbdd8789d5aaf14cf69f74d4925ad1336b4433a6efdf2fce91e8955dc921bf22
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.13"
+  geolocator_platform_interface:
+    dependency: transitive
+    description:
+      name: geolocator_platform_interface
+      sha256: "30cb64f0b9adcc0fb36f628b4ebf4f731a2961a0ebd849f4b56200205056fe67"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.6"
+  geolocator_web:
+    dependency: transitive
+    description:
+      name: geolocator_web
+      sha256: b1ae9bdfd90f861fde8fd4f209c37b953d65e92823cb73c7dee1fa021b06f172
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.3"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      sha256: "175435404d20278ffd220de83c2ca293b73db95eafbdc8131fe8609be1421eb6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.5"
   glob:
     dependency: transitive
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -52,6 +52,9 @@ dependencies:
   intl: ^0.20.2
   url_launcher: ^6.2.5
   flutter_secure_storage: ^10.0.0
+
+  # Geolocation (Story 10.1 — météo géolocalisée, client-only, iOS/Android/web)
+  geolocator: ^13.0.4
   
   # Home Screen Widget
   home_widget: ^0.7.0

--- a/apps/mobile/test/features/flux_continu/providers/geoloc_prompt_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/geoloc_prompt_provider_test.dart
@@ -1,0 +1,111 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:facteur/core/nudges/nudge_counters.dart';
+import 'package:facteur/features/flux_continu/models/weather_location.dart';
+import 'package:facteur/features/flux_continu/providers/geoloc_prompt_provider.dart';
+import 'package:facteur/features/flux_continu/providers/weather_location_provider.dart';
+
+/// Notifier de localisation factice : court-circuite le chargement Hive et
+/// renvoie une localisation fixe.
+class _FakeLocationNotifier extends WeatherLocationNotifier {
+  _FakeLocationNotifier(this._location);
+  final WeatherLocation _location;
+  @override
+  WeatherLocation build() => _location;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = Directory.systemTemp.createTempSync('geoloc_prompt_test');
+    Hive.init(tempDir.path);
+    // Box `settings` propre pour chaque test.
+    final box = await Hive.openBox<dynamic>('settings');
+    await box.clear();
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    tempDir.deleteSync(recursive: true);
+  });
+
+  ProviderContainer makeContainer(WeatherLocation location) {
+    final container = ProviderContainer(
+      overrides: [
+        weatherLocationProvider
+            .overrideWith(() => _FakeLocationNotifier(location)),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  final feedKey = 'nudge.counter.${NudgeCounters.feedOpenCount}';
+
+  test('false below 5 feed opens', () async {
+    SharedPreferences.setMockInitialValues({feedKey: 4});
+    final container = makeContainer(WeatherLocation.paris);
+    expect(
+      await container.read(geolocPromptShouldShowProvider.future),
+      isFalse,
+    );
+  });
+
+  test('true at 5 feed opens (Paris default, no cap reached)', () async {
+    SharedPreferences.setMockInitialValues({feedKey: 5});
+    final container = makeContainer(WeatherLocation.paris);
+    expect(
+      await container.read(geolocPromptShouldShowProvider.future),
+      isTrue,
+    );
+  });
+
+  test('false when already on device location', () async {
+    SharedPreferences.setMockInitialValues({feedKey: 10});
+    final container = makeContainer(
+      const WeatherLocation(
+        lat: 1,
+        lng: 2,
+        label: 'Ma position',
+        isDeviceLocation: true,
+      ),
+    );
+    expect(
+      await container.read(geolocPromptShouldShowProvider.future),
+      isFalse,
+    );
+  });
+
+  test('false when display cap is reached', () async {
+    SharedPreferences.setMockInitialValues({feedKey: 10});
+    final box = await Hive.openBox<dynamic>('settings');
+    await box.put(
+      GeolocPromptController.kShownCount,
+      kGeolocPromptMaxShown,
+    );
+    final container = makeContainer(WeatherLocation.paris);
+    expect(
+      await container.read(geolocPromptShouldShowProvider.future),
+      isFalse,
+    );
+  });
+
+  test('false when permanently dismissed', () async {
+    SharedPreferences.setMockInitialValues({feedKey: 10});
+    final box = await Hive.openBox<dynamic>('settings');
+    await box.put(GeolocPromptController.kDismissed, true);
+    final container = makeContainer(WeatherLocation.paris);
+    expect(
+      await container.read(geolocPromptShouldShowProvider.future),
+      isFalse,
+    );
+  });
+}

--- a/apps/mobile/test/features/flux_continu/repositories/weather_repository_test.dart
+++ b/apps/mobile/test/features/flux_continu/repositories/weather_repository_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/flux_continu/models/weather_snapshot.dart';
+import 'package:facteur/features/flux_continu/repositories/weather_repository.dart';
+
+void main() {
+  group('WeatherRepository.parseForecast', () {
+    // Corps Open-Meteo réaliste : current + daily sur 5 jours.
+    final body = <String, dynamic>{
+      'current': {
+        'temperature_2m': 18.6,
+        'apparent_temperature': 17.1,
+        'weather_code': 3, // overcast → cloudy
+      },
+      'daily': {
+        'time': [
+          '2026-06-01',
+          '2026-06-02',
+          '2026-06-03',
+          '2026-06-04',
+          '2026-06-05',
+        ],
+        'weather_code': [0, 1, 61, 71, 45],
+        'temperature_2m_max': [21.4, 23.0, 19.8, 5.2, 16.0],
+        'temperature_2m_min': [11.9, 12.3, 13.0, -1.4, 9.0],
+      },
+    };
+
+    test('maps current conditions, feels-like and 5-day forecast', () {
+      final f = WeatherRepository.parseForecast(body);
+
+      expect(f.condition, WeatherCondition.cloudy); // from current code 3
+      expect(f.currentC, 19); // 18.6 rounded
+      expect(f.feelsLikeC, 17); // 17.1 rounded
+      expect(f.days.length, 5);
+
+      // Top-level min/max come from today (days[0]).
+      expect(f.minC, 12); // 11.9 rounded
+      expect(f.maxC, 21); // 21.4 rounded
+    });
+
+    test('parses per-day condition mapping and rounding', () {
+      final f = WeatherRepository.parseForecast(body);
+
+      expect(f.days[0].condition, WeatherCondition.sunny); // code 0
+      expect(f.days[1].condition, WeatherCondition.partlyCloudy); // code 1
+      expect(f.days[2].condition, WeatherCondition.rainy); // code 61
+      expect(f.days[3].condition, WeatherCondition.snowy); // code 71
+      expect(f.days[4].condition, WeatherCondition.cloudy); // code 45
+
+      expect(f.days[0].date, DateTime(2026, 6, 1));
+      expect(f.days[3].minC, -1); // -1.4 rounded
+      expect(f.days[3].maxC, 5); // 5.2 rounded
+    });
+  });
+}

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -6,7 +6,9 @@ import 'package:google_fonts/google_fonts.dart';
 
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
+import 'package:facteur/features/flux_continu/models/weather_location.dart';
 import 'package:facteur/features/flux_continu/models/weather_snapshot.dart';
+import 'package:facteur/features/flux_continu/providers/weather_location_provider.dart';
 import 'package:facteur/features/flux_continu/providers/weather_provider.dart';
 import 'package:facteur/features/flux_continu/widgets/essentiel_hi_fi_card.dart';
 
@@ -22,9 +24,15 @@ Widget _wrap(Widget child, {List<Override> overrides = const []}) {
 
 class _FakeWeatherNotifier extends WeatherNotifier {
   _FakeWeatherNotifier(this._value);
-  final WeatherSnapshot _value;
+  final WeatherForecast _value;
   @override
-  Future<WeatherSnapshot> build() async => _value;
+  Future<WeatherForecast> build() async => _value;
+}
+
+/// Évite le chargement Hive (non initialisé en test unitaire) : renvoie Paris.
+class _FakeLocationNotifier extends WeatherLocationNotifier {
+  @override
+  WeatherLocation build() => WeatherLocation.paris;
 }
 
 EssentielArticle _article({
@@ -244,20 +252,31 @@ void main() {
       expect(find.byType(SvgPicture), findsNothing);
     });
 
-    testWidgets('flips to the weather badge once the user scrolls past 32 px',
-        (tester) async {
-      final snapshot = WeatherSnapshot(
+    testWidgets('flips to the weather badge and tapping it opens the detail '
+        'sheet', (tester) async {
+      final forecast = WeatherForecast(
         condition: WeatherCondition.sunny,
         currentC: 19,
+        feelsLikeC: 18,
         minC: 12,
         maxC: 21,
         fetchedAt: DateTime(2026, 5, 28),
+        days: [
+          for (var i = 0; i < 5; i++)
+            WeatherDay(
+              date: DateTime(2026, 5, 28).add(Duration(days: i)),
+              condition: WeatherCondition.sunny,
+              minC: 12 + i,
+              maxC: 21 + i,
+            ),
+        ],
       );
 
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            weatherProvider.overrideWith(() => _FakeWeatherNotifier(snapshot)),
+            weatherProvider.overrideWith(() => _FakeWeatherNotifier(forecast)),
+            weatherLocationProvider.overrideWith(_FakeLocationNotifier.new),
           ],
           child: MaterialApp(
             theme: ThemeData(extensions: [FacteurPalettes.light]),
@@ -273,21 +292,23 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Before timer fires → date stamp.
+      // Before timer fires → date stamp, no weather icon.
       expect(find.byType(SvgPicture), findsNothing);
 
-      // Advance 2 s → badge flips to weather.
+      // Advance 2 s → badge flips to weather (current temp + icon visible).
       await tester.pump(const Duration(seconds: 2));
       await tester.pumpAndSettle();
 
       expect(find.byType(SvgPicture), findsOneWidget);
+      expect(find.text('19°'), findsOneWidget);
 
-      // Tap the weather badge → flips back to date stamp.
+      // Tap the weather badge → opens the detail sheet (5-day forecast).
       await tester.tap(find.byType(SvgPicture), warnIfMissed: false);
       await tester.pumpAndSettle();
 
-      expect(find.byType(SvgPicture), findsNothing,
-          reason: 'Tap on the weather badge pins the date stamp back.');
+      expect(find.text('Prévisions'), findsOneWidget,
+          reason: 'Tapping the weather badge opens the detail sheet.');
+      expect(find.text("Aujourd'hui"), findsOneWidget);
     });
 
     testWidgets('slots 2-5 all use the medium layout (no dotted divider)',

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -101,7 +101,8 @@ void main() {
       expect(tapped?.contentId, 'c-1');
     });
 
-    testWidgets('tap on the personalize button fires the callback and not the '
+    testWidgets(
+        'tap on the personalize button fires the callback and not the '
         'lead', (tester) async {
       var personalizeTaps = 0;
       var articleTaps = 0;
@@ -154,7 +155,8 @@ void main() {
       expect(exploreTaps, 1);
     });
 
-    testWidgets('"Tout l\'essentiel" button is omitted when onTapExploreAll is null',
+    testWidgets(
+        '"Tout l\'essentiel" button is omitted when onTapExploreAll is null',
         (tester) async {
       await tester.pumpWidget(_wrap(
         EssentielHiFiCard(
@@ -252,7 +254,8 @@ void main() {
       expect(find.byType(SvgPicture), findsNothing);
     });
 
-    testWidgets('flips to the weather badge and tapping it opens the detail '
+    testWidgets(
+        'flips to the weather badge and tapping it opens the detail '
         'sheet', (tester) async {
       final forecast = WeatherForecast(
         condition: WeatherCondition.sunny,
@@ -295,12 +298,18 @@ void main() {
       // Before timer fires → date stamp, no weather icon.
       expect(find.byType(SvgPicture), findsNothing);
 
-      // Advance 2 s → badge flips to weather (current temp + icon visible).
+      // Advance 2 s → badge flips to weather (icon + min/max visible).
       await tester.pump(const Duration(seconds: 2));
       await tester.pumpAndSettle();
 
       expect(find.byType(SvgPicture), findsOneWidget);
-      expect(find.text('19°'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is RichText && widget.text.toPlainText() == '12°/21°',
+        ),
+        findsOneWidget,
+      );
 
       // Tap the weather badge → opens the detail sheet (5-day forecast).
       await tester.tap(find.byType(SvgPicture), warnIfMissed: false);

--- a/apps/mobile/windows/flutter/generated_plugin_registrant.cc
+++ b/apps/mobile/windows/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <flutter_inappwebview_windows/flutter_inappwebview_windows_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <flutter_timezone/flutter_timezone_plugin_c_api.h>
+#include <geolocator_windows/geolocator_windows.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -22,6 +23,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   FlutterTimezonePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterTimezonePluginCApi"));
+  GeolocatorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("GeolocatorWindows"));
   SentryFlutterPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/apps/mobile/windows/flutter/generated_plugins.cmake
+++ b/apps/mobile/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_inappwebview_windows
   flutter_secure_storage_windows
   flutter_timezone
+  geolocator_windows
   sentry_flutter
   url_launcher_windows
 )

--- a/docs/stories/core/10.1.meteo-geolocalisee.md
+++ b/docs/stories/core/10.1.meteo-geolocalisee.md
@@ -1,0 +1,84 @@
+# Story 10.1 — Météo géolocalisée, plus présente, cliquable
+
+> **Type** : Feature · **Statut** : En cours
+> **Épic** : 10 (Rituel quotidien / habitudes)
+
+## Contexte
+
+La météo est aujourd'hui un MVP : un badge dans le header de « Ton Essentiel »
+(`essentiel_hi_fi_card.dart`) qui flippe date↔météo après 2 s, alimenté en direct
+par Open-Meteo **codé en dur sur Paris** (`weather_repository.dart`,
+`forecast_days=1`), sans backend. Il n'est **pas cliquable** et **pas
+géolocalisé** → impossible d'en faire un motif de retour quotidien.
+
+## Objectif
+
+Transformer ce MVP en vraie fonctionnalité d'habitude :
+1. Météo **plus présente** dans le header (on garde le flip, on accentue le bloc).
+2. **Géolocalisée** via une demande in-feed (format « notif de progression »),
+   déclenchée **après 5 ouvertures du feed**. **Paris reste le défaut.** Stockage
+   **local (Hive)** uniquement — la météo reste 100 % client, **aucun backend ni
+   migration Alembic**.
+3. **Cliquable** → modal détaillée (temp actuelle + ressenti + min/max + condition
+   + **prévision 5 jours**).
+
+## Décisions PO validées
+
+- Header : garder le flip mais accentuer le bloc météo.
+- Stockage local Hive (box `settings`).
+- Modal niveau « essentiel » + 5 jours.
+- Déclenchement de la géoloc après 5 ouvertures du feed (pas à l'onboarding).
+
+## Plan technique
+
+### 1. Données & modèle (prévision 5 jours)
+- `models/weather_snapshot.dart` : conserve `WeatherCondition` +
+  `weatherConditionFromWmo`. Ajoute `WeatherDay` et `WeatherForecast`
+  (remplace `WeatherSnapshot`, un seul fetch alimente badge + modal).
+- `repositories/weather_repository.dart` : `fetch(lat, lng, {timezone})` →
+  `current=temperature_2m,apparent_temperature,weather_code`,
+  `daily=weather_code,temperature_2m_max,temperature_2m_min`, `forecast_days=5`.
+- `providers/weather_provider.dart` : dépend de `weatherLocationProvider`, cache
+  TTL 30 min **clé par localisation**.
+
+### 2. Localisation (Hive + géoloc)
+- `models/weather_location.dart` : `WeatherLocation` + `WeatherLocation.paris`.
+- `providers/weather_location_provider.dart` : `Notifier<WeatherLocation>`,
+  charge/persiste dans Hive `settings`, `useDeviceLocation()` via `geolocator`.
+- `pubspec.yaml` + iOS `Info.plist` (`NSLocationWhenInUseUsageDescription`) +
+  Android `AndroidManifest.xml` (`ACCESS_COARSE_LOCATION`).
+
+### 3. Bannière in-feed (« notif de progression »)
+- Incrémente `NudgeCounters.feedOpenCount` à l'ouverture du feed.
+- `providers/geoloc_prompt_provider.dart` : `geolocPromptShouldShowProvider`
+  (≥5 ouvertures, pas déjà device, cap 3, pas dismiss permanent).
+- `widgets/geoloc_prompt_banner.dart` : miroir de `NotificationRenudgeBanner`.
+- `core/orchestration/first_impression_orchestrator.dart` : slot `geolocPrompt`
+  (priorité basse, après `wellInformed`).
+- `screens/flux_continu_screen.dart` : sliver bannière + incrément compteur.
+
+### 4. Header accentué + cliquable
+- `widgets/essentiel_hi_fi_card.dart` : `_WeatherBadge` accentué (temp actuelle
+  en gros + icône + min/max + affordance). Tap sur la face météo → modal.
+
+### 5. Modal détaillée
+- `widgets/weather_detail_sheet.dart` : `showWeatherDetailSheet`, en miroir de
+  `settings_sheet.dart` (handle, coins arrondis, scroll). Aujourd'hui + 5 jours +
+  CTA « Activer ma position » si encore sur Paris.
+
+## Tasks
+- [ ] Modèle 5 jours + ressenti
+- [ ] Repository fetch par coords
+- [ ] weatherProvider dépendant de la localisation
+- [ ] WeatherLocation + provider Hive + géoloc
+- [ ] geoloc_prompt_provider + banner + orchestrator + écran
+- [ ] Header accentué + cliquable
+- [ ] Modal détaillée
+- [ ] pubspec + Info.plist + AndroidManifest
+- [ ] Tests unitaires + analyze
+
+## Vérification
+- `flutter test` (parsing repo, location provider, geolocPromptShouldShow).
+- `flutter analyze` zéro nouveau warning.
+- Validation web Chrome (viewport 390×844).
+- **Aucune migration Alembic** (feature 100 % client) → 1 head inchangé.


### PR DESCRIPTION
## Quoi

Transforme le badge météo MVP (Paris codé en dur, non cliquable) en vraie
fonctionnalité d'habitude : géolocalisable (opt-in in-feed), accentué dans le
header, et cliquable vers une modal détaillée 5 jours. **100 % client (Hive),
aucun backend ni migration Alembic.**

- **Modèle 5 jours** : `WeatherForecast` (+ ressenti, `days[]`) remplace `WeatherSnapshot` ; `WeatherDay` par jour. Un seul fetch alimente badge + modal.
- **Repository** : `fetch(lat, lng, {timezone})` Open-Meteo (`current` + `apparent_temperature` + `daily` sur 5 jours), défaut Paris.
- **Localisation** : `WeatherLocation` (+ `paris`), `weatherLocationProvider` (charge/persiste Hive `settings`, `useDeviceLocation()` via `geolocator`). `weatherProvider` dépend de la localisation, cache TTL 30 min clé par coords.
- **Bannière géoloc in-feed** : `geolocPromptShouldShowProvider` (≥5 ouvertures du feed, pas déjà device, cap 3), `GeolocPromptBanner`, nouveau slot `geolocPrompt` dans `FirstImpressionSlot`.
- **Header accentué + cliquable** : `_WeatherBadge` (temp actuelle en gros + icône + min/max + chevron). Tap → `showWeatherDetailSheet`.
- **Modal détaillée** : aujourd'hui + 5 jours + CTA « Activer ma position » si encore sur Paris.
- **Natif** : `geolocator`, iOS `NSLocationWhenInUseUsageDescription`, Android `ACCESS_COARSE_LOCATION`.

## Pourquoi

Le badge météo MVP était figé sur Paris et inerte. Cette story (10.1) en fait un
repère quotidien personnalisable, ancré dans le « moment de fermeture » du feed.

## Comment ça a été vérifié

- [x] `flutter analyze` sur tous les fichiers touchés : zéro issue
- [x] Tests scoped verts (20/20) : parsing repo 5 jours, `geolocPromptShouldShow` (seuils/cap/device/dismiss), badge flip + tap → modal
- [x] `/simplify` passé — 2 fixes appliqués : `displayCount` analytics réel (via `recordShown()` qui retourne le n° d'affichage) ; widget `_TempRange` extrait (dédup min/max RichText)
- [ ] CI = pytest backend uniquement (la suite mobile a ~27 échecs **pré-existants** Hive/Supabase non init, hors scope, non régressés)
- [ ] `/validate-feature` (QA Chrome) — handoff dans `.context/qa-handoff.md`, à lancer par le PO si souhaité

## Zones à risque

- Mobile-only, additif. `geolocator` est la seule nouvelle dépendance native.
- Aucune migration : 1 head Alembic inchangé.
