### PR TITLE
feat(flaner): onglets épinglés fiabilisés (cap 10, fix « disparus ») + modal 2 onglets

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,30 +1,42 @@
-# Fix Flâner refresh cache
+feat(flaner): onglets épinglés fiabilisés (cap 10, fix « disparus ») + modal 2 onglets
 
-Corrige un ensemble de régressions mobiles autour de Flâner: refresh trop fréquent au retour premier plan, perte de filtres lors de rebuilds auth sans changement d'utilisateur, et collision potentielle entre caches `normal` / `serein`.
-
-## Quoi
-- extrait et teste la règle `shouldRefreshFlanerOnForeground()` avec un seuil de 30 minutes,
-- stabilise `feedProvider` pour ignorer les rebuilds liés à la seule rotation JWT et conserver les filtres pour le même utilisateur,
-- remet les filtres à zéro uniquement sur logout ou vrai changement d'utilisateur,
-- sépare le cache feed par variante `normal` / `serein` avec fallback legacy pour `normal`,
-- corrige `theme_provider_test.dart` pour l'API actuelle `AppThemeMode`.
+Itération v2 de la modal d'épinglage Flâner (suite #748) : 1 bug + 3 évolutions UX
++ réduction des boutons filtre/recherche. **Mobile/UX only — aucune modif backend.**
 
 ## Pourquoi
