### PR TITLE
feat(flux-continu): snap d'ancrage section-par-section sur le fling

### DIFF
--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,73 +1,72 @@
-# QA Handoff — Allègement Couverture médiatique
+# QA Handoff — Snap d'ancrage « section par section » (L'Essentiel / flux-continu)
 
 ## Feature développée
-
-Allègement visuel de la section inline « Couverture médiatique » dans le reader
-article : état vide plus discret, badge de polarisation, explication du
-surlignage derrière un bouton info, analyse remontée, disclaimer Mistral Large,
-suppression du bloc « CET ARTICLE », et wash du pivot sur le titre de l'article.
+Remplacement du demi-snap intermittent de #772 par un **snap d'ancrage** intégré à la
+phase balistique du fling : au lâcher du doigt, une `ScrollPhysics` custom choisit une
+position de repos alignée sur le **début d'une section** (sous la sticky bar), sur geste
+lent **et** rapide (déclenchement constant, non gaté en vitesse), avec une haptique
+`mediumImpact` **au repos**. Scroll libre dedans ; sections hautes (carte Essentiel hi-fi)
+laissées libres.
 
 ## PR associée
-
-Non créée.
+À créer via `/go` (base `main`). Branche : `boujonlaurin-dotcom/essentiel-scroll-snap-ux`.
 
 ## Écrans impactés
-
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| Reader article | Détail contenu interne | Modifié |
-| Reader article alternatif | Second path de rendu détail contenu | Modifié |
-| Bottom sheet perspectives | Couverture médiatique | Modifié via zone analyse partagée |
+| L'Essentiel (flux continu) | onglet Essentiel | Modifié (physique de scroll) |
 
 ## Scénarios de test
 
-### Scénario 1 : État vide
+### Scénario 1 : Flick lent sur une frontière (happy path)
 **Parcours** :
-1. Ouvrir un article dont l'API perspectives ne renvoie aucune autre source.
-2. Observer la section « Couverture médiatique (0) ».
-**Résultat attendu** : le placeholder est discret, sans dividers pleine largeur
-au-dessus/en dessous, avec texte plus petit et atténué, sans caret ni spectrum.
+1. Aller sur L'Essentiel, scroller jusqu'à voir la sticky bar.
+2. Faire un petit flick lent près d'une frontière de section.
+**Résultat attendu** : le début de la section voisine se cale sous la sticky bar (snap
+ferme), **une** haptique medium nette au moment où ça se pose. Pas de rubber-band.
 
-### Scénario 2 : Section ouverte avec perspectives
+### Scénario 2 : Fling fort sur plusieurs sections
 **Parcours** :
-1. Ouvrir un article avec plusieurs perspectives.
-2. Déplier « Couverture médiatique ».
-3. Observer le haut de la section.
-**Résultat attendu** : la balise polarisation apparaît si niveau `medium` ou
-`high`, le bouton info ouvre le texte de surlignage, l'analyse est au-dessus des
-titres variants, et le bloc « CET ARTICLE » n'apparaît plus.
+1. Faire un fling appuyé qui traverse plusieurs sections.
+**Résultat attendu** : atterrit aligné sur un **début** de section (jamais au milieu d'une
+carte), **une seule** haptique au repos (pas de buzz par section traversée).
 
-### Scénario 3 : Analyse Facteur
+### Scénario 3 : Lecture dans la carte Essentiel hi-fi (section haute)
 **Parcours** :
