### PR TITLE
Fix mobile tab modals covering shared chrome

### DIFF
--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -11,7 +11,8 @@ import '../features/onboarding/screens/onboarding_screen.dart';
 import '../features/onboarding/screens/conclusion_animation_screen.dart';
 import '../features/feed/models/content_model.dart';
 import '../features/feed/screens/flaner_screen.dart';
-import '../features/feed/widgets/perspectives_bottom_sheet.dart' show Perspective;
+import '../features/feed/widgets/perspectives_bottom_sheet.dart'
+    show Perspective;
 import '../features/flux_continu/screens/digest_section_screen.dart';
 import '../features/flux_continu/screens/flux_continu_screen.dart';
 import '../features/flux_continu/screens/theme_section_screen.dart';
@@ -53,8 +54,9 @@ import '../shared/widgets/navigation/modal_bottom_sheet_page.dart';
 /// navigator *root* reste `NotificationService.navigatorKey` (cf. `GoRouter`
 /// plus bas) — c'est lui que ciblent les sous-routes article via
 /// `parentNavigatorKey` pour s'afficher plein écran au-dessus du footer.
-final _essentielBranchKey =
-    GlobalKey<NavigatorState>(debugLabel: 'essentielBranch');
+final _essentielBranchKey = GlobalKey<NavigatorState>(
+  debugLabel: 'essentielBranch',
+);
 final _flanerBranchKey = GlobalKey<NavigatorState>(debugLabel: 'flanerBranch');
 
 /// Noms des routes
