### PR TITLE
fix(notif): re-personnalise les notifs Essentiel + Bonnes Nouvelles

### DIFF
--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -185,6 +185,33 @@ class PushNotificationService {
     }
   }
 
+  /// Construit le triplet (title, body, bigText) pour la notif « Bonnes
+  /// nouvelles du jour » — miroir de [buildCopy] mais ton serein.
+  ///
+  /// - [teasers] vide → corps générique ([goodNewsTitle] / [goodNewsBody]) ;
+  /// - sinon → body collapsed avec le premier teaser (clip 60c), bigText en
+  ///   bullets (max 3).
+  static ({String title, String body, String bigText}) buildGoodNewsCopy({
+    List<String>? teasers,
+  }) {
+    final cleaned = (teasers ?? const <String>[])
+        .map((t) => t.trim())
+        .where((t) => t.isNotEmpty)
+        .take(3)
+        .toList();
+    if (cleaned.isEmpty) {
+      return (title: goodNewsTitle, body: goodNewsBody, bigText: goodNewsBody);
+    }
+    final first = cleaned.first;
+    final clipped = first.length > 60 ? '${first.substring(0, 57)}…' : first;
+    final bullets = cleaned.map((t) => '• $t').join('\n');
+    return (
+      title: goodNewsTitle,
+      body: 'À la une : $clipped',
+      bigText: 'Vos bonnes nouvelles du jour :\n$bullets',
+    );
+  }
+
   // --- Daily digest --------------------------------------------------------
 
   /// Planifie la notification quotidienne à l'heure correspondant à [timeSlot].
