### PR TITLE
feat(tournee): drag-drop UX — visual lift + haptic + hit zone + button redesign

### DIFF
--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,77 +1,28 @@
-# QA Handoff — Polish UX/UI « l'Essentiel » (Flux Continu)
+# QA Handoff — UX Drag & Drop + bouton « Composer ma Tournée »
 
-> Rempli par l'agent dev. Input de `/validate-feature` (Chrome 390×844).
+Branche : `boujonlaurin-dotcom/drag-drop-ux-tournee`
 
-Branche : `boujonlaurin-dotcom/essentiel-ux-scroll-haptics`
-Écran : **l'Essentiel** (Flux Continu) — `apps/mobile/lib/features/flux_continu/`
+## Écrans impactés
+- **Sheet « Mes favoris » / « Composer ma Tournée »** (`manage_favorites_sheet.dart`) — sections Essentiel & Flâner, listes réordonnables.
+- **Bouton « Composer ma Tournée »** (`ComposeTourneeButton`) rendu dans `section_block.dart` (carte Essentiel + empty-state), `flux_continu_screen.dart`, `sources_screen.dart`, `my_interests_screen.dart`.
 
-3 ajustements UX/UI livrés en une PR. **Point 1 (haptique/snap) = validation device réel
-obligatoire** (non simulable en web). Points 2 & 3 testables via Chrome (viewport 390×844).
+## Changements
+1. **Feedback visuel drag** : l'élément glissé est « soulevé » (scale 1.03 + ombre douce progressive). Vibration `mediumImpact` au pickup, `selectionClick` au dépôt.
+2. **Hit zone élargie** : toute la zone logo + label de chaque ligne démarre le drag (`ColoredBox` opaque), + poignée points portée à 44×44px. Boutons d'action (retirer/déplacer/veille) restent tappables.
+3. **Bouton** : tuile teintée douce (fond `primary` 12%, ombre subtile), plus grande (padding vertical 16, font 15, icône 18), ripple InkWell. Remplace l'ancien contour fin.
 
