### PR TITLE
feat(tournee): clarifier limites modal favoris + affordance bouton passage + auto-scroll

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,72 +1,54 @@
-# Veille — refonte curation deux blocs + UX fin de config
+# Tournée — clarifier les limites + affordance du bouton de passage + auto-scroll
 
 ## Résumé
 
-Le feed veille (`GET /api/veille/feed`, section `SectionKind.veille` du flux continu)
-est refondu en **deux blocs** pour corriger deux bugs PO :
-1. sources configurées invisibles (fenêtre 7 j + règle « floor » tuaient les flux
-   niche/anglophones) ;
-2. sources externes parasites (prédicat OR aspirait tout le pool global matchant un
-   mot-clé).
+Refonte de la modal « Mes favoris » (`manage_favorites_sheet.dart`, ouverte depuis
+L'Essentiel et les onglets Flâner) pour lever la confusion entre les trois
+mécanismes de limite, et élargissement du cap Tournée **5 → 7**.
 
-## Backend (backward-safe — le mobile ignore `group` jusqu'au déploiement frontend)
+## Changements
 
-- `scoring_config.py` : `VEILLE_CONFIGURED_RECENCY_HOURS=720` (30 j, Bloc A),
-  `VEILLE_SOURCE_DIVERSITY_CAP=3`.
-- `feed_filter.py` :
-  - `VeilleFilters.source_intents` (charge `VeilleSource.why`).
-  - `build_topic_keyword_predicate()` (= prédicat fort sans la clause source).
-  - `_score_and_rank` → `_score_block(..., *, apply_floor, apply_threshold, diversity_cap)`.
-  - `fetch_veille_feed()` : 2 requêtes (Bloc A `source_id IN` fenêtre 720 h, laisser-passer
-    + cap diversité ; Bloc B topic/keyword `NOTIN` sources, fenêtre 168 h, floor+seuil),
-    concaténées A→B, taguées `group`, paginées à plat. **Renvoie des 3-tuples
-    `(Content, axes, group)`.**
-- `scoring_context.py` : note d'intention `why` tokenisée (`_tokenize_intent`, stopwords FR
-  + len≥4) → angle « Intention » (réutilise le bonus mots-clés existant).
-- `schemas/veille.py` : `VeilleFeedArticle.group` (Literal sources/elargie, défaut
-  `sources`) ; `VeilleSourceResponse.last_article_at` + `recent_article_count`.
-- `routers/veille.py` : unpack 3-tuple + `group` ; agrégation santé source dans
-  `GET /config`. **Pas de migration** (`why` existe déjà).
+### 1. Cap Tournée 5 → 7 (mirrors synchronisés, aucune migration)
+- `tournee_order_prefs_provider.dart` : `kTourneeVisibleCap` 5 → 7.
+- `flux_continu_provider.dart` : `_kMaxFavoriteSections` & `_kMaxFavoriteSourceSections`
+  5 → 7 (sous-caps par catégorie, avant le `take(kTourneeVisibleCap)`).
+- `config/constants.dart` : `InterestConstants.favoriteCap` 5 → 7 (mirror).
+- `packages/api/app/constants.py` : `FAVORITE_CAP` 5 → 7 (mirror, constante produit —
+  pas de DDL/Alembic). `get_top_themes` borne juste un peu plus large la perso éditoriale.
+- Cap Flâner `kMaxFavoriteTabs = 10` : **inchangé**.
 
-### Tests backend
-- `tests/test_veille_curation.py` : Bloc A laisser-passer + cap diversité ; floor Bloc B ;
-  end-to-end deux blocs ; tokenisation intent.
-- `tests/services/test_veille_scoring.py` : intent `why` injecté ; split récence 30j/7j ;
-  unpacking 3-tuples mis à jour.
-- `tests/routers/test_veille_routes.py` : `group` par item ; ordre A→B ; pagination à la
-  frontière ; santé source dans `/config`.
-- **64 tests veille passent** ; suite backend complète **1524 passed** (la seule rouge —
-  `test_notification_preferences::test_patch_increments_refusal_count` — est pré-existante,
-  clock-dépendante, sans rapport).
+### 2. Suppression des blocages « max » par type
+Le backend n'impose aucun cap dur (`FavoriteCapReached` = code mort). Retiré côté
+modal : `interestsAtCap`/`sourcesAtCap`, le paramètre `atCap` des add-lists, les
+`_CapHint(« Maximum … atteint »)`, la classe `_CapHint`, les `catch
+(FavoriteCapReachedException)` et l'import devenu inutile. L'ajout n'est plus jamais
+bloqué ; le surplus reste grisé sous le trait `_CapDivider` existant.
 
-## Frontend (dépend du backend)
+### 3. Compteurs dans les en-têtes
+`_SectionLabel` accepte un `counter` optionnel rendu en pill discret (`· X/7`,
+`· X/10`). Essentiel = `clamp(0, 7)/7`, Flâner = `clamp(0, 10)/10`.
 
-- `feed/models/content_model.dart` : `Content.veilleGroup` (parse `json['group']`,
-  copyWith, clearNote) — backward-safe nullable.
-- `flux_continu/repositories/flux_continu_repository.dart` : passe `group` dans le JSON
-  Content normalisé.
-- `flux_continu/widgets/veille_group_header.dart` (nouveau) : `buildVeilleFeedRows()`
-  (en-têtes dérivés au rendu sur transitions de group) + `VeilleGroupHeader`.
-- `section_block.dart` + `theme_section_screen.dart` : en-têtes « Tes sources » /
-  « Couverture élargie » pour `SectionKind.veille` (pagination plate inchangée — lignes
-  reconstruites depuis la liste accumulée).
-- `veille/screens/veille_config_screen.dart` : modal « Épingler à ta Tournée ? » en fin de
-  **création** → insertion #1 (`markCustomized` + `setHidden(false)` +
-  `setOrder([veille, ...rest])`).
-- `veille/models/veille_config_dto.dart` : parse `last_article_at`/`recent_article_count`
-  + getter `healthWarning`.
+### 4. Affordance du bouton de passage
+Nouvelle puce `_MoveChip` (icône directionnelle + libellé de destination
+« Flâner » / « Essentiel », bord/fond accentués via `item.accent`, cible ≥ 44px,
+haptique conservée) en remplacement de la flèche seule, pour sources et thèmes.
 
