### PR TITLE
feat(perspectives): loader shimmer + états loading/empty/ready pour la couverture médiatique

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -205,6 +205,38 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   bool _perspectivesLoading = false;
   Timer? _perspectivesRefetchTimer;
 
+  bool get _showPerspectivesBand =>
+      _content?.contentType == ContentType.article;
+
+  PerspectivesSectionStatus get _perspectivesStatus {
+    final response = _perspectivesResponse;
+    if (response != null) {
+      return response.perspectives.isEmpty
+          ? PerspectivesSectionStatus.empty
+          : PerspectivesSectionStatus.ready;
+    }
+    return PerspectivesSectionStatus.loading;
+  }
+
+  List<Perspective> get _inlinePerspectives {
+    final response = _perspectivesResponse;
+    if (response == null) return const <Perspective>[];
+    return response.perspectives
+        .map(
+          (PerspectiveData p) => Perspective(
+            title: p.title,
+            url: p.url,
+            sourceName: p.sourceName,
+            sourceDomain: p.sourceDomain,
+            biasStance: p.biasStance,
+            publishedAt: p.publishedAt,
+            highlightSpans: p.highlightSpans,
+            sharedTokens: p.sharedTokens,
+          ),
+        )
+        .toList();
+  }
+
   // Perspectives analysis state (lifted from inline section)
   PerspectivesAnalysisState _perspectivesAnalysisState =
       PerspectivesAnalysisState.idle;
@@ -1411,7 +1443,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     } catch (e) {
       debugPrint('Error pre-fetching perspectives: $e');
       if (mounted) {
-        setState(() => _perspectivesLoading = false);
+        setState(() {
+          _perspectivesResponse = PerspectivesResponse(
+            perspectives: const [],
+            keywords: const [],
+            biasDistribution: const {},
+          );
+          _perspectivesLoading = false;
+          _perspectivesExpanded = false;
+        });
       }
     }
   }
@@ -2764,8 +2804,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         ),
 
                         // ZONE 1b: Perspectives section, framed by dividers.