@@ -314,9 +341,11 @@ class PushNotificationService {
   /// principal pour permettre un horaire dédié sans coupler les opt-ins.
   Future<bool> scheduleDailyGoodNewsNotification({
     NotifTimeSlot timeSlot = NotifTimeSlot.evening,
+    List<String>? teasers,
   }) async {
     final time = _timeOfDayFor(timeSlot);
     final scheduledDate = _nextInstanceOf(time);
+    final copy = buildGoodNewsCopy(teasers: teasers);
 
     final androidPlugin = _plugin.resolvePlatformSpecificImplementation<
         AndroidFlutterLocalNotificationsPlugin>();
@@ -345,7 +374,7 @@ class PushNotificationService {
         const Person(name: 'Toi'),
         groupConversation: false,
         messages: [
-          Message(goodNewsBody, DateTime.now(), sender),
+          Message(copy.bigText, DateTime.now(), sender),
         ],
       ),
     );
@@ -353,8 +382,8 @@ class PushNotificationService {
 
     await _plugin.zonedSchedule(
       id: _NotifIds.dailyGoodNews,
-      title: goodNewsTitle,
-      body: goodNewsBody,
+      title: copy.title,
+      body: copy.body,
       scheduledDate: scheduledDate,
       notificationDetails: NotificationDetails(
         android: androidDetails,
@@ -367,7 +396,7 @@ class PushNotificationService {
 
     debugPrint(
       'PushNotificationService: good news scheduled @ $scheduledDate '
-      '(slot: $timeSlot)',
+      '(slot: $timeSlot, teasers: ${teasers?.length ?? 0})',
     );
 
     return _isScheduled(_NotifIds.dailyGoodNews);

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -1,15 +1,12 @@
 import 'dart:async';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
 import '../../../core/providers/analytics_provider.dart';
-import '../../../core/services/push_notification_service.dart';
 import '../../../core/services/widget_service.dart';
 import '../../../core/ui/notification_service.dart';
 import '../../onboarding/providers/onboarding_provider.dart';
-import '../../settings/providers/notifications_settings_provider.dart';
 import '../models/digest_models.dart';
 import '../repositories/digest_repository.dart';
 import 'serein_toggle_provider.dart';
@@ -157,8 +154,6 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
         ref.read(sereinToggleProvider.notifier).initFromApi(dual.sereinEnabled);
         // Push to home screen widget
         _syncWidget();
-        // Update notification with dynamic topic keywords
-        unawaited(_updateNotificationWithTopics());
         // If either variant was served as yesterday's stale fallback while
         // fresh content is being generated in background, schedule a silent
         // auto-refetch so the user sees today's digest without pulling.
@@ -211,7 +206,6 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
           _normalDigest = digest;
           _cachedDate = _todayDateString;
           ref.read(sereinToggleProvider.notifier).initFromApi(false);
-          unawaited(_updateNotificationWithTopics());
           _maybeScheduleStaleFallbackRefetch();
           return digest;
         } catch (_) {
@@ -294,46 +288,6 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
   /// the in-app Serein/"Bonnes Nouvelles" toggle is on.
   void _syncWidget() {
     WidgetService.updateWidget(digest: _normalDigest);
-  }
-
-  /// Update the daily notification with topic keywords from the loaded digest.
-  /// Uses the normal digest topics to build an engaging notification body.
-  /// Only updates if push notifications are enabled in user settings.
-  ///
-  /// If the user has Serein mode enabled, a calmer notification copy is used
-  /// to avoid triggering anxiety before reading.
-  Future<void> _updateNotificationWithTopics() async {
-    try {
-      final settings = ref.read(notificationsSettingsProvider);
-      if (!settings.pushEnabled) return;
-
-      final digest = _normalDigest;
-      if (digest == null) return;
-
-      final isSerein = ref.read(sereinToggleProvider).enabled;
-      final topTopics = digest.topics
-          .map((t) => t.label.trim())
-          .where((l) => l.isNotEmpty)
-          .take(3)
-          .toList();
-
-      // Variante C (jour calme) hors v1 — Serein + variante A pour rester
-      // cohérent avec le brief §6.1 (variante C = override manuel uniquement).
-      final variant = (!isSerein && topTopics.isNotEmpty)
-          ? NotifVariant.variantB
-          : NotifVariant.variantA;
-
-      await PushNotificationService().scheduleDailyDigestNotification(
-        timeSlot: settings.timeSlot,
-        variant: variant,
-        teasers: variant == NotifVariant.variantB ? topTopics : null,
-      );
-      debugPrint(
-        'DigestNotifier: Re-scheduled (variant: $variant, slot: ${settings.timeSlot})',
-      );
-    } catch (e, stack) {
-      debugPrint('DigestNotifier: Failed to update notification: $e\n$stack');
-    }
   }
 
   /// Clear the in-memory cache (forces next load to call API).

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -14,12 +14,14 @@ import '../../feed/providers/feed_provider.dart' show feedRepositoryProvider;
 import '../../feed/repositories/feed_repository.dart';
 import '../../my_interests/models/user_interests_state.dart';
 import '../../my_interests/providers/user_interests_provider.dart';
+import '../../settings/providers/notifications_settings_provider.dart';
 import '../../veille/providers/veille_active_config_provider.dart';
 import '../models/flux_continu_models.dart';
 import '../repositories/essentiel_repository.dart';
 import '../repositories/flux_continu_repository.dart';
 import '../services/flux_continu_cache_service.dart';
 import '../services/tournee_progress_service.dart';
+import '../utils/notif_teasers.dart';
 import '../utils/theme_color_mapping.dart';
 
 /// Accent applied to the legacy "Actus du jour" digest topic section
@@ -200,8 +202,29 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
           essentielArticles: essentielArticles,
         ),
       );
+      // Re-pose les notifs perso (Essentiel + Bonnes Nouvelles) avec le contenu
+      // frais. Fire-and-forget, gated sur `dual != null` → ne tire jamais sur le
+      // chemin caché (stale) ni quand le digest a totalement échoué.
+      unawaited(_syncNotificationTeasers(dual, essentielArticles));
     }
     return next;
+  }
+
+  /// Pousse les derniers teasers connus vers `NotificationsSettingsNotifier`
+  /// pour re-planifier les notifs perso. Non bloquant, try/catch interne : une
+  /// erreur de scheduling ne doit jamais casser le rendu du home.
+  Future<void> _syncNotificationTeasers(
+    DualDigestResponse dual,
+    List<EssentielArticle> essentielArticles,
+  ) async {
+    try {
+      await ref.read(notificationsSettingsProvider.notifier).syncDigestTeasers(
+        essentielTeasers: buildEssentielTeasers(essentielArticles),
+        goodNewsTeasers: buildGoodNewsTeasers(dual.serein),
+      );
+    } catch (e) {
+      debugPrint('FluxContinu: syncNotificationTeasers failed: $e');
+    }
   }
 
   Future<FluxContinuState> _buildStateFromPayload({

--- a/apps/mobile/lib/features/flux_continu/utils/notif_teasers.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/notif_teasers.dart
@@ -1,0 +1,53 @@
+import '../../digest/models/digest_models.dart';
+import '../models/flux_continu_models.dart';
+
+/// Helpers purs (sans Riverpod/Hive) qui dérivent les bullet points des deux
+/// notifications locales personnalisées à partir des données déjà chargées par
+/// le home (`fluxContinuProvider`).
+///
+/// - [buildEssentielTeasers] : source = la carte « L'Essentiel du jour »
+///   (`GET /api/essentiel`). En mode serein, cet endpoint est déjà filtré aux
+///   articles sereins **côté serveur** (`essentiel.py` lit `serein_enabled`),
+///   donc utiliser `essentielArticles[].title` satisfait directement l'exigence
+///   PO « filtré aux articles sereins, comme dans l'app ».
+/// - [buildGoodNewsTeasers] : source = le top 3 des sujets du digest serein
+///   (`label`, fallback titre du 1er article du sujet).
+///
+/// Les deux passent par [sanitizeTeasers] : trim, drop des vides, dedup
+/// case-insensitive (1ère occurrence gagne), cap à 3.
+
+/// Top 3 titres de la carte Essentiel, triés par `rank` croissant.
+List<String> buildEssentielTeasers(List<EssentielArticle> articles) {
+  final sorted = [...articles]..sort((a, b) => a.rank.compareTo(b.rank));
+  return sanitizeTeasers(sorted.map((a) => a.title));
+}
+
+/// Top 3 labels des sujets du digest serein, triés par `rank` croissant.
+/// Fallback sur le titre du 1er article quand le label stocké est vide ; un
+/// sujet vide (label vide ET sans article) est ignoré.
+List<String> buildGoodNewsTeasers(DigestResponse? serein) {
+  if (serein == null) return const [];
+  final sorted = [...serein.topics]..sort((a, b) => a.rank.compareTo(b.rank));
+  return sanitizeTeasers(
+    sorted.map((t) {
+      final label = t.label.trim();
+      if (label.isNotEmpty) return label;
+      return t.articles.isNotEmpty ? t.articles.first.title : '';
+    }),
+  );
+}
+
+/// Normalise une suite de teasers candidats : trim, retrait des chaînes vides,
+/// dedup case-insensitive (la 1ère occurrence est conservée), puis cap à 3.
+List<String> sanitizeTeasers(Iterable<String> raw) {
+  final seen = <String>{};
+  final result = <String>[];
+  for (final value in raw) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) continue;
+    if (!seen.add(trimmed.toLowerCase())) continue;
+    result.add(trimmed);
+    if (result.length == 3) break;
+  }
+  return result;
+}

--- a/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
+++ b/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
@@ -112,6 +112,14 @@ class NotificationsSettingsNotifier
   static const _kGoodNewsEnabled = 'notif_good_news_enabled';
   static const _kGoodNewsTimeSlot = 'notif_good_news_time_slot';
   static const _kNotifVeilleEnabled = 'notif_veille_enabled';
+  // Derniers teasers connus, écrits/lus en direct dans la box (hors `state`,
+  // `_persist` et `_patchBackend`) : purement locaux, jamais shippés au
+  // backend. Le contenu d'une notif locale étant « cuit » au scheduling, ces
+  // clés permettent aux 3 points de déclenchement (cold start, load frais,
+  // mutation réglages) de re-poser la variante B personnalisée. Publiques pour
+  // que `main.dart` (cold start) lise la même clé sans dupliquer le littéral.
+  static const kEssentielTeasers = 'notif_essentiel_teasers';
+  static const kGoodNewsTeasers = 'notif_good_news_teasers';
 
   Future<Box<dynamic>> _box() => Hive.openBox<dynamic>(_boxName);
 
@@ -225,8 +233,17 @@ class NotificationsSettingsNotifier
     await push.cancelDigestNotification();
     await push.cancelWeeklyCommunityPick();
     await push.cancelGoodNewsNotification();
+    final box = await _box();
+    final essentielTeasers = readTeasers(box, kEssentielTeasers);
+    final goodNewsTeasers = readTeasers(box, kGoodNewsTeasers);
     if (state.pushEnabled) {
-      await push.scheduleDailyDigestNotification(timeSlot: state.timeSlot);
+      await push.scheduleDailyDigestNotification(
+        timeSlot: state.timeSlot,
+        variant: essentielTeasers.isEmpty
+            ? NotifVariant.variantA
+            : NotifVariant.variantB,
+        teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
+      );
       if (state.preset == NotifPreset.curieux) {
         await push.scheduleWeeklyCommunityPick();
       }
@@ -234,8 +251,40 @@ class NotificationsSettingsNotifier
     if (state.goodNewsEnabled) {
       await push.scheduleDailyGoodNewsNotification(
         timeSlot: state.goodNewsTimeSlot,
+        teasers: goodNewsTeasers.isEmpty ? null : goodNewsTeasers,
       );
     }
+  }
+
+  /// Lecture défensive d'une liste de teasers persistée. Hive rend des
+  /// `List<dynamic>` ; on filtre aux `String` pour éviter un crash de cast.
+  /// Statique + publique : `main.dart` (cold start) lit la même box sans
+  /// dupliquer la logique de cast défensif.
+  static List<String> readTeasers(Box<dynamic> box, String key) {
+    final raw = box.get(key);
+    if (raw is! List) return const [];
+    return raw.whereType<String>().toList(growable: false);
+  }
+
+  /// Met à jour les teasers persistés depuis le dernier digest chargé, puis
+  /// replanifie les notifs perso. Appelée fire-and-forget depuis
+  /// `fluxContinuProvider` après un load frais.
+  ///
+  /// Écriture **conditionnelle** : on n'écrase une liste persistée que si la
+  /// fraîche est non vide — un échec réseau transitoire (digest partiel) ne
+  /// doit pas effacer la perso d'hier.
+  Future<void> syncDigestTeasers({
+    required List<String> essentielTeasers,
+    required List<String> goodNewsTeasers,
+  }) async {
+    final box = await _box();
+    if (essentielTeasers.isNotEmpty) {
+      await box.put(kEssentielTeasers, essentielTeasers);
+    }
+    if (goodNewsTeasers.isNotEmpty) {
+      await box.put(kGoodNewsTeasers, goodNewsTeasers);
+    }
+    await _reschedule();
   }
 
   /// Persiste, replanifie, sync backend.

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -21,6 +21,7 @@ import 'core/services/posthog_service.dart';
 import 'core/services/push_notification_service.dart';
 import 'core/ui/notification_service.dart';
 import 'features/flux_continu/services/tournee_progress_service.dart';
+import 'features/settings/providers/notifications_settings_provider.dart';
 
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:timeago/src/messages/fr_messages.dart'
@@ -314,6 +315,18 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
         defaultValue: true) as bool;
     bootPushEnabledHive = pushEnabled;
 
