### PR TITLE
Refine article media coverage UI

### DIFF
--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,85 +1,73 @@
-# QA Handoff — Flâner : onglets épinglés fiabilisés + modal simplifiée (v2)
-
-> Itération v2 de la modal d'épinglage (suite PR #748). 1 bug + 3 évolutions UX
-> + réduction des boutons filtre/recherche. Input de /validate-feature (Chrome 390×844).
+# QA Handoff — Allègement Couverture médiatique
 
 ## Feature développée
-Fiabilise la barre d'onglets Flâner (les sujets/sources épinglés ne « disparaissent »
-plus), supprime l'onglet « Tous », transforme le `+` en engrenage au-delà de 4 onglets,
-et remplace les 2 listes « suivies » de la modal par 2 onglets (Sources / Sujets) avec
-sujets à plat.
+
+Allègement visuel de la section inline « Couverture médiatique » dans le reader
+article : état vide plus discret, badge de polarisation, explication du
+surlignage derrière un bouton info, analyse remontée, disclaimer Mistral Large,
+suppression du bloc « CET ARTICLE », et wash du pivot sur le titre de l'article.
 
 ## PR associée
-<!-- À compléter après /go : gh pr view --web -->
+
+Non créée.
 
 ## Écrans impactés
+
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| Flâner (feed principal) | onglet Flâner | Modifié (barre d'onglets + boutons filtre/recherche) |
-| Modal d'épinglage | `showPinSubjectsSheet` (bottom sheet) | Modifié (zone SUIVIS à 2 onglets) |
+| Reader article | Détail contenu interne | Modifié |
+| Reader article alternatif | Second path de rendu détail contenu | Modifié |
+| Bottom sheet perspectives | Couverture médiatique | Modifié via zone analyse partagée |
 
 ## Scénarios de test
 
-### Scénario 1 : Happy path — épingler sources + sujets, tout reste visible
+### Scénario 1 : État vide
 **Parcours** :
-1. Ouvrir Flâner, taper l'engrenage/`+` pour ouvrir la modal.
-2. Épingler 2-3 sources (onglet **Sources**) et 2-3 sujets (onglet **Sujets**).
-3. Fermer la modal, observer la barre d'onglets.
-**Résultat attendu** : tous les onglets épinglés (sources **et** sujets) sont visibles et
-intercalés dans l'ordre, aucun ne « disparaît » derrière le fade de droite.
+1. Ouvrir un article dont l'API perspectives ne renvoie aucune autre source.
+2. Observer la section « Couverture médiatique (0) ».
+**Résultat attendu** : le placeholder est discret, sans dividers pleine largeur
+au-dessus/en dessous, avec texte plus petit et atténué, sans caret ni spectrum.
 
-### Scénario 2 : Cap à 10 onglets
+### Scénario 2 : Section ouverte avec perspectives
 **Parcours** :
-1. Épingler plus de 10 éléments au total (sources + sujets).
-**Résultat attendu** : exactement 10 onglets dans la barre (les 10 premiers de l'ordre
-utilisateur) ; le reste reste gérable dans la modal. Pas de crash.
+1. Ouvrir un article avec plusieurs perspectives.
+2. Déplier « Couverture médiatique ».
+3. Observer le haut de la section.
+**Résultat attendu** : la balise polarisation apparaît si niveau `medium` ou
+`high`, le bouton info ouvre le texte de surlignage, l'analyse est au-dessus des
+titres variants, et le bloc « CET ARTICLE » n'apparaît plus.
 
-### Scénario 3 : Tap onglet actif = retour non filtré
+### Scénario 3 : Analyse Facteur
 **Parcours** :
-1. Taper un onglet **sujet** → le feed se filtre, l'onglet devient actif.
-2. Re-taper l'onglet actif.
-3. Idem avec un onglet **source**.
-**Résultat attendu** : le feed redevient non filtré, aucun onglet n'est actif. La source
-se désélectionne bien (régression historique `setSource(null)` corrigée).
+1. Dans une section ouverte, lancer ou afficher l'analyse Facteur.
+2. Lire la mention sous l'analyse.
+**Résultat attendu** : la mention affiche « Analyse générée par Mistral Large ·
+l'IA peut faire des erreurs. ».
 
-### Scénario 4 : Affordance + / engrenage
+### Scénario 4 : Wash pivot titre reader
 **Parcours** :
-1. Avec ≤ 4 onglets épinglés → observer l'icône en fin de barre.
-2. Épingler jusqu'à > 4 onglets → ré-observer.
-**Résultat attendu** : `+` quand ≤ 4 ; engrenage quand > 4. Dans les deux cas, le tap
-ouvre la même modal d'épinglage.
-
-### Scénario 5 : Modal — 2 onglets Sources / Sujets
-**Parcours** :
-1. Ouvrir la modal avec des sources suivies non épinglées **et** des sujets suivis.
-2. Basculer entre les segments **Sources** et **Sujets**.
-3. Taper une ligne pour l'épingler ; vérifier qu'elle remonte dans « ÉPINGLÉS ».
-4. Tester la recherche (filtre l'onglet actif) et un onglet vide.
-**Résultat attendu** : 2 segments fonctionnels ; sujets en liste à plat (emoji par ligne,
-**plus d'en-têtes de thème**) ; épingler/dé-épingler + drag dans « ÉPINGLÉS » OK ;
-placeholder muet (« Aucune source suivie » / « Aucun sujet ») si l'onglet actif est vide.
-
-### Scénario 6 : Boutons filtre + recherche réduits
-**Résultat attendu** : la loupe (recherche) et le bouton filtre sont légèrement plus petits
-(34 px, icônes 16) ; l'espace horizontal libéré profite à la liste d'onglets. Aucun
-chevauchement, alignement vertical correct.
+1. Ouvrir un article avec `reference_pivot`.
+2. Déplier la section « Couverture médiatique ».
+**Résultat attendu** : le pivot du titre de l'article reçoit un wash gris léger à
+l'ouverture, sans ajouter de bloc référence dans la section.
 
 ## Critères d'acceptation
-- [ ] N sources + M sujets (N+M ≤ 10) → tous visibles et intercalés dans l'ordre unifié.
-- [ ] > 10 épinglés → exactement 10 onglets, surplus non perdu (modal).
-- [ ] Aucun onglet « Tous ».
-- [ ] Tap onglet actif (sujet ET source) → feed non filtré, aucun onglet actif.
-- [ ] ≤ 4 onglets → `+` ; > 4 → engrenage (même action).
-- [ ] Modal : 2 segments Sources/Sujets, sujets à plat, drag « ÉPINGLÉS » non régressé.
-- [ ] Boutons filtre/recherche visiblement réduits, sans casser le layout.
+
+- [ ] État vide nettement moins chargé.
+- [ ] Section ouverte hiérarchisée : badge/info puis analyse puis variantes.
+- [ ] Disclaimer IA visible sous l'analyse.
+- [ ] Aucun rendu « CET ARTICLE ».
+- [ ] Wash pivot visible sur le titre du reader à l'ouverture.
+- [ ] Console sans erreur et pas de 4xx/5xx perspectives inattendus.
 
 ## Zones de risque
-- Cohérence **barre ↔ modal** : l'ordre des onglets doit suivre l'ordre validé par drag
-  (prefs `pinned_tabs_order_v1`). Drag dans la modal → la barre reflète le même ordre.
-- Réseau : `onTapActiveTab` enchaîne 4 `set*(null)` → potentiellement plusieurs refresh
-  (trade-off connu, follow-up hors scope).
+
+- Les deux chemins de rendu du reader doivent rester cohérents.
+- Le bouton info doit rester tappable en viewport mobile 390x844.
+- Le titre reader ne doit pas changer de hauteur de façon visible au moment du
+  wash.
 
 ## Dépendances
-- `tab_counts_provider`, `userInterestsProvider`, `userSourcesStateProvider`,
-  `userSourcesProvider`, `tabOrderPrefsProvider` (SharedPreferences `pinned_tabs_order_v1`).
-- Aucune modif backend / migration.
+
+Pas de changement backend. Le wash dépend du champ API existant
+`reference_pivot`.

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -2770,11 +2770,21 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 ),
                                 const SizedBox(height: FacteurSpacing.space4),
                               ],
-                              Text(
-                                content.title,
-                                style: textTheme.displayLarge?.copyWith(
+                              PivotWashTitle(
+                                key: ValueKey(
+                                  'article-title-wash-'
+                                  '$_perspectivesExpanded-'
+                                  '${_perspectivesResponse?.referencePivot?.start}-'
+                                  '${_perspectivesResponse?.referencePivot?.end}',
+                                ),
+                                title: content.title,
+                                pivot: _perspectivesExpanded
+                                    ? _perspectivesResponse?.referencePivot
+                                    : null,
+                                textStyle: textTheme.displayLarge?.copyWith(
                                   fontSize: 24,
                                 ),
+                                animate: _perspectivesExpanded,
                               ),
                               const SizedBox(height: FacteurSpacing.space2),
                               if (readingTime != null) ...[
@@ -2805,17 +2815,21 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
                         // ZONE 1b: Perspectives section, framed by dividers.
                         if (_showPerspectivesBand) ...[
-                          Container(
-                            color: colors.backgroundPrimary,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: FacteurSpacing.space4,
+                          if (_perspectivesStatus !=
+                              PerspectivesSectionStatus.empty)
+                            Container(
+                              color: colors.backgroundPrimary,
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: FacteurSpacing.space4,
+                              ),
+                              child: Divider(
+                                color: colors.textTertiary.withValues(
+                                  alpha: 0.3,
+                                ),
+                                height: 1,
+                                thickness: 1,
+                              ),
                             ),
-                            child: Divider(
-                              color: colors.textTertiary.withValues(alpha: 0.3),
-                              height: 1,
-                              thickness: 1,
-                            ),
-                          ),
                           Container(
                             color: colors.backgroundPrimary,
                             child: PerspectivesInlineSection(
@@ -2851,22 +2865,23 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                               analysisZoneKey: _analysisZoneKey,
                               isExpanded: _perspectivesExpanded,
                               onToggle: _onPerspectivesToggle,
-                              referenceTitle: _content?.title ?? '',
-                              referencePivot:
-                                  _perspectivesResponse?.referencePivot,
                             ),
                           ),
-                          Container(
-                            color: colors.backgroundPrimary,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: FacteurSpacing.space4,
+                          if (_perspectivesStatus !=
+                              PerspectivesSectionStatus.empty)
+                            Container(
+                              color: colors.backgroundPrimary,
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: FacteurSpacing.space4,
+                              ),
+                              child: Divider(
+                                color: colors.textTertiary.withValues(
+                                  alpha: 0.3,
+                                ),
+                                height: 1,
+                                thickness: 1,
+                              ),
                             ),
-                            child: Divider(
-                              color: colors.textTertiary.withValues(alpha: 0.3),
-                              height: 1,
-                              thickness: 1,
-                            ),
-                          ),
                           const SizedBox(height: FacteurSpacing.space4),
                         ],
 
@@ -3357,9 +3372,21 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           content.entities.isNotEmpty ||
                           content.topics.isNotEmpty)
                         _buildTagsWrap(context, content, isPartial: isPartial),
-                      Text(
-                        content.title,
-                        style: textTheme.displayLarge?.copyWith(fontSize: 24),
+                      PivotWashTitle(
+                        key: ValueKey(
+                          'article-title-wash-alt-'
+                          '$_perspectivesExpanded-'
+                          '${_perspectivesResponse?.referencePivot?.start}-'
+                          '${_perspectivesResponse?.referencePivot?.end}',
+                        ),
+                        title: content.title,
+                        pivot: _perspectivesExpanded
+                            ? _perspectivesResponse?.referencePivot
+                            : null,
+                        textStyle: textTheme.displayLarge?.copyWith(
+                          fontSize: 24,
+                        ),
+                        animate: _perspectivesExpanded,
                       ),
                       if (readingTime != null)
                         Row(
@@ -3385,16 +3412,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 // ── Perspectives section (avant l'article) ─────────────────
                 if (_showPerspectivesBand) ...[
                   const SizedBox(height: FacteurSpacing.space4),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: FacteurSpacing.space4,
+                  if (_perspectivesStatus != PerspectivesSectionStatus.empty)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: FacteurSpacing.space4,
+                      ),
+                      child: Divider(
+                        color: colors.textTertiary.withValues(alpha: 0.3),
+                        height: 1,
+                        thickness: 1,
+                      ),
                     ),
-                    child: Divider(
-                      color: colors.textTertiary.withValues(alpha: 0.3),
-                      height: 1,
-                      thickness: 1,
-                    ),
-                  ),
                   PerspectivesInlineSection(
                     key: _perspectivesKey,
                     status: _perspectivesStatus,
@@ -3420,19 +3448,18 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     analysisZoneKey: _analysisZoneKey,
                     isExpanded: _perspectivesExpanded,
                     onToggle: _onPerspectivesToggle,
-                    referenceTitle: _content?.title ?? '',
-                    referencePivot: _perspectivesResponse?.referencePivot,
                   ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: FacteurSpacing.space4,
+                  if (_perspectivesStatus != PerspectivesSectionStatus.empty)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: FacteurSpacing.space4,
+                      ),
+                      child: Divider(
+                        color: colors.textTertiary.withValues(alpha: 0.3),
+                        height: 1,
+                        thickness: 1,
+                      ),
                     ),
