### PR TITLE
fix(onboarding): supprime l'écran gris post-onboarding + premium sources basé sur la sélection

### DIFF
--- a/apps/mobile/lib/config/theme.dart
+++ b/apps/mobile/lib/config/theme.dart
@@ -38,6 +38,10 @@ class FacteurColors extends ThemeExtension<FacteurColors> {
   final Color biasUnknown;
   final Color border;
 
+  // Voile des modales (bottom sheets, dialogs) — aligné design-system, nettement
+  // plus doux que `black 0.6` qui virait l'écran de fond au gris/sombre.
+  final Color scrim;
+
   // Flux Continu V1.8 — accents par section éditoriale (Story 21.1)
   final Color sectionEssentiel;
   final Color sectionBonnes;
@@ -68,6 +72,7 @@ class FacteurColors extends ThemeExtension<FacteurColors> {
     required this.biasRight,
     required this.biasUnknown,
     required this.border,
+    required this.scrim,
     required this.sectionEssentiel,
     required this.sectionBonnes,
     required this.sectionVeille1,
@@ -99,6 +104,7 @@ class FacteurColors extends ThemeExtension<FacteurColors> {
     Color? biasRight,
     Color? biasUnknown,
     Color? border,
+    Color? scrim,
     Color? sectionEssentiel,
     Color? sectionBonnes,
     Color? sectionVeille1,
@@ -128,6 +134,7 @@ class FacteurColors extends ThemeExtension<FacteurColors> {
       biasRight: biasRight ?? this.biasRight,
       biasUnknown: biasUnknown ?? this.biasUnknown,
       border: border ?? this.border,
+      scrim: scrim ?? this.scrim,
       sectionEssentiel: sectionEssentiel ?? this.sectionEssentiel,
       sectionBonnes: sectionBonnes ?? this.sectionBonnes,
       sectionVeille1: sectionVeille1 ?? this.sectionVeille1,
@@ -172,6 +179,7 @@ class FacteurColors extends ThemeExtension<FacteurColors> {
       biasRight: Color.lerp(biasRight, other.biasRight, t)!,
       biasUnknown: Color.lerp(biasUnknown, other.biasUnknown, t)!,
       border: Color.lerp(border, other.border, t)!,
+      scrim: Color.lerp(scrim, other.scrim, t)!,
       sectionEssentiel:
           Color.lerp(sectionEssentiel, other.sectionEssentiel, t)!,
       sectionBonnes: Color.lerp(sectionBonnes, other.sectionBonnes, t)!,
@@ -221,6 +229,7 @@ class FacteurPalettes {
     biasRight: const Color(0xFF0D47A1), // Blue 900
     biasUnknown: const Color(0xFFD7CCC8), // Blue Grey 100
     border: const Color(0xFFD2C7B3),
+    scrim: const Color(0x59000000), // ~0.35 — voile doux sur fond clair
     sectionEssentiel: const Color(0xFFB0470A),
     sectionBonnes: const Color(0xFF2E7D32),
     sectionVeille1: const Color(0xFF2C3E50),
@@ -251,6 +260,7 @@ class FacteurPalettes {
     biasRight: const Color(0xFF1E88E5), // Blue 600
     biasUnknown: const Color(0xFF616161), // Grey 700
     border: const Color(0xFF333333),
+    scrim: const Color(0x59000000), // ~0.35 — voile doux sur fond sombre
     sectionEssentiel: const Color(0xFFD16A2C),
     sectionBonnes: const Color(0xFF4CAF50),
     sectionVeille1: const Color(0xFF5B7187),
@@ -282,6 +292,7 @@ class FacteurPalettes {
     biasRight: const Color(0xFF448AFF),
     biasUnknown: const Color(0xFF5A5A5A),
     border: const Color(0xFF1F1F1F),
+    scrim: const Color(0x59000000), // ~0.35 — voile doux sur fond true black
     sectionEssentiel: const Color(0xFFE07B3D),
     sectionBonnes: const Color(0xFF66BB6A),
     sectionVeille1: const Color(0xFF6E8AA3),

--- a/apps/mobile/lib/core/orchestration/first_impression_orchestrator.dart
+++ b/apps/mobile/lib/core/orchestration/first_impression_orchestrator.dart
@@ -26,6 +26,19 @@ enum FirstImpressionSlot {
 /// nudge (re-nudge, well-informed) avant le prochain cold start.
 final notifModalConsumedThisSessionProvider = StateProvider<bool>((_) => false);
 
+/// Flow post-onboarding en attente d'être joué sur l'écran Essentiel chargé.
+///
+/// Positionné par l'écran de conclusion **juste avant** de basculer
+/// `needsOnboarding=false` (et donc avant la redirection router → Essentiel).
+/// Consommé une seule fois par `FluxContinuScreen` quand son état passe en
+/// `data` : la page Essentiel chargée sert alors de fond aux modales (thème
+/// puis notifications), au lieu d'un Essentiel encore en chargement masqué par
+/// un voile gris. La valeur porte la liste `failedCustomTopics` à résumer
+/// (liste vide = flow à jouer sans dialog de customs échoués ; `null` = aucun
+/// flow en attente).
+final postOnboardingFlowPendingProvider =
+    StateProvider<List<String>?>((_) => null);
+
 /// Une fois un nudge consommé, on n'en affiche pas un second avant cold start.
 final nudgeConsumedThisSessionProvider = StateProvider<bool>((_) => false);
 

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -24,8 +24,11 @@ import '../../feed/models/content_model.dart';
 import '../../feed/providers/swipe_hint_provider.dart';
 import '../../feed/widgets/feedback_inline.dart';
 import '../../lettres/widgets/lettres_notification_banner.dart';
+import '../../notifications/widgets/notification_activation_modal.dart';
 import '../../notifications/widgets/notification_renudge_banner.dart';
+import '../../onboarding/widgets/theme_choice_bottom_sheet.dart';
 import '../../well_informed/widgets/well_informed_prompt.dart';
+import '../../../shared/strings/loader_error_strings.dart';
 import '../../../shared/widgets/loaders/loading_view.dart';
 import '../models/flux_continu_models.dart';
 import '../providers/flux_continu_provider.dart';
@@ -83,6 +86,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
 
   bool _showScrollTopFab = false;
   double _lastScrollPos = 0;
+
+  /// Garde-fou : le flow post-onboarding (dialog customs échoués + modales
+  /// thème & notifications) ne doit se jouer qu'une seule fois par montage,
+  /// jamais sur un refetch/scroll/rebuild.
+  bool _postOnboardingFlowRan = false;
 
   // Pull-to-refresh discoverability pill. Shown briefly when the user
   // scrolls back to the top after having browsed deep enough (>=
@@ -564,11 +572,94 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     return null;
   }
 
+  // ---------------------------------------------------------------------------
+  // Flow post-onboarding (présenté sur Essentiel chargé, cf.
+  // postOnboardingFlowPendingProvider)
+  // ---------------------------------------------------------------------------
+
+  /// Planifie le flow post-onboarding pour le prochain post-frame, une seule
+  /// fois par montage. Le garde-fou est armé immédiatement pour qu'aucun
+  /// rebuild concurrent n'empile de second callback.
+  void _schedulePostOnboardingFlow() {
+    if (_postOnboardingFlowRan) return;
+    _postOnboardingFlowRan = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_runPostOnboardingFlow());
+    });
+  }
+
+  /// Joue, dans l'ordre, sur le `context`/`ref` stables d'Essentiel chargé :
+  /// 1. le dialog des sujets personnalisés échoués (si non vide),
+  /// 2. la modal de choix de thème,
+  /// 3. la modal d'activation des notifications.
+  /// La page Essentiel chargée sert de fond aux modales : à leur fermeture elle
+  /// est révélée intacte (plus d'écran gris ni de contexte démonté).
+  Future<void> _runPostOnboardingFlow() async {
+    if (!mounted) return;
+    final failedCustomTopics = ref.read(postOnboardingFlowPendingProvider);
+    if (failedCustomTopics == null) return;
+    // Consomme le flag immédiatement : un refetch/rebuild ne doit pas rejouer.
+    ref.read(postOnboardingFlowPendingProvider.notifier).state = null;
+
+    if (mounted && failedCustomTopics.isNotEmpty) {
+      // Dialog bloquant : les bottom sheets suivants poseraient un barrier qui
+      // masquerait une SnackBar. Le dialog garantit que l'utilisateur voit
+      // l'info ("tu pourras les réajouter").
+      await showDialog<void>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          content: Text(
+            OnboardingFallbackStrings.failedCustomTopicsMessage(
+              failedCustomTopics,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (mounted) {
+      await showThemeChoiceBottomSheet(context, ref);
+    }
+
+    if (mounted) {
+      await showNotificationActivationModal(
+        context,
+        ref,
+        trigger: ActivationTrigger.onboarding,
+      );
+      // Marque la modal notif comme consommée pour la session : l'arbitre
+      // first-impression ne la reproposera pas et laisse passer les nudges.
+      if (mounted) {
+        ref.read(notifModalConsumedThisSessionProvider.notifier).state = true;
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(fluxContinuProvider);
     // Re-tap de l'onglet actif (depuis le shell) → remonter en haut.
     ref.listen(essentielScrollTriggerProvider, (_, __) => _scrollToTop());
+    // Flow post-onboarding : joué une seule fois quand Essentiel a chargé ses
+    // données (derrière les modales thème & notifications). Couvre la
+    // transition loading→data (via le listen) et le cas où l'état est déjà
+    // `data` au montage (check direct planifié en post-frame).
+    ref.listen<AsyncValue<FluxContinuState>>(fluxContinuProvider, (_, next) {
+      if (next is AsyncData<FluxContinuState> &&
+          ref.read(postOnboardingFlowPendingProvider) != null) {
+        _schedulePostOnboardingFlow();
+      }
+    });
+    if (state is AsyncData<FluxContinuState> &&
+        ref.read(postOnboardingFlowPendingProvider) != null) {
+      _schedulePostOnboardingFlow();
+    }
     return Scaffold(
       backgroundColor: context.facteurColors.backgroundPrimary,
       // Header & footer vivent dans le scaffold de page partagé :

--- a/apps/mobile/lib/features/notifications/widgets/notification_activation_modal.dart
+++ b/apps/mobile/lib/features/notifications/widgets/notification_activation_modal.dart
@@ -42,7 +42,7 @@ Future<void> showNotificationActivationModal(
   return showDialog<void>(
     context: context,
     barrierDismissible: false,
-    barrierColor: Colors.black.withOpacity(0.6),
+    barrierColor: context.facteurColors.scrim,
     useRootNavigator: true,
     builder: (_) => Dialog(
       insetPadding: const EdgeInsets.symmetric(

--- a/apps/mobile/lib/features/onboarding/screens/conclusion_animation_screen.dart
+++ b/apps/mobile/lib/features/onboarding/screens/conclusion_animation_screen.dart
@@ -5,14 +5,13 @@ import 'package:go_router/go_router.dart';
 import '../../../config/theme.dart';
 import '../../../config/routes.dart';
 import '../../../core/auth/auth_state.dart';
+import '../../../core/orchestration/first_impression_orchestrator.dart';
 import '../../../shared/strings/loader_error_strings.dart';
 import '../../../shared/widgets/states/laurin_fallback_view.dart';
 import '../providers/conclusion_notifier.dart';
 import '../providers/onboarding_provider.dart';
 import '../widgets/animated_message_text.dart';
 import '../widgets/minimal_loader.dart';
-import '../../notifications/widgets/notification_activation_modal.dart';
-import '../widgets/theme_choice_bottom_sheet.dart';
 
 /// Écran d'animation de conclusion de l'onboarding
 /// Affiche une animation élégante pendant la sauvegarde des réponses
@@ -67,9 +66,6 @@ class _ConclusionAnimationScreenState
   }
 
   Future<void> _completeOnboarding() async {
-    // Marquer l'onboarding comme terminé dans l'auth state
-    await ref.read(authStateProvider.notifier).setOnboardingCompleted();
-
     // Capture la liste des customs échoués AVANT clearSavedData pour pouvoir
     // afficher le résumé utilisateur ("tu pourras les réajouter").
     final failedCustomTopics = List<String>.from(
@@ -80,44 +76,20 @@ class _ConclusionAnimationScreenState
     ref.read(onboardingProvider.notifier).clearSavedData();
     ref.read(onboardingProvider.notifier).clearFailedCustomTopics();
 
-    if (mounted && failedCustomTopics.isNotEmpty) {
-      // Dialog bloquant au lieu d'une SnackBar : les bottom sheets suivants
-      // (thème, notifications) poseraient un barrier qui masquerait la
-      // SnackBar. Le dialog garantit que l'utilisateur voit l'info.
-      await showDialog<void>(
-        context: context,
-        builder: (ctx) => AlertDialog(
-          content: Text(
-            OnboardingFallbackStrings.failedCustomTopicsMessage(
-              failedCustomTopics,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(ctx).pop(),
-              child: const Text('OK'),
-            ),
-          ],
-        ),
-      );
-    }
+    // Armer le flow post-onboarding (dialog customs échoués + modales thème &
+    // notifications) AVANT de basculer l'auth state : on le veut posé avant la
+    // redirection router vers Essentiel. Les modales seront jouées par
+    // FluxContinuScreen une fois ses données chargées, derrière elles — plus
+    // aucun écran gris, plus aucun contexte démonté.
+    ref.read(postOnboardingFlowPendingProvider.notifier).state =
+        failedCustomTopics;
 
-    // Proposer le choix du thème avant de naviguer
-    if (mounted) {
-      await showThemeChoiceBottomSheet(context, ref);
-    }
-
-    // Proposer l'activation des notifications (une seule fois, post-onboarding)
-    if (mounted) {
-      await showNotificationActivationModal(
-        context,
-        ref,
-        trigger: ActivationTrigger.onboarding,
-      );
-    }
+    // Marquer l'onboarding comme terminé : la règle 5 du redirect route alors
+    // l'écran sous-jacent vers Essentiel (qui se monte et charge ses données).
+    await ref.read(authStateProvider.notifier).setOnboardingCompleted();
 
     // context.go() remplace toute la stack pour bloquer le back vers
-    // l'onboarding.
+    // l'onboarding (idempotent avec la redirection router déjà déclenchée).
     if (mounted) {
       context.go(RoutePaths.fluxContinu);
     }

--- a/apps/mobile/lib/features/onboarding/screens/questions/sources_page2_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/sources_page2_question.dart
@@ -107,6 +107,7 @@ class _SourcesPage2QuestionState extends ConsumerState<SourcesPage2Question> {
       backgroundColor: Colors.transparent,
       builder: (context) => PremiumSourcesSheet(
         allSources: allSources,
+        selectedSourceIds: _selectedSourceIds,
       ),
     );
   }

--- a/apps/mobile/lib/features/onboarding/widgets/premium_sources_sheet.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/premium_sources_sheet.dart
@@ -11,15 +11,23 @@ import '../onboarding_strings.dart';
 
 /// Bottom sheet for indicating press subscriptions during onboarding.
 ///
-/// Shows all curated sources so the user can mark which ones they have
-/// a paid subscription to. Returns the set of subscribed source IDs via [onDone].
+/// Shows the sources the user just validated ([selectedSourceIds]) so they can
+/// mark which ones they pay for. During onboarding these aren't persisted yet
+/// (`hasSubscription=false`) and may have no premium connector — gating on
+/// `premiumConnection` left the list empty, so we base it on the validated
+/// selection instead. Returns the set of subscribed source IDs via [onDone].
 class PremiumSourcesSheet extends ConsumerStatefulWidget {
   final List<Source> allSources;
+
+  /// Sources the user validated at the previous step. The sheet lists these
+  /// (plus any already-subscribed) so the toggle reflects what they own.
+  final Set<String> selectedSourceIds;
   final ValueChanged<Set<String>>? onDone;
 
   const PremiumSourcesSheet({
     super.key,
     required this.allSources,
+    required this.selectedSourceIds,
     this.onDone,
   });
 
@@ -56,7 +64,8 @@ class _PremiumSourcesSheetState extends ConsumerState<PremiumSourcesSheet> {
     var sources = widget.allSources
         .where((s) =>
             s.isCurated &&
-            (s.premiumConnection != null || _subscribed.contains(s.id)))
+            (widget.selectedSourceIds.contains(s.id) ||
+                _subscribed.contains(s.id)))
         .toList()
       ..sort((a, b) => a.name.compareTo(b.name));
 
@@ -161,7 +170,9 @@ class _PremiumSourcesSheetState extends ConsumerState<PremiumSourcesSheet> {
                     ),
                     child: Center(
                       child: Text(
-                        'Aucun média premium connectable pour le moment.',
+                        widget.selectedSourceIds.isEmpty
+                            ? "Vous n'avez pas encore validé de source."
+                            : 'Aucune source à afficher pour le moment.',
                         textAlign: TextAlign.center,
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                               color: colors.textSecondary,
@@ -280,10 +291,21 @@ class _PremiumSourcesSheetState extends ConsumerState<PremiumSourcesSheet> {
   }
 
   Future<void> _connectSource(BuildContext context, Source source) async {
-    if (source.premiumConnection == null) return;
-    final navigator = Navigator.of(context);
     await HapticFeedback.lightImpact();
+    // Source validée sans connecteur premium : un simple toggle « abonné »
+    // suffit (persisté via updateSourceSubscription), sans ouvrir l'écran de
+    // connexion premium qui n'aurait rien à connecter.
+    if (source.premiumConnection == null) {
+      await ref
+          .read(userSourcesProvider.notifier)
+          .connectSubscription(source.id);
+      if (mounted) {
+        setState(() => _subscribed.add(source.id));
+      }
+      return;
+    }
     if (!mounted) return;
+    final navigator = Navigator.of(context);
     await navigator.push<void>(
       MaterialPageRoute(
         builder: (_) => PremiumSourceConnection(

--- a/apps/mobile/lib/features/onboarding/widgets/theme_choice_bottom_sheet.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/theme_choice_bottom_sheet.dart
@@ -20,7 +20,7 @@ Future<void> showThemeChoiceBottomSheet(
   final confirmed = await showModalBottomSheet<bool>(
     context: context,
     backgroundColor: Colors.transparent,
-    barrierColor: Colors.black.withOpacity(0.6),
+    barrierColor: context.facteurColors.scrim,
     builder: (ctx) => ClipRect(
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),

--- a/apps/mobile/test/features/onboarding/premium_sources_sheet_test.dart
+++ b/apps/mobile/test/features/onboarding/premium_sources_sheet_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/onboarding/widgets/premium_sources_sheet.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+
+Source _source(
+  String id,
+  String name, {
+  bool isCurated = true,
+  bool hasSubscription = false,
+}) {
+  return Source(
+    id: id,
+    name: name,
+    type: SourceType.article,
+    isCurated: isCurated,
+    hasSubscription: hasSubscription,
+  );
+}
+
+Widget _wrap(Widget child) {
+  return ProviderScope(
+    child: MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(body: child),
+    ),
+  );
+}
+
+void main() {
+  testWidgets(
+    'liste = sources validées (sélection) — pas le gating premiumConnection',
+    (tester) async {
+      final sources = [
+        _source('a', 'Le Monde'), // validée
+        _source('b', 'Mediapart'), // non validée
+        _source('c', 'Source non curée', isCurated: false),
+      ];
+
+      await tester.pumpWidget(_wrap(
+        PremiumSourcesSheet(
+          allSources: sources,
+          selectedSourceIds: const {'a'},
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // Seule la source validée et curée est affichée.
+      expect(find.text('Le Monde'), findsOneWidget);
+      expect(find.text('Mediapart'), findsNothing);
+      expect(find.text('Source non curée'), findsNothing);
+    },
+  );
+
+  testWidgets('pré-coche les abonnements déjà connus (hasSubscription)',
+      (tester) async {
+    final sources = [
+      _source('a', 'Le Monde', hasSubscription: true),
+    ];
+
+    await tester.pumpWidget(_wrap(
+      PremiumSourcesSheet(
+        allSources: sources,
+        // Source absente de la sélection mais déjà abonnée → affichée + cochée.
+        selectedSourceIds: const {},
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Le Monde'), findsOneWidget);
+    // Un abonnement déjà connu propose de se « Dissocier ».
+    expect(find.text('Dissocier'), findsOneWidget);
+    expect(find.text('Connecter'), findsNothing);
+  });
+
+  testWidgets('aucune source validée → message d\'état vide adapté',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      PremiumSourcesSheet(
+        allSources: [_source('a', 'Le Monde')],
+        selectedSourceIds: const {},
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text("Vous n'avez pas encore validé de source."),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Quoi

Corrige l'écran gris pendant la transition fin d'onboarding → Essentiel, plus deux ajustements liés :

- **Flow post-onboarding rejoué sur Essentiel chargé** : les modales (dialog des sujets personnalisés échoués → choix du thème → activation notifications) ne sont plus jouées sur l'écran de conclusion. Elles sont *armées* via `postOnboardingFlowPendingProvider` avant le bascule `setOnboardingCompleted()`, puis *jouées* par `FluxContinuScreen` une fois ses données chargées — l'Essentiel chargé sert de fond aux modales au lieu d'un voile gris sur un écran encore en chargement.
- **Token `FacteurColors.scrim`** (~0.35, 3 palettes) en remplacement de `Colors.black.withOpacity(0.6)` sur les barrières des modales thème & notifications (voile nettement plus doux).
- **Premium sources sheet** : la liste se base désormais sur la sélection validée (`selectedSourceIds`) au lieu du gating `premiumConnection` qui la laissait vide en onboarding ; toggle « abonné » direct (sans écran de connexion premium) quand la source n'a pas de connecteur.

## Pourquoi

À la fin de l'onboarding, les modales étaient empilées sur l'écran de conclusion alors qu'Essentiel se montait/chargeait derrière, produisant un écran gris (voile sur écran de chargement, contexte démonté). La premium sources sheet apparaissait vide car les sources fraîchement validées n'ont ni `premiumConnection` ni `hasSubscription` persisté en onboarding.

## Comment ça a été vérifié

- [x] `flutter test test/features/onboarding/premium_sources_sheet_test.dart` → **3/3 passés** (nouveau fichier de test couvrant les 3 cas : liste = sélection validée, pré-cochage des abonnements connus, état vide adapté).
- [x] `flutter analyze` sur les 9 fichiers touchés → 0 erreur (uniquement des `info`/`warning` historiques hors périmètre : `withOpacity` déprécié, `prefer_const`).
- [x] Suite mobile complète exécutée : les 44 échecs (dont 23 dans `flux_continu_provider_test.dart`) sont **pré-existants et identiques sur `origin/main`** (vérifié en worktree baseline → `+0 -23`) — échecs d'init SharedPreferences/Hive, sans rapport avec ce diff. La CI = pytest backend uniquement.
- [x] `/simplify` passé (4 agents) : un nettoyage appliqué (`ref.watch` → `ref.read` du provider de flow dans `build()`, supprime la churn de rebuild sur un hot path) ; refactors plus profonds (intégration au `FirstImpressionSlot` enum) jugés hors-scope du correctif.

## Zones à risque

- **Orchestration first-impression** : le flow post-onboarding est un mécanisme parallèle au `FirstImpressionSlot` existant ; il marque `notifModalConsumedThisSessionProvider` pour ne pas re-proposer la modal notif. À surveiller si d'autres modales first-impression s'ajoutent.
- **Ordre des modales & garde-fou** : `_postOnboardingFlowRan` + consommation immédiate du provider (`= null`) garantissent un seul jeu par montage ; le double déclencheur (`ref.listen` transition loading→data + check direct au montage) couvre les deux cas sans rejeu.
- **Persistance abonnements premium en onboarding** : `connectSubscription` est appelé directement pour les sources sans connecteur premium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
