### PR TITLE
feat(essentiel): UX — fold gated lecture, grille post-Actus, sticky marker, flamme & météo

### DIFF
--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -281,6 +281,30 @@ DigestItem pickTopicLead(DigestTopic topic) {
   return topic.articles.first;
 }
 
+/// Vrai si toutes les cartes visibles en preview (les `coreVisibleCount`
+/// premières, avant « Plus de… ») de la section sont marquées lues. Gate du
+/// fold scroll-past : une section ne se replie automatiquement que lorsque
+/// l'utilisateur a réellement consommé ses cartes visibles.
+///
+/// Une preview vide ⇒ `false` (évite un fold vacuously-true sur une section
+/// sans contenu visible). Le repli manuel (caret/CTA) reste non gaté ailleurs.
+bool allPreviewArticlesRead(FluxSection section) {
+  final core = section.coreVisibleCount;
+  // Une preview non vide dont chaque carte visible passe le prédicat de lecture.
+  bool allRead<T>(Iterable<T> items, bool Function(T) isRead) {
+    final preview = items.take(core);
+    return preview.isNotEmpty && preview.every(isRead);
+  }
+
+  return switch (section) {
+    EssentielSection(:final articles) => allRead(articles, (a) => a.isRead),
+    DigestTopicSection(:final topics) => allRead(
+        topics, (t) => t.articles.isNotEmpty && pickTopicLead(t).isRead),
+    FeedThemeSection(:final items) =>
+      allRead(items, (c) => c.status == ContentStatus.consumed),
+  };
+}
+
 /// Snapshot of the Flux Continu screen state.
 ///
 /// `sections` is the **ordered** list to render (already accounting for the

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -64,6 +64,16 @@ const double _kFabHideAboveScroll = 380.0;
 /// pull-to-refresh hint pill — avoids nudging after a tiny inertia scroll.
 const double _kPullHintMinDepthPx = 800.0;
 
+/// Sliver « Grille du jour » (carte d'entrée de La Grille). Padding maquette
+/// partagé par ses deux sites de rendu : juste après « Actus du jour » (cas
+/// nominal) et le fallback bas quand le digest est absent.
+const _grilleSliver = SliverToBoxAdapter(
+  child: Padding(
+    padding: EdgeInsets.fromLTRB(16, 22, 16, 0),
+    child: GrilleCtaCard(),
+  ),
+);
+
 class FluxContinuScreen extends ConsumerStatefulWidget {
   const FluxContinuScreen({super.key});
 
@@ -197,6 +207,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     for (var i = 0; i < count; i++) {
       final section = value.sections[i];
       if (value.isFolded(section)) continue;
+      // Gate lecture : ne queue le repli scroll-past que si toutes les cartes
+      // visibles en preview de la section sont lues (décision PO).
+      if (!allPreviewArticlesRead(section)) continue;
       final key = _sectionKeys[i];
       final ctx = key.currentContext;
       if (ctx == null) continue;
@@ -478,12 +491,15 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     final fromKey = fromSection == null ? null : sectionKey(fromSection);
     if (fromKey == null) {
       for (final s in value.sections) {
+        // Gate lecture : même contrat que _maybeFoldSections (décision PO).
+        if (!allPreviewArticlesRead(s)) continue;
         unawaited(notifier.markScrolledPastForNextSession(s));
       }
       return;
     }
     for (final s in value.sections) {
       if (sectionKey(s) == fromKey) break;
+      if (!allPreviewArticlesRead(s)) continue;
       unawaited(notifier.markScrolledPastForNextSession(s));
     }
   }
@@ -747,6 +763,13 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     // Store) → on y montre une phrase de clôture au lieu du bouton.
     final isAndroid = defaultTargetPlatform == TargetPlatform.android;
 
+    // « Actus du jour » = DigestTopicSection kind essentiel (identité robuste,
+    // cf. _buildSectionSlivers). Quand elle existe, la Grille est rendue juste
+    // après elle ; sinon on garde la Grille en fallback bas (digest absent).
+    final hasActus = state.sections.any(
+      (s) => s is DigestTopicSection && s.kind == SectionKind.essentiel,
+    );
+
     if (_sectionKeys.length != state.sections.length) {
       _sectionKeys
         ..clear()
@@ -798,11 +821,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             SliverToBoxAdapter(
               child: _EmptySectionsHint(onRetry: notifier.refresh),
             ),
-          // Citation du jour — clôture éditoriale juste avant la Grille.
-          // Affichée dès qu'une citation existe et que la tournée n'est pas
-          // clôturée (`closingDismissed`), exactement comme la Grille en
-          // dessous : replier la tournée ne doit pas la masquer, c'est un
-          // rituel de fin de tournée.
+          // Citation du jour — clôture éditoriale en fin de tournée. Affichée
+          // dès qu'une citation existe et que la tournée n'est pas clôturée
+          // (`closingDismissed`) : replier la tournée ne doit pas la masquer,
+          // c'est un rituel de fin de tournée.
           if (state.quote != null && !state.closingDismissed)
             SliverToBoxAdapter(child: CitationDuJourCard(quote: state.quote!)),
           // « Le mot du jour » — récompense de fin de Tournée. Sliver additif
@@ -812,12 +834,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
           // Hors gate `closingDismissed` : elle reste dans le feed même après
           // fermeture de la tournée (en état « déjà jouée »), et se masque
           // seule (SizedBox.shrink) s'il n'y a pas de mot du jour.
-          const SliverToBoxAdapter(
-            child: Padding(
-              padding: EdgeInsets.fromLTRB(16, 22, 16, 0),
-              child: GrilleCtaCard(),
-            ),
-          ),
+          // Grille — rendue juste après « Actus du jour » (cf.
+          // _buildSectionSlivers) quand cette section existe. Fallback bas
+          // ici uniquement si le digest est absent / la liste vide, pour ne
+          // jamais perdre la Grille. Hors gate `closingDismissed`.
+          if (!hasActus) _grilleSliver,
           // Carte « Fin de tournée » — toujours affichée (jamais masquée) : elle
           // reste le repère de clôture même après être passé sur Flâner.
           // « Continuer » navigue vers Flâner sans masquer la carte. « Refermer »
@@ -919,6 +940,15 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
           ),
         ),
       );
