### PR TITLE
feat(veille): sujet sur-mesure Step1 + sources LLM Step3 (micro-ajustements)

### DIFF
--- a/apps/mobile/lib/features/veille/models/veille_config_dto.dart
+++ b/apps/mobile/lib/features/veille/models/veille_config_dto.dart
@@ -6,8 +6,8 @@ import 'package:flutter/foundation.dart';
 /// `last_delivered_at`/`next_scheduled_at` (scheduler async drop) et ajouté
 /// `keywords[]` (angles libres saisis par l'utilisateur).
 ///
-/// PR-4 (Story 23.3) : suggesters LLM (`VeilleSuggestSources*`,
-/// `VeilleSourceSuggestionDto`) retirés — `/suggest/sources` répond 410 Gone.
+/// Veille micro-ajustements : `POST /veille/suggest/sources` est reconnecté
+/// pour proposer des candidats niche non ingérés avant submit.
 ///
 /// Veille C3 (PR-3) : `VeilleAngleSuggestionDto` / `VeilleSuggestAnglesResponse`
 /// ré-introduits — `POST /veille/suggest/angles` est actif (suggestion d'angles
@@ -105,8 +105,9 @@ class VeilleSourceDto {
   factory VeilleSourceDto.fromJson(Map<String, dynamic> json) {
     return VeilleSourceDto(
       id: json['id'] as String,
-      source:
-          VeilleSourceLiteDto.fromJson(json['source'] as Map<String, dynamic>),
+      source: VeilleSourceLiteDto.fromJson(
+        json['source'] as Map<String, dynamic>,
+      ),
       kind: json['kind'] as String,
       why: json['why'] as String?,
       position: (json['position'] as num?)?.toInt() ?? 0,
@@ -218,13 +219,13 @@ class VeilleTopicSelectionRequest {
   });
 
   Map<String, dynamic> toJson() => {
-        'topic_id': topicId,
-        'label': label,
-        'kind': kind,
-        if (reason != null) 'reason': reason,
-        'position': position,
-        'keywords': keywords,
-      };
+    'topic_id': topicId,
+    'label': label,
+    'kind': kind,
+    if (reason != null) 'reason': reason,
+    'position': position,
+    'keywords': keywords,
+  };
 }
 
 @immutable
@@ -240,10 +241,10 @@ class VeilleNicheCandidateRequest {
   });
 
   Map<String, dynamic> toJson() => {
-        'name': name,
-        'url': url,
-        if (why != null) 'why': why,
-      };
+    'name': name,
+    'url': url,
+    if (why != null) 'why': why,
+  };
 }
 
 @immutable
@@ -263,12 +264,12 @@ class VeilleSourceSelectionRequest {
   });
 
   Map<String, dynamic> toJson() => {
-        'kind': kind,
-        if (sourceId != null) 'source_id': sourceId,
-        if (nicheCandidate != null) 'niche_candidate': nicheCandidate!.toJson(),
-        if (why != null) 'why': why,
-        'position': position,
-      };
+    'kind': kind,
+    if (sourceId != null) 'source_id': sourceId,
+    if (nicheCandidate != null) 'niche_candidate': nicheCandidate!.toJson(),
+    if (why != null) 'why': why,
+    'position': position,
+  };
 }
 
 @immutable
@@ -281,10 +282,7 @@ class VeilleKeywordSelectionRequest {
     this.position = 0,
   });
 
-  Map<String, dynamic> toJson() => {
-        'keyword': keyword,
-        'position': position,
-      };
+  Map<String, dynamic> toJson() => {'keyword': keyword, 'position': position};
 }
 
 @immutable
@@ -310,15 +308,15 @@ class VeilleConfigUpsertRequest {
   });
 
   Map<String, dynamic> toJson() => {
-        'theme_id': themeId,
-        'theme_label': themeLabel,
-        'topics': topics.map((t) => t.toJson()).toList(),
-        'source_selections': sourceSelections.map((s) => s.toJson()).toList(),
-        'keywords': keywords.map((k) => k.toJson()).toList(),
-        'purpose': purpose,
-        'editorial_brief': editorialBrief,
-        'preset_id': presetId,
-      };
+    'theme_id': themeId,
+    'theme_label': themeLabel,
+    'topics': topics.map((t) => t.toJson()).toList(),
+    'source_selections': sourceSelections.map((s) => s.toJson()).toList(),
+    'keywords': keywords.map((k) => k.toJson()).toList(),
+    'purpose': purpose,
+    'editorial_brief': editorialBrief,
+    'preset_id': presetId,
+  };
 }
 
 // ─── Suggestion d'angles LLM (POST /veille/suggest/angles) ──────────────────
@@ -362,6 +360,84 @@ class VeilleSuggestAnglesResponse {
       angles: ((json['angles'] as List?) ?? const [])
           .whereType<Map<String, dynamic>>()
           .map(VeilleAngleSuggestionDto.fromJson)
+          .toList(),
+    );
+  }
+}
+
+// ─── Résolution sujet local Veille (POST /veille/resolve/topic) ─────────────
+
+@immutable
+class VeilleResolvedTopicDto {
+  final String label;
+  final String topicId;
+  final List<String> keywords;
+  final String description;
+  final Map<String, String?> metadata;
+
+  const VeilleResolvedTopicDto({
+    required this.label,
+    required this.topicId,
+    this.keywords = const [],
+    this.description = '',
+    this.metadata = const {},
+  });
+
+  factory VeilleResolvedTopicDto.fromJson(Map<String, dynamic> json) {
+    final rawMeta = json['metadata'];
+    return VeilleResolvedTopicDto(
+      label: json['label'] as String,
+      topicId: json['topic_id'] as String,
+      keywords: ((json['keywords'] as List?) ?? const [])
+          .map((e) => e as String)
+          .toList(),
+      description: (json['description'] as String?) ?? '',
+      metadata: rawMeta is Map
+          ? rawMeta.map(
+              (key, value) => MapEntry(key.toString(), value?.toString()),
+            )
+          : const {},
+    );
+  }
+}
+
+// ─── Suggestion sources LLM (POST /veille/suggest/sources) ──────────────────
+
+@immutable
+class VeilleSourceSuggestionDto {
+  final String name;
+  final String url;
+  final String? why;
+  final double relevanceScore;
+
+  const VeilleSourceSuggestionDto({
+    required this.name,
+    required this.url,
+    this.why,
+    required this.relevanceScore,
+  });
+
+  factory VeilleSourceSuggestionDto.fromJson(Map<String, dynamic> json) {
+    return VeilleSourceSuggestionDto(
+      name: json['name'] as String,
+      url: json['url'] as String,
+      why: json['why'] as String?,
+      relevanceScore: (json['relevance_score'] as num?)?.toDouble() ?? 0,
+    );
+  }
+}
+
+@immutable
+class VeilleSuggestSourcesResponse {
+  final List<VeilleSourceSuggestionDto> sources;
+
+  const VeilleSuggestSourcesResponse({this.sources = const []});
+
+  factory VeilleSuggestSourcesResponse.fromJson(Map<String, dynamic> json) {
+    return VeilleSuggestSourcesResponse(
+      sources: ((json['sources'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleSourceSuggestionDto.fromJson)
           .toList(),
     );
   }

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -12,9 +12,8 @@ import 'veille_themes_provider.dart';
 
 /// Métadonnées attachées à une source dans le state du flow.
 ///
-/// Permet de distinguer les sources catalogue (UUID API) des sources mock-only ;
-/// au submit on filtre les mock-only et on envoie un `source_id` (UUID) ou un
-/// `niche_candidate{name, url}` selon ce qui est dispo.
+/// Permet de distinguer les sources catalogue (UUID API) des candidats niche ;
+/// au submit on envoie un `source_id` ou un `niche_candidate{name, url}`.
 @immutable
 class VeilleSourceMeta {
   final String slug;
@@ -146,35 +145,37 @@ class VeilleConfigState {
   });
 
   factory VeilleConfigState.initial() => const VeilleConfigState(
-        step: 1,
-        introCompleted: false,
-        previewPresetId: null,
-        selectedTheme: null,
-        mainTopicSlug: null,
-        mainTopicLabel: null,
-        selectedTopics: <String>{},
-        selectedSuggestions: <String>{},
-        selectedSourceIds: <String>{},
-        customTopics: [],
-        topicLabels: {},
-        sourcesMeta: {},
-        keywords: <String>{},
-        angleKeywords: {},
-        advancedMode: false,
-        skippedStep2: false,
-        purpose: null,
-        editorialBrief: null,
-        presetId: null,
-        isSubmitting: false,
-        lastError: null,
-        customThemeLabel: null,
-      );
+    step: 1,
+    introCompleted: false,
+    previewPresetId: null,
+    selectedTheme: null,
+    mainTopicSlug: null,
+    mainTopicLabel: null,
+    selectedTopics: <String>{},
+    selectedSuggestions: <String>{},
+    selectedSourceIds: <String>{},
+    customTopics: [],
+    topicLabels: {},
+    sourcesMeta: {},
+    keywords: <String>{},
+    angleKeywords: {},
+    advancedMode: false,
+    skippedStep2: false,
+    purpose: null,
+    editorialBrief: null,
+    presetId: null,
+    isSubmitting: false,
+    lastError: null,
+    customThemeLabel: null,
+  );
 
-  /// Nombre de sources réellement persistables (avec `apiSourceId`).
-  /// Une source mock sans `apiSourceId` est filtrée par `_buildUpsertRequest`,
-  /// donc elle ne compte pas pour autoriser le passage à step suivant.
-  int get realSelectedSourceCount =>
-      selectedSourceIds.where((id) => sourcesMeta[id]?.apiSourceId != null).length;
+  /// Nombre de sources réellement persistables : source catalogue avec
+  /// `apiSourceId`, ou candidat niche avec URL valide.
+  int get realSelectedSourceCount => selectedSourceIds.where((id) {
+    final meta = sourcesMeta[id];
+    if (meta == null) return false;
+    return meta.apiSourceId != null || _isValidHttpUrl(meta.url);
+  }).length;
 
   VeilleConfigState copyWith({
     int? step,
@@ -199,46 +200,44 @@ class VeilleConfigState {
     bool? isSubmitting,
     Object? lastError = _Sentinel.value,
     Object? customThemeLabel = _Sentinel.value,
-  }) =>
-      VeilleConfigState(
-        step: step ?? this.step,
-        introCompleted: introCompleted ?? this.introCompleted,
-        previewPresetId: previewPresetId == _Sentinel.value
-            ? this.previewPresetId
-            : previewPresetId as String?,
-        selectedTheme: selectedTheme == _Sentinel.value
-            ? this.selectedTheme
-            : selectedTheme as String?,
-        mainTopicSlug: mainTopicSlug == _Sentinel.value
-            ? this.mainTopicSlug
-            : mainTopicSlug as String?,
-        mainTopicLabel: mainTopicLabel == _Sentinel.value
-            ? this.mainTopicLabel
-            : mainTopicLabel as String?,
-        selectedTopics: selectedTopics ?? this.selectedTopics,
-        selectedSuggestions: selectedSuggestions ?? this.selectedSuggestions,
-        selectedSourceIds: selectedSourceIds ?? this.selectedSourceIds,
-        customTopics: customTopics ?? this.customTopics,
-        topicLabels: topicLabels ?? this.topicLabels,
-        sourcesMeta: sourcesMeta ?? this.sourcesMeta,
-        keywords: keywords ?? this.keywords,
-        angleKeywords: angleKeywords ?? this.angleKeywords,
-        advancedMode: advancedMode ?? this.advancedMode,
-        skippedStep2: skippedStep2 ?? this.skippedStep2,
-        purpose:
-            purpose == _Sentinel.value ? this.purpose : purpose as String?,
-        editorialBrief: editorialBrief == _Sentinel.value
-            ? this.editorialBrief
-            : editorialBrief as String?,
-        presetId:
-            presetId == _Sentinel.value ? this.presetId : presetId as String?,
-        isSubmitting: isSubmitting ?? this.isSubmitting,
-        lastError:
-            lastError == _Sentinel.value ? this.lastError : lastError as String?,
-        customThemeLabel: customThemeLabel == _Sentinel.value
-            ? this.customThemeLabel
-            : customThemeLabel as String?,
-      );
+  }) => VeilleConfigState(
+    step: step ?? this.step,
+    introCompleted: introCompleted ?? this.introCompleted,
+    previewPresetId: previewPresetId == _Sentinel.value
+        ? this.previewPresetId
+        : previewPresetId as String?,
+    selectedTheme: selectedTheme == _Sentinel.value
+        ? this.selectedTheme
+        : selectedTheme as String?,
+    mainTopicSlug: mainTopicSlug == _Sentinel.value
+        ? this.mainTopicSlug
+        : mainTopicSlug as String?,
+    mainTopicLabel: mainTopicLabel == _Sentinel.value
+        ? this.mainTopicLabel
+        : mainTopicLabel as String?,
+    selectedTopics: selectedTopics ?? this.selectedTopics,
+    selectedSuggestions: selectedSuggestions ?? this.selectedSuggestions,
+    selectedSourceIds: selectedSourceIds ?? this.selectedSourceIds,
+    customTopics: customTopics ?? this.customTopics,
+    topicLabels: topicLabels ?? this.topicLabels,
+    sourcesMeta: sourcesMeta ?? this.sourcesMeta,
+    keywords: keywords ?? this.keywords,
+    angleKeywords: angleKeywords ?? this.angleKeywords,
+    advancedMode: advancedMode ?? this.advancedMode,
+    skippedStep2: skippedStep2 ?? this.skippedStep2,
+    purpose: purpose == _Sentinel.value ? this.purpose : purpose as String?,
+    editorialBrief: editorialBrief == _Sentinel.value
+        ? this.editorialBrief
+        : editorialBrief as String?,
+    presetId: presetId == _Sentinel.value ? this.presetId : presetId as String?,
+    isSubmitting: isSubmitting ?? this.isSubmitting,
+    lastError: lastError == _Sentinel.value
+        ? this.lastError
+        : lastError as String?,
+    customThemeLabel: customThemeLabel == _Sentinel.value
+        ? this.customThemeLabel
+        : customThemeLabel as String?,
+  );
 
   /// `theme_label` final pour le backend — utilise `customThemeLabel` quand
   /// le thème est "other", sinon le label canonique du slug.
@@ -275,7 +274,9 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       mainTopicLabel: null,
       selectedTopics: const {},
       // Reset customThemeLabel quand on quitte 'other'.
-      customThemeLabel: id == kVeilleOtherThemeSlug ? state.customThemeLabel : null,
+      customThemeLabel: id == kVeilleOtherThemeSlug
+          ? state.customThemeLabel
+          : null,
     );
   }
 
