### PR TITLE
fix(digest): classement Actus du jour par importance éditoriale

### DIFF
--- a/docs/bugs/bug-actus-du-jour-ranking.md
+++ b/docs/bugs/bug-actus-du-jour-ranking.md
@@ -1,0 +1,78 @@
+# Bug — Classement des « Actus du jour » incompréhensible
+
+## Symptômes (rapportés par le PO)
+
+1. Des sujets à **1 seul article** remontent très haut.
+2. Un sujet **11 sources, polarisé, paru aujourd'hui** (qui « devrait être #1 »)
+   se retrouve 10ème.
+3. Les **faux-positifs France Culture** (séries type « Philippe Jaenada, l'art
+   de la contre-enquête ») peuplent toujours la section, malgré le fix
+   anti-doublon de mai 2026.
+
+## Cause racine
+
+« Actus du jour » = la `DigestTopicSection(kind: essentiel)` legacy, alimentée
+par les `subjects` du pipeline éditorial, en deux étapes :
+
+- **Étape 1 — sélection globale** (`editorial/pipeline.py::compute_global_context`).
+- **Étape 2 — projection per-user** (`digest_selector.py::_project_editorial_for_user`,
+  format `editorial_v2`, PR #740) : « À la Une » reste rang 1, **et tout le reste
+  est ré-trié par le score de personnalisation** de l'article représentant.
+
+Pourquoi les 3 symptômes :
+
+- **#2** : l'étape 2 ne passe pas la couverture multi-sources au tri ; la
+  personnalisation seule ordonne le rang 2+. La couverture a donc **zéro poids**.
+- **#1** : l'étape 2 injecte des **sujets solo** (`source_count=1`) triés dans le
+  même paquet par score perso → passent devant des sujets multi-sources.
+- **#3** : `curation.py` filtre/trie par `len(source_ids)`, **pas** `source_domains`
+  → les 2 sous-sources France Culture (même domaine `radiofrance.fr`) comptent
+  comme un cluster « 2 sources ». Le fix `source_domains` (commit 2667003b) est
+  appliqué partout ailleurs sauf ici. De plus `is_news_bulletin_title` ne matche
+  pas les titres de **séries**.
+
+## Décisions PO (validées)
+
+- Ordre rang 2+ : **importance éditoriale d'abord** (couverture + récence +
+  polarisation), personnalisation en **départage**.
+- Sujets solo (1 source) : **relégués** — autorisés mais jamais au-dessus d'un
+  sujet multi-sources.
+
+## Correctif (PR `fix(digest)`)
+
+- **A** — `curation.py` + `pipeline.py` : dédoublonnage par `source_domains`
+  (plus `source_ids`) pour la porte multi-source, les tris et `source_count`.
+- **B** — `filter_presets.py` : `is_news_bulletin_title` étendu aux séries
+  nommées ; garde d'éligibilité cluster dans `compute_global_context` (écarte un
+  cluster dont tous les contenus sont bulletin/série ou source denylistée).
+- **C** — `digest_selector.py::_project_editorial_for_user` : tri par clé
+  composite `(is_multi, importance, perso)`, « À la Une » rang 1 préservé.
+  `importance = coverage + recency + polarization`, réutilise
+  `helpers/coverage_score.py` + nouveau `helpers/editorial_ranking.py`.
+- **D** — `digest_service.py` : bump `editorial_v2` → `editorial_v3` (sémantique
+  d'ordre changée → régénération des digests cachés). Forme JSON inchangée.
+
+Aucun DDL → pas de migration Alembic.
+
+## Vérification terrain — cas « Philippe Jaenada » (lecture seule prod)
+
+Requête read-only sur `contents` (2026-06-02) : le sujet est une **série de 5
+épisodes France Culture**, tous portés par **le même `source_id`**
+(`b9becd34-…`, domaine `radiofrance.fr`) :
+
+| titre | source | published_at |
+|-------|--------|--------------|
+| …, l'art de la contre-enquête 1/5 … | France Culture | 2026-06-01 |
+| … 2/5 … | France Culture | 2026-06-02 |
+| … 3/5 / 4/5 / 5/5 … | France Culture | 06-03 → 06-05 |
+
+**Conclusion** : ce n'est **pas** « 2 feeds même domaine » (hypothèse initiale du
+plan pour #3) mais **1 source / 5 articles**. → c'est la **Partie B** qui le
+règle : le pattern série `,\s*l['']art (de|…)` matche les 5 titres, et la garde
+d'éligibilité cluster (`_is_non_actu_cluster`) écarte le cluster (100 % bulletins/
+séries). L'article légitime « …ou le grand art de la contre-enquête » (Slate, sans
+virgule + `l'art`) n'est **pas** matché → pas de faux-positif.
+
+La **Partie A** (dédoublonnage par domaine) reste un durcissement correct et
+nécessaire (le cas « 2 feeds radiofrance.fr » existe ailleurs), mais n'était pas
+le levier décisif pour ce cas précis.

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -46,6 +46,11 @@ from app.services.recommendation.filter_presets import (
     apply_good_news_filter,
     is_sport_content,
 )
+from app.services.recommendation.helpers.coverage_score import compute_coverage_score
+from app.services.recommendation.helpers.editorial_ranking import (
+    polarization_bonus,
+    recency_bonus,
+)
 from app.services.recommendation.scoring_config import ScoringWeights
 from app.services.recommendation.scoring_engine import ScoringContext
 from app.services.recommendation_service import RecommendationService
@@ -1225,12 +1230,39 @@ class DigestSelector:
                     user_id=str(context.user_id),
                 )
 
-        def subject_score(s: EditorialSubject) -> float:
+        def subject_perso(s: EditorialSubject) -> float:
+            """Score de personnalisation du représentant — départage uniquement."""
             if s.actu_article is None:
                 return float("-inf")
             return score_map.get(s.actu_article.content_id, 0.0)
 
