### PR TITLE
fix(onboarding): sources filtrées par état FOLLOWED/FAVORITE + feeds vides corrigés

### DIFF
--- a/apps/mobile/lib/features/onboarding/providers/conclusion_notifier.dart
+++ b/apps/mobile/lib/features/onboarding/providers/conclusion_notifier.dart
@@ -9,10 +9,15 @@ import '../../../core/auth/auth_state.dart';
 import '../../../core/providers/analytics_provider.dart';
 import '../../../models/onboarding_result.dart';
 import '../../../models/user_profile.dart';
-import '../../../features/sources/providers/sources_providers.dart';
 import '../../custom_topics/providers/custom_topics_provider.dart';
 import '../../custom_topics/providers/personalization_provider.dart';
 import '../../digest/providers/serein_toggle_provider.dart';
+import '../../feed/providers/feed_provider.dart';
+import '../../feed/repositories/feed_repository.dart';
+import '../../flux_continu/providers/flux_continu_provider.dart';
+import '../../my_interests/providers/user_interests_provider.dart';
+import '../../my_interests/providers/user_sources_state_provider.dart';
+import '../../sources/providers/sources_providers.dart';
 import 'onboarding_provider.dart';
 
 /// État de l'animation de conclusion
@@ -43,10 +48,7 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
   bool _animationCompleted = false;
 
   static const _maxRetries = 2;