@@ -331,9 +332,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     if (state.customTopics.any((t) => t.id == id)) {
       // Déjà présent → s'assurer juste qu'il est coché.
       if (!state.selectedTopics.contains(id)) {
-        state = state.copyWith(
-          selectedTopics: {...state.selectedTopics, id},
-        );
+        state = state.copyWith(selectedTopics: {...state.selectedTopics, id});
       }
       return;
     }
@@ -388,6 +387,12 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
   /// (`custom-`) pour ne pas collisionner dans `topicLabels`/`angleKeywords`.
   static String angleSlug(String title) => 'angle-${_slugifyBase(title)}';
 
+  static String sourceSuggestionSlug(String name, String url) {
+    final uri = Uri.tryParse(url);
+    final host = (uri?.host.isNotEmpty ?? false) ? uri!.host : url;
+    return 'niche-${_slugifyBase('$host-$name')}';
+  }
+
   /// Normalise un mot-clé : trim + lowercase, longueur 2..60 sinon `null`.
   static String? _normalizeKeyword(String raw) {
     final kw = raw.trim().toLowerCase();
@@ -411,8 +416,8 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       state = state.copyWith(selectedTopics: _toggle(state.selectedTopics, id));
 
   void toggleSuggestion(String id) => state = state.copyWith(
-        selectedSuggestions: _toggle(state.selectedSuggestions, id),
-      );
+    selectedSuggestions: _toggle(state.selectedSuggestions, id),
+  );
 
   // ─── Angles LLM (Step 2) ────────────────────────────────────────────────
 
@@ -471,8 +476,30 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
   }
 
   void toggleSource(String id) => state = state.copyWith(
-        selectedSourceIds: _toggle(state.selectedSourceIds, id),
+    selectedSourceIds: _toggle(state.selectedSourceIds, id),
+  );
+
+  /// Enregistre les candidats LLM Step 3 sans les sélectionner. Ils restent
+  /// locaux au flow et seront ingérés seulement si le user les coche.
+  void registerSuggestedSources(List<VeilleSourceSuggestionDto> suggestions) {
+    if (suggestions.isEmpty) return;
+    final nextMeta = Map<String, VeilleSourceMeta>.from(state.sourcesMeta);
+    var changed = false;
+    for (final s in suggestions) {
+      if (!_isValidHttpUrl(s.url)) continue;
+      final slug = sourceSuggestionSlug(s.name, s.url);
+      if (nextMeta.containsKey(slug)) continue;
+      nextMeta[slug] = VeilleSourceMeta(
+        slug: slug,
+        name: s.name,
+        kind: 'niche',
+        url: s.url,
+        why: s.why,
       );
+      changed = true;
+    }
+    if (changed) state = state.copyWith(sourcesMeta: nextMeta);
+  }
 
   /// Ajoute un mot-clé / angle libre (step2 advanced). Normalise lowercase,
   /// dédupe, respecte la cap backend (`maxKeywords`).
@@ -543,7 +570,10 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
   /// "Passer aux sources" → goToStep(3) avec skippedStep2=true).
   void goToStep(int step, {bool skipStep2 = false}) {
     final clamped = step.clamp(1, 3);
-    state = state.copyWith(step: clamped, skippedStep2: skipStep2 || state.skippedStep2);
+    state = state.copyWith(
+      step: clamped,
+      skippedStep2: skipStep2 || state.skippedStep2,
+    );
   }
 
   /// Recul instantané.
@@ -573,6 +603,46 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     state = state.copyWith(
       sourcesMeta: nextMeta,
       selectedSourceIds: {...state.selectedSourceIds, sourceId},
+    );
+  }
+
+  /// Résout un sujet libre saisi via la tuile "Autre" de Step 1. Le sujet
+  /// devient le sujet principal de la veille, sans création d'intérêt global.
+  Future<void> resolveCustomMainTopic(String rawLabel) async {
+    final label = rawLabel.trim();
+    if (label.length < 2) return;
+    final repo = _ref.read(veilleRepositoryProvider);
+    final theme = state.selectedTheme;
+    final themeLabel = theme == null
+        ? null
+        : state.resolvedThemeLabel(veilleThemeLabelForSlug(theme));
+    final resolved = await repo.resolveTopic(
+      topic: label,
+      themeId: theme,
+      themeLabel: themeLabel,
+    );
+    final slug = resolved.topicId.isEmpty
+        ? _slugifyCustom(resolved.label)
+        : resolved.topicId;
+    final topic = VeilleTopic(
+      id: slug,
+      label: resolved.label,
+      reason: resolved.description.isEmpty
+          ? 'sujet ajouté'
+          : resolved.description,
+    );
+    final nextLabels = Map<String, String>.from(state.topicLabels)
+      ..[slug] = resolved.label;
+    final nextAngleKw = Map<String, List<String>>.from(state.angleKeywords);
+    final normalizedKeywords = _normalizeAngleKeywords(resolved.keywords);
+    if (normalizedKeywords.isNotEmpty) nextAngleKw[slug] = normalizedKeywords;
+    final existing = state.customTopics.where((t) => t.id != slug);
+    state = state.copyWith(
+      mainTopicSlug: slug,
+      mainTopicLabel: resolved.label,
+      customTopics: [...existing, topic],
+      topicLabels: nextLabels,
+      angleKeywords: nextAngleKw,
     );
   }
 
@@ -609,7 +679,11 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       nextLabels[slug] = label;
       if (!state.customTopics.any((t) => t.id == slug)) {
         newCustomTopics.add(
-          VeilleTopic(id: slug, label: label, reason: 'depuis « ${preset.label} »'),
+          VeilleTopic(
+            id: slug,
+            label: label,
+            reason: 'depuis « ${preset.label} »',
+          ),
         );
       }
     }
@@ -639,7 +713,9 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       selectedSourceIds: followed,
       sourcesMeta: nextMeta,
       purpose: preset.purposes.isNotEmpty ? preset.purposes.first : null,
-      editorialBrief: preset.editorialBrief.isEmpty ? null : preset.editorialBrief,
+      editorialBrief: preset.editorialBrief.isEmpty
+          ? null
+          : preset.editorialBrief,
       presetId: preset.slug,
     );
   }
@@ -657,9 +733,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       final repo = _ref.read(veilleRepositoryProvider);
       final cfg = await repo.upsertConfig(body);
 
-      _ref
-          .read(veilleActiveConfigProvider.notifier)
-          .hydrateFromServer(cfg);
+      _ref.read(veilleActiveConfigProvider.notifier).hydrateFromServer(cfg);
       // La veille est un favori d'intérêt : sans invalidation, la liste des
       // favoris reste périmée (sans VeilleFavoriteRef) et le CTA « Créer ma
       // veille » reste affiché → clic → redirection feed (bug navigation).
@@ -667,16 +741,10 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       _ref.invalidate(userInterestsProvider);
       state = state.copyWith(isSubmitting: false);
     } on VeilleApiException catch (e) {
-      state = state.copyWith(
-        isSubmitting: false,
-        lastError: e.message,
-      );
+      state = state.copyWith(isSubmitting: false, lastError: e.message);
       rethrow;
     } catch (e) {
-      state = state.copyWith(
-        isSubmitting: false,
-        lastError: e.toString(),
-      );
+      state = state.copyWith(isSubmitting: false, lastError: e.toString());
       rethrow;
     }
   }
@@ -703,9 +771,20 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       final t = cfg.topics[i];
       topicLabels[t.topicId] = t.label;
       if (t.keywords.isNotEmpty) angleKeywords[t.topicId] = t.keywords;
