### PR TITLE
fix(sources): session premium persistante + découvrabilité (fallback générique, Mes abonnements)

### DIFF
--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,67 +1,59 @@
-# QA Handoff — L'Essentiel : cartes ≤ écran + footer auto-hide
+# QA Handoff — Sources payantes : session persistante + découvrabilité
 
-> Story `docs/stories/core/9.5.essentiel-cards-fit-screen.md`. UI/visuel + feel
-> de scroll → validation Chrome obligatoire (viewport mobile, **2 tailles**).
+> Bug doc : `docs/bugs/bug-sources-payantes-session-decouvrabilite.md`
+> Branche : `boujonlaurin-dotcom/webview-credentials-not-saving`. Base **main**.
 
-## Feature développée
-Aucune carte du Flux Continu ne dépasse la hauteur utile de l'écran (héros trimmé
-3→2→1, sections cap dynamique, bouton « Tout lire » inclus) ; le footer
-(MainBottomNav) se masque au scroll vers le bas et revient au scroll vers le haut
-(comportement LinkedIn), partout dans l'app.
+## ⚠️ Portée de la validation web (Chrome / `/validate-feature`)
 
-## PR associée
-À créer (`/go`). Base **main**.
+La **persistance de session** (capture/réinjection des cookies natifs WKWebView /
+Android WebView) **n'est pas testable sur le web** — elle requiert un device iOS **et**
+Android (cf. plan → Vérification → Device). La validation web couvre **la découvrabilité
+UI** uniquement.
 
 ## Écrans impactés
+
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| L'Essentiel (Flux Continu) | `/flux-continu` | Modifié |
-| Flâner | `/flaner` | Modifié (footer auto-hide uniquement) |
+| Fiche source (`SourceDetailModal`) | overlay | Modifié (CTA proéminent) |
+| Compte (`AccountScreen`) | `/settings/account` | Modifié (carte « ABONNEMENTS ») |
+| Mes abonnements (`SubscriptionsScreen`) | `/settings/subscriptions` | **Nouveau** |
+| Reader (`ContentDetailScreen`) | `/content/:id` | Modifié (CTA paywall) |
 
-## Scénarios de test (viewport **390×844** ET **360×640**)
+## Scénarios (viewport mobile 390×844)
 
-### Scénario 1 : Héros & sections ne dépassent jamais l'écran (happy path)
-1. Ouvrir L'Essentiel.
-2. Scroller carte par carte (snap).
-**Attendu** : chaque pile (héros « Ton Essentiel », Actus du jour, thèmes…) tient
-dans la hauteur utile, bouton « Lire plus / Tout lire » **visible et non couvert**.
-Aucune zone de **lecture libre interne** (pas de scroll fin *dans* une carte),
-aucun `_FreeReadEdgeFade` (dégradé bas) sur ces sections. Snap = 1 section/écran,
-haptique au franchissement (non régressée).
+### 1. CTA modal réapparaît (cœur du fix #2)
+Ouvrir la fiche d'un média payant (Le Monde, Mediapart, Le Figaro, L'Équipe, Libération,
+Les Échos, Télérama). **Attendu** : un CTA **primary en tête** :
+- jamais abonné, config curée → « Connecter mon abonnement »
+- jamais abonné, config générique → « Associer mon abonnement »
+- déjà abonné → « Reconnecter cet abonnement »
 
-### Scénario 2 : Trim du héros + réapparition aval
-1. Sur petit écran (360×640), observer le héros.
-**Attendu** : le héros affiche le lead + 1–2 médiums (pas 5). Les articles éjectés
-réapparaissent plus bas (digest/thème) si le même article y figure — jamais
-perdus.
+*(Avant : aucun CTA — `premium_connection_config` = 0/377 sources.)*
 
-### Scénario 3 : Footer auto-hide (LinkedIn)
-1. Scroller vers le **bas** → le footer glisse hors écran (~50px regagnés).
-2. Scroller vers le **haut** → le footer revient.
-3. Revenir tout en haut **ou** changer d'onglet → footer visible.
-**Attendu** : transition douce (220 ms), pas de footer « collé » masqué, le bas de
-carte (« Lire plus ») n'est jamais couvert. Même comportement sur Flâner.
+### 2. Mes abonnements
+Compte → carte « ABONNEMENTS » → « Mes abonnements ».
+- Sans abonnement : état vide « Aucun abonnement connecté ».
+- Avec abonnement : carte par source (logo, nom, statut session, Reconnecter / Dissocier).
 
-### Scénario 4 : Console / réseau
-**Attendu** : pas d'erreur console, pas de 4xx/5xx inattendu. En debug, surveiller
-le log `[fit-net] section "…" dépasse l'écran` : **aucune occurrence** sur héros /
-digest / thème (sinon estimation `section_fit` à régler).
+### 3. Dissocier
+Depuis « Mes abonnements » ou la fiche → la source quitte la liste / le badge abonné tombe.
 
-## Critères d'acceptation
-- [ ] Aucune carte (héros inclus) ne dépasse la hauteur utile, bouton « Lire plus » dégagé.
-- [ ] `_tallSections` vide pour héros/digest/thème (pas de free-scroll interne / fade).
-- [ ] Héros trimmé sur petit écran ; article éjecté visible plus bas.
-- [ ] Footer glisse au scroll down, revient au scroll up / changement d'onglet.
-- [ ] Snap 1 section/écran + haptique non régressés.
-- [ ] Pastille date/météo du héros intacte.
+## Edge cases
+- Source **gratuite** : **aucun** CTA abonnement, **aucune** entrée « Mes abonnements ».
+- Onboarding `PremiumSourcesSheet` : « Connecter » ouvre le flow (plus de 400
+  `PremiumConnectionNotEnabled`).
 
-## Zones de risque
-- **Constantes d'estimation** `section_fit.dart` : si une section reste « tall »
-  (log `[fit-net]`) ou si le 3ᵉ est masqué alors qu'il y avait la place → régler
-  les constantes, **pas** les call sites.
-- **`_kStickyBarHeight = 50`** doit refléter la hauteur réelle du sticky (rangée
-  44 + track 4 + strip 2). S'il change, re-synchroniser.
-- Footer auto-hide partagé entre L'Essentiel et Flâner (même `StatefulShellRoute`).
+## Critères d'acceptation (web)
+- [ ] CTA visible, libellé correct selon l'état, primary quand source payante.
+- [ ] `/settings/subscriptions` accessible depuis le Compte ; état vide + liste OK.
+- [ ] Aucune erreur console / 4xx-5xx inattendu sur les toggles d'abonnement.
+
+## Critères d'acceptation (device — manuel, hors Chrome)
+- [ ] Connecter Le Monde → ouvrir un autre article LM → **kill + relance** → toujours
+      connecté (pas de re-login). → valide le bug principal #1.
+- [ ] Dissocier → le paywall réapparaît.
+- [ ] Répéter **iOS et Android**.
 
 ## Dépendances
-Aucun endpoint backend touché. 100 % frontend (Flutter).
+Backend : PR 1 incluse dans la même branche (fallback générique `from_source` +
+`has_paywall`, pas de migration Alembic). `pytest` complet vert (1564).

--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -27,6 +27,7 @@ import '../features/sources/screens/add_source_screen.dart';
 import '../features/sources/screens/theme_sources_screen.dart';
 import '../features/settings/screens/profile_screen.dart';
 import '../features/settings/screens/account_screen.dart';
+import '../features/settings/screens/subscriptions_screen.dart';
 import '../features/settings/screens/notifications_screen.dart';
 import '../features/settings/screens/about_screen.dart';
 import '../features/settings/widgets/settings_sheet.dart';
@@ -81,6 +82,7 @@ class RouteNames {
   static const String addSource = 'add-source';
   static const String settings = 'settings';
   static const String account = 'account';
+  static const String subscriptions = 'subscriptions';
   static const String notifications = 'notifications';
   static const String about = 'about';
   static const String profile = 'profile';
@@ -118,6 +120,7 @@ class RoutePaths {
   // static const String addSource = '/sources/add'; // Removed for V0
   static const String settings = '/settings';
   static const String account = '/settings/account';
+  static const String subscriptions = '/settings/subscriptions';
   static const String notifications = '/settings/notifications';
   static const String about = '/settings/about';
   static const String profile = '/settings/profile';
@@ -528,6 +531,12 @@ final routerProvider = Provider<GoRouter>((ref) {
             name: RouteNames.account,
             pageBuilder: (context, state) =>
                 const FullSwipeCupertinoPage(child: AccountScreen()),
+          ),
+          GoRoute(
+            path: 'subscriptions', // /settings/subscriptions
+            name: RouteNames.subscriptions,
+            pageBuilder: (context, state) =>
+                const FullSwipeCupertinoPage(child: SubscriptionsScreen()),
           ),
           GoRoute(
             path: 'notifications', // /settings/notifications

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -11,6 +11,8 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:url_launcher/url_launcher.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart'
+    show InAppWebViewController, WebUri;
 import 'package:flutter/services.dart';
 import 'package:flutter/gestures.dart';
 import 'dart:async';
@@ -30,6 +32,8 @@ import '../../my_interests/providers/user_sources_state_provider.dart';
 import '../../my_interests/repositories/user_interests_repository.dart'
     show FavoriteCapReachedException;
 import '../../sources/providers/sources_providers.dart';
+import '../../sources/widgets/premium_source_connection.dart';
+import '../../sources/widgets/premium_web_view.dart';
 import '../../sources/widgets/source_logo_avatar.dart';
 import '../../../widgets/sunflower_icon.dart';
 import '../providers/nudge_provider.dart' show NudgeTracker;
@@ -205,6 +209,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   Timer? _linkCopiedHeaderTimer;
   late DateTime _startTime;
   WebViewController? _webViewController;
+  // Chemin premium (source payante connectée) : WebView sur flutter_inappwebview
+  // pour réutiliser la session du média (cookies). Distinct du WebView
+  // webview_flutter du scroll-to-site des sources gratuites.
+  InAppWebViewController? _premiumWebController;
+  // Bandeau non-bloquant « Session expirée — Reconnecter » (paywall détecté en
+  // mode reader sur une source connectée).
+  bool _premiumSessionExpired = false;
   // Mutable: flipped to `true` from `_onReadOnSiteTap` when the in-app
   // reader could not enter scroll-to-site mode (htmlContent missing or
   // too short on Android race conditions). Forces `_buildWebViewFallback`
@@ -645,21 +656,23 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     }
     if (msg.startsWith('progress:')) {
       final pct = double.tryParse(msg.substring(9));
-      if (pct != null) {
-        // For partial content: WebView scroll maps to 25%-100% of total progress
-        // For full content: WebView scroll maps to the full 0%-100%
-        final double normalized;
-        if (_isPartialContent) {
-          normalized = 0.25 + (pct / 100.0) * 0.75;
-        } else {
-          normalized = pct / 100.0;
-        }
-        final clamped = normalized.clamp(0.0, 1.0);
-        _readingProgress.value = clamped;
-        if (clamped > _maxReadingProgress) {
-          _maxReadingProgress = clamped;
-        }
-      }
+      if (pct != null) _applyWebReadingProgress(pct);
+    }
+  }
+
+  /// Normalisation partagée de la progression de lecture en WebView : utilisée
+  /// par le canal webview_flutter (scroll-to-site gratuit) ET par le callback
+  /// `onProgress` de [PremiumWebView] (chemin premium inappwebview).
+  ///
+  /// For partial content: WebView scroll maps to 25%-100% of total progress.
+  /// For full content: WebView scroll maps to the full 0%-100%.
+  void _applyWebReadingProgress(double pct) {
+    final double normalized =
+        _isPartialContent ? 0.25 + (pct / 100.0) * 0.75 : pct / 100.0;
+    final clamped = normalized.clamp(0.0, 1.0);
+    _readingProgress.value = clamped;
+    if (clamped > _maxReadingProgress) {
+      _maxReadingProgress = clamped;
     }
   }
 
@@ -1830,7 +1843,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     ? _buildScrollToSiteContent(context, content)
                     : useInAppReading
                     ? _buildInAppContent(context, content)
-                    : _buildWebViewFallback(content),
+                    : _buildWebViewFallback(
+                        content,
+                        isConnectedPremiumSource: isConnectedPremiumSource,
+                      ),
               ),
             ),
             // Header — pinned at the top of the screen; no scroll-driven
@@ -3755,13 +3771,50 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     }
   }
 
