### PR TITLE
feat(flux-continu): dédup inter-sections

### DIFF
--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -262,7 +262,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     }
 
     return FluxContinuState(
-      sections: _filterSections(ordered),
+      sections: _dedupeSectionsInOrder(_filterSections(ordered)),
       isSerene: isSerene,
       moreOpen: _moreOpen,
       folded: _folded,
@@ -373,6 +373,66 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             ),
         },
     ];
+  }
+
+  /// Dedup inter-sections ordonné : parcourt les sections dans l'ordre de
+  /// rendu et retire de chaque section les articles déjà vus plus haut. La
+  /// première section qui contient un article « gagne » — en mode normal
+  /// Essentiel est premier, donc il prive Actus du jour / thèmes de ses
+  /// doublons (Option A : pour un sujet digest, la tête déjà vue retire le
+  /// sujet entier).
+  ///
+  /// Identité par type, cohérente avec [renderedContentIds] / [_filterSections] :
+  ///   - [EssentielSection] → `article.contentId`
+  ///   - [DigestTopicSection] → `pickTopicLead(t).contentId`
+  ///   - [FeedThemeSection] → `content.id`
+  ///
+  /// Tourne à chaque [_compose] (contrairement à [_filterSections] qui ne
+  /// tourne que si des articles ont été dismissed), donc les champs de
+  /// pagination de [FeedThemeSection] sont préservés via [FeedThemeSection.copyWith]
+  /// — sinon « Voir +10 » serait réinitialisé à chaque recompose.
+  List<FluxSection> _dedupeSectionsInOrder(List<FluxSection> sections) {
+    final seen = <String>{};
+    final result = <FluxSection>[];
+    for (final s in sections) {
+      switch (s) {
+        case EssentielSection(:final articles):
+          result.add(
+            EssentielSection(
+              articles: articles
+                  .where((a) => seen.add(a.contentId))
+                  .toList(growable: false),
+              blurb: s.blurb,
+              illustrationAsset: s.illustrationAsset,
+            ),
+          );
+        case DigestTopicSection(:final topics):
+          final kept = topics
+              .where((t) => seen.add(pickTopicLead(t).contentId))
+              .toList(growable: false);
+          // Post-filtre : une section Actus du jour vidée par le dedup ne doit
+          // pas laisser un bandeau orphelin → on la retire.
+          if (kept.isEmpty) continue;
+          result.add(
+            DigestTopicSection(
+              kind: s.kind,
+              label: s.label,
+              accent: s.accent,
+              coreVisibleCount: s.coreVisibleCount,
+              blurb: s.blurb,
+              illustrationAsset: s.illustrationAsset,
+              topics: kept,
+            ),
+          );
+        case FeedThemeSection(:final items):
+          result.add(
+            s.copyWith(
+              items: items.where((c) => seen.add(c.id)).toList(growable: false),
+            ),
+          );
+      }
+    }
+    return result;
   }
 
   /// Marks a single article as read in-memory (same-session visual feedback).

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -301,39 +301,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     );
   }
 
