### PR TITLE
fix(app-update): masquer le prompt APK sur web + guard provider

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -42,8 +42,7 @@ jobs:
             --dart-define="POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" \
             --dart-define="POSTHOG_HOST=${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}" \
             --dart-define="SENTRY_DSN=${{ secrets.SENTRY_DSN }}" \
-            --dart-define="SENTRY_ENVIRONMENT=${{ vars.SENTRY_ENVIRONMENT || 'production' }}" \
-            --dart-define="APP_RELEASE_TAG=${{ github.sha }}"
+            --dart-define="SENTRY_ENVIRONMENT=${{ vars.SENTRY_ENVIRONMENT || 'production' }}"
 
       - name: Copy Documentation to Build
         run: |

--- a/apps/mobile/lib/features/app_update/providers/app_update_provider.dart
+++ b/apps/mobile/lib/features/app_update/providers/app_update_provider.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../config/constants.dart';
@@ -50,9 +53,10 @@ class AppUpdateInfo {
   }
 }
 
-/// Checks for app updates. Returns null if not a release build or check fails.
+/// Checks for app updates. Returns null on non-Android platforms or dev builds.
 final appUpdateProvider =
     FutureProvider.autoDispose<AppUpdateInfo?>((ref) async {
+  if (kIsWeb || !Platform.isAndroid) return null;
   if (!AppUpdateConstants.isReleaseBuild) return null;
 
   try {

--- a/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -175,6 +178,7 @@ class _UpdateAvailableTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    if (kIsWeb || !Platform.isAndroid) return const SizedBox.shrink();
     final colors = context.facteurColors;
     final info = ref.watch(appUpdateProvider).valueOrNull;
     if (info == null || !info.updateAvailable) {


### PR DESCRIPTION
## Quoi

Deux corrections liées au système de mise à jour in-app :

1. **`appUpdateProvider`** retourne désormais `null` sur tout contexte non-Android/web — guard unique au niveau du provider qui protège tous les consommateurs (header badge dans `main_shell`, tuile settings, bouton update)
2. **`_UpdateAvailableTile`** dans les Settings ajoute un guard de plateforme en défense en profondeur
3. **`build-web.yml`** ne passe plus `--dart-define="APP_RELEASE_TAG=${{ github.sha }}"` au build web

## Pourquoi

**Bug web confirmé** : le build web injectait le SHA du commit comme `APP_RELEASE_TAG` (ex: `bad1dbee...`), ce qui rendait `isReleaseBuild = true` sur le web. La comparaison lexicographique `"beta-YYYYMMDD".compareTo("bad1dbee...")` retournait positif (`'e' > 'a'`), donc `updateAvailable = true`. La tuile Settings n'avait pas de guard de plateforme → le prompt de téléchargement APK s'affichait sur le web.

**Vulnérabilité additionnelle** : `main_shell.dart` watch `appUpdateProvider` directement sans guard de plateforme pour afficher le badge rouge. Sans fix au niveau provider, le badge aurait aussi pu apparaître sur web.

## Comment ça a été vérifié

- [x] `flutter analyze` — 0 erreur sur les fichiers modifiés
- [x] `flutter test test/features/settings/` — 5/5 tests passent
- [x] Sentry consulté — aucune issue `app/update` backend dans les 7 derniers jours
- [x] `/simplify` passé — guard remonté au bon niveau (provider) plutôt que dupliqué dans chaque widget

## Zones à risque

- `appUpdateProvider` — tous les consommateurs du provider bénéficient du fix automatiquement
- `build-web.yml` — le prochain build web n'aura plus `isReleaseBuild = true`

## Diagnostic Android

Aucune erreur Sentry liée à `GET /app/update`. L'indicateur de mise à jour disparaît correctement une fois la dernière version installée — comportement attendu.