### PR TITLE
feat(flâner): onglets de découverte (followed-first) + bloc « Explorer de nouvelles sources »

### DIFF
--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -211,6 +211,15 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
   String? get selectedKeyword => _selectedKeyword;
   List<Content> get globalItems => _globalItems;
 
+  /// True quand l'onglet actif est un onglet de découverte (sujet / thème /
+  /// entité). Le bloc principal est alors restreint aux sources suivies
+  /// (`followed_only`) pour un chargement rapide, le bloc « Explorer » charge
+  /// les sources non-suivies en parallèle. Source/mot-clé/vue par défaut → false.
+  bool get _discoveryFiltered =>
+      _selectedTopic != null ||
+      _selectedTheme != null ||
+      _selectedEntity != null;
+
   bool get _isUnfiltered =>
       _selectedFilter == null &&
       _selectedTopic == null &&
@@ -652,6 +661,7 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       entity: _selectedEntity,
       keyword: _selectedKeyword,
       includeUnfollowed: _includeUnfollowed,
+      followedOnly: _discoveryFiltered,
       serein: isSerein,
     );
 

--- a/apps/mobile/lib/features/feed/providers/flaner_discovery_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/flaner_discovery_provider.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/content_model.dart';
+import '../widgets/favorite_topic_tabs.dart' show FavoriteTabKind;
+import 'feed_provider.dart';
+
+/// Filtre de découverte actif d'un onglet Flâner : un couple (kind, slug).
+/// Seuls les onglets sujet / thème / entité alimentent le bloc « Explorer » ;
+/// les onglets Source et les mots-clés n'en ont pas besoin.
+class FlanerDiscoveryArg {
+  final FavoriteTabKind kind;
+  final String slug;
+
+  const FlanerDiscoveryArg({required this.kind, required this.slug});
+
+  @override
+  bool operator ==(Object other) =>
+      other is FlanerDiscoveryArg &&
+      other.kind == kind &&
+      other.slug == slug;
+
+  @override
+  int get hashCode => Object.hash(kind, slug);
+}
+
+/// Récupère les articles du sujet/thème/entité **toutes sources confondues**
+/// (sources suivies incluses), pour alimenter le bloc « Explorer de nouvelles
+/// sources » en bas des onglets Flâner.
+///
+/// Le bloc principal (`feedProvider`) ne charge que les sources suivies
+/// (`followed_only`) → rapide ; ce provider charge le reste **en parallèle**,
+/// sans bloquer le rendu. Comme [themeDiscoveryProvider], le filtrage
+/// `isFollowedSource == false` et la déduplication contre le bloc principal se
+/// font dans la couche UI, ce qui garde le provider stateless et trivial à
+/// tester.
+final flanerDiscoveryProvider =
+    FutureProvider.family.autoDispose<List<Content>, FlanerDiscoveryArg>(
+  (ref, arg) async {
+    final repo = ref.watch(feedRepositoryProvider);
+    final resp = await repo.getFeed(
+      topic: arg.kind == FavoriteTabKind.subjectTopic ? arg.slug : null,
+      theme: arg.kind == FavoriteTabKind.theme ? arg.slug : null,
+      entity: arg.kind == FavoriteTabKind.subjectEntity ? arg.slug : null,
+      includeUnfollowed: true,
+      page: 1,
+      limit: 20,
+    );
+    return resp.items;
+  },
+);

--- a/apps/mobile/lib/features/feed/repositories/feed_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/feed_repository.dart
@@ -90,6 +90,7 @@ class FeedRepository {
     bool includeUnfollowed = false,
     bool serein = false,
     bool personalized = false,
+    bool followedOnly = false,
     bool forceFresh = false,
   }) async {
     final result = await getFeedWithRaw(
@@ -107,6 +108,7 @@ class FeedRepository {
       includeUnfollowed: includeUnfollowed,
       serein: serein,
       personalized: personalized,
+      followedOnly: followedOnly,
       forceFresh: forceFresh,
     );
     return result.feed;
@@ -135,6 +137,7 @@ class FeedRepository {
     bool includeUnfollowed = false,
     bool serein = false,
     bool personalized = false,
+    bool followedOnly = false,
     bool forceFresh = false,
   }) async {
     // R5.1 — single-flight + dedupe gate for the default view only.
@@ -147,6 +150,7 @@ class FeedRepository {
         !savedOnly &&
         !hasNote &&
         !personalized &&
+        !followedOnly &&
         contentType == null &&
         mode == null &&
         theme == null &&
@@ -181,6 +185,7 @@ class FeedRepository {
         includeUnfollowed: includeUnfollowed,
         serein: serein,
         personalized: personalized,
+        followedOnly: followedOnly,
       );
       _defaultViewInflight = future;
       try {
@@ -212,6 +217,7 @@ class FeedRepository {
       includeUnfollowed: includeUnfollowed,
       serein: serein,
       personalized: personalized,
+      followedOnly: followedOnly,
     );
   }
 
@@ -230,6 +236,7 @@ class FeedRepository {
     bool includeUnfollowed = false,
     bool serein = false,
     bool personalized = false,
+    bool followedOnly = false,
   }) async {
     try {
       // Le backend renvoie directement une List<dynamic> pour le moment
@@ -284,6 +291,10 @@ class FeedRepository {
 
       if (personalized) {
         queryParams['personalized'] = true;
+      }
+
+      if (followedOnly) {
+        queryParams['followed_only'] = true;
       }
 
       final sw = Stopwatch()..start();

--- a/apps/mobile/lib/features/feed/screens/flaner_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/flaner_screen.dart
@@ -17,6 +17,9 @@ import '../../flux_continu/widgets/section_banner.dart';
 import '../../sources/widgets/pepites_carousel.dart';
 import '../models/content_model.dart';
 import '../providers/feed_provider.dart';
+import '../providers/flaner_discovery_provider.dart';
+import '../widgets/explore_section.dart';
+import '../widgets/favorite_topic_tabs.dart' show FavoriteTabKind;
 import '../widgets/feed_carousel.dart';
 import '../widgets/feed_filter_bar.dart';
 import '../widgets/follow_keyword_suggestion_card.dart';
@@ -205,6 +208,7 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
           _buildFeedList(state),
           if (_loadingMore)
             const SliverToBoxAdapter(child: _LoadingMoreIndicator()),
+          ..._buildExploreSlivers(state),
           const SliverToBoxAdapter(child: SizedBox(height: 92)),
         ],
       ),
@@ -269,6 +273,69 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
           ),
         );
       }, childCount: contents.length + intercalations.length),
