### PR TITLE
fix(veille): skip unresolvable niche sources + remove unused reason field

### DIFF
--- a/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
@@ -386,18 +386,6 @@ class _AngleCard extends StatelessWidget {
                               color: const Color(0xFF2C2A29),
                             ),
                           ),
-                          if (angle.reason != null &&
-                              angle.reason!.trim().isNotEmpty) ...[
-                            const SizedBox(height: 3),
-                            Text(
-                              angle.reason!,
-                              style: GoogleFonts.dmSans(
-                                fontSize: 11.5,
-                                height: 1.4,
-                                color: const Color(0xFF959392),
-                              ),
-                            ),
-                          ],
                         ],
                       ),
                     ),

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -346,7 +346,19 @@ async def upsert_config(
 
     seen_source_ids: set[UUID] = set()
     for idx, sel in enumerate(body.source_selections):
-        source_id = await _resolve_source_id(db, sel, body.theme_id)
+        try:
+            source_id = await _resolve_source_id(db, sel, body.theme_id)
+        except ValueError as exc:
+            # Source niche dont le flux RSS est introuvable au moment du save :
+            # on l'ignore au lieu de faire échouer tout l'enregistrement (PYTHON-51).
+            # detect_source lève ce ValueError AVANT toute écriture DB → on peut
+            # `continue` sans corrompre la session.
+            logger.warning(
+                "veille.niche_source_skipped",
+                url=getattr(sel.niche_candidate, "url", None),
+                error=str(exc),
+            )
+            continue
         if source_id in seen_source_ids:
             continue
         seen_source_ids.add(source_id)

--- a/packages/api/app/services/veille/llm/angle_suggester.py
+++ b/packages/api/app/services/veille/llm/angle_suggester.py
@@ -31,7 +31,7 @@ _CACHE_TTL_SECONDS = 86400  # 24h
 class AngleSuggestion:
     title: str
     keywords: list[str]
-    reason: str | None
+    reason: str | None = None
 
 
 class _LLMAngle(BaseModel):
@@ -39,7 +39,6 @@ class _LLMAngle(BaseModel):
 
     title: str = Field(min_length=1, max_length=120)
     keywords: list[str] = Field(default_factory=list, min_length=1, max_length=10)
-    reason: str | None = Field(default=None, max_length=300)
 
 
 _SYSTEM_PROMPT = """Tu es un expert en curation éditoriale francophone, spécialisé en veille thématique.
@@ -51,8 +50,7 @@ Format JSON strict :
   "angles": [
     {
       "title": "<titre court fr, 4-8 mots>",
-      "keywords": ["<mot-cle-1>", "<mot-cle-2>", "..."],
-      "reason": "<1 phrase max sur le pourquoi de cet angle>"
+      "keywords": ["<mot-cle-1>", "<mot-cle-2>", "..."]
     },
     ...
   ]
@@ -62,7 +60,6 @@ Contraintes :
 - 8 à 12 angles distincts (pas de redondance).
 - title : titre court (max 80 chars), explicite, complémentaire aux autres angles.
 - keywords : 3 à 5 mots ou expressions courtes (1-3 mots chacun), en français, en minuscules. Ce sont les mots qui doivent matcher dans les titres / descriptions des articles. Pense large (synonymes, variantes, noms propres pertinents) mais reste précis pour le sujet.
-- reason : 1 phrase max 200 chars qui explique l'intérêt de cet angle pour le thème + brief.
 - Couvre plusieurs angles complémentaires (différents axes du sujet).
 - Réponds UNIQUEMENT avec le JSON, rien d'autre."""
 
@@ -73,42 +70,34 @@ def _fallback_angles(theme_label: str) -> list[AngleSuggestion]:
         AngleSuggestion(
             title=f"Actualité {theme_label}",
             keywords=[theme_label.lower(), "actualité", "nouveau"],
-            reason=f"Suit l'actualité courante de {theme_label}",
         ),
         AngleSuggestion(
             title="Analyses de fond",
             keywords=["analyse", "enquête", "décryptage"],
-            reason="Articles long format et tribunes d'experts",
         ),
         AngleSuggestion(
             title="Innovations et nouveautés",
             keywords=["innovation", "nouveauté", "lancement"],
-            reason="Suit les évolutions récentes du domaine",
         ),
         AngleSuggestion(
             title="Débats et controverses",
             keywords=["débat", "controverse", "polémique"],
-            reason="Sujets clivants et arguments contradictoires",
         ),
         AngleSuggestion(
             title="Initiatives et bonnes pratiques",
             keywords=["initiative", "bonne pratique", "retour d'expérience"],
-            reason="Cas concrets et solutions testées",
         ),
         AngleSuggestion(
             title="Acteurs et personnalités",
             keywords=["interview", "portrait", "personnalité"],
-            reason="Les figures qui font bouger le domaine",
         ),
         AngleSuggestion(
             title="Tendances de fond",
             keywords=["tendance", "prospective", "futur"],
-            reason="Mouvements de long terme et signaux faibles",
         ),
         AngleSuggestion(
             title="Réglementation et politique",
             keywords=["réglementation", "loi", "politique"],
-            reason="Cadre légal et décisions publiques",
         ),
     ]
 