-      if (i == 0 && t.kind == 'preset' && mainSlug == null) {
+      if (i == 0 &&
+          (t.kind == 'preset' || t.kind == 'custom') &&
+          mainSlug == null) {
         mainSlug = t.topicId;
         mainLabel = t.label;
+        if (t.kind == 'custom') {
+          customTopics.add(
+            VeilleTopic(
+              id: t.topicId,
+              label: t.label,
+              reason: t.reason ?? 'sujet ajouté',
+            ),
+          );
+        }
         continue;
       }
       switch (t.kind) {
@@ -729,7 +808,8 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     // ce n'est pas un macro canonique (legacy).
     final macro = AvailableSubtopics.byTheme.containsKey(cfg.themeId)
         ? cfg.themeId
-        : (mainSlug != null ? _macroForSubtopic(mainSlug) : null) ?? cfg.themeId;
+        : (mainSlug != null ? _macroForSubtopic(mainSlug) : null) ??
+              cfg.themeId;
 
     final selectedSourceIds = <String>{};
     final sourcesMeta = <String, VeilleSourceMeta>{};
@@ -761,7 +841,8 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       sourcesMeta: sourcesMeta,
       keywords: keywords,
       angleKeywords: angleKeywords,
-      advancedMode: keywords.isNotEmpty || (cfg.editorialBrief?.isNotEmpty ?? false),
+      advancedMode:
+          keywords.isNotEmpty || (cfg.editorialBrief?.isNotEmpty ?? false),
       purpose: cfg.purpose,
       editorialBrief: cfg.editorialBrief,
       presetId: cfg.presetId,
@@ -799,7 +880,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
         VeilleTopicSelectionRequest(
           topicId: mainSlug,
           label: s.mainTopicLabel ?? s.topicLabels[mainSlug] ?? mainSlug,
-          kind: 'preset',
+          kind: mainSlug.startsWith('custom-') ? 'custom' : 'preset',
           position: pos++,
           keywords: s.angleKeywords[mainSlug] ?? const <String>[],
         ),
@@ -834,11 +915,28 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     var spos = 0;
     for (final slug in s.selectedSourceIds) {
       final meta = s.sourcesMeta[slug];
-      if (meta?.apiSourceId == null) continue; // mock-only — drop
+      if (meta == null) continue;
+      final apiSourceId = meta.apiSourceId;
+      if (apiSourceId != null) {
+        sourceSelections.add(
+          VeilleSourceSelectionRequest(
+            kind: meta.kind, // 'followed' | 'niche'
+            sourceId: apiSourceId,
+            why: meta.why,
+            position: spos++,
+          ),
+        );
+        continue;
+      }
+      if (!_isValidHttpUrl(meta.url)) continue;
       sourceSelections.add(
         VeilleSourceSelectionRequest(
-          kind: meta!.kind, // 'followed' | 'niche'
-          sourceId: meta.apiSourceId,
+          kind: meta.kind,
+          nicheCandidate: VeilleNicheCandidateRequest(
+            name: meta.name,
+            url: meta.url!,
+            why: meta.why,
+          ),
           why: meta.why,
           position: spos++,
         ),
@@ -868,5 +966,13 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
 
 final veilleConfigProvider =
     StateNotifierProvider.autoDispose<VeilleConfigNotifier, VeilleConfigState>(
-  (ref) => VeilleConfigNotifier(ref),
-);
+      (ref) => VeilleConfigNotifier(ref),
+    );
+
+bool _isValidHttpUrl(String? value) {
+  if (value == null || value.trim().isEmpty) return false;
+  final uri = Uri.tryParse(value.trim());
+  return uri != null &&
+      (uri.scheme == 'https' || uri.scheme == 'http') &&
+      uri.host.isNotEmpty;
+}

--- a/apps/mobile/lib/features/veille/providers/veille_source_suggestions_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_source_suggestions_provider.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/veille_config_dto.dart';
+import 'veille_repository_provider.dart';
+
+typedef VeilleSourceSuggestionsQuery = ({
+  String themeId,
+  String themeLabel,
+  String brief,
+  String anglesKey,
+  String keywordsKey,
+});
+
+/// Suggestions de sources niche pour le Step 3.
+///
+/// Le repo renvoie `[]` en cas d'erreur/timeout ; l'UI affiche alors un état
+/// vide avec un bouton qui invalide ce provider pour relancer la pipeline.
+final veilleSourceSuggestionsProvider = FutureProvider.autoDispose
+    .family<List<VeilleSourceSuggestionDto>, VeilleSourceSuggestionsQuery>((
+      ref,
+      q,
+    ) async {
+      final repo = ref.watch(veilleRepositoryProvider);
+      return repo.suggestSources(
+        themeId: q.themeId,
+        themeLabel: q.themeLabel,
+        brief: q.brief,
+        angles: _splitKey(q.anglesKey),
+        keywords: _splitKey(q.keywordsKey),
+      );
+    });
+
+List<String> _splitKey(String value) {
+  if (value.trim().isEmpty) return const [];
+  return value
+      .split('|')
+      .map((v) => v.trim())
+      .where((v) => v.isNotEmpty)
+      .toList();
+}

--- a/apps/mobile/lib/features/veille/providers/veille_themes_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_themes_provider.dart
@@ -26,6 +26,9 @@ const List<({String slug, String label, String emoji})> kVeilleFacteurThemes = [
 /// vers `"custom"` à l'ingestion source pour respecter `ck_source_theme_valid`.
 const String kVeilleOtherThemeSlug = 'other';
 
+/// Slug de la tuile "Autre" dans la grille de sous-thèmes de Step 1.
+const String kVeilleOtherTopicSlug = 'other-topic';
+
 /// Borne de l'affichage Step 1 : 9 thèmes Facteur + 1 tuile "Autre" = 10 max.
 /// Les 2 premières (les plus pertinentes pour le user) sont marquées `hot`
 /// pour le badge visuel.

--- a/apps/mobile/lib/features/veille/repositories/veille_repository.dart
+++ b/apps/mobile/lib/features/veille/repositories/veille_repository.dart
@@ -52,8 +52,10 @@ class VeilleRepository {
 
   Future<VeilleConfigDto> upsertConfig(VeilleConfigUpsertRequest body) async {
     try {
-      final response =
-          await _dio.post<dynamic>('veille/config', data: body.toJson());
+      final response = await _dio.post<dynamic>(
+        'veille/config',
+        data: body.toJson(),
+      );
       return VeilleConfigDto.fromJson(response.data as Map<String, dynamic>);
     } on DioException catch (e) {
       throw _wrap(e);
@@ -101,11 +103,7 @@ class VeilleRepository {
     try {
       final response = await _dio.post<dynamic>(
         'veille/suggest/angles',
-        data: {
-          'theme_id': themeId,
-          'theme_label': themeLabel,
-          'brief': brief,
-        },
+        data: {'theme_id': themeId, 'theme_label': themeLabel, 'brief': brief},
       );
       return VeilleSuggestAnglesResponse.fromJson(
         response.data as Map<String, dynamic>,
@@ -113,6 +111,62 @@ class VeilleRepository {
     } catch (_) {
       // Erreur réseau/timeout (DioException) ou réponse inattendue/parsing :
       // on dégrade en silence vers les preset topics statiques.
+      return const [];
+    }
+  }
+
+  // ─── Résolution sujet local Veille (Step 1) ─────────────────────────────
+
+  /// `POST /api/veille/resolve/topic` — enrichit un sujet libre pour la veille
+  /// sans créer d'intérêt global. Erreur → exception visible par l'UI Step 1.
+  Future<VeilleResolvedTopicDto> resolveTopic({
+    required String topic,
+    String? themeId,
+    String? themeLabel,
+  }) async {
+    try {
+      final response = await _dio.post<dynamic>(
+        'veille/resolve/topic',
+        data: {
+          'topic': topic,
+          if (themeId != null) 'theme_id': themeId,
+          if (themeLabel != null) 'theme_label': themeLabel,
+        },
+      );
+      return VeilleResolvedTopicDto.fromJson(
+        response.data as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw _wrap(e);
+    }
+  }
+
+  // ─── Suggestion sources LLM (Step 3) ───────────────────────────────────
+
+  /// `POST /api/veille/suggest/sources` — candidats niche non ingérés.
+  /// Toute erreur/timeout/parsing inattendu → `[]` pour afficher le retry.
+  Future<List<VeilleSourceSuggestionDto>> suggestSources({
+    required String themeId,
+    required String themeLabel,
+    String brief = '',
+    List<String> angles = const [],
+    List<String> keywords = const [],
+  }) async {
+    try {
+      final response = await _dio.post<dynamic>(
+        'veille/suggest/sources',
+        data: {
+          'theme_id': themeId,
+          'theme_label': themeLabel,
+          'brief': brief,
+          'angles': angles,
+          'keywords': keywords,
+        },
+      );
+      return VeilleSuggestSourcesResponse.fromJson(
+        response.data as Map<String, dynamic>,
+      ).sources;
+    } catch (_) {
       return const [];
     }
   }

--- a/apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step1_theme_screen.dart
@@ -25,8 +25,18 @@ class Step1ThemeScreen extends ConsumerStatefulWidget {
 
 class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
   final GlobalKey _briefSectionKey = GlobalKey();
+  final GlobalKey _subtopicSectionKey = GlobalKey();
+  final TextEditingController _customTopicCtrl = TextEditingController();
   int _openSection = 1;
-  bool _didAutoOpenSection2 = false;
+  bool _showCustomTopicCard = false;
+  bool _resolvingCustomTopic = false;
+  String? _customTopicError;
+
+  @override
+  void dispose() {
+    _customTopicCtrl.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +44,8 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
     final notifier = ref.read(veilleConfigProvider.notifier);
     final hasTheme = state.selectedTheme != null;
     final isOther = state.selectedTheme == kVeilleOtherThemeSlug;
-    final customLabelOk = !isOther || (state.customThemeLabel ?? '').trim().isNotEmpty;
+    final customLabelOk =
+        !isOther || (state.customThemeLabel ?? '').trim().isNotEmpty;
     // Story 23.4 — sujets granulaires du macro choisi (drill macro→topic).
     final subtopics = (hasTheme && !isOther)
         ? (AvailableSubtopics.byTheme[state.selectedTheme] ?? const [])
@@ -43,7 +54,8 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
     // "Autre" (chemin free-text) et macro sans sous-thèmes connus (rare) — dans
     // ces cas le user peut continuer sans granulaire.
     final needsMainTopic = hasTheme && !isOther && subtopics.isNotEmpty;
-    final hasMainTopic = state.mainTopicSlug != null ||
+    final hasMainTopic =
+        state.mainTopicSlug != null ||
         state.selectedTopics.isNotEmpty; // presets : topics déjà choisis
     final canContinue =
         hasTheme && customLabelOk && (!needsMainTopic || hasMainTopic);
@@ -51,40 +63,41 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
     final selectedThemeLabel = state.selectedTheme == null
         ? ''
         : (isOther
-            ? (state.customThemeLabel ?? 'Autre')
-            : veilleThemeLabelForSlug(state.selectedTheme!));
+              ? (state.customThemeLabel ?? 'Autre')
+              : veilleThemeLabelForSlug(state.selectedTheme!));
 
     final themesAsync = ref.watch(veilleThemesProvider);
 
-    // Auto-ouvre la section 2 (brief) dès qu'un thème est choisi.
-    ref.listen<String?>(
-      veilleConfigProvider.select((s) => s.selectedTheme),
-      (prev, next) {
-        if (!_didAutoOpenSection2 && prev == null && next != null) {
-          _didAutoOpenSection2 = true;
-          setState(() => _openSection = 2);
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            final ctx = _briefSectionKey.currentContext;
-            if (ctx != null) {
-              Scrollable.ensureVisible(
-                ctx,
-                duration: const Duration(milliseconds: 380),
-                curve: Curves.easeOutCubic,
-                alignment: 0.05,
-              );
-            }
-          });
-        }
-      },
-    );
+    // Après choix du thème, scroll vers la section immédiatement suivante :
+    // la grille de sujets précis en priorité, le brief seulement en fallback.
+    ref.listen<String?>(veilleConfigProvider.select((s) => s.selectedTheme), (
+      prev,
+      next,
+    ) {
+      if (prev != next && next != null) {
+        final hasSubtopics =
+            next != kVeilleOtherThemeSlug &&
+            (AvailableSubtopics.byTheme[next] ?? const []).isNotEmpty;
+        setState(() => _openSection = hasSubtopics ? 1 : 2);
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          final ctx = hasSubtopics
+              ? _subtopicSectionKey.currentContext
+              : _briefSectionKey.currentContext;
+          if (ctx != null) {
+            Scrollable.ensureVisible(
+              ctx,
+              duration: const Duration(milliseconds: 380),
+              curve: Curves.easeOutCubic,
+              alignment: 0.08,
+            );
+          }
+        });
+      }
+    });
 
     return Column(
       children: [
-        VeilleStepHeader(
-          step: 1,
-          canGoBack: false,
-          onClose: widget.onClose,
-        ),
+        VeilleStepHeader(step: 1, canGoBack: false, onClose: widget.onClose),
         _PresetTeaserLink(onTap: () => _openPresetSheet(context)),
         Expanded(
           child: SingleChildScrollView(
@@ -97,8 +110,9 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
                   title:
                       'Sur quel thème aimerais-tu recevoir un condensé des '
                       'meilleurs articles récents ?',
-                  subtitleWhenCollapsed:
-                      hasTheme ? selectedThemeLabel.toUpperCase() : null,
+                  subtitleWhenCollapsed: hasTheme
+                      ? selectedThemeLabel.toUpperCase()
+                      : null,
                   expanded: _openSection == 1,
                   onToggle: () => setState(() => _openSection = 1),
                   child: themesAsync.when(
@@ -125,10 +139,39 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
                 ],
                 if (subtopics.isNotEmpty) ...[
                   const SizedBox(height: 18),
-                  _SubtopicGrid(
-                    subtopics: subtopics,
-                    selected: state.mainTopicSlug,
-                    onSelect: (o) => notifier.selectMainTopic(o.slug, o.label),
+                  Column(
+                    key: _subtopicSectionKey,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _SubtopicGrid(
+                        subtopics: subtopics,
+                        selected: state.mainTopicSlug,
+                        customSelected:
+                            state.mainTopicSlug?.startsWith('custom-') ?? false,
+                        onSelect: (o) {
+                          setState(() {
+                            _showCustomTopicCard = false;
+                            _customTopicError = null;
+                          });
+                          notifier.selectMainTopic(o.slug, o.label);
+                        },
+                        onOther: () {
+                          setState(() {
+                            _showCustomTopicCard = true;
+                            _customTopicError = null;
+                          });
+                        },
+                      ),
+                      if (_showCustomTopicCard) ...[
+                        const SizedBox(height: 10),
+                        _CustomTopicCard(
+                          controller: _customTopicCtrl,
+                          loading: _resolvingCustomTopic,
+                          error: _customTopicError,
+                          onSubmit: () => _submitCustomTopic(notifier),
+                        ),
+                      ],
+                    ],
                   ),
                 ],
                 const SizedBox(height: 18),
@@ -139,8 +182,8 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
                   expanded: _openSection == 2 && hasTheme,
                   subtitleWhenCollapsed:
                       (state.editorialBrief ?? '').trim().isEmpty
-                          ? null
-                          : 'BRIEF RENSEIGNÉ',
+                      ? null
+                      : 'BRIEF RENSEIGNÉ',
                   onToggle: () {
                     if (!hasTheme) return;
                     setState(() => _openSection = 2);
@@ -188,6 +231,30 @@ class _Step1ThemeScreenState extends ConsumerState<Step1ThemeScreen> {
         ),
       ],
     );
+  }
+
+  Future<void> _submitCustomTopic(VeilleConfigNotifier notifier) async {
+    final raw = _customTopicCtrl.text.trim();
+    if (raw.length < 2 || _resolvingCustomTopic) return;
+    setState(() {
+      _resolvingCustomTopic = true;
+      _customTopicError = null;
+    });
+    try {
+      await notifier.resolveCustomMainTopic(raw);
+      if (!mounted) return;
+      setState(() {
+        _showCustomTopicCard = false;
+        _resolvingCustomTopic = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _resolvingCustomTopic = false;
+        _customTopicError =
+            'Impossible d\'enrichir ce sujet pour l\'instant. Réessaie.';
+      });
+    }
   }
 }
 
@@ -241,11 +308,15 @@ class _ThemeGrid extends StatelessWidget {
 class _SubtopicGrid extends StatelessWidget {
   final List<SubtopicOption> subtopics;
   final String? selected;
+  final bool customSelected;
   final ValueChanged<SubtopicOption> onSelect;
+  final VoidCallback onOther;
   const _SubtopicGrid({
     required this.subtopics,
     required this.selected,
+    required this.customSelected,
     required this.onSelect,
+    required this.onOther,
   });
 
   @override
@@ -294,9 +365,119 @@ class _SubtopicGrid extends StatelessWidget {
                 selected: selected == o.slug,
                 onTap: () => onSelect(o),
               ),
+            ThemeCard(
+              theme: const VeilleTheme(
+                id: kVeilleOtherTopicSlug,
+                label: 'Autre',
+                meta: '',
+                iconKey: '',
+                emoji: '✎',
+              ),
+              selected: customSelected,
+              onTap: onOther,
+            ),
           ],
         ),
       ],
+    );
+  }
+}
+
+class _CustomTopicCard extends StatelessWidget {
+  final TextEditingController controller;
+  final bool loading;
+  final String? error;
+  final VoidCallback onSubmit;
+
+  const _CustomTopicCard({
+    required this.controller,
+    required this.loading,
+    required this.error,
+    required this.onSubmit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 14, 14, 12),
+      decoration: BoxDecoration(
+        color: FacteurColors.veilleTint,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FacteurColors.veilleLineSoft),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Sujet sur-mesure',
+            style: GoogleFonts.dmSans(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: const Color(0xFF2C2A29),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: controller,
+                  enabled: !loading,
+                  maxLength: 200,
+                  textCapitalization: TextCapitalization.sentences,
+                  decoration: InputDecoration(
+                    hintText: 'Ex : Musées contemporains à Barcelone',
+                    filled: true,
+                    fillColor: Colors.white,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(10),
+                      borderSide: const BorderSide(
+                        color: FacteurColors.veilleLineSoft,
+                      ),
+                    ),
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 12,
+                    ),
+                    counterText: '',
+                  ),
+                  onSubmitted: (_) => onSubmit(),
+                ),
+              ),
+              const SizedBox(width: 8),
+              IconButton.filled(
+                onPressed: loading ? null : onSubmit,
+                style: IconButton.styleFrom(
+                  backgroundColor: FacteurColors.veille,
+                  foregroundColor: Colors.white,
+                  disabledBackgroundColor: const Color(0xFFD2C9BB),
+                ),
+                icon: loading
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      )
+                    : Icon(PhosphorIcons.check()),
+              ),
+            ],
+          ),
+          if (error != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              error!,
+              style: GoogleFonts.dmSans(
+                fontSize: 12,
+                color: const Color(0xFF9B3D2E),
+              ),
+            ),
+          ],
+        ],
+      ),
     );
   }
 }
