### PR TITLE
feat(flux_continu): ≥5 articles par section thématique + deep-dive fiable

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
@@ -178,10 +178,16 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
     final scrollExhausted = !section.hasMore;
     final themeSlug = section.themeSlug;
 
+    // Carrousels + « Explorer plus » + footer (CTA « Sujet suivant ») sont
+    // rendus SOUS la liste chargée, indépendamment de l'exhaustion du scroll
+    // (aligné sur DigestSectionScreen). L'infinite-scroll continue d'ajouter des
+    // pages d'articles AU-DESSUS ; le bloc de clôture reste en bas, toujours
+    // accessible — c'est la seule route fiable vers le deep-dive.
+    //
     // Pré-calcul des carrousels : permet de passer `hasThemeCarousels` à
     // _buildDiscoverySection pour qu'elle décide si la carte "Vous êtes à
     // jour" doit s'afficher (aucun carrousel ET aucun article de découverte).
-    final themeCarousels = (scrollExhausted && themeSlug != null)
+    final themeCarousels = themeSlug != null
         ? _buildThemeCarousels(section, themeSlug)
         : const <Widget>[];
 
@@ -214,13 +220,14 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
             child: _LoadingMoreIndicator(visible: section.isLoadingMore),
           ),
         ...themeCarousels,
-        if (scrollExhausted && themeSlug != null)
+        if (themeSlug != null)
           ..._buildDiscoverySection(
             section,
             themeSlug,
             hasThemeCarousels: themeCarousels.isNotEmpty,
+            scrollExhausted: scrollExhausted,
           ),
-        if (scrollExhausted) _buildFooterSliver(section),
+        _buildFooterSliver(section),
         const SliverToBoxAdapter(child: SizedBox(height: 40)),
       ],
     );
