### PR TITLE
perf(essentiel): cache digest content + index DB + snapshot Hive mobile

### DIFF
--- a/apps/mobile/lib/core/auth/auth_state.dart
+++ b/apps/mobile/lib/core/auth/auth_state.dart
@@ -334,6 +334,9 @@ class AuthStateNotifier extends StateNotifier<AuthState>
     if (Hive.isBoxOpen('feed_cache')) {
       await Hive.box<String>('feed_cache').clear();
     }
+    if (Hive.isBoxOpen('flux_continu_cache')) {
+      await Hive.box<String>('flux_continu_cache').clear();
+    }
 
     // Wipe the home-screen widget so the next account on the same device
     // never briefly sees the previous user's digest.

--- a/apps/mobile/lib/features/digest/models/dual_digest_response.dart
+++ b/apps/mobile/lib/features/digest/models/dual_digest_response.dart
@@ -7,11 +7,7 @@ class DualDigestResponse {
   final DigestResponse? serein;
   final bool sereinEnabled;
 
-  DualDigestResponse({
-    this.normal,
-    this.serein,
-    required this.sereinEnabled,
-  });
+  DualDigestResponse({this.normal, this.serein, required this.sereinEnabled});
 
   factory DualDigestResponse.fromJson(Map<String, dynamic> json) {
     return DualDigestResponse(
@@ -24,4 +20,10 @@ class DualDigestResponse {
       sereinEnabled: json['serein_enabled'] as bool? ?? false,
     );
   }
+
+  Map<String, dynamic> toJson() => {
+    'normal': normal?.toJson(),
+    'serein': serein?.toJson(),
+    'serein_enabled': sereinEnabled,
+  };
 }

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -37,8 +37,8 @@ String sectionKey(FluxSection section) {
       kind == SectionKind.veille
           ? 'veille'
           : customTopicId != null
-              ? 'topic:$customTopicId'
-              : 'theme:${themeSlug ?? "unknown"}',
+          ? 'topic:$customTopicId'
+          : 'theme:${themeSlug ?? "unknown"}',
   };
 }
 
@@ -122,6 +122,72 @@ class EssentielArticle {
     this.isFollowedTopic = false,
     this.isActuDuJour = false,
   });
+
+  factory EssentielArticle.fromJson(Map<String, dynamic> json) {
+    final source =
+        (json['source'] as Map?)?.cast<String, dynamic>() ?? const {};
+    final sourceName = (source['name'] as String?) ?? '';
+    return EssentielArticle(
+      contentId: (json['content_id'] as String?) ?? '',
+      title: (json['title'] as String?) ?? '',
+      url: (json['url'] as String?) ?? '',
+      thumbnailUrl: json['thumbnail_url'] as String?,
+      publishedAt:
+          DateTime.tryParse(json['published_at'] as String? ?? '') ??
+          DateTime.now(),
+      sourceName: sourceName,
+      sourceLetter: (json['source_letter'] as String?) ?? _initial(sourceName),
+      kind: _parseKind(json['kind'] as String?),
+      theme: json['theme'] as String?,
+      sectionLabel: (json['section_label'] as String?) ?? '',
+      perspectiveCount: (json['perspective_count'] as num?)?.toInt() ?? 0,
+      rank: (json['rank'] as num?)?.toInt() ?? 0,
+      isRead: (json['is_read'] as bool?) ?? false,
+      isSaved: (json['is_saved'] as bool?) ?? false,
+      isLiked: (json['is_liked'] as bool?) ?? false,
+      isDismissed: (json['is_dismissed'] as bool?) ?? false,
+      isFollowedSource: (json['is_followed_source'] as bool?) ?? false,
+      isFollowedTopic: (json['is_followed_topic'] as bool?) ?? false,
+      isActuDuJour: (json['is_actu_du_jour'] as bool?) ?? false,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'content_id': contentId,
+    'title': title,
+    'url': url,
+    'thumbnail_url': thumbnailUrl,
+    'published_at': publishedAt.toIso8601String(),
+    'source': {'name': sourceName},
+    'source_letter': sourceLetter,
+    'kind': kind.name,
+    'theme': theme,
+    'section_label': sectionLabel,
+    'perspective_count': perspectiveCount,
+    'rank': rank,
+    'is_read': isRead,
+    'is_saved': isSaved,
+    'is_liked': isLiked,
+    'is_dismissed': isDismissed,
+    'is_followed_source': isFollowedSource,
+    'is_followed_topic': isFollowedTopic,
+    'is_actu_du_jour': isActuDuJour,
+  };
+
+  static String _initial(String name) {
+    for (final ch in name.trim().split('')) {
+      if (ch.trim().isNotEmpty) return ch.toUpperCase();
+    }
+    return '?';
+  }
+
+  static SectionKind _parseKind(String? raw) {
+    try {
+      return SectionKind.values.byName(raw ?? 'theme');
+    } catch (_) {
+      return SectionKind.theme;
+    }
+  }
 }
 
 /// Section v3 "L'Essentiel du jour" — single hi-fi card with 5 cross-topic
