### PR TITLE
fix(perspectives): empty-state dismissal animé + badge low-divergence + partial loading

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -1,7 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:facteur/core/utils/html_utils.dart';
 import 'package:flutter/foundation.dart'
-    show Factory, defaultTargetPlatform, kIsWeb;
+    show Factory, defaultTargetPlatform, kIsWeb, visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -48,6 +48,16 @@ import '../../lettres/providers/letters_provider.dart';
 import '../../saved/widgets/collection_picker_sheet.dart';
 import '../../saved/providers/collections_provider.dart';
 import '../../../widgets/design/facteur_thumbnail.dart';
+
+@visibleForTesting
+PerspectivesSectionStatus perspectivesStatusForTesting(
+  PerspectivesResponse? response,
+) {
+  if (response == null) return PerspectivesSectionStatus.loading;
+  if (response.perspectives.isNotEmpty) return PerspectivesSectionStatus.ready;
+  if (response.partial) return PerspectivesSectionStatus.loading;
+  return PerspectivesSectionStatus.empty;
+}
 
 /// Écran de détail d'un contenu avec mode lecture In-App (Story 5.2)
 /// Restauré avec les fonctionnalités de l'ancien ArticleViewerModal :
@@ -211,15 +221,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   bool get _showPerspectivesBand =>
       _content?.contentType == ContentType.article;
 
