### PR TITLE
fix(personalization): mute source — get_or_create_profile dans try/except + invalider fluxContinuProvider

### DIFF
--- a/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
+++ b/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
@@ -12,6 +12,7 @@ import '../../../config/topic_labels.dart';
 import '../../../core/ui/notification_service.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/repositories/personalization_repository.dart';
+import '../../flux_continu/providers/flux_continu_provider.dart';
 import '../../my_interests/widgets/interest_state_pill.dart';
 import '../../sources/widgets/premium_source_connection.dart';
 import '../models/topic_models.dart';
@@ -775,6 +776,7 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
                   final repo = ref.read(personalizationRepositoryProvider);
                   await repo.muteSource(widget.content.source.id);
                   ref.invalidate(personalizationProvider);
+                  ref.invalidate(fluxContinuProvider);
                   NotificationService.showInfo(
                       'Source ${widget.content.source.name} masquée');
                 } catch (e) {

--- a/packages/api/app/routers/personalization.py
+++ b/packages/api/app/routers/personalization.py
@@ -108,15 +108,12 @@ async def mute_source(
 ):
     """Ajoute une source à la liste des sources mutées."""
     user_uuid = UUID(current_user_id)
-    # Garantir l'existence du profil utilisateur (requis pour la FK)
-
-    # Garantir l'existence du profil utilisateur (requis pour la FK)
     user_service = UserService(db)
-    # Ensure profile exists to satisfy FK constraint
-    await user_service.get_or_create_profile(current_user_id)
-    await db.commit()  # S'assurer que le profil est persisté et visible pour la FK
 
     try:
+        await user_service.get_or_create_profile(current_user_id)
+        await db.commit()
+
         # Upsert: Insert if not exists, update if exists
         # Use COALESCE to handle case where muted_sources is NULL
         stmt = (


### PR DESCRIPTION
## Quoi

Deux corrections sur le flow \"masquer une source\" depuis les Actus du jour.

## Pourquoi

Le 2026-06-05, un utilisateur a tenté de masquer CNEWS — l'UI a renvoyé \"Impossible de masquer cette source\" et CNEWS est resté visible.

**Root cause 1 — Backend** : `get_or_create_profile` + `db.commit()` étaient hors du bloc `try/except` dans `mute_source`. Des timeouts `idle-in-transaction` Postgres (6:23, 6:25, 6:47, 6:49 UTC) tuaient la connexion pendant ce premier commit. L'exception remontait sans être loggée ni rollbackée, et Flutter recevait un 500 → toast d'erreur.

**Root cause 2 — Mobile** : après un mute réussi, seul `personalizationProvider` était invalidé. `fluxContinuProvider` (Actus du jour) n'était pas touché → les articles de la source masquée restaient visibles jusqu'au prochain refresh complet.

## Changements

- `packages/api/app/routers/personalization.py` : `get_or_create_profile` + premier `db.commit()` déplacés à l'intérieur du `try/except` pour garantir log + rollback propre en cas d'erreur.
- `apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart` : `ref.invalidate(fluxContinuProvider)` ajouté après mute réussi pour retirer immédiatement les articles de la source des Actus du jour.

## Comment ça a été vérifié

- [x] `pytest tests/test_personalization_router.py -v` — 3/3 OK
- [x] `flutter analyze` — 0 erreur (warnings pre-existants)
- [x] Endpoint `/api/users/personalization/mute-source` sans auth → 403 (expected)
- [x] `/simplify` passé (stale comment supprimé, import réordonné)

## Zones à risque

`personalization.py` — handler `mute_source` (transaction DB). Les handlers `mute_theme`, `mute_topic`, `mute_content_type` ont le même pattern non-protégé (hors scope de ce fix, à traiter séparément).