### PR TITLE
perf(mobile): démarrage matinal perçu quasi-instantané (squelette + auth non-bloquant + rendu progressif)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,54 +1,87 @@
-# Tournée — clarifier les limites + affordance du bouton de passage + auto-scroll
+# PR A — Mobile : démarrage perçu quasi-instantané (squelette + auth non-bloquant + rendu progressif)
 
 ## Résumé
 
-Refonte de la modal « Mes favoris » (`manage_favorites_sheet.dart`, ouverte depuis
-L'Essentiel et les onglets Flâner) pour lever la confusion entre les trois
-mécanismes de limite, et élargissement du cap Tournée **5 → 7**.
+À l'ouverture matinale, le temps perçu tap→contenu était >5s (jusqu'à 20s+ si
+`/api/digest` renvoie 202). Le matin est structurellement différent des
+ré-ouvertures : le cache local est invalidé chaque nuit (jamais de SWR matinal),
+le JWT (TTL 1h) est mort et un `await refresh()` **bloquant** gatait le splash,
+et rien ne s'affichait avant le retour de **tous** les endpoints (3 de base +
+jusqu'à 14 feeds thèmes/sources). Cette PR (mobile only, aucune nouvelle
+dépendance) supprime ces trois gates.
 
 ## Changements
 
-### 1. Cap Tournée 5 → 7 (mirrors synchronisés, aucune migration)
-- `tournee_order_prefs_provider.dart` : `kTourneeVisibleCap` 5 → 7.
-- `flux_continu_provider.dart` : `_kMaxFavoriteSections` & `_kMaxFavoriteSourceSections`
-  5 → 7 (sous-caps par catégorie, avant le `take(kTourneeVisibleCap)`).
-- `config/constants.dart` : `InterestConstants.favoriteCap` 5 → 7 (mirror).
-- `packages/api/app/constants.py` : `FAVORITE_CAP` 5 → 7 (mirror, constante produit —
-  pas de DDL/Alembic). `get_top_themes` borne juste un peu plus large la perso éditoriale.
-- Cap Flâner `kMaxFavoriteTabs = 10` : **inchangé**.
+- **A1 — Auth refresh non-bloquant** (`core/auth/auth_state.dart`)
+  - `_init` peint l'état authentifié **immédiatement** ; le refresh tourne en
+    arrière-plan, exposé via `AuthStateNotifier.initialRefresh`.
+  - `.catchError` ne gère que l'`AuthException` (refresh token mort → signout +
+    `sessionExpired`, identique à l'ancien chemin bloquant). On ne re-pose
+    **jamais** `lastTokenRefreshAt` à la main : l'event SDK `tokenRefreshed`
+    reste l'unique signal d'invalidation (cf. `bug-feed-403-auth-recovery.md`).
+    Single-flight conservé via `SessionRefresher` (cf.
+    `bug-android-disconnect-race.md`).
 
-### 2. Suppression des blocages « max » par type
-Le backend n'impose aucun cap dur (`FavoriteCapReached` = code mort). Retiré côté
-modal : `interestsAtCap`/`sourcesAtCap`, le paramètre `atCap` des add-lists, les
-`_CapHint(« Maximum … atteint »)`, la classe `_CapHint`, les `catch
-(FavoriteCapReachedException)` et l'import devenu inutile. L'ajout n'est plus jamais
-bloqué ; le surplus reste grisé sous le trait `_CapDivider` existant.
+- **A2 — Cache → squelette fidèle** (`services/flux_continu_cache_service.dart`)
+  - `readLatest()` ne jette plus sur day mismatch — pose `isStale` + lit
+    `savedAt`. `readToday()` devient un wrapper « du jour uniquement ». Le cache
+    d'hier sert à dessiner la structure, **jamais** à afficher du contenu périmé.
 
-### 3. Compteurs dans les en-têtes
-`_SectionLabel` accepte un `counter` optionnel rendu en pill discret (`· X/7`,
-`· X/10`). Essentiel = `clamp(0, 7)/7`, Flâner = `clamp(0, 10)/10`.
+- **A3 — Provider squelette + rendu progressif 2 phases**
+  (`providers/flux_continu_provider.dart`)
+  - `build()` peint un **squelette** (sections dérivées des prefs locales :
+    favoris thèmes/sources, ordre Tournée, veille) sur cache d'hier/cold, ou le
+    **vrai** contenu sur snapshot du jour (SWR in-day).
+  - **Garde anti-tempête 401** : `await initialRefresh` borné (~3s) avant le
+    batch → les ~3+14 appels partent avec un JWT frais ; sinon l'intercepteur 401
+    single-flight reste le filet.
+  - `_fetchAll` (via `_buildStateFromPayload`) émet en 2 phases :
+    hero/Essentiel/Actus/Bonnes d'abord (≈ 1 round-trip de base), puis les
+    sections thèmes/sources. L'émission progressive ne se fait QUE quand un
+    squelette est monté (pas de blink en SWR / pull-to-refresh).
+  - Flag `isSkeleton` sur `FluxContinuState`. Garde `_bootstrapping` : neutralise
+    les listeners de prefs pendant le bootstrap (le 1er `_fetchAll` lit déjà les
+    prefs fraîches) — restaure l'invariant « aucune réaction de listener avant le
+    1er build complet ».
 
-### 4. Affordance du bouton de passage
-Nouvelle puce `_MoveChip` (icône directionnelle + libellé de destination
-« Flâner » / « Essentiel », bord/fond accentués via `item.accent`, cible ≥ 44px,
-haptique conservée) en remplacement de la flèche seule, pour sources et thèmes.
+- **A4 — Squelette par section** (`screens/flux_continu_screen.dart`)
+  - Remplace le `LoadingView()` plein écran par `_FluxContinuSkeleton`
+    (en-têtes réels via `SectionBanner` + corps `ExploreDiscoverySkeleton`),
+    non scrollable, hors physics de snap. **Pas** de lazy-load au scroll
+    (garde-fou snap/haptique, cf. mémoire `flux_snap_haptic_feel`).
 
