### PR TITLE
fix(perspectives): éliminer N+1 queries sur /contents/{id}/perspectives

### DIFF
--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -16,6 +16,7 @@ import httpx
 import structlog
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import selectinload
 
 from app.services.text_similarity import jaccard_similarity, normalize_title
 
@@ -254,6 +255,14 @@ class PerspectiveService:
 
     def _has_db(self) -> bool:
         return self._session_maker is not None or self.db is not None
+
+    def _extract_bias_from_source(self, source, domain: str) -> str:
+        """Bias from an eager-loaded Source, falling back to DOMAIN_BIAS_MAP."""
+        if source is not None and source.bias_stance:
+            stance = source.bias_stance.value
+            if stance != "unknown":
+                return stance
+        return DOMAIN_BIAS_MAP.get(domain, "unknown")
 
     async def resolve_bias(self, domain: str, source_name: str | None = None) -> str:
         """Resolve bias for a domain: DOMAIN_BIAS_MAP first, then DB fallback by URL, then by name."""
@@ -599,7 +608,6 @@ class PerspectiveService:
         entity_names = entity_names[:3]
 
         from app.models.content import Content
-        from app.models.source import Source
 
         cutoff = datetime.now(UTC) - timedelta(hours=time_window_hours)
 
@@ -609,9 +617,12 @@ class PerspectiveService:
             for name in entity_names
         ]
 
