### PR TITLE
feat(veille): résolution background des sources + états de connexion (V0 UX)

### DIFF
--- a/apps/mobile/lib/features/veille/models/veille_config_dto.dart
+++ b/apps/mobile/lib/features/veille/models/veille_config_dto.dart
@@ -140,16 +140,22 @@ class VeilleKeywordDto {
 class VeilleUnconnectedSourceDto {
   final String url;
   final String reason;
+  final String? clientSlug;
+  final String? name;
 
   const VeilleUnconnectedSourceDto({
     required this.url,
     required this.reason,
+    this.clientSlug,
+    this.name,
   });
 
   factory VeilleUnconnectedSourceDto.fromJson(Map<String, dynamic> json) {
     return VeilleUnconnectedSourceDto(
       url: json['url'] as String? ?? '',
       reason: json['reason'] as String? ?? '',
+      clientSlug: json['client_slug'] as String?,
+      name: json['name'] as String?,
     );
   }
 }
@@ -257,17 +263,20 @@ class VeilleTopicSelectionRequest {
 
 @immutable
 class VeilleNicheCandidateRequest {
+  final String? clientSlug;
   final String name;
   final String url;
   final String? why;
 
   const VeilleNicheCandidateRequest({
+    this.clientSlug,
     required this.name,
     required this.url,
     this.why,
   });
 
   Map<String, dynamic> toJson() => {
+    if (clientSlug != null) 'client_slug': clientSlug,
     'name': name,
     'url': url,
     if (why != null) 'why': why,
@@ -465,6 +474,113 @@ class VeilleSuggestSourcesResponse {
       sources: ((json['sources'] as List?) ?? const [])
           .whereType<Map<String, dynamic>>()
           .map(VeilleSourceSuggestionDto.fromJson)
+          .toList(),
+    );
+  }
+}
+
+// ─── Résolution batch sources candidates (POST /veille/sources/resolve-candidates)
+
+@immutable
+class VeilleResolveSourceCandidateRequest {
+  final String clientSlug;
+  final String name;
+  final String url;
+  final String? why;
+
+  const VeilleResolveSourceCandidateRequest({
+    required this.clientSlug,
+    required this.name,
+    required this.url,
+    this.why,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'client_slug': clientSlug,
+    'name': name,
+    'url': url,
+    if (why != null) 'why': why,
+  };
+}
+
+@immutable
+class VeilleResolvedSourceCandidateDto {
+  final String clientSlug;
+  final String sourceId;
+  final String name;
+  final String url;
+  final String feedUrl;
+  final String? logoUrl;
+  final String? description;
+
+  const VeilleResolvedSourceCandidateDto({
+    required this.clientSlug,
+    required this.sourceId,
+    required this.name,
+    required this.url,
+    required this.feedUrl,
+    this.logoUrl,
+    this.description,
+  });
+
+  factory VeilleResolvedSourceCandidateDto.fromJson(Map<String, dynamic> json) {
+    return VeilleResolvedSourceCandidateDto(
+      clientSlug: json['client_slug'] as String,
+      sourceId: json['source_id'] as String,
+      name: json['name'] as String,
+      url: json['url'] as String,
+      feedUrl: json['feed_url'] as String,
+      logoUrl: json['logo_url'] as String?,
+      description: json['description'] as String?,
+    );
+  }
+}
+
+@immutable
+class VeilleFailedSourceCandidateDto {
+  final String clientSlug;
+  final String name;
+  final String url;
+  final String reason;
+
+  const VeilleFailedSourceCandidateDto({
+    required this.clientSlug,
+    required this.name,
+    required this.url,
+    required this.reason,
+  });
+
+  factory VeilleFailedSourceCandidateDto.fromJson(Map<String, dynamic> json) {
+    return VeilleFailedSourceCandidateDto(
+      clientSlug: json['client_slug'] as String,
+      name: json['name'] as String? ?? '',
+      url: json['url'] as String? ?? '',
+      reason: json['reason'] as String? ?? '',
+    );
+  }
+}
+
+@immutable
+class VeilleResolveSourceCandidatesResponseDto {
+  final List<VeilleResolvedSourceCandidateDto> resolved;
+  final List<VeilleFailedSourceCandidateDto> failed;
+
+  const VeilleResolveSourceCandidatesResponseDto({
+    this.resolved = const [],
+    this.failed = const [],
+  });
+
+  factory VeilleResolveSourceCandidatesResponseDto.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return VeilleResolveSourceCandidatesResponseDto(
+      resolved: ((json['resolved'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleResolvedSourceCandidateDto.fromJson)
+          .toList(),
+      failed: ((json['failed'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(VeilleFailedSourceCandidateDto.fromJson)
           .toList(),
     );
   }

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -10,6 +10,8 @@ import 'veille_active_config_provider.dart';
 import 'veille_repository_provider.dart';
 import 'veille_themes_provider.dart';
 
+enum VeilleSourceConnectionStatus { pending, connected, failed }
+
 /// Métadonnées attachées à une source dans le state du flow.
 ///
 /// Permet de distinguer les sources catalogue (UUID API) des candidats niche ;
@@ -22,6 +24,9 @@ class VeilleSourceMeta {
   final String? apiSourceId; // UUID si la source vient du catalogue
   final String? url;
   final String? why;
+  final VeilleSourceConnectionStatus connectionStatus;
+  final String? failureReason;
+  final String? logoUrl;
 
   const VeilleSourceMeta({
     required this.slug,
@@ -30,7 +35,38 @@ class VeilleSourceMeta {
     this.apiSourceId,
     this.url,
     this.why,
+    this.connectionStatus = VeilleSourceConnectionStatus.connected,
+    this.failureReason,
+    this.logoUrl,
   });
+
+  VeilleSourceMeta copyWith({
+    String? slug,
+    String? name,
+    String? kind,
+    Object? apiSourceId = _Sentinel.value,
+    Object? url = _Sentinel.value,
+    Object? why = _Sentinel.value,
+    VeilleSourceConnectionStatus? connectionStatus,
+    Object? failureReason = _Sentinel.value,
+    Object? logoUrl = _Sentinel.value,
+  }) {
+    return VeilleSourceMeta(
+      slug: slug ?? this.slug,
+      name: name ?? this.name,
+      kind: kind ?? this.kind,
+      apiSourceId: apiSourceId == _Sentinel.value
+          ? this.apiSourceId
+          : apiSourceId as String?,
+      url: url == _Sentinel.value ? this.url : url as String?,
+      why: why == _Sentinel.value ? this.why : why as String?,
+      connectionStatus: connectionStatus ?? this.connectionStatus,
+      failureReason: failureReason == _Sentinel.value
+          ? this.failureReason
+          : failureReason as String?,
+      logoUrl: logoUrl == _Sentinel.value ? this.logoUrl : logoUrl as String?,
+    );
+  }
 }
 
 /// État du flow de configuration de la veille.
@@ -82,6 +118,17 @@ class VeilleConfigState {
   /// Mapping slug → metadata pour sources.
   final Map<String, VeilleSourceMeta> sourcesMeta;
 
+  /// Contrôle explicite des fetch LLM. Initialement vrai en création ; remis
+  /// à faux en édition pour réafficher la config existante sans relancer de
+  /// suggestions automatiquement.
+  final bool angleSuggestionsRequested;
+  final bool sourceSuggestionsRequested;
+
+  /// Batch de résolution Step 3 en cours + slugs déjà tentés, pour éviter de
+  /// rappeler en boucle le resolver depuis le build.
+  final bool isResolvingSources;
+  final Set<String> sourceResolutionAttemptedSlugs;
+
   /// Angles libres / mots-clés saisis en mode advanced (step2). Normalisés
   /// lowercase, max 60 chars, dédupliqués. Mappés sur `VeilleKeywordSelection`
   /// backend.
@@ -132,6 +179,10 @@ class VeilleConfigState {
     required this.customTopics,
     required this.topicLabels,
     required this.sourcesMeta,
+    required this.angleSuggestionsRequested,
+    required this.sourceSuggestionsRequested,
+    required this.isResolvingSources,
+    required this.sourceResolutionAttemptedSlugs,
     required this.keywords,
     required this.angleKeywords,
     required this.advancedMode,
@@ -157,6 +208,10 @@ class VeilleConfigState {
     customTopics: [],
     topicLabels: {},
     sourcesMeta: {},
+    angleSuggestionsRequested: true,
+    sourceSuggestionsRequested: true,
+    isResolvingSources: false,
+    sourceResolutionAttemptedSlugs: <String>{},
     keywords: <String>{},
     angleKeywords: {},
     advancedMode: false,
@@ -169,13 +224,22 @@ class VeilleConfigState {
     customThemeLabel: null,
   );
 
-  /// Nombre de sources réellement persistables : source catalogue avec
-  /// `apiSourceId`, ou candidat niche avec URL valide.
+  /// Nombre de sources réellement persistables : seules les sources résolues
+  /// avec un `source_id` backend comptent pour la CTA.
   int get realSelectedSourceCount => selectedSourceIds.where((id) {
     final meta = sourcesMeta[id];
     if (meta == null) return false;
-    return meta.apiSourceId != null || _isValidHttpUrl(meta.url);
+    return meta.connectionStatus == VeilleSourceConnectionStatus.connected &&
+        meta.apiSourceId != null;
   }).length;
+
+  bool get hasPendingSelectedSources => selectedSourceIds.any((id) {
+    final meta = sourcesMeta[id];
+    return meta != null &&
+        meta.connectionStatus == VeilleSourceConnectionStatus.pending &&
+        meta.apiSourceId == null &&
+        _isValidHttpUrl(meta.url);
+  });
 
   VeilleConfigState copyWith({
     int? step,
@@ -190,6 +254,10 @@ class VeilleConfigState {
     List<VeilleTopic>? customTopics,
     Map<String, String>? topicLabels,
     Map<String, VeilleSourceMeta>? sourcesMeta,
+    bool? angleSuggestionsRequested,
+    bool? sourceSuggestionsRequested,
+    bool? isResolvingSources,
+    Set<String>? sourceResolutionAttemptedSlugs,
     Set<String>? keywords,
     Map<String, List<String>>? angleKeywords,
     bool? advancedMode,
@@ -221,6 +289,13 @@ class VeilleConfigState {
     customTopics: customTopics ?? this.customTopics,
     topicLabels: topicLabels ?? this.topicLabels,
     sourcesMeta: sourcesMeta ?? this.sourcesMeta,
+    angleSuggestionsRequested:
+        angleSuggestionsRequested ?? this.angleSuggestionsRequested,
+    sourceSuggestionsRequested:
+        sourceSuggestionsRequested ?? this.sourceSuggestionsRequested,
+    isResolvingSources: isResolvingSources ?? this.isResolvingSources,
+    sourceResolutionAttemptedSlugs:
+        sourceResolutionAttemptedSlugs ?? this.sourceResolutionAttemptedSlugs,
     keywords: keywords ?? this.keywords,
     angleKeywords: angleKeywords ?? this.angleKeywords,
     advancedMode: advancedMode ?? this.advancedMode,
@@ -485,11 +560,41 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     selectedSourceIds: _toggle(state.selectedSourceIds, id),
   );
 
-  /// Enregistre les candidats LLM Step 3 sans les sélectionner. Ils restent
-  /// locaux au flow et seront ingérés seulement si le user les coche.
-  void registerSuggestedSources(List<VeilleSourceSuggestionDto> suggestions) {
+  void removeSource(String id) {
+    final nextSelected = Set<String>.from(state.selectedSourceIds)..remove(id);
+    final nextMeta = Map<String, VeilleSourceMeta>.from(state.sourcesMeta)
+      ..remove(id);
+    final nextAttempted = Set<String>.from(state.sourceResolutionAttemptedSlugs)
+      ..remove(id);
+    state = state.copyWith(
+      selectedSourceIds: nextSelected,
+      sourcesMeta: nextMeta,
+      sourceResolutionAttemptedSlugs: nextAttempted,
+    );
+  }
+
+  void requestMoreAngles() {
+    if (state.angleSuggestionsRequested) return;
+    state = state.copyWith(angleSuggestionsRequested: true, lastError: null);
+  }
+
+  void requestMoreSources() {
+    if (state.sourceSuggestionsRequested) return;
+    state = state.copyWith(sourceSuggestionsRequested: true, lastError: null);
+  }
+
+  /// Enregistre les candidats LLM Step 3 et les présélectionne. Ils restent
+  /// en `pending` jusqu'à résolution batch, puis l'upsert envoie un `source_id`.
+  void registerSuggestedSources(
+    List<VeilleSourceSuggestionDto> suggestions, {
+    bool selectByDefault = true,
+  }) {
     if (suggestions.isEmpty) return;
     final nextMeta = Map<String, VeilleSourceMeta>.from(state.sourcesMeta);
+    final nextSelected = Set<String>.from(state.selectedSourceIds);
+    final nextAttempted = Set<String>.from(
+      state.sourceResolutionAttemptedSlugs,
+    );
     var changed = false;
     for (final s in suggestions) {
       if (!_isValidHttpUrl(s.url)) continue;
@@ -501,10 +606,112 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
         kind: 'niche',
         url: s.url,
         why: s.why,
+        logoUrl: _faviconForUrl(s.url),
+        connectionStatus: VeilleSourceConnectionStatus.pending,
       );
+      if (selectByDefault) nextSelected.add(slug);
+      nextAttempted.remove(slug);
       changed = true;
     }
-    if (changed) state = state.copyWith(sourcesMeta: nextMeta);
+    if (changed) {
+      state = state.copyWith(
+        sourcesMeta: nextMeta,
+        selectedSourceIds: nextSelected,
+        sourceResolutionAttemptedSlugs: nextAttempted,
+      );
+    }
+  }
+
+  Future<void> resolvePendingSources({bool force = false}) async {
+    if (state.isResolvingSources) return;
+    final candidates = <VeilleResolveSourceCandidateRequest>[];
+    for (final slug in state.selectedSourceIds) {
+      if (!force && state.sourceResolutionAttemptedSlugs.contains(slug)) {
+        continue;
+      }
+      final meta = state.sourcesMeta[slug];
+      if (meta == null ||
+          meta.connectionStatus != VeilleSourceConnectionStatus.pending ||
+          meta.apiSourceId != null ||
+          !_isValidHttpUrl(meta.url)) {
+        continue;
+      }
+      candidates.add(
+        VeilleResolveSourceCandidateRequest(
+          clientSlug: slug,
+          name: meta.name,
+          url: meta.url!,
+          why: meta.why,
+        ),
+      );
+    }
+    if (candidates.isEmpty) return;
+
+    final attempted = {
+      ...state.sourceResolutionAttemptedSlugs,
+      ...candidates.map((c) => c.clientSlug),
+    };
+    state = state.copyWith(
+      isResolvingSources: true,
+      sourceResolutionAttemptedSlugs: attempted,
+      lastError: null,
+    );
+
+    try {
+      final repo = _ref.read(veilleRepositoryProvider);
+      final result = await repo.resolveSourceCandidates(candidates);
+      final nextMeta = Map<String, VeilleSourceMeta>.from(state.sourcesMeta);
+      final nextSelected = Set<String>.from(state.selectedSourceIds);
+
+      for (final resolved in result.resolved) {
+        final current = nextMeta[resolved.clientSlug];
+        if (current == null) continue;
+        nextMeta[resolved.clientSlug] = current.copyWith(
+          name: resolved.name,
+          apiSourceId: resolved.sourceId,
+          url: resolved.url,
+          logoUrl: resolved.logoUrl ?? current.logoUrl,
+          connectionStatus: VeilleSourceConnectionStatus.connected,
+          failureReason: null,
+        );
+        nextSelected.add(resolved.clientSlug);
+      }
+
+      for (final failed in result.failed) {
+        final current =
+            nextMeta[failed.clientSlug] ??
+            VeilleSourceMeta(
+              slug: failed.clientSlug,
+              name: failed.name,
+              kind: 'niche',
+              url: failed.url,
+              connectionStatus: VeilleSourceConnectionStatus.pending,
+            );
+        nextMeta[failed.clientSlug] = current.copyWith(
+          name: failed.name.isEmpty ? current.name : failed.name,
+          url: failed.url.isEmpty ? current.url : failed.url,
+          apiSourceId: null,
+          connectionStatus: VeilleSourceConnectionStatus.failed,
+          failureReason: failed.reason,
+        );
+        nextSelected.remove(failed.clientSlug);
+      }
+
+      state = state.copyWith(
+        sourcesMeta: nextMeta,
+        selectedSourceIds: nextSelected,
+        isResolvingSources: false,
+        lastError: result.failed.isEmpty
+            ? null
+            : _sourceFailureMessage(result.failed.length),
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isResolvingSources: false,
+        lastError:
+            'Impossible de vérifier les sources pour l\'instant. Réessaie.',
+      );
+    }
   }
 
   /// Ajoute un mot-clé / angle libre (step2 advanced). Normalise lowercase,
@@ -605,6 +812,8 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       apiSourceId: sourceId,
       url: url,
       why: why,
+      logoUrl: _faviconForUrl(url),
+      connectionStatus: VeilleSourceConnectionStatus.connected,
     );
     state = state.copyWith(
       sourcesMeta: nextMeta,
@@ -635,10 +844,15 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       kind: 'niche',
       url: normalizedUrl,
       why: _emptyToNull(why),
+      logoUrl: _faviconForUrl(normalizedUrl),
+      connectionStatus: VeilleSourceConnectionStatus.pending,
     );
     state = state.copyWith(
       sourcesMeta: nextMeta,
       selectedSourceIds: {...state.selectedSourceIds, slug},
+      sourceResolutionAttemptedSlugs: Set<String>.from(
+        state.sourceResolutionAttemptedSlugs,
+      )..remove(slug),
     );
   }
 
@@ -740,6 +954,8 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
         kind: 'followed',
         apiSourceId: s.id,
         url: s.url,
+        logoUrl: s.logoUrl ?? _faviconForUrl(s.url),
+        connectionStatus: VeilleSourceConnectionStatus.connected,
       );
       followed.add(s.id);
     }
@@ -786,7 +1002,10 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       // veille » reste affiché → clic → redirection feed (bug navigation).
       // Le chemin archivage le fait déjà (my_interests_screen.dart).
       _ref.invalidate(userInterestsProvider);
-      state = state.copyWith(isSubmitting: false);
+      state = _applyServerConfigResult(
+        state,
+        cfg,
+      ).copyWith(isSubmitting: false);
       return cfg;
     } on VeilleApiException catch (e) {
       state = state.copyWith(isSubmitting: false, lastError: e.message);
@@ -869,6 +1088,8 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
         apiSourceId: s.source.id,
         url: s.source.url,
         why: s.why,
+        logoUrl: s.source.logoUrl,
+        connectionStatus: VeilleSourceConnectionStatus.connected,
       );
       selectedSourceIds.add(s.source.id);
     }
@@ -887,6 +1108,10 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       topicLabels: topicLabels,
       selectedSourceIds: selectedSourceIds,
       sourcesMeta: sourcesMeta,
+      angleSuggestionsRequested: false,
+      sourceSuggestionsRequested: false,
+      isResolvingSources: false,
+      sourceResolutionAttemptedSlugs: const <String>{},
       keywords: keywords,
       angleKeywords: angleKeywords,
       advancedMode:
@@ -895,6 +1120,82 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       editorialBrief: cfg.editorialBrief,
       presetId: cfg.presetId,
     );
+  }
+
+  VeilleConfigState _applyServerConfigResult(
+    VeilleConfigState current,
+    VeilleConfigDto cfg,
+  ) {
+    final nextMeta = Map<String, VeilleSourceMeta>.from(current.sourcesMeta);
+    final nextSelected = Set<String>.from(current.selectedSourceIds);
+
+    for (final sourceRef in cfg.sources) {
+      final source = sourceRef.source;
+      var key = source.id;
+      for (final entry in nextMeta.entries) {
+        if (entry.value.apiSourceId == source.id) {
+          key = entry.key;
+          break;
+        }
+      }
+      nextMeta[key] =
+          (nextMeta[key] ??
+                  VeilleSourceMeta(
+                    slug: key,
+                    name: source.name,
+                    kind: sourceRef.kind,
+                    apiSourceId: source.id,
+                    url: source.url,
+                  ))
+              .copyWith(
+                name: source.name,
+                kind: sourceRef.kind,
+                apiSourceId: source.id,
+                url: source.url,
+                why: sourceRef.why,
+                logoUrl: source.logoUrl,
+                connectionStatus: VeilleSourceConnectionStatus.connected,
+                failureReason: null,
+              );
+      nextSelected.add(key);
+    }
+
+    for (final failed in cfg.unconnectedSources) {
+      final key = _keyForUnconnected(nextMeta, failed);
+      if (key == null) continue;
+      final currentMeta = nextMeta[key]!;
+      nextMeta[key] = currentMeta.copyWith(
+        name: failed.name ?? currentMeta.name,
+        url: failed.url.isEmpty ? currentMeta.url : failed.url,
+        apiSourceId: null,
+        connectionStatus: VeilleSourceConnectionStatus.failed,
+        failureReason: failed.reason,
+      );
+      nextSelected.remove(key);
+    }
+
+    return current.copyWith(
+      step: cfg.unconnectedSources.isEmpty ? current.step : 3,
+      sourcesMeta: nextMeta,
+      selectedSourceIds: nextSelected,
+      lastError: cfg.unconnectedSources.isEmpty
+          ? null
+          : _sourceFailureMessage(cfg.unconnectedSources.length),
+    );
+  }
+
+  String? _keyForUnconnected(
+    Map<String, VeilleSourceMeta> sources,
+    VeilleUnconnectedSourceDto failed,
+  ) {
+    final slug = failed.clientSlug;
+    if (slug != null && sources.containsKey(slug)) return slug;
+    for (final entry in sources.entries) {
+      final meta = entry.value;
+      if (failed.url.isNotEmpty && meta.url == failed.url) return entry.key;
+      if (failed.name != null && meta.name == failed.name) return entry.key;
+    }
+    return null;
   }
 
   /// Réinitialise le flow (utilisé après suppression / pour repartir d'une
@@ -964,6 +1265,9 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     for (final slug in s.selectedSourceIds) {
       final meta = s.sourcesMeta[slug];
       if (meta == null) continue;
+      if (meta.connectionStatus != VeilleSourceConnectionStatus.connected) {
+        continue;
+      }
       final apiSourceId = meta.apiSourceId;
       if (apiSourceId != null) {
         sourceSelections.add(
@@ -981,6 +1285,7 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
         VeilleSourceSelectionRequest(
           kind: meta.kind,
           nicheCandidate: VeilleNicheCandidateRequest(
+            clientSlug: meta.slug,
             name: meta.name,
             url: meta.url!,
             why: meta.why,
@@ -1016,6 +1321,22 @@ final veilleConfigProvider =
     StateNotifierProvider.autoDispose<VeilleConfigNotifier, VeilleConfigState>(
       (ref) => VeilleConfigNotifier(ref),
     );
+
+String _sourceFailureMessage(int count) {
+  final source = count > 1 ? 'sources' : 'source';
+  final verb = count > 1 ? "n'ont" : "n'a";
+  final suffix = count > 1 ? 's' : '';
+  return '$count $source $verb pas pu être connectée$suffix. '
+      'Remplace-les pour continuer.';
+}
+
+String? _faviconForUrl(String? url) {
+  if (url == null || url.trim().isEmpty) return null;
+  final uri = Uri.tryParse(url.trim());
+  final host = uri?.host;
+  if (host == null || host.isEmpty) return null;
+  return 'https://www.google.com/s2/favicons?sz=128&domain=$host';
+}
 
 bool _isValidHttpUrl(String? value) {
   if (value == null || value.trim().isEmpty) return false;

--- a/apps/mobile/lib/features/veille/repositories/veille_repository.dart
+++ b/apps/mobile/lib/features/veille/repositories/veille_repository.dart
@@ -204,6 +204,24 @@ class VeilleRepository {
     }
   }
 
+  /// `POST /api/veille/sources/resolve-candidates` — valide en batch les
+  /// candidats sources et renvoie les `source_id` prêts pour l'upsert config.
+  Future<VeilleResolveSourceCandidatesResponseDto> resolveSourceCandidates(
+    List<VeilleResolveSourceCandidateRequest> candidates,
+  ) async {
+    try {
+      final response = await _dio.post<dynamic>(
+        'veille/sources/resolve-candidates',
+        data: {'candidates': candidates.map((c) => c.toJson()).toList()},
+      );
+      return VeilleResolveSourceCandidatesResponseDto.fromJson(
+        response.data as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw _wrap(e);
+    }
+  }
+
   VeilleApiException _wrap(DioException e) {
     final code = e.response?.statusCode;
     final detail = e.response?.data is Map

--- a/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step2_suggestions_screen.dart
@@ -27,7 +27,7 @@ class Step2SuggestionsScreen extends ConsumerWidget {
     final state = ref.watch(veilleConfigProvider);
     final notifier = ref.read(veilleConfigProvider.notifier);
     final theme = state.selectedTheme;
-    final anglesAsync = theme == null
+    final anglesAsync = theme == null || !state.angleSuggestionsRequested
         ? const AsyncValue<List<VeilleAngleSuggestionDto>>.data(
             <VeilleAngleSuggestionDto>[],
           )
@@ -87,11 +87,16 @@ class Step2SuggestionsScreen extends ConsumerWidget {
                   ),
                 ],
                 const SizedBox(height: 22),
-                _AnglesSection(
-                  anglesAsync: anglesAsync,
-                  state: state,
-                  notifier: notifier,
-                ),
+                _ExistingAnglesSection(state: state, notifier: notifier),
+                if (!state.angleSuggestionsRequested) ...[
+                  _LoadMoreAnglesButton(onTap: notifier.requestMoreAngles),
+                ] else ...[
+                  _AnglesSection(
+                    anglesAsync: anglesAsync,
+                    state: state,
+                    notifier: notifier,
+                  ),
+                ],
                 const SizedBox(height: 24),
                 _AdvancedToggle(
                   expanded: state.advancedMode,
@@ -202,6 +207,69 @@ class _MainTopicChip extends StatelessWidget {
   }
 }
 
+class _ExistingAnglesSection extends StatelessWidget {
+  final VeilleConfigState state;
+  final VeilleConfigNotifier notifier;
+  const _ExistingAnglesSection({required this.state, required this.notifier});
+
+  @override
+  Widget build(BuildContext context) {
+    if (state.selectedSuggestions.isEmpty) return const SizedBox.shrink();
+    final angles = [
+      for (final slug in state.selectedSuggestions)
+        (
+          slug: slug,
+          dto: VeilleAngleSuggestionDto(
+            title: state.topicLabels[slug] ?? slug,
+            keywords: state.angleKeywords[slug] ?? const <String>[],
+            reason: null,
+          ),
+        ),
+    ];
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 18),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'ANGLES SUIVIS',
+            style: GoogleFonts.dmSans(
+              fontSize: 10,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.8,
+              color: const Color(0xFF8B7E63),
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (int i = 0; i < angles.length; i++) ...[
+            if (i > 0) const SizedBox(height: 8),
+            _AngleCard(
+              angle: angles[i].dto,
+              state: state,
+              notifier: notifier,
+              slugOverride: angles[i].slug,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _LoadMoreAnglesButton extends StatelessWidget {
+  final VoidCallback onTap;
+  const _LoadMoreAnglesButton({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton.icon(
+      onPressed: onTap,
+      icon: Icon(PhosphorIcons.sparkle(), size: 15),
+      label: const Text('Proposer plus d’angles'),
+    );
+  }
+}
+
 /// Bloc « Angles suggérés » (LLM). Affiché au-dessus des preset topics.
 /// Pendant le fetch (~10-15 s) : un [FacteurLoader]. Liste vide (LLM KO ou
 /// thème sans angle) → rien (on retombe sur les preset topics → pas de
@@ -222,7 +290,14 @@ class _AnglesSection extends StatelessWidget {
       loading: () => const _AnglesLoading(),
       error: (_, __) => const SizedBox.shrink(),
       data: (angles) {
-        if (angles.isEmpty) return const SizedBox.shrink();
+        final visible = angles
+            .where(
+              (a) => !state.selectedSuggestions.contains(
+                VeilleConfigNotifier.angleSlug(a.title),
+              ),
+            )
+            .toList();
+        if (visible.isEmpty) return const SizedBox.shrink();
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -246,9 +321,9 @@ class _AnglesSection extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            for (int i = 0; i < angles.length; i++) ...[
+            for (int i = 0; i < visible.length; i++) ...[
               if (i > 0) const SizedBox(height: 8),
-              _AngleCard(angle: angles[i], state: state, notifier: notifier),
+              _AngleCard(angle: visible[i], state: state, notifier: notifier),
             ],
             const SizedBox(height: 22),
           ],
@@ -312,15 +387,17 @@ class _AngleCard extends StatelessWidget {
   final VeilleAngleSuggestionDto angle;
   final VeilleConfigState state;
   final VeilleConfigNotifier notifier;
+  final String? slugOverride;
   const _AngleCard({
     required this.angle,
     required this.state,
     required this.notifier,
+    this.slugOverride,
   });
 
   @override
   Widget build(BuildContext context) {
-    final slug = VeilleConfigNotifier.angleSlug(angle.title);
+    final slug = slugOverride ?? VeilleConfigNotifier.angleSlug(angle.title);
     final selected = state.selectedSuggestions.contains(slug);
     final keywords = selected
         ? (state.angleKeywords[slug] ?? const <String>[])
@@ -344,7 +421,9 @@ class _AngleCard extends StatelessWidget {
             borderRadius: BorderRadius.circular(12),
             child: InkWell(
               borderRadius: BorderRadius.circular(12),
-              onTap: () => notifier.toggleAngle(angle),
+              onTap: () => slugOverride == null
+                  ? notifier.toggleAngle(angle)
+                  : notifier.toggleSuggestion(slug),
               child: Padding(
                 padding: const EdgeInsets.all(12),
                 child: Row(

--- a/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step3_sources_screen.dart
@@ -18,8 +18,8 @@ import '../../widgets/veille_widgets.dart';
 /// Step 3 — choix des sources pour la veille.
 ///
 /// Les sources catalogue déjà appliquées gardent leurs exemples récents.
-/// Les sources LLM restent des candidats niche locaux au flow : elles sont
-/// ingérées seulement si le user les sélectionne puis submit.
+/// Les sources LLM sont présélectionnées puis résolues en arrière-plan pour
+/// obtenir un `source_id` avant le submit.
 class Step3SourcesScreen extends ConsumerWidget {
   final VoidCallback onClose;
   final Future<void> Function() onSubmit;
@@ -34,7 +34,9 @@ class Step3SourcesScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(veilleConfigProvider);
     final notifier = ref.read(veilleConfigProvider.notifier);
-    final query = buildSuggestionQuery(state);
+    final query = state.sourceSuggestionsRequested
+        ? buildSuggestionQuery(state)
+        : null;
     final VoidCallback? onRetry = query == null
         ? null
         : () => ref.invalidate(veilleSourceSuggestionsProvider(query));
@@ -44,23 +46,29 @@ class Step3SourcesScreen extends ConsumerWidget {
           )
         : ref.watch(veilleSourceSuggestionsProvider(query));
 
-    final canSubmit = state.realSelectedSourceCount > 0 && !state.isSubmitting;
+    if (state.hasPendingSelectedSources && !state.isResolvingSources) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        notifier.resolvePendingSources();
+      });
+    }
 
-    // Sources catalogue déjà appliquées (preset / customSourceAdded). Affichées
-    // d'abord les sélectionnées, puis le reste (preset non-cochés p.ex.).
-    final curatedSources = <VeilleSource>[];
+    final canSubmit =
+        state.realSelectedSourceCount > 0 &&
+        !state.isSubmitting &&
+        !state.isResolvingSources;
+
+    // Sources déjà en state : existantes d'abord, puis suggestions/pending.
+    final sourceMetas = <VeilleSourceMeta>[];
     final seen = <String>{};
     for (final id in state.selectedSourceIds) {
       final meta = state.sourcesMeta[id];
-      if (meta?.apiSourceId == null) continue;
-      if (!seen.add(id)) continue;
-      curatedSources.add(_metaToUiSource(meta!));
+      if (meta == null || !seen.add(id)) continue;
+      sourceMetas.add(meta);
     }
     for (final entry in state.sourcesMeta.entries) {
       if (state.selectedSourceIds.contains(entry.key)) continue;
-      if (entry.value.apiSourceId == null) continue;
       if (!seen.add(entry.key)) continue;
-      curatedSources.add(_metaToUiSource(entry.value));
+      sourceMetas.add(entry.value);
     }
 
     return Column(
@@ -75,11 +83,11 @@ class Step3SourcesScreen extends ConsumerWidget {
                 const VeilleFlowH1('Quelles sources veux-tu suivre ?'),
                 const SizedBox(height: 8),
                 Text(
-                  curatedSources.isEmpty
+                  sourceMetas.isEmpty
                       ? 'Ajoute une source par URL pour démarrer ta veille — '
-                          'un blog niche, un flux RSS, etc.'
+                            'un blog niche, un flux RSS, etc.'
                       : 'Décoche celles que tu ne veux pas suivre, ou ajoute '
-                          'une source par URL via la configuration avancée.',
+                            'une source par URL via la configuration avancée.',
                   style: GoogleFonts.dmSans(
                     fontSize: 13,
                     color: const Color(0xFF5D5B5A),
@@ -87,44 +95,64 @@ class Step3SourcesScreen extends ConsumerWidget {
                   ),
                 ),
                 const SizedBox(height: 22),
-                if (curatedSources.isNotEmpty) ...[
+                if (sourceMetas.isNotEmpty) ...[
                   Column(
                     children: [
-                      for (int i = 0; i < curatedSources.length; i++) ...[
+                      for (int i = 0; i < sourceMetas.length; i++) ...[
                         if (i > 0) const SizedBox(height: 6),
                         VeilleSourceCard(
-                          source: curatedSources[i],
+                          source: _metaToUiSource(sourceMetas[i]),
                           inVeille: state.selectedSourceIds.contains(
-                            curatedSources[i].id,
+                            sourceMetas[i].slug,
                           ),
                           isAlreadyFollowed: false,
-                          showExamples: true,
+                          showExamples:
+                              sourceMetas[i].connectionStatus ==
+                                  VeilleSourceConnectionStatus.connected &&
+                              sourceMetas[i].apiSourceId != null,
+                          exampleSourceId: sourceMetas[i].apiSourceId,
+                          connectionStatus: sourceMetas[i].connectionStatus,
+                          failureReason: sourceMetas[i].failureReason,
                           onToggle: () =>
-                              notifier.toggleSource(curatedSources[i].id),
+                              sourceMetas[i].connectionStatus ==
+                                  VeilleSourceConnectionStatus.failed
+                              ? notifier.removeSource(sourceMetas[i].slug)
+                              : notifier.toggleSource(sourceMetas[i].slug),
                         ),
                       ],
                     ],
                   ),
                   const SizedBox(height: 22),
                 ],
-                suggestionsAsync.when(
-                  loading: () => const _SourceSuggestionsLoading(),
-                  error: (_, __) =>
-                      _SourceSuggestionsEmpty(onRetry: onRetry, isError: true),
-                  data: (suggestions) {
-                    if (suggestions.isEmpty) {
-                      return _SourceSuggestionsEmpty(onRetry: onRetry);
-                    }
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      notifier.registerSuggestedSources(suggestions);
-                    });
-                    return _SuggestedSourcesList(
-                      suggestions: suggestions,
-                      state: state,
-                      notifier: notifier,
-                    );
-                  },
-                ),
+                if (!state.sourceSuggestionsRequested)
+                  _LoadMoreSourcesButton(onTap: notifier.requestMoreSources)
+                else
+                  suggestionsAsync.when(
+                    loading: () => const _SourceSuggestionsLoading(),
+                    error: (_, __) => _SourceSuggestionsEmpty(
+                      onRetry: onRetry,
+                      isError: true,
+                    ),
+                    data: (suggestions) {
+                      if (suggestions.isEmpty) {
+                        return _SourceSuggestionsEmpty(onRetry: onRetry);
+                      }
+                      final hasNewSuggestion = suggestions.any((s) {
+                        if (!_isValidHttpUrl(s.url)) return false;
+                        final slug = VeilleConfigNotifier.sourceSuggestionSlug(
+                          s.name,
+                          s.url,
+                        );
+                        return !state.sourcesMeta.containsKey(slug);
+                      });
+                      if (hasNewSuggestion) {
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          notifier.registerSuggestedSources(suggestions);
+                        });
+                      }
+                      return _LoadMoreSourcesButton(onTap: onRetry);
+                    },
+                  ),
                 const SizedBox(height: 24),
                 _AdvancedToggle(
                   expanded: state.advancedMode,
@@ -149,11 +177,22 @@ class Step3SourcesScreen extends ConsumerWidget {
                 if (!canSubmit && !state.isSubmitting) ...[
                   const SizedBox(height: 12),
                   Text(
-                    'Sélectionne au moins une source pour continuer.',
+                    state.isResolvingSources || state.hasPendingSelectedSources
+                        ? 'Vérification des sources en cours.'
+                        : 'Sélectionne au moins une source prête pour continuer.',
                     style: GoogleFonts.dmSans(
                       fontSize: 12,
                       color: const Color(0xFF8B7E63),
                     ),
+                  ),
+                ],
+                if (state.lastError != null) ...[
+                  const SizedBox(height: 12),
+                  _InlineSourceStatusBanner(
+                    message: state.lastError!,
+                    onRetry: state.hasPendingSelectedSources
+                        ? () => notifier.resolvePendingSources(force: true)
+                        : null,
                   ),
                 ],
               ],
@@ -167,10 +206,30 @@ class Step3SourcesScreen extends ConsumerWidget {
               top: BorderSide(color: FacteurColors.veilleLineSoft),
             ),
           ),
-          child: VeilleCtaButton(
-            label: state.isSubmitting ? 'Enregistrement…' : 'Créer ma veille',
-            trailingIcon: PhosphorIcons.check(),
-            onPressed: canSubmit ? () => onSubmit() : null,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              VeilleCtaButton(
+                label: state.isSubmitting
+                    ? 'Enregistrement…'
+                    : 'Créer ma veille',
+                trailingIcon: PhosphorIcons.check(),
+                onPressed: canSubmit ? () => onSubmit() : null,
+              ),
+              if (state.isSubmitting || state.isResolvingSources) ...[
+                const SizedBox(height: 8),
+                Text(
+                  state.isSubmitting
+                      ? 'Enregistrement en cours. Tes choix restent affichés.'
+                      : 'Vérification des sources en arrière-plan.',
+                  textAlign: TextAlign.center,
+                  style: GoogleFonts.dmSans(
+                    fontSize: 12,
+                    color: const Color(0xFF8B7E63),
+                  ),
+                ),
+              ],
+            ],
           ),
         ),
       ],
@@ -193,8 +252,9 @@ class Step3SourcesScreen extends ConsumerWidget {
               why: result.description,
             );
           } else {
-            final url =
-                result.feedUrl.trim().isNotEmpty ? result.feedUrl : result.url;
+            final url = result.feedUrl.trim().isNotEmpty
+                ? result.feedUrl
+                : result.url;
             if (_isValidHttpUrl(url)) {
               notifier.addUrlSourceToVeille(
                 name: result.name,
@@ -217,9 +277,7 @@ class Step3SourcesScreen extends ConsumerWidget {
       name: meta.name,
       meta: meta.kind == 'niche' ? 'Source niche' : 'Source curée',
       why: meta.why,
-      logoUrl: meta.url == null
-          ? null
-          : 'https://www.google.com/s2/favicons?sz=128&domain=${_domain(meta.url!)}',
+      logoUrl: meta.logoUrl,
     );
   }
 }
@@ -255,75 +313,69 @@ VeilleSourceSuggestionsQuery? buildSuggestionQuery(VeilleConfigState state) {
     themeId: theme,
     themeLabel: themeLabel,
     brief: state.editorialBrief ?? '',
-    anglesKey:
-        angleLabels.take(VeilleConfigNotifier.maxSuggestAngles).join('|'),
-    keywordsKey:
-        keywords.take(VeilleConfigNotifier.maxSuggestKeywords).join('|'),
+    anglesKey: angleLabels
+        .take(VeilleConfigNotifier.maxSuggestAngles)
+        .join('|'),
+    keywordsKey: keywords
+        .take(VeilleConfigNotifier.maxSuggestKeywords)
+        .join('|'),
   );
 }
 
-class _SuggestedSourcesList extends StatelessWidget {
-  final List<VeilleSourceSuggestionDto> suggestions;
-  final VeilleConfigState state;
-  final VeilleConfigNotifier notifier;
-
-  const _SuggestedSourcesList({
-    required this.suggestions,
-    required this.state,
-    required this.notifier,
-  });
+class _LoadMoreSourcesButton extends StatelessWidget {
+  final VoidCallback? onTap;
+  const _LoadMoreSourcesButton({required this.onTap});
 
   @override
   Widget build(BuildContext context) {
-    final valid = suggestions.where((s) => _isValidHttpUrl(s.url)).toList();
-    if (valid.isEmpty) {
-      return const _SourceSuggestionsEmpty(onRetry: null);
-    }
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'SOURCES PROPOSÉES',
-          style: GoogleFonts.dmSans(
-            fontSize: 10,
-            fontWeight: FontWeight.w700,
-            letterSpacing: 0.8,
-            color: const Color(0xFF8B7E63),
-          ),
-        ),
-        const SizedBox(height: 8),
-        for (int i = 0; i < valid.length; i++) ...[
-          if (i > 0) const SizedBox(height: 6),
-          _suggestionCard(valid[i]),
-        ],
-      ],
+    return OutlinedButton.icon(
+      onPressed: onTap,
+      icon: Icon(PhosphorIcons.plus(), size: 15),
+      label: const Text('Charger plus'),
     );
   }
+}
 
-  Widget _suggestionCard(VeilleSourceSuggestionDto suggestion) {
-    final slug = VeilleConfigNotifier.sourceSuggestionSlug(
-      suggestion.name,
-      suggestion.url,
-    );
-    final source = VeilleSource(
-      id: slug,
-      letter:
-          suggestion.name.isNotEmpty ? suggestion.name[0].toUpperCase() : '?',
-      name: suggestion.name,
-      meta: 'Source proposée',
-      why: suggestion.why,
-      logoUrl:
-          'https://www.google.com/s2/favicons?sz=128&domain=${_domain(suggestion.url)}',
-    );
-    return VeilleSourceCard(
-      source: source,
-      inVeille: state.selectedSourceIds.contains(slug),
-      isAlreadyFollowed: false,
-      showExamples: false,
-      onToggle: () {
-        notifier.registerSuggestedSources([suggestion]);
-        notifier.toggleSource(slug);
-      },
+class _InlineSourceStatusBanner extends StatelessWidget {
+  final String message;
+  final VoidCallback? onRetry;
+  const _InlineSourceStatusBanner({required this.message, this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFDFBF7),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: FacteurColors.veilleLineSoft),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            PhosphorIcons.warningCircle(),
+            size: 16,
+            color: const Color(0xFF8B7E63),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: GoogleFonts.dmSans(
+                fontSize: 12,
+                height: 1.35,
+                color: const Color(0xFF5D5B5A),
+              ),
+            ),
+          ),
+          if (onRetry != null) ...[
+            const SizedBox(width: 8),
+            TextButton(onPressed: onRetry, child: const Text('Réessayer')),
+          ],
+        ],
+      ),
     );
   }
 }
@@ -479,11 +531,6 @@ class _AddSourceButton extends StatelessWidget {
       ),
     );
   }
-}
-
-String _domain(String url) {
-  final uri = Uri.tryParse(url);
-  return uri?.host ?? url;
 }
 
 bool _isValidHttpUrl(String value) {

--- a/apps/mobile/lib/features/veille/widgets/veille_source_card.dart
+++ b/apps/mobile/lib/features/veille/widgets/veille_source_card.dart
@@ -10,10 +10,11 @@ import '../../sources/widgets/source_detail_modal.dart';
 import '../../sources/widgets/source_logo_avatar.dart';
 import '../models/veille_config.dart';
 import '../models/veille_source_example.dart';
+import '../providers/veille_config_provider.dart';
 import '../providers/veille_source_examples_provider.dart';
 
 /// Carte source pour le flow Veille — palette sépia, logo réel,
-/// CTA "Connecter/Connectée" unifié, badge "Source de confiance" pour les
+/// CTA d'état passif (Prête / Vérification / À remplacer), badge "Source de confiance" pour les
 /// sources déjà suivies par l'user. Tap → SourceDetailModal en consultation.
 /// Footer expansible "Voir 2 exemples récents" qui charge à la demande
 /// les derniers articles de la source via [veilleSourceExamplesProvider].
@@ -23,6 +24,9 @@ class VeilleSourceCard extends ConsumerStatefulWidget {
   final bool isAlreadyFollowed;
   final VoidCallback onToggle;
   final bool showExamples;
+  final String? exampleSourceId;
+  final VeilleSourceConnectionStatus connectionStatus;
+  final String? failureReason;
 
   const VeilleSourceCard({
     super.key,
@@ -31,6 +35,9 @@ class VeilleSourceCard extends ConsumerStatefulWidget {
     required this.isAlreadyFollowed,
     required this.onToggle,
     this.showExamples = true,
+    this.exampleSourceId,
+    this.connectionStatus = VeilleSourceConnectionStatus.connected,
+    this.failureReason,
   });
 
   @override
@@ -166,10 +173,24 @@ class _VeilleSourceCardState extends ConsumerState<VeilleSourceCard> {
                   const SizedBox(width: 8),
                   _ConnectButton(
                     active: widget.inVeille,
+                    status: widget.connectionStatus,
                     onTap: widget.onToggle,
                   ),
                 ],
               ),
+              if (widget.connectionStatus ==
+                      VeilleSourceConnectionStatus.failed &&
+                  widget.failureReason != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  widget.failureReason!,
+                  style: GoogleFonts.dmSans(
+                    fontSize: 11.5,
+                    height: 1.35,
+                    color: const Color(0xFF9A4F3F),
+                  ),
+                ),
+              ],
               if (widget.showExamples) ...[
                 const SizedBox(height: 10),
                 _ExamplesToggle(expanded: _expanded, onTap: _toggleExpanded),
@@ -180,7 +201,9 @@ class _VeilleSourceCardState extends ConsumerState<VeilleSourceCard> {
                   child: _expanded
                       ? Padding(
                           padding: const EdgeInsets.only(top: 8),
-                          child: _ExamplesPanel(sourceId: source.id),
+                          child: _ExamplesPanel(
+                            sourceId: widget.exampleSourceId ?? source.id,
+                          ),
                         )
                       : const SizedBox.shrink(),
                 ),
@@ -388,13 +411,41 @@ class _SourceDeConfianceBadge extends StatelessWidget {
 
 class _ConnectButton extends StatelessWidget {
   final bool active;
+  final VeilleSourceConnectionStatus status;
   final VoidCallback onTap;
-  const _ConnectButton({required this.active, required this.onTap});
+  const _ConnectButton({
+    required this.active,
+    required this.status,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final failed = status == VeilleSourceConnectionStatus.failed;
+    final pending = active && status == VeilleSourceConnectionStatus.pending;
+    final filled = active && !failed && !pending;
+    final borderColor = failed
+        ? const Color(0xFFB86A5B)
+        : (filled ? FacteurColors.veille : const Color(0xFFD2C9BB));
+    final fg = failed
+        ? const Color(0xFF9A4F3F)
+        : (filled ? Colors.white : FacteurColors.veille);
+    final label = failed
+        ? 'À remplacer'
+        : pending
+        ? 'Vérification…'
+        : active
+        ? 'Prête'
+        : 'Retirée';
+    final icon = failed
+        ? PhosphorIcons.warningCircle(PhosphorIconsStyle.bold)
+        : pending
+        ? PhosphorIcons.clock()
+        : active
+        ? PhosphorIcons.check(PhosphorIconsStyle.bold)
+        : PhosphorIcons.minus(PhosphorIconsStyle.bold);
     return Material(
-      color: active ? FacteurColors.veille : Colors.white,
+      color: filled ? FacteurColors.veille : Colors.white,
       borderRadius: BorderRadius.circular(100),
       child: InkWell(
         onTap: onTap,
@@ -403,28 +454,19 @@ class _ConnectButton extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 7),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(100),
-            border: Border.all(
-              color: active ? FacteurColors.veille : const Color(0xFFD2C9BB),
-              width: 1.5,
-            ),
+            border: Border.all(color: borderColor, width: 1.5),
           ),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(
-                active
-                    ? PhosphorIcons.check(PhosphorIconsStyle.bold)
-                    : PhosphorIcons.plus(PhosphorIconsStyle.bold),
-                size: 12,
-                color: active ? Colors.white : FacteurColors.veille,
-              ),
+              Icon(icon, size: 12, color: fg),
               const SizedBox(width: 5),
               Text(
-                active ? 'Connectée' : 'Connecter',
+                label,
                 style: GoogleFonts.dmSans(
                   fontSize: 12,
                   fontWeight: FontWeight.w700,
-                  color: active ? Colors.white : FacteurColors.veille,
+                  color: fg,
                 ),
               ),
             ],

--- a/apps/mobile/test/features/veille/models/veille_config_dto_test.dart
+++ b/apps/mobile/test/features/veille/models/veille_config_dto_test.dart
@@ -129,32 +129,73 @@ void main() {
 
   group('VeilleConfigDto.fromJson — unconnected_sources', () {
     Map<String, dynamic> baseConfig() => {
-      'id': 'cfg-1',
-      'user_id': 'user-1',
-      'theme_id': 'tech',
-      'theme_label': 'Tech',
-      'status': 'active',
-      'created_at': '2026-06-04T00:00:00Z',
-      'updated_at': '2026-06-04T00:00:00Z',
-      'topics': const [],
-      'sources': const [],
-      'keywords': const [],
-    };
+          'id': 'cfg-1',
+          'user_id': 'user-1',
+          'theme_id': 'tech',
+          'theme_label': 'Tech',
+          'status': 'active',
+          'created_at': '2026-06-04T00:00:00Z',
+          'updated_at': '2026-06-04T00:00:00Z',
+          'topics': const <dynamic>[],
+          'sources': const <dynamic>[],
+          'keywords': const <dynamic>[],
+        };
 
     test('mappe url + reason des sources non connectées', () {
       final dto = VeilleConfigDto.fromJson({
         ...baseConfig(),
         'unconnected_sources': const [
-          {'url': 'https://exemple.test', 'reason': 'Aucun flux RSS.'},
+          {
+            'client_slug': 'niche-exemple',
+            'name': 'Exemple',
+            'url': 'https://exemple.test',
+            'reason': 'Aucun flux RSS.',
+          },
         ],
       });
       expect(dto.unconnectedSources, hasLength(1));
+      expect(dto.unconnectedSources.first.clientSlug, 'niche-exemple');
+      expect(dto.unconnectedSources.first.name, 'Exemple');
       expect(dto.unconnectedSources.first.url, 'https://exemple.test');
       expect(dto.unconnectedSources.first.reason, 'Aucun flux RSS.');
     });
 
     test('clé absente → liste vide (rétro-compat backend non déployé)', () {
-      expect(VeilleConfigDto.fromJson(baseConfig()).unconnectedSources, isEmpty);
+      expect(
+        VeilleConfigDto.fromJson(baseConfig()).unconnectedSources,
+        isEmpty,
+      );
+    });
+  });
+
+  group('VeilleResolveSourceCandidatesResponseDto.fromJson', () {
+    test('mappe resolved + failed', () {
+      final dto = VeilleResolveSourceCandidatesResponseDto.fromJson(const {
+        'resolved': [
+          {
+            'client_slug': 'niche-macba',
+            'source_id': 'src-1',
+            'name': 'MACBA',
+            'url': 'https://www.macba.cat',
+            'feed_url': 'https://www.macba.cat/feed.xml',
+            'logo_url': 'https://logo.test/macba.png',
+            'description': 'Musée',
+          },
+        ],
+        'failed': [
+          {
+            'client_slug': 'niche-ko',
+            'name': 'KO',
+            'url': 'https://ko.test',
+            'reason': 'Aucun flux RSS.',
+          },
+        ],
+      });
+      expect(dto.resolved.single.clientSlug, 'niche-macba');
+      expect(dto.resolved.single.sourceId, 'src-1');
+      expect(dto.resolved.single.feedUrl, 'https://www.macba.cat/feed.xml');
+      expect(dto.failed.single.clientSlug, 'niche-ko');
+      expect(dto.failed.single.reason, 'Aucun flux RSS.');
     });
   });
 }

--- a/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
@@ -12,6 +12,9 @@ import 'package:facteur/features/veille/screens/steps/step3_sources_screen.dart'
 /// `_buildUpsertRequest`). Toute autre méthode throw → instrumentation à fixer.
 class _CaptureRepo implements VeilleRepository {
   VeilleConfigUpsertRequest? captured;
+  List<VeilleResolveSourceCandidateRequest>? capturedResolveCandidates;
+  VeilleResolveSourceCandidatesResponseDto resolveResponse =
+      const VeilleResolveSourceCandidatesResponseDto();
   VeilleResolvedTopicDto resolvedTopic = const VeilleResolvedTopicDto(
     label: 'Musées contemporains de Barcelone',
     topicId: 'custom-musees-contemporains-de-barcelone',
@@ -42,6 +45,14 @@ class _CaptureRepo implements VeilleRepository {
     String? themeId,
     String? themeLabel,
   }) async => resolvedTopic;
+
+  @override
+  Future<VeilleResolveSourceCandidatesResponseDto> resolveSourceCandidates(
+    List<VeilleResolveSourceCandidateRequest> candidates,
+  ) async {
+    capturedResolveCandidates = candidates;
+    return resolveResponse;
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) =>
@@ -182,7 +193,7 @@ void main() {
     expect(container.read(veilleConfigProvider).step, 1);
   });
 
-  test('realSelectedSourceCount compte catalogue et candidat niche valide', () {
+  test('source suggérée est présélectionnée pending et ne compte pas CTA', () {
     notifier.addCustomSourceToVeille(
       sourceId: 'src-1',
       name: 'Le Monde',
@@ -200,13 +211,121 @@ void main() {
       'MACBA',
       'https://www.macba.cat',
     );
-    notifier.toggleSource(slug);
+    final s = container.read(veilleConfigProvider);
 
-    expect(container.read(veilleConfigProvider).realSelectedSourceCount, 2);
+    expect(s.selectedSourceIds, contains(slug));
+    expect(
+      s.sourcesMeta[slug]!.connectionStatus,
+      VeilleSourceConnectionStatus.pending,
+    );
+    expect(s.realSelectedSourceCount, 1);
   });
 
-  test('submit sérialise un candidat niche en niche_candidate', () async {
+  test(
+    'resolvePendingSources marque les candidats résolus connected',
+    () async {
+      final repo = _CaptureRepo();
+      repo.resolveResponse = const VeilleResolveSourceCandidatesResponseDto(
+        resolved: [
+          VeilleResolvedSourceCandidateDto(
+            clientSlug: 'niche-wwwmacbacat-macba',
+            sourceId: 'src-macba',
+            name: 'MACBA',
+            url: 'https://www.macba.cat',
+            feedUrl: 'https://www.macba.cat/feed.xml',
+            logoUrl: 'https://logo.test/macba.png',
+          ),
+        ],
+      );
+      final c = ProviderContainer(
+        overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(c.dispose);
+      final n = c.read(veilleConfigProvider.notifier);
+
+      n.registerSuggestedSources(const [
+        VeilleSourceSuggestionDto(
+          name: 'MACBA',
+          url: 'https://www.macba.cat',
+          why: 'Musée officiel',
+          relevanceScore: 1,
+        ),
+      ]);
+      final slug = VeilleConfigNotifier.sourceSuggestionSlug(
+        'MACBA',
+        'https://www.macba.cat',
+      );
+      await n.resolvePendingSources();
+
+      final s = c.read(veilleConfigProvider);
+      expect(repo.capturedResolveCandidates!.single.clientSlug, slug);
+      expect(s.sourcesMeta[slug]!.apiSourceId, 'src-macba');
+      expect(
+        s.sourcesMeta[slug]!.connectionStatus,
+        VeilleSourceConnectionStatus.connected,
+      );
+      expect(s.realSelectedSourceCount, 1);
+    },
+  );
+
+  test('resolvePendingSources désélectionne les candidats KO', () async {
     final repo = _CaptureRepo();
+    final slug = VeilleConfigNotifier.sourceSuggestionSlug(
+      'MACBA',
+      'https://www.macba.cat',
+    );
+    repo.resolveResponse = VeilleResolveSourceCandidatesResponseDto(
+      failed: [
+        VeilleFailedSourceCandidateDto(
+          clientSlug: slug,
+          name: 'MACBA',
+          url: 'https://www.macba.cat',
+          reason: 'Aucun flux RSS.',
+        ),
+      ],
+    );
+    final c = ProviderContainer(
+      overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+    );
+    addTearDown(c.dispose);
+    final n = c.read(veilleConfigProvider.notifier);
+
+    n.registerSuggestedSources(const [
+      VeilleSourceSuggestionDto(
+        name: 'MACBA',
+        url: 'https://www.macba.cat',
+        why: 'Musée officiel',
+        relevanceScore: 1,
+      ),
+    ]);
+    await n.resolvePendingSources();
+
+    final s = c.read(veilleConfigProvider);
+    expect(s.selectedSourceIds, isNot(contains(slug)));
+    expect(
+      s.sourcesMeta[slug]!.connectionStatus,
+      VeilleSourceConnectionStatus.failed,
+    );
+    expect(s.lastError, contains("n'a pas pu être connectée"));
+  });
+
+  test('submit sérialise un candidat résolu en source_id', () async {
+    final repo = _CaptureRepo();
+    final slug = VeilleConfigNotifier.sourceSuggestionSlug(
+      'MACBA',
+      'https://www.macba.cat',
+    );
+    repo.resolveResponse = VeilleResolveSourceCandidatesResponseDto(
+      resolved: [
+        VeilleResolvedSourceCandidateDto(
+          clientSlug: slug,
+          sourceId: 'src-macba',
+          name: 'MACBA',
+          url: 'https://www.macba.cat',
+          feedUrl: 'https://www.macba.cat/feed.xml',
+        ),
+      ],
+    );
     final c = ProviderContainer(
       overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
     );
@@ -223,19 +342,14 @@ void main() {
         relevanceScore: 1,
       ),
     ]);
-    final slug = VeilleConfigNotifier.sourceSuggestionSlug(
-      'MACBA',
-      'https://www.macba.cat',
-    );
-    n.toggleSource(slug);
+    await n.resolvePendingSources();
     await n.submit();
 
     final source = repo.captured!.sourceSelections.single;
     expect(source.kind, 'niche');
-    expect(source.sourceId, isNull);
-    expect(source.nicheCandidate!.name, 'MACBA');
-    expect(source.nicheCandidate!.url, 'https://www.macba.cat');
-    expect(source.toJson()['niche_candidate'], isA<Map<String, dynamic>>());
+    expect(source.sourceId, 'src-macba');
+    expect(source.nicheCandidate, isNull);
+    expect(source.toJson()['source_id'], 'src-macba');
   });
 
   test('addUrlSourceToVeille ajoute une source niche locale sélectionnée', () {

--- a/apps/mobile/test/features/veille/screens/step2_suggestions_screen_test.dart
+++ b/apps/mobile/test/features/veille/screens/step2_suggestions_screen_test.dart
@@ -120,4 +120,65 @@ void main() {
     );
     expect(find.text('llm'), findsNothing);
   });
+
+  testWidgets('édition affiche les angles existants sans loader ni appel LLM', (
+    tester,
+  ) async {
+    var calls = 0;
+    final container = ProviderContainer(
+      overrides: [
+        veilleRepositoryProvider.overrideWithValue(
+          _FakeRepo(() {
+            calls++;
+            return Future.value(const []);
+          }),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final sub = container.listen(veilleConfigProvider, (_, __) {});
+    addTearDown(sub.close);
+    container
+        .read(veilleConfigProvider.notifier)
+        .hydrateFromActiveConfig(
+          VeilleConfigDto(
+            id: 'cfg-1',
+            userId: 'user-1',
+            themeId: 'tech',
+            themeLabel: 'Tech',
+            status: 'active',
+            createdAt: DateTime(2024),
+            updatedAt: DateTime(2024),
+            topics: const [
+              VeilleTopicDto(
+                id: 't0',
+                topicId: 'ai',
+                label: 'IA',
+                kind: 'preset',
+                reason: null,
+                position: 0,
+              ),
+              VeilleTopicDto(
+                id: 't1',
+                topicId: 'angle-regulation',
+                label: 'Régulation',
+                kind: 'suggested',
+                reason: null,
+                position: 1,
+                keywords: ['ai act'],
+              ),
+            ],
+            sources: const [],
+            keywords: const [],
+          ),
+        );
+
+    await tester.pumpWidget(_wrap(container));
+    await tester.pump();
+
+    expect(find.text('Régulation'), findsOneWidget);
+    expect(find.text('Recherche des bons angles'), findsNothing);
+    expect(calls, 0);
+    expect(find.text('Proposer plus d’angles'), findsOneWidget);
+  });
 }

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 import unicodedata
-import asyncio
 from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
@@ -33,17 +33,17 @@ from app.schemas.veille import (
     VeilleAngleSuggestion,
     VeilleConfigResponse,
     VeilleConfigUpsert,
+    VeilleFailedSourceCandidate,
     VeilleFeedArticle,
     VeilleFeedResponse,
     VeilleKeywordResponse,
     VeillePresetResponse,
-    VeilleFailedSourceCandidate,
-    VeilleResolveTopicRequest,
-    VeilleResolveTopicResponse,
+    VeilleResolvedSourceCandidate,
     VeilleResolveSourceCandidate,
     VeilleResolveSourceCandidatesRequest,
     VeilleResolveSourceCandidatesResponse,
-    VeilleResolvedSourceCandidate,
+    VeilleResolveTopicRequest,
+    VeilleResolveTopicResponse,
     VeilleSourceExample,
     VeilleSourceLite,
     VeilleSourceResponse,
@@ -398,9 +398,7 @@ async def resolve_source_candidates(
             continue
 
         existing = (
-            (
-                await db.execute(select(Source).where(Source.feed_url == feed_url))
-            )
+            (await db.execute(select(Source).where(Source.feed_url == feed_url)))
             .scalars()
             .first()
         )

--- a/packages/api/app/routers/veille.py
+++ b/packages/api/app/routers/veille.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
+import asyncio
 from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
@@ -36,8 +37,13 @@ from app.schemas.veille import (
     VeilleFeedResponse,
     VeilleKeywordResponse,
     VeillePresetResponse,
+    VeilleFailedSourceCandidate,
     VeilleResolveTopicRequest,
     VeilleResolveTopicResponse,
+    VeilleResolveSourceCandidate,
+    VeilleResolveSourceCandidatesRequest,
+    VeilleResolveSourceCandidatesResponse,
+    VeilleResolvedSourceCandidate,
     VeilleSourceExample,
     VeilleSourceLite,
     VeilleSourceResponse,
@@ -51,6 +57,7 @@ from app.schemas.veille import (
 )
 from app.services.ml.topic_enrichment_service import get_topic_enrichment_service
 from app.services.rss_parser import RSSParser
+from app.services.search.smart_source_search import SmartSourceSearchService
 from app.services.source_service import SourceService
 from app.services.user_interests_service import ensure_veille_favorite
 from app.services.veille.feed_filter import fetch_veille_feed, load_veille_filters
@@ -198,6 +205,42 @@ def _source_theme_for(veille_theme_id: str) -> str:
     return "custom" if veille_theme_id == "other" else veille_theme_id
 
 
+def _source_type_from_raw(raw: str | None) -> SourceType:
+    """Mappe les types RSS/feedparser vers l'enum `Source.type`."""
+    if raw in ("rss", "atom", None, ""):
+        return SourceType.ARTICLE
+    try:
+        return SourceType(raw)
+    except ValueError:
+        return SourceType.ARTICLE
+
+
+def _source_to_resolved_candidate(
+    source: Source, candidate: VeilleResolveSourceCandidate
+) -> VeilleResolvedSourceCandidate:
+    return VeilleResolvedSourceCandidate(
+        client_slug=candidate.client_slug,
+        source_id=source.id,
+        name=source.name,
+        url=source.url,
+        feed_url=source.feed_url,
+        logo_url=source.logo_url,
+        description=source.description,
+    )
+
+
+async def _find_source_by_url_or_feed(db: AsyncSession, url: str) -> Source | None:
+    return (
+        (
+            await db.execute(
+                select(Source).where(or_(Source.url == url, Source.feed_url == url))
+            )
+        )
+        .scalars()
+        .first()
+    )
+
+
 async def _resolve_source_id(
     db: AsyncSession,
     selection,
@@ -229,17 +272,12 @@ async def _resolve_source_id(
     if existing is not None:
         return existing.id, False
 
-    try:
-        source_type = SourceType(detected.detected_type)
-    except ValueError:
-        source_type = SourceType.ARTICLE
-
     new_source = Source(
         id=uuid4(),
         name=cand.name or detected.name,
         url=cand.url,
         feed_url=detected.feed_url,
-        type=source_type,
+        type=_source_type_from_raw(str(detected.detected_type)),
         theme=_source_theme_for(theme_id),
         description=detected.description,
         logo_url=detected.logo_url,
@@ -282,6 +320,118 @@ async def get_config(
         logger.warning("veille.favorite_self_heal_failed", exc_info=True)
 
     return await _hydrate_response(db, cfg)
+
+
+@router.post(
+    "/sources/resolve-candidates",
+    response_model=VeilleResolveSourceCandidatesResponse,
+)
+async def resolve_source_candidates(
+    body: VeilleResolveSourceCandidatesRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Résout des candidats source Step 3 sans les attacher à la veille.
+
+    Le mobile peut afficher vite les propositions, les présélectionner, puis
+    appeler ce batch en arrière-plan. Les sources résolues fournissent un
+    `source_id` prêt à être envoyé à `POST /config`, ce qui évite de relancer
+    une détection RSS lente au submit.
+    """
+    UUID(current_user_id)
+    if not body.candidates:
+        return VeilleResolveSourceCandidatesResponse()
+
+    resolved: list[VeilleResolvedSourceCandidate] = []
+    failed: list[VeilleFailedSourceCandidate] = []
+    pending: list[VeilleResolveSourceCandidate] = []
+    seen_slugs: set[str] = set()
+
+    for candidate in body.candidates:
+        if candidate.client_slug in seen_slugs:
+            continue
+        seen_slugs.add(candidate.client_slug)
+        existing = await _find_source_by_url_or_feed(db, candidate.url)
+        if existing is not None:
+            resolved.append(_source_to_resolved_candidate(existing, candidate))
+            continue
+        pending.append(candidate)
+
+    if not pending:
+        return VeilleResolveSourceCandidatesResponse(resolved=resolved, failed=failed)
+
+    search_service = SmartSourceSearchService(db)
+    semaphore = asyncio.Semaphore(5)
+
+    async def _detect(candidate: VeilleResolveSourceCandidate):
+        async with semaphore:
+            return candidate, await search_service.detect_feed(candidate.url)
+
+    try:
+        detections = await asyncio.gather(*(_detect(c) for c in pending))
+    finally:
+        await search_service.close()
+
+    for candidate, detection in detections:
+        if detection is None:
+            failed.append(
+                VeilleFailedSourceCandidate(
+                    client_slug=candidate.client_slug,
+                    name=candidate.name,
+                    url=candidate.url,
+                    reason="Aucun flux RSS détecté à cette adresse.",
+                )
+            )
+            continue
+
+        resolved_url, feed_meta = detection
+        feed_url = feed_meta.get("feed_url")
+        if not feed_url:
+            failed.append(
+                VeilleFailedSourceCandidate(
+                    client_slug=candidate.client_slug,
+                    name=candidate.name,
+                    url=candidate.url,
+                    reason="Aucun flux RSS détecté à cette adresse.",
+                )
+            )
+            continue
+
+        existing = (
+            (
+                await db.execute(select(Source).where(Source.feed_url == feed_url))
+            )
+            .scalars()
+            .first()
+        )
+        if existing is not None:
+            resolved.append(_source_to_resolved_candidate(existing, candidate))
+            continue
+
+        source = Source(
+            id=uuid4(),
+            name=candidate.name or feed_meta.get("name") or resolved_url,
+            url=resolved_url,
+            feed_url=feed_url,
+            type=_source_type_from_raw(feed_meta.get("type")),
+            theme="custom",
+            description=feed_meta.get("description"),
+            logo_url=feed_meta.get("favicon_url"),
+            is_curated=False,
+            is_active=True,
+        )
+        db.add(source)
+        await db.flush()
+        logger.info(
+            "veille.source_candidate_resolved",
+            source_id=str(source.id),
+            client_slug=candidate.client_slug,
+            feed_url=source.feed_url,
+        )
+        resolved.append(_source_to_resolved_candidate(source, candidate))
+
+    await db.commit()
+    return VeilleResolveSourceCandidatesResponse(resolved=resolved, failed=failed)
 
 
 @router.post("/config", response_model=VeilleConfigResponse)
@@ -376,6 +526,8 @@ async def upsert_config(
                     VeilleUnconnectedSource(
                         url=url,
                         reason="Aucun flux RSS détecté à cette adresse.",
+                        client_slug=getattr(sel.niche_candidate, "client_slug", None),
+                        name=getattr(sel.niche_candidate, "name", None),
                     )
                 )
             continue

--- a/packages/api/app/schemas/veille.py
+++ b/packages/api/app/schemas/veille.py
@@ -85,6 +85,8 @@ class VeilleUnconnectedSource(BaseModel):
 
     url: str
     reason: str
+    client_slug: str | None = None
+    name: str | None = None
 
 
 class VeilleConfigResponse(BaseModel):
@@ -137,6 +139,7 @@ class VeilleNicheCandidate(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     url: str = Field(min_length=4, max_length=2048)
     why: str | None = Field(default=None, max_length=500)
+    client_slug: str | None = Field(default=None, max_length=120)
 
 
 class VeilleSourceSelection(BaseModel):
@@ -323,3 +326,43 @@ class VeilleSourceSuggestion(BaseModel):
 
 class VeilleSuggestSourcesResponse(BaseModel):
     sources: list[VeilleSourceSuggestion] = Field(default_factory=list)
+
+
+# ─── Résolution batch de sources candidates (Step 3) ────────────────────────
+
+
+class VeilleResolveSourceCandidate(BaseModel):
+    """Candidat source proposé/local côté mobile, pas encore attaché à la veille."""
+
+    client_slug: str = Field(min_length=1, max_length=120)
+    name: str = Field(min_length=1, max_length=200)
+    url: str = Field(min_length=4, max_length=2048)
+    why: str | None = Field(default=None, max_length=500)
+
+
+class VeilleResolveSourceCandidatesRequest(BaseModel):
+    candidates: list[VeilleResolveSourceCandidate] = Field(
+        default_factory=list, max_length=12
+    )
+
+
+class VeilleResolvedSourceCandidate(BaseModel):
+    client_slug: str
+    source_id: UUID
+    name: str
+    url: str
+    feed_url: str
+    logo_url: str | None = None
+    description: str | None = None
+
+
+class VeilleFailedSourceCandidate(BaseModel):
+    client_slug: str
+    name: str
+    url: str
+    reason: str
+
+
+class VeilleResolveSourceCandidatesResponse(BaseModel):
+    resolved: list[VeilleResolvedSourceCandidate] = Field(default_factory=list)
+    failed: list[VeilleFailedSourceCandidate] = Field(default_factory=list)

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -700,6 +700,15 @@ class SmartSourceSearchService:
             return None
         return f"{parsed.scheme}://{parsed.netloc}"
 
+    async def detect_feed(self, url: str) -> tuple[str, dict] | None:
+        """Public one-off feed detection (root-fallback strategy).
+
+        Exposed so callers outside the search pipeline (e.g. the veille source
+        resolver) can reuse the detection logic without reaching into a private
+        helper. Returns ``(resolved_url, feed_meta)`` or ``None``.
+        """
+        return await self._detect_with_root_fallback(url)
+
     async def _detect_with_root_fallback(self, url: str) -> tuple[str, dict] | None:
         """Resolve *url* to a feed, preferring the host root.
 

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -662,6 +662,145 @@ class TestSuggestEndpoints:
         assert captured["keywords"] == [f"kw-{i}" for i in range(40)]
 
 
+class TestResolveSourceCandidates:
+    async def test_resolve_candidates_reuses_existing_source(
+        self, auth_user, curated_tech_source, monkeypatch
+    ):
+        from app.services.search import smart_source_search
+
+        async def _should_not_detect(self, url):
+            raise AssertionError("existing source should not trigger RSS detection")
+
+        monkeypatch.setattr(
+            smart_source_search.SmartSourceSearchService,
+            "_detect_with_root_fallback",
+            _should_not_detect,
+        )
+
+        async with _client() as c:
+            r = await c.post(
+                "/api/veille/sources/resolve-candidates",
+                json={
+                    "candidates": [
+                        {
+                            "client_slug": "existing-tech",
+                            "name": "Tech Daily",
+                            "url": curated_tech_source.url,
+                            "why": "Déjà au catalogue",
+                        }
+                    ]
+                },
+            )
+
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["failed"] == []
+        assert data["resolved"][0]["client_slug"] == "existing-tech"
+        assert data["resolved"][0]["source_id"] == str(curated_tech_source.id)
+
+    async def test_resolve_candidates_creates_source_and_returns_failures(
+        self, auth_user, db_session, monkeypatch
+    ):
+        from app.services.search import smart_source_search
+
+        async def _fake_detect(self, url):
+            if "macba" not in url:
+                return None
+            return (
+                "https://www.macba.cat",
+                {
+                    "feed_url": "https://www.macba.cat/feed.xml",
+                    "name": "MACBA feed",
+                    "type": "rss",
+                    "favicon_url": "https://www.macba.cat/favicon.ico",
+                    "description": "Musée contemporain",
+                },
+            )
+
+        monkeypatch.setattr(
+            smart_source_search.SmartSourceSearchService,
+            "_detect_with_root_fallback",
+            _fake_detect,
+        )
+
+        async with _client() as c:
+            r = await c.post(
+                "/api/veille/sources/resolve-candidates",
+                json={
+                    "candidates": [
+                        {
+                            "client_slug": "niche-macba",
+                            "name": "MACBA",
+                            "url": "https://www.macba.cat",
+                            "why": "Musée officiel",
+                        },
+                        {
+                            "client_slug": "niche-ko",
+                            "name": "Site KO",
+                            "url": "https://ko.test",
+                            "why": None,
+                        },
+                    ]
+                },
+            )
+
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["resolved"][0]["client_slug"] == "niche-macba"
+        assert data["resolved"][0]["name"] == "MACBA"
+        assert data["resolved"][0]["feed_url"] == "https://www.macba.cat/feed.xml"
+        assert data["resolved"][0]["logo_url"] == "https://www.macba.cat/favicon.ico"
+        assert data["failed"] == [
+            {
+                "client_slug": "niche-ko",
+                "name": "Site KO",
+                "url": "https://ko.test",
+                "reason": "Aucun flux RSS détecté à cette adresse.",
+            }
+        ]
+
+        source_id = UUID(data["resolved"][0]["source_id"])
+        src = await db_session.scalar(select(Source).where(Source.id == source_id))
+        assert src is not None
+        assert src.feed_url == "https://www.macba.cat/feed.xml"
+        assert src.type == SourceType.ARTICLE
+        assert src.theme == "custom"
+
+    async def test_post_config_with_source_id_does_not_detect(
+        self, auth_user, curated_tech_source, monkeypatch
+    ):
+        from app.services import source_service
+
+        async def _should_not_detect(self, url):
+            raise AssertionError("source_id upsert must not detect RSS")
+
+        monkeypatch.setattr(
+            source_service.SourceService, "detect_source", _should_not_detect
+        )
+
+        payload = {
+            "theme_id": "tech",
+            "theme_label": "Tech",
+            "topics": [],
+            "source_selections": [
+                {
+                    "kind": "niche",
+                    "source_id": str(curated_tech_source.id),
+                    "why": "résolue avant submit",
+                    "position": 0,
+                }
+            ],
+            "keywords": [],
+        }
+        async with _client() as c:
+            r = await c.post("/api/veille/config", json=payload)
+
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["sources"][0]["source"]["id"] == str(curated_tech_source.id)
+        assert data["unconnected_sources"] == []
+
+
 class TestOtherThemeIngestion:
     """theme_id='other' (tuile Autre) doit mapper vers theme='custom' à l'ingestion."""
 
@@ -752,6 +891,7 @@ class TestOtherThemeIngestion:
                 {
                     "kind": "niche",
                     "niche_candidate": {
+                        "client_slug": "niche-sans-flux",
                         "name": "Site sans flux",
                         "url": "https://exemple-sans-rss.test",
                         "why": None,
@@ -772,6 +912,8 @@ class TestOtherThemeIngestion:
         # La source non connectée est remontée au mobile (url + raison) pour
         # afficher « X sources n'ont pas pu être connectées » + CTA recherche.
         assert len(data["unconnected_sources"]) == 1
+        assert data["unconnected_sources"][0]["client_slug"] == "niche-sans-flux"
+        assert data["unconnected_sources"][0]["name"] == "Site sans flux"
         assert (
             data["unconnected_sources"][0]["url"] == "https://exemple-sans-rss.test"
         )


### PR DESCRIPTION
## Quoi

Refonte de l'UX V0 du flow de configuration de la veille (Step 2 « Angles » et Step 3 « Sources »), autour d'un **cycle de vie explicite des sources** et d'une **résolution en arrière-plan**.

**Backend**
- Nouveau `POST /veille/sources/resolve-candidates` : résout en **batch** les candidats source (détection RSS parallélisée via `asyncio.gather` + sémaphore 5) et renvoie des `source_id` prêts à être envoyés à `POST /config` — évite une détection RSS lente au submit.
- `VeilleUnconnectedSource` / `VeilleNicheCandidate` portent désormais `client_slug` + `name` pour réconcilier les échecs côté client.
- `SmartSourceSearchService.detect_feed` : méthode **publique** (le router n'appelle plus le helper privé `_detect_with_root_fallback`).
- `_source_type_from_raw` centralise le mapping type RSS → `SourceType`.

**Mobile**
- `VeilleSourceMeta` : statut de connexion `pending`/`connected`/`failed` (+ `failureReason`, `logoUrl`). Seules les sources `connected` comptent pour la CTA « Créer ma veille ».
- Résolution background des sources `pending` (`resolvePendingSources`) avec garde anti-boucle (`sourceResolutionAttemptedSlugs`).
- Suggestions LLM **à la demande** : « Proposer plus d'angles » (Step 2) / « Charger plus » (Step 3) — plus de fetch LLM automatique, notamment en édition d'une config existante.
- Carte source : CTA d'état passif (**Prête** / **Vérification…** / **À remplacer** / **Retirée**) + message d'échec inline.
- Réconciliation de l'état après submit (`_applyServerConfigResult`) à partir des `unconnectedSources` renvoyées par le backend.

## Pourquoi

L'onboarding veille V0 attachait les sources niche seulement au submit, déclenchant une détection RSS lente et opaque, sans feedback sur les sources non connectées. Cette PR pré-résout les sources en arrière-plan, donne un état clair par source, et ne lance les suggestions LLM que sur action explicite.

## Comment ça a été vérifié

- [x] **pytest backend** : 1493 passés (`tests/routers/test_veille_routes.py` 34 + `test_smart_source_search` inclus). 1 échec **pré-existant** hors scope : `test_notification_preferences::test_patch_increments_refusal_count` (Postgres local en `Europe/Paris` → attend de l'UTC ; vérifié identique sur `origin/main` avec mes changements stashés ; passe en CI/UTC).
- [x] **Endpoint live** : `uvicorn` OK, route présente dans l'OpenAPI, rejet 403 sans auth.
- [x] **flutter test** veille : 64 passés en isolation + 10 tests `flux_continu` dépendants (DTO veille) passés.
- [x] **flutter analyze** : 0 issue.
- [x] **/simplify** passé (1 fix appliqué : promotion `detect_feed` en méthode publique).
- [ ] **Validation Chrome / Playwright** : non exécutée en session (gros setup web + backend authentifié + LLM). À lancer via **`/validate-feature`** sur les Step 2/3.

> ⚠️ Suite mobile complète : 60 échecs **pré-existants** (init Hive/Supabase, ex. « App smoke test ») dans des fichiers qui **n'importent pas** le code modifié — blast radius confiné à `features/veille/` (+ 2 tests `flux_continu`, tous verts). La CI ne lance pas `flutter test` (backend pytest only).

## Zones à risque

- **Aucune migration DB** (changement logique seul, 1 head Alembic inchangé).
- Détection RSS réseau (cold path, ≤12 candidats) — parallélisée, sémaphore 5.
- Boucle de résolution background : protégée par `isResolvingSources` + `sourceResolutionAttemptedSlugs` (évite un re-trigger infini si le backend omet un slug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
