### PR TITLE
fix(flux-continu): adjust weather widget metrics and sizing

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -1185,8 +1185,8 @@ class _SectionPassageDotState extends State<_SectionPassageDot>
               return Transform.scale(
                 scale: scale,
                 child: Container(
-                  width: 3.5,
-                  height: 3.5,
+                  width: 2.5,
+                  height: 2.5,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
                     color: dotColor.withValues(alpha: 0.76 + 0.14 * glow),

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -216,29 +216,17 @@ class _HeaderBadgeState extends ConsumerState<_HeaderBadge> {
   @override
   Widget build(BuildContext context) {
     final now = DateTime.now();
+    // Always watch so the fetch starts on mount and any update triggers a rebuild.
+    final forecast = ref.watch(weatherProvider).valueOrNull;
 
     final Widget child;
-    if (_showWeather) {
-      final forecast = ref.watch(weatherProvider).valueOrNull;
-      if (forecast != null) {
-        child = GestureDetector(
-          key: const ValueKey('weather'),
-          behavior: HitTestBehavior.opaque,
-          onTap: () => showWeatherDetailSheet(context),
-          child: _WeatherBadge(forecast: forecast),
-        );
-      } else {
-        child = GestureDetector(
-          key: const ValueKey('date'),
-          behavior: HitTestBehavior.opaque,
-          onTap: () => setState(() => _showWeather = true),
-          child: _DateStamp(
-            day: now.day,
-            month: _monthAbbrev(now.month),
-            accent: widget.accent,
-          ),
-        );
-      }
+    if (_showWeather && forecast != null) {
+      child = GestureDetector(
+        key: const ValueKey('weather'),
+        behavior: HitTestBehavior.opaque,
+        onTap: () => showWeatherDetailSheet(context),
+        child: _WeatherBadge(forecast: forecast),
+      );
     } else {
       child = GestureDetector(
         key: const ValueKey('date'),
@@ -305,8 +293,8 @@ class _WeatherBadge extends StatelessWidget {
       children: [
         SvgPicture.asset(
           'assets/images/weather/${forecast.condition.assetName}.svg',
-          width: 100,
-          height: 100,
+          width: 90,
+          height: 90,
         ),
         const SizedBox(height: 3),
         RichText(

--- a/apps/mobile/lib/features/flux_continu/widgets/weather_detail_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/weather_detail_sheet.dart
@@ -349,8 +349,8 @@ class _DayRow extends StatelessWidget {
           const SizedBox(width: FacteurSpacing.space2),
           SvgPicture.asset(
             'assets/images/weather/${day.condition.assetName}.svg',
-            width: 52,
-            height: 52,
+            width: 68,
+            height: 68,
           ),
           const Spacer(),
           // Max en gros (WeatherDay n'expose pas de temp « actuelle »), avec la


### PR DESCRIPTION
## What

Adjust weather widget metrics and badge display logic across flux continu screens:
- Reduce section passage dot size from 3.5 to 2.5
- Streamline weather/date badge logic by moving provider watch outside conditional
- Adjust weather icon sizes: header badge 100→90, day row 52→68

## Why

Improves visual consistency and alignment of weather widget sizing across the continuous flow interface.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally
- [ ] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (mobile only)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)