### PR TITLE
feat(veille): curation par score v2 + UX (Story 23.4)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -815,30 +815,54 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   List<FavoriteRef> _pickFavorites(List<TopTheme> topFallback) {
     final favorites =
         ref.read(userInterestsProvider).valueOrNull?.favorites ?? const [];
-    if (favorites.isNotEmpty) {
-      return favorites.take(_kMaxFavoriteSections).toList(growable: false);
+
+    // Story 23.4 — la veille a un **slot dédié hors cap** : on la sépare des
+    // favoris thème/sujet (cap = [_kMaxFavoriteSections]) puis on l'ajoute en
+    // plus, pour qu'elle ne soit jamais coupée par le `.take(3)` (bug : favori
+    // veille en position 3 → invisible).
+    VeilleFavoriteRef? veilleRef;
+    final nonVeille = <FavoriteRef>[];
+    for (final f in favorites) {
+      if (f is VeilleFavoriteRef) {
+        veilleRef ??= f;
+      } else {
+        nonVeille.add(f);
+      }
     }
-    final valid = topFallback
-        .where((t) => themeMap.containsKey(t.interestSlug))
-        .map<FavoriteRef>((t) => ThemeFavoriteRef(slug: t.interestSlug))
-        .toList();
-    if (valid.length >= _kMaxFavoriteSections) {
-      return valid.take(_kMaxFavoriteSections).toList(growable: false);
+    // Toujours rendre la veille quand une config est active, même si le favori
+    // n'est pas (encore) dans la liste (favori orphelin / self-heal en cours).
+    final activeCfg = ref.read(veilleActiveConfigProvider).valueOrNull;
+    if (veilleRef == null && activeCfg != null) {
+      veilleRef = VeilleFavoriteRef(id: activeCfg.id);
     }
-    // Pad with canonical macro themes the user is missing — order: tech,
-    // environment, science (matches the backend backfill list).
-    const canonical = [fallbackTheme1, fallbackTheme2, 'science'];
-    final present = valid
-        .whereType<ThemeFavoriteRef>()
-        .map((r) => r.slug)
-        .toSet();
-    for (final slug in canonical) {
-      if (valid.length >= _kMaxFavoriteSections) break;
-      if (present.contains(slug)) continue;
-      valid.add(ThemeFavoriteRef(slug: slug));
-      present.add(slug);
+
+    final List<FavoriteRef> themeRefs;
+    if (nonVeille.isNotEmpty) {
+      themeRefs = nonVeille.take(_kMaxFavoriteSections).toList(growable: false);
+    } else {
+      // Fallback fresh accounts : top-themes pondérés puis macro canoniques.
+      final valid = topFallback
+          .where((t) => themeMap.containsKey(t.interestSlug))
+          .map<FavoriteRef>((t) => ThemeFavoriteRef(slug: t.interestSlug))
+          .toList();
+      // Pad with canonical macro themes the user is missing — order: tech,
+      // environment, science (matches the backend backfill list).
+      const canonical = [fallbackTheme1, fallbackTheme2, 'science'];
+      final present =
+          valid.whereType<ThemeFavoriteRef>().map((r) => r.slug).toSet();
+      for (final slug in canonical) {
+        if (valid.length >= _kMaxFavoriteSections) break;
+        if (present.contains(slug)) continue;
+        valid.add(ThemeFavoriteRef(slug: slug));
+        present.add(slug);
+      }
+      themeRefs = valid.take(_kMaxFavoriteSections).toList(growable: false);
     }
-    return valid.take(_kMaxFavoriteSections).toList(growable: false);
+
+    return [
+      ...themeRefs,
+      if (veilleRef != null) veilleRef,
+    ];
   }
 
   /// Fetches one FeedResponse per favorite ref in parallel and turns them
@@ -923,15 +947,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   /// dérivé du `theme_label` de la `VeilleConfig` active (résolu via
   /// `veilleActiveConfigProvider`). Story 23.2 PR-4.
   FeedThemeSection? _buildVeilleSection(FeedResponse? feed) {
-    final items = feed?.items ?? const <Content>[];
-    if (items.length < 2) return null;
     final activeCfg = ref.read(veilleActiveConfigProvider).valueOrNull;
-    final label = activeCfg == null
-        ? 'Ma veille'
-        : 'Ma veille — ${activeCfg.themeLabel}';
+    // Story 23.4 — section veille **toujours visible** quand une config est
+    // active, même avec 0/1 article (état vide rendu par SectionBlock). On ne
+    // la coupe plus sur un seuil min d'items ; `null` seulement sans config.
+    if (activeCfg == null) return null;
+    final items = feed?.items ?? const <Content>[];
     return FeedThemeSection(
       kind: SectionKind.veille,
-      label: label,
+      label: 'Ma veille — ${activeCfg.themeLabel}',
       blurb: 'Les derniers articles de ta veille personnalisée.',
       accent: _kVeilleAccent,
       illustrationAsset: _kVeilleIllustration,

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -800,6 +800,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
               },
               onTapFavorite:
                   isFavorite ? () => showMyInterestsBottomSheet(context) : null,
+              // Story 23.4 — bouton réglages (tune) sur la section veille →
+              // ouvre la config en édition. Réutilisé par le CTA d'état vide.
+              onTapSettings: section.kind == SectionKind.veille
+                  ? () => context.push('${RoutePaths.veilleConfig}?mode=edit')
+                  : null,
               onSeeAll: section is FeedThemeSection
                   ? () => _openThemeSection(context, section)
                   : section is DigestTopicSection

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -26,6 +26,12 @@ class SectionBanner extends StatelessWidget {
   /// sections (theme1 / theme2) wire this up.
   final VoidCallback? onTapFavorite;
 
+  /// Story 23.4 — optional settings affordance (top-right tune button). Only
+  /// wired for the veille section → opens the veille config in edit mode. As
+  /// an independent hit target it sits **outside** the `IgnorePointer`s so it
+  /// captures taps before the banner's fold InkWell.
+  final VoidCallback? onTapSettings;
+
   /// When true, the banner renders in a larger "page hero" variant (bigger
   /// title / blurb / illustration and a taller floor). Used by the dedicated
   /// Flâner page to distinguish it from the inline thematic banners. Default
@@ -40,6 +46,7 @@ class SectionBanner extends StatelessWidget {
     this.illustrationAsset,
     this.onTapFold,
     this.onTapFavorite,
+    this.onTapSettings,
     this.large = false,
   });
 
@@ -102,13 +109,26 @@ class SectionBanner extends StatelessWidget {
           if (onTapFold != null)
             Positioned(
               top: 12,
-              right: 12,
+              // Décalé à gauche du bouton réglages quand celui-ci est présent.
+              right: onTapSettings != null ? 46 : 12,
               child: IgnorePointer(
                 child: Icon(
                   Icons.expand_less,
                   size: 16,
                   color: colors.textPrimary.withValues(alpha: 0.45),
                 ),
+              ),
+            ),
+          // Bouton réglages (veille) — hors IgnorePointer pour rester tappable
+          // indépendamment du fold de la bannière.
+          if (onTapSettings != null)
+            Positioned(
+              top: 8,
+              right: 10,
+              child: _SettingsButton(
+                color: colors.textSecondary,
+                border: colors.border,
+                onTap: onTapSettings!,
               ),
             ),
           Padding(
@@ -212,6 +232,46 @@ class SectionBanner extends StatelessWidget {
         splashColor: accent.withValues(alpha: 0.08),
         highlightColor: accent.withValues(alpha: 0.04),
         child: container,
+      ),
+    );
+  }
+}
+
+/// Story 23.4 — bouton réglages 26×26 (tune), calqué sur le `_PersonalizeButton`
+/// de l'Essentiel. Ouvre la config veille en édition.
+class _SettingsButton extends StatelessWidget {
+  final Color color;
+  final Color border;
+  final VoidCallback onTap;
+  const _SettingsButton({
+    required this.color,
+    required this.border,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(FacteurRadius.full),
+        child: Container(
+          width: 26,
+          height: 26,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: Colors.white.withValues(alpha: 0.6),
+            shape: BoxShape.circle,
+            border: Border.all(color: border, width: 0.8),
+          ),
+          child: Icon(
+            Icons.tune_rounded,
+            size: 13,
+            color: color,
+            semanticLabel: 'Réglages de ma veille',
+          ),
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -64,6 +64,10 @@ class SectionBlock extends StatelessWidget {
   /// null on system sections (`essentiel` / `bonnes`).
   final VoidCallback? onTapFavorite;
 
+  /// Story 23.4 — settings affordance (tune button + empty-state CTA). Only
+  /// wired for the veille section → opens the veille config in edit mode.
+  final VoidCallback? onTapSettings;
+
   const SectionBlock({
     super.key,
     required this.section,
@@ -81,6 +85,7 @@ class SectionBlock extends StatelessWidget {
     this.enableSwipeHintOnFirstCard = false,
     this.onSwipeHintComplete,
     this.onTapFavorite,
+    this.onTapSettings,
     this.onSeeAll,
     this.onTapExploreAll,
     this.onTapSeeAllDown,
@@ -137,6 +142,7 @@ class SectionBlock extends StatelessWidget {
           illustrationAsset: section.illustrationAsset,
           onTapFold: onFold,
           onTapFavorite: onTapFavorite,
+          onTapSettings: onTapSettings,
         ),
         ...cards,
         _SectionFooterRow(
@@ -230,6 +236,11 @@ class SectionBlock extends StatelessWidget {
               ),
         ];
       case FeedThemeSection(:final items, :final coreVisibleCount):
+        // Story 23.4 — la section veille reste visible même vide : on rend un
+        // placeholder + CTA réglages au lieu de cartes.
+        if (items.isEmpty && section.kind == SectionKind.veille) {
+          return [_VeilleEmptyState(onTapSettings: onTapSettings)];
+        }
         final visible = items.take(coreVisibleCount).toList();
         return [
           for (var i = 0; i < visible.length; i++)
@@ -250,6 +261,55 @@ class SectionBlock extends StatelessWidget {
               ),
         ];
     }
+  }
+}
+
+/// Story 23.4 — état vide de la section veille (config active mais 0 article).
+/// Garde la section visible et propose un CTA réglages.
+class _VeilleEmptyState extends StatelessWidget {
+  final VoidCallback? onTapSettings;
+  const _VeilleEmptyState({this.onTapSettings});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(12, 0, 12, 4),
+      padding: const EdgeInsets.fromLTRB(16, 18, 16, 14),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFFE6E1D6)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Aucun nouvel article pour ta veille pour l\'instant.',
+            style: TextStyle(
+              fontSize: 14,
+              height: 1.4,
+              color: Color(0xFF5D5B5A),
+            ),
+          ),
+          if (onTapSettings != null) ...[
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed: onTapSettings,
+                icon: const Icon(Icons.tune_rounded, size: 16),
+                label: const Text('Régler ma veille'),
+                style: TextButton.styleFrom(
+                  foregroundColor: const Color(0xFF2C3E50),
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  minimumSize: const Size(0, 36),
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
   }
 }
 

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../onboarding/data/available_subtopics.dart';
 import '../../my_interests/providers/user_interests_provider.dart';
 import '../models/veille_config.dart';
 import '../models/veille_config_dto.dart';
@@ -55,6 +56,15 @@ class VeilleConfigState {
   final String? previewPresetId;
 
   final String? selectedTheme;
+
+  /// Story 23.4 — sujet principal **obligatoire** (drill macro→granulaire en
+  /// Step 1). Slug canonique (`AvailableSubtopics`, ex. `ai`) qui matche
+  /// `Content.topics` côté scoring. Émis en position 0 (`kind:'preset'`) à
+  /// l'upsert ; devient le gate principal de la curation. Null pour le thème
+  /// "Autre" (chemin free-text/mots-clés).
+  final String? mainTopicSlug;
+  final String? mainTopicLabel;
+
   final Set<String> selectedTopics;
   final Set<String> selectedSuggestions;
 
@@ -115,6 +125,8 @@ class VeilleConfigState {
     required this.introCompleted,
     required this.previewPresetId,
     required this.selectedTheme,
+    required this.mainTopicSlug,
+    required this.mainTopicLabel,
     required this.selectedTopics,
     required this.selectedSuggestions,
     required this.selectedSourceIds,
@@ -138,6 +150,8 @@ class VeilleConfigState {
         introCompleted: false,
         previewPresetId: null,
         selectedTheme: null,
+        mainTopicSlug: null,
+        mainTopicLabel: null,
         selectedTopics: <String>{},
         selectedSuggestions: <String>{},
         selectedSourceIds: <String>{},
@@ -167,6 +181,8 @@ class VeilleConfigState {
     bool? introCompleted,
     Object? previewPresetId = _Sentinel.value,
     Object? selectedTheme = _Sentinel.value,
+    Object? mainTopicSlug = _Sentinel.value,
+    Object? mainTopicLabel = _Sentinel.value,
     Set<String>? selectedTopics,
     Set<String>? selectedSuggestions,
     Set<String>? selectedSourceIds,
@@ -193,6 +209,12 @@ class VeilleConfigState {
         selectedTheme: selectedTheme == _Sentinel.value
             ? this.selectedTheme
             : selectedTheme as String?,
+        mainTopicSlug: mainTopicSlug == _Sentinel.value
+            ? this.mainTopicSlug
+            : mainTopicSlug as String?,
+        mainTopicLabel: mainTopicLabel == _Sentinel.value
+            ? this.mainTopicLabel
+            : mainTopicLabel as String?,
         selectedTopics: selectedTopics ?? this.selectedTopics,
         selectedSuggestions: selectedSuggestions ?? this.selectedSuggestions,
         selectedSourceIds: selectedSourceIds ?? this.selectedSourceIds,
@@ -244,14 +266,33 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
 
   void selectTheme(String id) {
     // Changer de thème reset les topics pré-sélectionnés (les preset topics
-    // dépendent du thème). Les customTopics, eux, persistent (le user les
-    // a saisis manuellement).
+    // dépendent du thème) ET le sujet principal granulaire (Story 23.4 — la
+    // grille granulaire dépend du macro). Les customTopics persistent.
     if (state.selectedTheme == id) return;
     state = state.copyWith(
       selectedTheme: id,
+      mainTopicSlug: null,
+      mainTopicLabel: null,
       selectedTopics: const {},
       // Reset customThemeLabel quand on quitte 'other'.
       customThemeLabel: id == kVeilleOtherThemeSlug ? state.customThemeLabel : null,
+    );
+  }
+
+  /// Story 23.4 — sélectionne le sujet principal granulaire (gate obligatoire).
+  /// `slug` est canonique (`AvailableSubtopics`, ex. `ai`) → matche
+  /// `Content.topics`. Re-tap sur le même sujet le désélectionne.
+  void selectMainTopic(String slug, String label) {
+    if (state.mainTopicSlug == slug) {
+      state = state.copyWith(mainTopicSlug: null, mainTopicLabel: null);
+      return;
+    }
+    final nextLabels = Map<String, String>.from(state.topicLabels)
+      ..[slug] = label;
+    state = state.copyWith(
+      mainTopicSlug: slug,
+      mainTopicLabel: label,
+      topicLabels: nextLabels,
     );
   }
 
@@ -332,6 +373,16 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
   }
 
   static String _slugifyCustom(String input) => 'custom-${_slugifyBase(input)}';
+
+  /// Mapping inverse granulaire→macro (Story 23.4). Le macro est stocké dans
+  /// `VeilleConfig.theme_id`, mais en fallback (configs legacy / theme_id non
+  /// canonique) on retrouve le macro qui contient ce sujet granulaire.
+  static String? _macroForSubtopic(String slug) {
+    for (final entry in AvailableSubtopics.byTheme.entries) {
+      if (entry.value.any((o) => o.slug == slug)) return entry.key;
+    }
+    return null;
+  }
 
   /// Slug d'un angle LLM (préfixe dédié `angle-`) — distinct des sujets custom
   /// (`custom-`) pour ne pas collisionner dans `topicLabels`/`angleKeywords`.
@@ -643,9 +694,20 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     final customTopics = <VeilleTopic>[];
     final topicLabels = <String, String>{};
     final angleKeywords = <String, List<String>>{};
-    for (final t in cfg.topics) {
+    // Story 23.4 — le topic position-0 'preset' est le sujet principal :
+    // restauré séparément (gate Step 1, grille granulaire), jamais comme
+    // topic optionnel (sinon doublon à l'upsert).
+    String? mainSlug;
+    String? mainLabel;
+    for (var i = 0; i < cfg.topics.length; i++) {
+      final t = cfg.topics[i];
       topicLabels[t.topicId] = t.label;
       if (t.keywords.isNotEmpty) angleKeywords[t.topicId] = t.keywords;
+      if (i == 0 && t.kind == 'preset' && mainSlug == null) {
+        mainSlug = t.topicId;
+        mainLabel = t.label;
+        continue;
+      }
       switch (t.kind) {
         case 'custom':
           customTopics.add(
@@ -662,6 +724,12 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
           selectedTopics.add(t.topicId);
       }
     }
+
+    // Macro : on privilégie le `theme_id` stocké ; fallback inverse-map si
+    // ce n'est pas un macro canonique (legacy).
+    final macro = AvailableSubtopics.byTheme.containsKey(cfg.themeId)
+        ? cfg.themeId
+        : (mainSlug != null ? _macroForSubtopic(mainSlug) : null) ?? cfg.themeId;
 
     final selectedSourceIds = <String>{};
     final sourcesMeta = <String, VeilleSourceMeta>{};
@@ -682,7 +750,9 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     state = state.copyWith(
       step: 1,
       introCompleted: true,
-      selectedTheme: cfg.themeId,
+      selectedTheme: macro,
+      mainTopicSlug: mainSlug,
+      mainTopicLabel: mainLabel,
       selectedTopics: selectedTopics,
       selectedSuggestions: selectedSuggestions,
       customTopics: customTopics,
@@ -719,7 +789,24 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
 
     final topics = <VeilleTopicSelectionRequest>[];
     var pos = 0;
+    // Story 23.4 — le sujet principal granulaire est émis en **position 0**
+    // (`kind:'preset'`, slug canonique → matche `Content.topics`, gate
+    // principal de la curation). Garantit ≥1 topic à l'upsert.
+    final mainSlug = s.mainTopicSlug;
+    final hasMain = mainSlug != null && mainSlug.isNotEmpty;
+    if (hasMain) {
+      topics.add(
+        VeilleTopicSelectionRequest(
+          topicId: mainSlug,
+          label: s.mainTopicLabel ?? s.topicLabels[mainSlug] ?? mainSlug,
+          kind: 'preset',
+          position: pos++,
+          keywords: s.angleKeywords[mainSlug] ?? const <String>[],
+        ),
+      );
+    }
     for (final slug in s.selectedTopics) {
+      if (hasMain && slug == mainSlug) continue; // déjà émis en position 0
       topics.add(
         VeilleTopicSelectionRequest(
           topicId: slug,
@@ -731,6 +818,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       );
     }
     for (final slug in s.selectedSuggestions) {
+      if (hasMain && slug == mainSlug) continue;
       topics.add(
         VeilleTopicSelectionRequest(
           topicId: slug,

--- a/apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart
@@ -4,6 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../../config/theme.dart';
+import '../../../onboarding/data/available_subtopics.dart';
 import '../../models/veille_config.dart';
 import '../../providers/veille_config_provider.dart';
 import '../../providers/veille_presets_provider.dart';
@@ -34,7 +35,18 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
     final hasTheme = state.selectedTheme != null;
     final isOther = state.selectedTheme == kVeilleOtherThemeSlug;
     final customLabelOk = !isOther || (state.customThemeLabel ?? '').trim().isNotEmpty;
-    final canContinue = hasTheme && customLabelOk;
+    // Story 23.4 — sujets granulaires du macro choisi (drill macro→topic).
+    final subtopics = (hasTheme && !isOther)
+        ? (AvailableSubtopics.byTheme[state.selectedTheme] ?? const [])
+        : const <SubtopicOption>[];
+    // Le sujet principal granulaire est le gate obligatoire. Exceptions : thème
+    // "Autre" (chemin free-text) et macro sans sous-thèmes connus (rare) — dans
+    // ces cas le user peut continuer sans granulaire.
+    final needsMainTopic = hasTheme && !isOther && subtopics.isNotEmpty;
+    final hasMainTopic = state.mainTopicSlug != null ||
+        state.selectedTopics.isNotEmpty; // presets : topics déjà choisis
+    final canContinue =
+        hasTheme && customLabelOk && (!needsMainTopic || hasMainTopic);
 
     final selectedThemeLabel = state.selectedTheme == null
         ? ''
@@ -109,6 +121,14 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
                   _OtherThemeLabelField(
                     initial: state.customThemeLabel ?? '',
                     onChanged: notifier.setCustomThemeLabel,
+                  ),
+                ],
+                if (subtopics.isNotEmpty) ...[
+                  const SizedBox(height: 18),
+                  _SubtopicGrid(
+                    subtopics: subtopics,
+                    selected: state.mainTopicSlug,
+                    onSelect: (o) => notifier.selectMainTopic(o.slug, o.label),
                   ),
                 ],
                 const SizedBox(height: 18),
@@ -210,6 +230,72 @@ class _ThemeGrid extends StatelessWidget {
             selected: selected == t.id,
             onTap: () => onSelect(t.id),
           ),
+      ],
+    );
+  }
+}
+
+/// Story 23.4 — 2ᵉ grille (granulaire) révélée après le choix du macro :
+/// l'utilisateur fixe le **sujet principal** qui gate la curation (slug
+/// canonique). Réutilise le visuel `ThemeCard`.
+class _SubtopicGrid extends StatelessWidget {
+  final List<SubtopicOption> subtopics;
+  final String? selected;
+  final ValueChanged<SubtopicOption> onSelect;
+  const _SubtopicGrid({
+    required this.subtopics,
+    required this.selected,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Quel sujet précis veux-tu suivre ?',
+          style: GoogleFonts.dmSans(
+            fontSize: 15,
+            fontWeight: FontWeight.w700,
+            height: 1.3,
+            color: const Color(0xFF2C2A29),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'On cible ta veille sur ce sujet — tu pourras ajouter des angles à '
+          'l\'étape suivante.',
+          style: GoogleFonts.dmSans(
+            fontSize: 13,
+            height: 1.45,
+            color: const Color(0xFF5D5B5A),
+          ),
+        ),
+        const SizedBox(height: 12),
+        GridView.count(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          crossAxisCount: 2,
+          mainAxisSpacing: 8,
+          crossAxisSpacing: 8,
+          childAspectRatio: 1.55,
+          children: [
+            for (final o in subtopics)
+              ThemeCard(
+                theme: VeilleTheme(
+                  id: o.slug,
+                  label: o.label,
+                  meta: '',
+                  iconKey: '',
+                  emoji: o.emoji,
+                  hot: o.isPopular,
+                ),
+                selected: selected == o.slug,
+                onTap: () => onSelect(o),
+              ),
+          ],
+        ),
       ],
     );
   }

--- a/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
@@ -48,10 +48,12 @@ class Step2SuggestionsScreen extends ConsumerWidget {
             )),
           );
 
-    // Un angle LLM sélectionné suffit à passer à l'étape suivante (les angles
-    // vivent dans `selectedSuggestions`, distincts des preset topics).
-    final hasSelection =
-        state.selectedTopics.isNotEmpty || state.selectedSuggestions.isNotEmpty;
+    // Story 23.4 — le sujet principal du Step 1 satisfait déjà l'upsert (≥1
+    // topic garanti), donc la CTA n'est plus gatée par une sélection
+    // supplémentaire : angles et preset topics deviennent optionnels.
+    final hasSelection = state.mainTopicSlug != null ||
+        state.selectedTopics.isNotEmpty ||
+        state.selectedSuggestions.isNotEmpty;
 
     return Column(
       children: [
@@ -67,17 +69,28 @@ class Step2SuggestionsScreen extends ConsumerWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const VeilleFlowH1('Quels sujets veux-tu suivre ?'),
+                const VeilleFlowH1('Affine ta veille'),
                 const SizedBox(height: 8),
                 Text(
-                  'Coche les sujets qui t\'intéressent dans ce thème. Tu peux '
-                  'aussi en ajouter un sur-mesure, ou passer cette étape.',
+                  state.mainTopicSlug != null
+                      ? 'Ton sujet principal est fixé. Ajoute des angles ou des '
+                          'sujets pour préciser — ou passe directement à la suite.'
+                      : 'Coche les sujets qui t\'intéressent dans ce thème. Tu '
+                          'peux aussi en ajouter un sur-mesure, ou passer cette étape.',
                   style: GoogleFonts.dmSans(
                     fontSize: 13,
                     color: const Color(0xFF5D5B5A),
                     height: 1.45,
                   ),
                 ),
+                if (state.mainTopicSlug != null) ...[
+                  const SizedBox(height: 16),
+                  _MainTopicChip(
+                    label: state.mainTopicLabel ??
+                        state.topicLabels[state.mainTopicSlug!] ??
+                        state.mainTopicSlug!,
+                  ),
+                ],
                 const SizedBox(height: 22),
                 _AnglesSection(
                   anglesAsync: anglesAsync,
@@ -142,6 +155,57 @@ class _SkipButton extends StatelessWidget {
           fontWeight: FontWeight.w600,
           color: FacteurColors.veille,
         ),
+      ),
+    );
+  }
+}
+
+/// Story 23.4 — chip non-supprimable du sujet principal (fixé en Step 1).
+/// Évite le double-ask et signale que ce sujet gate déjà la veille.
+class _MainTopicChip extends StatelessWidget {
+  final String label;
+  const _MainTopicChip({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 10, 14, 12),
+      decoration: BoxDecoration(
+        color: FacteurColors.veilleTint,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FacteurColors.veille, width: 1.2),
+      ),
+      child: Row(
+        children: [
+          Icon(PhosphorIcons.pushPin(PhosphorIconsStyle.fill),
+              size: 16, color: FacteurColors.veille),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'SUJET PRINCIPAL',
+                  style: GoogleFonts.courierPrime(
+                    fontSize: 9,
+                    letterSpacing: 0.4,
+                    fontWeight: FontWeight.w700,
+                    color: FacteurColors.veille,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  label,
+                  style: GoogleFonts.dmSans(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: const Color(0xFF2C2A29),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../providers/veille_active_config_provider.dart';
 import '../providers/veille_config_provider.dart';
 import '../repositories/veille_repository.dart';
+import '../widgets/veille_widgets.dart';
 import 'steps/step1_5_preset_preview_screen.dart';
 import 'steps/step1_theme_screen.dart';
 import 'steps/step2_suggestions_screen.dart';
@@ -42,10 +44,12 @@ class VeilleConfigScreen extends ConsumerWidget {
         if (context.mounted) context.go(RoutePaths.fluxContinu);
       });
     } else if (editMode &&
+        !activeConfig.isLoading &&
         activeCfgValue != null &&
         state.selectedTheme == null) {
-      // Mode édition : hydrate l'état une fois depuis la config active.
-      // Idempotent côté notifier (no-op si selectedTheme déjà set).
+      // Mode édition : hydrate l'état une fois depuis la config active, mais
+      // seulement quand le chargement est terminé (Story 23.4 — sinon flash
+      // d'un Step 1 vide). Idempotent côté notifier (no-op si selectedTheme set).
       WidgetsBinding.instance.addPostFrameCallback((_) {
         notifier.hydrateFromActiveConfig(activeCfgValue);
       });
@@ -91,7 +95,26 @@ class VeilleConfigScreen extends ConsumerWidget {
 
     Widget body;
     String key;
-    if (!editMode &&
+    if (editMode && state.selectedTheme == null && activeConfig.isLoading) {
+      // Mode édition : on charge la config active — scaffold de chargement au
+      // lieu d'un flash de Step 1 vide (Story 23.4).
+      body = Column(
+        children: [
+          VeilleStepHeader(step: 1, canGoBack: false, onClose: close),
+          const Expanded(child: VeilleStepSkeleton()),
+        ],
+      );
+      key = 'edit-loading';
+    } else if (editMode &&
+        state.selectedTheme == null &&
+        activeConfig.hasError) {
+      // GET /config a échoué en édition → écran erreur + retry.
+      body = _EditLoadError(
+        onClose: close,
+        onRetry: () => ref.invalidate(veilleActiveConfigProvider),
+      );
+      key = 'edit-error';
+    } else if (!editMode &&
         !state.introCompleted &&
         activeCfgValue == null &&
         !activeConfig.isLoading) {
@@ -137,6 +160,60 @@ class VeilleConfigScreen extends ConsumerWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Story 23.4 — écran d'erreur (mode édition) quand `GET /config` échoue.
+class _EditLoadError extends StatelessWidget {
+  final VoidCallback onClose;
+  final VoidCallback onRetry;
+  const _EditLoadError({required this.onClose, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        VeilleStepHeader(step: 1, canGoBack: false, onClose: onClose),
+        Expanded(
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.cloud_off_rounded,
+                      size: 40, color: Color(0xFF8B7E63)),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Impossible de charger ta veille',
+                    textAlign: TextAlign.center,
+                    style: GoogleFonts.fraunces(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
+                      color: const Color(0xFF2C2A29),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Vérifie ta connexion et réessaie.',
+                    textAlign: TextAlign.center,
+                    style: GoogleFonts.dmSans(
+                      fontSize: 13,
+                      color: const Color(0xFF5D5B5A),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  VeilleCtaButton(
+                    label: 'Réessayer',
+                    onPressed: onRetry,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/features/veille/widgets/veille_widgets.dart
+++ b/apps/mobile/lib/features/veille/widgets/veille_widgets.dart
@@ -726,3 +726,54 @@ class _VeilleStyledTextFieldState extends State<_VeilleStyledTextField> {
     );
   }
 }
+
+/// ===== Step skeleton (loading) =====
+/// Story 23.4 — placeholder de chargement affiché en mode édition pendant que
+/// `veilleActiveConfigProvider` charge (évite le flash d'un Step 1 vide).
+/// Extrait du `_ThemeGridSkeleton` de Step 1, généralisé pour servir de
+/// scaffold de chargement plein écran.
+class VeilleStepSkeleton extends StatelessWidget {
+  const VeilleStepSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    Widget bar(double w, double h) => Container(
+          width: w,
+          height: h,
+          decoration: BoxDecoration(
+            color: const Color(0xFFF5F0E5),
+            borderRadius: BorderRadius.circular(8),
+          ),
+        );
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 28, 20, 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          bar(180, 14),
+          const SizedBox(height: 10),
+          bar(240, 14),
+          const SizedBox(height: 28),
+          GridView.count(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            crossAxisCount: 2,
+            mainAxisSpacing: 8,
+            crossAxisSpacing: 8,
+            childAspectRatio: 1.55,
+            children: List.generate(
+              6,
+              (_) => DecoratedBox(
+                decoration: BoxDecoration(
+                  color: const Color(0xFFF5F0E5),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
@@ -248,4 +248,91 @@ void main() {
     final json = topic.toJson();
     expect(json['keywords'], ['ia générative', 'llm', 'chatgpt']);
   });
+
+  // ─── Sujet principal granulaire (Story 23.4) ────────────────────────────
+
+  test('selectMainTopic émet le sujet principal en position 0 (kind preset)',
+      () async {
+    final repo = _CaptureRepo();
+    final c = ProviderContainer(
+      overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+    );
+    addTearDown(c.dispose);
+    final n = c.read(veilleConfigProvider.notifier);
+
+    n.selectTheme('tech');
+    n.selectMainTopic('ai', 'Intelligence artificielle');
+    // Un angle optionnel à côté, pour vérifier que le main reste en tête.
+    n.toggleAngle(angle);
+    await n.submit();
+
+    final topics = repo.captured!.topics;
+    expect(topics.first.topicId, 'ai');
+    expect(topics.first.kind, 'preset', reason: 'slug canonique → Content.topics');
+    expect(topics.first.position, 0);
+    // Pas de doublon du main dans les angles.
+    expect(topics.where((t) => t.topicId == 'ai').length, 1);
+  });
+
+  test('selectTheme reset le sujet principal au changement de macro', () {
+    notifier.selectTheme('tech');
+    notifier.selectMainTopic('ai', 'IA');
+    expect(container.read(veilleConfigProvider).mainTopicSlug, 'ai');
+
+    notifier.selectTheme('science');
+    final s = container.read(veilleConfigProvider);
+    expect(s.mainTopicSlug, isNull);
+    expect(s.mainTopicLabel, isNull);
+  });
+
+  test('selectMainTopic re-tap désélectionne', () {
+    notifier.selectTheme('tech');
+    notifier.selectMainTopic('ai', 'IA');
+    notifier.selectMainTopic('ai', 'IA');
+    expect(container.read(veilleConfigProvider).mainTopicSlug, isNull);
+  });
+
+  test('hydrateFromActiveConfig restaure macro + sujet principal (position 0)',
+      () {
+    final cfg = VeilleConfigDto(
+      id: 'cfg-1',
+      userId: 'user-1',
+      themeId: 'tech',
+      themeLabel: 'Tech',
+      status: 'active',
+      createdAt: DateTime(2024),
+      updatedAt: DateTime(2024),
+      topics: const [
+        VeilleTopicDto(
+          id: 't0',
+          topicId: 'ai',
+          label: 'IA',
+          kind: 'preset',
+          reason: null,
+          position: 0,
+          keywords: [],
+        ),
+        VeilleTopicDto(
+          id: 't1',
+          topicId: 'angle-x',
+          label: 'Angle X',
+          kind: 'suggested',
+          reason: null,
+          position: 1,
+          keywords: ['gpt'],
+        ),
+      ],
+      sources: const [],
+      keywords: const [],
+    );
+
+    notifier.hydrateFromActiveConfig(cfg);
+    final s = container.read(veilleConfigProvider);
+    expect(s.selectedTheme, 'tech', reason: 'macro restauré');
+    expect(s.mainTopicSlug, 'ai', reason: 'granulaire = topic position 0');
+    expect(s.mainTopicLabel, 'IA');
+    // Le sujet principal n'est PAS rejoué comme topic optionnel (sinon doublon).
+    expect(s.selectedTopics, isNot(contains('ai')));
+    expect(s.selectedSuggestions, contains('angle-x'));
+  });
 }

--- a/docs/stories/core/23.4.veille-curation-scoring-ux.md
+++ b/docs/stories/core/23.4.veille-curation-scoring-ux.md
@@ -1,0 +1,71 @@
+# 23.4 — Veille : curation par score (v2) + UX
+
+> Rend la veille réellement ciblée (topic canonique qui *gate*, mots-clés qui amplifient le score), toujours visible quand configurée, configurable en 1 tap depuis la Tournée, sans page blanche. **1 seule PR vers `main`. Aucune migration Alembic.**
+
+**Status** : 🛠️ En cours — plan validé PO (décisions verrouillées).
+**Type** : Maintenance + amélioration produit (curation + UX).
+**Plan source** : `.context/attachments/fS4rOs/plan.md`.
+
+---
+
+## Contexte (diagnostic transcript + code/DB)
+
+Compte de référence : `laurin_boujon@proton.me` (`user_id=fd6b9d0b-4c16-422b-9688-bae34d63f41c`).
+
+5 problèmes confirmés :
+
+1. **Curation « fourre-tout »** — le prédicat candidat est un `OR` topics/sources/mots-clés ; le pilier Source (+35) + Fraîcheur suffisent à passer le seuil → une source suivie déverse tout son flux. Sur le compte test, les 4 topics sont des slugs `custom-…` qui ne matchent jamais `Content.topics` (vocab ML canonique) et 0 mot-clé → pool = 6 sources. Mesure 168h : `by_source=637`, `by_custom_topic=0`, `labeled_ai_total=577`.
+2. **Thèmes trop larges** — Step 1 propose 9 thèmes macro ; les topics granulaires (`ai`) n'existent qu'au Step 2 skippable, hors prédicat.
+3. **Invisible sur certains comptes** — config active mais favoris = refs thème (`veille_config_id=null`), aucun `VeilleFavoriteRef` ; rendu Tournée capé à 3 favoris (`_kMaxFavoriteSections`) → un favori veille auto-réparé tomberait en position 3 et serait coupé.
+4. **Chargement lent / page blanche** — `veille_config_screen.dart` n'affiche aucun loader pendant `veilleActiveConfigProvider.isLoading` ; le Step 2 appelle un LLM (~10-15 s).
+5. **Pas de bouton réglages dans le hero veille** — la section veille utilise un `SectionBanner` sans action.
+
+## Décisions verrouillées (PO)
+
+- **Curation** : pas de AND-gate SQL dur. Garder le moteur pilier, le rendre plus puissant/veille-spécifique : bonus mots-clés escaladant, bonus topic ML bien mappé, bonus source **conditionné** (jamais un free-pass). Calibration tunable, mesurable isolément.
+- **Granularité** : Step 1 = drill macro→topic granulaire (Technologie→IA) ; le topic granulaire devient le gate principal obligatoire (slug canonique).
+- **Visibilité** : section veille toujours affichée quand config active (état vide + bouton réglages) ; fiabiliser le lien favori.
+- **Périmètre** : 1 seule PR vers `main`.
+
+---
+
+## Tasks
+
+### Part A — Curation par score v2 (backend, cœur de la PR)
+- [x] A1. Constantes VEILLE dans `scoring_config.py` (kw escaladant, topic, combo, source on-topic, seuil 48, min feed 5).
+- [x] A2. `_score_custom_topics` veille-aware (`pertinence.py`) branché sur `is_veille`.
+- [x] A3. `VeilleAngleTopic.is_veille=True` (`scoring_context.py`) ; source conditionnée (+12 si bonus>0).
+- [x] A4. Floor (axes ⊆ {source} écarté) + anti-starvation + logs `floor_pruned`/`threshold_pruned` (`feed_filter.py`).
+- [x] A5. Aucune migration (topic principal = `VeilleTopic` position 0 existant).
+
+### Part B — Step 1 drill macro→topic granulaire (mobile)
+- [x] 2ᵉ grille granulaire (`AvailableSubtopics.byTheme`) après choix macro ; topic principal obligatoire (`_SubtopicGrid`, gate CTA).
+- [x] `veille_config_provider.dart` : `mainTopicSlug`/`mainTopicLabel` (+`selectMainTopic`), reset au changement de macro, émission position 0 (`kind:'preset'`, slug canonique), hydratation inverse (`_macroForSubtopic`).
+- [x] Step 2 : topic principal épinglé non-supprimable (`_MainTopicChip`) + CTA dégatée.
+
+### Part C — Section veille toujours visible + lien favori fiable
+- [x] Slot dédié hors cap `_kMaxFavoriteSections` (`flux_continu_provider._pickFavorites`).
+- [x] `_buildVeilleSection` : supprimé `if (items.length < 2) return null` ; section dès config active.
+- [x] État vide (`section_block._VeilleEmptyState`) : placeholder + CTA réglages.
+- [x] Self-heal favori dans `GET /api/veille/config` (`routers/veille.py`), idempotent + try/except + commit dédié.
+
+### Part D — Loading / erreur + LLM non-bloquant
+- [x] Scaffold loading (`VeilleStepSkeleton`) + écran erreur+retry (`_EditLoadError`) en édition ; post-frame hydrate gaté derrière `!isLoading`.
+- [x] Step 2 LLM déjà non-bloquant (loader inline, CTA satisfaite par le sujet principal).
+
+### Part E — Bouton réglages dans le hero veille
+- [x] `section_banner.dart` : `onTapSettings` → bouton tune top-right (`_SettingsButton`, hors `IgnorePointer`).
+- [x] `section_block.dart` + `flux_continu_screen.dart` : propagation `onTapSettings` (veille only) → route `?mode=edit`.
+
+### Vérification
+- [x] `scripts/prove_veille_curation.py` (offline, VERDICT OK) + `tests/test_veille_curation.py` (16 tests).
+- [x] `test_get_config_self_heals_missing_favorite` ajouté dans `tests/routers/test_veille_routes.py` (où vivent les fixtures client/auth, vs le fichier model-only).
+- [x] Régression : suite backend complète **1435 passed** ; scoring Tournée inchangé (chemin gaté derrière `is_veille`).
+- [x] Mobile : `flutter analyze` (0 issue sur les fichiers touchés) + `veille_config_provider_test` 20 passed (4 nouveaux).
+
+## Déviations vs plan
+- **Floor conditionnel** : le floor ne s'active que si la config a un axe topic/keyword. Une config *source-seule* (aucun topic/keyword) garde son comportement legacy (sinon le feed serait vidé — cas couvert par `test_feed_source_axis_returns_all`).
+- **Self-heal test** placé dans `test_veille_routes.py` (fixtures client/auth déjà présentes) au lieu de `test_user_favorite_interests_veille.py` (model-only).
+
+## Fichiers modifiés
+(voir plan source pour la liste détaillée)

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -248,6 +248,17 @@ async def get_config(
         raise HTTPException(
             status_code=404, detail="Aucune veille active pour cet utilisateur."
         )
+
+    # Self-heal (Story 23.4) : répare les configs actives orphelines (config
+    # active mais aucun VeilleFavoriteRef → section veille invisible dans la
+    # Tournée). Idempotent, commit dédié, best-effort : ne bloque jamais le GET.
+    try:
+        await ensure_veille_favorite(db, user_uuid, cfg.id)
+        await db.commit()
+    except Exception:  # noqa: BLE001 — self-heal best-effort
+        await db.rollback()
+        logger.warning("veille.favorite_self_heal_failed", exc_info=True)
+
     return await _hydrate_response(db, cfg)
 
 

--- a/packages/api/app/services/recommendation/pillars/pertinence.py
+++ b/packages/api/app/services/recommendation/pillars/pertinence.py
@@ -361,7 +361,14 @@ class PertinencePillar(BasePillar):
     def _score_custom_topics(
         self, content: Content, context: ScoringContext
     ) -> tuple[float, list[PillarContribution]]:
-        """Custom topics from Epic 11."""
+        """Custom topics (Epic 11) + branche veille (Story 23.4).
+
+        Les angles veille sont marqués `is_veille=True` (`VeilleAngleTopic`) et
+        empruntent un barème escaladant veille-spécifique ; les vrais custom
+        topics Epic 11 (`is_veille` absent) gardent le chemin plat `+25`
+        inchangé. On ne retient qu'un seul angle (le meilleur) — pas
+        d'empilement non borné.
+        """
         if not context.user_custom_topics:
             return 0.0, []
 
@@ -380,6 +387,15 @@ class PertinencePillar(BasePillar):
             # favorite floor le multiplier appliqué au bonus de base.
             tp_state = getattr(tp, "state", InterestState.FOLLOWED)
             if tp_state == InterestState.HIDDEN:
+                continue
+
+            if getattr(tp, "is_veille", False):
+                topic_score = self._score_veille_angle(
+                    tp, content, context, content_topics, title_lower, desc_lower
+                )
+                if topic_score > best_score:
+                    best_score = topic_score
+                    best_topic_name = tp.topic_name
                 continue
 
             matched = False
@@ -406,6 +422,62 @@ class PertinencePillar(BasePillar):
             return best_score, [PillarContribution(label=label, points=best_score)]
 
         return 0.0, []
+
+    def _score_veille_angle(
+        self,
+        tp,
+        content: Content,
+        context: ScoringContext,
+        content_topics: set[str],
+        title_lower: str,
+        desc_lower: str,
+    ) -> float:
+        """Barème veille (Story 23.4) pour un angle = topic canonique + grappe.
+
+        `bonus = composante_kw_escaladante + (50 si topic) + (15 si combo)
+                 + (12 si source suivie ET bonus > 0)`.
+
+        La composante mots-clés vaut `min(BASE + INC*(N-1), CAP)` où N = nombre
+        de mots-clés **distincts** de l'angle matchés (titre/description).
+        Renvoie 0.0 si ni topic ni mot-clé ne matche (source-seul = pas de
+        contribution de pertinence : « la source est un boost, pas un
+        free-pass »).
+        """
+        slug = (tp.slug_parent or "").lower().strip()
+        topic_hit = bool(slug) and slug in content_topics
+
+        kw_hits = 0
+        seen: set[str] = set()
+        for kw in tp.keywords or ():
+            kw_lower = kw.lower().strip()
+            if not kw_lower or kw_lower in seen:
+                continue
+            if kw_lower in title_lower or kw_lower in desc_lower:
+                seen.add(kw_lower)
+                kw_hits += 1
+
+        if not topic_hit and kw_hits == 0:
+            return 0.0
+
+        bonus = 0.0
+        if kw_hits > 0:
+            bonus += min(
+                ScoringWeights.VEILLE_KEYWORD_BASE_BONUS
+                + ScoringWeights.VEILLE_KEYWORD_INCREMENT * (kw_hits - 1),
+                ScoringWeights.VEILLE_KEYWORD_CAP,
+            )
+        if topic_hit:
+            bonus += ScoringWeights.VEILLE_TOPIC_MATCH_BONUS
+        if topic_hit and kw_hits > 0:
+            bonus += ScoringWeights.VEILLE_TOPIC_KEYWORD_COMBO_BONUS
+
+        # Source conditionnée : appliquée seulement quand l'article a déjà un
+        # topic ou un mot-clé (bonus > 0). Source-seul n'atteint jamais cette
+        # branche (early-return ci-dessus).
+        if bonus > 0 and content.source_id in context.followed_source_ids:
+            bonus += ScoringWeights.VEILLE_SOURCE_ON_TOPIC_BONUS
+
+        return bonus
 
     def _score_format(
         self, content: Content, context: ScoringContext

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -297,14 +297,40 @@ class ScoringWeights:
 
     # --- VEILLE (feed temps-réel curé par score) ---
 
+    # Bonus mots-clés **escaladant** (Story 23.4) : un angle dont N mots-clés
+    # distincts matchent (titre/description) rapporte
+    # `min(BASE + INCREMENT*(N-1), CAP)`. Remplace l'ancien `+25` plat de
+    # `_score_custom_topics` quand l'angle est marqué `is_veille`. Le cap (45)
+    # protège `MAX_PERTINENCE_RAW=130` d'un empilement non borné.
+    VEILLE_KEYWORD_BASE_BONUS = 18.0
+    VEILLE_KEYWORD_INCREMENT = 9.0
+    VEILLE_KEYWORD_CAP = 45.0
+
+    # Bonus quand l'article porte le `topic_id` de l'angle dans `Content.topics`
+    # (« article labellisé IA ») — le signal canonique le plus fort.
+    VEILLE_TOPIC_MATCH_BONUS = 50.0
+
+    # Bonus de combo : topic canonique **ET** ≥1 mot-clé matché (signal on-angle
+    # le plus net).
+    VEILLE_TOPIC_KEYWORD_COMBO_BONUS = 15.0
+
+    # Bonus source suivie appliqué **dans la pertinence** uniquement si l'article
+    # a déjà un topic ou un mot-clé (bonus angle > 0). « La source est un boost,
+    # pas un free-pass » : source-seul = 0 contribution de pertinence.
+    VEILLE_SOURCE_ON_TOPIC_BONUS = 12.0
+
     # Seuil de pertinence (score final piliers, échelle ~0-100) en-deçà duquel
-    # un article candidat est élagué du feed veille. Dérivé analytiquement :
-    # un article "thème seul" score ~47 (mais ne peut de toute façon pas entrer
-    # car le thème est absent du prédicat SQL), "thème + topic" ~66,
-    # "thème + mot-clé d'angle" ~55, "source suivie seule" ~37-45.
-    # 40 passe topic/mot-clé largement ; la source-seule reste limite.
-    # Point de calibration à figer via les logs de prod (max_score/pass_count).
-    VEILLE_RELEVANCE_THRESHOLD = 40.0
+    # un article candidat est élagué du feed veille. Relevé 40→48 (Story 23.4)
+    # avec la curation v2 : source-seul frais+riche ≈ 44 (< 48, écarté en plus
+    # par le floor) ; 1 mot-clé+source ≈ 52-58 ; topic+source ≈ 62-70 ;
+    # topic+2kw+source ≈ 75-82. Point de calibration tunable via les logs prod
+    # (max_score / pass_count / floor_pruned_count / threshold_pruned_count).
+    VEILLE_RELEVANCE_THRESHOLD = 48.0
+
+    # Anti-starvation : si après scoring moins de N articles passent ET que des
+    # candidats on-axis ont été coupés par le *seuil* (jamais par le floor), on
+    # relâche le seuil d'un cran (max -8, plancher 40).
+    VEILLE_MIN_FEED_SIZE = 5
 
     # Plafond du pool de candidats scorés par fetch (borne le coût ILIKE +
     # scoring sur un feed curé ; offsets au-delà renvoient vide — acceptable).

--- a/packages/api/app/services/veille/feed_filter.py
+++ b/packages/api/app/services/veille/feed_filter.py
@@ -213,22 +213,62 @@ def _score_and_rank(
     context,
     filters: VeilleFilters,
 ) -> list[tuple[Content, float, list[str]]]:
-    """Score chaque candidat, garde ≥ seuil, trie par (score, récence) desc."""
+    """Score chaque candidat, applique le floor + le seuil, trie par score.
+
+    Pipeline (Story 23.4) :
+
+    1. **Floor** — « la source est un boost, pas un free-pass » : tout candidat
+       dont les axes qualifiants ⊆ ``{source}`` (ni topic ni mot-clé) est écarté
+       *avant* le seuil. Plus chirurgical qu'un narrow-predicate : on préserve
+       l'UX ``matched_on`` et les articles on-topic venant d'une source suivie.
+       Le floor **ne s'active que si la config définit un axe topic/keyword** à
+       gater : une config *source-seule* (aucun topic, aucun mot-clé) garde son
+       comportement historique — ses sources **sont** le filtre, leurs articles
+       passent.
+    2. **Seuil** — parmi les candidats on-axis, on garde ceux dont le score
+       final ≥ ``VEILLE_RELEVANCE_THRESHOLD``.
+    3. **Anti-starvation** — si moins de ``VEILLE_MIN_FEED_SIZE`` passent ET que
+       des candidats on-axis ont été coupés par le *seuil* (jamais par le floor),
+       on relâche le seuil d'un cran (``max(threshold-8, 40)``) et on réadmet
+       ceux qui repassent — sans jamais réadmettre un article floor-pruned.
+    """
     engine = PillarScoringEngine()
     # Pré-calcul hors boucle : ces dérivations sont stables sur tout le fetch.
     topic_slugs = set(filters.topic_slugs)
     source_ids = set(filters.source_ids)
     keywords = filters.all_keywords
+    threshold = ScoringWeights.VEILLE_RELEVANCE_THRESHOLD
+    # Le floor n'a de sens que s'il existe un axe topic/keyword à côté de la
+    # source. Sans cela (config source-seule), la source est l'unique filtre.
+    floor_active = bool(topic_slugs or keywords)
+
     passing: list[tuple[Content, float, list[str]]] = []
+    # Candidats on-axis sous le seuil — réservés à l'anti-starvation.
+    below_threshold: list[tuple[Content, float, list[str]]] = []
     max_score = 0.0
+    floor_pruned_count = 0
     for content in candidates:
+        axes = _matched_axes(content, topic_slugs, source_ids, keywords)
+        if floor_active and "topic" not in axes and "keyword" not in axes:
+            # Floor : axes ⊆ {source} (ou vide) → source-seul, écarté.
+            floor_pruned_count += 1
+            continue
         result = engine.compute_score(content, context)
         score = result.final_score
         if score > max_score:
             max_score = score
-        if score >= ScoringWeights.VEILLE_RELEVANCE_THRESHOLD:
-            axes = _matched_axes(content, topic_slugs, source_ids, keywords)
+        if score >= threshold:
             passing.append((content, score, axes))
+        else:
+            below_threshold.append((content, score, axes))
+
+    threshold_pruned_count = len(below_threshold)
+    if len(passing) < ScoringWeights.VEILLE_MIN_FEED_SIZE and below_threshold:
+        relaxed = max(threshold - 8.0, 40.0)
+        if relaxed < threshold:
+            readmitted = [item for item in below_threshold if item[1] >= relaxed]
+            passing.extend(readmitted)
+            threshold_pruned_count -= len(readmitted)
 
     _epoch = datetime.min.replace(tzinfo=UTC)
     passing.sort(
@@ -240,6 +280,8 @@ def _score_and_rank(
         candidate_count=len(candidates),
         pass_count=len(passing),
         max_score=round(max_score, 1),
+        floor_pruned_count=floor_pruned_count,
+        threshold_pruned_count=threshold_pruned_count,
     )
     return passing
 

--- a/packages/api/app/services/veille/scoring_context.py
+++ b/packages/api/app/services/veille/scoring_context.py
@@ -36,9 +36,12 @@ class VeilleAngleTopic:
     """Adaptateur angle veille → custom-topic (duck-typing de `_score_custom_topics`).
 
     `_score_custom_topics` (pertinence.py) attend `slug_parent`, `keywords`,
-    `priority_multiplier`, `state`, `topic_name`. Un angle matche si son
-    `slug_parent` est dans `content.topics` **ou** si l'un de ses `keywords`
-    apparaît dans le titre/description → +CUSTOM_TOPIC_BASE_BONUS (25).
+    `priority_multiplier`, `state`, `topic_name`. Le flag `is_veille=True`
+    aiguille le pilier Pertinence vers sa **branche veille** (Story 23.4) :
+    bonus mots-clés escaladant + bonus topic canonique (+50) + combo (+15) +
+    source suivie conditionnée (+12 si bonus angle > 0). Hors veille (vrais
+    custom topics Epic 11), `getattr(tp, "is_veille", False)` reste `False` et
+    le chemin plat `+25` est inchangé.
     """
 
     slug_parent: str
@@ -46,6 +49,7 @@ class VeilleAngleTopic:
     topic_name: str
     priority_multiplier: float = 1.0
     state: InterestState = InterestState.FOLLOWED
+    is_veille: bool = True
 
 
 async def build_veille_scoring_context(

--- a/packages/api/scripts/prove_veille_curation.py
+++ b/packages/api/scripts/prove_veille_curation.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Preuve empirique avant/après — curation veille par score (Story 23.4).
+
+Fait tourner le **vrai** pipeline `_score_and_rank` (floor + scoring piliers +
+seuil + anti-starvation) sur un pool de candidats mixtes typique du bug observé
+sur le compte proton (`fd6b9d0b…`) : une poignée d'articles on-angle noyés sous
+le flot d'une source suivie qui « déverse » tout son flux.
+
+  AVANT  = dump OR chronologique (bug : la source est un free-pass, son flux
+           entier passe le seuil grâce au pilier Source + Fraîcheur)
+  APRÈS  = floor (« la source est un boost, pas un free-pass ») + scoring v2
+           (topic canonique +50, mots-clés escaladants, combo +15)
+
+Angle de veille : topic canonique ``ai`` (« IA ») + grappe ``[llm, gpt, agent]``.
+
+Verdict attendu (PO) :
+  - les articles source-seule **off-angle** (ni topic ni mot-clé) sont écartés
+    par le floor → le flood est tué ;
+  - l'article topic + 2 mots-clés d'une source suivie est **#1** ;
+  - un article on-topic d'une source **non suivie** survit (la source n'est pas
+    une condition d'entrée).
+
+Usage :
+    cd packages/api && PYTHONPATH=. python scripts/prove_veille_curation.py
+"""
+
+import datetime
+import sys
+from pathlib import Path
+from uuid import UUID, uuid4
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+UTC = datetime.UTC
+NOW = datetime.datetime(2026, 6, 2, 10, 0, 0, tzinfo=UTC)
+
+# Angle principal de la veille.
+ANGLE_TOPIC = "ai"
+ANGLE_LABEL = "IA"
+ANGLE_KEYWORDS = ["llm", "gpt", "agent"]
+
+# --- Sources (name -> followed?) -------------------------------------------
+SOURCES = {
+    "Next.ink": True,
+    "Le Monde": True,
+    "BDM": True,
+    "TechCrunch": False,  # non suivie : sert à prouver qu'un on-topic survit
+}
+
+# --- Candidats mixtes -------------------------------------------------------
+# (titre, source, topics, theme, mins_avant_now)
+# Les mots-clés d'angle apparaissent (ou non) littéralement dans le titre.
+CANDIDATES = [
+    # on-angle forts (source suivie)
+    ("Nouveau LLM GPT-5 : un agent IA autonome", "Next.ink", ["ai"], "tech", 30),
+    ("Le nouveau LLM de Mistral impressionne", "Le Monde", ["ai"], "tech", 65),
+    ("Avancées en intelligence artificielle générale", "Next.ink", ["ai"], "tech", 90),
+    # mot-clé seul (pas de topic ai) — reste on-angle via le keyword 'agent'
+    ("Un agent conversationnel pour le support client", "BDM", ["tech"], "tech", 120),
+    # on-topic d'une source NON suivie — doit survivre
+    ("OpenAI dévoile un nouveau modèle de raisonnement", "TechCrunch", ["ai"], "tech", 75),
+    # source-seule OFF-angle (ni topic ni keyword) — DOIT être floor-pruned
+    ("Résultats du PSG hier soir en Ligue 1", "Next.ink", ["sport"], "sport", 40),
+    # flood d'une source suivie, tout off-angle — DOIT être tué par le floor
+    ("Test du dernier smartphone pliable", "BDM", ["tech"], "tech", 50),
+    ("Comparatif des meilleures consoles 2026", "BDM", ["gaming"], "tech", 55),
+    ("Bons plans : -40% sur les écouteurs", "BDM", ["tech"], "tech", 60),
+    ("Tuto : installer Linux sur un vieux PC", "BDM", ["tech"], "tech", 70),
+    ("Le clavier mécanique qu'il vous faut", "BDM", ["tech"], "tech", 80),
+    ("Windows 11 : la mise à jour de juin", "Next.ink", ["tech"], "tech", 100),
+]
+
+
+def _build():
+    from app.models.content import Content
+    from app.models.enums import ContentType
+    from app.models.source import Source
+
+    src_ids: dict[str, UUID] = {}
+    src_objs: dict[str, Source] = {}
+    for name in SOURCES:
+        sid = uuid4()
+        src_ids[name] = sid
+        src_objs[name] = Source(
+            id=sid,
+            name=name,
+            theme="tech",
+            is_curated=True,
+            secondary_themes=[],
+            tone=None,
+        )
+
+    contents = []
+    for title, sname, topics, theme, mins in CANDIDATES:
+        contents.append(
+            Content(
+                id=uuid4(),
+                title=title,
+                description="",
+                theme=theme,
+                topics=topics,
+                published_at=NOW - datetime.timedelta(minutes=mins),
+                source_id=src_ids[sname],
+                source=src_objs[sname],
+                content_type=ContentType.ARTICLE,
+                duration_seconds=None,
+                entities=[],
+                content_quality="full",
+                thumbnail_url="https://img",
+            )
+        )
+    return contents, src_ids
+
+
+def _filters_and_context(src_ids):
+    from app.services.recommendation.scoring_engine import ScoringContext
+    from app.services.veille.feed_filter import VeilleAngle, VeilleFilters
+    from app.services.veille.scoring_context import VeilleAngleTopic
+
+    followed = {src_ids[n] for n in SOURCES if SOURCES[n]}
+    filters = VeilleFilters(
+        theme_id="tech",
+        angles=[VeilleAngle(topic_id=ANGLE_TOPIC, label=ANGLE_LABEL, keywords=ANGLE_KEYWORDS)],
+        source_ids=list(followed),
+        global_keywords=[],
+    )
+    context = ScoringContext(
+        user_profile=None,
+        user_interests={"tech"},
+        user_interest_weights={},
+        followed_source_ids=followed,
+        user_prefs={},
+        now=NOW,
+        user_subtopics={ANGLE_TOPIC},
+        user_subtopic_weights={},
+        user_custom_topics=[
+            VeilleAngleTopic(
+                slug_parent=ANGLE_TOPIC,
+                keywords=ANGLE_KEYWORDS,
+                topic_name=ANGLE_LABEL,
+                is_veille=True,
+            )
+        ],
+    )
+    return filters, context
+
+
+def main() -> int:
+    from app.services.veille.feed_filter import _matched_axes, _score_and_rank
+
+    contents, src_ids = _build()
+    filters, context = _filters_and_context(src_ids)
+
+    topic_slugs = set(filters.topic_slugs)
+    source_ids = set(filters.source_ids)
+    keywords = filters.all_keywords
+
+    kept = _score_and_rank(list(contents), context, filters)
+    kept_ids = {c.id for c, _s, _a in kept}
+
+    print("=" * 92)
+    print(f"Veille — angle ({ANGLE_TOPIC!r}, {ANGLE_LABEL!r}, {ANGLE_KEYWORDS}) — "
+          f"{len(contents)} candidats mixtes")
+    print("=" * 92)
+
+    print("\n--- AVANT (dump OR chronologique — la source est un free-pass) ---")
+    print(f"{'#':>2}  {'axes':<18} {'source':<12} titre")
+    chrono = sorted(contents, key=lambda c: c.published_at, reverse=True)
+    for i, c in enumerate(chrono, 1):
+        axes = _matched_axes(c, topic_slugs, source_ids, keywords)
+        print(f"{i:>2}  {','.join(axes) or '∅':<18} {c.source.name:<12} {c.title[:46]}")
+
+    print("\n--- APRÈS (floor + scoring v2 + seuil) ---")
+    print(f"{'#':>2}  {'score':>5} {'axes':<18} {'source':<12} titre")
+    for i, (c, score, axes) in enumerate(kept, 1):
+        print(f"{i:>2}  {score:>5.1f} {','.join(axes):<18} {c.source.name:<12} {c.title[:46]}")
+
+    _verdict(contents, kept, kept_ids, topic_slugs, source_ids, keywords)
+    return 0
+
+
+def _verdict(contents, kept, kept_ids, topic_slugs, source_ids, keywords):
+    from app.services.veille.feed_filter import _matched_axes
+
+    print("\n" + "=" * 92)
+    print("VERDICT")
+    print("=" * 92)
+
+    # 1. Tout candidat source-seule off-angle (axes ⊆ {source}) est écarté.
+    off_angle = [
+        c for c in contents
+        if "topic" not in _matched_axes(c, topic_slugs, source_ids, keywords)
+        and "keyword" not in _matched_axes(c, topic_slugs, source_ids, keywords)
+    ]
+    off_angle_kept = [c for c in off_angle if c.id in kept_ids]
+    ok_floor = not off_angle_kept
+    print(f"[{'OK' if ok_floor else 'FAIL'}] floor : {len(off_angle)} articles source-seule "
+          f"off-angle écartés ({len(off_angle_kept)} ont survécu)")
+
+    # 2. L'article topic + 2 mots-clés est #1.
+    top = kept[0][0] if kept else None
+    ok_top = top is not None and "GPT-5" in top.title
+    print(f"[{'OK' if ok_top else 'FAIL'}] #1 = topic + mots-clés : "
+          f"{top.title[:50] if top else '∅'!r}")
+
+    # 3. Un on-topic d'une source NON suivie survit.
+    non_followed_on_topic = next(
+        (c for c in contents if "OpenAI" in c.title), None
+    )
+    ok_nf = non_followed_on_topic is not None and non_followed_on_topic.id in kept_ids
+    print(f"[{'OK' if ok_nf else 'FAIL'}] on-topic source non suivie conservé : {ok_nf}")
+
+    all_ok = ok_floor and ok_top and ok_nf
+    print(f"\n{'✅ VERDICT GLOBAL : OK' if all_ok else '❌ VERDICT GLOBAL : FAIL'}")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -371,6 +371,33 @@ class TestFavoriteIntegration:
         favs = await self._favorites(db_session, auth_user)
         assert favs == []
 
+    async def test_get_config_self_heals_missing_favorite(
+        self, auth_user, db_session
+    ):
+        """Story 23.4 : une config active orpheline (sans favori — cas proton) est
+        réparée au `GET /config` (self-heal idempotent, commit dédié)."""
+        cfg = VeilleConfig(
+            id=uuid4(),
+            user_id=auth_user,
+            theme_id="tech",
+            theme_label="Tech",
+            status=VeilleStatus.ACTIVE.value,
+        )
+        db_session.add(cfg)
+        await db_session.commit()
+
+        # Orphelin : config active, aucun VeilleFavoriteRef.
+        assert await self._favorites(db_session, auth_user) == []
+
+        async with _client() as c:
+            r = await c.get("/api/veille/config")
+        assert r.status_code == 200
+
+        favs = await self._favorites(db_session, auth_user)
+        assert len(favs) == 1
+        assert favs[0].veille_config_id == cfg.id
+        assert favs[0].interest_slug is None
+
 
 class TestFeed:
     async def test_feed_empty_when_no_config(self, auth_user):

--- a/packages/api/tests/test_veille_curation.py
+++ b/packages/api/tests/test_veille_curation.py
@@ -1,0 +1,361 @@
+"""Tests curation veille par score (Story 23.4).
+
+Couvre la curation v2 du feed veille — gatée derrière `is_veille` pour ne pas
+toucher le chemin custom-topic de la Tournée (Epic 11) :
+
+- **Pertinence veille** (`PertinencePillar._score_custom_topics`) : barème
+  escaladant (2kw > 1kw), topic > keyword, combo (topic+kw) en tête, source
+  suivie conditionnée (boost on-angle only, jamais sur source-seul).
+- **Floor + seuil + anti-starvation** (`feed_filter._score_and_rank`) : la
+  source est un boost, pas un free-pass ; le seuil 48 coupe le bruit ; la
+  relâche anti-starvation ne réadmet jamais un floor-pruned.
+- **DB end-to-end** (`fetch_veille_feed`) : un article source-seule off-angle
+  est exclu du feed.
+- **Régression** : un custom topic Epic 11 (sans `is_veille`) garde le `+25` plat.
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.models.content import Content
+from app.models.enums import ContentType, InterestState
+from app.models.source import Source, SourceType
+from app.models.user import UserProfile
+from app.models.veille import (
+    VeilleConfig,
+    VeilleKeyword,
+    VeilleSource,
+    VeilleStatus,
+    VeilleTopic,
+)
+from app.services.recommendation.pillars.pertinence import PertinencePillar
+from app.services.recommendation.scoring_config import ScoringWeights
+from app.services.recommendation.scoring_engine import ScoringContext
+from app.services.veille.feed_filter import (
+    VeilleAngle,
+    VeilleFilters,
+    _matched_axes,
+    _score_and_rank,
+    fetch_veille_feed,
+)
+from app.services.veille.scoring_context import VeilleAngleTopic
+
+# ─── Helpers légers pour le pilier Pertinence ────────────────────────────────
+
+
+class _Content:
+    """Stand-in minimal pour `_score_custom_topics` (topics/title/desc/source)."""
+
+    def __init__(self, *, topics=None, title="", description="", source_id=None):
+        self.topics = topics or []
+        self.title = title
+        self.description = description
+        self.source_id = source_id
+
+
+class _Ctx:
+    def __init__(self, angles, followed=None):
+        self.user_custom_topics = angles
+        self.followed_source_ids = followed or set()
+
+
+def _veille_angle(slug="ai", keywords=("llm", "gpt", "agent")):
+    return VeilleAngleTopic(
+        slug_parent=slug,
+        keywords=list(keywords),
+        topic_name="IA",
+        is_veille=True,
+    )
+
+
+def _angle_score(content, *, followed=None) -> float:
+    pillar = PertinencePillar()
+    score, _ = pillar._score_custom_topics(content, _Ctx([_veille_angle()], followed))
+    return score
+
+
+# ─── Pertinence veille : barème ──────────────────────────────────────────────
+
+
+def test_keyword_bonus_escalates_with_distinct_matches():
+    """2 mots-clés distincts rapportent plus qu'un seul (courbe escaladante)."""
+    one = _angle_score(_Content(topics=["tech"], title="Un nouveau LLM est sorti"))
+    two = _angle_score(
+        _Content(topics=["tech"], title="Un nouveau LLM signé GPT débarque")
+    )
+    assert one == pytest.approx(ScoringWeights.VEILLE_KEYWORD_BASE_BONUS)
+    assert two == pytest.approx(
+        ScoringWeights.VEILLE_KEYWORD_BASE_BONUS + ScoringWeights.VEILLE_KEYWORD_INCREMENT
+    )
+    assert two > one
+
+
+def test_keyword_bonus_is_capped():
+    """Le bonus mots-clés ne dépasse jamais le cap, même avec beaucoup de hits."""
+    many = VeilleAngleTopic(
+        slug_parent="ai",
+        keywords=["a", "b", "c", "d", "e", "f", "g", "h"],
+        topic_name="IA",
+        is_veille=True,
+    )
+    pillar = PertinencePillar()
+    score, _ = pillar._score_custom_topics(
+        _Content(topics=["tech"], title="a b c d e f g h"), _Ctx([many])
+    )
+    assert score == pytest.approx(ScoringWeights.VEILLE_KEYWORD_CAP)
+
+
+def test_topic_beats_single_keyword():
+    """Le topic canonique (+50) pèse plus qu'un mot-clé seul (+18)."""
+    topic_only = _angle_score(_Content(topics=["ai"], title="Intelligence artificielle"))
+    kw_only = _angle_score(_Content(topics=["tech"], title="Un nouveau LLM"))
+    assert topic_only == pytest.approx(ScoringWeights.VEILLE_TOPIC_MATCH_BONUS)
+    assert topic_only > kw_only
+
+
+def test_combo_topic_and_keyword_is_strongest():
+    """Topic + mot-clé = signal on-angle le plus fort (topic + kw + combo)."""
+    combo = _angle_score(_Content(topics=["ai"], title="Le LLM star de l'IA"))
+    topic_only = _angle_score(_Content(topics=["ai"], title="Intelligence générale"))
+    kw_only = _angle_score(_Content(topics=["tech"], title="Un LLM impressionnant"))
+    expected = (
+        ScoringWeights.VEILLE_KEYWORD_BASE_BONUS
+        + ScoringWeights.VEILLE_TOPIC_MATCH_BONUS
+        + ScoringWeights.VEILLE_TOPIC_KEYWORD_COMBO_BONUS
+    )
+    assert combo == pytest.approx(expected)
+    assert combo > topic_only > kw_only
+
+
+def test_source_only_off_angle_scores_zero():
+    """Un article source-seule (ni topic ni mot-clé) n'a aucune pertinence veille."""
+    sid = uuid4()
+    score = _angle_score(
+        _Content(topics=["sport"], title="Résultats du match", source_id=sid),
+        followed={sid},
+    )
+    assert score == 0.0
+
+
+def test_followed_source_conditional_bonus():
+    """+12 source seulement quand l'article a déjà topic|keyword (bonus>0)."""
+    sid = uuid4()
+    on_angle = _Content(topics=["ai"], title="Avancées en IA", source_id=sid)
+    not_followed = _angle_score(on_angle)
+    followed = _angle_score(on_angle, followed={sid})
+    assert followed - not_followed == pytest.approx(
+        ScoringWeights.VEILLE_SOURCE_ON_TOPIC_BONUS
+    )
+
+
+def test_non_veille_custom_topic_keeps_flat_bonus():
+    """Régression : un custom topic Epic 11 (sans is_veille) garde le +25 plat."""
+
+    class _RealTopic:
+        slug_parent = "ai"
+        keywords = ["llm", "gpt", "agent"]
+        topic_name = "IA"
+        priority_multiplier = 1.0
+        state = InterestState.FOLLOWED
+        # pas de `is_veille` → getattr(..., False)
+
+    pillar = PertinencePillar()
+    # topic + 3 mots-clés : en veille ce serait ~113, ici reste plat à +25.
+    score, _ = pillar._score_custom_topics(
+        _Content(topics=["ai"], title="Le LLM GPT agent IA"), _Ctx([_RealTopic()])
+    )
+    assert score == pytest.approx(ScoringWeights.CUSTOM_TOPIC_BASE_BONUS)
+
+
+# ─── Floor + seuil + anti-starvation (`_score_and_rank`) ─────────────────────
+
+
+def _make_source(name="Src", followed=True):
+    return Source(
+        id=uuid4(),
+        name=name,
+        theme="tech",
+        is_curated=True,
+        secondary_themes=[],
+        tone=None,
+    )
+
+
+def _make_content(source, *, topics, title, mins=30):
+    return Content(
+        id=uuid4(),
+        title=title,
+        description="",
+        theme="tech",
+        topics=topics,
+        published_at=datetime(2026, 6, 2, 10, 0, tzinfo=UTC) - timedelta(minutes=mins),
+        source_id=source.id,
+        source=source,
+        content_type=ContentType.ARTICLE,
+        duration_seconds=None,
+        entities=[],
+        content_quality="full",
+        thumbnail_url="https://img",
+    )
+
+
+def _veille_context(followed_ids):
+    return ScoringContext(
+        user_profile=None,
+        user_interests={"tech"},
+        user_interest_weights={},
+        followed_source_ids=set(followed_ids),
+        user_prefs={},
+        now=datetime(2026, 6, 2, 10, 0, tzinfo=UTC),
+        user_subtopics={"ai"},
+        user_subtopic_weights={},
+        user_custom_topics=[_veille_angle()],
+    )
+
+
+def _veille_filters(source_ids):
+    return VeilleFilters(
+        theme_id="tech",
+        angles=[VeilleAngle(topic_id="ai", label="IA", keywords=["llm", "gpt", "agent"])],
+        source_ids=list(source_ids),
+        global_keywords=[],
+    )
+
+
+def test_floor_prunes_source_only_candidates():
+    """La source est un boost, pas un free-pass : source-seul off-angle écarté."""
+    src = _make_source()
+    on_angle = _make_content(src, topics=["ai"], title="Nouveau LLM GPT agent")
+    source_only = _make_content(src, topics=["sport"], title="Résultats du PSG")
+    flt = _veille_filters([src.id])
+    ctx = _veille_context([src.id])
+
+    kept = _score_and_rank([on_angle, source_only], ctx, flt)
+    kept_ids = {c.id for c, _s, _a in kept}
+    assert on_angle.id in kept_ids
+    assert source_only.id not in kept_ids
+
+
+def test_on_topic_from_unfollowed_source_survives():
+    """Un on-topic d'une source NON suivie passe le floor (topic = axe qualifiant)."""
+    followed = _make_source("Followed")
+    other = _make_source("Other")
+    on_topic = _make_content(other, topics=["ai"], title="Intelligence artificielle")
+    flt = _veille_filters([followed.id])  # other n'est pas suivie
+    ctx = _veille_context([followed.id])
+
+    kept = _score_and_rank([on_topic], ctx, flt)
+    assert {c.id for c, _s, _a in kept} == {on_topic.id}
+
+
+def test_threshold_cuts_below_floor_score():
+    """Le seuil 48 reste au-dessus du plancher anti-starvation (40)."""
+    assert ScoringWeights.VEILLE_RELEVANCE_THRESHOLD > 40.0
+
+
+def test_anti_starvation_never_readmits_floor_pruned():
+    """Sous le min feed, on relâche le seuil — mais jamais un source-seul."""
+    src = _make_source()
+    # 1 seul on-angle faible + plein de source-seul off-angle.
+    weak = _make_content(src, topics=["tech"], title="Un agent vaguement tech")
+    floods = [
+        _make_content(src, topics=["tech"], title=f"Bon plan #{i}", mins=40 + i)
+        for i in range(6)
+    ]
+    flt = _veille_filters([src.id])
+    ctx = _veille_context([src.id])
+
+    kept = _score_and_rank([weak, *floods], ctx, flt)
+    kept_ids = {c.id for c, _s, _a in kept}
+    # Aucun des articles source-seule (floods) n'est réadmis par l'anti-starvation.
+    for f in floods:
+        assert f.id not in kept_ids
+
+
+# ─── DB end-to-end (`fetch_veille_feed`) ─────────────────────────────────────
+
+
+async def _insert_source(db_session, name="Veille Source") -> Source:
+    src = Source(
+        id=uuid4(),
+        name=name,
+        url=f"https://{uuid4().hex}.com",
+        feed_url=f"https://{uuid4().hex}.com/feed.xml",
+        type=SourceType.ARTICLE,
+        theme="tech",
+        is_active=True,
+        is_curated=True,
+    )
+    db_session.add(src)
+    await db_session.commit()
+    return src
+
+
+async def _insert_content(db_session, source_id, *, topics, title) -> UUID:
+    cid = uuid4()
+    db_session.add(
+        Content(
+            id=cid,
+            source_id=source_id,
+            title=title,
+            url=f"https://example.com/{cid}",
+            guid=f"guid-{cid}",
+            published_at=datetime.now(UTC) - timedelta(hours=2),
+            content_type=ContentType.ARTICLE,
+            theme="tech",
+            topics=topics,
+            content_quality="full",
+        )
+    )
+    await db_session.commit()
+    return cid
+
+
+@pytest.mark.asyncio
+async def test_fetch_veille_feed_excludes_source_only(db_session):
+    """End-to-end : la veille remonte l'on-topic et exclut le source-seul off-angle."""
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    await db_session.commit()
+    src = await _insert_source(db_session)
+
+    cfg = VeilleConfig(
+        id=uuid4(),
+        user_id=user_id,
+        theme_id="tech",
+        theme_label="Tech",
+        status=VeilleStatus.ACTIVE.value,
+    )
+    db_session.add(cfg)
+    await db_session.commit()
+
+    db_session.add(
+        VeilleTopic(
+            veille_config_id=cfg.id,
+            topic_id="ai",
+            label="IA",
+            kind="preset",
+            position=0,
+        )
+    )
+    db_session.add(
+        VeilleSource(
+            veille_config_id=cfg.id, source_id=src.id, kind="curated", position=0
+        )
+    )
+    await db_session.commit()
+
+    on_topic = await _insert_content(
+        db_session, src.id, topics=["ai"], title="Avancées en IA"
+    )
+    source_only = await _insert_content(
+        db_session, src.id, topics=["sport"], title="Résultats du match"
+    )
+
+    items, _has_more = await fetch_veille_feed(db_session, user_id, limit=20)
+    returned_ids = {content.id for content, _axes in items}
+
+    assert on_topic in returned_ids
+    assert source_only not in returned_ids


### PR DESCRIPTION
## Quoi
Curation de la veille par **score v2** + refonte UX (Story 23.4). La veille devient réellement ciblée, toujours visible quand configurée, configurable en 1 tap depuis la Tournée, sans page blanche. **Aucune migration Alembic.**

- **A — Curation par score (backend)** : bonus mots-clés escaladant, bonus topic ML bien mappé, bonus source **conditionné** (jamais free-pass), seuil 48, floor (axes ⊆ {source} écartés) + anti-starvation. Tout le chemin est gaté derrière `is_veille` → scoring Tournée inchangé.
- **B — Step 1 drill macro→topic granulaire (mobile)** : 2ᵉ grille granulaire (Technologie→IA), topic principal obligatoire émis en position 0 (slug canonique), hydratation inverse.
- **C — Section veille toujours visible** : slot dédié hors cap favoris, état vide + CTA réglages, self-heal favori idempotent dans `GET /api/veille/config`.
- **D — Loading / erreur** : scaffold loading + écran erreur/retry en édition ; LLM Step 2 non-bloquant.
- **E — Bouton réglages** dans le hero veille → route `?mode=edit`.

## Pourquoi
La veille déversait tout le flux des sources suivies (pilier Source + Fraîcheur suffisaient à passer le seuil), les thèmes étaient trop larges, la section pouvait disparaître, et le chargement montrait une page blanche. Voir diagnostic complet dans `docs/stories/core/23.4.veille-curation-scoring-ux.md`.

## Comment ça a été vérifié
- [x] `pytest` suite complète backend — **1435 passed**, 1 skipped, 2 xfailed
- [x] `test_veille_curation.py` (16) + self-heal route dans `test_veille_routes.py` — **39 passed**
- [x] `scripts/prove_veille_curation.py` — **VERDICT GLOBAL : OK** (floor écarte 7 source-seule off-angle, #1 = topic+mots-clés, source on-topic non suivie conservée)
- [x] Mobile `veille_config_provider_test` — **20 passed**
- [x] `flutter analyze` — 0 issue sur les fichiers touchés
- [x] Alembic — exactement 1 head, aucune migration ajoutée
- [x] `/simplify` passé (code déjà propre, aucune correction nécessaire)

## Zones à risque
- Pilier de scoring `pertinence.py` (chemin veille gaté derrière `is_veille`, Tournée non impactée).
- `feed_filter.py` : floor conditionnel — une config *source-seule* garde son comportement legacy (couvert par `test_feed_source_axis_returns_all`).
- Self-heal favori dans le routeur veille (idempotent, try/except, commit dédié).