@@ -193,7 +182,7 @@ class AngleSuggester:
             AngleSuggestion(
                 title=a.title.strip(),
                 keywords=[k.strip().lower() for k in a.keywords if k.strip()],
-                reason=a.reason,
+                reason=None,
             )
             for a in parsed
         ]

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -708,6 +708,54 @@ class TestOtherThemeIngestion:
         # La source ingérée doit avoir theme='custom' (mappé depuis 'other')
         assert data["sources"][0]["source"]["theme"] == "custom"
 
+    async def test_post_config_skips_unresolvable_niche_source(
+        self, auth_user, monkeypatch
+    ):
+        """PYTHON-51 : une source niche dont le flux RSS est introuvable ne doit
+        plus faire échouer tout l'enregistrement (500) — on l'ignore, on garde le
+        reste de la veille."""
+        from app.services import source_service
+
+        async def _fake_detect(self, url):
+            raise ValueError("No RSS feed found")
+
+        monkeypatch.setattr(
+            source_service.SourceService, "detect_source", _fake_detect
+        )
+
+        payload = {
+            "theme_id": "other",
+            "theme_label": "Musées Barcelone",
+            "topics": [
+                {
+                    "topic_id": "expos",
+                    "label": "Expositions",
+                    "kind": "preset",
+                    "position": 0,
+                }
+            ],
+            "source_selections": [
+                {
+                    "kind": "niche",
+                    "niche_candidate": {
+                        "name": "Site sans flux",
+                        "url": "https://exemple-sans-rss.test",
+                        "why": None,
+                    },
+                }
+            ],
+            "keywords": [{"keyword": "vernissage", "position": 0}],
+        }
+        async with _client() as c:
+            r = await c.post("/api/veille/config", json=payload)
+
+        # Avant le fix : 500. Après : 200, source ignorée, reste persisté.
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["sources"] == []
+        assert len(data["topics"]) == 1
+        assert len(data["keywords"]) == 1
+
 
 class TestLegacyGoneShims:
     async def test_suggestions_topics_410(self, auth_user):

--- a/packages/api/tests/services/veille/test_angle_suggester.py
+++ b/packages/api/tests/services/veille/test_angle_suggester.py
@@ -46,7 +46,9 @@ async def test_suggest_angles_happy_path():
     assert len(angles) == 2
     assert angles[0].title == "Nouvelles expositions"
     assert angles[0].keywords == ["exposition", "vernissage", "macba"]
-    assert angles[0].reason == "Cible les annonces."
+    # `reason` n'est plus généré ni parsé (perf) — toujours None même si le LLM
+    # en renvoie un dans son payload.
+    assert angles[0].reason is None
     assert angles[1].reason is None
 
 


### PR DESCRIPTION
## What

Skip niche sources with unresolvable RSS feeds instead of failing the entire config save. Remove the unused 'reason' field from angle suggestions (was generated but never displayed on mobile).

## Why

PYTHON-51: When a niche source's feed URL doesn't have a detectable RSS endpoint, we previously failed the entire config save with a 500 error. This fix catches the ValueError before any DB writes and logs a warning, letting the user save the rest of their veille configuration.

The 'reason' field was generated by the LLM but never displayed in the UI, and removal saves bandwidth and LLM parsing overhead.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Maintenance / Refactor

## How it was verified

- Unit test: angle suggester test updated to assert reason is None
- Integration test added: test_post_config_skips_unresolvable_niche_source validates 200 response with source skipped
- Linting: ruff check passes on modified files