### PR TITLE
fix(couverture-médiatique): exclure le représentatif des perspectives (off-by-one card/section + barre de biais)

### DIFF
--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -543,21 +543,29 @@ class EditorialPipelineService:
             if not cluster or not cluster.contents:
                 return
 
-            representative = sorted(
+            # Most-recent-first ordering: the representative (pivot) is the
+            # freshest article, the rest are the "other sources".
+            ordered_contents = sorted(
                 cluster.contents, key=lambda c: c.published_at, reverse=True
-            )[0]
+            )
+            representative = ordered_contents[0]
 
             # Step 1 — cluster-based perspectives (source of truth).
             # Helper is shared with /contents/{id}/perspectives so the
             # endpoint returns the same merged count as this pipeline (the
             # PR #390 invariant still holds between header and bottom sheet).
-            ordered_contents = sorted(
-                cluster.contents, key=lambda c: c.published_at, reverse=True
-            )
+            # Exclure le représentatif — c'est l'article ouvert, pas une
+            # "autre source". Sans ça, perspective_count l'inclut (N) alors
+            # que l'endpoint /perspectives le retire du snapshot (N-1), d'où
+            # un off-by-one permanent card/section + une barre de biais
+            # divergente.
+            ordered_without_rep = [
+                c for c in ordered_contents if c.id != representative.id
+            ]
             try:
                 cluster_perspectives = (
                     await perspective_service.build_cluster_perspectives(
-                        ordered_contents
+                        ordered_without_rep
                     )
                 )
             except Exception:


### PR DESCRIPTION
## Quoi

Le pipeline éditorial incluait l'article **représentatif** (pivot) dans `cluster_perspectives`, donc dans `perspective_count` et `bias_distribution`. L'endpoint `/contents/{id}/perspectives` le retirait du snapshot et recalculait la distribution sans lui. Résultat : la card de preview affichait **N** perspectives (avec le pivot), la section « Couverture médiatique » affichait **N-1**, et les deux barres de biais divergeaient.

Fix au **point de production** (1 méthode, `_process_perspectives` dans `pipeline.py`) : on exclut le représentatif avant `build_cluster_perspectives`. `perspective_count`, `bias_distribution` et `perspective_articles` sont désormais calculés sans le pivot — alignés sur ce que renvoie déjà l'endpoint. Le stripping côté endpoint devient un no-op sécurisé (gardé comme filet).

Au passage : suppression d'un double tri identique de `cluster.contents` (le représentatif est dérivé de la liste déjà triée) — cleanup repéré par `/simplify`.

## Pourquoi

Bug remonté : « Voir les N perspectives » (card) ≠ « Couverture médiatique (N) » (section), barre gauche/centre/droite différente entre les deux. Même racine pour les deux symptômes.

## Comment ça a été vérifié

- [x] `pytest` ciblé : `test_perspectives_alignment.py` (8), `test_pipeline_target_count.py` (12), `test_perspective_service.py` (15) → **35 OK**
- [x] Suite backend complète : **1242 passed** (les 273 ERROR sont des échecs pré-existants de connexion DB sync hors-scope, false-negative connu en environnement local — voir mémoire projet)
- [x] `/simplify` passé (dédup du double tri)
- [ ] Pas d'UI / pas de migration Alembic → pas de Playwright ni de chaîne Alembic

## Zones à risque

Pipeline éditorial (batch 6h). **L'effet n'est visible qu'après le prochain run** qui re-persiste les snapshots — les sujets déjà en base gardent l'ancien `perspective_count` jusqu'au recalcul. Aucun changement de schéma DB, aucun changement de contrat d'endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)