### PR TITLE
fix(personalization): mute source depuis l'ArticleSheet — ref utilisée après dispose (vraie cause du bug)

### DIFF
--- a/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
+++ b/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
@@ -771,14 +771,22 @@ class _ArticleSheetState extends ConsumerState<ArticleSheet> {
               label: 'Ne plus afficher ${widget.content.source.name}',
               isDestructive: true,
               onTap: () async {
-                Navigator.pop(context);
+                // NE PAS pop() avant l'await : fermer la bottom sheet dispose
+                // ce ConsumerState, et `ref` lève alors StateError("Cannot use
+                // ref after the widget was disposed") au retour du await — même
+                // quand le backend a répondu 200. Le catch affichait donc
+                // "Impossible de masquer la source" sur un mute réussi.
+                // On suit le même ordre que le mute de sujet ci-dessus :
+                // await → garde `mounted` → invalidation → pop en dernier.
+                final sourceName = widget.content.source.name;
                 try {
                   final repo = ref.read(personalizationRepositoryProvider);
                   await repo.muteSource(widget.content.source.id);
+                  NotificationService.showInfo('Source $sourceName masquée');
+                  if (!mounted) return;
                   ref.invalidate(personalizationProvider);
                   ref.invalidate(fluxContinuProvider);
-                  NotificationService.showInfo(
-                      'Source ${widget.content.source.name} masquée');
+                  Navigator.pop(context);
                 } catch (e) {
                   NotificationService.showError(
                       'Impossible de masquer la source');


### PR DESCRIPTION
## Quoi

Corrige réellement le bug « Impossible de masquer cette source » depuis les Actus du jour. **Le PR #794 ne corrigeait pas le problème** : il sécurisait le backend (qui répond déjà 200) et ajoutait une invalidation… qui souffre elle-même du vrai bug.

## Vraie cause racine

Dans l'`ArticleSheet` (`topic_chip.dart`), le mute de source appelait `Navigator.pop(context)` **avant** l'appel réseau :

```dart
onTap: () async {
  Navigator.pop(context);                    // dispose ce ConsumerState
  try {
    final repo = ref.read(personalizationRepositoryProvider);
    await repo.muteSource(...);               // 200 OK — la source EST mutée
    ref.invalidate(personalizationProvider);  // context.mounted == false → throw
    ...
    NotificationService.showInfo('... masquée'); // jamais atteint
  } catch (e) {
    NotificationService.showError('Impossible de masquer la source'); // ← l'user voit ça
  }
}
```

`Navigator.pop` dispose la bottom sheet. Au retour de l'`await`, `context.mounted == false`, donc `ref.invalidate(...)` lève `StateError("Cannot use ref after the widget was disposed")`. Ce n'est **pas** un simple `assert` : dans flutter_riverpod 2.6.1, `_assertNotDisposed()` (`consumer.dart:548`) est un vrai `if/throw` qui s'exécute **aussi en release**. Le `catch` affiche donc l'erreur **alors que le mute a réussi (200)**, et aucun provider n'est invalidé → l'article reste visible.

### Ce qui explique tout
- ✅ Backend renvoie **200** (mute réellement effectué) — confirmé via logs Railway prod (service WEB = FastAPI `facteur-production`) : `POST /api/users/personalization/mute-source 200 OK`, **0** réponse 4xx/5xx.
- ✅ Aucune erreur Sentry / backend (c'est un `StateError` côté client).
- ✅ Les 3 fixs backend précédents + #794 n'ont rien changé (le bug est 100 % frontend, sur un 200).
- ✅ Le handoff « les logs custom n'apparaissent jamais » = l'agent testait un uvicorn **local** alors que l'app tape `facteur-production` (prod).

## Le fix

Suivre l'ordre déjà utilisé par le mute de **sujet** dans le même fichier (qui, lui, fonctionne) : `await` d'abord → garde `if (!mounted) return` → invalidation → `Navigator.pop` **en dernier**. Le chemin `source_adjust_sheet.dart` était déjà correct ; seul ce chemin de l'ArticleSheet était cassé.

## Comment ça a été vérifié

- [x] `flutter analyze lib/.../topic_chip.dart` — 0 erreur
- [x] `flutter test test/features/feed/personalization_logic_test.dart` — 2/2 OK
- [x] Logs prod Railway confirment le 200 côté serveur
- [x] Diagnostic croisé : Sentry (0 erreur mute), topologie Railway (WEB=FastAPI, 2 services API dupliqués)

## Zones à risque

`topic_chip.dart` — uniquement le handler `onTap` du mute de source dans l'ArticleSheet. Pattern aligné sur le mute de sujet voisin.

## Suivi (hors scope)
- Le projet Railway a **deux** services API (`API` maj. sans déploiement prod, `Api` = build Flutter `/apps/mobile`) — nommage confus à nettoyer.
- `MuteSourceRequest.source_id: UUID` rejetterait en 422 un id vide/`'fallback'` venant de `Source.fallback()` — non déclenché ici (le digest envoie toujours un UUID valide), mais fragile.