+        # Eager-load Content.source so the bias lookup below is in-memory.
+        # Sans selectinload, `resolve_bias(domain)` repartait au DB pour chaque
+        # ligne (N+1 sur /contents/{id}/perspectives — bottom-sheet "Autres regards").
         stmt = (
             select(Content)
-            .join(Source, Content.source_id == Source.id)
+            .options(selectinload(Content.source))
             .where(
                 or_(*entity_filters),
                 Content.source_id != content.source_id,
@@ -679,13 +690,16 @@ class PerspectiveService:
 
             # Extract domain from URL
             domain = self._extract_domain(row.url)
-            bias = await self.resolve_bias(domain)
+
+            source_obj = row.source
+            source_name = (source_obj.name or domain) if source_obj else domain
+            bias = self._extract_bias_from_source(source_obj, domain)
 
             perspectives.append(
                 Perspective(
                     title=row.title,
                     url=row.url,
-                    source_name=domain,  # Best we have without eager-loading source
+                    source_name=source_name,
                     source_domain=domain,
                     bias_stance=bias,
                     published_at=row.published_at.isoformat()
@@ -784,7 +798,7 @@ class PerspectiveService:
             if not domain and not source_name:
                 continue
 
-            bias = await self.resolve_bias(domain=domain, source_name=source_name)
+            bias = self._extract_bias_from_source(source, domain)
 
             result.append(
                 Perspective(

--- a/packages/api/tests/test_perspective_service_n1.py
+++ b/packages/api/tests/test_perspective_service_n1.py
@@ -1,0 +1,215 @@
+"""Regression: pas de N+1 sur PerspectiveService.search_internal_perspectives /
+build_cluster_perspectives — origine du ralentissement de la bottom-sheet
+"Autres regards" remonté par le monitoring (13 utilisateurs touchés).
+
+Avant fix : la boucle appelait `resolve_bias(domain)` par perspective →
+2 requêtes ILIKE additionnelles sur `sources` par perspective.
+Après fix : `Content.source` est eager-loadé (selectinload) et le bias est
+lu directement sur la ligne `Source` déjà en mémoire.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.orm import selectinload
+
+from app.models.content import Content
+from app.models.enums import BiasStance, ContentType, SourceType
+from app.models.source import Source
+from app.services.perspective_service import PerspectiveService
+
+
+class _QueryCounter:
+    """Compteur de requêtes SQL émises via une connexion sync_engine."""
+
+    def __init__(self) -> None:
+        self.count = 0
+
+    def _on_execute(self, conn, cursor, statement, parameters, context, executemany):
+        # On ignore les SAVEPOINT / RELEASE / ROLLBACK posés par la fixture
+        # db_session (transaction de test + savepoints).
+        upper = statement.lstrip().upper()
+        if upper.startswith(("SAVEPOINT", "RELEASE", "ROLLBACK")):
+            return
+        self.count += 1
+
+    def attach(self, sync_conn):
+        event.listen(sync_conn, "before_cursor_execute", self._on_execute)
+
+    def detach(self, sync_conn):
+        event.remove(sync_conn, "before_cursor_execute", self._on_execute)
+
+
+async def _make_source(db_session, *, name: str, url: str, bias: BiasStance) -> Source:
+    src = Source(
+        id=uuid4(),
+        name=name,
+        url=url,
+        feed_url=f"https://feed.example/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+        bias_stance=bias,
+    )
+    db_session.add(src)
+    await db_session.commit()
+    return src
+
+
+async def _make_content(
+    db_session,
+    source: Source,
+    *,
+    title: str,
+    url: str,
+    entity_name: str,
+) -> Content:
+    c = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title=title,
+        url=url,
+        published_at=datetime.now(UTC) - timedelta(hours=1),
+        content_type=ContentType.ARTICLE,
+        guid=str(uuid4()),
+        entities=[json.dumps({"name": entity_name, "type": "PERSON"})],
+        topics=["politics"],
+    )
+    db_session.add(c)
+    await db_session.commit()
+    return c
+
+
+@pytest.mark.asyncio
+async def test_search_internal_perspectives_no_n_plus_one(db_session, monkeypatch):
+    """Le code path interne ne doit PAS émettre une requête par perspective.
+
+    Avec 5 perspectives, l'ancien code émettait 1 + 5×2 = 11 requêtes
+    (1 SELECT Content + 5 × 2 ILIKE sur Source). Après fix : 2 requêtes
+    fixes (SELECT Content + selectinload Source), peu importe le nombre.
+    """
+    # Désactive le post-filtre de cohérence pour garder le titre & topics
+    # simples — on cible le compteur de requêtes, pas la logique de filtre.
+    monkeypatch.setattr(
+        "app.services.perspective_service.PERSPECTIVE_FILTER_ENABLED", False
+    )
+
+    # Seed source (différente des candidates pour passer le filtre source_id != ...)
+    seed_source = await _make_source(
+        db_session, name="Seed", url="https://seed.example", bias=BiasStance.UNKNOWN
+    )
+    seed = SimpleNamespace(
+        id=uuid4(),
+        title="Affaire Dupont : nouvelle audition",
+        url="https://seed.example/article",
+        source_id=seed_source.id,
+        entities=[json.dumps({"name": "Dupont", "type": "PERSON"})],
+        topics=["politics"],
+    )
+
+    # 5 sources distinctes avec bias variés + 1 article chacune partageant
+    # l'entité "Dupont"
+    biases = [
+        BiasStance.LEFT,
+        BiasStance.CENTER_LEFT,
+        BiasStance.CENTER,
+        BiasStance.CENTER_RIGHT,
+        BiasStance.RIGHT,
+    ]
+    for i, b in enumerate(biases):
+        src = await _make_source(
+            db_session,
+            name=f"Outlet {i}",
+            url=f"https://outlet{i}.example",
+            bias=b,
+        )
+        await _make_content(
+            db_session,
+            src,
+            title=f"Dupont {i}",
+            url=f"https://outlet{i}.example/a{i}",
+            entity_name="Dupont",
+        )
+
+    service = PerspectiveService(db=db_session)
+
+    counter = _QueryCounter()
+    sync_conn = await db_session.connection()
+    raw_conn = sync_conn.sync_connection
+    counter.attach(raw_conn)
+    try:
+        perspectives = await service.search_internal_perspectives(seed)
+    finally:
+        counter.detach(raw_conn)
+
+    # 5 perspectives attendues, une par source/bias
+    assert len(perspectives) == 5
+    biases_returned = {p.bias_stance for p in perspectives}
+    assert biases_returned == {"left", "center-left", "center", "center-right", "right"}
+
+    # Garde-fou N+1 : on tolère ≤ 3 requêtes (SELECT Content + selectinload Source
+    # + éventuelle requête de BEGIN du savepoint). L'ancien code en émettait ≥ 11.
+    assert counter.count <= 3, (
+        f"N+1 régression: {counter.count} requêtes émises pour 5 perspectives "
+        "(attendu ≤ 3 — selectinload doit éviter les ILIKE par perspective)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_cluster_perspectives_no_db_hit_when_source_preloaded(
+    db_session,
+):
+    """build_cluster_perspectives ne doit pas toucher la DB quand la source
+    est déjà eager-loadée par l'appelant (cas réel : pipeline éditorial +
+    _load_cluster_articles_for_representative)."""
+    src_a = await _make_source(
+        db_session, name="Le Monde", url="https://lemonde.fr", bias=BiasStance.CENTER_LEFT
+    )
+    src_b = await _make_source(
+        db_session, name="Le Figaro", url="https://lefigaro.fr", bias=BiasStance.CENTER_RIGHT
+    )
+    c_a = await _make_content(
+        db_session, src_a, title="Titre A", url="https://lemonde.fr/a", entity_name="X"
+    )
+    c_b = await _make_content(
+        db_session, src_b, title="Titre B", url="https://lefigaro.fr/b", entity_name="X"
+    )
+
+    # Recharger avec selectinload, comme le fait l'appelant prod
+    from sqlalchemy import select
+
+    stmt = (
+        select(Content)
+        .options(selectinload(Content.source))
+        .where(Content.id.in_([c_a.id, c_b.id]))
+    )
+    result = await db_session.execute(stmt)
+    contents = list(result.scalars().all())
+    assert len(contents) == 2
+
+    service = PerspectiveService(db=db_session)
+
+    counter = _QueryCounter()
+    sync_conn = await db_session.connection()
+    raw_conn = sync_conn.sync_connection
+    counter.attach(raw_conn)
+    try:
+        perspectives = await service.build_cluster_perspectives(contents)
+    finally:
+        counter.detach(raw_conn)
+
+    assert len(perspectives) == 2
+    stances = {p.bias_stance for p in perspectives}
+    assert stances == {"center-left", "center-right"}
+    # 0 requête attendue : tout est déjà en mémoire.
+    assert counter.count == 0, (
+        f"N+1 régression: build_cluster_perspectives a émis {counter.count} requêtes "
+        "alors que Content.source était pré-chargé."
+    )


### PR DESCRIPTION
## Quoi
Fix N+1 queries dans la bottom-sheet « Autres regards ». Remplace les appels `resolve_bias(domain)` par boucle par `selectinload(Content.source)` + lecture directe de `source.bias_stance`.

Extrait un helper `_extract_bias_from_source()` qui factorise la logique enum→string + fallback `DOMAIN_BIAS_MAP`.

## Pourquoi
La fiche perspectives émettait ≥11 requêtes SQL pour 5 sources (1 SELECT + 5×2 ILIKE par appel de `resolve_bias`). Après fix : ≤3 requêtes constantes quelle que soit la taille du cluster. Même optimisation appliquée à `build_cluster_perspectives` (0 DB hit quand source déjà eager-loadée).

## Comment ça a été vérifié
- [x] pytest `tests/test_perspective_service_n1.py` — 2 tests de régression N+1 (≤3 queries / 0 query avec compteur SQLAlchemy)
- [x] pytest -v suite complète — 1557 passed, 0 failed
- [x] /simplify passé — import déplacé au top-level, 2 blocs inline remplacés par helper

## Zones à risque
`perspective_service.py` — extraction biais/source (fallback `DOMAIN_BIAS_MAP` conservé, `resolve_bias` async préservé pour le chemin Google News RSS)