-  Widget _buildWebViewFallback(Content content) {
+  Widget _buildWebViewFallback(
+    Content content, {
+    bool isConnectedPremiumSource = false,
+  }) {
     final colors = context.facteurColors;
 
     // Legacy web fallback — unreachable since build() auto-redirects
     // and footer CTA opens externally on web. Kept as safety net.
     if (kIsWeb) {
       return Center(child: CircularProgressIndicator(color: colors.primary));
+    }
+
+    final topInset = MediaQuery.of(context).padding.top;
+    final headerHeight = topInset + _kHeaderContentHeight;
+
+    // Chemin premium (source payante connectée) : flutter_inappwebview pour
+    // réutiliser la session du média + détecter l'expiration. Les sources
+    // gratuites restent sur webview_flutter (pas de cookies, moindre risque).
+    if (isConnectedPremiumSource) {
+      final webView = PremiumWebView(
+        source: content.source,
+        url: WebUri(content.url),
+        sessionStore: ref.read(premiumSessionStoreProvider),
+        enableScrollBridge: true,
+        detectPaywall: true,
+        onWebViewCreated: (c) => _premiumWebController = c,
+        onGestureStart: _onGestureStart,
+        onGestureDelta: _onGestureDelta,
+        onGestureEnd: _onGestureEnd,
+        onScrollY: (y) => _webScrollY = y,
+        onProgress: _applyWebReadingProgress,
+        onPaywallDetected: _onPremiumPaywallDetected,
+      );
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(height: headerHeight),
+          if (_premiumSessionExpired)
+            _PremiumSessionExpiredBanner(
+              onReconnect: () => _reconnectPremium(content),
+            ),
+          Expanded(child: webView),
+        ],
+      );
     }
 
     // Mobile: Use native WebView with ScrollBridge for progress + auto-hide
@@ -3776,14 +3829,151 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       )
       ..loadRequest(Uri.parse(content.url));
 
-    final topInset = MediaQuery.of(context).padding.top;
-    final headerHeight = topInset + _kHeaderContentHeight;
+    // CTA discret : source payante non connectée → proposer de lire avec son
+    // abonnement (ouvre le flow de connexion).
+    final source = content.source;
+    final showConnectCta =
+        source.hasPaywall && source.premiumConnection != null;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         SizedBox(height: headerHeight),
+        if (showConnectCta)
+          _PremiumConnectBanner(
+            onConnect: () => _openPremiumConnectionFromReader(source),
+          ),
         Expanded(child: WebViewWidget(controller: _webViewController!)),
       ],
