### PR TITLE
fix(letters): provisioning gap — FK violation sur _init_progress pour users sans profil

### DIFF
--- a/packages/api/app/services/letters/service.py
+++ b/packages/api/app/services/letters/service.py
@@ -213,6 +213,9 @@ async def _get_rows(user_id: UUID, db: AsyncSession) -> dict[str, UserLetterProg
 
 async def _init_progress(user_id: UUID, db: AsyncSession) -> None:
     """Crée les 3 rows initiales pour un nouveau user."""
+    from app.services.user_service import UserService
+
+    await UserService(db).get_or_create_profile(str(user_id))
     now = datetime.now(UTC)
     for catalog in LETTERS_ORDER:
         default_status = catalog["default_status"]

--- a/packages/api/tests/routers/test_letters_routes.py
+++ b/packages/api/tests/routers/test_letters_routes.py
@@ -794,3 +794,63 @@ class TestLetter2Idempotence:
         assert r1.json()["status"] == "archived"
         assert r2.json()["status"] == "archived"
         assert len(r1.json()["completed_actions"]) == 5
+
+
+# ─── Fixture sans profil ────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def auth_user_no_profile(db_session):
+    """User JWT valide mais sans ligne dans user_profiles."""
+    user_id = uuid4()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        yield user_id
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+class TestProvisioningGap:
+    """Régression : user JWT valide sans profil → FK violation sur _init_progress."""
+
+    async def test_new_user_without_profile_gets_200(
+        self, auth_user_no_profile, db_session
+    ):
+        async with _client() as ac:
+            resp = await ac.get("/api/letters")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 3
+
+        from sqlalchemy import select as sa_select
+
+        from app.models.user import UserProfile
+
+        profile = (
+            await db_session.execute(
+                sa_select(UserProfile).where(
+                    UserProfile.user_id == auth_user_no_profile
+                )
+            )
+        ).scalar_one_or_none()
+        assert profile is not None
+
+        from app.models.user_letter_progress import UserLetterProgress
+
+        rows = (
+            await db_session.execute(
+                sa_select(UserLetterProgress).where(
+                    UserLetterProgress.user_id == auth_user_no_profile
+                )
+            )
+        ).scalars().all()
+        assert len(rows) == 3


### PR DESCRIPTION
## Problème

`IntegrityError / ForeignKeyViolation` sur `user_letter_progress_user_id_fkey` au premier appel de `GET /api/letters` pour 9 users qui ont un JWT Supabase valide mais aucune ligne dans `user_profiles` (pas passés par l'onboarding).

Chemin : `list_letters` → `get_user_letters` → `_init_progress` → `db.commit()` → FK violation.

## Fix

Ajout de `UserService(db).get_or_create_profile(str(user_id))` en tête de `_init_progress` (`service.py:214`).

- Le pattern `get_or_create_profile` existe déjà et est utilisé dans les routers personalization, custom_topics, notification_preferences.
- Fix à la source : couvre les deux paths qui appellent `_init_progress` (`get_user_letters` **et** `refresh_letter_status`).
- Import local pour éviter le cycle circulaire avec `user_service`.
- `UserService.create_profile` fait un `flush()` avant de retourner → FK satisfaite avant les `db.add()` des rows progress.

## Test de régression

`TestProvisioningGap.test_new_user_without_profile_gets_200` : user JWT valide, `user_profiles` vide → vérifie HTTP 200 + création profil + 3 rows progress.

## Pas de migration Alembic

Aucun changement de schéma.