### PR TITLE
Fix mes progressions letter redirects

### DIFF
--- a/apps/mobile/lib/features/lettres/navigation/letter_action_route_resolver.dart
+++ b/apps/mobile/lib/features/lettres/navigation/letter_action_route_resolver.dart
@@ -1,0 +1,52 @@
+import '../../../config/routes.dart';
+import '../models/letter.dart';
+
+/// Normalise les routes de progression vers les surfaces actuelles de l'app.
+///
+/// Défense en profondeur :
+/// - mappe les actions connues vers leurs destinations canoniques ;
+/// - remappe les anciennes routes serveur encore possibles (`/feed`, `/digest`)
+///   pour éviter les push vers des écrans legacy.
+String? resolveLetterActionRoute(LetterAction action) {
+  switch (action.id) {
+    case 'define_editorial_line':
+      return RoutePaths.myInterests;
+    case 'add_5_sources':
+      return RoutePaths.sources;
+    case 'add_2_personal_sources':
+      return '${RoutePaths.sources}/add';
+    case 'first_perspectives_open':
+    case 'read_3_long_articles':
+    case 'read_first_video_podcast':
+    case 'recommend_first_article':
+      return RoutePaths.flaner;
+    case 'read_first_essentiel':
+      return '${RoutePaths.fluxContinu}/section/essentiel';
+    case 'read_first_bonnes_nouvelles':
+      return '${RoutePaths.fluxContinu}/section/bonnes';
+  }
+
+  final raw = action.targetRoute?.trim();
+  if (raw == null || raw.isEmpty) return null;
+
+  final uri = Uri.tryParse(raw);
+  if (uri == null) return raw;
+
+  switch (uri.path) {
+    case RoutePaths.feed:
+      return RoutePaths.flaner;
+    case RoutePaths.digest:
+      return uri.queryParameters['serein'] == '1'
+          ? '${RoutePaths.fluxContinu}/section/bonnes'
+          : '${RoutePaths.fluxContinu}/section/essentiel';
+    case RoutePaths.myInterests:
+    case RoutePaths.sources:
+      return uri.path;
+  }
+
+  if (uri.path == '${RoutePaths.sources}/add') {
+    return uri.path;
+  }
+
+  return raw;
+}

--- a/apps/mobile/lib/features/lettres/screens/open_letter_screen.dart
+++ b/apps/mobile/lib/features/lettres/screens/open_letter_screen.dart
@@ -7,6 +7,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
+import '../navigation/letter_action_route_resolver.dart';
 import '../models/letter.dart';
 import '../models/letter_progress.dart';
 import '../providers/letters_provider.dart';
@@ -95,10 +96,8 @@ class _OpenLetterScreenState extends ConsumerState<OpenLetterScreen>
               opaque: true,
               fullscreenDialog: true,
               transitionDuration: const Duration(milliseconds: 280),
-              pageBuilder: (_, __, ___) => LetterCompletionOverlay(
-                letter: letter,
-                onDismiss: () {},
-              ),
+              pageBuilder: (_, __, ___) =>
+                  LetterCompletionOverlay(letter: letter, onDismiss: () {}),
             ),
           );
         },
@@ -123,8 +122,9 @@ class _OpenLetterScreenState extends ConsumerState<OpenLetterScreen>
       return;
     }
 
-    final newlyDone =
-        doneActions.where((a) => !_seenDoneActionIds.contains(a.id)).toList();
+    final newlyDone = doneActions
+        .where((a) => !_seenDoneActionIds.contains(a.id))
+        .toList();
     if (newlyDone.isEmpty) return;
     _seenDoneActionIds.addAll(newlyDone.map((a) => a.id));
 