@@ -392,7 +573,9 @@ class _OtherThemeLabelFieldState extends State<_OtherThemeLabelField> {
               fillColor: Colors.white,
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(10),
-                borderSide: const BorderSide(color: FacteurColors.veilleLineSoft),
+                borderSide: const BorderSide(
+                  color: FacteurColors.veilleLineSoft,
+                ),
               ),
               contentPadding: const EdgeInsets.symmetric(
                 horizontal: 12,
@@ -609,9 +792,7 @@ class _Footer extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
       decoration: const BoxDecoration(
-        border: Border(
-          top: BorderSide(color: Color(0xFFE6E1D6), width: 1),
-        ),
+        border: Border(top: BorderSide(color: Color(0xFFE6E1D6), width: 1)),
       ),
       child: VeilleCtaButton(
         label: 'Continuer',

--- a/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
@@ -5,24 +5,19 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../../config/theme.dart';
 import '../../../../shared/widgets/loaders/facteur_loader.dart';
-import '../../models/veille_config.dart';
 import '../../models/veille_config_dto.dart';
 import '../../providers/veille_angles_provider.dart';
 import '../../providers/veille_config_provider.dart';
-import '../../providers/veille_preset_topics_provider.dart';
 import '../../providers/veille_themes_provider.dart';
 import '../../widgets/veille_widgets.dart';
 
-/// Step 2 — choix des sujets pour la veille.
+/// Step 2 — angles optionnels pour la veille.
 ///
 /// Veille C3 (PR-3) : la suggestion LLM des angles est ré-introduite. À
 /// l'entrée du Step 2, on fetch `POST /veille/suggest/angles` (thème + brief)
 /// et on affiche chaque angle comme une carte « titre + grappe de mots-clés
-/// éditable » sélectionnable (opt-in). Les sujets curés du thème (via
-/// `veillePresetTopicsProvider`) + les sujets custom restent affichés en
-/// dessous. Si le LLM est KO, l'appel retourne `[]` → on retombe simplement
-/// sur les preset topics (aucune régression). Un toggle "Configuration
-/// avancée" expose les mots-clés libres pour les power-users.
+/// éditable » sélectionnable (opt-in). Le sujet principal est fixé en Step 1.
+/// Un toggle "Configuration avancée" expose les mots-clés libres.
 class Step2SuggestionsScreen extends ConsumerWidget {
   final VoidCallback onClose;
   const Step2SuggestionsScreen({super.key, required this.onClose});
@@ -32,18 +27,16 @@ class Step2SuggestionsScreen extends ConsumerWidget {
     final state = ref.watch(veilleConfigProvider);
     final notifier = ref.read(veilleConfigProvider.notifier);
     final theme = state.selectedTheme;
-    final presetTopicsAsync = theme == null
-        ? const AsyncValue<List<VeilleTopic>>.data(<VeilleTopic>[])
-        : ref.watch(veillePresetTopicsProvider(theme));
-
     final anglesAsync = theme == null
         ? const AsyncValue<List<VeilleAngleSuggestionDto>>.data(
-            <VeilleAngleSuggestionDto>[])
+            <VeilleAngleSuggestionDto>[],
+          )
         : ref.watch(
             veilleAnglesProvider((
               themeId: theme,
-              themeLabel:
-                  state.resolvedThemeLabel(veilleThemeLabelForSlug(theme)),
+              themeLabel: state.resolvedThemeLabel(
+                veilleThemeLabelForSlug(theme),
+              ),
               brief: state.editorialBrief ?? '',
             )),
           );
@@ -51,7 +44,8 @@ class Step2SuggestionsScreen extends ConsumerWidget {
     // Story 23.4 — le sujet principal du Step 1 satisfait déjà l'upsert (≥1
     // topic garanti), donc la CTA n'est plus gatée par une sélection
     // supplémentaire : angles et preset topics deviennent optionnels.
-    final hasSelection = state.mainTopicSlug != null ||
+    final hasSelection =
+        state.mainTopicSlug != null ||
         state.selectedTopics.isNotEmpty ||
         state.selectedSuggestions.isNotEmpty;
 
@@ -73,10 +67,10 @@ class Step2SuggestionsScreen extends ConsumerWidget {
                 const SizedBox(height: 8),
                 Text(
                   state.mainTopicSlug != null
-                      ? 'Ton sujet principal est fixé. Ajoute des angles ou des '
-                          'sujets pour préciser — ou passe directement à la suite.'
-                      : 'Coche les sujets qui t\'intéressent dans ce thème. Tu '
-                          'peux aussi en ajouter un sur-mesure, ou passer cette étape.',
+                      ? 'Ton sujet principal est fixé. Ajoute des angles pour '
+                            'préciser — ou passe directement à la suite.'
+                      : 'Ajoute des angles si tu veux préciser la veille, ou '
+                            'passe directement à la suite.',
                   style: GoogleFonts.dmSans(
                     fontSize: 13,
                     color: const Color(0xFF5D5B5A),
@@ -86,7 +80,8 @@ class Step2SuggestionsScreen extends ConsumerWidget {
                 if (state.mainTopicSlug != null) ...[
                   const SizedBox(height: 16),
                   _MainTopicChip(
-                    label: state.mainTopicLabel ??
+                    label:
+                        state.mainTopicLabel ??
                         state.topicLabels[state.mainTopicSlug!] ??
                         state.mainTopicSlug!,
                   ),
@@ -96,15 +91,6 @@ class Step2SuggestionsScreen extends ConsumerWidget {
                   anglesAsync: anglesAsync,
                   state: state,
                   notifier: notifier,
-                ),
-                _TopicsList(
-                  presetTopicsAsync: presetTopicsAsync,
-                  state: state,
-                  notifier: notifier,
-                ),
-                const SizedBox(height: 12),
-                _AddTopicChip(
-                  onTap: () => _openAddTopicSheet(context, notifier),
                 ),
                 const SizedBox(height: 24),
                 _AdvancedToggle(
@@ -122,7 +108,9 @@ class Step2SuggestionsScreen extends ConsumerWidget {
         Container(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
           decoration: const BoxDecoration(
-            border: Border(top: BorderSide(color: FacteurColors.veilleLineSoft)),
+            border: Border(
+              top: BorderSide(color: FacteurColors.veilleLineSoft),
+            ),
           ),
           child: VeilleCtaButton(
             label: 'Continuer',
@@ -177,8 +165,11 @@ class _MainTopicChip extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(PhosphorIcons.pushPin(PhosphorIconsStyle.fill),
-              size: 16, color: FacteurColors.veille),
+          Icon(
+            PhosphorIcons.pushPin(PhosphorIconsStyle.fill),
+            size: 16,
+            color: FacteurColors.veille,
+          ),
           const SizedBox(width: 10),
           Expanded(
             child: Column(
@@ -257,11 +248,7 @@ class _AnglesSection extends StatelessWidget {
             const SizedBox(height: 12),
             for (int i = 0; i < angles.length; i++) ...[
               if (i > 0) const SizedBox(height: 8),
-              _AngleCard(
-                angle: angles[i],
-                state: state,
-                notifier: notifier,
-              ),
+              _AngleCard(angle: angles[i], state: state, notifier: notifier),
             ],
             const SizedBox(height: 22),
           ],
@@ -312,8 +299,9 @@ class _AngleCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final slug = VeilleConfigNotifier.angleSlug(angle.title);
     final selected = state.selectedSuggestions.contains(slug);
-    final keywords =
-        selected ? (state.angleKeywords[slug] ?? const <String>[]) : angle.keywords;
+    final keywords = selected
+        ? (state.angleKeywords[slug] ?? const <String>[])
+        : angle.keywords;
     final showChips = keywords.isNotEmpty || selected;
 
     return Container(
@@ -354,7 +342,11 @@ class _AngleCard extends StatelessWidget {
                         ),
                       ),
                       child: selected
-                          ? const Icon(Icons.check, size: 11, color: Colors.white)
+                          ? const Icon(
+                              Icons.check,
+                              size: 11,
+                              color: Colors.white,
+                            )
                           : null,
                     ),
                     const SizedBox(width: 10),
@@ -416,197 +408,6 @@ class _AngleCard extends StatelessWidget {
               ),
             ),
         ],
-      ),
-    );
-  }
-}
-
-class _TopicsList extends ConsumerWidget {
-  final AsyncValue<List<VeilleTopic>> presetTopicsAsync;
-  final VeilleConfigState state;
-  final VeilleConfigNotifier notifier;
-  const _TopicsList({
-    required this.presetTopicsAsync,
-    required this.state,
-    required this.notifier,
-  });
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return presetTopicsAsync.when(
-      loading: () => const _SkeletonList(),
-      error: (_, __) => _renderList(const <VeilleTopic>[]),
-      data: (preset) {
-        // Hydrate les labels une fois pour que `_buildUpsertRequest` les envoie.
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          notifier.registerPresetTopicLabels(preset);
-        });
-        return _renderList(preset);
-      },
-    );
-  }
-
-  Widget _renderList(List<VeilleTopic> presetTopics) {
-    final seen = <String>{};
-    final merged = <VeilleTopic>[];
-    for (final t in state.customTopics) {
-      if (seen.add(t.id)) merged.add(t);
-    }
-    for (final t in presetTopics) {
-      if (seen.add(t.id)) merged.add(t);
-    }
-
-    if (merged.isEmpty) {
-      return Container(
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: const Color(0xFFFDFBF7),
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: FacteurColors.veilleLineSoft),
-        ),
-        child: Text(
-          'Aucun sujet pré-curé pour ce thème. Ajoute un sujet sur-mesure '
-          'ci-dessous ou passe cette étape.',
-          style: GoogleFonts.dmSans(
-            fontSize: 12.5,
-            color: const Color(0xFF5D5B5A),
-            height: 1.4,
-          ),
-        ),
-      );
-    }
-
-    return Column(
-      children: [
-        for (int i = 0; i < merged.length; i++) ...[
-          if (i > 0) const SizedBox(height: 8),
-          _TopicRow(
-            topic: merged[i],
-            selected: state.selectedTopics.contains(merged[i].id),
-            onToggle: () => notifier.toggleTopic(merged[i].id),
-          ),
-        ],
-      ],
-    );
-  }
-}
-
-class _TopicRow extends StatelessWidget {
-  final VeilleTopic topic;
-  final bool selected;
-  final VoidCallback onToggle;
-  const _TopicRow({
-    required this.topic,
-    required this.selected,
-    required this.onToggle,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      color: selected ? FacteurColors.veilleTint : Colors.white,
-      borderRadius: BorderRadius.circular(12),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: onToggle,
-        child: Container(
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: selected
-                  ? FacteurColors.veille
-                  : FacteurColors.veilleLineSoft,
-              width: 1.5,
-            ),
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                width: 18,
-                height: 18,
-                margin: const EdgeInsets.only(top: 1),
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(5),
-                  color: selected ? FacteurColors.veille : Colors.white,
-                  border: Border.all(
-                    color: selected
-                        ? FacteurColors.veille
-                        : const Color(0xFFD2C9BB),
-                    width: 1.5,
-                  ),
-                ),
-                child: selected
-                    ? const Icon(Icons.check, size: 11, color: Colors.white)
-                    : null,
-              ),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      topic.label,
-                      style: GoogleFonts.dmSans(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                        height: 1.3,
-                        color: const Color(0xFF2C2A29),
-                      ),
-                    ),
-                    const SizedBox(height: 3),
-                    Text(
-                      topic.reason,
-                      style: GoogleFonts.dmSans(
-                        fontSize: 11.5,
-                        height: 1.4,
-                        color: const Color(0xFF959392),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _AddTopicChip extends StatelessWidget {
-  final VoidCallback onTap;
-  const _AddTopicChip({required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(12),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: FacteurColors.veille.withValues(alpha: 0.55),
-            width: 1.5,
-          ),
-        ),
-        child: Row(
-          children: [
-            Icon(PhosphorIcons.plus(), size: 16, color: FacteurColors.veille),
-            const SizedBox(width: 10),
-            Text(
-              'Ajouter un sujet',
-              style: GoogleFonts.dmSans(
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                color: FacteurColors.veille,
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }
@@ -683,7 +484,10 @@ class _KeywordsSection extends StatelessWidget {
             runSpacing: 6,
             children: [
               for (final kw in state.keywords)
-                _KeywordChip(label: kw, onRemove: () => notifier.removeKeyword(kw)),
+                _KeywordChip(
+                  label: kw,
+                  onRemove: () => notifier.removeKeyword(kw),
+                ),
             ],
           ),
           const SizedBox(height: 10),
@@ -768,9 +572,7 @@ class _AddKeywordButton extends StatelessWidget {
             Icon(
               PhosphorIcons.plus(),
               size: 12,
-              color: enabled
-                  ? FacteurColors.veille
-                  : const Color(0xFFB8B0A0),
+              color: enabled ? FacteurColors.veille : const Color(0xFFB8B0A0),
             ),
             const SizedBox(width: 4),
             Text(
@@ -778,9 +580,7 @@ class _AddKeywordButton extends StatelessWidget {
               style: GoogleFonts.dmSans(
                 fontSize: 12,
                 fontWeight: FontWeight.w600,
-                color: enabled
-                    ? FacteurColors.veille
-                    : const Color(0xFFB8B0A0),
+                color: enabled ? FacteurColors.veille : const Color(0xFFB8B0A0),
               ),
             ),
           ],
@@ -788,120 +588,30 @@ class _AddKeywordButton extends StatelessWidget {
       ),
     );
   }
-}
-
-class _SkeletonList extends StatelessWidget {
-  const _SkeletonList();
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: List.generate(
-        4,
-        (i) => Padding(
-          padding: EdgeInsets.only(top: i == 0 ? 0 : 8),
-          child: Container(
-            height: 56,
-            decoration: BoxDecoration(
-              color: const Color(0xFFF5F0E5),
-              borderRadius: BorderRadius.circular(12),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-Future<void> _openAddTopicSheet(
-  BuildContext context,
-  VeilleConfigNotifier notifier,
-) async {
-  final ctrl = TextEditingController();
-  final result = await showModalBottomSheet<String>(
-    context: context,
-    isScrollControlled: true,
-    backgroundColor: Colors.white,
-    shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
-    ),
-    builder: (ctx) {
-      final viewInsets = MediaQuery.of(ctx).viewInsets;
-      return Padding(
-        padding: EdgeInsets.fromLTRB(20, 16, 20, 16 + viewInsets.bottom),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(
-              'Ajouter un sujet',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
-            ),
-            const SizedBox(height: 4),
-            const Text(
-              'Ex : « IA générative », « Politique numérique européenne »',
-              style: TextStyle(fontSize: 12, color: Color(0xFF8B7E63)),
-            ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: ctrl,
-              autofocus: true,
-              maxLength: 80,
-              textCapitalization: TextCapitalization.sentences,
-              decoration: const InputDecoration(
-                border: OutlineInputBorder(),
-                hintText: 'Ton sujet',
-                counterText: '',
-              ),
-              onSubmitted: (_) => Navigator.of(ctx).pop(ctrl.text.trim()),
-            ),
-            const SizedBox(height: 8),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                TextButton(
-                  onPressed: () => Navigator.of(ctx).pop(),
-                  child: const Text('Annuler'),
-                ),
-                const SizedBox(width: 8),
-                FilledButton(
-                  onPressed: () => Navigator.of(ctx).pop(ctrl.text.trim()),
-                  child: const Text('Ajouter'),
-                ),
-              ],
-            ),
-          ],
-        ),
-      );
-    },
-  );
-  ctrl.dispose();
-  if (result != null && result.isNotEmpty) notifier.addCustomTopic(result);
 }
 
 /// Mot-clé libre global (config avancée) → `notifier.addKeyword`.
 Future<void> _openAddKeywordSheet(
   BuildContext context,
   VeilleConfigNotifier notifier,
-) =>
-    _showAddKeywordSheet(
-      context,
-      subtitle: 'Sera utilisé pour filtrer les articles (titre, description).',
-      hint: 'Ex : gpt-5',
-      onAdd: notifier.addKeyword,
-    );
+) => _showAddKeywordSheet(
+  context,
+  subtitle: 'Sera utilisé pour filtrer les articles (titre, description).',
+  hint: 'Ex : gpt-5',
+  onAdd: notifier.addKeyword,
+);
 
 /// Mot-clé ajouté à la grappe d'un angle → `notifier.addAngleKeyword(slug, …)`.
 Future<void> _openAddAngleKeywordSheet(
   BuildContext context,
   VeilleConfigNotifier notifier,
   String slug,
-) =>
-    _showAddKeywordSheet(
-      context,
-      subtitle: 'Affine cet angle — filtre les articles sur ce terme.',
-      hint: 'Ex : régulation',
-      onAdd: (kw) => notifier.addAngleKeyword(slug, kw),
-    );
+) => _showAddKeywordSheet(
+  context,
+  subtitle: 'Affine cet angle — filtre les articles sur ce terme.',
+  hint: 'Ex : régulation',
+  onAdd: (kw) => notifier.addAngleKeyword(slug, kw),
+);
 
 /// Bottom sheet partagé de saisie d'un mot-clé. `onAdd` reçoit le texte trimé
 /// non-vide ; la normalisation/dédupe est faite côté notifier.

--- a/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
@@ -4,19 +4,22 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../../config/theme.dart';
+import '../../../../shared/widgets/loaders/facteur_loader.dart';
 import '../../../sources/models/smart_search_result.dart';
+import '../../models/veille_config_dto.dart';
 import '../../models/veille_config.dart';
 import '../../providers/veille_config_provider.dart';
+import '../../providers/veille_source_suggestions_provider.dart';
+import '../../providers/veille_themes_provider.dart';
 import '../../widgets/veille_add_source_sheet.dart';
 import '../../widgets/veille_source_card.dart';
 import '../../widgets/veille_widgets.dart';
 
 /// Step 3 — choix des sources pour la veille.
 ///
-/// PR-4 (Story 23.3) : la suggestion LLM des sources a été supprimée.
-/// L'écran affiche les sources curées déjà appliquées (depuis un preset ou
-/// l'historique de la config en mode édition). Un toggle "Configuration
-/// avancée" ouvre `VeilleAddSourceSheet` pour ajouter une source par URL.
+/// Les sources catalogue déjà appliquées gardent leurs exemples récents.
+/// Les sources LLM restent des candidats niche locaux au flow : elles sont
+/// ingérées seulement si le user les sélectionne puis submit.
 class Step3SourcesScreen extends ConsumerWidget {
   final VoidCallback onClose;
   final Future<void> Function() onSubmit;
@@ -31,6 +34,15 @@ class Step3SourcesScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(veilleConfigProvider);
     final notifier = ref.read(veilleConfigProvider.notifier);
+    final query = _buildSuggestionQuery(state);
+    final VoidCallback? onRetry = query == null
+        ? null
+        : () => ref.invalidate(veilleSourceSuggestionsProvider(query));
+    final suggestionsAsync = query == null
+        ? const AsyncValue<List<VeilleSourceSuggestionDto>>.data(
+            <VeilleSourceSuggestionDto>[],
+          )
+        : ref.watch(veilleSourceSuggestionsProvider(query));
 
     final canSubmit = state.realSelectedSourceCount > 0 && !state.isSubmitting;
 
@@ -53,11 +65,7 @@ class Step3SourcesScreen extends ConsumerWidget {
 
     return Column(
       children: [
-        VeilleStepHeader(
-          step: 3,
-          onClose: onClose,
-          onBack: notifier.goBack,
-        ),
+        VeilleStepHeader(step: 3, onClose: onClose, onBack: notifier.goBack),
         Expanded(
           child: SingleChildScrollView(
             padding: const EdgeInsets.fromLTRB(20, 20, 20, 24),
@@ -79,22 +87,43 @@ class Step3SourcesScreen extends ConsumerWidget {
                   ),
                 ),
                 const SizedBox(height: 22),
-                if (curatedSources.isNotEmpty)
+                if (curatedSources.isNotEmpty) ...[
                   Column(
                     children: [
                       for (int i = 0; i < curatedSources.length; i++) ...[
                         if (i > 0) const SizedBox(height: 6),
                         VeilleSourceCard(
                           source: curatedSources[i],
-                          inVeille: state.selectedSourceIds
-                              .contains(curatedSources[i].id),
+                          inVeille: state.selectedSourceIds.contains(
+                            curatedSources[i].id,
+                          ),
                           isAlreadyFollowed: false,
+                          showExamples: true,
                           onToggle: () =>
                               notifier.toggleSource(curatedSources[i].id),
                         ),
                       ],
                     ],
                   ),
+                  const SizedBox(height: 22),
+                ],
+                suggestionsAsync.when(
+                  loading: () => const _SourceSuggestionsLoading(),
+                  error: (_, __) => _SourceSuggestionsEmpty(onRetry: onRetry),
+                  data: (suggestions) {
+                    if (suggestions.isEmpty) {
+                      return _SourceSuggestionsEmpty(onRetry: onRetry);
+                    }
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      notifier.registerSuggestedSources(suggestions);
+                    });
+                    return _SuggestedSourcesList(
+                      suggestions: suggestions,
+                      state: state,
+                      notifier: notifier,
+                    );
+                  },
+                ),
                 const SizedBox(height: 24),
                 _AdvancedToggle(
                   expanded: state.advancedMode,
@@ -133,7 +162,9 @@ class Step3SourcesScreen extends ConsumerWidget {
         Container(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
           decoration: const BoxDecoration(
-            border: Border(top: BorderSide(color: FacteurColors.veilleLineSoft)),
+            border: Border(
+              top: BorderSide(color: FacteurColors.veilleLineSoft),
+            ),
           ),
           child: VeilleCtaButton(
             label: state.isSubmitting ? 'Enregistrement…' : 'Créer ma veille',
@@ -145,10 +176,7 @@ class Step3SourcesScreen extends ConsumerWidget {
     );
   }
 
-  void _openAddSheet(
-    BuildContext context,
-    VeilleConfigNotifier notifier,
-  ) {
+  void _openAddSheet(BuildContext context, VeilleConfigNotifier notifier) {
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
@@ -183,9 +211,168 @@ class Step3SourcesScreen extends ConsumerWidget {
     );
   }
 
-  static String _domain(String url) {
-    final uri = Uri.tryParse(url);
-    return uri?.host ?? url;
+  static VeilleSourceSuggestionsQuery? _buildSuggestionQuery(
+    VeilleConfigState state,
+  ) {
+    final theme = state.selectedTheme;
+    if (theme == null) return null;
+    final themeLabel = state.resolvedThemeLabel(veilleThemeLabelForSlug(theme));
+    final angleLabels = <String>[];
+    if (state.mainTopicSlug != null) {
+      angleLabels.add(
+        state.mainTopicLabel ??
+            state.topicLabels[state.mainTopicSlug!] ??
+            state.mainTopicSlug!,
+      );
+    }
+    for (final slug in state.selectedSuggestions) {
+      final label = state.topicLabels[slug];
+      if (label != null && label.trim().isNotEmpty) angleLabels.add(label);
+    }
+
+    final keywords = <String>{...state.keywords};
+    final selectedTopicSlugs = <String>{
+      if (state.mainTopicSlug != null) state.mainTopicSlug!,
+      ...state.selectedSuggestions,
+    };
+    for (final slug in selectedTopicSlugs) {
+      keywords.addAll(state.angleKeywords[slug] ?? const <String>[]);
+    }
+
+    return (
+      themeId: theme,
+      themeLabel: themeLabel,
+      brief: state.editorialBrief ?? '',
+      anglesKey: angleLabels.join('|'),
+      keywordsKey: keywords.join('|'),
+    );
+  }
+}
+
+class _SuggestedSourcesList extends StatelessWidget {
+  final List<VeilleSourceSuggestionDto> suggestions;
+  final VeilleConfigState state;
+  final VeilleConfigNotifier notifier;
+
+  const _SuggestedSourcesList({
+    required this.suggestions,
+    required this.state,
+    required this.notifier,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final valid = suggestions.where((s) => _isValidHttpUrl(s.url)).toList();
+    if (valid.isEmpty) {
+      return const _SourceSuggestionsEmpty(onRetry: null);
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'SOURCES PROPOSÉES',
+          style: GoogleFonts.dmSans(
+            fontSize: 10,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.8,
+            color: const Color(0xFF8B7E63),
+          ),
+        ),
+        const SizedBox(height: 8),
+        for (int i = 0; i < valid.length; i++) ...[
+          if (i > 0) const SizedBox(height: 6),
+          _suggestionCard(valid[i]),
+        ],
+      ],
+    );
+  }
+
+  Widget _suggestionCard(VeilleSourceSuggestionDto suggestion) {
+    final slug = VeilleConfigNotifier.sourceSuggestionSlug(
+      suggestion.name,
+      suggestion.url,
+    );
+    final source = VeilleSource(
+      id: slug,
+      letter:
+          suggestion.name.isNotEmpty ? suggestion.name[0].toUpperCase() : '?',
+      name: suggestion.name,
+      meta: 'Source proposée',
+      why: suggestion.why,
+      logoUrl:
+          'https://www.google.com/s2/favicons?sz=128&domain=${_domain(suggestion.url)}',
+    );
+    return VeilleSourceCard(
+      source: source,
+      inVeille: state.selectedSourceIds.contains(slug),
+      isAlreadyFollowed: false,
+      showExamples: false,
+      onToggle: () {
+        notifier.registerSuggestedSources([suggestion]);
+        notifier.toggleSource(slug);
+      },
+    );
+  }
+}
+
+class _SourceSuggestionsLoading extends StatelessWidget {
+  const _SourceSuggestionsLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 18),
+      child: Column(
+        children: [
+          const FacteurLoader(width: 64, height: 64),
+          const SizedBox(height: 8),
+          Text(
+            'Recherche de sources pour ta veille…',
+            style: GoogleFonts.dmSans(
+              fontSize: 12.5,
+              color: const Color(0xFF8B7E63),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SourceSuggestionsEmpty extends StatelessWidget {
+  final VoidCallback? onRetry;
+  const _SourceSuggestionsEmpty({required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFDFBF7),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FacteurColors.veilleLineSoft),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Aucune source proposée pour l\'instant.',
+            style: GoogleFonts.dmSans(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: const Color(0xFF2C2A29),
+            ),
+          ),
+          const SizedBox(height: 10),
+          OutlinedButton.icon(
+            onPressed: onRetry,
+            icon: Icon(PhosphorIcons.arrowsClockwise(), size: 15),
+            label: const Text('Proposer plus de sources'),
+          ),
+        ],
+      ),
+    );
   }
 }
 
@@ -240,10 +427,7 @@ class _AddSourceButton extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: FacteurColors.veilleLine,
-              width: 1.5,
-            ),
+            border: Border.all(color: FacteurColors.veilleLine, width: 1.5),
           ),
           child: Row(
             children: [
@@ -274,4 +458,16 @@ class _AddSourceButton extends StatelessWidget {
       ),
     );
   }
+}
+
+String _domain(String url) {
+  final uri = Uri.tryParse(url);
+  return uri?.host ?? url;
+}
+
+bool _isValidHttpUrl(String value) {
+  final uri = Uri.tryParse(value.trim());
+  return uri != null &&
+      (uri.scheme == 'https' || uri.scheme == 'http') &&
+      uri.host.isNotEmpty;
 }

--- a/apps/mobile/lib/features/veille/widgets/veille_source_card.dart
+++ b/apps/mobile/lib/features/veille/widgets/veille_source_card.dart
@@ -22,6 +22,7 @@ class VeilleSourceCard extends ConsumerStatefulWidget {
   final bool inVeille;
   final bool isAlreadyFollowed;
   final VoidCallback onToggle;
+  final bool showExamples;
 
   const VeilleSourceCard({
     super.key,
@@ -29,6 +30,7 @@ class VeilleSourceCard extends ConsumerStatefulWidget {
     required this.inVeille,
     required this.isAlreadyFollowed,
     required this.onToggle,
+    this.showExamples = true,
   });
 
   @override
@@ -56,10 +58,8 @@ class _VeilleSourceCardState extends ConsumerState<VeilleSourceCard> {
           context: context,
           isScrollControlled: true,
           backgroundColor: Colors.transparent,
-          builder: (_) => SourceDetailModal(
-            source: catalogSource,
-            onToggleTrust: () {},
-          ),
+          builder: (_) =>
+              SourceDetailModal(source: catalogSource, onToggleTrust: () {}),
         ),
         borderRadius: BorderRadius.circular(12),
         child: Container(
@@ -70,8 +70,8 @@ class _VeilleSourceCardState extends ConsumerState<VeilleSourceCard> {
               color: widget.inVeille
                   ? FacteurColors.veille
                   : (widget.isAlreadyFollowed
-                      ? FacteurColors.veilleLineSoft
-                      : FacteurColors.veilleLine),
+                        ? FacteurColors.veilleLineSoft
+                        : FacteurColors.veilleLine),
               width: 1.5,
             ),
           ),
@@ -81,11 +81,7 @@ class _VeilleSourceCardState extends ConsumerState<VeilleSourceCard> {
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  SourceLogoAvatar(
-                    source: catalogSource,
-                    size: 36,
-                    radius: 8,
-                  ),
+                  SourceLogoAvatar(source: catalogSource, size: 36, radius: 8),
                   const SizedBox(width: 12),
                   Expanded(
                     child: Column(
@@ -174,22 +170,21 @@ class _VeilleSourceCardState extends ConsumerState<VeilleSourceCard> {
                   ),
                 ],
               ),
-              const SizedBox(height: 10),
-              _ExamplesToggle(
-                expanded: _expanded,
-                onTap: _toggleExpanded,
-              ),
-              AnimatedSize(
-                duration: const Duration(milliseconds: 220),
-                curve: Curves.easeOut,
-                alignment: Alignment.topCenter,
-                child: _expanded
-                    ? Padding(
-                        padding: const EdgeInsets.only(top: 8),
-                        child: _ExamplesPanel(sourceId: source.id),
-                      )
-                    : const SizedBox.shrink(),
-              ),
+              if (widget.showExamples) ...[
+                const SizedBox(height: 10),
+                _ExamplesToggle(expanded: _expanded, onTap: _toggleExpanded),
+                AnimatedSize(
+                  duration: const Duration(milliseconds: 220),
+                  curve: Curves.easeOut,
+                  alignment: Alignment.topCenter,
+                  child: _expanded
+                      ? Padding(
+                          padding: const EdgeInsets.only(top: 8),
+                          child: _ExamplesPanel(sourceId: source.id),
+                        )
+                      : const SizedBox.shrink(),
+                ),
+              ],
             ],
           ),
         ),
@@ -228,9 +223,7 @@ class _ExamplesToggle extends StatelessWidget {
             ),
             const Spacer(),
             Icon(
-              expanded
-                  ? PhosphorIcons.caretUp()
-                  : PhosphorIcons.caretDown(),
+              expanded ? PhosphorIcons.caretUp() : PhosphorIcons.caretDown(),
               size: 12,
               color: const Color(0xFF5D5B5A),
             ),
@@ -250,11 +243,7 @@ class _ExamplesPanel extends ConsumerWidget {
     final async = ref.watch(veilleSourceExamplesProvider(sourceId));
     return async.when(
       loading: () => const Column(
-        children: [
-          _ExampleSkeleton(),
-          SizedBox(height: 6),
-          _ExampleSkeleton(),
-        ],
+        children: [_ExampleSkeleton(), SizedBox(height: 6), _ExampleSkeleton()],
       ),
       error: (_, __) => const _ExamplesEmpty(),
       data: (items) {

--- a/apps/mobile/test/features/veille/models/veille_config_dto_test.dart
+++ b/apps/mobile/test/features/veille/models/veille_config_dto_test.dart
@@ -19,8 +19,9 @@ void main() {
     });
 
     test('keywords absents → liste vide ; reason absent → null', () {
-      final dto =
-          VeilleAngleSuggestionDto.fromJson(const {'title': 'Sans grappe'});
+      final dto = VeilleAngleSuggestionDto.fromJson(const {
+        'title': 'Sans grappe',
+      });
       expect(dto.keywords, isEmpty);
       expect(dto.reason, isNull);
     });
@@ -45,8 +46,7 @@ void main() {
     });
 
     test('clé angles absente → liste vide (pas de crash)', () {
-      expect(
-          VeilleSuggestAnglesResponse.fromJson(const {}).angles, isEmpty);
+      expect(VeilleSuggestAnglesResponse.fromJson(const {}).angles, isEmpty);
     });
   });
 
@@ -83,6 +83,47 @@ void main() {
         keywords: ['ia', 'llm'],
       );
       expect(req.toJson()['keywords'], ['ia', 'llm']);
+    });
+  });
+
+  group('VeilleResolvedTopicDto.fromJson', () {
+    test('mappe label, topic_id, keywords, description et metadata', () {
+      final dto = VeilleResolvedTopicDto.fromJson(const {
+        'label': 'Musées contemporains de Barcelone',
+        'topic_id': 'custom-musees-contemporains-de-barcelone',
+        'keywords': ['macba', 'exposition'],
+        'description': 'Suivi des expositions',
+        'metadata': {'slug_parent': 'culture', 'entity_type': 'LOCATION'},
+      });
+      expect(dto.label, 'Musées contemporains de Barcelone');
+      expect(dto.topicId, 'custom-musees-contemporains-de-barcelone');
+      expect(dto.keywords, ['macba', 'exposition']);
+      expect(dto.description, 'Suivi des expositions');
+      expect(dto.metadata['slug_parent'], 'culture');
+    });
+  });
+
+  group('VeilleSuggestSourcesResponse.fromJson', () {
+    test('mappe les candidats sources', () {
+      final res = VeilleSuggestSourcesResponse.fromJson(const {
+        'sources': [
+          {
+            'name': 'MACBA',
+            'url': 'https://www.macba.cat',
+            'why': 'Musée officiel',
+            'relevance_score': 1.0,
+          },
+        ],
+      });
+      expect(res.sources.length, 1);
+      expect(res.sources.first.name, 'MACBA');
+      expect(res.sources.first.url, 'https://www.macba.cat');
+      expect(res.sources.first.why, 'Musée officiel');
+      expect(res.sources.first.relevanceScore, 1.0);
+    });
+
+    test('clé sources absente → liste vide', () {
+      expect(VeilleSuggestSourcesResponse.fromJson(const {}).sources, isEmpty);
     });
   });
 }