-  /// Folds the Essentiel card then scrolls to [targetIndex]. The 50ms delay
-  /// lets the fold settle so the scroll target's measured position is the
-  /// post-fold one. Used by both "Tout l'essentiel" (scroll to Actus du
-  /// jour) and "Tous mes articles ↓".
-  Future<void> _foldEssentielAndScroll(
-    EssentielSection essentiel,
-    int targetIndex,
-  ) async {
-    ref.read(fluxContinuProvider.notifier).foldLocally(essentiel);
-    await Future<void>.delayed(const Duration(milliseconds: 50));
-    if (!mounted) return;
-    await _scrollToSection(targetIndex);
-  }
-
-  Future<void> _exploreAllEssentiel(
-    EssentielSection essentiel,
-    int essentielIndex,
-  ) async {
-    final next = essentielIndex + 1;
-    if (next >= _sectionKeys.length) return;
-    await _foldEssentielAndScroll(essentiel, next);
-  }
-
-  /// "Tous mes articles ↓" action of the Essentiel hi-fi card: folds the
-  /// card then opens Flâner.
-  Future<void> _skipEssentielToExplorer(EssentielSection essentiel) async {
-    final notifier = ref.read(fluxContinuProvider.notifier);
-    notifier.foldLocally(essentiel);
-    await Future<void>.delayed(const Duration(milliseconds: 50));
-    if (!mounted) return;
-    context.go(RoutePaths.flaner);
-  }
-
   Future<void> _scrollToTop() async {
     if (!_scroll.hasClients) return;
     unawaited(HapticFeedback.lightImpact());
@@ -909,12 +876,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
                   : section is DigestTopicSection
                       ? () => _openDigestSection(context, section)
                       : null,
-              onTapExploreAll: section is EssentielSection
-                  ? () => _exploreAllEssentiel(section, i)
-                  : null,
-              onTapSeeAllDown: section is EssentielSection
-                  ? () => _skipEssentielToExplorer(section)
-                  : null,
             ),
           ),
         ),

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -23,16 +23,12 @@ class EssentielHiFiCard extends StatelessWidget {
   final List<EssentielArticle> articles;
   final void Function(EssentielArticle article) onTapArticle;
   final VoidCallback onTapPersonalize;
-  final VoidCallback? onTapSeeAllDown;
-  final VoidCallback? onTapExploreAll;
 
   const EssentielHiFiCard({
     super.key,
     required this.articles,
     required this.onTapArticle,
     required this.onTapPersonalize,
-    this.onTapSeeAllDown,
-    this.onTapExploreAll,
   });
 
   @override
@@ -88,12 +84,6 @@ class EssentielHiFiCard extends StatelessWidget {
               const SizedBox(height: FacteurSpacing.space2),
               _MediumTile(article: a, onTap: () => onTapArticle(a)),
             ],
-            const SizedBox(height: FacteurSpacing.space4),
-            _Footer(
-              accent: accent,
-              onSeeAllDown: onTapSeeAllDown,
-              onExploreAll: onTapExploreAll,
-            ),
           ],
         ),
       ),
@@ -704,62 +694,6 @@ class _Hairline extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<FacteurColors>()!;
     return Container(height: 0.6, color: colors.border.withValues(alpha: 0.20));
-  }
-}
-
-class _Footer extends StatelessWidget {
-  final Color accent;
-  final VoidCallback? onSeeAllDown;
-  final VoidCallback? onExploreAll;
-
-  const _Footer({required this.accent, this.onSeeAllDown, this.onExploreAll});
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = Theme.of(context).extension<FacteurColors>()!;
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.end,
-      children: [
-        if (onSeeAllDown != null) ...[
-          TextButton(
-            onPressed: onSeeAllDown,
-            style: TextButton.styleFrom(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              minimumSize: const Size(0, 32),
-              foregroundColor: colors.textTertiary,
-            ),
-            child: Text(
-              'Flâner →',
-              style: FacteurTypography.labelLarge(colors.textTertiary),
-            ),
-          ),
-          const SizedBox(width: FacteurSpacing.space2),
-        ],
-        if (onExploreAll != null)
-          Material(
-            color: accent,
-            borderRadius: BorderRadius.circular(FacteurRadius.pill),
-            child: InkWell(
-              onTap: onExploreAll,
-              borderRadius: BorderRadius.circular(FacteurRadius.pill),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: FacteurSpacing.space4,
-                  vertical: 8,
-                ),
-                child: Text(
-                  'Tout l’essentiel',
-                  style: GoogleFonts.dmSans(
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
-                    color: Colors.white,
-                  ),
-                ),
-              ),
-            ),
-          ),
-      ],
-    );
   }
 }
 

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -34,17 +34,6 @@ class SectionBlock extends StatelessWidget {
   /// for [DigestTopicSection] which keeps its in-place fold/expand button.
   final VoidCallback? onSeeAll;
 
-  /// "Tout l'essentiel" action of the [EssentielSection] hi-fi card. Wired
-  /// by the flux_continu screen to fold the Essentiel card AND scroll to the
-  /// next section ("Actus du jour"). Ignored for other section types.
-  final VoidCallback? onTapExploreAll;
-
-  /// "Tous mes articles ↓" action of the [EssentielSection] hi-fi card.
-  /// Wired by the flux_continu screen to fold the Essentiel card AND scroll
-  /// all the way down to the "Explorer" banner. Ignored for other section
-  /// types.
-  final VoidCallback? onTapSeeAllDown;
-
   /// IDs of articles currently in the inline-feedback pending state. When
   /// non-empty, the matching cards are swapped for a [FeedbackInline] at the
   /// same position.
@@ -87,8 +76,6 @@ class SectionBlock extends StatelessWidget {
     this.onTapFavorite,
     this.onTapSettings,
     this.onSeeAll,
-    this.onTapExploreAll,
-    this.onTapSeeAllDown,
   });
 
   @override