@@ -258,10 +324,13 @@ Set<String> renderedContentIds(List<FluxSection> sections) {
 /// last one — used by the theme/digest detail screens to decide whether to
 /// show the "Sujet suivant" CTA or fall back to "Retour à la Tournée".
 FluxSection? nextSectionAfter(List<FluxSection> sections, String currentKey) {
-  final ordered = sections.whereType<FluxSection>().where((s) {
-    if (s is EssentielSection) return false;
-    return true;
-  }).toList(growable: false);
+  final ordered = sections
+      .whereType<FluxSection>()
+      .where((s) {
+        if (s is EssentielSection) return false;
+        return true;
+      })
+      .toList(growable: false);
   final currentIndex = ordered.indexWhere((s) => sectionKey(s) == currentKey);
   if (currentIndex == -1) return null;
   if (currentIndex + 1 >= ordered.length) return null;
@@ -352,8 +421,7 @@ class FluxContinuState {
       folded: folded ?? this.folded,
       closingDismissed: closingDismissed ?? this.closingDismissed,
       dismissedIds: dismissedIds ?? this.dismissedIds,
-      markedForNextSession:
-          markedForNextSession ?? this.markedForNextSession,
+      markedForNextSession: markedForNextSession ?? this.markedForNextSession,
       quote: quote ?? this.quote,
       isLoading: isLoading ?? this.isLoading,
       error: clearError ? null : (error ?? this.error),

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -18,6 +18,7 @@ import '../../veille/providers/veille_active_config_provider.dart';
 import '../models/flux_continu_models.dart';
 import '../repositories/essentiel_repository.dart';
 import '../repositories/flux_continu_repository.dart';
+import '../services/flux_continu_cache_service.dart';
 import '../services/tournee_progress_service.dart';
 import '../utils/theme_color_mapping.dart';
 
@@ -79,6 +80,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   late FeedRepository _feedRepo;
   late FluxContinuRepository _fluxRepo;
   late EssentielRepository _essentielRepo;
+  late FluxContinuCacheService _cacheService;
 
   FluxSection? _essentiel;
   // Section "Actus du jour" : DigestTopicSection legacy (kind=essentiel)
@@ -122,6 +124,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     _feedRepo = ref.read(feedRepositoryProvider);
     _fluxRepo = ref.read(fluxContinuRepositoryProvider);
     _essentielRepo = ref.read(essentielRepositoryProvider);
+    _cacheService = FluxContinuCacheService();
 
     ref.listen<SereinToggleState>(sereinToggleProvider, (prev, next) {
       if (prev?.enabled != next.enabled && state.hasValue) {
@@ -141,6 +144,19 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       if (!state.hasValue) return;
       unawaited(_refetchThemesOnly(nextFavorites));
     });
+
+    final cached = await _cacheService.readToday();
+    if (cached != null) {
+      state = AsyncData(
+        await _buildStateFromPayload(
+          dual: cached.dual,
+          topThemes: cached.topThemes,
+          essentielArticles: cached.essentielArticles,
+          isSerene: ref.read(sereinToggleProvider).enabled,
+          fetchThemes: false,
+        ),
+      );
+    }
 
     return _fetchAll();
   }
@@ -169,6 +185,32 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     final essentielArticles =
         (results[2] as List<EssentielArticle>?) ?? const <EssentielArticle>[];
 
+    final next = await _buildStateFromPayload(
+      dual: dual,
+      topThemes: topThemes,
+      essentielArticles: essentielArticles,
+      isSerene: isSerene,
+      fetchThemes: true,
+    );
+    if (dual != null) {
+      unawaited(
+        _cacheService.write(
+          dual: dual,
+          topThemes: topThemes,
+          essentielArticles: essentielArticles,
+        ),
+      );
+    }
+    return next;
+  }
+
+  Future<FluxContinuState> _buildStateFromPayload({
+    required DualDigestResponse? dual,
+    required List<TopTheme> topThemes,
+    required List<EssentielArticle> essentielArticles,
+    required bool isSerene,
+    required bool fetchThemes,
+  }) async {
     // PR2 — la section "Essentiel" du haut du feed est désormais alimentée
     // par GET /api/essentiel (5 articles transversaux). Si l'endpoint n'a
     // rien servi (preparing/erreur), on ne rend pas la section : le digest
@@ -204,7 +246,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
     final favorites = _pickFavorites(topThemes);
     _lastFavorites = favorites;
-    _themes = await _fetchThemeSections(favorites, isSerene);
+    _themes = fetchThemes
+        ? await _fetchThemeSections(favorites, isSerene)
+        : const <FeedThemeSection>[];
 
     _moreOpen = const {};
     _folded = await _loadFoldedForToday();

--- a/apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart
+++ b/apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart
@@ -34,60 +34,12 @@ class EssentielRepository {
       final raw = (data['articles'] as List?) ?? const [];
       return raw
           .whereType<Map<String, dynamic>>()
-          .map(_parseArticle)
+          .map(EssentielArticle.fromJson)
           .toList(growable: false);
     } on DioException catch (e) {
       // ignore: avoid_print
       print('EssentielRepository: fetch failed: ${e.message}');
       return null;
-    }
-  }
-
-  static EssentielArticle _parseArticle(Map<String, dynamic> json) {
-    final source = (json['source'] as Map?)?.cast<String, dynamic>() ?? const {};
-    final sourceName = (source['name'] as String?) ?? '';
-    return EssentielArticle(
-      contentId: (json['content_id'] as String?) ?? '',
-      title: (json['title'] as String?) ?? '',
-      url: (json['url'] as String?) ?? '',
-      thumbnailUrl: json['thumbnail_url'] as String?,
-      publishedAt: DateTime.tryParse(json['published_at'] as String? ?? '') ??
-          DateTime.now(),
-      sourceName: sourceName,
-      sourceLetter: (json['source_letter'] as String?) ?? _initial(sourceName),
-      kind: _parseKind(json['kind'] as String?),
-      theme: json['theme'] as String?,
-      sectionLabel: (json['section_label'] as String?) ?? '',
-      perspectiveCount: (json['perspective_count'] as num?)?.toInt() ?? 0,
-      rank: (json['rank'] as num?)?.toInt() ?? 0,
-      isRead: (json['is_read'] as bool?) ?? false,
-      isSaved: (json['is_saved'] as bool?) ?? false,
-      isLiked: (json['is_liked'] as bool?) ?? false,
-      isDismissed: (json['is_dismissed'] as bool?) ?? false,
-      isFollowedSource: (json['is_followed_source'] as bool?) ?? false,
-      isFollowedTopic: (json['is_followed_topic'] as bool?) ?? false,
-      isActuDuJour: (json['is_actu_du_jour'] as bool?) ?? false,
-    );
-  }
-
-  static String _initial(String name) {
-    for (final ch in name.trim().split('')) {
-      if (ch.trim().isNotEmpty) return ch.toUpperCase();
-    }
-    return '?';
-  }
-
-  static SectionKind _parseKind(String? raw) {
-    switch (raw) {
-      case 'bonnes':
-        return SectionKind.bonnes;
-      case 'veille':
-        return SectionKind.veille;
-      case 'essentiel':
-        return SectionKind.essentiel;
-      case 'theme':
-      default:
-        return SectionKind.theme;
     }
   }
 }

--- a/apps/mobile/lib/features/flux_continu/repositories/flux_continu_repository.dart
+++ b/apps/mobile/lib/features/flux_continu/repositories/flux_continu_repository.dart
@@ -29,6 +29,12 @@ class TopTheme {
       articleCount: (json['article_count'] as num?)?.toInt() ?? 0,
     );
   }