-1. Dans une section ouverte, lancer ou afficher l'analyse Facteur.
-2. Lire la mention sous l'analyse.
-**Résultat attendu** : la mention affiche « Analyse générée par Mistral Large ·
-l'IA peut faire des erreurs. ».
+1. Scroller dans la grande carte Essentiel et s'arrêter au milieu.
+**Résultat attendu** : on peut s'arrêter **au milieu** — pas piégé/ramené à une ancre
+(garde « section haute » : atterrissage > 0,5 × viewport d'une ancre ⇒ scroll libre).
 
-### Scénario 4 : Wash pivot titre reader
+### Scénario 4 : Près du haut (pull-to-refresh)
 **Parcours** :
-1. Ouvrir un article avec `reference_pivot`.
-2. Déplier la section « Couverture médiatique ».
-**Résultat attendu** : le pivot du titre de l'article reçoit un wash gris léger à
-l'ouverture, sans ajouter de bloc référence dans la section.
+1. Remonter tout en haut, tirer pour rafraîchir.
+**Résultat attendu** : pull-to-refresh OK, **aucun** snap parasite dans la zone
+header/bannières (bail si `pixels <= première ancre`).
+
+### Scénario 5 : Highlight onglet + pulse du dot
+**Parcours** :
+1. Scroller section par section en observant la sticky bar.
+**Résultat attendu** : l'onglet actif se met à jour, le dot de passage pulse, **pas de
+double-buzz** (le `selectionClick` est supprimé pendant un snap, remplacé par le settle
+medium).
 
 ## Critères d'acceptation
-
-- [ ] État vide nettement moins chargé.
-- [ ] Section ouverte hiérarchisée : badge/info puis analyse puis variantes.
-- [ ] Disclaimer IA visible sous l'analyse.
-- [ ] Aucun rendu « CET ARTICLE ».
-- [ ] Wash pivot visible sur le titre du reader à l'ouverture.
-- [ ] Console sans erreur et pas de 4xx/5xx perspectives inattendus.
+- [ ] Le snap se sent **et** cadre tout le scroll (déclenchement constant lent + rapide).
+- [ ] Le snap fait partie de la décélération du fling (une seule motion, pas une 2e anim).
+- [ ] Haptique medium **au repos** du snap, jamais doublée.
+- [ ] Sections hautes / atterrissages loin d'une ancre laissés libres (lecture préservée).
+- [ ] Pull-to-refresh intact, aucun snap dans la zone header.
+- [ ] `flutter analyze` propre, tests `section_snap_test.dart` verts.
 
 ## Zones de risque
-
-- Les deux chemins de rendu du reader doivent rester cohérents.
-- Le bouton info doit rester tappable en viewport mobile 390x844.
-- Le titre reader ne doit pas changer de hauteur de façon visible au moment du
-  wash.
+- **iOS vs Android** : `naturalLanding` dérive du parent plateforme (Bouncing/Clamping) →
+  feel natif préservé, mais tuner `kSnapCaptureFraction` par plateforme si besoin.
+- **Ancres lazy/hors-écran** : `localToGlobal` ne résout que les boxes attachées ; slivers
+  non-lazy ici → bail gracieux si une ancre n'est pas montée cette frame.
+- **Carte Essentiel hi-fi** : re-vérifier spécifiquement qu'on n'est jamais piégé dedans.
 
 ## Dépendances
-
-Pas de changement backend. Le wash dépend du champ API existant
-`reference_pivot`.
+Aucune (mobile-only, zéro backend / API). 4 knobs de tuning regroupés dans
+`apps/mobile/lib/features/flux_continu/utils/section_snap.dart`
+(`kSnapCaptureFraction`, `kBoundaryCrossVelocity`, `kSnapEpsilon`, `kSnapSpring`) pour
+ajustement device au feeling.

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -32,6 +32,7 @@ import '../../../shared/strings/loader_error_strings.dart';
 import '../../../shared/widgets/loaders/loading_view.dart';
 import '../models/flux_continu_models.dart';
 import '../providers/flux_continu_provider.dart';
+import '../utils/section_snap.dart';
 import '../widgets/citation_du_jour_card.dart';
 import '../widgets/closing_card_v18.dart';
 import '../widgets/flux_continu_article_card.dart';
@@ -54,11 +55,10 @@ const double _kStickyThreshold = 60.0;
 /// couple px of slack.
 const double _kStickyBarHeight = 54.0;
 
-/// Section-passage affordance tuning. The visual marker carries the extra
-/// breathing room; the attraction only corrects tiny near-boundary drifts.
-const double _kPassageSlowScrollDeltaPx = 14.0;
-const double _kPassageAttractMaxPx = 42.0;
-const double _kPassageAttractMinPx = 2.0;
+// Section-snap tuning lives in `utils/section_snap.dart` (kSnapCaptureFraction,
+// kBoundaryCrossVelocity, kSnapEpsilon, kSnapSpring) so the resting-position
+// arithmetic stays a pure, unit-testable function. The snap itself is woven
+// into the fling's ballistic phase by [_SectionSnapPhysics] below.
 
 /// Minimum delta (px) before the scroll-up FAB toggles, to avoid flicker
 /// on tiny inertia bounces. Matches the legacy FeedScreen behaviour.
@@ -136,10 +136,22 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
 
   bool _showScrollTopFab = false;
   double _lastScrollPos = 0;
-  double _lastPassageScrollPos = 0;
-  double _lastPassageScrollDeltaAbs = double.infinity;
   int _passagePulseSequence = 0;
-  bool _isPassageAttracting = false;
+
+  /// Mutable, stable holder of the section-start anchors (absolute scroll
+  /// pixels). Passed *by reference* to the immutable [_SectionSnapPhysics],
+  /// which reads it live — the physics is rebuilt every frame and must never
+  /// own a copy. Recomputed only on layout/content changes (sections don't
+  /// resize mid-session), never per scroll frame.
+  final _SnapAnchors _snapAnchors = _SnapAnchors();
+  bool _snapAnchorsRecomputeScheduled = false;
+
+  /// A section snap is in flight (its ballistic spring is settling). While set,
+  /// the per-section `selectionClick` tick is suppressed so the medium settle
+  /// haptic isn't doubled. The settle haptic itself is deferred to the
+  /// [ScrollEndNotification] via [_pendingSnapHaptic].
+  bool _isSnapping = false;
+  bool _pendingSnapHaptic = false;
 
   /// Garde-fou : le flow post-onboarding (dialog customs échoués + modales
   /// thème & notifications) ne doit se jouer qu'une seule fois par montage,
@@ -182,8 +194,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     if (!_scroll.hasClients) return;
     final pos = _scroll.position;
     final currentScroll = pos.pixels;
-    _lastPassageScrollDeltaAbs = (currentScroll - _lastPassageScrollPos).abs();
-    _lastPassageScrollPos = currentScroll;
     final showSticky = currentScroll > _kStickyThreshold;
     if (_stickyVisible.value != showSticky) {
       _stickyVisible.value = showSticky;
@@ -300,10 +310,13 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       // Discrete "selection" tick when the active tab flips section under the
       // sticky bar. Gated on visibility so we don't buzz during the initial
       // layout / top-of-page scroll, before the sticky is even revealed.
+      // Suppressed while a snap is settling: the medium settle haptic owns the
+      // boundary crossing, so we don't double-buzz.
       if (_stickyVisible.value) {
-        unawaited(HapticFeedback.selectionClick());
+        if (!_isSnapping) {
+          unawaited(HapticFeedback.selectionClick());
+        }
         _pulsePassageForStickyIndex(activeAt);
-        unawaited(_maybeAttractToActiveSection(activeAt));
       }
       _activeIndex.value = activeAt;
       _alignTabsToActive(activeAt);
@@ -328,42 +341,80 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     );
   }
 