+      // Grille rendue immédiatement après « Actus du jour » (identité robuste :
+      // DigestTopicSection kind essentiel). Sliver séparé, hors du KeyedSubtree
+      // — pas de GlobalKey, n'altère pas l'indexation _sectionKeys. Le check
+      // porte sur l'identité de la section (pas son état fold) → la Grille suit
+      // même la carte repliée.
+      if (section is DigestTopicSection &&
+          section.kind == SectionKind.essentiel) {
+        slivers.add(_grilleSliver);
+      }
     }
     return slivers;
   }

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -22,12 +22,11 @@ class StickyTab {
 ///
 /// Layout per V6 maquette :
 /// - parchment-tinted backdrop with a 14px blur (saturate 140%),
-/// - horizontal tabs with section dot, label, a check icon when the tab is
-///   done (replaces the legacy strike-through, per PO feedback hotfix
-///   2026-05-23 — "lu = checked, pas barré"), and a soft accent wash behind
-///   the active tab (replaces the legacy 3px underline — the wash mirrors the
-///   "Couverture médiatique" highlight and lightens the bar above the
-///   progress track),
+/// - horizontal tabs with a label, a check icon when the tab is done
+///   (replaces the legacy strike-through, per PO feedback hotfix 2026-05-23 —
+///   "lu = checked, pas barré"), and a marker-style highlight on the active
+///   tab's label text (calque du highlight "Couverture médiatique" — cf.
+///   DiffTitle ; remplace l'ancien wash pleine-chip + le point),
 /// - 4-px progress track with a 4-stop gradient fill (essentiel → bonnes
 ///   → veille1 → veille2) and a soft accent glow,
 /// - when [showFilterBar] is true (Explorer mode), [FeedFilterBar] is
@@ -186,58 +185,48 @@ class _Tab extends StatelessWidget {
     } else {
       labelColor = colors.textSecondary;
     }
-    final dotColor = isActive
-        ? tab.accent
-        : (isDone ? colors.textTertiary : colors.textSecondary);
-    // Active tab is signaled by a soft accent wash (style "Couverture
-    // médiatique" — cf. DiffTitle), replacing the legacy 3px underline that
-    // doubled up visually with the progress track just below. The wash tint
-    // derives from the tab's own accent so each thematic section keeps its
-    // hue; the dot + textPrimary label still carry the active state.
+    // Active tab is signaled by a marker-style highlight on the **label text
+    // only** (calque du highlight "Couverture médiatique" — cf. DiffTitle),
+    // replacing the legacy full-chip wash + leading dot. The marker tint
+    // derives from the tab's own accent so each thematic section keeps its hue.
     const radius = BorderRadius.all(Radius.circular(FacteurRadius.small));
+    final label = Text(
+      tab.label,
+      style: GoogleFonts.dmSans(
+        fontSize: 16,
+        fontWeight: FontWeight.w600,
+        color: labelColor,
+      ),
+    );
     return InkWell(
       onTap: onTap,
       borderRadius: radius,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: isActive
-              ? tab.accent.withValues(alpha: 0.14)
-              : Colors.transparent,
-          borderRadius: radius,
-        ),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(12, 5, 12, 7),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 5, 12, 7),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isActive)
               Container(
-                width: 9,
-                height: 9,
-                margin: const EdgeInsets.only(right: 8),
+                padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
                 decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: dotColor,
+                  color: tab.accent.withValues(alpha: 0.22),
+                  borderRadius: BorderRadius.circular(4),
                 ),
