### PR TITLE
fix(digest): label non vide pour notif Essentiel personnalisée (variante B)

### DIFF
--- a/packages/api/app/services/briefing/importance_detector.py
+++ b/packages/api/app/services/briefing/importance_detector.py
@@ -246,7 +246,9 @@ class ImportanceDetector:
             topic_clusters.append(
                 TopicCluster(
                     cluster_id=str(uuid4()),
-                    label="",  # Set par TopicSelector après scoring
+                    # Label initialisé avec le titre du meilleur article du cluster :
+                    # sert de référence au LLM et garantit un fallback déterministe non vide.
+                    label=cluster_contents[0].title[:80] if cluster_contents else "",
                     tokens=raw["tokens"],
                     contents=cluster_contents,
                     source_ids=source_ids,

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -2351,10 +2351,17 @@ class DigestService:
                     _divergence_str = str(_divergence_raw)
                 else:
                     _divergence_str = _divergence_raw
+                # Fallback label : les digests editorial_v1/globaux persistés
+                # avant le fix write-side ont `label=""`, ce qui désactive la
+                # notification personnalisée (variante B). On répare au read en
+                # reprenant le titre de l'actu_article. Pas de regénération requise.
+                _label = subject.get("label") or ""
+                if not _label and subject.get("actu_article"):
+                    _label = (subject["actu_article"].get("title") or "")[:80]
                 response_topics.append(
                     DigestTopic(
                         topic_id=subject.get("topic_id", ""),
-                        label=subject.get("label", ""),
+                        label=_label,
                         rank=subject.get("rank", 0),
                         reason=subject.get("selection_reason", ""),
                         # `is_trending` = signal "≥3 sources couvrent le topic"

--- a/packages/api/tests/test_digest_service.py
+++ b/packages/api/tests/test_digest_service.py
@@ -1108,3 +1108,91 @@ class TestCloneGlobalEditorialDigest:
                 await service.get_or_create_digest(user_id=user_id, target_date=today)
 
         service.selector.select_for_user.assert_awaited()
+
+
+# ─── Tests: _build_editorial_response — fallback label (régression notif) ──────
+
+
+def _make_editorial_content(*, content_id, title):
+    """Mock Content suffisant pour _build_editorial_response."""
+    from app.models.enums import ContentType
+    from app.schemas.content import SourceMini
+
+    content = Mock()
+    content.id = content_id
+    content.title = title
+    content.url = "https://example.com/x"
+    content.thumbnail_url = None
+    content.description = None
+    content.html_content = None
+    content.topics = []
+    content.entities = []
+    content.content_type = ContentType.ARTICLE
+    content.duration_seconds = None
+    content.published_at = datetime(2026, 6, 1, 8, 0, 0)
+    content.is_paid = False
+    content.source_id = uuid4()
+    content.source = SourceMini(
+        id=content.source_id, name="Le Monde", logo_url=None, type="rss", theme=None
+    )
+    return content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stored_label, expected_label",
+    [
+        # Régression bug 21 mai : label persisté vide → on récupère le titre de
+        # l'actu_article pour réactiver la notification personnalisée (variante B).
+        ("", "Conflit au Liban"),
+        # Label déjà présent → on ne l'écrase pas.
+        ("À la une : Liban", "À la une : Liban"),
+    ],
+)
+async def test_editorial_label_falls_back_to_actu_title(
+    service, mock_session, stored_label, expected_label
+):
+    cid = uuid4()
+    content = _make_editorial_content(content_id=cid, title="Conflit au Liban")
+
+    digest = Mock()
+    digest.id = uuid4()
+    digest.user_id = uuid4()
+    digest.target_date = date(2026, 6, 1)
+    digest.generated_at = datetime(2026, 6, 1, 7, 30, 0)
+    digest.mode = "pour_vous"
+    digest.is_serene = False
+    digest.format_version = "editorial_v1"
+    digest.items = {
+        "subjects": [
+            {
+                "topic_id": "t1",
+                "label": stored_label,
+                "rank": 1,
+                "actu_article": {
+                    "content_id": str(cid),
+                    "title": "Conflit au Liban",
+                },
+            }
+        ]
+    }
+
+    # 1er execute() = sources suivies (aucune), 2e = contenus du digest.
+    followed_result = Mock()
+    followed_result.scalars.return_value.all.return_value = []
+    content_result = Mock()
+    content_result.scalars.return_value.all.return_value = [content]
+    mock_session.execute.side_effect = [followed_result, content_result]
+
+    with (
+        patch.object(
+            service, "_get_batch_action_states", new=AsyncMock(return_value={})
+        ),
+        patch.object(
+            service, "_compute_target_size", new=AsyncMock(return_value=5)
+        ),
+    ):
+        response = await service._build_editorial_response(digest, digest.user_id)
+
+    assert len(response.topics) == 1
+    assert response.topics[0].label == expected_label


### PR DESCRIPTION
## Quoi
Répare la **notification matinale "Ton Essentiel"** qui était redevenue générique (variante A) depuis le 21 mai, faute de `label` sur les sujets du digest.

- **Write-side** (`importance_detector.py`) : `cluster.label` est initialisé avec le titre du meilleur article du cluster au lieu de `""` — sert de référence au LLM et garantit un fallback déterministe non vide pour les nouveaux digests.
- **Read-side** (`digest_service._build_editorial_response`) : quand le `label` stocké est vide, on retombe sur le titre de l'`actu_article`. Répare **immédiatement** les digests déjà générés, sans regénération.

## Pourquoi
La notif personnalisée (bullet points « À la une : … ») n'est émise (variante B) que si `digest.topics[i].label` est non vide. La chaîne du `label` était cassée pour la pipeline éditoriale : `ImportanceDetector` créait les `TopicCluster` avec `label=""`, le fallback déterministe propageait ce vide jusqu'au JSONB, puis Flutter filtrait les labels vides → variante A.

Timeline (confirmée Supabase) : ~80% de sujets labellisés les 17-19 mai → **0/820 le 21 mai** → ≈0 depuis.

## Comment ça a été vérifié
- [x] `pytest` complet : **1433 passed**, 1 skipped, 2 xfailed
- [x] Test de régression ajouté (`test_editorial_label_falls_back_to_actu_title`) : label vide → fallback titre actu ; label présent → conservé
- [x] `/simplify` : diff déjà propre, aucun changement
- [ ] Backend-only — pas de Playwright requis

## Zones à risque
- `digest_service._build_editorial_response` (read hot-path du digest) — changement additif et gardé (`if not _label and subject.get("actu_article")`).
- `importance_detector` (pipeline éditoriale write-side) — affecte uniquement les digests générés à partir de demain 07h30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)