-  Future<void> _maybeAttractToActiveSection(int stickyIndex) async {
-    if (_isPassageAttracting) return;
-    if (!_scroll.hasClients) return;
-    if (_lastPassageScrollDeltaAbs > _kPassageSlowScrollDeltaPx) return;
-    if (_scroll.position.userScrollDirection == ScrollDirection.idle) return;
-    final sectionIndex = _sectionIndexForStickyIndex(stickyIndex);
-    if (sectionIndex <= 0) return;
-    final targetKey = _sectionKeys[sectionIndex];
-    final ctx = targetKey.currentContext;
-    if (ctx == null) return;
-    final box = ctx.findRenderObject();
-    if (box is! RenderBox || !box.attached) return;
+  /// Called by [_SectionSnapPhysics] the instant a ballistic simulation is
+  /// built: `true` when it chose a section-anchored spring, `false` for a free
+  /// (natural) fling. Plain flag writes — runs during the physics phase, never
+  /// touches `setState`.
+  void _setSnapping(bool snapping) {
+    _isSnapping = snapping;
+    _pendingSnapHaptic = snapping;
+  }
+
+  /// Drops a snap that is no longer reaching its settle — a driven scroll took
+  /// over, or a fresh drag interrupted it — so its deferred settle haptic does
+  /// not fire spuriously. Single seam so every non-ballistic scroll path stays
+  /// consistent (callers don't open-code the flag clears).
+  void _cancelPendingSnap() {
+    _isSnapping = false;
+    _pendingSnapHaptic = false;
+  }
+
+  /// Bridges scroll notifications to the snap haptic. The medium settle haptic
+  /// is fired at rest (not when the spring is built) so it reads as the section
+  /// "posing" under the sticky bar. A fresh drag cancels any pending settle.
+  bool _onScrollNotification(ScrollNotification n) {
+    if (n.depth != 0) return false;
+    if (n is ScrollStartNotification && n.dragDetails != null) {
+      _cancelPendingSnap();
+    } else if (n is ScrollEndNotification) {
+      if (_pendingSnapHaptic) {
+        _pendingSnapHaptic = false;
+        unawaited(HapticFeedback.mediumImpact());
+      }
+      _isSnapping = false;
+    }
+    return false;
+  }
+
+  /// Recomputes the section-start anchors from current layout. Each anchor is
+  /// the absolute scroll offset that would bring a sticky entry's top flush
+  /// under the sticky bar — identical maths to [_scrollToSection]. Offset-
+  /// invariant (we add `_scroll.offset` back), so it is safe to run mid-scroll.
+  void _recomputeSnapAnchors() {
+    if (!_scroll.hasClients) {
+      _snapAnchors.values = const [];
+      return;
+    }
     final scrollBox = _scroll.position.context.notificationContext
         ?.findRenderObject() as RenderBox?;
     if (scrollBox == null) return;
-    final delta = box.localToGlobal(Offset.zero, ancestor: scrollBox).dy -
-        _kStickyBarHeight;
-    if (delta.abs() < _kPassageAttractMinPx ||
-        delta.abs() > _kPassageAttractMaxPx) {
-      return;
+    final offset = _scroll.offset;
+    final result = <double>[];
+    for (final key in _stickyEntryKeys) {
+      final ctx = key.currentContext;
+      if (ctx == null) continue;
+      final box = ctx.findRenderObject();
+      if (box is! RenderBox || !box.attached) continue;
+      final anchor = offset +
+          (box.localToGlobal(Offset.zero, ancestor: scrollBox).dy -
+              _kStickyBarHeight);
+      result.add(anchor);
     }
-    final target = (_scroll.offset + delta).clamp(
-      0.0,
-      _scroll.position.maxScrollExtent,
-    );
-    _isPassageAttracting = true;
-    try {
-      unawaited(HapticFeedback.lightImpact());
-      await _scroll.animateTo(
-        target,
-        duration: const Duration(milliseconds: 230),
-        curve: Curves.easeOutQuart,
-      );
-    } finally {
-      _isPassageAttracting = false;
-    }
+    result.sort();
+    _snapAnchors.values = result;
+  }
+
+  /// Defers an anchor recompute to the next post-frame (when layout is settled),
+  /// coalescing the bursts of builds that fold/expand/content changes produce
+  /// into a single pass. Never runs per scroll frame.
+  void _scheduleAnchorRecompute() {
+    if (_snapAnchorsRecomputeScheduled) return;
+    _snapAnchorsRecomputeScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _snapAnchorsRecomputeScheduled = false;
+      if (!mounted) return;
+      _recomputeSnapAnchors();
+    });
   }
 
   void _alignTabsToActive(int index) {
@@ -411,6 +462,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       0.0,
       _scroll.position.maxScrollExtent,
     );