+                child: label,
+              )
+            else
+              label,
+            if (isDone) ...[
+              const SizedBox(width: 4),
+              Icon(
+                Icons.check_rounded,
+                size: 18,
+                color: labelColor,
+                semanticLabel: 'lu',
               ),
-              Text(
-                tab.label,
-                style: GoogleFonts.dmSans(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: labelColor,
-                ),
-              ),
-              if (isDone) ...[
-                const SizedBox(width: 4),
-                Icon(
-                  Icons.check_rounded,
-                  size: 18,
-                  color: labelColor,
-                  semanticLabel: 'lu',
-                ),
-              ],
             ],
-          ),
+          ],
         ),
       ),
     );

--- a/apps/mobile/lib/features/flux_continu/widgets/weather_detail_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/weather_detail_sheet.dart
@@ -349,11 +349,30 @@ class _DayRow extends StatelessWidget {
           const SizedBox(width: FacteurSpacing.space2),
           SvgPicture.asset(
             'assets/images/weather/${day.condition.assetName}.svg',
-            width: 40,
-            height: 40,
+            width: 52,
+            height: 52,
           ),
           const Spacer(),
-          _TempRange(minC: day.minC, maxC: day.maxC, fontSize: 16),
+          // Max en gros (WeatherDay n'expose pas de temp « actuelle »), avec la
+          // plage min/max conservée dessous (décision PO : « quitte à dupliquer
+          // le max »). Calque du « 40° » de la carte du jour, en plus petit.
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                '${day.maxC}°',
+                style: GoogleFonts.fraunces(
+                  fontSize: 26,
+                  fontWeight: FontWeight.w700,
+                  height: 1.0,
+                  color: colors.textPrimary,
+                ),
+              ),
+              const SizedBox(height: 2),
+              _TempRange(minC: day.minC, maxC: day.maxC, fontSize: 14),
+            ],
+          ),
         ],
       ),
     );

--- a/apps/mobile/lib/features/gamification/widgets/streak_indicator.dart
+++ b/apps/mobile/lib/features/gamification/widgets/streak_indicator.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
 import '../providers/gamification_preference_provider.dart';
