### PR TITLE
feat(flux-continu): UI section-passage tuning

### DIFF
--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -47,8 +47,7 @@ const String _kVeilleIllustration = 'assets/notifications/facteur_veille.png';
 /// Blurbs rendered under each section title.
 const String _kEssentielBlurb =
     "L'essentiel des actus les plus couvertes en France aujourd'hui, en privilégiant tes sources.";
-const String _kActusDuJourBlurb =
-    'Les actus les plus couvertes du jour en France, regroupées par sujet.';
+const String _kActusDuJourBlurb = 'Les sujets les + couverts en France.';
 const String _kBonnesBlurb = 'Un peu de douceur...';
 
 /// Hard cap on the number of favorite theme sections rendered in the tournée.

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -3,7 +3,7 @@ import 'dart:math' as math;
 import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform;
+    show ValueListenable, defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -54,6 +54,12 @@ const double _kStickyThreshold = 60.0;
 /// couple px of slack.
 const double _kStickyBarHeight = 54.0;
 
+/// Section-passage affordance tuning. The visual marker carries the extra
+/// breathing room; the attraction only corrects tiny near-boundary drifts.
+const double _kPassageSlowScrollDeltaPx = 14.0;
+const double _kPassageAttractMaxPx = 42.0;
+const double _kPassageAttractMinPx = 2.0;
+
 /// Minimum delta (px) before the scroll-up FAB toggles, to avoid flicker
 /// on tiny inertia bounces. Matches the legacy FeedScreen behaviour.
 const double _kScrollDirThreshold = 12.0;
@@ -69,10 +75,14 @@ const double _kPullHintMinDepthPx = 800.0;
 /// Onglets sticky des deux cartes virtuelles. Accents repris tels quels de
 /// chaque carte : ocre/ambre signature de La Grille pour « Mot du jour », brun
 /// chaud du tampon de [CitationDuJourCard] pour « Citation du jour ».
-const _motDuJourTab =
-    StickyTab(label: 'Mot du jour', accent: GrilleConstants.presentTile);
-const _citationTab =
-    StickyTab(label: 'Citation du jour', accent: CitationDuJourCard.stampColor);
+const _motDuJourTab = StickyTab(
+  label: 'Mot du jour',
+  accent: GrilleConstants.presentTile,
+);
+const _citationTab = StickyTab(
+  label: 'Citation du jour',
+  accent: CitationDuJourCard.stampColor,
+);
 
 class FluxContinuScreen extends ConsumerStatefulWidget {
   const FluxContinuScreen({super.key});
@@ -87,6 +97,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   final ValueNotifier<bool> _stickyVisible = ValueNotifier(false);
   final ValueNotifier<double> _scrollProgress = ValueNotifier(0);
   final ValueNotifier<int> _activeIndex = ValueNotifier(0);
+  final ValueNotifier<_SectionPassagePulse?> _sectionPassagePulse =
+      ValueNotifier(null);
 
   final List<GlobalKey> _sectionKeys = [];
 
@@ -124,6 +136,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
 
   bool _showScrollTopFab = false;
   double _lastScrollPos = 0;
+  double _lastPassageScrollPos = 0;
+  double _lastPassageScrollDeltaAbs = double.infinity;
+  int _passagePulseSequence = 0;
+  bool _isPassageAttracting = false;
 
   /// Garde-fou : le flow post-onboarding (dialog customs échoués + modales
   /// thème & notifications) ne doit se jouer qu'une seule fois par montage,
@@ -157,6 +173,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     _stickyVisible.dispose();
     _scrollProgress.dispose();
     _activeIndex.dispose();
+    _sectionPassagePulse.dispose();
     _pullHintTimer?.cancel();
     super.dispose();
   }
@@ -165,6 +182,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     if (!_scroll.hasClients) return;
     final pos = _scroll.position;
     final currentScroll = pos.pixels;