+    // Cold start : re-pose la variante B personnalisée avec les derniers
+    // teasers persistés (le home les rafraîchira au 1er load frais). Liste vide
+    // (1er lancement) → variante A générique, acceptable. Clé + lecture
+    // défensive partagées avec le provider (source de vérité).
+    final essentielTeasers = NotificationsSettingsNotifier.readTeasers(
+      settingsBox,
+      NotificationsSettingsNotifier.kEssentielTeasers,
+    );
+    final digestVariant = essentielTeasers.isEmpty
+        ? NotifVariant.variantA
+        : NotifVariant.variantB;
+
     // Diagnostic + scheduling sont indépendants : collecter le diagnostic
     // pendant la planification (alarms + permission). `pushEnabled=false`
     // → on collecte quand même le diagnostic (cf. bug-notifications-stalled).
@@ -327,14 +340,20 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
           await pushNotificationService.isDigestNotificationScheduled();
       if (!alreadyScheduled) {
         final scheduled =
-            await pushNotificationService.scheduleDailyDigestNotification();
+            await pushNotificationService.scheduleDailyDigestNotification(
+          variant: digestVariant,
+          teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
+        );
         if (!scheduled) {
           debugPrint(
             'Main: WARNING — digest notification scheduling failed, retrying...',
           );
           await pushNotificationService.requestExactAlarmPermission();
           final retryOk =
-              await pushNotificationService.scheduleDailyDigestNotification();
+              await pushNotificationService.scheduleDailyDigestNotification(
+            variant: digestVariant,
+            teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
+          );
           debugPrint('Main: Retry result: $retryOk');
         }
       } else {

--- a/apps/mobile/test/core/services/push_notification_service_copy_test.dart
+++ b/apps/mobile/test/core/services/push_notification_service_copy_test.dart
@@ -60,4 +60,39 @@ void main() {
       expect(copy.body, contains("Belle journée"));
     });
   });
