### PR TITLE
fix(essentiel): haptic sur changement d'onglet par scroll

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -355,26 +355,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     );
   }
 
-  /// Called by [_SectionSnapPhysics] the instant a ballistic simulation is
-  /// built: `true` when it chose a section-anchored spring, `false` for a free
-  /// (natural) fling. Plain flag writes — runs during the physics phase, never
-  /// touches `setState`.
-  void _setSnapping(bool snapping) {}
-
-  /// Drops a snap that is no longer reaching its settle — a driven scroll took
-  /// over, or a fresh drag interrupted it — so its deferred settle haptic does
-  /// not fire spuriously. Single seam so every non-ballistic scroll path stays
-  /// consistent (callers don't open-code the flag clears).
-  void _cancelPendingSnap() {}
-
-  /// Bridges scroll notifications to the snap haptic. The settle haptic
-  /// is fired at rest (not when the spring is built) so it reads as the section
-  /// "posing" under the sticky bar. A fresh drag cancels any pending settle.
   bool _onScrollNotification(ScrollNotification n) {
-    if (n.depth != 0) return false;
-    if (n is ScrollStartNotification && n.dragDetails != null) {
-      _cancelPendingSnap();
-    }
     return false;
   }
 
@@ -490,9 +471,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       0.0,
       _scroll.position.maxScrollExtent,
     );
-    // Driven scroll, not ballistic → clear any snap that was still in flight so
-    // its settle haptic doesn't fire at the end of this animation.
-    _cancelPendingSnap();
     await _scroll.animateTo(
       target,
       duration: const Duration(milliseconds: 700),
@@ -502,7 +480,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
 
   Future<void> _scrollToTop() async {
     if (!_scroll.hasClients) return;
-    _cancelPendingSnap();
     unawaited(HapticFeedback.lightImpact());
     _markSectionsAboveAsScrolledPast(null);
     await _scroll.animateTo(
@@ -1026,7 +1003,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
           physics: AlwaysScrollableScrollPhysics(
             parent: _SectionSnapPhysics(
               anchors: _snapAnchors,
-              onSnap: _setSnapping,
             ),
           ),
           slivers: [
@@ -1231,11 +1207,9 @@ class _SnapAnchors {
 /// gestures.
 class _SectionSnapPhysics extends ScrollPhysics {
   final _SnapAnchors anchors;
-  final ValueChanged<bool> onSnap;
 
   const _SectionSnapPhysics({
     required this.anchors,
-    required this.onSnap,
     super.parent,
   });
 
@@ -1243,7 +1217,6 @@ class _SectionSnapPhysics extends ScrollPhysics {
   _SectionSnapPhysics applyTo(ScrollPhysics? ancestor) {
     return _SectionSnapPhysics(
       anchors: anchors,
-      onSnap: onSnap,
       parent: buildParent(ancestor),
     );
   }
@@ -1255,7 +1228,6 @@ class _SectionSnapPhysics extends ScrollPhysics {
   ) {
     final natural = super.createBallisticSimulation(position, velocity);
     final target = _resolveTarget(position, velocity, natural);
-    onSnap(target != null);
     if (target == null) return natural;
     return ScrollSpringSimulation(
       kSnapSpring,

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -168,12 +168,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   /// (a post-frame callback) where reading `MediaQuery` directly is unsafe.
   double _safeAreaBottom = 0;
 
-  /// A section snap is in flight (its ballistic spring is settling). While set,
-  /// the per-section passage haptic is suppressed so the stronger settle
-  /// haptic isn't doubled. The settle haptic itself is deferred to the
-  /// [ScrollEndNotification] via [_pendingSnapHaptic].
-  bool _isSnapping = false;
-  bool _pendingSnapHaptic = false;
 
   /// Garde-fou : le flow post-onboarding (dialog customs échoués + modales
   /// thème & notifications) ne doit se jouer qu'une seule fois par montage,
@@ -335,9 +329,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       // Suppressed while a snap is settling: the settle haptic owns the
       // boundary crossing, so we don't double-buzz.
       if (_stickyVisible.value) {
-        if (!_isSnapping) {
-          unawaited(_triggerSectionChangeHaptic());
-        }
+        unawaited(_triggerSectionChangeHaptic());
         _pulsePassageForStickyIndex(activeAt);
       }
       _activeIndex.value = activeAt;
@@ -367,19 +359,13 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   /// built: `true` when it chose a section-anchored spring, `false` for a free
   /// (natural) fling. Plain flag writes — runs during the physics phase, never
   /// touches `setState`.
-  void _setSnapping(bool snapping) {
-    _isSnapping = snapping;
-    _pendingSnapHaptic = snapping;
-  }
+  void _setSnapping(bool snapping) {}
 
   /// Drops a snap that is no longer reaching its settle — a driven scroll took
   /// over, or a fresh drag interrupted it — so its deferred settle haptic does
   /// not fire spuriously. Single seam so every non-ballistic scroll path stays
   /// consistent (callers don't open-code the flag clears).
-  void _cancelPendingSnap() {
-    _isSnapping = false;
-    _pendingSnapHaptic = false;
-  }
+  void _cancelPendingSnap() {}
 
   /// Bridges scroll notifications to the snap haptic. The settle haptic
   /// is fired at rest (not when the spring is built) so it reads as the section
@@ -388,12 +374,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     if (n.depth != 0) return false;
     if (n is ScrollStartNotification && n.dragDetails != null) {
       _cancelPendingSnap();
-    } else if (n is ScrollEndNotification) {
-      if (_pendingSnapHaptic) {
-        _pendingSnapHaptic = false;
-        unawaited(_triggerSectionChangeHaptic());
-      }
-      _isSnapping = false;
     }
     return false;
   }


### PR DESCRIPTION
## Quoi
Corrige l'absence de vibration haptique lors des changements d'onglet déclenchés par scroll dans la page l'Essentiel. Les haptics ne se déclenchaient qu'au tap sur le sticky header.

## Pourquoi
`_updateActiveSection()` était gaté par `!_isSnapping` : dès que la physique de snap choisissait un ressort ancré (`ScrollSpringSimulation`), `_isSnapping = true` supprimait le haptic de passage et le reportait à un `ScrollEndNotification` via `_pendingSnapHaptic`. Ce chemin ne produisait pas de retour perceptible en pratique.

## Comment
- Supprime le gate `!_isSnapping` dans `_updateActiveSection` → haptic heavy dès que `_activeIndex` change, quel que soit le geste
- Supprime le haptic "settle" dans `_onScrollNotification` pour éviter le double-buzz
- Retire toute l'infrastructure devenue obsolète : `_isSnapping`, `_pendingSnapHaptic`, `_setSnapping`, `_cancelPendingSnap`, paramètre `onSnap` de `_SectionSnapPhysics`

## Comment ça a été vérifié
- [x] `flutter analyze` — zéro erreur
- [x] /simplify passé — cleanup complet de l'infra morte
- [x] Pas de test mécanique possible (haptique = device physique requis)

## Zones à risque
`flux_continu_screen.dart` — `_updateActiveSection`, `_SectionSnapPhysics`