### PR TITLE
Unify read marking and polish sticky feed UI

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -170,7 +170,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   double _webScrollY = 0.0;
   bool _isConsumed = false;
   bool _hasOpenedNote = false;
-  static const int _consumptionThreshold = 30; // seconds
+  // Marquage Lu unifié (décision PO) : « ouvrir un article = Lu ». Micro-délai
+  // de 1 s avant d'écrire le statut consumed — laisse le loader s'afficher et
+  // évite de marquer Lu un clic immédiatement annulé.
+  static const int _consumptionThreshold = 1; // seconds
   static const int _noteNudgeDelay = 20; // seconds
 
   // Reading progress tracking (0.0 - 1.0)
@@ -388,13 +391,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       }
     });
 
-    // Start timer if content is suitable for in-app reading/viewing and not already consumed.
-    // Mode externe : id synthétique vide ⇒ ne JAMAIS démarrer le timer (il
-    // appellerait updateContentStatus('') au bout de 30s).
-    final isVideo = _content?.isVideo ?? false;
-    if (!_isExternal &&
-        (_content?.hasInAppContent == true || isVideo) &&
-        !_isConsumed) {
+    // « Ouvrir = Lu » : on démarre le timer (1 s) pour TOUT contenu non externe,
+    // y compris les articles à lien externe portant un vrai content_id — la
+    // condition hasInAppContent/isVideo a été retirée pour que le statut Lu
+    // soit universel. Le garde _isExternal exclut l'id synthétique vide (il
+    // appellerait sinon updateContentStatus('')).
+    if (!_isExternal && !_isConsumed) {
       _startReadingTimer();
     }
 
@@ -967,9 +969,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             _contentResolved = true;
             _isConsumed = _content!.status == ContentStatus.consumed;
           });
