### PR TITLE
feat(flaner): modal d'épinglage unifiée sources + sujets (drag interleaved)

### DIFF
--- a/apps/mobile/lib/features/feed/providers/tab_order_prefs_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/tab_order_prefs_provider.dart
@@ -1,0 +1,80 @@
+/// Ordre unifié des onglets épinglés de Flâner (sujets + sources mélangés).
+///
+/// Les sujets (custom topics) et les sources sont deux systèmes de favoris
+/// distincts côté backend, chacun avec sa propre `position` serveur. Pour
+/// permettre un drag interleaved (sujet ↔ source) dans la modal d'épinglage,
+/// on stocke ici l'ordre global voulu par l'utilisateur sous forme de clés
+/// typées (`"topic:<id>"` / `"source:<id>"`) en SharedPreferences. Au rendu des
+/// onglets, [applyOrder] applique cet ordre ; les items absents de la liste
+/// (nouvellement épinglés) conservent leur ordre d'origine, en fin.
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _kTabOrderKey = 'pinned_tabs_order_v1';
+
+/// Préfixe de clé d'un sujet épinglé dans l'ordre unifié.
+String tabOrderTopicKey(String topicId) => 'topic:$topicId';
+
+/// Préfixe de clé d'une source épinglée dans l'ordre unifié.
+String tabOrderSourceKey(String sourceId) => 'source:$sourceId';
+
+/// Trie [items] selon [order] (liste de clés). Les items dont la clé figure
+/// dans [order] viennent en premier, dans l'ordre de [order] ; les autres
+/// suivent en conservant leur ordre relatif d'entrée (tri stable). Si [order]
+/// est vide, [items] est renvoyé tel quel.
+List<T> applyOrder<T>(
+  List<T> items,
+  List<String> order,
+  String Function(T) keyOf,
+) {
+  if (order.isEmpty || items.isEmpty) return items;
+  final rank = <String, int>{
+    for (var i = 0; i < order.length; i++) order[i]: i,
+  };
+  final indexed = <({T item, int i})>[
+    for (var i = 0; i < items.length; i++) (item: items[i], i: i),
+  ];
+  indexed.sort((a, b) {
+    final ra = rank[keyOf(a.item)];
+    final rb = rank[keyOf(b.item)];
+    if (ra != null && rb != null) return ra.compareTo(rb);
+    if (ra != null) return -1; // a est ordonné, b ne l'est pas → a d'abord
+    if (rb != null) return 1;
+    return a.i.compareTo(b.i); // les deux absents → ordre d'origine
+  });
+  return [for (final e in indexed) e.item];
+}
+
+final tabOrderPrefsProvider =
+    StateNotifierProvider<TabOrderPrefsNotifier, List<String>>((ref) {
+  return TabOrderPrefsNotifier();
+});
+
+class TabOrderPrefsNotifier extends StateNotifier<List<String>> {
+  TabOrderPrefsNotifier() : super(const []) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      state = prefs.getStringList(_kTabOrderKey) ?? const [];
+    } catch (_) {
+      // Pas de prefs disponibles (ex. tests sans mock) → ordre vide.
+      state = const [];
+    }
+  }
+
+  /// Écrit le nouvel ordre global (clés `"topic:<id>"` / `"source:<id>"`).
+  Future<void> setOrder(List<String> keys) async {
+    state = List.unmodifiable(keys);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList(_kTabOrderKey, keys);
+    } catch (_) {
+      // best-effort : l'ordre en mémoire reste appliqué pour la session.
+    }
+  }
+}

--- a/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
+++ b/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
@@ -7,11 +7,17 @@ import '../../../config/theme.dart';
 import '../../custom_topics/models/topic_models.dart';
 import '../../custom_topics/providers/custom_topics_provider.dart';
 import '../../my_interests/models/user_interests_state.dart';
+import '../../my_interests/models/user_sources_state.dart';
 import '../../my_interests/providers/user_interests_provider.dart';
+import '../../my_interests/providers/user_sources_state_provider.dart';
+import '../../sources/models/source_model.dart';
+import '../../sources/providers/sources_providers.dart';
+import '../../sources/widgets/source_logo_avatar.dart';
 import '../models/content_model.dart';
+import '../providers/tab_order_prefs_provider.dart';
 import '../repositories/feed_repository.dart';
 
