### PR TITLE
fix(veille): fixes & affinements UX config veille + troncature overflow

### DIFF
--- a/apps/mobile/lib/features/lettres/widgets/progress_toast.dart
+++ b/apps/mobile/lib/features/lettres/widgets/progress_toast.dart
@@ -21,6 +21,7 @@ void showProgressToast(
   String? sectionTitle,
   String? stepNum,
   String? stepTitle,
+  Color? accentColor,
   VoidCallback? onOpen,
 }) {
   final overlay = Overlay.maybeOf(context, rootOverlay: true);
@@ -53,6 +54,7 @@ void showProgressToast(
       sectionTitle: sectionTitle,
       stepNum: stepNum,
       stepTitle: stepTitle,
+      accentColor: accentColor,
       onOpen: onOpen,
       onDismissed: onDismissed,
       onRequestClose: (cb) {
@@ -90,6 +92,7 @@ class _ProgressToast extends StatefulWidget {
   final String? sectionTitle;
   final String? stepNum;
   final String? stepTitle;
+  final Color? accentColor;
   final VoidCallback? onOpen;
   final VoidCallback onDismissed;
   final ValueChanged<VoidCallback> onRequestClose;
@@ -104,6 +107,7 @@ class _ProgressToast extends StatefulWidget {
     this.sectionTitle,
     this.stepNum,
     this.stepTitle,
+    this.accentColor,
     this.onOpen,
   });
 
@@ -195,14 +199,16 @@ class _ProgressToastState extends State<_ProgressToast>
   }
 
   Widget _buildShell(FacteurColors colors) {
-    final accent = widget.level == ProgressToastLevel.step
-        ? colors.primary
-        : colors.success;
+    final accent =
+        widget.accentColor ??
+        (widget.level == ProgressToastLevel.step
+            ? colors.primary
+            : colors.success);
 
     final body = switch (widget.level) {
       ProgressToastLevel.micro => _MicroBody(accent: accent, toast: widget),
       ProgressToastLevel.section => _SectionBody(accent: accent, toast: widget),
-      ProgressToastLevel.step => _StepBody(toast: widget),
+      ProgressToastLevel.step => _StepBody(accent: accent, toast: widget),
     };
 
     return GestureDetector(
@@ -213,7 +219,7 @@ class _ProgressToastState extends State<_ProgressToast>
           color: colors.surface,
           borderRadius: BorderRadius.circular(12),
           border: widget.level == ProgressToastLevel.step
-              ? Border.all(color: colors.primary.withValues(alpha: 0.15))
+              ? Border.all(color: accent.withValues(alpha: 0.15))
               : null,
           boxShadow: const [
             BoxShadow(
@@ -782,9 +788,10 @@ class _EnvelopePainter extends CustomPainter {
    NIVEAU 3 · B — Étape (cachet + halo + CTA)
    ============================================================ */
 class _StepBody extends StatelessWidget {
+  final Color accent;
   final _ProgressToast toast;
 
-  const _StepBody({required this.toast});
+  const _StepBody({required this.accent, required this.toast});
 
   @override
   Widget build(BuildContext context) {
@@ -799,10 +806,7 @@ class _StepBody extends StatelessWidget {
           gradient: RadialGradient(
             center: const Alignment(-0.64, 0),
             radius: 0.55,
-            colors: [
-              colors.primary.withValues(alpha: 0.10),
-              Colors.transparent,
-            ],
+            colors: [accent.withValues(alpha: 0.10), Colors.transparent],
           ),
         ),
         child: Padding(
@@ -814,7 +818,7 @@ class _StepBody extends StatelessWidget {
               Row(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  _CachetStamp(num: num, accent: colors.primary),
+                  _CachetStamp(num: num, accent: accent),
                   const SizedBox(width: 11),
                   Expanded(
                     child: Column(
@@ -827,7 +831,7 @@ class _StepBody extends StatelessWidget {
                             fontSize: 8.5,
                             fontWeight: FontWeight.w700,
                             letterSpacing: 1.1,
-                            color: colors.primary,
+                            color: accent,
                           ),
                         ),
                         const SizedBox(height: 2),
@@ -853,7 +857,7 @@ class _StepBody extends StatelessWidget {
                 padding: const EdgeInsets.only(top: 6),
                 child: CustomPaint(
                   painter: _DashedTopBorder(
-                    color: colors.primary.withValues(alpha: 0.25),
+                    color: accent.withValues(alpha: 0.25),
                   ),
                   child: Padding(
                     padding: const EdgeInsets.only(top: 6),
@@ -870,7 +874,7 @@ class _StepBody extends StatelessWidget {
                                   style: GoogleFonts.dmSans(
                                     fontSize: 11.5,
                                     fontWeight: FontWeight.w600,
-                                    color: colors.primary,
+                                    color: accent,
                                   ),
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
@@ -880,7 +884,7 @@ class _StepBody extends StatelessWidget {
                               Icon(
                                 PhosphorIcons.arrowRight(),
                                 size: 13,
-                                color: colors.primary,
+                                color: accent,
                               ),
                             ],
                           ),

--- a/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
@@ -30,6 +30,7 @@ class SourceAddPanel extends ConsumerStatefulWidget {
   final bool showCommunityGems;
   final bool showAddedNudge;
   final bool autoFocusSearch;
+  final bool veilleMode;
 
   /// Appelé après un ajout réussi, une fois la modale détail fermée.
   /// Le hôte décide de fermer le sheet, naviguer ailleurs, etc.
@@ -47,6 +48,7 @@ class SourceAddPanel extends ConsumerStatefulWidget {
     this.showCommunityGems = true,
     this.showAddedNudge = true,
     this.autoFocusSearch = false,
+    this.veilleMode = false,
     this.onSourceAdded,
   });
 
@@ -107,10 +109,10 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
   }
 
   SmartSearchQuery get _searchParams => (
-        query: _currentQuery,
-        contentType: _selectedContentType,
-        expand: _expanded,
-      );
+    query: _currentQuery,
+    contentType: _selectedContentType,
+    expand: _expanded,
+  );
 
   void _runSearch([String? query]) {
     final value = (query ?? _searchController.text).trim();
@@ -154,10 +156,22 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
 
   Future<void> _addSource(SmartSearchResult result) async {
     try {
-      final repository = ref.read(sourcesRepositoryProvider);
       final sourceId = result.sourceId;
       final hasCatalogId =
           sourceId != null && sourceId.isNotEmpty && sourceId != 'null';
+
+      if (widget.veilleMode) {
+        setState(() {
+          if (hasCatalogId) _addedSourceIds.add(sourceId);
+          _sourceAdded = true;
+          _lastAddedName = result.name;
+        });
+        _resetForNextAdd();
+        widget.onSourceAdded?.call(result);
+        return;
+      }
+
+      final repository = ref.read(sourcesRepositoryProvider);
 
       if (hasCatalogId) {
         await repository.trustSource(sourceId);
@@ -202,7 +216,8 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
         if (!mounted) return;
       } else {
         NotificationService.showSuccess(
-            'Source ajoutee ! Ses contenus apparaitront dans ton feed.');
+          'Source ajoutee ! Ses contenus apparaitront dans ton feed.',
+        );
       }
       _resetForNextAdd();
       widget.onSourceAdded?.call(result);
@@ -250,7 +265,8 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
         await repository.trustSource(source.id);
         if (mounted) {
           NotificationService.showSuccess(
-              'Source ajoutee ! Ses contenus apparaitront dans ton feed.');
+            'Source ajoutee ! Ses contenus apparaitront dans ton feed.',
+          );
         }
       }
       ref.invalidate(trendingSourcesProvider);
@@ -282,7 +298,8 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
                 await Clipboard.setData(ClipboardData(text: source.url!));
                 if (mounted) {
                   NotificationService.showSuccess(
-                      'URL du flux copiee dans le presse-papiers !');
+                    'URL du flux copiee dans le presse-papiers !',
+                  );
                 }
               }
             : null,
@@ -306,9 +323,10 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
           ],
           _buildBreathingSearch(colors),
           SizedBox(
-              height: _currentQuery.isEmpty
-                  ? FacteurSpacing.space8
-                  : FacteurSpacing.space4),
+            height: _currentQuery.isEmpty
+                ? FacteurSpacing.space8
+                : FacteurSpacing.space4,
+          ),
           _buildContent(),
         ],
       ),
@@ -355,7 +373,8 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
     }
 
     final searchAsync = ref.watch(smartSearchProvider(_searchParams));
-    final followedIds = ref
+    final followedIds =
+        ref
             .watch(userSourcesProvider)
             .valueOrNull
             ?.where((s) => s.isTrusted)
@@ -373,7 +392,8 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
           error: (error, _) => _buildErrorState(),
           data: (response) {
             if (response.results.isEmpty) return _buildNoResults();
-            final canExpand = !_expanded &&
+            final canExpand =
+                !_expanded &&
                 response.layersCalled.length == 1 &&
                 response.layersCalled.first == 'catalog';
             return _buildResults(
@@ -441,8 +461,11 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
           ),
           child: Row(
             children: [
-              Icon(PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
-                  size: 22, color: colors.primary),
+              Icon(
+                PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                size: 22,
+                color: colors.primary,
+              ),
               const SizedBox(width: FacteurSpacing.space3),
               Expanded(
                 child: Column(
@@ -451,9 +474,9 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
                     Text(
                       name != null ? '« $name » ajoutée' : 'Source ajoutée',
                       style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                            fontWeight: FontWeight.w600,
-                            color: colors.textPrimary,
-                          ),
+                        fontWeight: FontWeight.w600,
+                        color: colors.textPrimary,
+                      ),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -461,15 +484,18 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
                     Text(
                       'Une autre à ajouter ?',
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: colors.textSecondary,
-                          ),
+                        color: colors.textSecondary,
+                      ),
                     ),
                   ],
                 ),
               ),
               const SizedBox(width: FacteurSpacing.space2),
-              Icon(PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
-                  size: 18, color: colors.primary),
+              Icon(
+                PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
+                size: 18,
+                color: colors.primary,
+              ),
             ],
           ),
         ),
@@ -484,17 +510,18 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
         Text(
           'Que veux-tu suivre ?',
           textAlign: TextAlign.center,
-          style: FacteurTypography.serifTitle(colors.textPrimary)
-              .copyWith(fontSize: 28, height: 1.15),
+          style: FacteurTypography.serifTitle(
+            colors.textPrimary,
+          ).copyWith(fontSize: 28, height: 1.15),
         ),
         const SizedBox(height: FacteurSpacing.space2),
         Text(
           'Tape un nom de média ou colle son URL.\nOn l\'ajoute à ton app.',
           textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: colors.textSecondary,
-                height: 1.45,
-              ),
+            color: colors.textSecondary,
+            height: 1.45,
+          ),
         ),
         const SizedBox(height: FacteurSpacing.space4),
         _buildSupportedTypesInfo(colors),
@@ -526,9 +553,9 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
             const SizedBox(width: 4),
             Text(
               it.label,
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                    color: colors.textTertiary,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.labelSmall?.copyWith(color: colors.textTertiary),
             ),
           ],
         );
