### PR TITLE
feat(flux-continu): rendre le snap lisible — signifiants feedforward (A1+A2+A3)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,42 +1,73 @@
-fix(mot-du-jour): anti-freeze + dico élargi + lien Actu + reveal article réel
+feat(flux-continu): rendre le snap *lisible* — signifiants feedforward (A1+A2+A3)
 
-« Mot du jour » (La Grille) — 2 bugs + 2 améliorations remontés en prod par le PO,
-livrés en **une seule PR groupée** (décision PO). Détail : `docs/bugs/bug-mot-du-jour-bugs.md`.
+## Quoi
 
-## Part A — Anti-freeze (critique)
-- Timeout dédié 12 s sur `POST grille/today/guess` (override le 30 s global).
-- `submitGuess` : suppression du `rethrow` (source du hang silencieux) → état
-  `networkError` ré-essayable + self-heal `_reconcileToday()` ; clavier réactivé.
-- `_submitGuess` (écran) : plus de future non gérée ; pas de tracking « valide »
-  sur erreur réseau.
-- Backend **idempotent** : re-submit du même dernier mot (partie en cours) ne
-  double-compte pas → retry réseau sûr.
+Le scroll-snap section-par-section frustrait certains users (« coupé dans mon
+geste », mouvement « subi » et imprévisible). Diagnostic : **la mécanique du snap
+est bonne** — c'est un manque de *lisibilité*. On ajoute des **signifiants**, sans
+toucher à la physique ni à une seule constante de tuning.
 
-## Part B — Dictionnaire élargi
-- Asset curé `grille_proper_nouns_fr.txt` (pays/villes/prénoms) → ITALIE, RUSSIE…
-  acceptés. Conjugaisons déjà couvertes par la source existante (vérifié) → pas
-  de 2ᵉ source (Lexique383 écarté : CC BY-SA share-alike). Dico régénéré committé.
+- **A1 — Feedforward pendant le drag.** Le `_SectionPassageDot` existant (déjà à
+  chaque frontière, déjà porteur du pulse de validation) **grossit/brille à
+  l'approche du bord**, pic pile au seuil de bascule (`kSectionEdgeMargin`). Le
+  même dot fusionne désormais feedforward (avant) + feedback (pulse après) →
+  lecture « j'approche un seuil → je l'ai franchi », un seul cue continu.
+- **A2 — Progress track *segmenté*.** Le track 4 px passe d'un dégradé continu à
+  **un pip par section** (fait rempli-désaturé / courant éclairé+glow / à venir
+  gris), piloté par `activeIndex` (même source que les checks d'onglets) → modèle
+  mental « pages » cohérent avec le snap discret.
+- **A3 — Signifiant « carte haute = lecture libre ».** Les sections plus hautes
+  que l'écran (qui autorisent un scroll libre *silencieusement*) reçoivent un
+  **fade bas subtil** (`backgroundPrimary` → transparent, 24 px), peint par
+  l'écran (zéro modif de signature `SectionBlock`).
 
-## Part C — Lien Actu du jour
-- `_goToActus` → page complète `…/section/essentiel`.
-- CTA « Lire l'actu du jour » toujours visible dans le jeu.
+## Pourquoi
 
-## Part D — Reveal lié à un vrai article (auto-matching)
-- Migration additive `gr02_grille_featured_article` (nullable, FK ON DELETE SET NULL).
-- `grille_matcher.py` accroche l'article du digest qui matche le mot (best-effort,
-  hooké dans le job digest, non bloquant, idempotent).
-- `featured*` gated fin de partie ; mobile affiche vrai titre/extrait/source +
-  bouton « Lire l'article » (détail in-app), fallback `pourquoi`.
+Décision PO (5 juin 2026) : garder le snap, le rendre lisible — priorité au
+« coupé dans mon geste ». Le défaut était l'absence de **feedforward** : tout le
+feedback existant (`_SectionPassageDot`, track, haptique) était *post-hoc*.
 
-## Vérif
-- 62 tests backend verts + 43 mobile verts. `ruff check/format app/` clean.
-- Alembic : 1 head (`gr02`), upgrade/downgrade round-trip OK sur DB vide.
-- `flutter analyze` clean (hors warning pré-existant carte_cta.dart).
+## Comment c'est construit (anti-duplication)
 
