### PR TITLE
feat(flux-continu): L'Essentiel — cartes ≤ écran (fit dynamique) + footer auto-hide

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,72 +1,56 @@
-# Veille — refonte curation deux blocs + UX fin de config
+# L'Essentiel : cartes qui ne dépassent jamais l'écran (+ footer auto-hide)
 
 ## Résumé
 
-Le feed veille (`GET /api/veille/feed`, section `SectionKind.veille` du flux continu)
-est refondu en **deux blocs** pour corriger deux bugs PO :
-1. sources configurées invisibles (fenêtre 7 j + règle « floor » tuaient les flux
-   niche/anglophones) ;
-2. sources externes parasites (prédicat OR aspirait tout le pool global matchant un
-   mot-clé).
+Dans **Flux Continu / L'Essentiel**, une carte plus haute que l'écran gagnait une
+« free-read interior » qui se battait avec le snap inter-sections. Cette PR
+garantit qu'**aucune carte ne dépasse la hauteur utile de l'écran** (bouton
+« Lire plus » inclus) → `_tallSections` vide → 1 point de snap par section, feel
+cohérent page par page. **1 seule PR** (validée PO).
 
-## Backend (backward-safe — le mobile ignore `group` jusqu'au déploiement frontend)
+## Décision d'architecture — « estimer pour contrôler, mesurer pour vérifier »
 
-- `scoring_config.py` : `VEILLE_CONFIGURED_RECENCY_HOURS=720` (30 j, Bloc A),
-  `VEILLE_SOURCE_DIVERSITY_CAP=3`.
-- `feed_filter.py` :
-  - `VeilleFilters.source_intents` (charge `VeilleSource.why`).
-  - `build_topic_keyword_predicate()` (= prédicat fort sans la clause source).
-  - `_score_and_rank` → `_score_block(..., *, apply_floor, apply_threshold, diversity_cap)`.
-  - `fetch_veille_feed()` : 2 requêtes (Bloc A `source_id IN` fenêtre 720 h, laisser-passer
-    + cap diversité ; Bloc B topic/keyword `NOTIN` sources, fenêtre 168 h, floor+seuil),
-    concaténées A→B, taguées `group`, paginées à plat. **Renvoie des 3-tuples
-    `(Content, axes, group)`.**
-- `scoring_context.py` : note d'intention `why` tokenisée (`_tokenize_intent`, stopwords FR
-  + len≥4) → angle « Intention » (réutilise le bonus mots-clés existant).
-- `schemas/veille.py` : `VeilleFeedArticle.group` (Literal sources/elargie, défaut
-  `sources`) ; `VeilleSourceResponse.last_article_at` + `recent_article_count`.
-- `routers/veille.py` : unpack 3-tuple + `group` ; agrégation santé source dans
-  `GET /config`. **Pas de migration** (`why` existe déjà).
+Le « combien d'articles tiennent » est décidé **côté provider** par une estimation
+de hauteur **conservatrice** (titre à son `maxLines` max), pas de mesure runtime
+qui pilote le rendu. La mesure post-frame (`_recomputeSnapAnchors` /
+`_tallSections`) sert de **filet QA**. Budget **identique au snap** :
+`usableHeight = scrollViewportHeight − safeAreaBottom − _kStickyBarHeight`.
 
-### Tests backend
-- `tests/test_veille_curation.py` : Bloc A laisser-passer + cap diversité ; floor Bloc B ;
-  end-to-end deux blocs ; tokenisation intent.
-- `tests/services/test_veille_scoring.py` : intent `why` injecté ; split récence 30j/7j ;
-  unpacking 3-tuples mis à jour.
-- `tests/routers/test_veille_routes.py` : `group` par item ; ordre A→B ; pagination à la
-  frontière ; santé source dans `/config`.
-- **64 tests veille passent** ; suite backend complète **1524 passed** (la seule rouge —
-  `test_notification_preferences::test_patch_increments_refusal_count` — est pré-existante,
-  clock-dépendante, sans rapport).
+« Le héros qui ne tient pas sort du pool et réapparaît ailleurs » est gratuit :
+trimmer la liste du héros **avant** le dédup inter-sections relâche les articles
+éjectés vers les sections aval qui portent le même `contentId`.
 
-## Frontend (dépend du backend)
+## Changements
 
-- `feed/models/content_model.dart` : `Content.veilleGroup` (parse `json['group']`,
-  copyWith, clearNote) — backward-safe nullable.
-- `flux_continu/repositories/flux_continu_repository.dart` : passe `group` dans le JSON
-  Content normalisé.
-- `flux_continu/widgets/veille_group_header.dart` (nouveau) : `buildVeilleFeedRows()`
-  (en-têtes dérivés au rendu sur transitions de group) + `VeilleGroupHeader`.
-- `section_block.dart` + `theme_section_screen.dart` : en-têtes « Tes sources » /
-  « Couverture élargie » pour `SectionKind.veille` (pagination plate inchangée — lignes
-  reconstruites depuis la liste accumulée).
-- `veille/screens/veille_config_screen.dart` : modal « Épingler à ta Tournée ? » en fin de
-  **création** → insertion #1 (`markCustomized` + `setHidden(false)` +
-  `setOrder([veille, ...rest])`).
-- `veille/models/veille_config_dto.dart` : parse `last_article_at`/`recent_article_count`
-  + getter `healthWarning`.
+- **A. Footer auto-hide app-wide** : `footerVisibleProvider` + `AnimatedSlide`/
+  `IgnorePointer` sur `MainBottomNav` ; `_onScroll` (Essentiel + Flâner) ;
+  re-visible au changement d'onglet / scroll-to-top.
+- **B. Compaction légère** : héros `maxLines 5→4` (lead) / `4→3` (medium) + paddings
+  resserrés (pastille date/météo conservée) ; sticky `48→44` + `_kStickyBarHeight
+  54→50`.
+- **C. Fit dynamique** : `utils/section_fit.dart` (pur) ; `usableViewportHeightProvider`
+  écrit par l'écran (anti-boucle) ; `_compose` trim héros + cap sections aval
+  (`min(défaut, fit)`, plancher 1) ; `FeedThemeSection.copyWith` +param
+  `coreVisibleCount`.
+- **D. Filet** : `assert` debug dans `_recomputeSnapAnchors` qui logge toute
+  section multi-articles restée « tall ».
 
-### Tests frontend
-- `test/.../widgets/veille_group_header_test.dart` : transitions de group, backward-safe,
-  index préservé, rendu du libellé — **5 passent**.
-- `flutter analyze lib` : 0 erreur / 0 warning dans les fichiers touchés.
+## Tests
+- `section_fit_test.dart` (12) : bornes `fitVisibleCount`/`fitHeroCount` (3/2/1,
+  jamais 0 ; héros garde le lead).
+- `flux_continu_provider_test.dart` (+4) : trim héros, réapparition aval de l'id
+  éjecté, cap aval ≤ défaut & ≥ 1, `+N` correct, cap survit au dismiss, copyWith
+  préserve `coreVisibleCount`.
+- `section_block_test.dart` : `+N` à `coreVisibleCount` réduit (+ correction des
+  lambdas `onTapArticle` héritées de #787 → fichier re-compilable, net positif).
+- `flutter analyze` : 0 issue sur les fichiers touchés.
+- ⚠️ Échec pré-existant non lié : `essentiel_hi_fi_card_test` « flips to the
+  weather badge » (échoue déjà sur `main`).
 
-## Reporté (follow-up, hors de ce lot)
-- Badge santé **visuel** dans la source card (DTO `healthWarning` prêt) + champs texte
-  « Préciser » (why source / reason angle) dans step2/step3 — nécessite du state provider
-  dans des écrans de 900+ lignes.
-- Expansion EN des mots-clés (`suggest_angles`) — PR-3 légère derrière flag.
+## QA visuelle
+Voir `.context/qa-handoff.md` — Chrome/Playwright **390×844** ET **360×640**
+(cartes ≤ écran, footer slide, snap+haptique non régressés).
 
-## Découpage proposé
-PR-1 backend (backward-safe) puis PR-2 frontend, OU un seul PR cohérent (PO préfère
-moins de PRs). À trancher au moment de la création.
+## Hors périmètre
+Grille / Citation / carte « Pour toi » / closing card (slivers virtuels) ; cartes
+article standard inchangées (choix PO « héros uniquement »).

--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,81 +1,67 @@
-# QA Handoff — Ajustements UX/UI de « L'Essentiel » (5 points)
+# QA Handoff — L'Essentiel : cartes ≤ écran + footer auto-hide
 
-> Rempli par l'agent dev. Input de `/validate-feature` (Chrome, viewport 390×844).
+> Story `docs/stories/core/9.5.essentiel-cards-fit-screen.md`. UI/visuel + feel
+> de scroll → validation Chrome obligatoire (viewport mobile, **2 tailles**).
 
 ## Feature développée
-5 frictions UX corrigées sur la page **L'Essentiel** (Flux Continu) et sa modal
-« Mes favoris » : carte de perso dédiée + inline lié au snap, Grille collée aux
-Actus, titres de sections plus clairs, thèmes livrables en onglet Flâner (modèle
-exclusif comme les sources), et cap max affiché entre parenthèses.
+Aucune carte du Flux Continu ne dépasse la hauteur utile de l'écran (héros trimmé
+3→2→1, sections cap dynamique, bouton « Tout lire » inclus) ; le footer
+(MainBottomNav) se masque au scroll vers le bas et revient au scroll vers le haut
+(comportement LinkedIn), partout dans l'app.
 
 ## PR associée
