### PR TITLE
fix(veille): 3 bugs critiques V0 — sources non connectées, sync niche, keyword mot-entier

### DIFF
--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -628,19 +628,35 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
     final isSerene = current.isSerene;
     final nextPage = target.currentPage + 1;
-    final theme = target.themeSlug;
-    final topic = target.customTopicId;
-    final response = await _safe<FeedResponse>(
-      () => _feedRepo.getFeed(
-        page: nextPage,
-        limit: _kThemeSectionPageLimit,
-        theme: theme,
-        topic: topic,
-        serein: isSerene,
-        personalized: true,
-      ),
-      'loadMoreTheme($key)',
-    );
+    final FeedResponse? response;
+    if (target.kind == SectionKind.veille) {
+      // La veille pagine via /api/veille/feed (offset), PAS via le feed général
+      // personnalisé : ce dernier injectait des articles hors-veille en fin de
+      // section et déclenchait tout le pipeline de reco (plan V0, Pb 2&3).
+      final offset = (nextPage - 1) * _kThemeSectionPageLimit;
+      response = await _safe<FeedResponse>(
+        () => ref.read(fluxContinuRepositoryProvider).getVeilleFeedItems(
+          limit: _kThemeSectionPageLimit,
+          offset: offset,
+          serein: isSerene,
+        ),
+        'loadMoreTheme(veille offset=$offset)',
+      );
+    } else {
+      final theme = target.themeSlug;
+      final topic = target.customTopicId;
+      response = await _safe<FeedResponse>(
+        () => _feedRepo.getFeed(
+          page: nextPage,
+          limit: _kThemeSectionPageLimit,
+          theme: theme,
+          topic: topic,
+          serein: isSerene,
+          personalized: true,
+        ),
+        'loadMoreTheme($key)',
+      );
+    }
 
     // Re-read state in case it shifted while the request was in flight.
     final afterCurrent = state.valueOrNull;
@@ -1063,7 +1079,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       VeilleFavoriteRef() => _safe<FeedResponse>(
         () => ref
             .read(fluxContinuRepositoryProvider)
-            .getVeilleFeedItems(limit: 10, serein: isSerene),
+            .getVeilleFeedItems(
+              limit: _kThemeSectionPageLimit,
+              serein: isSerene,
+            ),
         'getVeilleFeedItems',
       ),
     };
@@ -1079,6 +1098,13 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // la coupe plus sur un seuil min d'items ; `null` seulement sans config.
     if (activeCfg == null) return null;
     final items = feed?.items ?? const <Content>[];
+    // hasMore dérivé de la pagination backend (`has_more`), pas du défaut `true`
+    // du modèle : sans ça la section se croyait toujours paginable et
+    // `loadMoreTheme` partait chercher des articles hors-veille (plan V0, Pb 2&3).
+    final hasMore = _themeHasMore(
+      feed?.pagination.hasNext ?? false,
+      items.length,
+    );
     return FeedThemeSection(
       kind: SectionKind.veille,
       label: 'Ma veille — ${activeCfg.themeLabel}',
@@ -1087,6 +1113,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       illustrationAsset: _kVeilleIllustration,
       coreVisibleCount: 3,
       items: items,
+      hasMore: hasMore,
     );
   }
 