+    );
+  }
+
+  /// Bloc « Explorer de nouvelles sources » affiché sous la liste quand un
+  /// onglet de découverte (sujet / thème / entité) est actif. Le bloc principal
+  /// ne montre que les sources suivies (`followed_only`, rapide) ; ces articles
+  /// de sources non-suivies chargent **en parallèle** via
+  /// [flanerDiscoveryProvider] sans bloquer le rendu. Calque la section
+  /// « Explorer » de la page de section de la Tournée.
+  List<Widget> _buildExploreSlivers(FeedState state) {
+    final selection = ref.watch(feedFilterSelectionProvider);
+    final FlanerDiscoveryArg? arg;
+    if (selection.topic != null) {
+      arg = FlanerDiscoveryArg(
+        kind: FavoriteTabKind.subjectTopic,
+        slug: selection.topic!,
+      );
+    } else if (selection.theme != null) {
+      arg = FlanerDiscoveryArg(
+        kind: FavoriteTabKind.theme,
+        slug: selection.theme!,
+      );
+    } else if (selection.entity != null) {
+      arg = FlanerDiscoveryArg(
+        kind: FavoriteTabKind.subjectEntity,
+        slug: selection.entity!,
+      );
+    } else {
+      // Vue par défaut, onglet Source ou mot-clé → pas de bloc Explorer.
+      return const <Widget>[];
+    }
+
+    final async = ref.watch(flanerDiscoveryProvider(arg));
+    return async.when(
+      data: (items) {
+        final alreadyShownIds = state.items.map((c) => c.id).toSet();
+        final discovery = pickExploreItems(items, alreadyShownIds);
+        if (discovery.isEmpty) return const <Widget>[];
+        return [
+          const SliverToBoxAdapter(
+            child: ExploreBlockHeader(label: 'Explorer de nouvelles sources'),
+          ),
+          SliverList(
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                final article = discovery[index];
+                return FluxContinuArticleCard(
+                  article: article,
+                  onTap: () => _openArticle(article),
+                );
+              },
+              childCount: discovery.length,
+            ),
+          ),
+        ];
+      },
+      loading: () => const [
+        SliverToBoxAdapter(
+          child: ExploreBlockHeader(label: 'Explorer de nouvelles sources'),
+        ),
+        SliverToBoxAdapter(child: ExploreDiscoverySkeleton()),
+      ],
+      error: (_, __) => const <Widget>[],
     );
   }
 }

