### PR TITLE
fix(perspectives): divergence_level + partial background refresh + in-flight guard

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -74,12 +74,12 @@ class ContentDetailScreen extends ConsumerStatefulWidget {
   final bool isExternal;
 
   const ContentDetailScreen({super.key, required this.contentId, this.content})
-      : externalUrl = null,
-        sourceName = null,
-        sourceDomain = null,
-        externalTitle = null,
-        biasStance = 'unknown',
-        isExternal = false;
+    : externalUrl = null,
+      sourceName = null,
+      sourceDomain = null,
+      externalTitle = null,
+      biasStance = 'unknown',
+      isExternal = false;
 
   /// Ouvre une URL externe (perspective) dans le reader unique, en mode
   /// webview du site (header/footer/scroll/anti-saccades partagés).
@@ -90,11 +90,11 @@ class ContentDetailScreen extends ConsumerStatefulWidget {
     this.sourceDomain,
     String? title,
     this.biasStance = 'unknown',
-  })  : contentId = '',
-        content = null,
-        externalUrl = url,
-        externalTitle = title,
-        isExternal = true;
+  }) : contentId = '',
+       content = null,
+       externalUrl = url,
+       externalTitle = title,
+       isExternal = true;
 
   @override
   ConsumerState<ContentDetailScreen> createState() =>
@@ -203,6 +203,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   // Perspectives pill state
   PerspectivesResponse? _perspectivesResponse;
   bool _perspectivesLoading = false;
+  Timer? _perspectivesRefetchTimer;
 
   // Perspectives analysis state (lifted from inline section)
   PerspectivesAnalysisState _perspectivesAnalysisState =
@@ -318,7 +319,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       vsync: this,
     );
     _footerAutoController.addListener(() {
-      _footerOffset.value = _footerAutoStart +
+      _footerOffset.value =
+          _footerAutoStart +
           (_footerAutoTarget - _footerAutoStart) * _footerAutoController.value;
     });
 
@@ -684,7 +686,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (endBox == null || svBox == null) return;
     if (!_scrollController.hasClients) return;
     // content-coord of marker = screen Y of marker − screen Y of sv top + scroll offset
-    final extent = endBox.localToGlobal(Offset.zero).dy -
+    final extent =
+        endBox.localToGlobal(Offset.zero).dy -
         svBox.localToGlobal(Offset.zero).dy +
         _scrollController.offset;
     if (extent > 0) _articleContentExtent = extent;
@@ -744,8 +747,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     setState(() {
       final current = _perspectivesSelectedSegments;
       if (current.contains(key)) {
-        _perspectivesSelectedSegments =
-            current.length == 1 ? {} : (Set.from(current)..remove(key));
+        _perspectivesSelectedSegments = current.length == 1
+            ? {}
+            : (Set.from(current)..remove(key));
       } else {
         _perspectivesSelectedSegments = current.isEmpty || current.length == 3
             ? {key}
@@ -1221,15 +1225,16 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       vsync: this,
       duration: const Duration(milliseconds: 600),
     );
-    _perspectivesPulseScale ??= TweenSequence<double>([
-      TweenSequenceItem(tween: Tween(begin: 1.0, end: 1.08), weight: 50),
-      TweenSequenceItem(tween: Tween(begin: 1.08, end: 1.0), weight: 50),
-    ]).animate(
-      CurvedAnimation(
-        parent: _perspectivesPulseController!,
-        curve: Curves.easeOutCubic,
-      ),
-    );
+    _perspectivesPulseScale ??=
+        TweenSequence<double>([
+          TweenSequenceItem(tween: Tween(begin: 1.0, end: 1.08), weight: 50),
+          TweenSequenceItem(tween: Tween(begin: 1.08, end: 1.0), weight: 50),
+        ]).animate(
+          CurvedAnimation(
+            parent: _perspectivesPulseController!,
+            curve: Curves.easeOutCubic,
+          ),
+        );
     _perspectivesPulseController!.forward(from: 0).whenComplete(() async {
       if (!mounted) return;
       final coordinator = ref.read(nudgeCoordinatorProvider);
@@ -1281,6 +1286,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _inactivityTimer?.cancel();
     _articleLayerUnmountTimer?.cancel();
     _linkCopiedHeaderTimer?.cancel();
+    _perspectivesRefetchTimer?.cancel();
     _bookmarkBounceController.dispose();
     _likeBounceController.dispose();
     _perspectivesPulseController?.dispose();
@@ -1397,6 +1403,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           _perspectivesLoading = false;
           if (response.perspectives.isEmpty) _perspectivesExpanded = false;
         });
+        if (response.partial) {
+          _schedulePerspectivesPartialRefetch(content.id);
+        }
         _maybeTriggerPerspectivesCta();
       }
     } catch (e) {
@@ -1405,6 +1414,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         setState(() => _perspectivesLoading = false);
       }
     }
+  }
+
+  void _schedulePerspectivesPartialRefetch(String contentId) {
+    if (_perspectivesRefetchTimer != null) return;
+    _perspectivesRefetchTimer = Timer(const Duration(milliseconds: 2200), () {
+      _perspectivesRefetchTimer = null;
+      if (!mounted || _isExternal || _content?.id != contentId) return;
+      _fetchPerspectives();
+    });
   }
 
   /// Request Facteur analysis for the perspectives section.
@@ -1486,13 +1504,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     );
     final articleText = content.htmlContent ?? content.description;
     final hasEnoughContent = plainTextLength(articleText) >= 100;
-    final useScrollToSite = !isConnectedPremiumSource &&
+    final useScrollToSite =
+        !isConnectedPremiumSource &&
         content.hasInAppContent &&
         content.contentType == ContentType.article &&
         hasEnoughContent &&
         !_showWebView &&
         !kIsWeb;
-    final useInAppReading = !isConnectedPremiumSource &&
+    final useInAppReading =
+        !isConnectedPremiumSource &&
         content.hasInAppContent &&
         !_showWebView &&
         !useScrollToSite;
@@ -1591,10 +1611,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 child: isVideoContent
                     ? _buildVideoContent(context, content)
                     : useScrollToSite
-                        ? _buildScrollToSiteContent(context, content)
-                        : useInAppReading
-                            ? _buildInAppContent(context, content)
-                            : _buildWebViewFallback(content),
+                    ? _buildScrollToSiteContent(context, content)
+                    : useInAppReading
+                    ? _buildInAppContent(context, content)
+                    : _buildWebViewFallback(content),
               ),
             ),
             // Header — pinned at the top of the screen; no scroll-driven
@@ -1668,7 +1688,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (content == null) return;
     final articleText = content.htmlContent ?? content.description;
     final hasEnoughContent = plainTextLength(articleText) >= 100;
-    final isScrollToSite = content.hasInAppContent &&
+    final isScrollToSite =
+        content.hasInAppContent &&
         content.contentType == ContentType.article &&
         hasEnoughContent &&
         !_showWebView;
@@ -2083,7 +2104,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     // Fallback to the article payload before the provider has loaded — avoids
     // a flash of the "Suivre +" chip on cold open when the source is already
     // followed server-side.
-    final InterestState effectiveState = liveState ??
+    final InterestState effectiveState =
+        liveState ??
         (content.isFollowedSource
             ? InterestState.followed
             : InterestState.unfollowed);
@@ -2168,9 +2190,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                               child: Container(
                                                 padding:
                                                     const EdgeInsets.symmetric(
-                                                  horizontal: 6,
-                                                  vertical: 2,
-                                                ),
+                                                      horizontal: 6,
+                                                      vertical: 2,
+                                                    ),
                                                 decoration: BoxDecoration(
                                                   color: Color.lerp(
                                                     colors.backgroundSecondary,
@@ -2184,9 +2206,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                                   content.source.name,
                                                   style: textTheme.labelMedium
                                                       ?.copyWith(
-                                                    fontWeight: FontWeight.bold,
-                                                    color: colors.textPrimary,
-                                                  ),
+                                                        fontWeight:
+                                                            FontWeight.bold,
+                                                        color:
+                                                            colors.textPrimary,
+                                                      ),
                                                   maxLines: 1,
                                                   overflow:
                                                       TextOverflow.ellipsis,
@@ -2227,11 +2251,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                             child: InkWell(
                                               onTap: () =>
                                                   TopicChip.showArticleSheet(
-                                                context,
-                                                content,
-                                                initialSection:
-                                                    ArticleSheetSection.source,
-                                              ),
+                                                    context,
+                                                    content,
+                                                    initialSection:
+                                                        ArticleSheetSection
+                                                            .source,
+                                                  ),
                                               child: Padding(
                                                 padding: const EdgeInsets.all(
                                                   3,
@@ -2267,11 +2292,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                                   locale: 'fr_short',
                                                 )
                                                 .replaceAll('il y a ', ''),
-                                            style:
-                                                textTheme.bodySmall?.copyWith(
-                                              color: colors.textTertiary,
-                                              fontSize: 11,
-                                            ),
+                                            style: textTheme.bodySmall
+                                                ?.copyWith(
+                                                  color: colors.textTertiary,
+                                                  fontSize: 11,
+                                                ),
                                           ),
                                         ],
                                       ),
@@ -2508,8 +2533,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           Colors.grey.shade400,
           colors.primary,
           clamped,
-        )!
-            .withValues(alpha: alpha);
+        )!.withValues(alpha: alpha);
         return TweenAnimationBuilder<double>(
           tween: Tween<double>(end: clamped),
           duration: const Duration(milliseconds: 300),
@@ -2780,6 +2804,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                               contentId: widget.contentId,
                               comparisonQuality:
                                   _perspectivesResponse!.comparisonQuality,
+                              divergenceLevel:
+                                  _perspectivesResponse!.divergenceLevel,
                               externalSelectedSegments:
                                   _perspectivesSelectedSegments,
                               onSegmentTap: _onPerspectivesSegmentTap,
@@ -2891,8 +2917,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
     // Description text: prefer htmlContent (stripped), fallback to description
     final rawDescription = content.htmlContent ?? content.description;
-    final descriptionText =
-        rawDescription != null ? stripHtml(rawDescription).trim() : null;
+    final descriptionText = rawDescription != null
+        ? stripHtml(rawDescription).trim()
+        : null;
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -3057,7 +3084,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
                       // Bottom spacing — clears the persistent footer.
                       SizedBox(
-                        height: _kFooterContentHeight +
+                        height:
+                            _kFooterContentHeight +
                             MediaQuery.of(context).viewPadding.bottom,
                       ),
                     ],
@@ -3211,7 +3239,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
                     // Bottom spacing — clears the persistent footer.
                     SizedBox(
-                      height: _kFooterContentHeight +
+                      height:
+                          _kFooterContentHeight +
                           MediaQuery.of(context).viewPadding.bottom,
                     ),
                   ],
@@ -3256,8 +3285,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           title: content.title,
           shrinkWrap: true,
           onLinkTap: _animateAndLaunch,
-          bodyPlaceholder:
-              !_contentResolved ? _buildArticleBodySkeleton(colors) : null,
+          bodyPlaceholder: !_contentResolved
+              ? _buildArticleBodySkeleton(colors)
+              : null,
         );
 
         return ScrollConfiguration(
@@ -3357,6 +3387,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     sourceName: _content?.source.name ?? '',
                     contentId: widget.contentId,
                     comparisonQuality: _perspectivesResponse!.comparisonQuality,
+                    divergenceLevel: _perspectivesResponse!.divergenceLevel,
                     externalSelectedSegments: _perspectivesSelectedSegments,
                     onSegmentTap: _onPerspectivesSegmentTap,
                     onClearSegments: () {
@@ -3421,7 +3452,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 // ── Footer clearance ───────────────────────────────────────
                 const SizedBox(height: FacteurSpacing.space4),
                 SizedBox(
-                  height: _kFooterContentHeight +
+                  height:
+                      _kFooterContentHeight +
                       MediaQuery.of(context).viewPadding.bottom,
                 ),
               ],
@@ -3653,10 +3685,10 @@ class _FollowChip extends StatelessWidget {
               Text(
                 'Suivre',
                 style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                      color: colors.textSecondary,
-                      fontWeight: FontWeight.w700,
-                      letterSpacing: 0.2,
-                    ),
+                  color: colors.textSecondary,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.2,
+                ),
               ),
             ],
           ),