@@ -122,8 +109,6 @@ class SectionBlock extends StatelessWidget {
               articles: section.articles,
               onTapArticle: (a) => onTapArticle(a, section),
               onTapPersonalize: () => EssentielPersonalizeSheet.show(context),
-              onTapSeeAllDown: onTapSeeAllDown,
-              onTapExploreAll: onTapExploreAll,
             ),
             const SizedBox(height: 16),
           ],

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:facteur/features/digest/models/digest_models.dart';
 import 'package:facteur/features/digest/models/dual_digest_response.dart';
 import 'package:facteur/features/digest/providers/digest_provider.dart';
+import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
 import 'package:facteur/features/digest/repositories/digest_repository.dart';
 import 'package:facteur/features/feed/models/content_model.dart';
 import 'package:facteur/features/feed/providers/feed_provider.dart';
@@ -883,6 +884,7 @@ void main() {
           userInterestsProvider.overrideWith(
             () => _StubUserInterestsNotifier(_interestsState()),
           ),
+          sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref)),
         ],
       );
       addTearDown(container.dispose);
@@ -908,6 +910,123 @@ void main() {
         state.sections.indexOf(essentielV3.single),
         lessThan(state.sections.indexOf(actusDuJour.single)),
         reason: 'Hi-fi card renders above the legacy "Actus du jour"',
+      );
+    });
+  });
+
+  group('FluxContinuNotifier — dedup inter-sections', () {
+    /// Builds a container whose Essentiel hi-fi card surfaces a single article
+    /// with [hiFiContentId], coexisting with the digest [topics] that feed the
+    /// legacy "Actus du jour" section.
+    ProviderContainer makeDedupContainer({
+      required String hiFiContentId,
+      required List<DigestTopic> topics,
+    }) {
+      final hiFi = EssentielArticle(
+        contentId: hiFiContentId,
+        title: 'Hi-fi $hiFiContentId',
+        url: 'https://x.test/$hiFiContentId',
+        publishedAt: DateTime(2026, 1, 1),
+        sourceName: 'Source',
+        sourceLetter: 'S',
+        sectionLabel: 'Tech',
+        rank: 1,
+      );
+      final digest = DigestResponse(
+        digestId: 'd1',
+        userId: 'u1',
+        targetDate: DateTime(2026, 5, 23),
+        generatedAt: DateTime(2026, 5, 23),
+        topics: topics,
+      );
+      when(() => digestRepo.fetchBothDigests()).thenAnswer(
+        (_) async => DualDigestResponse(normal: digest, sereinEnabled: false),
+      );
+      return ProviderContainer(
+        overrides: [
+          digestRepositoryProvider.overrideWithValue(digestRepo),
+          feedRepositoryProvider.overrideWithValue(feedRepo),
+          fluxContinuRepositoryProvider.overrideWithValue(fluxRepo),
+          essentielRepositoryProvider
+              .overrideWithValue(_OneArticleEssentielRepository(hiFi)),
+          userInterestsProvider.overrideWith(
+            () => _StubUserInterestsNotifier(_interestsState()),
+          ),
+          // The real serein toggle watches authStateProvider → Supabase.instance
+          // (uninitialized in unit tests). Override with a notifier that skips
+          // the auth watch so the provider build doesn't blow up.
+          sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref)),
+        ],
+      );
+    }
+
+    test(
+        'a topic whose lead is already in Essentiel is dropped from Actus '
+        'du jour (Option A), the rest survives', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      // Topic A's lead shares the hi-fi card's contentId → it must be dropped.
+      // Topic B is untouched → "Actus du jour" survives with one topic.
+      final container = makeDedupContainer(
+        hiFiContentId: 'shared-1',
+        topics: const [
+          DigestTopic(
+            topicId: 't1',
+            label: 'Topic A',
+            articles: [DigestItem(contentId: 'shared-1', title: 'A')],
+          ),
+          DigestTopic(
+            topicId: 't2',
+            label: 'Topic B',
+            articles: [DigestItem(contentId: 'b1', title: 'B')],
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final state = await container.read(fluxContinuProvider.future);
+
+      // Essentiel keeps the shared article.
+      final essentiel = state.sections.whereType<EssentielSection>().single;
+      expect(essentiel.articles.map((a) => a.contentId), contains('shared-1'));
+
+      // Actus du jour survives but no longer carries the duplicated topic.
+      final actus = state.sections
+          .whereType<DigestTopicSection>()
+          .where((s) => s.kind == SectionKind.essentiel)
+          .single;
+      final actusLeadIds =
+          actus.topics.map((t) => pickTopicLead(t).contentId).toList();
+      expect(actusLeadIds, isNot(contains('shared-1')));
+      expect(actusLeadIds, contains('b1'));
+    });
+
+    test('Actus du jour disappears entirely when fully deduped', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      // The only topic's lead is the hi-fi article → Actus becomes empty and
+      // must be removed (no orphan banner).
+      final container = makeDedupContainer(
+        hiFiContentId: 'shared-1',
+        topics: const [
+          DigestTopic(
+            topicId: 't1',
+            label: 'Topic A',
+            articles: [DigestItem(contentId: 'shared-1', title: 'A')],
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final state = await container.read(fluxContinuProvider.future);
+
+      expect(state.sections.whereType<EssentielSection>(), hasLength(1));
+      expect(
+        state.sections
+            .whereType<DigestTopicSection>()
+            .where((s) => s.kind == SectionKind.essentiel),
+        isEmpty,
+        reason: 'A fully-deduped "Actus du jour" must be dropped, not orphaned',
       );
     });
   });

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -136,57 +136,19 @@ void main() {
       }
     });
 