+    _lastPassageScrollDeltaAbs = (currentScroll - _lastPassageScrollPos).abs();
+    _lastPassageScrollPos = currentScroll;
     final showSticky = currentScroll > _kStickyThreshold;
     if (_stickyVisible.value != showSticky) {
       _stickyVisible.value = showSticky;
@@ -283,9 +302,67 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       // layout / top-of-page scroll, before the sticky is even revealed.
       if (_stickyVisible.value) {
         unawaited(HapticFeedback.selectionClick());
+        _pulsePassageForStickyIndex(activeAt);
+        unawaited(_maybeAttractToActiveSection(activeAt));
       }
       _activeIndex.value = activeAt;
       _alignTabsToActive(activeAt);
+    }
+  }
+
+  int _sectionIndexForStickyIndex(int stickyIndex) {
+    if (stickyIndex < 0 || stickyIndex >= _stickyEntryKeys.length) return -1;
+    final key = _stickyEntryKeys[stickyIndex];
+    for (var i = 0; i < _sectionKeys.length; i++) {
+      if (identical(_sectionKeys[i], key)) return i;
+    }
+    return -1;
+  }
+
+  void _pulsePassageForStickyIndex(int stickyIndex) {
+    final sectionIndex = _sectionIndexForStickyIndex(stickyIndex);
+    if (sectionIndex <= 0) return;
+    _sectionPassagePulse.value = _SectionPassagePulse(
+      index: sectionIndex - 1,
+      sequence: ++_passagePulseSequence,
+    );
+  }
+
+  Future<void> _maybeAttractToActiveSection(int stickyIndex) async {
+    if (_isPassageAttracting) return;
+    if (!_scroll.hasClients) return;
+    if (_lastPassageScrollDeltaAbs > _kPassageSlowScrollDeltaPx) return;
+    if (_scroll.position.userScrollDirection == ScrollDirection.idle) return;
+    final sectionIndex = _sectionIndexForStickyIndex(stickyIndex);
+    if (sectionIndex <= 0) return;
+    final targetKey = _sectionKeys[sectionIndex];
+    final ctx = targetKey.currentContext;
+    if (ctx == null) return;
+    final box = ctx.findRenderObject();
+    if (box is! RenderBox || !box.attached) return;
+    final scrollBox = _scroll.position.context.notificationContext
+        ?.findRenderObject() as RenderBox?;
+    if (scrollBox == null) return;
+    final delta = box.localToGlobal(Offset.zero, ancestor: scrollBox).dy -
+        _kStickyBarHeight;
+    if (delta.abs() < _kPassageAttractMinPx ||
+        delta.abs() > _kPassageAttractMaxPx) {
+      return;
+    }
+    final target = (_scroll.offset + delta).clamp(
+      0.0,
+      _scroll.position.maxScrollExtent,
+    );
+    _isPassageAttracting = true;
+    try {
+      unawaited(HapticFeedback.lightImpact());
+      await _scroll.animateTo(
+        target,
+        duration: const Duration(milliseconds: 230),
+        curve: Curves.easeOutQuart,
+      );
+    } finally {
+      _isPassageAttracting = false;
     }
   }
 
@@ -959,6 +1036,16 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
           ),
         );
       }
+      if (i > 0) {
+        slivers.add(
+          SliverToBoxAdapter(
+            child: _SectionPassageDot(
+              index: i - 1,
+              pulseListenable: _sectionPassagePulse,
+            ),
+          ),
+        );
+      }
       final section = state.sections[i];
       final isFavorite = _isFavoriteSection(section);
       slivers.add(
@@ -1011,6 +1098,117 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       }
     }
     return slivers;