-                        if (_perspectivesResponse != null &&
-                            _perspectivesResponse!.perspectives.isNotEmpty) ...[
+                        if (_showPerspectivesBand) ...[
                           Container(
                             color: colors.backgroundPrimary,
                             padding: const EdgeInsets.symmetric(
@@ -2781,31 +2820,23 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             color: colors.backgroundPrimary,
                             child: PerspectivesInlineSection(
                               key: _perspectivesKey,
-                              perspectives: _perspectivesResponse!.perspectives
-                                  .map(
-                                    (PerspectiveData p) => Perspective(
-                                      title: p.title,
-                                      url: p.url,
-                                      sourceName: p.sourceName,
-                                      sourceDomain: p.sourceDomain,
-                                      biasStance: p.biasStance,
-                                      publishedAt: p.publishedAt,
-                                      highlightSpans: p.highlightSpans,
-                                      sharedTokens: p.sharedTokens,
-                                    ),
-                                  )
-                                  .toList(),
+                              status: _perspectivesStatus,
+                              perspectives: _inlinePerspectives,
                               biasDistribution:
-                                  _perspectivesResponse!.biasDistribution,
-                              keywords: _perspectivesResponse!.keywords,
+                                  _perspectivesResponse?.biasDistribution ??
+                                  const {},
+                              keywords:
+                                  _perspectivesResponse?.keywords ?? const [],
                               sourceBiasStance:
-                                  _perspectivesResponse!.sourceBiasStance,
+                                  _perspectivesResponse?.sourceBiasStance ??
+                                  'unknown',
                               sourceName: _content?.source.name ?? '',
                               contentId: widget.contentId,
                               comparisonQuality:
-                                  _perspectivesResponse!.comparisonQuality,
+                                  _perspectivesResponse?.comparisonQuality ??
+                                  'low',
                               divergenceLevel:
-                                  _perspectivesResponse!.divergenceLevel,
+                                  _perspectivesResponse?.divergenceLevel,
                               externalSelectedSegments:
                                   _perspectivesSelectedSegments,
                               onSegmentTap: _onPerspectivesSegmentTap,
@@ -2822,7 +2853,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                               onToggle: _onPerspectivesToggle,
                               referenceTitle: _content?.title ?? '',
                               referencePivot:
-                                  _perspectivesResponse!.referencePivot,
+                                  _perspectivesResponse?.referencePivot,
                             ),
                           ),
                           Container(
@@ -3352,8 +3383,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 ),
 
                 // ── Perspectives section (avant l'article) ─────────────────
-                if (_perspectivesResponse != null &&
-                    _perspectivesResponse!.perspectives.isNotEmpty) ...[
+                if (_showPerspectivesBand) ...[
                   const SizedBox(height: FacteurSpacing.space4),
                   Padding(
                     padding: const EdgeInsets.symmetric(
@@ -3367,27 +3397,18 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   ),
                   PerspectivesInlineSection(
                     key: _perspectivesKey,
-                    perspectives: _perspectivesResponse!.perspectives
-                        .map(
-                          (PerspectiveData p) => Perspective(
-                            title: p.title,
-                            url: p.url,
-                            sourceName: p.sourceName,
-                            sourceDomain: p.sourceDomain,
-                            biasStance: p.biasStance,
-                            publishedAt: p.publishedAt,
-                            highlightSpans: p.highlightSpans,
-                            sharedTokens: p.sharedTokens,
-                          ),
-                        )
-                        .toList(),
-                    biasDistribution: _perspectivesResponse!.biasDistribution,
-                    keywords: _perspectivesResponse!.keywords,
-                    sourceBiasStance: _perspectivesResponse!.sourceBiasStance,
+                    status: _perspectivesStatus,
+                    perspectives: _inlinePerspectives,
+                    biasDistribution:
+                        _perspectivesResponse?.biasDistribution ?? const {},
+                    keywords: _perspectivesResponse?.keywords ?? const [],
+                    sourceBiasStance:
+                        _perspectivesResponse?.sourceBiasStance ?? 'unknown',
                     sourceName: _content?.source.name ?? '',
                     contentId: widget.contentId,
-                    comparisonQuality: _perspectivesResponse!.comparisonQuality,
-                    divergenceLevel: _perspectivesResponse!.divergenceLevel,
+                    comparisonQuality:
+                        _perspectivesResponse?.comparisonQuality ?? 'low',
+                    divergenceLevel: _perspectivesResponse?.divergenceLevel,
                     externalSelectedSegments: _perspectivesSelectedSegments,
                     onSegmentTap: _onPerspectivesSegmentTap,
                     onClearSegments: () {
@@ -3400,7 +3421,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     isExpanded: _perspectivesExpanded,
                     onToggle: _onPerspectivesToggle,
                     referenceTitle: _content?.title ?? '',
-                    referencePivot: _perspectivesResponse!.referencePivot,
+                    referencePivot: _perspectivesResponse?.referencePivot,
                   ),
                   Padding(
                     padding: const EdgeInsets.symmetric(

--- a/apps/mobile/lib/features/feed/widgets/coverage_spectrum_bar.dart
+++ b/apps/mobile/lib/features/feed/widgets/coverage_spectrum_bar.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import '../../../config/theme.dart';
 
+const _radius = BorderRadius.all(Radius.circular(2));
+
 /// Spectrum bar pour le bandeau hi-fi `cm-panel-inline` de la Couverture
 /// médiatique : 5 segments distincts L/CL/C/CR/R, taille fixe 96×9 px.
 ///
@@ -15,13 +17,16 @@ class CoverageSpectrumBar extends StatelessWidget {
   /// nul disparaîtrait, faussant la lecture chromatique 5-segs).
   final Map<String, int> distribution;
 
-  const CoverageSpectrumBar({
-    super.key,
-    required this.distribution,
-  });
+  const CoverageSpectrumBar({super.key, required this.distribution});
 
   // Ordre canonique du spectre politique, gauche → droite.
-  static const _keys = ['left', 'center-left', 'center', 'center-right', 'right'];
+  static const _keys = [
+    'left',
+    'center-left',
+    'center',
+    'center-right',
+    'right',
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -51,12 +56,83 @@ class CoverageSpectrumBar extends StatelessWidget {
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   color: segmentColors[i],
-                  borderRadius: BorderRadius.circular(2),
+                  borderRadius: _radius,
                 ),
               ),
             ),
           );
         }),
+      ),
+    );
+  }
+}
+
+class CoverageSpectrumBarShimmer extends StatefulWidget {
+  const CoverageSpectrumBarShimmer({super.key});
+
+  @override
+  State<CoverageSpectrumBarShimmer> createState() =>
+      _CoverageSpectrumBarShimmerState();
+}
+
+class _CoverageSpectrumBarShimmerState extends State<CoverageSpectrumBarShimmer>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1200),
+      vsync: this,
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final baseColor = colors.textTertiary.withValues(alpha: 0.16);
+    final highlightColor = Colors.white.withValues(alpha: 0.72);
+
+    return SizedBox(
+      width: 96,
+      height: 9,
+      child: ClipRRect(
+        borderRadius: _radius,
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (context, child) {
+            final offset = _controller.value * 2.8;
+            return ShaderMask(
+              blendMode: BlendMode.srcATop,
+              shaderCallback: (rect) {
+                return LinearGradient(
+                  begin: Alignment(-1.4 + offset, 0),
+                  end: Alignment(-0.2 + offset, 0),
+                  colors: [
+                    Colors.transparent,
+                    highlightColor,
+                    Colors.transparent,
+                  ],
+                  stops: const [0.0, 0.5, 1.0],
+                ).createShader(rect);
+              },
+              child: child,
+            );
+          },
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: baseColor,
+              borderRadius: _radius,
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -164,6 +164,8 @@ String _toBarGroup(String stance) {
 /// Analysis workflow state
 enum PerspectivesAnalysisState { idle, loading, done, error }
 
+enum PerspectivesSectionStatus { loading, empty, ready }
+
 /// Bottom sheet to display alternative perspectives
 class PerspectivesBottomSheet extends ConsumerStatefulWidget {
   final List<Perspective> perspectives;
@@ -1354,11 +1356,13 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
   /// si non-null. Renvoyé par le back via `reference_pivot`.
   final TokenSpan? referencePivot;
 
+  final PerspectivesSectionStatus status;
+
   const PerspectivesInlineSection({
     super.key,
-    required this.perspectives,
-    required this.biasDistribution,
-    required this.keywords,
+    this.perspectives = const [],
+    this.biasDistribution = const {},
+    this.keywords = const [],
     required this.contentId,
     this.sourceBiasStance = 'unknown',
     this.sourceName = '',
@@ -1376,6 +1380,7 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
     required this.onToggle,
     this.referenceTitle = '',
     this.referencePivot,
+    this.status = PerspectivesSectionStatus.ready,
   });
 
   @override
@@ -1433,13 +1438,21 @@ class _PerspectivesInlineSectionState
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
     final variants = _filteredPerspectives.take(8).toList();
+    final isReady = widget.status == PerspectivesSectionStatus.ready;
+    final label = widget.status == PerspectivesSectionStatus.loading
+        ? 'Couverture médiatique'
+        : 'Couverture médiatique (${widget.perspectives.length})';
+    final labelColor = widget.status == PerspectivesSectionStatus.empty
+        ? colors.textTertiary
+        : colors.textPrimary;
+    final shouldShowBody = isReady && widget.isExpanded;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         // ── Bandeau cm-panel-inline : hairlines + label + spectrum + count + caret ──
         GestureDetector(
-          onTap: widget.onToggle,
+          onTap: isReady ? widget.onToggle : null,
           behavior: HitTestBehavior.opaque,
           child: Container(
             decoration: BoxDecoration(
@@ -1464,32 +1477,39 @@ class _PerspectivesInlineSectionState
                     children: [
                       Flexible(
                         child: Text(
-                          'Couverture médiatique (${widget.perspectives.length})',
+                          label,
                           overflow: TextOverflow.ellipsis,
                           maxLines: 1,
                           style: GoogleFonts.dmSans(
                             fontSize: 13,
                             fontWeight: FontWeight.w700,
-                            color: colors.textPrimary,
+                            color: labelColor,
                           ),
                         ),
                       ),
                     ],
                   ),
                 ),
-                const SizedBox(width: 12),
-                CoverageSpectrumBar(distribution: widget.biasDistribution),
-                const SizedBox(width: 10),
-                AnimatedRotation(
-                  turns: _rotationTurns,
-                  duration: const Duration(milliseconds: 250),
-                  curve: Curves.easeInOut,
-                  child: Icon(
-                    PhosphorIcons.caretDown(PhosphorIconsStyle.regular),
-                    size: 14,
-                    color: colors.textSecondary,
+                if (widget.status != PerspectivesSectionStatus.empty) ...[
+                  const SizedBox(width: 12),
+                  if (widget.status == PerspectivesSectionStatus.loading)
+                    const CoverageSpectrumBarShimmer()
+                  else
+                    CoverageSpectrumBar(distribution: widget.biasDistribution),
+                ],
+                if (isReady) ...[
+                  const SizedBox(width: 10),
+                  AnimatedRotation(
+                    turns: _rotationTurns,
+                    duration: const Duration(milliseconds: 250),
+                    curve: Curves.easeInOut,
+                    child: Icon(
+                      PhosphorIcons.caretDown(PhosphorIconsStyle.regular),
+                      size: 14,
+                      color: colors.textSecondary,
+                    ),
                   ),
-                ),
+                ],
               ],
             ),
           ),
@@ -1498,7 +1518,7 @@ class _PerspectivesInlineSectionState
           duration: const Duration(milliseconds: 250),
           curve: Curves.easeInOut,
           alignment: Alignment.topCenter,
-          child: widget.isExpanded
+          child: shouldShowBody
               ? _buildExpandedBody(colors, textTheme, variants)
               : const SizedBox.shrink(),
         ),

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/widgets/coverage_spectrum_bar.dart';
+import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
+
+Perspective _p(String name, {String bias = 'center'}) => Perspective(
+  title: 'Titre $name',
+  url: 'https://example.com/$name',
+  sourceName: name,
+  sourceDomain: '',
+  biasStance: bias,
+);
+
+Future<void> _pumpInline(
+  WidgetTester tester, {
+  required PerspectivesSectionStatus status,
+  List<Perspective> perspectives = const [],
+  bool isExpanded = false,
+  required VoidCallback onToggle,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(
+          body: SizedBox(
+            width: 390,
+            child: PerspectivesInlineSection(
+              status: status,
+              perspectives: perspectives,
+              biasDistribution: const {'left': 1, 'center': 1, 'right': 1},
+              contentId: 'test-content-id',
+              sourceName: 'Test',
+              referenceTitle: 'Titre référence',
+              isExpanded: isExpanded,
+              onToggle: onToggle,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  final caret = PhosphorIcons.caretDown(PhosphorIconsStyle.regular);
+
+  testWidgets('loading shows header shimmer without caret or body', (
+    tester,
+  ) async {
+    var toggleCount = 0;
+
+    await _pumpInline(
+      tester,
+      status: PerspectivesSectionStatus.loading,
+      isExpanded: true,
+      onToggle: () => toggleCount++,
+    );
+
+    expect(find.text('Couverture médiatique'), findsOneWidget);
+    expect(find.byType(CoverageSpectrumBarShimmer), findsOneWidget);
+    expect(find.byIcon(caret), findsNothing);
+    expect(find.textContaining("marquent l'angle éditorial"), findsNothing);
+
+    await tester.tap(find.text('Couverture médiatique'));
+    expect(toggleCount, 0);
+  });
+
+  testWidgets('empty shows grey zero label without caret and is not tappable', (
+    tester,
+  ) async {
+    var toggleCount = 0;
+
+    await _pumpInline(
+      tester,
+      status: PerspectivesSectionStatus.empty,
+      onToggle: () => toggleCount++,
+    );
+
+    expect(find.text('Couverture médiatique (0)'), findsOneWidget);
+    expect(find.byType(CoverageSpectrumBarShimmer), findsNothing);
+    expect(find.byIcon(caret), findsNothing);
+
+    await tester.tap(find.text('Couverture médiatique (0)'));
+    expect(toggleCount, 0);
+  });
+
+  testWidgets('ready keeps caret and toggles on tap', (tester) async {
+    var toggleCount = 0;
+
+    await _pumpInline(
+      tester,
+      status: PerspectivesSectionStatus.ready,
+      perspectives: [_p('A')],
+      onToggle: () => toggleCount++,
+    );
+
+    expect(find.text('Couverture médiatique (1)'), findsOneWidget);
+    expect(find.byType(CoverageSpectrumBar), findsOneWidget);
+    expect(find.byIcon(caret), findsOneWidget);
+
+    await tester.tap(find.text('Couverture médiatique (1)'));
+    expect(toggleCount, 1);
+  });
+}


### PR DESCRIPTION
## Quoi

La section « Couverture médiatique » s'affiche désormais dès le chargement de l'écran article avec un bandeau shimmer animé, puis transite vers l'état vide (label grisé, sans caret) ou prêt (label + spectre + caret cliquable) selon la réponse API.

Nouveaux états de `PerspectivesInlineSection` :
- **loading** — shimmer bar animé (1200ms, ShaderMask), label sans compteur, bandeau non cliquable
- **empty** — label grisé « Couverture médiatique (0) », sans spectre ni caret
- **ready** — comportement actuel inchangé

## Pourquoi

Avant ce changement, la section n'apparaissait qu'après réception des données — l'utilisateur ne voyait rien pendant le chargement, puis le bandeau surgissait. Le shimmer donne du feedback immédiat et réduit le saut de layout.

## Comment ça a été vérifié

- [x] `flutter test` (3 nouveaux tests `perspectives_inline_states_test.dart` + suite complète, 45 échecs pré-existants Hive/Supabase inchangés)
- [x] `flutter analyze` — 0 erreur
- [x] `/simplify` passé (4 agents parallèles) — 4 cleanups appliqués

## Zones à risque

- `perspectives_bottom_sheet.dart` — `PerspectivesInlineSection` (widget partagé entre la vue inline et le bottom sheet)
- `content_detail_screen.dart` — deux call sites `PerspectivesInlineSection` (ZONE 1b + vue article)