### PR TITLE
feat(essentiel): WeatherConditionIcon + date stamp météo UI

### DIFF
--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -3,7 +3,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
@@ -12,6 +11,7 @@ import '../models/flux_continu_models.dart';
 import '../models/weather_snapshot.dart';
 import '../providers/weather_provider.dart';
 import '../utils/theme_color_mapping.dart';
+import 'weather_condition_icon.dart';
 import 'weather_detail_sheet.dart';
 
 /// Carte hi-fi unique "L'Essentiel du jour".
@@ -291,12 +291,8 @@ class _WeatherBadge extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        SvgPicture.asset(
-          'assets/images/weather/${forecast.condition.assetName}.svg',
-          width: 90,
-          height: 90,
-        ),
-        const SizedBox(height: 3),
+        WeatherConditionIcon(condition: forecast.condition, size: 95),
+        const SizedBox(height: 2),
         RichText(
           text: TextSpan(
             style: GoogleFonts.courierPrime(
@@ -320,11 +316,11 @@ class _WeatherBadge extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 1),
+        const SizedBox(height: 2),
         Icon(
           Icons.keyboard_arrow_down_rounded,
-          size: 12,
-          color: colors.textTertiary.withValues(alpha: 0.7),
+          size: 16,
+          color: colors.textTertiary,
           semanticLabel: 'Voir la météo détaillée',
         ),
       ],
@@ -345,39 +341,69 @@ class _DateStamp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 60,
-      height: 60,
-      alignment: Alignment.center,
-      decoration: BoxDecoration(
-        color: Colors.transparent,
-        shape: BoxShape.circle,
-        border: Border.all(color: accent, width: 0.7),
-      ),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(
-            day.toString().padLeft(2, '0'),
-            style: GoogleFonts.courierPrime(
-              fontSize: 18,
-              fontWeight: FontWeight.w700,
-              height: 1.0,
-              color: accent,
-            ),
+    final colors = Theme.of(context).extension<FacteurColors>()!;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 68,
+          height: 68,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: Colors.transparent,
+            shape: BoxShape.circle,
+            border: Border.all(color: accent, width: 0.7),
           ),
-          Text(
-            month,
-            style: GoogleFonts.courierPrime(
-              fontSize: 10,
-              fontWeight: FontWeight.w700,
-              height: 1.0,
-              letterSpacing: 0.8,
-              color: accent,
-            ),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                day.toString().padLeft(2, '0'),
+                style: GoogleFonts.courierPrime(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                  height: 1.0,
+                  color: accent,
+                ),
+              ),
+              Text(
+                month,
+                style: GoogleFonts.courierPrime(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  height: 1.0,
+                  letterSpacing: 0.8,
+                  color: accent,
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Météo',
+              style: GoogleFonts.courierPrime(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                height: 1.0,
+                letterSpacing: 0.8,
+                color: colors.textTertiary.withValues(alpha: 0.76),
+              ),
+            ),
+            const SizedBox(width: 2),
+            Icon(
+              Icons.keyboard_return_rounded,
+              size: 11,
+              color: colors.textTertiary.withValues(alpha: 0.72),
+              semanticLabel: 'Retourner vers la météo',
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/features/flux_continu/widgets/weather_condition_icon.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/weather_condition_icon.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+import '../models/weather_snapshot.dart';
+
+/// SVG météo artistique + badge émoji condition superposé en bas-à-droite.
+class WeatherConditionIcon extends StatelessWidget {
+  final WeatherCondition condition;
+  final double size;
+
+  const WeatherConditionIcon({
+    super.key,
+    required this.condition,
+    required this.size,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        SvgPicture.asset(
+          'assets/images/weather/${condition.assetName}.svg',
+          width: size,
+          height: size,
+        ),
+        Positioned(
+          bottom: 5,
+          right: 5,
+          child: Container(
+            width: 28,
+            height: 28,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: Colors.white,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.12),
+                  blurRadius: 6,
+                  offset: const Offset(0, 1),
+                ),
+              ],
+            ),
+            child: Text(
+              _emoji(condition),
+              style: const TextStyle(fontSize: 17, height: 1),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+String _emoji(WeatherCondition condition) {
+  switch (condition) {
+    case WeatherCondition.sunny:
+      return '☀️';
+    case WeatherCondition.partlyCloudy:
+      return '⛅';
+    case WeatherCondition.cloudy:
+      return '☁️';
+    case WeatherCondition.rainy:
+      return '🌧️';
+    case WeatherCondition.snowy:
+      return '❄️';
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/weather_detail_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/weather_detail_sheet.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import '../../../config/theme.dart';
 import '../models/weather_snapshot.dart';
 import '../providers/weather_location_provider.dart';
 import '../providers/weather_provider.dart';
+import 'weather_condition_icon.dart';
 
 /// Ouvre la modal météo détaillée (aujourd'hui + prévision 5 jours).
 Future<void> showWeatherDetailSheet(BuildContext context) {
@@ -246,11 +246,7 @@ class _Content extends ConsumerWidget {
             children: [
               Row(
                 children: [
-                  SvgPicture.asset(
-                    'assets/images/weather/${forecast.condition.assetName}.svg',
-                    width: 72,
-                    height: 72,
-                  ),
+                  WeatherConditionIcon(condition: forecast.condition, size: 84),
                   const SizedBox(width: FacteurSpacing.space4),
                   Expanded(
                     child: Column(
@@ -347,11 +343,7 @@ class _DayRow extends StatelessWidget {
             ),
           ),
           const SizedBox(width: FacteurSpacing.space2),
-          SvgPicture.asset(
-            'assets/images/weather/${day.condition.assetName}.svg',
-            width: 68,
-            height: 68,
-          ),
+          WeatherConditionIcon(condition: day.condition, size: 76),
           const Spacer(),
           // Max en gros (WeatherDay n'expose pas de temp « actuelle »), avec la
           // plage min/max conservée dessous (décision PO : « quitte à dupliquer

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -243,6 +243,8 @@ void main() {
       ));
 
       expect(find.byType(SvgPicture), findsNothing);
+      expect(find.text('Météo'), findsOneWidget);
+      expect(find.byIcon(Icons.keyboard_return_rounded), findsOneWidget);
     });
 
     testWidgets(
@@ -288,12 +290,16 @@ void main() {
 
       // Before timer fires → date stamp, no weather icon.
       expect(find.byType(SvgPicture), findsNothing);
+      expect(find.text('Météo'), findsOneWidget);
+      expect(find.byIcon(Icons.keyboard_return_rounded), findsOneWidget);
 
       // Advance 2 s → badge flips to weather (icon + min/max visible).
       await tester.pump(const Duration(seconds: 2));
       await tester.pumpAndSettle();
 
       expect(find.byType(SvgPicture), findsOneWidget);
+      expect(find.text('Météo'), findsOneWidget);
+      expect(find.byIcon(Icons.keyboard_return_rounded), findsNothing);
       expect(
         find.byWidgetPredicate(
           (widget) =>


### PR DESCRIPTION
## What

Extrait un widget réutilisable `WeatherConditionIcon` (supprime les `SvgPicture.asset` inline dans `essentiel_hi_fi_card` et `weather_detail_sheet`). Agrandit les icônes météo et le cercle date stamp, et ajoute un label « Météo ↵ » sous le date stamp pour signaler l'interactivité de la zone flip.

## Why

Réduire la duplication de code SVG météo et améliorer la clarté visuelle de la carte Essentiel (affordance du tap météo plus explicite).

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)