-enum FavoriteTabKind { tous, subjectTopic, subjectEntity, theme }
+enum FavoriteTabKind { tous, subjectTopic, subjectEntity, theme, source }
 
 @immutable
 class FavoriteTabModel {
@@ -22,6 +28,10 @@ class FavoriteTabModel {
   final int count;
   final bool active;
 
+  /// Renseigné uniquement pour [FavoriteTabKind.source] : sert à rendre le logo
+  /// (avec fallback initiales) via [SourceLogoAvatar].
+  final Source? source;
+
   const FavoriteTabModel({
     required this.kind,
     required this.slug,
@@ -29,6 +39,7 @@ class FavoriteTabModel {
     required this.emoji,
     required this.count,
     required this.active,
+    this.source,
   });
 }
 
@@ -38,6 +49,7 @@ class FavoriteTopicTabs extends ConsumerStatefulWidget {
   final String? selectedTopicSlug;
   final String? selectedThemeSlug;
   final String? selectedEntitySlug;
+  final String? selectedSourceId;
   final void Function(FavoriteTabKind kind, String? slug) onTabTap;
   final VoidCallback onTapActiveTab;
   final VoidCallback onTapActiveTabRefresh;
@@ -50,6 +62,7 @@ class FavoriteTopicTabs extends ConsumerStatefulWidget {
     this.selectedTopicSlug,
     this.selectedThemeSlug,
     this.selectedEntitySlug,
+    this.selectedSourceId,
     required this.onTabTap,
     required this.onTapActiveTab,
     required this.onTapActiveTabRefresh,
@@ -71,7 +84,8 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
     final selectionChanged =
         old.selectedTopicSlug != widget.selectedTopicSlug ||
             old.selectedThemeSlug != widget.selectedThemeSlug ||
-            old.selectedEntitySlug != widget.selectedEntitySlug;
+            old.selectedEntitySlug != widget.selectedEntitySlug ||
+            old.selectedSourceId != widget.selectedSourceId;
     if (selectionChanged) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _scrollActiveIntoView();
@@ -109,19 +123,31 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
     final colors = context.facteurColors;
     final topicsAsync = ref.watch(customTopicsProvider);
     final interestsAsync = ref.watch(userInterestsProvider);
+    final sourcesStateAsync = ref.watch(userSourcesStateProvider);
+    final sourcesAsync = ref.watch(userSourcesProvider);
+    final order = ref.watch(tabOrderPrefsProvider);
 
     final topics = topicsAsync.valueOrNull ?? const <UserTopicProfile>[];
     final favorites =
         interestsAsync.valueOrNull?.favorites ?? const <FavoriteRef>[];
+    final sourceFavorites =
+        sourcesStateAsync.valueOrNull?.favorites ?? const <SourceFavoriteRef>[];
+    final sourceById = <String, Source>{
+      for (final s in sourcesAsync.valueOrNull ?? const <Source>[]) s.id: s,
+    };
 
     final tabs = _buildTabModels(
       topics: topics,
       favorites: favorites,
+      sourceFavorites: sourceFavorites,
+      sourceById: sourceById,
+      order: order,
       items: widget.items,
       serverCounts: widget.serverCounts,
       selectedTopicSlug: widget.selectedTopicSlug,
       selectedThemeSlug: widget.selectedThemeSlug,
       selectedEntitySlug: widget.selectedEntitySlug,
+      selectedSourceId: widget.selectedSourceId,
     );
 
     _activeKey = null;
@@ -184,32 +210,46 @@ List<FavoriteTabModel> buildFavoriteTabModelsForTest({
   required List<UserTopicProfile> topics,
   required List<FavoriteRef> favorites,
   required List<Content> items,
+  List<SourceFavoriteRef> sourceFavorites = const [],
+  Map<String, Source> sourceById = const {},
+  List<String> order = const [],
   TabCounts? serverCounts,
   String? selectedTopicSlug,
   String? selectedThemeSlug,
   String? selectedEntitySlug,
+  String? selectedSourceId,
 }) =>
     _buildTabModels(
       topics: topics,
       favorites: favorites,
+      sourceFavorites: sourceFavorites,
+      sourceById: sourceById,
+      order: order,
       items: items,
       serverCounts: serverCounts,
       selectedTopicSlug: selectedTopicSlug,
       selectedThemeSlug: selectedThemeSlug,
       selectedEntitySlug: selectedEntitySlug,
+      selectedSourceId: selectedSourceId,
     );
 
-/// Onglets Flâner = uniquement les *sujets épinglés* (custom topics + entités
-/// favoris). Les *thèmes/veille* pilotent la Tournée du jour et ne sont donc
-/// pas rendus en onglet ici — ils restent filtrables via la chip thème.
+/// Onglets Flâner = *sujets épinglés* (custom topics + entités favoris) **et**
+/// *sources épinglées* (favoris sources), mélangés selon l'ordre unifié
+/// [order] (cf. [tabOrderPrefsProvider]). Les *thèmes/veille* pilotent la
+/// Tournée du jour et ne sont donc pas rendus en onglet ici — ils restent
+/// filtrables via la chip thème.
 List<FavoriteTabModel> _buildTabModels({
   required List<UserTopicProfile> topics,
   required List<FavoriteRef> favorites,
+  required List<SourceFavoriteRef> sourceFavorites,
+  required Map<String, Source> sourceById,
+  required List<String> order,
   required List<Content> items,
   TabCounts? serverCounts,
   String? selectedTopicSlug,
   String? selectedThemeSlug,
   String? selectedEntitySlug,
+  String? selectedSourceId,
 }) {
   final useServer = serverCounts != null && serverCounts.total > 0;
 
@@ -247,47 +287,85 @@ List<FavoriteTabModel> _buildTabModels({
         selectedEntitySlug == null,
   ));
 
-  // 2. Onglets favoris (entités + sujets épinglés) triés par nombre
-  // d'articles disponibles décroissant.
-  final favoriteTabs = <FavoriteTabModel>[];
+  // 2. Onglets favoris (sujets + sources épinglés). On garde la clé d'ordre
+  // unifié (`topic:<id>` / `source:<id>`) à côté de chaque modèle pour pouvoir
+  // appliquer [order] ensuite.
+  final favoriteTabs = <({FavoriteTabModel tab, String key})>[];
 
   for (final entity in entitySubjects) {
     final slug = entity.canonicalName ?? entity.name;
-    favoriteTabs.add(FavoriteTabModel(
-      kind: FavoriteTabKind.subjectEntity,
-      slug: slug,
-      label: entity.name,
-      emoji: '',
-      count: useServer
-          ? (serverCounts.entities[slug.toLowerCase()] ?? 0)
-          : _countUnreadRecent(items,
-              cutoff: cutoff, kind: FavoriteTabKind.subjectEntity, slug: slug),
-      active: selectedEntitySlug != null && selectedEntitySlug == slug,
+    favoriteTabs.add((
+      key: tabOrderTopicKey(entity.id),
+      tab: FavoriteTabModel(
+        kind: FavoriteTabKind.subjectEntity,
+        slug: slug,
+        label: entity.name,
+        emoji: '',
+        count: useServer
+            ? (serverCounts.entities[slug.toLowerCase()] ?? 0)
+            : _countUnreadRecent(items,
+                cutoff: cutoff,
+                kind: FavoriteTabKind.subjectEntity,
+                slug: slug),
+        active: selectedEntitySlug != null && selectedEntitySlug == slug,
+      ),
     ));
   }
 
   for (final topic in topicSubjects) {
     final slug = topic.slugParent ?? topic.id;
-    favoriteTabs.add(FavoriteTabModel(
-      kind: FavoriteTabKind.subjectTopic,
-      slug: slug,
-      label: topic.name,
-      emoji: '',
-      count: useServer
-          ? (serverCounts.topics[slug] ?? 0)
-          : _countUnreadRecent(items,
-              cutoff: cutoff, kind: FavoriteTabKind.subjectTopic, slug: slug),
-      active: selectedTopicSlug != null && selectedTopicSlug == slug,
+    favoriteTabs.add((
+      key: tabOrderTopicKey(topic.id),
+      tab: FavoriteTabModel(
+        kind: FavoriteTabKind.subjectTopic,
+        slug: slug,
+        label: topic.name,
+        emoji: '',
+        count: useServer
+            ? (serverCounts.topics[slug] ?? 0)
+            : _countUnreadRecent(items,
+                cutoff: cutoff,
+                kind: FavoriteTabKind.subjectTopic,
+                slug: slug),
+        active: selectedTopicSlug != null && selectedTopicSlug == slug,
+      ),
     ));
   }
 
+  // Sources épinglées (favoris sources). Pas de count serveur par source pour
+  // l'instant → count 0 (pas de badge). On skippe les sources inconnues du
+  // catalogue (logo/nom non résolus).
+  final sortedSourceFavorites = [...sourceFavorites]
+    ..sort((a, b) => a.position.compareTo(b.position));
+  for (final ref in sortedSourceFavorites) {
+    final source = sourceById[ref.sourceId];
+    if (source == null) continue;
+    favoriteTabs.add((
+      key: tabOrderSourceKey(ref.sourceId),
+      tab: FavoriteTabModel(
+        kind: FavoriteTabKind.source,
+        slug: ref.sourceId,
+        label: source.name,
+        emoji: '',
+        count: 0,
+        active: selectedSourceId != null && selectedSourceId == ref.sourceId,
+        source: source,
+      ),
+    ));
+  }
+
+  // Ordre par défaut (avant ordre custom) : par count décroissant puis alpha —
+  // conserve le comportement historique pour les items pas encore réordonnés.
   favoriteTabs.sort((a, b) {
-    final byCount = b.count.compareTo(a.count);
+    final byCount = b.tab.count.compareTo(a.tab.count);
     if (byCount != 0) return byCount;
-    return a.label.toLowerCase().compareTo(b.label.toLowerCase());
+    return a.tab.label.toLowerCase().compareTo(b.tab.label.toLowerCase());
   });
 
-  tabs.addAll(favoriteTabs);
+  // Ordre unifié voulu par l'utilisateur (drag dans la modal d'épinglage).
+  final ordered = applyOrder(favoriteTabs, order, (e) => e.key);
+
+  tabs.addAll(ordered.map((e) => e.tab));
   return tabs;
 }
 
@@ -310,6 +388,9 @@ int _countUnreadRecent(
       case FavoriteTabKind.theme:
         // Les thèmes ne sont plus rendus en onglet Flâner (ils pilotent la
         // Tournée). Valeur conservée dans l'enum pour la chip thème.
+        return false;
+      case FavoriteTabKind.source:
+        // Pas de count local par source — les onglets source affichent 0.
         return false;
     }
   }
@@ -342,6 +423,10 @@ class _FavoriteTabItem extends StatelessWidget {
     final showBadge = tab.count >= 3;
     final showLabel =
         tab.emoji.isNotEmpty ? '${tab.emoji} ${tab.label}' : tab.label;
+    final sourceAvatar =
+        tab.kind == FavoriteTabKind.source && tab.source != null
+            ? tab.source
+            : null;
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -352,6 +437,10 @@ class _FavoriteTabItem extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
+            if (sourceAvatar != null) ...[
+              SourceLogoAvatar(source: sourceAvatar, size: 20, radius: 5),
+              const SizedBox(width: 6),
+            ],
             IntrinsicWidth(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,

--- a/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
@@ -61,6 +61,7 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
         selectedTopicSlug: selection.topic,
         selectedThemeSlug: selection.theme,
         selectedEntitySlug: selection.entity,
+        selectedSourceId: selection.sourceId,
         onTabTap: (kind, slug) async {
           // Sheet owns this override ; clear it so the chip label rebuilds
           // from the tapped tab's name on next layout.
@@ -81,6 +82,9 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
               break;
             case FavoriteTabKind.theme:
               await notifier.setTheme(slug);
+              break;
+            case FavoriteTabKind.source:
+              await notifier.setSource(slug);
               break;
           }
           widget.onAfterChange?.call();

--- a/apps/mobile/lib/features/feed/widgets/pin_subjects_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/pin_subjects_sheet.dart
@@ -9,22 +9,31 @@ import '../../../config/theme.dart';
 import '../../../core/ui/notification_service.dart';
 import '../../custom_topics/widgets/entity_add_sheet.dart';
 import '../../my_interests/models/user_interests_state.dart';
+import '../../my_interests/models/user_sources_state.dart';
 import '../../my_interests/providers/user_interests_provider.dart';
+import '../../my_interests/providers/user_sources_state_provider.dart';
+import '../../sources/models/source_model.dart';
+import '../../sources/providers/sources_providers.dart';
+import '../../sources/widgets/source_logo_avatar.dart';
 import '../../veille/providers/veille_themes_provider.dart';
+import '../providers/tab_order_prefs_provider.dart';
 
-/// Nombre de sujets épinglés en-dessous duquel on incite l'utilisateur à en
-/// épingler davantage (carte CTA + sous-titre). Aligné sur la promesse
-/// « 3-4 sujets suffisent ».
+/// Nombre d'éléments épinglés (sujets + sources) en-dessous duquel on incite
+/// l'utilisateur à en épingler davantage (carte CTA). Aligné sur la promesse
+/// « 3-4 suffisent ».
 const int kPinSubjectsTarget = 3;
 
-int _pinnedCount(UserInterestsState? interests) {
+int _pinnedTopicCount(UserInterestsState? interests) {
   final favorites = interests?.favorites ?? const <FavoriteRef>[];
   return favorites.whereType<CustomTopicFavoriteRef>().length;
 }
 
-/// Ouvre la modale d'épinglage de sujets précis (custom topics) — distincte des
-/// thèmes (qui pilotent la Tournée). Épingler un sujet le transforme en onglet
-/// dédié dans Flâner.
+int _pinnedSourceCount(UserSourcesState? sources) {
+  return sources?.favorites.length ?? 0;
+}
+
+/// Ouvre la modale d'épinglage unifiée (sources + sujets précis). Épingler un
+/// élément le transforme en onglet dédié dans Flâner.
 Future<void> showPinSubjectsSheet(BuildContext context) {
   return showModalBottomSheet<void>(
     context: context,
@@ -41,21 +50,29 @@ Future<void> showPinSubjectsSheet(BuildContext context) {
 }
 
 /// Carte proéminente (sliver) affichée en haut du feed Flâner tant que
-/// l'utilisateur a épinglé moins de [kPinSubjectsTarget] sujets. Sinon masquée.
+/// l'utilisateur a épinglé moins de [kPinSubjectsTarget] éléments. Sinon masquée.
 class PinSubjectsBanner extends ConsumerWidget {
   const PinSubjectsBanner({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Ne rebuild la bannière que lorsque le nombre de sujets épinglés change —
-    // pas sur chaque mutation d'intérêt (thèmes, veille, réordonnancement).
-    final pinnedCount = ref.watch(
+    // Ne rebuild la bannière que lorsque le nombre d'éléments épinglés change.
+    final pinnedTopics = ref.watch(
       userInterestsProvider.select((value) {
         final interests = value.valueOrNull;
-        return interests == null ? null : _pinnedCount(interests);
+        return interests == null ? null : _pinnedTopicCount(interests);
       }),
     );
-    if (pinnedCount == null || pinnedCount >= kPinSubjectsTarget) {
+    final pinnedSources = ref.watch(
+      userSourcesStateProvider.select(
+        (value) => _pinnedSourceCount(value.valueOrNull),
+      ),
+    );
+    if (pinnedTopics == null) {
+      return const SizedBox.shrink();
+    }
+    final pinnedCount = pinnedTopics + pinnedSources;
+    if (pinnedCount >= kPinSubjectsTarget) {
       return const SizedBox.shrink();
     }
     final colors = context.facteurColors;
@@ -86,29 +103,12 @@ class PinSubjectsBanner extends ConsumerWidget {
                 ),
                 const SizedBox(width: FacteurSpacing.space3),
                 Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Épingle tes sujets',
-                        style: Theme.of(context)
-                            .textTheme
-                            .titleSmall
-                            ?.copyWith(
-                              fontWeight: FontWeight.w700,
-                              color: colors.textPrimary,
-                            ),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        '3-4 sujets suffisent — ils deviennent tes onglets '
-                        'dans Flâner.',
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: colors.textSecondary,
-                              height: 1.35,
-                            ),
-                      ),
-                    ],
+                  child: Text(
+                    'Épinglez des sources ou sujets précis',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: colors.textPrimary,
+                        ),
                   ),
                 ),
                 const SizedBox(width: FacteurSpacing.space2),
@@ -149,6 +149,26 @@ String _normalize(String input) {
   return buffer.toString();
 }
 
+/// Un élément épinglé dans la section unifiée « ÉPINGLÉS » : un sujet (custom
+/// topic) ou une source.
+class _PinnedItem {
+  final String key; // "topic:<id>" | "source:<id>"
+  final bool isSource;
+  final String id; // topicId | sourceId
+  final String label;
+  final String emoji; // pour un sujet
+  final Source? source; // pour une source
+
+  const _PinnedItem({
+    required this.key,
+    required this.isSource,
+    required this.id,
+    required this.label,
+    required this.emoji,
+    this.source,
+  });
+}
+
 class _PinSubjectsContent extends ConsumerStatefulWidget {
   const _PinSubjectsContent();
 
@@ -167,7 +187,7 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
     super.dispose();
   }
 
-  Future<void> _setState(String topicId, InterestState state) async {
+  Future<void> _setTopicState(String topicId, InterestState state) async {
     try {
       await ref.read(userInterestsProvider.notifier).setInterestState(
             CustomTopicFavoriteRef(id: topicId),
@@ -178,9 +198,82 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
     }
   }
 
-  bool _matches(CustomTopicInterest t, String normalizedQuery) {
+  Future<void> _setSourceState(String sourceId, InterestState state) async {
+    try {
+      await ref
+          .read(userSourcesStateProvider.notifier)
+          .setSourceState(sourceId, state);
+    } catch (e) {
+      NotificationService.showError('Erreur : $e');
+    }
+  }
+
+  /// Persiste le nouvel ordre unifié (prefs) puis synchronise — best-effort et
+  /// en parallèle — les positions serveur de chaque type (sujets / sources)
+  /// pour garder les listes « Mes intérêts » / « Mes sources » cohérentes.
+  Future<void> _persistReorder(List<_PinnedItem> ordered) async {
+    final keys = ordered.map((e) => e.key).toList();
+    await ref.read(tabOrderPrefsProvider.notifier).setOrder(keys);
+
+    final topicIds = [
+      for (final e in ordered)
+        if (!e.isSource) e.id,
+    ];
+    final sourceIds = [
+      for (final e in ordered)
+        if (e.isSource) e.id,
+    ];
+
+    // Les deux syncs serveur sont indépendantes → on les lance en parallèle.
+    // L'ordre prefs reste appliqué pour les onglets même si une sync échoue.
+    await Future.wait([
+      _syncTopicPositions(topicIds),
+      _syncSourcePositions(sourceIds),
+    ]);
+  }
+
+  /// Réordonne les `CustomTopicFavoriteRef` serveur selon [topicIds] en
+  /// préservant la position des thèmes/veille (qui ne sont pas des onglets).
+  Future<void> _syncTopicPositions(List<String> topicIds) async {
+    final interests = ref.read(userInterestsProvider).valueOrNull;
+    if (interests == null) return;
+    final newTopicQueue = [
+      for (final id in topicIds) CustomTopicFavoriteRef(id: id),
+    ];
+    final topicSlots =
+        interests.favorites.whereType<CustomTopicFavoriteRef>().length;
+    if (newTopicQueue.length != topicSlots) return;
+    var i = 0;
+    final merged = [
+      for (final f in interests.favorites)
+        f is CustomTopicFavoriteRef ? newTopicQueue[i++] : f,
+    ];
+    try {
+      await ref.read(userInterestsProvider.notifier).reorderFavorites(merged);
+    } catch (_) {
+      // L'ordre prefs reste appliqué pour les onglets ; on ignore.
+    }
+  }
+
+  /// Réassigne les positions canoniques des sources favorites selon [sourceIds].
+  Future<void> _syncSourcePositions(List<String> sourceIds) async {
+    if (sourceIds.isEmpty) return;
+    final orderedRefs = [
+      for (var i = 0; i < sourceIds.length; i++)
+        SourceFavoriteRef(sourceId: sourceIds[i], position: i),
+    ];
+    try {
+      await ref
+          .read(userSourcesStateProvider.notifier)
+          .reorderFavorites(orderedRefs);
+    } catch (_) {
+      // idem : best-effort.
+    }
+  }
+
+  bool _matchesText(String text, String normalizedQuery) {
     if (normalizedQuery.isEmpty) return true;
-    return _normalize(t.topicName).contains(normalizedQuery);
+    return _normalize(text).contains(normalizedQuery);
   }
 
   /// Groupe les sujets par thème parent, dans l'ordre canonique des thèmes
@@ -215,26 +308,73 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
+
     final interests = ref.watch(userInterestsProvider).valueOrNull;
     final topics = interests?.customTopics ?? const <CustomTopicInterest>[];
+
+    final sourcesState = ref.watch(userSourcesStateProvider).valueOrNull;
+    final sourceInterests =
+        sourcesState?.sources ?? const <SourceInterest>[];
+    final sourceFavorites =
+        sourcesState?.favorites ?? const <SourceFavoriteRef>[];
+    final catalog = ref.watch(userSourcesProvider).valueOrNull ??
+        const <Source>[];
+    final sourceById = {for (final s in catalog) s.id: s};
+
+    final order = ref.watch(tabOrderPrefsProvider);
 
     final normalizedQuery = _normalize(_query.trim());
     final hasQuery = normalizedQuery.isNotEmpty;
 
-    final pinned = topics
-        .where((t) =>
-            t.state == InterestState.favorite && _matches(t, normalizedQuery))
-        .toList()
-      ..sort((a, b) =>
-          a.topicName.toLowerCase().compareTo(b.topicName.toLowerCase()));
-    final pinnable = topics
-        .where((t) =>
-            t.state != InterestState.favorite && _matches(t, normalizedQuery))
-        .toList();
-    final pinnableGroups = _groupByTheme(pinnable);
+    // ── Section ÉPINGLÉS (interleaved, drag) ──────────────────────────
+    final pinnedItems = <_PinnedItem>[];
+    for (final t in topics.where((t) => t.state == InterestState.favorite)) {
+      pinnedItems.add(_PinnedItem(
+        key: tabOrderTopicKey(t.id),
+        isSource: false,
+        id: t.id,
+        label: t.topicName,
+        emoji: _themeEmoji(t.slugParent),
+      ));
+    }
+    for (final f in sourceFavorites) {
+      final source = sourceById[f.sourceId];
+      if (source == null) continue;
+      pinnedItems.add(_PinnedItem(
+        key: tabOrderSourceKey(f.sourceId),
+        isSource: true,
+        id: f.sourceId,
+        label: source.name,
+        emoji: '',
+        source: source,
+      ));
+    }
+    final orderedPinned = applyOrder(pinnedItems, order, (e) => e.key);
 
-    final hasAnyTopic = topics.isNotEmpty;
-    final noMatch = pinned.isEmpty && pinnable.isEmpty;
+    // ── Section SOURCES SUIVIES (followed, non épinglées) ─────────────
+    final followedSourceIds = sourceInterests
+        .where((s) => s.state == InterestState.followed)
+        .map((s) => s.sourceId)
+        .toSet();
+    final followedSources = [
+      for (final s in catalog)
+        if (followedSourceIds.contains(s.id) &&
+            _matchesText(s.name, normalizedQuery))
+          s,
+    ]..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+
+    // ── Section SUJETS À ÉPINGLER (suivis non favoris, groupés) ───────
+    final pinnableTopics = topics
+        .where((t) =>
+            t.state != InterestState.favorite &&
+            _matchesText(t.topicName, normalizedQuery))
+        .toList();
+    final pinnableGroups = _groupByTheme(pinnableTopics);
+
+    final hasAnything = topics.isNotEmpty || catalog.isNotEmpty;
+    final noMatch = orderedPinned.isEmpty &&
+        followedSources.isEmpty &&
+        pinnableTopics.isEmpty;
 
     return SafeArea(
       top: false,
@@ -266,7 +406,7 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
                 ),
                 const SizedBox(height: FacteurSpacing.space4),
                 Text(
-                  'Épingler des sujets',
+                  'Épingler des sources et sujets',
                   style: textTheme.displaySmall?.copyWith(
                     fontSize: 20,
                     fontWeight: FontWeight.w700,
@@ -275,8 +415,8 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'Tes sujets précis deviennent des onglets dans Flâner. '
-                  'Les thèmes, eux, pilotent ta Tournée du jour.',
+                  'Sources et sujets épinglés deviennent vos onglets dans '
+                  'Flâner. Glissez pour les réordonner.',
                   style: textTheme.bodySmall?.copyWith(
                     color: colors.textTertiary,
                     height: 1.4,
@@ -284,9 +424,7 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
                 ),
                 const SizedBox(height: FacteurSpacing.space4),
 
-                // Barre de recherche — filtre les sujets ; fallback « créer »
-                // quand aucun ne matche.
-                if (hasAnyTopic)
+                if (hasAnything)
                   _SearchField(
                     controller: _searchController,
                     colors: colors,
@@ -296,30 +434,56 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
                       _query = '';
                     }),
                   ),
-                if (hasAnyTopic)
+                if (hasAnything)
                   const SizedBox(height: FacteurSpacing.space4),
 
-                // Sujets déjà épinglés → tap pour dé-épingler.
-                if (pinned.isNotEmpty) ...[
-                  _SectionLabel(label: 'SUJETS ÉPINGLÉS', colors: colors),
+                // Éléments déjà épinglés → drag pour réordonner, tap icône
+                // pour dé-épingler.
+                if (orderedPinned.isNotEmpty) ...[
+                  _SectionLabel(label: 'ÉPINGLÉS', colors: colors),
                   const SizedBox(height: 8),
-                  for (final t in pinned)
-                    _SubjectRow(
-                      key: ValueKey('pinned_${t.id}'),
-                      label: t.topicName,
-                      emoji: _themeEmoji(t.slugParent),
-                      pinned: true,
+                  _PinnedItemsList(
+                    items: orderedPinned,
+                    colors: colors,
+                    onReorder: (oldIndex, newIndex) {
+                      final reordered = [...orderedPinned];
+                      if (newIndex > oldIndex) newIndex -= 1;
+                      final moved = reordered.removeAt(oldIndex);
+                      reordered.insert(newIndex, moved);
+                      _persistReorder(reordered);
+                    },
+                    onUnpin: (item) {
+                      if (item.isSource) {
+                        _setSourceState(item.id, InterestState.followed);
+                      } else {
+                        _setTopicState(item.id, InterestState.unfollowed);
+                      }
+                    },
+                  ),
+                  const SizedBox(height: FacteurSpacing.space4),
+                ],
+
+                // Sources suivies non épinglées → 1 tap pour épingler.
+                if (followedSources.isNotEmpty) ...[
+                  _SectionLabel(label: 'SOURCES SUIVIES', colors: colors),
+                  const SizedBox(height: 8),
+                  for (final s in followedSources)
+                    _InterestRow(
+                      key: ValueKey('followed_${s.id}'),
+                      leading:
+                          SourceLogoAvatar(source: s, size: 28, radius: 6),
+                      label: s.name,
                       colors: colors,
-                      onTap: () => _setState(t.id, InterestState.unfollowed),
+                      onTap: () =>
+                          _setSourceState(s.id, InterestState.favorite),
                     ),
                   const SizedBox(height: FacteurSpacing.space4),
                 ],
 
-                // Sujets suivis non épinglés → groupés par thématique,
-                // 1 tap pour épingler.
-                if (pinnable.isNotEmpty) ...[
+                // Sujets suivis non épinglés → groupés par thématique.
+                if (pinnableTopics.isNotEmpty) ...[
                   _SectionLabel(
-                    label: 'ÉPINGLER UN SUJET SUIVI',
+                    label: 'SUJETS À ÉPINGLER',
                     colors: colors,
                   ),
                   const SizedBox(height: 8),
@@ -331,20 +495,23 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
                     ),
                     const SizedBox(height: 6),
                     for (final t in group.value)
-                      _SubjectRow(
+                      _InterestRow(
                         key: ValueKey('pinnable_${t.id}'),
+                        leading: Text(
+                          _themeEmoji(t.slugParent),
+                          style: const TextStyle(fontSize: 14),
+                        ),
                         label: t.topicName,
-                        emoji: _themeEmoji(t.slugParent),
-                        pinned: false,
                         colors: colors,
-                        onTap: () => _setState(t.id, InterestState.favorite),
+                        onTap: () =>
+                            _setTopicState(t.id, InterestState.favorite),
                       ),
                     const SizedBox(height: 10),
                   ],
                   const SizedBox(height: FacteurSpacing.space2),
                 ],
 
-                // Aucun sujet ne matche la recherche → proposer de le créer.
+                // Aucun élément ne matche la recherche → proposer de créer.
                 if (hasQuery && noMatch) ...[
                   _CreateSubjectTile(
                     query: _query.trim(),
@@ -358,8 +525,8 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
                   const SizedBox(height: FacteurSpacing.space4),
                 ],
 
-                // Aucun sujet du tout (et pas de recherche en cours).
-                if (!hasQuery && !hasAnyTopic) ...[
+                // Rien du tout (et pas de recherche en cours).
+                if (!hasQuery && !hasAnything) ...[
                   Text(
                     'Aucun sujet pour le moment. Crée ton premier sujet '
                     'à suivre ci-dessous.',
@@ -412,6 +579,96 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
   }
 }
 
+/// Liste réordonnable des éléments épinglés (sujets + sources interleaved).
+class _PinnedItemsList extends StatelessWidget {
+  final List<_PinnedItem> items;
+  final FacteurColors colors;
+  final void Function(int oldIndex, int newIndex) onReorder;
+  final void Function(_PinnedItem item) onUnpin;
+
+  const _PinnedItemsList({
+    required this.items,
+    required this.colors,
+    required this.onReorder,
+    required this.onUnpin,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ReorderableListView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      buildDefaultDragHandles: false,
+      itemCount: items.length,
+      onReorder: onReorder,
+      itemBuilder: (context, index) {
+        final item = items[index];
+        return Padding(
+          key: ValueKey(item.key),
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            decoration: BoxDecoration(
+              color: colors.primary.withValues(alpha: 0.06),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: colors.primary.withValues(alpha: 0.3)),
+            ),
+            child: Row(
+              children: [
+                if (item.isSource && item.source != null)
+                  SourceLogoAvatar(source: item.source!, size: 28, radius: 6)
+                else
+                  Text(item.emoji, style: const TextStyle(fontSize: 16)),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    item.label,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: colors.textPrimary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () {
+                    HapticFeedback.selectionClick();
+                    onUnpin(item);
+                  },
+                  child: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: Icon(
+                      PhosphorIcons.pushPin(PhosphorIconsStyle.fill),
+                      size: 16,
+                      color: colors.primary,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 4),
+                ReorderableDragStartListener(
+                  index: index,
+                  child: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: Icon(
+                      PhosphorIcons.dotsSixVertical(PhosphorIconsStyle.bold),
+                      size: 18,
+                      color: colors.textTertiary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
 class _SearchField extends StatelessWidget {
   final TextEditingController controller;
   final FacteurColors colors;
@@ -434,7 +691,7 @@ class _SearchField extends StatelessWidget {
       style: TextStyle(color: colors.textPrimary, fontSize: 14),
       decoration: InputDecoration(
         isDense: true,
-        hintText: 'Rechercher un sujet…',
+        hintText: 'Rechercher une source ou un sujet…',
         hintStyle: TextStyle(color: colors.textTertiary, fontSize: 14),
         prefixIcon: Icon(
           PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
@@ -588,18 +845,19 @@ class _SectionLabel extends StatelessWidget {
   }
 }
 
-class _SubjectRow extends StatelessWidget {
+/// Ligne tappable d'un élément suivi à épingler — un sujet (emoji en tête) ou
+/// une source ([SourceLogoAvatar] en tête). Le contenu de tête varie via
+/// [leading] ; le reste (libellé + icône « + ») est commun.
+class _InterestRow extends StatelessWidget {
+  final Widget leading;
   final String label;
-  final String emoji;
-  final bool pinned;
   final FacteurColors colors;
   final VoidCallback onTap;
 
-  const _SubjectRow({
+  const _InterestRow({
     super.key,
+    required this.leading,
     required this.label,
-    required this.emoji,
-    required this.pinned,
     required this.colors,
     required this.onTap,
   });
@@ -617,21 +875,15 @@ class _SubjectRow extends StatelessWidget {
             onTap();
           },
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
             decoration: BoxDecoration(
-              color: pinned
-                  ? colors.primary.withValues(alpha: 0.06)
-                  : colors.surface,
+              color: colors.surface,
               borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: pinned
-                    ? colors.primary.withValues(alpha: 0.3)
-                    : colors.border,
-              ),
+              border: Border.all(color: colors.border),
             ),
             child: Row(
               children: [
-                Text(emoji, style: const TextStyle(fontSize: 14)),
+                leading,
                 const SizedBox(width: 10),
                 Expanded(
                   child: Text(
@@ -647,11 +899,9 @@ class _SubjectRow extends StatelessWidget {
                 ),
                 const SizedBox(width: 10),
                 Icon(
-                  pinned
-                      ? PhosphorIcons.pushPin(PhosphorIconsStyle.fill)
-                      : PhosphorIcons.plus(PhosphorIconsStyle.bold),
+                  PhosphorIcons.plus(PhosphorIconsStyle.bold),
                   size: 16,
-                  color: pinned ? colors.primary : colors.textSecondary,
+                  color: colors.textSecondary,
                 ),
               ],
             ),

--- a/apps/mobile/lib/features/my_interests/models/user_interests_state.dart
+++ b/apps/mobile/lib/features/my_interests/models/user_interests_state.dart
@@ -45,7 +45,7 @@ extension InterestStateVisuals on InterestState {
   String get description {
     switch (this) {
       case InterestState.favorite:
-        return 'En haut de votre flux. Les 3 premiers sont dans la Tournée du jour.';
+        return 'Épingle dans Flâner + boostée dans toute l\'app.';
       case InterestState.followed:
         return 'Présent dans votre flux';
       case InterestState.unfollowed:

--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -565,7 +565,7 @@ class _SourceFavoritesSection extends StatelessWidget {
       items: favorites,
       keyOf: (r) => ValueKey('source:${r.sourceId}'),
       emptyStateText:
-          'Aucune source favorite — étoile une source pour la retrouver ici.',
+          'Aucune source favorite — marquez-en une pour l\'épingler dans Flâner.',
       padding: EdgeInsets.zero,
       itemBuilder: (context, refItem) {
         final source = byId[refItem.sourceId];
@@ -809,7 +809,7 @@ class _IntroBlock extends StatelessWidget {
           ),
           const SizedBox(height: 6),
           Text(
-            'Réglez les fréquences d\'apparitions de vos sources de 1 (occasionnellement) à 3 (tout voir), masquez celles qui ne vous parlent pas, et ajoutez plus de sources pour enrichir votre flux.',
+            'Passez une source en Favori pour l\'épingler dans Flâner et booster ses articles partout dans l\'app. Les 3 premiers favoris alimentent aussi votre Tournée du jour.',
             style: textTheme.bodySmall?.copyWith(
               color: colors.textSecondary,
               height: 1.45,

--- a/apps/mobile/test/features/feed/providers/tab_order_prefs_test.dart
+++ b/apps/mobile/test/features/feed/providers/tab_order_prefs_test.dart
@@ -1,0 +1,45 @@
+import 'package:facteur/features/feed/providers/tab_order_prefs_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('applyOrder', () {
+    String keyOf(String s) => s;
+
+    test('empty order → items unchanged', () {
+      final items = ['a', 'b', 'c'];
+      expect(applyOrder(items, const [], keyOf), ['a', 'b', 'c']);
+    });
+
+    test('reorders items according to order', () {
+      final items = ['a', 'b', 'c'];
+      expect(
+        applyOrder(items, const ['c', 'a', 'b'], keyOf),
+        ['c', 'a', 'b'],
+      );
+    });
+
+    test('items absent from order keep their relative position, at the end',
+        () {
+      final items = ['a', 'b', 'c', 'd'];
+      // Seuls c et a sont ordonnés → ils passent devant ; b et d (absents)
+      // suivent dans leur ordre d'origine.
+      expect(
+        applyOrder(items, const ['c', 'a'], keyOf),
+        ['c', 'a', 'b', 'd'],
+      );
+    });
+
+    test('order keys absent from items are ignored', () {
+      final items = ['a', 'b'];
+      expect(
+        applyOrder(items, const ['ghost', 'b', 'a'], keyOf),
+        ['b', 'a'],
+      );
+    });
+
+    test('key builders produce the expected prefixes', () {
+      expect(tabOrderTopicKey('t1'), 'topic:t1');
+      expect(tabOrderSourceKey('s1'), 'source:s1');
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
+++ b/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
@@ -8,8 +8,12 @@ import 'package:facteur/features/custom_topics/providers/custom_topics_provider.
 import 'package:facteur/features/feed/models/content_model.dart';
 import 'package:facteur/features/feed/widgets/favorite_topic_tabs.dart';
 import 'package:facteur/features/my_interests/models/user_interests_state.dart';
+import 'package:facteur/features/my_interests/models/user_sources_state.dart';
 import 'package:facteur/features/my_interests/providers/user_interests_provider.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
+
+Source _source({required String id, required String name}) =>
+    Source.fallback().copyWith(id: id, name: name);
 
 UserTopicProfile _topic({
   required String id,
@@ -186,6 +190,96 @@ void main() {
         tabs.firstWhere((t) => t.kind == FavoriteTabKind.tous).active,
         isFalse,
       );
+    });
+
+    test('source favorite → produces a source tab carrying its Source', () {
+      final src = _source(id: 's1', name: 'Le Monde');
+
+      final tabs = buildFavoriteTabModelsForTest(
+        topics: const [],
+        favorites: const [],
+        items: const [],
+        sourceFavorites: const [SourceFavoriteRef(sourceId: 's1', position: 0)],
+        sourceById: {'s1': src},
+      );
+
+      expect(tabs.map((t) => t.kind).toList(), [
+        FavoriteTabKind.tous,
+        FavoriteTabKind.source,
+      ]);
+      final sourceTab =
+          tabs.firstWhere((t) => t.kind == FavoriteTabKind.source);
+      expect(sourceTab.label, 'Le Monde');
+      expect(sourceTab.slug, 's1');
+      expect(sourceTab.source, isNotNull);
+    });
+
+    test('source favorite absent from catalog → skipped', () {
+      final tabs = buildFavoriteTabModelsForTest(
+        topics: const [],
+        favorites: const [],
+        items: const [],
+        sourceFavorites: const [
+          SourceFavoriteRef(sourceId: 'ghost', position: 0),
+        ],
+        sourceById: const {},
+      );
+
+      expect(tabs, hasLength(1));
+      expect(tabs.first.kind, FavoriteTabKind.tous);
+    });
+
+    test('selectedSourceId marks the matching source tab as active', () {
+      final src = _source(id: 's1', name: 'Le Monde');
+
+      final tabs = buildFavoriteTabModelsForTest(
+        topics: const [],
+        favorites: const [],
+        items: const [],
+        sourceFavorites: const [SourceFavoriteRef(sourceId: 's1', position: 0)],
+        sourceById: {'s1': src},
+        selectedSourceId: 's1',
+      );
+
+      expect(
+        tabs.firstWhere((t) => t.kind == FavoriteTabKind.source).active,
+        isTrue,
+      );
+    });
+
+    test('unified order interleaves topic and source tabs', () {
+      final topics = [_topic(id: 't1', name: 'IA', slugParent: 'ai')];
+      final src = _source(id: 's1', name: 'Le Monde');
+
+      // Sans ordre custom : tri par count (0) puis alpha → 'ia' < 'le monde'
+      // donc le sujet d'abord.
+      final defaultTabs = buildFavoriteTabModelsForTest(
+        topics: topics,
+        favorites: const [CustomTopicFavoriteRef(id: 't1')],
+        items: const [],
+        sourceFavorites: const [SourceFavoriteRef(sourceId: 's1', position: 0)],
+        sourceById: {'s1': src},
+      );
+      expect(defaultTabs.map((t) => t.kind).toList(), [
+        FavoriteTabKind.tous,
+        FavoriteTabKind.subjectTopic,
+        FavoriteTabKind.source,
+      ]);
+
+      // Avec ordre custom plaçant la source avant le sujet.
+      final orderedTabs = buildFavoriteTabModelsForTest(
+        topics: topics,
+        favorites: const [CustomTopicFavoriteRef(id: 't1')],
+        items: const [],
+        sourceFavorites: const [SourceFavoriteRef(sourceId: 's1', position: 0)],
+        sourceById: {'s1': src},
+        order: const ['source:s1', 'topic:t1'],
+      );
+      expect(orderedTabs.map((t) => t.kind).toList(), [
+        FavoriteTabKind.tous,
+        FavoriteTabKind.source,
+        FavoriteTabKind.subjectTopic,
+      ]);
     });
   });
 

--- a/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
+++ b/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
@@ -105,7 +105,10 @@ void main() {
       await tester.pumpWidget(_host(st, const PinSubjectsBanner()));
       await tester.pumpAndSettle();
 
-      expect(find.text('Épingle tes sujets'), findsOneWidget);
+      expect(
+        find.text('Épinglez des sources ou sujets précis'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('hidden when 3 or more subjects are pinned', (tester) async {
@@ -146,7 +149,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Le sujet suivi est proposé à l'épinglage.
-      expect(find.text('ÉPINGLER UN SUJET SUIVI'), findsOneWidget);
+      expect(find.text('SUJETS À ÉPINGLER'), findsOneWidget);
       expect(find.text('Climat'), findsOneWidget);
 
       await tester.tap(find.text('Climat'));
@@ -155,8 +158,8 @@ void main() {
       expect(notifier.calls, hasLength(1));
       expect(notifier.calls.first.$1, const CustomTopicFavoriteRef(id: 't1'));
       expect(notifier.calls.first.$2, InterestState.favorite);
-      // Après épinglage il bascule dans la section « SUJETS ÉPINGLÉS ».
-      expect(find.text('SUJETS ÉPINGLÉS'), findsOneWidget);
+      // Après épinglage il bascule dans la section « ÉPINGLÉS ».
+      expect(find.text('ÉPINGLÉS'), findsOneWidget);
     });
 
     testWidgets('search filters the followed subjects', (tester) async {


### PR DESCRIPTION
## Quoi
Refonte de la modal « Épingler » de Flâner en une **modal unifiée sources + sujets** :
- Les **sources épinglées** deviennent des onglets Flâner (logo + nom), aux côtés des sujets, **mélangés** selon un ordre unifié choisi par l'utilisateur.
- Section **ÉPINGLÉS** réordonnable par drag (sujets ↔ sources interleaved), **SOURCES SUIVIES** et **SUJETS À ÉPINGLER** ; la recherche couvre sources + sujets.
- Nouveau provider `tabOrderPrefsProvider` (SharedPreferences `pinned_tabs_order_v1`) + helper générique `applyOrder` pour appliquer l'ordre unifié, avec fallback stable pour les items pas encore réordonnés.
- Sync **best-effort et parallèle** des positions serveur (sujets via `userInterestsProvider`, sources via `userSourcesStateProvider`) pour garder « Mes intérêts » / « Mes sources » cohérentes.
- Copies (sources, intérêts) alignées sur la promesse d'épinglage Flâner.

## Pourquoi
Sources et sujets étaient deux systèmes de favoris séparés. Cette PR les unifie côté UI pour que l'utilisateur épingle et réordonne ses onglets Flâner d'un seul endroit, sans refonte backend (les `position` serveur restent la source de vérité par type ; l'ordre interleaved vit en prefs locales).

## Comment ça a été vérifié
- [x] `flutter test` ciblé : `tab_order_prefs_test`, `favorite_topic_tabs_test`, `pin_subjects_sheet_test` → **22/22 OK** (couvre onglet source, skip source hors catalogue, `selectedSourceId`, ordre interleaved, dé-épinglage, persistance).
- [x] `flutter analyze` sur les fichiers modifiés → **0 nouvelle issue** (infos pré-existantes `withOpacity`/`const` hors périmètre).
- [x] Suite complète `flutter test` : **783 OK / 45 échecs pré-existants** confirmés par baseline (stash → run) — failures identiques avec/sans ce diff (Hive/Supabase non init), aucun nouveau régression.
- [x] `/simplify` passé : fusion `_SubjectRow`+`_SourceRow` → `_InterestRow` (~70 lignes dédupliquées), parallélisation des deux syncs serveur dans `_persistReorder`.

## Zones à risque
- **Ordre unifié client-only** (SharedPreferences) : ne sync pas cross-device et peut diverger des `position` serveur ; `_persistReorder` réconcilie en best-effort. Choix pragmatique borné (pas de refonte backend dans une PR mobile).
- **Onglets source `count: 0`** : pas de compteur serveur par source pour l'instant (pas de badge) — limitation documentée, pas de fragilité cachée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)