-  static const _retryDelays = [
-    Duration(seconds: 1),
-    Duration(seconds: 2),
-  ];
+  static const _retryDelays = [Duration(seconds: 1), Duration(seconds: 2)];
 
   /// Démarre le processus de conclusion (animation + sauvegarde API)
   Future<void> startConclusion() async {
@@ -106,7 +108,9 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
     for (var attempt = 0; attempt <= _maxRetries; attempt++) {
       if (attempt > 0) {
         final delay = _retryDelays[attempt - 1];
-        debugPrint('Onboarding: retry $attempt/$_maxRetries après ${delay.inSeconds}s...');
+        debugPrint(
+          'Onboarding: retry $attempt/$_maxRetries après ${delay.inSeconds}s...',
+        );
         await Future<void>.delayed(delay);
       }
 
@@ -135,12 +139,8 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
         if (answers.digestMode == 'serein') {
           _ref.read(sereinToggleProvider.notifier).setEnabledLocal(true);
         }
-        // Trust sources en parallèle avec timeout (important pour le digest)
-        await _trustSelectedSourcesWithTimeout(answers.preferredSources);
         await _ref.read(onboardingProvider.notifier).clearSavedData();
-        _ref.invalidate(customTopicsProvider);
-        _ref.invalidate(userSourcesProvider);
-        _ref.invalidate(personalizationProvider);
+        await _invalidatePostOnboardingState();
 
         debugPrint(
           'Onboarding sauvegardé avec succès ! '
@@ -157,7 +157,9 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
         if (requestedSources > 0) {
           final created = result.sourcesCreated ?? 0;
           unawaited(
-            _ref.read(analyticsServiceProvider).trackOnboardingSourcesRegistered(
+            _ref
+                .read(analyticsServiceProvider)
+                .trackOnboardingSourcesRegistered(
                   requested: requestedSources,
                   created: created,
                 ),
@@ -186,14 +188,16 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
     }
 
     // Tous les retries ont échoué
-    debugPrint('Erreur sauvegarde onboarding après retries: ${lastResult?.errorMessage}');
+    debugPrint(
+      'Erreur sauvegarde onboarding après retries: ${lastResult?.errorMessage}',
+    );
     throw Exception(lastResult?.friendlyErrorMessage ?? 'Erreur inconnue');
   }
 
   /// Sauvegarde le profil localement après succès API
   Future<void> _saveProfileLocally(UserProfile profile) async {
     try {
-      final box = await Hive.openBox('user_profile');
+      final box = await Hive.openBox<dynamic>('user_profile');
       await box.put('profile', profile.toJson());
       await box.put('onboarding_completed', true);
       await box.put('pending_sync', false); // Synchronisé avec succès
@@ -204,29 +208,21 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
     }
   }
 
-  /// Marque les sources sélectionnées comme "de confiance" (avec timeout)
-  /// Awaité pour que les UserSource existent avant la génération du digest
-  Future<void> _trustSelectedSourcesWithTimeout(List<String>? sourceIds) async {
-    if (sourceIds == null || sourceIds.isEmpty) return;
-
-    final repository = _ref.read(sourcesRepositoryProvider);
-
-    try {
-      await Future.wait(
-        sourceIds.map((sourceId) async {
-          try {
-            await repository.trustSource(sourceId);
-            debugPrint('Source $sourceId marquée comme de confiance');
-          } catch (e) {
-            debugPrint('Erreur trust source $sourceId: $e');
-          }
-        }),
-      ).timeout(const Duration(seconds: 5));
-    } on TimeoutException {
-      debugPrint('Trust sources timeout (5s) — digest utilisera le fallback');
-    } catch (e) {
-      debugPrint('Erreur globale trust sources: $e');
+  Future<void> _invalidatePostOnboardingState() async {
+    FeedRepository.clearDefaultViewCache();
+    final userId = _ref.read(authStateProvider).user?.id;
+    if (userId != null) {
+      await _ref.read(feedCacheServiceProvider)?.clearForUser(userId);
     }
+
+    _ref.invalidate(userInterestsProvider);
+    _ref.invalidate(userSourcesStateProvider);
+    _ref.invalidate(userSourcesProvider);
+    _ref.invalidate(feedProvider);
+    _ref.invalidate(fluxContinuProvider);
+    _ref.invalidate(pepitesProvider);
+    _ref.invalidate(customTopicsProvider);
+    _ref.invalidate(personalizationProvider);
   }
 
   /// Réessayer après une erreur
@@ -240,13 +236,15 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
   Future<void> _saveProfileLocallyDegraded() async {
     try {
       final answers = _ref.read(onboardingProvider).answers;
-      final box = await Hive.openBox('user_profile');
+      final box = await Hive.openBox<dynamic>('user_profile');
 
       await box.put('onboarding_completed', true);
       await box.put('pending_sync', true); // Flag pour sync future
       await box.put('answers_backup', answers.toJson());
 
-      debugPrint('Mode dégradé : données sauvegardées localement pour sync future');
+      debugPrint(
+        'Mode dégradé : données sauvegardées localement pour sync future',
+      );
     } catch (e) {
       debugPrint('Erreur sauvegarde locale mode dégradé: $e');
     }

--- a/apps/mobile/lib/features/onboarding/providers/onboarding_sync_provider.dart
+++ b/apps/mobile/lib/features/onboarding/providers/onboarding_sync_provider.dart
@@ -4,6 +4,12 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
+import '../../feed/providers/feed_provider.dart';
+import '../../feed/repositories/feed_repository.dart';
+import '../../flux_continu/providers/flux_continu_provider.dart';
+import '../../my_interests/providers/user_interests_provider.dart';
+import '../../my_interests/providers/user_sources_state_provider.dart';
+import '../../sources/providers/sources_providers.dart';
 import 'onboarding_provider.dart';
 
 /// Re-sync onboarding answers saved locally when the previous attempt failed.
@@ -34,7 +40,7 @@ class OnboardingSyncNotifier extends StateNotifier<void> {
     if (_inFlight) return;
     _inFlight = true;
     try {
-      final box = await Hive.openBox(_boxName);
+      final box = await Hive.openBox<dynamic>(_boxName);
       final pending = box.get(_pendingSyncKey) as bool? ?? false;
       if (!pending) return;
 
@@ -48,9 +54,7 @@ class OnboardingSyncNotifier extends StateNotifier<void> {
         Map<String, dynamic>.from(rawBackup as Map),
       );
 
-      debugPrint(
-        '[ONBOARDING_TELEMETRY] event=resync_start pending=true',
-      );
+      debugPrint('[ONBOARDING_TELEMETRY] event=resync_start pending=true');
 
       final userService = _ref.read(userApiServiceProvider);
       final result = await userService.saveOnboarding(answers);
@@ -66,9 +70,8 @@ class OnboardingSyncNotifier extends StateNotifier<void> {
         // `authStateProvider` pour que `needsOnboarding` ne reste pas bloqué
         // à `true` (décision prise par `_checkOnboardingStatus` lancé avant
         // que le resync ne termine).
-        await _ref
-            .read(authStateProvider.notifier)
-            .refreshOnboardingStatus();
+        await _ref.read(authStateProvider.notifier).refreshOnboardingStatus();
+        await _invalidatePostOnboardingState();
         debugPrint('[ONBOARDING_TELEMETRY] event=resync_success');
       } else {
         debugPrint(
@@ -81,6 +84,21 @@ class OnboardingSyncNotifier extends StateNotifier<void> {
     } finally {
       _inFlight = false;
     }
+  }
+
+  Future<void> _invalidatePostOnboardingState() async {
+    FeedRepository.clearDefaultViewCache();
+    final userId = _ref.read(authStateProvider).user?.id;
+    if (userId != null) {
+      await _ref.read(feedCacheServiceProvider)?.clearForUser(userId);
+    }
+
+    _ref.invalidate(userInterestsProvider);
+    _ref.invalidate(userSourcesStateProvider);
+    _ref.invalidate(userSourcesProvider);
+    _ref.invalidate(feedProvider);
+    _ref.invalidate(fluxContinuProvider);
+    _ref.invalidate(pepitesProvider);
   }
 }
 

--- a/apps/mobile/lib/features/onboarding/providers/onboarding_sync_provider.dart
+++ b/apps/mobile/lib/features/onboarding/providers/onboarding_sync_provider.dart
@@ -4,6 +4,8 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
+import '../../custom_topics/providers/custom_topics_provider.dart';
+import '../../custom_topics/providers/personalization_provider.dart';
 import '../../feed/providers/feed_provider.dart';
 import '../../feed/repositories/feed_repository.dart';
 import '../../flux_continu/providers/flux_continu_provider.dart';
@@ -99,6 +101,8 @@ class OnboardingSyncNotifier extends StateNotifier<void> {
     _ref.invalidate(feedProvider);
     _ref.invalidate(fluxContinuProvider);
     _ref.invalidate(pepitesProvider);
+    _ref.invalidate(customTopicsProvider);
+    _ref.invalidate(personalizationProvider);
   }
 }
 

--- a/apps/mobile/lib/features/sources/widgets/pepites_carousel.dart
+++ b/apps/mobile/lib/features/sources/widgets/pepites_carousel.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
+import '../../my_interests/models/user_interests_state.dart';
+import '../../my_interests/providers/user_sources_state_provider.dart';
 import '../models/source_model.dart';
 import '../providers/sources_providers.dart';
 import 'pepite_card.dart';
@@ -80,13 +82,19 @@ class PepitesCarousel extends ConsumerWidget {
               separatorBuilder: (_, __) => const SizedBox(width: 10),
               itemBuilder: (_, index) {
                 final source = sources[index];
-                final isFollowing = ref.watch(userSourcesProvider).maybeWhen(
+                final state = ref.watch(userSourcesStateProvider).valueOrNull;
+                final legacyFollowing = ref
+                    .watch(userSourcesProvider)
+                    .maybeWhen(
                       data: (list) =>
                           list.any((s) => s.id == source.id && s.isTrusted),
-                      orElse: () => false,
+                      orElse: () => source.isTrusted,
                     );
+                final isFollowing =
+                    _isFollowedSourceState(state?.stateOf(source.id)) ||
+                    legacyFollowing;
                 return PepiteCard(
-                  source: source,
+                  source: source.copyWith(isTrusted: isFollowing),
                   isFollowing: isFollowing,
                   onToggleFollow: () =>
                       _onToggleFollow(ref, source, isFollowing),
@@ -105,9 +113,16 @@ class PepitesCarousel extends ConsumerWidget {
     Source source,
     bool currentlyFollowing,
   ) async {
-    await ref
-        .read(userSourcesProvider.notifier)
-        .toggleTrust(source.id, currentlyFollowing);
+    if (currentlyFollowing) return;
+
+    try {
+      await ref
+          .read(userSourcesStateProvider.notifier)
+          .setSourceState(source.id, InterestState.followed);
+      ref.invalidate(userSourcesProvider);
+    } catch (_) {
+      // Rollback is handled by userSourcesStateProvider's optimistic notifier.
+    }
   }
 
   void _onTap(BuildContext context, WidgetRef ref, Source source) {
@@ -116,21 +131,43 @@ class PepitesCarousel extends ConsumerWidget {
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (ctx) {
-        final live = ref.watch(userSourcesProvider).maybeWhen(
+        final state = ref.watch(userSourcesStateProvider).valueOrNull;
+        final live = ref
+            .watch(userSourcesProvider)
+            .maybeWhen(
               data: (list) =>
                   list.where((s) => s.id == source.id).firstOrNull ?? source,
               orElse: () => source,
             );
+        final stateFollowing = _isFollowedSourceState(
+          state?.stateOf(source.id),
+        );
+        final display = live.copyWith(
+          isTrusted: stateFollowing || live.isTrusted,
+        );
         return SourceDetailModal(
-          source: live,
-          onToggleTrust: () => ref
-              .read(userSourcesProvider.notifier)
-              .toggleTrust(source.id, live.isTrusted),
+          source: display,
+          onToggleTrust: () async {
+            final next = display.isTrusted
+                ? InterestState.unfollowed
+                : InterestState.followed;
+            try {
+              await ref
+                  .read(userSourcesStateProvider.notifier)
+                  .setSourceState(source.id, next);
+              ref.invalidate(userSourcesProvider);
+            } catch (_) {
+              // Optimistic rollback is handled by the canonical notifier.
+            }
+          },
         );
       },
     );
   }
 }
+
+bool _isFollowedSourceState(InterestState? state) =>
+    state == InterestState.followed || state == InterestState.favorite;
 
 class _DismissButton extends StatelessWidget {
   final VoidCallback onPressed;

--- a/apps/mobile/test/features/sources/widgets/pepites_carousel_test.dart
+++ b/apps/mobile/test/features/sources/widgets/pepites_carousel_test.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/my_interests/models/user_interests_state.dart';
+import 'package:facteur/features/my_interests/models/user_sources_state.dart';
+import 'package:facteur/features/my_interests/providers/user_sources_state_provider.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
 import 'package:facteur/features/sources/providers/sources_providers.dart';
 import 'package:facteur/features/sources/widgets/pepites_carousel.dart';
@@ -19,6 +22,44 @@ class _FakePepitesNotifier extends PepitesNotifier {
     dismissCalls++;
     state = const AsyncValue.data([]);
   }
+}
+
+class _FakeUserSourcesStateNotifier extends UserSourcesStateNotifier {
+  _FakeUserSourcesStateNotifier(this._initial);
+  final UserSourcesState _initial;
+  int setStateCalls = 0;
+  String? lastSourceId;
+  InterestState? lastState;
+
+  @override
+  Future<UserSourcesState> build() async => _initial;
+
+  @override
+  Future<void> setSourceState(String sourceId, InterestState newState) async {
+    setStateCalls++;
+    lastSourceId = sourceId;
+    lastState = newState;
+    final current = state.value ?? _initial;
+    final sources = [...current.sources];
+    final idx = sources.indexWhere((s) => s.sourceId == sourceId);
+    if (idx >= 0) {
+      sources[idx] = sources[idx].copyWith(state: newState);
+    } else {
+      sources.add(
+        SourceInterest(
+          sourceId: sourceId,
+          state: newState,
+          priorityMultiplier: 1,
+        ),
+      );
+    }
+    state = AsyncValue.data(current.copyWith(sources: sources));
+  }
+}
+
+class _FakeUserSourcesNotifier extends UserSourcesNotifier {
+  @override
+  Future<List<Source>> build() async => const [];
 }
 
 void main() {
@@ -40,11 +81,27 @@ void main() {
       ),
     ];
 
-    Widget wrap({required List<Source> sources, _FakePepitesNotifier? notifier}) {
+    Widget wrap({
+      required List<Source> sources,
+      _FakePepitesNotifier? notifier,
+      _FakeUserSourcesStateNotifier? sourcesState,
+    }) {
       final fake = notifier ?? _FakePepitesNotifier(sources);
+      final fakeSourcesState =
+          sourcesState ??
+          _FakeUserSourcesStateNotifier(
+            const UserSourcesState(
+              sources: [],
+              favorites: [],
+              favoriteCount: 0,
+              favoriteCap: 3,
+            ),
+          );
       return ProviderScope(
         overrides: [
           pepitesProvider.overrideWith(() => fake),
+          userSourcesProvider.overrideWith(() => _FakeUserSourcesNotifier()),
+          userSourcesStateProvider.overrideWith(() => fakeSourcesState),
         ],
         child: MaterialApp(
           theme: FacteurTheme.lightTheme,
@@ -53,8 +110,9 @@ void main() {
       );
     }
 
-    testWidgets('renders title and source cards when data loaded',
-        (tester) async {
+    testWidgets('renders title and source cards when data loaded', (
+      tester,
+    ) async {
       await tester.pumpWidget(wrap(sources: mockSources));
       await tester.pumpAndSettle();
 
@@ -83,6 +141,62 @@ void main() {
 
       expect(fake.dismissCalls, 1);
       expect(find.text('Le Grand Continent'), findsNothing);
+    });
+
+    testWidgets('follow button uses canonical source state provider', (
+      tester,
+    ) async {
+      final fakeSourcesState = _FakeUserSourcesStateNotifier(
+        const UserSourcesState(
+          sources: [],
+          favorites: [],
+          favoriteCount: 0,
+          favoriteCap: 3,
+        ),
+      );
+      await tester.pumpWidget(
+        wrap(sources: mockSources, sourcesState: fakeSourcesState),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Suivre').first);
+      await tester.pumpAndSettle();
+
+      expect(fakeSourcesState.setStateCalls, 1);
+      expect(fakeSourcesState.lastSourceId, '1');
+      expect(fakeSourcesState.lastState, InterestState.followed);
+      expect(find.text('Suivi'), findsOneWidget);
+    });
+
+    testWidgets('followed and favorite states render as Suivi', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          sources: mockSources,
+          sourcesState: _FakeUserSourcesStateNotifier(
+            const UserSourcesState(
+              sources: [
+                SourceInterest(
+                  sourceId: '1',
+                  state: InterestState.favorite,
+                  priorityMultiplier: 1,
+                ),
+                SourceInterest(
+                  sourceId: '2',
+                  state: InterestState.followed,
+                  priorityMultiplier: 1,
+                ),
+              ],
+              favorites: [],
+              favoriteCount: 0,
+              favoriteCap: 3,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Suivi'), findsNWidgets(2));
+      expect(find.text('Suivre'), findsNothing);
     });
   });
 }

--- a/packages/api/app/routers/feed.py
+++ b/packages/api/app/routers/feed.py
@@ -528,6 +528,7 @@ async def get_tab_counts(
     from sqlalchemy import exists, or_, select
 
     from app.models.content import Content
+    from app.models.enums import InterestState
     from app.models.source import UserSource
     from app.models.user_topic_profile import UserTopicProfile
     from app.schemas.feed import TabCountsResponse
@@ -536,7 +537,10 @@ async def get_tab_counts(
     user_uuid = UUID(current_user_id)
     cutoff = datetime.now(UTC) - timedelta(hours=48)
 
-    followed_stmt = select(UserSource.source_id).where(UserSource.user_id == user_uuid)
+    followed_stmt = select(UserSource.source_id).where(
+        UserSource.user_id == user_uuid,
+        UserSource.state.in_((InterestState.FOLLOWED, InterestState.FAVORITE)),
+    )
     favorites_stmt = select(UserTopicProfile).where(
         UserTopicProfile.user_id == user_uuid,
         UserTopicProfile.priority_multiplier == 2.0,

--- a/packages/api/app/routers/personalization.py
+++ b/packages/api/app/routers/personalization.py
@@ -5,13 +5,14 @@ from uuid import UUID
 import structlog
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import func, select, text
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.models.source import UserSource
+from app.models.user_favorites import UserFavoriteSource
 from app.models.user_personalization import UserPersonalization
 from app.schemas.learning import (
     EntityPreferenceRequest,
@@ -149,6 +150,12 @@ async def mute_source(
             )
         )
         if existing_trust:
+            await db.execute(
+                delete(UserFavoriteSource).where(
+                    UserFavoriteSource.user_id == user_uuid,
+                    UserFavoriteSource.source_id == request.source_id,
+                )
+            )
             await db.delete(existing_trust)
 
         await db.commit()

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -8,14 +8,15 @@ from uuid import UUID
 
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
+from app.models.enums import InterestState
 from app.models.failed_source_attempt import FailedSourceAttempt
-from app.models.source import Source
+from app.models.source import Source, UserSource
 from app.models.user import UserInterest
 from app.schemas.source import (
     PremiumConnectionResponse,
@@ -47,6 +48,7 @@ from app.services.sources_cache import SOURCES_CACHE
 from app.utils.db_retry import retry_db_op
 
 logger = structlog.get_logger()
+FOLLOWED_SOURCE_STATES = (InterestState.FOLLOWED, InterestState.FAVORITE)
 
 router = APIRouter()
 
@@ -360,10 +362,11 @@ async def get_sources_by_theme(
     db: AsyncSession = Depends(get_db),
 ) -> ThemeSourcesResponse:
     """Sources par thème : Curées → Candidates → Communauté."""
-    from app.models.source import UserSource
-
     # Sources déjà suivies par l'utilisateur (pour flag is_trusted dans la réponse)
-    trusted_stmt = select(UserSource.source_id).where(UserSource.user_id == user_id)
+    trusted_stmt = select(UserSource.source_id).where(
+        UserSource.user_id == UUID(user_id),
+        UserSource.state.in_(FOLLOWED_SOURCE_STATES),
+    )
     trusted_result = await db.execute(trusted_stmt)
     trusted_ids: set[UUID] = {row[0] for row in trusted_result.all()}
 
@@ -421,7 +424,13 @@ async def get_sources_by_theme(
 
             stmt_community = (
                 select(Source, func.count(UserSource.user_id).label("followers"))
-                .join(UserSource, UserSource.source_id == Source.id)
+                .join(
+                    UserSource,
+                    and_(
+                        UserSource.source_id == Source.id,
+                        UserSource.state.in_(FOLLOWED_SOURCE_STATES),
+                    ),
+                )
                 .where(Source.is_active.is_(True))
             )
             if exclude_ids:
@@ -452,10 +461,9 @@ async def get_themes_followed(
     db: AsyncSession = Depends(get_db),
 ) -> ThemesFollowedResponse:
     """Thèmes suivis par l'utilisateur avec count de sources."""
-    from app.models.source import UserSource
-
     # Get user interests
-    stmt = select(UserInterest.interest_slug).where(UserInterest.user_id == user_id)
+    user_uuid = UUID(user_id)
+    stmt = select(UserInterest.interest_slug).where(UserInterest.user_id == user_uuid)
     result = await db.execute(stmt)
     slugs = [row[0] for row in result.fetchall()]
 
@@ -465,7 +473,8 @@ async def get_themes_followed(
             select(func.count())
             .select_from(Source)
             .join(UserSource, UserSource.source_id == Source.id)
-            .where(UserSource.user_id == user_id)
+            .where(UserSource.user_id == user_uuid)
+            .where(UserSource.state.in_(FOLLOWED_SOURCE_STATES))
             .where(Source.is_active.is_(True))
             .where((Source.theme == slug) | (Source.secondary_themes.any(slug)))
         )

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -33,7 +33,7 @@ from sqlalchemy.orm import selectinload
 from app.models.content import Content, UserContentStatus
 from app.models.daily_digest import DailyDigest
 from app.models.digest_completion import DigestCompletion
-from app.models.enums import ContentStatus
+from app.models.enums import ContentStatus, InterestState
 from app.models.user import UserStreak
 from app.models.user_personalization import UserPersonalization
 from app.schemas.digest import (
@@ -1076,7 +1076,10 @@ class DigestService:
         from app.models.source import UserSource
 
         followed_result = await self.session.execute(
-            select(UserSource.source_id).where(UserSource.user_id == user_id)
+            select(UserSource.source_id).where(
+                UserSource.user_id == user_id,
+                UserSource.state.in_((InterestState.FOLLOWED, InterestState.FAVORITE)),
+            )
         )
         followed_source_ids = set(followed_result.scalars().all())
 
@@ -2197,7 +2200,10 @@ class DigestService:
         # The editorial digest is generated globally (match_global) and hard-
         # codes that flag to False, so the cached value is per-user wrong.
         followed_result = await self.session.execute(
-            select(UserSource.source_id).where(UserSource.user_id == user_id)
+            select(UserSource.source_id).where(
+                UserSource.user_id == user_id,
+                UserSource.state.in_((InterestState.FOLLOWED, InterestState.FAVORITE)),
+            )
         )
         followed_source_ids: set[UUID] = set(followed_result.scalars().all())
 
@@ -2464,7 +2470,10 @@ class DigestService:
         # users in some paths). Always recompute against the current
         # UserSource table so the badge in mobile reflects reality.
         followed_result = await self.session.execute(
-            select(UserSource.source_id).where(UserSource.user_id == user_id)
+            select(UserSource.source_id).where(
+                UserSource.user_id == user_id,
+                UserSource.state.in_((InterestState.FOLLOWED, InterestState.FAVORITE)),
+            )
         )
         followed_source_ids: set[UUID] = set(followed_result.scalars().all())
 

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -37,7 +37,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import ContentType, SourceType
+from app.models.enums import ContentType, InterestState, SourceType
 from app.models.source import UserSource
 from app.models.user import UserInterest, UserSubtopic
 from app.models.user_personalization import UserPersonalization
@@ -122,7 +122,8 @@ async def fetch_user_essentiel_context(
     src_rows = (
         await db.execute(
             select(UserSource.source_id, UserSource.priority_multiplier).where(
-                UserSource.user_id == user_id
+                UserSource.user_id == user_id,
+                UserSource.state.in_((InterestState.FOLLOWED, InterestState.FAVORITE)),
             )
         )
     ).all()

--- a/packages/api/app/services/pepite_service.py
+++ b/packages/api/app/services/pepite_service.py
@@ -9,9 +9,10 @@ from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 import structlog
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.enums import InterestState
 from app.models.source import Source, UserSource
 from app.models.user import UserInterest
 from app.models.user_personalization import UserPersonalization
@@ -21,6 +22,7 @@ logger = structlog.get_logger()
 
 DISMISS_COOL_DOWN_DAYS = 7
 RATE_LIMIT_HOURS = 24
+FOLLOWED_SOURCE_STATES = (InterestState.FOLLOWED, InterestState.FAVORITE)
 
 
 def _now() -> datetime:
@@ -80,7 +82,10 @@ class PepiteService:
 
     async def _user_followed_source_ids(self, user_uuid: UUID) -> set[UUID]:
         result = await self.db.execute(
-            select(UserSource.source_id).where(UserSource.user_id == user_uuid)
+            select(UserSource.source_id).where(
+                UserSource.user_id == user_uuid,
+                UserSource.state.in_(FOLLOWED_SOURCE_STATES),
+            )
         )
         return set(result.scalars().all())
 
@@ -119,7 +124,13 @@ class PepiteService:
         count_col = func.count(UserSource.user_id).label("follower_count")
         query = (
             select(Source, count_col)
-            .outerjoin(UserSource, UserSource.source_id == Source.id)
+            .outerjoin(
+                UserSource,
+                and_(
+                    UserSource.source_id == Source.id,
+                    UserSource.state.in_(FOLLOWED_SOURCE_STATES),
+                ),
+            )
             .where(Source.is_pepite_recommendation)
             .where(Source.is_active)
             .group_by(Source.id)

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -17,7 +17,7 @@ from sqlalchemy import and_, exists, func, literal_column, not_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.content import Content
-from app.models.enums import BiasStance
+from app.models.enums import BiasStance, InterestState
 from app.models.source import Source, UserSource
 from app.models.user import UserPreference
 from app.models.user_topic_profile import UserTopicProfile
@@ -697,7 +697,12 @@ async def calculate_user_bias(session: AsyncSession, user_id: UUID) -> BiasStanc
     Fallback CENTER si aucune source suivie.
     """
     result = await session.execute(
-        select(Source.bias_stance).join(UserSource).where(UserSource.user_id == user_id)
+        select(Source.bias_stance)
+        .join(UserSource)
+        .where(
+            UserSource.user_id == user_id,
+            UserSource.state.in_((InterestState.FOLLOWED, InterestState.FAVORITE)),
+        )
     )
     biases = result.scalars().all()
 

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -19,6 +19,7 @@ from app.models.source import Source, UserSource
 from app.models.user import UserProfile, UserSubtopic
 
 logger = structlog.get_logger()
+FOLLOWED_SOURCE_STATES = (InterestState.FOLLOWED, InterestState.FAVORITE)
 
 # Upper bound on the two-phase followed-sources query in the default feed
 # view. Above this, we rollback and fall back to a curated-only query so the
@@ -264,7 +265,10 @@ class RecommendationService:
         )
         sources_stmt = select(
             UserSource.source_id, UserSource.is_custom, UserSource.has_subscription
-        ).where(UserSource.user_id == user_id)
+        ).where(
+            UserSource.user_id == user_id,
+            UserSource.state.in_(FOLLOWED_SOURCE_STATES),
+        )
         subtopics_stmt = select(UserSubtopic).where(UserSubtopic.user_id == user_id)
         personalization_stmt = select(UserPersonalization).where(
             UserPersonalization.user_id == user_id
@@ -582,7 +586,8 @@ class RecommendationService:
         source_weight_rows = (
             await self.session.execute(
                 select(UserSource.source_id, UserSource.priority_multiplier).where(
-                    UserSource.user_id == user_id
+                    UserSource.user_id == user_id,
+                    UserSource.state.in_(FOLLOWED_SOURCE_STATES),
                 )
             )
         ).all()
@@ -1509,6 +1514,7 @@ class RecommendationService:
                         .join(Source, Source.id == UserSource.source_id)
                         .where(
                             UserSource.user_id == user_id,
+                            UserSource.state.in_(FOLLOWED_SOURCE_STATES),
                             UserSource.added_at > seven_days_ago,
                         )
                         .order_by(UserSource.added_at.desc())  # T3A: most recent first

--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -4,11 +4,12 @@ from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 import structlog
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.enums import InterestState
 from app.models.source import Source, UserSource
+from app.models.user_favorites import UserFavoriteSource
 from app.models.user_personalization import UserPersonalization
 from app.schemas.source import (
     PremiumConnectionResponse,
@@ -20,6 +21,7 @@ from app.services.language_user_filter import recompute_auto_pref
 from app.services.rss_parser import RSSParser
 
 logger = structlog.get_logger()
+FOLLOWED_SOURCE_STATES = (InterestState.FOLLOWED, InterestState.FAVORITE)
 
 
 class PremiumConnectionNotEnabled(Exception):
@@ -54,7 +56,10 @@ class SourceService:
                 UserSource.source_id,
                 UserSource.priority_multiplier,
                 UserSource.has_subscription,
-            ).where(UserSource.user_id == user_id)
+            ).where(
+                UserSource.user_id == user_id,
+                UserSource.state.in_(FOLLOWED_SOURCE_STATES),
+            )
         )
         rows = result.all()
         trusted_ids = {row.source_id for row in rows}
@@ -158,6 +163,7 @@ class SourceService:
             .join(UserSource)
             .where(
                 UserSource.user_id == user_uuid,
+                UserSource.state.in_(FOLLOWED_SOURCE_STATES),
                 ~Source.is_curated,
             )
             .distinct()
@@ -231,6 +237,7 @@ class SourceService:
         result = await self.db.execute(
             select(Source, count_col)
             .join(UserSource)
+            .where(UserSource.state.in_(FOLLOWED_SOURCE_STATES))
             .where(Source.is_active)
             .where(~Source.is_curated)
             .group_by(Source.id)
@@ -434,6 +441,14 @@ class SourceService:
         existing = existing_result.scalar_one_or_none()
 
         if existing:
+            existing.state = InterestState.FOLLOWED
+            await self.db.execute(
+                delete(UserFavoriteSource).where(
+                    UserFavoriteSource.user_id == UUID(user_id),
+                    UserFavoriteSource.source_id == UUID(source_id),
+                )
+            )
+            await self.db.flush()
             return True
 
         # Ajouter
@@ -568,6 +583,12 @@ class SourceService:
         if not user_source:
             return False
 
+        await self.db.execute(
+            delete(UserFavoriteSource).where(
+                UserFavoriteSource.user_id == UUID(user_id),
+                UserFavoriteSource.source_id == UUID(source_id),
+            )
+        )
         await self.db.delete(user_source)
         await self.db.flush()
         await recompute_auto_pref(self.db, UUID(user_id))

--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -441,14 +441,14 @@ class SourceService:
         existing = existing_result.scalar_one_or_none()
 
         if existing:
-            existing.state = InterestState.FOLLOWED
-            await self.db.execute(
-                delete(UserFavoriteSource).where(
-                    UserFavoriteSource.user_id == UUID(user_id),
-                    UserFavoriteSource.source_id == UUID(source_id),
+            if existing.state not in FOLLOWED_SOURCE_STATES:
+                existing.state = InterestState.FOLLOWED
+                await self.db.execute(
+                    delete(UserFavoriteSource).where(
+                        UserFavoriteSource.user_id == UUID(user_id),
+                        UserFavoriteSource.source_id == UUID(source_id),
+                    )
                 )
-            )
-            await self.db.flush()
             return True
 
         # Ajouter

--- a/packages/api/app/services/user_service.py
+++ b/packages/api/app/services/user_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.enums import InterestState
 from app.models.source import Source, UserSource
 from app.models.user import (
     UserInterest,
@@ -16,6 +17,7 @@ from app.models.user import (
     UserStreak,
     UserSubtopic,
 )
+from app.models.user_favorites import UserFavoriteInterest
 from app.models.user_personalization import UserPersonalization
 from app.models.user_topic_profile import UserTopicProfile
 from app.schemas.user import OnboardingAnswers, UserProfileUpdate, UserStatsResponse
@@ -173,18 +175,43 @@ class UserService:
             self.db.add(pref)
             pref_count += 1
 
+        user_uuid = UUID(user_id)
+
         # Sauvegarder les intérêts
         interest_count = 0
+        created_interests: dict[str, UserInterest] = {}
         if answers.themes:
             for interest_slug in answers.themes:
                 interest = UserInterest(
                     id=uuid4(),
-                    user_id=UUID(user_id),
+                    user_id=user_uuid,
                     interest_slug=interest_slug,
                     weight=1.0,
                 )
                 self.db.add(interest)
+                created_interests[interest_slug] = interest
                 interest_count += 1
+
+        favorites_seeded = 0
+        if answers.themes:
+            existing_favorite = await self.db.scalar(
+                select(UserFavoriteInterest).where(
+                    UserFavoriteInterest.user_id == user_uuid
+                )
+            )
+            if existing_favorite is None:
+                for position, interest_slug in enumerate(answers.themes[:3]):
+                    interest = created_interests.get(interest_slug)
+                    if interest is not None:
+                        interest.state = InterestState.FAVORITE
+                    self.db.add(
+                        UserFavoriteInterest(
+                            user_id=user_uuid,
+                            position=position,
+                            interest_slug=interest_slug,
+                        )
+                    )
+                    favorites_seeded += 1
 
         # Muter les thèmes non-sélectionnés (pour affichage "Mes Intérêts")
         all_themes = {
@@ -204,7 +231,7 @@ class UserService:
         stmt = (
             pg_insert(UserPersonalization)
             .values(
-                user_id=UUID(user_id),
+                user_id=user_uuid,
                 muted_themes=unselected_themes,
             )
             .on_conflict_do_update(
@@ -231,13 +258,13 @@ class UserService:
                 # (preserves manual priority changes from post-onboarding edits)
                 existing_profile = await self.db.scalar(
                     select(UserTopicProfile).where(
-                        UserTopicProfile.user_id == UUID(user_id),
+                        UserTopicProfile.user_id == user_uuid,
                         UserTopicProfile.slug_parent == topic_slug,
                     )
                 )
                 if not existing_profile:
                     topic_profile = UserTopicProfile(
-                        user_id=UUID(user_id),
+                        user_id=user_uuid,
                         topic_name=SLUG_TO_LABEL.get(
                             topic_slug, topic_slug.capitalize()
                         ),
@@ -252,6 +279,7 @@ class UserService:
         # Sauvegarder les sources sélectionnées (UserSource)
         # Atomique avec le reste de l'onboarding — pas de race condition
         sources_created = 0
+        sources_followed = 0
         sources_removed = 0
         if answers.preferred_sources:
             # Valider les UUIDs
@@ -292,21 +320,30 @@ class UserService:
                 valid_source_ids = existing_source_ids
 
             if valid_source_ids:
-                # Vérifier lesquelles l'utilisateur a déjà
+                # Vérifier lesquelles l'utilisateur a déjà pour forcer l'état
+                # déclaré `followed` si une row incohérente existe déjà.
                 already_result = await self.db.execute(
-                    select(UserSource.source_id).where(
-                        UserSource.user_id == UUID(user_id),
+                    select(UserSource).where(
+                        UserSource.user_id == user_uuid,
                         UserSource.source_id.in_(list(valid_source_ids)),
                     )
                 )
-                already_trusted = set(already_result.scalars().all())
+                existing_user_sources = {
+                    us.source_id: us for us in already_result.scalars().all()
+                }
 
-                for source_id in valid_source_ids - already_trusted:
+                for source_id, user_source in existing_user_sources.items():
+                    if user_source.state != InterestState.FOLLOWED:
+                        user_source.state = InterestState.FOLLOWED
+                        sources_followed += 1
+
+                for source_id in valid_source_ids - set(existing_user_sources):
                     user_source = UserSource(
                         id=uuid4(),
-                        user_id=UUID(user_id),
+                        user_id=user_uuid,
                         source_id=source_id,
                         is_custom=False,
+                        state=InterestState.FOLLOWED,
                     )
                     self.db.add(user_source)
                     sources_created += 1
@@ -315,7 +352,7 @@ class UserService:
             # Ne supprime que les sources non-custom ajoutées via onboarding
             all_user_sources_result = await self.db.execute(
                 select(UserSource).where(
-                    UserSource.user_id == UUID(user_id),
+                    UserSource.user_id == user_uuid,
                     UserSource.is_custom.is_(False),
                 )
             )
@@ -340,7 +377,9 @@ class UserService:
             subtopics_created=subtopic_count,
             preferences_created=pref_count,
             sources_created=sources_created,
+            sources_followed=sources_followed,
             sources_removed=sources_removed,
+            favorites_seeded=favorites_seeded,
             preferred_sources_count=len(answers.preferred_sources)
             if answers.preferred_sources
             else 0,

--- a/packages/api/scripts/backfill_onboarding_sources_favorites.py
+++ b/packages/api/scripts/backfill_onboarding_sources_favorites.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Repair post-onboarding source states and default theme favorites.
+
+Dry-run by default:
+    cd packages/api
+    python scripts/backfill_onboarding_sources_favorites.py
+
+Apply:
+    cd packages/api
+    python scripts/backfill_onboarding_sources_favorites.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from dataclasses import dataclass, field
+from uuid import UUID
+
+from dotenv import load_dotenv
+from sqlalchemy import select
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+load_dotenv()
+
+from app.database import safe_async_session  # noqa: E402
+from app.models.enums import InterestState  # noqa: E402
+from app.models.source import Source, UserSource  # noqa: E402
+from app.models.user import UserInterest, UserProfile  # noqa: E402
+from app.models.user_favorites import UserFavoriteInterest  # noqa: E402
+
+FOLLOWED_SOURCE_STATES = (InterestState.FOLLOWED, InterestState.FAVORITE)
+
+
+@dataclass
+class UserRepair:
+    user_id: UUID
+    favorite_slugs: list[str] = field(default_factory=list)
+    source_ids_followed: list[UUID] = field(default_factory=list)
+    manual_reason: str | None = None
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.favorite_slugs or self.source_ids_followed)
+
+
+async def repair_user(user_id: UUID, *, apply: bool) -> UserRepair:
+    repair = UserRepair(user_id=user_id)
+
+    async with safe_async_session() as session:
+        interests = (
+            (
+                await session.execute(
+                    select(UserInterest)
+                    .where(UserInterest.user_id == user_id)
+                    .order_by(UserInterest.created_at, UserInterest.interest_slug)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        favorites = (
+            (
+                await session.execute(
+                    select(UserFavoriteInterest).where(
+                        UserFavoriteInterest.user_id == user_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        user_sources = (
+            (
+                await session.execute(
+                    select(UserSource)
+                    .join(Source, Source.id == UserSource.source_id)
+                    .where(
+                        UserSource.user_id == user_id,
+                        UserSource.is_custom.is_(False),
+                        Source.is_active.is_(True),
+                    )
+                    .order_by(UserSource.added_at, UserSource.source_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        if not favorites and interests:
+            for position, interest in enumerate(interests[:3]):
+                repair.favorite_slugs.append(interest.interest_slug)
+                if apply:
+                    interest.state = InterestState.FAVORITE
+                    session.add(
+                        UserFavoriteInterest(
+                            user_id=user_id,
+                            position=position,
+                            interest_slug=interest.interest_slug,
+                        )
+                    )
+
+        for user_source in user_sources:
+            if user_source.state not in FOLLOWED_SOURCE_STATES:
+                repair.source_ids_followed.append(user_source.source_id)
+                if apply:
+                    user_source.state = InterestState.FOLLOWED
+
+        if not interests and not user_sources:
+            repair.manual_reason = "no user_interests or non-custom user_sources"
+
+        if apply:
+            await session.commit()
+        else:
+            await session.rollback()
+
+    return repair
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true", help="write repairs")
+    parser.add_argument("--limit", type=int, default=None)
+    args = parser.parse_args()
+
+    async with safe_async_session() as session:
+        stmt = (
+            select(UserProfile.user_id)
+            .where(UserProfile.onboarding_completed.is_(True))
+            .order_by(UserProfile.created_at, UserProfile.user_id)
+        )
+        if args.limit:
+            stmt = stmt.limit(args.limit)
+        user_ids = list((await session.execute(stmt)).scalars().all())
+        await session.rollback()
+
+    inspected = repaired = ignored = manual = 0
+    manual_rows: list[UserRepair] = []
+
+    for user_id in user_ids:
+        inspected += 1
+        repair = await repair_user(user_id, apply=args.apply)
+        if repair.manual_reason:
+            manual += 1
+            manual_rows.append(repair)
+        elif repair.changed:
+            repaired += 1
+        else:
+            ignored += 1
+
+        if repair.changed or repair.manual_reason:
+            print(
+                f"user={repair.user_id} "
+                f"favorites_seeded={len(repair.favorite_slugs)} "
+                f"sources_followed={len(repair.source_ids_followed)} "
+                f"manual_reason={repair.manual_reason or '-'}"
+            )
+
+    mode = "APPLY" if args.apply else "DRY_RUN"
+    print(
+        f"{mode} inspected={inspected} repaired={repaired} "
+        f"ignored={ignored} manual_review={manual}"
+    )
+    if manual_rows:
+        print("manual_review_users=" + ",".join(str(r.user_id) for r in manual_rows))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/api/tests/test_onboarding_sources.py
+++ b/packages/api/tests/test_onboarding_sources.py
@@ -1,12 +1,16 @@
 """Tests for onboarding source saving and theme muting."""
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4, UUID
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
+import pytest
+
+from app.models.enums import InterestState
+from app.models.source import UserSource
+from app.models.user import UserInterest
+from app.models.user_favorites import UserFavoriteInterest
 from app.schemas.user import OnboardingAnswers
 from app.services.user_service import UserService
-from app.models.source import UserSource
 
 
 class TestOnboardingAnswersParsing:
@@ -99,7 +103,10 @@ async def test_save_onboarding_creates_user_sources():
 
     # Mock: sources exist and are active in DB
     mock_sources_result = MagicMock()
-    mock_sources_result.scalars.return_value.all.return_value = [source_id_1, source_id_2]
+    mock_sources_result.scalars.return_value.all.return_value = [
+        source_id_1,
+        source_id_2,
+    ]
 
     # Mock: no existing UserSource for this user
     mock_already_result = MagicMock()
@@ -126,13 +133,12 @@ async def test_save_onboarding_creates_user_sources():
         # 5. select Source.id (existing sources check)
         # 6. select UserSource.source_id (already trusted check)
         # 7. select UserSource (cleanup query)
-        if execute_call_count == 5:
-            return mock_sources_result
-        elif execute_call_count == 6:
-            return mock_already_result
-        elif execute_call_count == 7:
-            return mock_all_user_sources_result
-        return MagicMock()
+        responses_by_call = {
+            5: mock_sources_result,
+            6: mock_already_result,
+            7: mock_all_user_sources_result,
+        }
+        return responses_by_call.get(execute_call_count, MagicMock())
 
     mock_db.execute = AsyncMock(side_effect=mock_execute)
 
@@ -159,6 +165,101 @@ async def test_save_onboarding_creates_user_sources():
     # Curated sources should have is_custom=False
     for us in user_sources:
         assert us.is_custom is False
+        assert us.state == InterestState.FOLLOWED
+
+
+@pytest.mark.asyncio
+async def test_save_onboarding_marks_existing_source_followed():
+    """Existing hidden/unfollowed source rows are restored to followed."""
+    mock_db = AsyncMock()
+    mock_db.add = MagicMock()
+    mock_db.scalar = AsyncMock(return_value=None)
+
+    service = UserService(mock_db)
+    mock_profile = MagicMock()
+    service.get_or_create_profile = AsyncMock(return_value=mock_profile)
+
+    source_id = uuid4()
+    existing_user_source = UserSource(
+        user_id=uuid4(),
+        source_id=source_id,
+        is_custom=False,
+        state=InterestState.HIDDEN,
+    )
+
+    mock_sources_result = MagicMock()
+    mock_sources_result.scalars.return_value.all.return_value = [source_id]
+    mock_already_result = MagicMock()
+    mock_already_result.scalars.return_value.all.return_value = [existing_user_source]
+    mock_all_user_sources_result = MagicMock()
+    mock_all_user_sources_result.scalars.return_value.all.return_value = [
+        existing_user_source
+    ]
+
+    execute_call_count = 0
+
+    async def mock_execute(stmt):
+        nonlocal execute_call_count
+        execute_call_count += 1
+        responses_by_call = {
+            5: mock_sources_result,
+            6: mock_already_result,
+            7: mock_all_user_sources_result,
+        }
+        return responses_by_call.get(execute_call_count, MagicMock())
+
+    mock_db.execute = AsyncMock(side_effect=mock_execute)
+
+    answers = OnboardingAnswers(
+        objective="noise",
+        approach="direct",
+        response_style="decisive",
+        themes=["tech"],
+        preferred_sources=[str(source_id)],
+    )
+
+    result = await service.save_onboarding(str(uuid4()), answers)
+
+    assert result["sources_created"] == 0
+    assert existing_user_source.state == InterestState.FOLLOWED
+
+
+@pytest.mark.asyncio
+async def test_save_onboarding_seeds_theme_favorites_when_empty():
+    """First onboarding seeds up to three favorite theme slots."""
+    mock_db = AsyncMock()
+    mock_db.add = MagicMock()
+    mock_db.scalar = AsyncMock(return_value=None)
+    mock_db.execute = AsyncMock(return_value=MagicMock())
+
+    service = UserService(mock_db)
+    mock_profile = MagicMock()
+    service.get_or_create_profile = AsyncMock(return_value=mock_profile)
+
+    answers = OnboardingAnswers(
+        objective="noise",
+        approach="direct",
+        response_style="decisive",
+        themes=["tech", "science", "culture", "economy"],
+    )
+
+    await service.save_onboarding(str(uuid4()), answers)
+
+    added_objects = [call.args[0] for call in mock_db.add.call_args_list]
+    favorites = [obj for obj in added_objects if isinstance(obj, UserFavoriteInterest)]
+    interests = [obj for obj in added_objects if isinstance(obj, UserInterest)]
+
+    assert [(f.interest_slug, f.position) for f in favorites] == [
+        ("tech", 0),
+        ("science", 1),
+        ("culture", 2),
+    ]
+    favorite_interest_states = {
+        i.interest_slug: i.state
+        for i in interests
+        if i.interest_slug in {"tech", "science", "culture"}
+    }
+    assert set(favorite_interest_states.values()) == {InterestState.FAVORITE}
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/test_source_addition_fix.py
+++ b/packages/api/tests/test_source_addition_fix.py
@@ -27,8 +27,9 @@ from uuid import uuid4
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.enums import InterestState, SourceType
 from app.models.source import Source, UserSource
-from app.models.enums import SourceType
+from app.models.user_favorites import UserFavoriteSource
 from app.schemas.source import SourceDetectResponse
 from app.services.source_service import SourceService
 
@@ -103,3 +104,49 @@ async def test_add_custom_source_idempotent(db_session: AsyncSession, fake_detec
     )
     rows = result.scalars().all()
     assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_legacy_trust_source_forces_existing_row_followed(
+    db_session: AsyncSession,
+):
+    user_id = uuid4()
+    source = Source(
+        id=uuid4(),
+        name="Existing Source",
+        url="https://existing.example.com",
+        feed_url="https://existing.example.com/feed.xml",
+        type=SourceType.ARTICLE,
+        theme="tech",
+        is_active=True,
+        is_curated=True,
+    )
+    db_session.add(source)
+    db_session.add(
+        UserSource(
+            user_id=user_id,
+            source_id=source.id,
+            state=InterestState.HIDDEN,
+        )
+    )
+    db_session.add(UserFavoriteSource(user_id=user_id, source_id=source.id, position=0))
+    await db_session.commit()
+
+    assert await SourceService(db_session).trust_source(str(user_id), str(source.id))
+    await db_session.commit()
+
+    user_source = await db_session.scalar(
+        select(UserSource).where(
+            UserSource.user_id == user_id,
+            UserSource.source_id == source.id,
+        )
+    )
+    favorite = await db_session.scalar(
+        select(UserFavoriteSource).where(
+            UserFavoriteSource.user_id == user_id,
+            UserFavoriteSource.source_id == source.id,
+        )
+    )
+    assert user_source is not None
+    assert user_source.state == InterestState.FOLLOWED
+    assert favorite is None

--- a/packages/api/tests/test_source_addition_fix.py
+++ b/packages/api/tests/test_source_addition_fix.py
@@ -29,6 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.enums import InterestState, SourceType
 from app.models.source import Source, UserSource
+from app.models.user import UserProfile
 from app.models.user_favorites import UserFavoriteSource
 from app.schemas.source import SourceDetectResponse
 from app.services.source_service import SourceService
@@ -122,6 +123,7 @@ async def test_legacy_trust_source_forces_existing_row_followed(
         is_curated=True,
     )
     db_session.add(source)
+    db_session.add(UserProfile(user_id=user_id))
     db_session.add(
         UserSource(
             user_id=user_id,


### PR DESCRIPTION
## Quoi
Corrige plusieurs causes de feeds vides en onboarding :
- Filtre `UserSource.state.in_(FOLLOWED, FAVORITE)` dans tous les services/routers qui listaient les sources sans égard à l'état (8 fichiers)
- Nettoie `UserFavoriteSource` orphelines lors de `add_source` (re-follow) et `remove_source` / `mute_source`
- Préserve l'état `FAVORITE` lors d'un re-follow (ne downgrade plus vers `FOLLOWED`)
- Refactorise `_invalidatePostOnboardingState()` dans `ConclusionNotifier` pour invalider correctement feed, flux_continu, user_interests, user_sources, pepites, custom_topics, personalization
- Aligne `OnboardingSyncNotifier` sur la même liste d'invalidations (manquait `customTopicsProvider` + `personalizationProvider`)
- Ajoute script de backfill `backfill_onboarding_sources_favorites.py` pour corriger les utilisateurs existants

## Pourquoi
Plusieurs services incluaient des sources non-suivies (dismissed, hidden, pending) dans les feeds et comptages — causant des feeds vides ou incohérents après onboarding. Les entrées `UserFavoriteSource` orphelines pouvaient provoquer des incohérences d'état. Côté mobile, l'invalidation post-onboarding était incomplète, laissant des providers obsolètes.

Sentry : PYTHON-4R, PYTHON-3C (IdleInTransactionSessionTimeout → sources_unavailable).

## Comment ça a été vérifié
- [x] pytest -v : 1224 passed, 0 failures (257 erreurs DB pre-existantes sans lien)
- [x] flutter test pepites_carousel_test : 5/5 passed
- [x] flutter analyze : exit 0 (530 infos pre-existants)
- [x] alembic heads : 1 head confirmé
- [x] /simplify passé (2 fixes : FAVORITE preservation + alignement invalidations sync)

## Zones à risque
- `source_service.py` : filtrage state + logique add_source — tout service qui compte/liste les sources suivies
- `UserFavoriteSource` cleanup dans add/remove/mute source
- `ConclusionNotifier` + `OnboardingSyncNotifier` : ordre d'invalidation des providers post-onboarding