-        # 3. Sujets solo au-dessus du seuil.
+        def subject_importance(s: EditorialSubject) -> float:
+            """Importance éditoriale = couverture + récence + polarisation.
+
+            Critère primaire du rang 2+. Réutilise `compute_coverage_score`
+            (source de vérité couverture) et les helpers partagés de récence /
+            polarisation. La personnalisation ne sert plus qu'à départager.
+            """
+            published = s.actu_article.published_at if s.actu_article else None
+            return (
+                compute_coverage_score(s.source_count)
+                + recency_bonus(published)
+                + polarization_bonus(s.divergence_level)
+            )
+
+        def subject_rank_key(s: EditorialSubject) -> tuple[bool, float, float]:
+            """Clé de tri reverse=True : importance éditoriale d'abord, perso en
+            départage, et les sujets solo (1 source) toujours sous les
+            multi-sources. Un sujet sans actu est relégué en dernier.
+            """
+            if s.actu_article is None:
+                return (False, float("-inf"), float("-inf"))
+            is_multi = s.source_count >= 2
+            return (is_multi, subject_importance(s), subject_perso(s))
+
+        # 3. Sujets solo au-dessus du seuil. Conservés mais RELÉGUÉS sous les
+        # sujets multi-sources par `subject_rank_key` (is_multi=False) — décision
+        # PO : un solo n'est jamais au-dessus d'un multi-sources.
         threshold = _read_solo_subject_min_score()
         solo_subjects: list[EditorialSubject] = []
         for c in solo_candidates:
@@ -1258,10 +1290,12 @@ class DigestSelector:
                 )
             )
 
-        # Re-ranking : « À la Une » reste rang 1 ; le reste trié par score desc.
+        # Re-ranking : « À la Une » reste rang 1 ; le reste trié par importance
+        # éditoriale (couverture + récence + polarisation), perso en départage,
+        # solos relégués sous les multi-sources. Cf. bug-actus-du-jour-ranking.md.
         une = [s for s in subjects if s.is_a_la_une]
         rest = [s for s in subjects if not s.is_a_la_une] + solo_subjects
-        rest_sorted = sorted(rest, key=subject_score, reverse=True)
+        rest_sorted = sorted(rest, key=subject_rank_key, reverse=True)
         ordered = (une + rest_sorted)[:target]
 
         renumbered: list[EditorialSubject] = []

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -330,16 +330,21 @@ def _select_daily_quote(user_id: str, target_date: str) -> dict | None:
 
 
 # Version courante du format editorial. Bumpée editorial_v1 -> editorial_v2 avec
-# la projection per-user (P2) : la FORME JSON est inchangée (toujours
-# `subjects[]`), mais la SÉMANTIQUE de sélection change (représentant source
-# suivie + re-ranking intérêts + sujets solo). Le bump force la régénération des
-# digests cachés `editorial_v1` (le cron les voit "stale") et évite de servir un
-# mix de sémantiques. Clé d'idempotence (user_id, target_date, is_serene)
-# inchangée.
-EDITORIAL_FORMAT_VERSION = "editorial_v2"
-# Tous les formats editorial rendus/clonables pendant la transition v1 -> v2.
+# la projection per-user (P2), puis editorial_v2 -> editorial_v3 avec le
+# classement par importance éditoriale (couverture + récence + polarisation,
+# perso en départage ; solos relégués) — cf. bug-actus-du-jour-ranking.md. La
+# FORME JSON est inchangée (toujours `subjects[]`), mais la SÉMANTIQUE D'ORDRE
+# change → le bump force la régénération des digests cachés `editorial_v2`
+# (le cron les voit "stale") et évite de servir un mix de sémantiques. Clé
+# d'idempotence (user_id, target_date, is_serene) inchangée.
+EDITORIAL_FORMAT_VERSION = "editorial_v3"
+# Tous les formats editorial rendus/clonables pendant les transitions.
 # Même forme JSON → `_build_editorial_response` les traite identiquement.
-_EDITORIAL_FORMATS: tuple[str, ...] = ("editorial_v1", "editorial_v2")
+_EDITORIAL_FORMATS: tuple[str, ...] = (
+    "editorial_v1",
+    "editorial_v2",
+    "editorial_v3",
+)
 
 # Format versions that the read-only hot path is willing to render. flat_v1
 # is legacy/expendable — never served from /digest or /digest/both.

--- a/packages/api/app/services/editorial/curation.py
+++ b/packages/api/app/services/editorial/curation.py
@@ -39,9 +39,9 @@ def _cluster_to_une_topic(cluster: TopicCluster) -> SelectedTopic:
     return SelectedTopic(
         topic_id=cluster.cluster_id,
         label=cluster.label[:80],
-        selection_reason=f"Traité par {len(cluster.source_ids)} sources",
+        selection_reason=f"Traité par {len(cluster.source_domains)} sources",
         deep_angle=deep_angle,
-        source_count=len(cluster.source_ids),
+        source_count=len(cluster.source_domains),
         theme=cluster.theme,
         is_a_la_une=True,
     )
@@ -113,16 +113,16 @@ class CurationService:
         logger.info(
             "curation.a_la_une_selected",
             topic_id=selected_id,
-            source_count=len(cluster.source_ids),
+            source_count=len(cluster.source_domains),
             reason=reason,
         )
 
         return SelectedTopic(
             topic_id=cluster.cluster_id,
             label=cluster.label[:80],
-            selection_reason=reason or f"Traité par {len(cluster.source_ids)} sources",
+            selection_reason=reason or f"Traité par {len(cluster.source_domains)} sources",
             deep_angle=deep_angle,
-            source_count=len(cluster.source_ids),
+            source_count=len(cluster.source_domains),
             theme=cluster.theme,
             is_a_la_une=True,
         )
@@ -185,16 +185,16 @@ class CurationService:
         logger.info(
             "curation.bonne_nouvelle_selected",
             topic_id=selected_id,
-            source_count=len(cluster.source_ids),
+            source_count=len(cluster.source_domains),
             reason=reason,
         )
 
         return SelectedTopic(
             topic_id=cluster.cluster_id,
             label=cluster.label[:80],
-            selection_reason=reason or f"Traité par {len(cluster.source_ids)} sources",
+            selection_reason=reason or f"Traité par {len(cluster.source_domains)} sources",
             deep_angle=deep_angle,
-            source_count=len(cluster.source_ids),
+            source_count=len(cluster.source_domains),
             theme=cluster.theme,
             is_a_la_une=True,
         )