--- a/apps/mobile/test/features/veille/models/veille_presets_test.dart
+++ b/apps/mobile/test/features/veille/models/veille_presets_test.dart
@@ -5,7 +5,7 @@ import 'package:facteur/features/veille/models/veille_config.dart';
 void main() {
   group('VeillePreset.fromJson', () {
     test('parses full payload including sources', () {
-      final preset = VeillePreset.fromJson({
+      final preset = VeillePreset.fromJson(const {
         'slug': 'ia_agentique',
         'label': 'Outils IA agentique',
         'accroche': 'Les derniers outils IA',
@@ -33,7 +33,7 @@ void main() {
     });
 
     test('handles missing optional fields with safe defaults', () {
-      final preset = VeillePreset.fromJson({
+      final preset = VeillePreset.fromJson(const {
         'slug': 's',
         'label': 'L',
         'accroche': 'A',

--- a/apps/mobile/test/features/veille/providers/veille_angles_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_angles_provider_test.dart
@@ -22,7 +22,7 @@ class _FakeRepo implements VeilleRepository {
       angles;
 
   @override
-  noSuchMethod(Invocation invocation) =>
+  dynamic noSuchMethod(Invocation invocation) =>
       throw UnimplementedError('${invocation.memberName} non mocké');
 }
 
@@ -42,10 +42,13 @@ void main() {
     expect(angles.single.title, 'IA');
   });
 
-  test('LLM KO (repo → []) : provider renvoie une liste vide (fallback presets)',
+  test(
+      'LLM KO (repo → []) : provider renvoie une liste vide (fallback presets)',
       () async {
     final container = ProviderContainer(
-      overrides: [veilleRepositoryProvider.overrideWithValue(_FakeRepo(const []))],
+      overrides: [
+        veilleRepositoryProvider.overrideWithValue(_FakeRepo(const []))
+      ],
     );
     addTearDown(container.dispose);
 

--- a/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
@@ -11,6 +11,12 @@ import 'package:facteur/features/veille/repositories/veille_repository.dart';
 /// `_buildUpsertRequest`). Toute autre méthode throw → instrumentation à fixer.
 class _CaptureRepo implements VeilleRepository {
   VeilleConfigUpsertRequest? captured;
+  VeilleResolvedTopicDto resolvedTopic = const VeilleResolvedTopicDto(
+    label: 'Musées contemporains de Barcelone',
+    topicId: 'custom-musees-contemporains-de-barcelone',
+    keywords: ['macba', 'exposition'],
+    description: 'Suivi des expositions',
+  );
 
   @override
   Future<VeilleConfigDto> upsertConfig(VeilleConfigUpsertRequest body) async {
@@ -30,7 +36,15 @@ class _CaptureRepo implements VeilleRepository {
   }
 
   @override
-  noSuchMethod(Invocation invocation) =>
+  Future<VeilleResolvedTopicDto> resolveTopic({
+    required String topic,
+    String? themeId,
+    String? themeLabel,
+  }) async =>
+      resolvedTopic;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
       throw UnimplementedError('${invocation.memberName} non mocké');
 }
 
@@ -51,8 +65,10 @@ void main() {
   test('selectTheme reset customThemeLabel quand on quitte "other"', () {
     notifier.selectTheme(kVeilleOtherThemeSlug);
     notifier.setCustomThemeLabel('Musées contemporains');
-    expect(container.read(veilleConfigProvider).customThemeLabel,
-        'Musées contemporains');
+    expect(
+      container.read(veilleConfigProvider).customThemeLabel,
+      'Musées contemporains',
+    );
 
     notifier.selectTheme('tech');
     expect(container.read(veilleConfigProvider).customThemeLabel, isNull);
@@ -66,8 +82,10 @@ void main() {
     expect(keywords.length, VeilleConfigNotifier.maxKeywords);
 
     notifier.addKeyword('  KW-0  '); // doublon normalisé
-    expect(container.read(veilleConfigProvider).keywords.length,
-        VeilleConfigNotifier.maxKeywords);
+    expect(
+      container.read(veilleConfigProvider).keywords.length,
+      VeilleConfigNotifier.maxKeywords,
+    );
   });
 
   test('addKeyword rejette les inputs trop courts ou trop longs', () {
@@ -134,16 +152,22 @@ void main() {
   test('resolvedThemeLabel utilise customThemeLabel quand thème = other', () {
     notifier.selectTheme(kVeilleOtherThemeSlug);
     notifier.setCustomThemeLabel('Musées');
-    expect(container.read(veilleConfigProvider).resolvedThemeLabel('Autre'),
-        'Musées');
+    expect(
+      container.read(veilleConfigProvider).resolvedThemeLabel('Autre'),
+      'Musées',
+    );
   });
 
-  test('resolvedThemeLabel fallback quand customThemeLabel vide en mode other',
-      () {
-    notifier.selectTheme(kVeilleOtherThemeSlug);
-    expect(container.read(veilleConfigProvider).resolvedThemeLabel('Autre'),
-        'Autre');
-  });
+  test(
+    'resolvedThemeLabel fallback quand customThemeLabel vide en mode other',
+    () {
+      notifier.selectTheme(kVeilleOtherThemeSlug);
+      expect(
+        container.read(veilleConfigProvider).resolvedThemeLabel('Autre'),
+        'Autre',
+      );
+    },
+  );
 
   test('goNext cap à step 3 / goBack cap à step 1', () {
     expect(container.read(veilleConfigProvider).step, 1);
@@ -158,13 +182,60 @@ void main() {
     expect(container.read(veilleConfigProvider).step, 1);
   });
 
-  test('realSelectedSourceCount ignore les sources sans apiSourceId', () {
+  test('realSelectedSourceCount compte catalogue et candidat niche valide', () {
     notifier.addCustomSourceToVeille(
       sourceId: 'src-1',
       name: 'Le Monde',
       url: 'https://lemonde.fr',
     );
-    expect(container.read(veilleConfigProvider).realSelectedSourceCount, 1);
+    notifier.registerSuggestedSources(const [
+      VeilleSourceSuggestionDto(
+        name: 'MACBA',
+        url: 'https://www.macba.cat',
+        why: 'Musée officiel',
+        relevanceScore: 1,
+      ),
+    ]);
+    final slug = VeilleConfigNotifier.sourceSuggestionSlug(
+      'MACBA',
+      'https://www.macba.cat',
+    );
+    notifier.toggleSource(slug);
+
+    expect(container.read(veilleConfigProvider).realSelectedSourceCount, 2);
+  });
+
+  test('submit sérialise un candidat niche en niche_candidate', () async {
+    final repo = _CaptureRepo();
+    final c = ProviderContainer(
+      overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+    );
+    addTearDown(c.dispose);
+    final n = c.read(veilleConfigProvider.notifier);
+
+    n.selectTheme('culture');
+    n.selectMainTopic('museums', 'Musées');
+    n.registerSuggestedSources(const [
+      VeilleSourceSuggestionDto(
+        name: 'MACBA',
+        url: 'https://www.macba.cat',
+        why: 'Musée officiel',
+        relevanceScore: 1,
+      ),
+    ]);
+    final slug = VeilleConfigNotifier.sourceSuggestionSlug(
+      'MACBA',
+      'https://www.macba.cat',
+    );
+    n.toggleSource(slug);
+    await n.submit();
+
+    final source = repo.captured!.sourceSelections.single;
+    expect(source.kind, 'niche');
+    expect(source.sourceId, isNull);
+    expect(source.nicheCandidate!.name, 'MACBA');
+    expect(source.nicheCandidate!.url, 'https://www.macba.cat');
+    expect(source.toJson()['niche_candidate'], isA<Map<String, dynamic>>());
   });
 
   // ─── Angles LLM (PR-3) ──────────────────────────────────────────────────
@@ -175,36 +246,46 @@ void main() {
     reason: 'Impact sur les workflows',
   );
 
-  test('toggleAngle sélectionne (slug angle-, label, grappe normalisée seedée)',
-      () {
-    notifier.toggleAngle(angle);
-    final s = container.read(veilleConfigProvider);
-    final slug = VeilleConfigNotifier.angleSlug('IA générative');
+  test(
+    'toggleAngle sélectionne (slug angle-, label, grappe normalisée seedée)',
+    () {
+      notifier.toggleAngle(angle);
+      final s = container.read(veilleConfigProvider);
+      final slug = VeilleConfigNotifier.angleSlug('IA générative');
 
-    expect(slug, 'angle-ia-generative');
-    expect(s.selectedSuggestions, {slug});
-    expect(s.topicLabels[slug], 'IA générative');
-    // Grappe normalisée : lowercase + dédupe (accents conservés, comme
-    // `addKeyword` — seul le slug strippe les diacritiques).
-    expect(s.angleKeywords[slug], ['ia générative', 'llm', 'chatgpt']);
-  });
+      expect(slug, 'angle-ia-generative');
+      expect(s.selectedSuggestions, {slug});
+      expect(s.topicLabels[slug], 'IA générative');
+      // Grappe normalisée : lowercase + dédupe (accents conservés, comme
+      // `addKeyword` — seul le slug strippe les diacritiques).
+      expect(s.angleKeywords[slug], ['ia générative', 'llm', 'chatgpt']);
+    },
+  );
 
-  test('toggleAngle re-toggle désélectionne mais conserve la grappe éditée', () {
-    notifier.toggleAngle(angle);
-    final slug = VeilleConfigNotifier.angleSlug(angle.title);
-    notifier.addAngleKeyword(slug, 'gpt-5');
+  test(
+    'toggleAngle re-toggle désélectionne mais conserve la grappe éditée',
+    () {
+      notifier.toggleAngle(angle);
+      final slug = VeilleConfigNotifier.angleSlug(angle.title);
+      notifier.addAngleKeyword(slug, 'gpt-5');
 
-    notifier.toggleAngle(angle); // désélection
-    final s = container.read(veilleConfigProvider);
-    expect(s.selectedSuggestions, isEmpty);
-    expect(s.angleKeywords[slug], contains('gpt-5'),
-        reason: 'edits préservés pour un re-toggle');
+      notifier.toggleAngle(angle); // désélection
+      final s = container.read(veilleConfigProvider);
+      expect(s.selectedSuggestions, isEmpty);
+      expect(
+        s.angleKeywords[slug],
+        contains('gpt-5'),
+        reason: 'edits préservés pour un re-toggle',
+      );
 
-    // Re-sélection : la grappe éditée n'est PAS écrasée par le seed initial.
-    notifier.toggleAngle(angle);
-    expect(container.read(veilleConfigProvider).angleKeywords[slug],
-        contains('gpt-5'));
-  });
+      // Re-sélection : la grappe éditée n'est PAS écrasée par le seed initial.
+      notifier.toggleAngle(angle);
+      expect(
+        container.read(veilleConfigProvider).angleKeywords[slug],
+        contains('gpt-5'),
+      );
+    },
+  );
 
   test('addAngleKeyword dédupe + cap maxAngleKeywords, removeAngleKeyword', () {
     notifier.toggleAngle(
@@ -215,64 +296,77 @@ void main() {
     for (var i = 0; i < VeilleConfigNotifier.maxAngleKeywords + 5; i++) {
       notifier.addAngleKeyword(slug, 'kw-$i');
     }
-    expect(container.read(veilleConfigProvider).angleKeywords[slug]!.length,
-        VeilleConfigNotifier.maxAngleKeywords);
+    expect(
+      container.read(veilleConfigProvider).angleKeywords[slug]!.length,
+      VeilleConfigNotifier.maxAngleKeywords,
+    );
 
     notifier.addAngleKeyword(slug, '  KW-0 '); // doublon normalisé
-    expect(container.read(veilleConfigProvider).angleKeywords[slug]!.length,
-        VeilleConfigNotifier.maxAngleKeywords);
+    expect(
+      container.read(veilleConfigProvider).angleKeywords[slug]!.length,
+      VeilleConfigNotifier.maxAngleKeywords,
+    );
 
     notifier.removeAngleKeyword(slug, 'kw-0');
-    expect(container.read(veilleConfigProvider).angleKeywords[slug],
-        isNot(contains('kw-0')));
-  });
-
-  test('_buildUpsertRequest peuple keywords sur le topic suggested de l\'angle',
-      () async {
-    final repo = _CaptureRepo();
-    final c = ProviderContainer(
-      overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+    expect(
+      container.read(veilleConfigProvider).angleKeywords[slug],
+      isNot(contains('kw-0')),
     );
-    addTearDown(c.dispose);
-    final n = c.read(veilleConfigProvider.notifier);
-
-    n.selectTheme('tech');
-    n.toggleAngle(angle);
-    await n.submit();
-
-    final slug = VeilleConfigNotifier.angleSlug(angle.title);
-    final topic =
-        repo.captured!.topics.firstWhere((t) => t.topicId == slug);
-    expect(topic.kind, 'suggested');
-    expect(topic.keywords, ['ia générative', 'llm', 'chatgpt']);
-    final json = topic.toJson();
-    expect(json['keywords'], ['ia générative', 'llm', 'chatgpt']);
   });
+
+  test(
+    '_buildUpsertRequest peuple keywords sur le topic suggested de l\'angle',
+    () async {
+      final repo = _CaptureRepo();
+      final c = ProviderContainer(
+        overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(c.dispose);
+      final n = c.read(veilleConfigProvider.notifier);
+
+      n.selectTheme('tech');
+      n.toggleAngle(angle);
+      await n.submit();
+
+      final slug = VeilleConfigNotifier.angleSlug(angle.title);
+      final topic = repo.captured!.topics.firstWhere((t) => t.topicId == slug);
+      expect(topic.kind, 'suggested');
+      expect(topic.keywords, ['ia générative', 'llm', 'chatgpt']);
+      final json = topic.toJson();
+      expect(json['keywords'], ['ia générative', 'llm', 'chatgpt']);
+    },
+  );
 
   // ─── Sujet principal granulaire (Story 23.4) ────────────────────────────
 
-  test('selectMainTopic émet le sujet principal en position 0 (kind preset)',
-      () async {
-    final repo = _CaptureRepo();
-    final c = ProviderContainer(
-      overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
-    );
-    addTearDown(c.dispose);
-    final n = c.read(veilleConfigProvider.notifier);
+  test(
+    'selectMainTopic émet le sujet principal en position 0 (kind preset)',
+    () async {
+      final repo = _CaptureRepo();
+      final c = ProviderContainer(
+        overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(c.dispose);
+      final n = c.read(veilleConfigProvider.notifier);
 
-    n.selectTheme('tech');
-    n.selectMainTopic('ai', 'Intelligence artificielle');
-    // Un angle optionnel à côté, pour vérifier que le main reste en tête.
-    n.toggleAngle(angle);
-    await n.submit();
+      n.selectTheme('tech');
+      n.selectMainTopic('ai', 'Intelligence artificielle');
+      // Un angle optionnel à côté, pour vérifier que le main reste en tête.
+      n.toggleAngle(angle);
+      await n.submit();
 
-    final topics = repo.captured!.topics;
-    expect(topics.first.topicId, 'ai');
-    expect(topics.first.kind, 'preset', reason: 'slug canonique → Content.topics');
-    expect(topics.first.position, 0);
-    // Pas de doublon du main dans les angles.
-    expect(topics.where((t) => t.topicId == 'ai').length, 1);
-  });
+      final topics = repo.captured!.topics;
+      expect(topics.first.topicId, 'ai');
+      expect(
+        topics.first.kind,
+        'preset',
+        reason: 'slug canonique → Content.topics',
+      );
+      expect(topics.first.position, 0);
+      // Pas de doublon du main dans les angles.
+      expect(topics.where((t) => t.topicId == 'ai').length, 1);
+    },
+  );
 
   test('selectTheme reset le sujet principal au changement de macro', () {
     notifier.selectTheme('tech');
@@ -292,47 +386,70 @@ void main() {
     expect(container.read(veilleConfigProvider).mainTopicSlug, isNull);
   });
 
-  test('hydrateFromActiveConfig restaure macro + sujet principal (position 0)',
-      () {
-    final cfg = VeilleConfigDto(
-      id: 'cfg-1',
-      userId: 'user-1',
-      themeId: 'tech',
-      themeLabel: 'Tech',
-      status: 'active',
-      createdAt: DateTime(2024),
-      updatedAt: DateTime(2024),
-      topics: const [
-        VeilleTopicDto(
-          id: 't0',
-          topicId: 'ai',
-          label: 'IA',
-          kind: 'preset',
-          reason: null,
-          position: 0,
-          keywords: [],
-        ),
-        VeilleTopicDto(
-          id: 't1',
-          topicId: 'angle-x',
-          label: 'Angle X',
-          kind: 'suggested',
-          reason: null,
-          position: 1,
-          keywords: ['gpt'],
-        ),
-      ],
-      sources: const [],
-      keywords: const [],
-    );
+  test(
+    'resolveCustomMainTopic enrichit un sujet local veille en main custom',
+    () async {
+      final repo = _CaptureRepo();
+      final c = ProviderContainer(
+        overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(c.dispose);
+      final n = c.read(veilleConfigProvider.notifier);
 
-    notifier.hydrateFromActiveConfig(cfg);
-    final s = container.read(veilleConfigProvider);
-    expect(s.selectedTheme, 'tech', reason: 'macro restauré');
-    expect(s.mainTopicSlug, 'ai', reason: 'granulaire = topic position 0');
-    expect(s.mainTopicLabel, 'IA');
-    // Le sujet principal n'est PAS rejoué comme topic optionnel (sinon doublon).
-    expect(s.selectedTopics, isNot(contains('ai')));
-    expect(s.selectedSuggestions, contains('angle-x'));
-  });
+      n.selectTheme('culture');
+      await n.resolveCustomMainTopic('musées barcelone');
+
+      final s = c.read(veilleConfigProvider);
+      expect(s.mainTopicSlug, 'custom-musees-contemporains-de-barcelone');
+      expect(s.mainTopicLabel, 'Musées contemporains de Barcelone');
+      expect(s.angleKeywords[s.mainTopicSlug], ['macba', 'exposition']);
+      expect(s.customTopics.single.id, s.mainTopicSlug);
+    },
+  );
+
+  test(
+    'hydrateFromActiveConfig restaure macro + sujet principal (position 0)',
+    () {
+      final cfg = VeilleConfigDto(
+        id: 'cfg-1',
+        userId: 'user-1',
+        themeId: 'tech',
+        themeLabel: 'Tech',
+        status: 'active',
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
+        topics: const [
+          VeilleTopicDto(
+            id: 't0',
+            topicId: 'ai',
+            label: 'IA',
+            kind: 'preset',
+            reason: null,
+            position: 0,
+            keywords: [],
+          ),
+          VeilleTopicDto(
+            id: 't1',
+            topicId: 'angle-x',
+            label: 'Angle X',
+            kind: 'suggested',
+            reason: null,
+            position: 1,
+            keywords: ['gpt'],
+          ),
+        ],
+        sources: const [],
+        keywords: const [],
+      );
+
+      notifier.hydrateFromActiveConfig(cfg);
+      final s = container.read(veilleConfigProvider);
+      expect(s.selectedTheme, 'tech', reason: 'macro restauré');
+      expect(s.mainTopicSlug, 'ai', reason: 'granulaire = topic position 0');
+      expect(s.mainTopicLabel, 'IA');
+      // Le sujet principal n'est PAS rejoué comme topic optionnel (sinon doublon).
+      expect(s.selectedTopics, isNot(contains('ai')));
+      expect(s.selectedSuggestions, contains('angle-x'));
+    },
+  );
 }

--- a/apps/mobile/test/features/veille/providers/veille_source_suggestions_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_source_suggestions_provider_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/veille/models/veille_config_dto.dart';
+import 'package:facteur/features/veille/providers/veille_repository_provider.dart';
+import 'package:facteur/features/veille/providers/veille_source_suggestions_provider.dart';
+import 'package:facteur/features/veille/repositories/veille_repository.dart';
+
+class _FakeRepo implements VeilleRepository {
+  final List<VeilleSourceSuggestionDto> sources;
+  List<String>? capturedAngles;
+  List<String>? capturedKeywords;
+
+  _FakeRepo(this.sources);
+
+  @override
+  Future<List<VeilleSourceSuggestionDto>> suggestSources({
+    required String themeId,
+    required String themeLabel,
+    String brief = '',
+    List<String> angles = const [],
+    List<String> keywords = const [],
+  }) async {
+    capturedAngles = angles;
+    capturedKeywords = keywords;
+    return sources;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} non mocké');
+}
+
+void main() {
+  const query = (
+    themeId: 'culture',
+    themeLabel: 'Culture',
+    brief: 'expos',
+    anglesKey: 'Musées|Expositions',
+    keywordsKey: 'macba|vernissage',
+  );
+
+  test('expose les sources renvoyées par le repo et split les clés', () async {
+    final repo = _FakeRepo(const [
+      VeilleSourceSuggestionDto(
+        name: 'MACBA',
+        url: 'https://www.macba.cat',
+        why: 'Musée officiel',
+        relevanceScore: 1,
+      ),
+    ]);
+    final container = ProviderContainer(
+      overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+    );
+    addTearDown(container.dispose);
+
+    final sources = await container.read(
+      veilleSourceSuggestionsProvider(query).future,
+    );
+    expect(sources.single.name, 'MACBA');
+    expect(repo.capturedAngles, ['Musées', 'Expositions']);
+    expect(repo.capturedKeywords, ['macba', 'vernissage']);
+  });
+
+  test('repo fallback [] : provider renvoie une liste vide', () async {
+    final container = ProviderContainer(
+      overrides: [
+        veilleRepositoryProvider.overrideWithValue(_FakeRepo(const [])),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final sources = await container.read(
+      veilleSourceSuggestionsProvider(query).future,
+    );
+    expect(sources, isEmpty);
+  });
+}

--- a/apps/mobile/test/features/veille/widgets/veille_source_card_test.dart
+++ b/apps/mobile/test/features/veille/widgets/veille_source_card_test.dart
@@ -28,7 +28,7 @@ class _FakeRepo implements VeilleRepository {
   }
 
   @override
-  noSuchMethod(Invocation invocation) =>
+  dynamic noSuchMethod(Invocation invocation) =>
       throw UnimplementedError('${invocation.memberName} non mocké');
 }
 

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -48,8 +48,8 @@ from app.schemas.veille import (
     VeilleSuggestSourcesResponse,
     VeilleTopicResponse,
 )
-from app.services.rss_parser import RSSParser
 from app.services.ml.topic_enrichment_service import get_topic_enrichment_service
+from app.services.rss_parser import RSSParser
 from app.services.source_service import SourceService
 from app.services.user_interests_service import ensure_veille_favorite
 from app.services.veille.feed_filter import fetch_veille_feed, load_veille_filters

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+import unicodedata
 from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
@@ -34,6 +36,8 @@ from app.schemas.veille import (
     VeilleFeedResponse,
     VeilleKeywordResponse,
     VeillePresetResponse,
+    VeilleResolveTopicRequest,
+    VeilleResolveTopicResponse,
     VeilleSourceExample,
     VeilleSourceLite,
     VeilleSourceResponse,
@@ -45,6 +49,7 @@ from app.schemas.veille import (
     VeilleTopicResponse,
 )
 from app.services.rss_parser import RSSParser
+from app.services.ml.topic_enrichment_service import get_topic_enrichment_service
 from app.services.source_service import SourceService
 from app.services.user_interests_service import ensure_veille_favorite
 from app.services.veille.feed_filter import fetch_veille_feed, load_veille_filters
@@ -60,6 +65,17 @@ _SOURCE_EXAMPLES_CACHE: TTLCache = TTLCache(maxsize=512, ttl=86400)
 _SOURCE_EXAMPLES_LIMIT = 2
 _SOURCE_EXAMPLES_LOOKBACK_DAYS = 30
 _SOURCE_EXAMPLES_EXCERPT_MAX = 120
+
+
+def _slugify_topic_id(raw: str) -> str:
+    """Slug court compatible `VeilleTopicSelection.topic_id`."""
+    normalized = unicodedata.normalize("NFKD", raw.strip().lower())
+    ascii_only = "".join(c for c in normalized if not unicodedata.combining(c))
+    cleaned = re.sub(r"[^a-z0-9\s-]", "", ascii_only)
+    cleaned = re.sub(r"\s+", "-", cleaned)
+    cleaned = re.sub(r"-+", "-", cleaned).strip("-")
+    base = cleaned or "sujet"
+    return f"custom-{base[:60]}"
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -627,6 +643,35 @@ async def get_source_examples(
 
 
 # ─── Suggesters LLM (Story 23.3) ─────────────────────────────────────────────
+
+
+@router.post("/resolve/topic", response_model=VeilleResolveTopicResponse)
+async def resolve_topic(
+    body: VeilleResolveTopicRequest,
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Enrichit un sujet libre pour le flow Veille, sans écrire d'intérêt global."""
+    UUID(current_user_id)
+    service = get_topic_enrichment_service()
+    try:
+        result = await service.enrich(body.topic)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    label = result.canonical_name or body.topic.strip()
+    return VeilleResolveTopicResponse(
+        label=label,
+        topic_id=_slugify_topic_id(label),
+        keywords=result.keywords[:10],
+        description=result.intent_description,
+        metadata={
+            "slug_parent": result.slug_parent,
+            "entity_type": result.entity_type,
+            "canonical_name": result.canonical_name,
+            "theme_id": body.theme_id,
+            "theme_label": body.theme_label,
+        },
+    )
 
 
 @router.post("/suggest/angles", response_model=VeilleSuggestAnglesResponse)

--- a/packages/api/app/schemas/veille.py
+++ b/packages/api/app/schemas/veille.py
@@ -237,6 +237,24 @@ class VeilleFeedResponse(BaseModel):
 # ─── Suggesters LLM (Story 23.3) ─────────────────────────────────────────────
 
 
+class VeilleResolveTopicRequest(BaseModel):
+    """Input du POST /api/veille/resolve/topic."""
+
+    topic: str = Field(min_length=2, max_length=200)
+    theme_id: str | None = Field(default=None, max_length=50)
+    theme_label: str | None = Field(default=None, max_length=120)
+
+
+class VeilleResolveTopicResponse(BaseModel):
+    """Sujet libre enrichi pour une veille, sans création de UserTopicProfile."""
+
+    label: str = Field(min_length=1, max_length=200)
+    topic_id: str = Field(min_length=1, max_length=80)
+    keywords: list[str] = Field(default_factory=list, max_length=10)
+    description: str = ""
+    metadata: dict[str, str | None] = Field(default_factory=dict)
+
+
 class VeilleSuggestAnglesRequest(BaseModel):
     """Input du POST /api/veille/suggest/angles."""
 

--- a/packages/api/app/services/veille/llm/source_suggester.py
+++ b/packages/api/app/services/veille/llm/source_suggester.py
@@ -140,9 +140,7 @@ class SourceSuggester:
 
         if not self._llm.is_ready:
             logger.warning("source_suggester.llm_unavailable", theme_id=theme_id)
-            result = _fallback_sources()
-            self._cache[cache_key] = result
-            return result
+            return _fallback_sources()
 
         angles_block = "\n".join(f"  - {a}" for a in angles) if angles else "  (aucun)"
         keywords_str = ", ".join(keywords) if keywords else "(aucun)"
@@ -169,14 +167,15 @@ class SourceSuggester:
                 theme_id=theme_id,
                 model=self._model,
             )
-            sources = _fallback_sources()
+            return _fallback_sources()
 
         # Dédoublonne par domaine racine (keep highest score)
         sources = self._dedupe_by_domain(sources)
         # Trie desc par relevance_score
         sources.sort(key=lambda s: s.relevance_score, reverse=True)
 
-        self._cache[cache_key] = sources
+        if sources:
+            self._cache[cache_key] = sources
         return sources
 
     @staticmethod

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -477,6 +477,61 @@ class TestFeed:
 class TestSuggestEndpoints:
     """POST /api/veille/suggest/{angles,sources} (Story 23.3)."""
 
+    async def test_resolve_topic_enriches_without_creating_profile(
+        self, auth_user, monkeypatch, db_session
+    ):
+        from app.models.user_topic_profile import UserTopicProfile
+        from app.services.ml import topic_enrichment_service as mod
+        from app.services.ml.topic_enrichment_service import TopicEnrichmentResult
+
+        async def _fake_enrich(self, topic_name):
+            return TopicEnrichmentResult(
+                slug_parent="culture",
+                keywords=["macba", "exposition", "art contemporain"],
+                intent_description="Suivi des expositions à Barcelone",
+                entity_type="LOCATION",
+                canonical_name="Musées contemporains de Barcelone",
+            )
+
+        monkeypatch.setattr(mod.TopicEnrichmentService, "enrich", _fake_enrich)
+        monkeypatch.setattr(mod, "_topic_enrichment_service", None)
+
+        async with _client() as c:
+            r = await c.post(
+                "/api/veille/resolve/topic",
+                json={
+                    "topic": "musées barcelone",
+                    "theme_id": "culture",
+                    "theme_label": "Culture",
+                },
+            )
+
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["label"] == "Musées contemporains de Barcelone"
+        assert data["topic_id"] == "custom-musees-contemporains-de-barcelone"
+        assert data["keywords"] == ["macba", "exposition", "art contemporain"]
+        assert data["description"] == "Suivi des expositions à Barcelone"
+        assert data["metadata"]["slug_parent"] == "culture"
+
+        rows = (
+            (
+                await db_session.execute(
+                    select(UserTopicProfile).where(
+                        UserTopicProfile.user_id == auth_user
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert rows == []
+
+    async def test_resolve_topic_validates_input(self, auth_user):
+        async with _client() as c:
+            r = await c.post("/api/veille/resolve/topic", json={"topic": ""})
+        assert r.status_code == 422
+
     async def test_suggest_angles_returns_llm_response(self, auth_user, monkeypatch):
         from app.services.veille.llm import angle_suggester as mod
         from app.services.veille.llm.angle_suggester import AngleSuggestion

--- a/packages/api/tests/services/veille/test_source_suggester.py
+++ b/packages/api/tests/services/veille/test_source_suggester.py
@@ -134,6 +134,18 @@ async def test_suggest_sources_empty_when_llm_returns_garbage():
     assert sources == []
 
 
+async def test_suggest_sources_does_not_cache_empty_fallback():
+    llm = _mk_llm(ready=True, response={"unexpected": "shape"})
+    suggester = SourceSuggester(llm=llm)
+
+    first = await suggester.suggest_sources("tech", "Tech", "", [], [])
+    second = await suggester.suggest_sources("tech", "Tech", "", [], [])
+
+    assert first == []
+    assert second == []
+    assert llm.chat_json.call_count == 2
+
+
 async def test_suggest_sources_skips_invalid_items():
     llm = _mk_llm(
         ready=True,


### PR DESCRIPTION
## Quoi

- **Step 1** : tuile « Autre » dans la grille de sous-thèmes → saisie libre résolue via `POST /api/veille/resolve/topic` (enrichissement LLM sans créer d'intérêt global) ; scroll auto vers la section suivante pertinente après choix du thème.
- **Step 2** : liste preset topics supprimée (déplacée en Step 1) ; angles LLM restent optionnels, sujet principal affiché en chip épinglé.
- **Step 3** : suggestion sources LLM reconnectée (`POST /veille/suggest/sources`) ; candidats niche locaux au flow, ingérés seulement au submit si cochés ; fallback/retry si LLM KO ; `showExamples: true` pour les sources catalogue.
- **Backend** : nouveau endpoint `POST /api/veille/resolve/topic` ; fix `source_suggester` ne cache plus les résultats fallback.

## Pourquoi

Permettre à l'utilisateur de définir un sujet de veille libre (non-présent dans la liste) dès le Step 1, avec enrichissement LLM pour slugifier/keywordiser le sujet. Les sources LLM proposées en Step 3 restent non-ingérées jusqu'au submit pour éviter la pollution du catalogue.

## Comment ça a été vérifié

- [x] `flutter test test/features/veille/` — 53 tests OK
- [x] `pytest tests/services/veille/test_source_suggester.py` — 8 tests OK (tests router nécessitent DB locale, KO en Conductor comme d'habitude)
- [x] `flutter analyze` — 0 erreur sur les fichiers veille
- [x] `/simplify` passé — 5 fixes appliqués (\_domain file-scope, onRetry dédupliqué, kind: meta.kind, imports module-level, kVeilleOtherTopicSlug)

## Zones à risque

- `veille_config_provider.dart` — `_buildUpsertRequest` : nouvelle branche nicheCandidate (source URL sans apiSourceId)
- `packages/api/app/routers/veille.py` — nouveau endpoint `/resolve/topic` utilise `get_topic_enrichment_service`