--- a/apps/mobile/lib/features/feed/repositories/feed_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/feed_repository.dart
@@ -140,7 +140,8 @@ class FeedRepository {
     // R5.1 — single-flight + dedupe gate for the default view only.
     // `personalized=true` opts out: theme/topic sections of the Tournée
     // are a different shape and must not share the default-view cache.
-    final bool isDefaultView = page == 1 &&
+    final bool isDefaultView =
+        page == 1 &&
         limit == 20 &&
         !serein &&
         !savedOnly &&
@@ -235,10 +236,7 @@ class FeedRepository {
       // et non une enveloppe { items: [], pagination: {} }
       final offset = (page - 1) * limit;
 
-      final queryParams = <String, dynamic>{
-        'limit': limit,
-        'offset': offset,
-      };
+      final queryParams = <String, dynamic>{'limit': limit, 'offset': offset};
 
       if (contentType != null) {
         queryParams['type'] = contentType;
@@ -299,7 +297,8 @@ class FeedRepository {
         final data = response.data;
         final responseSize = response.data.toString().length;
         print(
-            '[PERF] feed_repository GET /feed/: ${sw.elapsedMilliseconds}ms, response ~${(responseSize / 1024).toStringAsFixed(1)}KB');
+          '[PERF] feed_repository GET /feed/: ${sw.elapsedMilliseconds}ms, response ~${(responseSize / 1024).toStringAsFixed(1)}KB',
+        );
 
         final parsed = parseFeedData(data: data, page: page, limit: limit);
         return (feed: parsed, raw: data);
@@ -326,37 +325,37 @@ class FeedRepository {
 
     // Robustness: Handle both List (Legacy/Prod) and Map (New Backend) responses
     if (data is List) {
-          // Legacy format (List returned directly)
-          for (final e in data) {
-            try {
-              if (e is Map<String, dynamic>) {
-                itemsList.add(Content.fromJson(e));
-              }
-            } catch (err) {
-              print('FeedRepository: Skipping corrupt item in List: $err');
-            }
+      // Legacy format (List returned directly)
+      for (final e in data) {
+        try {
+          if (e is Map<String, dynamic>) {
+            itemsList.add(Content.fromJson(e));
           }
-        } else if (data is Map<String, dynamic>) {
-          // New format (FeedResponse object)
-          final itemsRaw = data['items'];
-          if (itemsRaw is List) {
-            for (final e in itemsRaw) {
-              try {
-                if (e is Map<String, dynamic>) {
-                  itemsList.add(Content.fromJson(e));
-                }
-              } catch (err) {
-                print('FeedRepository: Skipping corrupt item in items: $err');
-              }
+        } catch (err) {
+          print('FeedRepository: Skipping corrupt item in List: $err');
+        }
+      }
+    } else if (data is Map<String, dynamic>) {
+      // New format (FeedResponse object)
+      final itemsRaw = data['items'];
+      if (itemsRaw is List) {
+        for (final e in itemsRaw) {
+          try {
+            if (e is Map<String, dynamic>) {
+              itemsList.add(Content.fromJson(e));
             }
+          } catch (err) {
+            print('FeedRepository: Skipping corrupt item in items: $err');
           }
+        }
+      }
 
-          // Note: briefing is no longer parsed - digest moved to dedicated tab
-          // The briefing field in response is ignored
+      // Note: briefing is no longer parsed - digest moved to dedicated tab
+      // The briefing field in response is ignored
 
-          // Epic 11: Parse clusters if present
-          // DEADCODE: Feature "X autres articles" masquée.
-          /*
+      // Epic 11: Parse clusters if present
+      // DEADCODE: Feature "X autres articles" masquée.
+      /*
           final clustersRaw = data['clusters'];
           if (clustersRaw is List) {
             final clusters = <FeedCluster>[];
@@ -407,255 +406,256 @@ class FeedRepository {
           }
           */
 
-          // Epic 12: Parse source_overflow and annotate last card per source
-          final overflowRaw = data['source_overflow'];
-          if (overflowRaw is List) {
-            final overflowMap = <String, int>{};
-            for (final o in overflowRaw) {
-              if (o is Map<String, dynamic>) {
-                final sid = o['source_id'] as String?;
-                final count = o['hidden_count'] as int?;
-                if (sid != null && count != null && count > 0) {
-                  overflowMap[sid] = count;
-                }
-              }
-            }
-
-            if (overflowMap.isNotEmpty) {
-              // Find the LAST card per source and annotate with overflow count
-              // (only if no cluster chip already present — cluster takes priority)
-              final lastIndexBySource = <String, int>{};
-              for (var i = 0; i < itemsList.length; i++) {
-                final sid = itemsList[i].source.id;
-                if (overflowMap.containsKey(sid)) {
-                  lastIndexBySource[sid] = i;
-                }
-              }
-
-              for (final entry in lastIndexBySource.entries) {
-                final idx = entry.value;
-                final item = itemsList[idx];
-                // Don't annotate if cluster chip already present
-                // if (item.clusterHiddenCount == 0) {
-                  itemsList[idx] = item.copyWith(
-                    sourceOverflowCount: overflowMap[entry.key]!,
-                  );
-                // }
-              }
+      // Epic 12: Parse source_overflow and annotate last card per source
+      final overflowRaw = data['source_overflow'];
+      if (overflowRaw is List) {
+        final overflowMap = <String, int>{};
+        for (final o in overflowRaw) {
+          if (o is Map<String, dynamic>) {
+            final sid = o['source_id'] as String?;
+            final count = o['hidden_count'] as int?;
+            if (sid != null && count != null && count > 0) {
+              overflowMap[sid] = count;
             }
           }
-          // Topic overflow from topic-aware regroupement (Phase 2)
-          final topicOverflowRaw = data['topic_overflow'];
-          if (topicOverflowRaw is List) {
-            final topicOverflows = <TopicOverflow>[];
-            for (final t in topicOverflowRaw) {
-              try {
-                if (t is Map<String, dynamic>) {
-                  final tof = TopicOverflow.fromJson(t);
-                  print(
-                      '[DEBUG] TopicOverflow "${tof.groupLabel}": sources=${tof.sources.length}, raw_sources=${(t['sources'] as List?)?.length ?? 0}');
-                  topicOverflows.add(tof);
-                }
-              } catch (err) {
-                print('FeedRepository: Skipping corrupt topic_overflow: $err');
-              }
-            }
-
-            if (topicOverflows.isNotEmpty) {
-              // For each topic overflow group, find the last article matching
-              // that group and annotate it with overflow metadata.
-              // Priority: cluster > topic_overflow > source_overflow
-              for (final overflow in topicOverflows) {
-                int? lastMatchIdx;
-                for (var i = 0; i < itemsList.length; i++) {
-                  final item = itemsList[i];
-                  bool matches = false;
-                  if (overflow.groupType == 'topic') {
-                    matches = item.topics
-                        .any((t) => t.toLowerCase() == overflow.groupKey);
-                  } else {
-                    // theme match via source.theme
-                    matches = (item.source.theme?.toLowerCase() ?? '') ==
-                        overflow.groupKey;
-                  }
-                  if (matches) {
-                    lastMatchIdx = i;
-                  }
-                }
-
-                if (lastMatchIdx != null) {
-                  final item = itemsList[lastMatchIdx];
-                  // Don't overwrite cluster chip (highest priority)
-                  // if (item.clusterHiddenCount == 0) {
-                    // Fallback: if backend sends empty sources, use article's own source
-                    final sources = overflow.sources.isNotEmpty
-                        ? overflow.sources
-                        : [
-                            KeywordOverflowSource(
-                              sourceId: item.source.id,
-                              sourceName: item.source.name,
-                              sourceLogoUrl: item.source.logoUrl,
-                              articleCount: 1,
-                            )
-                          ];
-                    itemsList[lastMatchIdx] = item.copyWith(
-                      topicOverflowCount: overflow.hiddenCount,
-                      topicOverflowLabel: overflow.groupLabel,
-                      topicOverflowKey: overflow.groupKey,
-                      topicOverflowType: overflow.groupType,
-                      topicOverflowHiddenIds: overflow.hiddenIds,
-                      topicOverflowSources: sources,
-                    );
-                  // }
-                }
-              }
-            }
-          }
-          // Entity overflow from entity regroupement
-          final entityOverflowRaw = data['entity_overflow'];
-          if (entityOverflowRaw is List) {
-            final entityOverflows = <EntityOverflow>[];
-            for (final e in entityOverflowRaw) {
-              try {
-                if (e is Map<String, dynamic>) {
-                  entityOverflows.add(EntityOverflow.fromJson(e));
-                }
-              } catch (err) {
-                print('FeedRepository: Skipping corrupt entity_overflow: $err');
-              }
-            }
-
-            if (entityOverflows.isNotEmpty) {
-              // For each entity overflow group, find the last article whose
-              // entities contain the entity name and annotate it.
-              // Priority: cluster > entity_overflow > keyword_overflow > topic_overflow > source_overflow
-              for (final overflow in entityOverflows) {
-                final entityLower = overflow.entityName.toLowerCase();
-                int? lastMatchIdx;
-                for (var i = 0; i < itemsList.length; i++) {
-                  final item = itemsList[i];
-                  final matches = item.entities.any(
-                    (e) => e.text.toLowerCase() == entityLower,
-                  );
-                  if (matches) {
-                    lastMatchIdx = i;
-                  }
-                }
-
-                if (lastMatchIdx != null) {
-                  final item = itemsList[lastMatchIdx];
-                  // Don't overwrite cluster chip (highest priority)
-                  // if (item.clusterHiddenCount == 0) {
-                    final sources = overflow.sources.isNotEmpty
-                        ? overflow.sources
-                        : [
-                            KeywordOverflowSource(
-                              sourceId: item.source.id,
-                              sourceName: item.source.name,
-                              sourceLogoUrl: item.source.logoUrl,
-                              articleCount: 1,
-                            )
-                          ];
-                    itemsList[lastMatchIdx] = item.copyWith(
-                      entityOverflowCount: overflow.hiddenCount,
-                      entityOverflowLabel: overflow.displayLabel,
-                      entityOverflowKey: overflow.entityName,
-                      entityOverflowHiddenIds: overflow.hiddenIds,
-                      entityOverflowSources: sources,
-                    );
-                  // }
-                }
-              }
-            }
-          }
-          // Keyword overflow from keyword mining regroupement
-          final keywordOverflowRaw = data['keyword_overflow'];
-          if (keywordOverflowRaw is List) {
-            final keywordOverflows = <KeywordOverflow>[];
-            for (final k in keywordOverflowRaw) {
-              try {
-                if (k is Map<String, dynamic>) {
-                  keywordOverflows.add(KeywordOverflow.fromJson(k));
-                }
-              } catch (err) {
-                print(
-                    'FeedRepository: Skipping corrupt keyword_overflow: $err');
-              }
-            }
-
-            if (keywordOverflows.isNotEmpty) {
-              // For each keyword overflow group, find the last article whose
-              // title contains the keyword and annotate it.
-              // Priority: cluster > keyword_overflow > topic_overflow > source_overflow
-              for (final overflow in keywordOverflows) {
-                int? lastMatchIdx;
-                final kwLower = overflow.filterKeyword.toLowerCase();
-                for (var i = 0; i < itemsList.length; i++) {
-                  if (itemsList[i].title.toLowerCase().contains(kwLower)) {
-                    lastMatchIdx = i;
-                  }
-                }
-
-                if (lastMatchIdx != null) {
-                  final item = itemsList[lastMatchIdx];
-                  // Don't overwrite cluster chip (highest priority)
-                  // if (item.clusterHiddenCount == 0) {
-                    final sources = overflow.sources.isNotEmpty
-                        ? overflow.sources
-                        : [
-                            KeywordOverflowSource(
-                              sourceId: item.source.id,
-                              sourceName: item.source.name,
-                              sourceLogoUrl: item.source.logoUrl,
-                              articleCount: 1,
-                            )
-                          ];
-                    itemsList[lastMatchIdx] = item.copyWith(
-                      keywordOverflowCount: overflow.hiddenCount,
-                      keywordOverflowLabel: overflow.displayLabel,
-                      keywordOverflowKey: overflow.filterKeyword,
-                      keywordOverflowHiddenIds: overflow.hiddenIds,
-                      keywordOverflowSources: sources,
-                      keywordOverflowIsCustomTopic: overflow.isCustomTopic,
-                    );
-                  // }
-                }
-              }
-            }
-          }
-          // Carousels from overflow group promotion
-          final carouselsRaw = data['carousels'];
-          if (carouselsRaw is List) {
-            for (final c in carouselsRaw) {
-              try {
-                if (c is Map<String, dynamic>) {
-                  carousels.add(FeedCarouselData.fromJson(c));
-                }
-              } catch (err) {
-                print('FeedRepository: Skipping corrupt carousel: $err');
-              }
-            }
-            if (carousels.isNotEmpty) {
-              print(
-                  '[DEBUG] FeedRepository: ${carousels.length} carousels parsed');
-            }
-          }
-        } else if (data == null) {
-          // Empty response
-          itemsList = [];
         }
 
-        // Pagination: parsePagination handles both the legacy List shape
-        // (fallback: hasNext = itemsCount > 0) and the new Map shape with a
-        // `pagination` block emitted by the backend. The provider combines
-        // this with `items.isNotEmpty` via a hybrid check — see
-        // feed_provider.dart.
-        final pagination = FeedRepository.parsePagination(
-          data: data,
-          page: page,
-          limit: limit,
-          itemsCount: itemsList.length,
-        );
+        if (overflowMap.isNotEmpty) {
+          // Find the LAST card per source and annotate with overflow count
+          // (only if no cluster chip already present — cluster takes priority)
+          final lastIndexBySource = <String, int>{};
+          for (var i = 0; i < itemsList.length; i++) {
+            final sid = itemsList[i].source.id;
+            if (overflowMap.containsKey(sid)) {
+              lastIndexBySource[sid] = i;
+            }
+          }
+
+          for (final entry in lastIndexBySource.entries) {
+            final idx = entry.value;
+            final item = itemsList[idx];
+            // Don't annotate if cluster chip already present
+            // if (item.clusterHiddenCount == 0) {
+            itemsList[idx] = item.copyWith(
+              sourceOverflowCount: overflowMap[entry.key]!,
+            );
+            // }
+          }
+        }
+      }
+      // Topic overflow from topic-aware regroupement (Phase 2)
+      final topicOverflowRaw = data['topic_overflow'];
+      if (topicOverflowRaw is List) {
+        final topicOverflows = <TopicOverflow>[];
+        for (final t in topicOverflowRaw) {
+          try {
+            if (t is Map<String, dynamic>) {
+              final tof = TopicOverflow.fromJson(t);
+              print(
+                '[DEBUG] TopicOverflow "${tof.groupLabel}": sources=${tof.sources.length}, raw_sources=${(t['sources'] as List?)?.length ?? 0}',
+              );
+              topicOverflows.add(tof);
+            }
+          } catch (err) {
+            print('FeedRepository: Skipping corrupt topic_overflow: $err');
+          }
+        }
+
+        if (topicOverflows.isNotEmpty) {
+          // For each topic overflow group, find the last article matching
+          // that group and annotate it with overflow metadata.
+          // Priority: cluster > topic_overflow > source_overflow
+          for (final overflow in topicOverflows) {
+            int? lastMatchIdx;
+            for (var i = 0; i < itemsList.length; i++) {
+              final item = itemsList[i];
+              bool matches = false;
+              if (overflow.groupType == 'topic') {
+                matches = item.topics.any(
+                  (t) => t.toLowerCase() == overflow.groupKey,
+                );
+              } else {
+                // theme match via source.theme
+                matches =
+                    (item.source.theme?.toLowerCase() ?? '') ==
+                    overflow.groupKey;
+              }
+              if (matches) {
+                lastMatchIdx = i;
+              }
+            }
+
+            if (lastMatchIdx != null) {
+              final item = itemsList[lastMatchIdx];
+              // Don't overwrite cluster chip (highest priority)
+              // if (item.clusterHiddenCount == 0) {
+              // Fallback: if backend sends empty sources, use article's own source
+              final sources = overflow.sources.isNotEmpty
+                  ? overflow.sources
+                  : [
+                      KeywordOverflowSource(
+                        sourceId: item.source.id,
+                        sourceName: item.source.name,
+                        sourceLogoUrl: item.source.logoUrl,
+                        articleCount: 1,
+                      ),
+                    ];
+              itemsList[lastMatchIdx] = item.copyWith(
+                topicOverflowCount: overflow.hiddenCount,
+                topicOverflowLabel: overflow.groupLabel,
+                topicOverflowKey: overflow.groupKey,
+                topicOverflowType: overflow.groupType,
+                topicOverflowHiddenIds: overflow.hiddenIds,
+                topicOverflowSources: sources,
+              );
+              // }
+            }
+          }
+        }
+      }
+      // Entity overflow from entity regroupement
+      final entityOverflowRaw = data['entity_overflow'];
+      if (entityOverflowRaw is List) {
+        final entityOverflows = <EntityOverflow>[];
+        for (final e in entityOverflowRaw) {
+          try {
+            if (e is Map<String, dynamic>) {
+              entityOverflows.add(EntityOverflow.fromJson(e));
+            }
+          } catch (err) {
+            print('FeedRepository: Skipping corrupt entity_overflow: $err');
+          }
+        }
+
+        if (entityOverflows.isNotEmpty) {
+          // For each entity overflow group, find the last article whose
+          // entities contain the entity name and annotate it.
+          // Priority: cluster > entity_overflow > keyword_overflow > topic_overflow > source_overflow
+          for (final overflow in entityOverflows) {
+            final entityLower = overflow.entityName.toLowerCase();
+            int? lastMatchIdx;
+            for (var i = 0; i < itemsList.length; i++) {
+              final item = itemsList[i];
+              final matches = item.entities.any(
+                (e) => e.text.toLowerCase() == entityLower,
+              );
+              if (matches) {
+                lastMatchIdx = i;
+              }
+            }
+
+            if (lastMatchIdx != null) {
+              final item = itemsList[lastMatchIdx];
+              // Don't overwrite cluster chip (highest priority)
+              // if (item.clusterHiddenCount == 0) {
+              final sources = overflow.sources.isNotEmpty
+                  ? overflow.sources
+                  : [
+                      KeywordOverflowSource(
+                        sourceId: item.source.id,
+                        sourceName: item.source.name,
+                        sourceLogoUrl: item.source.logoUrl,
+                        articleCount: 1,
+                      ),
+                    ];
+              itemsList[lastMatchIdx] = item.copyWith(
+                entityOverflowCount: overflow.hiddenCount,
+                entityOverflowLabel: overflow.displayLabel,
+                entityOverflowKey: overflow.entityName,
+                entityOverflowHiddenIds: overflow.hiddenIds,
+                entityOverflowSources: sources,
+              );
+              // }
+            }
+          }
+        }
+      }
+      // Keyword overflow from keyword mining regroupement
+      final keywordOverflowRaw = data['keyword_overflow'];
+      if (keywordOverflowRaw is List) {
+        final keywordOverflows = <KeywordOverflow>[];
+        for (final k in keywordOverflowRaw) {
+          try {
+            if (k is Map<String, dynamic>) {
+              keywordOverflows.add(KeywordOverflow.fromJson(k));
+            }
+          } catch (err) {
+            print('FeedRepository: Skipping corrupt keyword_overflow: $err');
+          }
+        }
+
+        if (keywordOverflows.isNotEmpty) {
+          // For each keyword overflow group, find the last article whose
+          // title contains the keyword and annotate it.
+          // Priority: cluster > keyword_overflow > topic_overflow > source_overflow
+          for (final overflow in keywordOverflows) {
+            int? lastMatchIdx;
+            final kwLower = overflow.filterKeyword.toLowerCase();
+            for (var i = 0; i < itemsList.length; i++) {
+              if (itemsList[i].title.toLowerCase().contains(kwLower)) {
+                lastMatchIdx = i;
+              }
+            }
+
+            if (lastMatchIdx != null) {
+              final item = itemsList[lastMatchIdx];
+              // Don't overwrite cluster chip (highest priority)
+              // if (item.clusterHiddenCount == 0) {
+              final sources = overflow.sources.isNotEmpty
+                  ? overflow.sources
+                  : [
+                      KeywordOverflowSource(
+                        sourceId: item.source.id,
+                        sourceName: item.source.name,
+                        sourceLogoUrl: item.source.logoUrl,
+                        articleCount: 1,
+                      ),
+                    ];
+              itemsList[lastMatchIdx] = item.copyWith(
+                keywordOverflowCount: overflow.hiddenCount,
+                keywordOverflowLabel: overflow.displayLabel,
+                keywordOverflowKey: overflow.filterKeyword,
+                keywordOverflowHiddenIds: overflow.hiddenIds,
+                keywordOverflowSources: sources,
+                keywordOverflowIsCustomTopic: overflow.isCustomTopic,
+              );
+              // }
+            }
+          }
+        }
+      }
+      // Carousels from overflow group promotion
+      final carouselsRaw = data['carousels'];
+      if (carouselsRaw is List) {
+        for (final c in carouselsRaw) {
+          try {
+            if (c is Map<String, dynamic>) {
+              carousels.add(FeedCarouselData.fromJson(c));
+            }
+          } catch (err) {
+            print('FeedRepository: Skipping corrupt carousel: $err');
+          }
+        }
+        if (carousels.isNotEmpty) {
+          print('[DEBUG] FeedRepository: ${carousels.length} carousels parsed');
+        }
+      }
+    } else if (data == null) {
+      // Empty response
+      itemsList = [];
+    }
+
+    // Pagination: parsePagination handles both the legacy List shape
+    // (fallback: hasNext = itemsCount > 0) and the new Map shape with a
+    // `pagination` block emitted by the backend. The provider combines
+    // this with `items.isNotEmpty` via a hybrid check — see
+    // feed_provider.dart.
+    final pagination = FeedRepository.parsePagination(
+      data: data,
+      page: page,
+      limit: limit,
+      itemsCount: itemsList.length,
+    );
 
     return FeedResponse(
       items: itemsList,
@@ -784,9 +784,7 @@ class FeedRepository {
     try {
       await _apiClient.dio.post<void>(
         'feed/refresh/undo',
-        data: {
-          'previous_impressions': backups.map((b) => b.toJson()).toList(),
-        },
+        data: {'previous_impressions': backups.map((b) => b.toJson()).toList()},
       );
     } catch (e) {
       print('FeedRepository: [ERROR] undoRefresh: $e');
@@ -828,7 +826,9 @@ class FeedRepository {
 
   /// Fire-and-forget: persist reading progress on article close.
   Future<void> updateContentStatusWithProgress(
-      String contentId, int readingProgress) async {
+    String contentId,
+    int readingProgress,
+  ) async {
     try {
       await _apiClient.dio.post<void>(
         'contents/$contentId/status',
@@ -843,7 +843,9 @@ class FeedRepository {
   /// Backend accumulates across sessions (see ContentService.update_content_status).
   /// Cap client-side at 1800s to guard against forgotten background tabs.
   Future<void> updateContentStatusWithTimeSpent(
-      String contentId, int timeSpentSeconds) async {
+    String contentId,
+    int timeSpentSeconds,
+  ) async {
     if (timeSpentSeconds <= 0) return;
     final capped = timeSpentSeconds > 1800 ? 1800 : timeSpentSeconds;
     try {
@@ -857,7 +859,9 @@ class FeedRepository {
   }
 
   Future<void> updateContentStatus(
-      String contentId, ContentStatus status) async {
+    String contentId,
+    ContentStatus status,
+  ) async {
     try {
       await _apiClient.dio.post<void>(
         'contents/$contentId/status',
@@ -910,7 +914,10 @@ class FeedRepository {
       print('FeedRepository: [ERROR] getPerspectives: $e');
       // Return empty response instead of throwing to not break UX
       return PerspectivesResponse(
-          perspectives: [], keywords: [], biasDistribution: {});
+        perspectives: [],
+        keywords: [],
+        biasDistribution: {},
+      );
     }
   }
 }
@@ -958,6 +965,9 @@ class PerspectivesResponse {
   final bool shouldDisplay;
   final String? analysis;
   final bool analysisCached;
+  final bool partial;
+  final String? divergenceLevel;
+
   /// Verbe-pivot du titre de l'article lu — wash gris dans `cm-ref-inline`.
   /// `null` si le back n'a trouvé aucun verbe ou si déploiement back en retard.
   final TokenSpan? referencePivot;
@@ -971,16 +981,20 @@ class PerspectivesResponse {
     this.shouldDisplay = false,
     this.analysis,
     this.analysisCached = false,
+    this.partial = false,
+    this.divergenceLevel,
     this.referencePivot,
   });
 
   factory PerspectivesResponse.fromJson(Map<String, dynamic> json) {
-    final perspectivesList = (json['perspectives'] as List<dynamic>?)
+    final perspectivesList =
+        (json['perspectives'] as List<dynamic>?)
             ?.map((e) => PerspectiveData.fromJson(e as Map<String, dynamic>))
             .toList() ??
         [];
 
-    final keywordsList = (json['keywords'] as List<dynamic>?)
+    final keywordsList =
+        (json['keywords'] as List<dynamic>?)
             ?.map((e) => e.toString())
             .toList() ??
         [];
@@ -1002,6 +1016,8 @@ class PerspectivesResponse {
       shouldDisplay: (json['should_display'] as bool?) ?? false,
       analysis: json['analysis'] as String?,
       analysisCached: (json['analysis_cached'] as bool?) ?? false,
+      partial: (json['partial'] as bool?) ?? false,
+      divergenceLevel: json['divergence_level'] as String?,
       referencePivot: TokenSpan.fromJsonOrNull(json['reference_pivot']),
     );
   }
@@ -1051,11 +1067,7 @@ class TokenSpan {
   final int end;
   final String text;
 
-  const TokenSpan({
-    required this.start,
-    required this.end,
-    required this.text,
-  });
+  const TokenSpan({required this.start, required this.end, required this.text});
 
   factory TokenSpan.fromJson(Map<String, dynamic> json) {
     return TokenSpan(
@@ -1079,12 +1091,15 @@ class PerspectiveData {
   final String sourceDomain;
   final String biasStance;
   final String? publishedAt;
+
   /// Spans divergents du titre variant vs. référence (colorisés par bias).
   /// Liste vide si la chaîne back n'a pas pu calculer (cluster manquant, etc.).
   final List<HighlightSpan> highlightSpans;
+
   /// Spans partagés avec la référence — rendus en `text_tertiary` côté front
   /// pour faire ressortir les divergences. Liste vide en mode dégradé Mode 2.
   final List<TokenSpan> sharedTokens;
+
   /// Langue ISO du titre ("fr","en",...). Optionnel — exposé par PR 5
   /// (API enriched contract). Sert au regroupement "Couverture étrangère"
   /// (PR 6.1) côté front.
@@ -1115,13 +1130,13 @@ class PerspectiveData {
       highlightSpans: rawHighlights == null
           ? const []
           : rawHighlights
-              .map((e) => HighlightSpan.fromJson(e as Map<String, dynamic>))
-              .toList(),
+                .map((e) => HighlightSpan.fromJson(e as Map<String, dynamic>))
+                .toList(),
       sharedTokens: rawShared == null
           ? const []
           : rawShared
-              .map((e) => TokenSpan.fromJson(e as Map<String, dynamic>))
-              .toList(),
+                .map((e) => TokenSpan.fromJson(e as Map<String, dynamic>))
+                .toList(),
       language: json['language'] as String?,
     );
   }

--- a/apps/mobile/lib/features/feed/widgets/diff_title.dart
+++ b/apps/mobile/lib/features/feed/widgets/diff_title.dart
@@ -63,10 +63,7 @@ class _DiffTitleState extends State<DiffTitle>
   void initState() {
     super.initState();
     _rebuildChunks();
-    _controller = AnimationController(
-      vsync: this,
-      duration: _totalDuration(),
-    );
+    _controller = AnimationController(vsync: this, duration: _totalDuration());
     if (widget.animateIn && _animatedSpanCount > 0) {
       Future.delayed(DiffTitle.kStartDelay, () {
         if (mounted) _controller.forward();
@@ -79,7 +76,8 @@ class _DiffTitleState extends State<DiffTitle>
   @override
   void didUpdateWidget(DiffTitle oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final needsRebuild = oldWidget.title != widget.title ||
+    final needsRebuild =
+        oldWidget.title != widget.title ||
         oldWidget.highlightSpans != widget.highlightSpans ||
         oldWidget.sharedTokens != widget.sharedTokens;
     if (needsRebuild) {
@@ -102,7 +100,8 @@ class _DiffTitleState extends State<DiffTitle>
 
   Duration _totalDuration() {
     if (_animatedSpanCount == 0) return Duration.zero;
-    final ms = (_animatedSpanCount - 1) * DiffTitle.kSpanGap.inMilliseconds +
+    final ms =
+        (_animatedSpanCount - 1) * DiffTitle.kSpanGap.inMilliseconds +
         DiffTitle.kPerSpan.inMilliseconds;
     return Duration(milliseconds: ms);
   }
@@ -140,17 +139,21 @@ class _DiffTitleState extends State<DiffTitle>
     for (final span in spans) {
       if (span.start < cursor) continue;
       if (span.start > cursor) {
-        chunks.add(_Chunk(
-          text: title.substring(cursor, span.start),
-          type: _ChunkType.plain,
-        ));
+        chunks.add(
+          _Chunk(
+            text: title.substring(cursor, span.start),
+            type: _ChunkType.plain,
+          ),
+        );
       }
-      chunks.add(_Chunk(
-        text: title.substring(span.start, span.end),
-        type: span.type,
-        animIndex: animIndex,
-        weight: span.weight,
-      ));
+      chunks.add(
+        _Chunk(
+          text: title.substring(span.start, span.end),
+          type: span.type,
+          animIndex: animIndex,
+          weight: span.weight,
+        ),
+      );
       animIndex++;
       cursor = span.end;
     }
@@ -175,7 +178,10 @@ class _DiffTitleState extends State<DiffTitle>
     if (!useSharedAsTertiary && _animatedSpanCount > 0) {
       for (var i = 0; i < _chunks.length; i++) {
         if (_chunks[i].type == _ChunkType.plain) {
-          _chunks[i] = _Chunk(text: _chunks[i].text, type: _ChunkType.dimmedFallback);
+          _chunks[i] = _Chunk(
+            text: _chunks[i].text,
+            type: _ChunkType.dimmedFallback,
+          );
         }
       }
     }
@@ -223,7 +229,10 @@ class _DiffTitleState extends State<DiffTitle>
         // seul le surlignage de fond (key) différencie visuellement.
         return TextSpan(
           text: chunk.text,
-          style: TextStyle(color: colors.textPrimary, fontWeight: FontWeight.w400),
+          style: TextStyle(
+            color: colors.textPrimary,
+            fontWeight: FontWeight.w400,
+          ),
         );
       case _ChunkType.key:
         final t = _easedProgressFor(chunk.animIndex);
@@ -233,8 +242,9 @@ class _DiffTitleState extends State<DiffTitle>
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
             decoration: BoxDecoration(
-              color: widget.biasColor
-                  .withValues(alpha: _washAlpha(t, chunk.weight)),
+              color: widget.biasColor.withValues(
+                alpha: _washAlpha(t, chunk.weight),
+              ),
               borderRadius: BorderRadius.circular(4),
             ),
             child: Text(
@@ -251,13 +261,13 @@ class _DiffTitleState extends State<DiffTitle>
     }
   }
 
-  // weight=null (fallback spaCy hors digest) reste à 0.22 pour rétrocompat.
+  // Calibration 2026-06: keep hierarchy visible while reducing wash intensity.
   static double _washAlpha(double t, double? weight) {
-    if (weight == null) return 0.22 * t;
+    if (weight == null) return 0.16 * t;
     final base = switch (weight) {
-      >= 0.75 => 0.30,
-      >= 0.40 => 0.20,
-      _ => 0.12,
+      >= 0.75 => 0.24,
+      >= 0.40 => 0.16,
+      _ => 0.10,
     };
     return base * t;
   }
@@ -269,6 +279,7 @@ class _Chunk {
   final String text;
   final _ChunkType type;
   final int animIndex;
+
   /// LLM bias weight ∈ {0.25, 0.5, 1.0} ou null (fallback spaCy).
   /// Module l'opacité du surlignage pour les chunks de type `key`.
   /// null → traité comme 1.0 (comportement actuel).

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -45,10 +45,13 @@ class Perspective {
   final String sourceDomain;
   final String biasStance;
   final String? publishedAt;
+
   /// Tokens divergents du titre vs. référence, colorisés par bias.
   final List<HighlightSpan> highlightSpans;
+
   /// Tokens partagés avec la référence (rendus en text_tertiary par DiffTitle).
   final List<TokenSpan> sharedTokens;
+
   /// Langue ISO du titre ("fr","en",...). Optionnel — exposé par PR 5.
   /// Réservé au regroupement "Couverture étrangère" (PR 6.1).
   final String? language;
@@ -249,9 +252,11 @@ class _PerspectivesBottomSheetState
 
   List<Perspective> get _sortedPerspectives {
     final sorted = [...widget.perspectives];
-    sorted.sort((a, b) => _groupOrder
-        .indexOf(a.biasGroup)
-        .compareTo(_groupOrder.indexOf(b.biasGroup)));
+    sorted.sort(
+      (a, b) => _groupOrder
+          .indexOf(a.biasGroup)
+          .compareTo(_groupOrder.indexOf(b.biasGroup)),
+    );
     return sorted;
   }
 
@@ -318,10 +323,7 @@ class _PerspectivesBottomSheetState
     Widget card(Perspective p, {bool dim = false}) {
       final w = Padding(
         padding: const EdgeInsets.only(bottom: 8),
-        child: _PerspectiveCard(
-          perspective: p,
-          onView: _onPerspectiveViewed,
-        ),
+        child: _PerspectiveCard(perspective: p, onView: _onPerspectiveViewed),
       );
       return dim ? Opacity(opacity: 0.92, child: w) : w;
     }
@@ -342,8 +344,9 @@ class _PerspectivesBottomSheetState
     final filtered = _filteredPerspectives;
 
     return Container(
-      constraints:
-          BoxConstraints(maxHeight: MediaQuery.of(context).size.height * 0.92),
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.92,
+      ),
       decoration: BoxDecoration(
         color: colors.backgroundPrimary,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
@@ -403,7 +406,8 @@ class _PerspectivesBottomSheetState
                                 padding: EdgeInsets.zero,
                                 visualDensity: VisualDensity.compact,
                                 icon: Icon(
-                                    PhosphorIcons.x(PhosphorIconsStyle.bold)),
+                                  PhosphorIcons.x(PhosphorIconsStyle.bold),
+                                ),
                                 onPressed: () => Navigator.pop(context),
                                 color: colors.textSecondary,
                               ),
@@ -411,11 +415,14 @@ class _PerspectivesBottomSheetState
                           ),
                           if (widget.comparisonQuality == 'low')
                             PerspectivesWarningBadge(
-                                colors: colors, textTheme: textTheme),
+                              colors: colors,
+                              textTheme: textTheme,
+                            ),
                           if (widget.divergenceLevel != null) ...[
                             const SizedBox(height: 8),
                             DivergenceInlineBadge(
-                                divergenceLevel: widget.divergenceLevel),
+                              divergenceLevel: widget.divergenceLevel,
+                            ),
                             const SizedBox(height: 4),
                           ],
                           const SizedBox(height: 12),
@@ -442,7 +449,8 @@ class _PerspectivesBottomSheetState
                                     alignment: Alignment.centerRight,
                                     child: GestureDetector(
                                       onTap: () => setState(
-                                          () => _selectedSegments = {}),
+                                        () => _selectedSegments = {},
+                                      ),
                                       child: Row(
                                         mainAxisSize: MainAxisSize.min,
                                         children: [
@@ -457,7 +465,8 @@ class _PerspectivesBottomSheetState
                                           const SizedBox(width: 4),
                                           Icon(
                                             PhosphorIcons.x(
-                                                PhosphorIconsStyle.bold),
+                                              PhosphorIconsStyle.bold,
+                                            ),
                                             size: 12,
                                             color: colors.primary,
                                           ),
@@ -511,8 +520,9 @@ class _PerspectivesBottomSheetState
                           IconButton(
                             padding: EdgeInsets.zero,
                             visualDensity: VisualDensity.compact,
-                            icon:
-                                Icon(PhosphorIcons.x(PhosphorIconsStyle.bold)),
+                            icon: Icon(
+                              PhosphorIcons.x(PhosphorIconsStyle.bold),
+                            ),
                             onPressed: () => Navigator.pop(context),
                             color: colors.textSecondary,
                           ),
@@ -521,7 +531,9 @@ class _PerspectivesBottomSheetState
                     ),
                     const SizedBox(height: 16),
                     PerspectivesEmptyState(
-                        colors: colors, textTheme: textTheme),
+                      colors: colors,
+                      textTheme: textTheme,
+                    ),
                   ],
                 ],
               ),
@@ -574,8 +586,9 @@ class _ShimmerLineState extends State<_ShimmerLine>
             height: 12,
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(6),
-              color: widget.colors.textSecondary
-                  .withValues(alpha: 0.08 + 0.08 * _controller.value),
+              color: widget.colors.textSecondary.withValues(
+                alpha: 0.08 + 0.08 * _controller.value,
+              ),
             ),
           ),
         );
@@ -622,16 +635,13 @@ class _PerspectiveCard extends ConsumerWidget {
   Source? _findSource(List<Source> sources) {
     final domain = perspective.sourceDomain.toLowerCase();
     if (domain.isEmpty) return null;
-    return sources.cast<Source?>().firstWhere(
-      (s) {
-        if (s?.url == null) return false;
-        final uri = Uri.tryParse(s!.url!);
-        if (uri == null) return false;
-        final host = uri.host.toLowerCase().replaceFirst('www.', '');
-        return host == domain || host == 'www.$domain';
-      },
-      orElse: () => null,
-    );
+    return sources.cast<Source?>().firstWhere((s) {
+      if (s?.url == null) return false;
+      final uri = Uri.tryParse(s!.url!);
+      if (uri == null) return false;
+      final host = uri.host.toLowerCase().replaceFirst('www.', '');
+      return host == domain || host == 'www.$domain';
+    }, orElse: () => null);
   }
 
   void _showSourceDetail(BuildContext context, WidgetRef ref, Source source) {
@@ -751,7 +761,9 @@ class _PerspectiveCard extends ConsumerWidget {
                     // Bias badge
                     Container(
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 6, vertical: 2),
+                        horizontal: 6,
+                        vertical: 2,
+                      ),
                       decoration: BoxDecoration(
                         color: perspective
                             .getBiasColor(colors)
@@ -856,9 +868,7 @@ class PerspectivesWarningBadge extends StatelessWidget {
       padding: const EdgeInsets.only(top: 4),
       child: Text(
         'Comparaison limitée (sujet peu couvert)',
-        style: textTheme.labelSmall?.copyWith(
-          color: colors.textTertiary,
-        ),
+        style: textTheme.labelSmall?.copyWith(color: colors.textTertiary),
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
@@ -947,7 +957,8 @@ class PerspectivesBiasBar extends StatelessWidget {
             return Expanded(
               flex: flexValues[i],
               child: GestureDetector(
-                onTap: count > 0 && !compact ? () => onSegmentTap(seg.$1) : null,
+                onTap:
+                    count > 0 && !compact ? () => onSegmentTap(seg.$1) : null,
                 child: AnimatedOpacity(
                   duration: const Duration(milliseconds: 200),
                   opacity: isActive ? 1.0 : 0.3,
@@ -963,10 +974,13 @@ class PerspectivesBiasBar extends StatelessWidget {
                                 child: Center(
                                   child: Container(
                                     padding: const EdgeInsets.symmetric(
-                                        horizontal: 6, vertical: 2),
+                                      horizontal: 6,
+                                      vertical: 2,
+                                    ),
                                     decoration: BoxDecoration(
                                       color: seg.$3.withValues(
-                                          alpha: count > 0 ? 0.15 : 0.05),
+                                        alpha: count > 0 ? 0.15 : 0.05,
+                                      ),
                                       borderRadius: BorderRadius.circular(8),
                                     ),
                                     child: FittedBox(
@@ -997,7 +1011,8 @@ class PerspectivesBiasBar extends StatelessWidget {
                               ? seg.$3.withValues(
                                   alpha: count == 1
                                       ? 0.55
-                                      : (count == 2 ? 0.8 : 1.0))
+                                      : (count == 2 ? 0.8 : 1.0),
+                                )
                               : seg.$3.withValues(alpha: 0.25),
                           borderRadius: BorderRadius.circular(6),
                           border: count > 0
@@ -1025,8 +1040,10 @@ class PerspectivesBiasBar extends StatelessWidget {
                     padding: const EdgeInsets.only(top: 4),
                     child: LayoutBuilder(
                       builder: (context, constraints) {
-                        final totalFlex =
-                            flexValues.fold<int>(0, (sum, f) => sum + f);
+                        final totalFlex = flexValues.fold<int>(
+                          0,
+                          (sum, f) => sum + f,
+                        );
                         double offsetFraction = 0;
                         for (int i = 0; i < sourceIndex; i++) {
                           offsetFraction += flexValues[i] / totalFlex;
@@ -1051,12 +1068,15 @@ class PerspectivesBiasBar extends StatelessWidget {
                                 child: CustomPaint(
                                   size: const Size(10, 6),
                                   painter: PerspectivesTrianglePainter(
-                                      color: sourceColor),
+                                    color: sourceColor,
+                                  ),
                                 ),
                               ),
                               Positioned(
-                                left: (markerX - 50)
-                                    .clamp(0.0, constraints.maxWidth - 100),
+                                left: (markerX - 50).clamp(
+                                  0.0,
+                                  constraints.maxWidth - 100,
+                                ),
                                 top: 10,
                                 child: SizedBox(
                                   width: 100,
@@ -1148,8 +1168,9 @@ class PerspectivesAnalysisZoneState extends State<PerspectivesAnalysisZone> {
         ),
         style: OutlinedButton.styleFrom(
           side: BorderSide(color: widget.colors.primary.withValues(alpha: 0.4)),
-          shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
           padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 20),
         ),
       ),
@@ -1186,8 +1207,9 @@ class PerspectivesAnalysisZoneState extends State<PerspectivesAnalysisZone> {
       decoration: BoxDecoration(
         color: widget.colors.primary.withValues(alpha: 0.05),
         borderRadius: BorderRadius.circular(12),
-        border:
-            Border.all(color: widget.colors.primary.withValues(alpha: 0.15)),
+        border: Border.all(
+          color: widget.colors.primary.withValues(alpha: 0.15),
+        ),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -1298,6 +1320,7 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
   final String sourceName;
   final String contentId;
   final String comparisonQuality;
+  final String? divergenceLevel;
 
   /// Controlled mode: when provided, the parent owns the filter state.
   /// Préservé pour compatibilité avec le call-site existant — non utilisé
@@ -1340,6 +1363,7 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
     this.sourceBiasStance = 'unknown',
     this.sourceName = '',
     this.comparisonQuality = 'low',
+    this.divergenceLevel,
     this.externalSelectedSegments,
     this.onSegmentTap,
     this.onClearSegments,
@@ -1389,9 +1413,11 @@ class _PerspectivesInlineSectionState
 
   List<Perspective> get _sortedPerspectives {
     final sorted = [...widget.perspectives];
-    sorted.sort((a, b) => _groupOrder
-        .indexOf(a.biasGroup)
-        .compareTo(_groupOrder.indexOf(b.biasGroup)));
+    sorted.sort(
+      (a, b) => _groupOrder
+          .indexOf(a.biasGroup)
+          .compareTo(_groupOrder.indexOf(b.biasGroup)),
+    );
     return sorted;
   }
 
@@ -1419,9 +1445,13 @@ class _PerspectivesInlineSectionState
             decoration: BoxDecoration(
               border: Border(
                 top: BorderSide(
-                    color: Colors.black.withValues(alpha: 0.08), width: 1),
+                  color: Colors.black.withValues(alpha: 0.08),
+                  width: 1,
+                ),
                 bottom: BorderSide(
-                    color: Colors.black.withValues(alpha: 0.08), width: 1),
+                  color: Colors.black.withValues(alpha: 0.08),
+                  width: 1,
+                ),
               ),
             ),
             padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 13),
@@ -1429,16 +1459,29 @@ class _PerspectivesInlineSectionState
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Expanded(
-                  child: Text(
-                    'Couverture médiatique (${widget.perspectives.length})',
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 1,
-                    style: GoogleFonts.dmSans(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w700,
-                      letterSpacing: -0.1,
-                      color: colors.textPrimary,
-                    ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Flexible(
+                        child: Text(
+                          'Couverture médiatique (${widget.perspectives.length})',
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 1,
+                          style: GoogleFonts.dmSans(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w700,
+                            color: colors.textPrimary,
+                          ),
+                        ),
+                      ),
+                      if (widget.divergenceLevel != null) ...[
+                        const SizedBox(width: 8),
+                        DivergenceInlineBadge(
+                          divergenceLevel: widget.divergenceLevel,
+                          iconOnly: true,
+                        ),
+                      ],
+                    ],
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -1480,10 +1523,7 @@ class _PerspectivesInlineSectionState
         gradient: LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
-          colors: [
-            colors.primary.withValues(alpha: 0.045),
-            Colors.transparent,
-          ],
+          colors: [colors.primary.withValues(alpha: 0.045), Colors.transparent],
           stops: const [0.0, 0.5],
         ),
       ),
@@ -1517,6 +1557,20 @@ class _PerspectivesInlineSectionState
                 ),
               ),
             ),
+          if (_polarizationText != null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+              child: Text(
+                _polarizationText!,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: textTheme.bodySmall?.copyWith(
+                  color: colors.textSecondary,
+                  height: 1.35,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
           for (var i = 0; i < variants.length; i++)
             _VariantRow(
               key: ValueKey('variant_${_animationGeneration}_$i'),
@@ -1529,7 +1583,9 @@ class _PerspectivesInlineSectionState
               padding: const EdgeInsets.only(top: 8, bottom: 4),
               child: Center(
                 child: PerspectivesWarningBadge(
-                    colors: colors, textTheme: textTheme),
+                  colors: colors,
+                  textTheme: textTheme,
+                ),
               ),
             ),
           Padding(
@@ -1555,6 +1611,17 @@ class _PerspectivesInlineSectionState
         ],
       ),
     );
+  }
+
+  String? get _polarizationText {
+    switch (widget.divergenceLevel) {
+      case 'medium':
+        return 'Avis variés dans le traitement de ce sujet';
+      case 'high':
+        return 'Forte polarisation dans le traitement de ce sujet';
+      default:
+        return null;
+    }
   }
 }
 
@@ -1614,16 +1681,11 @@ class _RefBlock extends ConsumerWidget {
     final colors = context.facteurColors;
     return Container(
       decoration: BoxDecoration(
-        border: Border(
-          left: BorderSide(color: colors.primary, width: 3),
-        ),
+        border: Border(left: BorderSide(color: colors.primary, width: 3)),
         gradient: LinearGradient(
           begin: Alignment.centerLeft,
           end: Alignment.centerRight,
-          colors: [
-            colors.primary.withValues(alpha: 0.05),
-            Colors.transparent,
-          ],
+          colors: [colors.primary.withValues(alpha: 0.05), Colors.transparent],
           stops: const [0.0, 0.7],
         ),
       ),
@@ -1684,10 +1746,7 @@ class _PivotedRefTitle extends StatefulWidget {
   final String title;
   final TokenSpan? pivot;
 
-  const _PivotedRefTitle({
-    required this.title,
-    required this.pivot,
-  });
+  const _PivotedRefTitle({required this.title, required this.pivot});
 
   @override
   State<_PivotedRefTitle> createState() => _PivotedRefTitleState();
@@ -1743,7 +1802,7 @@ class _PivotedRefTitleState extends State<_PivotedRefTitle>
       animation: _controller,
       builder: (context, _) {
         final t = Curves.easeOut.transform(_controller.value);
-        final washColor = const Color(0xFF9E9E9E).withValues(alpha: 0.20 * t);
+        final washColor = const Color(0xFF9E9E9E).withValues(alpha: 0.14 * t);
         return RichText(
           text: TextSpan(
             style: fraunces,
@@ -1753,7 +1812,10 @@ class _PivotedRefTitleState extends State<_PivotedRefTitle>
                 alignment: PlaceholderAlignment.middle,
                 baseline: TextBaseline.alphabetic,
                 child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 5,
+                    vertical: 1,
+                  ),
                   decoration: BoxDecoration(
                     color: washColor,
                     borderRadius: BorderRadius.circular(4),
@@ -1764,8 +1826,7 @@ class _PivotedRefTitleState extends State<_PivotedRefTitle>
                   ),
                 ),
               ),
-              if (end < titleLen)
-                TextSpan(text: widget.title.substring(end)),
+              if (end < titleLen) TextSpan(text: widget.title.substring(end)),
             ],
           ),
         );
@@ -1820,7 +1881,9 @@ class _VariantRow extends ConsumerWidget {
             bottom: isLast
                 ? BorderSide.none
                 : BorderSide(
-                    color: Colors.black.withValues(alpha: 0.08), width: 1),
+                    color: Colors.black.withValues(alpha: 0.08),
+                    width: 1,
+                  ),
           ),
         ),
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
@@ -1850,12 +1913,13 @@ class _VariantRow extends ConsumerWidget {
                       width: 20,
                       height: 20,
                       errorBuilder: (_, __, ___) => _SourceFallback(
-                          name: perspective.sourceName, colors: colors),
+                        name: perspective.sourceName,
+                        colors: colors,
+                      ),
                     ),
                   )
                 else
-                  _SourceFallback(
-                      name: perspective.sourceName, colors: colors),
+                  _SourceFallback(name: perspective.sourceName, colors: colors),
                 const SizedBox(width: 8),
                 Flexible(
                   child: Text(
@@ -2015,8 +2079,11 @@ class _DashedBorderPainter extends CustomPainter {
     canvas.drawPath(dashed, paint);
   }
 
-  Path _dashPath(Path source,
-      {required double dashWidth, required double gapWidth}) {
+  Path _dashPath(
+    Path source, {
+    required double dashWidth,
+    required double gapWidth,
+  }) {
     final out = Path();
     for (final metric in source.computeMetrics()) {
       double distance = 0;

--- a/apps/mobile/test/features/feed/repositories/feed_repository_perspectives_test.dart
+++ b/apps/mobile/test/features/feed/repositories/feed_repository_perspectives_test.dart
@@ -30,18 +30,21 @@ void main() {
       expect(data.sharedTokens.first.text, 'Macron');
     });
 
-    test('back rétrocompatible : pas de highlight_spans/shared_tokens → listes vides', () {
-      final data = PerspectiveData.fromJson({
-        'title': 'X',
-        'url': 'https://y.fr',
-        'source_name': 'Y',
-        'source_domain': 'y.fr',
-        'bias_stance': 'unknown',
-      });
+    test(
+      'back rétrocompatible : pas de highlight_spans/shared_tokens → listes vides',
+      () {
+        final data = PerspectiveData.fromJson({
+          'title': 'X',
+          'url': 'https://y.fr',
+          'source_name': 'Y',
+          'source_domain': 'y.fr',
+          'bias_stance': 'unknown',
+        });
 
-      expect(data.highlightSpans, isEmpty);
-      expect(data.sharedTokens, isEmpty);
-    });
+        expect(data.highlightSpans, isEmpty);
+        expect(data.sharedTokens, isEmpty);
+      },
+    );
 
     test('valeurs vides parsent en listes vides (pas de crash)', () {
       final data = PerspectiveData.fromJson({
@@ -50,8 +53,8 @@ void main() {
         'source_name': 'Y',
         'source_domain': 'y.fr',
         'bias_stance': 'unknown',
-        'highlight_spans': [],
-        'shared_tokens': [],
+        'highlight_spans': <dynamic>[],
+        'shared_tokens': <dynamic>[],
       });
       expect(data.highlightSpans, isEmpty);
       expect(data.sharedTokens, isEmpty);
@@ -64,8 +67,12 @@ void main() {
         'perspectives': <dynamic>[],
         'keywords': <dynamic>[],
         'bias_distribution': <String, dynamic>{},
+        'partial': true,
+        'divergence_level': 'medium',
         'reference_pivot': {'start': 7, 'end': 14, 'text': 'frappe'},
       });
+      expect(res.partial, isTrue);
+      expect(res.divergenceLevel, 'medium');
       expect(res.referencePivot, isNotNull);
       expect(res.referencePivot!.start, 7);
       expect(res.referencePivot!.end, 14);
@@ -100,9 +107,11 @@ void main() {
     });
 
     test('parse une Map valide', () {
-      final span = TokenSpan.fromJsonOrNull(
-        {'start': 1, 'end': 5, 'text': 'foo'},
-      );
+      final span = TokenSpan.fromJsonOrNull({
+        'start': 1,
+        'end': 5,
+        'text': 'foo',
+      });
       expect(span, isNotNull);
       expect(span!.start, 1);
       expect(span.end, 5);

--- a/apps/mobile/test/features/feed/widgets/diff_title_weight_test.dart
+++ b/apps/mobile/test/features/feed/widgets/diff_title_weight_test.dart
@@ -12,10 +12,10 @@ import 'package:facteur/features/feed/widgets/diff_title.dart';
 /// → t=1.
 ///
 /// Spec :
-///   weight = 1.0    → alpha = 0.30 (max)
-///   weight = 0.5    → alpha = 0.20
-///   weight = 0.25   → alpha = 0.12 (floor lisible)
-///   weight = null   → alpha = 0.22 (fallback rétrocompat, sans modulation)
+///   weight = 1.0    → alpha = 0.24 (max)
+///   weight = 0.5    → alpha = 0.16
+///   weight = 0.25   → alpha = 0.10 (floor lisible)
+///   weight = null   → alpha = 0.16 (fallback rétrocompat, sans modulation)
 void main() {
   Widget host(DiffTitle child) {
     return MaterialApp(
@@ -45,96 +45,112 @@ void main() {
   }
 
   group('DiffTitle — weight modulation', () {
-    testWidgets('weight = 1.0 → alpha ≈ 0.30', (tester) async {
-      await tester.pumpWidget(host(DiffTitle(
-        title: 'Macron annonce une réforme',
-        highlightSpans: const [
-          HighlightSpan(
-            start: 7,
-            end: 14,
-            text: 'annonce',
-            bias: 'right',
-            weight: 1.0,
+    testWidgets('weight = 1.0 → alpha ≈ 0.24', (tester) async {
+      await tester.pumpWidget(
+        host(
+          DiffTitle(
+            title: 'Macron annonce une réforme',
+            highlightSpans: const [
+              HighlightSpan(
+                start: 7,
+                end: 14,
+                text: 'annonce',
+                bias: 'right',
+                weight: 1.0,
+              ),
+            ],
+            sharedTokens: const [],
+            biasColor: Colors.red,
+            baseStyle: const TextStyle(fontSize: 14),
+            animateIn: false,
           ),
-        ],
-        sharedTokens: const [],
-        biasColor: Colors.red,
-        baseStyle: const TextStyle(fontSize: 14),
-        animateIn: false,
-      )));
+        ),
+      );
       await tester.pumpAndSettle();
 
       final alpha = keyWashAlpha(tester);
       expect(alpha, isNotNull);
-      expect(alpha!, closeTo(0.30, 0.005));
+      expect(alpha!, closeTo(0.24, 0.005));
     });
 
-    testWidgets('weight = 0.5 → alpha ≈ 0.20', (tester) async {
-      await tester.pumpWidget(host(DiffTitle(
-        title: 'Macron annonce une réforme',
-        highlightSpans: const [
-          HighlightSpan(
-            start: 7,
-            end: 14,
-            text: 'annonce',
-            bias: 'right',
-            weight: 0.5,
+    testWidgets('weight = 0.5 → alpha ≈ 0.16', (tester) async {
+      await tester.pumpWidget(
+        host(
+          DiffTitle(
+            title: 'Macron annonce une réforme',
+            highlightSpans: const [
+              HighlightSpan(
+                start: 7,
+                end: 14,
+                text: 'annonce',
+                bias: 'right',
+                weight: 0.5,
+              ),
+            ],
+            sharedTokens: const [],
+            biasColor: Colors.red,
+            baseStyle: const TextStyle(fontSize: 14),
+            animateIn: false,
           ),
-        ],
-        sharedTokens: const [],
-        biasColor: Colors.red,
-        baseStyle: const TextStyle(fontSize: 14),
-        animateIn: false,
-      )));
+        ),
+      );
       await tester.pumpAndSettle();
 
       final alpha = keyWashAlpha(tester);
       expect(alpha, isNotNull);
-      expect(alpha!, closeTo(0.20, 0.005));
+      expect(alpha!, closeTo(0.16, 0.005));
     });
 
-    testWidgets('weight = 0.25 → alpha ≈ 0.12', (tester) async {
-      await tester.pumpWidget(host(DiffTitle(
-        title: 'Macron annonce une réforme',
-        highlightSpans: const [
-          HighlightSpan(
-            start: 7,
-            end: 14,
-            text: 'annonce',
-            bias: 'right',
-            weight: 0.25,
+    testWidgets('weight = 0.25 → alpha ≈ 0.10', (tester) async {
+      await tester.pumpWidget(
+        host(
+          DiffTitle(
+            title: 'Macron annonce une réforme',
+            highlightSpans: const [
+              HighlightSpan(
+                start: 7,
+                end: 14,
+                text: 'annonce',
+                bias: 'right',
+                weight: 0.25,
+              ),
+            ],
+            sharedTokens: const [],
+            biasColor: Colors.red,
+            baseStyle: const TextStyle(fontSize: 14),
+            animateIn: false,
           ),
-        ],
-        sharedTokens: const [],
-        biasColor: Colors.red,
-        baseStyle: const TextStyle(fontSize: 14),
-        animateIn: false,
-      )));
+        ),
+      );
       await tester.pumpAndSettle();
 
       final alpha = keyWashAlpha(tester);
       expect(alpha, isNotNull);
-      expect(alpha!, closeTo(0.12, 0.005));
+      expect(alpha!, closeTo(0.10, 0.005));
     });
 
-    testWidgets('weight = null → alpha ≈ 0.22 (rétrocompat)', (tester) async {
+    testWidgets('weight = null → alpha ≈ 0.16 (rétrocompat)', (tester) async {
       // C'est le cas pre-PR 5 : l'API ne renvoie pas weight. Le fallback (?? 1.0)
-      // garantit que le rendu est identique à l'avant-PR 6 (alpha = 0.22).
-      await tester.pumpWidget(host(DiffTitle(
-        title: 'Macron annonce une réforme',
-        highlightSpans: const [
-          HighlightSpan(start: 7, end: 14, text: 'annonce', bias: 'right'),
-        ],
-        sharedTokens: const [],
-        biasColor: Colors.red,
-        baseStyle: const TextStyle(fontSize: 14),
-        animateIn: false,
-      )));
+      // garde un rendu visible sans l'intensité maximale.
+      await tester.pumpWidget(
+        host(
+          DiffTitle(
+            title: 'Macron annonce une réforme',
+            highlightSpans: const [
+              HighlightSpan(start: 7, end: 14, text: 'annonce', bias: 'right'),
+            ],
+            sharedTokens: const [],
+            biasColor: Colors.red,
+            baseStyle: const TextStyle(fontSize: 14),
+            animateIn: false,
+          ),
+        ),
+      );
       await tester.pumpAndSettle();
 
       final alpha = keyWashAlpha(tester);
       expect(alpha, isNotNull);
-      expect(alpha!, closeTo(0.22, 0.005));
+      expect(alpha!, closeTo(0.16, 0.005));
     });
   });
 }

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart
@@ -6,17 +6,18 @@ import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
 
 Perspective _p(String name, {String bias = 'center'}) => Perspective(
-      title: 'Titre $name',
-      url: 'https://example.com/$name',
-      sourceName: name,
-      sourceDomain: '',
-      biasStance: bias,
-    );
+  title: 'Titre $name',
+  url: 'https://example.com/$name',
+  sourceName: name,
+  sourceDomain: '',
+  biasStance: bias,
+);
 
 Future<void> _pumpInline(
   WidgetTester tester, {
   required List<Perspective> perspectives,
   bool isExpanded = true,
+  String? divergenceLevel,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
@@ -33,6 +34,7 @@ Future<void> _pumpInline(
                 contentId: 'test-content-id',
                 sourceBiasStance: 'center',
                 sourceName: 'Test',
+                divergenceLevel: divergenceLevel,
                 referenceTitle: 'Titre référence',
                 isExpanded: isExpanded,
                 onToggle: () {},
@@ -52,7 +54,13 @@ void main() {
   testWidgets(
     'inline expanded + perspectives non vides → intro rendue en haut du groupe',
     (tester) async {
-      await _pumpInline(tester, perspectives: [_p('A'), _p('B', bias: 'left')]);
+      await _pumpInline(
+        tester,
+        perspectives: [
+          _p('A'),
+          _p('B', bias: 'left'),
+        ],
+      );
 
       expect(find.textContaining(introSnippet), findsOneWidget);
     },
@@ -67,16 +75,29 @@ void main() {
     },
   );
 
-  testWidgets(
-    'inline collapsé → pas d\'intro (body non rendu)',
-    (tester) async {
-      await _pumpInline(
-        tester,
-        perspectives: [_p('A')],
-        isExpanded: false,
-      );
+  testWidgets('inline collapsé → pas d\'intro (body non rendu)', (
+    tester,
+  ) async {
+    await _pumpInline(tester, perspectives: [_p('A')], isExpanded: false);
 
-      expect(find.textContaining(introSnippet), findsNothing);
-    },
-  );
+    expect(find.textContaining(introSnippet), findsNothing);
+  });
+
+  testWidgets('inline high divergence → phrase polarisation rendue', (
+    tester,
+  ) async {
+    await _pumpInline(
+      tester,
+      perspectives: [
+        _p('A'),
+        _p('B', bias: 'right'),
+      ],
+      divergenceLevel: 'high',
+    );
+
+    expect(
+      find.text('Forte polarisation dans le traitement de ce sujet'),
+      findsOneWidget,
+    );
+  });
 }

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -1,11 +1,12 @@
 import asyncio
+import time
 import uuid
 from datetime import UTC, datetime
 from typing import Literal
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -571,6 +572,28 @@ _perspectives_cache: TTLCache = TTLCache(maxsize=256, ttl=7200)
 # value ("llm"/"spacy") for the cached body — so cache hits re-emit the
 # debug header instead of dropping it silently.
 _perspectives_source_cache: TTLCache = TTLCache(maxsize=256, ttl=7200)
+# In-flight guard: prevent stacking background refresh tasks for the same key.
+_perspectives_refresh_inflight: set[str] = set()
+
+
+def _empty_timings() -> dict[str, int]:
+    return dict.fromkeys(
+        ("cache", "digest_snapshot", "cluster_internal_db", "google_news", "highlights", "total"),
+        0,
+    )
+
+
+def _perspective_to_dict(p: object) -> dict:
+    return {
+        "title": p.title,
+        "url": p.url,
+        "source_name": p.source_name,
+        "source_domain": p.source_domain,
+        "bias_stance": p.bias_stance,
+        "published_at": p.published_at,
+        "description": p.description,
+        "language": getattr(p, "language", None),
+    }
 
 
 def _normalize_url_for_match(raw: str | None) -> str:
@@ -723,7 +746,7 @@ async def _load_stored_perspectives_for_representative(
     db: AsyncSession,
     content_id: UUID,
     user_id: UUID,
-) -> tuple[list[dict], dict[str, int]] | None:
+) -> tuple[list[dict], dict[str, int], str | None] | None:
     """Return the perspective_articles list the pipeline persisted on the
     digest subject containing ``content_id``, plus its bias_distribution.
 
@@ -779,8 +802,9 @@ async def _load_stored_perspectives_for_representative(
             if target_str in ids:
                 stored = subject.get("perspective_articles")
                 bias = subject.get("bias_distribution") or {}
+                divergence_level = subject.get("divergence_level")
                 if stored is not None:
-                    return list(stored), dict(bias)
+                    return list(stored), dict(bias), divergence_level
                 # Subject trouvé dans un digest récent mais snapshot absent
                 # (legacy digest, ou bug pipeline). Pour préserver l'invariant
                 # "content_id du digest → toujours stored, jamais live",
@@ -792,8 +816,226 @@ async def _load_stored_perspectives_for_representative(
                     digest_id=str(digest.id),
                     subject_topic_id=subject.get("topic_id"),
                 )
-                return [], dict(bias)
+                return [], dict(bias), divergence_level
     return None
+
+
+def _stored_snapshot_has_highlights(perspectives: list[dict]) -> bool:
+    if not perspectives:
+        return False
+    return all(
+        isinstance(p, dict) and "highlight_spans" in p and "shared_tokens" in p
+        for p in perspectives
+    )
+
+
+def _snapshot_reference_pivot(perspectives: list[dict]) -> dict | None:
+    for p in perspectives:
+        if isinstance(p, dict) and isinstance(p.get("reference_pivot"), dict):
+            return p["reference_pivot"]
+    return None
+
+
+def _extract_source_context(content: Content) -> tuple[str | None, str]:
+    source_domain = None
+    source_bias_stance = "unknown"
+    if content.source:
+        from urllib.parse import urlparse
+
+        from app.services.perspective_service import DOMAIN_BIAS_MAP
+
+        try:
+            parsed = urlparse(content.source.url)
+            source_domain = parsed.netloc
+            if source_domain and source_domain.startswith("www."):
+                source_domain = source_domain[4:]
+        except Exception:
+            pass
+        if content.source.bias_stance:
+            source_bias_stance = (
+                content.source.bias_stance.value
+                if hasattr(content.source.bias_stance, "value")
+                else str(content.source.bias_stance)
+            )
+        if source_bias_stance == "unknown" and source_domain:
+            source_bias_stance = DOMAIN_BIAS_MAP.get(source_domain, "unknown")
+    return source_domain, source_bias_stance
+
+
+def _comparison_fields(
+    count: int,
+    bias_distribution: dict[str, int],
+    has_entities: bool,
+) -> tuple[int, str, bool, str]:
+    from app.services.editorial.schemas import compute_divergence_level
+    from app.services.perspective_service import (
+        PERSPECTIVE_MIN_BIAS_GROUPS,
+        PERSPECTIVE_MIN_VALID_RESULTS,
+    )
+
+    bias_groups = sum(1 for v in bias_distribution.values() if v > 0)
+    if has_entities and count >= 5 and bias_groups >= 3:
+        comparison_quality = "high"
+    elif count >= 3 and bias_groups >= 2:
+        comparison_quality = "medium"
+    else:
+        comparison_quality = "low"
+    should_display = (
+        count >= PERSPECTIVE_MIN_VALID_RESULTS
+        and bias_groups >= PERSPECTIVE_MIN_BIAS_GROUPS
+    )
+    divergence_level = compute_divergence_level(bias_distribution)
+    return bias_groups, comparison_quality, should_display, divergence_level
+
+
+async def _track_perspectives_open_background(
+    user_id: str,
+    content_id: str,
+) -> None:
+    try:
+        from app.services.analytics_service import AnalyticsService
+
+        async with safe_async_session() as session:
+            await AnalyticsService(session).log_event(
+                user_id=UUID(user_id),
+                event_type="perspectives_opened",
+                event_data={"content_id": content_id},
+            )
+    except Exception:
+        logger.warning("perspectives_open_tracking_failed", exc_info=True)
+
+
+async def _refresh_perspectives_cache_background(
+    content_id: str,
+    user_id: str,
+) -> None:
+    """Complete a fast-first partial response with the full Google News path."""
+    if content_id in _perspectives_refresh_inflight:
+        return
+    _perspectives_refresh_inflight.add(content_id)
+
+    from sqlalchemy import select
+    from sqlalchemy.orm import joinedload
+
+    from app.models.content import Content
+    from app.models.perspective_analysis import PerspectiveAnalysis
+    from app.services.perspective_service import PerspectiveService, _parse_entity_names
+
+    started = time.perf_counter()
+    timings = _empty_timings()
+    try:
+        async with safe_async_session() as db:
+            result = await db.execute(
+                select(Content)
+                .options(joinedload(Content.source))
+                .where(Content.id == UUID(content_id))
+            )
+            content = result.scalars().first()
+            if content is None:
+                return
+
+            source_domain, source_bias_stance = _extract_source_context(content)
+            service = PerspectiveService(db=db)
+
+            phase = time.perf_counter()
+            cluster_perspectives: list = []
+            cluster_domains: set[str] = set()
+            cluster_contents = await _load_cluster_articles_for_representative(
+                db=db,
+                content_id=UUID(content_id),
+                user_id=UUID(user_id),
+            )
+            if cluster_contents:
+                cluster_perspectives = await service.build_cluster_perspectives(
+                    cluster_contents
+                )
+                cluster_domains = {
+                    p.source_domain for p in cluster_perspectives if p.source_domain
+                }
+            timings["cluster_internal_db"] = round((time.perf_counter() - phase) * 1000)
+
+            phase = time.perf_counter()
+            gnews_perspectives, keywords = await service.get_perspectives_hybrid(
+                content=content,
+                exclude_domain=source_domain,
+            )
+            timings["google_news"] = round((time.perf_counter() - phase) * 1000)
+
+            new_gnews = [
+                p
+                for p in gnews_perspectives
+                if p.source_domain and p.source_domain not in cluster_domains
+            ]
+            ref_url_key_live = _normalize_url_for_match(content.url)
+            merged = [
+                p
+                for p in (cluster_perspectives + new_gnews)
+                if not ref_url_key_live
+                or _normalize_url_for_match(getattr(p, "url", None)) != ref_url_key_live
+            ]
+            known_perspectives = [p for p in merged if p.bias_stance != "unknown"]
+            perspectives = (
+                cluster_perspectives
+                if not known_perspectives and cluster_perspectives
+                else known_perspectives
+            )
+
+            perspectives_dicts_pre = [_perspective_to_dict(p) for p in perspectives]
+            bias_distribution = _recompute_bias_distribution(perspectives_dicts_pre)
+            has_entities = bool(
+                _parse_entity_names(content.entities, types={"PERSON", "ORG"})
+            )
+            bias_groups, comparison_quality, should_display, divergence_level = (
+                _comparison_fields(len(perspectives), bias_distribution, has_entities)
+            )
+
+            analysis_result = await db.execute(
+                select(PerspectiveAnalysis).where(
+                    PerspectiveAnalysis.content_id == UUID(content_id)
+                )
+            )
+            cached_row = analysis_result.scalars().first()
+            cached_analysis = cached_row.analysis_text if cached_row else None
+
+            perspectives_dicts = perspectives_dicts_pre
+            phase = time.perf_counter()
+            reference_pivot, bias_source = await _attach_highlight_spans(
+                db, content, perspectives_dicts
+            )
+            timings["highlights"] = round((time.perf_counter() - phase) * 1000)
+            timings["total"] = round((time.perf_counter() - started) * 1000)
+
+            response_body = {
+                "content_id": content_id,
+                "keywords": keywords,
+                "source_bias_stance": source_bias_stance,
+                "perspectives": perspectives_dicts,
+                "bias_distribution": bias_distribution,
+                "comparison_quality": comparison_quality,
+                "should_display": should_display,
+                "analysis": cached_analysis,
+                "analysis_cached": cached_analysis is not None,
+                "reference_pivot": reference_pivot,
+                "partial": False,
+                "divergence_level": divergence_level,
+                "timings_ms": timings,
+            }
+            _perspectives_cache[content_id] = response_body
+            _perspectives_source_cache[content_id] = bias_source
+            logger.info(
+                "perspectives_background_refresh_complete",
+                content_id=content_id,
+                count=len(perspectives),
+                bias_groups=bias_groups,
+                timings_ms=timings,
+            )
+    except Exception:
+        logger.exception(
+            "perspectives_background_refresh_failed",
+            content_id=content_id,
+        )
+    finally:
+        _perspectives_refresh_inflight.discard(content_id)
 
 
 async def _attach_highlight_spans(
@@ -922,6 +1164,7 @@ async def _attach_highlight_spans(
 async def get_perspectives(
     content_id: UUID,
     response: Response,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     current_user_id: str = Depends(get_current_user_id),
 ):
@@ -939,29 +1182,34 @@ async def get_perspectives(
     logger = structlog.get_logger(__name__)
 
     cache_key = str(content_id)
-
-    # Track perspective open (Story 19.1 — Lettres du Facteur, action 4).
-    # Non-bloquant : un échec ne doit pas casser l'endpoint. Un seul event
-    # suffit pour la détection (DETECTORS["first_perspectives_open"] LIMIT 1).
-    try:
-        from app.services.analytics_service import AnalyticsService
-
-        await AnalyticsService(db).log_event(
-            user_id=UUID(current_user_id),
-            event_type="perspectives_opened",
-            event_data={"content_id": cache_key},
-        )
-    except Exception:
-        logger.warning("perspectives_open_tracking_failed", exc_info=True)
+    endpoint_started = time.perf_counter()
+    timings = _empty_timings()
 
     # Check cache (TTLCache handles expiration automatically)
+    phase = time.perf_counter()
     cached_response = _perspectives_cache.get(cache_key)
+    timings["cache"] = round((time.perf_counter() - phase) * 1000)
     if cached_response is not None:
         logger.info("perspectives_cache_hit", content_id=cache_key)
         response.headers["X-Bias-Annotation-Source"] = _perspectives_source_cache.get(
             cache_key, "spacy"
         )
+        response.headers["X-Perspectives-Cache"] = "hit"
+        if cached_response.get("partial") is True:
+            background_tasks.add_task(
+                _refresh_perspectives_cache_background,
+                cache_key,
+                current_user_id,
+            )
         return cached_response
+
+    # Track perspective open (Story 19.1 — Lettres du Facteur, action 4).
+    # It must never delay the reader, and cache hits stay DB-free.
+    background_tasks.add_task(
+        _track_perspectives_open_background,
+        current_user_id,
+        cache_key,
+    )
 
     logger.info(
         "perspectives_endpoint_start",
@@ -991,29 +1239,7 @@ async def get_perspectives(
     )
 
     # Extract the source domain for exclusion and bias
-    source_domain = None
-    source_bias_stance = "unknown"
-    if content.source:
-        from urllib.parse import urlparse
-
-        from app.services.perspective_service import DOMAIN_BIAS_MAP
-
-        try:
-            parsed = urlparse(content.source.url)
-            source_domain = parsed.netloc
-            if source_domain and source_domain.startswith("www."):
-                source_domain = source_domain[4:]
-        except Exception:
-            pass
-        if content.source.bias_stance:
-            source_bias_stance = (
-                content.source.bias_stance.value
-                if hasattr(content.source.bias_stance, "value")
-                else str(content.source.bias_stance)
-            )
-        # Fallback to DOMAIN_BIAS_MAP if DB bias is unknown
-        if source_bias_stance == "unknown" and source_domain:
-            source_bias_stance = DOMAIN_BIAS_MAP.get(source_domain, "unknown")
+    source_domain, source_bias_stance = _extract_source_context(content)
 
     # Hybrid perspectives search: DB entities → Google News entities → fallback keywords
     service = PerspectiveService(db=db)
@@ -1024,11 +1250,13 @@ async def get_perspectives(
     # the same JSONB blob) instead of running a fresh Google News query
     # that drifts from the digest-time results.
     try:
+        phase = time.perf_counter()
         stored = await _load_stored_perspectives_for_representative(
             db=db,
             content_id=content_id,
             user_id=UUID(current_user_id),
         )
+        timings["digest_snapshot"] = round((time.perf_counter() - phase) * 1000)
     except Exception as e:
         stored = None
         logger.warning(
@@ -1038,7 +1266,7 @@ async def get_perspectives(
         )
 
     if stored is not None:
-        stored_perspectives, stored_bias = stored
+        stored_perspectives, stored_bias, stored_divergence_level = stored
         # Strip the reference article from the persisted snapshot — the
         # pipeline doesn't pre-filter it, and the UI must not show the
         # currently-open article as one of its alternative perspectives.
@@ -1055,28 +1283,12 @@ async def get_perspectives(
             if len(filtered) != len(stored_perspectives):
                 stored_perspectives = filtered
                 stored_bias = _recompute_bias_distribution(stored_perspectives)
-        bias_groups = len([v for v in stored_bias.values() if v > 0])
         count = len(stored_perspectives)
         has_entities = bool(
             _parse_entity_names(content.entities, types={"PERSON", "ORG"})
         )
-        if has_entities and count >= 5 and bias_groups >= 3:
-            comparison_quality = "high"
-        elif count >= 3 and bias_groups >= 2:
-            comparison_quality = "medium"
-        else:
-            comparison_quality = "low"
-
-        # Gate UI : masquer la Comparaison si trop peu d'angles distincts
-        # (cf. docs/bugs/bug-comparison-clustering-too-loose.md)
-        from app.services.perspective_service import (
-            PERSPECTIVE_MIN_BIAS_GROUPS,
-            PERSPECTIVE_MIN_VALID_RESULTS,
-        )
-
-        should_display = (
-            count >= PERSPECTIVE_MIN_VALID_RESULTS
-            and bias_groups >= PERSPECTIVE_MIN_BIAS_GROUPS
+        bias_groups, comparison_quality, should_display, derived_divergence = (
+            _comparison_fields(count, stored_bias, has_entities)
         )
 
         from app.models.perspective_analysis import PerspectiveAnalysis as _PA
@@ -1087,10 +1299,17 @@ async def get_perspectives(
         cached_row = analysis_result.scalars().first()
         cached_analysis = cached_row.analysis_text if cached_row else None
 
-        reference_pivot, bias_source = await _attach_highlight_spans(
-            db, content, stored_perspectives
-        )
+        if _stored_snapshot_has_highlights(stored_perspectives):
+            reference_pivot = _snapshot_reference_pivot(stored_perspectives)
+            bias_source = "llm"
+        else:
+            phase = time.perf_counter()
+            reference_pivot, bias_source = await _attach_highlight_spans(
+                db, content, stored_perspectives
+            )
+            timings["highlights"] = round((time.perf_counter() - phase) * 1000)
         response.headers["X-Bias-Annotation-Source"] = bias_source
+        timings["total"] = round((time.perf_counter() - endpoint_started) * 1000)
 
         response_body = {
             "content_id": cache_key,
@@ -1106,6 +1325,9 @@ async def get_perspectives(
             "analysis": cached_analysis,
             "analysis_cached": cached_analysis is not None,
             "reference_pivot": reference_pivot,
+            "partial": False,
+            "divergence_level": stored_divergence_level or derived_divergence,
+            "timings_ms": timings,
         }
         _perspectives_cache[cache_key] = response_body
         _perspectives_source_cache[cache_key] = bias_source
@@ -1125,6 +1347,7 @@ async def get_perspectives(
     cluster_perspectives: list = []
     cluster_domains: set[str] = set()
     try:
+        phase = time.perf_counter()
         cluster_contents = await _load_cluster_articles_for_representative(
             db=db,
             content_id=content_id,
@@ -1137,6 +1360,7 @@ async def get_perspectives(
             cluster_domains = {
                 p.source_domain for p in cluster_perspectives if p.source_domain
             }
+        timings["cluster_internal_db"] = round((time.perf_counter() - phase) * 1000)
     except Exception as e:
         logger.warning(
             "perspectives_cluster_lookup_failed",
@@ -1144,17 +1368,14 @@ async def get_perspectives(
             error=str(e),
         )
 
-    gnews_perspectives, keywords = await service.get_perspectives_hybrid(
-        content=content,
-        exclude_domain=source_domain,
-    )
-
-    # Keep only Google News entries whose domain isn't already covered by
-    # the cluster — no double-counting.
-    new_gnews = [
+    internal_perspectives = await service.search_internal_perspectives(content)
+    keywords = service.build_entity_query(content.entities, content.title)
+    quick_internal = [
         p
-        for p in gnews_perspectives
-        if p.source_domain and p.source_domain not in cluster_domains
+        for p in internal_perspectives
+        if p.source_domain
+        and p.source_domain not in cluster_domains
+        and p.source_domain != source_domain
     ]
 
     # Single source of truth for the 3 UI counters — mirror pipeline.py.
@@ -1164,7 +1385,7 @@ async def get_perspectives(
     ref_url_key_live = _normalize_url_for_match(content.url)
     merged = [
         p
-        for p in (cluster_perspectives + new_gnews)
+        for p in (cluster_perspectives + quick_internal)
         if not ref_url_key_live
         or _normalize_url_for_match(getattr(p, "url", None)) != ref_url_key_live
     ]
@@ -1184,9 +1405,9 @@ async def get_perspectives(
     logger.info(
         "perspectives_composition",
         content_id=cache_key,
-        path="live",
+        path="live_partial",
         cluster_sources_count=len(cluster_perspectives),
-        gnews_added=len(new_gnews),
+        internal_added=len(quick_internal),
         known_bias=len(known_perspectives),
         safety_net_triggered=safety_net_triggered,
     )
@@ -1203,28 +1424,10 @@ async def get_perspectives(
         if p.bias_stance in bias_distribution:
             bias_distribution[p.bias_stance] += 1
 
-    # Compute comparison quality from pipeline signals
-    bias_groups = len([v for v in bias_distribution.values() if v > 0])
     has_entities = bool(_parse_entity_names(content.entities, types={"PERSON", "ORG"}))
     count = len(perspectives)
-
-    if has_entities and count >= 5 and bias_groups >= 3:
-        comparison_quality = "high"
-    elif count >= 3 and bias_groups >= 2:
-        comparison_quality = "medium"
-    else:
-        comparison_quality = "low"
-
-    # Gate UI : masquer la Comparaison si trop peu d'angles distincts
-    # (cf. docs/bugs/bug-comparison-clustering-too-loose.md)
-    from app.services.perspective_service import (
-        PERSPECTIVE_MIN_BIAS_GROUPS,
-        PERSPECTIVE_MIN_VALID_RESULTS,
-    )
-
-    should_display = (
-        count >= PERSPECTIVE_MIN_VALID_RESULTS
-        and bias_groups >= PERSPECTIVE_MIN_BIAS_GROUPS
+    bias_groups, comparison_quality, should_display, divergence_level = (
+        _comparison_fields(count, bias_distribution, has_entities)
     )
 
     logger.info(
@@ -1234,6 +1437,7 @@ async def get_perspectives(
         keywords=keywords,
         should_display=should_display,
         comparison_quality=comparison_quality,
+        partial=True,
     )
 
     # Check if a cached Mistral analysis exists in DB
@@ -1247,23 +1451,14 @@ async def get_perspectives(
     if cached_row:
         cached_analysis = cached_row.analysis_text
 
-    perspectives_dicts = [
-        {
-            "title": p.title,
-            "url": p.url,
-            "source_name": p.source_name,
-            "source_domain": p.source_domain,
-            "bias_stance": p.bias_stance,
-            "published_at": p.published_at,
-            "description": p.description,
-            "language": getattr(p, "language", None),
-        }
-        for p in perspectives
-    ]
+    perspectives_dicts = [_perspective_to_dict(p) for p in perspectives]
+    phase = time.perf_counter()
     reference_pivot, bias_source = await _attach_highlight_spans(
         db, content, perspectives_dicts
     )
+    timings["highlights"] = round((time.perf_counter() - phase) * 1000)
     response.headers["X-Bias-Annotation-Source"] = bias_source
+    timings["total"] = round((time.perf_counter() - endpoint_started) * 1000)
 
     response_body = {
         "content_id": cache_key,
@@ -1276,11 +1471,20 @@ async def get_perspectives(
         "analysis": cached_analysis,
         "analysis_cached": cached_analysis is not None,
         "reference_pivot": reference_pivot,
+        "partial": True,
+        "divergence_level": divergence_level,
+        "timings_ms": timings,
     }
 
-    # Store in cache (TTLCache handles expiration automatically)
+    # Store partial response immediately; background refresh replaces this
+    # same cache key with the complete Google-enriched response.
     _perspectives_cache[cache_key] = response_body
     _perspectives_source_cache[cache_key] = bias_source
+    background_tasks.add_task(
+        _refresh_perspectives_cache_background,
+        cache_key,
+        current_user_id,
+    )
 
     return response_body
 

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -578,7 +578,14 @@ _perspectives_refresh_inflight: set[str] = set()
 
 def _empty_timings() -> dict[str, int]:
     return dict.fromkeys(
-        ("cache", "digest_snapshot", "cluster_internal_db", "google_news", "highlights", "total"),
+        (
+            "cache",
+            "digest_snapshot",
+            "cluster_internal_db",
+            "google_news",
+            "highlights",
+            "total",
+        ),
         0,
     )
 

--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -1,5 +1,6 @@
 """Perspectives service - hybrid search via DB entities + Google News RSS."""
 
+import asyncio
 import html
 import json
 import os
@@ -851,11 +852,36 @@ class PerspectiveService:
                 seen_domains.add(p.source_domain)
                 merged.append(p)
 
-        # Layer 2: Google News with quoted entities + post-filtre titre Jaccard
+        # Layer 2/3: run Google News entity and fallback queries in parallel.
+        # The endpoint may decide not to wait for Google at all (fast-first),
+        # but when this full path is used, avoid entity→fallback serial latency.
         entity_keywords = self.build_entity_query(content.entities, content.title)
-        google_raw = await self.search_perspectives(
-            entity_keywords, exclude_url, exclude_title, exclude_domain
+        fallback_keywords = self.extract_keywords(content.title)
+        google_tasks = [
+            self.search_perspectives(
+                entity_keywords, exclude_url, exclude_title, exclude_domain
+            )
+        ]
+        include_fallback = entity_keywords != fallback_keywords
+        if include_fallback:
+            google_tasks.append(
+                self.search_perspectives(
+                    fallback_keywords, exclude_url, exclude_title, exclude_domain
+                )
+            )
+
+        google_outputs = await asyncio.gather(*google_tasks, return_exceptions=True)
+        google_raw = (
+            google_outputs[0]
+            if google_outputs and not isinstance(google_outputs[0], Exception)
+            else []
         )
+        if google_outputs and isinstance(google_outputs[0], Exception):
+            logger.warning(
+                "perspectives_entity_google_failed",
+                error=str(google_outputs[0]),
+                error_type=type(google_outputs[0]).__name__,
+            )
         google_results, google_filtered = self._filter_external_perspectives(
             seed_tokens, google_raw
         )
@@ -864,13 +890,20 @@ class PerspectiveService:
                 seen_domains.add(p.source_domain)
                 merged.append(p)
 
-        # Layer 3: Fallback if < 6 results and entity query differs from title keywords
-        fallback_keywords = self.extract_keywords(content.title)
         fallback_filtered = 0
-        if len(merged) < 6 and entity_keywords != fallback_keywords:
-            fallback_raw = await self.search_perspectives(
-                fallback_keywords, exclude_url, exclude_title, exclude_domain
+        if include_fallback and len(merged) < 6:
+            fallback_raw = (
+                google_outputs[1]
+                if len(google_outputs) > 1
+                and not isinstance(google_outputs[1], Exception)
+                else []
             )
+            if len(google_outputs) > 1 and isinstance(google_outputs[1], Exception):
+                logger.warning(
+                    "perspectives_fallback_google_failed",
+                    error=str(google_outputs[1]),
+                    error_type=type(google_outputs[1]).__name__,
+                )
             fallback_results, fallback_filtered = self._filter_external_perspectives(
                 seed_tokens, fallback_raw
             )

--- a/packages/api/app/services/title_annotation_service.py
+++ b/packages/api/app/services/title_annotation_service.py
@@ -173,6 +173,7 @@ class TitleAnnotationService:
                 "end": t["end"],
                 "text": t["text"],
                 "bias": alt_bias,
+                "weight": 0.5,
             }
             for t in ranked[: self.MAX_HIGHLIGHTED_PER_TITLE]
         ]

--- a/packages/api/app/services/title_annotation_service.py
+++ b/packages/api/app/services/title_annotation_service.py
@@ -173,7 +173,6 @@ class TitleAnnotationService:
                 "end": t["end"],
                 "text": t["text"],
                 "bias": alt_bias,
-                "weight": 0.5,
             }
             for t in ranked[: self.MAX_HIGHLIGHTED_PER_TITLE]
         ]

--- a/packages/api/tests/test_perspectives_alignment.py
+++ b/packages/api/tests/test_perspectives_alignment.py
@@ -94,9 +94,10 @@ async def test_fast_path_matches_representative():
     )
 
     assert result is not None
-    perspectives, bias = result
+    perspectives, bias, divergence_level = result
     assert len(perspectives) == 5
     assert bias["center"] == 5
+    assert divergence_level is None
 
 
 @pytest.mark.asyncio
@@ -148,7 +149,7 @@ async def test_fast_path_matches_deep_article():
         db=db, content_id=deep, user_id=digest.user_id
     )
     assert result is not None
-    perspectives, bias = result
+    perspectives, bias, _ = result
     assert len(perspectives) == 5
     assert bias["center"] == 5
 
@@ -161,9 +162,7 @@ async def test_fast_path_all_five_ids_return_same_snapshot():
     actu = uuid4()
     extras = [uuid4(), uuid4()]
     deep = uuid4()
-    subject = _make_subject(
-        representative, actu, extras, deep, perspective_count=5
-    )
+    subject = _make_subject(representative, actu, extras, deep, perspective_count=5)
     digest = _make_digest([subject])
 
     all_ids = [representative, actu, *extras, deep]
@@ -200,7 +199,7 @@ async def test_fast_path_returns_empty_when_snapshot_missing():
     )
 
     assert result is not None, "must NOT fall back to live path"
-    perspectives, _ = result
+    perspectives, _, _ = result
     assert perspectives == []
 
 


### PR DESCRIPTION
## Quoi

- Expose `divergence_level` depuis le snapshot digest (stocké) et le chemin live, propagé au mobile via `PerspectivesResponse.divergenceLevel`
- Réponse partielle fast-first : sert les perspectives cluster immédiatement, puis un background task enrichit avec Google News ; `partial: true` signale au client de re-fetcher après 2,2 s
- Guard in-flight (`_perspectives_refresh_inflight`) pour éviter l'empilement de tâches background sur le même `content_id`
- Analytics tracking via `BackgroundTasks` — les cache hits restent sans accès DB
- Skip de `_attach_highlight_spans` si le snapshot a déjà les highlights
- `diff_spans` inclut maintenant `weight: 0.5` sur chaque span (plus de post-mutation dans le router)
- Mobile : `_schedulePerspectivesPartialRefetch` utilise un `Timer?` annulable dans `dispose()`

## Pourquoi

Améliore le temps de réponse de l'endpoint `/perspectives` en servant d'abord les données disponibles (cluster interne) puis en complétant en arrière-plan avec Google News. Le `divergence_level` alimente le widget `DiffTitle` pour moduler l'intensité visuelle selon la polarisation.

## Comment ça a été vérifié

- [x] pytest `tests/test_perspectives_alignment.py` — 8/8 OK
- [x] flutter test `feed_repository_perspectives_test` + `diff_title_weight_test` + `perspectives_inline_intro_test` — 16/16 OK
- [x] flutter analyze — 0 erreurs (warnings pré-existants uniquement)
- [x] /simplify passé — 8 cleanups appliqués

## Zones à risque

- `packages/api/app/routers/contents.py` — endpoint `/perspectives`, cache TTL, background tasks
- `packages/api/app/services/title_annotation_service.py` — `diff_spans` shape (ajout `weight`)
- `apps/mobile/lib/features/detail/screens/content_detail_screen.dart` — lifecycle timer, re-fetch partiel