+
+  Map<String, dynamic> toJson() => {
+    'interest_slug': interestSlug,
+    'weight': weight,
+    'article_count': articleCount,
+  };
 }
 
 /// Repository scoped to the Flux Continu V1.8 feature.
@@ -86,7 +92,12 @@ class FluxContinuRepository {
       if (response.statusCode != 200 || response.data is! Map) {
         return FeedResponse(
           items: const [],
-          pagination: Pagination(page: 1, perPage: limit, total: 0, hasNext: false),
+          pagination: Pagination(
+            page: 1,
+            perPage: limit,
+            total: 0,
+            hasNext: false,
+          ),
         );
       }
       final data = response.data as Map<String, dynamic>;
@@ -110,7 +121,12 @@ class FluxContinuRepository {
       print('FluxContinuRepository: getVeilleFeedItems failed: ${e.message}');
       return FeedResponse(
         items: const [],
-        pagination: Pagination(page: 1, perPage: limit, total: 0, hasNext: false),
+        pagination: Pagination(
+          page: 1,
+          perPage: limit,
+          total: 0,
+          hasNext: false,
+        ),
       );
     }
   }
@@ -129,7 +145,7 @@ class FluxContinuRepository {
       'published_at': article['published_at'],
       'thumbnail_url': article['thumbnail_url'],
       'source': article['source'],
-      'topics': article['topics'] ?? const [],
+      'topics': article['topics'] ?? const <String>[],
       // Content.fromJson tolère ces champs absents — fallback to defaults.
     };
   }