+    );
+  }
+
+  /// Ouvre le flow de connexion premium depuis le reader (source payante non
+  /// connectée). Le provider bascule en connecté → rebuild → chemin premium.
+  Future<void> _openPremiumConnectionFromReader(Source source) async {
+    if (source.premiumConnection == null) return;
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute(
+        builder: (_) => PremiumSourceConnection(
+          source: source,
+          onConnected: () => ref
+              .read(userSourcesProvider.notifier)
+              .connectSubscription(source.id),
+        ),
+      ),
+    );
+  }
+
+  void _onPremiumPaywallDetected() {
+    if (!mounted || _premiumSessionExpired) return;
+    setState(() => _premiumSessionExpired = true);
+  }
+
+  /// Rouvre le flow de connexion pour re-loguer le média (session expirée),
+  /// puis recharge la WebView premium. Ne dissocie jamais l'abonnement.
+  Future<void> _reconnectPremium(Content content) async {
+    final userSources = ref.read(userSourcesProvider).valueOrNull ?? const [];
+    final source = userSources.firstWhere(
+      (s) => s.id == content.source.id,
+      orElse: () => content.source,
+    );
+    if (source.premiumConnection == null) return;
+
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute(
+        builder: (_) => PremiumSourceConnection(
+          source: source,
+          onConnected: () => ref
+              .read(userSourcesProvider.notifier)
+              .connectSubscription(source.id),
+        ),
+      ),
+    );
+    if (!mounted) return;
+    setState(() => _premiumSessionExpired = false);
+    await _premiumWebController?.reload();
+  }
+}
+
+/// Bandeau non-bloquant affiché en mode reader premium quand un paywall est
+/// détecté (session du média expirée). Propose de se reconnecter sans
+/// dissocier l'abonnement.
+class _PremiumSessionExpiredBanner extends StatelessWidget {
+  final VoidCallback onReconnect;
+
+  const _PremiumSessionExpiredBanner({required this.onReconnect});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Material(
+      color: colors.surfaceElevated,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 8, 8),
+        child: Row(
+          children: [
+            Icon(
+              PhosphorIcons.warningCircle(PhosphorIconsStyle.fill),
+              size: 18,
+              color: colors.warning,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                'Session expirée chez ce média',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: colors.textSecondary,
+                    ),
+              ),
+            ),
+            TextButton(
+              onPressed: onReconnect,
+              child: const Text('Reconnecter'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// CTA discret affiché en haut du reader pour une source payante non connectée :
+/// propose de lire l'article avec son abonnement.
+class _PremiumConnectBanner extends StatelessWidget {
+  final VoidCallback onConnect;
+
+  const _PremiumConnectBanner({required this.onConnect});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Material(
+      color: colors.surfaceElevated,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 8, 8),
+        child: Row(
+          children: [
+            Icon(
+              PhosphorIcons.lockKey(PhosphorIconsStyle.regular),
+              size: 18,
+              color: colors.primary,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                'Article réservé aux abonnés',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: colors.textSecondary,
+                    ),
+              ),
+            ),
+            TextButton(
+              onPressed: onConnect,
+              child: const Text('Lire avec mon abonnement'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/onboarding/widgets/premium_sources_sheet.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/premium_sources_sheet.dart
@@ -291,21 +291,14 @@ class _PremiumSourcesSheetState extends ConsumerState<PremiumSourcesSheet> {
   }
 
   Future<void> _connectSource(BuildContext context, Source source) async {
-    await HapticFeedback.lightImpact();
-    // Source validée sans connecteur premium : un simple toggle « abonné »
-    // suffit (persisté via updateSourceSubscription), sans ouvrir l'écran de
-    // connexion premium qui n'aurait rien à connecter.
-    if (source.premiumConnection == null) {
-      await ref
-          .read(userSourcesProvider.notifier)
-          .connectSubscription(source.id);
-      if (mounted) {
-        setState(() => _subscribed.add(source.id));
-      }
-      return;
-    }
-    if (!mounted) return;
+    // Toujours passer par le flow de connexion premium. On ne fait plus de
+    // `connectSubscription` direct (il levait un 400 PremiumConnectionNotEnabled
+    // quand la config premium était absente). Depuis le fallback générique
+    // backend, premiumConnection est non-null pour toute source payante.
+    if (source.premiumConnection == null) return;
     final navigator = Navigator.of(context);
+    await HapticFeedback.lightImpact();
+    if (!mounted) return;
     await navigator.push<void>(
       MaterialPageRoute(
         builder: (_) => PremiumSourceConnection(

--- a/apps/mobile/lib/features/settings/screens/account_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/account_screen.dart
@@ -98,6 +98,72 @@ class AccountScreen extends ConsumerWidget {
               ),
             ),
 
+            // Section Abonnements (médias payants connectés)
+            const SizedBox(height: FacteurSpacing.space6),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(FacteurSpacing.space4),
+              decoration: BoxDecoration(
+                color: colors.surface,
+                borderRadius: BorderRadius.circular(FacteurRadius.large),
+                border: Border.all(color: colors.surfaceElevated),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'ABONNEMENTS',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: colors.textTertiary,
+                          letterSpacing: 1.5,
+                        ),
+                  ),
+                  const SizedBox(height: FacteurSpacing.space3),
+                  InkWell(
+                    onTap: () => context.push(RoutePaths.subscriptions),
+                    borderRadius: BorderRadius.circular(FacteurRadius.medium),
+                    child: Row(
+                      children: [
+                        Icon(
+                          PhosphorIcons.link(PhosphorIconsStyle.regular),
+                          color: colors.primary,
+                          size: 20,
+                        ),
+                        const SizedBox(width: FacteurSpacing.space3),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Mes abonnements',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodyMedium
+                                    ?.copyWith(fontWeight: FontWeight.w500),
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                'Gère tes médias payants connectés',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodySmall
+                                    ?.copyWith(color: colors.textSecondary),
+                              ),
+                            ],
+                          ),
+                        ),
+                        Icon(
+                          PhosphorIcons.caretRight(),
+                          color: colors.textTertiary,
+                          size: 18,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
             // Section Widget (Android uniquement, masquée sur Web)
             if (!kIsWeb && Platform.isAndroid) ...[
               const SizedBox(height: FacteurSpacing.space6),

--- a/apps/mobile/lib/features/settings/screens/subscriptions_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/subscriptions_screen.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../../sources/models/source_model.dart';
+import '../../sources/providers/sources_providers.dart';
+import '../../sources/widgets/premium_source_connection.dart';
+import '../../sources/widgets/source_logo_avatar.dart';
+
+/// Écran « Mes abonnements » : point d'entrée global pour gérer les sources
+/// payantes connectées (statut de session, reconnexion, dissociation).
+class SubscriptionsScreen extends ConsumerWidget {
+  const SubscriptionsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final subscribed = ref.watch(subscribedSourcesProvider);
+    final isLoading = ref.watch(userSourcesProvider).isLoading;
+
+    return Scaffold(
+      backgroundColor: colors.backgroundPrimary,
+      appBar: AppBar(
+        title: const Text('Mes abonnements'),
+        backgroundColor: colors.backgroundPrimary,
+        elevation: 0,
+        titleTextStyle: Theme.of(context).textTheme.displaySmall,
+      ),
+      body: SafeArea(
+        child: () {
+          if (subscribed.isEmpty && isLoading) {
+            return Center(
+              child: CircularProgressIndicator(color: colors.primary),
+            );
+          }
+          if (subscribed.isEmpty) {
+            return _EmptyState(colors: colors);
+          }
+          return ListView.separated(
+            padding: const EdgeInsets.all(FacteurSpacing.space4),
+            itemCount: subscribed.length,
+            separatorBuilder: (_, __) =>
+                const SizedBox(height: FacteurSpacing.space3),
+            itemBuilder: (_, i) => _SubscriptionTile(source: subscribed[i]),
+          );
+        }(),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  final FacteurColors colors;
+  const _EmptyState({required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(FacteurSpacing.space6),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              PhosphorIcons.lockKeyOpen(PhosphorIconsStyle.regular),
+              size: 48,
+              color: colors.textTertiary,
+            ),
+            const SizedBox(height: FacteurSpacing.space4),
+            Text(
+              'Aucun abonnement connecté',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: colors.textPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+            const SizedBox(height: FacteurSpacing.space2),
+            Text(
+              'Connecte un abonnement à un média payant depuis sa fiche pour '
+              'lire ses articles directement dans Facteur.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: colors.textSecondary,
+                    height: 1.45,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SubscriptionTile extends ConsumerWidget {
+  final Source source;
+  const _SubscriptionTile({required this.source});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final store = ref.watch(premiumSessionStoreProvider);
+
+    return Container(
+      padding: const EdgeInsets.all(FacteurSpacing.space4),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+        border: Border.all(color: colors.surfaceElevated),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              SourceLogoAvatar(source: source, size: 40),
+              const SizedBox(width: FacteurSpacing.space3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      source.name,
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                            color: colors.textPrimary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                    ),
+                    const SizedBox(height: 2),
+                    FutureBuilder<bool>(
+                      future: store.hasSession(source),
+                      builder: (context, snap) {
+                        final active = snap.data ?? false;
+                        return Text(
+                          active
+                              ? 'Session active'
+                              : 'Reconnexion nécessaire',
+                          style:
+                              Theme.of(context).textTheme.labelSmall?.copyWith(
+                                    color: active
+                                        ? colors.success
+                                        : colors.warning,
+                                  ),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: FacteurSpacing.space3),
+          Row(
+            children: [
+              Expanded(
+                child: TextButton.icon(
+                  onPressed: () => _reconnect(context, ref),
+                  icon: Icon(PhosphorIcons.link(), size: 18),
+                  label: const Text('Reconnecter'),
+                ),
+              ),
+              Expanded(
+                child: TextButton.icon(
+                  onPressed: () => _disconnect(ref),
+                  icon: Icon(PhosphorIcons.linkBreak(), size: 18),
+                  label: const Text('Dissocier'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _reconnect(BuildContext context, WidgetRef ref) async {
+    if (source.premiumConnection == null) return;
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute(
+        builder: (_) => PremiumSourceConnection(
+          source: source,
+          onConnected: () => ref
+              .read(userSourcesProvider.notifier)
+              .connectSubscription(source.id),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _disconnect(WidgetRef ref) async {
+    await ref
+        .read(userSourcesProvider.notifier)
+        .disconnectSubscription(source.id);
+    await ref.read(premiumSessionStoreProvider).clearForSource(source);
+  }
+}

--- a/apps/mobile/lib/features/sources/models/source_model.dart
+++ b/apps/mobile/lib/features/sources/models/source_model.dart
@@ -14,11 +14,17 @@ class PremiumConnection {
   final String testUrl;
   final String? displayHint;
 
+  /// `true` quand la config vient d'un fallback générique côté backend (URL =
+  /// home de la source) plutôt que d'une config curée/explicite. Sert à adapter
+  /// le label du CTA ("Associer" vs "Connecter").
+  final bool isGeneric;
+
   const PremiumConnection({
     this.enabled = true,
     required this.loginUrl,
     required this.testUrl,
     this.displayHint,
+    this.isGeneric = false,
   });
 
   factory PremiumConnection.fromJson(Map<String, dynamic> json) {
@@ -27,6 +33,7 @@ class PremiumConnection {
       loginUrl: (json['login_url'] as String?)?.trim() ?? '',
       testUrl: (json['test_url'] as String?)?.trim() ?? '',
       displayHint: (json['display_hint'] as String?)?.trim(),
+      isGeneric: (json['is_generic'] as bool?) ?? false,
     );
   }
 
@@ -57,6 +64,10 @@ class Source {
   final int followerCount;
   final double priorityMultiplier;
   final bool hasSubscription;
+
+  /// Source payante (paywall détecté ou média curé). Pilote l'affichage des
+  /// CTA "Lire avec mon abonnement" / "Associer mon abonnement". Défaut false.
+  final bool hasPaywall;
   final PremiumConnection? premiumConnection;
   final String? recommendedBy;
   final String? recommendationReason;
@@ -90,6 +101,7 @@ class Source {
     this.followerCount = 0,
     this.priorityMultiplier = 1.0,
     this.hasSubscription = false,
+    this.hasPaywall = false,
     this.premiumConnection,
     this.recommendedBy,
     this.recommendationReason,
@@ -120,6 +132,7 @@ class Source {
     int? followerCount,
     double? priorityMultiplier,
     bool? hasSubscription,
+    bool? hasPaywall,
     PremiumConnection? premiumConnection,
     String? recommendedBy,
     String? recommendationReason,
@@ -149,6 +162,7 @@ class Source {
       followerCount: followerCount ?? this.followerCount,
       priorityMultiplier: priorityMultiplier ?? this.priorityMultiplier,
       hasSubscription: hasSubscription ?? this.hasSubscription,
+      hasPaywall: hasPaywall ?? this.hasPaywall,
       premiumConnection: premiumConnection ?? this.premiumConnection,
       recommendedBy: recommendedBy ?? this.recommendedBy,
       recommendationReason: recommendationReason ?? this.recommendationReason,
@@ -193,6 +207,7 @@ class Source {
         priorityMultiplier:
             (json['priority_multiplier'] as num?)?.toDouble() ?? 1.0,
         hasSubscription: (json['has_subscription'] as bool?) ?? false,
+        hasPaywall: (json['has_paywall'] as bool?) ?? false,
         premiumConnection: _parsePremiumConnection(json['premium_connection']),
         recommendedBy: json['recommended_by'] as String?,
         recommendationReason: json['recommendation_reason'] as String?,

--- a/apps/mobile/lib/features/sources/providers/sources_providers.dart
+++ b/apps/mobile/lib/features/sources/providers/sources_providers.dart
@@ -10,9 +10,28 @@ import '../models/smart_search_result.dart';
 import '../models/source_model.dart';
 import '../models/theme_source_model.dart';
 import '../repositories/sources_repository.dart';
+import '../services/premium_session_store.dart';
 
 final sourcesRepositoryProvider = Provider<SourcesRepository>((ref) {
   return SourcesRepository(ApiClient(Supabase.instance.client));
+});
+
+/// Store de persistance des sessions des sources payantes (cookies média).
+/// Singleton app-wide : un seul `CookieManager`/secure storage partagé entre
+/// le flow de connexion et le reader.
+final premiumSessionStoreProvider = Provider<PremiumSessionStore>((ref) {
+  return PremiumSessionStore(
+    jar: InAppPremiumCookieJar(),
+    secureStore: FlutterSecureKeyValueStore(),
+  );
+});
+
+/// Sources auxquelles l'utilisateur a associé un abonnement (dérivé).
+/// Alimente l'écran « Mes abonnements ».
+final subscribedSourcesProvider = Provider<List<Source>>((ref) {
+  final sources =
+      ref.watch(userSourcesProvider).valueOrNull ?? const <Source>[];
+  return sources.where((s) => s.hasSubscription).toList();
 });
 
 typedef SmartSearchQuery = ({String query, String? contentType, bool expand});

--- a/apps/mobile/lib/features/sources/services/premium_session_store.dart
+++ b/apps/mobile/lib/features/sources/services/premium_session_store.dart
@@ -1,0 +1,247 @@
+import 'dart:convert';
+
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../models/source_model.dart';
+
+/// Persistance de la session d'une source payante (cookies du média).
+///
+/// `webview_flutter` n'expose pas les cookies → la session du média se perdait
+/// à chaque recyclage de WebView / redémarrage de l'app, forçant l'utilisateur
+/// à se reconnecter à chaque article. On capture les cookies via le
+/// `CookieManager` partagé d'`flutter_inappwebview` (store persistant) et on les
+/// recopie en `flutter_secure_storage` pour les **réinjecter** à l'ouverture de
+/// chaque WebView (filet de sécurité contre la disparition des cookies de
+/// session au redémarrage natif).
+///
+/// Les deux dépendances (cookies natifs, stockage sécurisé) sont abstraites
+/// ([PremiumCookieJar], [SecureKeyValueStore]) pour rester unit-testable sans
+/// plateforme.
+
+/// Abstraction fine autour de `CookieManager.instance()` (testabilité).
+abstract class PremiumCookieJar {
+  Future<List<Cookie>> getCookies(WebUri url);
+
+  Future<void> setCookie(
+    WebUri url, {
+    required String name,
+    required String value,
+    String? domain,
+    String path = '/',
+    int? expiresDate,
+    bool? isSecure,
+    bool? isHttpOnly,
+    HTTPCookieSameSitePolicy? sameSite,
+  });
+
+  Future<void> deleteCookies(WebUri url);
+}
+
+/// Implémentation réelle adossée au `CookieManager` partagé d'inappwebview.
+class InAppPremiumCookieJar implements PremiumCookieJar {
+  InAppPremiumCookieJar([CookieManager? manager])
+      : _manager = manager ?? CookieManager.instance();
+
+  final CookieManager _manager;
+
+  @override
+  Future<List<Cookie>> getCookies(WebUri url) => _manager.getCookies(url: url);
+
+  @override
+  Future<void> setCookie(
+    WebUri url, {
+    required String name,
+    required String value,
+    String? domain,
+    String path = '/',
+    int? expiresDate,
+    bool? isSecure,
+    bool? isHttpOnly,
+    HTTPCookieSameSitePolicy? sameSite,
+  }) async {
+    await _manager.setCookie(
+      url: url,
+      name: name,
+      value: value,
+      domain: domain,
+      path: path,
+      expiresDate: expiresDate,
+      isSecure: isSecure,
+      isHttpOnly: isHttpOnly,
+      sameSite: sameSite,
+    );
+  }
+
+  @override
+  Future<void> deleteCookies(WebUri url) => _manager.deleteCookies(url: url);
+}
+
+/// Abstraction minimale autour de `FlutterSecureStorage` (testabilité).
+abstract class SecureKeyValueStore {
+  Future<String?> read(String key);
+  Future<void> write(String key, String value);
+  Future<void> delete(String key);
+}
+
+class FlutterSecureKeyValueStore implements SecureKeyValueStore {
+  FlutterSecureKeyValueStore([FlutterSecureStorage? storage])
+      : _storage = storage ?? const FlutterSecureStorage();
+
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<String?> read(String key) => _storage.read(key: key);
+
+  @override
+  Future<void> write(String key, String value) =>
+      _storage.write(key: key, value: value);
+
+  @override
+  Future<void> delete(String key) => _storage.delete(key: key);
+}
+
+/// eTLD+1 normalisé d'une URL — miroir Dart de `domain_key` (backend).
+/// `https://www.lemonde.fr/x` → `lemonde.fr`. Approximation FR-first
+/// (deux derniers labels) avec garde pour quelques suffixes composés.
+String premiumDomainKey(String? url) {
+  if (url == null) return '';
+  var raw = url.trim();
+  if (raw.isEmpty) return '';
+  if (!raw.contains('//')) raw = '//$raw';
+  final host = (Uri.tryParse(raw)?.host ?? '').toLowerCase();
+  if (host.isEmpty) return '';
+  final labels = host.split('.');
+  if (labels.length <= 2) return host;
+  const multiPartTlds = {
+    'co.uk',
+    'org.uk',
+    'gov.uk',
+    'ac.uk',
+    'com.au',
+    'co.jp',
+    'co.nz',
+  };
+  final lastTwo = labels.sublist(labels.length - 2).join('.');
+  if (multiPartTlds.contains(lastTwo) && labels.length >= 3) {
+    return labels.sublist(labels.length - 3).join('.');
+  }
+  return lastTwo;
+}
+
+class PremiumSessionStore {
+  PremiumSessionStore({
+    required PremiumCookieJar jar,
+    required SecureKeyValueStore secureStore,
+  })  : _jar = jar,
+        _secure = secureStore;
+
+  final PremiumCookieJar _jar;
+  final SecureKeyValueStore _secure;
+
+  static const String _keyPrefix = 'premium_session';
+
+  String _domainFor(Source source, [WebUri? url]) {
+    if (url != null) {
+      final fromUrl = premiumDomainKey(url.toString());
+      if (fromUrl.isNotEmpty) return fromUrl;
+    }
+    return premiumDomainKey(source.url);
+  }
+
+  String _keyFor(Source source, [WebUri? url]) =>
+      '$_keyPrefix::${source.id}::${_domainFor(source, url)}';
+
+  /// Capture les cookies courants du média pour [url] et les persiste.
+  /// No-op si aucun cookie (on n'écrase pas une session valide par du vide).
+  Future<void> captureForSource(Source source, WebUri url) async {
+    final cookies = await _jar.getCookies(url);
+    if (cookies.isEmpty) return;
+    final encoded = jsonEncode(cookies.map(_cookieToJson).toList());
+    await _secure.write(_keyFor(source, url), encoded);
+  }
+
+  /// Réinjecte les cookies persistés dans le `CookieManager` avant chargement.
+  /// Retourne `true` si une session existait et a été réinjectée.
+  Future<bool> restoreForSource(Source source, WebUri url) async {
+    final raw = await _secure.read(_keyFor(source, url));
+    if (raw == null || raw.isEmpty) return false;
+    List<dynamic> decoded;
+    try {
+      decoded = jsonDecode(raw) as List<dynamic>;
+    } catch (_) {
+      return false;
+    }
+    var injected = false;
+    for (final item in decoded) {
+      if (item is! Map) continue;
+      final map = item.cast<String, dynamic>();
+      final name = map['name'] as String?;
+      if (name == null || name.isEmpty) continue;
+      await _jar.setCookie(
+        url,
+        name: name,
+        value: (map['value'] as String?) ?? '',
+        domain: map['domain'] as String?,
+        path: (map['path'] as String?) ?? '/',
+        expiresDate: map['expiresDate'] as int?,
+        isSecure: map['isSecure'] as bool?,
+        isHttpOnly: map['isHttpOnly'] as bool?,
+        sameSite: _sameSiteFromString(map['sameSite'] as String?),
+      );
+      injected = true;
+    }
+    return injected;
+  }
+
+  /// Une session persistée existe-t-elle pour cette source ?
+  Future<bool> hasSession(Source source) async {
+    final raw = await _secure.read(_keyFor(source));
+    return raw != null && raw.isNotEmpty;
+  }
+
+  /// Supprime la session persistée + purge les cookies natifs du média.
+  Future<void> clearForSource(Source source) async {
+    await _secure.delete(_keyFor(source));
+    final url = source.url?.trim();
+    if (url != null && url.isNotEmpty) {
+      final normalized = url.contains('//') ? url : 'https://$url';
+      final parsed = Uri.tryParse(normalized);
+      if (parsed != null && parsed.host.isNotEmpty) {
+        await _jar.deleteCookies(WebUri.uri(parsed));
+      }
+    }
+  }
+
+  Map<String, dynamic> _cookieToJson(Cookie cookie) => {
+        'name': cookie.name,
+        'value': cookie.value?.toString() ?? '',
+        if (cookie.expiresDate != null) 'expiresDate': cookie.expiresDate,
+        if (cookie.domain != null) 'domain': cookie.domain,
+        if (cookie.path != null) 'path': cookie.path,
+        if (cookie.isSecure != null) 'isSecure': cookie.isSecure,
+        if (cookie.isHttpOnly != null) 'isHttpOnly': cookie.isHttpOnly,
+        if (cookie.sameSite != null)
+          'sameSite': _sameSiteToString(cookie.sameSite),
+      };
+
+  static String? _sameSiteToString(HTTPCookieSameSitePolicy? policy) {
+    if (policy == HTTPCookieSameSitePolicy.LAX) return 'Lax';
+    if (policy == HTTPCookieSameSitePolicy.STRICT) return 'Strict';
+    if (policy == HTTPCookieSameSitePolicy.NONE) return 'None';
+    return null;
+  }
+
+  static HTTPCookieSameSitePolicy? _sameSiteFromString(String? value) {
+    switch (value) {
+      case 'Lax':
+        return HTTPCookieSameSitePolicy.LAX;
+      case 'Strict':
+        return HTTPCookieSameSitePolicy.STRICT;
+      case 'None':
+        return HTTPCookieSameSitePolicy.NONE;
+      default:
+        return null;
+    }
+  }
+}

--- a/apps/mobile/lib/features/sources/widgets/premium_source_connection.dart
+++ b/apps/mobile/lib/features/sources/widgets/premium_source_connection.dart
@@ -1,17 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:webview_flutter/webview_flutter.dart';
 
 import '../../../config/theme.dart';
 import '../../../widgets/design/facteur_button.dart';
 import '../models/source_model.dart';
+import '../providers/sources_providers.dart';
+import '../services/premium_session_store.dart';
+import 'premium_web_view.dart';
 import 'source_logo_avatar.dart';
 
 typedef PremiumWebViewBuilder = Widget Function(
     BuildContext context, String url);
 
-class PremiumSourceConnection extends StatefulWidget {
+class PremiumSourceConnection extends ConsumerStatefulWidget {
   final Source source;
   final Future<void> Function() onConnected;
   final VoidCallback? onFinished;
@@ -28,16 +32,20 @@ class PremiumSourceConnection extends StatefulWidget {
   });
 
   @override
-  State<PremiumSourceConnection> createState() =>
+  ConsumerState<PremiumSourceConnection> createState() =>
       _PremiumSourceConnectionState();
 }
 
-class _PremiumSourceConnectionState extends State<PremiumSourceConnection> {
+class _PremiumSourceConnectionState
+    extends ConsumerState<PremiumSourceConnection> {
   int _step = 0;
   bool _saving = false;
   String? _error;
 
   PremiumConnection get _connection => widget.source.premiumConnection!;
+
+  PremiumSessionStore get _sessionStore =>
+      ref.read(premiumSessionStoreProvider);
 
   Future<void> _openExternal(String url) async {
     if (widget.openExternal != null) {
@@ -56,6 +64,11 @@ class _PremiumSourceConnectionState extends State<PremiumSourceConnection> {
       _error = null;
     });
     try {
+      // Session validée par l'utilisateur : on capture les cookies du média
+      // (store partagé, jamais recréé entre login et test) AVANT de persister
+      // l'abonnement côté backend.
+      final testUri = WebUri(_connection.testUrl);
+      await _sessionStore.captureForSource(widget.source, testUri);
       await widget.onConnected();
       if (!mounted) return;
       setState(() {
@@ -102,6 +115,8 @@ class _PremiumSourceConnectionState extends State<PremiumSourceConnection> {
           key: const ValueKey('premium-webview-login'),
           title: 'Connexion',
           url: _connection.loginUrl,
+          source: widget.source,
+          sessionStore: _sessionStore,
           actionLabel: 'Continuer vers l\'article test',
           webViewBuilder: widget.webViewBuilder,
           onAction: () => setState(() => _step = 2),
@@ -112,6 +127,8 @@ class _PremiumSourceConnectionState extends State<PremiumSourceConnection> {
           key: const ValueKey('premium-webview-test'),
           title: 'Article test',
           url: _connection.testUrl,
+          source: widget.source,
+          sessionStore: _sessionStore,
           actionLabel: 'L\'article s\'affiche correctement',
           webViewBuilder: widget.webViewBuilder,
           onAction: _saving ? null : _confirm,
@@ -203,9 +220,11 @@ class _PremiumSourceConnectionState extends State<PremiumSourceConnection> {
   }
 }
 
-class _WebViewStep extends StatefulWidget {
+class _WebViewStep extends StatelessWidget {
   final String title;
   final String url;
+  final Source source;
+  final PremiumSessionStore sessionStore;
   final String actionLabel;
   final PremiumWebViewBuilder? webViewBuilder;
   final VoidCallback? onAction;
@@ -217,6 +236,8 @@ class _WebViewStep extends StatefulWidget {
     super.key,
     required this.title,
     required this.url,
+    required this.source,
+    required this.sessionStore,
     required this.actionLabel,
     required this.onAction,
     required this.onOpenExternal,
@@ -226,27 +247,15 @@ class _WebViewStep extends StatefulWidget {
   });
 
   @override
-  State<_WebViewStep> createState() => _WebViewStepState();
-}
-
-class _WebViewStepState extends State<_WebViewStep> {
-  WebViewController? _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    if (widget.webViewBuilder == null) {
-      _controller = WebViewController()
-        ..setJavaScriptMode(JavaScriptMode.unrestricted)
-        ..loadRequest(Uri.parse(widget.url));
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final webView = widget.webViewBuilder?.call(context, widget.url) ??
-        WebViewWidget(controller: _controller!);
+    final webView = webViewBuilder?.call(context, url) ??
+        PremiumWebView(
+          source: source,
+          url: WebUri(url),
+          sessionStore: sessionStore,
+          enableScrollBridge: false,
+        );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -261,7 +270,7 @@ class _WebViewStepState extends State<_WebViewStep> {
             children: [
               Expanded(
                 child: Text(
-                  widget.title,
+                  title,
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
                         color: colors.textPrimary,
                         fontWeight: FontWeight.w700,
@@ -269,7 +278,7 @@ class _WebViewStepState extends State<_WebViewStep> {
                 ),
               ),
               TextButton.icon(
-                onPressed: widget.onOpenExternal,
+                onPressed: onOpenExternal,
                 icon: Icon(PhosphorIcons.arrowSquareOut(), size: 18),
                 label: const Text('Navigateur'),
               ),
@@ -277,11 +286,11 @@ class _WebViewStepState extends State<_WebViewStep> {
           ),
         ),
         Expanded(child: webView),
-        if (widget.error != null)
+        if (error != null)
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
             child: Text(
-              widget.error!,
+              error!,
               textAlign: TextAlign.center,
               style: TextStyle(color: colors.error),
             ),
@@ -289,10 +298,10 @@ class _WebViewStepState extends State<_WebViewStep> {
         Padding(
           padding: const EdgeInsets.all(FacteurSpacing.space4),
           child: FacteurButton(
-            label: widget.isLoading ? 'Connexion...' : widget.actionLabel,
+            label: isLoading ? 'Connexion...' : actionLabel,
             type: FacteurButtonType.primary,
             icon: PhosphorIcons.arrowRight(),
-            onPressed: widget.onAction,
+            onPressed: onAction,
           ),
         ),
       ],

--- a/apps/mobile/lib/features/sources/widgets/premium_web_view.dart
+++ b/apps/mobile/lib/features/sources/widgets/premium_web_view.dart
@@ -1,0 +1,297 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import '../models/source_model.dart';
+import '../services/premium_session_store.dart';
+
+/// Mots-clés paywall (FR) testés en mode reader pour détecter une session
+/// expirée. Volontairement spécifiques pour limiter les faux positifs (un
+/// simple « s'abonner » en pied de page ne suffit pas).
+const List<String> kPremiumPaywallKeywords = [
+  'pour lire la suite',
+  'cet article est réservé',
+  'article réservé aux abonnés',
+  'réservé aux abonnés',
+  'contenu réservé aux abonnés',
+  'la lecture de cet article est réservée',
+];
+
+/// WebView des sources payantes, adossée à `flutter_inappwebview` (store de
+/// cookies persistant partagé), calquée sur `youtube_player_widget.dart`.
+///
+/// Deux modes :
+/// - **connexion** (`enableScrollBridge: false`) : l'utilisateur se logue au
+///   média ; on capture la session.
+/// - **reader** (`enableScrollBridge: true`) : lecture d'un article ; on porte
+///   le ScrollBridge (footer auto-hide + progression) et on détecte un paywall
+///   (session expirée).
+///
+/// Réinjection garantie avant chargement : `onWebViewCreated → await restore →
+/// loadUrl` (donc pas d'`initialUrlRequest`).
+class PremiumWebView extends StatefulWidget {
+  const PremiumWebView({
+    super.key,
+    required this.source,
+    required this.url,
+    required this.sessionStore,
+    this.enableScrollBridge = false,
+    this.detectPaywall = false,
+    this.onWebViewCreated,
+    this.onLoadStop,
+    this.onGestureStart,
+    this.onGestureDelta,
+    this.onGestureEnd,
+    this.onProgress,
+    this.onScrollY,
+    this.onPaywallDetected,
+  });
+
+  final Source source;
+  final WebUri url;
+  final PremiumSessionStore sessionStore;
+
+  /// Reader = true (footer auto-hide + progression). Connexion = false.
+  final bool enableScrollBridge;
+
+  /// Injecte le test paywall sur chaque `onLoadStop` (reader, source connectée).
+  final bool detectPaywall;
+
+  final ValueChanged<InAppWebViewController>? onWebViewCreated;
+  final ValueChanged<WebUri?>? onLoadStop;
+  final VoidCallback? onGestureStart;
+  final ValueChanged<double>? onGestureDelta;
+  final ValueChanged<double>? onGestureEnd;
+
+  /// Progression de lecture (0..100, brut depuis le JS).
+  final ValueChanged<double>? onProgress;
+  final ValueChanged<double>? onScrollY;
+  final VoidCallback? onPaywallDetected;
+
+  @override
+  State<PremiumWebView> createState() => _PremiumWebViewState();
+}
+
+class _PremiumWebViewState extends State<PremiumWebView> {
+  static const String _chromeUserAgent =
+      'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 '
+      '(KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36';
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = InAppWebViewSettings(
+      javaScriptEnabled: true,
+      // Store de cookies partagé & persistant (clé de la persistance de
+      // session) — surtout pas d'incognito ni de purge cache.
+      incognito: false,
+      clearCache: false,
+      cacheEnabled: true,
+      // SSO médias (Google/Apple) + partage du jar de cookies natif.
+      thirdPartyCookiesEnabled: true,
+      sharedCookiesEnabled: true,
+      // UA navigateur Chrome (pas de marqueur "wv") pour éviter les blocages
+      // de connexion côté médias.
+      userAgent: _chromeUserAgent,
+      transparentBackground: false,
+    );
+
+    return InAppWebView(
+      initialSettings: settings,
+      onWebViewCreated: _handleCreated,
+      onLoadStop: _handleLoadStop,
+    );
+  }
+
+  Future<void> _handleCreated(InAppWebViewController controller) async {
+    widget.onWebViewCreated?.call(controller);
+
+    controller.addJavaScriptHandler(
+      handlerName: 'ScrollBridge',
+      callback: (args) {
+        if (args.isEmpty) return;
+        final raw = args.first;
+        if (raw is String) _handleScrollBridgeMessage(raw);
+      },
+    );
+    controller.addJavaScriptHandler(
+      handlerName: 'PaywallDetected',
+      callback: (args) {
+        widget.onPaywallDetected?.call();
+      },
+    );
+
+    // Réinjection AVANT chargement (ordre garanti), puis chargement manuel.
+    try {
+      await widget.sessionStore.restoreForSource(widget.source, widget.url);
+    } catch (_) {
+      // Une session illisible ne doit pas empêcher le chargement.
+    }
+    if (!mounted) return;
+    await controller.loadUrl(urlRequest: URLRequest(url: widget.url));
+  }
+
+  Future<void> _handleLoadStop(
+    InAppWebViewController controller,
+    WebUri? url,
+  ) async {
+    // Capture opportuniste : toute page chargée avec succès rafraîchit la
+    // session persistée.
+    try {
+      await widget.sessionStore.captureForSource(widget.source, widget.url);
+    } catch (_) {
+      // best-effort
+    }
+
+    if (widget.enableScrollBridge) {
+      await controller.evaluateJavascript(source: _kScrollBridgeJs);
+    }
+    if (widget.detectPaywall) {
+      await controller.evaluateJavascript(source: _paywallProbeJs);
+    }
+
+    widget.onLoadStop?.call(url);
+  }
+
+  void _handleScrollBridgeMessage(String msg) {
+    if (msg == 'gesture_start') {
+      widget.onGestureStart?.call();
+      return;
+    }
+    if (msg.startsWith('gesture_delta:')) {
+      final delta = double.tryParse(msg.substring(14));
+      if (delta != null) widget.onGestureDelta?.call(delta);
+      return;
+    }
+    if (msg.startsWith('gesture_end:')) {
+      final vel = double.tryParse(msg.substring(12)) ?? 0;
+      widget.onGestureEnd?.call(vel);
+      return;
+    }
+    if (msg == 'gesture_cancel') {
+      widget.onGestureEnd?.call(0);
+      return;
+    }
+    if (msg.startsWith('scroll_y:')) {
+      final y = double.tryParse(msg.substring(9));
+      if (y != null) widget.onScrollY?.call(y);
+      return;
+    }
+    if (msg.startsWith('progress:')) {
+      final pct = double.tryParse(msg.substring(9));
+      if (pct != null) widget.onProgress?.call(pct);
+    }
+  }
+
+  /// JS du test paywall (reader, source connectée). Liste de mots-clés FR
+  /// dupliquée volontairement côté client.
+  String get _paywallProbeJs {
+    final keywordsJs = kPremiumPaywallKeywords
+        .map((k) => "'${k.replaceAll("'", "\\'")}'")
+        .join(',');
+    return '''
+      (function() {
+        try {
+          var text = (document.body && document.body.innerText || '').toLowerCase();
+          var kws = [$keywordsJs];
+          for (var i = 0; i < kws.length; i++) {
+            if (text.indexOf(kws[i]) !== -1) {
+              window.flutter_inappwebview.callHandler('PaywallDetected');
+              return;
+            }
+          }
+        } catch (e) {}
+      })();
+    ''';
+  }
+}
+
+/// ScrollBridge porté depuis `content_detail_screen.dart` : logique de geste
+/// identique, seul l'émetteur change (`ScrollBridge.postMessage(...)` →
+/// `window.flutter_inappwebview.callHandler('ScrollBridge', ...)`). Les messages
+/// émis sont strictement les mêmes, donc le parsing Dart est inchangé.
+const String _kScrollBridgeJs = '''
+  (function() {
+    if (window.__facteurScrollBridge) return;
+    window.__facteurScrollBridge = true;
+    function emit(msg) {
+      window.flutter_inappwebview.callHandler('ScrollBridge', msg);
+    }
+    var lastTouchY = 0;
+    var lastTouchT = 0;
+    var velocity = 0;
+    var touchActive = false;
+    var pendingDy = 0;
+    var rafScheduled = false;
+    var raf = window.requestAnimationFrame
+      ? function(cb) { window.requestAnimationFrame(cb); }
+      : function(cb) { setTimeout(cb, 16); };
+    function flushGesture() {
+      rafScheduled = false;
+      var dy = pendingDy;
+      pendingDy = 0;
+      if (Math.abs(dy) < 1) return;
+      if (dy >  150) dy =  150;
+      if (dy < -150) dy = -150;
+      emit('gesture_delta:' + (-dy));
+    }
+    document.addEventListener('touchstart', function(e) {
+      if (e.touches.length > 1) { touchActive = false; return; }
+      lastTouchY = e.touches[0].clientY;
+      lastTouchT = (window.performance && performance.now) ? performance.now() : Date.now();
+      velocity = 0;
+      pendingDy = 0;
+      touchActive = true;
+      emit('gesture_start');
+    }, { passive: true, capture: true });
+    document.addEventListener('touchmove', function(e) {
+      if (!touchActive || e.touches.length > 1) return;
+      var y = e.touches[0].clientY;
+      var t = (window.performance && performance.now) ? performance.now() : Date.now();
+      var dy = y - lastTouchY;
+      var dt = t - lastTouchT;
+      if (dt > 0) {
+        velocity = 0.7 * velocity + 0.3 * (dy / dt);
+      }
+      lastTouchY = y;
+      lastTouchT = t;
+      pendingDy += dy;
+      if (!rafScheduled) {
+        rafScheduled = true;
+        raf(flushGesture);
+      }
+    }, { passive: true, capture: true });
+    document.addEventListener('touchend', function(e) {
+      if (!touchActive) return;
+      touchActive = false;
+      if (rafScheduled) flushGesture();
+      emit('gesture_end:' + (-velocity * 1000));
+    }, { passive: true, capture: true });
+    document.addEventListener('touchcancel', function(e) {
+      if (!touchActive) return;
+      touchActive = false;
+      if (rafScheduled) flushGesture();
+      emit('gesture_cancel');
+    }, { passive: true, capture: true });
+    var lastProgress = 0;
+    var progressTimer = null;
+    var scrollYTimer = null;
+    function flushProgress() {
+      progressTimer = null;
+      var maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+      if (maxScroll <= 0) return;
+      var pct = parseFloat((window.scrollY / maxScroll * 100).toFixed(1));
+      pct = Math.min(100, Math.max(0, pct));
+      if (pct !== lastProgress) {
+        lastProgress = pct;
+        emit('progress:' + pct);
+      }
+    }
+    function flushScrollY() {
+      scrollYTimer = null;
+      emit('scroll_y:' + window.scrollY);
+    }
+    window.addEventListener('scroll', function() {
+      if (!scrollYTimer) scrollYTimer = setTimeout(flushScrollY, 100);
+      if (!progressTimer) progressTimer = setTimeout(flushProgress, 300);
+    }, { passive: true });
+  })();
+''';

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -302,6 +302,25 @@ class SourceDetailModal extends ConsumerWidget {
               ),
             ],
           ] else ...[
+            // CTA abonnement premium — proéminent (primary, en tête) pour les
+            // sources payantes. Label selon l'état : déjà abonné / config
+            // générique (« Associer ») / config curée (« Connecter »).
+            if (displaySource.premiumConnection != null) ...[
+              FacteurButton(
+                onPressed: () =>
+                    _openPremiumConnectionFlow(context, ref, displaySource),
+                label: displaySource.hasSubscription
+                    ? 'Reconnecter cet abonnement'
+                    : (displaySource.premiumConnection!.isGeneric
+                        ? 'Associer mon abonnement'
+                        : 'Connecter mon abonnement'),
+                type: displaySource.hasPaywall
+                    ? FacteurButtonType.primary
+                    : FacteurButtonType.secondary,
+                icon: PhosphorIcons.link(PhosphorIconsStyle.regular),
+              ),
+              const SizedBox(height: 8),
+            ],
             // Trust/Untrust button
             FacteurButton(
               onPressed: () {
@@ -311,7 +330,9 @@ class SourceDetailModal extends ConsumerWidget {
               label: displaySource.isTrusted
                   ? 'Ne plus suivre'
                   : 'Ajouter comme source de confiance',
-              type: !displaySource.isTrusted
+              type: (!displaySource.isTrusted &&
+                      !(displaySource.premiumConnection != null &&
+                          displaySource.hasPaywall))
                   ? FacteurButtonType.primary
                   : FacteurButtonType.secondary,
               icon: displaySource.isTrusted
@@ -358,18 +379,6 @@ class SourceDetailModal extends ConsumerWidget {
                 );
               }),
             ],
-            if (displaySource.premiumConnection != null) ...[
-              const SizedBox(height: 8),
-              FacteurButton(
-                onPressed: () =>
-                    _openPremiumConnectionFlow(context, ref, displaySource),
-                label: displaySource.hasSubscription
-                    ? 'Reconnecter cet abonnement'
-                    : 'Connecter mon abonnement',
-                type: FacteurButtonType.secondary,
-                icon: PhosphorIcons.link(PhosphorIconsStyle.regular),
-              ),
-            ],
             if (displaySource.hasSubscription) ...[
               const SizedBox(height: 8),
               FacteurButton(
@@ -378,6 +387,11 @@ class SourceDetailModal extends ConsumerWidget {
                     await ref
                         .read(userSourcesProvider.notifier)
                         .disconnectSubscription(displaySource.id);
+                    // Purge la session persistée (cookies média) — le paywall
+                    // doit réapparaître après dissociation.
+                    await ref
+                        .read(premiumSessionStoreProvider)
+                        .clearForSource(displaySource);
                     if (context.mounted) Navigator.pop(context);
                   } catch (_) {
                     if (!context.mounted) return;

--- a/apps/mobile/test/features/settings/screens/subscriptions_screen_test.dart
+++ b/apps/mobile/test/features/settings/screens/subscriptions_screen_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/settings/screens/subscriptions_screen.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/providers/sources_providers.dart';
+import 'package:facteur/features/sources/services/premium_session_store.dart';
+
+class _FakeUserSourcesNotifier extends UserSourcesNotifier {
+  _FakeUserSourcesNotifier(this._sources);
+  final List<Source> _sources;
+
+  @override
+  Future<List<Source>> build() async => _sources;
+}
+
+class _FakeCookieJar implements PremiumCookieJar {
+  @override
+  Future<List<Cookie>> getCookies(WebUri url) async => const [];
+  @override
+  Future<void> setCookie(
+    WebUri url, {
+    required String name,
+    required String value,
+    String? domain,
+    String path = '/',
+    int? expiresDate,
+    bool? isSecure,
+    bool? isHttpOnly,
+    HTTPCookieSameSitePolicy? sameSite,
+  }) async {}
+  @override
+  Future<void> deleteCookies(WebUri url) async {}
+}
+
+class _InMemorySecureStore implements SecureKeyValueStore {
+  final Map<String, String> map = {};
+  @override
+  Future<String?> read(String key) async => map[key];
+  @override
+  Future<void> write(String key, String value) async => map[key] = value;
+  @override
+  Future<void> delete(String key) async => map.remove(key);
+}
+
+Widget _wrap(List<Source> sources) {
+  final store = PremiumSessionStore(
+    jar: _FakeCookieJar(),
+    secureStore: _InMemorySecureStore(),
+  );
+  return ProviderScope(
+    overrides: [
+      userSourcesProvider.overrideWith(() => _FakeUserSourcesNotifier(sources)),
+      premiumSessionStoreProvider.overrideWithValue(store),
+    ],
+    child: MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: const SubscriptionsScreen(),
+    ),
+  );
+}
+
+Source _source({
+  required String id,
+  required String name,
+  bool hasSubscription = false,
+}) =>
+    Source(
+      id: id,
+      name: name,
+      type: SourceType.article,
+      url: 'https://$id.example',
+      hasSubscription: hasSubscription,
+      hasPaywall: true,
+      premiumConnection: const PremiumConnection(
+        loginUrl: 'https://example.com/login',
+        testUrl: 'https://example.com/test',
+      ),
+    );
+
+void main() {
+  testWidgets('lists only subscribed sources', (tester) async {
+    await tester.pumpWidget(_wrap([
+      _source(id: 'lemonde', name: 'Le Monde', hasSubscription: true),
+      _source(id: 'freeblog', name: 'Free Blog'),
+    ]));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Le Monde'), findsOneWidget);
+    expect(find.text('Free Blog'), findsNothing);
+    expect(find.text('Reconnecter'), findsOneWidget);
+    expect(find.text('Dissocier'), findsOneWidget);
+  });
+
+  testWidgets('shows empty state when no subscriptions', (tester) async {
+    await tester.pumpWidget(_wrap([
+      _source(id: 'freeblog', name: 'Free Blog'),
+    ]));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Aucun abonnement connecté'), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/features/sources/models/source_model_test.dart
+++ b/apps/mobile/test/features/sources/models/source_model_test.dart
@@ -46,5 +46,61 @@ void main() {
 
       expect(source.premiumConnection, isNull);
     });
+
+    test('parses is_generic flag on premium_connection', () {
+      final generic = Source.fromJson({
+        'id': 'source-id',
+        'name': 'Generic Paywalled',
+        'type': 'article',
+        'premium_connection': {
+          'enabled': true,
+          'login_url': 'https://example.com',
+          'test_url': 'https://example.com',
+          'is_generic': true,
+        },
+      });
+
+      expect(generic.premiumConnection, isNotNull);
+      expect(generic.premiumConnection!.isGeneric, isTrue);
+    });
+
+    test('is_generic defaults to false when absent', () {
+      final curated = Source.fromJson({
+        'id': 'source-id',
+        'name': 'Curated Paywalled',
+        'type': 'article',
+        'premium_connection': {
+          'enabled': true,
+          'login_url': 'https://example.com/login',
+          'test_url': 'https://example.com/test',
+        },
+      });
+
+      expect(curated.premiumConnection, isNotNull);
+      expect(curated.premiumConnection!.isGeneric, isFalse);
+    });
+  });
+
+  group('Source.fromJson hasPaywall', () {
+    test('parses has_paywall true', () {
+      final source = Source.fromJson({
+        'id': 'source-id',
+        'name': 'Paywalled Source',
+        'type': 'article',
+        'has_paywall': true,
+      });
+
+      expect(source.hasPaywall, isTrue);
+    });
+
+    test('defaults has_paywall to false when absent', () {
+      final source = Source.fromJson({
+        'id': 'source-id',
+        'name': 'Free Source',
+        'type': 'article',
+      });
+
+      expect(source.hasPaywall, isFalse);
+    });
   });
 }

--- a/apps/mobile/test/features/sources/services/premium_session_store_test.dart
+++ b/apps/mobile/test/features/sources/services/premium_session_store_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/services/premium_session_store.dart';
+
+class _FakeCookieJar implements PremiumCookieJar {
+  final Map<String, List<Cookie>> store = {};
+  final List<String> deletedHosts = [];
+
+  @override
+  Future<List<Cookie>> getCookies(WebUri url) async =>
+      List<Cookie>.of(store[url.host] ?? const []);
+
+  @override
+  Future<void> setCookie(
+    WebUri url, {
+    required String name,
+    required String value,
+    String? domain,
+    String path = '/',
+    int? expiresDate,
+    bool? isSecure,
+    bool? isHttpOnly,
+    HTTPCookieSameSitePolicy? sameSite,
+  }) async {
+    final list = store.putIfAbsent(url.host, () => <Cookie>[]);
+    list.removeWhere((c) => c.name == name);
+    list.add(Cookie(
+      name: name,
+      value: value,
+      domain: domain,
+      path: path,
+      expiresDate: expiresDate,
+      isSecure: isSecure,
+      isHttpOnly: isHttpOnly,
+      sameSite: sameSite,
+    ));
+  }
+
+  @override
+  Future<void> deleteCookies(WebUri url) async {
+    deletedHosts.add(url.host);
+    store.remove(url.host);
+  }
+}
+
+class _InMemorySecureStore implements SecureKeyValueStore {
+  final Map<String, String> map = {};
+
+  @override
+  Future<String?> read(String key) async => map[key];
+
+  @override
+  Future<void> write(String key, String value) async => map[key] = value;
+
+  @override
+  Future<void> delete(String key) async => map.remove(key);
+}
+
+Source _source({String url = 'https://www.lemonde.fr'}) => Source(
+      id: 'src-1',
+      name: 'Le Monde',
+      type: SourceType.article,
+      url: url,
+    );
+
+void main() {
+  group('premiumDomainKey', () {
+    test('normalizes subdomains to eTLD+1', () {
+      expect(premiumDomainKey('https://www.lemonde.fr/article'), 'lemonde.fr');
+      expect(premiumDomainKey('https://m.lemonde.fr/'), 'lemonde.fr');
+      expect(premiumDomainKey('https://abonnes.lemonde.fr'), 'lemonde.fr');
+      expect(premiumDomainKey('lemonde.fr'), 'lemonde.fr');
+    });
+
+    test('handles multi-part tld and invalids', () {
+      expect(premiumDomainKey('https://www.theguardian.co.uk/x'),
+          'theguardian.co.uk');
+      expect(premiumDomainKey(null), '');
+      expect(premiumDomainKey('   '), '');
+    });
+  });
+
+  group('PremiumSessionStore', () {
+    late _FakeCookieJar jar;
+    late _InMemorySecureStore secure;
+    late PremiumSessionStore store;
+
+    setUp(() {
+      jar = _FakeCookieJar();
+      secure = _InMemorySecureStore();
+      store = PremiumSessionStore(jar: jar, secureStore: secure);
+    });
+
+    test('capture → restore → clear round-trip', () async {
+      final source = _source();
+      final url = WebUri('https://www.lemonde.fr/article');
+      jar.store['www.lemonde.fr'] = [
+        Cookie(name: 'sid', value: 'abc', domain: '.lemonde.fr', path: '/'),
+        Cookie(name: 'auth', value: 'xyz', isSecure: true, isHttpOnly: true),
+      ];
+
+      // capture
+      await store.captureForSource(source, url);
+      expect(await store.hasSession(source), isTrue);
+      expect(secure.map.keys.single,
+          'premium_session::src-1::lemonde.fr');
+
+      // wipe native cookies (simulate kill/relaunch losing session cookies)
+      jar.store.clear();
+      expect(await jar.getCookies(url), isEmpty);
+
+      // restore re-injects
+      final restored = await store.restoreForSource(source, url);
+      expect(restored, isTrue);
+      final cookies = await jar.getCookies(url);
+      expect(cookies.map((c) => c.name).toSet(), {'sid', 'auth'});
+      expect(cookies.firstWhere((c) => c.name == 'sid').value, 'abc');
+
+      // clear
+      await store.clearForSource(source);
+      expect(await store.hasSession(source), isFalse);
+      expect(jar.deletedHosts, contains('www.lemonde.fr'));
+      expect(await jar.getCookies(url), isEmpty);
+    });
+
+    test('capture is a no-op when there are no cookies', () async {
+      final source = _source();
+      final url = WebUri('https://www.lemonde.fr/article');
+      await store.captureForSource(source, url);
+      expect(secure.map, isEmpty);
+      expect(await store.hasSession(source), isFalse);
+    });
+
+    test('key matches across subdomains (capture www, query source home)',
+        () async {
+      final source = _source(url: 'https://lemonde.fr');
+      jar.store['www.lemonde.fr'] = [
+        Cookie(name: 'sid', value: 'abc'),
+      ];
+      await store.captureForSource(
+          source, WebUri('https://www.lemonde.fr/x'));
+
+      // hasSession uses source.url (lemonde.fr) → same eTLD+1 key
+      expect(await store.hasSession(source), isTrue);
+      // restore on a different subdomain hits the same key
+      final restored = await store.restoreForSource(
+          source, WebUri('https://m.lemonde.fr/y'));
+      expect(restored, isTrue);
+    });
+
+    test('restore returns false when no session stored', () async {
+      final source = _source();
+      final restored = await store.restoreForSource(
+          source, WebUri('https://www.lemonde.fr/x'));
+      expect(restored, isFalse);
+    });
+  });
+}

--- a/apps/mobile/test/features/sources/widgets/premium_source_connection_test.dart
+++ b/apps/mobile/test/features/sources/widgets/premium_source_connection_test.dart
@@ -1,9 +1,47 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/providers/sources_providers.dart';
+import 'package:facteur/features/sources/services/premium_session_store.dart';
 import 'package:facteur/features/sources/widgets/premium_source_connection.dart';
+
+class _FakeCookieJar implements PremiumCookieJar {
+  final Map<String, List<Cookie>> store = {};
+
+  @override
+  Future<List<Cookie>> getCookies(WebUri url) async =>
+      List<Cookie>.of(store[url.host] ?? const []);
+
+  @override
+  Future<void> setCookie(
+    WebUri url, {
+    required String name,
+    required String value,
+    String? domain,
+    String path = '/',
+    int? expiresDate,
+    bool? isSecure,
+    bool? isHttpOnly,
+    HTTPCookieSameSitePolicy? sameSite,
+  }) async {}
+
+  @override
+  Future<void> deleteCookies(WebUri url) async {}
+}
+
+class _InMemorySecureStore implements SecureKeyValueStore {
+  final Map<String, String> map = {};
+  @override
+  Future<String?> read(String key) async => map[key];
+  @override
+  Future<void> write(String key, String value) async => map[key] = value;
+  @override
+  Future<void> delete(String key) async => map.remove(key);
+}
 
 void main() {
   setUp(() {
@@ -18,13 +56,23 @@ void main() {
         .setMockMethodCallHandler(SystemChannels.platform, null);
   });
 
-  testWidgets('PremiumSourceConnection completes login test confirmation flow',
-      (tester) async {
+  testWidgets(
+      'PremiumSourceConnection completes login test confirmation flow and '
+      'captures session at confirm', (tester) async {
     var connected = false;
+    final jar = _FakeCookieJar();
+    // Seed cookies on the media domain so the capture at _confirm persists.
+    jar.store['example.com'] = [Cookie(name: 'sid', value: 'abc')];
+    final store = PremiumSessionStore(
+      jar: jar,
+      secureStore: _InMemorySecureStore(),
+    );
+
     final source = Source(
       id: 'source-id',
       name: 'Premium Source',
       type: SourceType.article,
+      url: 'https://example.com',
       premiumConnection: const PremiumConnection(
         loginUrl: 'https://example.com/login',
         testUrl: 'https://example.com/test',
@@ -32,14 +80,17 @@ void main() {
     );
 
     await tester.pumpWidget(
-      MaterialApp(
-        theme: FacteurTheme.lightTheme,
-        home: PremiumSourceConnection(
-          source: source,
-          onConnected: () async {
-            connected = true;
-          },
-          webViewBuilder: (_, url) => Center(child: Text(url)),
+      ProviderScope(
+        overrides: [premiumSessionStoreProvider.overrideWithValue(store)],
+        child: MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: PremiumSourceConnection(
+            source: source,
+            onConnected: () async {
+              connected = true;
+            },
+            webViewBuilder: (_, url) => Center(child: Text(url)),
+          ),
         ),
       ),
     );
@@ -64,5 +115,7 @@ void main() {
 
     expect(connected, isTrue);
     expect(find.text('Abonnement connecté'), findsOneWidget);
+    // Session captured at confirm.
+    expect(await store.hasSession(source), isTrue);
   });
 }

--- a/docs/bugs/bug-sources-payantes-session-decouvrabilite.md
+++ b/docs/bugs/bug-sources-payantes-session-decouvrabilite.md
@@ -1,6 +1,8 @@
 # Bug Report: Sources payantes — session non persistée + découvrabilité cassée
 
-**Status:** EN COURS — PR 1 (backend découvrabilité) prête ; PR 2 (session + UI) à suivre
+**Status:** PRÊT POUR REVIEW — backend découvrabilité + session persistante + UI
+(une seule PR, décision PO du 2026-06-08 : « lancer les 2 en même temps »).
+Validation device (cookies natifs) restant à faire manuellement.
 **Severity:** HIGH (lecture des sources payantes inutilisable + CTA invisible)
 **Created:** 2026-06-08
 **Branch:** `boujonlaurin-dotcom/webview-credentials-not-saving`
@@ -59,14 +61,44 @@ dans `PREMIUM_CURATED_MAP`. On n'utilise **pas** `source_tier` (faux signal).
 
 ---
 
-## PR 2 — Session persistante + UI (après merge PR 1) — ⏳ à faire
+## PR 2 — Session persistante + UI — ✅ implémentée
 
-`premium_session_store.dart` (CookieManager + secure storage), `premium_web_view.dart`
-(InAppWebView calqué sur `youtube_player_widget.dart`, ScrollBridge porté), migration du
-flow de connexion + du chemin premium du reader, détection paywall/expiration → bandeau
-« Reconnecter », écran « Mes abonnements » (+ route + carte Compte), CTA reader, proéminence
-CTA modal, nettoyage `premium_sources_sheet.dart`, tests mobile.
+**Session (A+B) — mobile**
+- `apps/mobile/lib/features/sources/services/premium_session_store.dart` (nouveau) —
+  `PremiumSessionStore` (capture/restore/clear/hasSession) adossé à `CookieManager`
+  (inappwebview) + `FlutterSecureStorage`, via abstractions `PremiumCookieJar` /
+  `SecureKeyValueStore` (testabilité). Clé `premium_session::<sourceId>::<eTLD+1>` ;
+  `premiumDomainKey` miroir Dart de `domain_key`.
+- `apps/mobile/lib/features/sources/widgets/premium_web_view.dart` (nouveau) —
+  `InAppWebView` calqué sur `youtube_player_widget.dart` (UA Chrome, `incognito:false`,
+  `clearCache:false`, store partagé). `onWebViewCreated → await restore → loadUrl`.
+  ScrollBridge porté (`callHandler` au lieu de `postMessage`, messages identiques) ;
+  sonde paywall (mots-clés FR) → `PaywallDetected`.
+- Providers : `premiumSessionStoreProvider`, `subscribedSourcesProvider`
+  (`sources_providers.dart`).
+- Flow de connexion (`premium_source_connection.dart`) → `ConsumerStatefulWidget` +
+  `PremiumWebView` ; capture au `_confirm()` (`captureForSource(testUrl)`). Hooks de test
+  `webViewBuilder`/`openExternal` conservés.
+- Reader (`content_detail_screen.dart`) : **seul** le chemin premium migre
+  (`InAppWebViewController? _premiumWebController` + `PremiumWebView`) ; le scroll-to-site
+  gratuit reste sur `webview_flutter`. Progression partagée (`_applyWebReadingProgress`).
+  Paywall détecté → bandeau non-bloquant « Session expirée — Reconnecter » (jamais de
+  dissociation auto).
 
-**Validation device (non testable Playwright)** : connecter Le Monde → autre article LM →
-kill+relance app → toujours connecté → Dissocier → paywall revient. iOS **et** Android
+**Découvrabilité — UI**
+- `apps/mobile/lib/features/settings/screens/subscriptions_screen.dart` (nouveau) +
+  route `/settings/subscriptions` + carte « ABONNEMENTS » sur le Compte. Par source :
+  logo, statut session (`hasSession`), Reconnecter / Dissocier (`+ clearForSource`).
+- CTA reader « Lire avec mon abonnement » (source payante non connectée).
+- CTA modal proéminent (primary + en tête quand `hasPaywall`) ; label par état
+  (Reconnecter / Associer générique / Connecter curé).
+- `premium_sources_sheet.dart` : branche `connectSubscription` directe supprimée (le 400).
+
+**Tests mobile (verts)** : `premium_session_store_test.dart` (capture→restore→clear,
+domain key), `premium_source_connection_test.dart` (PremiumWebView injecté + capture au
+confirm), `subscriptions_screen_test.dart`, `source_model_test.dart`. `flutter analyze` :
+0 erreur / 0 warning introduits.
+
+**Validation device (non testable Playwright/CI)** : connecter Le Monde → autre article LM
+→ kill+relance app → toujours connecté → Dissocier → paywall revient. iOS **et** Android
 (WKWebView vs Android WebView diffèrent sur les cookies de session).

--- a/docs/bugs/bug-sources-payantes-session-decouvrabilite.md
+++ b/docs/bugs/bug-sources-payantes-session-decouvrabilite.md
@@ -1,0 +1,72 @@
+# Bug Report: Sources payantes — session non persistée + découvrabilité cassée
+
+**Status:** EN COURS — PR 1 (backend découvrabilité) prête ; PR 2 (session + UI) à suivre
+**Severity:** HIGH (lecture des sources payantes inutilisable + CTA invisible)
+**Created:** 2026-06-08
+**Branch:** `boujonlaurin-dotcom/webview-credentials-not-saving`
+**Plan source:** `.context/attachments/J6NgmX/plan.md` (validé PO)
+
+---
+
+## Symptômes
+
+| # | Problème | Symptôme | Cause racine |
+|---|----------|----------|--------------|
+| #1 | Session non persistée | L'utilisateur doit se reconnecter au média **à chaque article** | `webview_flutter` n'expose pas les cookies ; controllers WebView jetables ; aucun store partagé ni capture/réinjection |
+| #2 | CTA d'abonnement invisible | La modal d'une source n'affiche **jamais** "Connecter mon abonnement" | Sur 377 sources, `premium_connection_config` renseigné = **0** → `from_config` renvoie toujours `None` → CTA gated sur `premiumConnection != null` jamais vrai |
+| #3 | 400 actif en prod | `premium_sources_sheet.dart` appelle `connectSubscription` quand `premiumConnection == null` → backend lève `PremiumConnectionNotEnabled` (400) | Conséquence directe de #2 |
+
+---
+
+## Décisions (validées PO)
+
+- **Session = A+B** : migrer le flow premium sur `flutter_inappwebview` (store persistant
+  partagé) + capture/réinjection explicite des cookies via `flutter_secure_storage`.
+- **Bug + découvrabilité traités ensemble.**
+- **Découvrabilité = config curée quand on l'a + fallback générique sinon** + point
+  d'entrée global « Mes abonnements ».
+
+---
+
+## PR 1 — Backend découvrabilité (CI-couverte, débloque PR 2) — ✅ implémentée
+
+Chokepoint unique : toute la résolution config→réponse passe par
+`PremiumConnectionResponse` + le helper de source. Effet immédiat : le CTA réapparaît
+partout et le 400 disparaît, **sans migration Alembic** (zéro dépendance d'id, conforme
+« 1 head » / pas de SQL manuel).
+
+**Fichiers**
+- `packages/api/app/services/premium_curated_sources.py` (nouveau) — `PREMIUM_CURATED_MAP`
+  (keyé eTLD+1), `domain_key(url)`, `is_paywalled_source(source)`.
+- `packages/api/app/schemas/source.py` — `PremiumConnectionResponse.is_generic`,
+  classmethod `from_source(source, *, curated_map)` (config > map curée > générique > None) ;
+  `SourceResponse.has_paywall`.
+- `packages/api/app/services/source_service.py` — `_premium_connection` délègue à
+  `from_source` ; `_has_paywall` ; `has_paywall` câblé sur les 3 builders.
+- `packages/api/app/routers/sources.py` + `packages/api/app/services/pepite_service.py` —
+  2 builders inline alignés (`from_source` + `has_paywall`).
+- Mobile minimal : `apps/mobile/lib/features/sources/models/source_model.dart` —
+  `PremiumConnection.isGeneric` + `Source.hasPaywall` (parsing).
+- Tests : `packages/api/tests/test_premium_discoverability.py` (domain_key, from_source
+  a/b/c/d, has_paywall, 400 levé→résolu en générique) ;
+  `apps/mobile/test/features/sources/models/source_model_test.dart` (is_generic/has_paywall).
+
+**Signal « source payante » (`has_paywall`)** : `paywall_config is not None` **ou** domaine
+dans `PREMIUM_CURATED_MAP`. On n'utilise **pas** `source_tier` (faux signal).
+
+**Vérification** : `pytest` complet **1564 passed / 0 failed** ; mobile model tests verts ;
+`ruff`/`flutter analyze` propres.
+
+---
+
+## PR 2 — Session persistante + UI (après merge PR 1) — ⏳ à faire
+
+`premium_session_store.dart` (CookieManager + secure storage), `premium_web_view.dart`
+(InAppWebView calqué sur `youtube_player_widget.dart`, ScrollBridge porté), migration du
+flow de connexion + du chemin premium du reader, détection paywall/expiration → bandeau
+« Reconnecter », écran « Mes abonnements » (+ route + carte Compte), CTA reader, proéminence
+CTA modal, nettoyage `premium_sources_sheet.dart`, tests mobile.
+
+**Validation device (non testable Playwright)** : connecter Le Monde → autre article LM →
+kill+relance app → toujours connecté → Dissocier → paywall revient. iOS **et** Android
+(WKWebView vs Android WebView diffèrent sur les cookies de session).

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -39,6 +39,10 @@ from app.schemas.source import (
 )
 from app.services.feed_cache import FEED_CACHE
 from app.services.pepite_service import PepiteService
+from app.services.premium_curated_sources import (
+    PREMIUM_CURATED_MAP,
+    is_paywalled_source,
+)
 from app.services.search.smart_source_search import (
     SmartSourceSearchService,
     mark_search_abandoned,
@@ -263,8 +267,9 @@ def _source_to_response(
         score_ux=s.score_ux,
         recommended_by=getattr(s, "recommended_by", None),
         recommendation_reason=getattr(s, "recommendation_reason", None),
-        premium_connection=PremiumConnectionResponse.from_config(
-            getattr(s, "premium_connection_config", None)
+        has_paywall=is_paywalled_source(s, curated_map=PREMIUM_CURATED_MAP),
+        premium_connection=PremiumConnectionResponse.from_source(
+            s, curated_map=PREMIUM_CURATED_MAP
         ),
     )
 

--- a/packages/api/app/schemas/source.py
+++ b/packages/api/app/schemas/source.py
@@ -39,6 +39,7 @@ class SourceResponse(BaseModel):
     score_ux: float | None = None
     recommended_by: str | None = None
     recommendation_reason: str | None = None
+    has_paywall: bool = False
     premium_connection: "PremiumConnectionResponse | None" = None
 
     class Config:
@@ -52,6 +53,10 @@ class PremiumConnectionResponse(BaseModel):
     login_url: str
     test_url: str
     display_hint: str | None = None
+    # True quand la config est dérivée d'un fallback générique (URL = home de la
+    # source) plutôt que d'une config curée/explicite. Le mobile adapte le label
+    # du CTA ("Associer" vs "Connecter").
+    is_generic: bool = False
 
     @classmethod
     def from_config(cls, config: object) -> "PremiumConnectionResponse | None":
@@ -74,6 +79,65 @@ class PremiumConnectionResponse(BaseModel):
             if isinstance(display_hint, str) and display_hint.strip()
             else None,
         )
+
+    @classmethod
+    def from_source(
+        cls, source: object, *, curated_map: dict
+    ) -> "PremiumConnectionResponse | None":
+        """Résout la config de connexion premium d'une source, par priorité.
+
+        1. config explicite (``premium_connection_config``) si présente ;
+        2. sinon match domaine dans ``curated_map`` → config curée
+           (``is_generic=False``) ;
+        3. sinon, si la source est payante (paywall_config / map) et possède une
+           URL http(s) valide → fallback générique (login=test=home de la source,
+           ``is_generic=True``) ;
+        4. sinon ``None``.
+        """
+        # Import local : évite un cycle schemas → services au chargement.
+        from app.services.premium_curated_sources import (
+            domain_key,
+            is_paywalled_source,
+        )
+
+        explicit = cls.from_config(getattr(source, "premium_connection_config", None))
+        if explicit is not None:
+            return explicit
+
+        url = getattr(source, "url", None)
+        domain = domain_key(url)
+
+        curated = curated_map.get(domain) if domain else None
+        if isinstance(curated, dict):
+            login_url = str(curated.get("login_url", "")).strip()
+            test_url = str(curated.get("test_url", "")).strip()
+            if login_url and test_url:
+                hint = curated.get("display_hint")
+                return cls(
+                    enabled=True,
+                    login_url=login_url,
+                    test_url=test_url,
+                    display_hint=hint.strip()
+                    if isinstance(hint, str) and hint.strip()
+                    else None,
+                    is_generic=False,
+                )
+
+        if is_paywalled_source(source, curated_map=curated_map):
+            clean_url = url.strip() if isinstance(url, str) else ""
+            if clean_url.startswith(("http://", "https://")):
+                return cls(
+                    enabled=True,
+                    login_url=clean_url,
+                    test_url=clean_url,
+                    display_hint=(
+                        "Connecte-toi à ton compte sur le site du média, "
+                        "puis reviens lire tes articles."
+                    ),
+                    is_generic=True,
+                )
+
+        return None
 
 
 class SourceCreate(BaseModel):

--- a/packages/api/app/services/pepite_service.py
+++ b/packages/api/app/services/pepite_service.py
@@ -17,6 +17,10 @@ from app.models.source import Source, UserSource
 from app.models.user import UserInterest
 from app.models.user_personalization import UserPersonalization
 from app.schemas.source import PremiumConnectionResponse, SourceResponse
+from app.services.premium_curated_sources import (
+    PREMIUM_CURATED_MAP,
+    is_paywalled_source,
+)
 
 logger = structlog.get_logger()
 
@@ -195,8 +199,9 @@ class PepiteService:
                 score_ux=s.score_ux,
                 recommended_by=getattr(s, "recommended_by", None),
                 recommendation_reason=getattr(s, "recommendation_reason", None),
-                premium_connection=PremiumConnectionResponse.from_config(
-                    getattr(s, "premium_connection_config", None)
+                has_paywall=is_paywalled_source(s, curated_map=PREMIUM_CURATED_MAP),
+                premium_connection=PremiumConnectionResponse.from_source(
+                    s, curated_map=PREMIUM_CURATED_MAP
                 ),
             )
             for s, follower_count in selected

--- a/packages/api/app/services/premium_curated_sources.py
+++ b/packages/api/app/services/premium_curated_sources.py
@@ -1,0 +1,111 @@
+"""Config curée des sources payantes (connexion WebView mobile).
+
+Map en code plutôt qu'en base : la découvrabilité du CTA "Connecter mon
+abonnement" ne dépend d'aucun id de source ni d'aucune migration Alembic
+(conforme "exactement 1 head" / pas de SQL manuel via Supabase). On clé par
+domaine eTLD+1, ce qui couvre toutes les sources d'un même média (sous-domaines
+``www``/``m``/``abonnes`` inclus) sans connaître leur id.
+
+Facteur ne collecte jamais d'identifiants : ces URLs ne servent qu'à charger la
+page de connexion et une page de test dans la WebView de l'app, côté device.
+"""
+
+from urllib.parse import urlsplit
+
+# Suffixes composés courants (eTLD à deux labels). On reste centré FR/EU : le
+# fallback générique couvre tout le reste, donc cette liste n'a pas à être
+# exhaustive.
+_MULTI_PART_TLDS = frozenset(
+    {"co.uk", "org.uk", "gov.uk", "ac.uk", "com.au", "co.jp", "co.nz"}
+)
+
+
+def domain_key(url: str | None) -> str:
+    """Retourne l'eTLD+1 normalisé d'une URL (clé de ``PREMIUM_CURATED_MAP``).
+
+    ``https://www.lemonde.fr/...`` → ``lemonde.fr`` ;
+    ``https://abonnes.lefigaro.fr`` → ``lefigaro.fr``. Approximation FR-first
+    (deux derniers labels), avec garde pour les quelques suffixes composés
+    usuels. Renvoie ``""`` si l'URL est inexploitable.
+    """
+    if not isinstance(url, str):
+        return ""
+    raw = url.strip()
+    if not raw:
+        return ""
+    # Autorise les hôtes nus ("lemonde.fr") en leur donnant un schéma fictif.
+    if "//" not in raw:
+        raw = "//" + raw
+    host = (urlsplit(raw).hostname or "").lower().strip(".")
+    if not host:
+        return ""
+    labels = host.split(".")
+    if len(labels) <= 2:
+        return host
+    if ".".join(labels[-2:]) in _MULTI_PART_TLDS and len(labels) >= 3:
+        return ".".join(labels[-3:])
+    return ".".join(labels[-2:])
+
+
+# Config curée : login_url = page de connexion du média ; test_url = page chargée
+# pour vérifier que la session est active (idéalement un article abonné
+# "evergreen", à défaut la home du média). display_hint = consigne affichée à
+# l'utilisateur pendant la connexion. À enrichir éditorialement sans migration.
+PREMIUM_CURATED_MAP: dict[str, dict] = {
+    "lemonde.fr": {
+        "login_url": "https://secure.lemonde.fr/sfuser/connexion",
+        "test_url": "https://www.lemonde.fr/",
+        "display_hint": "Connecte-toi à ton compte Le Monde, puis reviens lire tes articles.",
+    },
+    "mediapart.fr": {
+        "login_url": "https://www.mediapart.fr/login",
+        "test_url": "https://www.mediapart.fr/",
+        "display_hint": "Connecte-toi à ton compte Mediapart pour lire les articles réservés.",
+    },
+    "lefigaro.fr": {
+        "login_url": "https://plus.lefigaro.fr/account/login",
+        "test_url": "https://www.lefigaro.fr/",
+        "display_hint": "Connecte-toi à ton compte Figaro pour lire les articles abonnés.",
+    },
+    "lequipe.fr": {
+        "login_url": "https://compte.lequipe.fr/",
+        "test_url": "https://www.lequipe.fr/",
+        "display_hint": "Connecte-toi à ton compte L'Équipe pour lire les articles abonnés.",
+    },
+    "liberation.fr": {
+        "login_url": "https://www.liberation.fr/auth/login/",
+        "test_url": "https://www.liberation.fr/",
+        "display_hint": "Connecte-toi à ton compte Libération pour lire les articles abonnés.",
+    },
+    "lesechos.fr": {
+        "login_url": "https://www.lesechos.fr/connexion",
+        "test_url": "https://www.lesechos.fr/",
+        "display_hint": "Connecte-toi à ton compte Les Échos pour lire les articles abonnés.",
+    },
+    "telerama.fr": {
+        "login_url": "https://www.telerama.fr/connexion",
+        "test_url": "https://www.telerama.fr/",
+        "display_hint": "Connecte-toi à ton compte Télérama pour lire les articles abonnés.",
+    },
+}
+
+
+def is_paywalled_source(source: object, *, curated_map: dict | None = None) -> bool:
+    """Indique si une source est payante (signal ``has_paywall`` côté mobile).
+
+    Vrai si l'un des deux signaux fiables est présent :
+    - ``paywall_config`` renseigné (patterns de détection paywall) ;
+    - domaine présent dans ``PREMIUM_CURATED_MAP``.
+
+    On n'utilise **pas** ``source_tier`` (faux signal), ni la simple présence
+    d'un ``premium_connection_config`` partiel (une config explicite valide est
+    gérée en amont par ``PremiumConnectionResponse.from_source``).
+    """
+    if curated_map is None:
+        curated_map = PREMIUM_CURATED_MAP
+
+    if getattr(source, "paywall_config", None) is not None:
+        return True
+
+    domain = domain_key(getattr(source, "url", None))
+    return bool(domain) and domain in curated_map

--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -18,6 +18,10 @@ from app.schemas.source import (
     SourceResponse,
 )
 from app.services.language_user_filter import recompute_auto_pref
+from app.services.premium_curated_sources import (
+    PREMIUM_CURATED_MAP,
+    is_paywalled_source,
+)
 from app.services.rss_parser import RSSParser
 
 logger = structlog.get_logger()
@@ -37,9 +41,11 @@ class SourceService:
 
     @staticmethod
     def _premium_connection(s: Source) -> PremiumConnectionResponse | None:
-        return PremiumConnectionResponse.from_config(
-            getattr(s, "premium_connection_config", None)
-        )
+        return PremiumConnectionResponse.from_source(s, curated_map=PREMIUM_CURATED_MAP)
+
+    @staticmethod
+    def _has_paywall(s: Source) -> bool:
+        return is_paywalled_source(s, curated_map=PREMIUM_CURATED_MAP)
 
     async def _load_user_source_context(
         self, user_id: UUID
@@ -108,6 +114,7 @@ class SourceService:
             score_ux=s.score_ux,
             recommended_by=getattr(s, "recommended_by", None),
             recommendation_reason=getattr(s, "recommendation_reason", None),
+            has_paywall=self._has_paywall(s),
             premium_connection=self._premium_connection(s),
         )
 
@@ -398,6 +405,7 @@ class SourceService:
             score_ux=source.score_ux,
             recommended_by=getattr(source, "recommended_by", None),
             recommendation_reason=getattr(source, "recommendation_reason", None),
+            has_paywall=self._has_paywall(source),
             premium_connection=self._premium_connection(source),
         )
 
@@ -568,6 +576,7 @@ class SourceService:
             score_ux=source.score_ux,
             recommended_by=getattr(source, "recommended_by", None),
             recommendation_reason=getattr(source, "recommendation_reason", None),
+            has_paywall=self._has_paywall(source),
             premium_connection=self._premium_connection(source),
         )
 

--- a/packages/api/tests/test_premium_discoverability.py
+++ b/packages/api/tests/test_premium_discoverability.py
@@ -1,0 +1,193 @@
+"""Découvrabilité des sources payantes : config curée + fallback générique.
+
+Couvre la résolution `PremiumConnectionResponse.from_source`, le signal
+`has_paywall` exposé au mobile, et le helper `domain_key`.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.enums import SourceType
+from app.models.source import Source
+from app.schemas.source import PremiumConnectionResponse
+from app.services.premium_curated_sources import (
+    PREMIUM_CURATED_MAP,
+    domain_key,
+    is_paywalled_source,
+)
+from app.services.source_service import SourceService
+
+MAP = PREMIUM_CURATED_MAP
+
+
+def _stub(url=None, premium_connection_config=None, paywall_config=None):
+    return SimpleNamespace(
+        url=url,
+        premium_connection_config=premium_connection_config,
+        paywall_config=paywall_config,
+    )
+
+
+# ─── domain_key ───────────────────────────────────────────────────
+
+
+def test_domain_key_normalizes_subdomains():
+    assert domain_key("https://www.lemonde.fr/article/x") == "lemonde.fr"
+    assert domain_key("https://m.lemonde.fr/") == "lemonde.fr"
+    assert domain_key("https://abonnes.lemonde.fr") == "lemonde.fr"
+    assert domain_key("https://LEMONDE.fr/UP") == "lemonde.fr"
+    assert domain_key("lemonde.fr") == "lemonde.fr"
+
+
+def test_domain_key_handles_multipart_tld_and_invalids():
+    assert domain_key("https://www.theguardian.co.uk/news") == "theguardian.co.uk"
+    assert domain_key(None) == ""
+    assert domain_key("   ") == ""
+    assert domain_key("https://") == ""
+
+
+# ─── from_source : priorité config > map > générique > None ────────
+
+
+def test_from_source_explicit_config_beats_curated_map():
+    # url lemonde.fr (présente dans la map) mais config explicite → config gagne.
+    src = _stub(
+        url="https://www.lemonde.fr/article",
+        premium_connection_config={
+            "enabled": True,
+            "login_url": "https://explicit.example/login",
+            "test_url": "https://explicit.example/test",
+        },
+    )
+    resp = PremiumConnectionResponse.from_source(src, curated_map=MAP)
+    assert resp is not None
+    assert resp.login_url == "https://explicit.example/login"
+    assert resp.is_generic is False
+
+
+def test_from_source_curated_map_is_not_generic():
+    src = _stub(url="https://www.lemonde.fr/section/x")
+    resp = PremiumConnectionResponse.from_source(src, curated_map=MAP)
+    assert resp is not None
+    assert resp.is_generic is False
+    assert resp.login_url == MAP["lemonde.fr"]["login_url"]
+    assert resp.test_url == MAP["lemonde.fr"]["test_url"]
+
+
+def test_from_source_paywall_config_only_is_generic_using_source_url():
+    src = _stub(
+        url="https://unknown-paper.example/news/x",
+        paywall_config={"keywords": ["réservé aux abonnés"]},
+    )
+    resp = PremiumConnectionResponse.from_source(src, curated_map=MAP)
+    assert resp is not None
+    assert resp.is_generic is True
+    assert resp.login_url == "https://unknown-paper.example/news/x"
+    assert resp.test_url == resp.login_url
+
+
+def test_from_source_free_source_returns_none():
+    src = _stub(url="https://free-paper.example/")
+    assert PremiumConnectionResponse.from_source(src, curated_map=MAP) is None
+
+
+def test_from_source_paywalled_but_non_http_url_returns_none():
+    src = _stub(url="ftp://weird-host", paywall_config={"keywords": ["x"]})
+    assert PremiumConnectionResponse.from_source(src, curated_map=MAP) is None
+
+
+# ─── is_paywalled_source ──────────────────────────────────────────
+
+
+def test_is_paywalled_source_signals():
+    assert is_paywalled_source(_stub(url="https://www.lemonde.fr/")) is True
+    assert (
+        is_paywalled_source(_stub(url="https://x.example/", paywall_config={"k": 1}))
+        is True
+    )
+    assert is_paywalled_source(_stub(url="https://x.example/")) is False
+    # premium_connection_config partiel ne suffit pas (faux signal).
+    assert (
+        is_paywalled_source(
+            _stub(
+                url="https://x.example/",
+                premium_connection_config={"enabled": True},
+            )
+        )
+        is False
+    )
+
+
+# ─── intégration service / DB ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_subscription_true_succeeds_for_generic_paywalled_source(
+    db_session: AsyncSession,
+):
+    """Le 400 PremiumConnectionNotEnabled disparaît pour une source payante
+    sans config explicite (fallback générique)."""
+    source = Source(
+        id=uuid4(),
+        name="Generic Paywalled",
+        url="https://generic-paper.example",
+        feed_url=f"https://generic-paper.example/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_curated=True,
+        is_active=True,
+        paywall_config={"keywords": ["réservé aux abonnés"]},
+    )
+    db_session.add(source)
+    await db_session.flush()
+
+    response = await SourceService(db_session).update_source_subscription(
+        str(uuid4()), str(source.id), True
+    )
+
+    assert response is not None
+    assert response.has_subscription is True
+    assert response.has_paywall is True
+    assert response.premium_connection is not None
+    assert response.premium_connection.is_generic is True
+
+
+@pytest.mark.asyncio
+async def test_curated_sources_expose_has_paywall(db_session: AsyncSession):
+    map_source = Source(
+        id=uuid4(),
+        name="Le Monde",
+        url="https://www.lemonde.fr",
+        feed_url=f"https://www.lemonde.fr/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_curated=True,
+        is_active=True,
+    )
+    free_source = Source(
+        id=uuid4(),
+        name="Free Blog",
+        url="https://free-blog.example",
+        feed_url=f"https://free-blog.example/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_curated=True,
+        is_active=True,
+    )
+    db_session.add_all([map_source, free_source])
+    await db_session.flush()
+
+    by_id = {r.id: r for r in await SourceService(db_session).get_curated_sources()}
+
+    assert by_id[map_source.id].has_paywall is True
+    assert by_id[map_source.id].premium_connection is not None
+    assert by_id[map_source.id].premium_connection.is_generic is False
+    assert (
+        by_id[map_source.id].premium_connection.login_url
+        == MAP["lemonde.fr"]["login_url"]
+    )
+    assert by_id[free_source.id].has_paywall is False
+    assert by_id[free_source.id].premium_connection is None


### PR DESCRIPTION
## Contexte

Bug **sources payantes** — deux problèmes traités ensemble (décision PO : 1 PR cohérente) :

1. **Session non persistée** : `webview_flutter` n'expose pas les cookies → re-login du média **à chaque article**.
2. **Découvrabilité cassée** : `premium_connection_config` renseigné sur **0/377 sources** → le CTA « Connecter mon abonnement » n'apparaissait jamais ; `premium_sources_sheet` levait un **400** `PremiumConnectionNotEnabled` en prod ; aucun écran « Mes abonnements ».

Bug doc : `docs/bugs/bug-sources-payantes-session-decouvrabilite.md`.

## Découvrabilité — backend (chokepoint unique, pas de migration Alembic)

- `premium_curated_sources.py` (nouveau) : `PREMIUM_CURATED_MAP` (keyé eTLD+1), `domain_key`, `is_paywalled_source`.
- `PremiumConnectionResponse.from_source(source, *, curated_map)` : **config explicite > map curée (`is_generic=False`) > fallback générique (`login=test=source.url`, `is_generic=True`) > None**. + `SourceResponse.has_paywall`.
- 5 builders de `SourceResponse` alignés (service ×3, router, pepite). → CTA réapparaît partout + corrige le 400.
- Mobile : `Source.hasPaywall`, `PremiumConnection.isGeneric` (parsing).

## Session persistante (A+B) — mobile

- `PremiumSessionStore` : `CookieManager` (inappwebview) + `FlutterSecureStorage`, via abstractions `PremiumCookieJar` / `SecureKeyValueStore` (testable). Clé `premium_session::<sourceId>::<eTLD+1>`.
- `PremiumWebView` : `InAppWebView` calqué sur `youtube_player_widget` (UA Chrome, `incognito:false`, `clearCache:false`, store partagé) ; `onWebViewCreated → restore → loadUrl` ; ScrollBridge porté (`callHandler`) ; sonde paywall → `PaywallDetected`.
- Flow de connexion → `ConsumerStatefulWidget` + `PremiumWebView`, capture au `_confirm()`.
- Reader : **seul** le chemin premium migre sur inappwebview ; le scroll-to-site gratuit reste sur `webview_flutter`. Bandeau non-bloquant « Session expirée — Reconnecter ».

## Découvrabilité — UI

- Écran **« Mes abonnements »** + route `/settings/subscriptions` + carte « ABONNEMENTS » sur le Compte.
- CTA reader « Lire avec mon abonnement » ; CTA modal proéminent (primary + en tête quand `hasPaywall`, label par état).
- `premium_sources_sheet` : branche `connectSubscription` directe supprimée.

## Tests

- **Backend** : `pytest` complet **1564 passed / 0 failed** (10 nouveaux cas : `domain_key`, `from_source` a/b/c/d, `has_paywall`, 400→résolu en générique).
- **Mobile** : `premium_session_store_test`, `premium_source_connection_test` (capture au confirm), `subscriptions_screen_test`, `source_model_test` — verts. `flutter analyze` : **0 erreur / 0 warning** introduits.

## ⚠️ Validation device requise (non couverte CI/Playwright)

La persistance des cookies natifs (WKWebView vs Android WebView) se valide **sur device** : connecter Le Monde → autre article LM → **kill+relance** → toujours connecté → Dissocier → paywall revient. À répéter **iOS et Android**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