-[#798 — feat(flux-continu): ajustements UX de L'Essentiel](https://github.com/boujonlaurin-dotcom/facteur/pull/798)
+À créer (`/go`). Base **main**.
 
 ## Écrans impactés
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| L'Essentiel (Flux Continu) | `/` (flux continu) | Modifié |
-| Modal « Mes favoris » | bottom sheet (depuis l'Essentiel / Flâner) | Modifié |
-| Carte de perso | nouveau widget `PersonalisationCtaCard` | Nouveau |
+| L'Essentiel (Flux Continu) | `/flux-continu` | Modifié |
+| Flâner | `/flaner` | Modifié (footer auto-hide uniquement) |
 
-## Scénarios de test
+## Scénarios de test (viewport **390×844** ET **360×640**)
 
-### Scénario 1 — Compte non personnalisé : grande carte de perso
-**Parcours** :
-1. Compte neuf (`tournee_customized_v1` absent / faux).
-2. Ouvrir l'Essentiel.
-**Résultat attendu** : juste après le hero « L'Essentiel du jour », une **grande
-carte** « Personnalise ton Essentiel » avec l'illustration
-(`facteur_reparation_velo.png`) et le bouton **« Composer ma Tournée »**. L'inline
-discret « Gérer / Tes N favoris » n'apparaît PAS. Taper le bouton → ouvre la sheet
-« Mes favoris ».
+### Scénario 1 : Héros & sections ne dépassent jamais l'écran (happy path)
+1. Ouvrir L'Essentiel.
+2. Scroller carte par carte (snap).
+**Attendu** : chaque pile (héros « Ton Essentiel », Actus du jour, thèmes…) tient
+dans la hauteur utile, bouton « Lire plus / Tout lire » **visible et non couvert**.
+Aucune zone de **lecture libre interne** (pas de scroll fin *dans* une carte),
+aucun `_FreeReadEdgeFade` (dégradé bas) sur ces sections. Snap = 1 section/écran,
+haptique au franchissement (non régressée).
 
-### Scénario 2 — Compte personnalisé : inline lié au snap
-**Parcours** :
-1. Personnaliser la Tournée (ajouter/retirer un favori) puis revenir à l'Essentiel.
-2. Scroller (fling) à travers les sections.
-**Résultat attendu** : la grande carte disparaît ; l'**inline** « Gérer / Tes N
-favoris » réapparaît, embarqué en tête de la 1ʳᵉ section après le hero. Au snap, il
-n'est plus « sauté » entre deux blocs — il fait partie du bloc de cette section.
+### Scénario 2 : Trim du héros + réapparition aval
+1. Sur petit écran (360×640), observer le héros.
+**Attendu** : le héros affiche le lead + 1–2 médiums (pas 5). Les articles éjectés
+réapparaissent plus bas (digest/thème) si le même article y figure — jamais
+perdus.
 
-### Scénario 3 — Modal : Grille, titres, caps
-**Parcours** :
-1. Ouvrir « Mes favoris ».
-**Résultat attendu** :
-- Sections nommées **« BLOCS DE TA PAGE L'ESSENTIEL »** et **« ONGLETS DE TA PAGE
-  FLÂNER »**.
-- **« Actus & Mot du jour »** présent ; **« La Grille du jour »** n'est PAS un bloc
-  drag&drop.
-- Au-delà du cap, les traits affichent **« Hors Tournée du jour (5) »** et **« Hors
-  onglets (10) »**.
+### Scénario 3 : Footer auto-hide (LinkedIn)
+1. Scroller vers le **bas** → le footer glisse hors écran (~50px regagnés).
+2. Scroller vers le **haut** → le footer revient.
+3. Revenir tout en haut **ou** changer d'onglet → footer visible.
+**Attendu** : transition douce (220 ms), pas de footer « collé » masqué, le bas de
+carte (« Lire plus ») n'est jamais couvert. Même comportement sur Flâner.
 
-### Scénario 4 — Thème Essentiel ⇄ Flâner (modèle exclusif)
-**Parcours** :
-1. Dans « Mes favoris », sur un **thème** côté Essentiel, taper l'icône
-   « déplacer vers Flâner » (flèche bas).
-2. Fermer la modal, observer la barre d'onglets Flâner et la page Essentiel.
-**Résultat attendu** : le thème apparaît en **onglet Flâner** (taper l'onglet filtre
-le feed sur ce thème) et **disparaît des sections de l'Essentiel**. Le mouvement
-inverse (flèche haut, côté Flâner) le ramène dans l'Essentiel.
-
-### Scénario 5 — Cas limite : retrait d'un thème en mode Flâner
-**Parcours** :
-1. Thème en onglet Flâner → le retirer via la croix dans la modal.
-**Résultat attendu** : il disparaît des deux modes (clé retirée de `tournee_order_v1`
-et de `pinned_tabs_order_v1`), repasse en « suivi ». Pas de crash.
+### Scénario 4 : Console / réseau
+**Attendu** : pas d'erreur console, pas de 4xx/5xx inattendu. En debug, surveiller
+le log `[fit-net] section "…" dépasse l'écran` : **aucune occurrence** sur héros /
+digest / thème (sinon estimation `section_fit` à régler).
 
 ## Critères d'acceptation
-- [ ] Carte de perso (illustration + CTA) sous le hero quand non personnalisé.
-- [ ] Inline réapparaît une fois personnalisé et ne « saute » plus au snap.
-- [ ] Grille non draggable + libellé « Actus & Mot du jour ».
-- [ ] Titres « BLOCS DE TA PAGE L'ESSENTIEL » / « ONGLETS DE TA PAGE FLÂNER ».
-- [ ] Thème déplaçable Essentiel ⇄ Flâner (filtre feed OK, exclusion Essentiel OK).
-- [ ] Caps affichés « (5) » / « (10) ».
-- [ ] Console sans erreurs, réseau sans 4xx/5xx inattendus.
+- [ ] Aucune carte (héros inclus) ne dépasse la hauteur utile, bouton « Lire plus » dégagé.
+- [ ] `_tallSections` vide pour héros/digest/thème (pas de free-scroll interne / fade).
+- [ ] Héros trimmé sur petit écran ; article éjecté visible plus bas.
+- [ ] Footer glisse au scroll down, revient au scroll up / changement d'onglet.
+- [ ] Snap 1 section/écran + haptique non régressés.
+- [ ] Pastille date/météo du héros intacte.
 
-## Notes techniques
-- Aucun changement backend / migration / requête feed (le filtre thème existait
-  déjà via `setTheme`).
-- Tests : `manage_favorites_sheet_test`, `favorite_topic_tabs_test`,
-  `flux_continu_tournee_order_test`, nouveau `personalisation_cta_card_test` — verts.
-- 3 échecs pré-existants dans `essentiel_hi_fi_card_test` (weather badge, non liés).
+## Zones de risque
+- **Constantes d'estimation** `section_fit.dart` : si une section reste « tall »
+  (log `[fit-net]`) ou si le 3ᵉ est masqué alors qu'il y avait la place → régler
+  les constantes, **pas** les call sites.
+- **`_kStickyBarHeight = 50`** doit refléter la hauteur réelle du sticky (rangée
+  44 + track 4 + strip 2). S'il change, re-synchroniser.
+- Footer auto-hide partagé entre L'Essentiel et Flâner (même `StatefulShellRoute`).
+
+## Dépendances
+Aucun endpoint backend touché. 100 % frontend (Flutter).

--- a/apps/mobile/lib/core/providers/navigation_providers.dart
+++ b/apps/mobile/lib/core/providers/navigation_providers.dart
@@ -12,3 +12,23 @@ final feedScrollTriggerProvider = StateProvider<int>((ref) => 0);
 /// Miroir de [feedScrollTriggerProvider] : incrémenté par `MainShell` au re-tap
 /// de l'onglet actif, écouté par `FluxContinuScreen`.
 final essentielScrollTriggerProvider = StateProvider<int>((ref) => 0);
+
+/// Visibilité du footer (MainBottomNav) — masqué au scroll vers le bas, révélé
+/// au scroll vers le haut, partout dans l'app (comportement LinkedIn).
+///
+/// Écrit par les écrans scrollables (`FluxContinuScreen`, `FlanerScreen`) dans
+/// leur `_onScroll` ; lu par `MainTabPageScaffold` qui glisse la barre hors
+/// écran (`AnimatedSlide` + `IgnorePointer`). Reconquiert ~50px + safe-area en
+/// lecture et garantit que le bas de carte (« Lire plus ») n'est jamais couvert
+/// par le footer. Toujours remis à `true` au changement d'onglet / retour haut
+/// pour qu'il ne reste pas « collé » masqué.
+final footerVisibleProvider = StateProvider<bool>((ref) => true);
+
+/// Met à jour [footerVisibleProvider] uniquement sur un vrai changement (le
+/// footer partagé le lit via `MainTabPageScaffold`). Appelé depuis les
+/// `_onScroll` des écrans scrollables (`FluxContinuScreen`, `FlanerScreen`) :
+/// le no-op quand inchangé évite d'écrire à chaque frame de scroll.
+void updateFooterVisibility(WidgetRef ref, bool visible) {
+  final notifier = ref.read(footerVisibleProvider.notifier);
+  if (notifier.state != visible) notifier.state = visible;
+}

--- a/apps/mobile/lib/features/feed/screens/flaner_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/flaner_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -27,7 +26,6 @@ import '../widgets/pin_subjects_sheet.dart';
 
 const double _kLoadMoreLeadingPx = 800.0;
 const double _kScrollDirThreshold = 12.0;
-const double _kFabHideAboveScroll = 380.0;
 
 /// Sous ce seuil le footer reste révélé même en scrollant vers le bas
 /// (on est effectivement « près du sommet »).
@@ -44,7 +42,6 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
   final ScrollController _scroll = ScrollController();
   final Set<String> _visibleContentIds = <String>{};
   bool _loadingMore = false;
-  bool _showScrollTopFab = false;
   double _lastScrollPos = 0;
 
   @override
@@ -67,17 +64,6 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
 
     final delta = currentScroll - _lastScrollPos;
     if (delta.abs() >= _kScrollDirThreshold) {
-      bool nextFab = _showScrollTopFab;
-      if (currentScroll < _kFabHideAboveScroll) {
-        nextFab = false;
-      } else if (delta < 0) {
-        nextFab = true;
-      } else if (delta > 0) {
-        nextFab = false;
-      }
-      if (nextFab != _showScrollTopFab) {
-        setState(() => _showScrollTopFab = nextFab);
-      }
       // Footer auto-hide (app-wide) : les deux branches du StatefulShellRoute
       // partagent ce footer → même logique que L'Essentiel.
       updateFooterVisibility(
@@ -154,23 +140,6 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
                 onRetry: () => ref.read(feedProvider.notifier).refresh(),
               ),
               data: (state) => _buildContent(context, state),
-            ),
-            Positioned(
-              right: 16,
-              bottom: 24,
-              child: SafeArea(
-                child: AnimatedSlide(
-                  duration: const Duration(milliseconds: 220),
-                  curve: Curves.easeOutCubic,
-                  offset:
-                      _showScrollTopFab ? Offset.zero : const Offset(0, 1.6),
-                  child: AnimatedOpacity(
-                    duration: const Duration(milliseconds: 220),
-                    opacity: _showScrollTopFab ? 1.0 : 0.0,
-                    child: _ScrollToTopButton(onTap: _scrollToTop),
-                  ),
-                ),
-              ),
             ),
           ],
         ),