-                    child: Divider(
-                      color: colors.textTertiary.withValues(alpha: 0.3),
-                      height: 1,
-                      thickness: 1,
-                    ),
-                  ),
                 ],
 
                 const SizedBox(height: FacteurSpacing.space4),

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -20,8 +20,8 @@ import 'coverage_spectrum_bar.dart';
 import 'diff_title.dart';
 
 /// Texte d'introduction expliquant le surlignage. Affiché dans le bottom-sheet
-/// modal ET en tête du groupe inline de la section « Couverture médiatique »
-/// du reader d'article — single source of truth pour les deux vues.
+/// modal ET derrière le bouton info de la section inline du reader d'article
+/// — single source of truth pour les deux vues.
 const String kHighlightIntroText =
     'Le surlignage met en évidence les termes qui '
     'marquent l\'angle éditorial : plus le surlignage '
@@ -81,13 +81,13 @@ class Perspective {
       highlightSpans: rawHighlights == null
           ? const []
           : rawHighlights
-              .map((e) => HighlightSpan.fromJson(e as Map<String, dynamic>))
-              .toList(),
+                .map((e) => HighlightSpan.fromJson(e as Map<String, dynamic>))
+                .toList(),
       sharedTokens: rawShared == null
           ? const []
           : rawShared
-              .map((e) => TokenSpan.fromJson(e as Map<String, dynamic>))
-              .toList(),
+                .map((e) => TokenSpan.fromJson(e as Map<String, dynamic>))
+                .toList(),
       language: json['language'] as String?,
     );
   }