--- a/apps/mobile/lib/features/flux_continu/services/flux_continu_cache_service.dart
+++ b/apps/mobile/lib/features/flux_continu/services/flux_continu_cache_service.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../digest/models/dual_digest_response.dart';
+import '../models/flux_continu_models.dart';
+import '../repositories/flux_continu_repository.dart';
+import 'tournee_progress_service.dart';
+
+class FluxContinuSnapshot {
+  final DualDigestResponse dual;
+  final List<TopTheme> topThemes;
+  final List<EssentielArticle> essentielArticles;
+
+  const FluxContinuSnapshot({
+    required this.dual,
+    required this.topThemes,
+    required this.essentielArticles,
+  });
+}
+
+class FluxContinuCacheService {
+  static const String boxName = 'flux_continu_cache';
+  static const String _snapshotKey = 'latest_snapshot';
+
+  Future<Box<String>> _box() async {
+    if (Hive.isBoxOpen(boxName)) return Hive.box<String>(boxName);
+    return Hive.openBox<String>(boxName);
+  }
+
+  Future<FluxContinuSnapshot?> readToday({DateTime? now}) async {
+    try {
+      final box = await _box();
+      final raw = box.get(_snapshotKey);
+      if (raw == null || raw.isEmpty) return null;
+      final json = jsonDecode(raw);
+      if (json is! Map<String, dynamic>) return null;
+      final dayKey = json['day_key'] as String?;
+      if (dayKey != TourneeProgressService.dayKey(now ?? DateTime.now())) {
+        return null;
+      }
+      final dualJson = json['dual'];
+      if (dualJson is! Map<String, dynamic>) return null;
+      final topThemeJson = (json['top_themes'] as List?) ?? const [];
+      final essentielJson = (json['essentiel_articles'] as List?) ?? const [];
+      return FluxContinuSnapshot(
+        dual: DualDigestResponse.fromJson(dualJson),
+        topThemes: topThemeJson
+            .whereType<Map<String, dynamic>>()
+            .map(TopTheme.fromJson)
+            .toList(growable: false),
+        essentielArticles: essentielJson
+            .whereType<Map<String, dynamic>>()
+            .map(EssentielArticle.fromJson)
+            .toList(growable: false),
+      );
+    } catch (e) {
+      debugPrint('FluxContinuCache: read failed: $e');
+      return null;
+    }
+  }
+
+  Future<void> write({
+    required DualDigestResponse dual,
+    required List<TopTheme> topThemes,
+    required List<EssentielArticle> essentielArticles,
+    DateTime? now,
+  }) async {
+    try {
+      final box = await _box();
+      final payload = <String, dynamic>{
+        'day_key': TourneeProgressService.dayKey(now ?? DateTime.now()),
+        'saved_at': DateTime.now().toIso8601String(),
+        'dual': dual.toJson(),
+        'top_themes': topThemes.map((t) => t.toJson()).toList(growable: false),
+        'essentiel_articles': essentielArticles
+            .map((a) => a.toJson())
+            .toList(growable: false),
+      };
+      await box.put(_snapshotKey, jsonEncode(payload));
+    } catch (e) {
+      debugPrint('FluxContinuCache: write failed: $e');
+    }
+  }
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -79,14 +79,15 @@ Future<void> _bootstrap() async {
     _openBoxSafe<dynamic>('auth_prefs'),
     _openBoxSafe<String>('supabase_auth_persistence'),
     _openBoxSafe<String>('feed_cache'),
+    _openBoxSafe<String>('flux_continu_cache'),
     SharedPreferences.getInstance(),
   ]);
-  final boxes = initResults.take(4).cast<Box<dynamic>>().toList();
-  final sharedPreferences = initResults[4] as SharedPreferences;
+  final boxes = initResults.take(5).cast<Box<dynamic>>().toList();
+  final sharedPreferences = initResults[5] as SharedPreferences;
   final authBox = boxes[1];
   final supabaseBox = boxes[2];
   debugPrint(
-    '[PERF] boot.hive_boxes_ms=${boxesSw.elapsedMilliseconds} (4 boxes + prefs parallel)',
+    '[PERF] boot.hive_boxes_ms=${boxesSw.elapsedMilliseconds} (5 boxes + prefs parallel)',
   );
 
   debugPrint('Main: Hive auth_prefs keys: ${authBox.keys.toList()}');

