### PR TITLE
feat(perspectives): calibrer la porte de clustering (floor 0.08→0.12) + harness de mesure

### DIFF
--- a/docs/maintenance/maintenance-clustering-calibration.md
+++ b/docs/maintenance/maintenance-clustering-calibration.md
@@ -1,0 +1,265 @@
+# Maintenance — Calibration de la porte de clustering « couverture médiatique »
+
+> **Date** : 2026-06-09
+> **Branche** : `boujonlaurin-dotcom/improve-clustering-quality`
+> **PR ciblée** : `main`
+> **Type** : outillage + 1er réglage data-driven (1 paramètre)
+> **Template** : [`maintenance-highlight-calibration.md`](./maintenance-highlight-calibration.md)
+
+## Contexte
+
+L'écran « couverture médiatique / Autres regards » regroupe trop d'articles qui
+ne partagent qu'une **entité saillante** (Trump, Macron…) sans parler du **même
+événement**. Capture PO : un cluster « Trump » mélange la guerre Iran-Israël,
+« Trump hué au NBA » et « Trump et le Sénat ». Conséquence : perte de confiance
++ le « niveau de polarisation » mesure le mauvais objet.
+
+Le clustering est **100 % lexical/entité, zéro sémantique**. La porte vit dans
+`packages/api/app/services/perspective_service.py` :
+
+- `_topical_signals()` → `{title_jaccard, shared_topics, shared_entities}`
+- `_is_topically_coherent()` accepte un candidat si :
+  1. `title_jaccard ≥ 0.30` (`PERSPECTIVE_TITLE_JACCARD_MIN`), **ou**
+  2. `shared_entities ≥ 2` (Layer 1 DB), **ou**
+  3. `title_jaccard ≥ 0.08` (`PERSPECTIVE_MIN_JACCARD_FLOOR`) **ET**
+     `shared_topics ≥ 1` **ET** `shared_entities ≥ 1` ← **la « weak double
+     signal », la fuite principale de faux-positifs**.
+
+À l'inverse, le Jaccard de titre seul rate les **paraphrases**
+(« guerre au Moyen-Orient » vs « conflit Israël-Iran ») → faux-négatifs.
+
+> Règle d'or PO (cf. mémoire `feedback_calibration_no_overfit`,
+> `feedback_highlight_no_brute_rules`) : **mesure avant règle**. On instrumente,
+> on chiffre, puis on règle **un seul paramètre** mesuré contre le gold —
+> jamais de stoplist / règle métier en dur.
+
+## Décision (validée PO)
+
+1. **Périmètre** : dataset + harness + baseline **ET** un 1er réglage de seuils
+   (durcir la branche 3) mesuré contre le gold, dans la même PR.
+2. **Surface** : **perspectives uniquement** (la porte de `perspective_service`).
+   On ne benche pas `importance_detector`.
+3. **Étiquetage** : LLM (Mistral-large) pré-partitionne par événement → **revue
+   PO** des `event_id`.
+4. **Embeddings** : actés en *next steps*, non implémentés ici.
+
+## Livrables
+
+| Fichier | Rôle |
+|---------|------|
+| `packages/api/scripts/build_event_dataset.py` | Construit les pools lâches par entité partagée (fenêtre + cap, pas de dédup source). |
+| `packages/api/scripts/label_event_dataset.py` | Pré-label LLM cluster-assign (1 prompt/pool) + substrat de revue PO. |
+| `packages/api/scripts/evaluate_event_clustering.py` | Harness sur la **porte réelle** : P/R/F1 pairwise, contamination, FP-par-chemin, FN-par-raison, sweep, `--compare`. |
+| `packages/api/tests/scripts/test_build_event_dataset.py` | Seeding / fenêtre / stratif. |
+| `packages/api/tests/scripts/test_label_event_dataset.py` | Validateur (exactly-once-or-NOISE, jamais d'écrasement revu) + dry-run. |
+| `packages/api/tests/scripts/test_evaluate_event_clustering.py` | Fns pures, anti-drift `gate_pair`, agrégation toy (FP planté → `weak_double_signal`). |
+| `packages/api/tests/scripts/fixtures/toy_event_dataset.json` | Toy : 1 pool Trump, événements iran(3)/nba(1) + NOISE. |
+| `.context/gold-events-*.json\|.md` | Généré, gitignored. |
+
+## Schéma du gold (`dataset_kind: event_membership`)
+
+```json
+{
+  "schema_version": 1, "dataset_kind": "event_membership", "seed_window_hours": 72,
+  "pools": [{
+    "pool_key": "trump", "pool_display": "Trump",
+    "seed_entity": {"name": "Trump", "type": "PERSON"}, "theme": "international",
+    "events": [{"event_id": "iran", "label": "Frappes Iran-Israël", "size": 3}],
+    "articles": [{
+      "id": "...", "title": "...", "topics": ["geopolitics","middleeast"],
+      "entities": ["{\"name\":\"Trump\",\"type\":\"PERSON\"}"],
+      "event_id": "iran", "label_source": "llm_pass1",
+      "label_reviewed": false, "label_confidence": 0.8, "label_notes": ""
+    }]
+  }]
+}
+```
+
+`event_id` = slug stable ; sentinelle `"NOISE"` = article partageant l'entité
+mais sans événement multi-articles cohérent (**jamais** « même événement » avec
+quoi que ce soit). `topics`/`entities` portés **verbatim** (forme `text[]` de
+chaînes JSON, parsées exactement comme `_parse_entity_names`).
+
+## Workflow
+
+### 1. Extraction du pool (MCP Supabase)
+
+`claude_analytics_ro` est RLS-0 ; passer par MCP Supabase. Sélectionner
+**`topics` ET `entities`** :
+
+```sql
+SELECT c.id, c.title, c.url, c.published_at, c.theme, c.topics, c.entities,
+       c.language, s.name AS source_name, s.bias_stance, c.source_id
+FROM contents c
+JOIN sources s ON s.id = c.source_id
+WHERE c.published_at >= NOW() - INTERVAL '72 hours'
+  AND c.language = 'fr'
+  AND c.title IS NOT NULL
+  AND c.entities IS NOT NULL
+  AND array_length(c.entities, 1) >= 1;
+```
+
+Repackager en `{ "generated_at": "...", "articles": [...] }` →
+`.context/raw-articles-<date>.json` (gitignored).
+
+### 2. Construction des pools
+
+```bash
+cd packages/api && source venv/bin/activate
+python scripts/build_event_dataset.py \
+    --raw ../../.context/raw-articles-<date>.json \
+    --out ../../.context/gold-events-<date>.json
+```
+
+Défauts : `--min-size 6 --max-per-pool 30 --window-hours 72`. **Pas** de dédup
+par source ni de filtre « ≥2 entités » (on veut les pools gras qui se scindent
++ les paires intra-événement multi-sources). Stratification par thème comptée
+**en pools** (`DEFAULT_QUOTAS`).
+
+### 3. Pré-label LLM + revue PO
+
+```bash
+python scripts/label_event_dataset.py \
+    --dataset ../../.context/gold-events-<date>.json --mode fill
+```
+
+Approche **cluster-assign** (1 prompt/pool, pas O(n²)). Validateur tolérant :
+un index assigné **exactement une fois** → son événement ; 0 ou ≥2 fois → NOISE.
+`EVENT_LABEL_DRY_RUN=1` → stub déterministe (tests).
+
+**Revue PO** (rubrique d'arbitrage) :
+
+- Un événement = mêmes **acteurs + action + moment**. Annonce vs réaction de
+  marché = events distincts si l'angle diffère ; en cas de doute → NOISE.
+- Éditer les `event_id` douteux dans le JSON `.context/`, passer
+  `label_reviewed: true` **pool par pool**.
+- Phases : **A** gold synchrone PO (2-3 pools en visio) · **B** miroir
+  (le PO valide le draft LLM) · **C** `--mode blind` re-label des pools revus
+  → mesure de l'accord LLM↔PO (`event_id_blind`) comme signal de qualité du gold.
+
+### 4. Baseline (Iter 0) + diagnostic
+
+```bash
+python scripts/evaluate_event_clustering.py \
+    --dataset ../../.context/gold-events-<date>.json --tag baseline
+```
+
+Le harness importe les **vraies** fonctions de la porte (anti-drift garanti par
+`test_gate_pair_matches_real_gate`) et rejoue **toutes les paires ordonnées**
+seed↔candidat. Métriques :
+
+- Pairwise **P/R/F1** micro **+ macro par pool** (un gros pool ne domine pas le
+  micro ; le n est affiché).
+- **Contamination par seed** : % d'articles hors-événement admis (moyenne +
+  pires offenders « junk-drawers »).
+- **FP par chemin d'acceptation** : `strong_jaccard` / `double_entity` /
+  `weak_double_signal`. Attendu : majorité des FP en `weak_double_signal`.
+- **FN par signal manquant** : `low_jaccard` / `jaccard_below_floor` /
+  `no_shared_topic` / `no_shared_entity` → révèle le gap des paraphrases.
+- **Couverture des signaux** : fraction `full_signals` (garde-fou si la prod a
+  des `entities` nulles, ~17 % — sinon la fuite serait mal attribuée).
+
+> **Hors-périmètre déterministe** : Layer 2/3 (Google News) génère des candidats
+> sans topics/entities — on mesure la *porte*, pas la génération de candidats.
+
+### 5. 1er réglage data-driven (Iter 1, même PR)
+
+```bash
+python scripts/evaluate_event_clustering.py \
+    --dataset ../../.context/gold-events-<date>.json --tag baseline --sweep
+```
+
+Le `--sweep` balaie `PERSPECTIVE_MIN_JACCARD_FLOOR ∈ {0.08, 0.12, 0.15, 0.20,
+0.25}` + la variante « exiger `shared_entities ≥ 2` partout » et imprime le
+tradeoff (P↑ / contamination↓ vs R). Choisir le réglage qui **maximise la
+précision sans dégrader le rappel au-delà d'un seuil acceptable** (validé PO).
+Vu le cas Cuba/Chagos (Jaccard ≈ 0.09), un floor à ~0.15 rejette ce FP — **à
+confirmer par la mesure sur le gold réel**.
+
+**Un seul paramètre** modifié dans `perspective_service.py`, puis re-run :
+
+```bash
+python scripts/evaluate_event_clustering.py \
+    --dataset ../../.context/gold-events-<date>.json --tag iter1
+python scripts/evaluate_event_clustering.py --compare \
+    ../../.context/gold-events-baseline-<date>.json \
+    ../../.context/gold-events-iter1-<date>.json
+```
+
+La fixture Texas existante (`tests/test_perspective_service.py`) doit rester
+verte ; ajouter une fixture Trump multi-événements.
+
+## Journal de calibration (append-only — 1 paramètre / PR)
+
+| Iter | Date | Param | P_pair | R_pair | F1_pair | Contam | FP_weak_double | FN_jaccard_floor | ΔF1 | Notes |
+|------|------|-------|--------|--------|---------|--------|----------------|------------------|-----|-------|
+| 0 | 2026-06-09 | baseline (floor 0.08) | 0.897 | 0.876 | 0.886 | 0.169 | 252 | 360 | — | gold **revu PO** (découpe NOISE/événements validée telle quelle) ; 20 pools / 4906 paires ordonnées |
+| 1 | 2026-06-09 | `PERSPECTIVE_MIN_JACCARD_FLOOR` 0.08 → 0.12 | 0.926 | 0.809 | 0.864 | 0.129 | 124 | 628 | −0.023 | arbitrage PO « moins de mauvais clusters » : FP −128 (−36 %), contamination −24 %, rappel −7,6 % |
+
+> **Iter 0** mesuré le 2026-06-09 sur gold **revu PO** (7 pools junk-drawer relus,
+> découpe NOISE/événements confirmée sans flip). Diagnostic confirmé sur données
+> prod : `weak_double_signal` = 71 % des FP (252/356), `jaccard_below_floor` =
+> 83 % des FN (360/436). Le `--sweep` montre que durcir le floor n'est PAS un
+> repas gratuit sur données réelles (contrairement au toy) : ↑précision et
+> ↓contamination se paient en ↓rappel (des paraphrases intra-événement
+> dépendent aussi de la branche faible).
+>
+> **Iter 1 — floor 0.08 → 0.12 (validé PO).** `weak_double_signal` FP 252 → 124
+> (la branche ciblée est bien coupée de moitié), `double_entity` FP **inchangé à
+> 92** : le floor ne touche QUE la branche faible — les FP qui partagent ≥2
+> entités (ex. Trump *Iran-Israël* ↔ *Pentagone-espionnage*, qui partagent
+> Trump + Israël) survivent à **toute** valeur de floor. Le cœur du grief Trump
+> reste donc adressable seulement par les embeddings (cf. *Suite*). Pareillement,
+> les FN paraphrases (`jaccard_below_floor` 360 → 628) s'aggravent avec le floor
+> et ne se règlent pas ici.
+>
+> | floor | P | R | F1 | Contam | FP | FN |
+> |-------|---|---|----|--------|----|----|
+> | 0.08 (actuel) | 0.897 | 0.876 | 0.886 | 0.169 | 356 | 436 |
+> | 0.12 | 0.926 | 0.809 | 0.864 | 0.129 | 228 | 672 |
+> | 0.15 | 0.933 | 0.756 | 0.835 | 0.105 | 192 | 858 |
+> | 0.20 | 0.942 | 0.693 | 0.798 | 0.082 | 150 | 1082 |
+> | 0.25 | 0.949 | 0.629 | 0.756 | 0.071 | 120 | 1306 |
+> | entités≥2 partout | 0.952 | 0.581 | 0.722 | 0.072 | 104 | 1474 |
+>
+> Chaque PR de calibration ajoute **une ligne et une seule** au journal. Le gold
+> (réel, revu PO) et le `--compare` fournissent le delta.
+
+## Tests
+
+```bash
+cd packages/api && pytest \
+    tests/scripts/test_build_event_dataset.py \
+    tests/scripts/test_label_event_dataset.py \
+    tests/scripts/test_evaluate_event_clustering.py \
+    tests/test_perspective_service.py -v
+```
+
+Tests **purs** (sans réseau ni DB). Le smoke `test_evaluate_toy_pool_*` vérifie
+le toy à confusion connue (TP=2, FP=4 `weak_double_signal`, FN=4
+`jaccard_below_floor`) et le sweep (floor 0.15 tue les 4 FP sans coût de rappel).
+
+## Pièges
+
+1. `Source.bias_stance` est un `StrEnum` SQLAlchemy ⇒ sérialiser via `.value`.
+2. `Content.entities` est `text[]` de chaînes JSON ⇒ `json.loads(raw)` par
+   élément (`_parse_entity_names`), jamais `c.entities[0]["name"]`.
+3. MCP Supabase tronque à ~1 000 rows ⇒ paginer si le pool dépasse.
+4. `LOCATION` est exclu des entités discriminantes (`Iran` ne compte pas) :
+   bien fournir des `entities` PERSON/ORG/EVENT pour exercer `full_signals`.
+5. Confirmer que le dump porte bien `content.topics` (slugs ML) et pas un thème
+   source (cf. risque « provenance topics » du plan).
+6. **Anti-drift** : ne pas réimplémenter la porte — `gate_pair` (défaut) DOIT
+   rester identique à `_is_topically_coherent` (test dédié). Les params de
+   `gate_pair` servent uniquement au sweep.
+7. PR base `main` obligatoire ; `staging` bloqué par hook.
+
+## Suite (hors PR — actés, non implémentés)
+
+**Direction de fond = sémantique par embeddings.** Le lexical seul ne distingue
+pas deux événements partageant une entité (FP) et rate les paraphrases (FN).
+Piste : colonne `pgvector` sur `Content`, embeddings `mistral-embed` sur
+`titre (+ description)`, appartenance gated par **cosinus dans une fenêtre
+temporelle serrée + ≥1 entité discriminante partagée**. Le gold + harness de
+cette PR deviennent le banc de mesure de cette refonte (chaque itération
+mesurée, journal de calibration).

--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -30,7 +30,10 @@ PERSPECTIVE_TITLE_JACCARD_MIN = 0.30
 # Empêche qu'un seul topic générique ("politics") suffise à valider deux articles
 # sur des sujets radicalement différents (ex: Congo/prisonniers vs Ukraine/trêve)
 # partageant seulement un nom propre omniprésent (Trump, Macron…).
-PERSPECTIVE_MIN_JACCARD_FLOOR = 0.08
+# Calibré sur le gold « event_membership » (Iter 1, 2026-06-09) : 0.08 → 0.12
+# coupe ~36% des FP « weak double signal » (contamination −24%) pour −7,6% de
+# rappel. Cf. docs/maintenance/maintenance-clustering-calibration.md.
+PERSPECTIVE_MIN_JACCARD_FLOOR = 0.12
 PERSPECTIVE_MIN_VALID_RESULTS = 2
 PERSPECTIVE_MIN_BIAS_GROUPS = 2
 # Entités jugées suffisamment discriminantes (LOCATION exclu : trop générique)

--- a/packages/api/scripts/build_event_dataset.py
+++ b/packages/api/scripts/build_event_dataset.py
@@ -1,0 +1,377 @@
+"""Construit le dataset annotable « appartenance à un événement » pour la
+calibration de la *porte de cohérence sujet* des perspectives
+(cf. `docs/maintenance/maintenance-clustering-calibration.md`).
+
+Contrairement à `build_highlight_dataset.py`, on ne cherche PAS des clusters
+« bien formés » : on veut des **pools lâches** seedés par l'entité la plus
+saillante (Trump, Macron, …) qui mélangent plusieurs événements distincts —
+c'est exactement là que la fuite de faux-positifs de la branche
+« weak double signal » se voit. Le LLM (puis le PO) re-partitionne ensuite
+chaque pool par événement concret (`label_event_dataset.py`).
+
+Workflow :
+    1. Le PO extrait un dump brut via MCP Supabase (SELECT incluant
+       **topics ET entities**, cf. doc de maintenance).
+    2. Ce script :
+       a. groupe les articles en pools par entité PERSON/ORG/EVENT partagée
+          (réutilise `build_pseudo_clusters` de `inspect_title_annotations.py`),
+       b. applique une fenêtre temporelle + un cap de taille par pool
+          (PAS de dédup par source ni de filtre « ≥2 entités » — on garde
+          les pools gras),
+       c. stratifie par thème (quotas comptés **en pools**),
+       d. sérialise le dataset annotable (`event_id: null` par article).
+
+Forme du dump d'entrée (sur-ensemble du format de
+`inspect_title_annotations.py`) :
+
+    {
+      "generated_at": "2026-06-09T15:00:00Z",
+      "articles": [
+        {
+          "id": "uuid", "title": "...", "url": "...",
+          "published_at": "2026-06-08T08:00:00Z",
+          "source_name": "Le Monde", "source_id": "uuid",
+          "bias_stance": "center-left", "theme": "international",
+          "topics": ["geopolitics", "middleeast"],
+          "entities": ["{\"name\": \"Trump\", \"type\": \"PERSON\"}", ...]
+        }, ...
+      ]
+    }
+
+Usage :
+    cd packages/api && source venv/bin/activate
+    python scripts/build_event_dataset.py \\
+        --raw ../../.context/raw-articles-2026-06-09.json \\
+        --out ../../.context/gold-events-2026-06-09.json
+
+Sortie :
+    JSON sérialisé (schéma documenté dans la doc de maintenance).
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.build_highlight_dataset import DEFAULT_QUOTAS  # noqa: E402
+from scripts.inspect_title_annotations import (  # noqa: E402
+    DISCRIMINANT_TYPES,
+    build_pseudo_clusters,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTEXT_DIR = REPO_ROOT / ".context"
+
+NOISE_EVENT_ID = "NOISE"
+
+
+@dataclass
+class EventArticle:
+    """Article porteur de `topics` (en plus des champs du highlight Article)."""
+
+    id: str
+    title: str
+    url: str
+    published_at: datetime
+    source_name: str
+    source_id: str
+    bias_stance: str
+    theme: str
+    topics: list[str]
+    entities: list[str]
+
+    def entity_keys(self) -> list[tuple[str, str]]:
+        """(key=lower, display) par entité PERSON/ORG/EVENT — comme le highlight Article.
+
+        Requis par `build_pseudo_clusters`, qui seede les pools par entité
+        discriminante partagée.
+        """
+        out: list[tuple[str, str]] = []
+        for raw in self.entities or []:
+            try:
+                obj = json.loads(raw)
+            except (ValueError, TypeError):
+                continue
+            if obj.get("type") not in DISCRIMINANT_TYPES:
+                continue
+            name = (obj.get("name") or "").strip()
+            if name:
+                out.append((name.lower(), name))
+        return out
+
+    def entity_type(self, name_lower: str) -> str | None:
+        """Type déclaré pour l'entité nommée `name_lower` (None si absente)."""
+        for raw in self.entities or []:
+            try:
+                obj = json.loads(raw)
+            except (ValueError, TypeError):
+                continue
+            if (obj.get("name") or "").strip().lower() == name_lower:
+                return obj.get("type")
+        return None
+
+
+@dataclass
+class Pool:
+    key: str
+    display: str
+    articles: list[EventArticle]
+    theme: str = ""
+    seed_type: str = "PERSON"
+
+
+@dataclass
+class BuildStats:
+    n_articles: int = 0
+    n_pseudo_pools: int = 0
+    n_after_window: int = 0
+    n_selected: int = 0
+    per_group: dict[str, int] = field(default_factory=dict)
+    skipped_themes: list[str] = field(default_factory=list)
+
+
+def load_articles(path: Path) -> list[EventArticle]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    out: list[EventArticle] = []
+    for a in data["articles"]:
+        out.append(
+            EventArticle(
+                id=str(a["id"]),
+                title=a["title"] or "",
+                url=a.get("url") or "",
+                published_at=datetime.fromisoformat(
+                    a["published_at"].replace("Z", "+00:00")
+                ),
+                source_name=a.get("source_name") or "?",
+                source_id=str(a.get("source_id") or ""),
+                bias_stance=a.get("bias_stance") or "unknown",
+                theme=(a.get("theme") or "").strip(),
+                topics=list(a.get("topics") or []),
+                entities=list(a.get("entities") or []),
+            )
+        )
+    return out
+
+
+def filter_window(arts: list[EventArticle], hours: int) -> list[EventArticle]:
+    """Garde les articles publiés ≤ `hours` avant le plus récent du pool.
+
+    Reproduit le `cutoff = now - time_window_hours` de
+    `search_internal_perspectives` (la porte ne voit que des candidats
+    récents), appliqué relativement au pool plutôt qu'à « now » pour rester
+    reproductible sur un dump figé.
+    """
+    if not arts:
+        return arts
+    latest = max(a.published_at for a in arts)
+    cutoff = latest - timedelta(hours=hours)
+    return [a for a in arts if a.published_at >= cutoff]
+
+
+def pick_theme(arts: list[EventArticle]) -> str:
+    counts = Counter(a.theme for a in arts if a.theme)
+    if not counts:
+        return ""
+    return counts.most_common(1)[0][0]
+
+
+def _seed_type(key: str, arts: list[EventArticle]) -> str:
+    """Type déclaré de l'entité seed (premier article qui la porte)."""
+    for a in arts:
+        t = a.entity_type(key)
+        if t:
+            return t
+    return "PERSON"
+
+
+def build_pools(
+    articles: list[EventArticle],
+    min_size: int,
+    window_hours: int,
+    max_per_pool: int,
+    stats: BuildStats,
+) -> list[Pool]:
+    """Pools lâches par entité partagée + fenêtre + cap de taille.
+
+    Volontairement PAS de dédup par source ni de filtre « ≥2 entités » : on
+    veut des paires intra-événement multi-sources ET des pools qui se scindent.
+    """
+    raw = build_pseudo_clusters(articles, min_size=min_size, top_n=10_000)
+    stats.n_pseudo_pools = len(raw)
+
+    pools: list[Pool] = []
+    for key, display, arts in raw:
+        windowed = filter_window(arts, window_hours)
+        if len(windowed) < min_size:
+            continue
+        stats.n_after_window += 1
+        capped = sorted(windowed, key=lambda a: a.published_at, reverse=True)[
+            :max_per_pool
+        ]
+        pools.append(
+            Pool(
+                key=key,
+                display=display,
+                articles=capped,
+                theme=pick_theme(capped),
+                seed_type=_seed_type(key, capped),
+            )
+        )
+    return pools
+
+
+def stratify_pools(
+    pools: list[Pool],
+    quotas: dict[str, dict],
+    seeds_per_theme: int | None,
+    stats: BuildStats,
+) -> list[Pool]:
+    """Sélectionne les plus gros pools par groupe thématique.
+
+    `seeds_per_theme` (si fourni) écrase le `target_clusters` de chaque groupe.
+    Tri par taille descendante : les pools gras (≥3 événements) sont prioritaires
+    car c'est là que la fuite FP est observable.
+    """
+    theme_to_group: dict[str, str] = {}
+    for group, cfg in quotas.items():
+        for theme in cfg["themes"]:
+            theme_to_group[theme] = group
+
+    targets = {
+        group: (seeds_per_theme if seeds_per_theme is not None else cfg["target_clusters"])
+        for group, cfg in quotas.items()
+    }
+
+    sorted_pools = sorted(pools, key=lambda p: len(p.articles), reverse=True)
+    selected: list[Pool] = []
+    taken: dict[str, int] = defaultdict(int)
+    for pool in sorted_pools:
+        group = theme_to_group.get(pool.theme)
+        if group is None:
+            continue
+        if taken[group] >= targets[group]:
+            continue
+        selected.append(pool)
+        taken[group] += 1
+
+    stats.per_group = dict(taken)
+    stats.skipped_themes = [g for g, t in targets.items() if taken[g] < t]
+    stats.n_selected = len(selected)
+    return selected
+
+
+def serialize_events(
+    selected: list[Pool], window_hours: int, quotas: dict[str, dict]
+) -> dict:
+    now = datetime.now(UTC).isoformat()
+    return {
+        "generated_at": now,
+        "schema_version": 1,
+        "dataset_kind": "event_membership",
+        "seed_window_hours": window_hours,
+        "stratification": {
+            g: cfg["target_clusters"] for g, cfg in quotas.items()
+        },
+        "pools": [
+            {
+                "pool_key": p.key,
+                "pool_display": p.display,
+                "seed_entity": {"name": p.display, "type": p.seed_type},
+                "theme": p.theme,
+                "events": [],
+                "articles": [
+                    {
+                        "id": a.id,
+                        "title": a.title,
+                        "url": a.url,
+                        "published_at": a.published_at.isoformat(),
+                        "source_name": a.source_name,
+                        "source_id": a.source_id,
+                        "bias_stance": a.bias_stance,
+                        "theme": a.theme,
+                        "topics": a.topics,
+                        "entities": a.entities,
+                        "event_id": None,
+                        "label_source": None,
+                        "label_reviewed": False,
+                        "label_confidence": None,
+                        "label_notes": "",
+                    }
+                    for a in sorted(p.articles, key=lambda a: a.published_at)
+                ],
+            }
+            for p in selected
+        ],
+    }
+
+
+def print_stats(stats: BuildStats, selected: list[Pool]) -> None:
+    print(f"Articles chargés                 : {stats.n_articles}")
+    print(f"Pseudo-pools bruts (≥min_size)   : {stats.n_pseudo_pools}")
+    print(f"  après fenêtre temporelle       : {stats.n_after_window}")
+    print(f"Pools sélectionnés (quotas)      : {stats.n_selected}")
+    print("Répartition par groupe :")
+    for group, n in sorted(stats.per_group.items()):
+        print(f"  - {group:14s} : {n}")
+    if stats.skipped_themes:
+        print(
+            f"⚠️  Quotas non atteints pour : {', '.join(stats.skipped_themes)}",
+            file=sys.stderr,
+        )
+    n_articles = sum(len(p.articles) for p in selected)
+    print(f"Articles à étiqueter             : {n_articles}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--raw", required=True, help="Dump JSON brut (cf. docstring)")
+    parser.add_argument("--out", default=None, help="Chemin de sortie")
+    parser.add_argument("--min-size", type=int, default=6)
+    parser.add_argument("--max-per-pool", type=int, default=30)
+    parser.add_argument("--window-hours", type=int, default=72)
+    parser.add_argument(
+        "--seeds-per-theme",
+        type=int,
+        default=None,
+        help="Écrase le target_clusters de chaque groupe (sinon DEFAULT_QUOTAS)",
+    )
+    args = parser.parse_args()
+
+    articles = load_articles(Path(args.raw))
+    if not articles:
+        print("⚠️  Dump vide.", file=sys.stderr)
+        sys.exit(1)
+
+    stats = BuildStats(n_articles=len(articles))
+    pools = build_pools(
+        articles,
+        min_size=args.min_size,
+        window_hours=args.window_hours,
+        max_per_pool=args.max_per_pool,
+        stats=stats,
+    )
+    selected = stratify_pools(pools, DEFAULT_QUOTAS, args.seeds_per_theme, stats)
+
+    payload = serialize_events(selected, args.window_hours, DEFAULT_QUOTAS)
+
+    today = datetime.now(UTC).date().isoformat()
+    out_path = (
+        Path(args.out) if args.out else CONTEXT_DIR / f"gold-events-{today}.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    print_stats(stats, selected)
+    print(f"✅ Dataset écrit : {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/evaluate_event_clustering.py
+++ b/packages/api/scripts/evaluate_event_clustering.py
@@ -1,0 +1,674 @@
+"""Évaluateur de la *porte de cohérence sujet* des perspectives
+(`PerspectiveService._is_topically_coherent`) contre un gold « appartenance
+à un événement » (cf. `docs/maintenance/maintenance-clustering-calibration.md`).
+
+Le harness importe les **vraies** fonctions de la porte (pas de
+réimplémentation) et rejoue, pour chaque pool, **toutes les paires ordonnées**
+seed↔candidat — la porte est asymétrique : n'importe quel article peut ouvrir
+l'écran « couverture médiatique ». Il mesure :
+
+- Pairwise **précision / rappel / F1** (micro + macro par pool ; NOISE jamais
+  positif).
+- **Contamination par seed** : % d'articles hors-événement admis dans le
+  cluster prédit (moyenne + pires offenders).
+- **FP par chemin d'acceptation** : `strong_jaccard` / `double_entity` /
+  `weak_double_signal` (la fuite). Attendu : majorité des FP en
+  `weak_double_signal`.
+- **FN par signal manquant** : `low_jaccard` / `jaccard_below_floor` /
+  `no_shared_topic` / `no_shared_entity` → révèle le gap des paraphrases.
+- **Couverture des signaux** : fraction de paires `full_signals` vs jaccard-seul.
+
+`--sweep` balaie `PERSPECTIVE_MIN_JACCARD_FLOOR` (et l'option « exiger
+`shared_entities ≥ 2` partout ») pour exposer le tradeoff précision/rappel.
+
+Hors-périmètre **déterministe** : Layer 2/3 (Google News) génère des candidats
+mais ne porte ni topics ni entities — on mesure la *porte*, pas la génération.
+
+Usage :
+    cd packages/api && source venv/bin/activate
+    python scripts/evaluate_event_clustering.py \\
+        --dataset ../../.context/gold-events-2026-06-09.json --tag baseline
+    python scripts/evaluate_event_clustering.py \\
+        --dataset ../../.context/gold-events-2026-06-09.json --sweep
+    python scripts/evaluate_event_clustering.py --compare \\
+        ../../.context/gold-events-baseline-2026-06-09.json \\
+        ../../.context/gold-events-iter1-2026-06-09.json
+
+Sorties :
+    .context/gold-events-<tag>-<date>.json  (machine, consommé par --compare)
+    .context/gold-events-<tag>-<date>.md    (lisible humain)
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from app.services.perspective_service import (  # noqa: E402
+    PERSPECTIVE_DISCRIMINANT_ENTITY_TYPES,
+    PERSPECTIVE_MIN_JACCARD_FLOOR,
+    PERSPECTIVE_TITLE_JACCARD_MIN,
+    PerspectiveService,
+    _parse_entity_names,
+)
+from app.services.text_similarity import normalize_title  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTEXT_DIR = REPO_ROOT / ".context"
+
+NOISE_EVENT_ID = "NOISE"
+
+# Valeurs balayées par défaut en mode --sweep.
+DEFAULT_FLOOR_SWEEP = [0.08, 0.12, 0.15, 0.20, 0.25]
+
+
+# ---------------------------------------------------------------------------
+# Réplique paramétrable de la porte — anti-drift garanti par les tests
+# ---------------------------------------------------------------------------
+
+
+def gate_pair(
+    signals: dict,
+    floor: float = PERSPECTIVE_MIN_JACCARD_FLOOR,
+    require_double_entity: bool = False,
+) -> tuple[bool, str]:
+    """Réplique de `_is_topically_coherent` avec floor + option configurables.
+
+    Avec les valeurs par défaut (`floor=PERSPECTIVE_MIN_JACCARD_FLOOR`,
+    `require_double_entity=False`), DOIT être identique octet pour octet à
+    `PerspectiveService._is_topically_coherent` — c'est ce que vérifie le test
+    anti-drift `test_gate_pair_matches_real_gate`. Les paramètres servent
+    uniquement au `--sweep` (Iter 1) :
+      - `floor` : durcit le Jaccard minimal de la branche « weak double signal ».
+      - `require_double_entity` : désactive la branche faible (exige ≥2 entités
+        discriminantes partout).
+    """
+    if signals["title_jaccard"] >= PERSPECTIVE_TITLE_JACCARD_MIN:
+        return True, ""
+    full_signals = (
+        signals["shared_topics"] is not None
+        and signals["shared_entities"] is not None
+    )
+    if full_signals:
+        if signals["shared_entities"] and signals["shared_entities"] >= 2:
+            return True, ""
+        if require_double_entity:
+            return False, "no_signal"
+        if signals["title_jaccard"] >= floor:
+            topic_ok = bool(signals["shared_topics"] and signals["shared_topics"] >= 1)
+            entity_ok = bool(
+                signals["shared_entities"] and signals["shared_entities"] >= 1
+            )
+            if topic_ok and entity_ok:
+                return True, ""
+        return False, "no_signal"
+    return False, "low_jaccard"
+
+
+def classify_accept_path(signals: dict) -> str | None:
+    """Chemin de la porte RÉELLE qui accepte cette paire (None si rejetée).
+
+    Sert à l'attribution des FP. Doit s'accorder avec
+    `_is_topically_coherent` (test anti-drift).
+    """
+    if signals["title_jaccard"] >= PERSPECTIVE_TITLE_JACCARD_MIN:
+        return "strong_jaccard"
+    full_signals = (
+        signals["shared_topics"] is not None
+        and signals["shared_entities"] is not None
+    )
+    if full_signals:
+        if signals["shared_entities"] and signals["shared_entities"] >= 2:
+            return "double_entity"
+        if signals["title_jaccard"] >= PERSPECTIVE_MIN_JACCARD_FLOOR:
+            topic_ok = bool(signals["shared_topics"] and signals["shared_topics"] >= 1)
+            entity_ok = bool(
+                signals["shared_entities"] and signals["shared_entities"] >= 1
+            )
+            if topic_ok and entity_ok:
+                return "weak_double_signal"
+    return None
+
+
+def classify_reject_reason(signals: dict) -> str | None:
+    """Raison du rejet d'une paire (attribution des FN). None si acceptée.
+
+    - `low_jaccard`        : signaux incomplets (Layer 2/3) + Jaccard < seuil fort.
+    - `jaccard_below_floor`: full_signals, mais Jaccard sous le floor de la
+      branche faible (le gap des paraphrases : titres reformulés → Jaccard ~0).
+    - `no_shared_topic`    : full_signals, Jaccard ≥ floor, mais 0 topic partagé.
+    - `no_shared_entity`   : idem, 0 entité discriminante partagée.
+    """
+    if classify_accept_path(signals) is not None:
+        return None
+    full_signals = (
+        signals["shared_topics"] is not None
+        and signals["shared_entities"] is not None
+    )
+    if not full_signals:
+        return "low_jaccard"
+    if signals["title_jaccard"] < PERSPECTIVE_MIN_JACCARD_FLOOR:
+        return "jaccard_below_floor"
+    if not (signals["shared_topics"] and signals["shared_topics"] >= 1):
+        return "no_shared_topic"
+    if not (signals["shared_entities"] and signals["shared_entities"] >= 1):
+        return "no_shared_entity"
+    return "no_signal"
+
+
+# ---------------------------------------------------------------------------
+# Modèle de données
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GoldArticle:
+    id: str
+    title: str
+    topics: list[str]
+    entities: list[str]
+    event_id: str
+
+    # Pré-calcul des primitives seed (mêmes formules que le call-site).
+    def seed_tokens(self) -> set[str]:
+        return normalize_title(self.title)
+
+    def seed_topics(self) -> set[str]:
+        return {t.lower() for t in (self.topics or []) if t}
+
+    def seed_disc_entities(self) -> set[str]:
+        return set(
+            _parse_entity_names(
+                self.entities, types=PERSPECTIVE_DISCRIMINANT_ENTITY_TYPES
+            )
+        )
+
+
+def load_dataset(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _pool_articles(pool: dict) -> list[GoldArticle]:
+    return [
+        GoldArticle(
+            id=str(a["id"]),
+            title=a.get("title") or "",
+            topics=list(a.get("topics") or []),
+            entities=list(a.get("entities") or []),
+            event_id=(a.get("event_id") or NOISE_EVENT_ID),
+        )
+        for a in pool["articles"]
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Évaluation pairwise
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PairResult:
+    pool_key: str
+    seed_id: str
+    cand_id: str
+    predicted_same: bool
+    gold_same: bool
+    accept_path: str | None  # si prédit positif
+    reject_reason: str | None  # si prédit négatif
+    full_signals: bool
+
+
+@dataclass
+class PoolScore:
+    pool_key: str
+    n_articles: int
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    tn: int = 0
+    # contamination : par seed, off_event_admitted / total_admitted
+    contamination: list[tuple[str, float]] = field(default_factory=list)
+
+    @property
+    def precision(self) -> float:
+        return _safe_div(self.tp, self.tp + self.fp)
+
+    @property
+    def recall(self) -> float:
+        return _safe_div(self.tp, self.tp + self.fn)
+
+    @property
+    def f1(self) -> float:
+        return _f1(self.precision, self.recall)
+
+
+def _gold_same(seed: GoldArticle, cand: GoldArticle) -> bool:
+    return seed.event_id == cand.event_id and seed.event_id != NOISE_EVENT_ID
+
+
+def evaluate_pool(
+    pool: dict,
+    floor: float = PERSPECTIVE_MIN_JACCARD_FLOOR,
+    require_double_entity: bool = False,
+) -> tuple[PoolScore, list[PairResult]]:
+    """Rejoue la porte sur toutes les paires ordonnées (seed≠cand) d'un pool."""
+    articles = _pool_articles(pool)
+    pool_key = pool.get("pool_key", "?")
+    score = PoolScore(pool_key=pool_key, n_articles=len(articles))
+    results: list[PairResult] = []
+
+    for seed in articles:
+        seed_tokens = seed.seed_tokens()
+        seed_topics = seed.seed_topics()
+        seed_disc = seed.seed_disc_entities()
+        admitted = 0
+        admitted_off = 0
+        for cand in articles:
+            if cand.id == seed.id:
+                continue
+            signals = PerspectiveService._topical_signals(
+                seed_tokens,
+                seed_topics,
+                seed_disc,
+                cand_title=cand.title,
+                cand_topics=cand.topics,
+                cand_entities=cand.entities,
+            )
+            predicted_same, _ = gate_pair(
+                signals, floor=floor, require_double_entity=require_double_entity
+            )
+            gold = _gold_same(seed, cand)
+            full = (
+                signals["shared_topics"] is not None
+                and signals["shared_entities"] is not None
+            )
+            accept_path = classify_accept_path(signals) if predicted_same else None
+            reject_reason = (
+                classify_reject_reason(signals) if not predicted_same else None
+            )
+            results.append(
+                PairResult(
+                    pool_key=pool_key,
+                    seed_id=seed.id,
+                    cand_id=cand.id,
+                    predicted_same=predicted_same,
+                    gold_same=gold,
+                    accept_path=accept_path,
+                    reject_reason=reject_reason,
+                    full_signals=full,
+                )
+            )
+            if predicted_same and gold:
+                score.tp += 1
+            elif predicted_same and not gold:
+                score.fp += 1
+            elif not predicted_same and gold:
+                score.fn += 1
+            else:
+                score.tn += 1
+            if predicted_same:
+                admitted += 1
+                if not gold:
+                    admitted_off += 1
+        if admitted:
+            score.contamination.append((seed.id, admitted_off / admitted))
+
+    return score, results
+
+
+# ---------------------------------------------------------------------------
+# Agrégation
+# ---------------------------------------------------------------------------
+
+
+def _safe_div(num: float, denom: float) -> float:
+    return num / denom if denom else 0.0
+
+
+def _f1(precision: float, recall: float) -> float:
+    return _safe_div(2 * precision * recall, precision + recall)
+
+
+def aggregate(
+    pool_scores: list[PoolScore], pair_results: list[PairResult]
+) -> dict:
+    tp = sum(s.tp for s in pool_scores)
+    fp = sum(s.fp for s in pool_scores)
+    fn = sum(s.fn for s in pool_scores)
+    tn = sum(s.tn for s in pool_scores)
+    p = _safe_div(tp, tp + fp)
+    r = _safe_div(tp, tp + fn)
+
+    # Macro = moyenne des métriques par pool (un gros pool ne domine pas).
+    scored_pools = [s for s in pool_scores if (s.tp + s.fp + s.fn) > 0]
+    macro_p = _safe_div(sum(s.precision for s in scored_pools), len(scored_pools))
+    macro_r = _safe_div(sum(s.recall for s in scored_pools), len(scored_pools))
+    macro_f1 = _safe_div(sum(s.f1 for s in scored_pools), len(scored_pools))
+
+    # Contamination : moyenne sur tous les seeds ayant admis ≥1 candidat.
+    contam_pairs = [c for s in pool_scores for c in s.contamination]
+    mean_contam = _safe_div(sum(v for _, v in contam_pairs), len(contam_pairs))
+    worst = sorted(contam_pairs, key=lambda c: c[1], reverse=True)[:10]
+
+    # FP par chemin d'acceptation ; FN par raison.
+    fp_paths: Counter = Counter()
+    for pr in pair_results:
+        if pr.predicted_same and not pr.gold_same:
+            fp_paths[pr.accept_path or "unknown"] += 1
+    fn_reasons: Counter = Counter()
+    for pr in pair_results:
+        if not pr.predicted_same and pr.gold_same:
+            fn_reasons[pr.reject_reason or "unknown"] += 1
+
+    # Couverture des signaux.
+    n_pairs = len(pair_results)
+    n_full = sum(1 for pr in pair_results if pr.full_signals)
+
+    return {
+        "n_pools": len(pool_scores),
+        "n_scored_pools": len(scored_pools),
+        "n_pairs": n_pairs,
+        "micro": {
+            "tp": tp, "fp": fp, "fn": fn, "tn": tn,
+            "precision": p, "recall": r, "f1": _f1(p, r),
+        },
+        "macro": {
+            "precision": macro_p, "recall": macro_r, "f1": macro_f1,
+        },
+        "contamination": {
+            "mean": mean_contam,
+            "n_seeds": len(contam_pairs),
+            "worst": worst,
+        },
+        "fp_by_accept_path": dict(fp_paths.most_common()),
+        "fn_by_reason": dict(fn_reasons.most_common()),
+        "signal_coverage": {
+            "n_pairs": n_pairs,
+            "n_full_signals": n_full,
+            "full_signals_ratio": _safe_div(n_full, n_pairs),
+        },
+        "per_pool": [
+            {
+                "pool_key": s.pool_key,
+                "n_articles": s.n_articles,
+                "tp": s.tp, "fp": s.fp, "fn": s.fn,
+                "precision": s.precision, "recall": s.recall, "f1": s.f1,
+            }
+            for s in pool_scores
+        ],
+    }
+
+
+def evaluate_dataset(
+    dataset: dict,
+    floor: float = PERSPECTIVE_MIN_JACCARD_FLOOR,
+    require_double_entity: bool = False,
+) -> dict:
+    pool_scores: list[PoolScore] = []
+    pair_results: list[PairResult] = []
+    for pool in dataset["pools"]:
+        score, results = evaluate_pool(
+            pool, floor=floor, require_double_entity=require_double_entity
+        )
+        pool_scores.append(score)
+        pair_results.extend(results)
+    return aggregate(pool_scores, pair_results)
+
+
+# ---------------------------------------------------------------------------
+# Sweep
+# ---------------------------------------------------------------------------
+
+
+def sweep(
+    dataset: dict, floors: list[float]
+) -> list[dict]:
+    """Balaie le floor + la variante « exiger 2 entités partout »."""
+    rows: list[dict] = []
+    for floor in floors:
+        m = evaluate_dataset(dataset, floor=floor)
+        rows.append({
+            "setting": f"floor={floor:.2f}",
+            "floor": floor,
+            "require_double_entity": False,
+            "precision": m["micro"]["precision"],
+            "recall": m["micro"]["recall"],
+            "f1": m["micro"]["f1"],
+            "contamination": m["contamination"]["mean"],
+            "fp": m["micro"]["fp"],
+            "fn": m["micro"]["fn"],
+        })
+    m2 = evaluate_dataset(dataset, require_double_entity=True)
+    rows.append({
+        "setting": "require_entities>=2",
+        "floor": None,
+        "require_double_entity": True,
+        "precision": m2["micro"]["precision"],
+        "recall": m2["micro"]["recall"],
+        "f1": m2["micro"]["f1"],
+        "contamination": m2["contamination"]["mean"],
+        "fp": m2["micro"]["fp"],
+        "fn": m2["micro"]["fn"],
+    })
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _id_short(s: str) -> str:
+    return s[:8] if len(s) > 8 else s
+
+
+def render_report(metrics: dict, dataset_path: Path, tag: str) -> str:
+    today = datetime.now(UTC).date().isoformat()
+    micro = metrics["micro"]
+    macro = metrics["macro"]
+    contam = metrics["contamination"]
+    cov = metrics["signal_coverage"]
+    out = [
+        f"# Évaluation clustering perspectives — `{tag}` ({today})",
+        "",
+        f"- Dataset : `{dataset_path.name}`",
+        f"- Pools : {metrics['n_pools']} (scorés : {metrics['n_scored_pools']}) · "
+        f"Paires ordonnées : {metrics['n_pairs']}",
+        "",
+        "> Périmètre **déterministe** = la *porte* `_is_topically_coherent`. "
+        "Layer 2/3 (Google News) génère des candidats sans topics/entities — "
+        "hors mesure ici (on évalue la porte, pas la génération de candidats).",
+        "",
+        "## Métriques pairwise",
+        "",
+        f"- **Micro** : P = {micro['precision']:.3f} · R = {micro['recall']:.3f} · "
+        f"F1 = {micro['f1']:.3f}  (TP={micro['tp']} FP={micro['fp']} "
+        f"FN={micro['fn']} TN={micro['tn']})",
+        f"- **Macro** (moyenne par pool) : P = {macro['precision']:.3f} · "
+        f"R = {macro['recall']:.3f} · F1 = {macro['f1']:.3f}",
+        "",
+        "## Contamination par seed",
+        "",
+        f"- Moyenne : {contam['mean']:.3f}  (sur {contam['n_seeds']} seeds "
+        "ayant admis ≥1 candidat)",
+    ]
+    if contam["worst"]:
+        out.append("- Pires offenders (junk-drawers) :")
+        for seed_id, val in contam["worst"][:5]:
+            out.append(f"  - `{_id_short(seed_id)}` : {val:.2f}")
+    out.append("")
+    out.append("## FP par chemin d'acceptation (la fuite)")
+    out.append("")
+    if metrics["fp_by_accept_path"]:
+        for path, n in metrics["fp_by_accept_path"].items():
+            out.append(f"- `{path}` : {n}")
+    else:
+        out.append("- *(aucun FP)*")
+    out.append("")
+    out.append("## FN par signal manquant (gap paraphrases)")
+    out.append("")
+    if metrics["fn_by_reason"]:
+        for reason, n in metrics["fn_by_reason"].items():
+            out.append(f"- `{reason}` : {n}")
+    else:
+        out.append("- *(aucun FN)*")
+    out.append("")
+    out.append("## Couverture des signaux")
+    out.append("")
+    out.append(
+        f"- `full_signals` : {cov['n_full_signals']}/{cov['n_pairs']} "
+        f"({cov['full_signals_ratio']:.1%}) — garde-fou attribution de la fuite"
+    )
+    out.append("")
+    out.append("## Détail par pool")
+    out.append("")
+    out.append("| pool | n | TP | FP | FN | P | R | F1 |")
+    out.append("|------|---|----|----|----|---|---|----|")
+    for p in metrics["per_pool"]:
+        out.append(
+            f"| `{p['pool_key']}` | {p['n_articles']} | {p['tp']} | {p['fp']} | "
+            f"{p['fn']} | {p['precision']:.2f} | {p['recall']:.2f} | "
+            f"{p['f1']:.2f} |"
+        )
+    out.append("")
+    return "\n".join(out)
+
+
+def render_sweep(rows: list[dict]) -> str:
+    out = [
+        "## Sweep floor (branche « weak double signal »)",
+        "",
+        "| Réglage | P | R | F1 | Contam | FP | FN |",
+        "|---------|---|---|----|--------|----|----|",
+    ]
+    for row in rows:
+        out.append(
+            f"| {row['setting']} | {row['precision']:.3f} | {row['recall']:.3f} | "
+            f"{row['f1']:.3f} | {row['contamination']:.3f} | {row['fp']} | "
+            f"{row['fn']} |"
+        )
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Compare mode
+# ---------------------------------------------------------------------------
+
+
+def render_compare(baseline: dict, after: dict) -> str:
+    lines = [
+        "# Comparaison baseline ↔ after",
+        "",
+        f"Paires baseline = {baseline['n_pairs']} · after = {after['n_pairs']}",
+        "",
+        "| Métrique | baseline | after | Δ |",
+        "|----------|----------|-------|---|",
+    ]
+    for metric in ("precision", "recall", "f1"):
+        b = baseline["micro"][metric]
+        a = after["micro"][metric]
+        lines.append(f"| micro {metric} | {b:.3f} | {a:.3f} | {a - b:+.3f} |")
+    bc = baseline["contamination"]["mean"]
+    ac = after["contamination"]["mean"]
+    lines.append(f"| contamination | {bc:.3f} | {ac:.3f} | {ac - bc:+.3f} |")
+    bfp = baseline["micro"]["fp"]
+    afp = after["micro"]["fp"]
+    lines.append(f"| FP | {bfp} | {afp} | {afp - bfp:+d} |")
+    bfn = baseline["micro"]["fn"]
+    afn = after["micro"]["fn"]
+    lines.append(f"| FN | {bfn} | {afn} | {afn - bfn:+d} |")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", help="Dataset gold étiqueté (mode évaluation)")
+    parser.add_argument("--tag", default="baseline", help="Nom de l'itération")
+    parser.add_argument(
+        "--sweep",
+        action="store_true",
+        help="Balaie le floor + variante « 2 entités partout » (Iter 1)",
+    )
+    parser.add_argument(
+        "--floor",
+        type=float,
+        default=None,
+        help="Override ponctuel du floor (sinon PERSPECTIVE_MIN_JACCARD_FLOOR)",
+    )
+    parser.add_argument(
+        "--require-double-entity",
+        action="store_true",
+        help="Évalue la variante « exiger ≥2 entités discriminantes partout »",
+    )
+    parser.add_argument(
+        "--compare",
+        nargs=2,
+        metavar=("BASELINE", "AFTER"),
+        help="Mode comparaison : 2 JSON produits par ce script",
+    )
+    parser.add_argument("--out-json", default=None)
+    parser.add_argument("--out-md", default=None)
+    args = parser.parse_args()
+
+    if args.compare:
+        baseline = json.loads(Path(args.compare[0]).read_text(encoding="utf-8"))
+        after = json.loads(Path(args.compare[1]).read_text(encoding="utf-8"))
+        print(render_compare(baseline["metrics"], after["metrics"]))
+        return
+
+    if not args.dataset:
+        parser.error("--dataset requis (sauf en mode --compare)")
+
+    dataset_path = Path(args.dataset)
+    dataset = load_dataset(dataset_path)
+
+    floor = args.floor if args.floor is not None else PERSPECTIVE_MIN_JACCARD_FLOOR
+    metrics = evaluate_dataset(
+        dataset, floor=floor, require_double_entity=args.require_double_entity
+    )
+    report = render_report(metrics, dataset_path, args.tag)
+
+    sweep_rows = sweep(dataset, DEFAULT_FLOOR_SWEEP) if args.sweep else None
+    if sweep_rows:
+        report = report + "\n" + render_sweep(sweep_rows) + "\n"
+
+    today = datetime.now(UTC).date().isoformat()
+    out_json = Path(
+        args.out_json or CONTEXT_DIR / f"gold-events-{args.tag}-{today}.json"
+    )
+    out_md = Path(args.out_md or CONTEXT_DIR / f"gold-events-{args.tag}-{today}.md")
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "dataset": dataset_path.name,
+        "tag": args.tag,
+        "floor": floor,
+        "require_double_entity": args.require_double_entity,
+        "metrics": metrics,
+        "sweep": sweep_rows,
+    }
+    out_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    out_md.write_text(report, encoding="utf-8")
+
+    print(f"✅ Résultats : {out_json}")
+    print(f"✅ Rapport   : {out_md}")
+    print()
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/label_event_dataset.py
+++ b/packages/api/scripts/label_event_dataset.py
@@ -1,0 +1,353 @@
+"""Pré-étiquetage LLM du gold « appartenance à un événement » + substrat de
+revue PO (cf. `docs/maintenance/maintenance-clustering-calibration.md`).
+
+Approche **cluster-assign** (1 prompt par pool, pas O(n²) de paires) : on
+demande à Mistral-large de re-partitionner les titres d'un pool — qui
+mentionnent tous l'entité seed — par **événement concret** (mêmes
+acteurs / action / moment). Deux titres qui ne partagent que la personnalité
+seed mais des sujets différents ne sont PAS le même événement → sentinelle
+`NOISE`.
+
+Le LLM ne fait qu'un *brouillon* : le PO relit ensuite chaque pool, corrige
+les `event_id` et passe `label_reviewed=true` directement dans le JSON
+`.context/`. Le validateur **n'écrase jamais** un article déjà revu.
+
+Modes :
+    --mode fill  : étiquette les pools NON revus (aucun `label_reviewed=true`).
+    --mode blind : ré-étiquette les pools DÉJÀ revus, dans un champ fantôme
+                   `event_id_blind`, pour mesurer l'accord LLM↔PO (qualité du
+                   gold) sans toucher au gold.
+    --mode all   : les deux.
+
+Garde-fous :
+    - `EVENT_LABEL_DRY_RUN=1` → stub déterministe (1 événement par article,
+      slug `evt-<i>`), aucun appel API. Utilisé par les tests hermétiques.
+
+Usage :
+    cd packages/api && python scripts/label_event_dataset.py \\
+        --dataset ../../.context/gold-events-2026-06-09.json --mode fill
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+import unicodedata
+from collections import Counter
+from pathlib import Path
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+import structlog  # noqa: E402
+
+from app.services.editorial.llm_client import EditorialLLMClient  # noqa: E402
+
+logger = structlog.get_logger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTEXT_DIR = REPO_ROOT / ".context"
+
+NOISE_EVENT_ID = "NOISE"
+DEFAULT_MODEL = "mistral-large-latest"
+
+
+# ---------------------------------------------------------------------------
+# Slug
+# ---------------------------------------------------------------------------
+
+
+def slugify(text: str) -> str:
+    """slug stable : minuscules, sans accents, [a-z0-9-], compacté."""
+    if not text:
+        return "event"
+    text = text.lower()
+    text = unicodedata.normalize("NFD", text)
+    text = "".join(c for c in text if unicodedata.category(c) != "Mn")
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = text.strip("-")
+    return text or "event"
+
+
+# ---------------------------------------------------------------------------
+# Prompt LLM
+# ---------------------------------------------------------------------------
+
+
+def build_system_prompt(seed_name: str) -> str:
+    return (
+        "Tu es un analyste média. On te donne une liste de titres d'actualité "
+        f"qui mentionnent tous « {seed_name} ». Regroupe-les par ÉVÉNEMENT "
+        "CONCRET : même acteurs, même action, même moment. "
+        f"Deux titres qui ne partagent QUE la personnalité/organisation « {seed_name} » "
+        "mais traitent de sujets différents ne sont PAS le même événement.\n\n"
+        "Réponds en JSON STRICT :\n"
+        '{"events": [{"event_id": "slug-court", "label": "Libellé humain", '
+        '"article_indices": [0, 2]}], "noise_indices": [1, 3]}\n\n'
+        "Règles :\n"
+        "- `article_indices` = indices (0-based) des titres de l'événement.\n"
+        "- Un événement doit regrouper ≥2 titres ; un titre isolé va dans "
+        "`noise_indices`.\n"
+        "- Chaque indice apparaît AU PLUS une fois (dans un seul événement, "
+        "ou dans noise).\n"
+        "- `event_id` : slug court, stable, en minuscules (ex: "
+        '"iran-israel-frappes").\n'
+        "- Ne renvoie QUE le JSON, rien d'autre."
+    )
+
+
+def build_user_message(titles: list[str]) -> str:
+    lines = [f"{i}. {t}" for i, t in enumerate(titles)]
+    return "Titres :\n" + "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Appel LLM (avec dry-run)
+# ---------------------------------------------------------------------------
+
+
+def _is_dry_run() -> bool:
+    return os.environ.get("EVENT_LABEL_DRY_RUN") == "1"
+
+
+def _dry_run_partition(titles: list[str]) -> dict:
+    """Stub déterministe : 1 événement par article (aucun appel API)."""
+    return {
+        "events": [
+            {"event_id": f"evt-{i}", "label": titles[i][:40], "article_indices": [i]}
+            for i in range(len(titles))
+        ],
+        "noise_indices": [],
+    }
+
+
+async def partition_pool(
+    client: EditorialLLMClient | None,
+    pool: dict,
+    model: str = DEFAULT_MODEL,
+) -> dict | None:
+    """Demande au LLM la partition par événement d'un pool. None sur échec."""
+    titles = [a.get("title") or "" for a in pool["articles"]]
+    if _is_dry_run():
+        return _dry_run_partition(titles)
+    assert client is not None, "client requis hors dry-run"
+    seed_name = (pool.get("seed_entity") or {}).get("name") or pool.get(
+        "pool_display", ""
+    )
+    result = await client.chat_json(
+        system=build_system_prompt(seed_name),
+        user_message=build_user_message(titles),
+        model=model,
+        temperature=0.0,
+        max_tokens=2000,
+    )
+    if not isinstance(result, dict) or "events" not in result:
+        return None
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Validateur + application
+# ---------------------------------------------------------------------------
+
+
+def resolve_assignment(partition: dict, n: int) -> tuple[list[str], dict[str, str]]:
+    """Calcule l'assignation finale par index.
+
+    Règle (tolérante) : un index assigné à **exactement un** événement →
+    cet événement ; assigné à 0 ou ≥2 événements → `NOISE`. Les labels sont
+    slugifiés.
+
+    Retourne (assignment[index] = event_id, {event_id: label}).
+    """
+    counts: Counter = Counter()
+    first_event: dict[int, str] = {}
+    labels: dict[str, str] = {}
+
+    for ev in partition.get("events") or []:
+        eid = slugify(ev.get("event_id") or ev.get("label") or "event")
+        labels.setdefault(eid, (ev.get("label") or eid))
+        for idx in ev.get("article_indices") or []:
+            if not isinstance(idx, int) or idx < 0 or idx >= n:
+                continue
+            counts[idx] += 1
+            first_event.setdefault(idx, eid)
+
+    assignment: list[str] = [NOISE_EVENT_ID] * n
+    for idx in range(n):
+        if counts[idx] == 1:
+            assignment[idx] = first_event[idx]
+        else:
+            assignment[idx] = NOISE_EVENT_ID
+    return assignment, labels
+
+
+def apply_partition(
+    pool: dict,
+    partition: dict,
+    *,
+    target_field: str = "event_id",
+    skip_reviewed: bool = True,
+    label_source: str = "llm_pass1",
+    confidence: float = 0.8,
+) -> int:
+    """Écrit l'assignation dans le pool. Retourne le nb d'articles écrits.
+
+    - `target_field` : `event_id` (mode fill) ou `event_id_blind` (mode blind).
+    - `skip_reviewed` : ne jamais écraser un article `label_reviewed=true`
+      (toujours True en mode fill ; False en blind où l'on écrit un champ
+      fantôme distinct).
+    """
+    articles = pool["articles"]
+    n = len(articles)
+    assignment, labels = resolve_assignment(partition, n)
+
+    written = 0
+    used_events: Counter = Counter()
+    for i, art in enumerate(articles):
+        if skip_reviewed and art.get("label_reviewed"):
+            used_events[art.get("event_id") or NOISE_EVENT_ID] += 1
+            continue
+        eid = assignment[i]
+        art[target_field] = eid
+        if target_field == "event_id":
+            art["label_source"] = label_source
+            art["label_confidence"] = confidence
+        used_events[eid] += 1
+        written += 1
+
+    # Reconstruit la liste `events` du pool (event_id → label + size) en mode fill.
+    if target_field == "event_id":
+        pool["events"] = [
+            {
+                "event_id": eid,
+                "label": labels.get(eid, eid),
+                "size": size,
+            }
+            for eid, size in sorted(used_events.items())
+            if eid != NOISE_EVENT_ID
+        ]
+        if used_events.get(NOISE_EVENT_ID):
+            pool["events"].append({
+                "event_id": NOISE_EVENT_ID,
+                "label": "singletons / hors-événement",
+                "size": used_events[NOISE_EVENT_ID],
+            })
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def pool_is_reviewed(pool: dict) -> bool:
+    return any(a.get("label_reviewed") for a in pool["articles"])
+
+
+def iter_pools_to_label(dataset: dict, mode: str):
+    """Yield (pool, reviewed) selon le mode."""
+    for pool in dataset["pools"]:
+        reviewed = pool_is_reviewed(pool)
+        if mode == "fill" and reviewed:
+            continue
+        if mode == "blind" and not reviewed:
+            continue
+        yield pool, reviewed
+
+
+async def run(
+    dataset_path: Path,
+    mode: str,
+    model: str,
+    out_path: Path,
+    limit: int | None,
+) -> None:
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+
+    client: EditorialLLMClient | None = None
+    if not _is_dry_run():
+        client = EditorialLLMClient()
+        if not client.is_ready:
+            print(
+                "❌ MISTRAL_API_KEY non défini. Set EVENT_LABEL_DRY_RUN=1 "
+                "pour un run sans API.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    n_done = 0
+    n_failed = 0
+    try:
+        for pool, reviewed in iter_pools_to_label(dataset, mode):
+            if limit is not None and n_done >= limit:
+                break
+            partition = await partition_pool(client, pool, model=model)
+            if partition is None:
+                n_failed += 1
+                logger.warning("event_label.failed", pool=pool.get("pool_key"))
+                continue
+            target_field = "event_id_blind" if reviewed else "event_id"
+            written = apply_partition(
+                pool,
+                partition,
+                target_field=target_field,
+                skip_reviewed=(not reviewed),
+            )
+            n_done += 1
+            n_events = len(partition.get("events") or [])
+            print(
+                f"  ✅ {pool.get('pool_key', '?')[:24]:<24} "
+                f"events={n_events} écrits={written} "
+                f"({'blind' if reviewed else 'fill'})"
+            )
+    finally:
+        if client is not None:
+            await client.close()
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(dataset, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(f"\n✅ Étiquetage terminé : {n_done} pools, {n_failed} échecs")
+    print(f"   Dataset enrichi : {out_path}")
+    if mode != "blind":
+        print(
+            "   → Revue PO : éditer les `event_id` douteux et passer "
+            "`label_reviewed: true` pool par pool."
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--mode", choices=("fill", "blind", "all"), default="fill")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Cap N pools (utile en dev)"
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Chemin de sortie (défaut : écrase le dataset d'entrée)",
+    )
+    args = parser.parse_args()
+
+    out_path = Path(args.out) if args.out else Path(args.dataset)
+
+    asyncio.run(
+        run(
+            dataset_path=Path(args.dataset),
+            mode=args.mode,
+            model=args.model,
+            out_path=out_path,
+            limit=args.limit,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/tests/scripts/fixtures/toy_event_dataset.json
+++ b/packages/api/tests/scripts/fixtures/toy_event_dataset.json
@@ -1,0 +1,120 @@
+{
+  "generated_at": "2026-06-09T00:00:00+00:00",
+  "schema_version": 1,
+  "dataset_kind": "event_membership",
+  "seed_window_hours": 72,
+  "pools": [
+    {
+      "pool_key": "trump",
+      "pool_display": "Trump",
+      "seed_entity": {"name": "Trump", "type": "PERSON"},
+      "theme": "international",
+      "events": [
+        {"event_id": "iran", "label": "Frappes Iran-Israël", "size": 3},
+        {"event_id": "nba", "label": "Finales NBA", "size": 1},
+        {"event_id": "NOISE", "label": "singletons / hors-événement", "size": 1}
+      ],
+      "articles": [
+        {
+          "id": "T1",
+          "title": "Trump frappe l'Iran, Téhéran riposte",
+          "url": "https://example.com/t1",
+          "published_at": "2026-06-08T08:00:00+00:00",
+          "source_name": "Le Monde",
+          "source_id": "src-1",
+          "bias_stance": "center-left",
+          "theme": "international",
+          "topics": ["geopolitics", "middleeast"],
+          "entities": [
+            "{\"name\": \"Trump\", \"type\": \"PERSON\"}",
+            "{\"name\": \"Iran\", \"type\": \"LOCATION\"}"
+          ],
+          "event_id": "iran",
+          "label_source": "po",
+          "label_reviewed": true,
+          "label_confidence": 1.0,
+          "label_notes": ""
+        },
+        {
+          "id": "T2",
+          "title": "Trump ordonne une frappe massive sur l'Iran",
+          "url": "https://example.com/t2",
+          "published_at": "2026-06-08T09:00:00+00:00",
+          "source_name": "Libération",
+          "source_id": "src-2",
+          "bias_stance": "left",
+          "theme": "international",
+          "topics": ["geopolitics", "middleeast"],
+          "entities": [
+            "{\"name\": \"Trump\", \"type\": \"PERSON\"}",
+            "{\"name\": \"Iran\", \"type\": \"LOCATION\"}"
+          ],
+          "event_id": "iran",
+          "label_source": "po",
+          "label_reviewed": true,
+          "label_confidence": 1.0,
+          "label_notes": ""
+        },
+        {
+          "id": "T4",
+          "title": "Guerre au Moyen-Orient : l'offensive se poursuit",
+          "url": "https://example.com/t4",
+          "published_at": "2026-06-08T10:00:00+00:00",
+          "source_name": "Le Figaro",
+          "source_id": "src-3",
+          "bias_stance": "right",
+          "theme": "international",
+          "topics": ["geopolitics", "middleeast"],
+          "entities": [
+            "{\"name\": \"Trump\", \"type\": \"PERSON\"}",
+            "{\"name\": \"Iran\", \"type\": \"LOCATION\"}"
+          ],
+          "event_id": "iran",
+          "label_source": "po",
+          "label_reviewed": true,
+          "label_confidence": 1.0,
+          "label_notes": "paraphrase : pas de token partagé avec T1/T2"
+        },
+        {
+          "id": "T3",
+          "title": "Trump hué aux finales NBA",
+          "url": "https://example.com/t3",
+          "published_at": "2026-06-08T11:00:00+00:00",
+          "source_name": "L'Équipe",
+          "source_id": "src-4",
+          "bias_stance": "center",
+          "theme": "international",
+          "topics": ["sport"],
+          "entities": [
+            "{\"name\": \"Trump\", \"type\": \"PERSON\"}",
+            "{\"name\": \"NBA\", \"type\": \"ORG\"}"
+          ],
+          "event_id": "nba",
+          "label_source": "po",
+          "label_reviewed": true,
+          "label_confidence": 1.0,
+          "label_notes": ""
+        },
+        {
+          "id": "N1",
+          "title": "Trump convoite les Chagos",
+          "url": "https://example.com/n1",
+          "published_at": "2026-06-08T12:00:00+00:00",
+          "source_name": "Mediapart",
+          "source_id": "src-5",
+          "bias_stance": "left",
+          "theme": "international",
+          "topics": ["geopolitics"],
+          "entities": [
+            "{\"name\": \"Trump\", \"type\": \"PERSON\"}"
+          ],
+          "event_id": "NOISE",
+          "label_source": "po",
+          "label_reviewed": true,
+          "label_confidence": 1.0,
+          "label_notes": "partage seulement l'entité Trump"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/api/tests/scripts/test_build_event_dataset.py
+++ b/packages/api/tests/scripts/test_build_event_dataset.py
@@ -1,0 +1,182 @@
+"""Tests hermétiques pour `scripts/build_event_dataset.py`.
+
+Couvre le seeding des pools par entité partagée, la fenêtre temporelle, le cap
+de taille, la stratification par thème (comptée en pools), et la sérialisation
+(`event_id: null`, prêt à étiqueter).
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from scripts.build_event_dataset import (
+    BuildStats,
+    EventArticle,
+    build_pools,
+    filter_window,
+    load_articles,
+    serialize_events,
+    stratify_pools,
+)
+from scripts.build_highlight_dataset import DEFAULT_QUOTAS
+
+BASE = datetime(2026, 6, 8, 12, 0, 0, tzinfo=UTC)
+
+
+def _entity(name: str, type_: str = "PERSON") -> str:
+    return json.dumps({"name": name, "type": type_})
+
+
+def _art(
+    aid: str,
+    entity: str,
+    *,
+    theme: str = "international",
+    topics=None,
+    hours_ago: int = 0,
+    source: str | None = None,
+) -> EventArticle:
+    return EventArticle(
+        id=aid,
+        title=f"Titre {aid} {entity}",
+        url=f"https://example.com/{aid}",
+        published_at=BASE - timedelta(hours=hours_ago),
+        source_name=source or f"src-{aid}",
+        source_id=source or f"src-{aid}",
+        bias_stance="center",
+        theme=theme,
+        topics=topics or ["geopolitics"],
+        entities=[_entity(entity)],
+    )
+
+
+def _pool_of(entity: str, n: int, **kw) -> list[EventArticle]:
+    return [_art(f"{entity}-{i}", entity, **kw) for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# load_articles porte topics
+# ---------------------------------------------------------------------------
+
+
+def test_load_articles_carries_topics(tmp_path: Path):
+    raw = {
+        "articles": [
+            {
+                "id": "a1",
+                "title": "T",
+                "url": "u",
+                "published_at": "2026-06-08T08:00:00Z",
+                "source_name": "Le Monde",
+                "source_id": "s1",
+                "bias_stance": "center",
+                "theme": "international",
+                "topics": ["geopolitics", "middleeast"],
+                "entities": [_entity("Trump")],
+            }
+        ]
+    }
+    p = tmp_path / "raw.json"
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    arts = load_articles(p)
+    assert len(arts) == 1
+    assert arts[0].topics == ["geopolitics", "middleeast"]
+    assert arts[0].entity_keys() == [("trump", "Trump")]
+
+
+# ---------------------------------------------------------------------------
+# build_pools : seeding par entité partagée, fenêtre, cap
+# ---------------------------------------------------------------------------
+
+
+def test_build_pools_seeds_by_shared_entity():
+    arts = _pool_of("Trump", 3) + _pool_of("Macron", 3)
+    stats = BuildStats(n_articles=len(arts))
+    pools = build_pools(arts, min_size=3, window_hours=72, max_per_pool=30, stats=stats)
+    keys = {p.key for p in pools}
+    assert keys == {"trump", "macron"}
+    trump = next(p for p in pools if p.key == "trump")
+    assert trump.seed_type == "PERSON"
+    assert trump.display == "Trump"
+    assert len(trump.articles) == 3
+
+
+def test_build_pools_drops_pool_below_min_size_after_window():
+    # 2 articles récents + 2 hors fenêtre → après fenêtre 72h il reste 2 < min 3
+    arts = _pool_of("Trump", 2, hours_ago=0) + _pool_of("Trump", 2, hours_ago=200)
+    # renommer les ids pour éviter collision
+    for i, a in enumerate(arts):
+        a.id = f"trump-{i}"
+    stats = BuildStats(n_articles=len(arts))
+    pools = build_pools(arts, min_size=3, window_hours=72, max_per_pool=30, stats=stats)
+    assert pools == []
+
+
+def test_build_pools_caps_pool_size_keeping_recent():
+    arts = [_art(f"trump-{i}", "Trump", hours_ago=i) for i in range(10)]
+    stats = BuildStats(n_articles=len(arts))
+    pools = build_pools(arts, min_size=3, window_hours=72, max_per_pool=4, stats=stats)
+    assert len(pools) == 1
+    pool = pools[0]
+    assert len(pool.articles) == 4
+    # les 4 plus récents (hours_ago 0..3)
+    kept_ids = {a.id for a in pool.articles}
+    assert kept_ids == {"trump-0", "trump-1", "trump-2", "trump-3"}
+
+
+def test_filter_window_keeps_within_window_of_latest():
+    arts = [
+        _art("a", "Trump", hours_ago=0),
+        _art("b", "Trump", hours_ago=50),
+        _art("c", "Trump", hours_ago=100),
+    ]
+    kept = filter_window(arts, hours=72)
+    assert {a.id for a in kept} == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# stratify_pools : quotas comptés en pools
+# ---------------------------------------------------------------------------
+
+
+def test_stratify_pools_respects_seeds_per_theme_override():
+    arts = _pool_of("Trump", 5) + _pool_of("Macron", 4) + _pool_of("Biden", 3)
+    stats = BuildStats(n_articles=len(arts))
+    pools = build_pools(arts, min_size=3, window_hours=72, max_per_pool=30, stats=stats)
+    selected = stratify_pools(pools, DEFAULT_QUOTAS, seeds_per_theme=2, stats=stats)
+    assert len(selected) == 2
+    # les 2 plus gros pools d'abord (Trump=5, Macron=4)
+    assert {p.key for p in selected} == {"trump", "macron"}
+
+
+def test_stratify_pools_skips_unknown_theme():
+    arts = _pool_of("Trump", 3, theme="theme-inexistant")
+    stats = BuildStats(n_articles=len(arts))
+    pools = build_pools(arts, min_size=3, window_hours=72, max_per_pool=30, stats=stats)
+    selected = stratify_pools(pools, DEFAULT_QUOTAS, seeds_per_theme=5, stats=stats)
+    assert selected == []
+
+
+# ---------------------------------------------------------------------------
+# serialize_events : event_id null, prêt à étiqueter
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_events_shape_ready_to_label():
+    arts = _pool_of("Trump", 3, topics=["geopolitics", "middleeast"])
+    stats = BuildStats(n_articles=len(arts))
+    pools = build_pools(arts, min_size=3, window_hours=72, max_per_pool=30, stats=stats)
+    payload = serialize_events(pools, window_hours=72, quotas=DEFAULT_QUOTAS)
+
+    assert payload["dataset_kind"] == "event_membership"
+    assert payload["seed_window_hours"] == 72
+    assert len(payload["pools"]) == 1
+    pool = payload["pools"][0]
+    assert pool["seed_entity"] == {"name": "Trump", "type": "PERSON"}
+    assert pool["events"] == []
+    for art in pool["articles"]:
+        assert art["event_id"] is None
+        assert art["label_reviewed"] is False
+        assert art["topics"] == ["geopolitics", "middleeast"]
+        # entities portées verbatim (chaînes JSON)
+        assert art["entities"] == [_entity("Trump")]

--- a/packages/api/tests/scripts/test_evaluate_event_clustering.py
+++ b/packages/api/tests/scripts/test_evaluate_event_clustering.py
@@ -1,0 +1,258 @@
+"""Tests hermétiques pour `scripts/evaluate_event_clustering.py`.
+
+Pas de réseau ni de DB : le harness importe les fonctions pures de la porte
+(`PerspectiveService._topical_signals`, `_is_topically_coherent`) et les
+rejoue sur un toy pool aux TP/FP/FN connus.
+
+Couvre :
+- `gate_pair` (défaut) == porte réelle `_is_topically_coherent` (anti-drift) ;
+- `classify_accept_path` / `classify_reject_reason` concordent avec la décision ;
+- agrégation pairwise sur le toy pool (TP/FP/FN connus, FP planté →
+  `weak_double_signal`, FN → `jaccard_below_floor`) ;
+- exclusion NOISE des positifs ;
+- sweep du floor (le FP planté disparaît à 0.15 sans coût de rappel) ;
+- format `render_compare`.
+"""
+
+import json
+from itertools import product
+from pathlib import Path
+
+from app.services.perspective_service import PerspectiveService
+from scripts.evaluate_event_clustering import (
+    classify_accept_path,
+    classify_reject_reason,
+    evaluate_dataset,
+    gate_pair,
+    render_compare,
+    sweep,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "toy_event_dataset.json"
+
+
+def _toy() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Anti-drift : gate_pair (défaut) doit reproduire la porte réelle
+# ---------------------------------------------------------------------------
+
+
+def _signal_grid():
+    jaccards = [0.0, 0.05, 0.08, 0.10, 0.1429, 0.15, 0.29, 0.30, 0.50]
+    topics = [None, 0, 1, 2]
+    entities = [None, 0, 1, 2]
+    for j, t, e in product(jaccards, topics, entities):
+        yield {"title_jaccard": j, "shared_topics": t, "shared_entities": e}
+
+
+def test_gate_pair_matches_real_gate():
+    """gate_pair() avec les params par défaut == _is_topically_coherent()."""
+    for signals in _signal_grid():
+        assert gate_pair(signals) == PerspectiveService._is_topically_coherent(
+            signals
+        ), signals
+
+
+def test_classify_accept_path_agrees_with_decision():
+    """accept_path non-None ⟺ porte accepte ; reject_reason non-None ⟺ rejette."""
+    for signals in _signal_grid():
+        is_ok, _ = PerspectiveService._is_topically_coherent(signals)
+        assert (classify_accept_path(signals) is not None) == is_ok, signals
+        assert (classify_reject_reason(signals) is None) == is_ok, signals
+
+
+def test_classify_accept_path_buckets():
+    """Les 3 chemins d'acceptation sont bien discriminés."""
+    # strong jaccard
+    assert (
+        classify_accept_path(
+            {"title_jaccard": 0.5, "shared_topics": 0, "shared_entities": 0}
+        )
+        == "strong_jaccard"
+    )
+    # 2 entités discriminantes (pas de floor requis)
+    assert (
+        classify_accept_path(
+            {"title_jaccard": 0.0, "shared_topics": 0, "shared_entities": 2}
+        )
+        == "double_entity"
+    )
+    # weak double signal (la fuite) — Jaccard ≥ floor (0.15 > 0.12 calibré Iter 1)
+    assert (
+        classify_accept_path(
+            {"title_jaccard": 0.15, "shared_topics": 1, "shared_entities": 1}
+        )
+        == "weak_double_signal"
+    )
+    # rejeté
+    assert (
+        classify_accept_path(
+            {"title_jaccard": 0.0, "shared_topics": 1, "shared_entities": 1}
+        )
+        is None
+    )
+
+
+def test_classify_reject_reason_buckets():
+    # signaux incomplets (Layer 2/3) + jaccard faible
+    assert (
+        classify_reject_reason(
+            {"title_jaccard": 0.0, "shared_topics": None, "shared_entities": None}
+        )
+        == "low_jaccard"
+    )
+    # full signals mais jaccard sous le floor (le gap des paraphrases)
+    assert (
+        classify_reject_reason(
+            {"title_jaccard": 0.0, "shared_topics": 2, "shared_entities": 1}
+        )
+        == "jaccard_below_floor"
+    )
+    # jaccard ≥ floor mais aucun topic partagé (0.15 > 0.12 calibré Iter 1)
+    assert (
+        classify_reject_reason(
+            {"title_jaccard": 0.15, "shared_topics": 0, "shared_entities": 1}
+        )
+        == "no_shared_topic"
+    )
+    # jaccard ≥ floor, topic partagé, mais aucune entité partagée
+    assert (
+        classify_reject_reason(
+            {"title_jaccard": 0.15, "shared_topics": 1, "shared_entities": 0}
+        )
+        == "no_shared_entity"
+    )
+
+
+# ---------------------------------------------------------------------------
+# gate_pair paramétrable (sweep)
+# ---------------------------------------------------------------------------
+
+
+def test_gate_pair_higher_floor_rejects_weak_double_signal():
+    """Un weak double signal à Jaccard 0.1429 est accepté à 0.08, rejeté à 0.15."""
+    signals = {"title_jaccard": 0.1429, "shared_topics": 1, "shared_entities": 1}
+    assert gate_pair(signals, floor=0.08)[0] is True
+    assert gate_pair(signals, floor=0.15)[0] is False
+
+
+def test_gate_pair_require_double_entity_disables_weak_branch():
+    signals = {"title_jaccard": 0.1429, "shared_topics": 1, "shared_entities": 1}
+    assert gate_pair(signals, require_double_entity=True)[0] is False
+    # mais 2 entités partagées passent toujours
+    strong = {"title_jaccard": 0.0, "shared_topics": 0, "shared_entities": 2}
+    assert gate_pair(strong, require_double_entity=True)[0] is True
+
+
+# ---------------------------------------------------------------------------
+# Agrégation pairwise sur le toy pool (TP/FP/FN connus)
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_toy_pool_known_confusion():
+    """5 articles : iran(3) + nba(1) + NOISE(1).
+
+    20 paires ordonnées → TP=2 (T1↔T2 fort Jaccard), FP=4 (Trump/NOISE via
+    weak_double_signal), FN=4 (paraphrase T4 ↔ T1/T2, Jaccard sous le floor),
+    TN=10.
+    """
+    metrics = evaluate_dataset(_toy())
+    micro = metrics["micro"]
+    assert metrics["n_pairs"] == 20
+    assert micro["tp"] == 2
+    assert micro["fp"] == 4
+    assert micro["fn"] == 4
+    assert micro["tn"] == 10
+    assert round(micro["precision"], 3) == 0.333
+    assert round(micro["recall"], 3) == 0.333
+
+
+def test_evaluate_toy_pool_fp_leak_is_weak_double_signal():
+    """La fuite : tous les FP passent par `weak_double_signal`."""
+    metrics = evaluate_dataset(_toy())
+    assert metrics["fp_by_accept_path"] == {"weak_double_signal": 4}
+
+
+def test_evaluate_toy_pool_fn_is_paraphrase_gap():
+    """Le gap : tous les FN sont des paraphrases sous le floor de Jaccard."""
+    metrics = evaluate_dataset(_toy())
+    assert metrics["fn_by_reason"] == {"jaccard_below_floor": 4}
+
+
+def test_evaluate_toy_pool_full_signal_coverage():
+    """Tous les articles portent topics+entities → 100% full_signals."""
+    metrics = evaluate_dataset(_toy())
+    assert metrics["signal_coverage"]["full_signals_ratio"] == 1.0
+
+
+def test_evaluate_toy_pool_contamination():
+    """Contamination moyenne = (0.5 + 0.5 + 1.0)/3 ; pire offender = le NOISE seed."""
+    metrics = evaluate_dataset(_toy())
+    contam = metrics["contamination"]
+    assert round(contam["mean"], 3) == 0.667
+    assert contam["n_seeds"] == 3
+    assert contam["worst"][0][1] == 1.0  # le seed NOISE admet 100% d'off-event
+
+
+def test_noise_never_counts_as_positive():
+    """Si TOUT est NOISE, aucun positif gold : TP=FN=0, et chaque paire admise
+    devient un FP (les 2 fort-Jaccard + les 4 weak = 6 acceptations)."""
+    ds = _toy()
+    for a in ds["pools"][0]["articles"]:
+        a["event_id"] = "NOISE"
+    metrics = evaluate_dataset(ds)
+    assert metrics["micro"]["tp"] == 0
+    assert metrics["micro"]["fn"] == 0
+    assert metrics["micro"]["fp"] == 6  # 2 (T1↔T2 fort) + 4 (Trump/NOISE weak)
+
+
+# ---------------------------------------------------------------------------
+# Sweep
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_floor_kills_planted_fp_without_recall_cost():
+    """À floor=0.15, les 4 FP plantés disparaissent ; le rappel ne bouge pas
+    (les FN sont des paraphrases à Jaccard 0, insensibles au floor)."""
+    rows = sweep(_toy(), [0.08, 0.15])
+    by_setting = {r["setting"]: r for r in rows}
+    base = by_setting["floor=0.08"]
+    tuned = by_setting["floor=0.15"]
+    assert base["fp"] == 4
+    assert tuned["fp"] == 0
+    assert tuned["precision"] == 1.0
+    # rappel inchangé : le floor ne touche pas les FN (paraphrases)
+    assert tuned["recall"] == base["recall"]
+
+
+def test_sweep_includes_require_double_entity_variant():
+    rows = sweep(_toy(), [0.08])
+    settings = {r["setting"] for r in rows}
+    assert "require_entities>=2" in settings
+    variant = next(r for r in rows if r["setting"] == "require_entities>=2")
+    assert variant["fp"] == 0  # weak branch off → FP plantés rejetés
+
+
+# ---------------------------------------------------------------------------
+# render_compare
+# ---------------------------------------------------------------------------
+
+
+def test_render_compare_delta():
+    baseline = {
+        "n_pairs": 20,
+        "micro": {"precision": 0.333, "recall": 0.333, "f1": 0.333, "fp": 4, "fn": 4},
+        "contamination": {"mean": 0.667},
+    }
+    after = {
+        "n_pairs": 20,
+        "micro": {"precision": 1.0, "recall": 0.333, "f1": 0.5, "fp": 0, "fn": 4},
+        "contamination": {"mean": 0.0},
+    }
+    report = render_compare(baseline, after)
+    assert "+0.667" in report  # Δ précision = 1.0 - 0.333
+    assert "-4" in report  # Δ FP
+    assert "contamination" in report

--- a/packages/api/tests/scripts/test_label_event_dataset.py
+++ b/packages/api/tests/scripts/test_label_event_dataset.py
@@ -1,0 +1,211 @@
+"""Tests hermétiques pour `scripts/label_event_dataset.py`.
+
+L'appel LLM est court-circuité par `EVENT_LABEL_DRY_RUN=1`. Les tests couvrent
+le validateur (assignation exactement-une-fois-sinon-NOISE, slug, jamais
+d'écrasement d'un article revu), l'itération par mode, et un run dry-run
+end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from scripts.label_event_dataset import (
+    apply_partition,
+    iter_pools_to_label,
+    partition_pool,
+    pool_is_reviewed,
+    resolve_assignment,
+    run,
+    slugify,
+)
+
+
+def _toy_dataset() -> dict:
+    return {
+        "pools": [
+            {
+                "pool_key": "trump",
+                "pool_display": "Trump",
+                "seed_entity": {"name": "Trump", "type": "PERSON"},
+                "events": [],
+                "articles": [
+                    {"id": "A0", "title": "Trump frappe l'Iran", "event_id": None,
+                     "label_reviewed": False},
+                    {"id": "A1", "title": "Trump et l'Iran", "event_id": None,
+                     "label_reviewed": False},
+                    {"id": "A2", "title": "Trump hué au NBA", "event_id": None,
+                     "label_reviewed": False},
+                ],
+            },
+            {
+                "pool_key": "macron",
+                "pool_display": "Macron",
+                "seed_entity": {"name": "Macron", "type": "PERSON"},
+                "events": [],
+                "articles": [
+                    {"id": "B0", "title": "Macron à Berlin", "event_id": "gold-evt",
+                     "label_reviewed": True},
+                    {"id": "B1", "title": "Macron en Allemagne", "event_id": None,
+                     "label_reviewed": False},
+                ],
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# slugify
+# ---------------------------------------------------------------------------
+
+
+def test_slugify_strips_accents_and_punct():
+    assert slugify("Iran-Israël: frappes!") == "iran-israel-frappes"
+    assert slugify("  ") == "event"
+    assert slugify("NBA Finals") == "nba-finals"
+
+
+# ---------------------------------------------------------------------------
+# resolve_assignment : exactly-once-or-NOISE
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_assignment_exactly_once_or_noise():
+    partition = {
+        "events": [
+            {"event_id": "evt-a", "label": "A", "article_indices": [0, 1]},
+            {"event_id": "evt-b", "label": "B", "article_indices": [1, 2]},
+        ],
+        "noise_indices": [3],
+    }
+    assignment, labels = resolve_assignment(partition, n=4)
+    assert assignment[0] == "evt-a"  # exactement une fois
+    assert assignment[1] == "NOISE"  # double-assigné → NOISE
+    assert assignment[2] == "evt-b"
+    assert assignment[3] == "NOISE"  # jamais assigné → NOISE
+    assert labels["evt-a"] == "A"
+
+
+def test_resolve_assignment_ignores_out_of_range_indices():
+    partition = {"events": [{"event_id": "x", "article_indices": [0, 99, -1]}]}
+    assignment, _ = resolve_assignment(partition, n=2)
+    assert assignment[0] == "x"
+    assert assignment[1] == "NOISE"
+
+
+def test_resolve_assignment_slugifies_labels():
+    partition = {"events": [{"label": "Iran & Israël", "article_indices": [0]}]}
+    assignment, labels = resolve_assignment(partition, n=1)
+    assert assignment[0] == "iran-israel"
+    assert "iran-israel" in labels
+
+
+# ---------------------------------------------------------------------------
+# apply_partition : jamais d'écrasement d'un article revu
+# ---------------------------------------------------------------------------
+
+
+def test_apply_partition_skips_reviewed_articles():
+    pool = _toy_dataset()["pools"][1]  # macron : B0 revu, B1 non
+    partition = {"events": [{"event_id": "evt-x", "article_indices": [0, 1]}]}
+    written = apply_partition(pool, partition, skip_reviewed=True)
+    assert pool["articles"][0]["event_id"] == "gold-evt"  # intact
+    assert pool["articles"][1]["event_id"] == "evt-x"
+    assert pool["articles"][1]["label_source"] == "llm_pass1"
+    assert written == 1
+
+
+def test_apply_partition_builds_events_list():
+    pool = _toy_dataset()["pools"][0]
+    partition = {
+        "events": [{"event_id": "iran", "label": "Iran", "article_indices": [0, 1]}],
+        "noise_indices": [2],
+    }
+    apply_partition(pool, partition, skip_reviewed=True)
+    events = {e["event_id"]: e for e in pool["events"]}
+    assert events["iran"]["size"] == 2
+    assert events["NOISE"]["size"] == 1
+
+
+def test_apply_partition_blind_writes_shadow_field():
+    pool = _toy_dataset()["pools"][1]
+    partition = {"events": [{"event_id": "evt-x", "article_indices": [0, 1]}]}
+    apply_partition(
+        pool, partition, target_field="event_id_blind", skip_reviewed=False
+    )
+    # event_id (gold) intact ; le champ fantôme reçoit la prédiction
+    assert pool["articles"][0]["event_id"] == "gold-evt"
+    assert pool["articles"][0]["event_id_blind"] == "evt-x"
+
+
+# ---------------------------------------------------------------------------
+# iter_pools_to_label : modes
+# ---------------------------------------------------------------------------
+
+
+def test_pool_is_reviewed():
+    ds = _toy_dataset()
+    assert pool_is_reviewed(ds["pools"][0]) is False
+    assert pool_is_reviewed(ds["pools"][1]) is True
+
+
+def test_iter_fill_yields_only_unreviewed_pools():
+    out = list(iter_pools_to_label(_toy_dataset(), mode="fill"))
+    assert [p["pool_key"] for p, _ in out] == ["trump"]
+
+
+def test_iter_blind_yields_only_reviewed_pools():
+    out = list(iter_pools_to_label(_toy_dataset(), mode="blind"))
+    assert [p["pool_key"] for p, _ in out] == ["macron"]
+
+
+def test_iter_all_yields_both():
+    out = list(iter_pools_to_label(_toy_dataset(), mode="all"))
+    assert {p["pool_key"] for p, _ in out} == {"trump", "macron"}
+
+
+# ---------------------------------------------------------------------------
+# Dry-run stub
+# ---------------------------------------------------------------------------
+
+
+def test_partition_pool_dry_run(monkeypatch):
+    monkeypatch.setenv("EVENT_LABEL_DRY_RUN", "1")
+    pool = _toy_dataset()["pools"][0]
+    partition = asyncio.run(partition_pool(client=None, pool=pool))
+    # 1 événement par article
+    assert len(partition["events"]) == 3
+    assert partition["events"][0]["article_indices"] == [0]
+
+
+# ---------------------------------------------------------------------------
+# run() end-to-end dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_run_dry_fill_labels_unreviewed_only(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("EVENT_LABEL_DRY_RUN", "1")
+    ds_path = tmp_path / "ds.json"
+    ds_path.write_text(json.dumps(_toy_dataset()), encoding="utf-8")
+    out_path = tmp_path / "out.json"
+
+    asyncio.run(
+        run(
+            dataset_path=ds_path,
+            mode="fill",
+            model="mistral-large-latest",
+            out_path=out_path,
+            limit=None,
+        )
+    )
+
+    out = json.loads(out_path.read_text(encoding="utf-8"))
+    trump = next(p for p in out["pools"] if p["pool_key"] == "trump")
+    macron = next(p for p in out["pools"] if p["pool_key"] == "macron")
+    # pool trump (non revu) étiqueté : 1 event/article (dry-run)
+    assert all(a["event_id"] is not None for a in trump["articles"])
+    # pool macron est revu → mode fill l'ignore : B1 reste non étiqueté
+    assert macron["articles"][0]["event_id"] == "gold-evt"
+    assert macron["articles"][1]["event_id"] is None

--- a/packages/api/tests/test_perspective_service.py
+++ b/packages/api/tests/test_perspective_service.py
@@ -360,6 +360,104 @@ def test_filter_external_perspectives_disabled_via_flag(monkeypatch):
     assert filtered_out == 0
 
 
+# ---------------------------------------------------------------------------
+# Calibration Iter 1 — floor « weak double signal » 0.08 → 0.12
+# Ref : docs/maintenance/maintenance-clustering-calibration.md
+# Pool junk-drawer « Trump » : deux articles ne partageant que l'entité saillante
+# (Trump) + un topic générique (geopolitics) mais parlant d'événements distincts.
+# ---------------------------------------------------------------------------
+
+# Le cas Cuba/Chagos du plan : Jaccard ≈ 0.091, dans la fenêtre [0.08, 0.12).
+# Avant Iter 1 (floor 0.08) → accepté à tort via « weak double signal » (FP).
+# Après Iter 1 (floor 0.12) → rejeté.
+TRUMP_CUBA = {
+    "title": "Cuba : l'ultimatum économique de Trump",
+    "topics": ["geopolitics", "usa"],
+    "entities": [json.dumps({"name": "Trump", "type": "PERSON"})],
+}
+TRUMP_CHAGOS = {
+    "title": (
+        "Après le Groenland, Donald Trump convoite un autre territoire, "
+        "l'archipel des îles Chagos"
+    ),
+    "topics": ["geopolitics", "usa"],
+    "entities": [json.dumps({"name": "Trump", "type": "PERSON"})],
+}
+
+# Vrai intra-événement (mobilisation anti-projet immobilier Trump en Albanie) :
+# Jaccard ≈ 0.143 ≥ 0.12 → reste accepté après Iter 1 (rappel préservé).
+TRUMP_ALBANIE_A = {
+    "title": (
+        "En Albanie, la mobilisation prend de l'ampleur contre le projet "
+        "immobilier de luxe porté par Trump"
+    ),
+    "topics": ["geopolitics", "usa"],
+    "entities": [json.dumps({"name": "Trump", "type": "PERSON"})],
+}
+TRUMP_ALBANIE_B = {
+    "title": (
+        "« Ce serait fatal » : des Albanais continuent à protester contre un "
+        "projet immobilier lié à Trump"
+    ),
+    "topics": ["geopolitics", "usa"],
+    "entities": [json.dumps({"name": "Trump", "type": "PERSON"})],
+}
+
+
+def test_trump_cross_event_rejected_after_floor_calibration():
+    """Cuba ↔ Chagos : même entité Trump + topic geopolitics, événements distincts.
+
+    Jaccard ≈ 0.091 tombe dans la fenêtre [ancien floor 0.08, nouveau floor 0.12) :
+    c'était la fuite « weak double signal » (cf. capture PO « cluster Trump »).
+    Après calibration Iter 1, la porte rejette la paire.
+    """
+    from app.services.perspective_service import PERSPECTIVE_MIN_JACCARD_FLOOR
+
+    seed_tokens = normalize_title(TRUMP_CUBA["title"])
+    seed_disc = {"Trump"}
+    signals = PerspectiveService._topical_signals(
+        seed_tokens,
+        seed_topics={"geopolitics", "usa"},
+        seed_disc_entities=seed_disc,
+        cand_title=TRUMP_CHAGOS["title"],
+        cand_topics=TRUMP_CHAGOS["topics"],
+        cand_entities=TRUMP_CHAGOS["entities"],
+    )
+    # Le signal qui fuyait : topic + entité partagés, Jaccard faible mais > 0.08.
+    assert signals["shared_topics"] >= 1
+    assert signals["shared_entities"] >= 1
+    assert 0.08 <= signals["title_jaccard"] < PERSPECTIVE_MIN_JACCARD_FLOOR
+    # La porte calibrée (floor 0.12) doit rejeter.
+    is_ok, reason = PerspectiveService._is_topically_coherent(signals)
+    assert is_ok is False
+    assert reason == "no_signal"
+
+
+def test_trump_intra_event_still_accepted_after_floor_calibration():
+    """Albanie ↔ Albanie : même événement, Jaccard ≈ 0.143 ≥ 0.12 → reste accepté.
+
+    Garde-fou de rappel : le durcissement du floor ne doit pas casser les vraies
+    paires intra-événement multi-sources qui dépassent le nouveau seuil.
+    """
+    from app.services.perspective_service import PERSPECTIVE_MIN_JACCARD_FLOOR
+
+    seed_tokens = normalize_title(TRUMP_ALBANIE_A["title"])
+    signals = PerspectiveService._topical_signals(
+        seed_tokens,
+        seed_topics={"geopolitics", "usa"},
+        seed_disc_entities={"Trump"},
+        cand_title=TRUMP_ALBANIE_B["title"],
+        cand_topics=TRUMP_ALBANIE_B["topics"],
+        cand_entities=TRUMP_ALBANIE_B["entities"],
+    )
+    assert signals["title_jaccard"] >= PERSPECTIVE_MIN_JACCARD_FLOOR
+    assert signals["shared_topics"] >= 1
+    assert signals["shared_entities"] >= 1
+    is_ok, reason = PerspectiveService._is_topically_coherent(signals)
+    assert is_ok is True
+    assert reason == ""
+
+
 def test_topical_signals_empty_seed_title():
     """Edge case : titre seed vide → tous les candidats rejetés (Jaccard=0)."""
     signals = PerspectiveService._topical_signals(


### PR DESCRIPTION
## Quoi

L'écran « couverture médiatique / Autres regards » regroupe trop d'articles qui ne partagent qu'une **entité saillante** (Trump, Macron…) sans parler du **même événement** (grief PO : un cluster « Trump » mélange guerre Iran-Israël, NBA, immobilier Albanie…).

Cette PR livre un **instrument de mesure** de la porte `_is_topically_coherent` + un **1er réglage data-driven** :

- **Harness** (`scripts/evaluate_event_clustering.py`) sur la porte réelle : P/R/F1 pairwise (micro+macro), contamination, **FP-par-chemin**, **FN-par-raison**, `--sweep`, `--compare`. Anti-drift garanti (`gate_pair` défaut == `_is_topically_coherent`, test dédié).
- **Build des pools** lâches par entité (`build_event_dataset.py`) + **pré-label LLM** cluster-assign + substrat de revue PO (`label_event_dataset.py`).
- **Iter 1 — 1 seul paramètre** : `PERSPECTIVE_MIN_JACCARD_FLOOR` **0.08 → 0.12**.
- Fixture Trump multi-événements (cas Cuba/Chagos) + journal de calibration append-only.

## Pourquoi

Mesuré contre un gold prod **revu PO** (20 pools / 4906 paires ordonnées) :

| | baseline (0.08) | Iter 1 (0.12) | Δ |
|---|---|---|---|
| Précision | 0.897 | 0.926 | **+0.029** |
| Rappel | 0.876 | 0.809 | −0.067 |
| F1 | 0.886 | 0.864 | −0.023 |
| Contamination | 0.169 | 0.129 | **−24 %** |
| FP | 356 | 228 | **−128 (−36 %)** |

Arbitrage PO assumé : « moins de mauvais clusters » > rappel. La branche ciblée `weak_double_signal` passe de 252 à 124 FP.

## Comment ça a été vérifié

- [x] `pytest tests/test_perspective_service.py tests/scripts/` → **89 passed** (incl. 2 nouveaux tests Trump : rejet cross-event Cuba/Chagos + maintien intra-event Albanie)
- [x] Collecte pleine suite : **1606 tests, 0 erreur d'import** (pas de régression)
- [x] Harness re-joué : Iter 0 → Iter 1 confirme le delta ci-dessus
- [x] `ruff check` clean sur les fichiers touchés
- [x] `/simplify` passé (aucune correction : findings hors-scope ou design délibéré anti-drift)
- [ ] Tests DB-backed : non exécutables dans ce workspace (pas de Postgres local 54322) → couverts par la CI

## Zones à risque

- `app/services/perspective_service.py` (porte de cohérence des perspectives) — changement isolé à **une constante** ; fixture Texas existante non régressée.
- **Caveat acté** : le floor ne coupe QUE la branche faible. Les FP `double_entity` (92, cœur du grief Trump : Iran-Israël ↔ Pentagone-espionnage partagent Trump+Israël) et les FN paraphrases ne bougent avec aucun floor → **embeddings** (next step, hors PR).
- Scripts + doc = **additifs** (aucun code app existant touché hormis la constante).

🤖 Generated with [Claude Code](https://claude.com/claude-code)