--- a/apps/mobile/lib/features/flux_continu/repositories/flux_continu_repository.dart
+++ b/apps/mobile/lib/features/flux_continu/repositories/flux_continu_repository.dart
@@ -82,18 +82,20 @@ class FluxContinuRepository {
   /// sectionVeille1 + badge "Ma veille") qui rend matched_on superflu V1.
   Future<FeedResponse> getVeilleFeedItems({
     int limit = 10,
+    int offset = 0,
     bool serein = false,
   }) async {
+    final pageNum = (offset ~/ limit) + 1;
     try {
       final response = await _apiClient.dio.get<dynamic>(
         'veille/feed',
-        queryParameters: {'limit': limit, 'offset': 0, 'serein': serein},
+        queryParameters: {'limit': limit, 'offset': offset, 'serein': serein},
       );
       if (response.statusCode != 200 || response.data is! Map) {
         return FeedResponse(
           items: const [],
           pagination: Pagination(
-            page: 1,
+            page: pageNum,
             perPage: limit,
             total: 0,
             hasNext: false,
@@ -110,7 +112,7 @@ class FluxContinuRepository {
       return FeedResponse(
         items: items,
         pagination: Pagination(
-          page: 1,
+          page: pageNum,
           perPage: limit,
           total: (data['total'] as num?)?.toInt() ?? items.length,
           hasNext: (data['has_more'] as bool?) ?? false,
@@ -122,7 +124,7 @@ class FluxContinuRepository {
       return FeedResponse(
         items: const [],
         pagination: Pagination(
-          page: 1,
+          page: pageNum,
           perPage: limit,
           total: 0,
           hasNext: false,

--- a/apps/mobile/lib/features/veille/models/veille_config_dto.dart
+++ b/apps/mobile/lib/features/veille/models/veille_config_dto.dart
@@ -137,6 +137,24 @@ class VeilleKeywordDto {
 }
 
 @immutable
+class VeilleUnconnectedSourceDto {
+  final String url;
+  final String reason;
+
+  const VeilleUnconnectedSourceDto({
+    required this.url,
+    required this.reason,
+  });
+
+  factory VeilleUnconnectedSourceDto.fromJson(Map<String, dynamic> json) {
+    return VeilleUnconnectedSourceDto(
+      url: json['url'] as String? ?? '',
+      reason: json['reason'] as String? ?? '',
+    );
+  }
+}
+
+@immutable
 class VeilleConfigDto {
   final String id;
   final String userId;
@@ -152,6 +170,10 @@ class VeilleConfigDto {
   final String? editorialBrief;
   final String? presetId;
 
+  /// Sources niche dont le flux RSS n'a pas pu être détecté lors de l'upsert.
+  /// Peuplé uniquement par la réponse de `POST /veille/config` ; vide sur GET.
+  final List<VeilleUnconnectedSourceDto> unconnectedSources;
+
   const VeilleConfigDto({
     required this.id,
     required this.userId,
@@ -166,6 +188,7 @@ class VeilleConfigDto {
     this.purpose,
     this.editorialBrief,
     this.presetId,
+    this.unconnectedSources = const [],
   });
 
   factory VeilleConfigDto.fromJson(Map<String, dynamic> json) {
@@ -192,6 +215,10 @@ class VeilleConfigDto {
       purpose: json['purpose'] as String?,
       editorialBrief: json['editorial_brief'] as String?,
       presetId: json['preset_id'] as String?,
+      unconnectedSources: ((json['unconnected_sources'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleUnconnectedSourceDto.fromJson)
+          .toList(),
     );
   }
 }

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -767,8 +767,12 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
 
   /// POST /api/veille/config — succès → hydrate `veilleActiveConfigProvider`
   /// pour que la home (Mes intérêts / Tournée) voie la veille immédiatement.
-  Future<void> submit() async {
-    if (state.isSubmitting) return;
+  ///
+  /// Renvoie la config persistée : son champ `unconnectedSources` permet à
+  /// l'UI d'avertir « X sources n'ont pas pu être connectées » + proposer une
+  /// CTA de recherche (plan veille V0, Problème 1). Null si submit déjà en vol.
+  Future<VeilleConfigDto?> submit() async {
+    if (state.isSubmitting) return null;
     state = state.copyWith(isSubmitting: true, lastError: null);
 
     try {
@@ -783,6 +787,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       // Le chemin archivage le fait déjà (my_interests_screen.dart).
       _ref.invalidate(userInterestsProvider);
       state = state.copyWith(isSubmitting: false);
+      return cfg;
     } on VeilleApiException catch (e) {
       state = state.copyWith(isSubmitting: false, lastError: e.message);
       rethrow;

--- a/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/veille_config_screen.dart
@@ -66,8 +66,28 @@ class VeilleConfigScreen extends ConsumerWidget {
 
     Future<void> handleSubmit() async {
       try {
-        await notifier.submit();
+        final cfg = await notifier.submit();
         if (!context.mounted) return;
+        // Sources niche dont le flux RSS est introuvable : on garde l'utilisateur
+        // sur l'étape Sources (recherche/ajout) au lieu de filer vers la Tournée,
+        // pour qu'il puisse en chercher d'autres (plan V0, Problème 1).
+        if (cfg != null && cfg.unconnectedSources.isNotEmpty) {
+          final n = cfg.unconnectedSources.length;
+          final s = n > 1 ? 's' : '';
+          final verb = n > 1 ? "n'ont" : "n'a";
+          notifier.goToStep(3);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              duration: const Duration(seconds: 6),
+              content: Text(
+                '$n source$s $verb pas pu être connectée$s '
+                '(flux RSS introuvable). Tu peux en chercher d\'autres '
+                'ci-dessous.',
+              ),
+            ),
+          );
+          return;
+        }
         showProgressToast(
           context,
           level: ProgressToastLevel.step,

--- a/apps/mobile/test/features/veille/models/veille_config_dto_test.dart
+++ b/apps/mobile/test/features/veille/models/veille_config_dto_test.dart
@@ -126,4 +126,35 @@ void main() {
       expect(VeilleSuggestSourcesResponse.fromJson(const {}).sources, isEmpty);
     });
   });
+
+  group('VeilleConfigDto.fromJson — unconnected_sources', () {
+    Map<String, dynamic> baseConfig() => {
+      'id': 'cfg-1',
+      'user_id': 'user-1',
+      'theme_id': 'tech',
+      'theme_label': 'Tech',
+      'status': 'active',
+      'created_at': '2026-06-04T00:00:00Z',
+      'updated_at': '2026-06-04T00:00:00Z',
+      'topics': const [],
+      'sources': const [],
+      'keywords': const [],
+    };
+
+    test('mappe url + reason des sources non connectées', () {
+      final dto = VeilleConfigDto.fromJson({
+        ...baseConfig(),
+        'unconnected_sources': const [
+          {'url': 'https://exemple.test', 'reason': 'Aucun flux RSS.'},
+        ],
+      });
+      expect(dto.unconnectedSources, hasLength(1));
+      expect(dto.unconnectedSources.first.url, 'https://exemple.test');
+      expect(dto.unconnectedSources.first.reason, 'Aucun flux RSS.');
+    });
+
+    test('clé absente → liste vide (rétro-compat backend non déployé)', () {
+      expect(VeilleConfigDto.fromJson(baseConfig()).unconnectedSources, isEmpty);
+    });
+  });
 }

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -10,7 +10,7 @@ from uuid import UUID, uuid4
 import sentry_sdk
 import structlog
 from cachetools import TTLCache
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from sqlalchemy import case, delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -47,6 +47,7 @@ from app.schemas.veille import (
     VeilleSuggestSourcesRequest,
     VeilleSuggestSourcesResponse,
     VeilleTopicResponse,
+    VeilleUnconnectedSource,
 )
 from app.services.ml.topic_enrichment_service import get_topic_enrichment_service
 from app.services.rss_parser import RSSParser
@@ -201,10 +202,15 @@ async def _resolve_source_id(
     db: AsyncSession,
     selection,
     theme_id: str,
-) -> UUID:
-    """Renvoie un source_id existant ou ingère le candidat niche."""
+) -> tuple[UUID, bool]:
+    """Renvoie `(source_id, created)`.
+
+    `created=True` uniquement quand une nouvelle ligne `Source` niche vient
+    d'être insérée (→ l'appelant doit enfiler un `sync_source` immédiat pour
+    ingérer son contenu ; cf. plan veille V0, Problème 1).
+    """
     if selection.source_id is not None:
-        return selection.source_id
+        return selection.source_id, False
     if selection.niche_candidate is None:
         raise HTTPException(
             status_code=400,
@@ -221,7 +227,7 @@ async def _resolve_source_id(
         .first()
     )
     if existing is not None:
-        return existing.id
+        return existing.id, False
 
     try:
         source_type = SourceType(detected.detected_type)
@@ -247,7 +253,7 @@ async def _resolve_source_id(
         source_id=str(new_source.id),
         feed_url=new_source.feed_url,
     )
-    return new_source.id
+    return new_source.id, True
 
 
 # ─── Endpoints config ────────────────────────────────────────────────────────
@@ -281,6 +287,7 @@ async def get_config(
 @router.post("/config", response_model=VeilleConfigResponse)
 async def upsert_config(
     body: VeilleConfigUpsert,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     current_user_id: str = Depends(get_current_user_id),
 ):
@@ -345,23 +352,38 @@ async def upsert_config(
             )
 
     seen_source_ids: set[UUID] = set()
+    # Sources niche nouvellement créées → sync immédiat après commit (Problème 1).
+    created_source_ids: list[UUID] = []
+    # Sources niche dont le flux RSS est introuvable → remontées au mobile.
+    unconnected: list[VeilleUnconnectedSource] = []
     for idx, sel in enumerate(body.source_selections):
         try:
-            source_id = await _resolve_source_id(db, sel, body.theme_id)
+            source_id, created = await _resolve_source_id(db, sel, body.theme_id)
         except ValueError as exc:
             # Source niche dont le flux RSS est introuvable au moment du save :
             # on l'ignore au lieu de faire échouer tout l'enregistrement (PYTHON-51).
             # detect_source lève ce ValueError AVANT toute écriture DB → on peut
-            # `continue` sans corrompre la session.
+            # `continue` sans corrompre la session. On remonte l'échec au mobile
+            # via `unconnected_sources` pour proposer une CTA de recherche.
+            url = getattr(sel.niche_candidate, "url", None)
             logger.warning(
                 "veille.niche_source_skipped",
-                url=getattr(sel.niche_candidate, "url", None),
+                url=url,
                 error=str(exc),
             )
+            if url:
+                unconnected.append(
+                    VeilleUnconnectedSource(
+                        url=url,
+                        reason="Aucun flux RSS détecté à cette adresse.",
+                    )
+                )
             continue
         if source_id in seen_source_ids:
             continue
         seen_source_ids.add(source_id)
+        if created:
+            created_source_ids.append(source_id)
         db.add(
             VeilleSource(
                 veille_config_id=cfg.id,
@@ -395,6 +417,15 @@ async def upsert_config(
     await db.commit()
     await db.refresh(cfg)
 
+    # Sync immédiat des sources niche fraîchement créées : sans ça leur table
+    # `contents` reste vide jusqu'au prochain cycle récurrent (« source associée
+    # mais aucun article »). Même pattern que POST /api/sources/custom.
+    if created_source_ids:
+        from app.workers.rss_sync import sync_source
+
+        for sid in created_source_ids:
+            background_tasks.add_task(sync_source, str(sid))
+
     try:
         from app.services.posthog_client import get_posthog_client
 
@@ -412,7 +443,9 @@ async def upsert_config(
     except Exception:  # noqa: BLE001 — métrique fire-and-forget
         logger.warning("veille.posthog_capture_failed", exc_info=True)
 
-    return await _hydrate_response(db, cfg)
+    response = await _hydrate_response(db, cfg)
+    response.unconnected_sources = unconnected
+    return response
 
 
 @router.delete("/config", status_code=204)

--- a/packages/api/app/schemas/veille.py
+++ b/packages/api/app/schemas/veille.py
@@ -75,6 +75,18 @@ class VeilleKeywordResponse(BaseModel):
     position: int = 0
 
 
+class VeilleUnconnectedSource(BaseModel):
+    """Source niche dont le flux RSS n'a pas pu être détecté à l'enregistrement.
+
+    Renvoyée par `POST /api/veille/config` pour que le mobile puisse afficher
+    « X sources n'ont pas pu être connectées » + une CTA de recherche, au lieu
+    de les laisser disparaître silencieusement (cf. plan veille V0, Problème 1).
+    """
+
+    url: str
+    reason: str
+
+
 class VeilleConfigResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -91,6 +103,9 @@ class VeilleConfigResponse(BaseModel):
     purpose: str | None = None
     editorial_brief: str | None = None
     preset_id: str | None = None
+    # Sources niche dont le flux RSS n'a pas pu être détecté lors de l'upsert.
+    # Toujours vide sur GET /config ; peuplé uniquement par POST /config.
+    unconnected_sources: list[VeilleUnconnectedSource] = Field(default_factory=list)
 
 
 class VeilleTopicSelection(BaseModel):

--- a/packages/api/app/services/recommendation/helpers/__init__.py
+++ b/packages/api/app/services/recommendation/helpers/__init__.py
@@ -7,5 +7,6 @@ Centralise les primitives qui étaient dupliquées avec valeurs divergentes :
 
 from app.services.recommendation.helpers.coverage_score import compute_coverage_score
 from app.services.recommendation.helpers.diversification import diversify
+from app.services.recommendation.helpers.keyword_match import matches_word_boundary
 
-__all__ = ["compute_coverage_score", "diversify"]
+__all__ = ["compute_coverage_score", "diversify", "matches_word_boundary"]

--- a/packages/api/app/services/recommendation/helpers/keyword_match.py
+++ b/packages/api/app/services/recommendation/helpers/keyword_match.py
@@ -1,0 +1,26 @@
+"""Matching mot-entier d'un mot-clé dans un texte (titre / description).
+
+Centralise la primitive qui était dupliquée à l'identique dans plusieurs
+couches de scoring (UserCustomTopicLayer, pilier Pertinence) : un mot-clé ne
+matche que sur une **frontière de mot** (regex `\\b…\\b`), pas en sous-chaîne —
+sinon des mots-clés génériques (« titre », « finale », « agent »…) ramènent des
+articles hors-sujet (plan veille V0, Problème 3).
+
+L'équivalent SQL (`~*` avec bornes Postgres `\\m…\\M`) vit dans
+`services/veille/feed_filter.py` car il produit un prédicat SQLAlchemy, pas un
+booléen Python — mais la sémantique est la même.
+"""
+
+import re
+
+
+def matches_word_boundary(keyword_lower: str, *texts_lower: str) -> bool:
+    """True si `keyword_lower` apparaît en **mot-entier** dans l'un des `texts_lower`.
+
+    `keyword_lower` et `texts_lower` sont attendus déjà en minuscules (le caller
+    normalise une fois). Un mot-clé vide renvoie toujours False.
+    """
+    if not keyword_lower:
+        return False
+    pattern = r"\b" + re.escape(keyword_lower) + r"\b"
+    return any(re.search(pattern, text) for text in texts_lower)

--- a/packages/api/app/services/recommendation/layers/user_custom_topics.py
+++ b/packages/api/app/services/recommendation/layers/user_custom_topics.py
@@ -11,9 +11,9 @@ Entity matches get a 1.5x multiplier bonus (precise match).
 """
 
 import json
-import re
 
 from app.models.content import Content
+from app.services.recommendation.helpers import matches_word_boundary
 from app.services.recommendation.scoring_config import ScoringWeights
 from app.services.recommendation.scoring_engine import BaseScoringLayer, ScoringContext
 
@@ -72,12 +72,7 @@ class UserCustomTopicLayer(BaseScoringLayer):
             if not matched and topic_profile.keywords:
                 for kw in topic_profile.keywords:
                     kw_lower = kw.lower().strip()
-                    if not kw_lower:
-                        continue
-                    pattern = r"\b" + re.escape(kw_lower) + r"\b"
-                    if re.search(pattern, title_lower) or re.search(
-                        pattern, desc_lower
-                    ):
+                    if matches_word_boundary(kw_lower, title_lower, desc_lower):
                         matched = True
                         match_type = f"keyword:{kw}"
                         break

--- a/packages/api/app/services/recommendation/pillars/pertinence.py
+++ b/packages/api/app/services/recommendation/pillars/pertinence.py
@@ -6,7 +6,10 @@ Consolide : CoreLayer (theme), ArticleTopicLayer, BehavioralLayer,
 
 from app.models.content import Content
 from app.models.enums import ContentType, InterestState
-from app.services.recommendation.helpers import compute_coverage_score
+from app.services.recommendation.helpers import (
+    compute_coverage_score,
+    matches_word_boundary,
+)
 from app.services.recommendation.pillars.base import BasePillar, PillarContribution
 from app.services.recommendation.scoring_config import ScoringWeights
 from app.services.recommendation.scoring_engine import ScoringContext
@@ -404,7 +407,7 @@ class PertinencePillar(BasePillar):
             if not matched and tp.keywords:
                 for kw in tp.keywords:
                     kw_lower = kw.lower().strip()
-                    if kw_lower and (kw_lower in title_lower or kw_lower in desc_lower):
+                    if matches_word_boundary(kw_lower, title_lower, desc_lower):
                         matched = True
                         break
 
@@ -452,7 +455,7 @@ class PertinencePillar(BasePillar):
             kw_lower = kw.lower().strip()
             if not kw_lower or kw_lower in seen:
                 continue
-            if kw_lower in title_lower or kw_lower in desc_lower:
+            if matches_word_boundary(kw_lower, title_lower, desc_lower):
                 seen.add(kw_lower)
                 kw_hits += 1
 

--- a/packages/api/app/services/sync_service.py
+++ b/packages/api/app/services/sync_service.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.content import Content
 from app.models.enums import ContentType, SourceType
 from app.models.source import Source, UserSource
+from app.models.veille import VeilleSource
 from app.services.content_extractor import ContentExtractor
 from app.services.ml.language_filter import detect_language
 from app.services.paywall_detector import detect_paywall
@@ -89,10 +90,17 @@ class SyncService:
             .distinct()
             .scalar_subquery()
         )
+        # Sources niche référencées par une veille : is_curated=False et absentes
+        # de user_sources → autrement jamais synchronisées (plan veille V0, Pb 1).
+        veille_source_ids = (
+            select(VeilleSource.source_id).distinct().scalar_subquery()
+        )
         result = await self.session.execute(
             select(Source).where(
                 Source.is_active,
-                (Source.is_curated) | (Source.id.in_(custom_source_ids)),
+                (Source.is_curated)
+                | (Source.id.in_(custom_source_ids))
+                | (Source.id.in_(veille_source_ids)),
             )
         )
         sources = result.scalars().all()

--- a/packages/api/app/services/sync_service.py
+++ b/packages/api/app/services/sync_service.py
@@ -92,9 +92,7 @@ class SyncService:
         )
         # Sources niche référencées par une veille : is_curated=False et absentes
         # de user_sources → autrement jamais synchronisées (plan veille V0, Pb 1).
-        veille_source_ids = (
-            select(VeilleSource.source_id).distinct().scalar_subquery()
-        )
+        veille_source_ids = select(VeilleSource.source_id).distinct().scalar_subquery()
         result = await self.session.execute(
             select(Source).where(
                 Source.is_active,

--- a/packages/api/app/services/veille/feed_filter.py
+++ b/packages/api/app/services/veille/feed_filter.py
@@ -9,6 +9,7 @@ les sources suivies et les mots-clés (globaux + grappes d'angles).
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
@@ -161,11 +162,16 @@ async def load_veille_filters(
 
 
 def build_strong_predicate(filters: VeilleFilters):
-    """Clause `OR` SQL sur les axes **forts uniquement** (jamais le thème).
+    r"""Clause `OR` SQL sur les axes **forts uniquement** (jamais le thème).
 
     - `topic` : Content.topics && topic_slugs — index GIN ix_contents_topics
     - `source` : Content.source_id IN (source_ids) — index ix_contents_source_id
-    - `keyword` : title ILIKE OR description ILIKE (globaux + grappes d'angles)
+    - `keyword` : title ~* OR description ~* en **mot-entier** (globaux + grappes)
+
+    Le matching mots-clés est en mot-entier (regex POSIX `\m…\M`) et non en
+    sous-chaîne : sans ça des mots-clés d'angle génériques (« titre », « finale »,
+    « draft »…) ramènent des articles hors-sujet (plan veille V0, Problème 3).
+    Aligné sur `layers/user_custom_topics.py` (regex `\b…\b`).
 
     Renvoie `None` si aucun axe fort (p.ex. thème seul) → exclusion voulue.
     """
@@ -175,9 +181,10 @@ def build_strong_predicate(filters: VeilleFilters):
     if filters.source_ids:
         clauses.append(Content.source_id.in_(filters.source_ids))
     for kw in filters.all_keywords:
-        pattern = f"%{kw}%"
-        clauses.append(Content.title.ilike(pattern))
-        clauses.append(Content.description.ilike(pattern))
+        # `\m` / `\M` = bornes de mot Postgres (équivalent SQL de `\b…\b`).
+        pattern = r"\m" + re.escape(kw) + r"\M"
+        clauses.append(Content.title.op("~*")(pattern))
+        clauses.append(Content.description.op("~*")(pattern))
     return or_(*clauses) if clauses else None
 
 

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -668,8 +668,8 @@ class TestOtherThemeIngestion:
     async def test_other_theme_niche_source_ingestion(
         self, auth_user, monkeypatch
     ):
-        from unittest.mock import AsyncMock
         from app.services import source_service
+        from app.workers import rss_sync
 
         async def _fake_detect(self, url):
             from types import SimpleNamespace
@@ -683,6 +683,16 @@ class TestOtherThemeIngestion:
             )
 
         monkeypatch.setattr(source_service.SourceService, "detect_source", _fake_detect)
+
+        # Une source niche fraîchement créée doit déclencher un sync immédiat
+        # (sinon sa table `contents` reste vide jusqu'au cycle récurrent).
+        synced: list[str] = []
+
+        async def _fake_sync_source(source_id):
+            synced.append(source_id)
+            return True
+
+        monkeypatch.setattr(rss_sync, "sync_source", _fake_sync_source)
 
         payload = {
             "theme_id": "other",
@@ -707,6 +717,10 @@ class TestOtherThemeIngestion:
         assert data["theme_id"] == "other"
         # La source ingérée doit avoir theme='custom' (mappé depuis 'other')
         assert data["sources"][0]["source"]["theme"] == "custom"
+        # Sync immédiat enfilé pour la source niche créée.
+        assert synced == [data["sources"][0]["source"]["id"]]
+        # Source bien connectée → aucune remontée d'échec.
+        assert data["unconnected_sources"] == []
 
     async def test_post_config_skips_unresolvable_niche_source(
         self, auth_user, monkeypatch
@@ -755,6 +769,13 @@ class TestOtherThemeIngestion:
         assert data["sources"] == []
         assert len(data["topics"]) == 1
         assert len(data["keywords"]) == 1
+        # La source non connectée est remontée au mobile (url + raison) pour
+        # afficher « X sources n'ont pas pu être connectées » + CTA recherche.
+        assert len(data["unconnected_sources"]) == 1
+        assert (
+            data["unconnected_sources"][0]["url"] == "https://exemple-sans-rss.test"
+        )
+        assert data["unconnected_sources"][0]["reason"]
 
 
 class TestLegacyGoneShims:

--- a/packages/api/tests/test_veille_curation.py
+++ b/packages/api/tests/test_veille_curation.py
@@ -92,6 +92,20 @@ def test_keyword_bonus_escalates_with_distinct_matches():
     assert two > one
 
 
+def test_keyword_matching_is_word_boundary():
+    """Mot-entier : « agent » matche « un agent » mais pas « agentic » (Pb 3).
+
+    Avant le fix, le matching en sous-chaîne laissait passer des articles
+    hors-sujet dont le titre contenait juste le mot-clé en fragment.
+    """
+    whole = _angle_score(_Content(topics=["tech"], title="Un agent autonome débarque"))
+    substring = _angle_score(
+        _Content(topics=["tech"], title="Les agentic workflows expliqués")
+    )
+    assert whole == pytest.approx(ScoringWeights.VEILLE_KEYWORD_BASE_BONUS)
+    assert substring == 0.0
+
+
 def test_keyword_bonus_is_capped():
     """Le bonus mots-clés ne dépasse jamais le cap, même avec beaucoup de hits."""
     many = VeilleAngleTopic(


### PR DESCRIPTION
## What

Corrige 3 bugs critiques identifiés sur le plan veille V0 :

1. **Problème 1 — Sources niche sans RSS disparaissaient silencieusement** : `POST /config` renvoie maintenant `unconnected_sources` (url + raison) ; le mobile affiche un snackbar et retourne à l'étape Sources pour proposer une CTA de recherche.
2. **Problème 2 — Sources niche sans contenu après création** : le router enfile un `sync_source` en `background_tasks` pour chaque source niche fraîchement créée ; `sync_service` inclut désormais les sources référencées par une veille (is_curated=False, absentes de user_sources). La pagination Veille dans le flux continu passe par `/api/veille/feed` (offset) et non le feed général.
3. **Problème 3 — Keyword matching en sous-chaîne hors-sujet** : remplacé ILIKE `%kw%` par regex mot-entier (`\b…\b` Python / `\m…\M` Postgres) dans les couches de scoring et le `feed_filter`. Primitive centralisée dans `helpers/keyword_match.py`.

## Why

Ces trois bugs rendaient la section Veille inutilisable : sources perdues sans feedback, sections vides même après connexion, et articles hors-sujet injectés via des mots-clés trop génériques.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)