@@ -162,9 +162,8 @@ class _OpenLetterScreenState extends ConsumerState<OpenLetterScreen>
     return Scaffold(
       backgroundColor: colors.backgroundPrimary,
       body: state.when(
-        loading: () => Center(
-          child: CircularProgressIndicator(color: colors.primary),
-        ),
+        loading: () =>
+            Center(child: CircularProgressIndicator(color: colors.primary)),
         error: (e, _) => _ErrorView(
           onRetry: () => ref.read(lettersProvider.notifier).refresh(),
         ),
@@ -197,8 +196,10 @@ class _NotFound extends StatelessWidget {
             Align(
               alignment: Alignment.centerLeft,
               child: IconButton(
-                icon:
-                    Icon(PhosphorIcons.arrowLeft(), color: colors.textPrimary),
+                icon: Icon(
+                  PhosphorIcons.arrowLeft(),
+                  color: colors.textPrimary,
+                ),
                 onPressed: () => Navigator.of(context).pop(),
               ),
             ),
@@ -262,8 +263,9 @@ class _Body extends ConsumerWidget {
         .where((p) => p.trim().isNotEmpty)
         .toList(growable: false);
 
-    final doneCount =
-        letter.actions.where((a) => a.status == LetterActionStatus.done).length;
+    final doneCount = letter.actions
+        .where((a) => a.status == LetterActionStatus.done)
+        .length;
     final total = letter.actions.length;
 
     return SafeArea(
@@ -275,8 +277,10 @@ class _Body extends ConsumerWidget {
               child: Row(
                 children: [
                   IconButton(
-                    icon: Icon(PhosphorIcons.arrowLeft(),
-                        color: colors.textPrimary),
+                    icon: Icon(
+                      PhosphorIcons.arrowLeft(),
+                      color: colors.textPrimary,
+                    ),
                     onPressed: () => Navigator.of(context).pop(),
                     tooltip: 'Retour',
                   ),
@@ -294,8 +298,10 @@ class _Body extends ConsumerWidget {
                     ),
                   ),
                   IconButton(
-                    icon: Icon(PhosphorIcons.dotsThreeVertical(),
-                        color: colors.textTertiary),
+                    icon: Icon(
+                      PhosphorIcons.dotsThreeVertical(),
+                      color: colors.textTertiary,
+                    ),
                     onPressed: () {},
                     tooltip: 'Plus',
                   ),
@@ -303,9 +309,7 @@ class _Body extends ConsumerWidget {
               ),
             ),
           ),
-          SliverToBoxAdapter(
-            child: _Illustration(colors: colors),
-          ),
+          SliverToBoxAdapter(child: _Illustration(colors: colors)),
           SliverPadding(
             padding: const EdgeInsets.symmetric(horizontal: 22),
             sliver: SliverList(
@@ -344,7 +348,8 @@ class _Body extends ConsumerWidget {
                     const SizedBox(height: 12),
                   ],
                 ),
-                if (letter.introPalier != null && letter.introPalier!.isNotEmpty) ...[
+                if (letter.introPalier != null &&
+                    letter.introPalier!.isNotEmpty) ...[
                   Text(
                     letter.introPalier!,
                     style: GoogleFonts.fraunces(
@@ -389,7 +394,7 @@ class _Body extends ConsumerWidget {
                   (a) => LetterActionTile(
                     action: a,
                     onTap: () async {
-                      final route = a.targetRoute;
+                      final route = resolveLetterActionRoute(a);
                       if (route != null && route.isNotEmpty) {
                         await context.push<void>(route);
                       }
@@ -446,10 +451,7 @@ class _IllustrationState extends State<_Illustration>
         gradient: RadialGradient(
           center: const Alignment(0.4, -0.4),
           radius: 1.0,
-          colors: [
-            widget.colors.primary.withOpacity(0.06),
-            Colors.transparent,
-          ],
+          colors: [widget.colors.primary.withOpacity(0.06), Colors.transparent],
           stops: const [0, 0.6],
         ),
       ),

--- a/apps/mobile/test/features/lettres/navigation/letter_action_route_resolver_test.dart
+++ b/apps/mobile/test/features/lettres/navigation/letter_action_route_resolver_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/lettres/models/letter.dart';
+import 'package:facteur/features/lettres/navigation/letter_action_route_resolver.dart';
+
+LetterAction _action({required String id, String? route}) => LetterAction(
+  id: id,
+  label: 'Label',
+  help: 'Help',
+  status: LetterActionStatus.active,
+  targetRoute: route,
+);
+
+void main() {
+  group('resolveLetterActionRoute', () {
+    test('maps known action ids to canonical routes', () {
+      expect(
+        resolveLetterActionRoute(_action(id: 'read_first_essentiel')),
+        '/flux-continu/section/essentiel',
+      );
+      expect(
+        resolveLetterActionRoute(_action(id: 'read_first_bonnes_nouvelles')),
+        '/flux-continu/section/bonnes',
+      );
+      expect(
+        resolveLetterActionRoute(_action(id: 'recommend_first_article')),
+        '/flaner',
+      );
+    });
+
+    test('normalizes legacy digest and feed routes', () {
+      expect(
+        resolveLetterActionRoute(
+          _action(id: 'unknown', route: '/digest?serein=1'),
+        ),
+        '/flux-continu/section/bonnes',
+      );
+      expect(
+        resolveLetterActionRoute(_action(id: 'unknown', route: '/digest')),
+        '/flux-continu/section/essentiel',
+      );
+      expect(
+        resolveLetterActionRoute(_action(id: 'unknown', route: '/feed')),
+        '/flaner',
+      );
+    });
+
+    test('keeps valid settings routes unchanged', () {
+      expect(
+        resolveLetterActionRoute(
+          _action(id: 'unknown', route: '/settings/interests'),
+        ),
+        '/settings/interests',
+      );
+      expect(
+        resolveLetterActionRoute(
+          _action(id: 'unknown', route: '/settings/sources/add'),
+        ),
+        '/settings/sources/add',
+      );
+    });
+  });
+}

--- a/apps/mobile/test/features/lettres/screens/open_letter_screen_test.dart
+++ b/apps/mobile/test/features/lettres/screens/open_letter_screen_test.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/core/auth/auth_state.dart' as app_auth;
+import 'package:facteur/features/lettres/models/letter.dart';
+import 'package:facteur/features/lettres/providers/letters_repository_provider.dart';
+import 'package:facteur/features/lettres/repositories/letters_repository.dart';
+import 'package:facteur/features/lettres/screens/open_letter_screen.dart';
+
+class _MockRepo extends Mock implements LettersRepository {}
+
+class _AuthNotifier extends StateNotifier<app_auth.AuthState>
+    implements app_auth.AuthStateNotifier {
+  _AuthNotifier()
+      : super(
+          const app_auth.AuthState(
+            user: supabase.User(
+              id: 'u1',
+              appMetadata: {},
+              userMetadata: {},
+              aud: 'authenticated',
+              createdAt: '2026-01-01',
+            ),
+          ),
+        );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Letter _letterWithAction({
+  required String actionId,
+  required String label,
+  required String targetRoute,
+}) =>
+    Letter(
+      id: 'letter_2',
+      letterNum: '02',
+      title: 'Tes premieres lectures',
+      message: 'Message',
+      signature: 'Le Facteur',
+      status: LetterStatus.active,
+      actions: [
+        LetterAction(
+          id: actionId,
+          label: label,
+          help: 'Help',
+          status: LetterActionStatus.active,
+          targetRoute: targetRoute,
+        ),
+      ],
+      completedActions: const [],
+      progress: 0.0,
+      startedAt: DateTime.utc(2026, 5, 2),
+      archivedAt: null,
+    );
+
+Widget _destination(String label) => Scaffold(
+      appBar: AppBar(title: Text(label)),
+      body: Center(child: Text(label)),
+    );
+
+Widget _wrap(_MockRepo repo) {
+  final router = GoRouter(
+    initialLocation: '/lettres/letter_2',
+    routes: [
+      GoRoute(
+        path: '/lettres/:id',
+        builder: (_, state) =>
+            OpenLetterScreen(letterId: state.pathParameters['id']!),
+      ),
+      GoRoute(path: '/flaner', builder: (_, __) => _destination('Flaner')),
+      GoRoute(
+        path: '/settings/interests',
+        builder: (_, __) => _destination('Interests'),
+      ),
+      GoRoute(
+        path: '/settings/sources',
+        builder: (_, __) => _destination('Sources'),
+      ),
+      GoRoute(
+        path: '/settings/sources/add',
+        builder: (_, __) => _destination('Add source'),
+      ),
+      GoRoute(
+        path: '/flux-continu/section/:key',
+        builder: (_, state) =>
+            _destination('Section ${state.pathParameters['key']}'),
+      ),
+    ],
+  );
+  return ProviderScope(
+    overrides: [
+      lettersRepositoryProvider.overrideWithValue(repo),
+      app_auth.authStateProvider.overrideWith((ref) => _AuthNotifier()),
+    ],
+    child: MaterialApp.router(
+      theme: ThemeData(extensions: [FacteurPalettes.light]),
+      routerConfig: router,
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  Future<void> _pumpForAction(
+    WidgetTester tester,
+    _MockRepo repo,
+    Letter letter,
+  ) async {
+    when(() => repo.getLetters()).thenAnswer((_) async => [letter]);
+    when(() => repo.refreshStatus('letter_2')).thenAnswer((_) async => letter);
+
+    await tester.pumpWidget(_wrap(repo));
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  testWidgets('normalizes Actu du jour action and preserves back stack', (
+    tester,
+  ) async {
+    final repo = _MockRepo();
+    await _pumpForAction(
+      tester,
+      repo,
+      _letterWithAction(
+        actionId: 'read_first_essentiel',
+        label: 'Lire Actu du jour',
+        targetRoute: '/digest',
+      ),
+    );
+
+    await tester.tap(find.text('Lire Actu du jour'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('Section essentiel'), findsWidgets);
+
+    await tester.pageBack();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('Tes premieres lectures'), findsOneWidget);
+  });
+
+  testWidgets('normalizes Bonnes nouvelles action and preserves back stack', (
+    tester,
+  ) async {
+    final repo = _MockRepo();
+    await _pumpForAction(
+      tester,
+      repo,
+      _letterWithAction(
+        actionId: 'read_first_bonnes_nouvelles',
+        label: 'Decouvrir Les bonnes nouvelles',
+        targetRoute: '/digest?serein=1',
+      ),
+    );
+
+    await tester.tap(find.text('Decouvrir Les bonnes nouvelles'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('Section bonnes'), findsWidgets);
+
+    await tester.pageBack();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('Tes premieres lectures'), findsOneWidget);
+  });
+
+  testWidgets('normalizes Flaner action and preserves back stack', (
+    tester,
+  ) async {
+    final repo = _MockRepo();
+    await _pumpForAction(
+      tester,
+      repo,
+      _letterWithAction(
+        actionId: 'recommend_first_article',
+        label: 'Recommander un article',
+        targetRoute: '/feed',
+      ),
+    );
+
+    await tester.tap(find.text('Recommander un article'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('Flaner'), findsWidgets);
+
+    await tester.pageBack();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('Tes premieres lectures'), findsOneWidget);
+  });
+}

--- a/packages/api/app/services/letters/catalog.py
+++ b/packages/api/app/services/letters/catalog.py
@@ -48,7 +48,7 @@ LETTER_1: dict = {
             "id": "first_perspectives_open",
             "label": "Lancer ta première analyse de comparaison",
             "help": "Compare deux angles sur le même sujet.",
-            "target_route": "/feed",
+            "target_route": "/flaner",
         },
     ],
     "message": (
@@ -70,10 +70,10 @@ LETTER_2: dict = {
     "actions": [
         {
             "id": "read_first_essentiel",
-            "label": "Lire L'essentiel du jour",
+            "label": "Lire Actu du jour",
             "help": "Cinq articles, choisis pour toi. C'est le rendez-vous quotidien.",
             "completion_palier": "Premier rendez-vous tenu. Ça commence ici.",
-            "target_route": "/digest",
+            "target_route": "/flux-continu/section/essentiel",
         },
         {
             "id": "read_first_bonnes_nouvelles",
@@ -82,7 +82,7 @@ LETTER_2: dict = {
             "completion_palier": (
                 "Tu sais maintenant que la lecture peut aussi faire du bien."
             ),
-            "target_route": "/digest?serein=1",
+            "target_route": "/flux-continu/section/bonnes",
         },
         {
             "id": "read_3_long_articles",
@@ -91,7 +91,7 @@ LETTER_2: dict = {
             "completion_palier": (
                 "Dix articles parcourus. Tu prends maintenant le rythme."
             ),
-            "target_route": "/feed",
+            "target_route": "/flaner",
         },
         {
             "id": "read_first_video_podcast",
@@ -103,7 +103,7 @@ LETTER_2: dict = {
             "completion_palier": (
                 "Trois articles mis de côté. Tu commences à te constituer un fonds."
             ),
-            "target_route": "/feed",
+            "target_route": "/flaner",
         },
         {
             "id": "recommend_first_article",
@@ -112,7 +112,7 @@ LETTER_2: dict = {
                 "Un like (🌻), c'est un signal. Il oriente ta sélection et celle des autres."
             ),
             "completion_palier": "Un signal envoyé. Le Facteur écoute.",
-            "target_route": "/feed",
+            "target_route": "/flaner",
         },
     ],
     "message": (

--- a/packages/api/tests/routers/test_letters_routes.py
+++ b/packages/api/tests/routers/test_letters_routes.py
@@ -316,6 +316,12 @@ class TestInitialState:
         assert l1["progress"] == 0.0
         assert l1["started_at"] is not None
         assert len(l1["actions"]) == 4
+        assert [action["target_route"] for action in l1["actions"]] == [
+            "/settings/interests",
+            "/settings/sources",
+            "/settings/sources/add",
+            "/flaner",
+        ]
 
         assert l2["id"] == "letter_2"
         assert l2["status"] == "upcoming"
@@ -728,6 +734,14 @@ class TestLetter2Shape:
         assert isinstance(l2.get("intro_palier"), str) and l2["intro_palier"]
         assert isinstance(l2.get("completion_voeu"), str) and l2["completion_voeu"]
         assert len(l2["actions"]) == 5
+        assert l2["actions"][0]["label"] == "Lire Actu du jour"
+        assert [action["target_route"] for action in l2["actions"]] == [
+            "/flux-continu/section/essentiel",
+            "/flux-continu/section/bonnes",
+            "/flaner",
+            "/flaner",
+            "/flaner",
+        ]
         for action in l2["actions"]:
             assert isinstance(action.get("completion_palier"), str)
             assert action["completion_palier"]


### PR DESCRIPTION
## What

Update mes progressions letter actions to point at current mobile destinations, add a client-side route normalizer for legacy server routes, and cover the behavior with API and Flutter tests.

## Why

Some letter actions still referenced legacy `/feed` and `/digest` routes, which could send users to outdated surfaces or break expected back navigation. This aligns the catalog and mobile navigation with the current app routes.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)