----
-
-## Point 1 — Snap « jamais sauter une section » (one-step cap)
-
-**Changement** : `resolveSnapTarget` (`utils/section_snap.dart`) borne désormais la cible du snap
-au **point d'ancrage adjacent à la position de lever de doigt** (`currentPixels`), plus au
-*naturalLanding* du fling. Quelle que soit la force du geste, on n'avance/recule que d'**une**
-section → un seul flip d'onglet actif → **un seul haptique** par pas.
-
-### Scénarios (device réel)
-- **Happy path** : scroller fort vers le bas → on ne descend que d'**une** section à la fois ;
-  enchaîner des scrolls rapides descend toute la tournée, un buzz net par pas.
-- Idem vers le haut (remonter une section par geste).
-- **Lecture libre conservée** : au milieu d'une section plus haute que l'écran, le scroll reste
-  libre (pas de snap), snap uniquement aux bords (haut/bas de section).
-- **Edge** : fling très violent depuis le haut → ne saute pas 2-3 sections, s'arrête à la suivante.
-- **Edge** : petit nudge (< 120 px d'inertie) → re-cadre la section courante (pull-back), pas de
-  switch.
-- **Edge bas de tournée** : sous « Fin de tournée », le rebond natif iOS reste propre (pas de
-  rebonds étagés / buzz répétés).
-
-> Si un fling très fort vers une cible proche dépasse légèrement : 1er levier = `kSectionEdgeMargin`
-> (120 px) ; 2e levier = caper la `velocity` transmise au spring dans `_SectionSnapPhysics`.
-
-## Point 2 — Désaturation de la progress bar (sticky header)
-
-**Changement** : `sticky_tab_bar.dart` — les 4 stops du dégradé saturés (rouge/orange/bleu/teal)
-remplacés par des tons **neutres/pastel** (rose poussiéreux → ocre doux → bleu ardoise → sauge) ;
-halo passé de alpha 0.35 → 0.10.
-
-### Scénarios (Chrome 390×844)
-- Scroller jusqu'à révéler le sticky header → la barre de progression doit être **nettement plus
-  discrète** (ne tire plus l'œil), tons neutres.
-- Vérifier la progression (le remplissage suit toujours le scroll, valeur inchangée).
-- Comparer light/dark si possible.
-- *(Valeurs facilement ajustables si encore trop/pas assez visibles.)*
-
-## Point 3 — Suppression complète du fold
-
-**Changement** : retrait total de la mécanique de repli des sections (repli auto scroll-past +
-chevrons manuels). Fichier `folded_section_card.dart` supprimé ; champs `folded`/
-`markedForNextSession` retirés du state ; chevron `expand_less` retiré de la bannière.
-
-### Scénarios (Chrome 390×844)
-- Plus **aucun chevron** de repli sur les bannières de section.
-- Les sections restent **toujours déployées**, même après avoir tout lu / scrollé au-delà /
-  rouvert l'écran.
-- **Non-régression à vérifier intactes** :
-  - « Voir plus » / « Voir tout » (overflow des sections) fonctionne.
-  - Carte de clôture « Fin de tournée » présente et ses CTA (Continuer / Refermer).
-  - Swipe-dismiss d'un article + feedback inline.
-  - Étoile favori (bannières thème) + bouton réglages (section veille) toujours tappables.
-
----
+## Scénarios de test (viewport 390×844)
+- **Happy path** : ouvrir « Composer ma Tournée » → nouveau bouton visible/élégant ; glisser une ligne par sa **zone label** (pas que la poignée) → vibration + élément soulevé + réordonnancement persiste après fermeture/réouverture.
+- **Edge** : taper retirer/déplacer/veille sur une ligne → action déclenchée SANS démarrer un drag.
+- **Edge** : tester les deux sections (Essentiel ⇄ Flâner), au-delà du cap (divider « Hors Tournée du jour »).
+- Console sans erreurs ; aucun 4xx/5xx réseau inattendu sur la persistance d'ordre.
 
 ## Critères d'acceptation
-- [ ] (device) 1 geste = 1 section + 1 haptique, dans les deux sens ; lecture libre intra-section OK.
-- [ ] Progress bar désaturée, discrète, progression correcte.
-- [ ] Zéro chevron / repli ; sections toujours ouvertes ; « Voir plus » + clôture + swipe intacts.
-- [ ] Console sans erreurs, réseau sans 4xx/5xx inattendus.
+- [ ] Drag démarre depuis le corps de la ligne ET depuis la poignée.
+- [ ] Retour visuel (soulèvement) + vibration perceptibles.
+- [ ] Boutons d'action toujours fonctionnels.
+- [ ] Bouton « Composer ma Tournée » nettement plus visible.
 
-## État technique
-- `flutter analyze` : propre sur flux_continu.
-- Tests unitaires : `section_snap_test` (15/15), `flux_continu_models_test`,
-  `section_banner_favorite_test` verts. `flux_continu_provider_test` échoue en local
-  (Hive/Supabase non-init — pré-existant) ; pas de régression (baseline 25 échecs, idem env).
-- Build APK debug : OK.
+## Vérifs auto déjà passées
+- `flutter analyze` (2 fichiers) : No issues.
+- `flutter test manage_favorites_sheet_test.dart tournee_composer_sheet_test.dart` : 11/11 ✓.

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -830,7 +830,11 @@ class _FavList extends StatelessWidget {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       buildDefaultDragHandles: false,
-      proxyDecorator: (child, index, animation) => child,
+      proxyDecorator: (child, index, animation) =>
+          _DragProxy(animation: animation, child: child),
+      // Vibration au « soulèvement » (cohérent cartes) + dépôt discret.
+      onReorderStart: (_) => HapticFeedback.mediumImpact(),
+      onReorderEnd: (_) => HapticFeedback.selectionClick(),
       itemCount: items.length,
       onReorder: onReorder,
       itemBuilder: (context, index) {
@@ -854,6 +858,47 @@ class _FavList extends StatelessWidget {
                   onSubjectVeille == null ? null : () => onSubjectVeille!(item),
             ),
           ],
+        );
+      },
+    );
+  }
+}
+
+/// Décorateur de drag : « soulève » l'élément (léger scale + ombre douce qui
+/// apparaît progressivement) pour un feedback visuel subtil et élégant.
+class _DragProxy extends StatelessWidget {
+  final Animation<double> animation;
+  final Widget child;
+
+  const _DragProxy({required this.animation, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: animation,
+      child: child,
+      builder: (context, child) {
+        final t = Curves.easeInOut.transform(animation.value.clamp(0.0, 1.0));
+        return Transform.scale(
+          scale: 1 + 0.03 * t,
+          child: Material(
+            type: MaterialType.transparency,
+            child: Container(
+              // L'ombre épouse le radius de la tuile _FavRow (12) ; le padding
+              // bas (8) déjà présent dans _FavRow reste transparent.
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.18 * t),
+                    blurRadius: 16 * t,
+                    offset: Offset(0, 4 * t),
+                  ),
+                ],
+              ),
+              child: child,
+            ),
+          ),
         );
       },
     );