-- éviter des refresh Flâner inutiles en revenant rapidement dans l'app,
-- empêcher la perte de contexte filtre lors de rebuilds auth sans impact fonctionnel,
-- garantir qu'un cache `serein` ne pollue pas la vue normale, et inversement,
-- débloquer `flutter analyze` pour permettre une PR conforme.
+Quand sources **et** sujets sont épinglés ensemble, des onglets « disparaissent ».
+Cause racine (`favorite_topic_tabs.dart`) : tous les onglets étaient triés par `count`
+(non-lus) décroissant, or les sources ont `count: 0` codé en dur → toute source passait
+derrière tout sujet ayant des non-lus, atterrissait en fin de `ListView` horizontal et
+restait cachée derrière le fade `ShaderMask` (pas de cap, pas d'auto-scroll).
 
-## Comment ça a été vérifié
-- [x] Tests ciblés feed/lifecycle:
-  - `flutter test test/app_lifecycle_test.dart test/features/feed/feed_provider_auth_filter_test.dart test/features/feed/feed_cache_service_test.dart test/features/feed/feed_refresh_recovery_test.dart test/features/feed/personalization_logic_test.dart`
-- [ ] `flutter test`
-  - Bloqué par des échecs hors diff dans `test/features/custom_topics/widgets/topic_chip_test.dart` et `test/features/custom_topics/widgets/topic_explorer_screen_test.dart`
-- [ ] `flutter analyze`
-  - Le `undefined_method` de `theme_provider_test.dart` est corrigé, mais `flutter analyze` reste rouge à cause de centaines d'`info`/`warning` historiques hors périmètre
-- [x] Review finale du diff
+## Quoi
+- **Chantier 1 — Cap 10 + fix « disparus »** (`favorite_topic_tabs.dart`) :
+  `kMaxFavoriteTabs = 10`, **suppression du tri par count** (ordre = insertion puis
+  `applyOrder`, aligné sur la modal), cap appliqué après `applyOrder` avec log du surplus
+  (pas de troncature silencieuse) + log diagnostic des favoris orphelins (desync).
+- **Chantier 2 — Suppression de l'onglet « Tous »** : membre d'enum conservé en no-op.
+  Taper l'onglet actif **vide toute la sélection** (`feed_filter_bar.dart`,
+  `setTopic/Theme/Entity/Source(null)` — corrige l'oubli historique de `setSource(null)`).
+  Suppression de `onTapActiveTabRefresh` + branche `count >= 3`.
+- **Chantier 3 — `+` → engrenage si > 4 onglets** : `_AddFavoritePill` reçoit `showGear`,
+  action inchangée (ouvre la modal).
+- **Chantier 4 — Modal : 2 onglets listes suivies** (`pin_subjects_sheet.dart`) : section
+  ÉPINGLÉS (drag interleaved) **inchangée** ; les listes suivies fusionnent en une zone
+  « SUIVIS » à 2 onglets (`SegmentedButton`). Sujets en **liste à plat** triée alpha (emoji
+  par ligne). Suppression de `_groupByTheme` / `_ThemeGroupHeader` / `pinnableGroups`.
+  Placeholder muet si l'onglet actif est vide.
+- **Point 4 — Boutons filtre + recherche réduits** : `_SearchTrigger` et le bouton filtre
+  (`filter_collapsible_panel.dart`) passent de 38 à 34 px (icônes 16). L'espace horizontal
+  libéré profite à la `ListView` des onglets.
 
-## Zones à risque
-- synchronisation différée via `scheduleMicrotask` entre owner/reset et provider de sélection,
-- UX potentiellement plus stale sur retour premier plan < 30 min, choix volontaire pour réduire les refresh inutiles,
-- persistance des filtres lors des rebuilds auth intermédiaires.
+## Tests
+- `favorite_topic_tabs_test.dart` : assertions « Tous » retirées ; ajout cap-10,
+  intercalage sujets/sources, sélection vide → aucun onglet actif.
+- `pin_subjects_sheet_test.dart` : liste à plat (en-têtes thème `findsNothing`), 2 segments
+  Sources/Sujets, épinglage 1-tap après bascule.
+- **26/26 tests verts** sur les 3 fichiers ciblés ; `flutter analyze` 0 nouvelle issue.
+- Suite feed : seules régressions = 5 échecs pré-existants `DioException` dans
+  `feed_sources_test.dart` (réseau non mocké, hors scope ; CI = backend only).
+
+Story : `docs/stories/core/10.1.sujets-epingles-flaner.md` (section « Itération v2 »).

--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,84 +1,85 @@
-# QA Handoff — « Le mot du jour » : refonte UX & ajustements (Story 24.3)
+# QA Handoff — Flâner : onglets épinglés fiabilisés + modal simplifiée (v2)
 
-> Rempli par l'agent dev. Input de /validate-feature (Chrome 390×844).
+> Itération v2 de la modal d'épinglage (suite PR #748). 1 bug + 3 évolutions UX
+> + réduction des boutons filtre/recherche. Input de /validate-feature (Chrome 390×844).
 
 ## Feature développée
-Refonte UX du module « Le mot du jour » (ex-« La Grille du jour ») : renommage,
-validation par « Entrée » (fin de l'auto-validation), animation de victoire
-(confettis + rebond), option « Donner sa langue au chat », lien explicite avec
-les Actus du jour, fix couleur dark mode (tuile « présent »), carte persistante
-dans le feed, lien de partage qui ouvre l'app, et graphique de classement
-recalibré.
+Fiabilise la barre d'onglets Flâner (les sujets/sources épinglés ne « disparaissent »
+plus), supprime l'onglet « Tous », transforme le `+` en engrenage au-delà de 4 onglets,
+et remplace les 2 listes « suivies » de la modal par 2 onglets (Sources / Sujets) avec
+sujets à plat.
 
 ## PR associée
-À créer (cf. `/go`).
+<!-- À compléter après /go : gh pr view --web -->
 
 ## Écrans impactés
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| Jeu / Résultat / Déjà-joué | `/grille` | Modifié |
-| Classement | `/grille/leaderboard` | Modifié (graphique) |
-| Partage | `/grille/share` | Modifié (titre + lien) |
-| Feed / fin de tournée | `/flux-continu` | Modifié (carte CTA persistante) |
+| Flâner (feed principal) | onglet Flâner | Modifié (barre d'onglets + boutons filtre/recherche) |
+| Modal d'épinglage | `showPinSubjectsSheet` (bottom sheet) | Modifié (zone SUIVIS à 2 onglets) |
 
 ## Scénarios de test
 
-### Scénario 1 : Validation par Entrée + clavier
-1. Ouvrir `/grille`, saisir un mot complet (6 lettres).
-2. **Attendu** : PAS d'auto-validation ; la touche `↵` (à droite, `⌫` à gauche)
-   se remplit en ocre primaire et pulse ; l'essai ne part qu'au tap sur `↵`.
+### Scénario 1 : Happy path — épingler sources + sujets, tout reste visible
+**Parcours** :
+1. Ouvrir Flâner, taper l'engrenage/`+` pour ouvrir la modal.
+2. Épingler 2-3 sources (onglet **Sources**) et 2-3 sujets (onglet **Sujets**).
+3. Fermer la modal, observer la barre d'onglets.
+**Résultat attendu** : tous les onglets épinglés (sources **et** sujets) sont visibles et
+intercalés dans l'ordre, aucun ne « disparaît » derrière le fade de droite.
 
-### Scénario 2 : Victoire
-1. Trouver le mot.
-2. **Attendu** : burst de confettis + rebond de la ligne gagnante sur l'écran
-   Résultat ; bouton « Lire les actus du jour » présent ; console sans erreurs.
+### Scénario 2 : Cap à 10 onglets
+**Parcours** :
+1. Épingler plus de 10 éléments au total (sources + sujets).
+**Résultat attendu** : exactement 10 onglets dans la barre (les 10 premiers de l'ordre
+utilisateur) ; le reste reste gérable dans la modal. Pas de crash.
 
-### Scénario 3 : Dark mode (couleur « présent »)
-1. Passer l'app en thème sombre, jouer un mot avec une bonne lettre mal placée.
-2. **Attendu** : tuile/touche « présent » = **jaune/ocre** (plus rouge) ;
-   « placé » = vert.
+### Scénario 3 : Tap onglet actif = retour non filtré
+**Parcours** :
+1. Taper un onglet **sujet** → le feed se filtre, l'onglet devient actif.
+2. Re-taper l'onglet actif.
+3. Idem avec un onglet **source**.
+**Résultat attendu** : le feed redevient non filtré, aucun onglet n'est actif. La source
+se désélectionne bien (régression historique `setSource(null)` corrigée).
 
-### Scénario 4 : Donner sa langue au chat
-1. En cours de jeu, menu `⋯` (app bar) → « Donner sa langue au chat » → confirmer.
-2. **Attendu** : mot révélé, écran Résultat mode « révélé » (cachet « ? RÉVÉLÉ »,
-   copie « Tu as donné ta langue au chat. »), **bouton classement masqué**,
-   streak préservé.
+### Scénario 4 : Affordance + / engrenage
+**Parcours** :
+1. Avec ≤ 4 onglets épinglés → observer l'icône en fin de barre.
+2. Épingler jusqu'à > 4 onglets → ré-observer.
+**Résultat attendu** : `+` quand ≤ 4 ; engrenage quand > 4. Dans les deux cas, le tap
+ouvre la même modal d'épinglage.
 
-### Scénario 5 : Lien Actus + mini-CTA
-1. Sur l'écran Résultat → « Lire les actus du jour » → navigue vers `/flux-continu`.
-2. En jeu, après 2 essais non gagnants → mini-CTA « le mot est dans l'actu du
-   jour — aller lire » s'affiche.
+### Scénario 5 : Modal — 2 onglets Sources / Sujets
+**Parcours** :
+1. Ouvrir la modal avec des sources suivies non épinglées **et** des sujets suivis.
+2. Basculer entre les segments **Sources** et **Sujets**.
+3. Taper une ligne pour l'épingler ; vérifier qu'elle remonte dans « ÉPINGLÉS ».
+4. Tester la recherche (filtre l'onglet actif) et un onglet vide.
+**Résultat attendu** : 2 segments fonctionnels ; sujets en liste à plat (emoji par ligne,
+**plus d'en-têtes de thème**) ; épingler/dé-épingler + drag dans « ÉPINGLÉS » OK ;
+placeholder muet (« Aucune source suivie » / « Aucun sujet ») si l'onglet actif est vide.
 
-### Scénario 6 : Carte persistante
-1. Compléter la grille, puis fermer la tournée (ClosingCard).
-2. **Attendu** : la carte « Le mot du jour » reste dans le feed (état « déjà
-   jouée »).
-
-### Scénario 7 : Partage → ouvre l'app
-1. Écran Partage / Classement → « Défier un·e ami·e » (copie le lien).
-2. **Attendu** : lien = `io.supabase.facteur://grille` (ouvre `/grille` dans
-   l'app via deep-link, plus le site facteur.app).
-
-### Scénario 8 : Classement
-1. Terminer la partie, ouvrir le classement.
-2. **Attendu** : barres de distribution proportionnelles (la plus fréquente =
-   pleine largeur), compactes ; ligne « toi » surlignée.
+### Scénario 6 : Boutons filtre + recherche réduits
+**Résultat attendu** : la loupe (recherche) et le bouton filtre sont légèrement plus petits
+(34 px, icônes 16) ; l'espace horizontal libéré profite à la liste d'onglets. Aucun
+chevauchement, alignement vertical correct.
 
 ## Critères d'acceptation
-- [ ] « Le mot du jour » partout / « Trouve le mot du jour » sur la carte feed
-- [ ] Validation uniquement via « Entrée », touche en avant + pulse
-- [ ] Confettis + rebond à la victoire (reduce-motion safe)
-- [ ] « Langue au chat » : mot révélé, non classé, streak conservé
-- [ ] Tuile « présent » jaune/ocre en dark mode
-- [ ] Carte reste dans le feed après fermeture
-- [ ] Lien de partage ouvre la grille dans l'app
-- [ ] Barres de classement aux bons ordres de grandeur
+- [ ] N sources + M sujets (N+M ≤ 10) → tous visibles et intercalés dans l'ordre unifié.
+- [ ] > 10 épinglés → exactement 10 onglets, surplus non perdu (modal).
+- [ ] Aucun onglet « Tous ».
+- [ ] Tap onglet actif (sujet ET source) → feed non filtré, aucun onglet actif.
+- [ ] ≤ 4 onglets → `+` ; > 4 → engrenage (même action).
+- [ ] Modal : 2 segments Sources/Sujets, sujets à plat, drag « ÉPINGLÉS » non régressé.
+- [ ] Boutons filtre/recherche visiblement réduits, sans casser le layout.
 
 ## Zones de risque
-- Reduce-motion (`MediaQuery.disableAnimations`) : pas de pulse/confetti/rebond.
-- Cold-load d'une partie « révélée » : retombe sur l'écran Déjà-joué standard.
+- Cohérence **barre ↔ modal** : l'ordre des onglets doit suivre l'ordre validé par drag
+  (prefs `pinned_tabs_order_v1`). Drag dans la modal → la barre reflète le même ordre.
+- Réseau : `onTapActiveTab` enchaîne 4 `set*(null)` → potentiellement plusieurs refresh
+  (trade-off connu, follow-up hors scope).
 
 ## Dépendances
-- Backend : nouvel endpoint `POST /api/grille/today/reveal` (aucune migration).
-- Le deep-link entrant `io.supabase.facteur://grille` est géré par
-  `DeepLinkService` + redirect GoRouter.
+- `tab_counts_provider`, `userInterestsProvider`, `userSourcesStateProvider`,
+  `userSourcesProvider`, `tabOrderPrefsProvider` (SharedPreferences `pinned_tabs_order_v1`).
+- Aucune modif backend / migration.

--- a/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
+++ b/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -17,7 +18,12 @@ import '../models/content_model.dart';
 import '../providers/tab_order_prefs_provider.dart';
 import '../repositories/feed_repository.dart';
 
-enum FavoriteTabKind { tous, subjectTopic, subjectEntity, theme, source }
+enum FavoriteTabKind { subjectTopic, subjectEntity, theme, source }
+
+/// Nombre maximum d'onglets épinglés rendus dans la barre Flâner. Au-delà, on
+/// garde les [kMaxFavoriteTabs] premiers dans l'ordre validé par l'utilisateur
+/// (drag de la modal) ; le surplus reste gérable dans la modal d'épinglage.
+const int kMaxFavoriteTabs = 10;
 
 @immutable
 class FavoriteTabModel {
@@ -52,7 +58,6 @@ class FavoriteTopicTabs extends ConsumerStatefulWidget {
   final String? selectedSourceId;
   final void Function(FavoriteTabKind kind, String? slug) onTabTap;
   final VoidCallback onTapActiveTab;
-  final VoidCallback onTapActiveTabRefresh;
   final VoidCallback onAddFavorite;
 
   const FavoriteTopicTabs({
@@ -65,7 +70,6 @@ class FavoriteTopicTabs extends ConsumerStatefulWidget {
     this.selectedSourceId,
     required this.onTabTap,
     required this.onTapActiveTab,
-    required this.onTapActiveTabRefresh,
     required this.onAddFavorite,
   });
 
@@ -151,6 +155,9 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
     );
 
     _activeKey = null;
+    // > 4 onglets épinglés → l'affordance d'ajout devient un engrenage
+    // (« gérer ») plutôt qu'un « + ». Même action (ouvre la modal).
+    final showGear = tabs.length > 4;
 
     return SizedBox(
       height: 38,
@@ -173,6 +180,7 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
           itemBuilder: (ctx, i) {
             if (i == tabs.length) {
               return _AddFavoritePill(
+                showGear: showGear,
                 onTap: () {
                   HapticFeedback.mediumImpact();
                   widget.onAddFavorite();
@@ -186,12 +194,10 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
               tab: tab,
               colors: colors,
               onTap: () {
+                // Taper l'onglet actif = vider la sélection (feed non filtré) ;
+                // le refresh est assuré par le pull-to-refresh de la page.
                 if (tab.active) {
-                  if (tab.count >= 3) {
-                    widget.onTapActiveTabRefresh();
-                  } else {
-                    widget.onTapActiveTab();
-                  }
+                  widget.onTapActiveTab();
                 } else {
                   HapticFeedback.selectionClick();
                   widget.onTabTap(tab.kind, tab.slug);
@@ -258,6 +264,21 @@ List<FavoriteTabModel> _buildTabModels({
       if (f is CustomTopicFavoriteRef) f.id,
   };
 
+  // Diagnostic : un sujet favori sans `UserTopicProfile` correspondant dans
+  // `topics` ne produira aucun onglet (hypothèse : `customTopicsProvider`
+  // incomplet vs `userInterestsProvider.favorites`).
+  if (kDebugMode) {
+    final knownTopicIds = {for (final t in topics) t.id};
+    final orphanFavorites =
+        favoriteCustomIds.where((id) => !knownTopicIds.contains(id)).toList();
+    if (orphanFavorites.isNotEmpty) {
+      debugPrint(
+        '[FavoriteTabs] ${orphanFavorites.length} sujet(s) favori(s) sans '
+        'UserTopicProfile (customTopicsProvider incomplet ?) : $orphanFavorites',
+      );
+    }
+  }
+
   final entitySubjects = topics
       .where((t) => t.entityType != null && favoriteCustomIds.contains(t.id))
       .toList()
@@ -272,24 +293,11 @@ List<FavoriteTabModel> _buildTabModels({
   final cutoff = DateTime.now().subtract(const Duration(hours: 48));
   final tabs = <FavoriteTabModel>[];
 
-  // 1. Tous (always first).
-  tabs.add(FavoriteTabModel(
-    kind: FavoriteTabKind.tous,
-    slug: null,
-    label: 'Tous',
-    emoji: '',
-    count: useServer
-        ? serverCounts.total
-        : _countUnreadRecent(items,
-            cutoff: cutoff, kind: FavoriteTabKind.tous, slug: null),
-    active: selectedTopicSlug == null &&
-        selectedThemeSlug == null &&
-        selectedEntitySlug == null,
-  ));
-
-  // 2. Onglets favoris (sujets + sources épinglés). On garde la clé d'ordre
-  // unifié (`topic:<id>` / `source:<id>`) à côté de chaque modèle pour pouvoir
-  // appliquer [order] ensuite.
+  // Onglets favoris (sujets + sources épinglés). On garde la clé d'ordre unifié
+  // (`topic:<id>` / `source:<id>`) à côté de chaque modèle pour pouvoir
+  // appliquer [order] ensuite. L'ordre d'insertion (entités, sujets, sources)
+  // reflète celui de la section « ÉPINGLÉS » de la modal : barre et modal
+  // passent ensuite par le même [applyOrder] avec les mêmes prefs.
   final favoriteTabs = <({FavoriteTabModel tab, String key})>[];
 
   for (final entity in entitySubjects) {
@@ -354,18 +362,25 @@ List<FavoriteTabModel> _buildTabModels({
     ));
   }
 
-  // Ordre par défaut (avant ordre custom) : par count décroissant puis alpha —
-  // conserve le comportement historique pour les items pas encore réordonnés.
-  favoriteTabs.sort((a, b) {
-    final byCount = b.tab.count.compareTo(a.tab.count);
-    if (byCount != 0) return byCount;
-    return a.tab.label.toLowerCase().compareTo(b.tab.label.toLowerCase());
-  });
-
-  // Ordre unifié voulu par l'utilisateur (drag dans la modal d'épinglage).
+  // Ordre unifié voulu par l'utilisateur (drag dans la modal d'épinglage). Plus
+  // de tri par count : il reléguait les sources (count: 0 codé en dur) derrière
+  // tout sujet ayant des non-lus → elles finissaient en fin de liste, cachées
+  // derrière le fade (« sujets/sources disparus »). On conserve l'ordre
+  // d'insertion comme base, puis on applique l'ordre custom.
   final ordered = applyOrder(favoriteTabs, order, (e) => e.key);
 
-  tabs.addAll(ordered.map((e) => e.tab));
+  // Cap : garder les [kMaxFavoriteTabs] premiers dans l'ordre utilisateur. Pas
+  // de troncature silencieuse — on logge les clés du surplus en debug.
+  final capped = ordered.take(kMaxFavoriteTabs).toList();
+  if (kDebugMode && ordered.length > kMaxFavoriteTabs) {
+    final dropped = ordered.skip(kMaxFavoriteTabs).map((e) => e.key).toList();
+    debugPrint(
+      '[FavoriteTabs] cap $kMaxFavoriteTabs atteint — '
+      '${dropped.length} onglet(s) tronqué(s) : $dropped',
+    );
+  }
+
+  tabs.addAll(capped.map((e) => e.tab));
   return tabs;
 }
 
@@ -377,8 +392,6 @@ int _countUnreadRecent(
 }) {
   bool matches(Content c) {
     switch (kind) {
-      case FavoriteTabKind.tous:
-        return true;
       case FavoriteTabKind.subjectTopic:
         return slug != null && c.topics.contains(slug);
       case FavoriteTabKind.subjectEntity:
@@ -499,10 +512,12 @@ class _FavoriteTabItem extends StatelessWidget {
 }
 
 class _AddFavoritePill extends StatelessWidget {
+  final bool showGear;
   final VoidCallback onTap;
   final FacteurColors colors;
 
   const _AddFavoritePill({
+    required this.showGear,
     required this.onTap,
     required this.colors,
   });
@@ -517,7 +532,9 @@ class _AddFavoritePill extends StatelessWidget {
         height: 38,
         child: Center(
           child: Icon(
-            PhosphorIcons.plus(PhosphorIconsStyle.regular),
+            showGear
+                ? PhosphorIcons.gear(PhosphorIconsStyle.regular)
+                : PhosphorIcons.plus(PhosphorIconsStyle.regular),
             size: 18,
             color: colors.textSecondary,
           ),

--- a/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
@@ -69,11 +69,6 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
             setState(() => _selectedInterestNameOverride = null);
           }
           switch (kind) {
-            case FavoriteTabKind.tous:
-              await notifier.setTopic(null);
-              await notifier.setTheme(null);
-              await notifier.setEntity(null);
-              break;
             case FavoriteTabKind.subjectTopic:
               await notifier.setTopic(slug);
               break;
@@ -89,9 +84,15 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
           }
           widget.onAfterChange?.call();
         },
-        onTapActiveTab: () => widget.onAfterChange?.call(),
-        onTapActiveTabRefresh: () {
-          HapticFeedback.mediumImpact();
+        // Taper l'onglet actif vide toute la sélection (feed non filtré). On
+        // remet aussi `setSource(null)` — oublié historiquement — pour bien
+        // désélectionner un onglet source actif.
+        onTapActiveTab: () async {
+          await HapticFeedback.selectionClick();
+          await notifier.setTopic(null);
+          await notifier.setTheme(null);
+          await notifier.setEntity(null);
+          await notifier.setSource(null);
           widget.onAfterChange?.call();
         },
         // Le « + » des onglets épingle des sujets précis (custom topics) —
@@ -202,7 +203,7 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
 
 /// Minimal search trigger — magnifier icon when idle, keyword pill with clear
 /// button when a search is active. Visually aligned with `FilterCollapsiblePanel`
-/// (32 px tall, primary accent when active).
+/// (34 px tall, primary accent when active).
 class _SearchTrigger extends StatelessWidget {
   final bool active;
   final String? keyword;
@@ -225,8 +226,8 @@ class _SearchTrigger extends StatelessWidget {
         onTap: onTap,
         behavior: HitTestBehavior.opaque,
         child: Container(
-          height: 38,
-          padding: const EdgeInsets.only(left: 12, right: 4),
+          height: 34,
+          padding: const EdgeInsets.only(left: 10, right: 4),
           decoration: BoxDecoration(
             color: primary.withValues(alpha: 0.12),
             border: Border.all(color: primary),
@@ -237,7 +238,7 @@ class _SearchTrigger extends StatelessWidget {
             children: [
               Icon(
                 PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.bold),
-                size: 15,
+                size: 14,
                 color: primary,
               ),
               const SizedBox(width: 5),
@@ -260,11 +261,11 @@ class _SearchTrigger extends StatelessWidget {
                 child: Padding(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 6,
-                    vertical: 8,
+                    vertical: 7,
                   ),
                   child: Icon(
                     PhosphorIcons.x(PhosphorIconsStyle.bold),
-                    size: 13,
+                    size: 12,
                     color: primary,
                   ),
                 ),
@@ -278,11 +279,11 @@ class _SearchTrigger extends StatelessWidget {
       onTap: onTap,
       behavior: HitTestBehavior.opaque,
       child: SizedBox(
-        height: 38,
-        width: 38,
+        height: 34,
+        width: 34,
         child: Icon(
           PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
-          size: 18,
+          size: 16,
           color: colors.textSecondary,
         ),
       ),

--- a/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
+++ b/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
@@ -106,9 +106,9 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
             behavior: HitTestBehavior.opaque,
             child: AnimatedContainer(
               duration: const Duration(milliseconds: 180),
-              height: 38,
+              height: 34,
               padding: EdgeInsets.symmetric(
-                horizontal: hasActive && !_expanded ? 14 : 10,
+                horizontal: hasActive && !_expanded ? 12 : 9,
               ),
               decoration: BoxDecoration(
                 color: (_expanded || hasActive)
@@ -126,7 +126,7 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
                     _expanded
                         ? PhosphorIcons.x(PhosphorIconsStyle.bold)
                         : PhosphorIcons.funnel(PhosphorIconsStyle.regular),
-                    size: 18,
+                    size: 16,
                     color: (_expanded || hasActive)
                         ? colors.primary
                         : colors.textSecondary,

--- a/apps/mobile/lib/features/feed/widgets/pin_subjects_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/pin_subjects_sheet.dart
@@ -181,6 +181,9 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
   final _searchController = TextEditingController();
   String _query = '';
 
+  /// Onglet actif de la zone « SUIVIS » : 0 = Sources, 1 = Sujets.
+  int _followedTab = 0;
+
   @override
   void dispose() {
     _searchController.dispose();
@@ -276,34 +279,6 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
     return _normalize(text).contains(normalizedQuery);
   }
 
-  /// Groupe les sujets par thème parent, dans l'ordre canonique des thèmes
-  /// Facteur (les thèmes inconnus en dernier), sujets triés alpha dans chaque
-  /// groupe.
-  List<MapEntry<String, List<CustomTopicInterest>>> _groupByTheme(
-    List<CustomTopicInterest> subjects,
-  ) {
-    final groups = <String, List<CustomTopicInterest>>{};
-    for (final t in subjects) {
-      groups.putIfAbsent(t.slugParent, () => []).add(t);
-    }
-    for (final list in groups.values) {
-      list.sort((a, b) =>
-          a.topicName.toLowerCase().compareTo(b.topicName.toLowerCase()));
-    }
-    final order = {
-      for (var i = 0; i < kVeilleFacteurThemes.length; i++)
-        kVeilleFacteurThemes[i].slug: i,
-    };
-    final entries = groups.entries.toList()
-      ..sort((a, b) {
-        final ia = order[a.key] ?? kVeilleFacteurThemes.length;
-        final ib = order[b.key] ?? kVeilleFacteurThemes.length;
-        if (ia != ib) return ia.compareTo(ib);
-        return a.key.compareTo(b.key);
-      });
-    return entries;
-  }
-
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
@@ -363,13 +338,14 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
           s,
     ]..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
 
-    // ── Section SUJETS À ÉPINGLER (suivis non favoris, groupés) ───────
+    // ── Onglet SUJETS (suivis non épinglés, liste à plat triée alpha) ─
     final pinnableTopics = topics
         .where((t) =>
             t.state != InterestState.favorite &&
             _matchesText(t.topicName, normalizedQuery))
-        .toList();
-    final pinnableGroups = _groupByTheme(pinnableTopics);
+        .toList()
+      ..sort((a, b) =>
+          a.topicName.toLowerCase().compareTo(b.topicName.toLowerCase()));
 
     final hasAnything = topics.isNotEmpty || catalog.isNotEmpty;
     final noMatch = orderedPinned.isEmpty &&
@@ -463,52 +439,72 @@ class _PinSubjectsContentState extends ConsumerState<_PinSubjectsContent> {
                   const SizedBox(height: FacteurSpacing.space4),
                 ],
 
-                // Sources suivies non épinglées → 1 tap pour épingler.
-                if (followedSources.isNotEmpty) ...[
-                  _SectionLabel(label: 'SOURCES SUIVIES', colors: colors),
+                // Listes suivies non épinglées → 2 onglets (Sources / Sujets).
+                // La recherche filtre naturellement l'onglet actif. 1 tap sur
+                // une ligne l'épingle (bascule dans « ÉPINGLÉS »).
+                if (followedSources.isNotEmpty ||
+                    pinnableTopics.isNotEmpty) ...[
+                  _SectionLabel(label: 'SUIVIS', colors: colors),
                   const SizedBox(height: 8),
-                  for (final s in followedSources)
-                    _InterestRow(
-                      key: ValueKey('followed_${s.id}'),
-                      leading:
-                          SourceLogoAvatar(source: s, size: 28, radius: 6),
-                      label: s.name,
-                      colors: colors,
-                      onTap: () =>
-                          _setSourceState(s.id, InterestState.favorite),
-                    ),
-                  const SizedBox(height: FacteurSpacing.space4),
-                ],
-
-                // Sujets suivis non épinglés → groupés par thématique.
-                if (pinnableTopics.isNotEmpty) ...[
-                  _SectionLabel(
-                    label: 'SUJETS À ÉPINGLER',
-                    colors: colors,
-                  ),
-                  const SizedBox(height: 8),
-                  for (final group in pinnableGroups) ...[
-                    _ThemeGroupHeader(
-                      emoji: _themeEmoji(group.key),
-                      label: veilleThemeLabelForSlug(group.key),
-                      colors: colors,
-                    ),
-                    const SizedBox(height: 6),
-                    for (final t in group.value)
-                      _InterestRow(
-                        key: ValueKey('pinnable_${t.id}'),
-                        leading: Text(
-                          _themeEmoji(t.slugParent),
-                          style: const TextStyle(fontSize: 14),
+                  SizedBox(
+                    width: double.infinity,
+                    child: SegmentedButton<int>(
+                      style: SegmentedButton.styleFrom(
+                        visualDensity: VisualDensity.compact,
+                        textStyle: const TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
                         ),
-                        label: t.topicName,
-                        colors: colors,
-                        onTap: () =>
-                            _setTopicState(t.id, InterestState.favorite),
                       ),
-                    const SizedBox(height: 10),
+                      showSelectedIcon: false,
+                      segments: const [
+                        ButtonSegment(value: 0, label: Text('Sources')),
+                        ButtonSegment(value: 1, label: Text('Sujets')),
+                      ],
+                      selected: {_followedTab},
+                      onSelectionChanged: (selection) =>
+                          setState(() => _followedTab = selection.first),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  if (_followedTab == 0) ...[
+                    if (followedSources.isEmpty)
+                      _EmptyFollowedHint(
+                        label: 'Aucune source suivie',
+                        colors: colors,
+                      )
+                    else
+                      for (final s in followedSources)
+                        _InterestRow(
+                          key: ValueKey('followed_${s.id}'),
+                          leading:
+                              SourceLogoAvatar(source: s, size: 28, radius: 6),
+                          label: s.name,
+                          colors: colors,
+                          onTap: () =>
+                              _setSourceState(s.id, InterestState.favorite),
+                        ),
+                  ] else ...[
+                    if (pinnableTopics.isEmpty)
+                      _EmptyFollowedHint(
+                        label: 'Aucun sujet',
+                        colors: colors,
+                      )
+                    else
+                      for (final t in pinnableTopics)
+                        _InterestRow(
+                          key: ValueKey('pinnable_${t.id}'),
+                          leading: Text(
+                            _themeEmoji(t.slugParent),
+                            style: const TextStyle(fontSize: 14),
+                          ),
+                          label: t.topicName,
+                          colors: colors,
+                          onTap: () =>
+                              _setTopicState(t.id, InterestState.favorite),
+                        ),
                   ],
-                  const SizedBox(height: FacteurSpacing.space2),
+                  const SizedBox(height: FacteurSpacing.space4),
                 ],
 
                 // Aucun élément ne matche la recherche → proposer de créer.
@@ -728,33 +724,21 @@ class _SearchField extends StatelessWidget {
   }
 }
 
-class _ThemeGroupHeader extends StatelessWidget {
-  final String emoji;
+/// Placeholder muet quand l'onglet actif de la zone « SUIVIS » (Sources /
+/// Sujets) n'a aucun élément à proposer.
+class _EmptyFollowedHint extends StatelessWidget {
   final String label;
   final FacteurColors colors;
 
-  const _ThemeGroupHeader({
-    required this.emoji,
-    required this.label,
-    required this.colors,
-  });
+  const _EmptyFollowedHint({required this.label, required this.colors});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(left: 2, bottom: 2),
-      child: Row(
-        children: [
-          Text(emoji, style: const TextStyle(fontSize: 13)),
-          const SizedBox(width: 6),
-          Text(
-            label,
-            style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  color: colors.textSecondary,
-                  fontWeight: FontWeight.w600,
-                ),
-          ),
-        ],
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Text(
+        label,
+        style: TextStyle(color: colors.textTertiary, fontSize: 13),
       ),
     );
   }

--- a/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
+++ b/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
@@ -57,17 +57,14 @@ Content _content({
 
 void main() {
   group('buildFavoriteTabModelsForTest', () {
-    test('0 favoris → only "Tous" tab', () {
+    test('0 favoris → aucun onglet (« Tous » supprimé)', () {
       final tabs = buildFavoriteTabModelsForTest(
         topics: const [],
         favorites: const [],
         items: const [],
       );
 
-      expect(tabs, hasLength(1));
-      expect(tabs.first.kind, FavoriteTabKind.tous);
-      expect(tabs.first.label, 'Tous');
-      expect(tabs.first.active, isTrue);
+      expect(tabs, isEmpty);
     });
 
     test(
@@ -98,17 +95,16 @@ void main() {
         items: const [],
       );
 
-      // Le thème favori (environment) ne produit PLUS d'onglet : seuls
-      // « Tous » + les 2 sujets épinglés sont présents. Counts à 0 → tri
-      // alphabétique : ia santé < trump.
+      // Le thème favori (environment) ne produit PAS d'onglet, et « Tous » est
+      // supprimé : seuls les 2 sujets épinglés sont présents. Plus de tri par
+      // count → ordre d'insertion : entités d'abord, puis sujets.
       expect(tabs.map((t) => t.kind).toList(), [
-        FavoriteTabKind.tous,
-        FavoriteTabKind.subjectTopic,
         FavoriteTabKind.subjectEntity,
+        FavoriteTabKind.subjectTopic,
       ]);
       expect(tabs.any((t) => t.kind == FavoriteTabKind.theme), isFalse);
+      expect(tabs[0].label, 'Trump');
       expect(tabs[1].label, 'IA santé');
-      expect(tabs[2].label, 'Trump');
     });
 
     test('topic not in favorites → excluded', () {
@@ -127,8 +123,7 @@ void main() {
         items: const [],
       );
 
-      expect(tabs, hasLength(1));
-      expect(tabs.first.kind, FavoriteTabKind.tous);
+      expect(tabs, isEmpty);
     });
 
     test('count = unseen items < 48h matching slug', () {
@@ -160,10 +155,6 @@ void main() {
       final iaTab =
           tabs.firstWhere((t) => t.kind == FavoriteTabKind.subjectTopic);
       expect(iaTab.count, 1);
-
-      final tousTab =
-          tabs.firstWhere((t) => t.kind == FavoriteTabKind.tous);
-      expect(tousTab.count, 2);
     });
 
     test('selected slug marks the matching tab as active', () {
@@ -186,10 +177,6 @@ void main() {
         tabs.firstWhere((t) => t.slug == 'ai').active,
         isTrue,
       );
-      expect(
-        tabs.firstWhere((t) => t.kind == FavoriteTabKind.tous).active,
-        isFalse,
-      );
     });
 
     test('source favorite → produces a source tab carrying its Source', () {
@@ -204,7 +191,6 @@ void main() {
       );
 
       expect(tabs.map((t) => t.kind).toList(), [
-        FavoriteTabKind.tous,
         FavoriteTabKind.source,
       ]);
       final sourceTab =
@@ -225,8 +211,7 @@ void main() {
         sourceById: const {},
       );
 
-      expect(tabs, hasLength(1));
-      expect(tabs.first.kind, FavoriteTabKind.tous);
+      expect(tabs, isEmpty);
     });
 
     test('selectedSourceId marks the matching source tab as active', () {
@@ -251,8 +236,8 @@ void main() {
       final topics = [_topic(id: 't1', name: 'IA', slugParent: 'ai')];
       final src = _source(id: 's1', name: 'Le Monde');
 
-      // Sans ordre custom : tri par count (0) puis alpha → 'ia' < 'le monde'
-      // donc le sujet d'abord.
+      // Sans ordre custom : ordre d'insertion = sujets puis sources (plus de
+      // tri par count, qui reléguait les sources en fin de liste).
       final defaultTabs = buildFavoriteTabModelsForTest(
         topics: topics,
         favorites: const [CustomTopicFavoriteRef(id: 't1')],
@@ -261,7 +246,6 @@ void main() {
         sourceById: {'s1': src},
       );
       expect(defaultTabs.map((t) => t.kind).toList(), [
-        FavoriteTabKind.tous,
         FavoriteTabKind.subjectTopic,
         FavoriteTabKind.source,
       ]);
@@ -276,10 +260,115 @@ void main() {
         order: const ['source:s1', 'topic:t1'],
       );
       expect(orderedTabs.map((t) => t.kind).toList(), [
-        FavoriteTabKind.tous,
         FavoriteTabKind.source,
         FavoriteTabKind.subjectTopic,
       ]);
+    });
+
+    test('cappe à 10 onglets, en gardant les 10 premiers dans l\'ordre user',
+        () {
+      final topics = [
+        for (var i = 0; i < 6; i++)
+          _topic(id: 't$i', name: 'Sujet $i', slugParent: 'p$i'),
+      ];
+      final favorites = [
+        for (var i = 0; i < 6; i++) CustomTopicFavoriteRef(id: 't$i'),
+      ];
+      final sourceById = {
+        for (var i = 0; i < 6; i++) 's$i': _source(id: 's$i', name: 'Source $i'),
+      };
+      final sourceFavorites = [
+        for (var i = 0; i < 6; i++)
+          SourceFavoriteRef(sourceId: 's$i', position: i),
+      ];
+      // Ordre utilisateur : alterne sujet/source (12 clés).
+      final order = <String>[
+        for (var i = 0; i < 6; i++) ...['topic:t$i', 'source:s$i'],
+      ];
+
+      final tabs = buildFavoriteTabModelsForTest(
+        topics: topics,
+        favorites: favorites,
+        items: const [],
+        sourceFavorites: sourceFavorites,
+        sourceById: sourceById,
+        order: order,
+      );
+
+      // Exactement 10 onglets = les 10 premières clés de `order`.
+      expect(tabs, hasLength(10));
+      expect(tabs.map((t) => t.label).toList(), const [
+        'Sujet 0',
+        'Source 0',
+        'Sujet 1',
+        'Source 1',
+        'Sujet 2',
+        'Source 2',
+        'Sujet 3',
+        'Source 3',
+        'Sujet 4',
+        'Source 4',
+      ]);
+      // Le surplus (11e/12e clés) est tronqué.
+      expect(tabs.any((t) => t.label == 'Sujet 5'), isFalse);
+      expect(tabs.any((t) => t.label == 'Source 5'), isFalse);
+    });
+
+    test('3 sujets + 3 sources en ordre alterné → les 6 présents, intercalés',
+        () {
+      final topics = [
+        for (var i = 0; i < 3; i++)
+          _topic(id: 't$i', name: 'Sujet $i', slugParent: 'p$i'),
+      ];
+      final favorites = [
+        for (var i = 0; i < 3; i++) CustomTopicFavoriteRef(id: 't$i'),
+      ];
+      final sourceById = {
+        for (var i = 0; i < 3; i++) 's$i': _source(id: 's$i', name: 'Source $i'),
+      };
+      final sourceFavorites = [
+        for (var i = 0; i < 3; i++)
+          SourceFavoriteRef(sourceId: 's$i', position: i),
+      ];
+      final order = const [
+        'topic:t0',
+        'source:s0',
+        'topic:t1',
+        'source:s1',
+        'topic:t2',
+        'source:s2',
+      ];
+
+      final tabs = buildFavoriteTabModelsForTest(
+        topics: topics,
+        favorites: favorites,
+        items: const [],
+        sourceFavorites: sourceFavorites,
+        sourceById: sourceById,
+        order: order,
+      );
+
+      expect(tabs, hasLength(6));
+      expect(tabs.map((t) => t.label).toList(), const [
+        'Sujet 0',
+        'Source 0',
+        'Sujet 1',
+        'Source 1',
+        'Sujet 2',
+        'Source 2',
+      ]);
+    });
+
+    test('aucune sélection → aucun onglet actif', () {
+      final topics = [_topic(id: 't1', name: 'IA', slugParent: 'ai')];
+
+      final tabs = buildFavoriteTabModelsForTest(
+        topics: topics,
+        favorites: const [CustomTopicFavoriteRef(id: 't1')],
+        items: const [],
+      );
+
+      expect(tabs.any((t) => t.active), isFalse);
     });
   });
 
@@ -311,17 +400,20 @@ void main() {
       var tabTapCalls = 0;
 
       await tester.pumpWidget(host(
+        topics: [_topic(id: 't1', name: 'IA', slugParent: 'ai')],
+        favorites: const [CustomTopicFavoriteRef(id: 't1')],
         child: FavoriteTopicTabs(
           items: const [],
+          selectedTopicSlug: 'ai',
           onTabTap: (_, __) => tabTapCalls++,
           onTapActiveTab: () => tapActiveCalls++,
-          onTapActiveTabRefresh: () => tapActiveCalls++,
           onAddFavorite: () {},
         ),
       ));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Tous'));
+      // L'onglet « IA » est actif (selectedTopicSlug) → tap = onTapActiveTab.
+      await tester.tap(find.text('IA'));
       await tester.pump();
 
       expect(tapActiveCalls, 1);
@@ -336,7 +428,6 @@ void main() {
           items: const [],
           onTabTap: (_, __) {},
           onTapActiveTab: () {},
-          onTapActiveTabRefresh: () {},
           onAddFavorite: () => addCalls++,
         ),
       ));

--- a/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
+++ b/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
@@ -89,7 +89,13 @@ Widget _host(
       ),
     ],
     child: MaterialApp(
-      theme: ThemeData(extensions: [FacteurPalettes.light]),
+      // splashFactory NoSplash : évite le shader Material 3 `ink_sparkle.frag`,
+      // absent du bundle `flutter test` (le tap d'une ligne sujet déclenche
+      // sinon « Asset 'shaders/ink_sparkle.frag' not found »). Test-only.
+      theme: ThemeData(
+        extensions: [FacteurPalettes.light],
+        splashFactory: NoSplash.splashFactory,
+      ),
       home: Scaffold(body: child),
     ),
   );
@@ -148,8 +154,11 @@ void main() {
       await tester.tap(find.text('open'));
       await tester.pumpAndSettle();
 
-      // Le sujet suivi est proposé à l'épinglage.
-      expect(find.text('SUJETS À ÉPINGLER'), findsOneWidget);
+      // La zone « SUIVIS » expose 2 onglets. Le sujet suivi est sous « Sujets ».
+      expect(find.text('Sources'), findsOneWidget);
+      expect(find.text('Sujets'), findsOneWidget);
+      await tester.tap(find.text('Sujets'));
+      await tester.pumpAndSettle();
       expect(find.text('Climat'), findsOneWidget);
 
       await tester.tap(find.text('Climat'));
@@ -181,6 +190,10 @@ void main() {
       ));
       await tester.pumpAndSettle();
       await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      // Les sujets suivis sont sous l'onglet « Sujets ».
+      await tester.tap(find.text('Sujets'));
       await tester.pumpAndSettle();
 
       // Recherche insensible aux accents/casse.
@@ -219,7 +232,8 @@ void main() {
       expect(find.textContaining('Créer le sujet « Zélande »'), findsOneWidget);
     });
 
-    testWidgets('groups followed subjects by theme', (tester) async {
+    testWidgets('lists followed subjects flat (no theme group headers)',
+        (tester) async {
       final st = _state(topics: [
         _topic('t1', 'Climat', InterestState.followed,
             slugParent: 'environment'),
@@ -241,9 +255,47 @@ void main() {
       await tester.tap(find.text('open'));
       await tester.pumpAndSettle();
 
-      // En-têtes de groupe par thématique (labels canoniques Facteur).
-      expect(find.text('Technologie'), findsOneWidget);
-      expect(find.text('Environnement'), findsOneWidget);
+      await tester.tap(find.text('Sujets'));
+      await tester.pumpAndSettle();
+
+      // Liste à plat : les sujets sont là, mais plus d'en-têtes de thème.
+      expect(find.text('Climat'), findsOneWidget);
+      expect(find.text('IA'), findsOneWidget);
+      expect(find.text('Technologie'), findsNothing);
+      expect(find.text('Environnement'), findsNothing);
+    });
+
+    testWidgets('followed lists are split into 2 segments (Sources / Sujets)',
+        (tester) async {
+      final st = _state(topics: [
+        _topic('t1', 'Climat', InterestState.followed),
+      ]);
+
+      await tester.pumpWidget(_host(
+        st,
+        Builder(
+          builder: (ctx) => Center(
+            child: ElevatedButton(
+              onPressed: () => showPinSubjectsSheet(ctx),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      // Les 2 segments sont présents ; par défaut l'onglet Sources (vide ici).
+      expect(find.byType(SegmentedButton<int>), findsOneWidget);
+      expect(find.text('Sources'), findsOneWidget);
+      expect(find.text('Sujets'), findsOneWidget);
+      expect(find.text('Aucune source suivie'), findsOneWidget);
+      // Le sujet suivi n'est visible qu'après bascule sur « Sujets ».
+      expect(find.text('Climat'), findsNothing);
+      await tester.tap(find.text('Sujets'));
+      await tester.pumpAndSettle();
+      expect(find.text('Climat'), findsOneWidget);
     });
   });
 }

--- a/docs/stories/core/10.1.sujets-epingles-flaner.md
+++ b/docs/stories/core/10.1.sujets-epingles-flaner.md
@@ -47,3 +47,57 @@ toute sa logique (`_buildTopicSuggestions`, `_fetchTopicSuggestions`,
 - `test/features/feed/widgets/pin_subjects_sheet_test.dart` (nouveau) — banner conditionnel,
   épinglage 1-tap.
 - `flutter analyze` propre sur les fichiers modifiés.
+
+---
+
+## Itération v2 — fiabiliser la barre + simplifier la modal (suite PR #748)
+
+**Type** : Bug + UX · **Statut** : Implémenté
+
+### Problème
+Quand sources **et** sujets sont épinglés ensemble, des onglets « disparaissent ».
+Cause racine (`favorite_topic_tabs.dart`) : tous les onglets étaient triés par `count`
+(non-lus) décroissant, or les sources ont `count: 0` codé en dur → toute source passait
+derrière tout sujet ayant des non-lus, atterrissait en fin de `ListView` horizontal et
+restait cachée derrière le fade `ShaderMask` (pas de cap, pas d'auto-scroll).
+
+### Chantier 1 — Cap 10 + fix « onglets disparus »
+`favorite_topic_tabs.dart` : ajout de `const kMaxFavoriteTabs = 10`. **Suppression du tri
+par `count`** : l'ordre de base suit l'ordre d'insertion (entités, sujets, sources), aligné
+sur la section ÉPINGLÉS de la modal — barre et modal partagent ensuite le même `applyOrder`
++ les mêmes prefs `pinned_tabs_order_v1`. Cap appliqué **après** `applyOrder`
+(`ordered.take(10)`), avec `debugPrint` du surplus tronqué (pas de troncature silencieuse)
+et log diagnostic des favoris sans `UserTopicProfile` (desync `customTopicsProvider`).
+
+### Chantier 2 — Suppression de l'onglet « Tous »
+Plus de construction du tab `FavoriteTabKind.tous` (membre d'enum conservé en `break;`
+no-op pour l'exhaustivité). **Taper l'onglet actif vide toute la sélection** :
+`feed_filter_bar.dart` `onTapActiveTab` enchaîne `setTopic/Theme/Entity/Source(null)` —
+correction de l'oubli historique de `setSource(null)`. Le refresh est assuré par le
+pull-to-refresh de la page : suppression de `onTapActiveTabRefresh` et de la branche
+`count >= 3`.
+
+### Chantier 3 — `+` → engrenage quand > 4 onglets
+`_AddFavoritePill` reçoit `showGear = tabs.length > 4` → icône `PhosphorIcons.gear` au lieu
+de `plus`. Action inchangée (ouvre `showPinSubjectsSheet`).
+
+### Chantier 4 — Modal : onglets sur les listes suivies
+`pin_subjects_sheet.dart` : section ÉPINGLÉS (drag interleaved) **inchangée**. Les blocs
+« SOURCES SUIVIES » + « SUJETS À ÉPINGLER » fusionnent en une zone « SUIVIS » à 2 onglets
+via `SegmentedButton<int>` (`_followedTab` : 0 = Sources, 1 = Sujets). Sujets en **liste à
+plat** triée alpha (emoji par ligne conservé). Suppression de `_groupByTheme`,
+`_ThemeGroupHeader`, `pinnableGroups`. Placeholder muet (`_EmptyFollowedHint`) si la liste
+de l'onglet actif est vide. Recherche + « Créer un sujet » conservés.
+
+### Point 4 — Boutons filtre + recherche réduits
+`_SearchTrigger` 38→34 (icône 18→16) ; bouton filtre de `filter_collapsible_panel.dart`
+aligné (34, icône 16). L'espace horizontal libéré bénéficie à la `ListView` des onglets.
+
+### Vérification v2
+- `favorite_topic_tabs_test.dart` : assertions « Tous » retirées ; ajout cap-10, intercalage
+  sujets/sources, sélection vide → aucun onglet actif. **26 tests verts** (avec les 3 fichiers).
+- `pin_subjects_sheet_test.dart` : liste à plat (en-têtes thème `findsNothing`), 2 segments
+  Sources/Sujets, épinglage 1-tap après bascule d'onglet.
+- `flutter analyze` : 0 nouvelle issue sur les 4 fichiers modifiés.
+- Suite feed : seules régressions = 5 échecs pré-existants `DioException` dans
+  `feed_sources_test.dart` (réseau non mocké, hors scope).


### PR DESCRIPTION
feat(flaner): onglets épinglés fiabilisés (cap 10, fix « disparus ») + modal 2 onglets

Itération v2 de la modal d'épinglage Flâner (suite #748) : 1 bug + 3 évolutions UX
+ réduction des boutons filtre/recherche. **Mobile/UX only — aucune modif backend.**

## Pourquoi
Quand sources **et** sujets sont épinglés ensemble, des onglets « disparaissent ».
Cause racine (`favorite_topic_tabs.dart`) : tous les onglets étaient triés par `count`
(non-lus) décroissant, or les sources ont `count: 0` codé en dur → toute source passait
derrière tout sujet ayant des non-lus, atterrissait en fin de `ListView` horizontal et
restait cachée derrière le fade `ShaderMask` (pas de cap, pas d'auto-scroll).

## Quoi
- **Chantier 1 — Cap 10 + fix « disparus »** (`favorite_topic_tabs.dart`) :
  `kMaxFavoriteTabs = 10`, **suppression du tri par count** (ordre = insertion puis
  `applyOrder`, aligné sur la modal), cap appliqué après `applyOrder` avec log du surplus
  (pas de troncature silencieuse) + log diagnostic des favoris orphelins (desync).
- **Chantier 2 — Suppression de l'onglet « Tous »** : membre d'enum conservé en no-op.
  Taper l'onglet actif **vide toute la sélection** (`feed_filter_bar.dart`,
  `setTopic/Theme/Entity/Source(null)` — corrige l'oubli historique de `setSource(null)`).
  Suppression de `onTapActiveTabRefresh` + branche `count >= 3`.
- **Chantier 3 — `+` → engrenage si > 4 onglets** : `_AddFavoritePill` reçoit `showGear`,
  action inchangée (ouvre la modal).
- **Chantier 4 — Modal : 2 onglets listes suivies** (`pin_subjects_sheet.dart`) : section
  ÉPINGLÉS (drag interleaved) **inchangée** ; les listes suivies fusionnent en une zone
  « SUIVIS » à 2 onglets (`SegmentedButton`). Sujets en **liste à plat** triée alpha (emoji
  par ligne). Suppression de `_groupByTheme` / `_ThemeGroupHeader` / `pinnableGroups`.
  Placeholder muet si l'onglet actif est vide.
- **Point 4 — Boutons filtre + recherche réduits** : `_SearchTrigger` et le bouton filtre
  (`filter_collapsible_panel.dart`) passent de 38 à 34 px (icônes 16). L'espace horizontal
  libéré profite à la `ListView` des onglets.

## Tests
- `favorite_topic_tabs_test.dart` : assertions « Tous » retirées ; ajout cap-10,
  intercalage sujets/sources, sélection vide → aucun onglet actif.
- `pin_subjects_sheet_test.dart` : liste à plat (en-têtes thème `findsNothing`), 2 segments
  Sources/Sujets, épinglage 1-tap après bascule.
- **26/26 tests verts** sur les 3 fichiers ciblés ; `flutter analyze` 0 nouvelle issue.
- Suite feed : seules régressions = 5 échecs pré-existants `DioException` dans
  `feed_sources_test.dart` (réseau non mocké, hors scope ; CI = backend only).

Story : `docs/stories/core/10.1.sujets-epingles-flaner.md` (section « Itération v2 »).
