### PR TITLE
feat(essentiel): sticky header UX — supprime titre zone, wash accent actif, haptic section

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -47,8 +47,10 @@ const double _kStickyThreshold = 60.0;
 
 /// Vertical offset the sticky bar consumes — used as a landing buffer
 /// when scrolling a section into view so its banner doesn't disappear
-/// behind the bar.
-const double _kStickyBarHeight = 90.0;
+/// behind the bar. Trimmed from 90 → 54 after the head title (~36px) was
+/// dropped from the sticky overlay: tabs row (48) + progress track (4) + a
+/// couple px of slack.
+const double _kStickyBarHeight = 54.0;
 
 /// Minimum delta (px) before the scroll-up FAB toggles, to avoid flicker
 /// on tiny inertia bounces. Matches the legacy FeedScreen behaviour.
@@ -236,6 +238,12 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       }
     }
     if (_activeIndex.value != activeAt) {
+      // Discrete "selection" tick when the active tab flips section under the
+      // sticky bar. Gated on visibility so we don't buzz during the initial
+      // layout / top-of-page scroll, before the sticky is even revealed.
+      if (_stickyVisible.value) {
+        unawaited(HapticFeedback.selectionClick());
+      }
       _activeIndex.value = activeAt;
       _alignTabsToActive(activeAt);
     }
@@ -963,7 +971,6 @@ class _StickyHostOverlay extends ConsumerWidget {
                 progress: progress,
                 onTapTab: onTapTab,
                 tabsController: tabsController,
-                title: 'Tournée du jour',
                 showFilterBar: false,
               ),
             ),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -132,9 +132,15 @@ class SectionBanner extends StatelessWidget {
               ),
             ),
           Padding(
+            // With a blurb the content fills `minHeight` exactly, so the
+            // centered column has no slack and the accent dash sticks to the
+            // fixed top inset — making the section feel cramped vs the
+            // thematic (blurb-less) banners, whose slack lets the dash drift
+            // down. Add a few px of top inset on the blurb variant to match
+            // the thematic dash's apparent inset.
             padding: large
                 ? const EdgeInsets.fromLTRB(22, 16, 16, 16)
-                : const EdgeInsets.fromLTRB(20, 8, 14, 9),
+                : EdgeInsets.fromLTRB(20, hasBlurb ? 14 : 8, 14, hasBlurb ? 12 : 9),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -22,11 +22,12 @@ class StickyTab {
 ///
 /// Layout per V6 maquette :
 /// - parchment-tinted backdrop with a 14px blur (saturate 140%),
-/// - "sticky-head" row : zone title ("Tournée du jour" or "Explorer"),
 /// - horizontal tabs with section dot, label, a check icon when the tab is
 ///   done (replaces the legacy strike-through, per PO feedback hotfix
-///   2026-05-23 — "lu = checked, pas barré"), and an underline tinted with
-///   the active section's accent,
+///   2026-05-23 — "lu = checked, pas barré"), and a soft accent wash behind
+///   the active tab (replaces the legacy 3px underline — the wash mirrors the
+///   "Couverture médiatique" highlight and lightens the bar above the
+///   progress track),
 /// - 4-px progress track with a 4-stop gradient fill (essentiel → bonnes
 ///   → veille1 → veille2) and a soft accent glow,
 /// - when [showFilterBar] is true (Explorer mode), [FeedFilterBar] is
@@ -38,7 +39,6 @@ class StickyTabBar extends StatelessWidget {
   final double progress;
   final ValueChanged<int> onTapTab;
   final ScrollController? tabsController;
-  final String title;
   final bool showFilterBar;
 
   const StickyTabBar({
@@ -48,7 +48,6 @@ class StickyTabBar extends StatelessWidget {
     required this.progress,
     required this.onTapTab,
     this.tabsController,
-    this.title = 'Tournée du jour',
     this.showFilterBar = false,
   });
 
@@ -63,7 +62,6 @@ class StickyTabBar extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          StickyHead(title: title),
           _TabsRow(
             tabs: tabs,
             activeIndex: activeIndex,
@@ -124,35 +122,6 @@ class _FeedRefreshIndicatorStrip extends ConsumerWidget {
               color: colors.primary,
             )
           : const SizedBox.shrink(),
-    );
-  }
-}
-
-/// Top row of the sticky overlay — a Fraunces label naming the current zone.
-/// L'avatar profil vit uniquement dans le header partagé de la page ; il a été
-/// retiré d'ici pour ne plus apparaître en double.
-class StickyHead extends ConsumerWidget {
-  final String title;
-
-  const StickyHead({super.key, this.title = 'Tournée du jour'});
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = context.facteurColors;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 3),
-      child: Row(
-        children: [
-          Text(
-            title,
-            style: GoogleFonts.fraunces(
-              fontSize: 21,
-              fontWeight: FontWeight.w700,
-              color: colors.textPrimary,
-            ),
-          ),
-        ],
-      ),
     );
   }
 }