@@ -438,53 +407,6 @@ class _LoadingMoreIndicator extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _ScrollToTopButton extends StatelessWidget {
-  final VoidCallback onTap;
-
-  const _ScrollToTopButton({required this.onTap});
-
-  static const _kRadius = BorderRadius.all(Radius.circular(22));
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.facteurColors;
-    final isDark = context.isDarkMode;
-    final fillColor = isDark
-        ? colors.backgroundPrimary.withValues(alpha: 0.78)
-        : const Color.fromRGBO(242, 232, 213, 0.82);
-    final borderColor = isDark
-        ? Colors.white.withValues(alpha: 0.10)
-        : const Color.fromRGBO(0, 0, 0, 0.08);
-
-    return ClipRRect(
-      borderRadius: _kRadius,
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: onTap,
-            borderRadius: _kRadius,
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-              decoration: BoxDecoration(
-                color: fillColor,
-                borderRadius: _kRadius,
-                border: Border.all(color: borderColor),
-              ),
-              child: Icon(
-                Icons.keyboard_arrow_up_rounded,
-                color: colors.textPrimary,
-                size: 24,
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/screens/flaner_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/flaner_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollDirection;
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -25,7 +26,6 @@ import '../widgets/follow_keyword_suggestion_card.dart';
 import '../widgets/pin_subjects_sheet.dart';
 
 const double _kLoadMoreLeadingPx = 800.0;
-const double _kScrollDirThreshold = 12.0;
 
 /// Sous ce seuil le footer reste révélé même en scrollant vers le bas
 /// (on est effectivement « près du sommet »).
@@ -42,7 +42,6 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
   final ScrollController _scroll = ScrollController();
   final Set<String> _visibleContentIds = <String>{};
   bool _loadingMore = false;
-  double _lastScrollPos = 0;
 
   @override
   void initState() {
@@ -62,15 +61,16 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
     final pos = _scroll.position;
     final currentScroll = pos.pixels;
 
-    final delta = currentScroll - _lastScrollPos;
-    if (delta.abs() >= _kScrollDirThreshold) {
-      // Footer auto-hide (app-wide) : les deux branches du StatefulShellRoute
-      // partagent ce footer → même logique que L'Essentiel.
-      updateFooterVisibility(
-        ref,
-        delta < 0 || currentScroll < _kFooterRevealNearTop,
-      );
-      _lastScrollPos = currentScroll;
+    // Footer auto-hide (app-wide) : ne se cache QUE sur un scroll-down
+    // utilisateur réel (`userScrollDirection`), pas sur un delta de position —
+    // sinon un ré-ajustement programmatique du scroll masquerait le footer sans
+    // intention de l'utilisateur. Même logique que L'Essentiel.
+    if (currentScroll < _kFooterRevealNearTop) {
+      updateFooterVisibility(ref, true);
+    } else if (pos.userScrollDirection == ScrollDirection.reverse) {
+      updateFooterVisibility(ref, false);
+    } else if (pos.userScrollDirection == ScrollDirection.forward) {
+      updateFooterVisibility(ref, true);
     }
 
     if (pos.maxScrollExtent - currentScroll >= _kLoadMoreLeadingPx) return;

--- a/apps/mobile/lib/features/feed/screens/flaner_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/flaner_screen.dart
@@ -29,6 +29,10 @@ const double _kLoadMoreLeadingPx = 800.0;
 const double _kScrollDirThreshold = 12.0;
 const double _kFabHideAboveScroll = 380.0;
 
+/// Sous ce seuil le footer reste révélé même en scrollant vers le bas
+/// (on est effectivement « près du sommet »).
+const double _kFooterRevealNearTop = 60.0;
+
 class FlanerScreen extends ConsumerStatefulWidget {
   const FlanerScreen({super.key});
 
@@ -74,6 +78,12 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
       if (nextFab != _showScrollTopFab) {
         setState(() => _showScrollTopFab = nextFab);
       }
+      // Footer auto-hide (app-wide) : les deux branches du StatefulShellRoute
+      // partagent ce footer → même logique que L'Essentiel.
+      updateFooterVisibility(
+        ref,
+        delta < 0 || currentScroll < _kFooterRevealNearTop,
+      );
       _lastScrollPos = currentScroll;
     }
 
@@ -111,6 +121,7 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
   Future<void> _scrollToTop() async {
     if (!_scroll.hasClients) return;
     unawaited(HapticFeedback.lightImpact());
+    updateFooterVisibility(ref, true);
     await _scroll.animateTo(
       0,
       duration: const Duration(milliseconds: 700),

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -295,12 +295,17 @@ class FeedThemeSection extends FluxSection {
     int? currentPage,
     bool? hasMore,
     bool? isLoadingMore,
+    // Story « cartes ≤ écran » : le compte d'affichage fitté (min(défaut, fit))
+    // est porté par la section. Sans ce paramètre, le dédup/`_filterSections`/
+    // `loadMoreTheme` (qui recopient via copyWith) réinitialiseraient le compte
+    // au défaut à chaque recompose — le piège le plus facile à introduire.
+    int? coreVisibleCount,
   }) {
     return FeedThemeSection(
       kind: kind,
       label: label,
       accent: accent,
-      coreVisibleCount: coreVisibleCount,
+      coreVisibleCount: coreVisibleCount ?? this.coreVisibleCount,
       items: items ?? this.items,
       themeSlug: themeSlug,
       customTopicId: customTopicId,

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -32,6 +32,7 @@ import '../repositories/flux_continu_repository.dart';
 import '../services/flux_continu_cache_service.dart';
 import '../services/tournee_progress_service.dart';
 import '../utils/notif_teasers.dart';
+import '../utils/section_fit.dart';
 import '../utils/theme_color_mapping.dart';
 import 'tournee_order_prefs_provider.dart'; // tourneeOrderPrefsProvider, TourneeOrderState, applyOrder (réexporté)
 
@@ -77,6 +78,21 @@ const int _kMaxFavoriteSourceSections = 5;
 /// no subsequent page can exist regardless of what the backend's
 /// pagination.hasNext (computed from a pre-compression candidate count) says.
 const int _kThemeSectionPageLimit = 10;
+
+/// Usable scroll height (px) of the Flux Continu viewport, threaded from
+/// [FluxContinuScreen] (the only place that can measure it post-layout):
+/// ```
+/// usableViewportHeight = scrollViewportHeight − safeAreaBottom − kStickyBarHeight
+/// ```
+/// — the **exact same budget** the section snap uses to decide whether a
+/// section is "tall". `null` on the first frame (no measure yet) ⇒ the provider
+/// keeps the default visible counts and recomposes once the measure lands
+/// (masked by the loading skeleton). The screen writes it only when the rounded
+/// value changes (anti-boucle). Consumed by [FluxContinuNotifier._compose] to
+/// trim the hero and cap each downstream section so no card stack ever exceeds
+/// the screen. The footer auto-hide does **not** change this budget (the snap
+/// already subtracts only `safeAreaBottom`, not the footer height).
+final usableViewportHeightProvider = StateProvider<double?>((ref) => null);
 
 /// Riverpod provider for the Flux Continu V1.8 home screen.
 ///
@@ -143,6 +159,16 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       if (prev?.enabled != next.enabled && state.hasValue) {
         ref.invalidateSelf();
       }
+    });
+
+    // La hauteur utile mesurée par l'écran pilote le « combien d'articles
+    // tiennent » (trim héros + cap des sections aval). On recompose à chaque
+    // changement, comme pour le toggle sérène — un simple recompose suffit, les
+    // sections sont déjà fetchées (on ne refait que le découpage d'affichage).
+    ref.listen<double?>(usableViewportHeightProvider, (prev, next) {
+      if (prev == next) return;
+      if (!state.hasValue) return;
+      state = AsyncData(_compose(ref.read(sereinToggleProvider).enabled));
     });
 
     // React to favorite reorders / additions / removals without rebuilding
@@ -377,13 +403,25 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       order: tournee.order,
     );
 
+    // « Cartes ≤ écran » : décidé côté provider par estimation conservatrice
+    // (pas de mesure runtime qui pilote le rendu). `null` au 1ᵉʳ frame ⇒ on
+    // garde les défauts, on recompose à l'arrivée de la mesure.
+    final usableHeight = ref.read(usableViewportHeightProvider);
+
     final rawOrdered = <FluxSection>[
-      if (_essentiel != null) _essentiel!,
+      // Héros trimmé AVANT le dédup : les articles éjectés ne sont jamais
+      // ajoutés à `seen` par [_dedupeSectionsInOrder] → ils sont relâchés vers
+      // les sections aval (digest/thème) qui portent le même contentId. Aucune
+      // plomberie de feedback à écrire — c'est « gratuit » via le dédup ordonné.
+      if (_essentiel != null) _fitHeroSection(_essentiel!, usableHeight),
       for (final key in orderedKeys)
         if (key != kTourneeGrilleKey && sectionByKey[key] != null)
           sectionByKey[key]!,
     ];
-    final finalSections = _dedupeSectionsInOrder(_filterSections(rawOrdered));
+    final finalSections = _capSectionsToFit(
+      _dedupeSectionsInOrder(_filterSections(rawOrdered)),
+      usableHeight,
+    );
     final grilleSlotIndex = _resolveGrilleSlotIndex(
       orderedKeys: orderedKeys,
       finalSections: finalSections,
@@ -411,6 +449,73 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       quote: _quote,
       isLoading: false,
     );
+  }
+
+  /// Trims the hero (« Ton Essentiel ») to the number of articles that fit the
+  /// usable viewport, keeping the lead. Returns the section untouched when the
+  /// height isn't measured yet (`null`) or everything already fits. The lead is
+  /// never dropped. The ejected articles leave the hero's `articles` list, so
+  /// the dedup downstream no longer claims them (cf. [_compose] rawOrdered).
+  FluxSection _fitHeroSection(FluxSection essentiel, double? usableHeight) {
+    if (essentiel is! EssentielSection || usableHeight == null) {
+      return essentiel;
+    }
+    final len = essentiel.articles.length;
+    final maxCount = len < 5 ? len : 5;
+    if (maxCount <= 1) return essentiel;
+    final fit = fitHeroCount(
+      usableHeight: usableHeight,
+      chromeHeight: kHeroChromeHeight,
+      leadHeight: kHeroLeadHeight,
+      mediumHeight: kHeroMediumHeight,
+      maxCount: maxCount,
+    );
+    if (fit >= len) return essentiel;
+    // Reconstruit comme [_filterSections]/[_dedupeSectionsInOrder] : seuls
+    // articles/blurb/illustration sont portés (label/accent = défauts canon).
+    return EssentielSection(
+      articles: essentiel.articles.take(fit).toList(growable: false),
+      blurb: essentiel.blurb,
+      illustrationAsset: essentiel.illustrationAsset,
+    );
+  }
+
+  /// Caps each downstream section's `coreVisibleCount` to what fits the usable
+  /// viewport (`min(défaut, fitVisibleCount)`, plancher 1). The defaults stay
+  /// the **ceiling** — fit can only reduce. No-op when the height isn't measured
+  /// yet. The hero is handled upstream (trim de la liste), so it passes through.
+  List<FluxSection> _capSectionsToFit(
+    List<FluxSection> sections,
+    double? usableHeight,
+  ) {
+    if (usableHeight == null) return sections;
+    return [for (final s in sections) _capSectionToFit(s, usableHeight)];
+  }
+
+  FluxSection _capSectionToFit(FluxSection s, double usableHeight) {
+    if (s is EssentielSection) return s;
+    final hasBlurb = s.blurb?.trim().isNotEmpty ?? false;
+    final fitCap = fitVisibleCount(
+      usableHeight: usableHeight,
+      bannerHeight: hasBlurb ? kBannerHeightWithBlurb : kBannerHeightNoBlurb,
+      footerHeight: kSectionFooterHeight,
+      cardHeight: estimateRegularCardHeight(),
+      maxCount: s.coreVisibleCount,
+    );
+    if (fitCap >= s.coreVisibleCount) return s;
+    return switch (s) {
+      EssentielSection() => s,
+      DigestTopicSection() => DigestTopicSection(
+          kind: s.kind,
+          label: s.label,
+          accent: s.accent,
+          coreVisibleCount: fitCap,
+          blurb: s.blurb,
+          illustrationAsset: s.illustrationAsset,
+          topics: s.topics,
+        ),
+      FeedThemeSection() => s.copyWith(coreVisibleCount: fitCap),
+    };
   }
 
   /// Fires the backend "hide" API for the article without touching local

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -61,10 +61,6 @@ const double _kStickyBarHeight = 50.0;
 // arithmetic stays a pure, unit-testable function. The snap itself is woven
 // into the fling's ballistic phase by [_SectionSnapPhysics] below.
 
-/// Minimum delta (px) before the footer auto-hide toggles, to avoid flicker
-/// on tiny inertia bounces. Matches the legacy FeedScreen behaviour.
-const double _kScrollDirThreshold = 12.0;
-
 /// Min depth (px) the user must reach before we surface the
 /// pull-to-refresh hint pill — avoids nudging after a tiny inertia scroll.
 const double _kPullHintMinDepthPx = 800.0;
@@ -169,7 +165,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   /// `confirmDismiss` or `undoHide` on the provider.
   final Set<String> _pendingFeedback = <String>{};
 
-  double _lastScrollPos = 0;
   int _passagePulseSequence = 0;
 
   /// Mutable, stable holder of the section-start anchors (absolute scroll
@@ -269,18 +264,19 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       _maxScrollDepthPx = currentScroll;
     }
 
-    // Scroll-up FAB: surfaces when the user reverses direction above the
-    // hide threshold, hides on scroll-down or near the top. Same logic the
-    // legacy feed used so the UX feels identical between the two screens.
-    final delta = currentScroll - _lastScrollPos;
-    if (delta.abs() >= _kScrollDirThreshold) {
-      // Footer auto-hide (app-wide) : visible vers le haut / près du sommet,
-      // caché vers le bas.
-      updateFooterVisibility(
-        ref,
-        delta < 0 || currentScroll < _kStickyThreshold,
-      );
-      _lastScrollPos = currentScroll;
+    // Footer auto-hide (app-wide) : ne se cache QUE sur un scroll-down
+    // utilisateur réel. On lit `userScrollDirection` (et non un delta de
+    // position) car le snap est une activité balistique qui conserve la
+    // dernière direction utilisateur : un settle qui ré-ajuste la carte vers le
+    // bas après un scroll-up reste `forward` → le footer ne disparaît jamais
+    // tant que l'utilisateur n'a pas effectivement scrollé vers le bas. `idle`
+    // (settle terminé / programmatique) ne touche pas à la visibilité.
+    if (currentScroll < _kStickyThreshold) {
+      updateFooterVisibility(ref, true);
+    } else if (pos.userScrollDirection == ScrollDirection.reverse) {
+      updateFooterVisibility(ref, false);
+    } else if (pos.userScrollDirection == ScrollDirection.forward) {
+      updateFooterVisibility(ref, true);
     }
 
     // Pull-to-refresh hint pill — discoverability cue when the user scrolls

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -52,10 +52,11 @@ const double _kStickyThreshold = 60.0;
 
 /// Vertical offset the sticky bar consumes — used as a landing buffer
 /// when scrolling a section into view so its banner doesn't disappear
-/// behind the bar. Trimmed from 90 → 54 after the head title (~36px) was
-/// dropped from the sticky overlay: tabs row (48) + progress track (4) + a
-/// couple px of slack.
-const double _kStickyBarHeight = 54.0;
+/// behind the bar. Trimmed 90 → 54 (head title dropped) then 54 → 50 after the
+/// tabs row was compacted 48 → 44 (« cartes ≤ écran »): tabs row (44) + progress
+/// track (4) + refresh strip (2). **Must mirror the real sticky bar height** —
+/// it feeds the snap framing AND the fit budget ([usableViewportHeightProvider]).
+const double _kStickyBarHeight = 50.0;
 
 // Section-snap tuning lives in `utils/section_snap.dart` (kSnapCaptureFraction,
 // kBoundaryCrossVelocity, kSnapEpsilon, kSnapSpring) so the resting-position
@@ -291,6 +292,12 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       if (nextFab != _showScrollTopFab) {
         setState(() => _showScrollTopFab = nextFab);
       }
+      // Footer auto-hide (app-wide) : visible vers le haut / près du sommet,
+      // caché vers le bas. Même seuil directionnel que le FAB.
+      updateFooterVisibility(
+        ref,
+        delta < 0 || currentScroll < _kStickyThreshold,
+      );
       _lastScrollPos = currentScroll;
     }
 
@@ -478,6 +485,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     // footer bar + bottom safe-area, else the last cards (« Lire plus ») are
     // truncated.
     final visibleBottom = scrollBox.size.height - _safeAreaBottom;
+    // « Estimer pour contrôler, mesurer pour vérifier » : on publie le budget
+    // de hauteur utile (identique à la frontière tall/free du snap ci-dessous)
+    // pour que le provider décide combien d'articles tiennent. Anti-boucle :
+    // écriture seulement si la valeur arrondie change.
+    _publishUsableHeight(visibleBottom - _kStickyBarHeight);
     final result = <SectionFrame>[];
     _dotIndexByTop.clear();
     final tall = <int>{};
@@ -511,6 +523,37 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     if (!setEquals(_tallSections.value, tall)) {
       _tallSections.value = tall;
     }
+    // Filet de vérification (pas de pilotage) : en debug, signale toute section
+    // multi-articles qui reste « tall » malgré le fit côté provider — c'est le
+    // symptôme d'une estimation `section_fit` trop généreuse (constantes à
+    // régler). `_FreeReadEdgeFade` ne devrait plus jamais s'afficher dessus.
+    assert(() {
+      if (tall.isEmpty) return true;
+      final sections = ref.read(fluxContinuProvider).valueOrNull?.sections;
+      if (sections == null) return true;
+      for (final idx in tall) {
+        if (idx < 0 || idx >= sections.length) continue;
+        debugPrint(
+          '[fit-net] section "${sections[idx].label}" dépasse l\'écran '
+          '(reste tall) — estimation section_fit trop généreuse, à régler.',
+        );
+      }
+      return true;
+    }());
+  }
+
+  /// Threads the measured usable scroll height to [usableViewportHeightProvider]
+  /// so the provider can decide how many articles each section may show. Same
+  /// budget the snap uses (viewport − safe-area-bottom − sticky bar). Anti-boucle :
+  /// only writes when the rounded value actually moves, so the provider recompose
+  /// it triggers (→ screen rebuild → this runs again, same value) terminates.
+  void _publishUsableHeight(double height) {
+    if (height <= 0) return;
+    final rounded = height.roundToDouble();
+    final notifier = ref.read(usableViewportHeightProvider.notifier);
+    final current = notifier.state;
+    if (current != null && (current - rounded).abs() < 1.0) return;
+    notifier.state = rounded;
   }
 
   /// Defers an anchor recompute to the next post-frame (when layout is settled),
@@ -581,6 +624,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   Future<void> _scrollToTop() async {
     if (!_scroll.hasClients) return;
     unawaited(HapticFeedback.lightImpact());
+    // Remonter doit toujours révéler le footer (jamais « collé » masqué).
+    updateFooterVisibility(ref, true);
     await _scroll.animateTo(
       0,
       duration: const Duration(milliseconds: 900),

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:math' as math;
-import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/foundation.dart'
     show ValueListenable, defaultTargetPlatform, setEquals, TargetPlatform;
@@ -9,7 +8,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:haptic_feedback/haptic_feedback.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
@@ -63,13 +61,9 @@ const double _kStickyBarHeight = 50.0;
 // arithmetic stays a pure, unit-testable function. The snap itself is woven
 // into the fling's ballistic phase by [_SectionSnapPhysics] below.
 
-/// Minimum delta (px) before the scroll-up FAB toggles, to avoid flicker
+/// Minimum delta (px) before the footer auto-hide toggles, to avoid flicker
 /// on tiny inertia bounces. Matches the legacy FeedScreen behaviour.
 const double _kScrollDirThreshold = 12.0;
-
-/// Below this scroll offset, the scroll-up FAB stays hidden even when the
-/// user reverses direction (we're effectively already at the top).
-const double _kFabHideAboveScroll = 380.0;
 
 /// Min depth (px) the user must reach before we surface the
 /// pull-to-refresh hint pill — avoids nudging after a tiny inertia scroll.
@@ -175,7 +169,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   /// `confirmDismiss` or `undoHide` on the provider.
   final Set<String> _pendingFeedback = <String>{};
 
-  bool _showScrollTopFab = false;
   double _lastScrollPos = 0;
   int _passagePulseSequence = 0;
 
@@ -281,19 +274,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     // legacy feed used so the UX feels identical between the two screens.
     final delta = currentScroll - _lastScrollPos;
     if (delta.abs() >= _kScrollDirThreshold) {
-      bool nextFab = _showScrollTopFab;
-      if (currentScroll < _kFabHideAboveScroll) {
-        nextFab = false;
-      } else if (delta < 0) {
-        nextFab = true;
-      } else if (delta > 0) {
-        nextFab = false;
-      }
-      if (nextFab != _showScrollTopFab) {
-        setState(() => _showScrollTopFab = nextFab);
-      }
       // Footer auto-hide (app-wide) : visible vers le haut / près du sommet,
-      // caché vers le bas. Même seuil directionnel que le FAB.
+      // caché vers le bas.
       updateFooterVisibility(
         ref,
         delta < 0 || currentScroll < _kStickyThreshold,
@@ -916,25 +898,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
               tabs: stickyTabs,
               onTapTab: _scrollToSection,
               tabsController: _tabsScroll,
-            ),
-            // Floating "back to top" button — reveals on upward scroll above
-            // the hide threshold, fades down on reverse / near top.
-            Positioned(
-              right: 16,
-              bottom: 24,
-              child: SafeArea(
-                child: AnimatedSlide(
-                  duration: const Duration(milliseconds: 220),
-                  curve: Curves.easeOutCubic,
-                  offset:
-                      _showScrollTopFab ? Offset.zero : const Offset(0, 1.6),
-                  child: AnimatedOpacity(
-                    duration: const Duration(milliseconds: 220),
-                    opacity: _showScrollTopFab ? 1.0 : 0.0,
-                    child: _ScrollToTopButton(onTap: _scrollToTop),
-                  ),
-                ),
-              ),
             ),
             // Pull-to-refresh discoverability pill.
             Positioned(
@@ -1595,79 +1558,6 @@ class _StickyHostOverlay extends StatelessWidget {
             ),
           );
         },
-      ),
-    );
-  }
-}
-
-class _ScrollToTopButton extends StatelessWidget {
-  final VoidCallback onTap;
-
-  const _ScrollToTopButton({required this.onTap});
-
-  static const _kRadius = BorderRadius.all(Radius.circular(22));
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.facteurColors;
-    final isDark = context.isDarkMode;
-    // Same liquidglass mix as StickyBackdrop so the pill reads as part of the
-    // same surface family (parchment in light, dark-surface tint in dark).
-    final fillColor = isDark
-        ? colors.backgroundPrimary.withValues(alpha: 0.78)
-        : const Color.fromRGBO(242, 232, 213, 0.82);
-    final borderColor = isDark
-        ? Colors.white.withValues(alpha: 0.10)
-        : const Color.fromRGBO(0, 0, 0, 0.08);
-
-    return ClipRRect(
-      borderRadius: _kRadius,
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            borderRadius: _kRadius,
-            onTap: onTap,
-            child: Container(
-              height: 44,
-              padding: const EdgeInsets.symmetric(horizontal: 14),
-              decoration: BoxDecoration(
-                color: fillColor,
-                borderRadius: _kRadius,
-                border: Border.all(color: borderColor, width: 1),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.10),
-                    blurRadius: 12,
-                    spreadRadius: -4,
-                    offset: const Offset(0, 4),
-                  ),
-                ],
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    PhosphorIcons.caretUp(PhosphorIconsStyle.bold),
-                    size: 16,
-                    color: colors.textPrimary,
-                  ),
-                  const SizedBox(width: 6),
-                  Text(
-                    'Remonter',
-                    style: GoogleFonts.dmSans(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      letterSpacing: -0.1,
-                      color: colors.textPrimary,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/flux_continu/utils/section_fit.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_fit.dart
@@ -24,13 +24,14 @@ library;
 
 // ── Regular section (banner + N article cards + « Tout lire » footer) ─────────
 
-/// Conservative height (px) of one regular article card
-/// ([FluxContinuArticleCard]) with its title at the 4-line ellipsis ceiling.
-/// Breakdown: outer padding (0+12) + inner padding (14+14) + title 4 lines
-/// (DM Sans 18 · height 1.3 ≈ 94) + gap 10 + footer row ≈ 20. The 78px thumb
-/// floors the head row, so a short-title card is never shorter than this minus
-/// the title slack — kept generous on purpose (overestimate ⇒ fit, never spill).
-const double kRegularCardHeight = 164;
+/// Realistic height (px) of one regular article card
+/// ([FluxContinuArticleCard]). The 78px thumbnail **floors the head row**, so a
+/// typical ≤3-line title is dominated by the thumb, not the text — modelling the
+/// 4-line worst case (the old 164) over-cut articles and left screens too empty.
+/// Breakdown: outer padding (0+12) + inner padding (14+14) + thumb-floored head
+/// row 78 + gap 10 + footer row ≈ 20 = 148. A rare 4-line title spills a few px
+/// past this; the runtime snap net (`[fit-net]`) flags it if it ever does.
+const double kRegularCardHeight = 148;
 
 /// Banner height (px) for a section **without** a blurb (theme / source):
 /// `minHeight 60` + vertical margin (3+5).
@@ -52,15 +53,17 @@ const double kSectionFooterHeight = 70;
 /// post-compaction) + the SectionBlock trailing 16px gap.
 const double kHeroChromeHeight = 208;
 
-/// Lead tile height (px), title at the 4-line ceiling (post-compaction):
-/// padding (12+12) + chips row ≈ 22 + gap 8 + title 4 lines (Fraunces 19 ·
-/// height 1.3 ≈ 99) + gap 8 + source row ≈ 20.
-const double kHeroLeadHeight = 181;
+/// Lead tile height (px), title at a **realistic 3-line height** (post-compaction)
+/// rather than the 4-line worst case (the old 181, which over-cut the hero):
+/// padding (12+12) + chips row ≈ 22 + gap 8 + title 3 lines (Fraunces 19 ·
+/// height 1.3 ≈ 74) + gap 8 + source row ≈ 20 = 160.
+const double kHeroLeadHeight = 160;
 
-/// One medium tile height (px) **including its hairline separators**, title at
-/// the 3-line ceiling (post-compaction): gaps 8+0.6+8 + tile (pad 4 + meta row
-/// 18 + gap 4 + title 3 lines Fraunces 16 · height 1.3 ≈ 62).
-const double kHeroMediumHeight = 105;
+/// One medium tile height (px) **including its hairline separators**, title at a
+/// **realistic 2-line height** (post-compaction) rather than the 3-line worst
+/// case (the old 105): gaps 8+0.6+8 + tile (pad 4 + meta row 18 + gap 4 + title
+/// 2 lines Fraunces 16 · height 1.3 ≈ 42) ≈ 88.
+const double kHeroMediumHeight = 88;
 
 /// Conservative height of one regular article card. Exposed as a function (not
 /// just the constant) so call sites read intent and a future per-card refinement

--- a/apps/mobile/lib/features/flux_continu/utils/section_fit.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_fit.dart
@@ -1,0 +1,115 @@
+/// Pure, unit-testable height-budget estimator deciding **how many articles a
+/// Flux Continu section may show so its rendered stack never exceeds the usable
+/// viewport** — the data-layer half of « estimer pour contrôler, mesurer pour
+/// vérifier ». Calqué sur `section_snap.dart` : arithmétique seule, aucun
+/// binding Flutter, donc testable sans le bootstrap Hive/Supabase du widget
+/// suite.
+///
+/// Conservative by design: every estimate assumes each title at its `maxLines`
+/// ceiling, so the function needs **one** input from the layout (the usable
+/// height) — no width, no font measurement. Consequence accepted by the PO: on
+/// a very small screen a section can drop to 2 (or 1); on a normal phone 3
+/// always holds. The runtime measure (`_recomputeSnapAnchors` / `_tallSections`)
+/// then confirms in QA that no card overflows — if the estimate is too strict
+/// (hides the 3rd when there was room) the constants below are the knobs to
+/// tune, never the call sites.
+///
+/// **Budget identique au snap** (sinon estimation et mesure divergent) :
+/// ```
+/// usableHeight = scrollViewportHeight − safeAreaBottom − kStickyBarHeight
+/// ```
+/// (cf. `_recomputeSnapAnchors` : une section est « tall » exactement quand sa
+/// hauteur dépasse cette même valeur.)
+library;
+
+// ── Regular section (banner + N article cards + « Tout lire » footer) ─────────
+
+/// Conservative height (px) of one regular article card
+/// ([FluxContinuArticleCard]) with its title at the 4-line ellipsis ceiling.
+/// Breakdown: outer padding (0+12) + inner padding (14+14) + title 4 lines
+/// (DM Sans 18 · height 1.3 ≈ 94) + gap 10 + footer row ≈ 20. The 78px thumb
+/// floors the head row, so a short-title card is never shorter than this minus
+/// the title slack — kept generous on purpose (overestimate ⇒ fit, never spill).
+const double kRegularCardHeight = 164;
+
+/// Banner height (px) for a section **without** a blurb (theme / source):
+/// `minHeight 60` + vertical margin (3+5).
+const double kBannerHeightNoBlurb = 68;
+
+/// Banner height (px) for a section **with** a blurb (Actus du jour, Bonnes
+/// Nouvelles, veille): `minHeight 92` + vertical margin (3+5).
+const double kBannerHeightWithBlurb = 100;
+
+/// Footer height (px): the always-present "Tout lire (+N)" CTA (≈54) plus the
+/// section's trailing 16px gap.
+const double kSectionFooterHeight = 70;
+
+// ── Hero card (« Ton Essentiel » — lead + up to 4 mediums) ────────────────────
+
+/// Non-tile chrome of the hi-fi hero card (px): card margins (8+16) + container
+/// padding (12+12, post-compaction) + the fixed 132px date/weather badge slot
+/// that drives the header height (kept per PO) + header→lead gap (12,
+/// post-compaction) + the SectionBlock trailing 16px gap.
+const double kHeroChromeHeight = 208;
+
+/// Lead tile height (px), title at the 4-line ceiling (post-compaction):
+/// padding (12+12) + chips row ≈ 22 + gap 8 + title 4 lines (Fraunces 19 ·
+/// height 1.3 ≈ 99) + gap 8 + source row ≈ 20.
+const double kHeroLeadHeight = 181;
+
+/// One medium tile height (px) **including its hairline separators**, title at
+/// the 3-line ceiling (post-compaction): gaps 8+0.6+8 + tile (pad 4 + meta row
+/// 18 + gap 4 + title 3 lines Fraunces 16 · height 1.3 ≈ 62).
+const double kHeroMediumHeight = 105;
+
+/// Conservative height of one regular article card. Exposed as a function (not
+/// just the constant) so call sites read intent and a future per-card refinement
+/// has a single seam.
+double estimateRegularCardHeight() => kRegularCardHeight;
+
+/// Largest article count in `[minCount, maxCount]` whose stack
+/// (`bannerHeight + count·cardHeight + footerHeight`) fits within
+/// [usableHeight]. **Never returns 0** — a section always shows at least
+/// [minCount] card even when nothing fits (the snap then treats it as a tall
+/// section and the QA net flags it). [maxCount] is the section's default cap
+/// kept as a **ceiling**: fit can only reduce it, never grow it.
+int fitVisibleCount({
+  required double usableHeight,
+  required double bannerHeight,
+  required double footerHeight,
+  required double cardHeight,
+  required int maxCount,
+  int minCount = 1,
+}) {
+  final lo = minCount < 1 ? 1 : minCount;
+  if (maxCount <= lo) return lo;
+  if (cardHeight <= 0) return lo;
+  final budget = usableHeight - bannerHeight - footerHeight;
+  if (budget <= 0) return lo;
+  final fit = (budget / cardHeight).floor();
+  return fit.clamp(lo, maxCount);
+}
+
+/// Number of articles the hero card may show so it fits within [usableHeight].
+/// The **lead is mandatory** (result ≥ 1, ≥ [minCount]); each additional
+/// article is a medium tile. Capped by [maxCount] (typically
+/// `min(5, articles.length)`). Ejected articles are dropped from the hero's
+/// list **before** the inter-section dedup, so a downstream section carrying the
+/// same `contentId` reclaims them automatically.
+int fitHeroCount({
+  required double usableHeight,
+  required double chromeHeight,
+  required double leadHeight,
+  required double mediumHeight,
+  required int maxCount,
+  int minCount = 1,
+}) {
+  final lo = minCount < 1 ? 1 : minCount;
+  if (maxCount <= 1) return 1;
+  if (mediumHeight <= 0) return lo.clamp(1, maxCount);
+  final budgetForMediums = usableHeight - chromeHeight - leadHeight;
+  if (budgetForMediums <= 0) return lo.clamp(1, maxCount);
+  final mediums = (budgetForMediums / mediumHeight).floor();
+  final count = 1 + (mediums < 0 ? 0 : mediums);
+  return count.clamp(lo.clamp(1, maxCount), maxCount);
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -62,9 +62,11 @@ class EssentielHiFiCard extends StatelessWidget {
         ],
       ),
       child: Padding(
+        // Compaction « cartes ≤ écran » : top resserré space4→space3 pour
+        // gagner ~4px sans toucher la pastille date/météo (choix PO).
         padding: const EdgeInsets.fromLTRB(
           FacteurSpacing.space4,
-          FacteurSpacing.space4,
+          FacteurSpacing.space3,
           FacteurSpacing.space4,
           FacteurSpacing.space3,
         ),
@@ -72,7 +74,8 @@ class EssentielHiFiCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _Header(accent: accent, onTapPersonalize: onTapPersonalize),
-            const SizedBox(height: FacteurSpacing.space4),
+            // Compaction : gap header→lead resserré space4→space3.
+            const SizedBox(height: FacteurSpacing.space3),
             if (lead != null)
               _LeadTile(
                 article: lead,
@@ -503,7 +506,9 @@ class _LeadTile extends StatelessWidget {
                     const SizedBox(height: FacteurSpacing.space2),
                     Text(
                       article.title,
-                      maxLines: 5,
+                      // Compaction « cartes ≤ écran » : plafond 5→4 lignes pour
+                      // borner la hauteur du lead (cohérent avec section_fit).
+                      maxLines: 4,
                       overflow: TextOverflow.ellipsis,
                       style: GoogleFonts.fraunces(
                         fontSize: 19,
@@ -581,7 +586,8 @@ class _MediumTile extends StatelessWidget {
                     const SizedBox(height: 4),
                     Text(
                       article.title,
-                      maxLines: 4,
+                      // Compaction « cartes ≤ écran » : plafond 4→3 lignes.
+                      maxLines: 3,
                       overflow: TextOverflow.ellipsis,
                       style: GoogleFonts.fraunces(
                         fontSize: 16,

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -152,11 +152,13 @@ class _TabsRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: 48,
+      // Compaction « cartes ≤ écran » : rangée d'onglets 48→44 (sync avec
+      // `_kStickyBarHeight` côté écran, qui alimente budget de fit ET snap).
+      height: 44,
       child: ListView.separated(
         controller: controller,
         scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
+        padding: const EdgeInsets.fromLTRB(12, 2, 12, 6),
         itemCount: tabs.length,
         separatorBuilder: (_, __) => const SizedBox(width: 2),
         itemBuilder: (context, i) {

--- a/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
@@ -47,25 +47,43 @@ class MainTabPageScaffold extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Footer auto-hide (LinkedIn) : glisse hors écran au scroll vers le bas,
+    // revient au scroll vers le haut. `IgnorePointer` quand caché pour ne pas
+    // capter de tap fantôme sous l'écran. Durée/courbe alignées sur le FAB
+    // « Remonter » (220 ms easeOutCubic).
+    final footerVisible = ref.watch(footerVisibleProvider);
     return Scaffold(
       backgroundColor: context.facteurColors.backgroundPrimary,
       // Le contenu passe sous le footer glassmorphique pour que le flou révèle
       // les cartes qui défilent derrière (chaque écran réserve un padding bas).
       extendBody: true,
-      bottomNavigationBar: MainBottomNav(
-        currentIndex: currentIndex,
-        onSelect: (index) {
-          if (index == currentIndex) {
-            // Re-tap de l'onglet actif → scroll-to-top, sans navigation (donc
-            // sans slide). L'écran concerné écoute son trigger.
-            final trigger = index == 0
-                ? essentielScrollTriggerProvider
-                : feedScrollTriggerProvider;
-            ref.read(trigger.notifier).state++;
-          } else {
-            context.go(index == 0 ? RoutePaths.fluxContinu : RoutePaths.flaner);
-          }
-        },
+      bottomNavigationBar: IgnorePointer(
+        ignoring: !footerVisible,
+        child: AnimatedSlide(
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOutCubic,
+          offset: footerVisible ? Offset.zero : const Offset(0, 1),
+          child: MainBottomNav(
+            currentIndex: currentIndex,
+            onSelect: (index) {
+              // Tout tap d'onglet redonne le footer (évite un footer « collé »
+              // masqué au changement de page).
+              ref.read(footerVisibleProvider.notifier).state = true;
+              if (index == currentIndex) {
+                // Re-tap de l'onglet actif → scroll-to-top, sans navigation
+                // (donc sans slide). L'écran concerné écoute son trigger.
+                final trigger = index == 0
+                    ? essentielScrollTriggerProvider
+                    : feedScrollTriggerProvider;
+                ref.read(trigger.notifier).state++;
+              } else {
+                context.go(
+                  index == 0 ? RoutePaths.fluxContinu : RoutePaths.flaner,
+                );
+              }
+            },
+          ),
+        ),
       ),
       body: Column(
         children: [

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -19,6 +19,7 @@ import 'package:facteur/features/grille/repositories/grille_repository.dart';
 import 'package:facteur/features/my_interests/models/user_interests_state.dart';
 import 'package:facteur/features/my_interests/providers/user_interests_provider.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:flutter/material.dart' show Color;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
@@ -920,6 +921,161 @@ void main() {
       );
     });
   });
+
+  group('FluxContinuNotifier — fit dynamique « cartes ≤ écran »', () {
+    EssentielArticle essArticle(String id) => EssentielArticle(
+          contentId: id,
+          title: 'Essentiel $id',
+          url: 'https://x.test/$id',
+          publishedAt: DateTime(2026, 1, 1),
+          sourceName: 'Source',
+          sourceLetter: 'S',
+          sectionLabel: 'Tech',
+          rank: 1,
+        );
+
+    /// Container with a hero of [essentielIds] and a single 'tech' theme
+    /// favorite whose feed carries [themeFeedIds]. [usableHeight] threads the
+    /// fit budget (null = pas encore mesuré ⇒ défauts).
+    ProviderContainer makeFitContainer({
+      required List<String> essentielIds,
+      required List<String> themeFeedIds,
+      double? usableHeight,
+    }) {
+      when(
+        () => feedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          theme: any(named: 'theme'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+        ),
+      ).thenAnswer(
+        (_) async => _feedResponseWithIds(themeFeedIds, hasNext: false),
+      );
+      return ProviderContainer(
+        overrides: [
+          digestRepositoryProvider.overrideWithValue(digestRepo),
+          feedRepositoryProvider.overrideWithValue(feedRepo),
+          fluxContinuRepositoryProvider.overrideWithValue(fluxRepo),
+          essentielRepositoryProvider.overrideWithValue(
+            _FixedEssentielRepository(essentielIds.map(essArticle).toList()),
+          ),
+          grilleRepositoryProvider.overrideWithValue(_NoGrilleRepository()),
+          userInterestsProvider.overrideWith(
+            () => _StubUserInterestsNotifier(
+              _interestsState(favorites: const [ThemeFavoriteRef(slug: 'tech')]),
+            ),
+          ),
+          sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref)),
+          if (usableHeight != null)
+            usableViewportHeightProvider.overrideWith((ref) => usableHeight),
+        ],
+      );
+    }
+
+    test(
+      'small usable height trims the hero AND releases ejected ids downstream',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        // 4 hero articles ; the 'tech' feed carries the two that would be
+        // ejected (e3, e4) plus its own items.
+        final container = makeFitContainer(
+          essentielIds: const ['e1', 'e2', 'e3', 'e4'],
+          themeFeedIds: const ['e3', 'e4', 'x1', 'x2'],
+          usableHeight: 500,
+        );
+        addTearDown(container.dispose);
+
+        final state = await container.read(fluxContinuProvider.future);
+
+        // (a) hero trimmed to the lead + one medium (fitHeroCount(500) == 2).
+        final hero = state.sections.whereType<EssentielSection>().single;
+        expect(hero.articles.map((a) => a.contentId), ['e1', 'e2']);
+
+        // (b) the ejected ids reappear in the next section (« sortent du pool »).
+        final theme = state.sections.whereType<FeedThemeSection>().single;
+        expect(theme.items.map((c) => c.id), containsAll(['e3', 'e4']));
+
+        // (c) downstream cap ≤ default (3) and ≥ 1 — fitVisibleCount(500) == 2.
+        expect(theme.coreVisibleCount, 2);
+
+        // (d) the "+N" footer count derives correctly (totalCount − cap).
+        expect(theme.totalCount - theme.coreVisibleCount, 2);
+      },
+    );
+
+    test(
+      'no measure yet (null height) keeps defaults — hero & dedup untouched',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final container = makeFitContainer(
+          essentielIds: const ['e1', 'e2', 'e3', 'e4'],
+          themeFeedIds: const ['e3', 'e4', 'x1', 'x2'],
+          // usableHeight null ⇒ provider default (no fit applied).
+        );
+        addTearDown(container.dispose);
+
+        final state = await container.read(fluxContinuProvider.future);
+
+        final hero = state.sections.whereType<EssentielSection>().single;
+        expect(hero.articles.map((a) => a.contentId), ['e1', 'e2', 'e3', 'e4']);
+        // Hero kept all 4 ⇒ dedup strips e3/e4 from the theme section.
+        final theme = state.sections.whereType<FeedThemeSection>().single;
+        expect(theme.items.map((c) => c.id), ['x1', 'x2']);
+        expect(theme.coreVisibleCount, 3);
+      },
+    );
+
+    test('the dynamic cap survives a dismiss (copyWith preserves it)', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final container = makeFitContainer(
+        essentielIds: const ['e1', 'e2'],
+        themeFeedIds: const ['x1', 'x2', 'x3', 'x4'],
+        usableHeight: 500,
+      );
+      addTearDown(container.dispose);
+
+      final state = await container.read(fluxContinuProvider.future);
+      final theme = state.sections.whereType<FeedThemeSection>().single;
+      expect(theme.coreVisibleCount, 2);
+
+      // Dismissing an item routes through _filterSections → copyWith, which must
+      // NOT reset the capped coreVisibleCount back to the default 3.
+      container.read(fluxContinuProvider.notifier).confirmDismiss('x4');
+      await pumpEventQueue(times: 2);
+
+      final after = container.read(fluxContinuProvider).requireValue;
+      final themeAfter = after.sections.whereType<FeedThemeSection>().single;
+      expect(themeAfter.coreVisibleCount, 2);
+      expect(themeAfter.items.map((c) => c.id), isNot(contains('x4')));
+    });
+  });
+
+  group('FeedThemeSection.copyWith', () {
+    test('preserves coreVisibleCount and the source/theme/pagination fields',
+        () {
+      const section = FeedThemeSection(
+        kind: SectionKind.theme,
+        label: 'Tech',
+        accent: Color(0xFF000000),
+        coreVisibleCount: 3,
+        themeSlug: 'tech',
+        items: <Content>[],
+        currentPage: 2,
+        hasMore: true,
+      );
+
+      // Untouched copy keeps the dynamic count.
+      expect(section.copyWith(hasMore: false).coreVisibleCount, 3);
+
+      // Explicit override sets the capped count while keeping other fields.
+      final capped = section.copyWith(coreVisibleCount: 1);
+      expect(capped.coreVisibleCount, 1);
+      expect(capped.themeSlug, 'tech');
+      expect(capped.currentPage, 2);
+    });
+  });
 }
 
 /// Stub EssentielRepository returning exactly one [EssentielArticle] so the
@@ -930,4 +1086,13 @@ class _OneArticleEssentielRepository implements EssentielRepository {
 
   @override
   Future<List<EssentielArticle>?> fetch() async => [_article];
+}
+
+/// Stub EssentielRepository returning a fixed list — drives the hero-fit tests.
+class _FixedEssentielRepository implements EssentielRepository {
+  _FixedEssentielRepository(this._articles);
+  final List<EssentielArticle> _articles;
+
+  @override
+  Future<List<EssentielArticle>?> fetch() async => _articles;
 }

--- a/apps/mobile/test/features/flux_continu/utils/section_fit_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/section_fit_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/features/flux_continu/utils/section_fit.dart';
+
+void main() {
+  group('fitVisibleCount', () {
+    // Section chrome = banner + footer. With the no-blurb banner that is
+    // 68 + 70 = 138 px of fixed chrome, then each card is 164 px.
+    const banner = kBannerHeightNoBlurb;
+    const footer = kSectionFooterHeight;
+    final card = estimateRegularCardHeight();
+
+    int fit(double usable, {int maxCount = 3, int minCount = 1}) =>
+        fitVisibleCount(
+          usableHeight: usable,
+          bannerHeight: banner,
+          footerHeight: footer,
+          cardHeight: card,
+          maxCount: maxCount,
+          minCount: minCount,
+        );
+
+    test('a tall screen fits the full default cap (3)', () {
+      expect(fit(2000), 3);
+    });
+
+    test('a mid screen drops to 2', () {
+      // 138 + 2·164 = 466 fits, 138 + 3·164 = 630 does not.
+      expect(fit(500), 2);
+    });
+
+    test('a small screen floors to 1 — never 0', () {
+      // Budget for cards is positive but below one card height.
+      expect(fit(200), 1);
+    });
+
+    test('a degenerate (≤ chrome) budget still returns minCount, never 0', () {
+      expect(fit(50), 1);
+      expect(fit(50, minCount: 2), 2);
+    });
+
+    test('the default cap is a ceiling — fit never grows past maxCount', () {
+      expect(fit(5000, maxCount: 4), 4);
+      expect(fit(5000, maxCount: 2), 2);
+    });
+
+    test('minCount is honoured on a cramped screen', () {
+      expect(fit(200, maxCount: 3, minCount: 2), 2);
+    });
+
+    test('a blurb banner reserves more chrome, so it can fit fewer cards', () {
+      // Same usable height, the with-blurb banner (100) leaves 32 px less.
+      // Pick a height where the extra 32 px tips 3 → 2.
+      // no-blurb: 138 + 3·164 = 630 ; with-blurb: 170 + 3·164 = 662.
+      const usable = 645.0;
+      final noBlurb = fitVisibleCount(
+        usableHeight: usable,
+        bannerHeight: kBannerHeightNoBlurb,
+        footerHeight: footer,
+        cardHeight: card,
+        maxCount: 3,
+      );
+      final withBlurb = fitVisibleCount(
+        usableHeight: usable,
+        bannerHeight: kBannerHeightWithBlurb,
+        footerHeight: footer,
+        cardHeight: card,
+        maxCount: 3,
+      );
+      expect(noBlurb, 3);
+      expect(withBlurb, 2);
+    });
+  });
+
+  group('fitHeroCount', () {
+    int fit(double usable, {int maxCount = 5, int minCount = 1}) => fitHeroCount(
+          usableHeight: usable,
+          chromeHeight: kHeroChromeHeight,
+          leadHeight: kHeroLeadHeight,
+          mediumHeight: kHeroMediumHeight,
+          maxCount: maxCount,
+          minCount: minCount,
+        );
+
+    test('a tall screen keeps the full pool (capped by maxCount)', () {
+      expect(fit(2000, maxCount: 5), 5);
+      expect(fit(2000, maxCount: 3), 3);
+    });
+
+    test('a mid screen keeps the lead + one medium (2)', () {
+      // chrome 208 + lead 181 = 389 ; one medium = 105.
+      // 389 + 105 = 494 fits, 389 + 2·105 = 599 does not.
+      expect(fit(540), 2);
+    });
+
+    test('a small screen keeps the lead alone — never 0', () {
+      // Below chrome + lead there is no room for any medium.
+      expect(fit(360), 1);
+      expect(fit(100), 1);
+    });
+
+    test('the lead is mandatory even when maxCount is 1', () {
+      expect(fit(2000, maxCount: 1), 1);
+      expect(fit(50, maxCount: 1), 1);
+    });
+
+    test('result never exceeds maxCount (= min(5, articles.length))', () {
+      expect(fit(5000, maxCount: 2), 2);
+      expect(fit(5000, maxCount: 4), 4);
+    });
+  });
+}

--- a/apps/mobile/test/features/flux_continu/utils/section_fit_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/section_fit_test.dart
@@ -4,7 +4,7 @@ import 'package:facteur/features/flux_continu/utils/section_fit.dart';
 void main() {
   group('fitVisibleCount', () {
     // Section chrome = banner + footer. With the no-blurb banner that is
-    // 68 + 70 = 138 px of fixed chrome, then each card is 164 px.
+    // 68 + 70 = 138 px of fixed chrome, then each card is 148 px.
     const banner = kBannerHeightNoBlurb;
     const footer = kSectionFooterHeight;
     final card = estimateRegularCardHeight();
@@ -24,7 +24,7 @@ void main() {
     });
 
     test('a mid screen drops to 2', () {
-      // 138 + 2·164 = 466 fits, 138 + 3·164 = 630 does not.
+      // 138 + 2·148 = 434 fits, 138 + 3·148 = 582 does not.
       expect(fit(500), 2);
     });
 
@@ -50,8 +50,8 @@ void main() {
     test('a blurb banner reserves more chrome, so it can fit fewer cards', () {
       // Same usable height, the with-blurb banner (100) leaves 32 px less.
       // Pick a height where the extra 32 px tips 3 → 2.
-      // no-blurb: 138 + 3·164 = 630 ; with-blurb: 170 + 3·164 = 662.
-      const usable = 645.0;
+      // no-blurb: 138 + 3·148 = 582 ; with-blurb: 170 + 3·148 = 614.
+      const usable = 600.0;
       final noBlurb = fitVisibleCount(
         usableHeight: usable,
         bannerHeight: kBannerHeightNoBlurb,
@@ -87,13 +87,13 @@ void main() {
     });
 
     test('a mid screen keeps the lead + one medium (2)', () {
-      // chrome 208 + lead 181 = 389 ; one medium = 105.
-      // 389 + 105 = 494 fits, 389 + 2·105 = 599 does not.
+      // chrome 208 + lead 160 = 368 ; one medium = 88.
+      // 368 + 88 = 456 fits, 368 + 2·88 = 544 does not.
       expect(fit(540), 2);
     });
 
     test('a small screen keeps the lead alone — never 0', () {
-      // Below chrome + lead there is no room for any medium.
+      // Below chrome + lead (368) there is no room for any medium.
       expect(fit(360), 1);
       expect(fit(100), 1);
     });

--- a/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
@@ -96,7 +96,7 @@ void main() {
           section: _sourceSection(items: 3),
           isOpen: false,
           onToggleMore: () {},
-          onTapArticle: (_, __) {},
+          onTapArticle: (_) {},
           onSeeAll: () {},
         ),
       ));
@@ -117,7 +117,7 @@ void main() {
           section: _sourceSection(items: 0),
           isOpen: false,
           onToggleMore: () {},
-          onTapArticle: (_, __) {},
+          onTapArticle: (_) {},
           onSeeAll: () {},
         ),
       ));
@@ -139,7 +139,7 @@ void main() {
           section: _themeSection(items: 0),
           isOpen: false,
           onToggleMore: () {},
-          onTapArticle: (_, __) {},
+          onTapArticle: (_) {},
           onSeeAll: () {},
           onAddSources: () => tapped = true,
         ),
@@ -165,7 +165,7 @@ void main() {
           section: _themeSection(items: 1),
           isOpen: false,
           onToggleMore: () {},
-          onTapArticle: (_, __) {},
+          onTapArticle: (_) {},
           onSeeAll: () {},
           onAddSources: () {},
         ),
@@ -185,7 +185,7 @@ void main() {
           section: _themeSection(items: 7, coreVisibleCount: 3),
           isOpen: false,
           onToggleMore: () {},
-          onTapArticle: (_, __) {},
+          onTapArticle: (_) {},
           onSeeAll: () {},
         ),
       ));
@@ -201,13 +201,32 @@ void main() {
           section: _themeSection(items: 7, coreVisibleCount: 3),
           isOpen: false,
           onToggleMore: () {},
-          onTapArticle: (_, __) {},
+          onTapArticle: (_) {},
           onSeeAll: () {},
         ),
       ));
 
       // 7 items - 3 visible = +4 hidden.
       expect(find.text('Tout lire (+4)'), findsOneWidget);
+    });
+
+    testWidgets(
+        'a dynamically reduced coreVisibleCount renders fewer cards and a '
+        'larger (+N) — « cartes ≤ écran »', (tester) async {
+      // On a small screen the provider caps coreVisibleCount (e.g. 3 → 2). The
+      // block must render only 2 cards and surface the remaining 5 behind +N.
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(items: 7, coreVisibleCount: 2),
+          isOpen: false,
+          onToggleMore: () {},
+          onTapArticle: (_) {},
+          onSeeAll: () {},
+        ),
+      ));
+
+      expect(find.byType(FluxContinuArticleCard), findsNWidgets(2));
+      expect(find.text('Tout lire (+5)'), findsOneWidget);
     });
 
     testWidgets(
@@ -219,7 +238,7 @@ void main() {
           section: _themeSection(items: 2, coreVisibleCount: 3),
           isOpen: false,
           onToggleMore: () {},
-          onTapArticle: (_, __) {},
+          onTapArticle: (_) {},
           onSeeAll: () {},
         ),
       ));