-## Notes review
-- Migration = zone à risque DB : additive + nullable + FK SET NULL, testée en
-  round-trip. Le Dockerfile rejoue `alembic upgrade head` au boot Railway.
-- Suite mobile complète a ~27 échecs pré-existants hors-scope (Hive/Supabase) ;
-  CI = pytest backend only.
+- **Une seule source de vérité** : `snapPointsOf(List<SectionFrame>)` extrait de
+  `resolveSnapTarget` (comportement strictement inchangé) — la rampe visuelle de
+  A1 ramène donc *exactement* aux offsets où le snap commit.
+- Tout s'accroche à l'infra existante : listener `_onScroll`, anchors
+  `_snapAnchors`, `ValueNotifier` (rebuilds ciblés, **zéro `setState`/frame**).
+- Mapping direction `ScrollDirection → ±1` factorisé (`_travelDirection`) et
+  partagé entre le feedforward (A1) et la physique → impossible qu'ils
+  divergent.
+- Hot path propre : snap points **cachés une fois par layout** (plus de
+  re-`sort()` par frame) ; lookup dot via `Map<double,int>` exact (offsets
+  bit-identiques aux frame tops) ; proximity quantizée (~20 paliers) ; merged
+  `Listenable` du dot mis en cache.
+- **Nettoyage** : la prop `progress` continue de `StickyTabBar` + le
+  `ValueNotifier _scrollProgress` (écrit chaque frame) sont supprimés — le track
+  segmenté n'a besoin que de `activeIndex`.
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+## Comment ça a été vérifié
+
+- [x] `flutter analyze` — **clean** (lib/features/flux_continu + tests modifiés).
+- [x] `flutter test test/features/flux_continu/` — tous verts **sauf** 1 échec
+      **pré-existant hors-scope** (`section_block_test.dart` ne compile pas :
+      `onTapArticle: (_, __)` vs signature 1-arg de `SectionBlock`, inchangé vs
+      `origin/main`, dernier touché par #785).
+- [x] Tests ajoutés : `snapPointsOf()` (frames canon ⇒ `{0,300,600,1200}`,
+      single-point, vide, + « tout target commit ∈ snapPointsOf ») ; les tests
+      `resolveSnapTarget` existants **restent verts** (preuve de non-régression de
+      la physique). Track A2 : capture image + sampling pixels (1 fait + 1
+      courant remplis / 1 à venir muté ; un segment à-venir se remplit quand il
+      devient courant).
+- [ ] Validation device/feel : à confirmer par le PO (le « grain » du snap se
+      juge sur device ; aucune constante de physique n'a bougé).
+
+> CI = backend pytest only (pas de `flutter test`) → l'échec mobile pré-existant
+> ne bloque pas la CI.
+
+## Zones à risque
+
+- `flux_continu_screen.dart` (Router/scroll feature, fichier central) : aucune
+  modif de `_SectionSnapPhysics`, `resolveSnapTarget`, ni des constantes de
+  tuning. Changements additifs (notifiers + overlay) sur l'infra existante.
+- A3 (`_FreeReadEdgeFade`) = ligne de coupe nette ; son absence ne créerait
+  aucune incohérence (la lecture libre est silencieuse aujourd'hui).

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -3,7 +3,7 @@ import 'dart:math' as math;
 import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/foundation.dart'
-    show ValueListenable, defaultTargetPlatform, TargetPlatform;
+    show ValueListenable, defaultTargetPlatform, setEquals, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -90,6 +90,32 @@ const _closingTab = StickyTab(
   accent: Color(0xFF2E7D32),
 );
 
+/// Drag-time feedforward payload for [_SectionPassageDot]. Computed live in
+/// [_FluxContinuScreenState._updateBoundaryApproach] and broadcast via a
+/// [ValueNotifier] so the dots rebuild without a per-frame `setState`.
+/// - [dotIndex] : the passage dot sitting at the boundary the gesture is
+///   approaching (= the section index *before* it, same `k-1` convention as
+///   [_FluxContinuScreenState._pulsePassageForStickyIndex]), or `null` when the
+///   next snap point in the travel direction is **not** an inter-section
+///   boundary (a tall section's free-reading bottom) — so no « va snapper » cue
+///   appears inside the free interior, matching the physics which returns `null`
+///   there too.
+/// - [proximity] : ramps 0→1 as the lift point nears that boundary, reaching 1
+///   exactly at [kSectionEdgeMargin] (the deadband where the snap commits), so
+///   the dot peaks precisely at the switch threshold.
+typedef _BoundaryApproach = ({int? dotIndex, double proximity});
+
+/// Signed *travel* direction from a [ScrollDirection]: +1 scrolling down (offset
+/// increasing), -1 up, 0 idle/unknown. Single mapping shared by the drag-time
+/// feedforward ([_FluxContinuScreenState._updateBoundaryApproach]) and the snap
+/// physics ([_SectionSnapPhysics._resolveTarget]) so the cue and the commit can
+/// never disagree on « which way am I going ».
+double _travelDirection(ScrollDirection d) => switch (d) {
+  ScrollDirection.reverse => 1.0,
+  ScrollDirection.forward => -1.0,
+  ScrollDirection.idle => 0.0,
+};
+
 class FluxContinuScreen extends ConsumerStatefulWidget {
   const FluxContinuScreen({super.key});
 
@@ -101,7 +127,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   final ScrollController _scroll = ScrollController();
   final ScrollController _tabsScroll = ScrollController();
   final ValueNotifier<bool> _stickyVisible = ValueNotifier(false);
-  final ValueNotifier<double> _scrollProgress = ValueNotifier(0);
   final ValueNotifier<int> _activeIndex = ValueNotifier(0);
   final ValueNotifier<_SectionPassagePulse?> _sectionPassagePulse =
       ValueNotifier(null);
@@ -153,6 +178,33 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   final _SnapAnchors _snapAnchors = _SnapAnchors();
   bool _snapAnchorsRecomputeScheduled = false;
 
+  /// Drag-time « distance to the next boundary » cue, written by
+  /// [_updateBoundaryApproach] on every scroll frame (quantized) and read by the
+  /// in-flow [_SectionPassageDot]s. Feedforward twin of [_sectionPassagePulse]
+  /// (the post-validation pulse) — both ride the same dot so the gesture reads
+  /// as a single continuous « j'approche un seuil → je l'ai franchi ».
+  final ValueNotifier<_BoundaryApproach?> _boundaryApproach =
+      ValueNotifier(null);
+
+  /// Sorted snap points of [_snapAnchors], cached once per layout (frames only
+  /// change on layout, never per scroll frame) so the per-frame
+  /// [_updateBoundaryApproach] doesn't re-allocate + re-sort them every frame.
+  List<double> _snapPoints = const [];
+
+  /// Maps a section *top* (an inter-section boundary) to the passage dot above
+  /// it (section index − 1). Rebuilt alongside the snap anchors in
+  /// [_recomputeSnapAnchors]; [_updateBoundaryApproach] looks up an approached
+  /// snap point here directly (the offsets are bit-identical to the stored
+  /// frame tops). Tops absent here (a tall section's bottom, the first section,
+  /// the virtual cards) carry no « va snapper » cue.
+  final Map<double, int> _dotIndexByTop = {};
+
+  /// (A3) Indices (into `state.sections`) of sections taller than the viewport —
+  /// the ones with a free-reading interior (`bottom > top`, same predicate as
+  /// the physics' free zone). Drives the [_FreeReadEdgeFade] « lecture libre »
+  /// signifier. Rebuilt in [_recomputeSnapAnchors].
+  final ValueNotifier<Set<int>> _tallSections = ValueNotifier(const {});
+
   /// Total bottom overlay height (app nav bar + system insets), captured from
   /// [MediaQuery.paddingOf] in [build]. With [extendBody: true] on the outer
   /// Scaffold, padding.bottom reflects the actual rendered height of
@@ -192,9 +244,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     _scroll.dispose();
     _tabsScroll.dispose();
     _stickyVisible.dispose();
-    _scrollProgress.dispose();
     _activeIndex.dispose();
     _sectionPassagePulse.dispose();
+    _boundaryApproach.dispose();
+    _tallSections.dispose();
     _pullHintTimer?.cancel();
     super.dispose();
   }
@@ -207,14 +260,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     if (_stickyVisible.value != showSticky) {
       _stickyVisible.value = showSticky;
     }
-    final maxExtent = pos.maxScrollExtent;
-    final nextProgress = maxExtent > 0
-        ? (currentScroll / maxExtent).clamp(0.0, 1.0).toDouble()
-        : 0.0;
-    if (_scrollProgress.value != nextProgress) {
-      _scrollProgress.value = nextProgress;
-    }
     _updateActiveSection();
+    _updateBoundaryApproach(pos);
 
     if (currentScroll > _maxScrollDepthPx) {
       _maxScrollDepthPx = currentScroll;
@@ -325,6 +372,68 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     return false;
   }
 
+  /// (A1) Feedforward: as the reader drags toward a section boundary, ramp the
+  /// in-flow passage dot that sits there so the snap reads as « j'approche un
+  /// seuil marqué » *before* the finger lifts — not a post-hoc surprise. Runs
+  /// inside [_onScroll] (already firing every frame); reuses the live snap
+  /// anchors and the shared [snapPointsOf], so the cue is mechanically true to
+  /// where the snap commits. Cheap: writes a quantized value to
+  /// [_boundaryApproach] only when it changes.
+  void _updateBoundaryApproach(ScrollPosition pos) {
+    final points = _snapPoints;
+    final currentScroll = pos.pixels;
+    // Header zone (above the first section): the sticky is hidden anyway ⇒ no
+    // boundary cue.
+    if (points.isEmpty || currentScroll <= points.first) {
+      if (_boundaryApproach.value != null) _boundaryApproach.value = null;
+      return;
+    }
+    // Travel direction (shared mapping with the physics). On idle, keep the
+    // previous value so a pause mid-drag doesn't flicker the cue off.
+    final dir = _travelDirection(pos.userScrollDirection);
+    if (dir == 0) return;
+
+    // The next snap point strictly in the travel direction.
+    double? edge;
+    if (dir > 0) {
+      for (final p in points) {
+        if (p > currentScroll + kSnapEpsilon) {
+          edge = p;
+          break;
+        }
+      }
+    } else {
+      for (var i = points.length - 1; i >= 0; i--) {
+        if (points[i] < currentScroll - kSnapEpsilon) {
+          edge = points[i];
+          break;
+        }
+      }
+    }
+    if (edge == null) {
+      if (_boundaryApproach.value != null) _boundaryApproach.value = null;
+      return;
+    }
+
+    // Proximity ramps to 1 across the deadband where the snap commits, so the
+    // dot peaks exactly at the switch threshold. The cue rides a dot only when
+    // the approached point is an inter-section boundary (present in
+    // [_dotIndexByTop]); a tall section's bottom maps to null ⇒ no « va snapper »
+    // cue inside the free interior.
+    final dist = (edge - currentScroll).abs();
+    final proximity = (1 - dist / kSectionEdgeMargin).clamp(0.0, 1.0);
+    // Quantize (~20 steps) so the small dot rebuilds only a handful of times
+    // per gesture rather than every frame.
+    final quantized = (proximity * 20).round() / 20;
+    final next = (dotIndex: _dotIndexByTop[edge], proximity: quantized);
+    final cur = _boundaryApproach.value;
+    if (cur == null ||
+        cur.dotIndex != next.dotIndex ||
+        cur.proximity != next.proximity) {
+      _boundaryApproach.value = next;
+    }
+  }
+
   Future<void> _triggerSectionChangeHaptic() async {
     try {
       await Haptics.vibrate(HapticsType.medium, usage: HapticsUsage.touch);
@@ -348,6 +457,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   void _recomputeSnapAnchors() {
     if (!_scroll.hasClients) {
       _snapAnchors.values = const [];
+      _snapPoints = const [];
+      _dotIndexByTop.clear();
+      _tallSections.value = const {};
       return;
     }
     final scrollBox =
@@ -361,8 +473,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     // truncated.
     final visibleBottom = scrollBox.size.height - _safeAreaBottom;
     final result = <SectionFrame>[];
-    for (final key in _stickyEntryKeys) {
-      final ctx = key.currentContext;
+    _dotIndexByTop.clear();
+    final tall = <int>{};
+    for (var k = 0; k < _stickyEntryKeys.length; k++) {
+      final ctx = _stickyEntryKeys[k].currentContext;
       if (ctx == null) continue;
       final box = ctx.findRenderObject();
       if (box is! RenderBox || !box.attached) continue;
@@ -374,9 +488,23 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       // free-reading zone.
       final bottom = offset + (topGlobal + box.size.height) - visibleBottom;
       result.add((top: top, bottom: bottom));
+      // Map this entry to its real section index (virtual cards ⇒ −1) for the
+      // A1 passage-dot cue and the A3 free-read fade. Same convention as
+      // [_pulsePassageForStickyIndex].
+      final sectionIndex = _sectionIndexForStickyIndex(k);
+      if (sectionIndex > 0) {
+        _dotIndexByTop[top] = sectionIndex - 1;
+      }
+      if (sectionIndex >= 0 && bottom > top + kSnapEpsilon) {
+        tall.add(sectionIndex);
+      }
     }
     result.sort((a, b) => a.top.compareTo(b.top));
     _snapAnchors.values = result;
+    _snapPoints = snapPointsOf(result);
+    if (!setEquals(_tallSections.value, tall)) {
+      _tallSections.value = tall;
+    }
   }
 
   /// Defers an anchor recompute to the next post-frame (when layout is settled),
@@ -737,7 +865,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             ),
             _StickyHostOverlay(
               stickyVisible: _stickyVisible,
-              scrollProgress: _scrollProgress,
               activeIndex: _activeIndex,
               tabs: stickyTabs,
               onTapTab: _scrollToSection,
@@ -973,6 +1100,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             child: _SectionPassageDot(
               index: i - 1,
               pulseListenable: _sectionPassagePulse,
+              approachListenable: _boundaryApproach,
             ),
           ),
         );
@@ -983,7 +1111,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
         SliverToBoxAdapter(
           child: KeyedSubtree(
             key: _sectionKeys[i],
-            child: SectionBlock(
+            child: _FreeReadEdgeFade(
+              index: i,
+              tallSections: _tallSections,
+              child: SectionBlock(
               section: section,
               isOpen: state.isOpen(section),
               onToggleMore: () => notifier.toggleMore(section),
@@ -1021,6 +1152,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
                   : section is DigestTopicSection
                   ? () => _openDigestSection(context, section)
                   : null,
+              ),
             ),
           ),
         ),
@@ -1101,14 +1233,9 @@ class _SectionSnapPhysics extends ScrollPhysics {
 
     // Travel direction from the controller, not the lift velocity: a slow
     // drag-to-read down ends at ≈ 0 velocity, which would misread as "going
-    // up". ScrollDirection.reverse = scrolling down (offset increasing) ⇒ +1;
-    // .forward = up ⇒ -1.
+    // up". Shared mapping with the drag-time feedforward via [_travelDirection].
     final scrollDirection = position is ScrollPosition
-        ? switch (position.userScrollDirection) {
-            ScrollDirection.reverse => 1.0,
-            ScrollDirection.forward => -1.0,
-            ScrollDirection.idle => 0.0,
-          }
+        ? _travelDirection(position.userScrollDirection)
         : 0.0;
 
     final raw = resolveSnapTarget(
@@ -1154,8 +1281,16 @@ class _SectionPassageDot extends StatefulWidget {
   final int index;
   final ValueListenable<_SectionPassagePulse?> pulseListenable;
 
-  _SectionPassageDot({required this.index, required this.pulseListenable})
-    : super(key: ValueKey('section_passage_dot_$index'));
+  /// (A1) Drag-time feedforward: when `value.dotIndex == index`, the dot grows
+  /// and brightens with `value.proximity` *before* the snap commits, fusing
+  /// feedforward and the post-validation [pulseListenable] pulse in one object.
+  final ValueListenable<_BoundaryApproach?> approachListenable;
+
+  _SectionPassageDot({
+    required this.index,
+    required this.pulseListenable,
+    required this.approachListenable,
+  }) : super(key: ValueKey('section_passage_dot_$index'));
 
   @override
   State<_SectionPassageDot> createState() => _SectionPassageDotState();
@@ -1164,6 +1299,10 @@ class _SectionPassageDot extends StatefulWidget {
 class _SectionPassageDotState extends State<_SectionPassageDot>
     with SingleTickerProviderStateMixin {
   late final AnimationController _pulseController;
+  /// Cached rebuild trigger (pulse OR drag-approach) so the merged listenable
+  /// isn't re-allocated on every build. Rebuilt only if [approachListenable]
+  /// identity changes.
+  late Listenable _repaint;
   int _lastSequence = -1;
 
   @override
@@ -1173,6 +1312,7 @@ class _SectionPassageDotState extends State<_SectionPassageDot>
       vsync: this,
       duration: const Duration(milliseconds: 360),
     );
+    _repaint = Listenable.merge([_pulseController, widget.approachListenable]);
     widget.pulseListenable.addListener(_onPulse);
   }
 
@@ -1182,6 +1322,9 @@ class _SectionPassageDotState extends State<_SectionPassageDot>
     if (oldWidget.pulseListenable != widget.pulseListenable) {
       oldWidget.pulseListenable.removeListener(_onPulse);
       widget.pulseListenable.addListener(_onPulse);
+    }
+    if (oldWidget.approachListenable != widget.approachListenable) {
+      _repaint = Listenable.merge([_pulseController, widget.approachListenable]);
     }
   }
 
@@ -1216,12 +1359,26 @@ class _SectionPassageDotState extends State<_SectionPassageDot>
         child: Align(
           alignment: const Alignment(0, -0.68),
           child: AnimatedBuilder(
-            animation: _pulseController,
+            // Rebuild on either the post-validation pulse OR the drag-time
+            // approach cue — both feed the same dot (cached merged listenable).
+            animation: _repaint,
             builder: (context, _) {
               final t = Curves.easeOutCubic.transform(_pulseController.value);
-              final scale =
-                  1 + (0.30 * (1 - (2 * t - 1).abs()).clamp(0.0, 1.0));
+              final pulseBump = 0.30 * (1 - (2 * t - 1).abs()).clamp(0.0, 1.0);
               final glow = (1 - t).clamp(0.0, 1.0);
+              // Feedforward proximity (0 when this dot isn't the one being
+              // approached). Folded into the same scale/alpha/shadow as the
+              // pulse so the two cues read as one continuous gesture.
+              final approach = widget.approachListenable.value;
+              final proximity =
+                  (approach != null && approach.dotIndex == widget.index)
+                  ? approach.proximity
+                  : 0.0;
+              final scale = 1 + pulseBump + 0.9 * proximity;
+              final fillAlpha = (0.76 + 0.14 * glow + 0.20 * proximity).clamp(
+                0.0,
+                1.0,
+              );
               return Transform.scale(
                 scale: scale,
                 child: Container(
@@ -1229,12 +1386,14 @@ class _SectionPassageDotState extends State<_SectionPassageDot>
                   height: 2.5,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
-                    color: dotColor.withValues(alpha: 0.76 + 0.14 * glow),
+                    color: dotColor.withValues(alpha: fillAlpha),
                     boxShadow: [
                       BoxShadow(
-                        color: dotColor.withValues(alpha: 0.13 * glow),
-                        blurRadius: 5,
-                        spreadRadius: 0.5,
+                        color: dotColor.withValues(
+                          alpha: 0.13 * glow + 0.30 * proximity,
+                        ),
+                        blurRadius: 5 + 4 * proximity,
+                        spreadRadius: 0.5 + proximity,
                       ),
                     ],
                     border: Border.all(
@@ -1252,9 +1411,61 @@ class _SectionPassageDotState extends State<_SectionPassageDot>
   }
 }
 
+/// (A3) « Carte haute = lecture libre » signifier. A section taller than the
+/// viewport (its index is in [tallSections]) gets a subtle bottom fade
+/// (`backgroundPrimary` → transparent, ~24 px), reading as « ce contenu coule
+/// sous le bord, tu peux scroller librement » — coherent with the physics
+/// leaving that interior un-snapped and with A1 emitting no « va snapper » dot
+/// there. Short/snapping sections render the child untouched. Painted by the
+/// screen (Stack overlay) so [SectionBlock]'s signature stays unchanged.
+class _FreeReadEdgeFade extends StatelessWidget {
+  final int index;
+  final ValueListenable<Set<int>> tallSections;
+  final Widget child;
+
+  const _FreeReadEdgeFade({
+    required this.index,
+    required this.tallSections,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<Set<int>>(
+      valueListenable: tallSections,
+      child: child,
+      builder: (context, tall, child) {
+        if (!tall.contains(index)) return child!;
+        final base = context.facteurColors.backgroundPrimary;
+        return Stack(
+          children: [
+            child!,
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: 24,
+              child: IgnorePointer(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [base.withValues(alpha: 0), base],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
 class _StickyHostOverlay extends StatelessWidget {
   final ValueNotifier<bool> stickyVisible;
-  final ValueNotifier<double> scrollProgress;
   final ValueNotifier<int> activeIndex;
 
   /// Descripteurs d'onglets (label+accent) dans l'ordre des slivers, calculés
@@ -1266,7 +1477,6 @@ class _StickyHostOverlay extends StatelessWidget {
 
   const _StickyHostOverlay({
     required this.stickyVisible,
-    required this.scrollProgress,
     required this.activeIndex,
     required this.tabs,
     required this.onTapTab,
@@ -1286,18 +1496,16 @@ class _StickyHostOverlay extends StatelessWidget {
           if (!showSticky) {
             return const SizedBox.shrink();
           }
+          // The progress track is now segmented and driven solely by the
+          // discrete active index — no continuous scroll-fraction needed.
           return ValueListenableBuilder<int>(
             valueListenable: activeIndex,
-            builder: (context, idx, _) => ValueListenableBuilder<double>(
-              valueListenable: scrollProgress,
-              builder: (context, progress, _) => StickyTabBar(
-                tabs: tabs,
-                activeIndex: idx.clamp(0, tabs.length - 1),
-                progress: progress,
-                onTapTab: onTapTab,
-                tabsController: tabsController,
-                showFilterBar: false,
-              ),
+            builder: (context, idx, _) => StickyTabBar(
+              tabs: tabs,
+              activeIndex: idx.clamp(0, tabs.length - 1),
+              onTapTab: onTapTab,
+              tabsController: tabsController,
+              showFilterBar: false,
             ),
           );
         },

--- a/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
@@ -22,7 +22,7 @@ const double kSectionEdgeMargin = 120.0;
 /// La **force / vitesse** du tir vers la cible. Plus haut ⇒ snap plus rapide et
 /// « net » (claque vers la section) ; plus bas ⇒ plus lent et mou. C'est le
 /// premier levier pour la « vitesse de switch ».
-const double kSnapStiffness = 550.0;
+const double kSnapStiffness = 700.0;
 
 /// L'**amortissement**. Plus haut ⇒ aucune oscillation, arrivée « posée » et
 /// smooth (mais trop haut = traînant) ; plus bas ⇒ vif, voire un léger rebond.
@@ -31,7 +31,7 @@ const double kSnapDamping = 40.0;
 
 /// L'**inertie** de la masse animée. Plus haut ⇒ démarrage plus pesant / lent ;
 /// plus bas ⇒ réaction plus immédiate. À laisser ≈ 0.5 sauf besoin précis.
-const double kSnapMass = 0.05;
+const double kSnapMass = 0.03;
 
 /// Ressort de pose du snap, assemblé depuis les 3 leviers ci-dessus. Visible
 /// « pose » (~250-350ms) sans wobble — le snap fait partie de la décélération
@@ -109,12 +109,7 @@ double? resolveSnapTarget({
 
   // Every framing offset is a snap point: each section top, plus the bottom of
   // each tall section (rest on its last cards). Sorted ascending.
-  final points = <double>[];
-  for (final f in frames) {
-    points.add(f.top);
-    if (f.bottom > f.top + kSnapEpsilon) points.add(f.bottom);
-  }
-  points.sort();
+  final points = snapPointsOf(frames);
 
   // Travel direction: controller first, then the fling sign (lift velocity).
   final dir = scrollDirection != 0 ? scrollDirection : velocity.sign;
@@ -140,6 +135,26 @@ double? resolveSnapTarget({
   }
   final prev = _lastStrictlyBefore(points, currentPixels);
   return _commit(prev ?? _nearest(points, currentPixels), currentPixels);
+}
+
+/// The snap points of a frame list, sorted ascending: each section [top], plus
+/// the [bottom] of every section taller than the viewport (its last-cards
+/// resting offset). A section shorter than the viewport collapses
+/// `bottom == top`, so it contributes a single point.
+///
+/// **Single source of truth** shared by [resolveSnapTarget] (which commits to
+/// one of these) and the screen's drag-time feedforward (which measures the
+/// distance to the next one). Keeping both off the same list guarantees the
+/// visual cue ramps against the exact offsets the snap actually lands on — no
+/// duplicated arithmetic, no drift. Pure, unit-testable.
+List<double> snapPointsOf(List<SectionFrame> frames) {
+  final points = <double>[];
+  for (final f in frames) {
+    points.add(f.top);
+    if (f.bottom > f.top + kSnapEpsilon) points.add(f.bottom);
+  }
+  points.sort();
+  return points;
 }
 
 /// `null` when [target] is already aligned with [currentPixels] (± epsilon).

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -29,15 +29,15 @@ class StickyTab {
 ///   "lu = checked, pas barré"), and a marker-style highlight on the active
 ///   tab's label text (calque du highlight "Couverture médiatique" — cf.
 ///   DiffTitle ; remplace l'ancien wash pleine-chip + le point),
-/// - 4-px progress track with a 4-stop gradient fill (essentiel → bonnes
-///   → veille1 → veille2) and a soft accent glow,
+/// - 4-px **segmented** progress track — one rounded pip per section (done /
+///   current / upcoming), driven by [activeIndex], so the bar reads as discrete
+///   « pages » matching the section snap rather than a continuous gauge,
 /// - when [showFilterBar] is true (Explorer mode), [FeedFilterBar] is
 ///   inserted below the tabs so the filter chips morph in under the same
 ///   parchment surface rather than swapping the whole sticky.
 class StickyTabBar extends StatelessWidget {
   final List<StickyTab> tabs;
   final int activeIndex;
-  final double progress;
   final ValueChanged<int> onTapTab;
   final ScrollController? tabsController;
   final bool showFilterBar;
@@ -46,7 +46,6 @@ class StickyTabBar extends StatelessWidget {
     super.key,
     required this.tabs,
     required this.activeIndex,
-    required this.progress,
     required this.onTapTab,
     this.tabsController,
     this.showFilterBar = false,
@@ -73,7 +72,10 @@ class StickyTabBar extends StatelessWidget {
             height: 4,
             child: CustomPaint(
               painter: _ProgressPainter(
-                progress: progress.clamp(0.0, 1.0),
+                // Track segmenté (un pip par section) : modèle mental « pages »
+                // qui correspond au snap discret, au lieu d'une jauge continue.
+                segmentCount: tabs.length,
+                currentIndex: activeIndex,
                 // Désaturation forte (PO 2026-06) : on garde l'ordre/identité
                 // chromatique (rouge → ocre → bleu → sauge) mais saturation
                 // abaissée ~65 % + luminosité remontée vers des tons pastel,
@@ -299,42 +301,87 @@ class _MarkerHighlight extends CustomPainter {
   bool shouldRepaint(_MarkerHighlight old) => old.color != color;
 }
 
+/// Segmented progress track — one rounded pip per section, mirroring the
+/// discrete section-snap ("pages") instead of a continuous gauge. State is read
+/// from [currentIndex] (same source as the tabs' `isDone` check, so the bar and
+/// the checkmarks never disagree):
+/// - `i < currentIndex` → **done**: filled with the section's own desaturated
+///   identity colour (preserves the per-section hue ordering);
+/// - `i == currentIndex` → **current**: full-opacity segment colour + the soft
+///   accent [glow], scoped to that segment;
+/// - `i > currentIndex` → **upcoming**: the muted [trackColor].
+///
+/// The current segment is filled whole (no sub-fill by scroll fraction) for
+/// maximal discrete reading, so a repaint is only needed when the active
+/// section, the count, or the colours change.
 class _ProgressPainter extends CustomPainter {
-  final double progress;
+  final int segmentCount;
+  final int currentIndex;
   final List<Color> gradient;
   final Color glow;
   final Color trackColor;
 
   _ProgressPainter({
-    required this.progress,
+    required this.segmentCount,
+    required this.currentIndex,
     required this.gradient,
     required this.glow,
     required this.trackColor,
   });
 
+  /// ~3 px gutter between pips so they read as distinct pages.
+  static const double _gutter = 3.0;
+
   @override
   void paint(Canvas canvas, Size size) {
-    final fullRect = Offset.zero & size;
-    final trackPaint = Paint()..color = trackColor;
-    canvas.drawRect(fullRect, trackPaint);
+    if (segmentCount <= 0) return;
+    final segWidth =
+        (size.width - _gutter * (segmentCount - 1)) / segmentCount;
+    // Degenerate (too many sections for the width): fall back to a plain track
+    // rather than painting negative-width pips.
+    if (segWidth <= 0) {
+      canvas.drawRect(Offset.zero & size, Paint()..color = trackColor);
+      return;
+    }
+    final radius = Radius.circular(size.height / 2);
+    for (var i = 0; i < segmentCount; i++) {
+      final left = i * (segWidth + _gutter);
+      final rrect = RRect.fromRectAndRadius(
+        Rect.fromLTWH(left, 0, segWidth, size.height),
+        radius,
+      );
+      if (i == currentIndex) {
+        canvas.drawRRect(
+          rrect,
+          Paint()
+            ..color = glow
+            ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 5),
+        );
+        canvas.drawRRect(rrect, Paint()..color = _segmentColor(i));
+      } else if (i < currentIndex) {
+        canvas.drawRRect(rrect, Paint()..color = _segmentColor(i));
+      } else {
+        canvas.drawRRect(rrect, Paint()..color = trackColor);
+      }
+    }
+  }
 
-    if (progress <= 0) return;
-    final clipped = Rect.fromLTWH(0, 0, size.width * progress, size.height);
-    final glowPaint = Paint()
-      ..color = glow
-      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 5);
-    canvas.drawRect(clipped, glowPaint);
-    final fillPaint = Paint()
-      ..shader = LinearGradient(
-        colors: gradient,
-        stops: const [0.0, 0.4, 0.7, 1.0],
-      ).createShader(fullRect);
-    canvas.drawRect(clipped, fillPaint);
+  /// Maps a segment to a colour along [gradient], so each section keeps its
+  /// chromatic identity even when the section count differs from the number of
+  /// gradient stops (lerped across the stops).
+  Color _segmentColor(int i) {
+    if (gradient.isEmpty) return trackColor;
+    if (gradient.length == 1 || segmentCount == 1) return gradient.first;
+    final scaled = (i / (segmentCount - 1)) * (gradient.length - 1);
+    final lo = scaled.floor().clamp(0, gradient.length - 1);
+    final hi = math.min(lo + 1, gradient.length - 1);
+    return Color.lerp(gradient[lo], gradient[hi], scaled - lo) ?? gradient[lo];
   }
 
   @override
   bool shouldRepaint(_ProgressPainter old) =>
-      old.progress != progress ||
+      old.segmentCount != segmentCount ||
+      old.currentIndex != currentIndex ||
       old.gradient != gradient ||
       old.glow != glow ||
       old.trackColor != trackColor;

--- a/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
@@ -17,6 +17,36 @@ void main() {
   const within = kSectionEdgeMargin - 10; // inside the deadband
   const beyond = kSectionEdgeMargin + 10; // past it ⇒ commit
 
+  group('snapPointsOf', () {
+    test('canonical frames yield each top + each tall bottom, sorted', () {
+      // Short@0 (no bottom), tall 300…600 (both), short@1200 (no bottom).
+      expect(snapPointsOf(frames), [0.0, 300.0, 600.0, 1200.0]);
+    });
+
+    test('a short section contributes a single point (bottom == top)', () {
+      expect(snapPointsOf(const [(top: 50.0, bottom: 50.0)]), [50.0]);
+    });
+
+    test('empty frames yield no points', () {
+      expect(snapPointsOf(const []), isEmpty);
+    });
+
+    test('is the source of truth resolveSnapTarget commits to', () {
+      // Every committed target must be one of the published snap points — the
+      // guarantee that the drag-time cue (which reads snapPointsOf) ramps to
+      // exactly where the snap lands.
+      final points = snapPointsOf(frames);
+      final target = resolveSnapTarget(
+        currentPixels: 10,
+        naturalLanding: 5000,
+        velocity: 9000,
+        scrollDirection: 1,
+        frames: frames,
+      );
+      expect(points, contains(target));
+    });
+  });
+
   group('resolveSnapTarget', () {
     test('free while inside a tall section (it fills the screen)', () {
       // Landing at 450, inside the (300, 600) interior: no edge shows ⇒ free,

--- a/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/sticky_three_state_bar_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -9,7 +10,8 @@ import 'package:facteur/features/flux_continu/widgets/sticky_tab_bar.dart';
 /// Tests cover the [StickyTabBar] restored by the Story 9.2 hotfix
 /// (PR follow-up to #650). The file name kept its historical name so the
 /// existing CI globs don't need an update.
-Widget _wrap(Widget child) {
+Widget _wrap(Widget child, {Key? boundaryKey}) {
+  final body = Align(alignment: Alignment.topCenter, child: child);
   return ProviderScope(
     child: MaterialApp(
       theme: ThemeData(extensions: [FacteurPalettes.light]),
@@ -20,11 +22,55 @@ Widget _wrap(Widget child) {
         // Wrapping the test fixture in a top-aligned Align keeps the layout
         // faithful and lets the FeedFilterBar variant compute its natural
         // height without being stretched to fill the Scaffold body.
-        body: Align(alignment: Alignment.topCenter, child: child),
+        body: boundaryKey == null
+            ? body
+            : RepaintBoundary(key: boundaryKey, child: body),
       ),
     ),
   );
 }
+
+/// Raw RGBA of the captured [boundaryKey] image at the centre of the progress
+/// segment whose horizontal centre is at fraction [fx] of the track width.
+Future<List<int>> _sampleTrack(
+  WidgetTester tester,
+  Key boundaryKey,
+  Finder trackPaint,
+  double fx,
+) async {
+  final rect = tester.getRect(trackPaint);
+  final boundary =
+      tester.renderObject<RenderRepaintBoundary>(find.byKey(boundaryKey));
+  // toImage() is backed by the engine; it only resolves on the real event loop,
+  // so it must run inside runAsync (default pixelRatio 1.0 ⇒ image px == logical
+  // px, no devicePixelRatio scaling).
+  late List<int> data;
+  late int width;
+  await tester.runAsync(() async {
+    final image = await boundary.toImage();
+    data = (await image.toByteData())!.buffer.asUint8List();
+    width = image.width;
+  });
+  final x = (rect.left + rect.width * fx).round();
+  final y = rect.center.dy.round();
+  final i = (y * width + x) * 4;
+  return [data[i], data[i + 1], data[i + 2], data[i + 3]];
+}
+
+int _rgbaDist(List<int> a, List<int> b) {
+  var d = 0;
+  for (var i = 0; i < 4; i++) {
+    d += (a[i] - b[i]).abs();
+  }
+  return d;
+}
+
+Finder get _progressTrack => find.byWidgetPredicate(
+      (w) =>
+          w is CustomPaint &&
+          (w.painter?.runtimeType.toString().contains('ProgressPainter') ??
+              false),
+    );
 
 const _tabs = [
   StickyTab(label: 'Essentiel', accent: Color(0xFFB0470A)),
@@ -43,7 +89,6 @@ void main() {
         StickyTabBar(
           tabs: _tabs,
           activeIndex: 0,
-          progress: 0.2,
           onTapTab: (_) {},
         ),
       ));
@@ -62,7 +107,6 @@ void main() {
         StickyTabBar(
           tabs: _tabs,
           activeIndex: 2,
-          progress: 0.9,
           onTapTab: (_) {},
         ),
       ));
@@ -80,7 +124,6 @@ void main() {
         StickyTabBar(
           tabs: _tabs,
           activeIndex: 0,
-          progress: 0.0,
           onTapTab: (i) => lastTapped = i,
         ),
       ));
@@ -94,7 +137,6 @@ void main() {
         StickyTabBar(
           tabs: _tabs,
           activeIndex: 0,
-          progress: 0.2,
           onTapTab: (_) {},
         ),
       ));
@@ -111,13 +153,79 @@ void main() {
       expect(markerPainters, hasLength(1));
     });
 
+    testWidgets(
+        'progress track is segmented: 1 done + 1 current filled, 1 upcoming muted',
+        (tester) async {
+      const boundaryKey = ValueKey('progress-boundary');
+      // activeIndex = 1, 3 tabs ⇒ segment 0 done, segment 1 current (both
+      // colour-filled), segment 2 upcoming (muted track colour).
+      await tester.pumpWidget(_wrap(
+        StickyTabBar(
+          tabs: _tabs,
+          activeIndex: 1,
+          onTapTab: (_) {},
+        ),
+        boundaryKey: boundaryKey,
+      ));
+      await tester.pumpAndSettle();
+      expect(_progressTrack, findsOneWidget);
+
+      // Sample the centre of each of the three pips.
+      final done = await _sampleTrack(tester, boundaryKey, _progressTrack, 1 / 6);
+      final current =
+          await _sampleTrack(tester, boundaryKey, _progressTrack, 3 / 6);
+      final upcoming =
+          await _sampleTrack(tester, boundaryKey, _progressTrack, 5 / 6);
+
+      // The upcoming pip (muted track over parchment) is visibly distinct from
+      // both the filled done and current pips — the segmentation boundary the
+      // user reads as "pages".
+      expect(_rgbaDist(upcoming, done), greaterThan(24),
+          reason: 'upcoming should differ from the filled done pip');
+      expect(_rgbaDist(upcoming, current), greaterThan(24),
+          reason: 'upcoming should differ from the filled current pip');
+    });
+
+    testWidgets(
+        'a previously-upcoming segment fills once it becomes current/done',
+        (tester) async {
+      const boundaryKey = ValueKey('progress-boundary-2');
+      // First capture the last segment while it is upcoming (activeIndex = 1).
+      await tester.pumpWidget(_wrap(
+        StickyTabBar(
+          tabs: _tabs,
+          activeIndex: 1,
+          onTapTab: (_) {},
+        ),
+        boundaryKey: boundaryKey,
+      ));
+      await tester.pumpAndSettle();
+      final whenUpcoming =
+          await _sampleTrack(tester, boundaryKey, _progressTrack, 5 / 6);
+
+      // Now make it the current segment (activeIndex = 2) — it must fill.
+      await tester.pumpWidget(_wrap(
+        StickyTabBar(
+          tabs: _tabs,
+          activeIndex: 2,
+          onTapTab: (_) {},
+        ),
+        boundaryKey: boundaryKey,
+      ));
+      await tester.pumpAndSettle();
+      final whenCurrent =
+          await _sampleTrack(tester, boundaryKey, _progressTrack, 5 / 6);
+
+      expect(_rgbaDist(whenUpcoming, whenCurrent), greaterThan(24),
+          reason: 'the segment colour must change with activeIndex');
+    });
+
     testWidgets('no leading dot before tab labels (removed in marker redesign)',
         (tester) async {
       await tester.pumpWidget(_wrap(
         StickyTabBar(
           tabs: _tabs,
           activeIndex: 0,
-          progress: 0.2,
           onTapTab: (_) {},
         ),
       ));


### PR DESCRIPTION
feat(flux-continu): rendre le snap *lisible* — signifiants feedforward (A1+A2+A3)

## Quoi

Le scroll-snap section-par-section frustrait certains users (« coupé dans mon
geste », mouvement « subi » et imprévisible). Diagnostic : **la mécanique du snap
est bonne** — c'est un manque de *lisibilité*. On ajoute des **signifiants**, sans
toucher à la physique ni à une seule constante de tuning.

- **A1 — Feedforward pendant le drag.** Le `_SectionPassageDot` existant (déjà à
  chaque frontière, déjà porteur du pulse de validation) **grossit/brille à
  l'approche du bord**, pic pile au seuil de bascule (`kSectionEdgeMargin`). Le
  même dot fusionne désormais feedforward (avant) + feedback (pulse après) →
  lecture « j'approche un seuil → je l'ai franchi », un seul cue continu.
- **A2 — Progress track *segmenté*.** Le track 4 px passe d'un dégradé continu à
  **un pip par section** (fait rempli-désaturé / courant éclairé+glow / à venir
  gris), piloté par `activeIndex` (même source que les checks d'onglets) → modèle
  mental « pages » cohérent avec le snap discret.
- **A3 — Signifiant « carte haute = lecture libre ».** Les sections plus hautes
  que l'écran (qui autorisent un scroll libre *silencieusement*) reçoivent un
  **fade bas subtil** (`backgroundPrimary` → transparent, 24 px), peint par
  l'écran (zéro modif de signature `SectionBlock`).

## Pourquoi

Décision PO (5 juin 2026) : garder le snap, le rendre lisible — priorité au
« coupé dans mon geste ». Le défaut était l'absence de **feedforward** : tout le
feedback existant (`_SectionPassageDot`, track, haptique) était *post-hoc*.

## Comment c'est construit (anti-duplication)

- **Une seule source de vérité** : `snapPointsOf(List<SectionFrame>)` extrait de
  `resolveSnapTarget` (comportement strictement inchangé) — la rampe visuelle de
  A1 ramène donc *exactement* aux offsets où le snap commit.
- Tout s'accroche à l'infra existante : listener `_onScroll`, anchors
  `_snapAnchors`, `ValueNotifier` (rebuilds ciblés, **zéro `setState`/frame**).
- Mapping direction `ScrollDirection → ±1` factorisé (`_travelDirection`) et
  partagé entre le feedforward (A1) et la physique → impossible qu'ils
  divergent.
- Hot path propre : snap points **cachés une fois par layout** (plus de
  re-`sort()` par frame) ; lookup dot via `Map<double,int>` exact (offsets
  bit-identiques aux frame tops) ; proximity quantizée (~20 paliers) ; merged
  `Listenable` du dot mis en cache.
- **Nettoyage** : la prop `progress` continue de `StickyTabBar` + le
  `ValueNotifier _scrollProgress` (écrit chaque frame) sont supprimés — le track
  segmenté n'a besoin que de `activeIndex`.

## Comment ça a été vérifié

- [x] `flutter analyze` — **clean** (lib/features/flux_continu + tests modifiés).
- [x] `flutter test test/features/flux_continu/` — tous verts **sauf** 1 échec
      **pré-existant hors-scope** (`section_block_test.dart` ne compile pas :
      `onTapArticle: (_, __)` vs signature 1-arg de `SectionBlock`, inchangé vs
      `origin/main`, dernier touché par #785).
- [x] Tests ajoutés : `snapPointsOf()` (frames canon ⇒ `{0,300,600,1200}`,
      single-point, vide, + « tout target commit ∈ snapPointsOf ») ; les tests
      `resolveSnapTarget` existants **restent verts** (preuve de non-régression de
      la physique). Track A2 : capture image + sampling pixels (1 fait + 1
      courant remplis / 1 à venir muté ; un segment à-venir se remplit quand il
      devient courant).
- [ ] Validation device/feel : à confirmer par le PO (le « grain » du snap se
      juge sur device ; aucune constante de physique n'a bougé).

> CI = backend pytest only (pas de `flutter test`) → l'échec mobile pré-existant
> ne bloque pas la CI.

## Zones à risque

- `flux_continu_screen.dart` (Router/scroll feature, fichier central) : aucune
  modif de `_SectionSnapPhysics`, `resolveSnapTarget`, ni des constantes de
  tuning. Changements additifs (notifiers + overlay) sur l'infra existante.
- A3 (`_FreeReadEdgeFade`) = ligne de coupe nette ; son absence ne créerait
  aucune incohérence (la lecture libre est silencieuse aujourd'hui).