-    testWidgets('"Tout l\'essentiel" button fires onTapExploreAll when wired',
-        (tester) async {
-      var exploreTaps = 0;
-      await tester.pumpWidget(_wrap(
-        EssentielHiFiCard(
-          articles: [_article(rank: 1)],
-          onTapArticle: (_) {},
-          onTapPersonalize: () {},
-          onTapSeeAllDown: () {},
-          onTapExploreAll: () => exploreTaps++,
-        ),
-      ));
-
-      expect(find.text('Tout l’essentiel'), findsOneWidget);
-      await tester.tap(find.text('Tout l’essentiel'));
-      await tester.pumpAndSettle();
-      expect(exploreTaps, 1);
-    });
-
     testWidgets(
-        '"Tout l\'essentiel" button is omitted when onTapExploreAll is null',
+        'no footer CTAs: the card is a standalone section, not a teaser',
         (tester) async {
       await tester.pumpWidget(_wrap(
         EssentielHiFiCard(
-          articles: [_article(rank: 1)],
+          articles: List.generate(5, (i) => _article(rank: i + 1)),
           onTapArticle: (_) {},
           onTapPersonalize: () {},
-          onTapSeeAllDown: () {},
         ),
       ));
 
       expect(find.text('Tout l’essentiel'), findsNothing);
-    });
-
-    testWidgets('"Flâner →" button fires onTapSeeAllDown when wired',
-        (tester) async {
-      var seeAllDownTaps = 0;
-      await tester.pumpWidget(_wrap(
-        EssentielHiFiCard(
-          articles: [_article(rank: 1)],
-          onTapArticle: (_) {},
-          onTapPersonalize: () {},
-          onTapSeeAllDown: () => seeAllDownTaps++,
-          onTapExploreAll: () {},
-        ),
-      ));
-
-      expect(find.text('Flâner →'), findsOneWidget);
-      await tester.tap(find.text('Flâner →'));
-      await tester.pumpAndSettle();
-      expect(seeAllDownTaps, 1);
+      expect(find.text('Flâner →'), findsNothing);
     });
 
     testWidgets('"Ton Essentiel" header is rendered', (tester) async {


### PR DESCRIPTION
## What

Adds a cross-section deduplication pass in `FluxContinuNotifier`: articles already shown in `EssentielSection` are stripped from downstream `DigestTopicSection` and `FeedThemeSection` to prevent duplicate content. Removes the now-redundant "Tout l'essentiel" / "Flaner →" footer CTAs from `EssentielHiFiCard`.

## Why

Users were seeing the same articles appear in both the Essentiel section and subsequent digest/theme sections. The previous workaround (CTA buttons to navigate elsewhere) was UX friction; deduplication at the data layer is cleaner.

## Type

- [x] Feature

## Checklist

- [x] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)