@@ -238,7 +257,7 @@ void main() {
           section: _themeSection(items: 3, coreVisibleCount: 3, hasMore: true),
           isOpen: false,
           onToggleMore: () {},
-          onTapArticle: (_, __) {},
+          onTapArticle: (_) {},
           onSeeAll: () {},
         ),
       ));
@@ -257,7 +276,7 @@ void main() {
           section: _digestTopicSection(topics: 5, coreVisibleCount: 3),
           isOpen: false,
           onToggleMore: () {},
-          onTapArticle: (_, __) {},
+          onTapArticle: (_) {},
           onSeeAll: () {},
         ),
       ));
@@ -274,7 +293,7 @@ void main() {
           section: _themeSection(items: 7, coreVisibleCount: 3),
           isOpen: false,
           onToggleMore: () {},
-          onTapArticle: (_, __) {},
+          onTapArticle: (_) {},
           onSeeAll: () {},
         ),
       ));

--- a/docs/stories/core/9.5.essentiel-cards-fit-screen.md
+++ b/docs/stories/core/9.5.essentiel-cards-fit-screen.md
@@ -1,0 +1,95 @@
+# Story 9.5 — L'Essentiel : cartes qui ne dépassent jamais l'écran (+ footer auto-hide)
+
+**Type** : Feature · **Épic** : 9 (Essentiel / Flux Continu) · **1 seule PR** (validée PO)
+
+## Problème
+
+Dans **Flux Continu / L'Essentiel**, quand une carte est plus haute que la
+hauteur utile de l'écran, le snap lui octroie une « free-read interior » (scroll
+fin *dans* la carte) qui se bat avec le snap inter-sections → sensation
+incohérente (`section_snap.dart` : une section mesurée > viewport devient
+« tall »).
+
+## Objectif
+
+Aucune carte ne dépasse la hauteur utile de l'écran (bouton « Lire plus / Tout
+lire » inclus). Quand tout est plus petit que l'écran, `_tallSections` devient
+vide → chaque section = un seul point de snap → feel cohérent, page par page.
+
+## Décision d'architecture
+
+« Estimer pour contrôler, mesurer pour vérifier » : le **« combien d'articles
+tiennent » est décidé côté provider** par une estimation de hauteur
+**conservatrice** (titre à son `maxLines` max), pas de mesure runtime qui pilote
+le rendu (pas de reflow). La mesure post-frame existante
+(`_recomputeSnapAnchors` / `_tallSections`) sert de **filet de vérification QA**.
+
+Budget identique au snap (sinon estimation et mesure divergent) :
+```
+usableHeight = scrollViewportHeight − safeAreaBottom − _kStickyBarHeight
+```
+
+Pourquoi côté provider :
+- « le héros qui ne tient pas **sort du pool** et **réapparaît ailleurs** » est
+  *gratuit* : le dédup inter-sections (`_dedupeSectionsInOrder`) n'ajoute à
+  `seen` que les articles présents dans `EssentielSection.articles`. Trimmer la
+  liste du héros **avant** le dédup relâche automatiquement les articles éjectés
+  vers les sections aval qui portent le même `contentId`.
+- `coreVisibleCount` est déjà le levier du dépassement (banner →
+  `take(coreVisibleCount)` → bouton « Tout lire (+N) »). On le rend dynamique
+  (`min(défaut, fit)`, plancher 1) → le `+N` reste correct tout seul.
+
+## Changements livrés
+
+### A. Footer auto-hide au scroll (app-wide)
+- `footerVisibleProvider` (`core/providers/navigation_providers.dart`).
+- `MainTabPageScaffold` : `MainBottomNav` enveloppé dans `AnimatedSlide` +
+  `IgnorePointer` (220 ms easeOutCubic, comme le FAB).
+- `FluxContinuScreen._onScroll` + `FlanerScreen._onScroll` : `visible = delta < 0
+  || near-top`. Remis à `true` au changement d'onglet (onSelect) et au
+  scroll-to-top.
+
+### B. Compaction légère (statique)
+- Héros `essentiel_hi_fi_card.dart` : `_LeadTile` titre `maxLines 5→4`,
+  `_MediumTile` `4→3`, top padding `space4→space3`, gap header→lead
+  `space4→space3`. **Pastille date/météo conservée** (choix PO).
+- Sticky `sticky_tab_bar.dart` : rangée d'onglets `48→44` ; constante miroir
+  `_kStickyBarHeight 54→50`.
+
+### C. Fit dynamique (provider + util pur)
+- **`utils/section_fit.dart`** (nouveau, pur) : constantes de hauteur
+  conservatrices + `fitVisibleCount` + `fitHeroCount` + `estimateRegularCardHeight`.
+- `usableViewportHeightProvider` (StateProvider<double?>), écrit par
+  `FluxContinuScreen._publishUsableHeight` (post-frame, anti-boucle : seulement
+  si la valeur arrondie change). `null` au 1ᵉʳ frame ⇒ défauts (masqué par le
+  skeleton).
+- `flux_continu_provider._compose` : `ref.listen(usableViewportHeightProvider)`
+  recompose ; trim héros (`_fitHeroSection`) **avant** dédup ; cap sections aval
+  (`_capSectionToFit`) **après** dédup.
+- `FeedThemeSection.copyWith` : **param `coreVisibleCount`** ajouté (sinon le
+  compte fitté est perdu au dédup/`_filterSections`/`loadMoreTheme`).
+
+### D. Filet de vérification (pas de pilotage)
+- `_recomputeSnapAnchors` : `assert(() {…}())` (debug) logge toute section
+  multi-articles qui reste « tall » → estimation `section_fit` trop généreuse,
+  constantes à régler.
+
+## Hors périmètre
+Grille / Citation / carte « Pour toi » / closing card (slivers virtuels) :
+bénéficient du footer-hide + sticky compact mais pas du fit dynamique. Cartes
+article standard inchangées (choix PO « héros uniquement »).
+
+## Tests
+- `test/.../utils/section_fit_test.dart` (12) : bornes de `fitVisibleCount` /
+  `fitHeroCount` (3/2/1, jamais 0 ; héros garde le lead).
+- `flux_continu_provider_test.dart` (+4) : trim héros, **réapparition aval** de
+  l'id éjecté, cap aval ≤ défaut & ≥ 1, `+N` correct, cap qui survit à un dismiss
+  (copyWith), `FeedThemeSection.copyWith` préserve `coreVisibleCount`.
+- `section_block_test.dart` : `+N` à `coreVisibleCount` réduit (+ correction des
+  lambdas `onTapArticle` héritées de #787 → fichier re-compilable).
+- `flutter analyze` : 0 issue sur les fichiers touchés.
+
+## Reste à faire (QA visuelle)
+Validation Chrome/Playwright 390×844 **et** 360×640 : voir
+`.context/qa-handoff.md`. Si l'estimateur s'avère trop strict/généreux sur device
+réel → régler les constantes de `section_fit.dart` (jamais les call sites).


### PR DESCRIPTION
# L'Essentiel : cartes qui ne dépassent jamais l'écran (+ footer auto-hide)

## Résumé

Dans **Flux Continu / L'Essentiel**, une carte plus haute que l'écran gagnait une
« free-read interior » qui se battait avec le snap inter-sections. Cette PR
garantit qu'**aucune carte ne dépasse la hauteur utile de l'écran** (bouton
« Lire plus » inclus) → `_tallSections` vide → 1 point de snap par section, feel
cohérent page par page. **1 seule PR** (validée PO).

## Décision d'architecture — « estimer pour contrôler, mesurer pour vérifier »

Le « combien d'articles tiennent » est décidé **côté provider** par une estimation
de hauteur **conservatrice** (titre à son `maxLines` max), pas de mesure runtime
qui pilote le rendu. La mesure post-frame (`_recomputeSnapAnchors` /
`_tallSections`) sert de **filet QA**. Budget **identique au snap** :
`usableHeight = scrollViewportHeight − safeAreaBottom − _kStickyBarHeight`.

« Le héros qui ne tient pas sort du pool et réapparaît ailleurs » est gratuit :
trimmer la liste du héros **avant** le dédup inter-sections relâche les articles
éjectés vers les sections aval qui portent le même `contentId`.

## Changements

- **A. Footer auto-hide app-wide** : `footerVisibleProvider` + `AnimatedSlide`/
  `IgnorePointer` sur `MainBottomNav` ; `_onScroll` (Essentiel + Flâner) ;
  re-visible au changement d'onglet / scroll-to-top.
- **B. Compaction légère** : héros `maxLines 5→4` (lead) / `4→3` (medium) + paddings
  resserrés (pastille date/météo conservée) ; sticky `48→44` + `_kStickyBarHeight
  54→50`.
- **C. Fit dynamique** : `utils/section_fit.dart` (pur) ; `usableViewportHeightProvider`
  écrit par l'écran (anti-boucle) ; `_compose` trim héros + cap sections aval
  (`min(défaut, fit)`, plancher 1) ; `FeedThemeSection.copyWith` +param
  `coreVisibleCount`.
- **D. Filet** : `assert` debug dans `_recomputeSnapAnchors` qui logge toute
  section multi-articles restée « tall ».

## Tests
- `section_fit_test.dart` (12) : bornes `fitVisibleCount`/`fitHeroCount` (3/2/1,
  jamais 0 ; héros garde le lead).
- `flux_continu_provider_test.dart` (+4) : trim héros, réapparition aval de l'id
  éjecté, cap aval ≤ défaut & ≥ 1, `+N` correct, cap survit au dismiss, copyWith
  préserve `coreVisibleCount`.
- `section_block_test.dart` : `+N` à `coreVisibleCount` réduit (+ correction des
  lambdas `onTapArticle` héritées de #787 → fichier re-compilable, net positif).
- `flutter analyze` : 0 issue sur les fichiers touchés.
- ⚠️ Échec pré-existant non lié : `essentiel_hi_fi_card_test` « flips to the
  weather badge » (échoue déjà sur `main`).

## QA visuelle
Voir `.context/qa-handoff.md` — Chrome/Playwright **390×844** ET **360×640**
(cartes ≤ écran, footer slide, snap+haptique non régressés).

## Hors périmètre
Grille / Citation / carte « Pour toi » / closing card (slivers virtuels) ; cartes
article standard inchangées (choix PO « héros uniquement »).

---

## Vérification (/go)
- [x] `flutter analyze` — 0 issue sur les fichiers touchés.
- [x] Tests ciblés : `section_fit_test` (12) + `flux_continu_provider_test` (+4) + `section_block_test` → **43/43 OK**.
- [x] `/simplify` : dédup de `_updateFooterVisibility` (identique dans 2 écrans) → helper partagé `updateFooterVisibility(ref, …)` dans `navigation_providers.dart`. Re-run VERIFY après edit → vert.
- [ ] QA Chrome (`/validate-feature`) — feel scroll/snap/haptique + footer slide aux 2 viewports (390×844 / 360×640), non couvert par l'automatisé.

> ⚠️ Échec pré-existant non lié : `essentiel_hi_fi_card_test` « flips to the weather badge » — échoue déjà sur `main` (vérifié en restaurant le fichier stock).