@@ -230,7 +230,7 @@ class CurationService:
         # singletons si le pool multi-source est insuffisant (week-end,
         # jours fériés). Symétrique de `a_la_une_pool` (pipeline.py:176-179).
         # Cf. bug-essentiel-pipeline.md.
-        multi_source = [c for c in available if len(c.source_ids) >= 2]
+        multi_source = [c for c in available if len(c.source_domains) >= 2]
         pool = multi_source if len(multi_source) >= count else available
         if pool is available and multi_source:
             logger.info(
@@ -241,7 +241,7 @@ class CurationService:
             )
 
         # Take top clusters by source count
-        top_clusters = sorted(pool, key=lambda c: len(c.source_ids), reverse=True)[
+        top_clusters = sorted(pool, key=lambda c: len(c.source_domains), reverse=True)[
             :limit
         ]
 
@@ -304,7 +304,7 @@ class CurationService:
         # Validate and parse
         valid_topic_ids = {c.cluster_id for c in clusters}
         # Build source_count and theme lookups from cluster data
-        cluster_source_counts = {c.cluster_id: len(c.source_ids) for c in clusters}
+        cluster_source_counts = {c.cluster_id: len(c.source_domains) for c in clusters}
         cluster_themes = {c.cluster_id: c.theme for c in clusters}
         selected: list[SelectedTopic] = []
 
@@ -356,7 +356,7 @@ class CurationService:
 
         # Sort by source_count desc
         sorted_clusters = sorted(
-            clusters, key=lambda c: len(c.source_ids), reverse=True
+            clusters, key=lambda c: len(c.source_domains), reverse=True
         )
 
         for cluster in sorted_clusters:
@@ -372,9 +372,9 @@ class CurationService:
                 SelectedTopic(
                     topic_id=cluster.cluster_id,
                     label=cluster.label[:80],
-                    selection_reason=f"Couvert par {len(cluster.source_ids)} sources",
+                    selection_reason=f"Couvert par {len(cluster.source_domains)} sources",
                     deep_angle=deep_angle,
-                    source_count=len(cluster.source_ids),
+                    source_count=len(cluster.source_domains),
                     theme=cluster.theme,
                 )
             )
@@ -395,9 +395,9 @@ class CurationService:
                     SelectedTopic(
                         topic_id=cluster.cluster_id,
                         label=cluster.label[:80],
-                        selection_reason=f"Couvert par {len(cluster.source_ids)} sources",
+                        selection_reason=f"Couvert par {len(cluster.source_domains)} sources",
                         deep_angle=deep_angle,
-                        source_count=len(cluster.source_ids),
+                        source_count=len(cluster.source_domains),
                         theme=cluster.theme,
                     )
                 )
@@ -411,7 +411,7 @@ class CurationService:
             topic_id=cluster.cluster_id,
             label=cluster.label,
             article_titles=[c.title for c in cluster.contents[:10]],
-            source_count=len(cluster.source_ids),
+            source_count=len(cluster.source_domains),
             is_trending=cluster.is_trending,
             theme=cluster.theme,
         )