-### Tests frontend
-- `test/.../widgets/veille_group_header_test.dart` : transitions de group, backward-safe,
-  index préservé, rendu du libellé — **5 passent**.
-- `flutter analyze lib` : 0 erreur / 0 warning dans les fichiers touchés.
+### 5. Bonus — auto-scroll vers Flâner
+`ScrollController` + `GlobalKey` sur l'en-tête Flâner ; en `initState`, si
+`entry == ManageFavoritesEntry.flaner`, `Scrollable.ensureVisible` (300 ms, easeOut).
+Entrée Essentiel → pas de scroll (déjà en tête).
 
-## Reporté (follow-up, hors de ce lot)
-- Badge santé **visuel** dans la source card (DTO `healthWarning` prêt) + champs texte
-  « Préciser » (why source / reason angle) dans step2/step3 — nécessite du state provider
-  dans des écrans de 900+ lignes.
-- Expansion EN des mots-clés (`suggest_angles`) — PR-3 légère derrière flag.
+## Fichiers modifiés
+- `apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart`
+- `apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart`
+- `apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart`
+- `apps/mobile/lib/config/constants.dart`
+- `packages/api/app/constants.py`
+- Tests : `manage_favorites_sheet_test.dart`, `flux_continu_tournee_order_test.dart`,
+  `flux_continu_sources_test.dart`, `flux_continu_provider_test.dart`,
+  `tournee_composer_sheet_test.dart` (caps 5 → 7, scénarios de coupe ré-équilibrés).
 
-## Découpage proposé
-PR-1 backend (backward-safe) puis PR-2 frontend, OU un seul PR cohérent (PO préfère
-moins de PRs). À trancher au moment de la création.
+## Vérification
+- Backend : `pytest` complet → **1525 passed, 1 skipped, 2 xfailed** (DB test 54322).
+- Mobile : `flutter analyze` (aucune issue sur les fichiers touchés) + tests
+  flux_continu touchés → **tous verts**.

--- a/apps/mobile/lib/config/constants.dart
+++ b/apps/mobile/lib/config/constants.dart
@@ -301,7 +301,7 @@ class SentryConstants {
 class InterestConstants {
   InterestConstants._();
 
-  static const int favoriteCap = 5;
+  static const int favoriteCap = 7;
 }
 
 /// Alias top-level expliciment demandé par le hand-off 22.1.2.

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -62,14 +62,14 @@ const String _kActusDuJourBlurb = 'Les sujets les + couverts en France.';
 const String _kBonnesBlurb = 'Un peu de douceur...';
 
 /// Hard cap on the number of favorite theme sections rendered in the tournée.
-/// Mirrors `kFavoriteCap = 5` in the my_interests provider — the value is
+/// Mirrors `kFavoriteCap = 7` in the my_interests provider — the value is
 /// duplicated here only because the maps key by sectionKey and we slice the
 /// favorite list during composition. Keep aligned with the backend constant.
-const int _kMaxFavoriteSections = 5;
+const int _kMaxFavoriteSections = 7;
 
 /// Hard cap on the number of favorite SOURCE sections rendered in the tournée
 /// (PR « Sources dans la Tournée »). Parité avec les thèmes.
-const int _kMaxFavoriteSourceSections = 5;
+const int _kMaxFavoriteSourceSections = 7;
 
 /// Number of items requested per page for each theme section of the Tournée
 /// (initial load + each "loadMoreTheme" call). When the backend returns

--- a/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
@@ -32,7 +32,7 @@ const _kLegacyVeilleHiddenKey = 'tournee_veille_hidden_v1';
 const _kTourneeCustomizedKey = 'tournee_customized_v1';
 
 /// Cap d'affichage de la Tournée du jour, partagé provider + composer.
-const int kTourneeVisibleCap = 5;
+const int kTourneeVisibleCap = 7;
 
 /// Clé d'un thème favori dans l'ordre Tournée (= `sectionKey` d'une section thème).
 String tourneeThemeKey(String slug) => 'theme:$slug';

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -17,8 +17,6 @@ import '../../my_interests/models/user_interests_state.dart';
 import '../../my_interests/models/user_sources_state.dart';
 import '../../my_interests/providers/user_interests_provider.dart';
 import '../../my_interests/providers/user_sources_state_provider.dart';
-import '../../my_interests/repositories/user_interests_repository.dart'
-    show FavoriteCapReachedException;
 import '../../sources/models/source_model.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../../sources/widgets/source_logo_avatar.dart';
@@ -29,9 +27,11 @@ import '../utils/theme_color_mapping.dart';
 import 'choice_tile.dart';
 
 /// Story 10.2 — sheet unifiée « Mes favoris », deux modes de livraison :
-/// « Chaque matin dans ton Essentiel » (Tournée, cap 5) et « Tes onglets pour
-/// explorer » (Flâner, cap 10). Une seule sheet, deux portes : [entry] ne
-/// change que le segment « Ajouter » présélectionné — le contenu est identique.
+/// « Chaque matin dans ton Essentiel » (Tournée, cap 7) et « Tes onglets pour
+/// explorer » (Flâner, cap 10). L'ajout n'est jamais bloqué : le surplus
+/// au-delà du cap de section apparaît grisé sous un trait. Une seule sheet, deux
+/// portes : [entry] présélectionne le segment « Ajouter » et, côté Flâner,
+/// scrolle vers la section Flâner à l'ouverture — le contenu est identique.
 enum ManageFavoritesEntry { essentiel, flaner }
 
 /// Accent des Actus du jour (aligné provider Tournée).
@@ -111,6 +111,28 @@ class _ManageFavoritesContentState
   /// Onglet actif de la zone « AJOUTER » : 0 = Sources, 1 = Thèmes, 2 = Sujets.
   late int _addTab = widget.entry == ManageFavoritesEntry.flaner ? 2 : 1;
 
+  /// Ancre l'en-tête de la section Flâner pour le scroll auto à l'ouverture.
+  final GlobalKey _flanerSectionKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    // Bonus UX : ouverture depuis un onglet Flâner → on amène la section
+    // « ONGLETS DE TA PAGE FLÂNER » à l'écran (l'Essentiel est déjà en tête).
+    if (widget.entry == ManageFavoritesEntry.flaner) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final ctx = _flanerSectionKey.currentContext;
+        if (ctx == null) return;
+        Scrollable.ensureVisible(
+          ctx,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+          alignment: 0,
+        );
+      });
+    }
+  }
+
   // ── Helpers d'ordre (prefs) ──────────────────────────────────────────────
 
   Future<void> _appendTournee(String key) async {
@@ -135,8 +157,10 @@ class _ManageFavoritesContentState
   }
 
   Future<void> _removeTab(String key) async {
-    final next =
-        ref.read(tabOrderPrefsProvider).where((k) => k != key).toList();
+    final next = ref
+        .read(tabOrderPrefsProvider)
+        .where((k) => k != key)
+        .toList();
     await ref.read(tabOrderPrefsProvider.notifier).setOrder(next);
   }
 