@@ -76,9 +75,6 @@ class _StreakIndicatorState extends ConsumerState<StreakIndicator>
         return streakAsync.when(
           data: (streak) {
             final isActive = streak.currentStreak > 0;
-            final flameColor = colors.primary.withValues(
-              alpha: isActive ? 0.78 : 0.38,
-            );
             final textColor = isActive
                 ? colors.textPrimary
                 : colors.textSecondary.withValues(alpha: 0.55);
@@ -112,8 +108,8 @@ class _StreakIndicatorState extends ConsumerState<StreakIndicator>
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         SizedBox(
-                          width: 16,
-                          height: 16,
+                          width: 22,
+                          height: 22,
                           child: AnimatedBuilder(
                             animation: _controller,
                             builder: (context, child) {
@@ -133,8 +129,8 @@ class _StreakIndicatorState extends ConsumerState<StreakIndicator>
                                   scale: _scale.value,
                                   child: SvgPicture.asset(
                                     'assets/icons/streak_flame.svg',
-                                    width: 16,
-                                    height: 16,
+                                    width: 22,
+                                    height: 22,
                                     colorFilter: isActive
                                         ? null
                                         : ColorFilter.mode(
@@ -168,8 +164,8 @@ class _StreakIndicatorState extends ConsumerState<StreakIndicator>
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
             child: SvgPicture.asset(
               'assets/icons/streak_flame.svg',
-              width: 16,
-              height: 16,
+              width: 22,
+              height: 22,
               colorFilter: ColorFilter.mode(
                 colors.primary.withValues(alpha: 0.3),
                 BlendMode.srcIn,

--- a/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
+++ b/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
@@ -301,4 +301,215 @@ void main() {
       expect(nextSectionAfter([a], 'theme:nope'), isNull);
     });
   });
+
+  group('allPreviewArticlesRead', () {
+    EssentielArticle essentielArticle(String id, {bool read = false}) =>
+        EssentielArticle(
+          contentId: id,
+          title: 't$id',
+          url: 'https://x.test/$id',
+          publishedAt: DateTime(2026, 1, 1),
+          sourceName: 'S',
+          sourceLetter: 'S',
+          sectionLabel: 'Essentiel',
+          rank: 1,
+          isRead: read,
+        );
+
+    DigestItem digestItem(
+      String id, {
+      bool read = false,
+      bool followed = false,
+    }) =>
+        DigestItem(
+          contentId: id,
+          title: 't$id',
+          isRead: read,
+          isFollowedSource: followed,
+        );
+
+    DigestTopicSection digestWith(
+      List<DigestTopic> topics, {
+      int core = 3,
+    }) =>
+        DigestTopicSection(
+          kind: SectionKind.essentiel,
+          label: 'Actus du jour',
+          accent: const Color(0xFFB0470A),
+          coreVisibleCount: core,
+          topics: topics,
+        );
+
+    Content contentItem(String id, {bool consumed = false}) => Content(
+          id: id,
+          title: 't$id',
+          url: 'https://x.test/$id',
+          contentType: ContentType.article,
+          publishedAt: DateTime(2026, 1, 1),
+          source: Source(id: 's', name: 'S', type: SourceType.article),
+          status: consumed ? ContentStatus.consumed : ContentStatus.unseen,
+        );
+
+    FeedThemeSection feedWith(List<Content> items, {int core = 2}) =>
+        FeedThemeSection(
+          kind: SectionKind.theme,
+          label: 'tech',
+          accent: const Color(0xFF2C3E50),
+          coreVisibleCount: core,
+          themeSlug: 'tech',
+          items: items,
+        );
+
+    // --- EssentielSection (coreVisibleCount fixed at 5) ---------------------
+    test('EssentielSection: all 5 preview read → true', () {
+      final section = EssentielSection(
+        articles: List.generate(5, (i) => essentielArticle('c$i', read: true)),
+      );
+      expect(allPreviewArticlesRead(section), isTrue);
+    });
+
+    test('EssentielSection: 4/5 read → false', () {
+      final section = EssentielSection(
+        articles: [
+          for (var i = 0; i < 4; i++) essentielArticle('c$i', read: true),
+          essentielArticle('c4', read: false),
+        ],
+      );
+      expect(allPreviewArticlesRead(section), isFalse);
+    });
+
+    test('EssentielSection: empty → false (no vacuous fold)', () {
+      const section = EssentielSection(articles: []);
+      expect(allPreviewArticlesRead(section), isFalse);
+    });
+
+    // --- DigestTopicSection -------------------------------------------------
+    test('DigestTopicSection: all leads read → true', () {
+      final section = digestWith([
+        for (var i = 0; i < 3; i++)
+          DigestTopic(
+            topicId: 't$i',
+            label: 't$i',
+            articles: [digestItem('c$i', read: true)],
+          ),
+      ]);
+      expect(allPreviewArticlesRead(section), isTrue);
+    });
+
+    test('DigestTopicSection: one lead unread → false', () {
+      final section = digestWith([
+        DigestTopic(
+            topicId: 't0', label: 't0', articles: [digestItem('c0', read: true)]),
+        DigestTopic(
+            topicId: 't1',
+            label: 't1',
+            articles: [digestItem('c1', read: false)]),
+        DigestTopic(
+            topicId: 't2', label: 't2', articles: [digestItem('c2', read: true)]),
+      ]);
+      expect(allPreviewArticlesRead(section), isFalse);
+    });
+
+    test('DigestTopicSection: empty topic in preview → false without throwing',
+        () {
+      final section = digestWith([
+        DigestTopic(
+            topicId: 't0', label: 't0', articles: [digestItem('c0', read: true)]),
+        // Empty topic — pickTopicLead would throw if reached; the
+        // `topic.articles.isNotEmpty` guard must short-circuit to false.
+        const DigestTopic(topicId: 't1', label: 't1', articles: []),
+      ]);
+      expect(allPreviewArticlesRead(section), isFalse);
+    });
+
+    test('DigestTopicSection: fewer topics than core, all read → true', () {
+      final section = digestWith(
+        [
+          DigestTopic(
+              topicId: 't0',
+              label: 't0',
+              articles: [digestItem('c0', read: true)]),
+          DigestTopic(
+              topicId: 't1',
+              label: 't1',
+              articles: [digestItem('c1', read: true)]),
+        ],
+        core: 5,
+      );
+      expect(allPreviewArticlesRead(section), isTrue);
+    });
+
+    test('DigestTopicSection: gate reads pickTopicLead (followed), not first',
+        () {
+      // The followed-source article is the lead even though it isn't first.
+      // First is unread, lead is read → gate must follow the lead → true.
+      final section = digestWith(
+        [
+          DigestTopic(
+            topicId: 't0',
+            label: 't0',
+            articles: [
+              digestItem('first', read: false),
+              digestItem('lead', read: true, followed: true),
+            ],
+          ),
+        ],
+        core: 1,
+      );
+      expect(allPreviewArticlesRead(section), isTrue);
+    });
+
+    test('DigestTopicSection: followed lead unread → false even if first read',
+        () {
+      final section = digestWith(
+        [
+          DigestTopic(
+            topicId: 't0',
+            label: 't0',
+            articles: [
+              digestItem('first', read: true),
+              digestItem('lead', read: false, followed: true),
+            ],
+          ),
+        ],
+        core: 1,
+      );
+      expect(allPreviewArticlesRead(section), isFalse);
+    });
+
+    // --- FeedThemeSection ---------------------------------------------------
+    test('FeedThemeSection: all preview consumed → true', () {
+      final section = feedWith([
+        contentItem('c0', consumed: true),
+        contentItem('c1', consumed: true),
+      ]);
+      expect(allPreviewArticlesRead(section), isTrue);
+    });
+
+    test('FeedThemeSection: one not consumed → false', () {
+      final section = feedWith([
+        contentItem('c0', consumed: true),
+        contentItem('c1', consumed: false),
+      ]);
+      expect(allPreviewArticlesRead(section), isFalse);
+    });
+
+    test('FeedThemeSection: empty → false', () {
+      final section = feedWith(const <Content>[]);
+      expect(allPreviewArticlesRead(section), isFalse);
+    });
+
+    test('FeedThemeSection: only the preview cards gate (overflow ignored)', () {
+      // core=2: the third (unconsumed) item sits behind "Plus de…" → ignored.
+      final section = feedWith(
+        [
+          contentItem('c0', consumed: true),
+          contentItem('c1', consumed: true),
+          contentItem('c2', consumed: false),
+        ],
+        core: 2,
+      );
+      expect(allPreviewArticlesRead(section), isTrue);
+    });
+  });
 }

--- a/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
@@ -88,7 +88,7 @@ void main() {
       expect(lastTapped, 1);
     });
 
-    testWidgets('active tab carries an accent wash, others stay transparent',
+    testWidgets('active tab highlights its label text with an accent marker',
         (tester) async {
       await tester.pumpWidget(_wrap(
         StickyTabBar(
@@ -98,17 +98,37 @@ void main() {
           onTapTab: (_) {},
         ),
       ));
-      // The active tab (index 0) is highlighted by a DecoratedBox tinted with
-      // its own accent — the legacy 3px underline is gone. Exactly one tab
-      // should carry that wash.
-      final expectedWash = const Color(0xFFB0470A).withValues(alpha: 0.14);
-      final washed = tester
-          .widgetList<DecoratedBox>(find.byType(DecoratedBox))
-          .where((d) {
-        final deco = d.decoration;
-        return deco is BoxDecoration && deco.color == expectedWash;
+      // The active tab (index 0) highlights its **label text** with a
+      // marker-style Container tinted with its own accent (calque du highlight
+      // "Couverture médiatique" — cf. DiffTitle). The legacy full-chip wash and
+      // the leading dot are gone. Exactly one marker should be present.
+      final expectedMarker = const Color(0xFFB0470A).withValues(alpha: 0.22);
+      final markers =
+          tester.widgetList<Container>(find.byType(Container)).where((c) {
+        final deco = c.decoration;
+        return deco is BoxDecoration && deco.color == expectedMarker;
       });
-      expect(washed, hasLength(1));
+      expect(markers, hasLength(1));
+    });
+
+    testWidgets('no leading dot before tab labels (removed in marker redesign)',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        StickyTabBar(
+          tabs: _tabs,
+          activeIndex: 0,
+          progress: 0.2,
+          onTapTab: (_) {},
+        ),
+      ));
+      // The legacy 9×9 circle dot is gone — no BoxShape.circle decorations
+      // should remain in the tab row.
+      final dots =
+          tester.widgetList<Container>(find.byType(Container)).where((c) {
+        final deco = c.decoration;
+        return deco is BoxDecoration && deco.shape == BoxShape.circle;
+      });
+      expect(dots, isEmpty);
     });
   });
 }

--- a/docs/maintenance/maintenance-essentiel-ux-ajustements.md
+++ b/docs/maintenance/maintenance-essentiel-ux-ajustements.md
@@ -1,0 +1,58 @@
+# Maintenance — Ajustements UX/UI L'Essentiel, Sticky Header, Flamme & Météo
+
+> Type : **Maintenance UI**. Lot de 5 ajustements indépendants sur l'écran
+> L'Essentiel (interne *Flux Continu*) + 2 détails transverses (flamme streak,
+> modal météo). Aucun changement backend / DB / Alembic. Plan confirmé PO.
+
+## Décisions PO confirmées
+
+- **Fold gated lecture** : une section dont les cartes « previewed » ne sont pas
+  toutes lues ne se replie **jamais** automatiquement. Carte Essentiel = ses 5
+  articles lus.
+- **Flamme streak** : resize **uniquement** dans `StreakIndicator` (header
+  d'accueil).
+- **Météo jours suivants** : afficher le **max** en gros (quitte à le dupliquer
+  avec la plage min/max).
+
+## Changements
+
+1. **Fold gated lecture** — nouveau prédicat `allPreviewArticlesRead(FluxSection)`
+   dans `flux_continu_models.dart`, gaté aux 2 sites d'appel écran
+   (`_maybeFoldSections`, `_markSectionsAboveAsScrolledPast`). Le repli manuel
+   (`foldLocally`) reste non gaté.
+2. **Grille déplacée** — `GrilleCtaCard` rendue juste après la section « Actus du
+   jour » (`DigestTopicSection` `kind == essentiel`). Le sliver grille bas
+   devient un fallback `if (!hasActus)`.
+3. **Sticky header** — highlight sur le **texte** (style « Couverture médiatique »
+   / `DiffTitle`), retrait du point et du wash arrondi pleine-chip.
+4. **Flamme streak** — 16 → 22px (+40%) dans `StreakIndicator` (actif + loading).
+5. **Modal météo** — `_DayRow` : max en gros (`fraunces`) + plage min/max
+   conservée, asset météo 40 → 52px.
+
+## Fichiers modifiés
+
+| Fichier | Changement |
+|---|---|
+| `models/flux_continu_models.dart` | + `allPreviewArticlesRead()` |
+| `screens/flux_continu_screen.dart` | gate fold ×2 ; déplacement Grille + fallback |
+| `widgets/sticky_tab_bar.dart` | highlight texte + retrait points |
+| `gamification/widgets/streak_indicator.dart` | flamme 16→22 |
+| `widgets/weather_detail_sheet.dart` | `_DayRow` max gros + asset 52 |
+
+## Tests
+
+- `flux_continu_models_test.dart` — group `allPreviewArticlesRead`.
+- Widget test placement Grille (Actus présent / absent / replié).
+- `flutter analyze` propre + tests ciblés `flux_continu/` & `gamification/` verts.
+
+## Statut
+
+- [x] Plan confirmé PO
+- [x] Change 1 — fold gated
+- [x] Change 2 — Grille déplacée
+- [x] Change 3 — sticky header highlight texte
+- [x] Change 4 — flamme streak +40%
+- [x] Change 5 — météo max gros
+- [x] Tests ajoutés
+- [ ] VERIFY (flutter analyze + tests ciblés)
+- [ ] PR `--base main`


### PR DESCRIPTION
## Quoi

Lot de 5 ajustements UX/UI sur **L'Essentiel** (interne *Flux Continu*) + 2 détails transverses. Plan confirmé PO, aucun changement backend/DB/Alembic.

1. **Fold gated lecture** — une section ne se replie **automatiquement** que si toutes ses cartes « preview » (les `coreVisibleCount` premières) sont lues. Nouveau prédicat `allPreviewArticlesRead()` gaté aux **2 sites écran** (`_maybeFoldSections`, `_markSectionsAboveAsScrolledPast`) ; le repli manuel (caret/CTA) reste non gaté.
2. **Grille déplacée** — `GrilleCtaCard` rendue juste **après « Actus du jour »** (`DigestTopicSection` `kind == essentiel`) ; sliver bas conservé en **fallback** uniquement si le digest est absent.
3. **Sticky header** — highlight **marqueur sur le texte** de l'onglet actif (calque « Couverture médiatique » / `DiffTitle`), retrait du point et du wash pleine-chip.
4. **Flamme streak** — 16 → 22px (+40%), `StreakIndicator` / header d'accueil **uniquement**.
5. **Modal météo** — jours suivants : **max en gros** (`fraunces`) + plage min/max conservée, asset 40 → 52px.

## Pourquoi

Affinage de comportements/styles déjà en place (pas de refonte) demandé par le PO :
- fold = intention assumée « ne replie pas ce que je n'ai pas lu » ;
- la Grille (CTA La Grille) gagne en visibilité juste après les Actus ;
- le sticky lisible comme un surlignage de texte plutôt qu'une chip pleine ;
- flamme plus présente dans le header ; météo plus lisible (température en gros).

## Comment ça a été vérifié

- [x] `flutter analyze` sur les 5 fichiers modifiés — **0 issue**
- [x] `flux_continu_models_test.dart` — **46 tests OK** (dont 13 nouveaux `allPreviewArticlesRead` : Essentiel 5/5/4-5/vide, Digest leads/topic vide/followed-lead, FeedTheme consumed/overflow)
- [x] `sticky_three_state_bar_test.dart` — **5 OK** (test wash obsolète remplacé par assertion marqueur-texte + test no-dot)
- [x] `/simplify` passé : extraction d'un `_grilleSliver` const partagé (dedup) + helper générique `allRead<T>` dans `allPreviewArticlesRead` ; nettoyage import/var morts dans `streak_indicator`
- [ ] **Validation visuelle non exécutée ici** — changements purement visuels/UX (tailles, teintes, placement). Recommandé : `/validate-feature` (Chrome 390×844) pour valider fold / placement Grille / sticky / flamme / météo. CI = backend pytest only ; suite mobile a des échecs pré-existants (Hive/Supabase non init) — `flux_continu_provider_test` échoue identiquement sur la baseline (non lié à cette PR, gate volontairement côté écran).

## Zones à risque

- `flux_continu_screen.dart` (logique de fold scroll-past, placement de slivers) — gate ajouté aux 3 boucles d'appel de `markScrolledPastForNextSession` (airtight vérifié : aucun autre appelant). Indexation `_sectionKeys` préservée (sliver Grille hors `KeyedSubtree`).
- `sticky_tab_bar.dart` — rendu de l'onglet refondu (point + DecoratedBox supprimés).

Doc : `docs/maintenance/maintenance-essentiel-ux-ajustements.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