+    // Driven scroll, not ballistic → clear any snap that was still in flight so
+    // its settle haptic doesn't fire at the end of this animation.
+    _cancelPendingSnap();
     await _scroll.animateTo(
       target,
       duration: const Duration(milliseconds: 700),
@@ -420,6 +474,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
 
   Future<void> _scrollToTop() async {
     if (!_scroll.hasClients) return;
+    _cancelPendingSnap();
     unawaited(HapticFeedback.lightImpact());
     _markSectionsAboveAsScrolledPast(null);
     await _scroll.animateTo(
@@ -763,6 +818,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     // Source unique : aligne [_sectionKeys] + [_stickyEntryKeys] sur les slivers
     // et dérive les descripteurs d'onglets (label+accent), dans le même ordre.
     final stickyTabs = _syncStickyEntries(state.valueOrNull, grillePresent);
+    // Sections don't resize mid-session (folds defer to next launch), so we
+    // refresh the snap anchors only on these content/layout-driven rebuilds —
+    // never per scroll frame.
+    _scheduleAnchorRecompute();
     return Scaffold(
       backgroundColor: context.facteurColors.backgroundPrimary,
       // Header & footer vivent dans le scaffold de page partagé :
@@ -914,91 +973,104 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     // NB : [_sectionKeys] est synchronisé en amont par [_syncStickyEntries]
     // (appelé dans build) → on s'appuie sur cet alignement ici.
 
-    return RefreshIndicator(
-      onRefresh: _handleRefresh,
-      color: colors.primary,
-      child: CustomScrollView(
-        controller: _scroll,
-        physics: const AlwaysScrollableScrollPhysics(),
-        slivers: [
-          // NB : le header (logo · streak · réglages) vit dans le scaffold de
-          // page partagé — fixe, hors du scroll.
-          SliverToBoxAdapter(
-            child: impressionSlot == FirstImpressionSlot.renudgeBanner
-                ? const NotificationRenudgeBanner()
-                : const SizedBox.shrink(),
-          ),
-          SliverToBoxAdapter(
-            child: impressionSlot == FirstImpressionSlot.wellInformed
-                ? const WellInformedPrompt()
-                : const SizedBox.shrink(),
-          ),
-          SliverToBoxAdapter(
-            child: impressionSlot == FirstImpressionSlot.geolocPrompt
-                ? const GeolocPromptBanner()
-                : const SizedBox.shrink(),
-          ),
-          const SliverToBoxAdapter(child: LettresNotificationBanner()),
-          // One SliverToBoxAdapter per section. Sections never resize during
-          // a session (folds are deferred to the next cold launch), so the
-          // simpler non-lazy adapter is sufficient and keeps the GlobalKey
-          // measurement reliable.
-          //
-          // The "Mes intérêts" intro (V10) is injected once, right before the
-          // first user-favorite theme section (`theme1` / `theme2`). The
-          // computed index handles both ordering modes (normal / sereine) by
-          // tracking the actual position of the first favorite kind.
-          // Folded sections render as individual FoldedSectionCards directly,
-          // in place — no "Tournée du jour" grouping toggle.
-          ..._buildSectionSlivers(
-            context: context,
-            state: state,
-            notifier: notifier,
-          ),
-          if (state.sections.isEmpty)
-            SliverToBoxAdapter(
-              child: _EmptySectionsHint(onRetry: notifier.refresh),
+    return NotificationListener<ScrollNotification>(
+      onNotification: _onScrollNotification,
+      child: RefreshIndicator(
+        onRefresh: _handleRefresh,
+        color: colors.primary,
+        child: CustomScrollView(
+          controller: _scroll,
+          // Section-anchored snap woven into the fling's ballistic phase. The
+          // platform parent (Bouncing/Clamping) is preserved via `applyTo`, so
+          // overscroll/pull-to-refresh feel native; the snap only chooses the
+          // resting position. AlwaysScrollable keeps the page scrollable even
+          // when content is short.
+          physics: AlwaysScrollableScrollPhysics(
+            parent: _SectionSnapPhysics(
+              anchors: _snapAnchors,
+              onSnap: _setSnapping,
             ),
-          // Citation du jour — clôture éditoriale en fin de tournée. Affichée
-          // dès qu'une citation existe et que la tournée n'est pas clôturée
-          // (`closingDismissed`) : replier la tournée ne doit pas la masquer,
-          // c'est un rituel de fin de tournée.
-          if (state.quote != null && !state.closingDismissed)
+          ),
+          slivers: [
+            // NB : le header (logo · streak · réglages) vit dans le scaffold de
+            // page partagé — fixe, hors du scroll.
             SliverToBoxAdapter(
-              child: KeyedSubtree(
-                key: _citationKey,
-                child: CitationDuJourCard(quote: state.quote!),
+              child: impressionSlot == FirstImpressionSlot.renudgeBanner
+                  ? const NotificationRenudgeBanner()
+                  : const SizedBox.shrink(),
+            ),
+            SliverToBoxAdapter(
+              child: impressionSlot == FirstImpressionSlot.wellInformed
+                  ? const WellInformedPrompt()
+                  : const SizedBox.shrink(),
+            ),
+            SliverToBoxAdapter(
+              child: impressionSlot == FirstImpressionSlot.geolocPrompt
+                  ? const GeolocPromptBanner()
+                  : const SizedBox.shrink(),
+            ),
+            const SliverToBoxAdapter(child: LettresNotificationBanner()),
+            // One SliverToBoxAdapter per section. Sections never resize during
+            // a session (folds are deferred to the next cold launch), so the
+            // simpler non-lazy adapter is sufficient and keeps the GlobalKey
+            // measurement reliable.
+            //
+            // The "Mes intérêts" intro (V10) is injected once, right before the
+            // first user-favorite theme section (`theme1` / `theme2`). The
+            // computed index handles both ordering modes (normal / sereine) by
+            // tracking the actual position of the first favorite kind.
+            // Folded sections render as individual FoldedSectionCards directly,
+            // in place — no "Tournée du jour" grouping toggle.
+            ..._buildSectionSlivers(
+              context: context,
+              state: state,
+              notifier: notifier,
+            ),
+            if (state.sections.isEmpty)
+              SliverToBoxAdapter(
+                child: _EmptySectionsHint(onRetry: notifier.refresh),
+              ),
+            // Citation du jour — clôture éditoriale en fin de tournée. Affichée
+            // dès qu'une citation existe et que la tournée n'est pas clôturée
+            // (`closingDismissed`) : replier la tournée ne doit pas la masquer,
+            // c'est un rituel de fin de tournée.
+            if (state.quote != null && !state.closingDismissed)
+              SliverToBoxAdapter(
+                child: KeyedSubtree(
+                  key: _citationKey,
+                  child: CitationDuJourCard(quote: state.quote!),
+                ),
+              ),
+            // « Le mot du jour » — récompense de fin de Tournée. Sliver additif
+            // au-dessus de ClosingCardV18 (cette dernière n'est pas modifiée :
+            // zéro régression, revert trivial). La carte se câble seule au
+            // grilleProvider et ne rend rien tant que `GET today` n'a pas répondu.
+            // Hors gate `closingDismissed` : elle reste dans le feed même après
+            // fermeture de la tournée (en état « déjà jouée »), et se masque
+            // seule (SizedBox.shrink) s'il n'y a pas de mot du jour.
+            // Grille — rendue juste après « Actus du jour » (cf.
+            // _buildSectionSlivers) quand cette section existe. Fallback bas
+            // ici uniquement si le digest est absent / la liste vide, pour ne
+            // jamais perdre la Grille. Hors gate `closingDismissed`.
+            if (!hasActus) _grilleSliver,
+            // Carte « Fin de tournée » — toujours affichée (jamais masquée) : elle
+            // reste le repère de clôture même après être passé sur Flâner.
+            // « Continuer » navigue vers Flâner sans masquer la carte. « Refermer »
+            // ferme réellement l'app sur Android (SystemNavigator.pop) ; sur iOS,
+            // la fermeture programmatique est interdite → on masque le bouton et
+            // on affiche une phrase de clôture à la place.
+            SliverToBoxAdapter(
+              child: ClosingCardV18(
+                articleCount: totalArticles,
+                onContinue: () => context.go(RoutePaths.flaner),
+                onClose: isAndroid ? () => SystemNavigator.pop() : null,
+                closeHint:
+                    isAndroid ? null : 'Vous pouvez refermer l’app — à demain',
               ),
             ),
-          // « Le mot du jour » — récompense de fin de Tournée. Sliver additif
-          // au-dessus de ClosingCardV18 (cette dernière n'est pas modifiée :
-          // zéro régression, revert trivial). La carte se câble seule au
-          // grilleProvider et ne rend rien tant que `GET today` n'a pas répondu.
-          // Hors gate `closingDismissed` : elle reste dans le feed même après
-          // fermeture de la tournée (en état « déjà jouée »), et se masque
-          // seule (SizedBox.shrink) s'il n'y a pas de mot du jour.
-          // Grille — rendue juste après « Actus du jour » (cf.
-          // _buildSectionSlivers) quand cette section existe. Fallback bas
-          // ici uniquement si le digest est absent / la liste vide, pour ne
-          // jamais perdre la Grille. Hors gate `closingDismissed`.
-          if (!hasActus) _grilleSliver,
-          // Carte « Fin de tournée » — toujours affichée (jamais masquée) : elle
-          // reste le repère de clôture même après être passé sur Flâner.
-          // « Continuer » navigue vers Flâner sans masquer la carte. « Refermer »
-          // ferme réellement l'app sur Android (SystemNavigator.pop) ; sur iOS,
-          // la fermeture programmatique est interdite → on masque le bouton et
-          // on affiche une phrase de clôture à la place.
-          SliverToBoxAdapter(
-            child: ClosingCardV18(
-              articleCount: totalArticles,
-              onContinue: () => context.go(RoutePaths.flaner),
-              onClose: isAndroid ? () => SystemNavigator.pop() : null,
-              closeHint:
-                  isAndroid ? null : 'Vous pouvez refermer l’app — à demain',
-            ),
-          ),
-          const SliverToBoxAdapter(child: SizedBox(height: 92)),
-        ],
+            const SliverToBoxAdapter(child: SizedBox(height: 92)),
+          ],
+        ),
       ),
     );
   }
@@ -1099,6 +1171,105 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     }
     return slivers;
   }
+}
+
+/// Mutable, stable holder of the section-start anchors shared between the
+/// screen state and the (immutable) [_SectionSnapPhysics]. The physics reads
+/// [values] live each ballistic build; the state owns the writes.
+class _SnapAnchors {
+  List<double> values = const [];
+}
+
+/// Scroll physics that folds a section-anchored snap into the fling's ballistic
+/// phase. The platform parent (Bouncing iOS / Clamping Android) is preserved
+/// via [applyTo], so `naturalLanding` inherits the native deceleration and the
+/// snap is intrinsically un-gated by speed — it triggers on slow *and* fast
+/// gestures.
+class _SectionSnapPhysics extends ScrollPhysics {
+  final _SnapAnchors anchors;
+  final ValueChanged<bool> onSnap;
+
+  const _SectionSnapPhysics({
+    required this.anchors,
+    required this.onSnap,
+    super.parent,
+  });
+
+  @override
+  _SectionSnapPhysics applyTo(ScrollPhysics? ancestor) {
+    return _SectionSnapPhysics(
+      anchors: anchors,
+      onSnap: onSnap,
+      parent: buildParent(ancestor),
+    );
+  }
+
+  @override
+  Simulation? createBallisticSimulation(
+    ScrollMetrics position,
+    double velocity,
+  ) {
+    final natural = super.createBallisticSimulation(position, velocity);
+    final target = _resolveTarget(position, velocity, natural);
+    onSnap(target != null);
+    if (target == null) return natural;
+    return ScrollSpringSimulation(
+      kSnapSpring,
+      position.pixels,
+      target,
+      velocity,
+      tolerance: toleranceFor(position),
+    );
+  }
+
+  /// Resolves the clamped section-anchored resting position, or `null` to keep
+  /// the natural fling (header zone, deep inside a tall section, already
+  /// aligned, or no anchors).
+  double? _resolveTarget(
+    ScrollMetrics position,
+    double velocity,
+    Simulation? natural,
+  ) {
+    final list = anchors.values;
+    if (list.isEmpty) return null;
+    // Header/banner zone (above the first section) → let the RefreshIndicator
+    // own pull-to-refresh; never snap.
+    if (position.pixels <= list.first) return null;
+
+    final landing =
+        natural == null ? position.pixels : _simulationEndX(natural, position);
+    if (landing <= 0) return null;
+
+    final raw = resolveSnapTarget(
+      currentPixels: position.pixels,
+      naturalLanding: landing,
+      velocity: velocity,
+      anchors: list,
+      usableViewport: position.viewportDimension - _kStickyBarHeight,
+    );
+    if (raw == null) return null;
+
+    final clamped = raw.clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    if ((clamped - position.pixels).abs() <= kSnapEpsilon) return null;
+    return clamped;
+  }
+}
+
+/// Estimates the resting position of a ballistic [sim] by sampling it forward
+/// until it reports done (capped). Honours the platform deceleration baked into
+/// [sim] rather than re-deriving a friction model.
+double _simulationEndX(Simulation sim, ScrollMetrics position) {
+  var last = position.pixels;
+  for (var t = 0.0; t <= 10.0; t += 1 / 60) {
+    final x = sim.x(t);
+    if (x.isNaN) break;
+    last = x;
+    if (sim.isDone(t)) break;
+  }
+  return last;
 }
 
 class _SectionPassagePulse {

--- a/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/physics.dart' show SpringDescription;
+
+/// Section-snap tuning. All four knobs live here so the feeling can be
+/// iterated in one place after a device pass (cf. plan « snap d'ancrage »).
+/// `resolveSnapTarget` consumes the first three; the screen physics consumes
+/// [kSnapSpring] (motion) and [kSnapEpsilon] (already-aligned guard).
+///
+/// ≤ this fraction of the usable viewport between the natural landing and an
+/// anchor ⇒ snap; beyond it the landing sits deep inside a tall section
+/// (e.g. the hi-fi Essentiel card) and we leave the reader free.
+const double kSnapCaptureFraction = 0.5;
+
+/// px/s. Above this the fling is a deliberate flick: we commit firmly across
+/// the next boundary in the gesture direction instead of letting friction
+/// drop the reader mid-card (no rubber-band back).
+const double kBoundaryCrossVelocity = 320.0;
+
+/// px. A target this close to the current position is already aligned ⇒ no
+/// snap (avoids a 0-length spring that would still fire a settle haptic).
+const double kSnapEpsilon = 1.0;
+
+/// Settle spring for the snap. Visible « pose » (~250-350ms) without wobble —
+/// the snap is part of the fling's deceleration, not a second animation.
+/// Pass to [ScrollSpringSimulation]. Soften (lower stiffness) if it feels abrupt.
+const SpringDescription kSnapSpring = SpringDescription(
+  mass: 0.5,
+  stiffness: 140,
+  damping: 18,
+);
+
+/// Chooses a section-anchored resting position for a fling, or `null` to leave
+/// the scroll free (deep inside a tall section, already aligned, or no anchors).
+///
+/// Pure arithmetic — no Flutter binding — so it is unit-testable without the
+/// Hive/Supabase bootstrap that the widget suite needs.
+///
+/// - [currentPixels]   : scroll offset at finger lift.
+/// - [naturalLanding]  : where the platform ballistic *would* settle (carries
+///   the fling energy → the rule is intrinsically un-gated by speed).
+/// - [velocity]        : fling velocity (px/s, signed).
+/// - [anchors]         : section-start offsets (absolute scroll pixels), sorted
+///   ascending.
+/// - [usableViewport]  : viewport height minus the sticky bar.
+///
+/// The caller clamps the result to `[min, max]ScrollExtent`.
+double? resolveSnapTarget({
+  required double currentPixels,
+  required double naturalLanding,
+  required double velocity,
+  required List<double> anchors,
+  required double usableViewport,
+}) {
+  if (anchors.isEmpty) return null;
+  final viewport = usableViewport <= 0 ? 1.0 : usableViewport;
+
+  // 1. Nearest anchor to the natural landing.
+  final nearest = _nearestAnchor(anchors, naturalLanding);
+
+  // 3. Firmness on boundary crossing — a deliberate flick commits across the
+  //    next boundary in the gesture direction (within reach), never snapping
+  //    back behind it.
+  if (velocity.abs() > kBoundaryCrossVelocity) {
+    final dir = velocity.sign;
+    final boundary = _firstAnchorBeyond(anchors, currentPixels, dir);
+    if (boundary != null &&
+        (boundary - currentPixels).abs() <= 1.25 * viewport) {
+      // Stay aligned to the natural landing when the fling reaches further
+      // (hard multi-section fling), but never fall behind the crossed boundary.
+      var target = nearest;
+      if (dir > 0 && target < boundary) target = boundary;
+      if (dir < 0 && target > boundary) target = boundary;
+      return _epsilon(target, currentPixels);
+    }
+  }
+
+  // 2. High-section guard — the landing is deep inside a section taller than
+  //    the capture window ⇒ leave the reader free.
+  if ((nearest - naturalLanding).abs() > kSnapCaptureFraction * viewport) {
+    return null;
+  }
+
+  // 4. Otherwise snap to the nearest anchor.
+  return _epsilon(nearest, currentPixels);
+}
+
+/// `null` when [target] is already aligned with [currentPixels] (± epsilon).
+double? _epsilon(double target, double currentPixels) {
+  if ((target - currentPixels).abs() <= kSnapEpsilon) return null;
+  return target;
+}
+
+/// Nearest value in the ascending [sorted] list to [value] (binary search).
+double _nearestAnchor(List<double> sorted, double value) {
+  if (value <= sorted.first) return sorted.first;
+  if (value >= sorted.last) return sorted.last;
+  var lo = 0;
+  var hi = sorted.length - 1;
+  while (lo <= hi) {
+    final mid = (lo + hi) >> 1;
+    if (sorted[mid] < value) {
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  // lo = first index whose value >= [value]; hi = lo - 1.
+  final above = sorted[lo];
+  final below = sorted[hi];
+  return (value - below) <= (above - value) ? below : above;
+}
+
+/// First anchor strictly beyond [from] in direction [dir] (+1 fwd / -1 back),
+/// or `null` if none.
+double? _firstAnchorBeyond(List<double> sorted, double from, double dir) {
+  if (dir > 0) {
+    for (final a in sorted) {
+      if (a > from + kSnapEpsilon) return a;
+    }
+  } else {
+    for (var i = sorted.length - 1; i >= 0; i--) {
+      if (sorted[i] < from - kSnapEpsilon) return sorted[i];
+    }
+  }
+  return null;
+}

--- a/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/features/flux_continu/utils/section_snap.dart';
+
+void main() {
+  // Canonical layout: four section starts, one usable viewport tall apart.
+  const anchors = [0.0, 300.0, 600.0, 900.0];
+  const viewport = 700.0;
+
+  group('resolveSnapTarget', () {
+    test('snaps to the nearest anchor on a calm landing', () {
+      // Lands 20px below the 600 anchor, gentle velocity → snap up to 600.
+      final target = resolveSnapTarget(
+        currentPixels: 540,
+        naturalLanding: 620,
+        velocity: 40,
+        anchors: anchors,
+        usableViewport: viewport,
+      );
+      expect(target, 600.0);
+    });
+
+    test('returns null when landing is deep inside a tall section', () {
+      // Tall section 300→1500; user rests at 900, far from both 300 and 1500.
+      final target = resolveSnapTarget(
+        currentPixels: 880,
+        naturalLanding: 900, // |900-300|=600, |900-1500|=600 → both > 350
+        velocity: 20,
+        anchors: const [0.0, 300.0, 1500.0],
+        usableViewport: viewport,
+      );
+      expect(target, isNull);
+    });
+
+    test('commits firmly across the boundary on a fast flick', () {
+      // currentPixels just past the 300 boundary; a fast forward flick must not
+      // snap back to 300 — it crosses to the next anchor (600).
+      final target = resolveSnapTarget(
+        currentPixels: 310,
+        naturalLanding: 340, // nearest would be 300 (behind the gesture)
+        velocity: 600, // > kBoundaryCrossVelocity → firm crossing
+        anchors: anchors,
+        usableViewport: viewport,
+      );
+      expect(target, 600.0);
+    });
+
+    test('the same lift snaps backward to the nearest anchor when slow', () {
+      // Proves the firmness branch is velocity-gated, while the snap itself is
+      // NOT (a slow lift still snaps — just to the nearest anchor).
+      final target = resolveSnapTarget(
+        currentPixels: 310,
+        naturalLanding: 340,
+        velocity: 60, // below kBoundaryCrossVelocity
+        anchors: anchors,
+        usableViewport: viewport,
+      );
+      expect(target, 300.0);
+    });
+
+    test('snaps on a slow near-anchor lift (un-gated by speed)', () {
+      final target = resolveSnapTarget(
+        currentPixels: 580,
+        naturalLanding: 590, // 10px below the 600 anchor
+        velocity: 8, // very slow
+        anchors: anchors,
+        usableViewport: viewport,
+      );
+      expect(target, 600.0);
+    });
+
+    test('returns null when already aligned with an anchor', () {
+      final target = resolveSnapTarget(
+        currentPixels: 600,
+        naturalLanding: 600.4, // within kSnapEpsilon of the 600 anchor
+        velocity: 10,
+        anchors: anchors,
+        usableViewport: viewport,
+      );
+      expect(target, isNull);
+    });
+
+    test('returns null for an empty anchor list', () {
+      final target = resolveSnapTarget(
+        currentPixels: 400,
+        naturalLanding: 450,
+        velocity: 200,
+        anchors: const [],
+        usableViewport: viewport,
+      );
+      expect(target, isNull);
+    });
+
+    test('a hard multi-section fling lands aligned near the natural landing',
+        () {
+      // Fast fling whose natural landing reaches the third section: we honour
+      // the far anchor (900) rather than truncating at the first boundary.
+      final target = resolveSnapTarget(
+        currentPixels: 120,
+        naturalLanding: 880, // nearest = 900
+        velocity: 900,
+        anchors: anchors,
+        usableViewport: viewport,
+      );
+      expect(target, 900.0);
+    });
+  });
+}


### PR DESCRIPTION
## Quoi
Remplace le demi-snap intermittent de #772 par un **snap d'ancrage** intégré à la phase balistique du fling. Au lâcher du doigt, une `ScrollPhysics` custom (`_SectionSnapPhysics`) choisit une position de repos alignée sur le **début d'une section** sous la sticky bar — sur geste lent **et** rapide (déclenchement constant, non gaté en vitesse), avec une haptique `mediumImpact` **au repos** (la section qui « se pose »). Scroll libre à l'intérieur des sections hautes (carte Essentiel hi-fi laissée libre) ; firmness au franchissement de frontière sur flick rapide (pas de rubber-band).

La décision de repos est extraite dans une fonction **pure** `resolveSnapTarget` (`utils/section_snap.dart`), testable sans le bootstrap Hive/Supabase. Le parent plateforme (Bouncing iOS / Clamping Android) est préservé via `applyTo` → overscroll & pull-to-refresh restent natifs.

**Mobile / UX only — aucune modif backend.**

## Pourquoi
Le mécanisme d'« attraction » post-hoc précédent (`animateTo` déclenché quand l'utilisateur scrollait lentement près d'une frontière) se battait avec la physique du fling et ne se déclenchait qu'à basse vitesse. Le déplacer dans la couche physique au moment où la simulation balistique est construite donne un mouvement unique et cohérent, déclenché quelle que soit la vitesse.

## Comment ça a été vérifié
- [x] `flutter analyze` sur `lib/features/flux_continu/` + le test : **No issues found**
- [x] **8/8** tests unitaires `section_snap_test.dart` (calm landing, tall-section guard, boundary-cross firm/slow, multi-section fling, already-aligned, liste vide)
- [x] Suite `test/features/flux_continu/` : passants **98 → 106** (les +8 nouveaux), **0 nouvelle régression** (37 échecs pré-existants Supabase/Hive non init, baseline confirmée par stash)
- [x] `/simplify` passé — 3/4 angles clean ; centralisation du clear haptique (`_cancelPendingSnap`) + auto-annulation sur drag (honore le commentaire existant)
- [ ] Validation tactile (haptiques + feeling du fling) : non couvrable en CI/Playwright — nécessite un device. Scénarios listés dans `.context/qa-handoff.md`.

## Zones à risque
- `_SectionSnapPhysics` / `createBallisticSimulation` : couche physique du scroll de L'Essentiel. Le snap ne change que la **position de repos** ; overscroll/refresh préservés via `applyTo`.
- Chorégraphie haptique (`_isSnapping` / `_pendingSnapHaptic`) : centralisée dans `_cancelPendingSnap()` ; settle haptic déféré au `ScrollEndNotification`.