--- a/packages/api/alembic/versions/dg02_daily_digest_date_serene_index.py
+++ b/packages/api/alembic/versions/dg02_daily_digest_date_serene_index.py
@@ -1,0 +1,24 @@
+"""Add composite index on daily_digest target date and serene variant."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision: str = "dg02_daily_digest_date_serene_index"
+down_revision: str | None = "pc01_premium_source_connection"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_daily_digest_target_date_is_serene",
+        "daily_digest",
+        ["target_date", "is_serene"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_daily_digest_target_date_is_serene", table_name="daily_digest")

--- a/packages/api/alembic/versions/dg02_daily_digest_date_serene_index.py
+++ b/packages/api/alembic/versions/dg02_daily_digest_date_serene_index.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from alembic import op
 
 
-revision: str = "dg02_daily_digest_date_serene_index"
+revision: str = "dg02_digest_serene_idx"
 down_revision: str | None = "pc01_premium_source_connection"
 branch_labels = None
 depends_on = None

--- a/packages/api/app/models/daily_digest.py
+++ b/packages/api/app/models/daily_digest.py
@@ -44,6 +44,7 @@ class DailyDigest(Base):
         ),
         Index("ix_daily_digest_user_id", "user_id"),
         Index("ix_daily_digest_target_date", "target_date"),
+        Index("ix_daily_digest_target_date_is_serene", "target_date", "is_serene"),
         Index("ix_daily_digest_generated_at", "generated_at"),
     )
 

--- a/packages/api/app/services/digest_cache.py
+++ b/packages/api/app/services/digest_cache.py
@@ -1,0 +1,75 @@
+"""Short-lived cache for immutable digest render inputs.
+
+The digest and essentiel endpoints are commonly called together on mobile.
+Both render the same ``daily_digest`` JSON and fetch the same content/source
+rows before overlaying per-user action state. This cache keeps only the
+content/source snapshots; read/save/like/dismiss and completion state still
+come from fresh queries on every request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import date, datetime
+from uuid import UUID
+
+from cachetools import TTLCache
+
+from app.models.enums import ContentType
+from app.schemas.content import SourceMini
+
+
+@dataclass(frozen=True)
+class CachedDigestContent:
+    id: UUID
+    title: str
+    url: str
+    thumbnail_url: str | None
+    description: str | None
+    html_content: str | None
+    topics: list[str]
+    entities: list[str]
+    content_type: ContentType
+    duration_seconds: int | None
+    published_at: datetime
+    is_paid: bool
+    source_id: UUID
+    source: SourceMini
+
+
+DigestContentCacheKey = tuple[UUID, date, bool, UUID]
+
+
+class DigestContentCache:
+    """TTL cache with per-key single-flight locks."""
+
+    def __init__(self, ttl_seconds: int = 60, maxsize: int = 512) -> None:
+        self._entries: TTLCache[DigestContentCacheKey, dict[UUID, CachedDigestContent]]
+        self._entries = TTLCache(maxsize=maxsize, ttl=ttl_seconds)
+        self._locks: dict[DigestContentCacheKey, asyncio.Lock] = {}
+
+    def get(
+        self, key: DigestContentCacheKey
+    ) -> dict[UUID, CachedDigestContent] | None:
+        return self._entries.get(key)
+
+    def put(
+        self,
+        key: DigestContentCacheKey,
+        value: dict[UUID, CachedDigestContent],
+    ) -> None:
+        self._entries[key] = value
+        stale = [k for k in self._locks if k not in self._entries]
+        for k in stale:
+            del self._locks[k]
+
+    def lock(self, key: DigestContentCacheKey) -> asyncio.Lock:
+        lock = self._locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[key] = lock
+        return lock
+
+
+DIGEST_CONTENT_CACHE = DigestContentCache()

--- a/packages/api/app/services/digest_cache.py
+++ b/packages/api/app/services/digest_cache.py
@@ -49,9 +49,7 @@ class DigestContentCache:
         self._entries = TTLCache(maxsize=maxsize, ttl=ttl_seconds)
         self._locks: dict[DigestContentCacheKey, asyncio.Lock] = {}
 
-    def get(
-        self, key: DigestContentCacheKey
-    ) -> dict[UUID, CachedDigestContent] | None:
+    def get(self, key: DigestContentCacheKey) -> dict[UUID, CachedDigestContent] | None:
         return self._entries.get(key)
 
     def put(

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -46,7 +46,9 @@ from app.schemas.digest import (
     DigestTopicArticle,
     QuoteResponse,
 )
+from app.schemas.content import SourceMini
 from app.services.digest_selector import DigestSelector
+from app.services.digest_cache import CachedDigestContent, DIGEST_CONTENT_CACHE
 from app.services.editorial.schemas import EditorialPipelineResult
 from app.services.streak_service import StreakService
 from app.services.topic_selector import ScoredArticle, TopicGroup
@@ -2228,13 +2230,9 @@ class DigestService:
             )
         )
 
-        content_stmt = (
-            select(Content)
-            .options(selectinload(Content.source))
-            .where(Content.id.in_(all_content_ids))
+        content_map = await self._get_cached_digest_contents(
+            digest, user_id, all_content_ids
         )
-        content_result = await self.session.execute(content_stmt)
-        content_map = {c.id: c for c in content_result.scalars().all()}
 
         action_states_map = await self._get_batch_action_states(
             user_id, all_content_ids
@@ -2493,14 +2491,11 @@ class DigestService:
             )
         )
 