+  }
+}
+
+class _SectionPassagePulse {
+  final int index;
+  final int sequence;
+
+  const _SectionPassagePulse({required this.index, required this.sequence});
+}
+
+class _SectionPassageDot extends StatefulWidget {
+  final int index;
+  final ValueListenable<_SectionPassagePulse?> pulseListenable;
+
+  _SectionPassageDot({
+    required this.index,
+    required this.pulseListenable,
+  }) : super(key: ValueKey('section_passage_dot_$index'));
+
+  @override
+  State<_SectionPassageDot> createState() => _SectionPassageDotState();
+}
+
+class _SectionPassageDotState extends State<_SectionPassageDot>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulseController;
+  int _lastSequence = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 360),
+    );
+    widget.pulseListenable.addListener(_onPulse);
+  }
+
+  @override
+  void didUpdateWidget(_SectionPassageDot oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.pulseListenable != widget.pulseListenable) {
+      oldWidget.pulseListenable.removeListener(_onPulse);
+      widget.pulseListenable.addListener(_onPulse);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.pulseListenable.removeListener(_onPulse);
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  void _onPulse() {
+    final pulse = widget.pulseListenable.value;
+    if (pulse == null || pulse.index != widget.index) return;
+    if (pulse.sequence == _lastSequence) return;
+    _lastSequence = pulse.sequence;
+    _pulseController
+      ..stop()
+      ..value = 0
+      ..forward();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final dotColor = context.isDarkMode
+        ? Colors.white.withValues(alpha: 0.42)
+        : Colors.black.withValues(alpha: 0.34);
+    return Semantics(
+      label: 'Passage de section',
+      child: SizedBox(
+        height: 36,
+        child: Align(
+          alignment: const Alignment(0, -0.68),
+          child: AnimatedBuilder(
+            animation: _pulseController,
+            builder: (context, _) {
+              final t = Curves.easeOutCubic.transform(_pulseController.value);
+              final scale =
+                  1 + (0.30 * (1 - (2 * t - 1).abs()).clamp(0.0, 1.0));
+              final glow = (1 - t).clamp(0.0, 1.0);
+              return Transform.scale(
+                scale: scale,
+                child: Container(
+                  width: 3.5,
+                  height: 3.5,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: dotColor.withValues(alpha: 0.76 + 0.14 * glow),
+                    boxShadow: [
+                      BoxShadow(
+                        color: dotColor.withValues(alpha: 0.13 * glow),
+                        blurRadius: 5,
+                        spreadRadius: 0.5,
+                      ),
+                    ],
+                    border: Border.all(
+                      color: colors.backgroundPrimary.withValues(alpha: 0.78),
+                      width: 0.75,
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -54,8 +54,8 @@ class FluxArticleVM {
         thumbnailUrl: article.thumbnailUrl,
         sourceName: article.source?.name ?? 'Inconnu',
         sourceLogoUrl: article.source?.logoUrl,
-        themeLabel: (article.source?.theme != null &&
-                article.source!.theme!.isNotEmpty)
+        themeLabel:
+            (article.source?.theme != null && article.source!.theme!.isNotEmpty)
             ? getTopicLabel(article.source!.theme!)
             : null,
         contentType: article.contentType,
@@ -77,7 +77,8 @@ class FluxArticleVM {
         durationSeconds: article.durationSeconds,
         publishedAt: article.publishedAt,
         isFollowedSource: article.isFollowedSource,
-        isRead: article.status == ContentStatus.consumed ||
+        isRead:
+            article.status == ContentStatus.consumed ||
             article.readingProgress > 0,
       );
     }
@@ -131,9 +132,11 @@ class _FluxContinuArticleCardState extends State<FluxContinuArticleCard> {
     // Reclaim the thumb slot when the network image fails — avoids the
     // grey/broken visual reported on many Reporterre articles (cached
     // vignettes that 404 or load empty).
-    final hasThumb = vm.thumbnailUrl != null &&
+    final hasThumb =
+        vm.thumbnailUrl != null &&
         vm.thumbnailUrl!.isNotEmpty &&
         !_thumbErrored;
+    const cardRadius = BorderRadius.all(Radius.circular(FacteurRadius.large));
 
     Widget card = Padding(
       padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
@@ -143,22 +146,25 @@ class _FluxContinuArticleCardState extends State<FluxContinuArticleCard> {
           children: [
             Material(
               color: colors.surface,
-              borderRadius: BorderRadius.circular(12),
+              borderRadius: cardRadius,
               elevation: 0,
               child: GestureDetector(
                 onLongPressStart: (_) => ArticlePreviewOverlay.show(
-                    context, articleToContent(widget.article)),
+                  context,
+                  articleToContent(widget.article),
+                ),
                 onLongPressMoveUpdate: (details) =>
                     ArticlePreviewOverlay.updateScroll(
-                        details.localOffsetFromOrigin.dy),
+                      details.localOffsetFromOrigin.dy,
+                    ),
                 onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
                 child: InkWell(
                   onTap: widget.onTap,
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: cardRadius,
                   child: Ink(
                     decoration: BoxDecoration(
                       color: colors.surface,
-                      borderRadius: BorderRadius.circular(12),
+                      borderRadius: cardRadius,
                       boxShadow: [
                         BoxShadow(
                           color: Colors.black.withValues(alpha: 0.05),
@@ -210,7 +216,8 @@ class _FluxContinuArticleCardState extends State<FluxContinuArticleCard> {
                             vm: vm,
                             colors: colors,
                             showPressReview:
-                                widget.isEssentiel && widget.pressReviewCount > 0,
+                                widget.isEssentiel &&
+                                widget.pressReviewCount > 0,
                             pressReviewCount: widget.pressReviewCount,
                             perspectiveSources: widget.perspectiveSources,
                             divergenceLevel: widget.divergenceLevel,
@@ -334,15 +341,11 @@ class _Thumbnail extends StatelessWidget {
                 // Bubble up so the parent card can drop the thumb slot
                 // entirely (next rebuild). Returning shrink keeps the
                 // current frame from flashing a placeholder.
-                WidgetsBinding.instance
-                    .addPostFrameCallback((_) => onError());
+                WidgetsBinding.instance.addPostFrameCallback((_) => onError());
                 return const SizedBox.shrink();
               },
             ),
-            if (isVideo)
-              const Center(
-                child: _VideoPlayBadge(),
-              ),
+            if (isVideo) const Center(child: _VideoPlayBadge()),
           ],
         ),
       ),
@@ -455,8 +458,7 @@ class _Footer extends StatelessWidget {
         const SizedBox(width: 6),
         separator,
         const SizedBox(width: 6),
-        Icon(PhosphorIconsRegular.clock,
-            size: 12, color: colors.textTertiary),
+        Icon(PhosphorIconsRegular.clock, size: 12, color: colors.textTertiary),
         const SizedBox(width: 3),
         Text(
           _publishedAtShort(vm.publishedAt),
@@ -522,11 +524,7 @@ class _SourceDot extends StatelessWidget {
         color: accent,
         shape: BoxShape.circle,
         boxShadow: [
-          BoxShadow(
-            color: ringColor,
-            spreadRadius: 1.5,
-            blurRadius: 0,
-          ),
+          BoxShadow(color: ringColor, spreadRadius: 1.5, blurRadius: 0),
         ],
       ),
       child: hasLogo
@@ -553,8 +551,9 @@ class _Initial extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final trimmed = name.trim();
-    final initial =
-        trimmed.isEmpty ? '?' : trimmed.characters.first.toUpperCase();
+    final initial = trimmed.isEmpty
+        ? '?'
+        : trimmed.characters.first.toUpperCase();
     return Text(
       initial,
       style: GoogleFonts.dmSans(

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -50,29 +50,51 @@ class SectionBanner extends StatelessWidget {
     this.large = false,
   });
 
+  double _trailingControlReserve() {
+    if (onTapSettings != null) return 58;
+    if (onTapFold != null) return 30;
+    return 0;
+  }
+
+  String? _displayBlurbFor(String title, String? rawBlurb) {
+    // Keep the visible copy current even when a route was opened with a stale
+    // section snapshot built before the provider constants changed.
+    if (title.trim() == 'Actus du jour') {
+      return 'Les sujets les + couverts en France.';
+    }
+    return rawBlurb;
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final hasBlurb = blurb != null && blurb!.trim().isNotEmpty;
+    final effectiveBlurb = _displayBlurbFor(title, blurb);
+    final hasBlurb = effectiveBlurb != null && effectiveBlurb.trim().isNotEmpty;
     // `width: double.infinity` is required because the parent SectionBlock
     // Column uses `CrossAxisAlignment.start`, which would otherwise size
     // this Container to its intrinsic width and leave parchment showing
     // past the gradient on the right.
-    // Top-only radius : the cards below the banner butt up against its
-    // bottom edge, so rounding the bottom would carve out a parchment notch.
-    const topRadius = BorderRadius.vertical(top: Radius.circular(10));
+    // Inline sections keep a top-only radius because the cards below the
+    // banner butt up against its bottom edge. The large Flâner hero stands
+    // alone, so it gets the same radius on every corner.
+    const inlineRadius = BorderRadius.vertical(
+      top: Radius.circular(FacteurRadius.large),
+    );
+    const largeRadius = BorderRadius.all(Radius.circular(FacteurRadius.large));
+    final borderRadius = large ? largeRadius : inlineRadius;
     final container = Container(
       width: double.infinity,
       margin: const EdgeInsets.fromLTRB(0, 3, 0, 5),
       // Thematic sections have no blurb — a single title line doesn't need
       // the taller editorial floor, so we drop it to keep the scroll tight.
-      // The `large` page-hero variant gets a taller floor to breathe.
+      // The `large` page-hero variant gets a taller floor to breathe, while
+      // content can still grow naturally when title/blurb wrap.
       constraints: BoxConstraints(
-        minHeight: hasBlurb ? (large ? 120 : 78) : 60,
+        minHeight: hasBlurb ? (large ? 140 : 92) : 60,
       ),
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
-        borderRadius: topRadius,
+        borderRadius: borderRadius,
         gradient: LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
@@ -139,57 +161,69 @@ class SectionBanner extends StatelessWidget {
             // down. Add a few px of top inset on the blurb variant to match
             // the thematic dash's apparent inset.
             padding: large
-                ? const EdgeInsets.fromLTRB(22, 16, 16, 16)
-                : EdgeInsets.fromLTRB(20, hasBlurb ? 14 : 8, 14, hasBlurb ? 12 : 9),
+                ? const EdgeInsets.fromLTRB(22, 24, 16, 20)
+                : EdgeInsets.fromLTRB(
+                    20,
+                    hasBlurb ? 20 : 8,
+                    14,
+                    hasBlurb ? 14 : 9,
+                  ),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      _AccentDash(accent: accent, large: large),
-                      Padding(
-                        padding: EdgeInsets.only(
-                          top: 2,
-                          bottom: hasBlurb ? 4 : 0,
-                        ),
-                        child: Text.rich(
-                          TextSpan(
-                            text: title,
-                            children: onTapFavorite == null
-                                ? null
-                                : <InlineSpan>[
-                                    const TextSpan(text: '  '),
-                                    WidgetSpan(
-                                      alignment: PlaceholderAlignment.middle,
-                                      child: _FavoriteStar(
-                                        color: colors.primary,
-                                        onTap: onTapFavorite!,
+                  child: Padding(
+                    padding: EdgeInsets.only(
+                      right: illustrationAsset == null
+                          ? _trailingControlReserve()
+                          : 0,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        _AccentDash(accent: accent, large: large),
+                        Padding(
+                          padding: EdgeInsets.only(
+                            top: 2,
+                            bottom: hasBlurb ? (large ? 10 : 8) : 0,
+                          ),
+                          child: Text.rich(
+                            TextSpan(
+                              text: title,
+                              children: onTapFavorite == null
+                                  ? null
+                                  : <InlineSpan>[
+                                      const TextSpan(text: '  '),
+                                      WidgetSpan(
+                                        alignment: PlaceholderAlignment.middle,
+                                        child: _FavoriteStar(
+                                          color: colors.primary,
+                                          onTap: onTapFavorite!,
+                                        ),
                                       ),
-                                    ),
-                                  ],
-                            style: GoogleFonts.fraunces(
-                              fontSize: large ? 28 : 20,
-                              fontWeight: FontWeight.w700,
-                              height: 1.06,
-                              letterSpacing: -0.4,
-                              color: colors.textPrimary,
+                                    ],
+                              style: GoogleFonts.fraunces(
+                                fontSize: large ? 28 : 20,
+                                fontWeight: FontWeight.w700,
+                                height: large ? 1.12 : 1.08,
+                                letterSpacing: -0.4,
+                                color: colors.textPrimary,
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                      if (hasBlurb)
-                        Text(
-                          blurb!,
-                          style: GoogleFonts.dmSans(
-                            fontSize: large ? 14 : 12,
-                            height: 1.35,
-                            color: colors.textSecondary,
+                        if (hasBlurb)
+                          Text(
+                            effectiveBlurb,
+                            style: GoogleFonts.dmSans(
+                              fontSize: large ? 14 : 12,
+                              height: large ? 1.42 : 1.36,
+                              color: colors.textSecondary,
+                            ),
                           ),
-                        ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
                 if (illustrationAsset != null) ...[
@@ -234,7 +268,7 @@ class SectionBanner extends StatelessWidget {
       color: Colors.transparent,
       child: InkWell(
         onTap: onTapFold,
-        borderRadius: topRadius,
+        borderRadius: borderRadius,
         splashColor: accent.withValues(alpha: 0.08),
         highlightColor: accent.withValues(alpha: 0.04),
         child: container,

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -238,13 +238,12 @@ class _Tab extends StatelessWidget {
 
 /// Felt-tip "surligneur" stroke painted behind a tab label. Reads as a
 /// hand-drawn highlighter pass rather than a flat rounded chip :
-/// - a band covering only the lower ~66 % of the text height, anchored to the
+/// - a band covering only the lower ~62 % of the text height, anchored to the
 ///   baseline so ascenders/descenders peek out,
-/// - a slight ~-2° tilt,
-/// - uneven rounded caps (leading tighter, trailing longer) for the
-///   "movement / manual trace" feel,
-/// - reduced opacity (0.16) with a second translucent pass (0.10) layered near
-///   the baseline to build up the felt density.
+/// - a slight ~-1.2° tilt,
+/// - softly uneven rounded caps for the "movement / manual trace" feel,
+/// - reduced opacity (0.13) with a second translucent pass (0.07) layered near
+///   the baseline to keep the felt density restrained.
 class _MarkerHighlight extends CustomPainter {
   final Color color;
 
@@ -253,36 +252,38 @@ class _MarkerHighlight extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     if (size.width <= 0 || size.height <= 0) return;
-    final bandHeight = size.height * 0.66;
+    final bandHeight = size.height * 0.62;
     final top = size.height - bandHeight; // anchored to the baseline
     final rect = Rect.fromLTWH(0, top, size.width, bandHeight);
 
     canvas.save();
     // Tilt around the band centre so the whole stroke leans slightly.
     canvas.translate(size.width / 2, size.height / 2);
-    canvas.rotate(-2 * math.pi / 180);
+    canvas.rotate(-1.2 * math.pi / 180);
     canvas.translate(-size.width / 2, -size.height / 2);
 
-    // Uneven caps: leading (left) tighter, trailing (right) longer/rounder.
+    // Uneven caps, kept subtle so the marker feels hand-drawn but steady.
     final base = RRect.fromRectAndCorners(
       rect,
-      topLeft: Radius.circular(bandHeight * 0.32),
-      bottomLeft: Radius.circular(bandHeight * 0.28),
-      topRight: Radius.circular(bandHeight * 0.55),
-      bottomRight: Radius.circular(bandHeight * 0.62),
+      topLeft: Radius.circular(bandHeight * 0.38),
+      bottomLeft: Radius.circular(bandHeight * 0.36),
+      topRight: Radius.circular(bandHeight * 0.48),
+      bottomRight: Radius.circular(bandHeight * 0.52),
     );
-    canvas.drawRRect(base, Paint()..color = color.withValues(alpha: 0.16));
+    canvas.drawRRect(base, Paint()..color = color.withValues(alpha: 0.13));
 
     // Second pass, inset toward the baseline, adds the denser felt core.
     final core = Rect.fromLTWH(
-      rect.left + size.width * 0.05,
+      rect.left + size.width * 0.06,
       rect.top + bandHeight * 0.30,
-      size.width * 0.90,
-      bandHeight * 0.70,
+      size.width * 0.88,
+      bandHeight * 0.66,
     );
-    final coreRRect =
-        RRect.fromRectAndRadius(core, Radius.circular(bandHeight * 0.4));
-    canvas.drawRRect(coreRRect, Paint()..color = color.withValues(alpha: 0.10));
+    final coreRRect = RRect.fromRectAndRadius(
+      core,
+      Radius.circular(bandHeight * 0.4),
+    );
+    canvas.drawRRect(coreRRect, Paint()..color = color.withValues(alpha: 0.07));
 
     canvas.restore();
   }


### PR DESCRIPTION
## What

Enhanced the section passage experience in Flux Continu with visual affordance markers and smart attraction behavior. Refined banner layouts and marker highlight styling for better visual polish.

## Why

Users need clearer visual feedback when navigating between feed sections. The passage marker (small dot between sections) now pulses on tab tap, and when scrolling slowly near section boundaries, the scroll automatically attracts to the next section for frictionless navigation. Layout spacing improvements enhance breathing room in banners.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)