@@ -220,61 +189,56 @@ class _Tab extends StatelessWidget {
     final dotColor = isActive
         ? tab.accent
         : (isDone ? colors.textTertiary : colors.textSecondary);
+    // Active tab is signaled by a soft accent wash (style "Couverture
+    // médiatique" — cf. DiffTitle), replacing the legacy 3px underline that
+    // doubled up visually with the progress track just below. The wash tint
+    // derives from the tab's own accent so each thematic section keeps its
+    // hue; the dot + textPrimary label still carry the active state.
+    const radius = BorderRadius.all(Radius.circular(FacteurRadius.small));
     return InkWell(
       onTap: onTap,
-      borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
-      child: Stack(
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(12, 5, 12, 7),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Container(
-                  width: 9,
-                  height: 9,
-                  margin: const EdgeInsets.only(right: 8),
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: dotColor,
-                  ),
-                ),
-                Text(
-                  tab.label,
-                  style: GoogleFonts.dmSans(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                    color: labelColor,
-                  ),
-                ),
-                if (isDone) ...[
-                  const SizedBox(width: 4),
-                  Icon(
-                    Icons.check_rounded,
-                    size: 18,
-                    color: labelColor,
-                    semanticLabel: 'lu',
-                  ),
-                ],
-              ],
-            ),
-          ),
-          if (isActive)
-            Positioned(
-              left: 10,
-              right: 10,
-              bottom: 0,
-              height: 3,
-              child: Container(
+      borderRadius: radius,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: isActive
+              ? tab.accent.withValues(alpha: 0.14)
+              : Colors.transparent,
+          borderRadius: radius,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 5, 12, 7),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 9,
+                height: 9,
+                margin: const EdgeInsets.only(right: 8),
                 decoration: BoxDecoration(
-                  color: tab.accent,
-                  borderRadius: const BorderRadius.vertical(
-                    top: Radius.circular(2),
-                  ),
+                  shape: BoxShape.circle,
+                  color: dotColor,
                 ),
               ),
-            ),
-        ],
+              Text(
+                tab.label,
+                style: GoogleFonts.dmSans(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: labelColor,
+                ),
+              ),
+              if (isDone) ...[
+                const SizedBox(width: 4),
+                Icon(
+                  Icons.check_rounded,
+                  size: 18,
+                  color: labelColor,
+                  semanticLabel: 'lu',
+                ),
+              ],
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
@@ -1,10 +1,7 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/flux_continu/widgets/sticky_tab_bar.dart';
@@ -36,25 +33,12 @@ const _tabs = [
 ];
 
 void main() {
-  late Directory tempDir;
-
-  setUpAll(() async {
+  setUpAll(() {
     GoogleFonts.config.allowRuntimeFetching = false;
-    // StickyHead renders a ProfileAvatarButton, which reads providers backed
-    // by Hive (user profile cache). Initialize Hive against a temp dir so the
-    // avatar can build; Supabase stays uninitialized and is handled gracefully
-    // by the providers (auth-less → default/empty state).
-    tempDir = await Directory.systemTemp.createTemp('sticky_tab_bar_test_');
-    Hive.init(tempDir.path);
-  });
-
-  tearDownAll(() async {
-    await Hive.close();
-    await tempDir.delete(recursive: true);
   });
 
   group('StickyTabBar', () {
-    testWidgets('renders the head title + every tab label', (tester) async {
+    testWidgets('renders every tab label (no head title)', (tester) async {
       await tester.pumpWidget(_wrap(
         StickyTabBar(
           tabs: _tabs,
@@ -63,7 +47,8 @@ void main() {
           onTapTab: (_) {},
         ),
       ));
-      expect(find.text('Tournée du jour'), findsOneWidget);
+      // The sticky no longer carries a zone title — only the tab labels.
+      expect(find.text('Tournée du jour'), findsNothing);
       expect(find.text('Essentiel'), findsOneWidget);
       expect(find.text('Tech'), findsOneWidget);
       expect(find.text('Flâner'), findsOneWidget);
@@ -103,22 +88,27 @@ void main() {
       expect(lastTapped, 1);
     });
 
-    testWidgets('switches head title to "Flâner" in Explorer mode',
+    testWidgets('active tab carries an accent wash, others stay transparent',
         (tester) async {
-      // `showFilterBar: false` here — we only assert on the head title
-      // swap. The full filter-bar variant pulls in Riverpod-backed feed
-      // providers, which is covered by the integration tests instead.
       await tester.pumpWidget(_wrap(
         StickyTabBar(
           tabs: _tabs,
-          activeIndex: 2,
-          progress: 1.0,
+          activeIndex: 0,
+          progress: 0.2,
           onTapTab: (_) {},
-          title: 'Flâner',
         ),
       ));
-      // Head title becomes Flâner and the last tab keeps the same label.
-      expect(find.text('Flâner'), findsNWidgets(2));
+      // The active tab (index 0) is highlighted by a DecoratedBox tinted with
+      // its own accent — the legacy 3px underline is gone. Exactly one tab
+      // should carry that wash.
+      final expectedWash = const Color(0xFFB0470A).withValues(alpha: 0.14);
+      final washed = tester
+          .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+          .where((d) {
+        final deco = d.decoration;
+        return deco is BoxDecoration && deco.color == expectedWash;
+      });
+      expect(washed, hasLength(1));
     });
   });
 }


### PR DESCRIPTION
## What

Refonte UX du sticky header de l'écran Essentiel : suppression du titre de zone (« Tournée du jour »), remplacement du soulignement 3px par un wash d'accent translucide sur l'onglet actif (style « Couverture médiatique »), ajout d'un retour haptique `selectionClick` lors du changement de section, et ajustement du padding des bannières avec blurb pour aligner visuellement le dash d'accent.

## Why

Le titre de zone doublait l'information déjà présente dans le header de page. Le soulignement 3px se superposait visuellement à la piste de progression juste en dessous. Le wash d'accent est plus léger et cohérent avec le design system. Le haptic donne un feedback discret lors de la navigation par scroll.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)