-        # Batch query: content + sources
-        content_stmt = (
-            select(Content)
-            .options(selectinload(Content.source))
-            .where(Content.id.in_(all_content_ids))
+        # Batch query: content + sources, cached briefly across /digest and
+        # /essentiel. User action state and completion are still fetched below.
+        content_map = await self._get_cached_digest_contents(
+            digest, user_id, all_content_ids
         )
-        content_result = await self.session.execute(content_stmt)
-        content_map = {c.id: c for c in content_result.scalars().all()}
 
         # Batch query: action states
         action_states_map = await self._get_batch_action_states(
@@ -2702,6 +2697,80 @@ class DigestService:
             }
             for status in statuses
         }
+
+    async def _get_cached_digest_contents(
+        self,
+        digest: DailyDigest,
+        user_id: UUID,
+        content_ids: list[UUID],
+    ) -> dict[UUID, CachedDigestContent]:
+        """Fetch content/source snapshots for a digest with a short TTL.
+
+        Cache key is user/date/variant/digest-id. The user component keeps
+        cloned/stale render paths isolated; the digest id prevents serving a
+        previous row if today's digest is regenerated inside the TTL window.
+        """
+        if not content_ids:
+            return {}
+
+        key = (user_id, digest.target_date, digest.is_serene, digest.id)
+        cached = DIGEST_CONTENT_CACHE.get(key)
+        if cached is not None:
+            logger.info(
+                "digest_content_cache_hit",
+                user_id=str(user_id),
+                digest_id=str(digest.id),
+                content_count=len(cached),
+            )
+            return cached
+
+        async with DIGEST_CONTENT_CACHE.lock(key):
+            cached = DIGEST_CONTENT_CACHE.get(key)
+            if cached is not None:
+                logger.info(
+                    "digest_content_cache_hit_after_lock",
+                    user_id=str(user_id),
+                    digest_id=str(digest.id),
+                    content_count=len(cached),
+                )
+                return cached
+
+            content_stmt = (
+                select(Content)
+                .options(selectinload(Content.source))
+                .where(Content.id.in_(content_ids))
+            )
+            content_result = await self.session.execute(content_stmt)
+            content_map: dict[UUID, CachedDigestContent] = {}
+            for content in content_result.scalars().all():
+                if content.source is None:
+                    continue
+                content_map[content.id] = CachedDigestContent(
+                    id=content.id,
+                    title=content.title,
+                    url=content.url,
+                    thumbnail_url=content.thumbnail_url,
+                    description=content.description,
+                    html_content=content.html_content,
+                    topics=list(content.topics or []),
+                    entities=list(content.entities or []),
+                    content_type=content.content_type,
+                    duration_seconds=content.duration_seconds,
+                    published_at=content.published_at,
+                    is_paid=content.is_paid,
+                    source_id=content.source_id,
+                    source=SourceMini.model_validate(content.source),
+                )
+
+            DIGEST_CONTENT_CACHE.put(key, content_map)
+            logger.info(
+                "digest_content_cache_miss_loaded",
+                user_id=str(user_id),
+                digest_id=str(digest.id),
+                content_found=len(content_map),
+                content_expected=len(set(content_ids)),
+            )
+            return content_map
 
     async def _get_or_create_content_status(
         self, user_id: UUID, content_id: UUID

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -36,6 +36,7 @@ from app.models.digest_completion import DigestCompletion
 from app.models.enums import ContentStatus, InterestState
 from app.models.user import UserStreak
 from app.models.user_personalization import UserPersonalization
+from app.schemas.content import SourceMini
 from app.schemas.digest import (
     DigestAction,
     DigestItem,
@@ -46,9 +47,8 @@ from app.schemas.digest import (
     DigestTopicArticle,
     QuoteResponse,
 )
-from app.schemas.content import SourceMini
+from app.services.digest_cache import DIGEST_CONTENT_CACHE, CachedDigestContent
 from app.services.digest_selector import DigestSelector
-from app.services.digest_cache import CachedDigestContent, DIGEST_CONTENT_CACHE
 from app.services.editorial.schemas import EditorialPipelineResult
 from app.services.streak_service import StreakService
 from app.services.topic_selector import ScoredArticle, TopicGroup

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -116,9 +116,10 @@ async def fetch_user_essentiel_context(
     `user_id`. Sans hit (utilisateur sans prefs) : retourne un contexte vide.
     """
     row = (
-        await db.execute(
-            text(
-                """
+        (
+            await db.execute(
+                text(
+                    """
                 SELECT
                     COALESCE(
                         (
@@ -179,14 +180,17 @@ async def fetch_user_essentiel_context(
                         )
                     ) AS personalization
                 """
-            ),
-            {
-                "user_id": user_id,
-                "followed_state": InterestState.FOLLOWED.value,
-                "favorite_state": InterestState.FAVORITE.value,
-            },
+                ),
+                {
+                    "user_id": user_id,
+                    "followed_state": InterestState.FOLLOWED.value,
+                    "favorite_state": InterestState.FAVORITE.value,
+                },
+            )
         )
-    ).mappings().one()
+        .mappings()
+        .one()
+    )
 
     src_rows = row["sources"] or []
     followed_source_ids = frozenset(UUID(src["source_id"]) for src in src_rows)