-### 5. Bonus — auto-scroll vers Flâner
-`ScrollController` + `GlobalKey` sur l'en-tête Flâner ; en `initState`, si
-`entry == ManageFavoritesEntry.flaner`, `Scrollable.ensureVisible` (300 ms, easeOut).
-Entrée Essentiel → pas de scroll (déjà en tête).
+- **A5 — Micro-opt Sentry** : non inclus (optionnel, gain à confirmer au
+  profiling ; réordonner l'init Sentry touche la capture des crashs de boot).
 
-## Fichiers modifiés
-- `apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart`
-- `apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart`
-- `apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart`
-- `apps/mobile/lib/config/constants.dart`
-- `packages/api/app/constants.py`
-- Tests : `manage_favorites_sheet_test.dart`, `flux_continu_tournee_order_test.dart`,
-  `flux_continu_sources_test.dart`, `flux_continu_provider_test.dart`,
-  `tournee_composer_sheet_test.dart` (caps 5 → 7, scénarios de coupe ré-équilibrés).
+## Note d'archi (Riverpod) — important pour la review
+
+`provider.future` se résout à la **1ère** émission mid-build (vérifié). Comme
+`build()` émet désormais squelette → base-only → complet, les tests attendent
+l'état stabilisé via un helper `settle()` au lieu de `.future`. Migration
+appliquée aux 3 suites flux provider (comportement final inchangé).
 
 ## Vérification
-- Backend : `pytest` complet → **1525 passed, 1 skipped, 2 xfailed** (DB test 54322).
-- Mobile : `flutter analyze` (aucune issue sur les fichiers touchés) + tests
-  flux_continu touchés → **tous verts**.
+
+- `flutter analyze` : **clean** sur les 5 fichiers lib touchés ; 0 erreur projet.
+- Tests : `flutter test test/features/flux_continu/ test/features/auth/ test/core/auth/`
+  → `+272 -3`. Les **3 échecs sont pré-existants** (baseline pristine = `+266 -3` :
+  `essentiel_hi_fi_card` badge Météo/layout — flaky, et `router_redirection`
+  EmailConfirmationScreen — Hive/Supabase non init en widget test). **Aucun
+  nouvel échec dans les zones touchées.**
+- Tests ajoutés :
+  - `flux_continu_cache_service_test.dart` (nouveau) : `readLatest` isStale/savedAt,
+    `readToday` null sur périmé, JSON corrompu → null.
+  - `flux_continu_provider_test.dart` : cache d'hier → 1ère peinture squelette
+    (jamais de contenu périmé) ; cold → base-only émis avant les sections thèmes.
+
+## À faire côté review / suivi (hors PR)
+
+- **Profiling cold-launch sur device réel** + simulation d'un matin (cache d'hier)
+  pour mesurer splash→1ère frame avant/après (le plancher moteur Flutter domine
+  l'absolu ; on prouve la suppression des gates refresh + fan-out). Logs
+  `[PERF] fluxContinu.build mode=content_fresh|skeleton_stale|cold` ajoutés.
+- **PR B (backend)** recommandée juste après : tuer le 202 du chemin critique
+  (cas nouveau-user post-store), caches courts, payload allégé. Voir
+  `docs/maintenance/maintenance-quick-start-boot-perf.md`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/apps/mobile/lib/core/auth/auth_state.dart
+++ b/apps/mobile/lib/core/auth/auth_state.dart
@@ -113,6 +113,21 @@ class AuthStateNotifier extends StateNotifier<AuthState>
   /// repeated 403s and avoid redirect loops.
   DateTime? _lastForceUnconfirmedAt;
 
+  /// Refresh **non-bloquant** lancé par [_init] quand une session est restaurée
+  /// au cold start (le JWT d'accès expire en 1h → mort chaque matin). Exposé via
+  /// [initialRefresh] pour que les data providers (ex. `FluxContinuNotifier`)
+  /// puissent l'attendre — borné par un timeout court — AVANT de partir en
+  /// rafale d'appels, garantissant un JWT frais et zéro tempête de 401
+  /// (single-flight via [SessionRefresher]). `null` quand aucune session n'a été
+  /// restaurée ou avant que [_init] ne l'ait lancé.
+  Future<Session?>? _initialRefresh;
+
+  /// Le refresh initial en cours (cf. [_initialRefresh]), ou `null`. Les
+  /// consommateurs l'attendent avec leur propre `timeout` puis tombent sur le
+  /// filet single-flight de l'intercepteur 401 si besoin — ils ne doivent
+  /// jamais bloquer l'UI dessus.
+  Future<Session?>? get initialRefresh => _initialRefresh;
+
   Future<void> _init() async {
     try {
       WidgetsBinding.instance.addObserver(this);
@@ -148,54 +163,8 @@ class AuthStateNotifier extends StateNotifier<AuthState>
         session = null;
       }
 
-      // 4. Refresh bloquant : rafraîchir le token AVANT de set l'état authentifié.
-      // Le token d'accès Supabase expire après 1h. Si l'app est relancée après,
-      // le token stocké est mort. On le rafraîchit ici pour éviter des 401 immédiats.
-      // Single-flight via SessionRefresher pour éviter la race "double-refresh"
-      // (cf. docs/bugs/bug-android-disconnect-race.md).
-      if (session != null) {
-        debugPrint(
-            'AuthStateNotifier: Session found, attempting blocking refresh...');
-        try {
-          final refreshed = await SessionRefresher.instance.refresh();
-          if (refreshed != null) {
-            session = refreshed;
-            debugPrint('AuthStateNotifier: ✅ Session refreshed successfully.');
-          }
-        } on AuthException catch (e) {
-          debugPrint(
-              'AuthStateNotifier: Refresh failed (AuthException): ${e.message}');
-          // Si SessionRefresher a propagé une AuthException, c'est qu'il a déjà
-          // vérifié que `currentSession` est null/expirée. La session est morte.
-          unawaited(PostHogService().capture(
-            event: 'auth_session_expired',
-            properties: {'reason': 'init_refresh_failed'},
-          ));
-          unawaited(Sentry.captureException(
-            e,
-            withScope: (scope) =>
-                scope.setTag('auth_event', 'init_refresh_failed'),
-          ));
-          session = null;
-          await _supabase.auth.signOut().timeout(
-            const Duration(seconds: 3),
-            onTimeout: () {},
-          );
-          state = state.copyWith(isLoading: false, sessionExpired: true);
-          _setupAuthListener();
-          return;
-        } on TimeoutException {
-          debugPrint(
-              'AuthStateNotifier: Refresh timed out. Using existing session.');
-          // Réseau lent → garder session existante, SDK auto-refresh prendra le relais
-        } catch (e) {
-          debugPrint(
-              'AuthStateNotifier: Refresh failed (unknown): $e. Using existing session.');
-          // Erreur réseau → garder session existante
-        }
-      }
-
-      // 5. Verification stricte de l'email confirmé (Fix mismatch 403)
+      // 4. Verification stricte de l'email confirmé (Fix mismatch 403) — log
+      // uniquement, AVANT de peindre (synchrone, ne bloque rien).
       if (session != null) {
         final user = session.user;
         final isConfirmed = user.emailConfirmedAt != null ||
@@ -211,7 +180,58 @@ class AuthStateNotifier extends StateNotifier<AuthState>
         }
       }
 
-      // 6. Mettre à jour l'état initial (avec session fraîche).
+      // 5. Refresh NON-BLOQUANT : le token d'accès Supabase expire après 1h, donc
+      // le token restauré est mort chaque matin. Auparavant on le rafraîchissait
+      // de façon BLOQUANTE avant de peindre → gate du splash de plusieurs
+      // secondes. On le lance désormais en arrière-plan (single-flight via
+      // SessionRefresher, cf. docs/bugs/bug-android-disconnect-race.md) et on
+      // l'expose via [initialRefresh] : les data providers l'attendent avec un
+      // timeout court avant leur 1er batch (garde anti-tempête 401) sans gater
+      // les pixels. On le lance AVANT de set l'état (étape 6) pour qu'il soit
+      // disponible dès que le router montera le home.
+      if (session != null) {
+        final refreshFuture = SessionRefresher.instance.refresh();
+        _initialRefresh = refreshFuture;
+        // Le seul cas traité ici est l'AuthException (refresh token réellement
+        // mort) → chemin signout + sessionExpired identique à l'ancien blocage.
+        // Le succès ne fait RIEN : l'event SDK `tokenRefreshed` (listener) reste
+        // l'unique source du signal d'invalidation (cf.
+        // bug-feed-403-auth-recovery.md) — on ne re-pose pas `lastTokenRefreshAt`.
+        unawaited(refreshFuture.then((_) {
+          debugPrint('AuthStateNotifier: ✅ Initial refresh done.');
+        }).catchError((Object e) async {
+          if (e is! AuthException) {
+            // Réseau lent / timeout → garder la session ; le SDK auto-refresh
+            // (et l'intercepteur 401 single-flight) prendront le relais.
+            debugPrint(
+                'AuthStateNotifier: Initial refresh failed (non-auth): $e. Using existing session.');
+            return;
+          }
+          debugPrint(
+              'AuthStateNotifier: Initial refresh failed (AuthException): ${e.message}');
+          unawaited(PostHogService().capture(
+            event: 'auth_session_expired',
+            properties: {'reason': 'init_refresh_failed'},
+          ));
+          unawaited(Sentry.captureException(
+            e,
+            withScope: (scope) =>
+                scope.setTag('auth_event', 'init_refresh_failed'),
+          ));
+          await _supabase.auth.signOut().timeout(
+            const Duration(seconds: 3),
+            onTimeout: () {},
+          );
+          // Clear user + isLoading + pose sessionExpired (le state authentifié a
+          // déjà été peint à l'étape 6 ; la garde `_fetchAll` des data providers
+          // maintient le squelette jusqu'à cette résolution).
+          state = const AuthState(sessionExpired: true);
+        }));
+      }
+
+      // 6. Mettre à jour l'état initial AVEC la session restaurée (le refresh
+      // tourne en arrière-plan). Plus de gate bloquant : l'utilisateur voit la
+      // structure immédiatement.
       // forceUnconfirmed est reset systématiquement : flag volatile qui ne doit
       // pas survivre à un restart (si l'email est réellement non-confirmé, le
       // prochain appel API renverra 403 et le flag sera re-set proprement).

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -414,6 +414,14 @@ class FluxContinuState {
   final bool isLoading;
   final Object? error;
 
+  /// True quand l'état n'est qu'un **squelette** : structure de sections
+  /// (en-têtes réels dérivés des prefs locales) sans contenu réel encore
+  /// chargé. Émis au démarrage matinal (cache d'hier invalidé / cold start)
+  /// pour afficher une page fidèle instantanément, jamais du contenu périmé.
+  /// Le rendu réel (`_buildContent`) ne s'active que lorsque ce flag est
+  /// `false` ; le screen rend un scaffold placeholder tant qu'il est `true`.
+  final bool isSkeleton;
+
   const FluxContinuState({
     this.sections = const [],
     this.grilleSlotIndex,
@@ -424,6 +432,7 @@ class FluxContinuState {
     this.quote,
     this.isLoading = true,
     this.error,
+    this.isSkeleton = false,
   });
 
   FluxContinuState copyWith({
@@ -437,6 +446,7 @@ class FluxContinuState {
     bool? isLoading,
     Object? error,
     bool clearError = false,
+    bool? isSkeleton,
   }) {
     return FluxContinuState(
       sections: sections ?? this.sections,
@@ -448,6 +458,7 @@ class FluxContinuState {
       quote: quote ?? this.quote,
       isLoading: isLoading ?? this.isLoading,
       error: clearError ? null : (error ?? this.error),
+      isSkeleton: isSkeleton ?? this.isSkeleton,
     );
   }
 

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/auth/auth_state.dart' show authStateProvider;
 import '../../digest/models/digest_models.dart';
 import '../../digest/models/dual_digest_response.dart';
 import '../../digest/providers/digest_provider.dart'
@@ -142,6 +143,16 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
   bool _closingPersistQueued = false;
 
+  /// True du tout début de [build] jusqu'à la fin du 1er [_fetchAll]. Pendant
+  /// cette fenêtre, l'état affiché peut être un **squelette** (sections vides) :
+  /// les listeners de prefs ne doivent donc ni recomposer (le dédup viderait les
+  /// sections éditoriales vides) ni refetch (tempête de 401 prématurée). Le 1er
+  /// `_fetchAll` lit de toute façon les prefs les plus fraîches, donc tout
+  /// changement survenu pendant le bootstrap est capturé sans listener. Restaure
+  /// l'invariant « aucune réaction de listener avant le 1er build complet » que
+  /// l'ancien chemin cold tenait implicitement (state sans valeur).
+  bool _bootstrapping = false;
+
   /// Snapshot of the favorite order we last fetched for. Used by the
   /// userInterestsProvider listener to detect changes and refetch only the
   /// theme sections (cheap) instead of the full tournée.
@@ -149,6 +160,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
   @override
   Future<FluxContinuState> build() async {
+    _bootstrapping = true;
     _digestRepo = ref.read(digestRepositoryProvider);
     _feedRepo = ref.read(feedRepositoryProvider);
     _fluxRepo = ref.read(fluxContinuRepositoryProvider);
@@ -156,6 +168,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     _cacheService = FluxContinuCacheService();
 
     ref.listen<SereinToggleState>(sereinToggleProvider, (prev, next) {
+      if (_bootstrapping) return;
       if (prev?.enabled != next.enabled && state.hasValue) {
         ref.invalidateSelf();
       }
@@ -166,6 +179,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // changement, comme pour le toggle sérène — un simple recompose suffit, les
     // sections sont déjà fetchées (on ne refait que le découpage d'affichage).
     ref.listen<double?>(usableViewportHeightProvider, (prev, next) {
+      if (_bootstrapping) return;
       if (prev == next) return;
       if (!state.hasValue) return;
       state = AsyncData(_compose(ref.read(sereinToggleProvider).enabled));
@@ -177,6 +191,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       prev,
       next,
     ) {
+      if (_bootstrapping) return;
       final nextFavorites = next.valueOrNull?.favorites;
       if (nextFavorites == null) return;
       final picked = _pickExplicitFavorites(nextFavorites);
@@ -192,6 +207,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       prev,
       next,
     ) {
+      if (_bootstrapping) return;
       final nextFavorites = next.valueOrNull?.favorites;
       if (nextFavorites == null) return;
       final picked = _pickFavoriteSources(nextFavorites);
@@ -207,6 +223,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     //    n'existe pas encore dans `_sources` ; une qui sort doit en disparaître.
     //  - sinon (réordre/masques) ⇒ simple recompose (sections déjà fetchées).
     ref.listen<TourneeOrderState>(tourneeOrderPrefsProvider, (prev, next) {
+      if (_bootstrapping) return;
       if (!state.hasValue) return;
       if (prev != null &&
           listEquals(prev.order, next.order) &&
@@ -226,6 +243,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // sections Essentiel. On recompose seulement quand l'ensemble des clés
     // `theme:` change (un réordre sujets/sources Flâner n'affecte pas la Tournée).
     ref.listen<List<String>>(tabOrderPrefsProvider, (prev, next) {
+      if (_bootstrapping) return;
       if (!state.hasValue) return;
       Set<String> themeKeys(List<String>? keys) => {
             for (final k in keys ?? const <String>[])
@@ -238,6 +256,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // La Grille est un slot autonome dans la liste cappée : sa présence dépend
     // uniquement de `today != null`, pas des sections déjà fetchées.
     ref.listen<AsyncValue<GrilleState>>(grilleProvider, (prev, next) {
+      if (_bootstrapping) return;
       if (!state.hasValue) return;
       final wasPresent = prev?.valueOrNull?.today != null;
       final isPresent = next.valueOrNull?.today != null;
@@ -245,20 +264,60 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       state = AsyncData(_compose(ref.read(sereinToggleProvider).enabled));
     });
 
-    final cached = await _cacheService.readToday();
-    if (cached != null) {
+    final isSerene = ref.read(sereinToggleProvider).enabled;
+
+    // Première peinture : on lit le snapshot SANS le jeter sur un day mismatch.
+    final snapshot = await _cacheService.readLatest();
+    if (snapshot != null && !snapshot.isStale) {
+      // Snapshot du jour → SWR in-day : on peint le **vrai** contenu
+      // instantanément (puis revalidation via _fetchAll).
+      debugPrint('[PERF] fluxContinu.build mode=content_fresh');
       state = AsyncData(
         await _buildStateFromPayload(
-          dual: cached.dual,
-          topThemes: cached.topThemes,
-          essentielArticles: cached.essentielArticles,
-          isSerene: ref.read(sereinToggleProvider).enabled,
+          dual: snapshot.dual,
+          topThemes: snapshot.topThemes,
+          essentielArticles: snapshot.essentielArticles,
+          isSerene: isSerene,
           fetchThemes: false,
         ),
       );
+    } else {
+      // Snapshot d'hier (stale) ou aucun → on ne peint JAMAIS de contenu
+      // périmé : on émet un squelette fidèle dérivé des prefs locales
+      // (bon nombre/ordre/labels/accents de sections), qui se remplit derrière.
+      debugPrint(
+          '[PERF] fluxContinu.build mode=${snapshot == null ? 'cold' : 'skeleton_stale'}');
+      state = AsyncData(_buildSkeletonState(isSerene));
     }
 
-    return _fetchAll();
+    // Garde anti-tempête 401 (stabilité + scalabilité) : on laisse le refresh
+    // initial (lancé non-bloquant par AuthStateNotifier) se résoudre — borné par
+    // un timeout court — AVANT de tirer les ~3+14 appels, pour qu'ils partent
+    // avec un JWT frais. Le squelette/cache est déjà peint, donc cette attente
+    // gate la DATA, pas les pixels.
+    await _awaitInitialRefresh();
+
+    try {
+      return await _fetchAll();
+    } finally {
+      _bootstrapping = false;
+    }
+  }
+
+  /// Attend le refresh initial en cours (cf. `AuthStateNotifier.initialRefresh`)
+  /// borné par un timeout court. Tout échec (timeout, AuthException, ou notifier
+  /// auth indisponible en test) est avalé : on tombe alors dans [_fetchAll] où
+  /// l'intercepteur 401 single-flight (`api_client`) reste le filet de sécurité.
+  Future<void> _awaitInitialRefresh() async {
+    try {
+      final refresh = ref.read(authStateProvider.notifier).initialRefresh;
+      if (refresh == null) return;
+      await refresh.timeout(const Duration(seconds: 3));
+    } catch (_) {
+      // Refresh raté/expiré ou auth indisponible (tests) — le filet 401 prend
+      // le relais ; AuthStateNotifier gère lui-même le chemin signout sur un
+      // refresh token mort.
+    }
   }
 
   Future<FluxContinuState> _fetchAll() async {
@@ -370,24 +429,198 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     _lastFavorites = favorites;
     final favoriteSources = _pickFavoriteSources();
     _lastSourceFavorites = favoriteSources;
-    final fetched = fetchThemes
-        ? await Future.wait([
-            _fetchThemeSections(
-              favorites,
-              isSerene,
-              isExplicitFavorite: !picked.isFallback,
-            ),
-            _fetchSourceSections(favoriteSources, isSerene),
-          ])
-        : const [<FeedThemeSection>[], <FeedThemeSection>[]];
-    _themes = fetched[0];
-    _sources = fetched[1];
 
+    // Sections thèmes/sources vidées d'abord — peuplées en phase 2 si fetch.
+    _themes = const [];
+    _sources = const [];
     _moreOpen = const {};
     _closingDismissed = await _loadClosingDismissedForToday();
     unawaited(_purgeOldPrefsKeys());
 
+    if (!fetchThemes) {
+      // Chemin cache in-day : pas de fan-out réseau, on compose directement.
+      return _compose(isSerene);
+    }
+
+    // Rendu progressif deux-phases. On n'émet l'état base-only intermédiaire que
+    // si l'état monté est un squelette (ou absent) — c.-à-d. au démarrage à
+    // froid. En SWR in-day / pull-to-refresh, du vrai contenu est déjà monté :
+    // on le garde tel quel jusqu'à l'arrivée du set complet (pas de blink des
+    // sections thèmes/sources).
+    final mounted = state.valueOrNull;
+    final emitProgressive = mounted == null || mounted.isSkeleton;
+
+    // Phase 1 — hero/Essentiel/Actus/Bonnes composés (sections thèmes/sources
+    // encore vides) : le haut de page réel remplace le squelette après ~1
+    // round-trip de base.
+    if (emitProgressive) {
+      state = AsyncData(_compose(isSerene));
+    }
+
+    // Phase 2 — fan-out thèmes + sources, puis recompose avec le set complet
+    // (réutilise exactement le pattern de _refetchThemesOnly/_refetchSourcesOnly).
+    final fetched = await Future.wait([
+      _fetchThemeSections(
+        favorites,
+        isSerene,
+        isExplicitFavorite: !picked.isFallback,
+      ),
+      _fetchSourceSections(favoriteSources, isSerene),
+    ]);
+    _themes = fetched[0];
+    _sources = fetched[1];
+
     return _compose(isSerene);
+  }
+
+  /// Construit l'état **squelette** affiché au démarrage matinal (cache d'hier
+  /// invalidé) ou à froid : structure de sections fidèle (en-têtes réels —
+  /// nombre/ordre/labels/accents dérivés des prefs locales) **sans** contenu.
+  /// Les sections sont des coquilles vides (items/topics vides) ; le screen rend
+  /// un placeholder par section. Jamais de contenu périmé. Pas de réseau.
+  FluxContinuState _buildSkeletonState(bool isSerene) {
+    _essentiel = const EssentielSection(
+      articles: <EssentielArticle>[],
+      illustrationAsset: _kEssentielIllustration,
+      blurb: _kEssentielBlurb,
+    );
+    _actusDuJour = const DigestTopicSection(
+      kind: SectionKind.essentiel,
+      label: 'Actus du jour',
+      blurb: _kActusDuJourBlurb,
+      accent: _kEssentielAccent,
+      illustrationAsset: _kEssentielIllustration,
+      coreVisibleCount: 3,
+      topics: <DigestTopic>[],
+    );
+    _bonnes = DigestTopicSection(
+      kind: SectionKind.bonnes,
+      label: 'Bonnes Nouvelles',
+      blurb: _kBonnesBlurb,
+      accent: _kBonnesAccent,
+      illustrationAsset: _kBonnesIllustration,
+      coreVisibleCount: isSerene ? 4 : 2,
+      topics: const <DigestTopic>[],
+    );
+    _quote = null;
+    _themes = _skeletonThemeSections();
+    _sources = _skeletonSourceSections();
+    _moreOpen = const {};
+    return _composeSkeleton(isSerene);
+  }
+
+  /// Ordonne les coquilles de sections du squelette via les mêmes helpers que
+  /// [_compose] (`_tourneeSectionByKey` / `_orderedTourneeKeys`) — source unique
+  /// de l'ordre — mais SANS dédup/cap/filtre (rien à dédupliquer sur des
+  /// sections vides ; le dédup retirerait au contraire les sections éditoriales
+  /// vides). Marque `isSkeleton: true`.
+  FluxContinuState _composeSkeleton(bool isSerene) {
+    final tournee = ref.read(tourneeOrderPrefsProvider);
+    final grilleAvailable = ref.read(grilleProvider).valueOrNull?.today != null;
+    final sectionByKey = _tourneeSectionByKey();
+    final orderedKeys = _orderedTourneeKeys(
+      isSerene: isSerene,
+      customized: tournee.customized,
+      sectionByKey: sectionByKey,
+      grilleAvailable: grilleAvailable,
+      hiddenKeys: tournee.hiddenKeys,
+      order: tournee.order,
+    );
+    final sections = <FluxSection>[
+      if (_essentiel != null) _essentiel!,
+      for (final key in orderedKeys)
+        if (key != kTourneeGrilleKey && sectionByKey[key] != null)
+          sectionByKey[key]!,
+    ];
+    final grilleSlotIndex = _resolveGrilleSlotIndex(
+      orderedKeys: orderedKeys,
+      finalSections: sections,
+    );
+    return FluxContinuState(
+      sections: sections,
+      grilleSlotIndex: grilleSlotIndex,
+      isSerene: isSerene,
+      isSkeleton: true,
+      isLoading: false,
+    );
+  }
+
+  /// Coquilles de sections thème/sujet/veille pour le squelette, dérivées des
+  /// favoris locaux (réutilise `_pickFavorites` + les mêmes label/accent que
+  /// [_fetchThemeSections]). `topFallback` vide ⇒ comptes neufs voient les
+  /// thèmes canoniques (tech/env/science), ce qui rend une structure utile.
+  List<FeedThemeSection> _skeletonThemeSections() {
+    final picked = _pickFavorites(const <TopTheme>[]);
+    final interestsState = ref.read(userInterestsProvider).valueOrNull;
+    final sections = <FeedThemeSection>[];
+    for (final favRef in picked.refs) {
+      final FeedThemeSection? shell = switch (favRef) {
+        ThemeFavoriteRef(:final slug) => FeedThemeSection(
+            kind: SectionKind.theme,
+            label: visualFor(slug).label,
+            accent: visualFor(slug).accent,
+            illustrationAsset: _kVeilleIllustration,
+            coreVisibleCount: 3,
+            themeSlug: slug,
+            items: const [],
+            hasMore: false,
+          ),
+        CustomTopicFavoriteRef(:final id) => FeedThemeSection(
+            kind: SectionKind.theme,
+            label: _customTopicLabel(interestsState, id),
+            accent: _customTopicAccent(interestsState, id),
+            illustrationAsset: _kVeilleIllustration,
+            coreVisibleCount: 3,
+            customTopicId: id,
+            items: const [],
+            hasMore: false,
+          ),
+        VeilleFavoriteRef() => _skeletonVeilleSection(),
+      };
+      if (shell != null) sections.add(shell);
+    }
+    return sections;
+  }
+
+  FeedThemeSection? _skeletonVeilleSection() {
+    final activeCfg = ref.read(veilleActiveConfigProvider).valueOrNull;
+    if (activeCfg == null) return null;
+    return FeedThemeSection(
+      kind: SectionKind.veille,
+      label: 'Ma veille — ${activeCfg.themeLabel}',
+      blurb: 'Les derniers articles de ta veille personnalisée.',
+      accent: _kVeilleAccent,
+      illustrationAsset: _kVeilleIllustration,
+      coreVisibleCount: 3,
+      items: const [],
+      hasMore: false,
+    );
+  }
+
+  /// Coquilles de sections source pour le squelette, résolues via le même
+  /// catalogue/sélection que [_fetchSourceSections] (label/logo/accent réels).
+  List<FeedThemeSection> _skeletonSourceSections() {
+    final favs = _pickFavoriteSources();
+    if (favs.isEmpty) return const [];
+    final catalog =
+        ref.read(userSourcesProvider).valueOrNull ?? const <Source>[];
+    final sourceById = {for (final s in catalog) s.id: s};
+    final sections = <FeedThemeSection>[];
+    for (final fav in favs) {
+      final src = sourceById[fav.sourceId];
+      if (src == null) continue;
+      sections.add(FeedThemeSection(
+        kind: SectionKind.source,
+        label: src.name,
+        accent: sourceAccentFor(src.id),
+        coreVisibleCount: 3,
+        sourceId: src.id,
+        sourceLogoUrl: src.logoUrl,
+        items: const [],
+        hasMore: false,
+      ));
+    }
+    return sections;
   }
 
   FluxContinuState _compose(bool isSerene) {

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -21,6 +21,7 @@ import '../../custom_topics/widgets/topic_chip.dart';
 import '../../digest/models/digest_models.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/providers/swipe_hint_provider.dart';
+import '../../feed/widgets/explore_section.dart' show ExploreDiscoverySkeleton;
 import '../../feed/widgets/feedback_inline.dart';
 import '../../lettres/widgets/lettres_notification_banner.dart';
 import '../../notifications/widgets/notification_activation_modal.dart';
@@ -28,7 +29,6 @@ import '../../notifications/widgets/notification_renudge_banner.dart';
 import '../../onboarding/widgets/theme_choice_bottom_sheet.dart';
 import '../../well_informed/widgets/well_informed_prompt.dart';
 import '../../../shared/strings/loader_error_strings.dart';
-import '../../../shared/widgets/loaders/loading_view.dart';
 import '../models/flux_continu_models.dart';
 import '../providers/flux_continu_provider.dart';
 import '../providers/tournee_order_prefs_provider.dart'
@@ -41,6 +41,7 @@ import '../widgets/my_interests_intro.dart';
 import '../widgets/personalisation_cta_card.dart';
 import '../widgets/tournee_composer_sheet.dart';
 import '../widgets/geoloc_prompt_banner.dart';
+import '../widgets/section_banner.dart';
 import '../widgets/section_block.dart';
 import '../widgets/sticky_tab_bar.dart';
 import '../../grille/widgets/grille_cta_card.dart';
@@ -847,29 +848,42 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(fluxContinuProvider);
+    final data = state.valueOrNull;
+    // Squelette : fenêtre de loading initiale (avant 1ère peinture) OU état
+    // squelette explicite émis par le provider (cache d'hier invalidé / cold
+    // start). On rend alors un scaffold placeholder, jamais le spinner plein
+    // écran ni le vrai `_buildContent`.
+    final isSkeleton = state is AsyncLoading || (data?.isSkeleton ?? false);
     // Re-tap de l'onglet actif (depuis le shell) → remonter en haut.
     ref.listen(essentielScrollTriggerProvider, (_, __) => _scrollToTop());
     // Flow post-onboarding : joué une seule fois quand Essentiel a chargé ses
-    // données (derrière les modales thème & notifications). Couvre la
-    // transition loading→data (via le listen) et le cas où l'état est déjà
-    // `data` au montage (check direct planifié en post-frame).
+    // **vraies** données (derrière les modales thème & notifications). On exclut
+    // l'état squelette : le flow attend du contenu réel. Couvre la transition
+    // loading→data (via le listen) et le cas où l'état est déjà `data` au
+    // montage (check direct planifié en post-frame).
     ref.listen<AsyncValue<FluxContinuState>>(fluxContinuProvider, (_, next) {
       if (next is AsyncData<FluxContinuState> &&
+          !next.value.isSkeleton &&
           ref.read(postOnboardingFlowPendingProvider) != null) {
         _schedulePostOnboardingFlow();
       }
     });
-    if (state is AsyncData<FluxContinuState> &&
+    if (!isSkeleton &&
+        state is AsyncData<FluxContinuState> &&
         ref.read(postOnboardingFlowPendingProvider) != null) {
       _schedulePostOnboardingFlow();
     }
     // Source unique : aligne [_sectionKeys] + [_stickyEntryKeys] sur les slivers
     // et dérive les descripteurs d'onglets (label+accent), dans le même ordre.
-    final stickyTabs = _syncStickyEntries(state.valueOrNull);
-    // Sections don't resize mid-session, so we refresh the snap anchors only on
-    // these content/layout-driven rebuilds — never per scroll frame.
-    _safeAreaBottom = MediaQuery.paddingOf(context).bottom;
-    _scheduleAnchorRecompute();
+    // Hors squelette uniquement : le scaffold placeholder n'attache pas les
+    // GlobalKeys de section ni la physics de snap.
+    final stickyTabs = isSkeleton ? const <StickyTab>[] : _syncStickyEntries(data);
+    if (!isSkeleton) {
+      // Sections don't resize mid-session, so we refresh the snap anchors only
+      // on these content/layout-driven rebuilds — never per scroll frame.
+      _safeAreaBottom = MediaQuery.paddingOf(context).bottom;
+      _scheduleAnchorRecompute();
+    }
     return Scaffold(
       backgroundColor: context.facteurColors.backgroundPrimary,
       // Header & footer vivent dans le scaffold de page partagé :
@@ -880,21 +894,26 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
         bottom: false,
         child: Stack(
           children: [
-            state.when(
-              loading: () => const LoadingView(),
-              error: (e, _) => _ErrorView(
-                error: e,
-                onRetry: () => ref.read(fluxContinuProvider.notifier).refresh(),
+            if (isSkeleton)
+              _FluxContinuSkeleton(sections: data?.sections ?? const [])
+            else
+              state.when(
+                loading: () => const _FluxContinuSkeleton(sections: []),
+                error: (e, _) => _ErrorView(
+                  error: e,
+                  onRetry: () =>
+                      ref.read(fluxContinuProvider.notifier).refresh(),
+                ),
+                data: (data) => _buildContent(context, data),
               ),
-              data: (data) => _buildContent(context, data),
-            ),
-            _StickyHostOverlay(
-              stickyVisible: _stickyVisible,
-              activeIndex: _activeIndex,
-              tabs: stickyTabs,
-              onTapTab: _scrollToSection,
-              tabsController: _tabsScroll,
-            ),
+            if (!isSkeleton)
+              _StickyHostOverlay(
+                stickyVisible: _stickyVisible,
+                activeIndex: _activeIndex,
+                tabs: stickyTabs,
+                onTapTab: _scrollToSection,
+                tabsController: _tabsScroll,
+              ),
             // Pull-to-refresh discoverability pill.
             Positioned(
               top: 0,
@@ -1206,6 +1225,87 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       slivers.add(_grilleSliver);
     }
     return slivers;
+  }
+}
+
+/// Scaffold squelette du démarrage matinal : en-têtes de sections **réels**
+/// (label/accent/illustration dérivés des prefs locales, portés par [sections])
+/// + cartes placeholder, au lieu du `LoadingView` plein écran. Évite tout saut
+/// de layout quand le contenu réel arrive : la structure est déjà en place, on
+/// ne fait que remplir.
+///
+/// Volontairement **non scrollable** (NeverScrollableScrollPhysics) et sans la
+/// physics de snap : le squelette est transitoire (≈ 1 round-trip), l'user est
+/// en haut de page, et on ne touche pas au système snap/settle délicat. Reçoit
+/// les coquilles de sections du provider ([FluxContinuState.sections] avec
+/// `isSkeleton:true`) ; liste vide pendant la brève fenêtre de loading initiale
+/// → on rend un hero + quelques placeholders génériques.
+class _FluxContinuSkeleton extends StatelessWidget {
+  final List<FluxSection> sections;
+
+  const _FluxContinuSkeleton({required this.sections});
+
+  @override
+  Widget build(BuildContext context) {
+    final children = <Widget>[
+      // Hero « L'Essentiel du jour » — placeholder pleine largeur en tête.
+      const _HeroSkeleton(),
+    ];
+    if (sections.isEmpty) {
+      // Fenêtre de loading initiale (pas encore de coquilles) → placeholders
+      // génériques pour occuper l'espace sans labels.
+      for (var i = 0; i < 3; i++) {
+        children.add(const Padding(
+          padding: EdgeInsets.only(top: 8),
+          child: ExploreDiscoverySkeleton(),
+        ));
+      }
+    } else {
+      for (final section in sections) {
+        // Le hero est déjà rendu au-dessus.
+        if (section is EssentielSection) continue;
+        final isSource =
+            section is FeedThemeSection && section.kind == SectionKind.source;
+        children.add(SectionBanner(
+          title: section.label,
+          accent: section.accent,
+          blurb: section.blurb,
+          illustrationAsset: isSource ? null : section.illustrationAsset,
+          logoUrl: isSource ? section.sourceLogoUrl : null,
+        ));
+        children.add(const ExploreDiscoverySkeleton());
+        children.add(const SizedBox(height: 16));
+      }
+    }
+    return ListView(
+      // Le squelette ne défile pas — il est remplacé dès l'arrivée du contenu.
+      physics: const NeverScrollableScrollPhysics(),
+      padding: const EdgeInsets.only(top: 8, bottom: 92),
+      children: children,
+    );
+  }
+}
+
+/// Placeholder du hero « L'Essentiel du jour » (carte hi-fi) pendant le
+/// squelette : un grand bloc neutre arrondi qui réserve l'espace au-dessus de
+/// la ligne de flottaison.
+class _HeroSkeleton extends StatelessWidget {
+  const _HeroSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 16),
+      child: Container(
+        height: 260,
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: Colors.black.withValues(alpha: 0.04)),
+        ),
+      ),
+    );
   }
 }
 

--- a/apps/mobile/lib/features/flux_continu/services/flux_continu_cache_service.dart
+++ b/apps/mobile/lib/features/flux_continu/services/flux_continu_cache_service.dart
@@ -13,10 +13,23 @@ class FluxContinuSnapshot {
   final List<TopTheme> topThemes;
   final List<EssentielArticle> essentielArticles;
 
+  /// `true` quand le snapshot a été écrit un **autre jour** que celui passé à
+  /// [FluxContinuCacheService.readLatest] (cache d'hier, invalidé chaque nuit).
+  /// Le provider ne peint alors **jamais** ce contenu comme réel : il sert
+  /// uniquement à confirmer qu'un snapshot existe. `false` = snapshot du jour
+  /// (SWR in-day, peut être affiché tel quel puis revalidé).
+  final bool isStale;
+
+  /// Horodatage d'écriture (`saved_at`), lu pour le profiling / debug. `null`
+  /// si absent ou illisible.
+  final DateTime? savedAt;
+
   const FluxContinuSnapshot({
     required this.dual,
     required this.topThemes,
     required this.essentielArticles,
+    this.isStale = false,
+    this.savedAt,
   });
 }
 
@@ -29,7 +42,13 @@ class FluxContinuCacheService {
     return Hive.openBox<String>(boxName);
   }
 
-  Future<FluxContinuSnapshot?> readToday({DateTime? now}) async {
+  /// Lit le dernier snapshot persisté **sans** le jeter sur un day mismatch :
+  /// pose [FluxContinuSnapshot.isStale] = `(day_key != aujourd'hui)`. Le matin,
+  /// le cache d'hier reste lisible (isStale:true) pour dessiner un squelette
+  /// fidèle, mais le contenu n'est jamais affiché tel quel (cf. provider).
+  /// Renvoie `null` uniquement si rien n'est persisté ou si le payload est
+  /// corrompu.
+  Future<FluxContinuSnapshot?> readLatest({DateTime? now}) async {
     try {
       final box = await _box();
       final raw = box.get(_snapshotKey);
@@ -37,9 +56,8 @@ class FluxContinuCacheService {
       final json = jsonDecode(raw);
       if (json is! Map<String, dynamic>) return null;
       final dayKey = json['day_key'] as String?;
-      if (dayKey != TourneeProgressService.dayKey(now ?? DateTime.now())) {
-        return null;
-      }
+      final isStale =
+          dayKey != TourneeProgressService.dayKey(now ?? DateTime.now());
       final dualJson = json['dual'];
       if (dualJson is! Map<String, dynamic>) return null;
       final topThemeJson = (json['top_themes'] as List?) ?? const [];
@@ -54,11 +72,22 @@ class FluxContinuCacheService {
             .whereType<Map<String, dynamic>>()
             .map(EssentielArticle.fromJson)
             .toList(growable: false),
+        isStale: isStale,
+        savedAt: DateTime.tryParse(json['saved_at'] as String? ?? ''),
       );
     } catch (e) {
       debugPrint('FluxContinuCache: read failed: $e');
       return null;
     }
+  }
+
+  /// Snapshot **du jour** uniquement (SWR in-day) — wrapper sur [readLatest]
+  /// qui renvoie `null` dès que le snapshot est périmé (cache d'hier). Conservé
+  /// pour les appelants qui ne veulent jamais de contenu périmé.
+  Future<FluxContinuSnapshot?> readToday({DateTime? now}) async {
+    final snapshot = await readLatest(now: now);
+    if (snapshot == null || snapshot.isStale) return null;
+    return snapshot;
   }
 
   Future<void> write({

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -26,6 +26,8 @@ import 'package:hive/hive.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'flux_continu_settle.dart';
+
 class _MockDigestRepository extends Mock implements DigestRepository {}
 
 class _MockFeedRepository extends Mock implements FeedRepository {}
@@ -223,7 +225,7 @@ void main() {
         final container = makeContainer();
         addTearDown(container.dispose);
 
-        await container.read(fluxContinuProvider.future);
+        await settle(container);
         // Purge runs as `unawaited` — give the microtask queue a beat.
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
@@ -247,7 +249,7 @@ void main() {
         final container = makeContainer();
         addTearDown(container.dispose);
 
-      await container.read(fluxContinuProvider.future);
+      await settle(container);
       await Future<void>.delayed(Duration.zero);
       await Future<void>.delayed(Duration.zero);
 
@@ -264,7 +266,7 @@ void main() {
       final container = makeContainer();
       addTearDown(container.dispose);
 
-      final state = await container.read(fluxContinuProvider.future);
+      final state = await settle(container);
 
       expect(state.closingDismissed, isFalse);
       expect(state.moreOpen, isEmpty);
@@ -290,7 +292,7 @@ void main() {
         final container = makeContainer(); // 0 favorites in stub
         addTearDown(container.dispose);
 
-        await container.read(fluxContinuProvider.future);
+        await settle(container);
 
         // 3 fallback canonical theme fetches (tech, environment, science).
         final captured = verify(
@@ -325,7 +327,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      await container.read(fluxContinuProvider.future);
+      await settle(container);
 
       verify(
         () => feedRepo.getFeed(
@@ -358,7 +360,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final state = await container.read(fluxContinuProvider.future);
+      final state = await settle(container);
 
       verifyNever(
         () => feedRepo.getFeed(
@@ -396,7 +398,7 @@ void main() {
       final container = makeContainer(interestsNotifier: interestsNotifier);
       addTearDown(container.dispose);
 
-      await container.read(fluxContinuProvider.future);
+      await settle(container);
       clearInteractions(feedRepo);
 
       interestsNotifier.setState(
@@ -466,7 +468,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final state = await container.read(fluxContinuProvider.future);
+      final state = await settle(container);
       final slugs = state.sections
           .whereType<FeedThemeSection>()
           .map((s) => s.themeSlug)
@@ -503,7 +505,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      await container.read(fluxContinuProvider.future);
+      await settle(container);
 
       // The Tournée du jour theme sections opt in to the backend curation
       // (followed sources only + 24h window + user_subtopics boost).
@@ -540,7 +542,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        await container.read(fluxContinuProvider.future);
+        await settle(container);
 
         verifyNever(
           () => feedRepo.getFeed(
@@ -599,7 +601,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final initial = await container.read(fluxContinuProvider.future);
+        final initial = await settle(container);
         final themeSection =
             initial.sections.whereType<FeedThemeSection>().single;
         expect(themeSection.items.map((c) => c.id), pageOneIds);
@@ -653,7 +655,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final initial = await container.read(fluxContinuProvider.future);
+      final initial = await settle(container);
       final themeSection =
           initial.sections.whereType<FeedThemeSection>().single;
       expect(themeSection.items.length, 3);
@@ -688,7 +690,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final initial = await container.read(fluxContinuProvider.future);
+        final initial = await settle(container);
         final themeSection =
             initial.sections.whereType<FeedThemeSection>().single;
         expect(themeSection.hasMore, false);
@@ -786,7 +788,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final state = await container.read(fluxContinuProvider.future);
+        final state = await settle(container);
 
         // Both must be present, with distinct sectionKeys.
         final essentielV3 =
@@ -885,7 +887,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final state = await container.read(fluxContinuProvider.future);
+      final state = await settle(container);
 
       // Essentiel keeps the shared article.
       final essentiel = state.sections.whereType<EssentielSection>().single;
@@ -919,7 +921,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final state = await container.read(fluxContinuProvider.future);
+      final state = await settle(container);
 
       expect(state.sections.whereType<EssentielSection>(), hasLength(1));
       expect(
@@ -997,7 +999,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final state = await container.read(fluxContinuProvider.future);
+        final state = await settle(container);
 
         // (a) hero trimmed to the lead + one medium (fitHeroCount(500) == 2).
         final hero = state.sections.whereType<EssentielSection>().single;
@@ -1026,7 +1028,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final state = await container.read(fluxContinuProvider.future);
+        final state = await settle(container);
 
         final hero = state.sections.whereType<EssentielSection>().single;
         expect(hero.articles.map((a) => a.contentId), ['e1', 'e2', 'e3', 'e4']);
@@ -1046,7 +1048,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final state = await container.read(fluxContinuProvider.future);
+      final state = await settle(container);
       final theme = state.sections.whereType<FeedThemeSection>().single;
       expect(theme.coreVisibleCount, 2);
 
@@ -1060,6 +1062,180 @@ void main() {
       expect(themeAfter.coreVisibleCount, 2);
       expect(themeAfter.items.map((c) => c.id), isNot(contains('x4')));
     });
+  });
+
+  group('FluxContinuNotifier — démarrage matinal (squelette + 2 phases)', () {
+    EssentielArticle essArticle(String id) => EssentielArticle(
+          contentId: id,
+          title: 'Essentiel $id',
+          url: 'https://x.test/$id',
+          publishedAt: DateTime(2026, 1, 1),
+          sourceName: 'Source',
+          sourceLetter: 'S',
+          sectionLabel: 'Tech',
+          rank: 1,
+        );
+
+    DigestResponse digestWithTopics() => DigestResponse(
+          digestId: 'd1',
+          userId: 'u1',
+          targetDate: DateTime(2026, 5, 23),
+          generatedAt: DateTime(2026, 5, 23),
+          topics: const [
+            DigestTopic(
+              topicId: 't1',
+              label: 'Topic A',
+              articles: [DigestItem(contentId: 'topic-a-1', title: 'A')],
+            ),
+          ],
+        );
+
+    test(
+      'cache d\'hier → 1ère peinture = squelette fidèle, jamais de contenu périmé',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        when(
+          () => feedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            theme: any(named: 'theme'),
+            serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
+          ),
+        ).thenAnswer((_) async => _feedResponseWith(3));
+
+        // Snapshot d'HIER en cache, avec un contenu distinctif.
+        await FluxContinuCacheService().write(
+          dual: DualDigestResponse(
+            normal: DigestResponse(
+              digestId: 'old',
+              userId: 'u1',
+              targetDate: DateTime(2020, 1, 1),
+              generatedAt: DateTime(2020, 1, 1),
+              topics: const [
+                DigestTopic(
+                  topicId: 'old-t',
+                  label: 'Vieux sujet',
+                  articles: [DigestItem(contentId: 'stale-topic-1', title: 'X')],
+                ),
+              ],
+            ),
+            sereinEnabled: false,
+          ),
+          topThemes: const [],
+          essentielArticles: [essArticle('stale-essentiel-1')],
+          now: DateTime(2020, 1, 1, 12), // périmé
+        );
+
+        final container = makeContainer(
+          interests: _interestsState(
+            favorites: const [ThemeFavoriteRef(slug: 'tech')],
+          ),
+        );
+        addTearDown(container.dispose);
+
+        final captured = <AsyncValue<FluxContinuState>>[];
+        container.listen<AsyncValue<FluxContinuState>>(
+          fluxContinuProvider,
+          (_, next) => captured.add(next),
+          fireImmediately: true,
+        );
+
+        final finalState = await settle(container);
+
+        // 1ère donnée émise = squelette.
+        final firstData = captured
+                .whereType<AsyncData<FluxContinuState>>()
+                .first
+                .value;
+        expect(firstData.isSkeleton, isTrue,
+            reason: 'le matin, on peint d\'abord un squelette');
+
+        // Le squelette ne porte AUCUN contenu (ni périmé ni frais).
+        expect(renderedContentIds(firstData.sections), isEmpty);
+        // …mais il a la STRUCTURE dérivée des prefs : une coquille thème 'tech'.
+        final techShell = firstData.sections
+            .whereType<FeedThemeSection>()
+            .where((s) => s.themeSlug == 'tech');
+        expect(techShell, hasLength(1));
+        expect(techShell.single.items, isEmpty);
+
+        // État final = vrai contenu, plus squelette.
+        expect(finalState.isSkeleton, isFalse);
+        expect(
+          finalState.sections
+              .whereType<FeedThemeSection>()
+              .where((s) => s.items.isNotEmpty),
+          isNotEmpty,
+        );
+      },
+    );
+
+    test(
+      'cold start → base-only (hero/digest) émis AVANT les sections thèmes',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        when(() => digestRepo.fetchBothDigests()).thenAnswer(
+          (_) async =>
+              DualDigestResponse(normal: digestWithTopics(), sereinEnabled: false),
+        );
+        when(
+          () => feedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            theme: any(named: 'theme'),
+            serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
+          ),
+        ).thenAnswer((_) async => _feedResponseWith(3));
+
+        // Pas de cache → chemin cold → squelette puis rendu progressif.
+        final container = makeContainer(
+          interests: _interestsState(
+            favorites: const [ThemeFavoriteRef(slug: 'tech')],
+          ),
+        );
+        addTearDown(container.dispose);
+
+        final captured = <FluxContinuState>[];
+        container.listen<AsyncValue<FluxContinuState>>(
+          fluxContinuProvider,
+          (_, next) {
+            final v = next.valueOrNull;
+            if (v != null) captured.add(v);
+          },
+          fireImmediately: true,
+        );
+
+        final finalState = await settle(container);
+
+        // Séquence attendue : squelette → base-only → complet.
+        final skeletonIdx = captured.indexWhere((s) => s.isSkeleton);
+        expect(skeletonIdx, greaterThanOrEqualTo(0));
+
+        // base-only : contenu réel (Actus du jour) mais ENCORE aucune section
+        // thème (le fan-out de phase 2 n'a pas répondu).
+        final baseIdx = captured.indexWhere(
+          (s) =>
+              !s.isSkeleton &&
+              s.sections.isNotEmpty &&
+              s.sections.whereType<FeedThemeSection>().isEmpty,
+        );
+        expect(baseIdx, greaterThan(skeletonIdx),
+            reason: 'le haut de page réel remplace le squelette avant le fan-out');
+
+        // complet : la section thème 'tech' est présente, après le base-only.
+        final fullIdx = captured.lastIndexWhere(
+          (s) => s.sections.whereType<FeedThemeSection>().isNotEmpty,
+        );
+        expect(fullIdx, greaterThan(baseIdx));
+        expect(finalState.isSkeleton, isFalse);
+        expect(
+          finalState.sections.whereType<FeedThemeSection>(),
+          isNotEmpty,
+        );
+      },
+    );
   });
 
   group('FeedThemeSection.copyWith', () {

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_settle.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_settle.dart
@@ -1,0 +1,22 @@
+import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
+import 'package:facteur/features/flux_continu/providers/flux_continu_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Démarrage matinal : `build()` émet désormais de façon **progressive**
+/// (squelette → base-only → complet) ; le `.future` du provider se résout à la
+/// PREMIÈRE émission. Ce helper draine la file jusqu'à ce que l'état complet
+/// (non squelette) se stabilise, puis le renvoie — remplace l'ancien
+/// `container.read(fluxContinuProvider.future)` qui donnait l'état complet
+/// avant l'introduction du rendu progressif.
+Future<FluxContinuState> settle(ProviderContainer container) async {
+  container.read(fluxContinuProvider);
+  FluxContinuState? prev;
+  for (var i = 0; i < 60; i++) {
+    await pumpEventQueue(times: 3);
+    final cur = container.read(fluxContinuProvider).valueOrNull;
+    if (cur != null && !cur.isSkeleton && identical(cur, prev)) break;
+    prev = cur;
+  }
+  return container.read(fluxContinuProvider).requireValue;
+}

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
@@ -27,6 +27,8 @@ import 'package:hive/hive.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'flux_continu_settle.dart';
+
 class _MockDigestRepository extends Mock implements DigestRepository {}
 
 class _MockFeedRepository extends Mock implements FeedRepository {}
@@ -105,6 +107,7 @@ FeedResponse _feedWithIds(List<String> ids, {String sourceId = 's'}) {
     carousels: const [],
   );
 }
+
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -233,7 +236,7 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    await container.read(fluxContinuProvider.future);
+    await settle(container);
     final sections = feedSections(container);
 
     final themeIdx = sections.indexWhere((s) => s.kind == SectionKind.theme);
@@ -271,7 +274,7 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    await container.read(fluxContinuProvider.future);
+    await settle(container);
     final sections = feedSections(container);
 
     final theme = sections.firstWhere((s) => s.kind == SectionKind.theme);
@@ -299,7 +302,7 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    await container.read(fluxContinuProvider.future);
+    await settle(container);
     final sections = feedSections(container);
 
     final source = sections.where((s) => s.kind == SectionKind.source).toList();
@@ -360,7 +363,7 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    await container.read(fluxContinuProvider.future);
+    await settle(container);
     final sources = feedSections(container)
         .where((s) => s.kind == SectionKind.source)
         .map((s) => s.sourceId)

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
@@ -36,6 +36,8 @@ import 'package:hive/hive.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'flux_continu_settle.dart';
+
 class _MockDigestRepository extends Mock implements DigestRepository {}
 
 class _MockFeedRepository extends Mock implements FeedRepository {}
@@ -366,7 +368,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final state = await container.read(fluxContinuProvider.future);
+        final state = await settle(container);
 
         expect(state.sections.map(sectionKey).toList(), [
           kTourneeActusKey,
@@ -408,7 +410,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final state = await container.read(fluxContinuProvider.future);
+      final state = await settle(container);
 
       expect(state.sections.map(sectionKey).toList(), [
         kTourneeActusKey,
@@ -441,7 +443,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final state = await container.read(fluxContinuProvider.future);
+      final state = await settle(container);
 
       expect(state.sections.map(sectionKey), [kTourneeBonnesKey]);
       expect(state.grilleSlotIndex, isNull);
@@ -467,7 +469,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final state = await container.read(fluxContinuProvider.future);
+        final state = await settle(container);
 
         expect(state.sections.map(sectionKey).toList(), [
           kTourneeBonnesKey,
@@ -501,7 +503,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final state = await container.read(fluxContinuProvider.future);
+        final state = await settle(container);
 
         expect(state.sections.map(sectionKey).toList(), [
           kTourneeActusKey,
@@ -541,7 +543,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final state = await container.read(fluxContinuProvider.future);
+      final state = await settle(container);
 
       expect(state.sections.map(sectionKey).toList(), [
         kTourneeActusKey,
@@ -604,7 +606,7 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    await container.read(fluxContinuProvider.future);
+    await settle(container);
     final sections = favoriteSections(container);
 
     expect(
@@ -658,7 +660,7 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    await container.read(fluxContinuProvider.future);
+    await settle(container);
     final sections = favoriteSections(container);
 
     final sourceIdx = sections.indexWhere((s) => s.kind == SectionKind.source);
@@ -723,7 +725,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      await container.read(fluxContinuProvider.future);
+      await settle(container);
       final sections = favoriteSections(container);
 
       expect(sections, hasLength(7));
@@ -758,7 +760,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      await container.read(fluxContinuProvider.future);
+      await settle(container);
       final sections = favoriteSections(container);
 
       expect(
@@ -795,7 +797,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      await container.read(fluxContinuProvider.future);
+      await settle(container);
       final sections = favoriteSections(container);
 
       expect(
@@ -826,7 +828,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      await container.read(fluxContinuProvider.future);
+      await settle(container);
       final slugs = favoriteSections(container)
           .where((s) => s.kind == SectionKind.theme)
           .map((s) => s.themeSlug)
@@ -854,7 +856,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      await container.read(fluxContinuProvider.future);
+      await settle(container);
       expect(
         favoriteSections(container).where((s) => s.kind == SectionKind.theme),
         isEmpty,
@@ -897,7 +899,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      await container.read(fluxContinuProvider.future);
+      await settle(container);
       final sections = favoriteSections(container);
       expect(
         sections.where((s) => s.kind == SectionKind.theme),
@@ -927,7 +929,7 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    await container.read(fluxContinuProvider.future);
+    await settle(container);
     final society = favoriteSections(
       container,
     ).where((s) => s.themeSlug == 'society').toList();
@@ -967,7 +969,7 @@ void main() {
     container.read(tabOrderPrefsProvider);
     await pumpEventQueue();
 
-    final state = await container.read(fluxContinuProvider.future);
+    final state = await settle(container);
 
     expect(
       state.sections.map(sectionKey),
@@ -1018,7 +1020,7 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    final state = await container.read(fluxContinuProvider.future);
+    final state = await settle(container);
 
     expect(
       state.grilleSlotIndex,

--- a/apps/mobile/test/features/flux_continu/services/flux_continu_cache_service_test.dart
+++ b/apps/mobile/test/features/flux_continu/services/flux_continu_cache_service_test.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+
+import 'package:facteur/features/digest/models/dual_digest_response.dart';
+import 'package:facteur/features/flux_continu/repositories/flux_continu_repository.dart';
+import 'package:facteur/features/flux_continu/services/flux_continu_cache_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+/// Tests de [FluxContinuCacheService.readLatest] — la primitive du démarrage
+/// matinal quasi-instantané. `readLatest` ne jette plus sur un day mismatch
+/// (cache d'hier invalidé chaque nuit) : il pose `isStale` pour que le provider
+/// dessine un squelette fidèle sans jamais afficher de contenu périmé.
+/// `readToday` reste le wrapper « du jour uniquement ».
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  DualDigestResponse dual() => DualDigestResponse(sereinEnabled: false);
+
+  Future<Box<String>> box() async {
+    return Hive.isBoxOpen(FluxContinuCacheService.boxName)
+        ? Hive.box<String>(FluxContinuCacheService.boxName)
+        : await Hive.openBox<String>(FluxContinuCacheService.boxName);
+  }
+
+  setUpAll(() {
+    tempDir = Directory.systemTemp.createTempSync('flux_cache_test');
+    Hive.init(tempDir.path);
+  });
+
+  setUp(() async {
+    await (await box()).clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    tempDir.deleteSync(recursive: true);
+  });
+
+  test('empty cache → readLatest & readToday both null', () async {
+    final service = FluxContinuCacheService();
+    expect(await service.readLatest(), isNull);
+    expect(await service.readToday(), isNull);
+  });
+
+  test('snapshot du jour → isStale:false, savedAt non-null, readToday le sert',
+      () async {
+    final service = FluxContinuCacheService();
+    final now = DateTime(2026, 6, 9, 12);
+    await service.write(
+      dual: dual(),
+      topThemes: const [TopTheme(interestSlug: 'tech', weight: 1)],
+      essentielArticles: const [],
+      now: now,
+    );
+
+    final latest = await service.readLatest(now: now);
+    expect(latest, isNotNull);
+    expect(latest!.isStale, isFalse);
+    expect(latest.savedAt, isNotNull);
+    expect(latest.topThemes.map((t) => t.interestSlug), ['tech']);
+
+    // Le wrapper « du jour » sert bien le snapshot non périmé.
+    final today = await service.readToday(now: now);
+    expect(today, isNotNull);
+    expect(today!.isStale, isFalse);
+  });
+
+  test('snapshot d\'hier → readLatest isStale:true, readToday null', () async {
+    final service = FluxContinuCacheService();
+    // Écrit avec un jour passé (bien au-delà de la frontière 07h30).
+    await service.write(
+      dual: dual(),
+      topThemes: const [],
+      essentielArticles: const [],
+      now: DateTime(2020, 1, 1, 12),
+    );
+
+    // Lu « aujourd'hui » → day mismatch.
+    final latest = await service.readLatest(now: DateTime(2026, 6, 9, 12));
+    expect(latest, isNotNull, reason: 'le snapshot reste lisible (squelette)');
+    expect(latest!.isStale, isTrue);
+
+    // readToday refuse tout snapshot périmé.
+    expect(await service.readToday(now: DateTime(2026, 6, 9, 12)), isNull);
+  });
+
+  test('JSON corrompu → readLatest null (pas d\'exception)', () async {
+    final b = await box();
+    await b.put('latest_snapshot', '{ this is : not json');
+    final service = FluxContinuCacheService();
+    expect(await service.readLatest(), isNull);
+    expect(await service.readToday(), isNull);
+  });
+
+  test('payload sans clé `dual` → readLatest null', () async {
+    final b = await box();
+    await b.put('latest_snapshot', '{"day_key":"2026-06-09"}');
+    final service = FluxContinuCacheService();
+    expect(await service.readLatest(now: DateTime(2026, 6, 9, 12)), isNull);
+  });
+}

--- a/docs/maintenance/maintenance-quick-start-boot-perf.md
+++ b/docs/maintenance/maintenance-quick-start-boot-perf.md
@@ -2,7 +2,13 @@
 
 ## Status
 
-In Progress — PR1/3 (boot parallélisé)
+In Progress — **PR1 (boot parallélisé) ✅ livrée** · **PR A (démarrage perçu quasi-instantané, mobile) ✅ livrée** · PR B (robustesse/scalabilité backend) à suivre.
+
+> Le diagnostic post-PR1 a montré que le **matin** est structurellement différent
+> des ré-ouvertures : le cache local est invalidé chaque nuit (jamais de SWR
+> matinal), le JWT est mort (TTL 1h) et un `await refresh()` bloquant gatait le
+> splash, et rien ne s'affichait avant le retour de **tous** les endpoints
+> (3 de base + jusqu'à 14 feeds). PR A attaque ces trois gates. Détail ci-dessous.
 
 ## Problème
 
@@ -36,22 +42,74 @@ FluxContinuScreen mount → LoadingView() plein écran
 - Réduire timeout Supabase 15s → 3s (au-delà, on continue avec la session Hive restaurée si dispo)
 - Logs `[PERF]` pour mesurer chaque étape
 
-### PR2 — SWR Flux Continu + preload + rendu progressif (gain : ré-ouvertures <100ms perçu, 1ère ouverture −1 à −2s)
+### PR A — Mobile « Démarrage perçu quasi-instantané » ✅ livrée (gain matin garanti)
 
-- `FluxContinuCacheService` (Hive `flux_continu_cache`, clé `flux_continu:{userId}:{date}`)
-- `fluxContinuPreloadProvider` watché dans `FacteurApp.build()`
-- Split `fluxContinuProvider._fetchAll` en sous-notifiers indépendants
-- Remplacement `LoadingView()` plein écran par skeleton par section
-- `Future.wait` sur les 3 themes (au lieu de série)
+Une PR cohérente mobile-only, sans nouvelle dépendance. Réutilise
+`FluxContinuCacheService`, les patterns `_compose`/`_refetchThemesOnly`/
+`_refetchSourcesOnly` et le single-flight `SessionRefresher`.
 
-### PR3 — Backend caches + fix retry 202
+- **A1 — Auth refresh non-bloquant** (`core/auth/auth_state.dart`) : `_init`
+  peint l'état authentifié **immédiatement** (plus de `await refresh()`
+  bloquant) ; le refresh tourne en arrière-plan, exposé via
+  `AuthStateNotifier.initialRefresh`. Le `.catchError` ne gère que
+  l'`AuthException` (refresh token mort → signout + `sessionExpired` identique à
+  l'ancien chemin). On ne re-pose **jamais** `lastTokenRefreshAt` à la main :
+  l'event SDK `tokenRefreshed` reste l'unique signal d'invalidation
+  (cf. `bug-feed-403-auth-recovery.md`).
+- **A2 — Cache → squelette fidèle** (`flux_continu_cache_service.dart`) :
+  `readLatest()` ne jette plus sur day mismatch — pose `isStale` (+ lit
+  `savedAt`). `readToday()` devient un wrapper « du jour uniquement ». Le cache
+  d'hier sert à dessiner la structure, **jamais** à afficher du contenu périmé.
+- **A3 — Provider squelette + rendu progressif 2 phases**
+  (`flux_continu_provider.dart`) : `build()` peint un **squelette** (sections
+  dérivées des prefs locales — favoris thèmes/sources, ordre Tournée) sur cache
+  d'hier/cold, ou le **vrai** contenu sur snapshot du jour (SWR in-day). Garde
+  **anti-tempête 401** : `await initialRefresh` borné (~3s) avant le batch, pour
+  que les ~3+14 appels partent avec un JWT frais. `_fetchAll` émet en 2 phases :
+  hero/Essentiel/Actus/Bonnes d'abord (≈ 1 round-trip de base), puis les
+  sections thèmes/sources. Flag `isSkeleton` sur `FluxContinuState`. Un garde
+  `_bootstrapping` neutralise les listeners de prefs pendant le bootstrap
+  (le 1er `_fetchAll` lit déjà les prefs fraîches).
+- **A4 — Squelette par section** (`flux_continu_screen.dart`) : remplace le
+  `LoadingView()` plein écran par un scaffold `FluxContinuSkeleton` (en-têtes
+  réels via `SectionBanner` + corps `ExploreDiscoverySkeleton`), non scrollable,
+  hors physics de snap. Pas de lazy-load au scroll (garde-fou snap/haptique).
+- **A5 — Micro-opt boot Sentry** : *non inclus* (optionnel, gain à confirmer au
+  profiling ; réordonner l'init Sentry touche la capture des crashs de boot).
 
-- Cache in-memory 30s sur `/api/essentiel`, `/api/users/top-themes`, `/api/digest/both`
-- Retry 202 digest non-bloquant + polling background mobile
+> Note d'archi (Riverpod) : `provider.future` se résout à la **1ère** émission
+> mid-build. Comme `build()` émet désormais squelette→base→complet, les tests
+> attendent l'état stabilisé (helper `settle()`) au lieu de `.future`.
+
+### PR B — Backend « Robustesse & scalabilité du 1er démarrage » (à suivre)
+
+- **Tuer le 202 du chemin critique** (cas nouveau-user post-store) : `/api/digest`,
+  `/api/digest/both`, `/api/essentiel` renvoient toujours quelque chose vite
+  (digest générique/découverte) + génération perso en background ; idéalement
+  génération **eager au signup**.
+- Caches : `Cache-Control` courts sur `/api/essentiel` + `/api/users/top-themes`,
+  extension des caches in-memory (`digest_cache` 60s, `feed_cache` 30s).
+- Payload allégé : ne pas servir `html_content` (10-50KB/article) dans la liste home.
+- (Optionnel) endpoint agrégé `/api/home/bootstrap` (collapse 17→1) si la mesure
+  PR A montre que le fan-out reste le goulot.
+
+### Différé (après mesure)
+
+- Pré-chargement background nuit (FCM data-push / WorkManager — absents du pubspec).
+- Lazy-load des sections au scroll (levier fort mais risqué pour le snap).
 
 ## Fichiers touchés PR1
 
 - `apps/mobile/lib/main.dart` — refactor bootstrap
+
+## Fichiers touchés PR A
+
+- `apps/mobile/lib/core/auth/auth_state.dart` — refresh non-bloquant + getter `initialRefresh`
+- `apps/mobile/lib/features/flux_continu/services/flux_continu_cache_service.dart` — `readLatest()` + `isStale`/`savedAt`
+- `apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart` — squelette + 2 phases + garde `initialRefresh` + `_bootstrapping`
+- `apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart` — flag `isSkeleton`
+- `apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart` — `FluxContinuSkeleton` par section
+- Tests : `flux_continu_cache_service_test.dart` (nouveau), `flux_continu_provider_test.dart` (squelette + 2 phases), migration `settle()` des suites flux provider.
 
 ## Vérification PR1
 


### PR DESCRIPTION
# PR A — Mobile : démarrage perçu quasi-instantané (squelette + auth non-bloquant + rendu progressif)

## Résumé

À l'ouverture matinale, le temps perçu tap→contenu était >5s (jusqu'à 20s+ si
`/api/digest` renvoie 202). Le matin est structurellement différent des
ré-ouvertures : le cache local est invalidé chaque nuit (jamais de SWR matinal),
le JWT (TTL 1h) est mort et un `await refresh()` **bloquant** gatait le splash,
et rien ne s'affichait avant le retour de **tous** les endpoints (3 de base +
jusqu'à 14 feeds thèmes/sources). Cette PR (mobile only, aucune nouvelle
dépendance) supprime ces trois gates.

## Changements

- **A1 — Auth refresh non-bloquant** (`core/auth/auth_state.dart`)
  - `_init` peint l'état authentifié **immédiatement** ; le refresh tourne en
    arrière-plan, exposé via `AuthStateNotifier.initialRefresh`.
  - `.catchError` ne gère que l'`AuthException` (refresh token mort → signout +
    `sessionExpired`, identique à l'ancien chemin bloquant). On ne re-pose
    **jamais** `lastTokenRefreshAt` à la main : l'event SDK `tokenRefreshed`
    reste l'unique signal d'invalidation (cf. `bug-feed-403-auth-recovery.md`).
    Single-flight conservé via `SessionRefresher` (cf.
    `bug-android-disconnect-race.md`).

- **A2 — Cache → squelette fidèle** (`services/flux_continu_cache_service.dart`)
  - `readLatest()` ne jette plus sur day mismatch — pose `isStale` + lit
    `savedAt`. `readToday()` devient un wrapper « du jour uniquement ». Le cache
    d'hier sert à dessiner la structure, **jamais** à afficher du contenu périmé.

- **A3 — Provider squelette + rendu progressif 2 phases**
  (`providers/flux_continu_provider.dart`)
  - `build()` peint un **squelette** (sections dérivées des prefs locales :
    favoris thèmes/sources, ordre Tournée, veille) sur cache d'hier/cold, ou le
    **vrai** contenu sur snapshot du jour (SWR in-day).
  - **Garde anti-tempête 401** : `await initialRefresh` borné (~3s) avant le
    batch → les ~3+14 appels partent avec un JWT frais ; sinon l'intercepteur 401
    single-flight reste le filet.
  - `_fetchAll` (via `_buildStateFromPayload`) émet en 2 phases :
    hero/Essentiel/Actus/Bonnes d'abord (≈ 1 round-trip de base), puis les
    sections thèmes/sources. L'émission progressive ne se fait QUE quand un
    squelette est monté (pas de blink en SWR / pull-to-refresh).
  - Flag `isSkeleton` sur `FluxContinuState`. Garde `_bootstrapping` : neutralise
    les listeners de prefs pendant le bootstrap (le 1er `_fetchAll` lit déjà les
    prefs fraîches) — restaure l'invariant « aucune réaction de listener avant le
    1er build complet ».

- **A4 — Squelette par section** (`screens/flux_continu_screen.dart`)
  - Remplace le `LoadingView()` plein écran par `_FluxContinuSkeleton`
    (en-têtes réels via `SectionBanner` + corps `ExploreDiscoverySkeleton`),
    non scrollable, hors physics de snap. **Pas** de lazy-load au scroll
    (garde-fou snap/haptique, cf. mémoire `flux_snap_haptic_feel`).

- **A5 — Micro-opt Sentry** : non inclus (optionnel, gain à confirmer au
  profiling ; réordonner l'init Sentry touche la capture des crashs de boot).

## Note d'archi (Riverpod) — important pour la review

`provider.future` se résout à la **1ère** émission mid-build (vérifié). Comme
`build()` émet désormais squelette → base-only → complet, les tests attendent
l'état stabilisé via un helper `settle()` au lieu de `.future`. Migration
appliquée aux 3 suites flux provider (comportement final inchangé).

## Vérification

- `flutter analyze` : **clean** sur les 5 fichiers lib touchés ; 0 erreur projet.
- Tests : `flutter test test/features/flux_continu/ test/features/auth/ test/core/auth/`
  → `+272 -3`. Les **3 échecs sont pré-existants** (baseline pristine = `+266 -3` :
  `essentiel_hi_fi_card` badge Météo/layout — flaky, et `router_redirection`
  EmailConfirmationScreen — Hive/Supabase non init en widget test). **Aucun
  nouvel échec dans les zones touchées.**
- Tests ajoutés :
  - `flux_continu_cache_service_test.dart` (nouveau) : `readLatest` isStale/savedAt,
    `readToday` null sur périmé, JSON corrompu → null.
  - `flux_continu_provider_test.dart` : cache d'hier → 1ère peinture squelette
    (jamais de contenu périmé) ; cold → base-only émis avant les sections thèmes.

## À faire côté review / suivi (hors PR)

- **Profiling cold-launch sur device réel** + simulation d'un matin (cache d'hier)
  pour mesurer splash→1ère frame avant/après (le plancher moteur Flutter domine
  l'absolu ; on prouve la suppression des gates refresh + fan-out). Logs
  `[PERF] fluxContinu.build mode=content_fresh|skeleton_stale|cold` ajoutés.
- **PR B (backend)** recommandée juste après : tuer le 202 du chemin critique
  (cas nouveau-user post-store), caches courts, payload allégé. Voir
  `docs/maintenance/maintenance-quick-start-boot-perf.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