+
+  group('PushNotificationService.buildGoodNewsCopy', () {
+    test('no teasers falls back to generic good news copy', () {
+      final copy = PushNotificationService.buildGoodNewsCopy();
+      expect(copy.title, PushNotificationService.goodNewsTitle);
+      expect(copy.body, PushNotificationService.goodNewsBody);
+      expect(copy.bigText, PushNotificationService.goodNewsBody);
+    });
+
+    test('empty teasers list falls back to generic copy', () {
+      final copy = PushNotificationService.buildGoodNewsCopy(teasers: const []);
+      expect(copy.body, PushNotificationService.goodNewsBody);
+    });
+
+    test('teasers render bullet bigText (max 3) + collapsed body', () {
+      final copy = PushNotificationService.buildGoodNewsCopy(
+        teasers: ['Solidarité', 'Avancée médicale', 'Climat positif', 'Quatrième'],
+      );
+      expect(copy.title, PushNotificationService.goodNewsTitle);
+      expect(copy.body, 'À la une : Solidarité');
+      expect(
+        copy.bigText,
+        'Vos bonnes nouvelles du jour :\n'
+        '• Solidarité\n• Avancée médicale\n• Climat positif',
+      );
+    });
+
+    test('truncates first teaser longer than 60 chars', () {
+      final copy = PushNotificationService.buildGoodNewsCopy(
+        teasers: ['A' * 80],
+      );
+      expect(copy.body, endsWith('…'));
+      expect(copy.body.length, lessThanOrEqualTo('À la une : '.length + 58));
+    });
+  });
 }