-  PerspectivesSectionStatus get _perspectivesStatus {
-    final response = _perspectivesResponse;
-    if (response != null) {
-      return response.perspectives.isEmpty
-          ? PerspectivesSectionStatus.empty
-          : PerspectivesSectionStatus.ready;
-    }
-    return PerspectivesSectionStatus.loading;
-  }
+  PerspectivesSectionStatus get _perspectivesStatus =>
+      perspectivesStatusForTesting(_perspectivesResponse);
 
   List<Perspective> get _inlinePerspectives {
     final response = _perspectivesResponse;

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -50,7 +50,7 @@ import '../../saved/providers/collections_provider.dart';
 import '../../../widgets/design/facteur_thumbnail.dart';
 
 @visibleForTesting
-PerspectivesSectionStatus perspectivesStatusForTesting(
+PerspectivesSectionStatus resolvePerspectivesStatus(
   PerspectivesResponse? response,
 ) {
   if (response == null) return PerspectivesSectionStatus.loading;
@@ -222,7 +222,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       _content?.contentType == ContentType.article;
 
   PerspectivesSectionStatus get _perspectivesStatus =>
-      perspectivesStatusForTesting(_perspectivesResponse);
+      resolvePerspectivesStatus(_perspectivesResponse);
 
   List<Perspective> get _inlinePerspectives {
     final response = _perspectivesResponse;

--- a/apps/mobile/lib/features/digest/widgets/divergence_inline_badge.dart
+++ b/apps/mobile/lib/features/digest/widgets/divergence_inline_badge.dart
@@ -41,7 +41,7 @@ class DivergenceInlineBadge extends StatelessWidget {
 
     final glyph = CustomPaint(
       size: Size(28 * scale, 12 * scale),
-      painter: _DivergenceGlyphPainter(config),
+      painter: _DivergenceGlyphPainter(config, scale),
     );
 
     if (iconOnly) return glyph;
@@ -139,16 +139,14 @@ class _Dot {
 
 class _DivergenceGlyphPainter extends CustomPainter {
   final _BadgeConfig config;
-  _DivergenceGlyphPainter(this.config);
+  final double scale;
+  _DivergenceGlyphPainter(this.config, this.scale);
 
   static const double _radius = 1.5;
 
   @override
   void paint(Canvas canvas, Size size) {
-    // Coordonnées des dots calées sur une base 28×12 ; on scale le canvas pour
-    // honorer une taille demandée plus grande (cf. `scale` du badge).
-    final s = size.width / 28;
-    if (s != 1) canvas.scale(s);
+    if (scale != 1.0) canvas.scale(scale);
     for (final dot in config.dots) {
       final paint = Paint()..color = dot.color.withValues(alpha: dot.opacity);
       canvas.drawCircle(Offset(dot.x, dot.y), _radius, paint);
@@ -157,6 +155,6 @@ class _DivergenceGlyphPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant _DivergenceGlyphPainter oldDelegate) {
-    return oldDelegate.config != config;
+    return oldDelegate.config != config || oldDelegate.scale != scale;
   }
 }

--- a/apps/mobile/lib/features/digest/widgets/divergence_inline_badge.dart
+++ b/apps/mobile/lib/features/digest/widgets/divergence_inline_badge.dart
@@ -8,7 +8,7 @@ import '../../../config/theme.dart';
 /// mono uppercase. Niveau dérivé directement du `divergenceLevel` exposé par
 /// le back via `DigestTopic.divergenceLevel` :
 ///
-/// * `'low'`  → `Consensus`  (3 dots groupés au centre, label tertiary)
+/// * `'low'`  → `Traitements similaires` (3 dots groupés au centre)
 /// * `'medium'` → `Avis variés` (5 dots étalés régulièrement, label tertiary)
 /// * `'high'` → `Polarisé`   (2 paires brique-marine, label primary bold)
 ///
@@ -22,10 +22,16 @@ class DivergenceInlineBadge extends StatelessWidget {
   /// compenser l'absence du label qui portait l'information sémantique.
   final bool iconOnly;
 
+  /// Facteur d'échelle appliqué au glyphe ET au label (1.0 = taille de base).
+  /// Utilisé par la section « Couverture médiatique » pour grossir la balise
+  /// (~+45 %) ; toutes les autres call-sites gardent 1.0.
+  final double scale;
+
   const DivergenceInlineBadge({
     super.key,
     this.divergenceLevel,
     this.iconOnly = false,
+    this.scale = 1.0,
   });
 
   @override
@@ -34,7 +40,7 @@ class DivergenceInlineBadge extends StatelessWidget {
     if (config == null) return const SizedBox.shrink();
 
     final glyph = CustomPaint(
-      size: const Size(28, 12),
+      size: Size(28 * scale, 12 * scale),
       painter: _DivergenceGlyphPainter(config),
     );
 
@@ -44,14 +50,14 @@ class DivergenceInlineBadge extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         glyph,
-        const SizedBox(width: 4),
+        SizedBox(width: 4 * scale),
         Text(
           config.label,
           style: GoogleFonts.courierPrime(
-            fontSize: 10,
+            fontSize: 8 * scale,
             fontWeight: config.bold ? FontWeight.w700 : FontWeight.w500,
             color: config.labelColor,
-            letterSpacing: 0.4,
+            letterSpacing: 0.35 * scale,
           ),
         ),
       ],
@@ -59,10 +65,23 @@ class DivergenceInlineBadge extends StatelessWidget {
   }
 
   static _BadgeConfig? _configFor(
-      String? level, FacteurColors colors, bool iconOnly) {
+    String? level,
+    FacteurColors colors,
+    bool iconOnly,
+  ) {
     switch (level) {
       case 'low':
-        return null;
+        final dotOpacity = iconOnly ? 0.85 : 0.72;
+        return _BadgeConfig(
+          label: 'TRAITEMENTS SIMILAIRES',
+          dots: [
+            _Dot(11, 6, colors.success, dotOpacity),
+            _Dot(15, 6, colors.success, dotOpacity),
+            _Dot(19, 6, colors.success, dotOpacity),
+          ],
+          labelColor: colors.textSecondary,
+          bold: false,
+        );
       case 'medium':
         // En iconOnly les dots portent tout le sens — on remonte l'opacité
         // pour qu'ils restent lisibles sans le label.
@@ -126,6 +145,10 @@ class _DivergenceGlyphPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
+    // Coordonnées des dots calées sur une base 28×12 ; on scale le canvas pour
+    // honorer une taille demandée plus grande (cf. `scale` du badge).
+    final s = size.width / 28;
+    if (s != 1) canvas.scale(s);
     for (final dot in config.dots) {
       final paint = Paint()..color = dot.color.withValues(alpha: dot.opacity);
       canvas.drawCircle(Offset(dot.x, dot.y), _radius, paint);

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1389,6 +1389,14 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
 
 enum _EmptyStage { none, fading, collapsed }
 
+// ── Timing de la séquence "aucune source trouvée" ──────────────────────────
+// Ajuster ces 4 valeurs pour calibrer l'animation :
+const _kEmptyReadDelay   = Duration(milliseconds: 1500); // pause avant le fade
+const _kEmptyFadeDuration = Duration(milliseconds: 800);  // fade 0.28 → 0
+const _kEmptySlideDuration = Duration(milliseconds: 960); // glissement vers la droite
+const _kEmptyInitialOpacity = 0.28;                       // opacité pendant la pause
+// ──────────────────────────────────────────────────────────────────────────
+
 class _PerspectivesInlineSectionState
     extends ConsumerState<PerspectivesInlineSection> {
   double _rotationTurns = 0.0;
@@ -1444,11 +1452,11 @@ class _PerspectivesInlineSectionState
 
     if (_emptyStage != _EmptyStage.none) return;
     // Pause de lecture avant de démarrer le fade+slide
-    _emptyDismissTimer = Timer(const Duration(milliseconds: 500), () {
+    _emptyDismissTimer = Timer(_kEmptyReadDelay, () {
       if (!mounted || widget.status != PerspectivesSectionStatus.empty) return;
       setState(() => _emptyStage = _EmptyStage.fading);
       // Collapse hauteur une fois le slide terminé
-      _emptyCollapseTimer = Timer(const Duration(milliseconds: 960), () {
+      _emptyCollapseTimer = Timer(_kEmptySlideDuration, () {
         if (!mounted || widget.status != PerspectivesSectionStatus.empty) return;
         setState(() => _emptyStage = _EmptyStage.collapsed);
       });
@@ -1501,7 +1509,7 @@ class _PerspectivesInlineSectionState
               // droite hors écran avant que l'`AnimatedSize` ne replie la
               // hauteur — sortie franche plutôt qu'un simple collapse vertical.
               ? AnimatedSlide(
-                  duration: const Duration(milliseconds: 960),
+                  duration: _kEmptySlideDuration,
                   curve: Curves.easeOutCubic,
                   offset: isEmpty && _emptyStage != _EmptyStage.none
                       ? const Offset(1.1, 0)
@@ -1509,9 +1517,9 @@ class _PerspectivesInlineSectionState
                   // Fondu front-loadé : disparaît progressivement avant que le
                   // slide ne s'amorce.
                   child: AnimatedOpacity(
-                    duration: const Duration(milliseconds: 800),
+                    duration: _kEmptyFadeDuration,
                     curve: Curves.easeOut,
-                    opacity: isEmpty ? (_emptyStage != _EmptyStage.none ? 0 : 0.28) : 1,
+                    opacity: isEmpty ? (_emptyStage != _EmptyStage.none ? 0 : _kEmptyInitialOpacity) : 1,
                     child: GestureDetector(
                       onTap: isReady ? widget.onToggle : null,
                       behavior: HitTestBehavior.opaque,

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1391,9 +1391,9 @@ enum _EmptyStage { none, fading, collapsed }
 
 // ── Timing de la séquence "aucune source trouvée" ──────────────────────────
 // Ajuster ces 4 valeurs pour calibrer l'animation :
-const _kEmptyReadDelay   = Duration(milliseconds: 1500); // pause avant le fade
-const _kEmptyFadeDuration = Duration(milliseconds: 800);  // fade 0.28 → 0
-const _kEmptySlideDuration = Duration(milliseconds: 960); // glissement vers la droite
+const _kEmptyReadDelay   = Duration(milliseconds: 2000); // pause avant le fade
+const _kEmptyFadeDuration = Duration(milliseconds: 2000);  // fade 0.28 → 0
+const _kEmptySlideDuration = Duration(milliseconds: 650); // glissement vers la droite
 const _kEmptyInitialOpacity = 0.28;                       // opacité pendant la pause
 // ──────────────────────────────────────────────────────────────────────────
 

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1443,10 +1443,12 @@ class _PerspectivesInlineSectionState
     }
 
     if (_emptyStage != _EmptyStage.none) return;
-    _emptyDismissTimer = Timer(const Duration(seconds: 1), () {
+    // Fade + slide démarrent ensemble dès la détection (prochain frame)
+    _emptyDismissTimer = Timer(Duration.zero, () {
       if (!mounted || widget.status != PerspectivesSectionStatus.empty) return;
       setState(() => _emptyStage = _EmptyStage.fading);
-      _emptyCollapseTimer = Timer(const Duration(milliseconds: 350), () {
+      // Collapse hauteur une fois le slide terminé
+      _emptyCollapseTimer = Timer(const Duration(milliseconds: 960), () {
         if (!mounted || widget.status != PerspectivesSectionStatus.empty) return;
         setState(() => _emptyStage = _EmptyStage.collapsed);
       });
@@ -1513,15 +1515,20 @@ class _PerspectivesInlineSectionState
                     child: GestureDetector(
                       onTap: isReady ? widget.onToggle : null,
                       behavior: HitTestBehavior.opaque,
-                      child: Container(
+                      child: AnimatedContainer(
+                        duration: const Duration(milliseconds: 300),
                         decoration: BoxDecoration(
                           border: Border(
                             top: BorderSide(
-                              color: Colors.black.withValues(alpha: 0.08),
+                              color: Colors.black.withValues(
+                                alpha: isReady ? 0.08 : 0,
+                              ),
                               width: 1,
                             ),
                             bottom: BorderSide(
-                              color: Colors.black.withValues(alpha: 0.08),
+                              color: Colors.black.withValues(
+                                alpha: isReady ? 0.08 : 0,
+                              ),
                               width: 1,
                             ),
                           ),

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1499,16 +1499,15 @@ class _PerspectivesInlineSectionState
               // droite hors écran avant que l'`AnimatedSize` ne replie la
               // hauteur — sortie franche plutôt qu'un simple collapse vertical.
               ? AnimatedSlide(
-                  duration: const Duration(milliseconds: 480),
+                  duration: const Duration(milliseconds: 960),
                   curve: Curves.easeOutCubic,
                   offset: isEmpty && _emptyStage != _EmptyStage.none
                       ? const Offset(1.1, 0)
                       : Offset.zero,
-                  // Fondu front-loadé (rapide + easeOut) : le bandeau est déjà
-                  // quasi invisible quand le slide démarre, plutôt que de rester
-                  // visible le temps que la translation s'amorce.
+                  // Fondu front-loadé : disparaît progressivement avant que le
+                  // slide ne s'amorce.
                   child: AnimatedOpacity(
-                    duration: const Duration(milliseconds: 180),
+                    duration: const Duration(milliseconds: 500),
                     curve: Curves.easeOut,
                     opacity: isEmpty ? (_emptyStage != _EmptyStage.none ? 0 : 0.28) : 1,
                     child: GestureDetector(

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1444,7 +1444,7 @@ class _PerspectivesInlineSectionState
 
     if (_emptyStage != _EmptyStage.none) return;
     // Pause de lecture avant de démarrer le fade+slide
-    _emptyDismissTimer = Timer(const Duration(seconds: 3), () {
+    _emptyDismissTimer = Timer(const Duration(milliseconds: 500), () {
       if (!mounted || widget.status != PerspectivesSectionStatus.empty) return;
       setState(() => _emptyStage = _EmptyStage.fading);
       // Collapse hauteur une fois le slide terminé
@@ -1509,7 +1509,7 @@ class _PerspectivesInlineSectionState
                   // Fondu front-loadé : disparaît progressivement avant que le
                   // slide ne s'amorce.
                   child: AnimatedOpacity(
-                    duration: const Duration(milliseconds: 500),
+                    duration: const Duration(milliseconds: 800),
                     curve: Curves.easeOut,
                     opacity: isEmpty ? (_emptyStage != _EmptyStage.none ? 0 : 0.28) : 1,
                     child: GestureDetector(

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1443,8 +1443,8 @@ class _PerspectivesInlineSectionState
     }
 
     if (_emptyStage != _EmptyStage.none) return;
-    // Fade + slide démarrent ensemble dès la détection (prochain frame)
-    _emptyDismissTimer = Timer(Duration.zero, () {
+    // Pause de lecture avant de démarrer le fade+slide
+    _emptyDismissTimer = Timer(const Duration(seconds: 3), () {
       if (!mounted || widget.status != PerspectivesSectionStatus.empty) return;
       setState(() => _emptyStage = _EmptyStage.fading);
       // Collapse hauteur une fois le slide terminé

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1381,13 +1381,14 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
       _PerspectivesInlineSectionState();
 }
 
+enum _EmptyStage { none, fading, collapsed }
+
 class _PerspectivesInlineSectionState
     extends ConsumerState<PerspectivesInlineSection> {
   double _rotationTurns = 0.0;
   Timer? _emptyDismissTimer;
   Timer? _emptyCollapseTimer;
-  bool _emptyDismissed = false;
-  bool _emptyCollapsed = false;
+  _EmptyStage _emptyStage = _EmptyStage.none;
   // Incrementé à chaque transition replié → ouvert : chaque DiffTitle reçoit
   // ce nombre dans sa Key, ce qui le re-crée et relance sa cascade. Garantit
   // que l'animation est jouée 1× par ouverture et pas re-déclenchée sur les
@@ -1429,24 +1430,19 @@ class _PerspectivesInlineSectionState
     _emptyCollapseTimer = null;
 
     if (widget.status != PerspectivesSectionStatus.empty) {
-      if (_emptyDismissed || _emptyCollapsed) {
-        setState(() {
-          _emptyDismissed = false;
-          _emptyCollapsed = false;
-        });
+      if (_emptyStage != _EmptyStage.none) {
+        setState(() => _emptyStage = _EmptyStage.none);
       }
       return;
     }
 
-    if (_emptyDismissed || _emptyCollapsed) return;
+    if (_emptyStage != _EmptyStage.none) return;
     _emptyDismissTimer = Timer(const Duration(seconds: 1), () {
       if (!mounted || widget.status != PerspectivesSectionStatus.empty) return;
-      setState(() => _emptyDismissed = true);
+      setState(() => _emptyStage = _EmptyStage.fading);
       _emptyCollapseTimer = Timer(const Duration(milliseconds: 350), () {
-        if (!mounted || widget.status != PerspectivesSectionStatus.empty) {
-          return;
-        }
-        setState(() => _emptyCollapsed = true);
+        if (!mounted || widget.status != PerspectivesSectionStatus.empty) return;
+        setState(() => _emptyStage = _EmptyStage.collapsed);
       });
     });
   }
@@ -1477,7 +1473,7 @@ class _PerspectivesInlineSectionState
     final variants = _filteredPerspectives.take(8).toList();
     final isReady = widget.status == PerspectivesSectionStatus.ready;
     final isEmpty = widget.status == PerspectivesSectionStatus.empty;
-    final shouldShowHeader = !isEmpty || !_emptyCollapsed;
+    final shouldShowHeader = !isEmpty || _emptyStage != _EmptyStage.collapsed;
     final label = widget.status == PerspectivesSectionStatus.loading
         ? 'Couverture médiatique'
         : 'Couverture médiatique (${widget.perspectives.length})';
@@ -1499,7 +1495,7 @@ class _PerspectivesInlineSectionState
               ? AnimatedSlide(
                   duration: const Duration(milliseconds: 350),
                   curve: Curves.easeOutCubic,
-                  offset: isEmpty && _emptyDismissed
+                  offset: isEmpty && _emptyStage != _EmptyStage.none
                       ? const Offset(1.1, 0)
                       : Offset.zero,
                   // Fondu front-loadé (rapide + easeOut) : le bandeau est déjà
@@ -1508,7 +1504,7 @@ class _PerspectivesInlineSectionState
                   child: AnimatedOpacity(
                     duration: const Duration(milliseconds: 180),
                     curve: Curves.easeOut,
-                    opacity: isEmpty ? (_emptyDismissed ? 0 : 0.5) : 1,
+                    opacity: isEmpty ? (_emptyStage != _EmptyStage.none ? 0 : 0.5) : 1,
                     child: GestureDetector(
                       onTap: isReady ? widget.onToggle : null,
                       behavior: HitTestBehavior.opaque,

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -81,13 +83,13 @@ class Perspective {
       highlightSpans: rawHighlights == null
           ? const []
           : rawHighlights
-                .map((e) => HighlightSpan.fromJson(e as Map<String, dynamic>))
-                .toList(),
+              .map((e) => HighlightSpan.fromJson(e as Map<String, dynamic>))
+              .toList(),
       sharedTokens: rawShared == null
           ? const []
           : rawShared
-                .map((e) => TokenSpan.fromJson(e as Map<String, dynamic>))
-                .toList(),
+              .map((e) => TokenSpan.fromJson(e as Map<String, dynamic>))
+              .toList(),
       language: json['language'] as String?,
     );
   }
@@ -211,9 +213,7 @@ class _PerspectivesBottomSheetState
     _openedAt = DateTime.now();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      ref
-          .read(analyticsServiceProvider)
-          .trackPerspectiveComparisonOpened(
+      ref.read(analyticsServiceProvider).trackPerspectiveComparisonOpened(
             contentId: widget.contentId,
             sourcesCount: widget.perspectives.length,
           );
@@ -223,15 +223,12 @@ class _PerspectivesBottomSheetState
   @override
   void dispose() {
     final opened = _openedAt;
-    final elapsed = opened != null
-        ? DateTime.now().difference(opened).inSeconds
-        : 0;
+    final elapsed =
+        opened != null ? DateTime.now().difference(opened).inSeconds : 0;
     // En tests / teardown rapide, le ProviderScope peut être disposé avant
     // ce widget — on ne veut pas crasher pour un event analytics.
     try {
-      ref
-          .read(analyticsServiceProvider)
-          .trackPerspectiveComparisonClosed(
+      ref.read(analyticsServiceProvider).trackPerspectiveComparisonClosed(
             contentId: widget.contentId,
             viewedArticles: _viewedPerspectiveIds.length,
             openedSeconds: elapsed,
@@ -242,9 +239,7 @@ class _PerspectivesBottomSheetState
 
   void _onPerspectiveViewed(String perspectiveId) {
     if (!_viewedPerspectiveIds.add(perspectiveId)) return;
-    ref
-        .read(analyticsServiceProvider)
-        .trackPerspectiveArticleViewed(
+    ref.read(analyticsServiceProvider).trackPerspectiveArticleViewed(
           contentId: widget.contentId,
           perspectiveArticleId: perspectiveId,
         );
@@ -406,8 +401,8 @@ class _PerspectivesBottomSheetState
                                     color: colors.textPrimary,
                                     fontSize:
                                         (textTheme.titleMedium?.fontSize ??
-                                            16) +
-                                        1,
+                                                16) +
+                                            1,
                                   ),
                                 ),
                               ),
@@ -465,11 +460,11 @@ class _PerspectivesBottomSheetState
                                         children: [
                                           Text(
                                             'Tout afficher',
-                                            style: textTheme.labelSmall
-                                                ?.copyWith(
-                                                  color: colors.primary,
-                                                  fontWeight: FontWeight.w600,
-                                                ),
+                                            style:
+                                                textTheme.labelSmall?.copyWith(
+                                              color: colors.primary,
+                                              fontWeight: FontWeight.w600,
+                                            ),
                                           ),
                                           const SizedBox(width: 4),
                                           Icon(
@@ -707,8 +702,7 @@ class _PerspectiveCard extends ConsumerWidget {
                           highlightSpans: perspective.highlightSpans,
                           sharedTokens: perspective.sharedTokens,
                           biasColor: perspective.getBiasColor(colors),
-                          baseStyle:
-                              textTheme.bodyMedium?.copyWith(
+                          baseStyle: textTheme.bodyMedium?.copyWith(
                                 color: colors.textPrimary,
                                 fontSize:
                                     (textTheme.bodyMedium?.fontSize ?? 14) + 2,
@@ -967,9 +961,8 @@ class PerspectivesBiasBar extends StatelessWidget {
             return Expanded(
               flex: flexValues[i],
               child: GestureDetector(
-                onTap: count > 0 && !compact
-                    ? () => onSegmentTap(seg.$1)
-                    : null,
+                onTap:
+                    count > 0 && !compact ? () => onSegmentTap(seg.$1) : null,
                 child: AnimatedOpacity(
                   duration: const Duration(milliseconds: 200),
                   opacity: isActive ? 1.0 : 0.3,
@@ -1391,6 +1384,10 @@ class PerspectivesInlineSection extends ConsumerStatefulWidget {
 class _PerspectivesInlineSectionState
     extends ConsumerState<PerspectivesInlineSection> {
   double _rotationTurns = 0.0;
+  Timer? _emptyDismissTimer;
+  Timer? _emptyCollapseTimer;
+  bool _emptyDismissed = false;
+  bool _emptyCollapsed = false;
   // Incrementé à chaque transition replié → ouvert : chaque DiffTitle reçoit
   // ce nombre dans sa Key, ce qui le re-crée et relance sa cascade. Garantit
   // que l'animation est jouée 1× par ouverture et pas re-déclenchée sur les
@@ -1401,6 +1398,7 @@ class _PerspectivesInlineSectionState
   void initState() {
     super.initState();
     _rotationTurns = widget.isExpanded ? 0.5 : 0.0;
+    _syncEmptyDismissal();
   }
 
   @override
@@ -1412,6 +1410,45 @@ class _PerspectivesInlineSectionState
         _animationGeneration++;
       }
     }
+    if (widget.status != oldWidget.status) {
+      _syncEmptyDismissal();
+    }
+  }
+
+  @override
+  void dispose() {
+    _emptyDismissTimer?.cancel();
+    _emptyCollapseTimer?.cancel();
+    super.dispose();
+  }
+
+  void _syncEmptyDismissal() {
+    _emptyDismissTimer?.cancel();
+    _emptyDismissTimer = null;
+    _emptyCollapseTimer?.cancel();
+    _emptyCollapseTimer = null;
+
+    if (widget.status != PerspectivesSectionStatus.empty) {
+      if (_emptyDismissed || _emptyCollapsed) {
+        setState(() {
+          _emptyDismissed = false;
+          _emptyCollapsed = false;
+        });
+      }
+      return;
+    }
+
+    if (_emptyDismissed || _emptyCollapsed) return;
+    _emptyDismissTimer = Timer(const Duration(seconds: 1), () {
+      if (!mounted || widget.status != PerspectivesSectionStatus.empty) return;
+      setState(() => _emptyDismissed = true);
+      _emptyCollapseTimer = Timer(const Duration(milliseconds: 350), () {
+        if (!mounted || widget.status != PerspectivesSectionStatus.empty) {
+          return;
+        }
+        setState(() => _emptyCollapsed = true);
+      });
+    });
   }
 
   static const _groupOrder = ['gauche', 'centre', 'droite'];
@@ -1440,85 +1477,112 @@ class _PerspectivesInlineSectionState
     final variants = _filteredPerspectives.take(8).toList();
     final isReady = widget.status == PerspectivesSectionStatus.ready;
     final isEmpty = widget.status == PerspectivesSectionStatus.empty;
+    final shouldShowHeader = !isEmpty || !_emptyCollapsed;
     final label = widget.status == PerspectivesSectionStatus.loading
         ? 'Couverture médiatique'
         : 'Couverture médiatique (${widget.perspectives.length})';
-    final labelColor = isEmpty
-        ? colors.textTertiary.withValues(alpha: 0.62)
-        : colors.textPrimary;
+    final labelColor = colors.textPrimary;
     final shouldShowBody = isReady && widget.isExpanded;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         // ── Bandeau cm-panel-inline : hairlines + label + spectrum + count + caret ──
-        GestureDetector(
-          onTap: isReady ? widget.onToggle : null,
-          behavior: HitTestBehavior.opaque,
-          child: Container(
-            decoration: BoxDecoration(
-              border: Border(
-                top: BorderSide(
-                  color: Colors.black.withValues(alpha: isEmpty ? 0.025 : 0.08),
-                  width: 1,
-                ),
-                bottom: BorderSide(
-                  color: Colors.black.withValues(alpha: isEmpty ? 0.025 : 0.08),
-                  width: 1,
-                ),
-              ),
-            ),
-            padding: EdgeInsets.symmetric(
-              horizontal: 18,
-              vertical: isEmpty ? 8 : 13,
-            ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Expanded(
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Flexible(
-                        child: Text(
-                          label,
-                          overflow: TextOverflow.ellipsis,
-                          maxLines: 1,
-                          style: GoogleFonts.dmSans(
-                            fontSize: isEmpty ? 11 : 13,
-                            fontWeight: isEmpty
-                                ? FontWeight.w600
-                                : FontWeight.w700,
-                            color: labelColor,
+        AnimatedSize(
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeInOut,
+          alignment: Alignment.topCenter,
+          child: shouldShowHeader
+              // Disparition empty : à la fin du fade, le bandeau glisse vers la
+              // droite hors écran avant que l'`AnimatedSize` ne replie la
+              // hauteur — sortie franche plutôt qu'un simple collapse vertical.
+              ? AnimatedSlide(
+                  duration: const Duration(milliseconds: 350),
+                  curve: Curves.easeOutCubic,
+                  offset: isEmpty && _emptyDismissed
+                      ? const Offset(1.1, 0)
+                      : Offset.zero,
+                  // Fondu front-loadé (rapide + easeOut) : le bandeau est déjà
+                  // quasi invisible quand le slide démarre, plutôt que de rester
+                  // visible le temps que la translation s'amorce.
+                  child: AnimatedOpacity(
+                    duration: const Duration(milliseconds: 180),
+                    curve: Curves.easeOut,
+                    opacity: isEmpty ? (_emptyDismissed ? 0 : 0.5) : 1,
+                    child: GestureDetector(
+                      onTap: isReady ? widget.onToggle : null,
+                      behavior: HitTestBehavior.opaque,
+                      child: Container(
+                        decoration: BoxDecoration(
+                          border: Border(
+                            top: BorderSide(
+                              color: Colors.black.withValues(alpha: 0.08),
+                              width: 1,
+                            ),
+                            bottom: BorderSide(
+                              color: Colors.black.withValues(alpha: 0.08),
+                              width: 1,
+                            ),
                           ),
                         ),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 18,
+                          vertical: 13,
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            Expanded(
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Flexible(
+                                    child: Text(
+                                      label,
+                                      overflow: TextOverflow.ellipsis,
+                                      maxLines: 1,
+                                      style: GoogleFonts.dmSans(
+                                        fontSize: 13,
+                                        fontWeight: FontWeight.w700,
+                                        color: labelColor,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            if (!isEmpty) ...[
+                              const SizedBox(width: 12),
+                              if (widget.status ==
+                                  PerspectivesSectionStatus.loading)
+                                const CoverageSpectrumBarShimmer()
+                              else
+                                CoverageSpectrumBar(
+                                  distribution: widget.biasDistribution,
+                                ),
+                            ],
+                            if (isReady) ...[
+                              const SizedBox(width: 10),
+                              AnimatedRotation(
+                                turns: _rotationTurns,
+                                duration: const Duration(milliseconds: 250),
+                                curve: Curves.easeInOut,
+                                child: Icon(
+                                  PhosphorIcons.caretDown(
+                                    PhosphorIconsStyle.regular,
+                                  ),
+                                  size: 14,
+                                  color: colors.textSecondary,
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
                       ),
-                    ],
-                  ),
-                ),
-                if (widget.status != PerspectivesSectionStatus.empty) ...[
-                  const SizedBox(width: 12),
-                  if (widget.status == PerspectivesSectionStatus.loading)
-                    const CoverageSpectrumBarShimmer()
-                  else
-                    CoverageSpectrumBar(distribution: widget.biasDistribution),
-                ],
-                if (isReady) ...[
-                  const SizedBox(width: 10),
-                  AnimatedRotation(
-                    turns: _rotationTurns,
-                    duration: const Duration(milliseconds: 250),
-                    curve: Curves.easeInOut,
-                    child: Icon(
-                      PhosphorIcons.caretDown(PhosphorIconsStyle.regular),
-                      size: 14,
-                      color: colors.textSecondary,
                     ),
                   ),
-                ],
-              ],
-            ),
-          ),
+                )
+              : const SizedBox.shrink(),
         ),
         AnimatedSize(
           duration: const Duration(milliseconds: 250),
@@ -1537,83 +1601,81 @@ class _PerspectivesInlineSectionState
     TextTheme textTheme,
     List<Perspective> variants,
   ) {
-    final hasDivergenceBadge =
-        widget.divergenceLevel == 'medium' || widget.divergenceLevel == 'high';
+    final hasDivergenceBadge = widget.divergenceLevel != null;
     final shouldShowIntroInfo = variants.isNotEmpty;
     final shouldShowToolsRow = hasDivergenceBadge || shouldShowIntroInfo;
 
-    return Container(
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [colors.primary.withValues(alpha: 0.045), Colors.transparent],
-          stops: const [0.0, 0.5],
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (shouldShowToolsRow)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 10, 16, 6),
-              child: Row(
-                children: [
-                  if (hasDivergenceBadge)
-                    _DivergenceChip(
-                      divergenceLevel: widget.divergenceLevel,
-                      colors: colors,
-                    ),
-                  const Spacer(),
-                  if (shouldShowIntroInfo)
-                    _HighlightInfoButton(
-                      colors: colors,
-                      onTap: () =>
-                          _showHighlightInfo(context, colors, textTheme),
-                    ),
-                ],
-              ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (shouldShowToolsRow)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 10, 16, 6),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Expanded(
+                  child: hasDivergenceBadge
+                      // scaleDown : pleine taille (+45 %) quand ça rentre, se
+                      // réduit gracieusement pour le label long « low » sur les
+                      // largeurs serrées plutôt que d'overflow.
+                      ? FittedBox(
+                          fit: BoxFit.scaleDown,
+                          alignment: Alignment.centerLeft,
+                          child: DivergenceInlineBadge(
+                            divergenceLevel: widget.divergenceLevel,
+                            scale: 1.45,
+                          ),
+                        )
+                      : const SizedBox.shrink(),
+                ),
+                if (shouldShowIntroInfo)
+                  _HighlightInfoButton(
+                    colors: colors,
+                    onTap: () => _showHighlightInfo(context, colors, textTheme),
+                  ),
+              ],
             ),
-          if (widget.analysisState == PerspectivesAnalysisState.idle)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(18, 8, 18, 8),
-              child: _AnalysisCtaCard(
-                onTap: widget.onRequestAnalysis,
-                state: widget.analysisState,
-              ),
-            ),
-          if (widget.analysisState != PerspectivesAnalysisState.idle)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 16, 10),
-              child: PerspectivesAnalysisZone(
-                state: widget.analysisState,
-                text: widget.analysisText,
-                onRequestAnalysis: widget.onRequestAnalysis,
+          ),
+        for (var i = 0; i < variants.length; i++)
+          _VariantRow(
+            key: ValueKey('variant_${_animationGeneration}_$i'),
+            firstCardKey: i == 0 ? widget.firstCardKey : null,
+            perspective: variants[i],
+            isLast: i == variants.length - 1,
+          ),
+        if (widget.comparisonQuality == 'low')
+          Padding(
+            padding: const EdgeInsets.only(top: 8, bottom: 4),
+            child: Center(
+              child: PerspectivesWarningBadge(
                 colors: colors,
                 textTheme: textTheme,
-                zoneKey: widget.analysisZoneKey,
               ),
             ),
-          for (var i = 0; i < variants.length; i++)
-            _VariantRow(
-              key: ValueKey('variant_${_animationGeneration}_$i'),
-              firstCardKey: i == 0 ? widget.firstCardKey : null,
-              perspective: variants[i],
-              isLast: i == variants.length - 1,
+          ),
+        if (widget.analysisState == PerspectivesAnalysisState.idle)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(18, 8, 18, 8),
+            child: _AnalysisCtaCard(
+              onTap: widget.onRequestAnalysis,
+              state: widget.analysisState,
             ),
-          if (widget.comparisonQuality == 'low')
-            Padding(
-              padding: const EdgeInsets.only(top: 8, bottom: 4),
-              child: Center(
-                child: PerspectivesWarningBadge(
-                  colors: colors,
-                  textTheme: textTheme,
-                ),
-              ),
+          ),
+        if (widget.analysisState != PerspectivesAnalysisState.idle)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 10),
+            child: PerspectivesAnalysisZone(
+              state: widget.analysisState,
+              text: widget.analysisText,
+              onRequestAnalysis: widget.onRequestAnalysis,
+              colors: colors,
+              textTheme: textTheme,
+              zoneKey: widget.analysisZoneKey,
             ),
-          const SizedBox(height: 16),
-        ],
-      ),
+          ),
+        const SizedBox(height: 16),
+      ],
     );
   }
 
@@ -1684,25 +1746,6 @@ class _PerspectivesInlineSectionState
   }
 }
 
-class _DivergenceChip extends StatelessWidget {
-  final String? divergenceLevel;
-  final FacteurColors colors;
-
-  const _DivergenceChip({required this.divergenceLevel, required this.colors});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
-      decoration: BoxDecoration(
-        color: colors.primary.withValues(alpha: 0.07),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: DivergenceInlineBadge(divergenceLevel: divergenceLevel),
-    );
-  }
-}
-
 class _HighlightInfoButton extends StatelessWidget {
   final FacteurColors colors;
   final VoidCallback onTap;
@@ -1717,19 +1760,10 @@ class _HighlightInfoButton extends StatelessWidget {
       visualDensity: VisualDensity.compact,
       padding: EdgeInsets.zero,
       constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
-      icon: Container(
-        width: 24,
-        height: 24,
-        decoration: BoxDecoration(
-          color: colors.textSecondary.withValues(alpha: 0.08),
-          shape: BoxShape.circle,
-        ),
-        alignment: Alignment.center,
-        child: Icon(
-          PhosphorIcons.info(PhosphorIconsStyle.regular),
-          size: 15,
-          color: colors.textSecondary,
-        ),
+      icon: Icon(
+        PhosphorIcons.info(PhosphorIconsStyle.regular),
+        size: 17,
+        color: colors.textSecondary,
       ),
     );
   }
@@ -1803,8 +1837,7 @@ class _PivotWashTitleState extends State<PivotWashTitle>
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final titleStyle =
-        widget.textStyle ??
+    final titleStyle = widget.textStyle ??
         GoogleFonts.fraunces(
           fontSize: 16.5,
           fontWeight: FontWeight.w600,
@@ -1919,8 +1952,7 @@ class _VariantRow extends ConsumerWidget {
               highlightSpans: perspective.highlightSpans,
               sharedTokens: perspective.sharedTokens,
               biasColor: biasColor,
-              baseStyle:
-                  textTheme.bodyMedium?.copyWith(
+              baseStyle: textTheme.bodyMedium?.copyWith(
                     fontSize: 15.5,
                     height: 1.35,
                     color: colors.textPrimary,

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -29,6 +29,12 @@ const String kHighlightIntroText =
     'marquent l\'angle éditorial : plus le surlignage '
     'est intense, plus le choix de mot est éditorialisé.';
 
+const String kDivergenceExplanationText =
+    'Facteur mesure la divergence en comparant le vocabulaire et le cadrage '
+    'adopté par chaque source ayant couvert cet article. '
+    'Un niveau élevé (Polarisé) signale des angles éditoriaux très différents ; '
+    'un niveau bas (Traitements similaires) indique un traitement convergent.';
+
 /// Ouvre l'URL d'une perspective dans le reader unique (`ContentDetailScreen`
 /// en mode externe) via la route `content-external` sur le root navigator.
 /// On garde ainsi le MÊME header / footer / scroll / anti-saccades que pour un
@@ -1640,16 +1646,6 @@ class _PerspectivesInlineSectionState
             perspective: variants[i],
             isLast: i == variants.length - 1,
           ),
-        if (widget.comparisonQuality == 'low')
-          Padding(
-            padding: const EdgeInsets.only(top: 8, bottom: 4),
-            child: Center(
-              child: PerspectivesWarningBadge(
-                colors: colors,
-                textTheme: textTheme,
-              ),
-            ),
-          ),
         if (widget.analysisState == PerspectivesAnalysisState.idle)
           Padding(
             padding: const EdgeInsets.fromLTRB(18, 8, 18, 8),
@@ -1709,11 +1705,70 @@ class _PerspectivesInlineSectionState
                 ),
               ),
             ),
-            const SizedBox(height: 18),
+            const SizedBox(height: 16),
+            if (widget.comparisonQuality == 'low') ...[
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                decoration: BoxDecoration(
+                  color: colors.textTertiary.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      PhosphorIcons.warning(PhosphorIconsStyle.regular),
+                      size: 14,
+                      color: colors.textSecondary,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'Comparaison limitée — sujet peu couvert par les médias',
+                        style: textTheme.labelSmall?.copyWith(
+                          color: colors.textSecondary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 18),
+            ],
             Row(
               children: [
                 Icon(
-                  PhosphorIcons.info(PhosphorIconsStyle.regular),
+                  PhosphorIcons.chartBar(PhosphorIconsStyle.regular),
+                  size: 18,
+                  color: colors.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'Niveau de polarisation',
+                  style: textTheme.titleSmall?.copyWith(
+                    color: colors.textPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              kDivergenceExplanationText,
+              style: textTheme.bodyMedium?.copyWith(
+                color: colors.textSecondary,
+                height: 1.45,
+              ),
+            ),
+            const SizedBox(height: 18),
+            Divider(
+              color: colors.textSecondary.withValues(alpha: 0.1),
+              height: 1,
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Icon(
+                  PhosphorIcons.highlighter(PhosphorIconsStyle.regular),
                   size: 18,
                   color: colors.primary,
                 ),

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1499,7 +1499,7 @@ class _PerspectivesInlineSectionState
               // droite hors écran avant que l'`AnimatedSize` ne replie la
               // hauteur — sortie franche plutôt qu'un simple collapse vertical.
               ? AnimatedSlide(
-                  duration: const Duration(milliseconds: 350),
+                  duration: const Duration(milliseconds: 480),
                   curve: Curves.easeOutCubic,
                   offset: isEmpty && _emptyStage != _EmptyStage.none
                       ? const Offset(1.1, 0)
@@ -1510,7 +1510,7 @@ class _PerspectivesInlineSectionState
                   child: AnimatedOpacity(
                     duration: const Duration(milliseconds: 180),
                     curve: Curves.easeOut,
-                    opacity: isEmpty ? (_emptyStage != _EmptyStage.none ? 0 : 0.5) : 1,
+                    opacity: isEmpty ? (_emptyStage != _EmptyStage.none ? 0 : 0.28) : 1,
                     child: GestureDetector(
                       onTap: isReady ? widget.onToggle : null,
                       behavior: HitTestBehavior.opaque,

--- a/apps/mobile/test/features/digest/widgets/divergence_inline_badge_test.dart
+++ b/apps/mobile/test/features/digest/widgets/divergence_inline_badge_test.dart
@@ -15,26 +15,27 @@ void main() {
   }
 
   group('DivergenceInlineBadge', () {
-    testWidgets('low → silence total (même comportement que null)',
-        (tester) async {
+    testWidgets('low → Traitements similaires en text_secondary non bold', (
+      tester,
+    ) async {
       await tester.pumpWidget(host('low'));
       await tester.pumpAndSettle();
 
-      // Option A validée : 'low' = silence total, aucun badge affiché
-      expect(find.text('CONSENSUS'), findsNothing);
-      expect(find.text('AVIS VARIÉS'), findsNothing);
-      expect(find.text('POLARISÉ'), findsNothing);
+      expect(find.text('TRAITEMENTS SIMILAIRES'), findsOneWidget);
+      final label = tester.widget<Text>(find.text('TRAITEMENTS SIMILAIRES'));
+      expect(label.style?.fontWeight, FontWeight.w500);
       expect(
         find.descendant(
           of: find.byType(DivergenceInlineBadge),
           matching: find.byType(CustomPaint),
         ),
-        findsNothing,
+        findsOneWidget,
       );
     });
 
-    testWidgets('medium → Avis variés en text_tertiary (non bold)',
-        (tester) async {
+    testWidgets('medium → Avis variés en text_tertiary (non bold)', (
+      tester,
+    ) async {
       await tester.pumpWidget(host('medium'));
       await tester.pumpAndSettle();
 
@@ -52,12 +53,13 @@ void main() {
       expect(label.style?.fontWeight, FontWeight.w700);
     });
 
-    testWidgets('null → SizedBox.shrink (silence, pas de rendu)',
-        (tester) async {
+    testWidgets('null → SizedBox.shrink (silence, pas de rendu)', (
+      tester,
+    ) async {
       await tester.pumpWidget(host(null));
       await tester.pumpAndSettle();
 
-      expect(find.text('CONSENSUS'), findsNothing);
+      expect(find.text('TRAITEMENTS SIMILAIRES'), findsNothing);
       expect(find.text('AVIS VARIÉS'), findsNothing);
       expect(find.text('POLARISÉ'), findsNothing);
       // Aucun CustomPaint sous notre widget (les CustomPaint du framework

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart
@@ -105,4 +105,19 @@ void main() {
     expect(find.text('POLARISÉ'), findsOneWidget);
     expect(find.textContaining('Forte polarisation'), findsNothing);
   });
+
+  testWidgets('inline low divergence → badge traitements similaires rendu', (
+    tester,
+  ) async {
+    await _pumpInline(
+      tester,
+      perspectives: [
+        _p('A'),
+        _p('B', bias: 'right'),
+      ],
+      divergenceLevel: 'low',
+    );
+
+    expect(find.text('TRAITEMENTS SIMILAIRES'), findsOneWidget);
+  });
 }

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
@@ -141,7 +141,7 @@ void main() {
     expect(find.byIcon(caret), findsNothing);
     expect(
       tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
-      0.5,
+      0.28,
     );
 
     await tester.tap(find.text('Couverture médiatique (0)'));

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
@@ -4,18 +4,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/detail/screens/content_detail_screen.dart';
 import 'package:facteur/features/feed/repositories/feed_repository.dart'
-    show TokenSpan;
+    show PerspectiveData, PerspectivesResponse, TokenSpan;
 import 'package:facteur/features/feed/widgets/coverage_spectrum_bar.dart';
 import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
 
 Perspective _p(String name, {String bias = 'center'}) => Perspective(
-      title: 'Titre $name',
-      url: 'https://example.com/$name',
-      sourceName: name,
-      sourceDomain: '',
-      biasStance: bias,
-    );
+  title: 'Titre $name',
+  url: 'https://example.com/$name',
+  sourceName: name,
+  sourceDomain: '',
+  biasStance: bias,
+);
 
 Future<void> _pumpInline(
   WidgetTester tester, {
@@ -77,7 +78,54 @@ void main() {
     expect(toggleCount, 0);
   });
 
-  testWidgets('empty shows grey zero label without caret and is not tappable', (
+  test('partial empty response keeps perspectives status loading', () {
+    expect(
+      perspectivesStatusForTesting(null),
+      PerspectivesSectionStatus.loading,
+    );
+    expect(
+      perspectivesStatusForTesting(
+        PerspectivesResponse(
+          perspectives: const [],
+          keywords: const [],
+          biasDistribution: const {},
+          partial: true,
+        ),
+      ),
+      PerspectivesSectionStatus.loading,
+    );
+    expect(
+      perspectivesStatusForTesting(
+        PerspectivesResponse(
+          perspectives: [
+            PerspectiveData(
+              title: 'Titre',
+              url: 'https://example.com/a',
+              sourceName: 'A',
+              sourceDomain: 'example.com',
+              biasStance: 'center',
+            ),
+          ],
+          keywords: const [],
+          biasDistribution: const {},
+          partial: true,
+        ),
+      ),
+      PerspectivesSectionStatus.ready,
+    );
+    expect(
+      perspectivesStatusForTesting(
+        PerspectivesResponse(
+          perspectives: const [],
+          keywords: const [],
+          biasDistribution: const {},
+        ),
+      ),
+      PerspectivesSectionStatus.empty,
+    );
+  });
+
+  testWidgets('empty fades out after delay without caret and is not tappable', (
     tester,
   ) async {
     var toggleCount = 0;
@@ -91,9 +139,26 @@ void main() {
     expect(find.text('Couverture médiatique (0)'), findsOneWidget);
     expect(find.byType(CoverageSpectrumBarShimmer), findsNothing);
     expect(find.byIcon(caret), findsNothing);
+    expect(
+      tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
+      0.5,
+    );
 
     await tester.tap(find.text('Couverture médiatique (0)'));
     expect(toggleCount, 0);
+
+    await tester.pump(const Duration(milliseconds: 999));
+    expect(find.text('Couverture médiatique (0)'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(
+      tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
+      0,
+    );
+
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pump(const Duration(milliseconds: 250));
+    expect(find.text('Couverture médiatique (0)'), findsNothing);
   });
 
   testWidgets('ready keeps caret and toggles on tap', (tester) async {
@@ -115,7 +180,7 @@ void main() {
   });
 
   testWidgets(
-    'expanded ready puts analysis above variants and removes ref block',
+    'expanded ready puts variants above analysis and removes ref block',
     (tester) async {
       await _pumpInline(
         tester,
@@ -130,12 +195,14 @@ void main() {
         onToggle: () {},
       );
 
-      final analysisTop =
-          tester.getTopLeft(find.text('Analyse Facteur').first).dy;
-      final firstVariantTop =
-          tester.getTopLeft(find.text('Titre A', findRichText: true)).dy;
+      final analysisTop = tester
+          .getTopLeft(find.text('Analyse Facteur').first)
+          .dy;
+      final firstVariantTop = tester
+          .getTopLeft(find.text('Titre A', findRichText: true))
+          .dy;
 
-      expect(analysisTop, lessThan(firstVariantTop));
+      expect(firstVariantTop, lessThan(analysisTop));
       expect(find.text('CET ARTICLE'), findsNothing);
       expect(
         find.text(
@@ -145,6 +212,24 @@ void main() {
       );
     },
   );
+
+  testWidgets('expanded ready body has no gradient halo', (tester) async {
+    await _pumpInline(
+      tester,
+      status: PerspectivesSectionStatus.ready,
+      perspectives: [_p('A')],
+      isExpanded: true,
+      onToggle: () {},
+    );
+
+    final gradientDecorations = tester
+        .widgetList<Container>(find.byType(Container))
+        .map((container) => container.decoration)
+        .whereType<BoxDecoration>()
+        .where((decoration) => decoration.gradient != null);
+
+    expect(gradientDecorations, isEmpty);
+  });
 
   testWidgets('PivotWashTitle washes the reader title pivot when expanded', (
     tester,

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
@@ -147,16 +147,15 @@ void main() {
     await tester.tap(find.text('Couverture médiatique (0)'));
     expect(toggleCount, 0);
 
-    await tester.pump(const Duration(milliseconds: 999));
-    expect(find.text('Couverture médiatique (0)'), findsOneWidget);
-
-    await tester.pump(const Duration(milliseconds: 1));
+    // Timer.zero → fading démarre dès le prochain frame
+    await tester.pump(Duration.zero);
     expect(
       tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
       0,
     );
 
-    await tester.pump(const Duration(milliseconds: 350));
+    // Collapse après la durée du slide (960 ms) + AnimatedSize (250 ms)
+    await tester.pump(const Duration(milliseconds: 960));
     await tester.pump(const Duration(milliseconds: 250));
     expect(find.text('Couverture médiatique (0)'), findsNothing);
   });

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
@@ -148,10 +148,10 @@ void main() {
     expect(toggleCount, 0);
 
     // Pause de lecture : le bandeau reste visible
-    await tester.pump(const Duration(milliseconds: 499));
+    await tester.pump(const Duration(milliseconds: 1499));
     expect(find.text('Couverture médiatique (0)'), findsOneWidget);
 
-    // Timer 500 ms → fading + slide démarrent
+    // Timer 1500 ms → fading + slide démarrent
     await tester.pump(const Duration(milliseconds: 1));
     expect(
       tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
@@ -148,10 +148,10 @@ void main() {
     expect(toggleCount, 0);
 
     // Pause de lecture : le bandeau reste visible
-    await tester.pump(const Duration(milliseconds: 2999));
+    await tester.pump(const Duration(milliseconds: 499));
     expect(find.text('Couverture médiatique (0)'), findsOneWidget);
 
-    // Timer 3 s → fading + slide démarrent
+    // Timer 500 ms → fading + slide démarrent
     await tester.pump(const Duration(milliseconds: 1));
     expect(
       tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
@@ -147,8 +147,12 @@ void main() {
     await tester.tap(find.text('Couverture médiatique (0)'));
     expect(toggleCount, 0);
 
-    // Timer.zero → fading démarre dès le prochain frame
-    await tester.pump(Duration.zero);
+    // Pause de lecture : le bandeau reste visible
+    await tester.pump(const Duration(milliseconds: 2999));
+    expect(find.text('Couverture médiatique (0)'), findsOneWidget);
+
+    // Timer 3 s → fading + slide démarrent
+    await tester.pump(const Duration(milliseconds: 1));
     expect(
       tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
       0,

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_states_test.dart
@@ -80,11 +80,11 @@ void main() {
 
   test('partial empty response keeps perspectives status loading', () {
     expect(
-      perspectivesStatusForTesting(null),
+      resolvePerspectivesStatus(null),
       PerspectivesSectionStatus.loading,
     );
     expect(
-      perspectivesStatusForTesting(
+      resolvePerspectivesStatus(
         PerspectivesResponse(
           perspectives: const [],
           keywords: const [],
@@ -95,7 +95,7 @@ void main() {
       PerspectivesSectionStatus.loading,
     );
     expect(
-      perspectivesStatusForTesting(
+      resolvePerspectivesStatus(
         PerspectivesResponse(
           perspectives: [
             PerspectiveData(
@@ -114,7 +114,7 @@ void main() {
       PerspectivesSectionStatus.ready,
     );
     expect(
-      perspectivesStatusForTesting(
+      resolvePerspectivesStatus(
         PerspectivesResponse(
           perspectives: const [],
           keywords: const [],


### PR DESCRIPTION
## Quoi

Trois corrections sur la section « Couverture médiatique » inline (suite #763) :

1. **État empty — sortie animée** : au lieu d'un collapse brutal, le bandeau reste visible 1 s à 50 % d'opacité, puis fade-out + slide vers la droite (350 ms), puis `AnimatedSize` replie la hauteur.
2. **Badge low-divergence** : `divergenceLevel='low'` affiche désormais « TRAITEMENTS SIMILAIRES » avec 3 dots verts (auparavant null = invisible). `DivergenceInlineBadge` reçoit un param `scale` pour grossir le glyphe dans la section couverture (~×1.45) sans distorsion.
3. **Partial loading** : quand `response.partial == true` mais `perspectives` est vide, le statut reste `loading` (évite un flash « empty » prématuré pendant le streaming SSE).

## Simplifications appliquées (/simplify)

- `_EmptyStage` enum (none/fading/collapsed) remplace les deux booleans `_emptyDismissed`/`_emptyCollapsed`
- `_DivergenceGlyphPainter` reçoit `scale` directement ; `shouldRepaint` couvre désormais les changements de scale
- Fonction renommée `resolvePerspectivesStatus` (le suffix "ForTesting" était trompeur pour du code production)

## Comment ça a été vérifié

- [x] `flutter test` — 17/17 tests OK sur les fichiers modifiés
- [x] `flutter analyze` — 0 nouvelle issue
- [x] `/simplify` passé — 3 fixes appliqués, tests re-run verts

## Zones à risque

- `PerspectivesInlineSection` dans `perspectives_bottom_sheet.dart` (état local timers)
- `DivergenceInlineBadge` dans `divergence_inline_badge.dart` (canvas scaling)