### PR TITLE
Fix weather badge icon size

### DIFF
--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -263,8 +263,8 @@ class _HeaderBadgeState extends ConsumerState<_HeaderBadge> {
 
     // Fixed slot: the header never reflows when flipping between date/weather.
     return SizedBox(
-      width: 90,
-      height: 108,
+      width: 110,
+      height: 132,
       child: AnimatedSwitcher(
         duration: const Duration(milliseconds: 320),
         switchInCurve: Curves.easeInOut,
@@ -314,8 +314,8 @@ class _WeatherBadge extends StatelessWidget {
       children: [
         SvgPicture.asset(
           'assets/images/weather/${forecast.condition.assetName}.svg',
-          width: 60,
-          height: 60,
+          width: 100,
+          height: 100,
         ),
         const SizedBox(height: 3),
         RichText(


### PR DESCRIPTION
## Summary\n- Restore the weather badge SVG to a size matching the pre-feature main baseline, with a slight increase (100px vs 94px).\n- Expand the fixed badge slot so the larger SVG, min/max line, and subtle chevron do not overflow or reflow.\n\n## Validation\n- flutter analyze lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart lib/features/flux_continu/widgets/weather_detail_sheet.dart test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart\n- flutter test test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart\n\nNote: this PR is intentionally clean and contains only one file / four line changes.