--- a/apps/mobile/test/features/flux_continu/utils/notif_teasers_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/notif_teasers_test.dart
@@ -1,0 +1,139 @@
+import 'package:facteur/features/digest/models/digest_models.dart';
+import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
+import 'package:facteur/features/flux_continu/utils/notif_teasers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+EssentielArticle _article({
+  required String id,
+  required String title,
+  required int rank,
+}) =>
+    EssentielArticle(
+      contentId: id,
+      title: title,
+      url: 'https://x.test/$id',
+      publishedAt: DateTime(2026, 1, 1),
+      sourceName: 'S',
+      sourceLetter: 'S',
+      sectionLabel: 'Essentiel',
+      rank: rank,
+    );
+
+DigestTopic _topic({
+  required String label,
+  required int rank,
+  List<String> articleTitles = const [],
+}) =>
+    DigestTopic(
+      topicId: 'topic-$label-$rank',
+      label: label,
+      rank: rank,
+      articles: [
+        for (var i = 0; i < articleTitles.length; i++)
+          DigestItem(contentId: '$label-$i', title: articleTitles[i]),
+      ],
+    );
+
+DigestResponse _digest(List<DigestTopic> topics) => DigestResponse(
+      digestId: 'd1',
+      userId: 'u1',
+      targetDate: DateTime(2026, 1, 1),
+      generatedAt: DateTime(2026, 1, 1),
+      topics: topics,
+    );
+
+void main() {
+  group('buildEssentielTeasers', () {
+    test('returns top 3 titles ordered by rank ascending', () {
+      final teasers = buildEssentielTeasers([
+        _article(id: 'c', title: 'Climat', rank: 3),
+        _article(id: 'a', title: 'Trump', rank: 1),
+        _article(id: 'b', title: 'Marseille', rank: 2),
+        _article(id: 'd', title: 'Quatrième', rank: 4),
+      ]);
+      expect(teasers, ['Trump', 'Marseille', 'Climat']);
+    });
+
+    test('empty input → empty list', () {
+      expect(buildEssentielTeasers(const []), isEmpty);
+    });
+
+    test('drops blank titles and trims', () {
+      final teasers = buildEssentielTeasers([
+        _article(id: 'a', title: '  Trump  ', rank: 1),
+        _article(id: 'b', title: '   ', rank: 2),
+        _article(id: 'c', title: 'Climat', rank: 3),
+      ]);
+      expect(teasers, ['Trump', 'Climat']);
+    });
+
+    test('dedups case-insensitively, first occurrence wins', () {
+      final teasers = buildEssentielTeasers([
+        _article(id: 'a', title: 'Trump', rank: 1),
+        _article(id: 'b', title: 'trump', rank: 2),
+        _article(id: 'c', title: 'Climat', rank: 3),
+      ]);
+      expect(teasers, ['Trump', 'Climat']);
+    });
+
+    test('fewer than 3 items → renders what is available', () {
+      final teasers = buildEssentielTeasers([
+        _article(id: 'a', title: 'Trump', rank: 1),
+      ]);
+      expect(teasers, ['Trump']);
+    });
+  });
+
+  group('buildGoodNewsTeasers', () {
+    test('null digest → empty list', () {
+      expect(buildGoodNewsTeasers(null), isEmpty);
+    });
+
+    test('returns top 3 labels ordered by rank ascending', () {
+      final teasers = buildGoodNewsTeasers(_digest([
+        _topic(label: 'Solidarité', rank: 2),
+        _topic(label: 'Avancée médicale', rank: 1),
+        _topic(label: 'Climat positif', rank: 3),
+        _topic(label: 'Quatrième', rank: 4),
+      ]));
+      expect(teasers, ['Avancée médicale', 'Solidarité', 'Climat positif']);
+    });
+
+    test('falls back to first article title when label is blank', () {
+      final teasers = buildGoodNewsTeasers(_digest([
+        _topic(label: '   ', rank: 1, articleTitles: ['Une bonne nouvelle']),
+      ]));
+      expect(teasers, ['Une bonne nouvelle']);
+    });
+
+    test('topic with blank label and no article is dropped', () {
+      final teasers = buildGoodNewsTeasers(_digest([
+        _topic(label: '', rank: 1),
+        _topic(label: 'Espoir', rank: 2),
+      ]));
+      expect(teasers, ['Espoir']);
+    });
+
+    test('all topics empty → empty list', () {
+      final teasers = buildGoodNewsTeasers(_digest([
+        _topic(label: '', rank: 1),
+      ]));
+      expect(teasers, isEmpty);
+    });
+  });
+
+  group('sanitizeTeasers', () {
+    test('trims, drops empty, dedups, caps at 3', () {
+      final result = sanitizeTeasers([
+        ' A ',
+        'a',
+        '',
+        '   ',
+        'B',
+        'C',
+        'D',
+      ]);
+      expect(result, ['A', 'B', 'C']);
+    });
+  });
+}