@@ -181,14 +183,15 @@ final routerProvider = Provider<GoRouter>((ref) {
       final isOnLoginPage = matchedLocation == RoutePaths.login;
       final isOnEmailConfirmation =
           matchedLocation == RoutePaths.emailConfirmation;
-      final isOnOnboarding = matchedLocation == RoutePaths.onboarding ||
+      final isOnOnboarding =
+          matchedLocation == RoutePaths.onboarding ||
           matchedLocation == RoutePaths.onboardingConclusion;
       // Escape hatch: the onboarding "Personnaliser mon mode serein" CTA pushes
       // the interests screen with ?serein=1. Let that through so the user can
       // configure their exclusions before completing onboarding.
       final isOnInterestsFromOnboarding =
           matchedLocation == RoutePaths.myInterests &&
-              state.uri.queryParameters['serein'] == '1';
+          state.uri.queryParameters['serein'] == '1';
 
       // 1. Les utilisateurs non connectés
       if (!isLoggedIn) {
@@ -253,7 +256,8 @@ final routerProvider = Provider<GoRouter>((ref) {
         builder: (context, state) {
           final authState = ref.read(authStateProvider);
           return EmailConfirmationScreen(
-            email: authState.user?.email ??
+            email:
+                authState.user?.email ??
                 authState.pendingEmailConfirmation ??
                 '',
           );
@@ -274,19 +278,20 @@ final routerProvider = Provider<GoRouter>((ref) {
         builder: (context, state) => const ConclusionAnimationScreen(),
       ),
 
-      // Shell principal des deux onglets (Essentiel / Flâner). Le shell pose un
-      // header + footer FIXES (MainShell) ; seul le body glisse au changement
-      // d'onglet (BranchPageView). Les sous-routes article s'échappent vers le
-      // navigator root via `parentNavigatorKey` pour s'afficher plein écran
-      // au-dessus du footer (swipe-back Cupertino conservé).
+      // Shell principal des deux onglets (Essentiel / Flâner). MainShell ne
+      // garde que le conteneur de branches (BranchPageView) ; le header/footer
+      // partagés sont rendus dans les pages racines de branche pour rester sous
+      // les modales ouvertes depuis ces pages. Les sous-routes article
+      // s'échappent vers le navigator root via `parentNavigatorKey` pour
+      // s'afficher plein écran (swipe-back Cupertino conservé).
       StatefulShellRoute(
         builder: (context, state, navigationShell) =>
             MainShell(navigationShell: navigationShell),
         navigatorContainerBuilder: (context, navigationShell, children) =>
             BranchPageView(
-          navigationShell: navigationShell,
-          children: children,
-        ),
+              navigationShell: navigationShell,
+              children: children,
+            ),
         branches: [
           // Branche 0 — L'Essentiel (Flux Continu, home post-auth Story 21.1).
           StatefulShellBranch(
@@ -295,8 +300,10 @@ final routerProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: RoutePaths.fluxContinu,
                 name: RouteNames.fluxContinu,
-                builder: (context, state) =>
-                    const Stack(children: [FluxContinuScreen(), NudgeHost()]),
+                builder: (context, state) => const MainTabPageScaffold(
+                  currentIndex: 0,
+                  child: Stack(children: [FluxContinuScreen(), NudgeHost()]),
+                ),
                 routes: [
                   GoRoute(
                     path: 'content/:id',
@@ -354,8 +361,10 @@ final routerProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: RoutePaths.flaner,
                 name: RouteNames.flaner,
-                builder: (context, state) =>
-                    const Stack(children: [FlanerScreen(), NudgeHost()]),
+                builder: (context, state) => const MainTabPageScaffold(
+                  currentIndex: 1,
+                  child: Stack(children: [FlanerScreen(), NudgeHost()]),
+                ),
                 routes: [
                   GoRoute(
                     path: 'content/:id',

--- a/apps/mobile/lib/features/feed/screens/flaner_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/flaner_screen.dart
@@ -79,13 +79,15 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
     final notifier = ref.read(feedProvider.notifier);
     if (!notifier.hasNext || notifier.isLoadingMore) return;
     setState(() => _loadingMore = true);
-    unawaited(notifier.loadMore().whenComplete(() {
-      if (mounted) {
-        setState(() => _loadingMore = false);
-      } else {
-        _loadingMore = false;
-      }
-    }));
+    unawaited(
+      notifier.loadMore().whenComplete(() {
+        if (mounted) {
+          setState(() => _loadingMore = false);
+        } else {
+          _loadingMore = false;
+        }
+      }),
+    );
   }
 
   Future<void> _refresh() async {
@@ -125,7 +127,7 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
     ref.listen(feedScrollTriggerProvider, (_, __) => _scrollToTop());
     return Scaffold(
       backgroundColor: colors.backgroundPrimary,
-      // Header & footer vivent désormais dans le shell partagé (MainShell).
+      // Header & footer vivent dans le scaffold de page partagé.
       body: SafeArea(
         top: false,
         bottom: false,
@@ -146,8 +148,9 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
                 child: AnimatedSlide(
                   duration: const Duration(milliseconds: 220),
                   curve: Curves.easeOutCubic,
-                  offset:
-                      _showScrollTopFab ? Offset.zero : const Offset(0, 1.6),
+                  offset: _showScrollTopFab
+                      ? Offset.zero
+                      : const Offset(0, 1.6),
                   child: AnimatedOpacity(
                     duration: const Duration(milliseconds: 220),
                     opacity: _showScrollTopFab ? 1.0 : 0.0,
@@ -172,8 +175,8 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
         controller: _scroll,
         physics: const AlwaysScrollableScrollPhysics(),
         slivers: [
-          // NB : le header (logo · streak · réglages) vit dans le shell partagé
-          // (MainShell) — fixe, hors du scroll.
+          // NB : le header (logo · streak · réglages) vit dans le scaffold de
+          // page partagé — fixe, hors du scroll.
           const SliverToBoxAdapter(
             child: SectionBanner(
               title: 'Flâner',
@@ -222,21 +225,20 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
       intercalations.add((
         position: carousel.position,
         builder: () => Padding(
-              key: ValueKey('flaner_carousel_${carousel.carouselType}'),
-              padding: const EdgeInsets.only(bottom: 12),
-              child: FeedCarousel(
-                data: carousel,
-                onArticleTap: _openArticle,
-                onLongPressStart: (c, _) =>
-                    ArticlePreviewOverlay.show(context, c),
-                onLongPressMoveUpdate: (details) =>
-                    ArticlePreviewOverlay.updateScroll(
+          key: ValueKey('flaner_carousel_${carousel.carouselType}'),
+          padding: const EdgeInsets.only(bottom: 12),
+          child: FeedCarousel(
+            data: carousel,
+            onArticleTap: _openArticle,
+            onLongPressStart: (c, _) => ArticlePreviewOverlay.show(context, c),
+            onLongPressMoveUpdate: (details) =>
+                ArticlePreviewOverlay.updateScroll(
                   details.localOffsetFromOrigin.dy,
                 ),
-                onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
-                onItemVisible: _markVisible,
-              ),
-            ),
+            onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
+            onItemVisible: _markVisible,
+          ),
+        ),
       ));
     }
 

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui' show ImageFilter;
 
-import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -42,7 +43,7 @@ const double _kStickyThreshold = 60.0;
 /// Vertical offset the sticky bar consumes — used as a landing buffer
 /// when scrolling a section into view so its banner doesn't disappear
 /// behind the bar.
-const double _kStickyBarHeight = 100.0;
+const double _kStickyBarHeight = 90.0;
 
 /// Minimum delta (px) before the scroll-up FAB toggles, to avoid flicker
 /// on tiny inertia bounces. Matches the legacy FeedScreen behaviour.
@@ -571,9 +572,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     ref.listen(essentielScrollTriggerProvider, (_, __) => _scrollToTop());
     return Scaffold(
       backgroundColor: context.facteurColors.backgroundPrimary,
-      // Header & footer vivent désormais dans le shell partagé (MainShell) :
+      // Header & footer vivent dans le scaffold de page partagé :
       // l'écran ne fournit plus de bottomNavigationBar ni de header, et son top
-      // inset est déjà consommé par le header fixe du shell.
+      // inset est déjà consommé par le header partagé.
       body: SafeArea(
         top: false,
         bottom: false,
@@ -662,8 +663,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
         controller: _scroll,
         physics: const AlwaysScrollableScrollPhysics(),
         slivers: [
-          // NB : le header (logo · streak · réglages) vit dans le shell partagé
-          // (MainShell) — fixe, hors du scroll.
+          // NB : le header (logo · streak · réglages) vit dans le scaffold de
+          // page partagé — fixe, hors du scroll.
           SliverToBoxAdapter(
             child: impressionSlot == FirstImpressionSlot.renudgeBanner
                 ? const NotificationRenudgeBanner()
@@ -701,9 +702,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
           // dessous : replier la tournée ne doit pas la masquer, c'est un
           // rituel de fin de tournée.
           if (state.quote != null && !state.closingDismissed)
-            SliverToBoxAdapter(
-              child: CitationDuJourCard(quote: state.quote!),
-            ),
+            SliverToBoxAdapter(child: CitationDuJourCard(quote: state.quote!)),
           // « Le mot du jour » — récompense de fin de Tournée. Sliver additif
           // au-dessus de ClosingCardV18 (cette dernière n'est pas modifiée :
           // zéro régression, revert trivial). La carte se câble seule au
@@ -728,8 +727,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
               articleCount: totalArticles,
               onContinue: () => context.go(RoutePaths.flaner),
               onClose: isAndroid ? () => SystemNavigator.pop() : null,
-              closeHint:
-                  isAndroid ? null : 'Vous pouvez refermer l’app — à demain',
+              closeHint: isAndroid
+                  ? null
+                  : 'Vous pouvez refermer l’app — à demain',
             ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 92)),

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -73,10 +73,7 @@ class EssentielHiFiCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _Header(
-              accent: accent,
-              onTapPersonalize: onTapPersonalize,
-            ),
+            _Header(accent: accent, onTapPersonalize: onTapPersonalize),
             const SizedBox(height: FacteurSpacing.space4),
             if (lead != null)
               _LeadTile(
@@ -107,10 +104,7 @@ class _Header extends StatelessWidget {
   final Color accent;
   final VoidCallback onTapPersonalize;
 
-  const _Header({
-    required this.accent,
-    required this.onTapPersonalize,
-  });
+  const _Header({required this.accent, required this.onTapPersonalize});
 
   @override
   Widget build(BuildContext context) {
@@ -125,6 +119,8 @@ class _Header extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              _HeaderAccentDash(accent: accent),
+              const SizedBox(height: 7),
               Row(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
@@ -148,14 +144,34 @@ class _Header extends StatelessWidget {
               const SizedBox(height: 4),
               Text(
                 'Tes 5 articles du jour, basé sur tes préférences',
-                style: FacteurTypography.bodySmall(colors.textSecondary).copyWith(
-                  height: 1.35,
-                ),
+                style: FacteurTypography.bodySmall(
+                  colors.textSecondary,
+                ).copyWith(height: 1.35),
               ),
             ],
           ),
         ),
       ],
+    );
+  }
+}
+
+class _HeaderAccentDash extends StatelessWidget {
+  final Color accent;
+
+  const _HeaderAccentDash({required this.accent});
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Container(
+        width: 30,
+        height: 3,
+        decoration: BoxDecoration(
+          color: accent.withValues(alpha: 0.82),
+          borderRadius: BorderRadius.circular(999),
+        ),
+      ),
     );
   }
 }
@@ -257,8 +273,10 @@ class _HeaderBadgeState extends ConsumerState<_HeaderBadge> {
           children: [...previous, if (current != null) current],
         ),
         transitionBuilder: (Widget child, Animation<double> animation) {
-          final rotate = Tween<double>(begin: math.pi, end: 0.0)
-              .animate(animation);
+          final rotate = Tween<double>(
+            begin: math.pi,
+            end: 0.0,
+          ).animate(animation);
           return AnimatedBuilder(
             animation: rotate,
             builder: (context, c) {
@@ -565,10 +583,7 @@ class _SectionChip extends StatelessWidget {
             Container(
               width: 6,
               height: 6,
-              decoration: BoxDecoration(
-                color: accent,
-                shape: BoxShape.circle,
-              ),
+              decoration: BoxDecoration(color: accent, shape: BoxShape.circle),
             ),
             const SizedBox(width: 5),
           ],
@@ -632,8 +647,9 @@ class _SourceRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
     final isFollowed = article.isFollowedSource;
-    final avatarBg =
-        isFollowed ? accent.withValues(alpha: 0.18) : colors.backgroundSecondary;
+    final avatarBg = isFollowed
+        ? accent.withValues(alpha: 0.18)
+        : colors.backgroundSecondary;
     final avatarBorder = isFollowed ? accent : colors.border;
     final avatarTextColor = isFollowed ? accent : colors.textSecondary;
     return Row(
@@ -676,10 +692,7 @@ class _Hairline extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
-    return Container(
-      height: 0.6,
-      color: colors.border.withValues(alpha: 0.20),
-    );
+    return Container(height: 0.6, color: colors.border.withValues(alpha: 0.20));
   }
 }
 
@@ -764,4 +777,3 @@ String _sectionLabelFor(EssentielArticle article) {
   if (raw.isNotEmpty) return raw;
   return 'Actus';
 }
-

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -123,8 +123,12 @@ class SectionBanner extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
                     children: [
+                      _AccentDash(accent: accent, large: large),
                       Padding(
-                        padding: EdgeInsets.only(top: 2, bottom: hasBlurb ? 4 : 0),
+                        padding: EdgeInsets.only(
+                          top: 2,
+                          bottom: hasBlurb ? 4 : 0,
+                        ),
                         child: Text.rich(
                           TextSpan(
                             text: title,
@@ -208,6 +212,28 @@ class SectionBanner extends StatelessWidget {
         splashColor: accent.withValues(alpha: 0.08),
         highlightColor: accent.withValues(alpha: 0.04),
         child: container,
+      ),
+    );
+  }
+}
+
+class _AccentDash extends StatelessWidget {
+  final Color accent;
+  final bool large;
+
+  const _AccentDash({required this.accent, required this.large});
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Container(
+        width: large ? 34 : 28,
+        height: 3,
+        margin: const EdgeInsets.only(bottom: 7),
+        decoration: BoxDecoration(
+          color: accent.withValues(alpha: 0.78),
+          borderRadius: BorderRadius.circular(999),
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -129,8 +129,8 @@ class _FeedRefreshIndicatorStrip extends ConsumerWidget {
 }
 
 /// Top row of the sticky overlay — a Fraunces label naming the current zone.
-/// L'avatar profil vit désormais uniquement dans le header fixe du shell
-/// (`MainShell`) ; il a été retiré d'ici pour ne plus apparaître en double.
+/// L'avatar profil vit uniquement dans le header partagé de la page ; il a été
+/// retiré d'ici pour ne plus apparaître en double.
 class StickyHead extends ConsumerWidget {
   final String title;
 
@@ -140,7 +140,7 @@ class StickyHead extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 6),
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 3),
       child: Row(
         children: [
           Text(
@@ -173,11 +173,11 @@ class _TabsRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: 56,
+      height: 48,
       child: ListView.separated(
         controller: controller,
         scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.fromLTRB(12, 6, 12, 12),
+        padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
         itemCount: tabs.length,
         separatorBuilder: (_, __) => const SizedBox(width: 2),
         itemBuilder: (context, i) {
@@ -226,7 +226,7 @@ class _Tab extends StatelessWidget {
       child: Stack(
         children: [
           Padding(
-            padding: const EdgeInsets.fromLTRB(12, 7, 12, 9),
+            padding: const EdgeInsets.fromLTRB(12, 5, 12, 7),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [

--- a/apps/mobile/lib/shared/widgets/navigation/main_bottom_nav.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/main_bottom_nav.dart
@@ -7,9 +7,9 @@ import '../../../config/theme.dart';
 
 /// Bottom nav persistante des deux onglets principaux (Essentiel / Flâner).
 ///
-/// Posée dans le shell partagé (`MainShell`) — elle ne navigue pas elle-même :
-/// elle remonte les taps via [onSelect] et c'est le shell qui décide (changement
-/// d'onglet vs scroll-to-top sur re-tap de l'onglet actif).
+/// Posée dans le chrome partagé des pages racines — elle ne navigue pas
+/// elle-même : elle remonte les taps via [onSelect] et le parent décide
+/// (changement d'onglet vs scroll-to-top sur re-tap de l'onglet actif).
 ///
 /// Style « point » historique de l'app (repris de `sticky_tab_bar.dart` `_Tab`)
 /// posé sur une surface glassmorphique premium : coins supérieurs arrondis, flou
@@ -18,7 +18,7 @@ class MainBottomNav extends StatelessWidget {
   /// Index de l'onglet actif (0 = L'Essentiel, 1 = Flâner).
   final int currentIndex;
 
-  /// Appelé au tap d'un onglet (actif ou non). Le shell arbitre la suite.
+  /// Appelé au tap d'un onglet (actif ou non). Le parent arbitre la suite.
   final ValueChanged<int> onSelect;
 
   const MainBottomNav({

--- a/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
@@ -13,15 +13,37 @@ import 'main_bottom_nav.dart';
 
 /// Shell partagé des deux onglets principaux (L'Essentiel / Flâner).
 ///
-/// C'est le `builder` du `StatefulShellRoute` : il pose un header **fixe** et un
-/// footer **fixe** (`MainBottomNav`), et confie le contenu central à
-/// [navigationShell] (rendu par [BranchPageView] via le `navigatorContainerBuilder`).
-/// Seul ce contenu glisse au changement d'onglet — header et footer restent
-/// immobiles.
-class MainShell extends ConsumerWidget {
+/// C'est le `builder` du `StatefulShellRoute` : il ne garde que le conteneur
+/// de navigation entre branches. Le chrome partagé vit dans chaque page racine
+/// via [MainTabPageScaffold], afin que les routes modales ouvertes depuis une
+/// branche passent naturellement au-dessus du header et du footer.
+class MainShell extends StatelessWidget {
   final StatefulNavigationShell navigationShell;
 
   const MainShell({super.key, required this.navigationShell});
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: context.facteurColors.backgroundPrimary,
+      child: navigationShell,
+    );
+  }
+}
+
+/// Chrome partagé des pages racines du shell principal.
+///
+/// Comme ce scaffold est rendu dans le navigator de branche, une bottom sheet
+/// ouverte depuis la page recouvre aussi le header et le footer.
+class MainTabPageScaffold extends ConsumerWidget {
+  final int currentIndex;
+  final Widget child;
+
+  const MainTabPageScaffold({
+    super.key,
+    required this.currentIndex,
+    required this.child,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -31,9 +53,9 @@ class MainShell extends ConsumerWidget {
       // les cartes qui défilent derrière (chaque écran réserve un padding bas).
       extendBody: true,
       bottomNavigationBar: MainBottomNav(
-        currentIndex: navigationShell.currentIndex,
+        currentIndex: currentIndex,
         onSelect: (index) {
-          if (index == navigationShell.currentIndex) {
+          if (index == currentIndex) {
             // Re-tap de l'onglet actif → scroll-to-top, sans navigation (donc
             // sans slide). L'écran concerné écoute son trigger.
             final trigger = index == 0
@@ -41,14 +63,14 @@ class MainShell extends ConsumerWidget {
                 : feedScrollTriggerProvider;
             ref.read(trigger.notifier).state++;
           } else {
-            navigationShell.goBranch(index);
+            context.go(index == 0 ? RoutePaths.fluxContinu : RoutePaths.flaner);
           }
         },
       ),
       body: Column(
         children: [
           const _SharedTopHeader(),
-          Expanded(child: navigationShell),
+          Expanded(child: child),
         ],
       ),
     );
@@ -59,7 +81,7 @@ class MainShell extends ConsumerWidget {
 /// (droite, avec pastille « mise à jour disponible »).
 ///
 /// Repris du header historique de `FluxContinuScreen` afin de garder l'apparence
-/// identique tout en le sortant du scroll (il ne défile plus ni ne glisse).
+/// identique sur les deux pages racines.
 class _SharedTopHeader extends StatelessWidget {
   const _SharedTopHeader();
 
@@ -85,7 +107,8 @@ class _SharedTopHeader extends StatelessWidget {
               alignment: Alignment.centerRight,
               child: Consumer(
                 builder: (context, ref, _) {
-                  final hasUpdate = ref
+                  final hasUpdate =
+                      ref
                           .watch(appUpdateProvider)
                           .valueOrNull
                           ?.updateAvailable ==
@@ -148,8 +171,9 @@ class BranchPageView extends StatefulWidget {
 }
 
 class _BranchPageViewState extends State<BranchPageView> {
-  late final PageController _controller =
-      PageController(initialPage: widget.navigationShell.currentIndex);
+  late final PageController _controller = PageController(
+    initialPage: widget.navigationShell.currentIndex,
+  );
 
   @override
   void didUpdateWidget(BranchPageView oldWidget) {
@@ -177,9 +201,7 @@ class _BranchPageViewState extends State<BranchPageView> {
     return PageView(
       controller: _controller,
       physics: const NeverScrollableScrollPhysics(),
-      children: [
-        for (final child in widget.children) _KeepAlive(child: child),
-      ],
+      children: [for (final child in widget.children) _KeepAlive(child: child)],
     );
   }
 }

--- a/apps/mobile/test/shared/widgets/navigation/main_bottom_nav_test.dart
+++ b/apps/mobile/test/shared/widgets/navigation/main_bottom_nav_test.dart
@@ -34,7 +34,7 @@ void main() {
     });
 
     testWidgets('tap onglet actif → onSelect(indexCourant) (scroll-to-top géré '
-        'par le shell)', (tester) async {
+        'par le parent)', (tester) async {
       final taps = <int>[];
       await tester.pumpWidget(
         wrap(currentIndex: 0, onSelect: taps.add),


### PR DESCRIPTION
## Summary
- move the shared Essentiel/Flâner header and bottom nav into each root tab page so branch-level modals cover the full tab chrome
- keep MainShell as the branch navigation container only
- tighten sticky tab/header spacing and add small accent dashes to section/Essentiel headers

## Tests
- ✅ `cd apps/mobile && flutter test test/shared/widgets/navigation/main_bottom_nav_test.dart`
- ❌ `make test-mobile` currently fails in existing suites: unimplemented notification tests in `test/features/detail/notification_test.dart`, plus `test/widget_test.dart` failing because Supabase is not initialized in the app smoke test. The run reached `+767 -45` before exiting with `make: *** [test-mobile] Error 1`.

## UX/UI manual test command
```sh
cd apps/mobile && flutter run
```