@@ -145,15 +169,13 @@ class _ManageFavoritesContentState
   Future<void> _onAddTheme(String slug) async {
     await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
     try {
-      await ref.read(userInterestsProvider.notifier).setInterestState(
+      await ref
+          .read(userInterestsProvider.notifier)
+          .setInterestState(
             ThemeFavoriteRef(slug: slug),
             InterestState.favorite,
           );
       await _appendTournee(tourneeThemeKey(slug));
-    } on FavoriteCapReachedException catch (e) {
-      NotificationService.showError(
-        'Tu as déjà ${e.cap} favoris. Retires-en un avant d\'en ajouter.',
-      );
     } catch (e) {
       NotificationService.showError('Erreur : $e');
     }
@@ -175,10 +197,6 @@ class _ManageFavoritesContentState
       } else {
         await _appendTab(tabOrderSourceKey(sourceId));
       }
-    } on FavoriteCapReachedException catch (e) {
-      NotificationService.showError(
-        'Tu as déjà ${e.cap} sources favorites. Retires-en une d\'abord.',
-      );
     } catch (e) {
       NotificationService.showError('Erreur : $e');
     }
@@ -242,7 +260,9 @@ class _ManageFavoritesContentState
         // Modèle exclusif : la clé `theme:<slug>` peut être côté Flâner.
         await _removeTab(item.key);
         try {
-          await ref.read(userInterestsProvider.notifier).setInterestState(
+          await ref
+              .read(userInterestsProvider.notifier)
+              .setInterestState(
                 ThemeFavoriteRef(slug: item.id),
                 InterestState.followed,
               );
@@ -250,8 +270,9 @@ class _ManageFavoritesContentState
           NotificationService.showError('Erreur : $e');
         }
       case _FavKind.source:
-        final wasEssentiel =
-            ref.read(tourneeOrderPrefsProvider).sourceIsEssentiel(item.id);
+        final wasEssentiel = ref
+            .read(tourneeOrderPrefsProvider)
+            .sourceIsEssentiel(item.id);
         if (wasEssentiel) {
           await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
         }
@@ -267,7 +288,9 @@ class _ManageFavoritesContentState
       case _FavKind.subject:
         await _removeTab(item.key);
         try {
-          await ref.read(userInterestsProvider.notifier).setInterestState(
+          await ref
+              .read(userInterestsProvider.notifier)
+              .setInterestState(
                 CustomTopicFavoriteRef(id: item.id),
                 InterestState.unfollowed,
               );
@@ -350,8 +373,9 @@ class _ManageFavoritesContentState
     final interests = ref.read(userInterestsProvider).valueOrNull;
     if (interests == null) return;
     final queue = [for (final id in topicIds) CustomTopicFavoriteRef(id: id)];
-    final slots =
-        interests.favorites.whereType<CustomTopicFavoriteRef>().length;
+    final slots = interests.favorites
+        .whereType<CustomTopicFavoriteRef>()
+        .length;
     if (queue.length != slots) return;
     var i = 0;
     final merged = [
@@ -379,14 +403,15 @@ class _ManageFavoritesContentState
     final reorderedSet = reorderedIds.toSet();
     final others = [
       for (final f in [
-        ...sourcesState.favorites
+        ...sourcesState.favorites,
       ]..sort((a, b) => a.position.compareTo(b.position)))
         if ((essentiel ? !isEssentiel(f.sourceId) : isEssentiel(f.sourceId)) &&
             !reorderedSet.contains(f.sourceId))
           f.sourceId,
     ];
-    final fullIds =
-        essentiel ? [...reorderedIds, ...others] : [...others, ...reorderedIds];
+    final fullIds = essentiel
+        ? [...reorderedIds, ...others]
+        : [...others, ...reorderedIds];
     final refs = [
       for (var i = 0; i < fullIds.length; i++)
         SourceFavoriteRef(sourceId: fullIds[i], position: i),
@@ -524,8 +549,11 @@ class _ManageFavoritesContentState
       for (final item in essentielDefault)
         if (!tournee.hiddenKeys.contains(item.key)) item,
     ];
-    final essentielOrdered =
-        applyOrder(essentielVisible, tournee.order, (e) => e.key);
+    final essentielOrdered = applyOrder(
+      essentielVisible,
+      tournee.order,
+      (e) => e.key,
+    );
 
     // ── Items Flâner (sujets + sources mode-Flâner) ────────────────────────
     final subjectItems = <_FavItem>[
@@ -562,18 +590,14 @@ class _ManageFavoritesContentState
       for (final t in kVeilleFacteurThemes)
         if (!favThemeSlugs.contains(t.slug)) t,
     ];
-    final pinnableTopics = [
-      for (final t in customTopics)
-        if (!favoriteTopicIds.contains(t.id)) t,
-    ]..sort(
-        (a, b) =>
-            a.topicName.toLowerCase().compareTo(b.topicName.toLowerCase()),
-      );
-
-    final interestsAtCap =
-        interests != null && interests.favoriteCount >= interests.favoriteCap;
-    final sourcesAtCap = sourcesState != null &&
-        sourcesState.favorites.length >= sourcesState.favoriteCap;
+    final pinnableTopics =
+        [
+          for (final t in customTopics)
+            if (!favoriteTopicIds.contains(t.id)) t,
+        ]..sort(
+          (a, b) =>
+              a.topicName.toLowerCase().compareTo(b.topicName.toLowerCase()),
+        );
 
     final hiddenEditorialItems = <_FavItem>[
       if (tournee.hiddenKeys.contains(kTourneeActusKey)) actusItem,
@@ -632,6 +656,9 @@ class _ManageFavoritesContentState
                 // ── Section ESSENTIEL ───────────────────────────────────────
                 _SectionLabel(
                   label: 'BLOCS DE TA PAGE L\'ESSENTIEL',
+                  counter:
+                      '${essentielOrdered.length.clamp(0, kTourneeVisibleCap)}'
+                      '/$kTourneeVisibleCap',
                   colors: colors,
                 ),
                 const SizedBox(height: 8),
@@ -653,9 +680,11 @@ class _ManageFavoritesContentState
                       _persistEssentielReorder(reordered);
                     },
                     onRemove: _onRemove,
-                    moveIcon:
-                        PhosphorIcons.arrowLineDown(PhosphorIconsStyle.bold),
+                    moveIcon: PhosphorIcons.arrowLineDown(
+                      PhosphorIconsStyle.bold,
+                    ),
                     moveTooltip: 'Déplacer vers Flâner',
+                    moveLabel: 'Flâner',
                     onMove: (item) => item.kind == _FavKind.theme
                         ? _moveThemeToFlaner(item.id)
                         : _moveSourceToFlaner(item.id),
@@ -664,7 +693,11 @@ class _ManageFavoritesContentState
 
                 // ── Section FLÂNER ──────────────────────────────────────────
                 _SectionLabel(
+                  key: _flanerSectionKey,
                   label: 'ONGLETS DE TA PAGE FLÂNER',
+                  counter:
+                      '${flanerOrdered.length.clamp(0, kMaxFavoriteTabs)}'
+                      '/$kMaxFavoriteTabs',
                   colors: colors,
                 ),
                 const SizedBox(height: 8),
@@ -687,9 +720,11 @@ class _ManageFavoritesContentState
                       _persistFlanerReorder(reordered);
                     },
                     onRemove: _onRemove,
-                    moveIcon:
-                        PhosphorIcons.arrowLineUp(PhosphorIconsStyle.bold),
+                    moveIcon: PhosphorIcons.arrowLineUp(
+                      PhosphorIconsStyle.bold,
+                    ),
                     moveTooltip: 'Déplacer vers l\'Essentiel',
+                    moveLabel: 'Essentiel',
                     onMove: (item) => item.kind == _FavKind.theme
                         ? _moveThemeToEssentiel(item.id)
                         : _moveSourceToEssentiel(item.id),
@@ -725,21 +760,18 @@ class _ManageFavoritesContentState
                 if (_addTab == 0)
                   _SourcesAddList(
                     sources: followedSources,
-                    atCap: sourcesAtCap,
                     colors: colors,
                     onAdd: _onAddSource,
                   )
                 else if (_addTab == 1)
                   _ThemesAddList(
                     themes: addableThemes,
-                    atCap: interestsAtCap,
                     colors: colors,
                     onAdd: _onAddTheme,
                   )
                 else
                   _SubjectsAddList(
                     topics: pinnableTopics,
-                    atCap: interestsAtCap,
                     colors: colors,
                     onAdd: (id) async {
                       try {
@@ -750,18 +782,12 @@ class _ManageFavoritesContentState
                               InterestState.favorite,
                             );
                         await _appendTab(tabOrderTopicKey(id));
-                      } on FavoriteCapReachedException catch (e) {
-                        NotificationService.showError(
-                          'Tu as déjà ${e.cap} favoris. Retires-en un d\'abord.',
-                        );
                       } catch (e) {
                         NotificationService.showError('Erreur : $e');
                       }
                     },
-                    onCreate: () => EntityAddSheet.show(
-                      context,
-                      pinOnFollow: true,
-                    ),
+                    onCreate: () =>
+                        EntityAddSheet.show(context, pinOnFollow: true),
                   ),
 
                 if (hiddenEditorialItems.isNotEmpty) ...[
@@ -769,10 +795,11 @@ class _ManageFavoritesContentState
                   for (final item in hiddenEditorialItems)
                     _AddRow(
                       key: ValueKey('restore_${item.key}'),
-                      leading: Text(item.emoji,
-                          style: const TextStyle(fontSize: 14)),
+                      leading: Text(
+                        item.emoji,
+                        style: const TextStyle(fontSize: 14),
+                      ),
                       label: 'Réafficher ${item.label}',
-                      disabled: false,
                       colors: colors,
                       onTap: () => _onRestoreEditorial(item.key),
                     ),
@@ -837,6 +864,7 @@ class _FavList extends StatelessWidget {
   final void Function(_FavItem item) onRemove;
   final IconData moveIcon;
   final String moveTooltip;
+  final String moveLabel;
   final void Function(_FavItem item) onMove;
   final void Function(_FavItem item)? onSubjectVeille;
 
@@ -849,6 +877,7 @@ class _FavList extends StatelessWidget {
     required this.onRemove,
     required this.moveIcon,
     required this.moveTooltip,
+    required this.moveLabel,
     required this.onMove,
     this.onSubjectVeille,
   });
@@ -881,10 +910,12 @@ class _FavList extends StatelessWidget {
               colors: colors,
               moveIcon: moveIcon,
               moveTooltip: moveTooltip,
+              moveLabel: moveLabel,
               onRemove: () => onRemove(item),
               onMove: () => onMove(item),
-              onSubjectVeille:
-                  onSubjectVeille == null ? null : () => onSubjectVeille!(item),
+              onSubjectVeille: onSubjectVeille == null
+                  ? null
+                  : () => onSubjectVeille!(item),
             ),
           ],
         );
@@ -941,6 +972,7 @@ class _FavRow extends StatelessWidget {
   final FacteurColors colors;
   final IconData moveIcon;
   final String moveTooltip;
+  final String moveLabel;
   final VoidCallback onRemove;
   final VoidCallback onMove;
   final VoidCallback? onSubjectVeille;
@@ -952,6 +984,7 @@ class _FavRow extends StatelessWidget {
     required this.colors,
     required this.moveIcon,
     required this.moveTooltip,
+    required this.moveLabel,
     required this.onRemove,
     required this.onMove,
     this.onSubjectVeille,
@@ -993,8 +1026,10 @@ class _FavRow extends StatelessWidget {
                             radius: 6,
                           )
                         else
-                          Text(item.emoji,
-                              style: const TextStyle(fontSize: 16)),
+                          Text(
+                            item.emoji,
+                            style: const TextStyle(fontSize: 16),
+                          ),
                         const SizedBox(width: 10),
                         Expanded(
                           child: Text(
@@ -1023,11 +1058,14 @@ class _FavRow extends StatelessWidget {
                   onTap: onSubjectVeille!,
                 ),
               // Source ou thème : déplacement de mode (Essentiel ⇄ Flâner).
+              // Puce lisible (icône directionnelle + destination) — bien plus
+              // découvrable que l'ancienne flèche seule.
               if (isSource || isTheme)
-                _RowIconButton(
+                _MoveChip(
                   icon: moveIcon,
+                  label: moveLabel,
                   tooltip: moveTooltip,
-                  color: colors.textSecondary,
+                  accent: item.accent,
                   onTap: onMove,
                 ),
               _RowIconButton(
@@ -1094,6 +1132,67 @@ class _RowIconButton extends StatelessWidget {
   }
 }
 
+/// Puce de passage de mode (Essentiel ⇄ Flâner) pour sources et thèmes :
+/// icône directionnelle + libellé de destination, accentuée et lisible. Cible
+/// tactile ≥ 44px, haptique conservée. Remplace l'ancienne flèche seule peu
+/// découvrable.
+class _MoveChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String tooltip;
+  final Color accent;
+  final VoidCallback onTap;
+
+  const _MoveChip({
+    required this.icon,
+    required this.label,
+    required this.tooltip,
+    required this.accent,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () {
+          HapticFeedback.selectionClick();
+          onTap();
+        },
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 44),
+          child: Container(
+            alignment: Alignment.center,
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
+              color: accent.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: accent.withValues(alpha: 0.5)),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, size: 14, color: accent),
+                const SizedBox(width: 4),
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: accent,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// Trait de cap séparant les éléments visibles du surplus grisé.
 class _CapDivider extends StatelessWidget {
   final FacteurColors colors;
@@ -1129,13 +1228,11 @@ class _CapDivider extends StatelessWidget {
 
 class _SourcesAddList extends StatelessWidget {
   final List<Source> sources;
-  final bool atCap;
   final FacteurColors colors;
   final ValueChanged<String> onAdd;
 
   const _SourcesAddList({
     required this.sources,
-    required this.atCap,
     required this.colors,
     required this.onAdd,
   });
@@ -1151,18 +1248,11 @@ class _SourcesAddList extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (atCap)
-          _CapHint(
-            label: 'Maximum de sources favorites atteint (partagé Essentiel + '
-                'Flâner).',
-            colors: colors,
-          ),
         for (final s in sources)
           _AddRow(
             key: ValueKey('add_source_${s.id}'),
             leading: SourceLogoAvatar(source: s, size: 28, radius: 6),
             label: s.name,
-            disabled: atCap,
             colors: colors,
             onTap: () => onAdd(s.id),
           ),
@@ -1173,13 +1263,11 @@ class _SourcesAddList extends StatelessWidget {
 
 class _ThemesAddList extends StatelessWidget {
   final List<({String slug, String label, String emoji})> themes;
-  final bool atCap;
   final FacteurColors colors;
   final ValueChanged<String> onAdd;
 
   const _ThemesAddList({
     required this.themes,
-    required this.atCap,
     required this.colors,
     required this.onAdd,
   });
@@ -1195,14 +1283,11 @@ class _ThemesAddList extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (atCap)
-          _CapHint(label: 'Maximum de favoris atteint.', colors: colors),
         for (final t in themes)
           _AddRow(
             key: ValueKey('add_theme_${t.slug}'),
             leading: Text(t.emoji, style: const TextStyle(fontSize: 14)),
             label: t.label,
-            disabled: atCap,
             colors: colors,
             onTap: () => onAdd(t.slug),
           ),
@@ -1213,14 +1298,12 @@ class _ThemesAddList extends StatelessWidget {
 
 class _SubjectsAddList extends StatelessWidget {
   final List<CustomTopicInterest> topics;
-  final bool atCap;
   final FacteurColors colors;
   final ValueChanged<String> onAdd;
   final VoidCallback onCreate;
 
   const _SubjectsAddList({
     required this.topics,
-    required this.atCap,
     required this.colors,
     required this.onAdd,
     required this.onCreate,
@@ -1231,8 +1314,6 @@ class _SubjectsAddList extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (atCap)
-          _CapHint(label: 'Maximum de favoris atteint.', colors: colors),
         if (topics.isEmpty)
           _EmptyHint(
             label: 'Aucun sujet suivi à épingler. Crée-en un ci-dessous.',
@@ -1247,7 +1328,6 @@ class _SubjectsAddList extends StatelessWidget {
                 style: const TextStyle(fontSize: 14),
               ),
               label: t.topicName,
-              disabled: atCap,
               colors: colors,
               onTap: () => onAdd(t.id),
             ),
@@ -1279,7 +1359,6 @@ class _SubjectsAddList extends StatelessWidget {
 class _AddRow extends StatelessWidget {
   final Widget leading;
   final String label;
-  final bool disabled;
   final FacteurColors colors;
   final VoidCallback onTap;
 
@@ -1287,58 +1366,52 @@ class _AddRow extends StatelessWidget {
     super.key,
     required this.leading,
     required this.label,
-    required this.disabled,
     required this.colors,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Opacity(
-      opacity: disabled ? 0.4 : 1,
-      child: Padding(
-        padding: const EdgeInsets.only(bottom: 8),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(12),
-            onTap: disabled
-                ? null
-                : () {
-                    HapticFeedback.selectionClick();
-                    onTap();
-                  },
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-              decoration: BoxDecoration(
-                color: colors.surface,
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(color: colors.border),
-              ),
-              child: Row(
-                children: [
-                  leading,
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Text(
-                      label,
-                      style: TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                        color: colors.textPrimary,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: () {
+            HapticFeedback.selectionClick();
+            onTap();
+          },
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            decoration: BoxDecoration(
+              color: colors.surface,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: colors.border),
+            ),
+            child: Row(
+              children: [
+                leading,
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: colors.textPrimary,
                     ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  const SizedBox(width: 10),
-                  Icon(
-                    PhosphorIcons.plus(PhosphorIconsStyle.bold),
-                    size: 16,
-                    color: colors.textSecondary,
-                  ),
-                ],
-              ),
+                ),
+                const SizedBox(width: 10),
+                Icon(
+                  PhosphorIcons.plus(PhosphorIconsStyle.bold),
+                  size: 16,
+                  color: colors.textSecondary,
+                ),
+              ],
             ),
           ),
         ),
@@ -1407,19 +1480,35 @@ class _VeilleTile extends StatelessWidget {
 
 class _SectionLabel extends StatelessWidget {
   final String label;
+
+  /// Compteur discret affiché en suffixe (ex. « · 5/7 ») rappelant le cap de
+  /// la section. `null` → pas de compteur (ex. en-têtes AJOUTER / GÉRER).
+  final String? counter;
   final FacteurColors colors;
 
-  const _SectionLabel({required this.label, required this.colors});
+  const _SectionLabel({
+    super.key,
+    required this.label,
+    required this.colors,
+    this.counter,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      label,
-      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-            color: colors.textTertiary,
-            fontWeight: FontWeight.w700,
-            letterSpacing: 1.2,
-          ),
+    final labelStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
+      color: colors.textTertiary,
+      fontWeight: FontWeight.w700,
+      letterSpacing: 1.2,
+    );
+    if (counter == null) return Text(label, style: labelStyle);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.baseline,
+      textBaseline: TextBaseline.alphabetic,
+      children: [
+        Flexible(child: Text(label, style: labelStyle)),
+        const SizedBox(width: 6),
+        Text('· $counter', style: labelStyle?.copyWith(letterSpacing: 0.2)),
+      ],
     );
   }
 }
@@ -1437,28 +1526,6 @@ class _EmptyHint extends StatelessWidget {
       child: Text(
         label,
         style: TextStyle(color: colors.textTertiary, fontSize: 13, height: 1.4),
-      ),
-    );
-  }
-}
-
-class _CapHint extends StatelessWidget {
-  final String label;
-  final FacteurColors colors;
-
-  const _CapHint({required this.label, required this.colors});
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
-      child: Text(
-        label,
-        style: TextStyle(
-          color: colors.textTertiary,
-          fontSize: 12,
-          fontStyle: FontStyle.italic,
-        ),
       ),
     );
   }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -80,7 +80,7 @@ UserInterestsState _interestsState({
     customTopics: customTopics,
     favorites: favorites,
     favoriteCount: favorites.length,
-    favoriteCap: 5,
+    favoriteCap: 7,
   );
 }
 
@@ -437,7 +437,7 @@ void main() {
       );
     });
 
-    test('5 favorites cap (6th ignored)', () async {
+    test('7 favorites cap (8th ignored)', () async {
       SharedPreferences.setMockInitialValues(<String, Object>{});
       when(
         () => feedRepo.getFeed(
@@ -457,7 +457,9 @@ void main() {
             ThemeFavoriteRef(slug: 'culture'),
             ThemeFavoriteRef(slug: 'economy'),
             ThemeFavoriteRef(slug: 'politics'),
-            ThemeFavoriteRef(slug: 'sport'), // 6th — must be dropped
+            ThemeFavoriteRef(slug: 'sport'),
+            ThemeFavoriteRef(slug: 'environment'),
+            ThemeFavoriteRef(slug: 'society'), // 8th — must be dropped
           ],
         ),
       );
@@ -468,7 +470,15 @@ void main() {
           .whereType<FeedThemeSection>()
           .map((s) => s.themeSlug)
           .toList();
-      expect(slugs, ['tech', 'science', 'culture', 'economy', 'politics']);
+      expect(slugs, [
+        'tech',
+        'science',
+        'culture',
+        'economy',
+        'politics',
+        'sport',
+        'environment',
+      ]);
     });
   });
 

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
@@ -66,7 +66,7 @@ UserInterestsState _interestsState({List<FavoriteRef> favorites = const []}) {
     customTopics: const [],
     favorites: favorites,
     favoriteCount: favorites.length,
-    favoriteCap: 5,
+    favoriteCap: 7,
   );
 }
 
@@ -81,7 +81,7 @@ UserSourcesState _sourcesState({List<SourceFavoriteRef> favorites = const []}) {
         .toList(),
     favorites: favorites,
     favoriteCount: favorites.length,
-    favoriteCap: 5,
+    favoriteCap: 7,
   );
 }
 
@@ -311,7 +311,7 @@ void main() {
 
   test(
       'plusieurs sources favorites respectent l\'ordre par position et le '
-      'cap (parité thèmes = 5)', () async {
+      'cap (parité thèmes = 7)', () async {
     stubFeed(
       themeIds: const {},
       sourceIds: {
@@ -321,6 +321,8 @@ void main() {
         'd': ['d1', 'd2'],
         'e': ['e1', 'e2'],
         'f': ['f1', 'f2'],
+        'g': ['g1', 'g2'],
+        'h': ['h1', 'h2'],
       },
     );
     final container = await buildContainer(
@@ -332,6 +334,8 @@ void main() {
         SourceFavoriteRef(sourceId: 'd', position: 3),
         SourceFavoriteRef(sourceId: 'f', position: 5),
         SourceFavoriteRef(sourceId: 'e', position: 4),
+        SourceFavoriteRef(sourceId: 'h', position: 7),
+        SourceFavoriteRef(sourceId: 'g', position: 6),
       ]),
       catalog: [
         _source('a'),
@@ -340,6 +344,8 @@ void main() {
         _source('d'),
         _source('e'),
         _source('f'),
+        _source('g'),
+        _source('h'),
       ],
       tourneeOrder: const [
         'source:a',
@@ -348,6 +354,8 @@ void main() {
         'source:d',
         'source:e',
         'source:f',
+        'source:g',
+        'source:h',
       ],
     );
     addTearDown(container.dispose);
@@ -358,7 +366,7 @@ void main() {
         .map((s) => s.sourceId)
         .toList();
 
-    // Triées par position (a,b,c,d,e,f) puis capées à 5 → a,b,c,d,e.
-    expect(sources, ['a', 'b', 'c', 'd', 'e']);
+    // Triées par position (a..h) puis capées à 7 → a,b,c,d,e,f,g.
+    expect(sources, ['a', 'b', 'c', 'd', 'e', 'f', 'g']);
   });
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
@@ -1,6 +1,6 @@
 // PR 2 — couverture du bloc favori UNIFIÉ de la Tournée composé par le
 // FluxContinuNotifier : ordre 100 % libre (thèmes + sources + veille mélangés
-// via « Composer ma Tournée »), cap d'affichage 5, exclusion des sujets perso,
+// via « Composer ma Tournée »), cap d'affichage 7, exclusion des sujets perso,
 // et masquage de la veille (veilleHidden).
 import 'dart:io';
 
@@ -106,7 +106,7 @@ UserInterestsState _interestsState({List<FavoriteRef> favorites = const []}) {
     customTopics: const [],
     favorites: favorites,
     favoriteCount: favorites.length,
-    favoriteCap: 5,
+    favoriteCap: 7,
   );
 }
 
@@ -123,7 +123,7 @@ UserSourcesState _sourcesState({List<SourceFavoriteRef> favorites = const []}) {
         .toList(),
     favorites: favorites,
     favoriteCount: favorites.length,
-    favoriteCap: 5,
+    favoriteCap: 7,
   );
 }
 
@@ -381,13 +381,15 @@ void main() {
       },
     );
 
-    test('cap 5 unifié : Actus + Grille + 3 thèmes coupent Bonnes', () async {
+    test('cap 7 unifié : Actus + Grille + 5 thèmes coupent Bonnes', () async {
       stubDigest();
       stubFeed(
         themeIds: {
           'society': ['s1'],
           'culture': ['c1'],
           'economy': ['e1'],
+          'politics': ['p1'],
+          'tech': ['t1'],
         },
       );
       final container = await buildContainer(
@@ -396,6 +398,8 @@ void main() {
             ThemeFavoriteRef(slug: 'society'),
             ThemeFavoriteRef(slug: 'culture'),
             ThemeFavoriteRef(slug: 'economy'),
+            ThemeFavoriteRef(slug: 'politics'),
+            ThemeFavoriteRef(slug: 'tech'),
           ],
         ),
         sourcesState: _sourcesState(),
@@ -411,12 +415,15 @@ void main() {
         'theme:society',
         'theme:culture',
         'theme:economy',
+        'theme:politics',
+        'theme:tech',
       ]);
       expect(state.grilleSlotIndex, 1);
       expect(
         state.sections.map(sectionKey),
         isNot(contains(kTourneeBonnesKey)),
-        reason: 'Bonnes est 6e dans la liste unifiée et tombe sous le cap',
+        reason: 'Bonnes est 8e dans la liste unifiée (Actus+Grille+5 thèmes) '
+            'et tombe sous le cap de 7',
       );
     });
 
@@ -547,8 +554,8 @@ void main() {
   });
 
   test(
-      'cap d\'affichage 5 : 3 thèmes + 3 sources + veille (7 candidats) → '
-      'seulement 5 sections, veille (en queue par défaut) coupée', () async {
+      'cap d\'affichage 7 : 4 thèmes + 3 sources + veille (8 candidats) → '
+      'seulement 7 sections, veille (en queue par défaut) coupée', () async {
     // Story 10.2 — les sources doivent être en mode « Essentiel » (clé dans
     // l'ordre) pour entrer dans la Tournée ; on garde l'ordre par défaut
     // (thèmes avant sources) en plaçant les clés thème d'abord.
@@ -557,6 +564,7 @@ void main() {
         'theme:society',
         'theme:culture',
         'theme:economy',
+        'theme:politics',
         'source:a',
         'source:b',
         'source:c',
@@ -567,6 +575,7 @@ void main() {
         'society': ['s1', 's2'],
         'culture': ['c1', 'c2'],
         'economy': ['e1', 'e2'],
+        'politics': ['p1', 'p2'],
       },
       sourceIds: {
         'a': ['a1'],
@@ -580,6 +589,7 @@ void main() {
           ThemeFavoriteRef(slug: 'society'),
           ThemeFavoriteRef(slug: 'culture'),
           ThemeFavoriteRef(slug: 'economy'),
+          ThemeFavoriteRef(slug: 'politics'),
         ],
       ),
       sourcesState: _sourcesState(
@@ -599,19 +609,21 @@ void main() {
 
     expect(
       sections,
-      hasLength(5),
-      reason: 'cap d\'affichage de la Tournée = 5',
+      hasLength(7),
+      reason: 'cap d\'affichage de la Tournée = 7',
     );
     expect(
       sections.where((s) => s.kind == SectionKind.veille),
       isEmpty,
-      reason: 'ordre par défaut thèmes→sources→veille → veille en 7e, coupée',
+      reason: 'ordre par défaut thèmes→sources→veille → veille en 8e, coupée',
     );
-    // Ordre par défaut : 3 thèmes puis 2 sources (a, b) ; c et veille tombent.
+    // Ordre par défaut : 4 thèmes puis 3 sources (a, b, c) ; veille tombe.
     expect(sections.map((s) => s.kind).toList(), [
       SectionKind.theme,
       SectionKind.theme,
       SectionKind.theme,
+      SectionKind.theme,
+      SectionKind.source,
       SectionKind.source,
       SectionKind.source,
     ]);
@@ -619,7 +631,7 @@ void main() {
       sections
           .where((s) => s.kind == SectionKind.source)
           .map((s) => s.sourceId),
-      ['a', 'b'],
+      ['a', 'b', 'c'],
     );
   });
 
@@ -664,13 +676,14 @@ void main() {
     'veille en tête d\'ordre : présente dans le cap, un autre item tombe',
     () async {
       // Story 10.2 — sources en mode « Essentiel » (clés dans l'ordre) ; veille
-      // remontée en tête. 7 candidats → cap 5, veille première.
+      // remontée en tête. 8 candidats → cap 7, veille première (source c tombe).
       SharedPreferences.setMockInitialValues(<String, Object>{
         'tournee_order_v1': [
           'veille',
           'theme:society',
           'theme:culture',
           'theme:economy',
+          'theme:politics',
           'source:a',
           'source:b',
           'source:c',
@@ -681,6 +694,7 @@ void main() {
           'society': ['s1', 's2'],
           'culture': ['c1', 'c2'],
           'economy': ['e1', 'e2'],
+          'politics': ['p1', 'p2'],
         },
         sourceIds: {
           'a': ['a1'],
@@ -694,6 +708,7 @@ void main() {
             ThemeFavoriteRef(slug: 'society'),
             ThemeFavoriteRef(slug: 'culture'),
             ThemeFavoriteRef(slug: 'economy'),
+            ThemeFavoriteRef(slug: 'politics'),
           ],
         ),
         sourcesState: _sourcesState(
@@ -711,7 +726,7 @@ void main() {
       await container.read(fluxContinuProvider.future);
       final sections = favoriteSections(container);
 
-      expect(sections, hasLength(5));
+      expect(sections, hasLength(7));
       expect(
         sections.first.kind,
         SectionKind.veille,
@@ -967,7 +982,7 @@ void main() {
       () async {
     // Régression : la Grille n'étant plus réordonnable, sa clé `grille` est
     // absente de `tournee_order_v1`. `applyOrder` la reléguait en fin de liste
-    // → coupée par le cap de 5 → disparition totale. Elle doit rester collée
+    // → coupée par le cap → disparition totale. Elle doit rester collée
     // aux Actus.
     SharedPreferences.setMockInitialValues(<String, Object>{
       'tournee_customized_v1': true,

--- a/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
@@ -1,7 +1,7 @@
 // Story 10.2 — sheet unifiée « Mes favoris » : deux sections (Essentiel /
 // Flâner), appartenance exclusive des sources (la clé `source:` dans
 // `tournee_order_v1` ⇒ Essentiel, sinon Flâner), déplacement de mode, funnel
-// veille sur les sujets, et caps 5/10 par section.
+// veille sur les sujets, et caps 7/10 par section.
 import 'package:facteur/config/routes.dart';
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
@@ -109,7 +109,7 @@ UserInterestsState _interests({
       customTopics: customTopics,
       favorites: favorites,
       favoriteCount: favorites.length,
-      favoriteCap: 5,
+      favoriteCap: 7,
     );
 
 UserSourcesState _sources({
@@ -129,7 +129,7 @@ UserSourcesState _sources({
       ],
       favorites: favorites,
       favoriteCount: favorites.length,
-      favoriteCap: 5,
+      favoriteCap: 7,
     );
 
 CustomTopicInterest _topic(String id, String name,
@@ -346,7 +346,7 @@ void main() {
   });
 
   testWidgets(
-      '« Hors Tournée du jour (5) » apparaît au-delà de 5 sections Essentiel',
+      '« Hors Tournée du jour (7) » apparaît au-delà de 7 sections Essentiel',
       (tester) async {
     await _openSheet(
       tester,
@@ -357,12 +357,16 @@ void main() {
         ThemeFavoriteRef(slug: 'politics'),
         ThemeFavoriteRef(slug: 'environment'),
         ThemeFavoriteRef(slug: 'international'),
+        ThemeFavoriteRef(slug: 'economy'),
+        ThemeFavoriteRef(slug: 'culture'),
       ]),
       sources: _sources(),
     );
 
-    // Item 5 — le cap est explicité entre parenthèses.
-    expect(find.text('Hors Tournée du jour (5)'), findsOneWidget);
+    // Le cap (élargi 5 → 7) est explicité entre parenthèses.
+    expect(find.text('Hors Tournée du jour (7)'), findsOneWidget);
+    // Le compteur de l'en-tête reflète aussi le cap.
+    expect(find.text('· 7/7'), findsOneWidget);
   });
 
   testWidgets(

--- a/apps/mobile/test/features/flux_continu/widgets/tournee_composer_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/tournee_composer_sheet_test.dart
@@ -27,7 +27,7 @@ class _StubInterests extends UserInterestsNotifier {
         customTopics: [],
         favorites: [],
         favoriteCount: 0,
-        favoriteCap: 5,
+        favoriteCap: 7,
       );
 }
 
@@ -37,7 +37,7 @@ class _StubSources extends UserSourcesStateNotifier {
         sources: [],
         favorites: [],
         favoriteCount: 0,
-        favoriteCap: 5,
+        favoriteCap: 7,
       );
 }
 

--- a/packages/api/app/constants.py
+++ b/packages/api/app/constants.py
@@ -6,10 +6,11 @@ sont hard-codées pour rester en phase avec le mobile (constante miroir
 `kFavoriteCap` côté Flutter, cf. plan 22.1).
 """
 
-FAVORITE_CAP: int = 5
-"""Cap d'affichage de la « Tournée du jour » (Story 22.2 — révision 2026-05-18).
+FAVORITE_CAP: int = 7
+"""Cap d'affichage de la « Tournée du jour » (Story 22.2 — révision 2026-05-18 ;
+élargi 5 → 7 le 2026-06-08, cf. plan « limites + affordance modal favoris »).
 
-N'est PLUS un cap dur : l'utilisateur peut avoir > 5 favoris ; seuls les 5
+N'est PLUS un cap dur : l'utilisateur peut avoir > 7 favoris ; seuls les 7
 premiers (ordre `position` modifiable) sont retenus pour la Tournée du jour.
 Conservé sous le nom `FAVORITE_CAP` pour compat des imports ; sémantiquement
 équivalent à `DAILY_TOUR_CAP`. Mirror mobile : `dailyTourCap` dans
@@ -21,7 +22,7 @@ MIN_BACKFILL_FAVORITES: int = 2
 
 Story 22.1 — décision PO 2026-05-16 : tout user existant doit avoir ≥ 2
 favoris pour que la tournée du jour (PR2) soit non-vide. Inférieur à
-FAVORITE_CAP (5) pour laisser de la place à la promo mobile post-migration
+FAVORITE_CAP (7) pour laisser de la place à la promo mobile post-migration
 (sync `theme_priority_*` SharedPrefs → POST favoris).
 """
 


### PR DESCRIPTION
# Tournée — clarifier les limites + affordance du bouton de passage + auto-scroll

## Résumé

Refonte de la modal « Mes favoris » (`manage_favorites_sheet.dart`, ouverte depuis
L'Essentiel et les onglets Flâner) pour lever la confusion entre les trois
mécanismes de limite, et élargissement du cap Tournée **5 → 7**.

## Changements

### 1. Cap Tournée 5 → 7 (mirrors synchronisés, aucune migration)
- `tournee_order_prefs_provider.dart` : `kTourneeVisibleCap` 5 → 7.
- `flux_continu_provider.dart` : `_kMaxFavoriteSections` & `_kMaxFavoriteSourceSections`
  5 → 7 (sous-caps par catégorie, avant le `take(kTourneeVisibleCap)`).
- `config/constants.dart` : `InterestConstants.favoriteCap` 5 → 7 (mirror).
- `packages/api/app/constants.py` : `FAVORITE_CAP` 5 → 7 (mirror, constante produit —
  pas de DDL/Alembic). `get_top_themes` borne juste un peu plus large la perso éditoriale.
- Cap Flâner `kMaxFavoriteTabs = 10` : **inchangé**.

### 2. Suppression des blocages « max » par type
Le backend n'impose aucun cap dur (`FavoriteCapReached` = code mort). Retiré côté
modal : `interestsAtCap`/`sourcesAtCap`, le paramètre `atCap` des add-lists, les
`_CapHint(« Maximum … atteint »)`, la classe `_CapHint`, les `catch
(FavoriteCapReachedException)` et l'import devenu inutile. L'ajout n'est plus jamais
bloqué ; le surplus reste grisé sous le trait `_CapDivider` existant.

### 3. Compteurs dans les en-têtes
`_SectionLabel` accepte un `counter` optionnel rendu en pill discret (`· X/7`,
`· X/10`). Essentiel = `clamp(0, 7)/7`, Flâner = `clamp(0, 10)/10`.

### 4. Affordance du bouton de passage
Nouvelle puce `_MoveChip` (icône directionnelle + libellé de destination
« Flâner » / « Essentiel », bord/fond accentués via `item.accent`, cible ≥ 44px,
haptique conservée) en remplacement de la flèche seule, pour sources et thèmes.

### 5. Bonus — auto-scroll vers Flâner
`ScrollController` + `GlobalKey` sur l'en-tête Flâner ; en `initState`, si
`entry == ManageFavoritesEntry.flaner`, `Scrollable.ensureVisible` (300 ms, easeOut).
Entrée Essentiel → pas de scroll (déjà en tête).

## Fichiers modifiés
- `apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart`
- `apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart`
- `apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart`
- `apps/mobile/lib/config/constants.dart`
- `packages/api/app/constants.py`
- Tests : `manage_favorites_sheet_test.dart`, `flux_continu_tournee_order_test.dart`,
  `flux_continu_sources_test.dart`, `flux_continu_provider_test.dart`,
  `tournee_composer_sheet_test.dart` (caps 5 → 7, scénarios de coupe ré-équilibrés).

## Vérification
- Backend : `pytest` complet → **1525 passed, 1 skipped, 2 xfailed** (DB test 54322).
- Mobile : `flutter analyze` (aucune issue sur les fichiers touchés) + tests
  flux_continu touchés → **tous verts**.