### PR DESCRIPTION
fix(notif): re-personnalise les notifs Essentiel + Bonnes Nouvelles

## Contexte
Deux notifications locales quotidiennes affichaient un corps générique :
- **« Ton Essentiel »** (id 0) avait **perdu** ses bullets depuis le refactor #713
  (« Flâner »/Flux Continu) : la seule fonction qui personnalisait la notif
  (`_updateNotificationWithTopics`) vivait dans `DigestNotifier.build()`, devenu
  **orphelin** (plus aucun `watch`/`.future` ne le monte).
- **« Bonnes Nouvelles »** (id 2) n'avait **jamais** été personnalisée.

Le contenu d'une notif locale est « cuit » au scheduling, avec 3 points de
déclenchement (cold start, load frais, mutation réglages). Le fix re-loge le
scheduling dans le provider réellement monté (`fluxContinuProvider`) et persiste
les derniers teasers connus dans la box Hive `settings` pour que la variante B
personnalisée survive partout.

## Quoi
- **Helpers purs** `notif_teasers.dart` : `buildEssentielTeasers` (top 3 titres
  de la carte Essentiel, déjà filtrée serein côté serveur),
  `buildGoodNewsTeasers` (top 3 sujets du digest serein, fallback titre article),
  `sanitizeTeasers` (trim/dedup case-insensitive/cap 3).