--- a/packages/api/app/services/editorial/curation.py
+++ b/packages/api/app/services/editorial/curation.py
@@ -120,7 +120,8 @@ class CurationService:
         return SelectedTopic(
             topic_id=cluster.cluster_id,
             label=cluster.label[:80],
-            selection_reason=reason or f"Traité par {len(cluster.source_domains)} sources",
+            selection_reason=reason
+            or f"Traité par {len(cluster.source_domains)} sources",
             deep_angle=deep_angle,
             source_count=len(cluster.source_domains),
             theme=cluster.theme,
@@ -192,7 +193,8 @@ class CurationService:
         return SelectedTopic(
             topic_id=cluster.cluster_id,
             label=cluster.label[:80],
-            selection_reason=reason or f"Traité par {len(cluster.source_domains)} sources",
+            selection_reason=reason
+            or f"Traité par {len(cluster.source_domains)} sources",
             deep_angle=deep_angle,
             source_count=len(cluster.source_domains),
             theme=cluster.theme,

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -425,9 +425,7 @@ class EditorialPipelineService:
         # `source_count` reflète les MÉDIAS distincts (domaines), pas les
         # feeds : 2 flux radiofrance.fr = 1 média. Aligné sur curation.py et le
         # fix `source_domains` (commit 2667003b). Cf. bug-actus-du-jour-ranking.md.
-        cluster_map_counts = {
-            c.cluster_id: len(c.source_domains) for c in clusters
-        }
+        cluster_map_counts = {c.cluster_id: len(c.source_domains) for c in clusters}
         subjects = [
             EditorialSubject(
                 rank=i + 1,

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -72,6 +72,29 @@ def _is_singleton_podcast(cluster: TopicCluster) -> bool:
         return False
 
 
+def _is_non_actu_cluster(cluster: TopicCluster) -> bool:
+    """Vrai si TOUS les contenus du cluster sont des bulletins/séries/denylist.
+
+    Empêche un sujet « série éditoriale » (ex. « Philippe Jaenada, l'art de la
+    contre-enquête ») ou une source denylistée d'entrer dans le pool même s'il
+    a passé la curation. Réutilise les prédicats partagés avec l'actu_matcher.
+    Un cluster mixte (au moins un contenu d'actu chaude) reste éligible.
+    Cf. bug-actus-du-jour-ranking.md (Partie B).
+    """
+    from app.services.recommendation.filter_presets import (
+        is_denylisted_editorial_source,
+        is_news_bulletin_title,
+    )
+
+    if not cluster.contents:
+        return False
+    return all(
+        is_news_bulletin_title(getattr(c, "title", None))
+        or is_denylisted_editorial_source(c)
+        for c in cluster.contents
+    )
+
+
 # Curation oversample : on demande +buffer sujets de plus que la cible pour
 # absorber les échecs d'actu/deep matching. EDITORIAL_TARGET_SUBJECT_COUNT=5
 # permet un rollback safe au comportement pré-passage 5→10.
@@ -223,6 +246,19 @@ class EditorialPipelineService:
                 remaining=len(filtered),
             )
         clusters = filtered
+
+        # Garde d'éligibilité : écarte les clusters dont TOUS les contenus sont
+        # des bulletins/séries (« …, l'art de la contre-enquête ») ou des
+        # sources denylistées — pas de l'actu chaude. Empêche un sujet série
+        # d'entrer dans le pool même s'il a passé la curation.
+        actu_eligible = [c for c in clusters if not _is_non_actu_cluster(c)]
+        if dropped := len(clusters) - len(actu_eligible):
+            logger.info(
+                "editorial_pipeline.non_actu_cluster_filtered",
+                dropped=dropped,
+                remaining=len(actu_eligible),
+            )
+        clusters = actu_eligible
 
         # ÉTAPE 1B: Pré-sélection "À la Une" — cluster le plus couvert.
         # Cas standard : on prend parmi les clusters "trending" (≥3 sources).
@@ -386,7 +422,12 @@ class EditorialPipelineService:
             **llm_bias_stats,
         )
 
-        cluster_map_counts = {c.cluster_id: len(c.source_ids) for c in clusters}
+        # `source_count` reflète les MÉDIAS distincts (domaines), pas les
+        # feeds : 2 flux radiofrance.fr = 1 média. Aligné sur curation.py et le
+        # fix `source_domains` (commit 2667003b). Cf. bug-actus-du-jour-ranking.md.
+        cluster_map_counts = {
+            c.cluster_id: len(c.source_domains) for c in clusters
+        }
         subjects = [
             EditorialSubject(
                 rank=i + 1,

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -496,6 +496,17 @@ NEWS_BULLETIN_PATTERNS = [
     # « L'humeur du jour », « L'idée du jour » — chronique matinale type
     # France Culture / France Inter.
     r"^\s*l[''’][a-zéèêàâîôûç]+ du jour\b",
+    # --- Séries / feuilletons éditoriaux nommés (France Culture & co.) ---
+    # Épisodes d'une série récurrente : pas de l'actu chaude, ils saturent les
+    # top slots malgré le dédoublonnage par domaine (cf.
+    # bug-actus-du-jour-ranking.md, Partie B). Deux marqueurs robustes :
+    #  - sous-titre de série après virgule : « Philippe Jaenada, l'art de la
+    #    contre-enquête », « …, l'art du roman ».
+    r",\s*l[''’]art (de|du|des|d[''’])\b",
+    #  - compteur d'épisode parenthésé en fin de titre : « (1/4) », « (2 / 5) ».
+    #    Forme canonique des feuilletons ; parenthèses requises pour ne pas
+    #    attraper une date « 15/05 » en fin de titre.
+    r"\(\s*\d{1,2}\s?/\s?\d{1,2}\s*\)\s*$",
 ]
 
 _BULLETIN_RE = re.compile("|".join(NEWS_BULLETIN_PATTERNS), re.IGNORECASE)

--- a/packages/api/app/services/recommendation/helpers/editorial_ranking.py
+++ b/packages/api/app/services/recommendation/helpers/editorial_ranking.py
@@ -1,0 +1,63 @@
+"""Helpers de classement par importance éditoriale.
+
+Récence (paliers `ScoringWeights.RECENT_*`) et polarisation (`divergence_level`)
+partagés entre `topic_selector` (Essentiel) et la projection per-user du digest
+(`digest_selector::_project_editorial_for_user`). Source de vérité unique pour
+que l'« importance éditoriale » se calcule à l'identique des deux côtés.
+
+Cf. bug-actus-du-jour-ranking.md (Partie C).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.services.recommendation.scoring_config import ScoringWeights
+
+
+def recency_bonus(published_at: datetime | None) -> float:
+    """Bonus de fraîcheur hiérarchisé pour une date de publication.
+
+    Mêmes paliers que `topic_selector._best_recency_bonus` (qui en dérive
+    désormais). Retourne 0.0 pour une date absente ou > 168h.
+    """
+    if published_at is None:
+        return 0.0
+
+    published = published_at
+    if published.tzinfo is None:
+        published = published.replace(tzinfo=UTC)
+
+    hours_old = (datetime.now(UTC) - published).total_seconds() / 3600
+
+    if hours_old < 6:
+        return ScoringWeights.RECENT_VERY_BONUS
+    if hours_old < 24:
+        return ScoringWeights.RECENT_BONUS
+    if hours_old < 48:
+        return ScoringWeights.RECENT_DAY_BONUS
+    if hours_old < 72:
+        return ScoringWeights.RECENT_YESTERDAY_BONUS
+    if hours_old < 120:
+        return ScoringWeights.RECENT_WEEK_BONUS
+    if hours_old < 168:
+        return ScoringWeights.RECENT_OLD_BONUS
+    return 0.0
+
+
+_POLARIZATION_BONUS: dict[str, float] = {
+    "high": ScoringWeights.POLARIZATION_HIGH_BONUS,
+    "medium": ScoringWeights.POLARIZATION_MEDIUM_BONUS,
+}
+
+
+def polarization_bonus(divergence_level: str | None) -> float:
+    """Bonus d'importance dérivé de `divergence_level`.
+
+    "high" → +12, "medium" → +6, "low"/"none"/None → 0. Aucun recalcul : le
+    niveau est déjà porté par le subject (étape 1 via `compute_divergence_level`
+    ou l'analyse LLM).
+    """
+    if not divergence_level:
+        return 0.0
+    return _POLARIZATION_BONUS.get(divergence_level.lower(), 0.0)

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -176,6 +176,15 @@ class ScoringWeights:
     ESSENTIEL_PERSPECTIVE_BASE = COVERAGE_BASE
     ESSENTIEL_PERSPECTIVE_CAP = COVERAGE_CAP
 
+    # --- DIGEST POLARISATION (importance éditoriale — Actus du jour) ---
+    # Bonus d'importance pour un sujet où les médias divergent (gauche ET
+    # droite représentées). Signal tertiaire derrière couverture (cap 30) et
+    # récence (max 30) : il départage les sujets très couverts du jour sans
+    # jamais dominer la couverture. `divergence_level` "low"/"none" = 0 (pas
+    # de polarisation notable). Cf. bug-actus-du-jour-ranking.md (Partie C).
+    POLARIZATION_MEDIUM_BONUS = 6.0
+    POLARIZATION_HIGH_BONUS = 12.0
+
     # --- DIGEST TRENDING/IMPORTANCE (Pour vous hybride) ---
 
     # Bonus pour article trending (couvert par ≥3 sources distinctes).

--- a/packages/api/app/services/topic_selector.py
+++ b/packages/api/app/services/topic_selector.py
@@ -26,6 +26,7 @@ from app.services.digest_selector import DigestContext, GlobalTrendingContext
 from app.services.ml.classification_service import SLUG_TO_LABEL
 from app.services.perspective_service import PerspectiveService
 from app.services.recommendation.filter_presets import is_cluster_serein_compatible
+from app.services.recommendation.helpers.editorial_ranking import recency_bonus
 from app.services.recommendation.scoring_config import ScoringWeights
 from app.services.recommendation.scoring_engine import (
     PillarScoringEngine,
@@ -241,38 +242,15 @@ class TopicSelector:
         return scored
 
     def _best_recency_bonus(self, contents: list[Content]) -> float:
-        """Retourne le meilleur bonus recency parmi les articles."""
-        now = datetime.datetime.now(datetime.UTC)
-        best = 0.0
+        """Retourne le meilleur bonus recency parmi les articles.
 
-        for content in contents:
-            published = content.published_at
-            if published and published.tzinfo is None:
-                published = published.replace(tzinfo=datetime.UTC)
-            if not published:
-                continue
-
-            hours_old = (now - published).total_seconds() / 3600
-
-            if hours_old < 6:
-                bonus = ScoringWeights.RECENT_VERY_BONUS
-            elif hours_old < 24:
-                bonus = ScoringWeights.RECENT_BONUS
-            elif hours_old < 48:
-                bonus = ScoringWeights.RECENT_DAY_BONUS
-            elif hours_old < 72:
-                bonus = ScoringWeights.RECENT_YESTERDAY_BONUS
-            elif hours_old < 120:
-                bonus = ScoringWeights.RECENT_WEEK_BONUS
-            elif hours_old < 168:
-                bonus = ScoringWeights.RECENT_OLD_BONUS
-            else:
-                bonus = 0.0
-
-            if bonus > best:
-                best = bonus
-
-        return best
+        Délègue les paliers à `helpers/editorial_ranking.recency_bonus` (source
+        de vérité partagée avec la projection per-user du digest).
+        """
+        return max(
+            (recency_bonus(c.published_at) for c in contents),
+            default=0.0,
+        )
 
     def _select_n_topics(
         self,

--- a/packages/api/tests/editorial/test_curation.py
+++ b/packages/api/tests/editorial/test_curation.py
@@ -17,12 +17,22 @@ def _make_cluster(
     source_count: int = 3,
     theme: str | None = "politique",
     is_trending: bool = False,
+    domain_count: int | None = None,
 ):
-    """Create a mock TopicCluster."""
+    """Create a mock TopicCluster.
+
+    `source_count` = nombre de feeds (source_ids) ; `domain_count` = nombre de
+    médias distincts (source_domains, défaut = source_count). Pour simuler le
+    cas France Culture (2 feeds, même domaine `radiofrance.fr`), passer
+    `source_count=2, domain_count=1` : la curation, qui dédoublonne par domaine,
+    doit le traiter comme un cluster mono-source.
+    """
     cluster = MagicMock()
     cluster.cluster_id = cluster_id
     cluster.label = label
     cluster.source_ids = set(uuid4() for _ in range(source_count))
+    domains = domain_count if domain_count is not None else source_count
+    cluster.source_domains = {f"media-{cluster_id}-{i}.fr" for i in range(domains)}
     cluster.theme = theme
     cluster.is_trending = is_trending
 
@@ -230,6 +240,56 @@ class TestSelectTopics:
 
         # Sans fallback, on n'aurait que 2 sujets ; avec fallback, on a les 5.
         assert len(result) == 5
+
+    @pytest.mark.asyncio
+    async def test_france_culture_two_feeds_one_domain_excluded_from_multi_source(
+        self,
+    ):
+        """Régression bug-actus-du-jour-ranking.md (Partie A) : 2 feeds d'un même
+        domaine (`radiofrance.fr`) = 1 média → échoue la porte ≥2 domaines et
+        n'entre PAS dans le pool multi-source quand de vrais multi-sources
+        existent."""
+        clusters = [
+            _make_cluster("c1", "Retraites", source_count=3, theme="politique"),
+            _make_cluster("c2", "Inflation", source_count=3, theme="economie"),
+            _make_cluster("c3", "Canicule", source_count=2, theme="environnement"),
+            _make_cluster("c4", "Logement", source_count=2, theme="societe"),
+            _make_cluster("c5", "Climat", source_count=2, theme="sciences"),
+            # France Culture : 2 feeds, 1 seul domaine → mono-source effectif.
+            _make_cluster(
+                "fc", "Jaenada", source_count=2, domain_count=1, theme="culture"
+            ),
+        ]
+
+        llm = MagicMock()
+        llm.is_ready = False  # déterministe : on capture le pool multi-source
+
+        svc = CurationService(llm, _make_config(subjects_count=5))
+        result = await svc.select_topics(clusters)
+
+        assert len(result) == 5
+        topic_ids = {t.topic_id for t in result}
+        # 5 vrais multi-sources disponibles → le cluster France Culture (1 domaine)
+        # ne doit pas remonter.
+        assert "fc" not in topic_ids
+
+    @pytest.mark.asyncio
+    async def test_source_count_reflects_domains_not_feeds(self):
+        """`source_count` exposé reflète les médias distincts (domaines), pas le
+        nombre de feeds. France Culture 2 feeds / 1 domaine → source_count=1."""
+        clusters = [
+            _make_cluster(
+                "fc", "Jaenada", source_count=2, domain_count=1, theme="culture"
+            ),
+        ]
+        llm = MagicMock()
+        llm.is_ready = False
+
+        svc = CurationService(llm, _make_config(subjects_count=1))
+        result = await svc.select_topics(clusters)
+
+        assert len(result) == 1
+        assert result[0].source_count == 1
 
 
 class TestDeterministicSelect:

--- a/packages/api/tests/editorial/test_pipeline_mode_filters.py
+++ b/packages/api/tests/editorial/test_pipeline_mode_filters.py
@@ -265,3 +265,83 @@ class TestLowPrioritySportCap:
         sport_kept = [c for c in captured_ids if c.startswith("sport")]
         # Cap skipped because pruning would leave < 5 clusters
         assert len(sport_kept) >= 2
+
+
+class TestNonActuClusterGuard:
+    """Clusters dont tous les contenus sont bulletins/séries sont écartés.
+
+    Régression bug-actus-du-jour-ranking.md (Partie B) : une série éditoriale
+    (« Philippe Jaenada, l'art de la contre-enquête ») ne doit pas atteindre la
+    curation, même si elle a passé le clustering.
+    """
+
+    @pytest.mark.asyncio
+    async def test_series_only_cluster_excluded_from_curation(self, mock_deps):
+        from app.services.editorial.pipeline import EditorialPipelineService
+
+        clusters = [
+            _make_cluster(
+                "serie",
+                ["Philippe Jaenada, l'art de la contre-enquête"],
+                theme="culture",
+                source_count=2,
+            ),
+            _make_cluster("pol", ["Macron annonce réforme"], theme="politics", source_count=4),
+            _make_cluster("eco", ["Inflation en hausse"], theme="economy", source_count=3),
+        ]
+
+        captured_ids: list[str] = []
+
+        async def _capture_select_topics(
+            available, subjects_count=None, excluded_cluster_ids=None
+        ):
+            captured_ids.extend(c.cluster_id for c in available)
+            return []
+
+        mock_deps["curation"].select_topics.side_effect = _capture_select_topics
+
+        svc = EditorialPipelineService(AsyncMock())
+        with patch(
+            "app.services.editorial.pipeline.ImportanceDetector"
+        ) as mock_detector_cls:
+            mock_detector = MagicMock()
+            mock_detector.build_topic_clusters.return_value = clusters
+            mock_detector_cls.return_value = mock_detector
+            await svc.compute_global_context(
+                [_make_content("x") for _ in range(5)], mode="pour_vous"
+            )
+
+        assert "serie" not in captured_ids
+        assert "pol" in captured_ids
+        assert "eco" in captured_ids
+
+    def test_helper_all_bulletin_cluster_flagged(self):
+        from app.services.editorial.pipeline import _is_non_actu_cluster
+
+        cluster = _make_cluster(
+            "serie",
+            [
+                "Philippe Jaenada, l'art de la contre-enquête",
+                "Chronique du matin",
+            ],
+        )
+        assert _is_non_actu_cluster(cluster) is True
+
+    def test_helper_mixed_cluster_not_flagged(self):
+        """Un cluster avec AU MOINS un contenu d'actu chaude reste éligible."""
+        from app.services.editorial.pipeline import _is_non_actu_cluster
+
+        cluster = _make_cluster(
+            "mixed",
+            [
+                "Chronique du matin",  # bulletin
+                "Réforme des retraites : le détail du texte",  # actu chaude
+            ],
+        )
+        assert _is_non_actu_cluster(cluster) is False
+
+    def test_helper_empty_cluster_not_flagged(self):
+        from app.services.editorial.pipeline import _is_non_actu_cluster
+
+        cluster = _make_cluster("empty", [])
+        assert _is_non_actu_cluster(cluster) is False

--- a/packages/api/tests/recommendation/test_editorial_ranking.py
+++ b/packages/api/tests/recommendation/test_editorial_ranking.py
@@ -1,0 +1,49 @@
+"""Tests du helper de classement par importance éditoriale.
+
+Cf. bug-actus-du-jour-ranking.md (Partie C).
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from app.services.recommendation.helpers.editorial_ranking import (
+    polarization_bonus,
+    recency_bonus,
+)
+from app.services.recommendation.scoring_config import ScoringWeights
+
+
+class TestRecencyBonus:
+    def test_none_is_zero(self):
+        assert recency_bonus(None) == 0.0
+
+    def test_very_recent(self):
+        now = datetime.now(UTC) - timedelta(hours=1)
+        assert recency_bonus(now) == ScoringWeights.RECENT_VERY_BONUS
+
+    def test_today(self):
+        ts = datetime.now(UTC) - timedelta(hours=30)
+        assert recency_bonus(ts) == ScoringWeights.RECENT_DAY_BONUS
+
+    def test_naive_datetime_treated_as_utc(self):
+        naive = datetime.now() - timedelta(hours=1)  # noqa: DTZ005
+        assert recency_bonus(naive) == ScoringWeights.RECENT_VERY_BONUS
+
+    def test_old_is_zero(self):
+        ts = datetime.now(UTC) - timedelta(days=10)
+        assert recency_bonus(ts) == 0.0
+
+
+class TestPolarizationBonus:
+    def test_high(self):
+        assert polarization_bonus("high") == ScoringWeights.POLARIZATION_HIGH_BONUS
+
+    def test_medium(self):
+        assert polarization_bonus("medium") == ScoringWeights.POLARIZATION_MEDIUM_BONUS
+
+    def test_low_and_none_are_zero(self):
+        assert polarization_bonus("low") == 0.0
+        assert polarization_bonus("none") == 0.0
+        assert polarization_bonus(None) == 0.0
+
+    def test_case_insensitive(self):
+        assert polarization_bonus("HIGH") == ScoringWeights.POLARIZATION_HIGH_BONUS

--- a/packages/api/tests/test_digest_per_user_projection.py
+++ b/packages/api/tests/test_digest_per_user_projection.py
@@ -58,7 +58,15 @@ def _make_topic_cluster(cluster_id, contents):
     )
 
 
-def _make_subject(topic_id, content, *, rank=1, is_a_la_une=False):
+def _make_subject(
+    topic_id,
+    content,
+    *,
+    rank=1,
+    is_a_la_une=False,
+    source_count=0,
+    divergence_level=None,
+):
     return EditorialSubject(
         rank=rank,
         topic_id=topic_id,
@@ -66,6 +74,8 @@ def _make_subject(topic_id, content, *, rank=1, is_a_la_une=False):
         selection_reason="trending",
         deep_angle=None,
         is_a_la_une=is_a_la_une,
+        source_count=source_count,
+        divergence_level=divergence_level,
         actu_article=MatchedActuArticle(
             content_id=content.id,
             title=content.title,
@@ -298,3 +308,151 @@ async def test_solo_subject_created_for_follower_only(monkeypatch):
     )
     other_solo = [s for s in res_other.subjects if s.topic_id.startswith("solo-")]
     assert other_solo == [], "pas de fuite cross-user : aucun solo pour le non-suiveur"
+
+
+# ─── Tests: classement par importance éditoriale (bug-actus-du-jour-ranking) ──
+
+
+@pytest.mark.asyncio
+async def test_multi_source_ranks_above_personalized_single_source():
+    """Partie C : un sujet multi-sources passe devant un sujet mono-source
+    même quand ce dernier est porté par une source SUIVIE (perso fort). La
+    couverture éditoriale prime, la perso ne fait que départager."""
+    srcMulti, srcFollowed = uuid4(), uuid4()
+    now = datetime.now(UTC)
+    a_multi = _make_content(srcMulti, published_at=now, title="Sujet très couvert")
+    a_solo = _make_content(srcFollowed, published_at=now, title="Sujet d'une source suivie")
+
+    c_multi = _make_topic_cluster("multi", [a_multi])
+    c_solo = _make_topic_cluster("solo", [a_solo])
+    clusters = [c_multi, c_solo]
+
+    subjects = [
+        _make_subject("multi", a_multi, rank=1, source_count=5),
+        _make_subject("solo", a_solo, rank=2, source_count=1),
+    ]
+    global_ctx = types.SimpleNamespace(subjects=subjects, cluster_data=[])
+
+    selector = _make_selector()
+    pipeline = _StubPipeline()
+
+    # L'utilisateur SUIT la source du sujet mono-source → perso boost dessus.
+    ctx = _make_context(uuid4(), {srcFollowed})
+    res = await selector._project_editorial_for_user(
+        pipeline=pipeline,
+        global_ctx=global_ctx,
+        clusters=clusters,
+        context=ctx,
+        mode="pour_vous",
+    )
+    order = [s.topic_id for s in res.subjects]
+    # Le multi-sources est en tête malgré la perso favorable au mono-source.
+    assert order[0] == "multi"
+    assert order.index("multi") < order.index("solo")
+
+
+@pytest.mark.asyncio
+async def test_solo_subject_never_above_multi_source(monkeypatch):
+    """Partie C : un sujet solo (source suivie, créé per-user) est relégué sous
+    tout sujet multi-sources, même si son score perso est élevé."""
+    monkeypatch.setenv("EDITORIAL_SOLO_SUBJECT_MIN_SCORE", "0")
+
+    srcMulti, srcFollowed = uuid4(), uuid4()
+    now = datetime.now(UTC)
+    a_multi = _make_content(srcMulti, published_at=now, title="Multi")
+    # Source suivie, non représentée → deviendra un sujet solo per-user.
+    a_leftover = _make_content(srcFollowed, published_at=now, title="Leftover suivi")
+
+    c_multi = _make_topic_cluster("multi", [a_multi])
+    c_followed = _make_topic_cluster("followed", [a_leftover])
+    clusters = [c_multi, c_followed]
+
+    # Seul le sujet multi est dans le contexte global ; a_leftover devient solo.
+    subjects = [_make_subject("multi", a_multi, rank=1, source_count=4)]
+    global_ctx = types.SimpleNamespace(subjects=subjects, cluster_data=[])
+
+    selector = _make_selector()
+    pipeline = _StubPipeline()
+
+    ctx = _make_context(uuid4(), {srcFollowed})
+    res = await selector._project_editorial_for_user(
+        pipeline=pipeline,
+        global_ctx=global_ctx,
+        clusters=clusters,
+        context=ctx,
+        mode="pour_vous",
+    )
+    order = [s.topic_id for s in res.subjects]
+    solo_ids = [t for t in order if t.startswith("solo-")]
+    assert solo_ids, "le sujet solo doit exister"
+    # Aucun solo ne précède le sujet multi-sources.
+    assert order[0] == "multi"
+    assert order.index("multi") < order.index(solo_ids[0])
+
+
+@pytest.mark.asyncio
+async def test_a_la_une_stays_rank_1_despite_higher_importance_elsewhere():
+    """Partie C : « À la Une » reste rang 1 même si un autre sujet a une
+    importance éditoriale supérieure (couverture/récence)."""
+    srcUne, srcBig = uuid4(), uuid4()
+    now = datetime.now(UTC)
+    a_une = _make_content(srcUne, published_at=now, title="À la Une")
+    a_big = _make_content(srcBig, published_at=now, title="Énorme couverture")
+
+    c_une = _make_topic_cluster("une", [a_une])
+    c_big = _make_topic_cluster("big", [a_big])
+    clusters = [c_une, c_big]
+
+    subjects = [
+        _make_subject("une", a_une, rank=1, is_a_la_une=True, source_count=2),
+        _make_subject("big", a_big, rank=2, source_count=10),
+    ]
+    global_ctx = types.SimpleNamespace(subjects=subjects, cluster_data=[])
+
+    selector = _make_selector()
+    pipeline = _StubPipeline()
+
+    ctx = _make_context(uuid4(), set())
+    res = await selector._project_editorial_for_user(
+        pipeline=pipeline,
+        global_ctx=global_ctx,
+        clusters=clusters,
+        context=ctx,
+        mode="pour_vous",
+    )
+    assert res.subjects[0].topic_id == "une"
+    assert res.subjects[0].is_a_la_une is True
+
+
+@pytest.mark.asyncio
+async def test_polarization_breaks_tie_between_multi_sources():
+    """Partie C : à couverture et récence égales, le sujet le plus polarisé
+    (divergence_level high) passe devant."""
+    srcA, srcB = uuid4(), uuid4()
+    now = datetime.now(UTC)
+    a_plain = _make_content(srcA, published_at=now, title="Consensus")
+    a_polar = _make_content(srcB, published_at=now, title="Polarisé")
+
+    clusters = [
+        _make_topic_cluster("plain", [a_plain]),
+        _make_topic_cluster("polar", [a_polar]),
+    ]
+    subjects = [
+        _make_subject("plain", a_plain, rank=1, source_count=4, divergence_level="low"),
+        _make_subject("polar", a_polar, rank=2, source_count=4, divergence_level="high"),
+    ]
+    global_ctx = types.SimpleNamespace(subjects=subjects, cluster_data=[])
+
+    selector = _make_selector()
+    pipeline = _StubPipeline()
+
+    ctx = _make_context(uuid4(), set())
+    res = await selector._project_editorial_for_user(
+        pipeline=pipeline,
+        global_ctx=global_ctx,
+        clusters=clusters,
+        context=ctx,
+        mode="pour_vous",
+    )
+    order = [s.topic_id for s in res.subjects]
+    assert order.index("polar") < order.index("plain")

--- a/packages/api/tests/test_low_priority_cap.py
+++ b/packages/api/tests/test_low_priority_cap.py
@@ -327,6 +327,36 @@ class TestIsNewsBulletinTitle:
             "L'émission du président qu'il faut écouter"
         )
 
+    # --- bug-actus-du-jour-ranking.md (Partie B) : séries éditoriales nommées ---
+
+    def test_serie_jaenada_art_de_la_contre_enquete(self):
+        """« Philippe Jaenada, l'art de la contre-enquête » — série France
+        Culture qui peuplait l'Essentiel malgré le fix anti-doublon."""
+        assert is_news_bulletin_title(
+            "Philippe Jaenada, l'art de la contre-enquête"
+        )
+
+    def test_serie_art_de_typographic_apostrophe(self):
+        assert is_news_bulletin_title("Marguerite Duras, l’art du roman")
+
+    def test_serie_episode_counter_parenthesized(self):
+        assert is_news_bulletin_title("Histoire de la Commune (2/4)")
+
+    def test_serie_episode_counter_with_spaces(self):
+        assert is_news_bulletin_title("Les grandes énigmes ( 1 / 5 )")
+
+    def test_art_de_vivre_article_not_matched(self):
+        """Faux-positif à éviter : « l'art de vivre » sans virgule de série en
+        milieu de titre ne doit pas matcher (pas précédé d'une virgule)."""
+        assert not is_news_bulletin_title(
+            "Comment l'art de vivre à la française séduit le monde"
+        )
+
+    def test_date_without_parens_not_episode_counter(self):
+        """« 15/05 » en fin de titre (date) sans parenthèses ne doit pas être
+        pris pour un compteur d'épisode."""
+        assert not is_news_bulletin_title("Le grand débat du 15/05")
+
 
 class TestIsDenylistedEditorialSource:
     """Sources bloquées du top 10 éditorial."""


### PR DESCRIPTION
## Quoi

Refonte du tri rang 2+ de **« Actus du jour »** (`DigestTopicSection(kind: essentiel)`) : l'**importance éditoriale** (couverture + récence + polarisation) devient le critère primaire, la personnalisation ne sert plus qu'à départager, et les sujets solo (1 média) sont relégués sous les multi-sources.

## Pourquoi

Trois symptômes rapportés par le PO (cf. `docs/bugs/bug-actus-du-jour-ranking.md`) :
1. des sujets à 1 seul article remontaient très haut ;
2. un sujet 11 sources / polarisé / du jour finissait 10ème (couverture à poids zéro dans la projection per-user) ;
3. les séries France Culture (« …, l'art de la contre-enquête ») peuplaient encore la section.

## Comment

- **A** — `curation.py` + `pipeline.py` : dédoublonnage / tri / `source_count` par `source_domains` (médias distincts) au lieu de `source_ids` (feeds) — aligne sur le fix `2667003b`.
- **B** — `filter_presets.py` : `is_news_bulletin_title` étendu aux séries nommées (`, l'art de …`, compteurs d'épisode `(1/4)`) + garde `_is_non_actu_cluster` dans `compute_global_context` (écarte un cluster 100 % bulletins/séries/denylist).
- **C** — `digest_selector._project_editorial_for_user` : tri sur clé composite `(is_multi, importance, perso)`, « À la Une » rang 1 préservé. Nouveau helper partagé `recommendation/helpers/editorial_ranking.py` (récence + polarisation), réutilisé par `topic_selector` (qui délègue désormais sa récence).
- **D** — `digest_service.py` : bump `editorial_v2` → `editorial_v3` (sémantique d'ordre changée → régénération des digests cachés ; forme JSON inchangée).

Pas de DDL → **pas de migration Alembic**.

## Comment ça a été vérifié

- [x] `pytest` — suite backend complète : **1469 passed, 1 skipped, 2 xfailed**
- [x] Tests ciblés (curation, pipeline, projection per-user, bulletins) : 99 passed, dont régressions des 3 symptômes
- [x] `/simplify` passé (reuse / simplification / efficiency / altitude) — code déjà propre, 2 findings analysés et écartés (convention locale d'import inline ; dead code pré-existant hors scope)
- [ ] Pas d'UI mobile / Flutter touché (backend-only)

## Zones à risque

- Tri de la projection per-user du digest (`digest_selector`) — couvert par 4 nouveaux tests de classement.
- Pipeline éditorial (`compute_global_context`) : nouvelle étape de filtrage `_is_non_actu_cluster`.
- Bump de version `editorial_v3` → régénération des digests cachés au prochain cron (pas d'impact schéma).

🤖 Generated with [Claude Code](https://claude.com/claude-code)