@@ -900,21 +945,42 @@ class _FavRow extends StatelessWidget {
           ),
           child: Row(
             children: [
-              if (isSource && item.source != null)
-                SourceLogoAvatar(source: item.source!, size: 28, radius: 6)
-              else
-                Text(item.emoji, style: const TextStyle(fontSize: 16)),
-              const SizedBox(width: 10),
+              // Hit zone : toute la zone logo + label initie le drag (en plus
+              // de la poignée), ce qui agrandit nettement la cible tactile.
               Expanded(
-                child: Text(
-                  item.label,
-                  style: TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w600,
-                    color: colors.textPrimary,
+                child: ReorderableDragStartListener(
+                  index: index,
+                  child: Container(
+                    // color transparent → la ligne entière (gaps inclus) reste
+                    // hit-testable pour démarrer le drag.
+                    color: Colors.transparent,
+                    child: Row(
+                      children: [
+                        if (isSource && item.source != null)
+                          SourceLogoAvatar(
+                            source: item.source!,
+                            size: 28,
+                            radius: 6,
+                          )
+                        else
+                          Text(item.emoji,
+                              style: const TextStyle(fontSize: 16)),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: Text(
+                            item.label,
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                              color: colors.textPrimary,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
                 ),
               ),
               const SizedBox(width: 4),
@@ -941,10 +1007,16 @@ class _FavRow extends StatelessWidget {
                 onTap: onRemove,
               ),
               const SizedBox(width: 2),
+              // Poignée explicite — affordance visuelle ; cible tactile ≥44px.
+              // Container(color) = ColoredBox (hit opaque) → toute la zone 44px
+              // démarre le drag, pas seulement le glyphe 18px.
               ReorderableDragStartListener(
                 index: index,
-                child: Padding(
-                  padding: const EdgeInsets.all(4),
+                child: Container(
+                  width: 44,
+                  height: 44,
+                  color: Colors.transparent,
+                  alignment: Alignment.center,
                   child: Icon(
                     PhosphorIcons.dotsSixVertical(PhosphorIconsStyle.bold),
                     size: 18,

--- a/apps/mobile/lib/features/flux_continu/widgets/tournee_composer_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/tournee_composer_sheet.dart
@@ -28,29 +28,50 @@ class ComposeTourneeButton extends StatelessWidget {
       padding: padding ?? EdgeInsets.zero,
       child: SizedBox(
         width: double.infinity,
-        child: OutlinedButton.icon(
-          onPressed: () {
-            HapticFeedback.mediumImpact();
-            showTourneeComposerSheet(context);
-          },
-          icon: Icon(
-            PhosphorIcons.slidersHorizontal(PhosphorIconsStyle.bold),
-            size: 16,
-            color: colors.primary,
+        // Tuile teintée douce : fond primary léger + ombre subtile pour la
+        // détacher du fond crème, plus grande et plus visible que le contour.
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(FacteurRadius.medium),
+            boxShadow: [
+              BoxShadow(
+                color: colors.primary.withValues(alpha: 0.18),
+                blurRadius: 12,
+                offset: const Offset(0, 4),
+              ),
+            ],
           ),
-          label: Text(
-            'Composer ma Tournée',
-            style: TextStyle(
-              color: colors.primary,
-              fontWeight: FontWeight.w600,
-              fontSize: 14,
-            ),
-          ),
-          style: OutlinedButton.styleFrom(
-            side: BorderSide(color: colors.primary.withValues(alpha: 0.5)),
-            padding: const EdgeInsets.symmetric(vertical: 14),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(FacteurRadius.medium),
+          child: Material(
+            color: colors.primary.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(FacteurRadius.medium),
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: () {
+                HapticFeedback.mediumImpact();
+                showTourneeComposerSheet(context);
+              },
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      PhosphorIcons.slidersHorizontal(PhosphorIconsStyle.bold),
+                      size: 18,
+                      color: colors.primary,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Composer ma Tournée',
+                      style: TextStyle(
+                        color: colors.primary,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 15,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## What

Améliore l'UX drag-and-drop dans la sheet "Mes favoris" (sections Essentiel et Flâner) et refondu le bouton "Composer ma Tournée".

## Why

- Le drag visuel manquait de feedback (pas d'animation de lift, pas de vibration)
- La zone de tap pour déclencher le drag était trop petite (icône 18px seulement)
- Le bouton d'entrée était peu visible (bordure fine sur fond parchemin)

## Type

- [x] Feature

## Checklist

- [x] Tests pass locally (`flutter test` — 11 tests OK, `flutter analyze` propre)
- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)