- **`push_notification_service.dart`** : `buildGoodNewsCopy` + paramètre `teasers`
  sur `scheduleDailyGoodNewsNotification` (corps serein avec bullets).
- **`notifications_settings_provider.dart`** : clés Hive `notif_essentiel_teasers`
  / `notif_good_news_teasers` (locales, jamais shippées backend), méthode
  `syncDigestTeasers` (écriture conditionnelle), `_reschedule` lit/passe les
  teasers (variante B au lieu de la variante A générique).
- **`flux_continu_provider.dart`** : `_syncNotificationTeasers` fire-and-forget
  dans `_fetchAll`, gated `dual != null`.
- **`main.dart`** : cold start lit les teasers persistés → variante B (liste vide
  au 1er lancement → variante A, acceptable).
- **`digest_provider.dart`** : suppression du code mort
  `_updateNotificationWithTopics` + ses 2 appels + import `foundation` inutilisé.

> Le garde-fou backend label (write `importance_detector.py` + read fallback
> `digest_service.py`) est **déjà mergé** (PR #750) — aucun changement backend ni
> migration Alembic dans cette PR.

## Tests
- `notif_teasers_test.dart` (11) + `push_notification_service_copy_test.dart`
  (good news, 5) : **21 passed**.
- `flutter analyze` propre sur les fichiers touchés (infos pré-existantes seules).
- Backend `pytest tests/test_digest_service.py -k label` : **2 passed**.
- Alembic : exactement 1 head, aucune migration ajoutée.
- Note : `flux_continu_provider_test` est rouge **avant et après** ce changement
  (Hive/Supabase non init en test — pré-existant, cf. `project_ci_no_flutter_tests`).

## Edge cases couverts
`dual == null` (digest KO) → dernière notif préservée ; `essentielArticles` vide
→ teasers non écrasés (write conditionnel) ; `dual.serein == null` → good news
garde teasers persistés ; labels serein vides → fallback titre article ; dedup
case-insensitive ; Hive `List<dynamic>` → lecture défensive `whereType<String>`.