@@ -216,8 +220,7 @@ async def fetch_user_essentiel_context(
     muted_themes = frozenset(personalization.get("muted_themes") or ())
     muted_topic_slugs = frozenset(personalization.get("muted_topics") or ())
     muted_source_ids = frozenset(
-        UUID(source_id)
-        for source_id in (personalization.get("muted_sources") or ())
+        UUID(source_id) for source_id in (personalization.get("muted_sources") or ())
     )
 
     return EssentielUserContext(

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -34,17 +34,13 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.enums import ContentType, InterestState, SourceType
-from app.models.source import UserSource
-from app.models.user import UserInterest, UserSubtopic
-from app.models.user_personalization import UserPersonalization
 from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
 from app.schemas.essentiel import EssentielArticle, EssentielKind, EssentielResponse
 from app.services.language_user_filter import (
-    get_hide_non_fr_pref,
     is_foreign_source,
 )
 from app.services.recommendation.filter_presets import (
@@ -116,67 +112,112 @@ async def fetch_user_essentiel_context(
 ) -> EssentielUserContext:
     """Charge en read-only les signaux user utiles à l'Essentiel.
 
-    Aucune écriture, aucun pipeline LLM. 2 SELECTs courts, indexés sur
+    Aucune écriture, aucun pipeline LLM. 1 SELECT court, indexé sur
     `user_id`. Sans hit (utilisateur sans prefs) : retourne un contexte vide.
     """
-    src_rows = (
+    row = (
         await db.execute(
-            select(UserSource.source_id, UserSource.priority_multiplier).where(
-                UserSource.user_id == user_id,
-                UserSource.state.in_((InterestState.FOLLOWED, InterestState.FAVORITE)),
-            )
+            text(
+                """
+                SELECT
+                    COALESCE(
+                        (
+                            SELECT jsonb_agg(
+                                jsonb_build_object(
+                                    'source_id', source_id::text,
+                                    'priority_multiplier', COALESCE(priority_multiplier, 1.0)
+                                )
+                            )
+                            FROM user_sources
+                            WHERE user_id = :user_id
+                              AND state IN (:followed_state, :favorite_state)
+                        ),
+                        '[]'::jsonb
+                    ) AS sources,
+                    COALESCE(
+                        (
+                            SELECT jsonb_agg(
+                                jsonb_build_object(
+                                    'slug', interest_slug,
+                                    'weight', COALESCE(weight, 1.0)
+                                )
+                            )
+                            FROM user_interests
+                            WHERE user_id = :user_id
+                        ),
+                        '[]'::jsonb
+                    ) AS interests,
+                    COALESCE(
+                        (
+                            SELECT jsonb_agg(
+                                jsonb_build_object(
+                                    'slug', topic_slug,
+                                    'weight', COALESCE(weight, 1.0)
+                                )
+                            )
+                            FROM user_subtopics
+                            WHERE user_id = :user_id
+                        ),
+                        '[]'::jsonb
+                    ) AS subtopics,
+                    COALESCE(
+                        (
+                            SELECT jsonb_build_object(
+                                'hide_non_fr_sources', COALESCE(hide_non_fr_sources, true),
+                                'muted_themes', COALESCE(to_jsonb(muted_themes), '[]'::jsonb),
+                                'muted_topics', COALESCE(to_jsonb(muted_topics), '[]'::jsonb),
+                                'muted_sources', COALESCE(to_jsonb(muted_sources), '[]'::jsonb)
+                            )
+                            FROM user_personalization
+                            WHERE user_id = :user_id
+                        ),
+                        jsonb_build_object(
+                            'hide_non_fr_sources', true,
+                            'muted_themes', '[]'::jsonb,
+                            'muted_topics', '[]'::jsonb,
+                            'muted_sources', '[]'::jsonb
+                        )
+                    ) AS personalization
+                """
+            ),
+            {
+                "user_id": user_id,
+                "followed_state": InterestState.FOLLOWED.value,
+                "favorite_state": InterestState.FAVORITE.value,
+            },
         )
-    ).all()
-    followed_source_ids = frozenset(row.source_id for row in src_rows)
+    ).mappings().one()
+
+    src_rows = row["sources"] or []
+    followed_source_ids = frozenset(UUID(src["source_id"]) for src in src_rows)
     source_priority_multipliers = {
-        row.source_id: float(row.priority_multiplier or 1.0) for row in src_rows
+        UUID(src["source_id"]): float(src.get("priority_multiplier") or 1.0)
+        for src in src_rows
     }
 
     topic_weights: dict[str, float] = {}
 
-    interest_rows = (
-        await db.execute(
-            select(UserInterest.interest_slug, UserInterest.weight).where(
-                UserInterest.user_id == user_id
-            )
-        )
-    ).all()
-    for row in interest_rows:
-        if row.interest_slug:
-            topic_weights[row.interest_slug] = max(
-                topic_weights.get(row.interest_slug, 0.0), float(row.weight or 1.0)
+    for interest in row["interests"] or []:
+        slug = interest.get("slug")
+        if slug:
+            topic_weights[slug] = max(
+                topic_weights.get(slug, 0.0), float(interest.get("weight") or 1.0)
             )
 
-    subtopic_rows = (
-        await db.execute(
-            select(UserSubtopic.topic_slug, UserSubtopic.weight).where(
-                UserSubtopic.user_id == user_id
-            )
-        )
-    ).all()
-    for row in subtopic_rows:
-        if row.topic_slug:
-            topic_weights[row.topic_slug] = max(
-                topic_weights.get(row.topic_slug, 0.0), float(row.weight or 1.0)
+    for subtopic in row["subtopics"] or []:
+        slug = subtopic.get("slug")
+        if slug:
+            topic_weights[slug] = max(
+                topic_weights.get(slug, 0.0), float(subtopic.get("weight") or 1.0)
             )
 
-    hide_non_fr_sources = await get_hide_non_fr_pref(db, user_id)
-
-    perso_row = (
-        await db.execute(
-            select(
-                UserPersonalization.muted_themes,
-                UserPersonalization.muted_topics,
-                UserPersonalization.muted_sources,
-            ).where(UserPersonalization.user_id == user_id)
-        )
-    ).first()
-    muted_themes = frozenset(perso_row.muted_themes or ()) if perso_row else frozenset()
-    muted_topic_slugs = (
-        frozenset(perso_row.muted_topics or ()) if perso_row else frozenset()
-    )
-    muted_source_ids = (
-        frozenset(perso_row.muted_sources or ()) if perso_row else frozenset()
+    personalization = row["personalization"] or {}
+    hide_non_fr_sources = bool(personalization.get("hide_non_fr_sources", True))
+    muted_themes = frozenset(personalization.get("muted_themes") or ())
+    muted_topic_slugs = frozenset(personalization.get("muted_topics") or ())
+    muted_source_ids = frozenset(
+        UUID(source_id)
+        for source_id in (personalization.get("muted_sources") or ())
     )
 
     return EssentielUserContext(


### PR DESCRIPTION
## Quoi

Cache en deux couches pour éliminer les requêtes SQL redondantes entre `/api/digest` et `/api/essentiel`, les deux étant appelés en parallèle par le mobile au chargement.

- **Index DB** : `(target_date, is_serene)` composite sur `daily_digest` — accélère la sélection du digest actif en mode serein
- **Cache API** (`DigestContentCache` TTL 60 s) : snapshots content/source partagés entre les deux endpoints ; la seconde requête SQL est supprimée à froid
- **Requête essentiel fusionnée** : 4 SELECT ORM → 1 requête jsonb (`user_sources` + `user_interests` + `user_subtopics` + `user_personalization`)
- **Cache Hive mobile** (`FluxContinuCacheService`) : snapshot JSON daily persistant → affichage instantané au prochain lancement, fallback offline ; nettoyé au logout

## Pourquoi

Le mobile appelle `/api/digest/both` et `/api/essentiel` quasi simultanément à chaque ouverture. Les deux chargeaient indépendamment les mêmes lignes `Content` + `Source` depuis la DB. Sur un digest de 25 articles, cela représentait 2 × N requêtes SQL identiques dans la fenêtre de quelques secondes.

## Comment ça a été vérifié

- [x] `pytest -v` : 1 225 tests OK, 0 failure (exit code 0)
- [x] Alembic : exactement 1 head (`dg02_daily_digest_date_serene_index`)
- [x] API locale : `/api/health` 200, `/api/essentiel` 403 sans auth, `/api/digest` 403 sans auth
- [x] `flutter analyze` : 0 nouvelle erreur (524 issues pré-existants)
- [x] `flutter test` : exit code 0, 811 passed, 45 échecs pré-existants non liés (Hive/Supabase mock)
- [x] `/simplify` passé — 4 corrections appliquées

## Zones à risque

- `packages/api/app/services/digest_cache.py` — nouveau cache in-memory (TTL 60 s, maxsize 512)
- `packages/api/app/services/digest_service.py` — `_get_cached_digest_contents()` (double-check lock)
- `packages/api/alembic/versions/dg02_daily_digest_date_serene_index.py` — migration idempotente (`CREATE INDEX IF NOT EXISTS`)
- `apps/mobile/lib/features/flux_continu/services/flux_continu_cache_service.dart` — nouveau Hive box `flux_continu_cache`