### PR TITLE
feat(sources): refonte page Sources — catalogue thématique + modal bouton association restauré

### DIFF
--- a/apps/mobile/lib/features/feed/widgets/pin_subjects_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/pin_subjects_sheet.dart
@@ -595,6 +595,7 @@ class _PinnedItemsList extends StatelessWidget {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       buildDefaultDragHandles: false,
+      proxyDecorator: (child, index, animation) => child,
       itemCount: items.length,
       onReorder: onReorder,
       itemBuilder: (context, index) {

--- a/apps/mobile/lib/features/my_interests/widgets/favorites_reorderable_section.dart
+++ b/apps/mobile/lib/features/my_interests/widgets/favorites_reorderable_section.dart
@@ -107,6 +107,7 @@ class FavoritesReorderableSection<T> extends StatelessWidget {
                 shrinkWrap: true,
                 physics: const NeverScrollableScrollPhysics(),
                 buildDefaultDragHandles: false,
+                proxyDecorator: (child, index, animation) => child,
                 itemCount: items.length,
                 padding: const EdgeInsets.only(bottom: FacteurSpacing.space2),
                 itemBuilder: (context, index) {

--- a/apps/mobile/lib/features/sources/models/source_theme_filters.dart
+++ b/apps/mobile/lib/features/sources/models/source_theme_filters.dart
@@ -1,0 +1,13 @@
+typedef SourceThemeFilter = ({String? key, String label});
+
+const sourceThemeFilters = <SourceThemeFilter>[
+  (key: null, label: 'Toutes'),
+  (key: 'tech', label: 'Tech'),
+  (key: 'society', label: 'Société'),
+  (key: 'environment', label: 'Environnement'),
+  (key: 'economy', label: 'Économie'),
+  (key: 'politics', label: 'Politique'),
+  (key: 'culture', label: 'Culture'),
+  (key: 'science', label: 'Sciences'),
+  (key: 'international', label: 'International'),
+];

--- a/apps/mobile/lib/features/sources/providers/sources_providers.dart
+++ b/apps/mobile/lib/features/sources/providers/sources_providers.dart
@@ -18,19 +18,21 @@ final sourcesRepositoryProvider = Provider<SourcesRepository>((ref) {
 typedef SmartSearchQuery = ({String query, String? contentType, bool expand});
 
 final smartSearchProvider =
-    FutureProvider.family<SmartSearchResponse, SmartSearchQuery>(
-        (ref, params) async {
-  final trimmed = params.query.trim();
-  if (trimmed.isEmpty) {
-    return const SmartSearchResponse(queryNormalized: '', results: []);
-  }
-  final repository = ref.watch(sourcesRepositoryProvider);
-  return repository.smartSearch(
-    trimmed,
-    contentType: params.contentType,
-    expand: params.expand,
-  );
-});
+    FutureProvider.family<SmartSearchResponse, SmartSearchQuery>((
+      ref,
+      params,
+    ) async {
+      final trimmed = params.query.trim();
+      if (trimmed.isEmpty) {
+        return const SmartSearchResponse(queryNormalized: '', results: []);
+      }
+      final repository = ref.watch(sourcesRepositoryProvider);
+      return repository.smartSearch(
+        trimmed,
+        contentType: params.contentType,
+        expand: params.expand,
+      );
+    });
 
 final trendingSourcesProvider = FutureProvider<List<Source>>((ref) async {
   final repository = ref.watch(sourcesRepositoryProvider);
@@ -44,20 +46,26 @@ final themesFollowedProvider = FutureProvider<List<FollowedTheme>>((ref) async {
 
 final sourcesByThemeProvider =
     FutureProvider.family<ThemeSourcesResponse, String>((ref, slug) async {
-  final repository = ref.watch(sourcesRepositoryProvider);
-  return repository.getSourcesByTheme(slug);
-});
+      final repository = ref.watch(sourcesRepositoryProvider);
+      return repository.getSourcesByTheme(slug);
+    });
 
 final userSourcesProvider =
     AsyncNotifierProvider<UserSourcesNotifier, List<Source>>(() {
-  return UserSourcesNotifier();
-});
+      return UserSourcesNotifier();
+    });
 
 /// Pépites — sources curées poussées dans le feed.
 /// Liste vide si aucun trigger actif, rate-limit, ou cool-down côté backend.
-final pepitesProvider =
-    AsyncNotifierProvider<PepitesNotifier, List<Source>>(() {
-  return PepitesNotifier();
+final pepitesProvider = AsyncNotifierProvider<PepitesNotifier, List<Source>>(
+  () {
+    return PepitesNotifier();
+  },
+);
+
+final pepitesAlwaysProvider = FutureProvider<List<Source>>((ref) async {
+  final repository = ref.watch(sourcesRepositoryProvider);
+  return repository.getPepites(forceShow: true);
 });
 
 class PepitesNotifier extends AsyncNotifier<List<Source>> {
@@ -98,14 +106,15 @@ class UserSourcesNotifier extends AsyncNotifier<List<Source>> {
           if (source.id == sourceId)
             source.copyWith(isTrusted: !currentlyTrusted)
           else
-            source
+            source,
       ]);
     }
 
     try {
       // ignore: avoid_print
       print(
-          'UserSourcesNotifier: Calling repository.trust/untrust for $sourceId...');
+        'UserSourcesNotifier: Calling repository.trust/untrust for $sourceId...',
+      );
 
       if (currentlyTrusted) {
         await repository.untrustSource(sourceId);
@@ -117,9 +126,7 @@ class UserSourcesNotifier extends AsyncNotifier<List<Source>> {
       print('UserSourcesNotifier: Toggle success (persisted to DB)');
       // Le backend peut basculer auto `hide_non_fr_sources` tant que
       // `language_filter_user_set = false` — on resync sans bloquer l'UI.
-      unawaited(
-        ref.read(languagePreferenceProvider.notifier).refresh(),
-      );
+      unawaited(ref.read(languagePreferenceProvider.notifier).refresh());
       // No need to re-fetch entire list: optimistic update is sufficient and avoids race conditions
     } catch (e, stack) {
       // ignore: avoid_print
@@ -155,7 +162,7 @@ class UserSourcesNotifier extends AsyncNotifier<List<Source>> {
               isTrusted: hasSubscription ? true : source.isTrusted,
             )
           else
-            source
+            source,
       ]);
     }
 
@@ -165,8 +172,7 @@ class UserSourcesNotifier extends AsyncNotifier<List<Source>> {
       unawaited(ref.read(lettersProvider.notifier).silentRefresh());
     } catch (e, stack) {
       // ignore: avoid_print
-      print(
-          'UserSourcesNotifier: [ERROR] setSubscription failed: $e\n$stack');
+      print('UserSourcesNotifier: [ERROR] setSubscription failed: $e\n$stack');
       state = previousState;
       if (rethrowOnError) rethrow;
     }
@@ -187,7 +193,7 @@ class UserSourcesNotifier extends AsyncNotifier<List<Source>> {
               isTrusted: !currentlyMuted ? false : source.isTrusted,
             )
           else
-            source
+            source,
       ]);
     }
 

--- a/apps/mobile/lib/features/sources/repositories/sources_repository.dart
+++ b/apps/mobile/lib/features/sources/repositories/sources_repository.dart
@@ -25,18 +25,25 @@ class SourcesRepository {
           if (data.containsKey('curated')) {
             final result = <Source>[];
             if (data['curated'] != null) {
-              result.addAll((data['curated'] as List).map(
-                  (json) => Source.fromJson(json as Map<String, dynamic>)));
+              result.addAll(
+                (data['curated'] as List).map(
+                  (json) => Source.fromJson(json as Map<String, dynamic>),
+                ),
+              );
             }
             if (data['custom'] != null) {
-              result.addAll((data['custom'] as List).map(
-                  (json) => Source.fromJson(json as Map<String, dynamic>)));
+              result.addAll(
+                (data['custom'] as List).map(
+                  (json) => Source.fromJson(json as Map<String, dynamic>),
+                ),
+              );
             }
             return result;
           }
           // Log unexpected map
           print(
-              'SourcesRepository: [WARNING] Received Map but expected List or Catalog: $data');
+            'SourcesRepository: [WARNING] Received Map but expected List or Catalog: $data',
+          );
         }
         return [];
       }
@@ -50,8 +57,10 @@ class SourcesRepository {
 
   Future<List<Source>> getTrendingSources({int limit = 10}) async {
     try {
-      final response = await _apiClient.dio
-          .get<dynamic>('sources/trending', queryParameters: {'limit': limit});
+      final response = await _apiClient.dio.get<dynamic>(
+        'sources/trending',
+        queryParameters: {'limit': limit},
+      );
       if (response.statusCode == 200) {
         final data = response.data;
         if (data is List) {
@@ -106,7 +115,9 @@ class SourcesRepository {
   }
 
   Future<void> updateSourceSubscription(
-      String sourceId, bool hasSubscription) async {
+    String sourceId,
+    bool hasSubscription,
+  ) async {
     try {
       await _apiClient.dio.put<dynamic>(
         'sources/$sourceId/subscription',
@@ -159,14 +170,16 @@ class SourcesRepository {
 
   Future<List<FollowedTheme>> getThemesFollowed() async {
     try {
-      final response =
-          await _apiClient.dio.get<dynamic>('sources/themes-followed');
+      final response = await _apiClient.dio.get<dynamic>(
+        'sources/themes-followed',
+      );
       if (response.statusCode == 200 && response.data is Map) {
         final themes = (response.data as Map<String, dynamic>)['themes'];
         if (themes is List) {
           return themes
-              .map((json) =>
-                  FollowedTheme.fromJson(json as Map<String, dynamic>))
+              .map(
+                (json) => FollowedTheme.fromJson(json as Map<String, dynamic>),
+              )
               .toList();
         }
       }
@@ -189,10 +202,15 @@ class SourcesRepository {
     }
   }
 
-  Future<List<Source>> getPepites({int limit = 10}) async {
+  Future<List<Source>> getPepites({
+    int limit = 10,
+    bool forceShow = false,
+  }) async {
     try {
-      final response = await _apiClient.dio
-          .get<dynamic>('sources/pepites', queryParameters: {'limit': limit});
+      final response = await _apiClient.dio.get<dynamic>(
+        'sources/pepites',
+        queryParameters: {'limit': limit, if (forceShow) 'force_show': true},
+      );
       if (response.statusCode == 200) {
         final data = response.data;
         if (data is List) {
@@ -221,14 +239,19 @@ class SourcesRepository {
 
   Future<ThemeSourcesResponse> getSourcesByTheme(String slug) async {
     try {
-      final response =
-          await _apiClient.dio.get<dynamic>('sources/by-theme/$slug');
+      final response = await _apiClient.dio.get<dynamic>(
+        'sources/by-theme/$slug',
+      );
       if (response.statusCode == 200 && response.data is Map) {
         return ThemeSourcesResponse.fromJson(
-            response.data as Map<String, dynamic>);
+          response.data as Map<String, dynamic>,
+        );
       }
       return const ThemeSourcesResponse(
-          curated: [], candidates: [], community: []);
+        curated: [],
+        candidates: [],
+        community: [],
+      );
     } catch (e) {
       // ignore: avoid_print
       print('SourcesRepository: [ERROR] getSourcesByTheme: $e');

--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -664,7 +664,7 @@ class _SourceFavoritesSection extends StatelessWidget {
                         children: [
                           Expanded(
                             child: Divider(
-                              color: colors.surfaceElevated,
+                              color: colors.border,
                               height: 1,
                             ),
                           ),
@@ -679,7 +679,7 @@ class _SourceFavoritesSection extends StatelessWidget {
                           const SizedBox(width: 8),
                           Expanded(
                             child: Divider(
-                              color: colors.surfaceElevated,
+                              color: colors.border,
                               height: 1,
                             ),
                           ),

--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -16,7 +16,9 @@ import '../../my_interests/widgets/favorites_reorderable_section.dart';
 import '../../my_interests/widgets/interest_state_picker_sheet.dart';
 import '../../settings/providers/paid_content_provider.dart';
 import '../models/source_model.dart';
+import '../models/source_theme_filters.dart';
 import '../providers/sources_providers.dart';
+import '../widgets/pepites_carousel.dart';
 import '../widgets/source_list_item.dart';
 
 class SourcesScreen extends ConsumerStatefulWidget {
@@ -34,25 +36,12 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
   bool _isSearching = false;
   // Collapsible section state (open by default)
   bool _premiumExpanded = true;
-  bool _customExpanded = true;
-  bool _curatedExpanded = true;
+  bool _followedExpanded = true;
   bool _mutedExpanded = true;
 
   // Compteur d'échecs consécutifs : bascule entre FriendlyErrorView et
   // LaurinFallbackView après 2 échecs (pattern de feed_screen.dart).
   int _consecutiveErrorCount = 0;
-
-  static const _themeFilters = <({String? key, String label})>[
-    (key: null, label: 'Toutes'),
-    (key: 'tech', label: 'Tech'),
-    (key: 'society', label: 'Société'),
-    (key: 'environment', label: 'Environnement'),
-    (key: 'economy', label: 'Economie'),
-    (key: 'politics', label: 'Politique'),
-    (key: 'culture', label: 'Culture'),
-    (key: 'science', label: 'Sciences'),
-    (key: 'international', label: 'International'),
-  ];
 
   static const _typeFilters = <({SourceType? key, String label})>[
     (key: null, label: 'Tous'),
@@ -163,15 +152,17 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
               title: const Text('Sources de confiance'),
               actions: [
                 IconButton(
-                  icon: Icon(PhosphorIcons.magnifyingGlass(
-                      PhosphorIconsStyle.regular)),
+                  icon: Icon(
+                    PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
+                  ),
                   onPressed: () => setState(() => _isSearching = true),
                 ),
                 Stack(
                   children: [
                     IconButton(
                       icon: Icon(
-                          PhosphorIcons.funnel(PhosphorIconsStyle.regular)),
+                        PhosphorIcons.funnel(PhosphorIconsStyle.regular),
+                      ),
                       onPressed: () => _showFilterSheet(colors),
                     ),
                     if (_hasActiveFilter)
@@ -212,32 +203,18 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                   ),
           ),
           data: (sources) {
-            // Sort alphabetically
-            var allSources = sources.toList()
-              ..sort((a, b) =>
-                  a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+            final sourcesState = sourcesStateAsync.value;
 
-            // Apply search filter
+            var filteredSources = sources.toList();
             if (_searchQuery.isNotEmpty) {
-              allSources = allSources
-                  .where((s) =>
-                      s.name.toLowerCase().contains(_searchQuery.toLowerCase()))
+              filteredSources = filteredSources
+                  .where(
+                    (s) => s.name.toLowerCase().contains(
+                          _searchQuery.toLowerCase(),
+                        ),
+                  )
                   .toList();
             }
-
-            if (allSources.isEmpty && _searchQuery.isEmpty) {
-              return _scrollableCenter(
-                Text(
-                  'Aucune source disponible',
-                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        color: colors.textSecondary,
-                      ),
-                ),
-              );
-            }
-
-            // Apply theme + type filters for display
-            var filteredSources = allSources.toList();
             if (_selectedTheme != null) {
               filteredSources = filteredSources
                   .where((s) => s.theme?.toLowerCase() == _selectedTheme)
@@ -248,53 +225,59 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                   .where((s) => s.type == _selectedType)
                   .toList();
             }
-            // Split into 4 groups: premium, custom (non-muted), curated (non-muted), muted
-            final premiumSources = filteredSources
-                .where((s) => s.hasSubscription && !s.isMuted)
-                .toList();
-            final customSources =
-                filteredSources.where((s) => s.isCustom && !s.isMuted).toList();
-            final curatedSources = filteredSources
-                .where((s) => s.isCurated && !s.isMuted)
-                .toList();
-            final mutedSources =
-                filteredSources.where((s) => s.isMuted).toList();
+            filteredSources.sort(_compareByThemeThenName);
 
-            final noResults = filteredSources.isEmpty && _hasActiveFilter;
-
-            if (noResults) {
+            if (sources.isEmpty && _searchQuery.isEmpty) {
               return _scrollableCenter(
-                Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      PhosphorIcons.funnel(PhosphorIconsStyle.regular),
-                      size: 40,
-                      color: colors.textTertiary,
-                    ),
-                    const SizedBox(height: 12),
-                    Text(
-                      'Aucune source pour ces filtres',
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodyMedium
-                          ?.copyWith(color: colors.textSecondary),
-                    ),
-                    const SizedBox(height: 8),
-                    TextButton(
-                      onPressed: () {
-                        setState(() {
-                          _selectedTheme = null;
-                          _selectedType = null;
-                        });
-                      },
-                      child: const Text('Réinitialiser les filtres'),
-                    ),
-                    ...mutedSources.map((source) => _buildSourceItem(source)),
-                  ],
+                Text(
+                  'Aucune source disponible',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyLarge?.copyWith(color: colors.textSecondary),
                 ),
               );
             }
+
+            final followedNonMuted = filteredSources
+                .where(
+                  (s) => !s.isMuted && _isFollowedSource(s, sourcesState),
+                )
+                .map((s) => s.copyWith(isTrusted: true))
+                .toList();
+
+            final visibleFavoriteIds = followedNonMuted
+                .where((s) => _isFavoriteSource(s, sourcesState))
+                .map((s) => s.id)
+                .toSet();
+            final allFavorites = sourcesState?.favorites ?? const [];
+            final visibleFavorites = allFavorites
+                .where((f) => visibleFavoriteIds.contains(f.sourceId))
+                .toList();
+            final premiumSources = filteredSources
+                .where(
+                  (s) =>
+                      !s.isMuted &&
+                      s.hasSubscription &&
+                      _isFollowedSource(s, sourcesState) &&
+                      !_isFavoriteSource(s, sourcesState),
+                )
+                .map((s) => s.copyWith(isTrusted: true))
+                .toList();
+            final followedSources = followedNonMuted
+                .where(
+                  (s) =>
+                      !s.hasSubscription && !_isFavoriteSource(s, sourcesState),
+                )
+                .toList();
+            final mutedSources = filteredSources
+                .where((s) => s.isMuted)
+                .toList();
+
+            final noFollowedSources =
+                !sources.any((s) => !s.isMuted && _isFollowedSource(s, sourcesState));
+            final noResults = followedNonMuted.isEmpty &&
+                mutedSources.isEmpty &&
+                (_hasActiveFilter || _searchQuery.isNotEmpty);
 
             return ListView(
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
@@ -303,70 +286,93 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                 _IntroBlock(colors: colors),
                 const SizedBox(height: 12),
                 // Story 22.1 — section Favoris (drag-reorderable, cap 3).
-                _SourceFavoritesSection(
-                  favorites: sourcesStateAsync.value?.favorites ?? const [],
-                  allSources: allSources,
-                  onReorder: (reordered) async {
-                    try {
-                      await ref
-                          .read(userSourcesStateProvider.notifier)
-                          .reorderFavorites(reordered);
-                    } catch (_) {
-                      if (!mounted) return;
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content:
-                              Text('Impossible de réordonner les favoris.'),
-                          duration: Duration(seconds: 3),
-                        ),
-                      );
-                    }
-                  },
-                ),
+                if (!noFollowedSources || visibleFavorites.isNotEmpty)
+                  _SourceFavoritesSection(
+                    favorites: visibleFavorites,
+                    allSources: followedNonMuted,
+                    onReorder: (reordered) async {
+                      final messenger = ScaffoldMessenger.of(context);
+                      final reorderedIds =
+                          reordered.map((f) => f.sourceId).toSet();
+                      var reorderedIndex = 0;
+                      final mergedFavorites = [
+                        for (final favorite in allFavorites)
+                          if (reorderedIds.contains(favorite.sourceId))
+                            reordered[reorderedIndex++]
+                          else
+                            favorite,
+                      ];
+                      try {
+                        await ref
+                            .read(userSourcesStateProvider.notifier)
+                            .reorderFavorites(mergedFavorites);
+                      } catch (_) {
+                        if (!mounted) return;
+                        messenger.showSnackBar(
+                          const SnackBar(
+                            content: Text(
+                              'Impossible de réordonner les favoris.',
+                            ),
+                            duration: Duration(seconds: 3),
+                          ),
+                        );
+                      }
+                    },
+                  ),
                 const SizedBox(height: 8),
                 if (premiumSources.isNotEmpty)
                   _buildCollapsibleSection(
-                    title: 'Mes abonnements Premium',
+                    title: 'Abonnements premium',
                     count: premiumSources.length,
                     isExpanded: _premiumExpanded,
                     onToggle: () =>
                         setState(() => _premiumExpanded = !_premiumExpanded),
                     sources: premiumSources,
                     colors: colors,
+                    sourcesState: sourcesState,
                     icon: PhosphorIcons.star(PhosphorIconsStyle.fill),
                   ),
                 const _HidePaidToggleCard(),
                 const SizedBox(height: 8),
-                if (customSources.isNotEmpty)
+                if (noResults)
+                  _NoSourcesMatchBlock(
+                    hasActiveFilter: _hasActiveFilter,
+                    hasSearchQuery: _searchQuery.isNotEmpty,
+                    onReset: () {
+                      setState(() {
+                        _selectedTheme = null;
+                        _selectedType = null;
+                        _searchController.clear();
+                        _searchQuery = '';
+                      });
+                    },
+                  )
+                else if (noFollowedSources)
+                  const _NoFollowedSourcesBlock()
+                else if (followedSources.isNotEmpty)
                   _buildCollapsibleSection(
-                    title: 'Mes sources personnalisees',
-                    count: customSources.length,
-                    isExpanded: _customExpanded,
+                    title: 'Sources suivies',
+                    count: followedSources.length,
+                    isExpanded: _followedExpanded,
                     onToggle: () =>
-                        setState(() => _customExpanded = !_customExpanded),
-                    sources: customSources,
+                        setState(() => _followedExpanded = !_followedExpanded),
+                    sources: followedSources,
                     colors: colors,
+                    sourcesState: sourcesState,
                   ),
-                if (curatedSources.isNotEmpty)
-                  _buildCollapsibleSection(
-                    title: 'Sources suggerees',
-                    count: curatedSources.length,
-                    isExpanded: _curatedExpanded,
-                    onToggle: () =>
-                        setState(() => _curatedExpanded = !_curatedExpanded),
-                    sources: curatedSources,
-                    colors: colors,
-                  ),
+                const SizedBox(height: 8),
+                const PepitesCarousel(alwaysVisible: true),
                 if (mutedSources.isNotEmpty) ...[
                   const SizedBox(height: 8),
                   _buildCollapsibleSection(
-                    title: 'Sources masquees',
+                    title: 'Sources masquées',
                     count: mutedSources.length,
                     isExpanded: _mutedExpanded,
                     onToggle: () =>
                         setState(() => _mutedExpanded = !_mutedExpanded),
                     sources: mutedSources,
                     colors: colors,
+                    sourcesState: sourcesState,
                     icon: PhosphorIcons.eyeSlash(PhosphorIconsStyle.bold),
                     isMuted: true,
                   ),
@@ -414,6 +420,24 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
     );
   }
 
+  bool _isFollowedSource(Source source, UserSourcesState? state) {
+    final sourceState = state?.stateOf(source.id);
+    return source.isTrusted ||
+        sourceState == InterestState.followed ||
+        sourceState == InterestState.favorite;
+  }
+
+  bool _isFavoriteSource(Source source, UserSourcesState? state) {
+    return state?.stateOf(source.id) == InterestState.favorite ||
+        (state?.favorites.any((f) => f.sourceId == source.id) ?? false);
+  }
+
+  static int _compareByThemeThenName(Source a, Source b) {
+    final themeCompare = a.getThemeLabel().compareTo(b.getThemeLabel());
+    if (themeCompare != 0) return themeCompare;
+    return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+  }
+
   // ─── Filter bottom sheet ───────────────────────────────────
 
   void _showFilterSheet(FacteurColors colors) {
@@ -424,7 +448,7 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
       builder: (_) => _FilterSheetContent(
         selectedTheme: _selectedTheme,
         selectedType: _selectedType,
-        themeFilters: _themeFilters,
+        themeFilters: sourceThemeFilters,
         typeFilters: _typeFilters,
         hasActiveFilter: _hasActiveFilter,
         onThemeChanged: (v) => setState(() => _selectedTheme = v),
@@ -446,6 +470,7 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
     required VoidCallback onToggle,
     required List<Source> sources,
     required FacteurColors colors,
+    required UserSourcesState? sourcesState,
     IconData? icon,
     bool isMuted = false,
   }) {
@@ -454,60 +479,55 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        GestureDetector(
-          onTap: onToggle,
-          behavior: HitTestBehavior.opaque,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 10),
-            child: Row(
-              children: [
-                if (icon != null) ...[
-                  Icon(icon, size: 16, color: titleColor),
-                  const SizedBox(width: 8),
-                ],
-                Expanded(
-                  child: Text(
-                    title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+        Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onToggle,
+            borderRadius: BorderRadius.circular(FacteurRadius.small),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(2, 12, 2, 10),
+              child: Row(
+                children: [
+                  if (icon != null) ...[
+                    Icon(icon, size: 17, color: titleColor),
+                    const SizedBox(width: 8),
+                  ],
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                            color: titleColor,
+                            fontWeight: FontWeight.w700,
+                          ),
+                    ),
+                  ),
+                  Text(
+                    '$count',
+                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
                           color: titleColor,
-                          fontWeight: FontWeight.bold,
+                          fontWeight: FontWeight.w700,
                         ),
                   ),
-                ),
-                Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-                  decoration: BoxDecoration(
-                    color: titleColor.withOpacity(0.1),
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: Text(
-                    '$count',
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
+                  const SizedBox(width: 8),
+                  AnimatedRotation(
+                    turns: isExpanded ? 0.0 : -0.25,
+                    duration: const Duration(milliseconds: 200),
+                    child: Icon(
+                      PhosphorIcons.caretDown(PhosphorIconsStyle.bold),
+                      size: 15,
                       color: titleColor,
                     ),
                   ),
-                ),
-                const SizedBox(width: 6),
-                AnimatedRotation(
-                  turns: isExpanded ? 0.0 : -0.25,
-                  duration: const Duration(milliseconds: 200),
-                  child: Icon(
-                    PhosphorIcons.caretDown(PhosphorIconsStyle.bold),
-                    size: 14,
-                    color: titleColor,
-                  ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),
         AnimatedCrossFade(
           firstChild: Column(
-            children:
-                sources.map((source) => _buildSourceItem(source)).toList(),
+            children: sources
+                .map((source) => _buildSourceItem(source, sourcesState))
+                .toList(),
           ),
           secondChild: const SizedBox.shrink(),
           crossFadeState:
@@ -519,26 +539,27 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
     );
   }
 
-  Widget _buildSourceItem(Source source) {
-    final isFavorite = ref
-            .watch(userSourcesStateProvider)
-            .value
-            ?.favorites
-            .any((f) => f.sourceId == source.id) ??
-        false;
+  Widget _buildSourceItem(Source source, UserSourcesState? sourcesState) {
+    final isFavorite =
+        sourcesState?.favorites.any((f) => f.sourceId == source.id) ?? false;
+    final displaySource = source.copyWith(
+      isTrusted: source.isMuted
+          ? source.isTrusted
+          : _isFollowedSource(source, sourcesState),
+    );
     return SourceListItem(
-      source: source,
+      source: displaySource,
       isFavorite: isFavorite,
-      onPickInterestState: () => _pickSourceState(source),
+      onPickInterestState: () => _pickSourceState(displaySource),
       onTap: () {
         ref
             .read(userSourcesProvider.notifier)
-            .toggleTrust(source.id, source.isTrusted);
+            .toggleTrust(displaySource.id, displaySource.isTrusted);
       },
       onToggleMute: () {
         ref
             .read(userSourcesProvider.notifier)
-            .toggleMute(source.id, source.isMuted);
+            .toggleMute(displaySource.id, displaySource.isMuted);
       },
     );
   }
@@ -599,6 +620,92 @@ class _SourceFavoritesSection extends StatelessWidget {
   }
 }
 
+class _NoFollowedSourcesBlock extends StatelessWidget {
+  const _NoFollowedSourcesBlock();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Container(
+      padding: const EdgeInsets.all(FacteurSpacing.space4),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        border: Border.all(color: colors.surfaceElevated),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            PhosphorIcons.plusCircle(PhosphorIconsStyle.regular),
+            size: 24,
+            color: colors.primary,
+          ),
+          const SizedBox(width: FacteurSpacing.space3),
+          Expanded(
+            child: Text(
+              'Aucune source suivie pour le moment. Ajoutez une source pour personnaliser votre veille.',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: colors.textSecondary,
+                    height: 1.35,
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NoSourcesMatchBlock extends StatelessWidget {
+  final bool hasActiveFilter;
+  final bool hasSearchQuery;
+  final VoidCallback onReset;
+
+  const _NoSourcesMatchBlock({
+    required this.hasActiveFilter,
+    required this.hasSearchQuery,
+    required this.onReset,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final label = hasSearchQuery
+        ? 'Aucune source suivie ne correspond à cette recherche.'
+        : 'Aucune source suivie pour ces filtres.';
+
+    return Container(
+      padding: const EdgeInsets.all(FacteurSpacing.space4),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        border: Border.all(color: colors.surfaceElevated),
+      ),
+      child: Column(
+        children: [
+          Icon(
+            PhosphorIcons.funnel(PhosphorIconsStyle.regular),
+            size: 34,
+            color: colors.textTertiary,
+          ),
+          const SizedBox(height: 10),
+          Text(
+            label,
+            textAlign: TextAlign.center,
+            style: Theme.of(
+              context,
+            ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
+          ),
+          if (hasActiveFilter || hasSearchQuery) ...[
+            const SizedBox(height: 8),
+            TextButton(onPressed: onReset, child: const Text('Réinitialiser')),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
 // ─── Filter sheet widget ─────────────────────────────────────
 
 class _FilterSheetContent extends ConsumerWidget {
@@ -642,7 +749,7 @@ class _FilterSheetContent extends ConsumerWidget {
               width: 40,
               height: 4,
               decoration: BoxDecoration(
-                color: colors.textTertiary.withOpacity(0.3),
+                color: colors.textTertiary.withValues(alpha: 0.3),
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
@@ -804,8 +911,9 @@ class _IntroBlock extends StatelessWidget {
         children: [
           Text(
             'Vos sources de confiance',
-            style: FacteurTypography.serifTitle(colors.textPrimary)
-                .copyWith(fontSize: 20, height: 1.2),
+            style: FacteurTypography.serifTitle(
+              colors.textPrimary,
+            ).copyWith(fontSize: 20, height: 1.2),
           ),
           const SizedBox(height: 6),
           Text(
@@ -856,7 +964,7 @@ class _HidePaidToggleCard extends ConsumerWidget {
                   height: 36,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
-                    color: colors.primary.withOpacity(0.10),
+                    color: colors.primary.withValues(alpha: 0.10),
                   ),
                   alignment: Alignment.center,
                   child: Icon(
@@ -872,25 +980,23 @@ class _HidePaidToggleCard extends ConsumerWidget {
                     children: [
                       Text(
                         'Masquer les articles payants*',
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodyMedium
-                            ?.copyWith(fontWeight: FontWeight.w600),
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                            ),
                       ),
                       const SizedBox(height: 2),
                       Text(
                         '*: Sauf abonnements connectés.',
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodySmall
-                            ?.copyWith(color: colors.textSecondary),
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: colors.textSecondary,
+                            ),
                       ),
                     ],
                   ),
                 ),
                 Switch.adaptive(
                   value: hidePaid,
-                  activeColor: colors.primary,
+                  activeThumbColor: colors.primary,
                   onChanged: (v) =>
                       ref.read(hidePaidContentProvider.notifier).toggle(v),
                 ),

--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -12,7 +12,7 @@ import '../../../shared/widgets/states/laurin_fallback_view.dart';
 import '../../my_interests/models/user_interests_state.dart' show InterestState;
 import '../../my_interests/models/user_sources_state.dart';
 import '../../my_interests/providers/user_sources_state_provider.dart';
-import '../../my_interests/widgets/favorites_reorderable_section.dart';
+import '../../../config/constants.dart';
 import '../../my_interests/widgets/interest_state_picker_sheet.dart';
 import '../../settings/providers/paid_content_provider.dart';
 import '../models/source_model.dart';
@@ -285,6 +285,8 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
               children: [
                 _IntroBlock(colors: colors),
                 const SizedBox(height: 12),
+                const _HidePaidToggleCard(),
+                const SizedBox(height: 4),
                 // Story 22.1 — section Favoris (drag-reorderable, cap 3).
                 if (!noFollowedSources || visibleFavorites.isNotEmpty)
                   _SourceFavoritesSection(
@@ -318,6 +320,8 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                         );
                       }
                     },
+                    buildItem: (source) =>
+                        _buildSourceItem(source, sourcesState),
                   ),
                 const SizedBox(height: 8),
                 if (premiumSources.isNotEmpty)
@@ -332,7 +336,6 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                     sourcesState: sourcesState,
                     icon: PhosphorIcons.star(PhosphorIconsStyle.fill),
                   ),
-                const _HidePaidToggleCard(),
                 const SizedBox(height: 8),
                 if (noResults)
                   _NoSourcesMatchBlock(
@@ -570,52 +573,152 @@ class _SourceFavoritesSection extends StatelessWidget {
   final List<SourceFavoriteRef> favorites;
   final List<Source> allSources;
   final void Function(List<SourceFavoriteRef> reordered) onReorder;
+  final Widget Function(Source source) buildItem;
 
   const _SourceFavoritesSection({
     required this.favorites,
     required this.allSources,
     required this.onReorder,
+    required this.buildItem,
   });
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
     final byId = {for (final s in allSources) s.id: s};
 
-    return FavoritesReorderableSection<SourceFavoriteRef>(
-      items: favorites,
-      keyOf: (r) => ValueKey('source:${r.sourceId}'),
-      emptyStateText:
-          'Aucune source favorite — marquez-en une pour l\'épingler dans Flâner.',
-      padding: EdgeInsets.zero,
-      itemBuilder: (context, refItem) {
-        final source = byId[refItem.sourceId];
-        return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 6),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(2, 12, 2, 4),
           child: Row(
             children: [
               Icon(
                 PhosphorIcons.star(PhosphorIconsStyle.fill),
-                color: colors.primary,
-                size: 14,
+                size: 17,
+                color: colors.textSecondary,
               ),
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  source?.name ?? 'Source',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
-                        color: colors.textPrimary,
-                      ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                  'Favoris',
+                  style: textTheme.titleSmall?.copyWith(
+                    color: colors.textSecondary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              Text(
+                '${favorites.length}',
+                style: textTheme.labelMedium?.copyWith(
+                  color: colors.textSecondary,
+                  fontWeight: FontWeight.w700,
                 ),
               ),
             ],
           ),
-        );
-      },
-      onReorder: onReorder,
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(2, 0, 2, 8),
+          child: Text(
+            'Les $kFavoriteCap premiers (ordre modifiable) sont dans votre Tournée du jour.',
+            style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
+          ),
+        ),
+        if (favorites.isEmpty)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(2, 0, 2, 8),
+            child: Text(
+              'Aucune source favorite — marquez-en une pour l\'épingler dans Flâner.',
+              style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
+            ),
+          )
+        else
+          ReorderableListView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            buildDefaultDragHandles: false,
+            itemCount: favorites.length,
+            padding: EdgeInsets.zero,
+            itemBuilder: (context, index) {
+              final refItem = favorites[index];
+              final source = byId[refItem.sourceId];
+              if (source == null) {
+                return SizedBox.shrink(
+                    key: ValueKey('source:${refItem.sourceId}'));
+              }
+              final inTour = index < kFavoriteCap;
+              final isTourBoundary =
+                  index == kFavoriteCap && favorites.length > kFavoriteCap;
+              return Column(
+                key: ValueKey('source:${refItem.sourceId}'),
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (isTourBoundary)
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(0, 8, 0, 4),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Divider(
+                              color: colors.surfaceElevated,
+                              height: 1,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            'Hors Tournée du jour',
+                            style: textTheme.bodySmall?.copyWith(
+                              color: colors.textTertiary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Divider(
+                              color: colors.surfaceElevated,
+                              height: 1,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  Opacity(
+                    opacity: inTour ? 1.0 : 0.55,
+                    child: Row(
+                      children: [
+                        Expanded(child: buildItem(source)),
+                        ReorderableDragStartListener(
+                          index: index,
+                          child: Padding(
+                            padding: const EdgeInsets.all(8),
+                            child: Icon(
+                              PhosphorIcons.dotsSixVertical(
+                                  PhosphorIconsStyle.regular),
+                              color: colors.textTertiary,
+                              size: 18,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              );
+            },
+            onReorder: (oldIndex, newIndex) {
+              final reordered = [...favorites];
+              final adjusted =
+                  newIndex > oldIndex ? newIndex - 1 : newIndex;
+              final moved = reordered.removeAt(oldIndex);
+              reordered.insert(adjusted, moved);
+              onReorder(reordered);
+            },
+          ),
+        const SizedBox(height: 8),
+      ],
     );
   }
 }
@@ -899,32 +1002,24 @@ class _IntroBlock extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    return Container(
-      padding: const EdgeInsets.all(FacteurSpacing.space4),
-      decoration: BoxDecoration(
-        color: colors.surface,
-        borderRadius: BorderRadius.circular(FacteurRadius.large),
-        border: Border.all(color: colors.surfaceElevated),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Vos sources de confiance',
-            style: FacteurTypography.serifTitle(
-              colors.textPrimary,
-            ).copyWith(fontSize: 20, height: 1.2),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Vos sources de confiance',
+          style: FacteurTypography.serifTitle(
+            colors.textPrimary,
+          ).copyWith(fontSize: 20, height: 1.2),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          'Gérez vos préférences par sources. Ajoutez certaines en favoris pour les voir apparaitre plus souvent. Masquez celles que vous souhaitez filtrer de vos flux.',
+          style: textTheme.bodySmall?.copyWith(
+            color: colors.textSecondary,
+            height: 1.45,
           ),
-          const SizedBox(height: 6),
-          Text(
-            'Gérez vos préférences par sources. Ajoutez certaines en favoris pour les voir apparaitre plus souvent. Masquez celles que vous souhaitez filtrer de vos flux.',
-            style: textTheme.bodySmall?.copyWith(
-              color: colors.textSecondary,
-              height: 1.45,
-            ),
-          ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }
@@ -938,72 +1033,52 @@ class _HidePaidToggleCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
     final hidePaid = ref.watch(hidePaidContentProvider);
-    final borderRadius = BorderRadius.circular(FacteurRadius.large);
     return Padding(
-      padding: const EdgeInsets.only(bottom: 14),
-      child: Material(
-        color: colors.surface,
-        borderRadius: borderRadius,
-        child: InkWell(
-          onTap: () =>
-              ref.read(hidePaidContentProvider.notifier).toggle(!hidePaid),
-          borderRadius: borderRadius,
-          child: Container(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          Container(
+            width: 36,
+            height: 36,
             decoration: BoxDecoration(
-              borderRadius: borderRadius,
-              border: Border.all(color: colors.surfaceElevated),
+              shape: BoxShape.circle,
+              color: colors.primary.withValues(alpha: 0.10),
             ),
-            padding: const EdgeInsets.symmetric(
-              horizontal: FacteurSpacing.space4,
-              vertical: FacteurSpacing.space3,
+            alignment: Alignment.center,
+            child: Icon(
+              PhosphorIcons.lock(PhosphorIconsStyle.regular),
+              color: colors.primary,
+              size: 18,
             ),
-            child: Row(
+          ),
+          const SizedBox(width: FacteurSpacing.space3),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Container(
-                  width: 36,
-                  height: 36,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: colors.primary.withValues(alpha: 0.10),
-                  ),
-                  alignment: Alignment.center,
-                  child: Icon(
-                    PhosphorIcons.lock(PhosphorIconsStyle.regular),
-                    color: colors.primary,
-                    size: 18,
-                  ),
-                ),
-                const SizedBox(width: FacteurSpacing.space3),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Masquer les articles payants*',
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                              fontWeight: FontWeight.w600,
-                            ),
+                Text(
+                  'Masquer les articles payants*',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
                       ),
-                      const SizedBox(height: 2),
-                      Text(
-                        '*: Sauf abonnements connectés.',
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: colors.textSecondary,
-                            ),
-                      ),
-                    ],
-                  ),
                 ),
-                Switch.adaptive(
-                  value: hidePaid,
-                  activeThumbColor: colors.primary,
-                  onChanged: (v) =>
-                      ref.read(hidePaidContentProvider.notifier).toggle(v),
+                const SizedBox(height: 2),
+                Text(
+                  '*: Sauf abonnements connectés.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colors.textSecondary,
+                      ),
                 ),
               ],
             ),
           ),
-        ),
+          Switch.adaptive(
+            value: hidePaid,
+            activeThumbColor: colors.primary,
+            onChanged: (v) =>
+                ref.read(hidePaidContentProvider.notifier).toggle(v),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -640,6 +640,7 @@ class _SourceFavoritesSection extends StatelessWidget {
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
             buildDefaultDragHandles: false,
+            proxyDecorator: (child, index, animation) => child,
             itemCount: favorites.length,
             padding: EdgeInsets.zero,
             itemBuilder: (context, index) {
@@ -1033,53 +1034,59 @@ class _HidePaidToggleCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
     final hidePaid = ref.watch(hidePaidContentProvider);
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      child: Row(
-        children: [
-          Container(
-            width: 36,
-            height: 36,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: colors.primary.withValues(alpha: 0.10),
-            ),
-            alignment: Alignment.center,
-            child: Icon(
-              PhosphorIcons.lock(PhosphorIconsStyle.regular),
-              color: colors.primary,
-              size: 18,
-            ),
-          ),
-          const SizedBox(width: FacteurSpacing.space3),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Masquer les articles payants*',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Divider(height: 1, color: colors.surfaceElevated),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6),
+          child: Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: colors.primary.withValues(alpha: 0.10),
                 ),
-                const SizedBox(height: 2),
-                Text(
-                  '*: Sauf abonnements connectés.',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: colors.textSecondary,
-                      ),
+                alignment: Alignment.center,
+                child: Icon(
+                  PhosphorIcons.lock(PhosphorIconsStyle.regular),
+                  color: colors.primary,
+                  size: 18,
                 ),
-              ],
-            ),
+              ),
+              const SizedBox(width: FacteurSpacing.space3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Masquer les articles payants*',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                    ),
+                    Text(
+                      '*: Sauf abonnements connectés.',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colors.textSecondary,
+                          ),
+                    ),
+                  ],
+                ),
+              ),
+              Switch.adaptive(
+                value: hidePaid,
+                activeThumbColor: colors.primary,
+                onChanged: (v) =>
+                    ref.read(hidePaidContentProvider.notifier).toggle(v),
+              ),
+            ],
           ),
-          Switch.adaptive(
-            value: hidePaid,
-            activeThumbColor: colors.primary,
-            onChanged: (v) =>
-                ref.read(hidePaidContentProvider.notifier).toggle(v),
-          ),
-        ],
-      ),
+        ),
+        Divider(height: 1, color: colors.surfaceElevated),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/features/sources/widgets/catalog_sources_strip.dart
+++ b/apps/mobile/lib/features/sources/widgets/catalog_sources_strip.dart
@@ -1,0 +1,273 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../models/source_model.dart';
+import '../models/source_theme_filters.dart';
+import '../providers/sources_providers.dart';
+import 'source_logo_avatar.dart';
+
+class CatalogSourcesStrip extends ConsumerStatefulWidget {
+  final void Function(Source source) onSourceTap;
+
+  const CatalogSourcesStrip({super.key, required this.onSourceTap});
+
+  @override
+  ConsumerState<CatalogSourcesStrip> createState() =>
+      _CatalogSourcesStripState();
+}
+
+class _CatalogSourcesStripState extends ConsumerState<CatalogSourcesStrip> {
+  bool _expanded = false;
+  String? _selectedTheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _buildHeader(context, colors),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOut,
+            alignment: Alignment.topCenter,
+            child: _expanded
+                ? _buildExpanded(context, colors)
+                : const SizedBox.shrink(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, FacteurColors colors) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () => setState(() => _expanded = !_expanded),
+        child: Padding(
+          padding: const EdgeInsets.all(14),
+          child: Row(
+            children: [
+              Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  color: colors.primary.withValues(alpha: 0.10),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  PhosphorIcons.bookOpen(PhosphorIconsStyle.regular),
+                  size: 17,
+                  color: colors.primary,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Toutes les sources déjà ajoutées',
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: colors.textPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'Parcourez le catalogue Facteur par thème',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colors.textTertiary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              AnimatedRotation(
+                turns: _expanded ? 0.5 : 0,
+                duration: const Duration(milliseconds: 200),
+                child: Icon(
+                  PhosphorIcons.caretDown(PhosphorIconsStyle.regular),
+                  size: 18,
+                  color: colors.textTertiary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildExpanded(BuildContext context, FacteurColors colors) {
+    final sourcesAsync = ref.watch(userSourcesProvider);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(14, 0, 14, 14),
+      child: sourcesAsync.when(
+        data: (sources) {
+          final curated =
+              sources
+                  .where(
+                    (s) =>
+                        s.isCurated &&
+                        (_selectedTheme == null ||
+                            s.theme?.toLowerCase() == _selectedTheme),
+                  )
+                  .toList()
+                ..sort((a, b) {
+                  final themeCompare = a.getThemeLabel().compareTo(
+                    b.getThemeLabel(),
+                  );
+                  if (themeCompare != 0) return themeCompare;
+                  return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+                });
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Divider(height: 1, color: colors.border),
+              const SizedBox(height: 12),
+              _buildThemeChips(colors),
+              const SizedBox(height: 10),
+              if (curated.isEmpty)
+                Text(
+                  'Aucune source dans ce thème.',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodySmall?.copyWith(color: colors.textTertiary),
+                )
+              else
+                SizedBox(
+                  height: math.min(336, curated.length * 58).toDouble(),
+                  child: ListView.separated(
+                    padding: EdgeInsets.zero,
+                    itemCount: curated.length,
+                    separatorBuilder: (_, __) =>
+                        Divider(height: 1, color: colors.border),
+                    itemBuilder: (_, index) =>
+                        _buildCatalogTile(context, colors, curated[index]),
+                  ),
+                ),
+            ],
+          );
+        },
+        loading: () => const Padding(
+          padding: EdgeInsets.symmetric(vertical: 16),
+          child: Center(
+            child: SizedBox(
+              width: 22,
+              height: 22,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+        ),
+        error: (_, __) => Text(
+          'Impossible de charger le catalogue.',
+          style: Theme.of(
+            context,
+          ).textTheme.bodySmall?.copyWith(color: colors.textTertiary),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildThemeChips(FacteurColors colors) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: sourceThemeFilters.map((filter) {
+          final selected = _selectedTheme == filter.key;
+          return Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: ChoiceChip(
+              label: Text(filter.label),
+              selected: selected,
+              showCheckmark: false,
+              onSelected: (_) => setState(() => _selectedTheme = filter.key),
+              selectedColor: colors.primary,
+              backgroundColor: colors.backgroundSecondary,
+              labelStyle: TextStyle(
+                color: selected ? colors.surface : colors.textSecondary,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+              side: BorderSide(
+                color: selected ? colors.primary : colors.border,
+              ),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(18),
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  Widget _buildCatalogTile(
+    BuildContext context,
+    FacteurColors colors,
+    Source source,
+  ) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: () => widget.onSourceTap(source),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+        child: Row(
+          children: [
+            SourceLogoAvatar(source: source, size: 36, radius: 8),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    source.name,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: colors.textPrimary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    source.getThemeLabel(),
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: colors.textTertiary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Icon(
+              PhosphorIcons.caretRight(PhosphorIconsStyle.regular),
+              size: 16,
+              color: colors.textTertiary,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+}

--- a/apps/mobile/lib/features/sources/widgets/pepites_carousel.dart
+++ b/apps/mobile/lib/features/sources/widgets/pepites_carousel.dart
@@ -14,12 +14,16 @@ import 'source_detail_modal.dart';
 /// le feed pour aider à découvrir des sources de qualité. Visibilité gérée
 /// côté backend (rate-limit + cool-down) : liste vide → SizedBox.shrink.
 class PepitesCarousel extends ConsumerWidget {
-  const PepitesCarousel({super.key});
+  final bool alwaysVisible;
+
+  const PepitesCarousel({super.key, this.alwaysVisible = false});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
-    final asyncPepites = ref.watch(pepitesProvider);
+    final asyncPepites = alwaysVisible
+        ? ref.watch(pepitesAlwaysProvider)
+        : ref.watch(pepitesProvider);
 
     return asyncPepites.when(
       data: (sources) {
@@ -66,9 +70,11 @@ class PepitesCarousel extends ConsumerWidget {
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
-                _DismissButton(
-                  onPressed: () => ref.read(pepitesProvider.notifier).dismiss(),
-                ),
+                if (!alwaysVisible)
+                  _DismissButton(
+                    onPressed: () =>
+                        ref.read(pepitesProvider.notifier).dismiss(),
+                  ),
               ],
             ),
           ),

--- a/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
@@ -11,6 +11,7 @@ import '../../my_interests/providers/user_sources_state_provider.dart';
 import '../models/smart_search_result.dart';
 import '../models/source_model.dart';
 import '../providers/sources_providers.dart';
+import 'catalog_sources_strip.dart';
 import 'community_gems_strip.dart';
 import 'example_chips.dart';
 import 'smart_search_field.dart';
@@ -427,13 +428,16 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
         ],
         ExampleChips(onTap: _onExampleTap),
         const SizedBox(height: FacteurSpacing.space8),
-        if (widget.showCommunityGems)
+        if (widget.showCommunityGems) ...[
           CommunityGemsStrip(
             onSourceTap: _showSourceModal,
             onGemTap: (sourceId) {
               ref.read(analyticsServiceProvider).trackAddSourceGemTap(sourceId);
             },
           ),
+          const SizedBox(height: FacteurSpacing.space4),
+          CatalogSourcesStrip(onSourceTap: _showSourceModal),
+        ],
       ],
     );
   }

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -73,7 +73,7 @@ class SourceDetailModal extends ConsumerWidget {
                       padding: const EdgeInsets.symmetric(
                           horizontal: 8, vertical: 4),
                       decoration: BoxDecoration(
-                        color: source.getBiasColor().withOpacity(0.1),
+                        color: source.getBiasColor().withValues(alpha: 0.1),
                         borderRadius: BorderRadius.circular(8),
                       ),
                       child: Text(
@@ -123,7 +123,7 @@ class SourceDetailModal extends ConsumerWidget {
             decoration: BoxDecoration(
               color: colors.backgroundSecondary,
               borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: colors.textTertiary.withOpacity(0.2)),
+              border: Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
             ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -169,7 +169,7 @@ class SourceDetailModal extends ConsumerWidget {
               decoration: BoxDecoration(
                 color: colors.backgroundSecondary,
                 borderRadius: BorderRadius.circular(16),
-                border: Border.all(color: colors.textTertiary.withOpacity(0.2)),
+                border: Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
               ),
               child: Row(
                 children: [
@@ -205,7 +205,7 @@ class SourceDetailModal extends ConsumerWidget {
               decoration: BoxDecoration(
                 color: colors.backgroundSecondary,
                 borderRadius: BorderRadius.circular(16),
-                border: Border.all(color: colors.textTertiary.withOpacity(0.2)),
+                border: Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -257,7 +257,7 @@ class SourceDetailModal extends ConsumerWidget {
             decoration: BoxDecoration(
               color: colors.surface,
               borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: colors.textTertiary.withOpacity(0.2)),
+              border: Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
             ),
             child: Text(
               source.description ??
@@ -451,7 +451,7 @@ class SourceDetailModal extends ConsumerWidget {
       decoration: BoxDecoration(
         color: colors.backgroundSecondary,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: colors.textTertiary.withOpacity(0.2)),
+        border: Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -190,6 +190,7 @@ async def get_trending_sources(
 @router.get("/pepites", response_model=list[SourceResponse])
 async def get_pepites(
     limit: int = 4,
+    force_show: bool = False,
     user_id: str = Depends(get_current_user_id),
     db: AsyncSession = Depends(get_db),
 ) -> list[SourceResponse]:
@@ -199,8 +200,10 @@ async def get_pepites(
     (rate-limité ou dismiss récent).
     """
     service = PepiteService(db)
-    sources = await service.get_pepites_for_user(user_id, limit=limit)
-    if sources:
+    sources = await service.get_pepites_for_user(
+        user_id, limit=limit, force_show=force_show
+    )
+    if sources and not force_show:
         await db.commit()
     return sources
 

--- a/packages/api/app/services/pepite_service.py
+++ b/packages/api/app/services/pepite_service.py
@@ -99,7 +99,7 @@ class PepiteService:
         return created
 
     async def get_pepites_for_user(
-        self, user_id: str, limit: int = 4
+        self, user_id: str, limit: int = 4, force_show: bool = False
     ) -> list[SourceResponse]:
         """Retourne jusqu'à `limit` sources pépites pour l'utilisateur.
 
@@ -108,7 +108,7 @@ class PepiteService:
         user_uuid = UUID(user_id)
         personalization = await self._load_personalization(user_uuid)
 
-        if not self._is_eligible(personalization):
+        if not force_show and not self._is_eligible(personalization):
             return []
 
         followed_ids = await self._user_followed_source_ids(user_uuid)
@@ -162,9 +162,12 @@ class PepiteService:
         if not selected:
             return []
 
-        personalization = await self._ensure_personalization(user_uuid, personalization)
-        personalization.pepite_carousel_last_shown_at = _now()
-        await self.db.flush()
+        if not force_show:
+            personalization = await self._ensure_personalization(
+                user_uuid, personalization
+            )
+            personalization.pepite_carousel_last_shown_at = _now()
+            await self.db.flush()
 
         return [
             SourceResponse(

--- a/packages/api/tests/services/test_pepite_service.py
+++ b/packages/api/tests/services/test_pepite_service.py
@@ -169,6 +169,36 @@ class TestSelection:
         assert results == []
 
     @pytest.mark.asyncio
+    async def test_force_show_bypasses_cool_down_without_touching_last_shown(self):
+        session = AsyncMock()
+        old_last_shown = _now() - timedelta(hours=1)
+        src = _mk_source(name="Forced")
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=old_last_shown,
+            pepite_carousel_dismissed_at=_now() - timedelta(days=1),
+            muted_sources=[],
+        )
+        session.scalar = AsyncMock(return_value=perso)
+        session.flush = AsyncMock()
+
+        followed_result = MagicMock()
+        followed_result.scalars.return_value.all.return_value = []
+        interests_result = MagicMock()
+        interests_result.all.return_value = []
+        sources_result = MagicMock()
+        sources_result.all.return_value = [(src, 0)]
+        session.execute = AsyncMock(
+            side_effect=[followed_result, interests_result, sources_result]
+        )
+
+        service = PepiteService(session)
+        results = await service.get_pepites_for_user(str(uuid4()), force_show=True)
+
+        assert [r.name for r in results] == ["Forced"]
+        assert perso.pepite_carousel_last_shown_at == old_last_shown
+        session.flush.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_excludes_followed_and_muted(self):
         session = AsyncMock()
         user_id = uuid4()


### PR DESCRIPTION
## Quoi

- **`CatalogSourcesStrip`** (nouveau) : catalogue des sources curées par thème, collapsible, filtres chips, tap → modal détail
- **`SourcesScreen` refonte** : section Favoris filtrée sur les sources visibles (merge reorder partiel), sections Premium/Suivies/Masquées avec Material InkWell + caret animé ; `PepitesCarousel` intégré ; états vides dédiés (`_NoFollowedSourcesBlock`, `_NoSourcesMatchBlock`)
- **`source_detail_modal`** : revert du `DraggableScrollableSheet` ajouté par l'agent précédent — le bouton « Connecter mon abonnement » est à nouveau visible (condition `!isMuted &&` incorrecte supprimée) ; migration `withOpacity → withValues`
- **`sourceThemeFilters`** (nouveau model) : centralise la liste des thèmes, supprime le doublon inline dans `SourcesScreen`
- **Backend** : `PepiteService` + `routers/sources.py` — ajustements mineurs de format/tests

## Pourquoi

La page Sources manquait d'un catalogue navigable par thème. Le bouton d'association d'abonnement premium avait disparu suite à une condition `!isMuted` incorrecte ajoutée lors d'un refactor scroll.

## Comment ça a été vérifié

- [x] `flutter test test/features/sources/` — 56/56 tests OK
- [x] `flutter analyze lib/features/sources/` — 0 erreur, 0 warning dans les fichiers touchés
- [x] `pytest tests/services/test_pepite_service.py` — 20/20 OK
- [x] `/simplify` passé : sorts redondants supprimés, `_buildSourceItem` dé-dupliqué (N watches → 1), `SourceLogoAvatar` réutilisé dans le catalogue, `_compareByThemeThenName` rendu static

## Zones à risque

- `_SourceFavoritesSection` : la logique de merge partiel (reorder des favoris visibles dans la liste complète) est dans le callback UI — fonctionnel mais à terme déplacer dans le notifier
- `source_detail_modal` : retour à `Container` (sans scroll) ; si le contenu déborde sur très petits écrans, un `SingleChildScrollView` peut être ajouté sans DraggableScrollableSheet