--- a/apps/mobile/lib/features/feed/widgets/explore_section.dart
+++ b/apps/mobile/lib/features/feed/widgets/explore_section.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../models/content_model.dart';
+
+/// Plafond du nombre d'articles « Explorer de nouvelles sources » affichés.
+/// Au-delà de 6 le bloc cesse d'être un teaser de découverte et ressemble à un
+/// feed secondaire — volontairement court. Partagé entre la page de section de
+/// la Tournée et les onglets Flâner.
+const int kExploreItemCap = 6;
+
+/// Sélectionne les articles du bloc « Explorer » : retire les sources déjà
+/// suivies (le bloc sert à *découvrir* de nouvelles sources) et les articles
+/// déjà affichés plus haut ([alreadyShownIds], dédup), puis plafonne à
+/// [kExploreItemCap]. Partagé entre la page de section de la Tournée et les
+/// onglets Flâner pour garder une sémantique de découverte identique.
+List<Content> pickExploreItems(
+  List<Content> items,
+  Set<String> alreadyShownIds,
+) =>
+    items
+        .where((c) => !c.isFollowedSource && !alreadyShownIds.contains(c.id))
+        .take(kExploreItemCap)
+        .toList(growable: false);
+
+/// Titre de section partagé (« Explorer de nouvelles sources », etc.).
+class ExploreBlockHeader extends StatelessWidget {
+  final String label;
+
+  const ExploreBlockHeader({super.key, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 12),
+      child: Text(
+        label,
+        style: GoogleFonts.dmSans(
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+          color: colors.textPrimary,
+        ),
+      ),
+    );
+  }
+}
+
+/// Squelette de chargement affiché pendant que le bloc « Explorer » charge les
+/// articles de sources non-suivies en parallèle.
+class ExploreDiscoverySkeleton extends StatelessWidget {
+  const ExploreDiscoverySkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Column(
+      children: List.generate(3, (_) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+          child: Container(
+            height: 88,
+            decoration: BoxDecoration(
+              color: colors.surface,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: Colors.black.withValues(alpha: 0.04),
+              ),
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
+++ b/apps/mobile/lib/features/feed/widgets/favorite_topic_tabs.dart
@@ -6,7 +6,6 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
 import '../../custom_topics/models/topic_models.dart';
-import '../../custom_topics/providers/custom_topics_provider.dart';
 import '../../my_interests/models/user_interests_state.dart';
 import '../../my_interests/models/user_sources_state.dart';
 import '../../my_interests/providers/user_interests_provider.dart';
@@ -59,6 +58,7 @@ class FavoriteTopicTabs extends ConsumerStatefulWidget {
   final void Function(FavoriteTabKind kind, String? slug) onTabTap;
   final VoidCallback onTapActiveTab;
   final VoidCallback onAddFavorite;
+  final Widget? trailingFilterTrigger;
 
   const FavoriteTopicTabs({
     super.key,
@@ -71,6 +71,7 @@ class FavoriteTopicTabs extends ConsumerStatefulWidget {
     required this.onTabTap,
     required this.onTapActiveTab,
     required this.onAddFavorite,
+    this.trailingFilterTrigger,
   });
 
   @override
@@ -125,15 +126,15 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final topicsAsync = ref.watch(customTopicsProvider);
     final interestsAsync = ref.watch(userInterestsProvider);
     final sourcesStateAsync = ref.watch(userSourcesStateProvider);
     final sourcesAsync = ref.watch(userSourcesProvider);
     final order = ref.watch(tabOrderPrefsProvider);
 
-    final topics = topicsAsync.valueOrNull ?? const <UserTopicProfile>[];
-    final favorites =
-        interestsAsync.valueOrNull?.favorites ?? const <FavoriteRef>[];
+    final interests = interestsAsync.valueOrNull;
+    final customTopics =
+        interests?.customTopics ?? const <CustomTopicInterest>[];
+    final favorites = interests?.favorites ?? const <FavoriteRef>[];
     final sourceFavorites =
         sourcesStateAsync.valueOrNull?.favorites ?? const <SourceFavoriteRef>[];
     final sourceById = <String, Source>{
@@ -141,7 +142,7 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
     };
 
     final tabs = _buildTabModels(
-      topics: topics,
+      customTopics: customTopics,
       favorites: favorites,
       sourceFavorites: sourceFavorites,
       sourceById: sourceById,
@@ -158,6 +159,8 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
     // > 4 onglets épinglés → l'affordance d'ajout devient un engrenage
     // (« gérer ») plutôt qu'un « + ». Même action (ouvre la modal).
     final showGear = tabs.length > 4;
+    final trailingFilterTrigger = widget.trailingFilterTrigger;
+    final itemCount = tabs.length + 1 + (trailingFilterTrigger == null ? 0 : 1);
 
     return SizedBox(
       height: 38,
@@ -175,7 +178,7 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
           controller: _scrollController,
           scrollDirection: Axis.horizontal,
           padding: const EdgeInsets.only(right: 16),
-          itemCount: tabs.length + 1,
+          itemCount: itemCount,
           separatorBuilder: (_, __) => const SizedBox(width: 2),
           itemBuilder: (ctx, i) {
             if (i == tabs.length) {
@@ -186,6 +189,12 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
                   widget.onAddFavorite();
                 },
                 colors: colors,
+              );
+            }
+            if (i == tabs.length + 1) {
+              return Padding(
+                padding: const EdgeInsets.only(left: 2),
+                child: trailingFilterTrigger,
               );
             }
             final tab = tabs[i];
@@ -214,6 +223,7 @@ class _FavoriteTopicTabsState extends ConsumerState<FavoriteTopicTabs> {
 @visibleForTesting
 List<FavoriteTabModel> buildFavoriteTabModelsForTest({
   required List<UserTopicProfile> topics,
+  List<CustomTopicInterest>? customTopics,
   required List<FavoriteRef> favorites,
   required List<Content> items,
   List<SourceFavoriteRef> sourceFavorites = const [],
@@ -226,7 +236,8 @@ List<FavoriteTabModel> buildFavoriteTabModelsForTest({
   String? selectedSourceId,
 }) =>
     _buildTabModels(
-      topics: topics,
+      customTopics:
+          customTopics ?? topics.map(_customInterestFromProfile).toList(),
       favorites: favorites,
       sourceFavorites: sourceFavorites,
       sourceById: sourceById,
@@ -239,13 +250,26 @@ List<FavoriteTabModel> buildFavoriteTabModelsForTest({
       selectedSourceId: selectedSourceId,
     );
 
+CustomTopicInterest _customInterestFromProfile(UserTopicProfile topic) {
+  return CustomTopicInterest(
+    id: topic.id,
+    topicName: topic.name,
+    slugParent: topic.slugParent ?? topic.id,
+    state: InterestState.favorite,
+    priorityMultiplier: topic.priorityMultiplier,
+    entityType: topic.entityType,
+    canonicalName: topic.canonicalName,
+    compositeScore: topic.compositeScore,
+  );
+}
+
 /// Onglets Flâner = *sujets épinglés* (custom topics + entités favoris) **et**
 /// *sources épinglées* (favoris sources), mélangés selon l'ordre unifié
 /// [order] (cf. [tabOrderPrefsProvider]). Les *thèmes/veille* pilotent la
 /// Tournée du jour et ne sont donc pas rendus en onglet ici — ils restent
 /// filtrables via la chip thème.
 List<FavoriteTabModel> _buildTabModels({
-  required List<UserTopicProfile> topics,
+  required List<CustomTopicInterest> customTopics,
   required List<FavoriteRef> favorites,
   required List<SourceFavoriteRef> sourceFavorites,
   required Map<String, Source> sourceById,
@@ -264,31 +288,31 @@ List<FavoriteTabModel> _buildTabModels({
       if (f is CustomTopicFavoriteRef) f.id,
   };
 
-  // Diagnostic : un sujet favori sans `UserTopicProfile` correspondant dans
-  // `topics` ne produira aucun onglet (hypothèse : `customTopicsProvider`
-  // incomplet vs `userInterestsProvider.favorites`).
+  // Diagnostic : un sujet favori sans `CustomTopicInterest` correspondant ne
+  // produira aucun onglet (réponse `user/interests` incohérente).
   if (kDebugMode) {
-    final knownTopicIds = {for (final t in topics) t.id};
+    final knownTopicIds = {for (final t in customTopics) t.id};
     final orphanFavorites =
         favoriteCustomIds.where((id) => !knownTopicIds.contains(id)).toList();
     if (orphanFavorites.isNotEmpty) {
       debugPrint(
         '[FavoriteTabs] ${orphanFavorites.length} sujet(s) favori(s) sans '
-        'UserTopicProfile (customTopicsProvider incomplet ?) : $orphanFavorites',
+        'CustomTopicInterest : $orphanFavorites',
       );
     }
   }
 
-  final entitySubjects = topics
+  final entitySubjects = customTopics
       .where((t) => t.entityType != null && favoriteCustomIds.contains(t.id))
       .toList()
     ..sort((a, b) => b.compositeScore.compareTo(a.compositeScore));
 
-  final topicSubjects = topics
-      .where((t) =>
-          t.entityType == null && favoriteCustomIds.contains(t.id))
+  final topicSubjects = customTopics
+      .where((t) => t.entityType == null && favoriteCustomIds.contains(t.id))
       .toList()
-    ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    ..sort(
+      (a, b) => a.topicName.toLowerCase().compareTo(b.topicName.toLowerCase()),
+    );
 
   final cutoff = DateTime.now().subtract(const Duration(hours: 48));
   final tabs = <FavoriteTabModel>[];
@@ -301,13 +325,13 @@ List<FavoriteTabModel> _buildTabModels({
   final favoriteTabs = <({FavoriteTabModel tab, String key})>[];
 
   for (final entity in entitySubjects) {
-    final slug = entity.canonicalName ?? entity.name;
+    final slug = entity.canonicalName ?? entity.topicName;
     favoriteTabs.add((
       key: tabOrderTopicKey(entity.id),
       tab: FavoriteTabModel(
         kind: FavoriteTabKind.subjectEntity,
         slug: slug,
-        label: entity.name,
+        label: entity.topicName,
         emoji: '',
         count: useServer
             ? (serverCounts.entities[slug.toLowerCase()] ?? 0)
@@ -321,20 +345,18 @@ List<FavoriteTabModel> _buildTabModels({
   }
 
   for (final topic in topicSubjects) {
-    final slug = topic.slugParent ?? topic.id;
+    final slug = topic.slugParent;
     favoriteTabs.add((
       key: tabOrderTopicKey(topic.id),
       tab: FavoriteTabModel(
         kind: FavoriteTabKind.subjectTopic,
         slug: slug,
-        label: topic.name,
+        label: topic.topicName,
         emoji: '',
         count: useServer
             ? (serverCounts.topics[slug] ?? 0)
             : _countUnreadRecent(items,
-                cutoff: cutoff,
-                kind: FavoriteTabKind.subjectTopic,
-                slug: slug),
+                cutoff: cutoff, kind: FavoriteTabKind.subjectTopic, slug: slug),
         active: selectedTopicSlug != null && selectedTopicSlug == slug,
       ),
     ));
@@ -430,8 +452,7 @@ class _FavoriteTabItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final labelColor =
-        tab.active ? colors.textPrimary : colors.textSecondary;
+    final labelColor = tab.active ? colors.textPrimary : colors.textSecondary;
     final labelWeight = tab.active ? FontWeight.w700 : FontWeight.w500;
     final showBadge = tab.count >= 3;
     final showLabel =
@@ -440,6 +461,18 @@ class _FavoriteTabItem extends StatelessWidget {
         tab.kind == FavoriteTabKind.source && tab.source != null
             ? tab.source
             : null;
+    final label = Text(
+      showLabel,
+      style: TextStyle(
+        fontSize: 14.5,
+        fontWeight: labelWeight,
+        color: labelColor,
+        height: 1.15,
+      ),
+      maxLines: 1,
+      overflow: tab.active ? TextOverflow.visible : TextOverflow.ellipsis,
+      softWrap: false,
+    );
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -460,15 +493,13 @@ class _FavoriteTabItem extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  Text(
-                    showLabel,
-                    style: TextStyle(
-                      fontSize: 14.5,
-                      fontWeight: labelWeight,
-                      color: labelColor,
-                      height: 1.15,
+                  if (tab.active)
+                    label
+                  else
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 108),
+                      child: label,
                     ),
-                  ),
                   const SizedBox(height: 2),
                   Container(
                     height: 2,

--- a/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
@@ -55,7 +55,7 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
     return FilterCollapsiblePanel(
       activeCount: selection.activeCount,
       chipsRow: _buildChipsRow(context, selection),
-      leadingContent: FavoriteTopicTabs(
+      collapsedContentBuilder: (filterTrigger) => FavoriteTopicTabs(
         items: feedItems.cast(),
         serverCounts: serverCounts,
         selectedTopicSlug: selection.topic,
@@ -101,6 +101,7 @@ class _FeedFilterBarState extends ConsumerState<FeedFilterBar> {
           HapticFeedback.mediumImpact();
           showPinSubjectsSheet(context);
         },
+        trailingFilterTrigger: filterTrigger,
       ),
       leadingTrigger: _SearchTrigger(
         active: hasSearch,

--- a/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
+++ b/apps/mobile/lib/features/feed/widgets/filter_collapsible_panel.dart
@@ -4,26 +4,26 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
 
-/// Filter row with the trigger button on the RIGHT.
+/// Filter row with an expandable chips area.
 ///
-/// - Collapsed + no active filter: [leadingContent] (or "Flux continu"
-///   fallback) fills the left side ; "Filtres" pill sits on the right.
-/// - Collapsed + active filter(s): [leadingContent] still shown when provided
-///   (e.g. favorite topic tabs) ; pill shows count.
+/// - Collapsed: [collapsedContentBuilder] fills the left side and is handed the
+///   filter trigger so callers can place it inside that content (e.g. as the
+///   last scrollable item of favorite topic tabs). With no builder, a
+///   "FLUX CONTINU" rule fills the space and the trigger sits on the right.
 /// - Expanded: pills slide in to the left ; the trigger morphs into a pill of
 ///   the same shape with an × icon (primary, "selected" look).
 class FilterCollapsiblePanel extends StatefulWidget {
   final int activeCount;
   final Widget chipsRow;
   final Widget? leadingTrigger;
-  final Widget? leadingContent;
+  final Widget Function(Widget filterTrigger)? collapsedContentBuilder;
 
   const FilterCollapsiblePanel({
     super.key,
     required this.activeCount,
     required this.chipsRow,
     this.leadingTrigger,
-    this.leadingContent,
+    this.collapsedContentBuilder,
   });
 
   @override
@@ -42,7 +42,12 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final hasActive = widget.activeCount > 0;
-    final label = hasActive ? '${widget.activeCount}' : '';
+    final filterTrigger = _FilterTriggerButton(
+      expanded: _expanded,
+      activeCount: widget.activeCount,
+      onTap: _toggle,
+    );
+    final collapsedContent = widget.collapsedContentBuilder;
 
     return SizedBox(
       height: 38,
@@ -60,10 +65,10 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
                       padding: const EdgeInsets.only(right: 8),
                       child: widget.chipsRow,
                     )
-                  : (widget.leadingContent != null
+                  : (collapsedContent != null
                       ? KeyedSubtree(
-                          key: const ValueKey('leading-content'),
-                          child: widget.leadingContent!,
+                          key: const ValueKey('collapsed-builder'),
+                          child: collapsedContent(filterTrigger),
                         )
                       : (hasActive
                           ? const SizedBox.shrink(key: ValueKey('idle'))
@@ -82,7 +87,8 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
                                   Expanded(
                                     child: Container(
                                       height: 1,
-                                      color: colors.border.withOpacity(0.5),
+                                      color: colors.border
+                                          .withValues(alpha: 0.5),
                                     ),
                                   ),
                                 ],
@@ -90,63 +96,80 @@ class _FilterCollapsiblePanelState extends State<FilterCollapsiblePanel> {
                             ))),
             ),
           ),
-          if (widget.leadingContent != null && !_expanded)
+          if (collapsedContent != null && !_expanded)
             Container(
               width: 1,
               height: 18,
               margin: const EdgeInsets.symmetric(horizontal: 8),
-              color: colors.border.withOpacity(0.6),
+              color: colors.border.withValues(alpha: 0.6),
             ),
           if (widget.leadingTrigger != null) ...[
             widget.leadingTrigger!,
             const SizedBox(width: 4),
           ],
-          GestureDetector(
-            onTap: _toggle,
-            behavior: HitTestBehavior.opaque,
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 180),
-              height: 34,
-              padding: EdgeInsets.symmetric(
-                horizontal: hasActive && !_expanded ? 12 : 9,
-              ),
-              decoration: BoxDecoration(
-                color: (_expanded || hasActive)
-                    ? colors.primary.withOpacity(0.12)
-                    : Colors.transparent,
-                border: (_expanded || hasActive)
-                    ? Border.all(color: colors.primary)
-                    : null,
-                borderRadius: BorderRadius.circular(FacteurRadius.full),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    _expanded
-                        ? PhosphorIcons.x(PhosphorIconsStyle.bold)
-                        : PhosphorIcons.funnel(PhosphorIconsStyle.regular),
-                    size: 16,
-                    color: (_expanded || hasActive)
-                        ? colors.primary
-                        : colors.textSecondary,
-                  ),
-                  if (!_expanded && hasActive) ...[
-                    const SizedBox(width: 5),
-                    Text(
-                      label,
-                      style: TextStyle(
-                        fontSize: 12.5,
-                        fontWeight: FontWeight.w700,
-                        color: colors.primary,
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-          ),
+          if (_expanded || collapsedContent == null) filterTrigger,
         ],
+      ),
+    );
+  }
+}
+
+class _FilterTriggerButton extends StatelessWidget {
+  final bool expanded;
+  final int activeCount;
+  final VoidCallback onTap;
+
+  const _FilterTriggerButton({
+    required this.expanded,
+    required this.activeCount,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final hasActive = activeCount > 0;
+    final selected = expanded || hasActive;
+
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        height: 34,
+        padding: EdgeInsets.symmetric(
+          horizontal: hasActive && !expanded ? 12 : 9,
+        ),
+        decoration: BoxDecoration(
+          color: selected
+              ? colors.primary.withValues(alpha: 0.12)
+              : Colors.transparent,
+          border: selected ? Border.all(color: colors.primary) : null,
+          borderRadius: BorderRadius.circular(FacteurRadius.full),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              expanded
+                  ? PhosphorIcons.x(PhosphorIconsStyle.bold)
+                  : PhosphorIcons.funnel(PhosphorIconsStyle.regular),
+              size: 16,
+              color: selected ? colors.primary : colors.textSecondary,
+            ),
+            if (!expanded && hasActive) ...[
+              const SizedBox(width: 5),
+              Text(
+                '$activeCount',
+                style: TextStyle(
+                  fontSize: 12.5,
+                  fontWeight: FontWeight.w700,
+                  color: colors.primary,
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
@@ -7,6 +7,7 @@ import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/providers/feed_provider.dart';
+import '../../feed/widgets/explore_section.dart';
 import '../../feed/widgets/feed_carousel.dart';
 import '../models/flux_continu_models.dart';
 import '../providers/flux_continu_provider.dart';
@@ -19,11 +20,6 @@ import '../widgets/theme_detail_footer.dart';
 /// articles for the current theme. Mirrors the threshold used on the main
 /// Flux Continu screen so the feel of the infinite scroll is identical.
 const double _kLoadMoreLeadingPx = 800.0;
-
-/// Cap on the number of "Explorer de nouvelles sources" articles surfaced.
-/// Past 6 the block stops being a discovery tease and starts to feel like a
-/// secondary feed — kept short on purpose.
-const int _kDiscoveryItemCap = 6;
 
 /// Full-page view of a Tournée du jour theme section (a `FeedThemeSection`).
 ///
@@ -248,7 +244,7 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
 
     return [
       SliverToBoxAdapter(
-        child: _BlockHeader(label: 'À explorer dans ${section.label}'),
+        child: ExploreBlockHeader(label: 'À explorer dans ${section.label}'),
       ),
       SliverList(
         delegate: SliverChildBuilderDelegate(
@@ -275,16 +271,12 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
     return async.when(
       data: (items) {
         final alreadyShownIds = section.items.map((c) => c.id).toSet();
-        final discovery = items
-            .where((c) =>
-                !c.isFollowedSource && !alreadyShownIds.contains(c.id))
-            .take(_kDiscoveryItemCap)
-            .toList(growable: false);
+        final discovery = pickExploreItems(items, alreadyShownIds);
 
         if (discovery.isNotEmpty) {
           return [
             const SliverToBoxAdapter(
-              child: _BlockHeader(label: 'Explorer de nouvelles sources'),
+              child: ExploreBlockHeader(label: 'Explorer de nouvelles sources'),
             ),
             SliverList(
               delegate: SliverChildBuilderDelegate(
@@ -317,9 +309,9 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
       },
       loading: () => const [
         SliverToBoxAdapter(
-          child: _BlockHeader(label: 'Explorer de nouvelles sources'),
+          child: ExploreBlockHeader(label: 'Explorer de nouvelles sources'),
         ),
-        SliverToBoxAdapter(child: _DiscoverySkeleton()),
+        SliverToBoxAdapter(child: ExploreDiscoverySkeleton()),
       ],
       error: (_, __) => const <Widget>[],
     );
@@ -375,54 +367,6 @@ class _LoadingMoreIndicator extends StatelessWidget {
           ),
         ],
       ),
-    );
-  }
-}
-
-class _BlockHeader extends StatelessWidget {
-  final String label;
-
-  const _BlockHeader({required this.label});
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.facteurColors;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 24, 16, 12),
-      child: Text(
-        label,
-        style: GoogleFonts.dmSans(
-          fontSize: 14,
-          fontWeight: FontWeight.w600,
-          color: colors.textPrimary,
-        ),
-      ),
-    );
-  }
-}
-
-class _DiscoverySkeleton extends StatelessWidget {
-  const _DiscoverySkeleton();
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.facteurColors;
-    return Column(
-      children: List.generate(3, (_) {
-        return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-          child: Container(
-            height: 88,
-            decoration: BoxDecoration(
-              color: colors.surface,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: Colors.black.withValues(alpha: 0.04),
-              ),
-            ),
-          ),
-        );
-      }),
     );
   }
 }

--- a/apps/mobile/lib/features/my_interests/models/user_interests_state.dart
+++ b/apps/mobile/lib/features/my_interests/models/user_interests_state.dart
@@ -188,6 +188,9 @@ class CustomTopicInterest {
   final String slugParent;
   final InterestState state;
   final double priorityMultiplier;
+  final String? entityType;
+  final String? canonicalName;
+  final double compositeScore;
 
   const CustomTopicInterest({
     required this.id,
@@ -195,6 +198,9 @@ class CustomTopicInterest {
     required this.slugParent,
     required this.state,
     required this.priorityMultiplier,
+    this.entityType,
+    this.canonicalName,
+    this.compositeScore = 0.0,
   });
 
   factory CustomTopicInterest.fromJson(Map<String, dynamic> json) {
@@ -204,12 +210,18 @@ class CustomTopicInterest {
       slugParent: json['slug_parent'] as String,
       state: InterestState.fromJson(json['state'] as String),
       priorityMultiplier: (json['priority_multiplier'] as num).toDouble(),
+      entityType: json['entity_type'] as String?,
+      canonicalName: json['canonical_name'] as String?,
+      compositeScore: ((json['composite_score'] as num?) ?? 0.0).toDouble(),
     );
   }
 
   CustomTopicInterest copyWith({
     InterestState? state,
     double? priorityMultiplier,
+    String? entityType,
+    String? canonicalName,
+    double? compositeScore,
   }) =>
       CustomTopicInterest(
         id: id,
@@ -217,6 +229,9 @@ class CustomTopicInterest {
         slugParent: slugParent,
         state: state ?? this.state,
         priorityMultiplier: priorityMultiplier ?? this.priorityMultiplier,
+        entityType: entityType ?? this.entityType,
+        canonicalName: canonicalName ?? this.canonicalName,
+        compositeScore: compositeScore ?? this.compositeScore,
       );
 }
 
@@ -277,13 +292,10 @@ class UserInterestsState {
               .map((t) => t.state)
               .firstOrNull ??
           InterestState.unfollowed,
-      CustomTopicFavoriteRef(:final id) => customTopics
-              .where((t) => t.id == id)
-              .map((t) => t.state)
-              .firstOrNull ??
-          InterestState.unfollowed,
+      CustomTopicFavoriteRef(:final id) =>
+        customTopics.where((t) => t.id == id).map((t) => t.state).firstOrNull ??
+            InterestState.unfollowed,
       VeilleFavoriteRef() => InterestState.favorite,
     };
   }
-
 }

--- a/apps/mobile/test/features/feed/feed_provider_auth_filter_test.dart
+++ b/apps/mobile/test/features/feed/feed_provider_auth_filter_test.dart
@@ -67,6 +67,7 @@ void main() {
         entity: any(named: 'entity'),
         keyword: any(named: 'keyword'),
         includeUnfollowed: any(named: 'includeUnfollowed'),
+        followedOnly: any(named: 'followedOnly'),
         serein: any(named: 'serein'),
       ),
     ).thenAnswer((invocation) async {

--- a/apps/mobile/test/features/feed/providers/flaner_discovery_provider_test.dart
+++ b/apps/mobile/test/features/feed/providers/flaner_discovery_provider_test.dart
@@ -1,0 +1,153 @@
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/feed/providers/feed_provider.dart';
+import 'package:facteur/features/feed/providers/flaner_discovery_provider.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart';
+import 'package:facteur/features/feed/widgets/favorite_topic_tabs.dart'
+    show FavoriteTabKind;
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockFeedRepository extends Mock implements FeedRepository {}
+
+FeedResponse _resp(List<String> ids) {
+  return FeedResponse(
+    items: ids
+        .map((id) => Content(
+              id: id,
+              title: 'title-$id',
+              url: 'https://x.test/$id',
+              contentType: ContentType.article,
+              publishedAt: DateTime(2026, 1, 1),
+              source: Source(id: 's', name: 'S', type: SourceType.article),
+            ))
+        .toList(),
+    pagination: Pagination(page: 1, perPage: 20, total: 0, hasNext: false),
+    carousels: const [],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockFeedRepository feedRepo;
+
+  setUp(() {
+    feedRepo = _MockFeedRepository();
+  });
+
+  ProviderContainer _container() {
+    final container = ProviderContainer(
+      overrides: [feedRepositoryProvider.overrideWithValue(feedRepo)],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test(
+    'subjectTopic → getFeed(topic, includeUnfollowed: true, no followedOnly)',
+    () async {
+      when(() => feedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            topic: any(named: 'topic'),
+            theme: any(named: 'theme'),
+            entity: any(named: 'entity'),
+            includeUnfollowed: any(named: 'includeUnfollowed'),
+          )).thenAnswer((_) async => _resp(['a', 'b']));
+
+      final items = await _container().read(
+        flanerDiscoveryProvider(
+          const FlanerDiscoveryArg(
+            kind: FavoriteTabKind.subjectTopic,
+            slug: 'startups',
+          ),
+        ).future,
+      );
+
+      expect(items.map((c) => c.id), ['a', 'b']);
+      verify(() => feedRepo.getFeed(
+            topic: 'startups',
+            theme: null,
+            entity: null,
+            includeUnfollowed: true,
+            page: 1,
+            limit: 20,
+          )).called(1);
+    },
+  );
+
+  test('theme → getFeed(theme, includeUnfollowed: true)', () async {
+    when(() => feedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          topic: any(named: 'topic'),
+          theme: any(named: 'theme'),
+          entity: any(named: 'entity'),
+          includeUnfollowed: any(named: 'includeUnfollowed'),
+        )).thenAnswer((_) async => _resp(['c']));
+
+    await _container().read(
+      flanerDiscoveryProvider(
+        const FlanerDiscoveryArg(kind: FavoriteTabKind.theme, slug: 'tech'),
+      ).future,
+    );
+
+    verify(() => feedRepo.getFeed(
+          topic: null,
+          theme: 'tech',
+          entity: null,
+          includeUnfollowed: true,
+          page: 1,
+          limit: 20,
+        )).called(1);
+  });
+
+  test('subjectEntity → getFeed(entity, includeUnfollowed: true)', () async {
+    when(() => feedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          topic: any(named: 'topic'),
+          theme: any(named: 'theme'),
+          entity: any(named: 'entity'),
+          includeUnfollowed: any(named: 'includeUnfollowed'),
+        )).thenAnswer((_) async => _resp(['d']));
+
+    await _container().read(
+      flanerDiscoveryProvider(
+        const FlanerDiscoveryArg(
+          kind: FavoriteTabKind.subjectEntity,
+          slug: 'OpenAI',
+        ),
+      ).future,
+    );
+
+    verify(() => feedRepo.getFeed(
+          topic: null,
+          theme: null,
+          entity: 'OpenAI',
+          includeUnfollowed: true,
+          page: 1,
+          limit: 20,
+        )).called(1);
+  });
+
+  test('FlanerDiscoveryArg equality keys the family cache', () {
+    const a = FlanerDiscoveryArg(
+      kind: FavoriteTabKind.subjectTopic,
+      slug: 'startups',
+    );
+    const b = FlanerDiscoveryArg(
+      kind: FavoriteTabKind.subjectTopic,
+      slug: 'startups',
+    );
+    const c = FlanerDiscoveryArg(
+      kind: FavoriteTabKind.theme,
+      slug: 'startups',
+    );
+    expect(a, equals(b));
+    expect(a.hashCode, equals(b.hashCode));
+    expect(a, isNot(equals(c)));
+  });
+}

--- a/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
+++ b/apps/mobile/test/features/feed/widgets/favorite_topic_tabs_test.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/custom_topics/models/topic_models.dart';
 import 'package:facteur/features/custom_topics/providers/custom_topics_provider.dart';
 import 'package:facteur/features/feed/models/content_model.dart';
 import 'package:facteur/features/feed/widgets/favorite_topic_tabs.dart';
+import 'package:facteur/features/feed/widgets/filter_collapsible_panel.dart';
 import 'package:facteur/features/my_interests/models/user_interests_state.dart';
 import 'package:facteur/features/my_interests/models/user_sources_state.dart';
 import 'package:facteur/features/my_interests/providers/user_interests_provider.dart';
@@ -32,6 +34,19 @@ UserTopicProfile _topic({
     entityType: entityType,
     canonicalName: canonicalName,
     compositeScore: compositeScore,
+  );
+}
+
+CustomTopicInterest _interestFromProfile(UserTopicProfile topic) {
+  return CustomTopicInterest(
+    id: topic.id,
+    topicName: topic.name,
+    slugParent: topic.slugParent ?? topic.id,
+    state: InterestState.favorite,
+    priorityMultiplier: topic.priorityMultiplier,
+    entityType: topic.entityType,
+    canonicalName: topic.canonicalName,
+    compositeScore: topic.compositeScore,
   );
 }
 
@@ -275,7 +290,8 @@ void main() {
         for (var i = 0; i < 6; i++) CustomTopicFavoriteRef(id: 't$i'),
       ];
       final sourceById = {
-        for (var i = 0; i < 6; i++) 's$i': _source(id: 's$i', name: 'Source $i'),
+        for (var i = 0; i < 6; i++)
+          's$i': _source(id: 's$i', name: 'Source $i'),
       };
       final sourceFavorites = [
         for (var i = 0; i < 6; i++)
@@ -324,13 +340,14 @@ void main() {
         for (var i = 0; i < 3; i++) CustomTopicFavoriteRef(id: 't$i'),
       ];
       final sourceById = {
-        for (var i = 0; i < 3; i++) 's$i': _source(id: 's$i', name: 'Source $i'),
+        for (var i = 0; i < 3; i++)
+          's$i': _source(id: 's$i', name: 'Source $i'),
       };
       final sourceFavorites = [
         for (var i = 0; i < 3; i++)
           SourceFavoriteRef(sourceId: 's$i', position: i),
       ];
-      final order = const [
+      const order = [
         'topic:t0',
         'source:s0',
         'topic:t1',
@@ -377,14 +394,19 @@ void main() {
       required Widget child,
       List<UserTopicProfile> topics = const [],
       List<FavoriteRef> favorites = const [],
+      bool throwCustomTopics = false,
     }) {
       return ProviderScope(
         overrides: [
           customTopicsProvider.overrideWith(() {
+            if (throwCustomTopics) return _ThrowingCustomTopicsNotifier();
             return _StaticCustomTopicsNotifier(topics);
           }),
           userInterestsProvider.overrideWith(() {
-            return _StaticUserInterestsNotifier(favorites);
+            return _StaticUserInterestsNotifier(
+              favorites: favorites,
+              customTopics: topics.map(_interestFromProfile).toList(),
+            );
           }),
         ],
         child: MaterialApp(
@@ -438,6 +460,105 @@ void main() {
 
       expect(addCalls, 1);
     });
+
+    testWidgets(
+        'renders favorite subjects from user interests even if custom topics fail',
+        (tester) async {
+      await tester.pumpWidget(host(
+        topics: [_topic(id: 't1', name: 'IA santé', slugParent: 'ai-health')],
+        favorites: const [CustomTopicFavoriteRef(id: 't1')],
+        throwCustomTopics: true,
+        child: FavoriteTopicTabs(
+          items: const [],
+          onTabTap: (_, __) {},
+          onTapActiveTab: () {},
+          onAddFavorite: () {},
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('IA santé'), findsOneWidget);
+    });
+
+    testWidgets(
+        'inactive long tab labels are ellipsized while active label is complete',
+        (tester) async {
+      const inactiveLabel = 'Nom de sujet extrêmement long et difficile';
+      const activeLabel = 'Libellé actif extrêmement long et complet';
+
+      await tester.pumpWidget(host(
+        topics: [
+          _topic(id: 't1', name: inactiveLabel, slugParent: 'inactive'),
+          _topic(id: 't2', name: activeLabel, slugParent: 'active'),
+        ],
+        favorites: const [
+          CustomTopicFavoriteRef(id: 't1'),
+          CustomTopicFavoriteRef(id: 't2'),
+        ],
+        child: FavoriteTopicTabs(
+          items: const [],
+          selectedTopicSlug: 'active',
+          onTabTap: (_, __) {},
+          onTapActiveTab: () {},
+          onAddFavorite: () {},
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      final inactiveText = tester.widget<Text>(find.text(inactiveLabel));
+      final activeText = tester.widget<Text>(find.text(activeLabel));
+      expect(inactiveText.maxLines, 1);
+      expect(inactiveText.overflow, TextOverflow.ellipsis);
+      expect(activeText.maxLines, 1);
+      expect(activeText.overflow, TextOverflow.visible);
+    });
+  });
+
+  group('FilterCollapsiblePanel', () {
+    testWidgets('funnel lives in collapsed horizontal content and expands',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(
+          body: FilterCollapsiblePanel(
+            activeCount: 0,
+            chipsRow: const Text('chips row'),
+            leadingTrigger: const Text('search'),
+            collapsedContentBuilder: (filterTrigger) => SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [
+                  const Text('Sujet épinglé'),
+                  filterTrigger,
+                ],
+              ),
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      final funnel = find.byIcon(
+        PhosphorIcons.funnel(PhosphorIconsStyle.regular),
+      );
+      expect(funnel, findsOneWidget);
+      expect(
+        find.ancestor(
+          of: funnel,
+          matching: find.byType(SingleChildScrollView),
+        ),
+        findsOneWidget,
+      );
+
+      await tester.tap(funnel);
+      await tester.pumpAndSettle();
+
+      expect(find.text('chips row'), findsOneWidget);
+      expect(
+        find.byIcon(PhosphorIcons.x(PhosphorIconsStyle.bold)),
+        findsOneWidget,
+      );
+    });
   });
 }
 
@@ -451,16 +572,28 @@ class _StaticCustomTopicsNotifier extends CustomTopicsNotifier {
 }
 
 class _StaticUserInterestsNotifier extends UserInterestsNotifier {
-  _StaticUserInterestsNotifier(this._favorites);
+  _StaticUserInterestsNotifier({
+    required List<FavoriteRef> favorites,
+    required List<CustomTopicInterest> customTopics,
+  })  : _favorites = favorites,
+        _customTopics = customTopics;
 
   final List<FavoriteRef> _favorites;
+  final List<CustomTopicInterest> _customTopics;
 
   @override
   Future<UserInterestsState> build() async => UserInterestsState(
         themes: const [],
-        customTopics: const [],
+        customTopics: _customTopics,
         favorites: _favorites,
         favoriteCount: _favorites.length,
         favoriteCap: 3,
       );
+}
+
+class _ThrowingCustomTopicsNotifier extends CustomTopicsNotifier {
+  @override
+  Future<List<UserTopicProfile>> build() async {
+    throw StateError('customTopicsProvider unavailable');
+  }
 }

--- a/packages/api/app/routers/feed.py
+++ b/packages/api/app/routers/feed.py
@@ -164,6 +164,16 @@ async def get_personalized_feed(
             "the Tournée du jour theme sections."
         ),
     ),
+    followed_only: bool = Query(
+        False,
+        description=(
+            "When True AND theme/topic/entity is set, restrict candidates to "
+            "followed sources while keeping the chronological order (unlike "
+            "`personalized`). Powers the fast 'followed-first' block of the "
+            "Flâner discovery tabs; the 'Explorer' block fetches unfollowed "
+            "sources separately."
+        ),
+    ),
     db: AsyncSession = Depends(get_db),
     current_user_id: str = Depends(get_current_user_id),
 ):
@@ -226,6 +236,7 @@ async def get_personalized_feed(
                 keyword=keyword,
                 include_unfollowed=include_unfollowed,
                 personalized=personalized,
+                followed_only=followed_only,
             )
             payload = json.dumps(response.model_dump(mode="json")).encode("utf-8")
             FEED_CACHE.put(user_uuid, payload)
@@ -248,6 +259,7 @@ async def get_personalized_feed(
         keyword=keyword,
         include_unfollowed=include_unfollowed,
         personalized=personalized,
+        followed_only=followed_only,
     )
     return response
 
@@ -270,6 +282,7 @@ async def _compute_feed(
     keyword: str | None,
     include_unfollowed: bool = False,
     personalized: bool = False,
+    followed_only: bool = False,
 ) -> FeedResponse:
     """Run the full recommendation pipeline. Identical to the pre-Round-5
     body of `get_personalized_feed`, extracted for cache-miss reuse."""
@@ -299,6 +312,7 @@ async def _compute_feed(
         serein=serein,
         include_unfollowed=include_unfollowed,
         personalized=personalized,
+        followed_only=followed_only,
     )
 
     # Epic 11: Build clusters from custom topics (reuse from service, no duplicate query)

--- a/packages/api/app/schemas/user_interests.py
+++ b/packages/api/app/schemas/user_interests.py
@@ -45,6 +45,9 @@ class CustomTopicInterestResponse(BaseModel):
     slug_parent: str
     state: InterestState
     priority_multiplier: float
+    entity_type: str | None = None
+    canonical_name: str | None = None
+    composite_score: float = 0.0
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -230,6 +230,7 @@ class RecommendationService:
         serein: bool = False,
         include_unfollowed: bool = False,
         personalized: bool = False,
+        followed_only: bool = False,
     ) -> list[Content]:
         """
         Génère un feed personnalisé pour l'utilisateur.
@@ -500,6 +501,9 @@ class RecommendationService:
             # sources + 24h window + boost user_subtopics.
             personalized=personalized,
             user_subtopics=user_subtopics,
+            # Onglets Flâner : restreindre le bloc principal aux sources suivies
+            # (tri chronologique conservé, contrairement à personalized).
+            followed_only=followed_only,
         )
         self.total_candidates = len(candidates)
 
@@ -2375,6 +2379,7 @@ class RecommendationService:
         excluded_topics: list[Any] | None = None,
         personalized: bool = False,
         user_subtopics: set[str] | None = None,
+        followed_only: bool = False,
     ) -> list[Content]:
         """Récupère les N contenus les plus récents que l'utilisateur n'a pas encore vus/consommés et qui ne sont pas masqués."""
         from sqlalchemy import and_, or_
@@ -2489,6 +2494,16 @@ class RecommendationService:
         elif personalized_theme_mode:
             # Edge: user follows zero sources → fallback curated pour ne pas
             # rendre la section vide.
+            query = query.where(Source.is_curated, Source.source_tier != "deep")
+        elif (theme or topic or entity) and followed_only and followed_source_ids:
+            # Onglets Flâner (sujet/thème/entité) : bloc principal restreint aux
+            # sources suivies → requête rapide, tri chronologique conservé
+            # (personalized reste False). Le bloc « Explorer » charge les sources
+            # non-suivies en parallèle via un appel séparé sans followed_only.
+            query = query.where(Content.source_id.in_(followed_source_ids))
+        elif (theme or topic or entity) and followed_only:
+            # 0 source suivie → repli curé pour ne pas vider le bloc principal
+            # (même sémantique que personalized_theme_mode ci-dessus).
             query = query.where(Source.is_curated, Source.source_tier != "deep")
         elif theme or topic or entity or (keyword and include_unfollowed):
             pass

--- a/packages/api/tests/routers/test_user_interests.py
+++ b/packages/api/tests/routers/test_user_interests.py
@@ -269,6 +269,9 @@ async def test_patch_allows_favorite_for_custom_topic(auth_user, db_session):
         slug_parent="sport",
         state=InterestState.FOLLOWED,
         priority_multiplier=1.0,
+        entity_type="EVENT",
+        canonical_name="Plongée",
+        composite_score=0.42,
     )
     db_session.add(topic)
     await db_session.commit()
@@ -292,6 +295,12 @@ async def test_patch_allows_favorite_for_custom_topic(auth_user, db_session):
         f["kind"] == "custom_topic" and f["target_id"] == str(topic.id)
         for f in body["favorites"]
     )
+    custom_topic = next(
+        t for t in body["custom_topics"] if t["id"] == str(topic.id)
+    )
+    assert custom_topic["entity_type"] == "EVENT"
+    assert custom_topic["canonical_name"] == "Plongée"
+    assert custom_topic["composite_score"] == pytest.approx(0.42)
 
     await db_session.refresh(topic)
     assert topic.state == InterestState.FAVORITE

--- a/packages/api/tests/test_personalized_theme_mode.py
+++ b/packages/api/tests/test_personalized_theme_mode.py
@@ -346,6 +346,138 @@ async def test_source_alone_stays_chronological():
 
 
 # ---------------------------------------------------------------------------
+# `followed_only` — onglets de découverte Flâner (sujet / thème / entité).
+#
+# Le bloc principal de chaque onglet ne charge que les sources suivies → requête
+# rapide. Contrairement à `personalized`, le tri reste CHRONOLOGIQUE (pas de
+# scoring piliers ni de fenêtre adaptative). Le bloc « Explorer » charge les
+# sources non-suivies via un appel séparé SANS `followed_only` (chemin existant).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_followed_only_topic_restricts_to_followed_chronological():
+    """topic + followed_only=True + sources suivies → restriction aux sources
+    suivies (contents.source_id IN) SANS fenêtre de fraîcheur (chronologique)."""
+    service, session = _make_service()
+    captured: list[str] = []
+    session.scalars, _ = _stub_scalars(captured)
+
+    followed = {uuid4(), uuid4()}
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            topic="startups",
+            personalized=False,
+            followed_only=True,
+            followed_source_ids=followed,
+        ),
+        timeout=5.0,
+    )
+
+    assert captured, "expected at least one SQL statement"
+    sql = captured[0].lower()
+    # Restriction directe aux sources suivies (pas le two-phase sources.id IN).
+    assert "source_id in" in sql, (
+        "followed_only topic must restrict to followed sources via "
+        f"contents.source_id IN. Got:\n{captured[0]}"
+    )
+    # Tri chronologique conservé : aucune fenêtre published_at >= cutoff.
+    assert ">= " not in sql or "published_at" not in sql, (
+        "followed_only must stay chronological (no freshness window)."
+        f" Got:\n{captured[0]}"
+    )
+    # Pas de boost subtopic (réservé à personalized).
+    assert "overlap" not in sql and "&&" not in sql, (
+        f"followed_only must not add a subtopic overlap ORDER BY. Got:\n{captured[0]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_followed_only_entity_restricts_to_followed():
+    """entity + followed_only=True → même restriction aux sources suivies."""
+    service, session = _make_service()
+    captured: list[str] = []
+    session.scalars, _ = _stub_scalars(captured)
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            entity="OpenAI",
+            personalized=False,
+            followed_only=True,
+            followed_source_ids={uuid4()},
+        ),
+        timeout=5.0,
+    )
+
+    sql = captured[0].lower()
+    assert "source_id in" in sql, (
+        f"followed_only entity must restrict to followed sources. Got:\n{captured[0]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_followed_only_zero_followed_falls_back_to_curated():
+    """topic + followed_only=True + zéro source suivie → repli curé pour ne pas
+    vider le bloc principal (même sémantique que personalized_theme_mode)."""
+    service, session = _make_service()
+    captured: list[str] = []
+    session.scalars, _ = _stub_scalars(captured)
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            topic="startups",
+            personalized=False,
+            followed_only=True,
+            followed_source_ids=set(),
+        ),
+        timeout=5.0,
+    )
+
+    sql = captured[0].lower()
+    assert "is_curated" in sql, (
+        "followed_only with zero followed sources must fall back to curated."
+        f" Got:\n{captured[0]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_topic_without_followed_only_unchanged():
+    """Régression : topic + followed_only=False → comportement actuel inchangé
+    (toutes sources, aucune restriction suivie ni curée)."""
+    service, session = _make_service()
+    captured: list[str] = []
+    session.scalars, _ = _stub_scalars(captured)
+
+    await asyncio.wait_for(
+        service._get_candidates(
+            user_id=uuid4(),
+            limit_candidates=500,
+            topic="startups",
+            personalized=False,
+            followed_only=False,
+            followed_source_ids={uuid4()},
+        ),
+        timeout=5.0,
+    )
+
+    sql = captured[0].lower()
+    # Branche fourre-tout : ni restriction sources suivies, ni filtre curé.
+    assert "source_id in" not in sql, (
+        "topic without followed_only must not restrict to followed sources."
+        f" Got:\n{captured[0]}"
+    )
+    assert "is_curated" not in sql, (
+        f"topic without followed_only must not apply curated filter. Got:\n{captured[0]}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Backfill curé NON-suivi : garantit ≥ THEMATIC_HARD_FLOOR articles par section
 # thématique quand le pool des sources suivies est trop maigre (même au palier
 # 72h). On complète avec des sources curées non-suivies (comme Flâner), marquées


### PR DESCRIPTION
## Quoi
Les onglets sujet/thème/entité de **Flâner** chargent d'abord les **sources suivies**
(`followed_only`, tri chronologique conservé) pour un rendu rapide, puis un bloc
**« Explorer de nouvelles sources »** charge les sources non-suivies **en parallèle**
(calque la section Explorer de la page de section de la Tournée). Le bouton **Filtres**
glisse dans la rangée d'onglets, et les sujets favoris sont désormais lus depuis
`userInterestsProvider` au lieu d'un `customTopicsProvider` séparé.

## Pourquoi
Un onglet de découverte qui chargeait *toutes* les sources était lent et noyait les
sources suivies. On sépare : bloc principal rapide (sources suivies) + teaser de
découverte des autres sources, sans bloquer le rendu. Consolider la lecture des sujets
sur `userInterestsProvider` supprime une 2ᵉ source de vérité (le provider portait
`entity_type`/`canonical_name`/`composite_score`, maintenant exposés par l'API).

## Comment ça a été vérifié
- [x] **Backend** : `pytest` complet — **1494 passés**, 1 échec **pré-existant** sans
  rapport (`test_notification_preferences` : sérialisation TZ locale CEST vs UTC en CI,
  fichier non touché). 4 nouveaux tests `followed_only` (capture SQL : `source_id IN`,
  tri chrono conservé, repli curé si 0 suivie, non-régression sans le flag).
- [x] **App boot + endpoint** : `app.main` importe OK ; `GET /api/feed/?...&followed_only=true`
  accepté (403 auth-gate, param reconnu).
- [x] **Mobile** : `flutter analyze` **0 erreur** sur les fichiers touchés ; tests
  ciblés **25 OK** (provider Explorer, onglets depuis interests, ellipsis label actif,
  funnel dans la rangée repliée).
- [x] **Non-régression mobile** : les 43 échecs des suites feed/flux_continu sont
  **identiques sur `origin/main`** (Hive/Supabase non init, timers) — 0 régression.
- [x] **/simplify** passé : suppression du champ mort `leadingContent`
  (`FilterCollapsiblePanel`) + extraction du helper partagé `pickExploreItems`.

## Zones à risque
- `recommendation_service._get_candidates` (moteur de reco — guardrail) : nouvelle
  branche `followed_only`, isolée des branches `personalized` ; couverte par capture SQL.
  **Aucune migration.**
- `FilterCollapsiblePanel` refactor (rangée de filtres partagée par Flâner) — testé.

## Limite de vérif locale
Docker/OrbStack indisponible dans ce workspace → pas de stack Supabase complète : la
validation Chrome (390×844) du bloc « Explorer » live reste à faire via `/validate-feature`.
Le comportement backend est couvert au niveau unitaire (capture de la clause WHERE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)