@@ -552,7 +579,8 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
         const SizedBox(height: 12),
         ...results.map((result) {
           final id = result.sourceId;
-          final isAdded = _addedSourceIds.contains(id) ||
+          final isAdded =
+              _addedSourceIds.contains(id) ||
               (id != null && followedIds.contains(id));
           return SourceResultCard(
             result: result,
@@ -575,9 +603,9 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
           const SizedBox(height: 4),
           Text(
             'Cherche aussi sur YouTube, Reddit et le web.',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: colors.textTertiary,
-                ),
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(color: colors.textTertiary),
             textAlign: TextAlign.center,
           ),
         ],
@@ -592,22 +620,25 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
         padding: const EdgeInsets.all(32.0),
         child: Column(
           children: [
-            Icon(PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
-                size: 48, color: colors.textTertiary),
+            Icon(
+              PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
+              size: 48,
+              color: colors.textTertiary,
+            ),
             const SizedBox(height: 16),
             Text(
               'Aucun resultat pour "$_currentQuery"',
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: colors.textSecondary,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 8),
             Text(
               'Essayez avec une URL directe ou d\'autres mots-cles.',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: colors.textTertiary,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: colors.textTertiary),
               textAlign: TextAlign.center,
             ),
           ],
@@ -623,14 +654,17 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
         padding: const EdgeInsets.all(32.0),
         child: Column(
           children: [
-            Icon(PhosphorIcons.warning(PhosphorIconsStyle.regular),
-                size: 48, color: colors.error),
+            Icon(
+              PhosphorIcons.warning(PhosphorIconsStyle.regular),
+              size: 48,
+              color: colors.error,
+            ),
             const SizedBox(height: 16),
             Text(
               'Impossible de rechercher pour le moment.',
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: colors.textSecondary,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 12),
@@ -647,12 +681,12 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
 
   static const _contentTypeOptions =
       <({String label, String apiValue, int iconIndex})>[
-    (label: 'Médias', apiValue: 'article', iconIndex: 0),
-    (label: 'Newsletters', apiValue: 'article', iconIndex: 1),
-    (label: 'YouTube', apiValue: 'youtube', iconIndex: 2),
-    (label: 'Reddit', apiValue: 'reddit', iconIndex: 3),
-    (label: 'Podcasts', apiValue: 'podcast', iconIndex: 4),
-  ];
+        (label: 'Médias', apiValue: 'article', iconIndex: 0),
+        (label: 'Newsletters', apiValue: 'article', iconIndex: 1),
+        (label: 'YouTube', apiValue: 'youtube', iconIndex: 2),
+        (label: 'Reddit', apiValue: 'reddit', iconIndex: 3),
+        (label: 'Podcasts', apiValue: 'podcast', iconIndex: 4),
+      ];
 
   IconData _iconForContentType(int idx) {
     switch (idx) {

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -263,6 +263,12 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
   /// Limite backend par angle (`VeilleTopicSelection.keywords` max_length=10).
   static const int maxAngleKeywords = 10;
 
+  /// Limite backend des angles envoyés au suggester de sources.
+  static const int maxSuggestAngles = 20;
+
+  /// Limite backend des mots-clés envoyés au suggester de sources.
+  static const int maxSuggestKeywords = 40;
+
   void selectTheme(String id) {
     // Changer de thème reset les topics pré-sélectionnés (les preset topics
     // dépendent du thème) ET le sujet principal granulaire (Story 23.4 — la
@@ -604,6 +610,43 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       sourcesMeta: nextMeta,
       selectedSourceIds: {...state.selectedSourceIds, sourceId},
     );
+  }
+
+  /// Ajoute une URL libre localement à la veille, sans trust global.
+  ///
+  /// Utilisé par le sheet Step 3 pour les flux niche hors catalogue. Le submit
+  /// les sérialise ensuite en `niche_candidate`.
+  void addUrlSourceToVeille({
+    required String name,
+    required String url,
+    String? why,
+  }) {
+    final normalizedUrl = url.trim();
+    if (!_isValidHttpUrl(normalizedUrl)) return;
+    final trimmedName = name.trim();
+    final sourceName = trimmedName.isEmpty
+        ? _sourceNameFallback(normalizedUrl)
+        : trimmedName;
+    final slug = sourceSuggestionSlug(sourceName, normalizedUrl);
+    final nextMeta = Map<String, VeilleSourceMeta>.from(state.sourcesMeta);
+    nextMeta[slug] = VeilleSourceMeta(
+      slug: slug,
+      name: sourceName,
+      kind: 'niche',
+      url: normalizedUrl,
+      why: _emptyToNull(why),
+    );
+    state = state.copyWith(
+      sourcesMeta: nextMeta,
+      selectedSourceIds: {...state.selectedSourceIds, slug},
+    );
+  }
+
+  static String _sourceNameFallback(String url) {
+    final uri = Uri.tryParse(url);
+    final host = uri?.host;
+    if (host != null && host.isNotEmpty) return host;
+    return 'Source ajoutée';
   }
 
   /// Résout un sujet libre saisi via la tuile "Autre" de Step 1. Le sujet

--- a/apps/mobile/lib/features/veille/providers/veille_source_suggestions_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_source_suggestions_provider.dart
@@ -13,8 +13,9 @@ typedef VeilleSourceSuggestionsQuery = ({
 
 /// Suggestions de sources niche pour le Step 3.
 ///
-/// Le repo renvoie `[]` en cas d'erreur/timeout ; l'UI affiche alors un état
-/// vide avec un bouton qui invalide ce provider pour relancer la pipeline.
+/// Une réponse 200 vide est un vide légitime. Les erreurs transport/API
+/// remontent en `AsyncError`, ce qui permet à l'UI d'afficher un retry
+/// distinct de l'état "aucune source".
 final veilleSourceSuggestionsProvider = FutureProvider.autoDispose
     .family<List<VeilleSourceSuggestionDto>, VeilleSourceSuggestionsQuery>((
       ref,

--- a/apps/mobile/lib/features/veille/repositories/veille_repository.dart
+++ b/apps/mobile/lib/features/veille/repositories/veille_repository.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../../../core/api/api_client.dart';
 import '../models/veille_config_dto.dart';
@@ -144,7 +147,9 @@ class VeilleRepository {
   // ─── Suggestion sources LLM (Step 3) ───────────────────────────────────
 
   /// `POST /api/veille/suggest/sources` — candidats niche non ingérés.
-  /// Toute erreur/timeout/parsing inattendu → `[]` pour afficher le retry.
+  /// Les erreurs transport/API remontent en `VeilleApiException` pour que l'UI
+  /// affiche un état retry. Une réponse 200 vide reste un vide légitime ;
+  /// une réponse 200 malformée se dégrade en `[]`.
   Future<List<VeilleSourceSuggestionDto>> suggestSources({
     required String themeId,
     required String themeLabel,
@@ -166,7 +171,35 @@ class VeilleRepository {
       return VeilleSuggestSourcesResponse.fromJson(
         response.data as Map<String, dynamic>,
       ).sources;
-    } catch (_) {
+    } on DioException catch (e, st) {
+      unawaited(
+        Sentry.captureException(
+          e,
+          stackTrace: st,
+          withScope: (scope) {
+            scope.setTag('endpoint', 'veille_suggest_sources');
+            final code = e.response?.statusCode;
+            scope.setContexts('veille_suggest_sources', {
+              'path': e.requestOptions.path,
+              if (code != null) 'statusCode': code,
+            });
+          },
+        ),
+      );
+      throw _wrap(e);
+    } catch (e) {
+      unawaited(
+        Sentry.captureMessage(
+          'veille_suggest_sources_malformed_response',
+          level: SentryLevel.warning,
+          withScope: (scope) {
+            scope.setTag('endpoint', 'veille_suggest_sources');
+            scope.setContexts('veille_suggest_sources', {
+              'error': e.toString(),
+            });
+          },
+        ),
+      );
       return const [];
     }
   }

--- a/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
@@ -264,18 +264,41 @@ class _AnglesLoading extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 22),
-      child: Column(
-        children: [
-          const FacteurLoader(width: 64, height: 64),
-          const SizedBox(height: 8),
-          Text(
-            'Recherche d\'angles pour ton thème…',
-            style: GoogleFonts.dmSans(
-              fontSize: 12.5,
-              color: const Color(0xFF8B7E63),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.fromLTRB(18, 18, 18, 20),
+        decoration: BoxDecoration(
+          color: const Color(0xFFFDFBF7),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: FacteurColors.veilleLineSoft),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const FacteurLoader(width: 56, height: 56),
+            const SizedBox(height: 12),
+            Text(
+              'Recherche des bons angles',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.fraunces(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: const Color(0xFF2C2A29),
+              ),
             ),
-          ),
-        ],
+            const SizedBox(height: 6),
+            Text(
+              'Un angle est une facette précise de ton sujet. Les sélectionner '
+              'avec soin permet de cibler les aspects qui t\'intéressent le plus.',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.dmSans(
+                fontSize: 13,
+                height: 1.45,
+                color: const Color(0xFF5D5B5A),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -386,27 +409,101 @@ class _AngleCard extends StatelessWidget {
           if (showChips)
             Padding(
               padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-              child: Wrap(
-                spacing: 6,
-                runSpacing: 6,
-                children: [
-                  for (final kw in keywords)
-                    _KeywordChip(
-                      label: kw,
-                      onRemove: selected
-                          ? () => notifier.removeAngleKeyword(slug, kw)
-                          : null,
-                    ),
-                  if (selected &&
-                      keywords.length < VeilleConfigNotifier.maxAngleKeywords)
-                    _AddKeywordButton(
-                      enabled: true,
-                      onTap: () =>
-                          _openAddAngleKeywordSheet(context, notifier, slug),
-                    ),
-                ],
-              ),
+              child: selected
+                  ? _KeywordsSummaryChip(
+                      count: keywords.length,
+                      onTap: () => _openKeywordsManagerSheet(context, slug),
+                    )
+                  : _KeywordsPreviewChip(count: keywords.length),
             ),
+        ],
+      ),
+    );
+  }
+}
+
+class _KeywordsSummaryChip extends StatelessWidget {
+  final int count;
+  final VoidCallback onTap;
+  const _KeywordsSummaryChip({required this.count, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final label = count == 1 ? '1 mot clé tracké' : '$count mots clés trackés';
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(20),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: FacteurColors.veilleTint,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: FacteurColors.veille),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                PhosphorIcons.listBullets(),
+                size: 13,
+                color: FacteurColors.veille,
+              ),
+              const SizedBox(width: 5),
+              Text(
+                label,
+                style: GoogleFonts.dmSans(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: FacteurColors.veille,
+                ),
+              ),
+              const SizedBox(width: 4),
+              Icon(
+                PhosphorIcons.caretRight(PhosphorIconsStyle.bold),
+                size: 12,
+                color: FacteurColors.veille,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _KeywordsPreviewChip extends StatelessWidget {
+  final int count;
+  const _KeywordsPreviewChip({required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    final label = count == 1 ? '1 mot clé' : '$count mots clés';
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FacteurColors.veilleLineSoft),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            PhosphorIcons.listBullets(),
+            size: 12,
+            color: const Color(0xFF8B7E63),
+          ),
+          const SizedBox(width: 5),
+          Text(
+            label,
+            style: GoogleFonts.dmSans(
+              fontSize: 12,
+              color: const Color(0xFF5D5B5A),
+            ),
+          ),
         ],
       ),
     );
@@ -612,6 +709,103 @@ Future<void> _openAddAngleKeywordSheet(
   hint: 'Ex : régulation',
   onAdd: (kw) => notifier.addAngleKeyword(slug, kw),
 );
+
+Future<void> _openKeywordsManagerSheet(
+  BuildContext context,
+  String slug,
+) async {
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.white,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
+    ),
+    builder: (ctx) {
+      final viewInsets = MediaQuery.of(ctx).viewInsets;
+      return Consumer(
+        builder: (context, ref, _) {
+          final state = ref.watch(veilleConfigProvider);
+          final notifier = ref.read(veilleConfigProvider.notifier);
+          final keywords = state.angleKeywords[slug] ?? const <String>[];
+          final canAdd =
+              keywords.length < VeilleConfigNotifier.maxAngleKeywords;
+          return SafeArea(
+            top: false,
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(20, 16, 20, 16 + viewInsets.bottom),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          'Mots clés trackés',
+                          style: GoogleFonts.fraunces(
+                            fontSize: 17,
+                            fontWeight: FontWeight.w700,
+                            color: const Color(0xFF2C2A29),
+                          ),
+                        ),
+                      ),
+                      IconButton(
+                        onPressed: () => Navigator.of(ctx).pop(),
+                        icon: Icon(PhosphorIcons.x(), size: 18),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'Ils filtrent les articles de cet angle dans le titre et '
+                    'la description.',
+                    style: GoogleFonts.dmSans(
+                      fontSize: 12.5,
+                      height: 1.4,
+                      color: const Color(0xFF5D5B5A),
+                    ),
+                  ),
+                  const SizedBox(height: 14),
+                  if (keywords.isEmpty) ...[
+                    Text(
+                      'Aucun mot clé pour cet angle.',
+                      style: GoogleFonts.dmSans(
+                        fontSize: 12.5,
+                        color: const Color(0xFF8B7E63),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                  ] else ...[
+                    Wrap(
+                      spacing: 6,
+                      runSpacing: 6,
+                      children: [
+                        for (final kw in keywords)
+                          _KeywordChip(
+                            label: kw,
+                            onRemove: () =>
+                                notifier.removeAngleKeyword(slug, kw),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 14),
+                  ],
+                  _AddKeywordButton(
+                    enabled: canAdd,
+                    onTap: canAdd
+                        ? () => _openAddAngleKeywordSheet(ctx, notifier, slug)
+                        : () {},
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      );
+    },
+  );
+}
 
 /// Bottom sheet partagé de saisie d'un mot-clé. `onAdd` reçoit le texte trimé
 /// non-vide ; la normalisation/dédupe est faite côté notifier.

--- a/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
@@ -34,7 +34,7 @@ class Step3SourcesScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(veilleConfigProvider);
     final notifier = ref.read(veilleConfigProvider.notifier);
-    final query = _buildSuggestionQuery(state);
+    final query = buildSuggestionQuery(state);
     final VoidCallback? onRetry = query == null
         ? null
         : () => ref.invalidate(veilleSourceSuggestionsProvider(query));
@@ -109,7 +109,8 @@ class Step3SourcesScreen extends ConsumerWidget {
                 ],
                 suggestionsAsync.when(
                   loading: () => const _SourceSuggestionsLoading(),
-                  error: (_, __) => _SourceSuggestionsEmpty(onRetry: onRetry),
+                  error: (_, __) =>
+                      _SourceSuggestionsEmpty(onRetry: onRetry, isError: true),
                   data: (suggestions) {
                     if (suggestions.isEmpty) {
                       return _SourceSuggestionsEmpty(onRetry: onRetry);
@@ -189,7 +190,18 @@ class Step3SourcesScreen extends ConsumerWidget {
               sourceId: id,
               name: result.name,
               url: result.url,
+              why: result.description,
             );
+          } else {
+            final url =
+                result.feedUrl.trim().isNotEmpty ? result.feedUrl : result.url;
+            if (_isValidHttpUrl(url)) {
+              notifier.addUrlSourceToVeille(
+                name: result.name,
+                url: url,
+                why: result.description,
+              );
+            }
           }
           Navigator.of(sheetContext).pop();
         },
@@ -210,43 +222,44 @@ class Step3SourcesScreen extends ConsumerWidget {
           : 'https://www.google.com/s2/favicons?sz=128&domain=${_domain(meta.url!)}',
     );
   }
+}
 
-  static VeilleSourceSuggestionsQuery? _buildSuggestionQuery(
-    VeilleConfigState state,
-  ) {
-    final theme = state.selectedTheme;
-    if (theme == null) return null;
-    final themeLabel = state.resolvedThemeLabel(veilleThemeLabelForSlug(theme));
-    final angleLabels = <String>[];
-    if (state.mainTopicSlug != null) {
-      angleLabels.add(
-        state.mainTopicLabel ??
-            state.topicLabels[state.mainTopicSlug!] ??
-            state.mainTopicSlug!,
-      );
-    }
-    for (final slug in state.selectedSuggestions) {
-      final label = state.topicLabels[slug];
-      if (label != null && label.trim().isNotEmpty) angleLabels.add(label);
-    }
-
-    final keywords = <String>{...state.keywords};
-    final selectedTopicSlugs = <String>{
-      if (state.mainTopicSlug != null) state.mainTopicSlug!,
-      ...state.selectedSuggestions,
-    };
-    for (final slug in selectedTopicSlugs) {
-      keywords.addAll(state.angleKeywords[slug] ?? const <String>[]);
-    }
-
-    return (
-      themeId: theme,
-      themeLabel: themeLabel,
-      brief: state.editorialBrief ?? '',
-      anglesKey: angleLabels.join('|'),
-      keywordsKey: keywords.join('|'),
+@visibleForTesting
+VeilleSourceSuggestionsQuery? buildSuggestionQuery(VeilleConfigState state) {
+  final theme = state.selectedTheme;
+  if (theme == null) return null;
+  final themeLabel = state.resolvedThemeLabel(veilleThemeLabelForSlug(theme));
+  final angleLabels = <String>[];
+  if (state.mainTopicSlug != null) {
+    angleLabels.add(
+      state.mainTopicLabel ??
+          state.topicLabels[state.mainTopicSlug!] ??
+          state.mainTopicSlug!,
     );
   }
+  for (final slug in state.selectedSuggestions) {
+    final label = state.topicLabels[slug];
+    if (label != null && label.trim().isNotEmpty) angleLabels.add(label);
+  }
+
+  final keywords = <String>{...state.keywords};
+  final selectedTopicSlugs = <String>{
+    if (state.mainTopicSlug != null) state.mainTopicSlug!,
+    ...state.selectedSuggestions,
+  };
+  for (final slug in selectedTopicSlugs) {
+    keywords.addAll(state.angleKeywords[slug] ?? const <String>[]);
+  }
+
+  return (
+    themeId: theme,
+    themeLabel: themeLabel,
+    brief: state.editorialBrief ?? '',
+    anglesKey:
+        angleLabels.take(VeilleConfigNotifier.maxSuggestAngles).join('|'),
+    keywordsKey:
+        keywords.take(VeilleConfigNotifier.maxSuggestKeywords).join('|'),
+  );
 }
 
 class _SuggestedSourcesList extends StatelessWidget {
@@ -320,20 +333,25 @@ class _SourceSuggestionsLoading extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 18),
-      child: Column(
-        children: [
-          const FacteurLoader(width: 64, height: 64),
-          const SizedBox(height: 8),
-          Text(
-            'Recherche de sources pour ta veille…',
-            style: GoogleFonts.dmSans(
-              fontSize: 12.5,
-              color: const Color(0xFF8B7E63),
+    return SizedBox(
+      width: double.infinity,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const FacteurLoader(width: 64, height: 64),
+            const SizedBox(height: 8),
+            Text(
+              'Recherche de sources pour ta veille…',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.dmSans(
+                fontSize: 12.5,
+                color: const Color(0xFF8B7E63),
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -341,7 +359,8 @@ class _SourceSuggestionsLoading extends StatelessWidget {
 
 class _SourceSuggestionsEmpty extends StatelessWidget {
   final VoidCallback? onRetry;
-  const _SourceSuggestionsEmpty({required this.onRetry});
+  final bool isError;
+  const _SourceSuggestionsEmpty({required this.onRetry, this.isError = false});
 
   @override
   Widget build(BuildContext context) {
@@ -357,7 +376,9 @@ class _SourceSuggestionsEmpty extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Aucune source proposée pour l\'instant.',
+            isError
+                ? 'Impossible de proposer des sources pour l\'instant.'
+                : 'Aucune source proposée pour l\'instant.',
             style: GoogleFonts.dmSans(
               fontSize: 13,
               fontWeight: FontWeight.w600,
@@ -368,7 +389,7 @@ class _SourceSuggestionsEmpty extends StatelessWidget {
           OutlinedButton.icon(
             onPressed: onRetry,
             icon: Icon(PhosphorIcons.arrowsClockwise(), size: 15),
-            label: const Text('Proposer plus de sources'),
+            label: Text(isError ? 'Réessayer' : 'Proposer plus de sources'),
           ),
         ],
       ),

--- a/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
@@ -8,6 +8,7 @@ import '../../../config/theme.dart';
 import '../providers/veille_active_config_provider.dart';
 import '../providers/veille_config_provider.dart';
 import '../repositories/veille_repository.dart';
+import '../../lettres/widgets/progress_toast.dart';
 import '../widgets/veille_widgets.dart';
 import 'steps/step1_5_preset_preview_screen.dart';
 import 'steps/step1_theme_screen.dart';
@@ -67,10 +68,12 @@ class VeilleConfigScreen extends ConsumerWidget {
       try {
         await notifier.submit();
         if (!context.mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(editMode ? 'Veille mise à jour' : 'Veille créée'),
-          ),
+        showProgressToast(
+          context,
+          level: ProgressToastLevel.step,
+          stepNum: '01',
+          stepTitle: editMode ? 'Veille mise à jour' : 'Veille créée',
+          accentColor: FacteurColors.veille,
         );
         context.go(RoutePaths.fluxContinu);
       } on VeilleApiException catch (e) {
@@ -78,16 +81,14 @@ class VeilleConfigScreen extends ConsumerWidget {
         final message = e.statusCode == 422
             ? 'Sélectionne au moins un sujet, une source ou un angle pour ta veille.'
             : 'Impossible d\'enregistrer ta veille (${e.statusCode ?? '?'}). Réessaie.';
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(message)),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(message)));
       } catch (_) {
         if (!context.mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
-            content: Text(
-              'Erreur réseau. Vérifie ta connexion et réessaie.',
-            ),
+            content: Text('Erreur réseau. Vérifie ta connexion et réessaie.'),
           ),
         );
       }
@@ -119,10 +120,7 @@ class VeilleConfigScreen extends ConsumerWidget {
         activeCfgValue == null &&
         !activeConfig.isLoading) {
       // Premier accès sans config : on cadre via l'intro avant Step1.
-      body = VeilleIntroScreen(
-        onClose: close,
-        onStart: notifier.completeIntro,
-      );
+      body = VeilleIntroScreen(onClose: close, onStart: notifier.completeIntro);
       key = 'intro';
     } else if (state.previewPresetId != null) {
       body = Step15PresetPreviewScreen(
@@ -154,10 +152,7 @@ class VeilleConfigScreen extends ConsumerWidget {
           duration: FacteurDurations.medium,
           switchInCurve: Curves.easeOut,
           switchOutCurve: Curves.easeIn,
-          child: KeyedSubtree(
-            key: ValueKey(key),
-            child: body,
-          ),
+          child: KeyedSubtree(key: ValueKey(key), child: body),
         ),
       ),
     );
@@ -182,8 +177,11 @@ class _EditLoadError extends StatelessWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const Icon(Icons.cloud_off_rounded,
-                      size: 40, color: Color(0xFF8B7E63)),
+                  const Icon(
+                    Icons.cloud_off_rounded,
+                    size: 40,
+                    color: Color(0xFF8B7E63),
+                  ),
                   const SizedBox(height: 16),
                   Text(
                     'Impossible de charger ta veille',
@@ -204,10 +202,7 @@ class _EditLoadError extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: 20),
-                  VeilleCtaButton(
-                    label: 'Réessayer',
-                    onPressed: onRetry,
-                  ),
+                  VeilleCtaButton(label: 'Réessayer', onPressed: onRetry),
                 ],
               ),
             ),

--- a/apps/mobile/lib/features/veille/widgets/veille_add_source_sheet.dart
+++ b/apps/mobile/lib/features/veille/widgets/veille_add_source_sheet.dart
@@ -27,9 +27,7 @@ class VeilleAddSourceSheet extends ConsumerWidget {
         return Container(
           decoration: BoxDecoration(
             color: colors.backgroundPrimary,
-            borderRadius: const BorderRadius.vertical(
-              top: Radius.circular(20),
-            ),
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
           ),
           child: Column(
             children: [
@@ -66,8 +64,8 @@ class VeilleAddSourceSheet extends ConsumerWidget {
                 child: Text(
                   'Ajouter une source à ta veille',
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
               const SizedBox(height: 8),
@@ -80,6 +78,7 @@ class VeilleAddSourceSheet extends ConsumerWidget {
                     showCommunityGems: false,
                     showAddedNudge: false,
                     autoFocusSearch: true,
+                    veilleMode: true,
                     onSourceAdded: onSourceAdded,
                   ),
                 ),

--- a/apps/mobile/test/features/lettres/widgets/progress_toast_test.dart
+++ b/apps/mobile/test/features/lettres/widgets/progress_toast_test.dart
@@ -74,6 +74,38 @@ void main() {
     expect(opened, 1);
   });
 
+  testWidgets('accentColor teinte le cachet du niveau étape', (tester) async {
+    const accent = Color(0xFF445566);
+    await tester.pumpWidget(
+      _harness(
+        onReady: (ctx) => showProgressToast(
+          ctx,
+          level: ProgressToastLevel.step,
+          stepNum: '01',
+          stepTitle: 'Veille créée',
+          accentColor: accent,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(
+      find.byWidgetPredicate((widget) {
+        if (widget is! Container || widget.decoration is! BoxDecoration) {
+          return false;
+        }
+        final decoration = widget.decoration! as BoxDecoration;
+        final border = decoration.border;
+        return decoration.shape == BoxShape.circle &&
+            border is Border &&
+            border.top.color == accent &&
+            border.top.width == 2;
+      }),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('niveau section affiche titre Fraunces + sous-titre 100%', (
     tester,
   ) async {

--- a/apps/mobile/test/features/sources/widgets/source_add_panel_test.dart
+++ b/apps/mobile/test/features/sources/widgets/source_add_panel_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/sources/models/smart_search_result.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/providers/sources_providers.dart';
+import 'package:facteur/features/sources/repositories/sources_repository.dart';
+import 'package:facteur/features/sources/widgets/source_add_panel.dart';
+
+class _FakeSourcesRepository implements SourcesRepository {
+  final SmartSearchResult result;
+  int trustCalls = 0;
+  int addCustomCalls = 0;
+
+  _FakeSourcesRepository(this.result);
+
+  @override
+  Future<SmartSearchResponse> smartSearch(
+    String query, {
+    String? contentType,
+    bool expand = false,
+  }) async {
+    return SmartSearchResponse(
+      queryNormalized: query,
+      results: [result],
+      layersCalled: const ['catalog'],
+    );
+  }
+
+  @override
+  Future<List<Source>> getAllSources() async => const [];
+
+  @override
+  Future<void> trustSource(String sourceId) async {
+    trustCalls++;
+  }
+
+  @override
+  Future<void> addCustomSource(String url, {String? name}) async {
+    addCustomCalls++;
+  }
+
+  @override
+  Future<void> logSearchAbandoned(String query) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} non mocké');
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('veilleMode remonte la source sans trust ni ajout global', (
+    tester,
+  ) async {
+    const result = SmartSearchResult(
+      name: 'Le Monde',
+      type: 'article',
+      url: 'https://www.lemonde.fr',
+      feedUrl: 'https://www.lemonde.fr/rss/une.xml',
+      inCatalog: true,
+      sourceId: 'src-1',
+    );
+    final repo = _FakeSourcesRepository(result);
+    SmartSearchResult? added;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [sourcesRepositoryProvider.overrideWithValue(repo)],
+        child: MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: Scaffold(
+            body: SourceAddPanel(
+              showIntro: false,
+              showCommunityGems: false,
+              showAddedNudge: false,
+              veilleMode: true,
+              onSourceAdded: (result) => added = result,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'le monde');
+    await tester.testTextInput.receiveAction(TextInputAction.search);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Le Monde'), findsOneWidget);
+    await tester.tap(find.text('Ajouter'));
+    await tester.pumpAndSettle();
+
+    expect(added?.sourceId, 'src-1');
+    expect(repo.trustCalls, 0);
+    expect(repo.addCustomCalls, 0);
+  });
+}

--- a/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:facteur/features/veille/providers/veille_config_provider.dart';
 import 'package:facteur/features/veille/providers/veille_repository_provider.dart';
 import 'package:facteur/features/veille/providers/veille_themes_provider.dart';
 import 'package:facteur/features/veille/repositories/veille_repository.dart';
+import 'package:facteur/features/veille/screens/steps/step3_sources_screen.dart';
 
 /// Repo factice qui capture le body d'`upsertConfig` (pour tester le mapping
 /// `_buildUpsertRequest`). Toute autre méthode throw → instrumentation à fixer.
@@ -40,8 +41,7 @@ class _CaptureRepo implements VeilleRepository {
     required String topic,
     String? themeId,
     String? themeLabel,
-  }) async =>
-      resolvedTopic;
+  }) async => resolvedTopic;
 
   @override
   dynamic noSuchMethod(Invocation invocation) =>
@@ -236,6 +236,50 @@ void main() {
     expect(source.nicheCandidate!.name, 'MACBA');
     expect(source.nicheCandidate!.url, 'https://www.macba.cat');
     expect(source.toJson()['niche_candidate'], isA<Map<String, dynamic>>());
+  });
+
+  test('addUrlSourceToVeille ajoute une source niche locale sélectionnée', () {
+    notifier.addUrlSourceToVeille(
+      name: 'Blog niche',
+      url: 'https://example.com/rss.xml',
+      why: 'Flux spécialisé',
+    );
+
+    final s = container.read(veilleConfigProvider);
+    final slug = VeilleConfigNotifier.sourceSuggestionSlug(
+      'Blog niche',
+      'https://example.com/rss.xml',
+    );
+    expect(s.selectedSourceIds, contains(slug));
+    expect(s.sourcesMeta[slug]!.kind, 'niche');
+    expect(s.sourcesMeta[slug]!.apiSourceId, isNull);
+    expect(s.sourcesMeta[slug]!.url, 'https://example.com/rss.xml');
+  });
+
+  test('buildSuggestionQuery borne angles et mots-clés au cap suggester', () {
+    notifier.selectTheme('tech');
+    notifier.selectMainTopic('ai', 'Intelligence artificielle');
+
+    for (var i = 0; i < VeilleConfigNotifier.maxKeywords; i++) {
+      notifier.addKeyword('global-$i');
+    }
+    for (var i = 0; i < 25; i++) {
+      notifier.toggleAngle(
+        VeilleAngleSuggestionDto(
+          title: 'Angle $i',
+          keywords: [for (var j = 0; j < 10; j++) 'kw-$i-$j'],
+        ),
+      );
+    }
+
+    final query = buildSuggestionQuery(container.read(veilleConfigProvider))!;
+    final angles = query.anglesKey.split('|');
+    final keywords = query.keywordsKey.split('|');
+
+    expect(angles.length, VeilleConfigNotifier.maxSuggestAngles);
+    expect(keywords.length, VeilleConfigNotifier.maxSuggestKeywords);
+    expect(angles.first, 'Intelligence artificielle');
+    expect(keywords.take(2), ['global-0', 'global-1']);
   });
 
   // ─── Angles LLM (PR-3) ──────────────────────────────────────────────────

--- a/apps/mobile/test/features/veille/providers/veille_source_suggestions_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_source_suggestions_provider_test.dart
@@ -8,10 +8,11 @@ import 'package:facteur/features/veille/repositories/veille_repository.dart';
 
 class _FakeRepo implements VeilleRepository {
   final List<VeilleSourceSuggestionDto> sources;
+  final Object? error;
   List<String>? capturedAngles;
   List<String>? capturedKeywords;
 
-  _FakeRepo(this.sources);
+  _FakeRepo(this.sources, {this.error});
 
   @override
   Future<List<VeilleSourceSuggestionDto>> suggestSources({
@@ -23,6 +24,8 @@ class _FakeRepo implements VeilleRepository {
   }) async {
     capturedAngles = angles;
     capturedKeywords = keywords;
+    final err = error;
+    if (err != null) throw err;
     return sources;
   }
 
@@ -74,5 +77,27 @@ void main() {
       veilleSourceSuggestionsProvider(query).future,
     );
     expect(sources, isEmpty);
+  });
+
+  test('erreur API repo : provider expose un AsyncError', () async {
+    final container = ProviderContainer(
+      overrides: [
+        veilleRepositoryProvider.overrideWithValue(
+          _FakeRepo(
+            const [],
+            error: const VeilleApiException(
+              'requête invalide',
+              statusCode: 422,
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container.read(veilleSourceSuggestionsProvider(query).future),
+      throwsA(isA<VeilleApiException>()),
+    );
   });
 }

--- a/apps/mobile/test/features/veille/screens/step2_suggestions_screen_test.dart
+++ b/apps/mobile/test/features/veille/screens/step2_suggestions_screen_test.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/veille/models/veille_config_dto.dart';
+import 'package:facteur/features/veille/providers/veille_config_provider.dart';
+import 'package:facteur/features/veille/providers/veille_repository_provider.dart';
+import 'package:facteur/features/veille/repositories/veille_repository.dart';
+import 'package:facteur/features/veille/screens/steps/step2_suggestions_screen.dart';
+
+class _FakeRepo implements VeilleRepository {
+  final Future<List<VeilleAngleSuggestionDto>> Function() loadAngles;
+
+  _FakeRepo(this.loadAngles);
+
+  @override
+  Future<List<VeilleAngleSuggestionDto>> suggestAngles({
+    required String themeId,
+    required String themeLabel,
+    String brief = '',
+  }) {
+    return loadAngles();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} non mocké');
+}
+
+Widget _wrap(ProviderContainer container) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(body: Step2SuggestionsScreen(onClose: () {})),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('loading affiche la carte explicative centrée', (tester) async {
+    final pending = Completer<List<VeilleAngleSuggestionDto>>();
+    final container = ProviderContainer(
+      overrides: [
+        veilleRepositoryProvider.overrideWithValue(
+          _FakeRepo(() => pending.future),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final sub = container.listen(veilleConfigProvider, (_, __) {});
+    addTearDown(sub.close);
+    addTearDown(() {
+      if (!pending.isCompleted) pending.complete(const []);
+    });
+    container.read(veilleConfigProvider.notifier).selectTheme('tech');
+
+    await tester.pumpWidget(_wrap(container));
+    await tester.pump();
+
+    final title = find.text('Recherche des bons angles');
+    expect(title, findsOneWidget);
+    expect(
+      find.textContaining('Un angle est une facette précise'),
+      findsOneWidget,
+    );
+    expect(
+      tester.getCenter(title).dx,
+      closeTo(tester.getSize(find.byType(MaterialApp)).width / 2, 1),
+    );
+  });
+
+  testWidgets('angle sélectionné ouvre le gestionnaire de mots clés', (
+    tester,
+  ) async {
+    const angle = VeilleAngleSuggestionDto(
+      title: 'IA générative',
+      keywords: ['llm', 'agents', 'régulation'],
+      reason: 'Impact sur les workflows',
+    );
+    final container = ProviderContainer(
+      overrides: [
+        veilleRepositoryProvider.overrideWithValue(
+          _FakeRepo(() async => const [angle]),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final sub = container.listen(veilleConfigProvider, (_, __) {});
+    addTearDown(sub.close);
+    final notifier = container.read(veilleConfigProvider.notifier);
+    notifier.selectTheme('tech');
+    notifier.toggleAngle(angle);
+
+    await tester.pumpWidget(_wrap(container));
+    await tester.pumpAndSettle();
+
+    expect(find.text('3 mots clés trackés'), findsOneWidget);
+    await tester.tap(find.text('3 mots clés trackés'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Mots clés trackés'), findsOneWidget);
+    expect(find.text('llm'), findsOneWidget);
+
+    await tester.tap(find.text('llm'));
+    await tester.pumpAndSettle();
+
+    final slug = VeilleConfigNotifier.angleSlug(angle.title);
+    expect(
+      container.read(veilleConfigProvider).angleKeywords[slug],
+      isNot(contains('llm')),
+    );
+    expect(find.text('llm'), findsNothing);
+  });
+}

--- a/packages/api/app/schemas/veille.py
+++ b/packages/api/app/schemas/veille.py
@@ -21,6 +21,8 @@ VeilleThemeSlug = Literal[
 ]
 
 MAX_KEYWORDS_PER_CONFIG = 20
+MAX_SUGGEST_SOURCE_ANGLES = 20
+MAX_SUGGEST_SOURCE_KEYWORDS = 40
 
 
 def _normalize_keyword(raw: str) -> str:
@@ -281,8 +283,18 @@ class VeilleSuggestSourcesRequest(BaseModel):
     theme_id: str = Field(min_length=1, max_length=50)
     theme_label: str = Field(min_length=1, max_length=120)
     brief: str = Field(default="", max_length=500)
-    angles: list[str] = Field(default_factory=list, max_length=20)
-    keywords: list[str] = Field(default_factory=list, max_length=40)
+    angles: list[str] = Field(default_factory=list)
+    keywords: list[str] = Field(default_factory=list)
+
+    @field_validator("angles", mode="after")
+    @classmethod
+    def truncate_angles(cls, v: list[str]) -> list[str]:
+        return v[:MAX_SUGGEST_SOURCE_ANGLES]
+
+    @field_validator("keywords", mode="after")
+    @classmethod
+    def truncate_keywords(cls, v: list[str]) -> list[str]:
+        return v[:MAX_SUGGEST_SOURCE_KEYWORDS]
 
 
 class VeilleSourceSuggestion(BaseModel):

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -629,6 +629,38 @@ class TestSuggestEndpoints:
         assert r.status_code == 200
         assert r.json() == {"sources": []}
 
+    async def test_suggest_sources_truncates_overflow_instead_of_422(
+        self, auth_user, monkeypatch
+    ):
+        from app.services.veille.llm import source_suggester as mod
+
+        captured = {}
+
+        async def _fake_empty(self, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr(mod.SourceSuggester, "suggest_sources", _fake_empty)
+        monkeypatch.setattr(mod, "_source_suggester", None)
+
+        async with _client() as c:
+            r = await c.post(
+                "/api/veille/suggest/sources",
+                json={
+                    "theme_id": "other",
+                    "theme_label": "Niche super pointue",
+                    "brief": "",
+                    "angles": [f"angle-{i}" for i in range(30)],
+                    "keywords": [f"kw-{i}" for i in range(60)],
+                },
+            )
+        assert r.status_code == 200, r.text
+        assert r.json() == {"sources": []}
+        assert len(captured["angles"]) == 20
+        assert len(captured["keywords"]) == 40
+        assert captured["angles"] == [f"angle-{i}" for i in range(20)]
+        assert captured["keywords"] == [f"kw-{i}" for i in range(40)]
+
 
 class TestOtherThemeIngestion:
     """theme_id='other' (tuile Autre) doit mapper vers theme='custom' à l'ingestion."""


### PR DESCRIPTION
## What

Série de fixes et affinements UX sur le tunnel de configuration veille (steps 2 & 3), le panneau d'ajout de sources, et le widget `ProgressToast`. Côté API, la validation `VeilleSuggestSourcesRequest` tronque désormais silencieusement les listes `angles`/`keywords` au lieu de retourner 422 quand le client envoie plus d'entrées que le maximum autorisé.

## Why

Corrections de comportements incorrects ou dégradés détectés lors de l'usage : états vides/loading manquants sur step2, gestion des sources dans step3, ergonomie du panneau `source_add_panel`, et une régression API qui provoquait des 422 non attendus sur l'endpoint suggest/sources.

## Type

- [x] Bug fix

## Checklist

- [x] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)