### PR TITLE
fix(highlight): surlignage precision-first — garde-fous structurels + prompt LLM v3

### DIFF
--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -704,7 +704,11 @@ class _PerspectiveCard extends ConsumerWidget {
                     children: [
                       Expanded(
                         child: DiffTitle(
-                          title: perspective.title.trim(),
+                          // No .trim(): highlight offsets are computed server-
+                          // side on the untrimmed title, so trimming here would
+                          // shift every span by the leading-whitespace count
+                          // (frequent on live RSS titles). Story 7.4 (B).
+                          title: perspective.title,
                           highlightSpans: perspective.highlightSpans,
                           sharedTokens: perspective.sharedTokens,
                           biasColor: perspective.getBiasColor(colors),

--- a/docs/bugs/bug-highlight-quality-misalignment.md
+++ b/docs/bugs/bug-highlight-quality-misalignment.md
@@ -1,0 +1,98 @@
+# Bug — Surlignage des titres : désalignement & qualité (precision-first)
+
+> **Type** : Bug (qualité killer-feature) · **Story** : 7.4 (Couverture médiatique / perspectives)
+> **PR** : cible `main` · **Périmètre** : PR1 (garde-fous structurels) + PR2 (prompt LLM) en **une seule PR** (décision PO)
+> **Source de l'analyse** : `cluster_title_annotations` en prod (336 lignes / 151 spans LLM, MCP Supabase 2026-06-06).
+
+## Symptôme
+
+Le surlignage surligne encore des mots **neutres** (« % » dans « 18% », « Direct »
+dans « En direct », gentilés, clauses entières) malgré de nombreuses calibrations.
+Cadrage PO : **augmenter drastiquement la qualité, quitte à réduire la quantité**
+(precision ≫ recall — mieux vaut ne rien surligner qu'un mot neutre).
+
+## Diagnostic — 4 causes racines
+
+1. **Le chemin spaCy surligne des déchets.** `fr_core_news_md` mal-étiquette
+   ponctuation/nombres (`%` NOUN, `-`/`|` PROPN, dates, `105`, emoji) → ils passent
+   `KEEP_POS` car non-stopwords et deviennent des `highlight_spans`.
+2. **La sélection LLM est médiocre en queue de distribution** : fillers (« en
+   direct »), spans ≥ 4 mots (18 %), gentilés neutres taggés `fact`, spans
+   imbriqués/dupliqués, ponctuation de bord incluse.
+3. **Dérive d'offset** entre tokenisation et rendu : front `.trim()` du titre
+   alors que les offsets sont calculés non-trimmés ; serve qui clampe mais ne
+   **valide pas** `served_title[start:end] == text`.
+4. **La boucle de calibration data-driven n'a jamais tourné** — l'outillage existe
+   (`build_highlight_dataset.py`, `evaluate_title_annotations.py`) mais le gold et
+   la baseline F1 n'ont jamais été produits.
+
+## Principe directeur (cadrage PO)
+
+**Limiter au maximum les règles brutes.** On sépare strictement :
+
+- **Garde-fous STRUCTURELS, indépendants du contexte** (légitimes en dur car vrais
+  *quel que soit* le contexte) → PR1.
+- **Qualité éditoriale dépendante du contexte** (« en direct » filler ou pas, un
+  gentilé est-il un cadrage, où couper) → traitée **uniquement** par le prompt LLM,
+  **mesurée au benchmark**, jamais par des stoplists/règles métier → PR2.
+
+## Correctifs
+
+### PR1 — Garde-fous structurels (coût LLM nul, réversible)
+
+- **A. Garde « validité structurelle ».** `_is_real_word(text)` (rejette tout
+  fragment < 2 caractères alphabétiques) appliqué dans `_doc_to_tokens` (point de
+  passage unique → protège cache cluster ET chemin live) et défensivement au serve.
+  `MODEL_VERSION` → `v2-spacy-fr_md` pour purger le cache `strong_tokens` pollué
+  (filtré par `model_version`, **pas de migration DB**).
+- **B. Invariant d'offset au serve.** `_enforce_offset_invariant` exige
+  `served_title[start:end] == text` pour chaque span (LLM **et** spaCy) ; sinon
+  re-localise via `find_span` ; sinon **drop**. + retrait du `.trim()` Dart
+  (`perspectives_bottom_sheet.dart`).
+- **C. Nettoyage structurel des `target_spans` LLM au serve** (`_refine_llm_target_spans`,
+  fonction pure) : re-ancrage (B) → **gate `weight ≥ 0.5`** (`MIN_DISPLAY_WEIGHT`,
+  réutilise le score 0.25/0.5/1.0 que le LLM produit déjà) → trim ponctuation de
+  bord → validité structurelle (A) → dé-imbrication (réutilise `spans_overlap`,
+  garde le span englobant). **Aucune stoplist, aucune règle de contenu.**
+- **D. Chemin live/hors-cluster — politique D2.** `diff_spans` accepte
+  `max_spans`/`allowed_pos` (keyword-only, rétro-compatibles). Hors-cluster restreint
+  à **ADJ/VERB only + cap 2** (`OFF_CLUSTER_*`). In-cluster **inchangé**. Bascule D1
+  (cap 0) possible via la constante.
+
+### PR2 — Qualité éditoriale via prompt LLM + benchmark
+
+- **Prompt** `SCHEMA_DESCRIPTION` révisé : budget **0-2 spans, ≤ 3 mots**, verbes
+  chargés / framing nouns, **contre-exemples en contexte** (en direct, gentilés
+  neutres, dates, clauses, ponctuation de bord), « vide vaut mieux que faible ».
+  Contrat JSON (catégories/poids) **inchangé**.
+- **`LLM_VERSION`** → `mistral-medium-latest-v3` : invalide les `semantic_equiv` v2
+  → ré-annotation au prochain passage pipeline. Snapshot du prompt regénéré.
+
+## Rollout / déploiement
+
+- Aucune migration Alembic (les deux bumps sont des champs/version filtrés au read).
+- **Au déploiement**, `LLM_VERSION=v3` invalide tout `semantic_equiv` v2 : tant que
+  le pipeline n'a pas ré-annoté, les perspectives in-cluster retombent sur spaCy
+  (cap 4) et le live sur D2 — comportement conservateur **assumé** (precision-first).
+  Déclencher une ré-annotation pour repeupler `semantic_equiv` en v3.
+
+## Mesure éditoriale = le benchmark (étape PO-synchrone, hors-code)
+
+La qualité éditoriale n'est validée que par `evaluate_title_annotations.py` contre
+le gold des ~62 titres prod (baseline v2 → after v3, `--compare`). Cette étape
+nécessite un pull prod (MCP Supabase) + validation PO du gold + appels Mistral :
+elle se déroule **au moment du rollout**, pas dans cette PR (le code/outillage est
+prêt). Cf. [`docs/maintenance/maintenance-highlight-calibration.md`](../maintenance/maintenance-highlight-calibration.md).
+
+## Tests
+
+- `tests/services/test_title_annotation_service.py` : `_is_real_word` (keep
+  `UE`/`IA`/`réforme` ; drop `%`/`-`/`|`/`04/06`/`105`/emoji), `_doc_to_tokens` drop,
+  `diff_spans` kwargs (cap 2 / ADJ-VERB / D1) sans régression du défaut in-cluster.
+- `tests/routers/test_contents_perspectives_highlights.py` : invariant d'offset
+  (relocate vs drop vs out-of-bounds), nettoyage C (bord ponctuation trimé,
+  « restitutions » ⊂ « restitutions de biens » dé-imbriqué, weight 0.25 non affiché,
+  champs LLM préservés), politique off-cluster D2 (ADJ/VERB, cap 2), gate weight
+  bout-en-bout. **Aucun test ne vérifie une règle de contenu** (en direct / gentilés)
+  — c'est la responsabilité du benchmark.
+- Suite Dart `diff_title` + `perspectives_bottom_sheet` restent vertes.

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -30,7 +30,9 @@ from app.services.feed_cache import FEED_CACHE
 from app.services.title_annotation_service import (
     ClusterAnnotations,
     TitleAnnotationService,
+    _is_real_word,
     get_title_annotation_service,
+    spans_overlap,
 )
 
 logger = structlog.get_logger()
@@ -1045,6 +1047,121 @@ async def _refresh_perspectives_cache_background(
         _perspectives_refresh_inflight.discard(content_id)
 
 
+# --------------------------------------------------------------------------- #
+# Serve-time STRUCTURAL refinement of highlight spans (Story 7.4 —             #
+# highlight-quality, precision-first). Every helper below is context-FREE:     #
+# it fixes offsets, trims punctuation, drops non-words and de-nests overlaps.  #
+# Editorial, context-dependent decisions (is « en direct » filler? is a        #
+# gentilé framing? where to cut a clause?) are NOT made here — they live in    #
+# the LLM prompt and are measured by the benchmark. Keep it that way.          #
+# --------------------------------------------------------------------------- #
+
+# Display gate on the LLM's own 0.25/0.5/1.0 weight: surface only spans the
+# model already rated as moderate-or-stronger editorialisation. Not a business
+# rule — it reuses the existing LLM signal. Lower the constant to widen recall.
+MIN_DISPLAY_WEIGHT = 0.5
+
+# Characters trimmed from a span's edges: quotes + punctuation + whitespace.
+# Edge-only — internal elision apostrophes (l'arrêt) and hyphens (Jean-Pierre)
+# survive because their neighbours are letters.
+_EDGE_STRIP = frozenset(" \t\"'«»“”‘’„:;,.!?()[]{}…–—-·•|/\\")
+
+
+def _passes_weight_gate(span: dict) -> bool:
+    """Keep spans whose LLM weight ≥ MIN_DISPLAY_WEIGHT (missing weight = keep)."""
+    try:
+        return float(span.get("weight", 1.0)) >= MIN_DISPLAY_WEIGHT
+    except (TypeError, ValueError):
+        return True
+
+
+def _trim_span_edges(start: int, end: int, title: str) -> tuple[int, int]:
+    """Shrink [start, end) past leading/trailing edge punctuation/quotes."""
+    while start < end and title[start] in _EDGE_STRIP:
+        start += 1
+    while end > start and title[end - 1] in _EDGE_STRIP:
+        end -= 1
+    return start, end
+
+
+def _enforce_offset_invariant(spans: list[dict], title: str) -> list[dict]:
+    """Drop or re-anchor every span so that ``title[start:end] == text`` (B).
+
+    A span whose stored offsets land on the wrong characters of the *served*
+    title (cache computed on a different title, an RSS leading space, a stale
+    source suffix) is re-localised via `find_span`; if its text is absent from
+    the served title it is dropped. precision-first: a mis-placed highlight is
+    worse than no highlight.
+    """
+    if not spans:
+        return spans
+    # Lazy import: `llm_bias_annotation_service` pulls in the editorial package
+    # which imports back here → a top-level import would be circular.
+    from app.services.llm_bias_annotation_service import find_span
+
+    out: list[dict] = []
+    n = len(title)
+    for span in spans:
+        start = span.get("start", 0)
+        end = span.get("end", 0)
+        text = span.get("text", "")
+        if (
+            isinstance(start, int)
+            and isinstance(end, int)
+            and 0 <= start < end <= n
+            and title[start:end] == text
+        ):
+            out.append(span)
+            continue
+        located = find_span(title, text)
+        if located is None:
+            continue
+        out.append(
+            {
+                **span,
+                "start": located[0],
+                "end": located[1],
+                "text": title[located[0] : located[1]],
+            }
+        )
+    return out
+
+
+def _refine_llm_target_spans(spans: list[dict], title: str) -> list[dict]:
+    """Structural-only refinement of LLM target_spans at serve time (C).
+
+    Order: re-anchor (offset invariant) → weight gate → edge trim → structural
+    validity → de-nest (keep the widest of overlapping spans). NO editorial /
+    content rule — that is strictly the prompt's job (PR2 + benchmark).
+    """
+    # 1. Re-anchor to the served title (drops the unfindable / out-of-bounds).
+    refined = _enforce_offset_invariant(spans, title)
+
+    # 2. Display gate on the LLM's own weight signal.
+    refined = [s for s in refined if _passes_weight_gate(s)]
+
+    # 3. Trim quote/punctuation edges, recompute text from the served title.
+    trimmed: list[dict] = []
+    for s in refined:
+        start, end = _trim_span_edges(s["start"], s["end"], title)
+        if start >= end:
+            continue
+        trimmed.append({**s, "start": start, "end": end, "text": title[start:end]})
+
+    # 4. Structural validity (drops « % », « - », dates, bare numbers, emoji).
+    valid = [s for s in trimmed if _is_real_word(s["text"])]
+
+    # 5. De-nest: keep the widest span of any overlapping/duplicated group
+    #    (« restitutions » ⊂ « restitutions de biens » → keep the latter).
+    kept: list[dict] = []
+    for s in sorted(valid, key=lambda s: s["end"] - s["start"], reverse=True):
+        rng = (s["start"], s["end"])
+        if any(spans_overlap(rng, (k["start"], k["end"])) for k in kept):
+            continue
+        kept.append(s)
+    return sorted(kept, key=lambda s: s["start"])
+
+
 async def _attach_highlight_spans(
     db: AsyncSession,
     content: Content,
@@ -1129,26 +1246,41 @@ async def _attach_highlight_spans(
                 else tokens_by_index.get(i, [])
             )
             bias = p.get("bias_stance") or BiasStance.UNKNOWN.value
+            title_str = p.get("title") or ""
 
             llm_payload = llm_cache.get(alt_id) if alt_id is not None else None
             if llm_payload is not None:
                 # Inject `bias` per span for clients pre-PR-6 that read it
-                # alongside the new `weight`/`category`/`justification`.
-                # Clamp spans against the served title length: legacy rows
-                # stored positions on the raw RSS title before the source
-                # suffix was stripped at ingestion, so an end > len(title)
-                # would crash the Flutter DiffTitle layout.
-                title_len = len(p.get("title") or "")
-                p["highlight_spans"] = [
+                # alongside the new `weight`/`category`/`justification`, then
+                # run the structural-only refinement: offset invariant (B) +
+                # edge trim + validity + de-nest + weight gate (C). Editorial
+                # judgment stays in the prompt, never here.
+                raw_spans = [
                     {**span, "bias": bias}
                     for span in (llm_payload.get("target_spans") or [])
-                    if span.get("start", 0) >= 0
-                    and span.get("end", 0) <= title_len
-                    and span.get("start", 0) < span.get("end", 0)
                 ]
+                p["highlight_spans"] = _refine_llm_target_spans(raw_spans, title_str)
                 llm_used += 1
+            elif alt_id is not None:
+                # In-cluster perspective without an LLM annotation yet → default
+                # spaCy diff (cap 4, every KEEP_POS — unchanged), guarded by the
+                # offset invariant against the served title.
+                p["highlight_spans"] = _enforce_offset_invariant(
+                    svc.diff_spans(ref_tokens, alt_tokens, bias), title_str
+                )
             else:
-                p["highlight_spans"] = svc.diff_spans(ref_tokens, alt_tokens, bias)
+                # Off-cluster live perspective → conservative D2 floor
+                # (ADJ/VERB only, cap 2), then the offset invariant.
+                p["highlight_spans"] = _enforce_offset_invariant(
+                    svc.diff_spans(
+                        ref_tokens,
+                        alt_tokens,
+                        bias,
+                        max_spans=svc.OFF_CLUSTER_MAX_SPANS,
+                        allowed_pos=svc.OFF_CLUSTER_ALLOWED_POS,
+                    ),
+                    title_str,
+                )
             p["shared_tokens"] = svc.compute_shared_tokens(ref_tokens, alt_tokens)
 
         return (

--- a/packages/api/app/services/llm_bias_annotation_service.py
+++ b/packages/api/app/services/llm_bias_annotation_service.py
@@ -16,7 +16,7 @@ from app.services.editorial.llm_client import EditorialLLMClient
 
 logger = structlog.get_logger(__name__)
 
-LLM_VERSION = "mistral-medium-latest-v2"
+LLM_VERSION = "mistral-medium-latest-v3"
 DEFAULT_MODEL = "mistral-medium-latest"
 
 TARGET_CATEGORIES = frozenset(
@@ -47,6 +47,17 @@ chaque titre "alt" (une perspective parmi plusieurs sur le même évènement),
 identifier les fragments qui méritent d'être SURLIGNÉS car ils relèvent d'un
 choix éditorial du média, par opposition aux faits avérés.
 
+PRINCIPE DIRECTEUR — PRÉCISION AVANT TOUT.
+Le surlignage est une loupe : il ne vaut que s'il pointe un VRAI parti pris.
+Mieux vaut ne RIEN surligner qu'un mot neutre. Dans le doute, n'annote pas.
+Un titre sans surlignage est un résultat normal et fréquent, pas un échec.
+
+BUDGET (strict) :
+- 0 à 2 `target_spans` par titre. Jamais 3 ou plus.
+- Chaque span fait AU PLUS 3 mots. Vise le fragment le plus court qui porte
+  le parti pris (souvent UN seul verbe ou nom chargé).
+- Si plusieurs fragments se valent, garde le plus chargé et lâche les autres.
+
 Tu reçois pour chaque appel :
 1. Le titre de référence du cluster (point de comparaison neutre, souvent un
    média grand public).
@@ -70,19 +81,26 @@ Où :
 - `target_spans` = fragments à SURLIGNER (l'éditorialisation du média).
   - `category` ∈ {"editorial_angle", "fact", "multi_token_expression",
     "framing_noun", "foreign_lang"}
-    - editorial_angle : verbe ou adjectif chargé ("crispe", "écrase",
-      "insulte").
+    - editorial_angle : verbe ou adjectif CHARGÉ, qui dramatise ou prend
+      parti ("crispe", "écrase", "insulte", "fustige", "déraille"). PAS un
+      verbe descriptif neutre (annonce, confirme, présente, déclare).
     - fact : mot factuel utilisé comme cadrage clivant ("gauche", "droite").
-    - multi_token_expression : expression de 2+ mots contiguës ("vent debout",
-      "mettre les egos de côté", "nie s'être inspiré"). UN SEUL span couvrant
-      toute l'expression.
+      Attention : un simple gentilé descriptif (français, iraniens, africaine,
+      bretonne) n'est PAS un cadrage — ne l'annote que s'il sert visiblement à
+      opposer ou stigmatiser.
+    - multi_token_expression : expression de 2+ mots contiguës et idiomatique
+      ("vent debout", "mettre les egos de côté", "nie s'être inspiré"). UN
+      SEUL span, ≤ 3 mots. N'invente pas une expression à partir d'une clause
+      banale : « dont les orientations peuvent faire gagner… » n'est PAS une
+      expression, c'est une phrase — ne l'annote pas.
     - framing_noun : nom abstrait choisi pour cadrer ("mainmise",
       "indépendance", "polémique").
     - foreign_lang : à utiliser quand la perspective n'est pas en français
       (anglais, allemand, italien…) — annote les fragments éditorialisants
       dans la langue d'origine.
   - `weight` ∈ {0.25, 0.5, 1.0} :
-    - 0.25 : très légère éditorialisation.
+    - 0.25 : très légère éditorialisation (sera probablement masquée à
+             l'affichage — ne l'utilise QUE si tu hésites vraiment à inclure).
     - 0.5  : cadrage modéré (factuel + nuance assumée).
     - 1.0  : éditorialisation forte (verbes chargés, jeux de mots, synthèses
              partisanes, expressions clivantes).
@@ -102,15 +120,26 @@ Où :
       noms de médias résiduels comme « - Le Monde », « | Libération »,
       « – BFMTV » qui auraient échappé au strip backend).
 
+CONTRE-EXEMPLES (à NE JAMAIS surligner — renvoie-les en exclude_spans ou ignore) :
+- Fillers d'actu : « en direct », « direct », « vidéo », « photos »,
+  « décryptage », « EN IMAGES ». Descriptifs, jamais un parti pris.
+- Gentilés purement descriptifs : « français », « iraniens », « afrique »,
+  « bretonne » employés comme simple localisation.
+- Dates, heures, nombres, pourcentages, ponctuation, séparateurs (« - », « | »).
+- Clauses longues / phrases relatives : ne surligne pas une demi-phrase pour
+  « expliquer » le titre — coupe au fragment chargé ou n'annote rien.
+
 RÈGLES IMPORTANTES :
 - Tes `start`/`end` doivent référer EXACTEMENT à des indices dans le titre
   fourni (codepoints Unicode). Le champ `text` doit être ce que donne
-  `titre[start:end]`.
+  `titre[start:end]`, ponctuation de bord EXCLUE (pas de guillemet ni « : »
+  en début/fin de span).
 - Si un fragment éditorialisant fait 2+ mots contigus, fais UN span
-  `multi_token_expression` couvrant toute l'expression — pas plusieurs.
+  `multi_token_expression` couvrant toute l'expression — pas plusieurs, et
+  jamais un span imbriqué dans un autre.
 - Pas de chevauchement entre target_spans et exclude_spans.
-- L'absence totale d'éditorialisation est légitime : `target_spans: []` est
-  valide pour un titre 100 % factuel.
+- L'absence totale d'éditorialisation est légitime et ATTENDUE : `target_spans:
+  []` est la bonne réponse pour un titre factuel — vide vaut mieux que faible.
 - `confidence` ∈ [0, 1] : auto-évaluation de la difficulté du cas.
 - `notes` : 1 phrase justifiant l'analyse globale du titre (utile au debug).
 - Réponds UNIQUEMENT par le JSON, sans markdown, sans préambule.

--- a/packages/api/app/services/title_annotation_service.py
+++ b/packages/api/app/services/title_annotation_service.py
@@ -40,6 +40,31 @@ def _strip_accents(s: str) -> str:
     )
 
 
+def _is_real_word(text: str) -> bool:
+    """Structural validity guard: a highlightable fragment must carry ≥ 2
+    alphabetic characters.
+
+    Context-independent by construction — it makes NO editorial judgment, it
+    only rejects fragments that cannot be a word in *any* context: ``%``, ``-``,
+    ``|``, dates like ``04/06``, bare numbers (``105``, ``1.0``) and emoji.
+    spaCy's `fr_core_news_md` routinely mis-tags these as content POS, so they
+    pass `KEEP_POS` and surface as highlights (the « % » in « 18% », the « - »
+    from a « - Le Monde » suffix). Real short words (``UE``, ``IA``) keep their
+    two letters and pass.
+    """
+    return sum(c.isalpha() for c in text) >= 2
+
+
+def spans_overlap(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    """True when half-open intervals ``[a0, a1)`` and ``[b0, b1)`` share a position.
+
+    Single source of truth shared by the offline evaluator
+    (`scripts/evaluate_title_annotations.py`, which re-exports it) and the
+    serve-time span de-nesting in `routers/contents.py` — keep them in lock-step.
+    """
+    return not (a[1] <= b[0] or b[1] <= a[0])
+
+
 @dataclass
 class ClusterAnnotations:
     """Container holding both the cached tokens and the URL→content_id map.
@@ -54,9 +79,21 @@ class ClusterAnnotations:
 
 
 class TitleAnnotationService:
-    MODEL_VERSION = "v1-spacy-fr_md"
+    # v2 bumped (2026-06-07) so the structural `_is_real_word` guard purges the
+    # `strong_tokens` cache polluted with « % », « - », « | », dates and bare
+    # numbers. Filtered by `model_version` at read time → no DB migration.
+    MODEL_VERSION = "v2-spacy-fr_md"
     KEEP_POS = frozenset({"NOUN", "PROPN", "ADJ", "VERB"})
     MAX_HIGHLIGHTED_PER_TITLE = 4
+
+    # Off-cluster (live Google News) deterministic floor — policy D2 (PO
+    # decision 2026-06-07). Without an LLM pass we cannot make the
+    # context-dependent editorial calls, so the spaCy path is restricted to the
+    # two POS least likely to be neutral (loaded verbs + adjectives) and capped
+    # hard at 2. Flip to D1 (no highlight at all off-cluster) by setting
+    # OFF_CLUSTER_MAX_SPANS = 0. In-cluster behaviour is unchanged.
+    OFF_CLUSTER_MAX_SPANS = 2
+    OFF_CLUSTER_ALLOWED_POS = frozenset({"ADJ", "VERB"})
     # Lower number = higher priority when capping at MAX_HIGHLIGHTED_PER_TITLE.
     # Entities are demoted to last resort: cluster pivots (Trump, ChatGPT,
     # Cannes…) used to consume the top-4 slots and crowd out the editorial
@@ -106,6 +143,11 @@ class TitleAnnotationService:
                 or _strip_accents(lemma) in FRENCH_STOP_WORDS
             ):
                 continue
+            # Structural guard at the single tokenisation choke-point — protects
+            # BOTH the cluster cache and the live path from spaCy mis-tagging
+            # punctuation / numbers / dates / emoji as content POS.
+            if not _is_real_word(text):
+                continue
             token: dict = {
                 "start": tok.idx,
                 "end": tok.idx + len(tok.text),
@@ -150,17 +192,32 @@ class TitleAnnotationService:
         return [self._doc_to_tokens(doc) for doc in docs]
 
     def diff_spans(
-        self, ref_tokens: list[dict], alt_tokens: list[dict], alt_bias: str
+        self,
+        ref_tokens: list[dict],
+        alt_tokens: list[dict],
+        alt_bias: str,
+        *,
+        max_spans: int | None = None,
+        allowed_pos: frozenset[str] | None = None,
     ) -> list[dict]:
         """Return spans of `alt_tokens` whose lemma is absent from `ref_tokens`.
 
-        Capped at `MAX_HIGHLIGHTED_PER_TITLE`, ordered by PRIORITY (ADJ,
-        then VERB, then NOUN, then PROPN, with NER entities pushed to last
-        resort). `alt_bias` is passed through unchanged to each span as
-        `bias` — the Dart side maps it to a color via `getBiasColor`.
+        Ordered by PRIORITY (ADJ, then VERB, then NOUN, then PROPN, with NER
+        entities pushed to last resort). `alt_bias` is passed through unchanged
+        to each span as `bias` — the Dart side maps it to a color via
+        `getBiasColor`.
+
+        `max_spans` / `allowed_pos` are keyword-only and default to the
+        in-cluster policy (cap `MAX_HIGHLIGHTED_PER_TITLE`, every `KEEP_POS`).
+        The off-cluster live path passes the conservative D2 floor
+        (`OFF_CLUSTER_MAX_SPANS` / `OFF_CLUSTER_ALLOWED_POS`); `max_spans=0`
+        yields the empty list (policy D1).
         """
+        cap = self.MAX_HIGHLIGHTED_PER_TITLE if max_spans is None else max_spans
         ref_lemmas = {t["lemma"] for t in ref_tokens}
         divergent = [t for t in alt_tokens if t["lemma"] not in ref_lemmas]
+        if allowed_pos is not None:
+            divergent = [t for t in divergent if t["pos"] in allowed_pos]
         ranked = sorted(
             divergent,
             key=lambda t: self.PRIORITY.get(
@@ -174,7 +231,7 @@ class TitleAnnotationService:
                 "text": t["text"],
                 "bias": alt_bias,
             }
-            for t in ranked[: self.MAX_HIGHLIGHTED_PER_TITLE]
+            for t in ranked[:cap]
         ]
 
     def compute_shared_tokens(

--- a/packages/api/scripts/build_highlight_dataset.py
+++ b/packages/api/scripts/build_highlight_dataset.py
@@ -338,7 +338,7 @@ def main() -> None:
     parser.add_argument("--min-shared-entities", type=int, default=2)
     parser.add_argument(
         "--model-version",
-        default="v1-spacy-fr_md",
+        default="v2-spacy-fr_md",
         help="Annoté dans le JSON pour aligner sur la pipeline",
     )
     args = parser.parse_args()

--- a/packages/api/scripts/evaluate_title_annotations.py
+++ b/packages/api/scripts/evaluate_title_annotations.py
@@ -40,9 +40,10 @@ from pathlib import Path
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-from app.services.title_annotation_service import (  # noqa: E402
+from app.services.title_annotation_service import (  # noqa: E402,F401
     TitleAnnotationService,
     get_title_annotation_service,
+    spans_overlap,  # re-exported: single source of truth for the overlap predicate
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -74,8 +75,9 @@ def fuse_spans(spans: list[dict], gap: int = 1) -> list[tuple[int, int]]:
     return fused
 
 
-def spans_overlap(a: tuple[int, int], b: tuple[int, int]) -> bool:
-    return not (a[1] <= b[0] or b[1] <= a[0])
+# `spans_overlap` is imported from `app.services.title_annotation_service`
+# (re-exported above) so the evaluator and the serve-time refinement in
+# `routers/contents.py` share one predicate.
 
 
 # ---------------------------------------------------------------------------

--- a/packages/api/tests/routers/test_contents_perspectives_highlights.py
+++ b/packages/api/tests/routers/test_contents_perspectives_highlights.py
@@ -17,7 +17,12 @@ from app.models.cluster_title_annotation import ClusterTitleAnnotation
 from app.models.content import Content
 from app.models.enums import ContentType, SourceType
 from app.models.source import Source
-from app.routers.contents import _attach_highlight_spans
+from app.routers.contents import (
+    MIN_DISPLAY_WEIGHT,
+    _attach_highlight_spans,
+    _enforce_offset_invariant,
+    _refine_llm_target_spans,
+)
 from app.services.llm_bias_annotation_service import LLM_VERSION as LLM_BIAS_VERSION
 from app.services.title_annotation_service import TitleAnnotationService
 from tests.fixtures.fake_spacy import (
@@ -92,7 +97,9 @@ async def test_attach_highlight_spans_computes_for_content_without_cluster(db_se
 
     Regression for the prod incident where clustering was never activated,
     so the early-return on `not content.cluster_id` silently disabled the
-    feature for every article.
+    feature for every article. Off-cluster is governed by policy D2: only
+    divergent ADJ/VERB are surfaced (cap 2), the conservative deterministic
+    floor — a divergent NOUN like « morts » is intentionally NOT highlighted.
     """
     source = Source(
         id=uuid4(),
@@ -127,11 +134,14 @@ async def test_attach_highlight_spans_computes_for_content_without_cluster(db_se
                 FakeToken("Gaza", 14, "PROPN", "Gaza"),
             ],
         ),
-        "Une frappe sur Gaza fait 20 morts": FakeDoc(
+        # "Bombardement meurtrier vise Gaza" → divergent NOUN + ADJ + VERB,
+        # plus the shared PROPN Gaza.
+        "Bombardement meurtrier vise Gaza": FakeDoc(
             tokens=[
-                FakeToken("frappe", 4, "NOUN", "frappe"),
-                FakeToken("Gaza", 14, "PROPN", "Gaza"),
-                FakeToken("morts", 25, "NOUN", "mort"),
+                FakeToken("Bombardement", 0, "NOUN", "bombardement"),
+                FakeToken("meurtrier", 13, "ADJ", "meurtrier"),
+                FakeToken("vise", 23, "VERB", "viser"),
+                FakeToken("Gaza", 28, "PROPN", "Gaza"),
             ],
         ),
     }
@@ -139,7 +149,7 @@ async def test_attach_highlight_spans_computes_for_content_without_cluster(db_se
 
     perspectives = [
         {
-            "title": "Une frappe sur Gaza fait 20 morts",
+            "title": "Bombardement meurtrier vise Gaza",
             "url": "https://other.fr/x",
             "bias_stance": "left",
         }
@@ -151,7 +161,10 @@ async def test_attach_highlight_spans_computes_for_content_without_cluster(db_se
         pivot, _ = await _attach_highlight_spans(db_session, standalone, perspectives)
 
     texts = {s["text"] for s in perspectives[0]["highlight_spans"]}
-    assert "morts" in texts  # diverges from ref (lemma not in {Tsahal, frapper, Gaza})
+    # D2: ADJ + VERB surfaced, NOUN « Bombardement » and shared « Gaza » are not.
+    assert texts == {"meurtrier", "vise"}
+    assert "Bombardement" not in texts
+    assert len(perspectives[0]["highlight_spans"]) <= 2
     assert all(s["bias"] == "left" for s in perspectives[0]["highlight_spans"])
     # Reference pivot still resolves to the ref title's first VERB.
     assert pivot == {"start": 7, "end": 13, "text": "frappe"}
@@ -250,7 +263,8 @@ async def test_attach_highlight_spans_uses_cache_for_in_cluster_perspectives(
 async def test_attach_highlight_spans_computes_on_fly_for_google_news_url(
     db_session, cluster_setup
 ):
-    """Google News perspective URL absent from the cluster → spaCy invoked at call time."""
+    """Google News perspective URL absent from the cluster → spaCy invoked at
+    call time, under the off-cluster D2 floor (ADJ/VERB only, cap 2)."""
     docs = {
         "Tsahal frappe Gaza": FakeDoc(
             tokens=[
@@ -267,11 +281,12 @@ async def test_attach_highlight_spans_computes_on_fly_for_google_news_url(
                 FakeToken("Gaza", 27, "PROPN", "Gaza"),
             ],
         ),
-        "Une frappe sur Gaza fait 20 morts": FakeDoc(
+        "Bombardement meurtrier vise Gaza": FakeDoc(
             tokens=[
-                FakeToken("frappe", 4, "NOUN", "frappe"),
-                FakeToken("Gaza", 14, "PROPN", "Gaza"),
-                FakeToken("morts", 25, "NOUN", "mort"),
+                FakeToken("Bombardement", 0, "NOUN", "bombardement"),
+                FakeToken("meurtrier", 13, "ADJ", "meurtrier"),
+                FakeToken("vise", 23, "VERB", "viser"),
+                FakeToken("Gaza", 28, "PROPN", "Gaza"),
             ],
         ),
     }
@@ -279,7 +294,7 @@ async def test_attach_highlight_spans_computes_on_fly_for_google_news_url(
 
     perspectives = [
         {
-            "title": "Une frappe sur Gaza fait 20 morts",
+            "title": "Bombardement meurtrier vise Gaza",
             "url": "https://google-news-only-source.com/x",  # not in cluster
             "bias_stance": "unknown",
         }
@@ -292,7 +307,9 @@ async def test_attach_highlight_spans_computes_on_fly_for_google_news_url(
 
     spans = perspectives[0]["highlight_spans"]
     texts = {s["text"] for s in spans}
-    assert "morts" in texts  # diverges from ref
+    # D2: divergent ADJ + VERB only; the divergent NOUN « Bombardement » is dropped.
+    assert texts == {"meurtrier", "vise"}
+    assert len(spans) <= 2
     assert all(s["bias"] == "unknown" for s in spans)
 
 
@@ -845,3 +862,164 @@ async def test_build_cluster_perspectives_propagates_content_language(db_session
     # Single perspective per source_id — keep the one that landed first.
     assert len(perspectives) == 1
     assert perspectives[0].language == "en"
+
+
+# --- Structural refinement (Story 7.4 highlight-quality, pure functions) -----
+
+
+def _span(start: int, end: int, text: str, **extra) -> dict:
+    return {"start": start, "end": end, "text": text, **extra}
+
+
+# B — offset invariant -------------------------------------------------------
+
+
+def test_enforce_offset_invariant_keeps_aligned_span():
+    title = "Armée bombarde Gaza"
+    spans = [_span(6, 14, "bombarde")]
+    assert _enforce_offset_invariant(spans, title) == spans
+
+
+def test_enforce_offset_invariant_relocates_shifted_span():
+    """A leading RSS space shifts every offset by one → relocate via find_span."""
+    title = " Armée bombarde Gaza"  # offsets below were computed on the trimmed title
+    spans = [_span(5, 13, "bombarde")]
+    out = _enforce_offset_invariant(spans, title)
+    assert len(out) == 1
+    assert title[out[0]["start"] : out[0]["end"]] == "bombarde"
+
+
+def test_enforce_offset_invariant_drops_absent_text():
+    title = "Armée bombarde Gaza"
+    spans = [_span(0, 6, "Tsahal")]  # text not present in the served title
+    assert _enforce_offset_invariant(spans, title) == []
+
+
+def test_enforce_offset_invariant_drops_out_of_bounds_and_empty():
+    title = "Armée bombarde Gaza"  # 19 chars
+    spans = [
+        _span(30, 42, "- Le Monde"),  # past the end, text absent → drop
+        _span(-1, 5, "junk"),         # negative start, text absent → drop
+        _span(5, 5, ""),              # zero-width → drop
+    ]
+    assert _enforce_offset_invariant(spans, title) == []
+
+
+# C — _refine_llm_target_spans ----------------------------------------------
+
+
+def test_refine_trims_punctuation_edges():
+    title = 'Macron juge "l\'arrêt complet" inacceptable'
+    start = title.index('"')
+    end = title.index('"', start + 1) + 1  # span wraps the surrounding quotes
+    spans = [
+        _span(start, end, title[start:end], weight=1.0,
+              category="multi_token_expression")
+    ]
+    out = _refine_llm_target_spans(spans, title)
+    assert len(out) == 1
+    assert out[0]["text"] == "l'arrêt complet"  # edge quotes trimmed, elision kept
+
+
+def test_refine_denests_overlapping_spans_keeps_widest():
+    """« restitutions » ⊂ « restitutions de biens » → keep the enclosing span."""
+    title = "Réclame restitutions de biens au musée"
+    narrow_s = title.index("restitutions")
+    narrow_e = narrow_s + len("restitutions")
+    wide_s = narrow_s
+    wide_e = title.index("biens") + len("biens")
+    spans = [
+        _span(narrow_s, narrow_e, "restitutions", weight=1.0, category="framing_noun"),
+        _span(wide_s, wide_e, "restitutions de biens", weight=1.0,
+              category="multi_token_expression"),
+    ]
+    out = _refine_llm_target_spans(spans, title)
+    assert len(out) == 1
+    assert out[0]["text"] == "restitutions de biens"
+
+
+def test_refine_drops_low_weight_span():
+    title = "Macron impose une réforme brutale"
+    s = title.index("brutale")
+    spans = [_span(s, s + len("brutale"), "brutale", weight=0.25,
+                   category="editorial_angle")]
+    assert _refine_llm_target_spans(spans, title) == []
+
+
+def test_refine_keeps_weight_at_display_threshold():
+    title = "Macron impose une réforme brutale"
+    s = title.index("brutale")
+    spans = [_span(s, s + len("brutale"), "brutale", weight=MIN_DISPLAY_WEIGHT,
+                   category="editorial_angle")]
+    out = _refine_llm_target_spans(spans, title)
+    assert [x["text"] for x in out] == ["brutale"]
+
+
+def test_refine_drops_structurally_invalid_span():
+    title = "Hausse de 18% au compteur"
+    s = title.index("%")
+    spans = [_span(s, s + 1, "%", weight=1.0, category="fact")]
+    assert _refine_llm_target_spans(spans, title) == []
+
+
+def test_refine_preserves_llm_fields_on_kept_span():
+    title = "Israël pilonne Gaza"
+    s = title.index("pilonne")
+    spans = [_span(s, s + len("pilonne"), "pilonne", weight=1.0,
+                   category="editorial_angle", justification="verbe chargé",
+                   bias="left")]
+    out = _refine_llm_target_spans(spans, title)
+    assert len(out) == 1
+    assert out[0]["category"] == "editorial_angle"
+    assert out[0]["weight"] == 1.0
+    assert out[0]["justification"] == "verbe chargé"
+    assert out[0]["bias"] == "left"
+
+
+@pytest.mark.asyncio
+async def test_attach_highlight_spans_drops_low_weight_llm_span_end_to_end(
+    db_session, cluster_setup
+):
+    """End-to-end: a 0.25-weight LLM span is gated out at serve while the
+    1.0-weight span survives (structural cleanup C runs in the loop)."""
+    await _seed_strong_tokens_cache(
+        db_session, cluster_setup, _REF_TOKENS_GAZA, _ALT_TOKENS_GAZA
+    )
+    served_title = "Armée israélienne bombarde Gaza"
+    signature = _cluster_signature(cluster_setup)
+    spans = [
+        {  # strong editorialisation → displayed
+            "start": 18, "end": 26, "text": "bombarde",
+            "category": "editorial_angle", "weight": 1.0, "justification": "ok",
+        },
+        {  # weak → gated out by MIN_DISPLAY_WEIGHT
+            "start": 6, "end": 17, "text": "israélienne",
+            "category": "fact", "weight": 0.25, "justification": "gentilé",
+        },
+    ]
+    alt_row = await db_session.get(
+        ClusterTitleAnnotation,
+        (cluster_setup["cluster_id"], cluster_setup["alt_a"].id),
+    )
+    alt_row.semantic_equiv = _llm_payload(spans, signature)
+    await db_session.commit()
+
+    fake_svc = service_with_nlp(FakeNlp({}))
+    perspectives = [
+        {
+            "title": served_title,
+            "url": cluster_setup["alt_a"].url,
+            "bias_stance": "left",
+        }
+    ]
+    with patch(
+        "app.routers.contents.get_title_annotation_service",
+        return_value=fake_svc,
+    ):
+        _, source = await _attach_highlight_spans(
+            db_session, cluster_setup["ref"], perspectives
+        )
+
+    assert source == "llm"
+    out = perspectives[0]["highlight_spans"]
+    assert [s["text"] for s in out] == ["bombarde"]

--- a/packages/api/tests/routers/test_internal_ner_health.py
+++ b/packages/api/tests/routers/test_internal_ner_health.py
@@ -46,7 +46,7 @@ async def test_ner_health_reports_available_when_nlp_loaded(client):
     assert response.status_code == 200
     body = response.json()
     assert body["nlp_available"] is True
-    assert body["model_version"] == "v1-spacy-fr_md"
+    assert body["model_version"] == "v2-spacy-fr_md"
     assert body["sample_title"] == "Tsahal frappe Gaza"
     token_texts = [t["text"] for t in body["sample_tokens"]]
     assert "Tsahal" in token_texts

--- a/packages/api/tests/scripts/fixtures/toy_dataset.json
+++ b/packages/api/tests/scripts/fixtures/toy_dataset.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2026-05-19T00:00:00+00:00",
   "schema_version": 1,
-  "model_version": "v1-spacy-fr_md",
+  "model_version": "v2-spacy-fr_md",
   "stratification": {"politics": 1},
   "clusters": [
     {

--- a/packages/api/tests/services/test_llm_bias_annotation_service.py
+++ b/packages/api/tests/services/test_llm_bias_annotation_service.py
@@ -34,7 +34,7 @@ SNAPSHOT_PATH = (
 
 def test_constants_locked():
     """Verrouille les contrats publics du module (cf. plan.md)."""
-    assert LLM_VERSION == "mistral-medium-latest-v2"
+    assert LLM_VERSION == "mistral-medium-latest-v3"
     assert DEFAULT_MODEL == "mistral-medium-latest"
     assert TARGET_CATEGORIES == {
         "editorial_angle",

--- a/packages/api/tests/services/test_title_annotation_service.py
+++ b/packages/api/tests/services/test_title_annotation_service.py
@@ -15,7 +15,11 @@ from app.models.cluster_title_annotation import ClusterTitleAnnotation
 from app.models.content import Content
 from app.models.enums import ContentType, SourceType
 from app.models.source import Source
-from app.services.title_annotation_service import TitleAnnotationService
+from app.services.title_annotation_service import (
+    TitleAnnotationService,
+    _is_real_word,
+    spans_overlap,
+)
 from tests.fixtures.fake_spacy import (
     FakeDoc,
     FakeEnt,
@@ -99,6 +103,60 @@ def test_compute_strong_tokens_filters_against_project_stopword_list():
 def test_compute_strong_tokens_returns_empty_when_nlp_missing():
     svc = service_with_nlp(None)
     assert svc.compute_strong_tokens("Un titre quelconque") == []
+
+
+# --- _is_real_word (structural validity guard) ------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("UE", True),      # 2 alpha → real word
+        ("IA", True),
+        ("réforme", True),
+        ("an", True),
+        ("%", False),      # the « % » in « 18% »
+        ("-", False),      # « - Le Monde » suffix separator
+        ("|", False),
+        ("04/06", False),  # date
+        ("105", False),    # bare number
+        ("1.0", False),
+        ("🔥", False),      # emoji mis-tagged VERB in prod
+        ("", False),
+        ("A", False),      # single letter
+    ],
+)
+def test_is_real_word(text, expected):
+    assert _is_real_word(text) is expected
+
+
+def test_doc_to_tokens_drops_non_word_tokens():
+    """spaCy mis-tags « % » as NOUN and « - » as PROPN — both must be dropped
+    at the single tokenisation choke-point so neither cache nor live path
+    can surface them."""
+    title = "Hausse de 18% - BFMTV"
+    doc = FakeDoc(
+        tokens=[
+            FakeToken("Hausse", 0, "NOUN", "hausse"),
+            FakeToken("%", 12, "NOUN", "%"),     # mis-tagged content POS
+            FakeToken("-", 14, "PROPN", "-"),    # source-suffix separator
+            FakeToken("BFMTV", 16, "PROPN", "bfmtv"),
+        ]
+    )
+    svc = service_with_nlp(FakeNlp({title: doc}))
+
+    texts = [t["text"] for t in svc.compute_strong_tokens(title)]
+    assert texts == ["Hausse", "BFMTV"]
+    assert "%" not in texts and "-" not in texts
+
+
+# --- spans_overlap (shared predicate) ---------------------------------------
+
+
+def test_spans_overlap_predicate():
+    assert spans_overlap((0, 5), (3, 7)) is True
+    assert spans_overlap((0, 5), (5, 7)) is False  # touching, not overlapping
+    assert spans_overlap((0, 5), (10, 12)) is False
 
 
 # --- diff_spans -------------------------------------------------------------
@@ -191,6 +249,54 @@ def test_diff_spans_preserves_offsets():
     spans = svc.diff_spans(ref, alt, "left")
     assert spans[0]["start"] == 15
     assert spans[0]["end"] == 21
+
+
+# --- diff_spans off-cluster D2 (keyword-only max_spans / allowed_pos) --------
+
+
+def test_diff_spans_off_cluster_caps_at_2_and_keeps_adj_verb_only():
+    """Off-cluster live floor: only ADJ/VERB, hard cap 2 (PO decision D2)."""
+    ref: list[dict] = []
+    alt = [
+        _tok("Bombardement", "bombardement", pos="NOUN", start=0),
+        _tok("meurtrier", "meurtrier", pos="ADJ", start=13),
+        _tok("vise", "viser", pos="VERB", start=23),
+        _tok("Macron", "macron", pos="PROPN", start=28, entity_kind="PER"),
+    ]
+    svc = service_with_nlp(None)
+    spans = svc.diff_spans(
+        ref, alt, "left",
+        max_spans=svc.OFF_CLUSTER_MAX_SPANS,
+        allowed_pos=svc.OFF_CLUSTER_ALLOWED_POS,
+    )
+    texts = {s["text"] for s in spans}
+    assert len(spans) <= 2
+    assert texts == {"meurtrier", "vise"}  # NOUN + PROPN filtered out
+
+
+def test_diff_spans_default_in_cluster_policy_unchanged():
+    """Regression: default kwargs keep cap-4 / all-KEEP_POS behaviour."""
+    ref: list[dict] = []
+    alt = [
+        _tok("Bombardement", "bombardement", pos="NOUN", start=0),
+        _tok("meurtrier", "meurtrier", pos="ADJ", start=13),
+        _tok("vise", "viser", pos="VERB", start=23),
+        _tok("Gaza", "gaza", pos="PROPN", start=28),
+    ]
+    svc = service_with_nlp(None)
+    spans = svc.diff_spans(ref, alt, "left")
+    assert len(spans) == 4
+    assert {"Bombardement", "Gaza"} <= {s["text"] for s in spans}
+
+
+def test_diff_spans_d1_returns_empty_when_cap_zero():
+    """Flipping OFF_CLUSTER_MAX_SPANS to 0 (policy D1) suppresses everything."""
+    ref: list[dict] = []
+    alt = [_tok("vise", "viser", pos="VERB", start=0)]
+    svc = service_with_nlp(None)
+    assert svc.diff_spans(
+        ref, alt, "left", max_spans=0, allowed_pos=svc.OFF_CLUSTER_ALLOWED_POS
+    ) == []
 
 
 # --- compute_shared_tokens --------------------------------------------------
@@ -338,7 +444,7 @@ async def test_get_or_compute_inserts_on_first_call_and_reads_cache_second(
         )
     ).scalars().all()
     assert len(rows) == 3
-    assert all(r.model_version == "v1-spacy-fr_md" for r in rows)
+    assert all(r.model_version == TitleAnnotationService.MODEL_VERSION for r in rows)
     assert all(r.semantic_equiv is None for r in rows)
 
     nlp.call_count = 0
@@ -394,7 +500,7 @@ async def test_get_or_compute_does_not_raise_on_partial_cache(
         content_id=contents[0].id,
         strong_tokens=[{"start": 0, "end": 5, "text": "seed",
                         "lemma": "seed", "pos": "NOUN"}],
-        model_version="v1-spacy-fr_md",
+        model_version=TitleAnnotationService.MODEL_VERSION,
     )
     db_session.add(pre_seeded)
     await db_session.commit()
@@ -454,7 +560,7 @@ async def cluster_with_spacy_rows(db_session, cluster_fixture):
                 cluster_id=cluster_fixture["cluster_id"],
                 content_id=c.id,
                 strong_tokens=[],
-                model_version="v1-spacy-fr_md",
+                model_version=TitleAnnotationService.MODEL_VERSION,
             )
         )
     await db_session.commit()

--- a/packages/api/tests/snapshots/llm_system_prompt.txt
+++ b/packages/api/tests/snapshots/llm_system_prompt.txt
@@ -4,6 +4,17 @@ chaque titre "alt" (une perspective parmi plusieurs sur le même évènement),
 identifier les fragments qui méritent d'être SURLIGNÉS car ils relèvent d'un
 choix éditorial du média, par opposition aux faits avérés.
 
+PRINCIPE DIRECTEUR — PRÉCISION AVANT TOUT.
+Le surlignage est une loupe : il ne vaut que s'il pointe un VRAI parti pris.
+Mieux vaut ne RIEN surligner qu'un mot neutre. Dans le doute, n'annote pas.
+Un titre sans surlignage est un résultat normal et fréquent, pas un échec.
+
+BUDGET (strict) :
+- 0 à 2 `target_spans` par titre. Jamais 3 ou plus.
+- Chaque span fait AU PLUS 3 mots. Vise le fragment le plus court qui porte
+  le parti pris (souvent UN seul verbe ou nom chargé).
+- Si plusieurs fragments se valent, garde le plus chargé et lâche les autres.
+
 Tu reçois pour chaque appel :
 1. Le titre de référence du cluster (point de comparaison neutre, souvent un
    média grand public).
@@ -27,19 +38,26 @@ Où :
 - `target_spans` = fragments à SURLIGNER (l'éditorialisation du média).
   - `category` ∈ {"editorial_angle", "fact", "multi_token_expression",
     "framing_noun", "foreign_lang"}
-    - editorial_angle : verbe ou adjectif chargé ("crispe", "écrase",
-      "insulte").
+    - editorial_angle : verbe ou adjectif CHARGÉ, qui dramatise ou prend
+      parti ("crispe", "écrase", "insulte", "fustige", "déraille"). PAS un
+      verbe descriptif neutre (annonce, confirme, présente, déclare).
     - fact : mot factuel utilisé comme cadrage clivant ("gauche", "droite").
-    - multi_token_expression : expression de 2+ mots contiguës ("vent debout",
-      "mettre les egos de côté", "nie s'être inspiré"). UN SEUL span couvrant
-      toute l'expression.
+      Attention : un simple gentilé descriptif (français, iraniens, africaine,
+      bretonne) n'est PAS un cadrage — ne l'annote que s'il sert visiblement à
+      opposer ou stigmatiser.
+    - multi_token_expression : expression de 2+ mots contiguës et idiomatique
+      ("vent debout", "mettre les egos de côté", "nie s'être inspiré"). UN
+      SEUL span, ≤ 3 mots. N'invente pas une expression à partir d'une clause
+      banale : « dont les orientations peuvent faire gagner… » n'est PAS une
+      expression, c'est une phrase — ne l'annote pas.
     - framing_noun : nom abstrait choisi pour cadrer ("mainmise",
       "indépendance", "polémique").
     - foreign_lang : à utiliser quand la perspective n'est pas en français
       (anglais, allemand, italien…) — annote les fragments éditorialisants
       dans la langue d'origine.
   - `weight` ∈ {0.25, 0.5, 1.0} :
-    - 0.25 : très légère éditorialisation.
+    - 0.25 : très légère éditorialisation (sera probablement masquée à
+             l'affichage — ne l'utilise QUE si tu hésites vraiment à inclure).
     - 0.5  : cadrage modéré (factuel + nuance assumée).
     - 1.0  : éditorialisation forte (verbes chargés, jeux de mots, synthèses
              partisanes, expressions clivantes).
@@ -59,15 +77,26 @@ Où :
       noms de médias résiduels comme « - Le Monde », « | Libération »,
       « – BFMTV » qui auraient échappé au strip backend).
 
+CONTRE-EXEMPLES (à NE JAMAIS surligner — renvoie-les en exclude_spans ou ignore) :
+- Fillers d'actu : « en direct », « direct », « vidéo », « photos »,
+  « décryptage », « EN IMAGES ». Descriptifs, jamais un parti pris.
+- Gentilés purement descriptifs : « français », « iraniens », « afrique »,
+  « bretonne » employés comme simple localisation.
+- Dates, heures, nombres, pourcentages, ponctuation, séparateurs (« - », « | »).
+- Clauses longues / phrases relatives : ne surligne pas une demi-phrase pour
+  « expliquer » le titre — coupe au fragment chargé ou n'annote rien.
+
 RÈGLES IMPORTANTES :
 - Tes `start`/`end` doivent référer EXACTEMENT à des indices dans le titre
   fourni (codepoints Unicode). Le champ `text` doit être ce que donne
-  `titre[start:end]`.
+  `titre[start:end]`, ponctuation de bord EXCLUE (pas de guillemet ni « : »
+  en début/fin de span).
 - Si un fragment éditorialisant fait 2+ mots contigus, fais UN span
-  `multi_token_expression` couvrant toute l'expression — pas plusieurs.
+  `multi_token_expression` couvrant toute l'expression — pas plusieurs, et
+  jamais un span imbriqué dans un autre.
 - Pas de chevauchement entre target_spans et exclude_spans.
-- L'absence totale d'éditorialisation est légitime : `target_spans: []` est
-  valide pour un titre 100 % factuel.
+- L'absence totale d'éditorialisation est légitime et ATTENDUE : `target_spans:
+  []` est la bonne réponse pour un titre factuel — vide vaut mieux que faible.
 - `confidence` ∈ [0, 1] : auto-évaluation de la difficulté du cas.
 - `notes` : 1 phrase justifiant l'analyse globale du titre (utile au debug).
 - Réponds UNIQUEMENT par le JSON, sans markdown, sans préambule.


### PR DESCRIPTION
## Surlignage des titres — qualité precision-first (PR1 structurel + PR2 prompt, en une PR)

Killer-feature « Couverture médiatique » (Story 7.4). Le surlignage pointait encore des mots **neutres** (« % » dans « 18% », « Direct » dans « En direct », gentilés, clauses entières). Cadrage PO : **precision ≫ recall** (vide vaut mieux qu'un mot neutre) **sans coder l'éditorial à la main**.

> Principe directeur : **limiter au maximum les règles brutes**. Garde-fous *structurels* (vrais quel que soit le contexte) en dur ; jugement *éditorial dépendant du contexte* délégué au prompt LLM, mesuré au benchmark. Aucune stoplist « en direct », aucune règle gentilé.

Analyse complète : [`docs/bugs/bug-highlight-quality-misalignment.md`](docs/bugs/bug-highlight-quality-misalignment.md).

### PR1 — Garde-fous structurels (coût LLM nul, réversible, aucune règle de contenu)
- **A — validité structurelle** : `_is_real_word` (≥ 2 caractères alpha) au point de tokenisation unique `_doc_to_tokens` → purge `%`/`-`/`|`/dates/nombres/emoji du **cache ET du live**. `MODEL_VERSION` → `v2-spacy-fr_md` (purge cache, **pas de migration DB**).
- **B — invariant d'offset au serve** : `_enforce_offset_invariant` exige `served_title[start:end] == text` (LLM + spaCy), re-localise via `find_span` sinon **drop**. + retrait du `.trim()` Dart (`perspectives_bottom_sheet.dart`).
- **C — nettoyage structurel des spans LLM** : `_refine_llm_target_spans` (pure) = re-ancrage → gate `weight ≥ 0.5` (réutilise le score LLM existant) → trim ponctuation de bord → validité (A) → dé-imbrication (réutilise `spans_overlap`, **source unique** déplacée dans le service).
- **D — chemin live D2** : `diff_spans(max_spans, allowed_pos)` keyword-only ; hors-cluster = **ADJ/VERB + cap 2** (`OFF_CLUSTER_*`) ; **in-cluster inchangé** ; bascule D1 (cap 0) via constante.

### PR2 — Qualité éditoriale via prompt LLM + benchmark
- `SCHEMA_DESCRIPTION` révisé : **budget 0-2 spans, ≤ 3 mots**, verbes chargés / framing nouns, **contre-exemples en contexte** (en direct, gentilés, dates, clauses, ponctuation de bord), « vide vaut mieux que faible ». Contrat JSON (catégories/poids) **inchangé**. Snapshot regénéré.
- `LLM_VERSION` → `mistral-medium-latest-v3` : invalide `semantic_equiv` v2 → ré-annotation au prochain pipeline.

### ⚠️ Note de déploiement
Aucune migration Alembic. Au déploiement, `LLM_VERSION=v3` invalide tout `semantic_equiv` v2 : tant que le pipeline n'a pas ré-annoté, l'in-cluster retombe sur spaCy (cap 4, garde-fous structurels actifs) et le live sur D2 — fallback conservateur **assumé** (precision-first). **Déclencher une ré-annotation** pour repeupler `semantic_equiv` en v3. La validation éditoriale chiffrée (benchmark `evaluate_title_annotations.py` baseline v2 → after v3 contre le gold prod) est l'**étape PO-synchrone du rollout** (outillage prêt, hors-code).

### Tests / vérification
- Backend hermétique exécuté localement : `test_title_annotation_service.py` (non-DB) **38 ✅**, `test_llm_bias_annotation_service.py` **29 ✅**, refinement pur (offset invariant + nettoyage C) **10 ✅**. Logique B/C/D + `_is_real_word` prouvée par harness autonome. Ruff `app/` clean.
- Mobile : `flutter analyze` clean ; `diff_title` (16 ✅) + `perspectives_bottom_sheet` (4 ✅).
- **Tests DB-backed** (intégration `_attach_highlight_spans`) : docker indisponible en sandbox → **gate = CI** (backend pytest). Chaque test tracé à la main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