@@ -211,7 +211,9 @@ class _PerspectivesBottomSheetState
     _openedAt = DateTime.now();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      ref.read(analyticsServiceProvider).trackPerspectiveComparisonOpened(
+      ref
+          .read(analyticsServiceProvider)
+          .trackPerspectiveComparisonOpened(
             contentId: widget.contentId,
             sourcesCount: widget.perspectives.length,
           );
@@ -221,12 +223,15 @@ class _PerspectivesBottomSheetState
   @override
   void dispose() {
     final opened = _openedAt;
-    final elapsed =
-        opened != null ? DateTime.now().difference(opened).inSeconds : 0;
+    final elapsed = opened != null
+        ? DateTime.now().difference(opened).inSeconds
+        : 0;
     // En tests / teardown rapide, le ProviderScope peut être disposé avant
     // ce widget — on ne veut pas crasher pour un event analytics.
     try {
-      ref.read(analyticsServiceProvider).trackPerspectiveComparisonClosed(
+      ref
+          .read(analyticsServiceProvider)
+          .trackPerspectiveComparisonClosed(
             contentId: widget.contentId,
             viewedArticles: _viewedPerspectiveIds.length,
             openedSeconds: elapsed,
@@ -237,7 +242,9 @@ class _PerspectivesBottomSheetState
 
   void _onPerspectiveViewed(String perspectiveId) {
     if (!_viewedPerspectiveIds.add(perspectiveId)) return;
-    ref.read(analyticsServiceProvider).trackPerspectiveArticleViewed(
+    ref
+        .read(analyticsServiceProvider)
+        .trackPerspectiveArticleViewed(
           contentId: widget.contentId,
           perspectiveArticleId: perspectiveId,
         );
@@ -399,8 +406,8 @@ class _PerspectivesBottomSheetState
                                     color: colors.textPrimary,
                                     fontSize:
                                         (textTheme.titleMedium?.fontSize ??
-                                                16) +
-                                            1,
+                                            16) +
+                                        1,
                                   ),
                                 ),
                               ),
@@ -458,11 +465,11 @@ class _PerspectivesBottomSheetState
                                         children: [
                                           Text(
                                             'Tout afficher',
-                                            style:
-                                                textTheme.labelSmall?.copyWith(
-                                              color: colors.primary,
-                                              fontWeight: FontWeight.w600,
-                                            ),
+                                            style: textTheme.labelSmall
+                                                ?.copyWith(
+                                                  color: colors.primary,
+                                                  fontWeight: FontWeight.w600,
+                                                ),
                                           ),
                                           const SizedBox(width: 4),
                                           Icon(
@@ -700,7 +707,8 @@ class _PerspectiveCard extends ConsumerWidget {
                           highlightSpans: perspective.highlightSpans,
                           sharedTokens: perspective.sharedTokens,
                           biasColor: perspective.getBiasColor(colors),
-                          baseStyle: textTheme.bodyMedium?.copyWith(
+                          baseStyle:
+                              textTheme.bodyMedium?.copyWith(
                                 color: colors.textPrimary,
                                 fontSize:
                                     (textTheme.bodyMedium?.fontSize ?? 14) + 2,
@@ -959,8 +967,9 @@ class PerspectivesBiasBar extends StatelessWidget {
             return Expanded(
               flex: flexValues[i],
               child: GestureDetector(
-                onTap:
-                    count > 0 && !compact ? () => onSegmentTap(seg.$1) : null,
+                onTap: count > 0 && !compact
+                    ? () => onSegmentTap(seg.$1)
+                    : null,
                 child: AnimatedOpacity(
                   duration: const Duration(milliseconds: 200),
                   opacity: isActive ? 1.0 : 0.3,
@@ -1261,7 +1270,7 @@ class PerspectivesAnalysisZoneState extends State<PerspectivesAnalysisZone> {
             Align(
               alignment: Alignment.centerRight,
               child: Text(
-                'Analyse Facteur',
+                'Analyse générée par Mistral Large · l\'IA peut faire des erreurs.',
                 style: widget.textTheme.bodySmall?.copyWith(
                   fontSize: 10,
                   fontStyle: FontStyle.italic,
@@ -1349,13 +1358,6 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
   /// Called when the user taps the header to toggle collapse/expand.
   final VoidCallback onToggle;
 
-  /// Titre de l'article lu — rendu dans le bloc référence en mode ouvert.
-  final String referenceTitle;
-
-  /// Verbe-pivot du titre référence — washé en gris dans le bloc référence
-  /// si non-null. Renvoyé par le back via `reference_pivot`.
-  final TokenSpan? referencePivot;
-
   final PerspectivesSectionStatus status;
 
   const PerspectivesInlineSection({
@@ -1378,8 +1380,6 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
     this.firstCardKey,
     this.isExpanded = true,
     required this.onToggle,
-    this.referenceTitle = '',
-    this.referencePivot,
     this.status = PerspectivesSectionStatus.ready,
   });
 
@@ -1439,11 +1439,12 @@ class _PerspectivesInlineSectionState
     final textTheme = Theme.of(context).textTheme;
     final variants = _filteredPerspectives.take(8).toList();
     final isReady = widget.status == PerspectivesSectionStatus.ready;
+    final isEmpty = widget.status == PerspectivesSectionStatus.empty;
     final label = widget.status == PerspectivesSectionStatus.loading
         ? 'Couverture médiatique'
         : 'Couverture médiatique (${widget.perspectives.length})';
-    final labelColor = widget.status == PerspectivesSectionStatus.empty
-        ? colors.textTertiary
+    final labelColor = isEmpty
+        ? colors.textTertiary.withValues(alpha: 0.62)
         : colors.textPrimary;
     final shouldShowBody = isReady && widget.isExpanded;
 
@@ -1458,16 +1459,19 @@ class _PerspectivesInlineSectionState
             decoration: BoxDecoration(
               border: Border(
                 top: BorderSide(
-                  color: Colors.black.withValues(alpha: 0.08),
+                  color: Colors.black.withValues(alpha: isEmpty ? 0.025 : 0.08),
                   width: 1,
                 ),
                 bottom: BorderSide(
-                  color: Colors.black.withValues(alpha: 0.08),
+                  color: Colors.black.withValues(alpha: isEmpty ? 0.025 : 0.08),
                   width: 1,
                 ),
               ),
             ),
-            padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 13),
+            padding: EdgeInsets.symmetric(
+              horizontal: 18,
+              vertical: isEmpty ? 8 : 13,
+            ),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
@@ -1481,8 +1485,10 @@ class _PerspectivesInlineSectionState
                           overflow: TextOverflow.ellipsis,
                           maxLines: 1,
                           style: GoogleFonts.dmSans(
-                            fontSize: 13,
-                            fontWeight: FontWeight.w700,
+                            fontSize: isEmpty ? 11 : 13,
+                            fontWeight: isEmpty
+                                ? FontWeight.w600
+                                : FontWeight.w700,
                             color: labelColor,
                           ),
                         ),
@@ -1531,6 +1537,11 @@ class _PerspectivesInlineSectionState
     TextTheme textTheme,
     List<Perspective> variants,
   ) {
+    final hasDivergenceBadge =
+        widget.divergenceLevel == 'medium' || widget.divergenceLevel == 'high';
+    final shouldShowIntroInfo = variants.isNotEmpty;
+    final shouldShowToolsRow = hasDivergenceBadge || shouldShowIntroInfo;
+
     return Container(
       decoration: BoxDecoration(
         gradient: LinearGradient(
@@ -1543,27 +1554,44 @@ class _PerspectivesInlineSectionState
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (_polarizationText != null)
+          if (shouldShowToolsRow)
             Padding(
-              padding: const EdgeInsets.fromLTRB(16, 10, 16, 4),
-              child: Text(
-                _polarizationText!,
-                style: textTheme.bodySmall?.copyWith(
-                  color: colors.textSecondary,
-                  height: 1.35,
-                  fontWeight: FontWeight.w600,
-                ),
+              padding: const EdgeInsets.fromLTRB(16, 10, 16, 6),
+              child: Row(
+                children: [
+                  if (hasDivergenceBadge)
+                    _DivergenceChip(
+                      divergenceLevel: widget.divergenceLevel,
+                      colors: colors,
+                    ),
+                  const Spacer(),
+                  if (shouldShowIntroInfo)
+                    _HighlightInfoButton(
+                      colors: colors,
+                      onTap: () =>
+                          _showHighlightInfo(context, colors, textTheme),
+                    ),
+                ],
               ),
             ),
-          if (variants.isNotEmpty)
+          if (widget.analysisState == PerspectivesAnalysisState.idle)
             Padding(
-              padding: EdgeInsets.fromLTRB(16, _polarizationText != null ? 0 : 10, 16, 6),
-              child: Text(
-                kHighlightIntroText,
-                style: textTheme.bodySmall?.copyWith(
-                  color: colors.textSecondary,
-                  height: 1.35,
-                ),
+              padding: const EdgeInsets.fromLTRB(18, 8, 18, 8),
+              child: _AnalysisCtaCard(
+                onTap: widget.onRequestAnalysis,
+                state: widget.analysisState,
+              ),
+            ),
+          if (widget.analysisState != PerspectivesAnalysisState.idle)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 10),
+              child: PerspectivesAnalysisZone(
+                state: widget.analysisState,
+                text: widget.analysisText,
+                onRequestAnalysis: widget.onRequestAnalysis,
+                colors: colors,
+                textTheme: textTheme,
+                zoneKey: widget.analysisZoneKey,
               ),
             ),
           for (var i = 0; i < variants.length; i++)
@@ -1583,185 +1611,153 @@ class _PerspectivesInlineSectionState
                 ),
               ),
             ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(18, 14, 18, 8),
-            child: _AnalysisCtaCard(
-              onTap: widget.onRequestAnalysis,
-              state: widget.analysisState,
-            ),
-          ),
-          if (widget.analysisState != PerspectivesAnalysisState.idle)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
-              child: PerspectivesAnalysisZone(
-                state: widget.analysisState,
-                text: widget.analysisText,
-                onRequestAnalysis: widget.onRequestAnalysis,
-                colors: colors,
-                textTheme: textTheme,
-                zoneKey: widget.analysisZoneKey,
-              ),
-            ),
-          if (widget.referenceTitle.isNotEmpty) ...[
-            Container(
-              margin: const EdgeInsets.fromLTRB(16, 14, 16, 0),
-              height: 1,
-              color: colors.textSecondary.withValues(alpha: 0.18),
-            ),
-            _RefBlock(
-              key: ValueKey('ref_$_animationGeneration'),
-              title: widget.referenceTitle,
-              pivot: widget.referencePivot,
-              sourceBiasStance: widget.sourceBiasStance,
-              sourceName: widget.sourceName,
-            ),
-          ],
           const SizedBox(height: 16),
         ],
       ),
     );
   }
 
-  String? get _polarizationText {
-    switch (widget.divergenceLevel) {
-      case 'medium':
-        return 'Avis variés dans le traitement de ce sujet';
-      case 'high':
-        return 'Forte polarisation dans le traitement de ce sujet';
-      default:
-        return null;
-    }
-  }
-}
-
-/// Bloc référence (cm-ref-inline) — visible en mode ouvert seulement.
-/// Border-left ocre, wash gradient ocre 5%, titre Fraunces avec wash gris
-/// sur le verbe-pivot si fourni, footer source.
-class _RefBlock extends ConsumerWidget {
-  final String title;
-  final TokenSpan? pivot;
-  final String sourceBiasStance;
-  final String sourceName;
-
-  const _RefBlock({
-    super.key,
-    required this.title,
-    required this.pivot,
-    required this.sourceBiasStance,
-    required this.sourceName,
-  });
-
-  Color _biasColor(FacteurColors colors) {
-    switch (sourceBiasStance) {
-      case 'left':
-        return colors.biasLeft;
-      case 'center-left':
-        return colors.biasCenterLeft;
-      case 'center':
-        return colors.biasCenter;
-      case 'center-right':
-        return colors.biasCenterRight;
-      case 'right':
-        return colors.biasRight;
-      default:
-        return colors.biasUnknown;
-    }
-  }
-
-  String _biasLabel() {
-    switch (sourceBiasStance) {
-      case 'left':
-        return 'GAUCHE';
-      case 'center-left':
-        return 'CENTRE-G';
-      case 'center':
-        return 'CENTRE';
-      case 'center-right':
-        return 'CENTRE-D';
-      case 'right':
-        return 'DROITE';
-      default:
-        return 'SOURCE';
-    }
-  }
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = context.facteurColors;
-    return Container(
-      decoration: BoxDecoration(
-        border: Border(left: BorderSide(color: colors.primary, width: 3)),
-        gradient: LinearGradient(
-          begin: Alignment.centerLeft,
-          end: Alignment.centerRight,
-          colors: [colors.primary.withValues(alpha: 0.05), Colors.transparent],
-          stops: const [0.0, 0.7],
+  void _showHighlightInfo(
+    BuildContext context,
+    FacteurColors colors,
+    TextTheme textTheme,
+  ) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) => Container(
+        decoration: BoxDecoration(
+          color: colors.backgroundPrimary,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
         ),
-      ),
-      padding: const EdgeInsets.fromLTRB(20, 12, 20, 14),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'CET ARTICLE',
-            style: GoogleFonts.dmSans(
-              fontSize: 10,
-              fontWeight: FontWeight.w700,
-              letterSpacing: 0.4,
-              color: colors.primary,
+        padding: EdgeInsets.fromLTRB(
+          20,
+          12,
+          20,
+          24 + MediaQuery.of(sheetContext).padding.bottom,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: colors.textSecondary.withValues(alpha: 0.2),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
             ),
-          ),
-          const SizedBox(height: 6),
-          _PivotedRefTitle(title: title, pivot: pivot),
-          const SizedBox(height: 8),
-          Row(
-            children: [
-              Icon(
-                PhosphorIcons.user(PhosphorIconsStyle.fill),
-                size: 12,
-                color: colors.textTertiary,
-              ),
-              const SizedBox(width: 6),
-              Text(
-                sourceName.isNotEmpty ? sourceName : 'Source',
-                style: GoogleFonts.dmSans(
-                  fontSize: 11,
-                  fontWeight: FontWeight.w500,
-                  color: colors.textSecondary,
+            const SizedBox(height: 18),
+            Row(
+              children: [
+                Icon(
+                  PhosphorIcons.info(PhosphorIconsStyle.regular),
+                  size: 18,
+                  color: colors.primary,
                 ),
-              ),
-              const SizedBox(width: 8),
-              Text(
-                _biasLabel(),
-                style: GoogleFonts.courierPrime(
-                  fontSize: 9.5,
-                  fontWeight: FontWeight.w700,
-                  color: _biasColor(colors),
-                  letterSpacing: 0.5,
+                const SizedBox(width: 8),
+                Text(
+                  'Surlignage',
+                  style: textTheme.titleSmall?.copyWith(
+                    color: colors.textPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              kHighlightIntroText,
+              style: textTheme.bodyMedium?.copyWith(
+                color: colors.textSecondary,
+                height: 1.45,
               ),
-            ],
-          ),
-        ],
+            ),
+          ],
+        ),
       ),
     );
   }
 }
 
-/// Titre référence : RichText avec wash gris autour du pivot (si fourni),
-/// fade-in du wash 300 ms easeOut au moment de l'expand. Si pivot null,
-/// titre plein sans animation.
-class _PivotedRefTitle extends StatefulWidget {
-  final String title;
-  final TokenSpan? pivot;
+class _DivergenceChip extends StatelessWidget {
+  final String? divergenceLevel;
+  final FacteurColors colors;
 
-  const _PivotedRefTitle({required this.title, required this.pivot});
+  const _DivergenceChip({required this.divergenceLevel, required this.colors});
 
   @override
-  State<_PivotedRefTitle> createState() => _PivotedRefTitleState();
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+      decoration: BoxDecoration(
+        color: colors.primary.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: DivergenceInlineBadge(divergenceLevel: divergenceLevel),
+    );
+  }
 }
 
-class _PivotedRefTitleState extends State<_PivotedRefTitle>
+class _HighlightInfoButton extends StatelessWidget {
+  final FacteurColors colors;
+  final VoidCallback onTap;
+
+  const _HighlightInfoButton({required this.colors, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: onTap,
+      tooltip: 'Surlignage',
+      visualDensity: VisualDensity.compact,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+      icon: Container(
+        width: 24,
+        height: 24,
+        decoration: BoxDecoration(
+          color: colors.textSecondary.withValues(alpha: 0.08),
+          shape: BoxShape.circle,
+        ),
+        alignment: Alignment.center,
+        child: Icon(
+          PhosphorIcons.info(PhosphorIconsStyle.regular),
+          size: 15,
+          color: colors.textSecondary,
+        ),
+      ),
+    );
+  }
+}
+
+/// RichText avec wash gris autour du pivot (si fourni). Utilisé pour signaler
+/// le token-pivot du titre de référence dans le reader.
+class PivotWashTitle extends StatefulWidget {
+  final String title;
+  final TokenSpan? pivot;
+  final TextStyle? textStyle;
+  final bool animate;
+  final int? maxLines;
+
+  const PivotWashTitle({
+    super.key,
+    required this.title,
+    required this.pivot,
+    this.textStyle,
+    this.animate = true,
+    this.maxLines,
+  });
+
+  @override
+  State<PivotWashTitle> createState() => _PivotWashTitleState();
+}
+
+class _PivotWashTitleState extends State<PivotWashTitle>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
 
@@ -1772,12 +1768,29 @@ class _PivotedRefTitleState extends State<_PivotedRefTitle>
       vsync: this,
       duration: const Duration(milliseconds: 300),
     );
-    if (widget.pivot != null) {
+    if (widget.pivot != null && widget.animate) {
       Future.delayed(DiffTitle.kStartDelay, () {
         if (mounted) _controller.forward();
       });
     } else {
       _controller.value = 1.0;
+    }
+  }
+
+  @override
+  void didUpdateWidget(PivotWashTitle oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.title != widget.title ||
+        oldWidget.pivot != widget.pivot ||
+        oldWidget.animate != widget.animate) {
+      if (widget.pivot != null && widget.animate) {
+        _controller.value = 0;
+        Future.delayed(DiffTitle.kStartDelay, () {
+          if (mounted) _controller.forward();
+        });
+      } else {
+        _controller.value = 1.0;
+      }
     }
   }
 
@@ -1790,22 +1803,23 @@ class _PivotedRefTitleState extends State<_PivotedRefTitle>
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final fraunces = GoogleFonts.fraunces(
-      fontSize: 16.5,
-      fontWeight: FontWeight.w600,
-      letterSpacing: -0.2,
-      color: colors.textPrimary,
-      height: 1.3,
-    );
+    final titleStyle =
+        widget.textStyle ??
+        GoogleFonts.fraunces(
+          fontSize: 16.5,
+          fontWeight: FontWeight.w600,
+          color: colors.textPrimary,
+          height: 1.3,
+        );
     final pivot = widget.pivot;
     if (pivot == null) {
-      return Text(widget.title, style: fraunces);
+      return Text(widget.title, style: titleStyle, maxLines: widget.maxLines);
     }
     final titleLen = widget.title.length;
     final start = pivot.start.clamp(0, titleLen);
     final end = pivot.end.clamp(start, titleLen);
     if (end == start) {
-      return Text(widget.title, style: fraunces);
+      return Text(widget.title, style: titleStyle, maxLines: widget.maxLines);
     }
     return AnimatedBuilder(
       animation: _controller,
@@ -1813,8 +1827,9 @@ class _PivotedRefTitleState extends State<_PivotedRefTitle>
         final t = Curves.easeOut.transform(_controller.value);
         final washColor = const Color(0xFF9E9E9E).withValues(alpha: 0.14 * t);
         return RichText(
+          maxLines: widget.maxLines,
           text: TextSpan(
-            style: fraunces,
+            style: titleStyle,
             children: [
               if (start > 0) TextSpan(text: widget.title.substring(0, start)),
               WidgetSpan(
@@ -1831,7 +1846,7 @@ class _PivotedRefTitleState extends State<_PivotedRefTitle>
                   ),
                   child: Text(
                     widget.title.substring(start, end),
-                    style: fraunces,
+                    style: titleStyle,
                   ),
                 ),
               ),
@@ -1904,7 +1919,8 @@ class _VariantRow extends ConsumerWidget {
               highlightSpans: perspective.highlightSpans,
               sharedTokens: perspective.sharedTokens,
               biasColor: biasColor,
-              baseStyle: textTheme.bodyMedium?.copyWith(
+              baseStyle:
+                  textTheme.bodyMedium?.copyWith(
                     fontSize: 15.5,
                     height: 1.35,
                     color: colors.textPrimary,

--- a/apps/mobile/test/features/feed/widgets/perspective_opens_in_app_reader_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspective_opens_in_app_reader_test.dart
@@ -20,16 +20,16 @@ import 'package:facteur/widgets/design/facteur_card.dart';
 /// `MissingPluginException` de `url_launcher` en widget test) serait une
 /// régression directe.
 Perspective _persp(String name, String bias) => Perspective(
-      title: 'Titre court avec mot fort',
-      url: 'https://example.com/$name',
-      sourceName: name,
-      sourceDomain: '$name.example.com',
-      biasStance: bias,
-      highlightSpans: const [
-        HighlightSpan(start: 18, end: 22, text: 'fort', bias: 'left'),
-      ],
-      sharedTokens: const [TokenSpan(start: 0, end: 5, text: 'Titre')],
-    );
+  title: 'Titre court avec mot fort',
+  url: 'https://example.com/$name',
+  sourceName: name,
+  sourceDomain: '$name.example.com',
+  biasStance: bias,
+  highlightSpans: const [
+    HighlightSpan(start: 18, end: 22, text: 'fort', bias: 'left'),
+  ],
+  sharedTokens: const [TokenSpan(start: 0, end: 5, text: 'Titre')],
+);
 
 /// Capture la `Perspective` reçue par la route `content-external` (au lieu
 /// d'instancier le vrai `ContentDetailScreen`, qui dépend de Supabase/Hive et
@@ -56,9 +56,7 @@ GoRouter _router(Widget home) {
         name: RouteNames.contentExternal,
         builder: (_, state) {
           _routedPerspective = state.extra as Perspective?;
-          return const Scaffold(
-            body: SizedBox(key: _kExternalReaderMarker),
-          );
+          return const Scaffold(body: SizedBox(key: _kExternalReaderMarker));
         },
       ),
     ],
@@ -80,7 +78,6 @@ Widget _variantRowHome() {
           onClearSegments: () {},
           onToggle: () {},
           isExpanded: true,
-          referenceTitle: '',
         ),
       ),
     ),
@@ -124,8 +121,11 @@ void main() {
   // /content-external" : une GoRoute top-level DOIT avoir un path absolu
   // (commençant par '/'), sinon go_router ne sait pas résoudre la route nommée.
   test('content-external : route top-level avec path absolu résolvable', () {
-    expect(RoutePaths.contentExternal.startsWith('/'), isTrue,
-        reason: 'Une GoRoute top-level doit avoir un path absolu.');
+    expect(
+      RoutePaths.contentExternal.startsWith('/'),
+      isTrue,
+      reason: 'Une GoRoute top-level doit avoir un path absolu.',
+    );
     final router = GoRouter(
       routes: [
         GoRoute(path: '/', builder: (_, __) => const SizedBox()),
@@ -136,8 +136,10 @@ void main() {
         ),
       ],
     );
-    expect(router.namedLocation(RouteNames.contentExternal),
-        RoutePaths.contentExternal);
+    expect(
+      router.namedLocation(RouteNames.contentExternal),
+      RoutePaths.contentExternal,
+    );
   });
 
   setUp(() {
@@ -147,7 +149,10 @@ void main() {
     // jamais en widget test et la navigation ne se déclenche pas.
     TestWidgetsFlutterBinding.ensureInitialized();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(SystemChannels.platform, (call) async => null);
+        .setMockMethodCallHandler(
+          SystemChannels.platform,
+          (call) async => null,
+        );
   });
 
   tearDown(() {
@@ -156,53 +161,68 @@ void main() {
   });
 
   testWidgets(
-      '_VariantRow tap → route vers content-external (pas de launchUrl)',
-      (tester) async {
-    await tester.pumpWidget(_app(_variantRowHome()));
-    await tester.pumpAndSettle(const Duration(seconds: 1));
+    '_VariantRow tap → route vers content-external (pas de launchUrl)',
+    (tester) async {
+      await tester.pumpWidget(_app(_variantRowHome()));
+      await tester.pumpAndSettle(const Duration(seconds: 1));
 
-    expect(find.byKey(_kExternalReaderMarker), findsNothing,
-        reason: 'Le reader ne doit pas être présent avant le tap.');
+      expect(
+        find.byKey(_kExternalReaderMarker),
+        findsNothing,
+        reason: 'Le reader ne doit pas être présent avant le tap.',
+      );
 
-    // Tape sur le DiffTitle (le titre est rendu via RichText, pas Text).
-    final tappable = find.byType(DiffTitle);
-    expect(tappable, findsWidgets);
-    await tester.tap(tappable.first, warnIfMissed: false);
-    await tester.pumpAndSettle(const Duration(milliseconds: 400));
+      // Tape sur le DiffTitle (le titre est rendu via RichText, pas Text).
+      final tappable = find.byType(DiffTitle);
+      expect(tappable, findsWidgets);
+      await tester.tap(tappable.first, warnIfMissed: false);
+      await tester.pumpAndSettle(const Duration(milliseconds: 400));
 
-    expect(find.byKey(_kExternalReaderMarker), findsOneWidget,
+      expect(
+        find.byKey(_kExternalReaderMarker),
+        findsOneWidget,
         reason:
             'Le tap doit router vers ContentDetailScreen (mode externe) via '
-            'pushNamed(RouteNames.contentExternal) — pas launchUrl.');
-    expect(_routedPerspective?.url, 'https://example.com/Source-Gauche',
-        reason: 'La Perspective tapée doit être transmise via extra.');
-  });
+            'pushNamed(RouteNames.contentExternal) — pas launchUrl.',
+      );
+      expect(
+        _routedPerspective?.url,
+        'https://example.com/Source-Gauche',
+        reason: 'La Perspective tapée doit être transmise via extra.',
+      );
+    },
+  );
 
   testWidgets(
-      '_PerspectiveCard tap → route vers content-external (pas de launchUrl)',
-      (tester) async {
-    await tester.pumpWidget(_app(_bottomSheetHome()));
-    await tester.pumpAndSettle();
+    '_PerspectiveCard tap → route vers content-external (pas de launchUrl)',
+    (tester) async {
+      await tester.pumpWidget(_app(_bottomSheetHome()));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.text('open sheet'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('open sheet'));
+      await tester.pumpAndSettle();
 
-    expect(find.byType(PerspectivesBottomSheet), findsOneWidget);
-    expect(find.byKey(_kExternalReaderMarker), findsNothing);
+      expect(find.byType(PerspectivesBottomSheet), findsOneWidget);
+      expect(find.byKey(_kExternalReaderMarker), findsNothing);
 
-    // Tape sur la zone titre de la FacteurCard. Le footer interne a un
-    // `GestureDetector` opaque (pour le source detail modal) qui absorbe les
-    // taps même quand son onTap est null — donc on cible une position en
-    // haut de la carte, dans la région du DiffTitle.
-    final card = find.byType(FacteurCard);
-    expect(card, findsOneWidget);
-    final cardRect = tester.getRect(card);
-    await tester.tapAt(Offset(cardRect.center.dx, cardRect.top + 24));
-    await tester.pumpAndSettle(const Duration(milliseconds: 600));
+      // Tape sur la zone titre de la FacteurCard. Le footer interne a un
+      // `GestureDetector` opaque (pour le source detail modal) qui absorbe les
+      // taps même quand son onTap est null — donc on cible une position en
+      // haut de la carte, dans la région du DiffTitle.
+      final card = find.byType(FacteurCard);
+      expect(card, findsOneWidget);
+      final cardRect = tester.getRect(card);
+      await tester.tapAt(Offset(cardRect.center.dx, cardRect.top + 24));
+      await tester.pumpAndSettle(const Duration(milliseconds: 600));
 
-    expect(find.byKey(_kExternalReaderMarker), findsOneWidget,
-        reason: 'Le tap sur _PerspectiveCard doit router vers '
-            'ContentDetailScreen (mode externe) via pushNamed.');
-    expect(_routedPerspective?.url, 'https://example.com/Source-Gauche');
-  });
+      expect(
+        find.byKey(_kExternalReaderMarker),
+        findsOneWidget,
+        reason:
+            'Le tap sur _PerspectiveCard doit router vers '
+            'ContentDetailScreen (mode externe) via pushNamed.',
+      );
+      expect(_routedPerspective?.url, 'https://example.com/Source-Gauche');
+    },
+  );
 }

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_animation_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_animation_test.dart
@@ -9,16 +9,16 @@ import 'package:facteur/features/feed/widgets/diff_title.dart';
 import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
 
 Perspective _persp(String name, String bias) => Perspective(
-      title: 'Titre court avec mot fort',
-      url: 'https://example.com/$name',
-      sourceName: name,
-      sourceDomain: '',
-      biasStance: bias,
-      highlightSpans: const [
-        HighlightSpan(start: 18, end: 22, text: 'fort', bias: 'left'),
-      ],
-      sharedTokens: const [TokenSpan(start: 0, end: 5, text: 'Titre')],
-    );
+  title: 'Titre court avec mot fort',
+  url: 'https://example.com/$name',
+  sourceName: name,
+  sourceDomain: '',
+  biasStance: bias,
+  highlightSpans: const [
+    HighlightSpan(start: 18, end: 22, text: 'fort', bias: 'left'),
+  ],
+  sharedTokens: const [TokenSpan(start: 0, end: 5, text: 'Titre')],
+);
 
 class _Harness extends StatefulWidget {
   final bool initialExpanded;
@@ -57,7 +57,6 @@ class _HarnessState extends State<_Harness> {
             onClearSegments: () {},
             onToggle: toggle,
             isExpanded: _expanded,
-            referenceTitle: 'Titre référence',
           ),
         ),
       ),
@@ -82,29 +81,32 @@ Future<void> _pumpHarness(
 
 void main() {
   test(
-      'kStartDelay must outlast PerspectivesInlineSection AnimatedSize (250 ms)',
-      () {
-    // The bug the PO reported: when the panel expands, the AnimatedSize
-    // takes 250 ms to grow. If DiffTitle starts its cascade before then,
-    // the highlights finalize while still hidden behind the growing
-    // container and the user perceives them as already there.
-    expect(
-      DiffTitle.kStartDelay.inMilliseconds,
-      greaterThan(250),
-      reason:
-          'kStartDelay must exceed the 250 ms AnimatedSize duration so the '
-          'cascade is visible after the panel finishes expanding.',
-    );
-  });
+    'kStartDelay must outlast PerspectivesInlineSection AnimatedSize (250 ms)',
+    () {
+      // The bug the PO reported: when the panel expands, the AnimatedSize
+      // takes 250 ms to grow. If DiffTitle starts its cascade before then,
+      // the highlights finalize while still hidden behind the growing
+      // container and the user perceives them as already there.
+      expect(
+        DiffTitle.kStartDelay.inMilliseconds,
+        greaterThan(250),
+        reason:
+            'kStartDelay must exceed the 250 ms AnimatedSize duration so the '
+            'cascade is visible after the panel finishes expanding.',
+      );
+    },
+  );
 
-  testWidgets('section starts collapsed → no DiffTitle in the tree',
-      (tester) async {
+  testWidgets('section starts collapsed → no DiffTitle in the tree', (
+    tester,
+  ) async {
     await _pumpHarness(tester, initialExpanded: false);
     expect(find.byType(DiffTitle), findsNothing);
   });
 
-  testWidgets('tap toggle → DiffTitle mounts and is still pending its anim',
-      (tester) async {
+  testWidgets('tap toggle → DiffTitle mounts and is still pending its anim', (
+    tester,
+  ) async {
     await _pumpHarness(tester, initialExpanded: false);
     expect(find.byType(DiffTitle), findsNothing);
 

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
@@ -35,7 +36,6 @@ Future<void> _pumpInline(
                 sourceBiasStance: 'center',
                 sourceName: 'Test',
                 divergenceLevel: divergenceLevel,
-                referenceTitle: 'Titre référence',
                 isExpanded: isExpanded,
                 onToggle: () {},
               ),
@@ -52,7 +52,7 @@ void main() {
   const introSnippet = "marquent l'angle éditorial";
 
   testWidgets(
-    'inline expanded + perspectives non vides → intro rendue en haut du groupe',
+    'inline expanded + perspectives non vides → intro derrière le bouton info',
     (tester) async {
       await _pumpInline(
         tester,
@@ -61,6 +61,13 @@ void main() {
           _p('B', bias: 'left'),
         ],
       );
+
+      expect(find.textContaining(introSnippet), findsNothing);
+
+      await tester.tap(
+        find.byIcon(PhosphorIcons.info(PhosphorIconsStyle.regular)).first,
+      );
+      await tester.pumpAndSettle();
 
       expect(find.textContaining(introSnippet), findsOneWidget);
     },
@@ -83,7 +90,7 @@ void main() {
     expect(find.textContaining(introSnippet), findsNothing);
   });
 
-  testWidgets('inline high divergence → phrase polarisation rendue', (
+  testWidgets('inline high divergence → badge polarisation rendu', (
     tester,
   ) async {
     await _pumpInline(
@@ -95,9 +102,7 @@ void main() {
       divergenceLevel: 'high',
     );
 
-    expect(
-      find.text('Forte polarisation dans le traitement de ce sujet'),
-      findsOneWidget,
-    );
+    expect(find.text('POLARISÉ'), findsOneWidget);
+    expect(find.textContaining('Forte polarisation'), findsNothing);
   });
 }

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
@@ -4,22 +4,26 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart'
+    show TokenSpan;
 import 'package:facteur/features/feed/widgets/coverage_spectrum_bar.dart';
 import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
 
 Perspective _p(String name, {String bias = 'center'}) => Perspective(
-  title: 'Titre $name',
-  url: 'https://example.com/$name',
-  sourceName: name,
-  sourceDomain: '',
-  biasStance: bias,
-);
+      title: 'Titre $name',
+      url: 'https://example.com/$name',
+      sourceName: name,
+      sourceDomain: '',
+      biasStance: bias,
+    );
 
 Future<void> _pumpInline(
   WidgetTester tester, {
   required PerspectivesSectionStatus status,
   List<Perspective> perspectives = const [],
   bool isExpanded = false,
+  PerspectivesAnalysisState analysisState = PerspectivesAnalysisState.idle,
+  String? analysisText,
   required VoidCallback onToggle,
 }) async {
   await tester.pumpWidget(
@@ -35,7 +39,8 @@ Future<void> _pumpInline(
               biasDistribution: const {'left': 1, 'center': 1, 'right': 1},
               contentId: 'test-content-id',
               sourceName: 'Test',
-              referenceTitle: 'Titre référence',
+              analysisState: analysisState,
+              analysisText: analysisText,
               isExpanded: isExpanded,
               onToggle: onToggle,
             ),
@@ -66,6 +71,7 @@ void main() {
     expect(find.byType(CoverageSpectrumBarShimmer), findsOneWidget);
     expect(find.byIcon(caret), findsNothing);
     expect(find.textContaining("marquent l'angle éditorial"), findsNothing);
+    expect(find.text('CET ARTICLE'), findsNothing);
 
     await tester.tap(find.text('Couverture médiatique'));
     expect(toggleCount, 0);
@@ -106,5 +112,63 @@ void main() {
 
     await tester.tap(find.text('Couverture médiatique (1)'));
     expect(toggleCount, 1);
+  });
+
+  testWidgets(
+    'expanded ready puts analysis above variants and removes ref block',
+    (tester) async {
+      await _pumpInline(
+        tester,
+        status: PerspectivesSectionStatus.ready,
+        perspectives: [
+          _p('A'),
+          _p('B', bias: 'left'),
+        ],
+        isExpanded: true,
+        analysisState: PerspectivesAnalysisState.done,
+        analysisText: 'Synthèse test',
+        onToggle: () {},
+      );
+
+      final analysisTop =
+          tester.getTopLeft(find.text('Analyse Facteur').first).dy;
+      final firstVariantTop =
+          tester.getTopLeft(find.text('Titre A', findRichText: true)).dy;
+
+      expect(analysisTop, lessThan(firstVariantTop));
+      expect(find.text('CET ARTICLE'), findsNothing);
+      expect(
+        find.text(
+          'Analyse générée par Mistral Large · l\'IA peut faire des erreurs.',
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets('PivotWashTitle washes the reader title pivot when expanded', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: const Scaffold(
+          body: PivotWashTitle(
+            title: 'Le gouvernement annonce une réforme',
+            pivot: TokenSpan(start: 3, end: 15, text: 'gouvernement'),
+            animate: false,
+          ),
+        ),
+      ),
+    );
+
+    final pivotText = find.text('gouvernement');
+    expect(pivotText, findsOneWidget);
+
+    final pivotContainer = tester.widget<Container>(
+      find.ancestor(of: pivotText, matching: find.byType(Container)).first,
+    );
+    final decoration = pivotContainer.decoration! as BoxDecoration;
+    expect(decoration.color, const Color(0xFF9E9E9E).withValues(alpha: 0.14));
   });
 }

--- a/apps/mobile/test/features/feed/widgets/variant_row_source_below_test.dart
+++ b/apps/mobile/test/features/feed/widgets/variant_row_source_below_test.dart
@@ -13,16 +13,16 @@ import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
 /// (favicon + source + bias label + arrow) doit passer SOUS le DiffTitle.
 /// Vérifie l'ordre vertical via les positions absolues des deux widgets.
 Perspective _persp(String name, String bias) => Perspective(
-      title: 'Titre court avec mot fort',
-      url: 'https://example.com/$name',
-      sourceName: name,
-      sourceDomain: '',
-      biasStance: bias,
-      highlightSpans: const [
-        HighlightSpan(start: 18, end: 22, text: 'fort', bias: 'left'),
-      ],
-      sharedTokens: const [TokenSpan(start: 0, end: 5, text: 'Titre')],
-    );
+  title: 'Titre court avec mot fort',
+  url: 'https://example.com/$name',
+  sourceName: name,
+  sourceDomain: '',
+  biasStance: bias,
+  highlightSpans: const [
+    HighlightSpan(start: 18, end: 22, text: 'fort', bias: 'left'),
+  ],
+  sharedTokens: const [TokenSpan(start: 0, end: 5, text: 'Titre')],
+);
 
 Widget _harness() {
   return ProviderScope(
@@ -45,7 +45,6 @@ Widget _harness() {
               onClearSegments: () {},
               onToggle: () {},
               isExpanded: true,
-              referenceTitle: '',
             ),
           ),
         ),
@@ -56,32 +55,44 @@ Widget _harness() {
 
 void main() {
   testWidgets(
-      '_VariantRow : DiffTitle est placé AU-DESSUS de la head row (favicon + arrow)',
-      (tester) async {
-    await tester.pumpWidget(_harness());
-    await tester.pumpAndSettle(const Duration(seconds: 2));
+    '_VariantRow : DiffTitle est placé AU-DESSUS de la head row (favicon + arrow)',
+    (tester) async {
+      await tester.pumpWidget(_harness());
+      await tester.pumpAndSettle(const Duration(seconds: 2));
 
-    final diffTitles = find.byType(DiffTitle);
-    expect(diffTitles, findsWidgets,
-        reason: 'Au moins un DiffTitle doit être présent dans les variants.');
+      final diffTitles = find.byType(DiffTitle);
+      expect(
+        diffTitles,
+        findsWidgets,
+        reason: 'Au moins un DiffTitle doit être présent dans les variants.',
+      );
 
-    // L'icône arrowRight ne se trouve que dans la head row du _VariantRow.
-    final arrowIcons = find.byWidgetPredicate((w) =>
-        w is Icon &&
-        w.icon == PhosphorIcons.arrowRight(PhosphorIconsStyle.regular));
-    expect(arrowIcons, findsWidgets,
+      // L'icône arrowRight ne se trouve que dans la head row du _VariantRow.
+      final arrowIcons = find.byWidgetPredicate(
+        (w) =>
+            w is Icon &&
+            w.icon == PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
+      );
+      expect(
+        arrowIcons,
+        findsWidgets,
         reason:
-            'L\'icône arrow-right est l\'ancre de la head row dans _VariantRow.');
+            'L\'icône arrow-right est l\'ancre de la head row dans _VariantRow.',
+      );
 
-    // Compare la position verticale du premier DiffTitle vs le premier arrow :
-    // après PR 6, le DiffTitle doit être au-dessus (dy plus petit).
-    final firstDiffTitleY = tester.getTopLeft(diffTitles.first).dy;
-    final firstArrowY = tester.getTopLeft(arrowIcons.first).dy;
+      // Compare la position verticale du premier DiffTitle vs le premier arrow :
+      // après PR 6, le DiffTitle doit être au-dessus (dy plus petit).
+      final firstDiffTitleY = tester.getTopLeft(diffTitles.first).dy;
+      final firstArrowY = tester.getTopLeft(arrowIcons.first).dy;
 
-    expect(firstDiffTitleY, lessThan(firstArrowY),
+      expect(
+        firstDiffTitleY,
+        lessThan(firstArrowY),
         reason:
             'Le DiffTitle doit être placé AU-DESSUS de la head row (favicon + '
             'source + arrow). Position DiffTitle.dy=$firstDiffTitleY doit être '
-            '< position arrow.dy=$firstArrowY.');
-  });
+            '< position arrow.dy=$firstArrowY.',
+      );
+    },
+  );
 }

--- a/docs/maintenance/maintenance-couverture-mediatique-allegement.md
+++ b/docs/maintenance/maintenance-couverture-mediatique-allegement.md
@@ -1,0 +1,53 @@
+# Maintenance — Allègement visuel Couverture médiatique
+
+> Type : **Maintenance UI**. Ajustement de la section inline « Couverture
+> médiatique » dans le reader article. Aucun changement backend / DB / Alembic.
+> Plan confirmé PO.
+
+## Objectif
+
+Rendre la section moins chargée visuellement dans l'état vide et dans l'état
+ouvert, tout en réutilisant les composants existants :
+`DivergenceInlineBadge`, la logique de wash du pivot, et le wording de
+transparence de l'analyse IA.
+
+## Changements
+
+1. État vide plus discret : padding réduit, label plus petit et atténué,
+   filets externes supprimés quand aucune perspective n'est disponible.
+2. Polarisation : remplacement de la phrase longue par une balise
+   `DivergenceInlineBadge`.
+3. Explication du surlignage : paragraphe inline supprimé, texte placé derrière
+   un bouton info.
+4. Analyse Facteur : CTA/résultat remontés avant la liste des variantes.
+5. Transparence IA : mention « Analyse générée par Mistral Large · l'IA peut
+   faire des erreurs. » sous le résultat.
+6. Bloc « CET ARTICLE » retiré ; le wash du pivot est appliqué au titre du
+   reader via `PivotWashTitle`.
+
+## Fichiers modifiés
+
+| Fichier | Changement |
+|---|---|
+| `apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart` | Header vide, body inline, badge/info, analyse, `PivotWashTitle` |
+| `apps/mobile/lib/features/detail/screens/content_detail_screen.dart` | Dividers conditionnels, wash pivot sur le titre reader |
+| `apps/mobile/test/features/feed/widgets/perspectives_inline_*` | Tests ciblés mis à jour |
+
+## Statut
+
+- [x] Plan confirmé PO
+- [x] Header vide allégé
+- [x] Badge polarisation + bouton info
+- [x] Analyse remontée + disclaimer IA
+- [x] Bloc référence inline retiré
+- [x] Wash pivot sur le titre reader
+- [x] Tests ciblés perspectives inline
+- [x] Analyse ciblée perspectives widget/tests
+- [ ] `flutter analyze` global propre
+
+## Vérification
+
+- `flutter test test/features/feed/widgets/perspectives_inline_intro_test.dart test/features/feed/widgets/perspectives_inline_states_test.dart test/features/feed/widgets/perspectives_inline_animation_test.dart test/features/feed/widgets/perspectives_inline_overflow_test.dart test/features/feed/widgets/perspectives_inline_filter_test.dart test/features/feed/widgets/perspective_opens_in_app_reader_test.dart test/features/feed/widgets/variant_row_source_below_test.dart` — **OK**, 22 tests.
+- `flutter analyze lib/features/feed/widgets/perspectives_bottom_sheet.dart test/features/feed/widgets/perspectives_inline_intro_test.dart test/features/feed/widgets/perspectives_inline_states_test.dart test/features/feed/widgets/perspectives_inline_animation_test.dart test/features/feed/widgets/perspective_opens_in_app_reader_test.dart test/features/feed/widgets/variant_row_source_below_test.dart` — **OK**.
+- `flutter analyze` global — **non OK**, 522 issues pré-existantes dans le package mobile.
+- `flutter analyze ... content_detail_screen.dart ...` — **non OK**, uniquement des infos async/context déjà présentes dans `content_detail_screen.dart`.


### PR DESCRIPTION
## What

Refines the article reader's inline media coverage section to reduce visual weight, move the AI analysis higher in the hierarchy, and apply the reference-pivot wash directly on the reader title instead of rendering a separate reference block.

## Why

The current section feels too heavy in both empty and expanded states, and the highlight/explanation/analysis pieces compete for attention instead of reinforcing the article reading flow.

## Type

- [ ] Feature
- [ ] Bug fix
- [x] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)