-          final isVideoFetched = _content!.isVideo;
-          if ((_content!.hasInAppContent == true || isVideoFetched) &&
-              !_isConsumed) {
+          // « Ouvrir = Lu » : redémarre le timer dès que le contenu est résolu
+          // si on ne l'a pas encore marqué Lu (cas où _content était null au
+          // montage, ou fetch plus long que le micro-délai initial). Même
+          // contrat universel que l'initState (plus de garde in-app/vidéo).
+          if (!_isConsumed) {
             _startReadingTimer();
           }
           // Re-check short article + measure article extent after content
@@ -1029,9 +1033,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   Future<void> _markAsConsumed() async {
     // Mode externe : id synthétique vide ⇒ pas de statut backend.
     if (_isExternal) return;
-    setState(() => _isConsumed = true);
     final content = _content;
+    // Ne latch PAS _isConsumed tant que le contenu n'est pas résolu : sinon un
+    // fetch plus lent que le micro-délai laisserait l'article « consommé » en
+    // local sans jamais écrire le statut backend (le re-start de _fetchContent
+    // est gardé par !_isConsumed).
     if (content == null) return;
+    setState(() => _isConsumed = true);
 
     try {
       final supabase = Supabase.instance.client;

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -40,6 +40,8 @@ import '../widgets/my_interests_sheet.dart';
 import '../widgets/geoloc_prompt_banner.dart';
 import '../widgets/section_block.dart';
 import '../widgets/sticky_tab_bar.dart';
+import '../../grille/grille_constants.dart';
+import '../../grille/providers/grille_provider.dart';
 import '../../grille/widgets/grille_cta_card.dart';
 
 /// Scroll offset at which the AppBar is swapped with the sticky tab bar.
@@ -64,15 +66,13 @@ const double _kFabHideAboveScroll = 380.0;
 /// pull-to-refresh hint pill — avoids nudging after a tiny inertia scroll.
 const double _kPullHintMinDepthPx = 800.0;
 
-/// Sliver « Grille du jour » (carte d'entrée de La Grille). Padding maquette
-/// partagé par ses deux sites de rendu : juste après « Actus du jour » (cas
-/// nominal) et le fallback bas quand le digest est absent.
-const _grilleSliver = SliverToBoxAdapter(
-  child: Padding(
-    padding: EdgeInsets.fromLTRB(16, 22, 16, 0),
-    child: GrilleCtaCard(),
-  ),
-);
+/// Onglets sticky des deux cartes virtuelles. Accents repris tels quels de
+/// chaque carte : ocre/ambre signature de La Grille pour « Mot du jour », brun
+/// chaud du tampon de [CitationDuJourCard] pour « Citation du jour ».
+const _motDuJourTab =
+    StickyTab(label: 'Mot du jour', accent: GrilleConstants.presentTile);
+const _citationTab =
+    StickyTab(label: 'Citation du jour', accent: CitationDuJourCard.stampColor);
 
 class FluxContinuScreen extends ConsumerStatefulWidget {
   const FluxContinuScreen({super.key});
@@ -89,6 +89,32 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   final ValueNotifier<int> _activeIndex = ValueNotifier(0);
 
   final List<GlobalKey> _sectionKeys = [];
+
+  // Clés dédiées aux deux cartes virtuelles qui ont désormais un onglet sticky.
+  // La Grille n'est montée qu'à un seul endroit à la fois (après Actus, ou en
+  // fallback bas) → une seule clé suffit. Disjointes de [_sectionKeys] : la
+  // logique de fold (qui itère _sectionKeys) reste inchangée.
+  final GlobalKey _grilleKey = GlobalKey();
+  final GlobalKey _citationKey = GlobalKey();
+
+  // Clés des « entrées sticky » dans l'ordre exact des slivers : sections +
+  // Mot du jour + Citation. Source unique pour le suivi de section active et le
+  // scroll-to-section (les onglets en dérivent via [_syncStickyEntries]).
+  final List<GlobalKey> _stickyEntryKeys = [];
+
+  /// Sliver « Grille du jour » (carte d'entrée de La Grille). Padding maquette
+  /// partagé par ses deux sites de rendu : juste après « Actus du jour » (cas
+  /// nominal) et le fallback bas quand le digest est absent. Wrappé dans un
+  /// `KeyedSubtree(_grilleKey)` pour exposer la carte au suivi sticky.
+  SliverToBoxAdapter get _grilleSliver => SliverToBoxAdapter(
+        child: KeyedSubtree(
+          key: _grilleKey,
+          child: const Padding(
+            padding: EdgeInsets.fromLTRB(16, 22, 16, 0),
+            child: GrilleCtaCard(),
+          ),
+        ),
+      );
 
   /// Articles swipe-dismissed and replaced by a [FeedbackInline] banner at
   /// the same position. The hide API has already fired (via
@@ -223,20 +249,21 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   }
 
   void _updateActiveSection() {
-    if (_sectionKeys.isEmpty) return;
-    // Active = section that occupies the most visible area below the sticky
-    // bar. The previous heuristic ("last section whose top has crossed
+    if (_stickyEntryKeys.isEmpty) return;
+    // Active = sticky entry that occupies the most visible area below the
+    // sticky bar. The previous heuristic ("last section whose top has crossed
     // stickyBar + 200px lookahead") switched late on long sections because it
     // ignored how much of the upcoming section was already on screen. Viewport
-    // dominance flips the active tab as soon as the next section becomes
-    // majority-visible, which matches what the user is actually reading.
+    // dominance flips the active tab as soon as the next entry becomes
+    // majority-visible, which matches what the user is actually reading. Itère
+    // la liste combinée (sections + Mot du jour + Citation).
     const viewportTop = _kStickyBarHeight;
     final viewportBottom = viewportTop +
         (_scroll.hasClients ? _scroll.position.viewportDimension : 0.0);
     int activeAt = 0;
     double bestVisible = -1;
-    for (var i = 0; i < _sectionKeys.length; i++) {
-      final ctx = _sectionKeys[i].currentContext;
+    for (var i = 0; i < _stickyEntryKeys.length; i++) {
+      final ctx = _stickyEntryKeys[i].currentContext;
       if (ctx == null) continue;
       final box = ctx.findRenderObject();
       if (box is! RenderBox) continue;
@@ -285,8 +312,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
 
   Future<void> _scrollToSection(int index) async {
     if (index < 0) return;
-    if (index >= _sectionKeys.length) return;
-    final targetKey = _sectionKeys[index];
+    if (index >= _stickyEntryKeys.length) return;
+    final targetKey = _stickyEntryKeys[index];
     final ctx = targetKey.currentContext;
     if (ctx == null) return;
     final box = ctx.findRenderObject();
@@ -651,6 +678,14 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
         ref.read(postOnboardingFlowPendingProvider) != null) {
       _schedulePostOnboardingFlow();
     }
+    // Mot du jour présent ⇔ la Grille a un mot du jour (sinon GrilleCtaCard se
+    // masque). `.select` ne reconstruit que lorsque la présence bascule.
+    final grillePresent = ref.watch(
+      grilleProvider.select((v) => v.valueOrNull?.today != null),
+    );
+    // Source unique : aligne [_sectionKeys] + [_stickyEntryKeys] sur les slivers
+    // et dérive les descripteurs d'onglets (label+accent), dans le même ordre.
+    final stickyTabs = _syncStickyEntries(state.valueOrNull, grillePresent);
     return Scaffold(
       backgroundColor: context.facteurColors.backgroundPrimary,
       // Header & footer vivent dans le scaffold de page partagé :
@@ -673,7 +708,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
               stickyVisible: _stickyVisible,
               scrollProgress: _scrollProgress,
               activeIndex: _activeIndex,
-              stateProvider: fluxContinuProvider,
+              tabs: stickyTabs,
               onTapTab: _scrollToSection,
               tabsController: _tabsScroll,
             ),
@@ -718,6 +753,69 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     );
   }
 
+  /// Construit la liste ordonnée d'« entrées sticky » (sections + cartes
+  /// virtuelles Mot du jour / Citation) reflétant l'ordre exact des slivers de
+  /// [_buildContent]. Synchronise [_sectionKeys] (1 clé/section) et
+  /// [_stickyEntryKeys] (clés combinées pour le suivi actif + le scroll), puis
+  /// retourne les descripteurs d'onglets (label+accent) dans le même ordre.
+  ///
+  /// Ne touche PAS à la logique de fold (`_maybeFoldSections`,
+  /// `_measureFoldCandidateHeights`, `_markSectionsAboveAsScrolledPast`) qui
+  /// continue d'itérer `_sectionKeys` / `state.sections`.
+  List<StickyTab> _syncStickyEntries(
+    FluxContinuState? state,
+    bool grillePresent,
+  ) {
+    if (state == null) {
+      _stickyEntryKeys.clear();
+      return const [];
+    }
+    if (_sectionKeys.length != state.sections.length) {
+      _sectionKeys
+        ..clear()
+        ..addAll(List.generate(state.sections.length, (_) => GlobalKey()));
+    }
+    // « Actus du jour » = DigestTopicSection kind essentiel : la Grille est
+    // rendue juste après elle (sinon en fallback bas, après la Citation).
+    final hasActus = state.sections.any(
+      (s) => s is DigestTopicSection && s.kind == SectionKind.essentiel,
+    );
+    final citationPresent = state.quote != null && !state.closingDismissed;
+
+    final keys = <GlobalKey>[];
+    final tabs = <StickyTab>[];
+    void add(GlobalKey key, StickyTab tab) {
+      keys.add(key);
+      tabs.add(tab);
+    }
+
+    for (var i = 0; i < state.sections.length; i++) {
+      final section = state.sections[i];
+      add(
+        _sectionKeys[i],
+        StickyTab(label: section.label, accent: section.accent),
+      );
+      if (grillePresent &&
+          section is DigestTopicSection &&
+          section.kind == SectionKind.essentiel) {
+        add(_grilleKey, _motDuJourTab);
+      }
+    }
+    if (citationPresent) {
+      add(_citationKey, _citationTab);
+    }
+    // Fallback bas : Grille rendue après la Citation quand il n'y a pas d'Actus
+    // (cf. `if (!hasActus) _grilleSliver` dans _buildContent).
+    if (!hasActus && grillePresent) {
+      add(_grilleKey, _motDuJourTab);
+    }
+
+    _stickyEntryKeys
+      ..clear()
+      ..addAll(keys);
+    return tabs;
+  }
+
   Widget _buildContent(BuildContext context, FluxContinuState state) {
     final notifier = ref.read(fluxContinuProvider.notifier);
     final colors = context.facteurColors;
@@ -736,12 +834,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     final hasActus = state.sections.any(
       (s) => s is DigestTopicSection && s.kind == SectionKind.essentiel,
     );
-
-    if (_sectionKeys.length != state.sections.length) {
-      _sectionKeys
-        ..clear()
-        ..addAll(List.generate(state.sections.length, (_) => GlobalKey()));
-    }
+    // NB : [_sectionKeys] est synchronisé en amont par [_syncStickyEntries]
+    // (appelé dans build) → on s'appuie sur cet alignement ici.
 
     return RefreshIndicator(
       onRefresh: _handleRefresh,
@@ -793,7 +887,12 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
           // (`closingDismissed`) : replier la tournée ne doit pas la masquer,
           // c'est un rituel de fin de tournée.
           if (state.quote != null && !state.closingDismissed)
-            SliverToBoxAdapter(child: CitationDuJourCard(quote: state.quote!)),
+            SliverToBoxAdapter(
+              child: KeyedSubtree(
+                key: _citationKey,
+                child: CitationDuJourCard(quote: state.quote!),
+              ),
+            ),
           // « Le mot du jour » — récompense de fin de Tournée. Sliver additif
           // au-dessus de ClosingCardV18 (cette dernière n'est pas modifiée :
           // zéro régression, revert trivial). La carte se câble seule au
@@ -915,12 +1014,15 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   }
 }
 
-class _StickyHostOverlay extends ConsumerWidget {
+class _StickyHostOverlay extends StatelessWidget {
   final ValueNotifier<bool> stickyVisible;
   final ValueNotifier<double> scrollProgress;
   final ValueNotifier<int> activeIndex;
-  final AsyncNotifierProvider<FluxContinuNotifier, FluxContinuState>
-      stateProvider;
+
+  /// Descripteurs d'onglets (label+accent) dans l'ordre des slivers, calculés
+  /// par [_FluxContinuScreenState._syncStickyEntries] — source unique partagée
+  /// avec les clés du suivi actif, pour éviter tout recalcul divergent ici.
+  final List<StickyTab> tabs;
   final ValueChanged<int> onTapTab;
   final ScrollController tabsController;
 
@@ -928,15 +1030,13 @@ class _StickyHostOverlay extends ConsumerWidget {
     required this.stickyVisible,
     required this.scrollProgress,
     required this.activeIndex,
-    required this.stateProvider,
+    required this.tabs,
     required this.onTapTab,
     required this.tabsController,
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final sections =
-        ref.watch(stateProvider).valueOrNull?.sections ?? const <FluxSection>[];
+  Widget build(BuildContext context) {
     return Positioned(
       top: 0,
       left: 0,
@@ -944,14 +1044,10 @@ class _StickyHostOverlay extends ConsumerWidget {
       child: ValueListenableBuilder<bool>(
         valueListenable: stickyVisible,
         builder: (context, visible, _) {
-          final showSticky = visible && sections.isNotEmpty;
+          final showSticky = visible && tabs.isNotEmpty;
           if (!showSticky) {
             return const SizedBox.shrink();
           }
-          final tabs = <StickyTab>[
-            for (final s in sections)
-              StickyTab(label: s.label, accent: s.accent),
-          ];
           return ValueListenableBuilder<int>(
             valueListenable: activeIndex,
             builder: (context, idx, _) => ValueListenableBuilder<double>(

--- a/apps/mobile/lib/features/flux_continu/widgets/citation_du_jour_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/citation_du_jour_card.dart
@@ -14,6 +14,10 @@ import '../../digest/models/digest_models.dart';
 /// mais nettement plus sobre : tampon brun chaud distinct du vert "fin de
 /// tournée", pas de CTA, pas d'illustration.
 class CitationDuJourCard extends StatelessWidget {
+  /// Brun chaud du tampon « CITATION DU JOUR ». Exposé pour que l'onglet sticky
+  /// « Citation du jour » réutilise exactement l'accent de la carte.
+  static const Color stampColor = Color(0xFF8D6E63);
+
   final QuoteResponse quote;
 
   const CitationDuJourCard({super.key, required this.quote});
@@ -21,7 +25,6 @@ class CitationDuJourCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    const stampColor = Color(0xFF8D6E63);
     return Container(
       margin: const EdgeInsets.fromLTRB(18, 24, 18, 8),
       clipBehavior: Clip.antiAlias,

--- a/apps/mobile/lib/features/flux_continu/widgets/closing_card_v18.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/closing_card_v18.dart
@@ -14,7 +14,7 @@ import 'tournee_cta_buttons.dart';
 /// - Heading "Vous êtes à jour" Fraunces 700 24px.
 /// - Description (DM Sans 13, line-height 1.5, max-w 280, centered) — "X
 ///   étape(s) parcourue(s)" or "Tournée terminée" when empty.
-/// - Primary CTA "Continuer sur Flâner" (background #D35400) + ghost CTA
+/// - Primary CTA "Continuer à Flâner" (background #D35400) + ghost CTA
 ///   "Refermer pour aujourd'hui" (border 1.5px rgba(0,0,0,0.1)).
 class ClosingCardV18 extends StatelessWidget {
   final int articleCount;
@@ -114,7 +114,7 @@ class ClosingCardV18 extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: TourneePrimaryButton(
-                label: 'Continuer sur Flâner',
+                label: 'Continuer à Flâner',
                 onTap: onContinue,
               ),
             ),

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
 import '../models/flux_continu_models.dart';
@@ -446,52 +447,68 @@ class _LeadTile extends StatelessWidget {
       child: InkWell(
         onTap: onTap,
         borderRadius: BorderRadius.circular(FacteurRadius.medium),
-        child: Container(
-          padding: const EdgeInsets.fromLTRB(
-            FacteurSpacing.space3,
-            FacteurSpacing.space3,
-            FacteurSpacing.space3,
-            FacteurSpacing.space3,
-          ),
-          decoration: BoxDecoration(
-            color: accent.withValues(alpha: 0.06),
-            borderRadius: BorderRadius.circular(FacteurRadius.medium),
-            border: Border(left: BorderSide(color: accent, width: 3)),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+        // Lu : grise la tuile (0.6) + coche verte, comme les autres sections
+        // (cf. flux_continu_article_card.dart). Le badge est inclus dans
+        // l'Opacity pour s'estomper de concert avec le contenu.
+        child: Opacity(
+          opacity: article.isRead ? 0.6 : 1.0,
+          child: Stack(
             children: [
-              Wrap(
-                spacing: 6,
-                runSpacing: 4,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: [
-                  if (article.isActuDuJour)
-                    _ActuBadge(
-                      accent: chipAccent,
-                      overrideBackground: colors.sectionEssentiel,
+              Container(
+                padding: const EdgeInsets.fromLTRB(
+                  FacteurSpacing.space3,
+                  FacteurSpacing.space3,
+                  FacteurSpacing.space3,
+                  FacteurSpacing.space3,
+                ),
+                decoration: BoxDecoration(
+                  color: accent.withValues(alpha: 0.06),
+                  borderRadius: BorderRadius.circular(FacteurRadius.medium),
+                  border: Border(left: BorderSide(color: accent, width: 3)),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Wrap(
+                      spacing: 6,
+                      runSpacing: 4,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        if (article.isActuDuJour)
+                          _ActuBadge(
+                            accent: chipAccent,
+                            overrideBackground: colors.sectionEssentiel,
+                          ),
+                        _SectionChip(
+                          label: _sectionLabelFor(article),
+                          accent: chipAccent,
+                          showFollowed: article.isFollowedTopic,
+                        ),
+                      ],
                     ),
-                  _SectionChip(
-                    label: _sectionLabelFor(article),
-                    accent: chipAccent,
-                    showFollowed: article.isFollowedTopic,
-                  ),
-                ],
-              ),
-              const SizedBox(height: FacteurSpacing.space2),
-              Text(
-                article.title,
-                maxLines: 5,
-                overflow: TextOverflow.ellipsis,
-                style: GoogleFonts.fraunces(
-                  fontSize: 19,
-                  fontWeight: FontWeight.w700,
-                  height: 1.3,
-                  color: colors.textPrimary,
+                    const SizedBox(height: FacteurSpacing.space2),
+                    Text(
+                      article.title,
+                      maxLines: 5,
+                      overflow: TextOverflow.ellipsis,
+                      style: GoogleFonts.fraunces(
+                        fontSize: 19,
+                        fontWeight: FontWeight.w700,
+                        height: 1.3,
+                        color: colors.textPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: FacteurSpacing.space2),
+                    _SourceRow(article: article, accent: chipAccent),
+                  ],
                 ),
               ),
-              const SizedBox(height: FacteurSpacing.space2),
-              _SourceRow(article: article, accent: chipAccent),
+              if (article.isRead)
+                Positioned(
+                  top: 8,
+                  right: 8,
+                  child: _ReadCheckBadge(color: colors.success),
+                ),
             ],
           ),
         ),
@@ -515,41 +532,59 @@ class _MediumTile extends StatelessWidget {
       child: InkWell(
         onTap: onTap,
         borderRadius: BorderRadius.circular(FacteurRadius.small),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 2),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+        // Lu : grise la tuile (0.6) + petite coche verte (cf. _LeadTile).
+        child: Opacity(
+          opacity: article.isRead ? 0.6 : 1.0,
+          child: Stack(
             children: [
-              Row(
-                children: [
-                  _SectionChip(
-                    label: _sectionLabelFor(article),
-                    accent: themeAccent,
-                    showFollowed: article.isFollowedTopic,
-                  ),
-                  const SizedBox(width: FacteurSpacing.space2),
-                  Flexible(
-                    child: Text(
-                      article.sourceName,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: FacteurTypography.labelSmall(colors.textTertiary),
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        _SectionChip(
+                          label: _sectionLabelFor(article),
+                          accent: themeAccent,
+                          showFollowed: article.isFollowedTopic,
+                        ),
+                        const SizedBox(width: FacteurSpacing.space2),
+                        Flexible(
+                          child: Text(
+                            article.sourceName,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style:
+                                FacteurTypography.labelSmall(colors.textTertiary),
+                          ),
+                        ),
+                        // Réserve l'espace de la coche pour qu'elle ne
+                        // chevauche pas la source ellipsée.
+                        if (article.isRead) const SizedBox(width: 22),
+                      ],
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 4),
-              Text(
-                article.title,
-                maxLines: 4,
-                overflow: TextOverflow.ellipsis,
-                style: GoogleFonts.fraunces(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  height: 1.3,
-                  color: colors.textPrimary,
+                    const SizedBox(height: 4),
+                    Text(
+                      article.title,
+                      maxLines: 4,
+                      overflow: TextOverflow.ellipsis,
+                      style: GoogleFonts.fraunces(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        height: 1.3,
+                        color: colors.textPrimary,
+                      ),
+                    ),
+                  ],
                 ),
               ),
+              if (article.isRead)
+                Positioned(
+                  top: 0,
+                  right: 0,
+                  child: _ReadCheckBadge(color: colors.success, size: 18),
+                ),
             ],
           ),
         ),
@@ -683,6 +718,42 @@ class _SourceRow extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Coche « lu » verte, reproduite à l'identique du motif de
+/// `flux_continu_article_card.dart` pour une cohérence visuelle entre la carte
+/// Essentiel et les cartes des autres sections. [size] permet une coche plus
+/// compacte sur les tuiles médiums.
+class _ReadCheckBadge extends StatelessWidget {
+  final Color color;
+  final double size;
+
+  const _ReadCheckBadge({required this.color, this.size = 22});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.12),
+            blurRadius: 4,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      alignment: Alignment.center,
+      child: Icon(
+        PhosphorIcons.check(PhosphorIconsStyle.bold),
+        size: size * 0.55,
+        color: Colors.white,
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -185,10 +187,12 @@ class _Tab extends StatelessWidget {
     } else {
       labelColor = colors.textSecondary;
     }
-    // Active tab is signaled by a marker-style highlight on the **label text
-    // only** (calque du highlight "Couverture médiatique" — cf. DiffTitle),
-    // replacing the legacy full-chip wash + leading dot. The marker tint
-    // derives from the tab's own accent so each thematic section keeps its hue.
+    // Active tab is signaled by a felt-tip marker stroke painted **behind the
+    // label text only** (calque du highlight "Couverture médiatique" — cf.
+    // DiffTitle), replacing the legacy full-chip wash + leading dot. The marker
+    // tint derives from the tab's own accent so each thematic section keeps its
+    // hue ; le trait est légèrement incliné, à extrémités inégales et opacité
+    // douce pour lire comme un tracé manuel (cf. [_MarkerHighlight]).
     const radius = BorderRadius.all(Radius.circular(FacteurRadius.small));
     final label = Text(
       tab.label,
@@ -207,13 +211,12 @@ class _Tab extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             if (isActive)
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
-                decoration: BoxDecoration(
-                  color: tab.accent.withValues(alpha: 0.22),
-                  borderRadius: BorderRadius.circular(4),
+              CustomPaint(
+                painter: _MarkerHighlight(color: tab.accent),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: label,
                 ),
-                child: label,
               )
             else
               label,
@@ -231,6 +234,61 @@ class _Tab extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Felt-tip "surligneur" stroke painted behind a tab label. Reads as a
+/// hand-drawn highlighter pass rather than a flat rounded chip :
+/// - a band covering only the lower ~66 % of the text height, anchored to the
+///   baseline so ascenders/descenders peek out,
+/// - a slight ~-2° tilt,
+/// - uneven rounded caps (leading tighter, trailing longer) for the
+///   "movement / manual trace" feel,
+/// - reduced opacity (0.16) with a second translucent pass (0.10) layered near
+///   the baseline to build up the felt density.
+class _MarkerHighlight extends CustomPainter {
+  final Color color;
+
+  const _MarkerHighlight({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (size.width <= 0 || size.height <= 0) return;
+    final bandHeight = size.height * 0.66;
+    final top = size.height - bandHeight; // anchored to the baseline
+    final rect = Rect.fromLTWH(0, top, size.width, bandHeight);
+
+    canvas.save();
+    // Tilt around the band centre so the whole stroke leans slightly.
+    canvas.translate(size.width / 2, size.height / 2);
+    canvas.rotate(-2 * math.pi / 180);
+    canvas.translate(-size.width / 2, -size.height / 2);
+
+    // Uneven caps: leading (left) tighter, trailing (right) longer/rounder.
+    final base = RRect.fromRectAndCorners(
+      rect,
+      topLeft: Radius.circular(bandHeight * 0.32),
+      bottomLeft: Radius.circular(bandHeight * 0.28),
+      topRight: Radius.circular(bandHeight * 0.55),
+      bottomRight: Radius.circular(bandHeight * 0.62),
+    );
+    canvas.drawRRect(base, Paint()..color = color.withValues(alpha: 0.16));
+
+    // Second pass, inset toward the baseline, adds the denser felt core.
+    final core = Rect.fromLTWH(
+      rect.left + size.width * 0.05,
+      rect.top + bandHeight * 0.30,
+      size.width * 0.90,
+      bandHeight * 0.70,
+    );
+    final coreRRect =
+        RRect.fromRectAndRadius(core, Radius.circular(bandHeight * 0.4));
+    canvas.drawRRect(coreRRect, Paint()..color = color.withValues(alpha: 0.10));
+
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(_MarkerHighlight old) => old.color != color;
 }
 
 class _ProgressPainter extends CustomPainter {

--- a/apps/mobile/lib/features/gamification/widgets/streak_indicator.dart
+++ b/apps/mobile/lib/features/gamification/widgets/streak_indicator.dart
@@ -108,8 +108,8 @@ class _StreakIndicatorState extends ConsumerState<StreakIndicator>
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         SizedBox(
-                          width: 22,
-                          height: 22,
+                          width: 29,
+                          height: 29,
                           child: AnimatedBuilder(
                             animation: _controller,
                             builder: (context, child) {
@@ -129,8 +129,8 @@ class _StreakIndicatorState extends ConsumerState<StreakIndicator>
                                   scale: _scale.value,
                                   child: SvgPicture.asset(
                                     'assets/icons/streak_flame.svg',
-                                    width: 22,
-                                    height: 22,
+                                    width: 29,
+                                    height: 29,
                                     colorFilter: isActive
                                         ? null
                                         : ColorFilter.mode(
@@ -164,8 +164,8 @@ class _StreakIndicatorState extends ConsumerState<StreakIndicator>
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
             child: SvgPicture.asset(
               'assets/icons/streak_flame.svg',
-              width: 22,
-              height: 22,
+              width: 29,
+              height: 29,
               colorFilter: ColorFilter.mode(
                 colors.primary.withValues(alpha: 0.3),
                 BlendMode.srcIn,

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
@@ -41,6 +42,7 @@ EssentielArticle _article({
   String? theme = 'tech',
   String source = 'Le Monde',
   bool isActuDuJour = false,
+  bool isRead = false,
 }) {
   return EssentielArticle(
     contentId: 'c-$rank',
@@ -54,6 +56,7 @@ EssentielArticle _article({
     rank: rank,
     perspectiveCount: 3,
     isActuDuJour: isActuDuJour,
+    isRead: isRead,
   );
 }
 
@@ -280,6 +283,48 @@ void main() {
       expect(find.text('Prévisions'), findsOneWidget,
           reason: 'Tapping the weather badge opens the detail sheet.');
       expect(find.text("Aujourd'hui"), findsOneWidget);
+    });
+
+    testWidgets('read article dims its tile to 0.6 and shows a check badge',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [_article(rank: 1, isRead: true)],
+          onTapArticle: (_) {},
+          onTapPersonalize: () {},
+        ),
+      ));
+
+      // Read tiles dim to 0.6 (même valeur que les autres sections) — un
+      // Opacity à 0.6 est propre au wrapper d'état Lu.
+      final dimmed = tester
+          .widgetList<Opacity>(find.byType(Opacity))
+          .where((o) => o.opacity == 0.6);
+      expect(dimmed, isNotEmpty);
+      // Green check badge (same Phosphor glyph as the other sections).
+      expect(
+        find.byIcon(PhosphorIcons.check(PhosphorIconsStyle.bold)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('unread article is not dimmed (no read badge)', (tester) async {
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [_article(rank: 1)],
+          onTapArticle: (_) {},
+          onTapPersonalize: () {},
+        ),
+      ));
+
+      final dimmed = tester
+          .widgetList<Opacity>(find.byType(Opacity))
+          .where((o) => o.opacity == 0.6);
+      expect(dimmed, isEmpty);
+      expect(
+        find.byIcon(PhosphorIcons.check(PhosphorIconsStyle.bold)),
+        findsNothing,
+      );
     });
 
     testWidgets('slots 2-5 all use the medium layout (no dotted divider)',

--- a/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
@@ -88,7 +88,7 @@ void main() {
       expect(lastTapped, 1);
     });
 
-    testWidgets('active tab highlights its label text with an accent marker',
+    testWidgets('active tab paints a felt-tip marker behind its label',
         (tester) async {
       await tester.pumpWidget(_wrap(
         StickyTabBar(
@@ -98,17 +98,17 @@ void main() {
           onTapTab: (_) {},
         ),
       ));
-      // The active tab (index 0) highlights its **label text** with a
-      // marker-style Container tinted with its own accent (calque du highlight
-      // "Couverture médiatique" — cf. DiffTitle). The legacy full-chip wash and
-      // the leading dot are gone. Exactly one marker should be present.
-      final expectedMarker = const Color(0xFFB0470A).withValues(alpha: 0.22);
-      final markers =
-          tester.widgetList<Container>(find.byType(Container)).where((c) {
-        final deco = c.decoration;
-        return deco is BoxDecoration && deco.color == expectedMarker;
+      // The active tab (index 0) paints a felt-tip "surligneur" stroke behind
+      // its **label text** via a dedicated CustomPainter (remplace l'ancien chip
+      // plat + le wash pleine-chip + le point). Exactly one such marker painter
+      // should be present (one active tab).
+      final markerPainters =
+          tester.widgetList<CustomPaint>(find.byType(CustomPaint)).where((cp) {
+        final painter = cp.painter;
+        return painter != null &&
+            painter.runtimeType.toString().contains('MarkerHighlight');
       });
-      expect(markers, hasLength(1));
+      expect(markerPainters, hasLength(1));
     });
 
     testWidgets('no leading dot before tab labels (removed in marker redesign)',

--- a/packages/api/config/serein_quotes.yaml
+++ b/packages/api/config/serein_quotes.yaml
@@ -122,3 +122,32 @@ quotes:
 
   - text: "Les gens ne font pas des voyages, ce sont les voyages qui font les gens."
     author: "John Steinbeck"
+
+  - text: "Nous sommes tous dans le caniveau, mais certains d'entre nous regardent les étoiles."
+    author: "Oscar Wilde"
+    source: "L'Éventail de Lady Windermere"
+
+  - text: "Le hasard, c'est peut-être le pseudonyme de Dieu quand il ne veut pas signer."
+    author: "Anatole France"
+
+  - text: "On ne reçoit pas la sagesse, il faut la découvrir soi-même après un trajet que personne ne peut faire à notre place."
+    author: "Marcel Proust"
+    source: "À la recherche du temps perdu"
+
+  - text: "La simplicité est la sophistication suprême."
+    author: "Léonard de Vinci"
+
+  - text: "Rien n'est plus dangereux qu'une idée, quand on n'a qu'une idée."
+    author: "Alain"
+    source: "Propos sur la religion"
+
+  - text: "Ceux qui ne bougent pas ne sentent pas leurs chaînes."
+    author: "Rosa Luxemburg"
+
+  - text: "Le rire est le propre de l'homme."
+    author: "Rabelais"
+    source: "Gargantua"
+
+  - text: "Le doute est un hommage rendu à l'espoir."
+    author: "Lautréamont"
+    source: "Poésies"


### PR DESCRIPTION
## What

Unifies article read marking to trigger on open, adds sticky tabs for Mot du jour and Citation du jour, and polishes several mobile feed UI details.

## Why

This aligns read-state behavior with the current product decision, makes the sticky navigation reflect more of the feed structure, and improves read-state clarity and visual consistency in Flux Continu.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)