@@ -262,6 +269,7 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
     FeedThemeSection section,
     String themeSlug, {
     bool hasThemeCarousels = false,
+    bool scrollExhausted = false,
   }) {
     final async = ref.watch(themeDiscoveryProvider(themeSlug));
     return async.when(
@@ -295,7 +303,9 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
 
         // Rien à montrer après les articles personnalisés : ni carrousel
         // éditorial, ni article de découverte → carte "Vous êtes à jour".
-        if (!hasThemeCarousels) {
+        // Gardée sur scrollExhausted pour ne pas annoncer "à jour" alors que
+        // d'autres pages d'articles peuvent encore charger.
+        if (scrollExhausted && !hasThemeCarousels) {
           return [
             SliverToBoxAdapter(
               child: _ThemeClosingCard(label: section.label),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -156,9 +156,11 @@ class SectionBlock extends StatelessWidget {
   /// Returns the "Voir tout" / "Plus de…" button for this section, or null
   /// when no overflow CTA applies.
   Widget? _buildVoirPlusButton(FluxSection section, int hiddenCount) {
-    if (section is FeedThemeSection &&
-        onSeeAll != null &&
-        (hiddenCount > 0 || section.hasMore)) {
+    // Filet de sécurité : le bouton est TOUJOURS rendu pour une section thème
+    // (indépendant de la taille du pool). Le deep-dive est la seule route vers
+    // carrousels / « Explorer plus » / CTA « Sujet suivant », donc on ne le
+    // masque jamais — même quand la section tient en entier à l'écran.
+    if (section is FeedThemeSection && onSeeAll != null) {
       return SeeAllSectionButton(
         hiddenCount: hiddenCount > 0 ? hiddenCount : 0,
         onTap: onSeeAll!,

--- a/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
+++ b/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
@@ -281,6 +281,15 @@ void main() {
       expect(result, same(b));
     });
 
+    test('returns the next digest section after a theme section', () {
+      // La section suivante peut être une section digest (Bonnes Nouvelles /
+      // Actus du jour) — le footer route alors vers /section/ et non /theme/.
+      final a = themeSection(slug: 'tech');
+      final b = digestSection(kind: SectionKind.bonnes);
+      final result = nextSectionAfter([a, b], sectionKey(a));
+      expect(result, same(b));
+    });
+
     test('returns null when current section is the last one', () {
       final a = themeSection(slug: 'tech');
       final b = themeSection(slug: 'climat');

--- a/apps/mobile/test/features/flux_continu/screens/theme_section_screen_test.dart
+++ b/apps/mobile/test/features/flux_continu/screens/theme_section_screen_test.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/feed/providers/feed_provider.dart';
+import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
+import 'package:facteur/features/flux_continu/providers/flux_continu_provider.dart';
+import 'package:facteur/features/flux_continu/providers/theme_discovery_provider.dart';
+import 'package:facteur/features/flux_continu/screens/theme_section_screen.dart';
+import 'package:facteur/features/flux_continu/widgets/theme_detail_footer.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+
+/// Both top-level AsyncNotifiers stay in `loading` forever so the screen renders
+/// from `initialSection` and `valueOrNull` is null — exactly the slide-in state
+/// where the footer/carousels/discovery used to be hidden behind `scrollExhausted`.
+class _LoadingFluxNotifier extends FluxContinuNotifier {
+  @override
+  Future<FluxContinuState> build() => Completer<FluxContinuState>().future;
+}
+
+class _LoadingFeedNotifier extends FeedNotifier {
+  @override
+  Future<FeedState> build() => Completer<FeedState>().future;
+}
+
+Content _content(String id, {bool followed = false}) {
+  return Content(
+    id: id,
+    title: 'title-$id',
+    url: 'https://x.test/$id',
+    contentType: ContentType.article,
+    publishedAt: DateTime(2026, 1, 1),
+    source: Source(id: 's-$id', name: 'S', type: SourceType.article),
+    isFollowedSource: followed,
+  );
+}
+
+FeedThemeSection _themeSection({required bool hasMore}) {
+  return FeedThemeSection(
+    kind: SectionKind.theme,
+    label: 'Tech',
+    accent: const Color(0xFF2C3E50),
+    coreVisibleCount: 3,
+    themeSlug: 'tech',
+    items: [_content('c0'), _content('c1')],
+    hasMore: hasMore,
+  );
+}
+
+Widget _wrap(Widget child, {required List<Override> overrides}) {
+  return ProviderScope(
+    overrides: overrides,
+    child: MaterialApp(
+      theme: ThemeData(extensions: [FacteurPalettes.light]),
+      home: child,
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets(
+      'ThemeDetailFooter + discovery render even when section.hasMore is true '
+      '(no scroll exhaustion required)', (tester) async {
+    await tester.pumpWidget(_wrap(
+      ThemeSectionScreen(
+        sectionKeyValue: 'theme:tech',
+        initialSection: _themeSection(hasMore: true),
+      ),
+      overrides: [
+        fluxContinuProvider.overrideWith(_LoadingFluxNotifier.new),
+        feedProvider.overrideWith(_LoadingFeedNotifier.new),
+        // A non-followed discovery item not already shown → the "Explorer de
+        // nouvelles sources" block must render despite hasMore == true.
+        themeDiscoveryProvider('tech').overrideWith(
+          (ref) async => [_content('d0', followed: false)],
+        ),
+      ],
+    ));
+    // Pump frames without settling (the two notifiers never complete).
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    // Footer is always present now — it carries the "Sujet suivant" / "Retour
+    // à la Tournée" CTA, the whole point of the fix.
+    expect(find.byType(ThemeDetailFooter), findsOneWidget);
+    // No next section resolvable (provider still loading) → graceful fallback.
+    expect(find.text('Retour à la Tournée'), findsWidgets);
+    // Discovery block surfaced below the loaded list without scroll exhaustion.
+    expect(find.text('Explorer de nouvelles sources'), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
@@ -105,8 +105,9 @@ void main() {
     });
 
     testWidgets(
-        'SeeAllSectionButton hidden when nothing left to show (no overflow, '
-        'no hasMore)', (tester) async {
+        'SeeAllSectionButton ALWAYS shown for FeedThemeSection even when the '
+        'section fits (no overflow, no hasMore) — deep-dive is the only route '
+        'to carousels/Explorer/next-CTA', (tester) async {
       await tester.pumpWidget(_wrap(
         SectionBlock(
           section: _themeSection(items: 2, coreVisibleCount: 3),
@@ -117,7 +118,9 @@ void main() {
         ),
       ));
 
-      expect(find.byType(SeeAllSectionButton), findsNothing);
+      // hiddenCount = 2 - 3 = -1 → clamped to 0 → label "Tout lire" (no suffix).
+      expect(find.byType(SeeAllSectionButton), findsOneWidget);
+      expect(find.text('Tout lire'), findsOneWidget);
     });
 
     testWidgets(

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -83,6 +83,12 @@ class ScoringWeights:
     # scoring Fraîcheur continue de privilégier « le plus frais d'abord ».
     THEMATIC_WINDOW_TIERS_HOURS = (24, 48, 72)  # paliers d'élargissement successifs
     THEMATIC_MIN_POOL_SIZE = 8  # sous ce seuil → on tente le palier suivant
+    # Plancher absolu de candidats par section thématique. Si le pool des sources
+    # suivies reste en dessous (même au palier 72h), on complète avec des sources
+    # curées NON-suivies (comme Flâner), marquées « Suivre + » à l'affichage. Le
+    # deep-dive (carrousels / Explorer plus / CTA Sujet suivant) reste toujours
+    # accessible.
+    THEMATIC_HARD_FLOOR = 5
 
     # --- QUALITY LAYER (FQS - Facteur Quality Score) ---
 

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -2685,6 +2685,56 @@ class RecommendationService:
                 candidates=len(candidates_list),
                 threshold=ScoringWeights.THEMATIC_MIN_POOL_SIZE,
             )
+
+            # Backfill curé NON-suivi : quand l'utilisateur suit ≥1 source
+            # (_use_two_phase) mais que le pool suivi reste sous le plancher
+            # absolu, on complète avec des sources curées non-suivies (comme
+            # Flâner) pour garantir un deep-dive exploitable. `is_followed_source`
+            # (calculé plus bas) marquera ces articles à false → chip « Suivre + »
+            # côté client. On NE backfill PAS quand l'utilisateur ne suit aucune
+            # source (le `query` est déjà restreint aux sources curées non-deep).
+            if (
+                _use_two_phase
+                and len(candidates_list) < ScoringWeights.THEMATIC_HARD_FLOOR
+            ):
+                followed_pool = len(candidates_list)
+                since_backfill = now_window - datetime.timedelta(
+                    hours=ScoringWeights.THEMATIC_WINDOW_TIERS_HOURS[-1]
+                )
+                # `query` hérite déjà des filtres thème/topic, mutes, serein,
+                # paywall, langue. On ajoute la restriction curée non-suivie et la
+                # fenêtre la plus large autorisée (72h). Requête simple sur le plan
+                # `is_curated` (rapide) — pas besoin du garde-fou timeout réservé à
+                # la branche followed-only.
+                backfill_query = (
+                    query.where(
+                        Content.published_at >= since_backfill,
+                        Source.is_curated,
+                        Source.source_tier != "deep",
+                        Source.id.notin_(list(followed_source_ids)),
+                    )
+                    .order_by(Content.published_at.desc())
+                    .limit(limit_candidates)
+                )
+                backfill_result = await self.session.scalars(backfill_query)
+                backfill_list = list(backfill_result.all())
+
+                # Ordre suivies-d'abord : concaténer le backfill APRÈS le pool
+                # suivi, dédupe par id (1ʳᵉ occurrence gardée), tronquer.
+                seen_ids: set = {c.id for c in candidates_list}
+                for c in backfill_list:
+                    if c.id not in seen_ids:
+                        candidates_list.append(c)
+                        seen_ids.add(c.id)
+                candidates_list = candidates_list[:limit_candidates]
+
+                logger.info(
+                    "feed_thematic_backfill",
+                    user_id=str(user_id),
+                    followed_pool=followed_pool,
+                    backfilled=len(candidates_list) - followed_pool,
+                    final=len(candidates_list),
+                )
         else:
             candidates_list = await _fetch_candidates(query)
 

--- a/packages/api/tests/test_personalized_theme_mode.py
+++ b/packages/api/tests/test_personalized_theme_mode.py
@@ -45,6 +45,32 @@ def _make_service():
     return RecommendationService(session), session
 
 
+def _mock_content():
+    """Minimal Content stub: only `.id` (dedup) + `.source` (logging) used."""
+    c = MagicMock()
+    c.id = uuid4()
+    return c
+
+
+def _stub_scalars_two_pools(captured: list, followed: list, backfill: list):
+    """`session.scalars` returning the followed pool for the two-phase query and
+    the backfill pool for the curated `NOT IN` query (distinguished by SQL)."""
+
+    def _result(items):
+        r = MagicMock()
+        r.all.return_value = items
+        return r
+
+    async def _scalars(stmt):
+        sql = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        captured.append(sql)
+        if " not in " in sql.lower():
+            return _result(backfill)
+        return _result(followed)
+
+    return _scalars
+
+
 @pytest.mark.asyncio
 async def test_personalized_theme_filters_to_followed_sources():
     """personalized=True + theme + followed → SQL restricts to followed sources."""
@@ -237,6 +263,134 @@ async def test_personalized_theme_relaxes_seen_consumed_filter():
     assert "manually_impressed" not in sql, (
         "personalized_theme_mode ne doit pas filtrer manually_impressed.\n"
         f"SQL:\n{captured[0]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backfill curé NON-suivi : garantit ≥ THEMATIC_HARD_FLOOR articles par section
+# thématique quand le pool des sources suivies est trop maigre (même au palier
+# 72h). On complète avec des sources curées non-suivies (comme Flâner), marquées
+# « Suivre + » côté client. Décisions PO : compléter par du curé non-suivi,
+# profondeur 72h, pas de palier 7 jours.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thematic_backfill_reaches_floor():
+    """Pool suivi = 3 (< plancher 5) → une requête curée non-suivie est émise et
+    le résultat fusionné a ≥5, les articles suivis d'abord."""
+    from app.services.recommendation.scoring_config import ScoringWeights
+
+    service, session = _make_service()
+    captured: list[str] = []
+    followed = [_mock_content() for _ in range(3)]
+    backfill = [_mock_content() for _ in range(5)]
+    session.scalars = _stub_scalars_two_pools(captured, followed, backfill)
+
+    result = await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            theme="science",
+            personalized=True,
+            followed_source_ids={uuid4(), uuid4()},
+        ),
+        timeout=5.0,
+    )
+
+    # Plancher atteint, suivies d'abord puis backfill.
+    assert len(result) >= ScoringWeights.THEMATIC_HARD_FLOOR
+    assert result[: len(followed)] == followed, "followed sources must come first"
+    assert result[len(followed) :] == backfill, "backfill appended after followed"
+
+    # La requête de backfill : curée, fenêtre 72h, exclut les sources suivies.
+    backfill_sql = next((s for s in captured if " not in " in s.lower()), None)
+    assert backfill_sql is not None, "expected a curated NOT IN backfill query"
+    low = backfill_sql.lower()
+    assert "is_curated" in low
+    assert "published_at" in low and ">=" in low
+    # Filtre thème hérité du `query` (chemin (1) ou (2) du theme focus filter).
+    assert "contents.theme = " in low or "sources.theme = " in low
+
+
+@pytest.mark.asyncio
+async def test_thematic_backfill_carries_serein_filter():
+    """En mode serein, le backfill réutilise le `query` déjà filtré serein →
+    la requête curée porte la condition is_serene."""
+    service, session = _make_service()
+    captured: list[str] = []
+    followed = [_mock_content() for _ in range(2)]
+    backfill = [_mock_content() for _ in range(5)]
+    session.scalars = _stub_scalars_two_pools(captured, followed, backfill)
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            theme="science",
+            personalized=True,
+            followed_source_ids={uuid4()},
+            serein=True,
+        ),
+        timeout=5.0,
+    )
+
+    backfill_sql = next((s for s in captured if " not in " in s.lower()), None)
+    assert backfill_sql is not None
+    assert "is_serene" in backfill_sql.lower(), (
+        "serein backfill must carry the is_serene filter inherited from query"
+    )
+
+
+@pytest.mark.asyncio
+async def test_thematic_backfill_skipped_when_followed_pool_sufficient():
+    """Pool suivi ≥ plancher → aucune requête de backfill (pas de NOT IN)."""
+    service, session = _make_service()
+    captured: list[str] = []
+    # 6 ≥ THEMATIC_HARD_FLOOR (5) mais < THEMATIC_MIN_POOL_SIZE (8) : la fenêtre
+    # adaptative tourne, mais le plancher est dépassé → pas de backfill.
+    followed = [_mock_content() for _ in range(6)]
+    session.scalars = _stub_scalars_two_pools(captured, followed, [])
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            theme="tech",
+            personalized=True,
+            followed_source_ids={uuid4()},
+        ),
+        timeout=5.0,
+    )
+
+    assert not any(" not in " in s.lower() for s in captured), (
+        "no curated backfill query should be issued when the followed pool "
+        "already meets the floor"
+    )
+
+
+@pytest.mark.asyncio
+async def test_thematic_backfill_skipped_zero_followed():
+    """Zéro source suivie → branche curée directe, pas de backfill (pas de
+    NOT IN sur les sources suivies)."""
+    service, session = _make_service()
+    captured: list[str] = []
+    followed = [_mock_content() for _ in range(2)]
+    session.scalars = _stub_scalars_two_pools(captured, followed, [])
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            theme="tech",
+            personalized=True,
+            followed_source_ids=set(),
+        ),
+        timeout=5.0,
+    )
+
+    assert not any(" not in " in s.lower() for s in captured), (
+        "zero-followed case is already curated-only; no backfill expected"
     )
 
 

--- a/packages/api/tests/test_thematic_curation.py
+++ b/packages/api/tests/test_thematic_curation.py
@@ -141,6 +141,90 @@ async def test_adaptive_window_stays_24h_when_pool_sufficient(
     assert not (older & ids), "le pool 24h suffit, pas d'élargissement à 48h"
 
 
+def test_thematic_window_tiers_and_floor_config():
+    """Paliers (24,48,72) — plafond 72h, pas de palier 7j (décision PO) — et
+    le plancher absolu THEMATIC_HARD_FLOOR=5 existe."""
+    assert ScoringWeights.THEMATIC_WINDOW_TIERS_HOURS == (24, 48, 72)
+    assert max(ScoringWeights.THEMATIC_WINDOW_TIERS_HOURS) == 72  # pas de 168h
+    assert ScoringWeights.THEMATIC_HARD_FLOOR == 5
+
+
+@pytest.fixture
+async def curated_unfollowed_tech_source(db_session):
+    """Source curée tech NON suivie par l'utilisateur (alimente le backfill)."""
+    source = Source(
+        id=uuid4(),
+        name="Tech Curated Unfollowed",
+        url="https://tech-curated.com",
+        feed_url=f"https://tech-curated.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="tech",
+        is_active=True,
+        is_curated=True,
+    )
+    db_session.add(source)
+    await db_session.commit()
+    return source
+
+
+async def test_backfill_reaches_floor_with_curated_unfollowed(
+    db_session, followed_tech_source, curated_unfollowed_tech_source, user_id
+):
+    """Pool suivi sous le plancher (3) → complété par des sources curées NON
+    suivies pour atteindre ≥5 ; les articles suivis restent en tête."""
+    followed = await _add_tech_contents(
+        db_session, followed_tech_source.id, count=3, hours_ago=10
+    )
+    unfollowed = await _add_tech_contents(
+        db_session, curated_unfollowed_tech_source.id, count=6, hours_ago=20
+    )
+
+    service = RecommendationService(db_session)
+    candidates = await service._get_candidates(
+        user_id=user_id,
+        limit_candidates=100,
+        theme="tech",
+        personalized=True,
+        followed_source_ids={followed_tech_source.id},
+    )
+
+    ids = [c.id for c in candidates]
+    id_set = set(ids)
+    assert len(candidates) >= ScoringWeights.THEMATIC_HARD_FLOOR
+    assert followed <= id_set, "les articles suivis doivent être présents"
+    assert unfollowed & id_set, "le backfill curé non-suivi doit compléter le pool"
+    # Suivies d'abord : tous les articles suivis précèdent le 1er article backfill.
+    last_followed = max(i for i, cid in enumerate(ids) if cid in followed)
+    first_backfill = min(i for i, cid in enumerate(ids) if cid in unfollowed)
+    assert last_followed < first_backfill, "followed sources must precede backfill"
+
+
+async def test_no_backfill_when_followed_pool_sufficient_db(
+    db_session, followed_tech_source, curated_unfollowed_tech_source, user_id
+):
+    """Pool suivi ≥ plancher → aucun article de source non-suivie n'est ajouté."""
+    await _add_tech_contents(
+        db_session, followed_tech_source.id, count=6, hours_ago=10
+    )
+    unfollowed = await _add_tech_contents(
+        db_session, curated_unfollowed_tech_source.id, count=6, hours_ago=20
+    )
+
+    service = RecommendationService(db_session)
+    candidates = await service._get_candidates(
+        user_id=user_id,
+        limit_candidates=100,
+        theme="tech",
+        personalized=True,
+        followed_source_ids={followed_tech_source.id},
+    )
+
+    id_set = {c.id for c in candidates}
+    assert not (unfollowed & id_set), (
+        "pool suivi suffisant (≥ plancher) → pas de backfill non-suivi"
+    )
+
+
 # --------------------------------------------------------------------------
 # Fix #1 — le PillarScoringEngine privilégie la qualité (article riche > teaser)
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Quoi
Les sections thématiques de la Tournée du jour étaient souvent trop vides (2-3 articles) et le deep-dive (page de détail thème) était difficile à atteindre. Cette PR garantit **un minimum d'articles par section** et rend le deep-dive **toujours accessible**.

**Backend** — plancher de candidats par section thématique :
- ajout de `THEMATIC_HARD_FLOOR = 5` (`scoring_config.py`) ;
- dans `_get_candidates`, après la fenêtre adaptative (24/48/72h inchangée), quand l'utilisateur suit ≥1 source mais que le pool suivi reste < plancher, **backfill avec des sources curées NON-suivies** (comme Flâner), fenêtre 72h. Les articles suivis restent en tête, dédupe par id ; les articles backfillés seront marqués « Suivre + » côté client (`is_followed_source=false`).
- **Pas** de backfill si zéro source suivie (déjà curé) ; le mode serein est porté (réutilise le `query` déjà filtré).

**Frontend** — deep-dive toujours accessible :
- bouton « Tout lire » **toujours rendu** pour une section thème (`section_block.dart`) ;
- footer (CTA « Sujet suivant » / « Retour à la Tournée »), carrousels et « Explorer plus » **dé-gatés de `scrollExhausted`** (`theme_section_screen.dart`) → rendus sous la liste chargée, aligné sur `DigestSectionScreen`. La carte « Vous êtes à jour » reste gardée sur l'exhaustion.

## Pourquoi
Le pool était restreint aux sources suivies avec une fenêtre plafonnée à 72h s'arrêtant dès 8 candidats, alors que Flâner pioche dans toutes les sources curées → sections quasi vides. Côté UI, une section de 2-3 articles n'affichait aucun bouton « Lire plus » et la page de détail masquait carrousels/Explorer/CTA tant qu'on n'avait pas paginé jusqu'au bout. Décisions PO validées : compléter par du curé non-suivi, profondeur 72h (pas de palier 7 jours).

## Comment ça a été vérifié
- [x] **Backend `pytest -v`** — suite complète : **1451 passed, 1 skipped, 2 xfailed**. Nouveaux tests : backfill atteint le plancher (suivies-d'abord), serein porté, skip si pool suffisant, skip si zéro suivi, config tiers/floor (unit mockés + intégration DB réelle). Régression two-phase-timeout OK.
- [x] **Mobile** — `flutter analyze` sur les fichiers modifiés : *No issues found*. Tests `flux_continu` (modèles, widget section_block, nouveau widget-test écran) : **40 passed**. (`flutter test` complet a des échecs pré-existants hors périmètre — Hive/Supabase non init ; CI = backend pytest only.)
- [x] **/simplify** — 4 agents (reuse/simplification/efficiency/altitude) : code confirmé propre, findings écartés (comportement voulu par le plan / hors-scope).
- [ ] Playwright (UI) : non exécuté — l'intégration DB exerce déjà `_get_candidates` bout-à-bout ; validation visuelle possible via `/validate-feature` si souhaité.

## Zones à risque
- `recommendation_service._get_candidates` (chemin feed thématique) — le backfill n'ajoute **une** requête que sous le plancher (rare sur thèmes denses), sur le plan `is_curated` rapide.
- `theme_section_screen` / `section_block` — changements de rendu (footer/carrousels toujours visibles).
- **Pas de migration Alembic** (aucun changement de schéma).

🤖 Generated with [Claude Code](https://claude.com/claude-code)