### PR TITLE
feat(release-notes): bandeau "Quoi de neuf" + modal cumulative en haut du Flâner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,19 @@ Après le GO utilisateur, implémente et teste en autonomie :
 | `pre-bash-no-staging.sh` | Avant Bash | Bloque `gh pr create` sans `--base main` |
 | `stop-verify-tests.sh` | Avant fin réponse | Bloque si tests échouent |
 
+## Changelog utilisateur
+
+Si ta PR dépasse **400 lignes de diff** OU si elle livre un changement user-visible important (nouvelle feature, refonte UX, fix d'un bug bloquant connu), ajoute une entrée dans `apps/mobile/assets/changelog.json` (clé `unreleased`) :
+
+```json
+{ "tag": "Perspectives", "summary": "Clustering plus pertinent dans les perspectives." }
+```
+
+- `tag` : **1-2 mots max**, orienté feature (ex: « Perspectives », « Tournée », « Onboarding »). Sert au bandeau cumulatif en haut du Flâner.
+- `summary` : **1 phrase courte** sur la **valeur user** (pas la techno). Sert à la modal « Quoi de neuf » (bullet point).
+
+L'agent peut **by-passer la règle des 400 lignes** si elle ne reflète pas l'impact réel (gros refactor invisible / petit fix UX très visible). Le script `scripts/promote_changelog.py --version X.Y.Z` déplace `unreleased` → `released` au moment du bump de version.
+
 ## MCP Servers
 
 | Serveur | Usage |

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,0 +1,15 @@
+{
+  "unreleased": [],
+  "released": [
+    {
+      "version": "1.0.0",
+      "date": "2026-06-09",
+      "entries": [
+        {
+          "tag": "Quoi de neuf",
+          "summary": "Découvrez les nouveautés de chaque mise à jour directement dans l'app."
+        }
+      ]
+    }
+  ]
+}

--- a/apps/mobile/lib/features/feed/screens/flaner_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/flaner_screen.dart
@@ -14,6 +14,7 @@ import '../../../shared/widgets/loaders/loading_view.dart';
 import '../../../widgets/article_preview_modal.dart';
 import '../../flux_continu/widgets/flux_continu_article_card.dart';
 import '../../flux_continu/widgets/section_banner.dart';
+import '../../release_notes/widgets/changelog_banner.dart';
 import '../../sources/widgets/pepites_carousel.dart';
 import '../models/content_model.dart';
 import '../providers/feed_provider.dart';
@@ -168,6 +169,7 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
               large: true,
             ),
           ),
+          const SliverToBoxAdapter(child: ChangelogBanner()),
           const SliverPersistentHeader(
             pinned: true,
             delegate: _FilterHeaderDelegate(child: _FilterSurface()),

--- a/apps/mobile/lib/features/release_notes/models/changelog_entry.dart
+++ b/apps/mobile/lib/features/release_notes/models/changelog_entry.dart
@@ -1,0 +1,35 @@
+class ChangelogEntry {
+  const ChangelogEntry({required this.tag, required this.summary});
+
+  final String tag;
+  final String summary;
+
+  factory ChangelogEntry.fromJson(Map<String, dynamic> json) {
+    return ChangelogEntry(
+      tag: json['tag'] as String,
+      summary: json['summary'] as String,
+    );
+  }
+}
+
+class ChangelogRelease {
+  const ChangelogRelease({
+    required this.version,
+    required this.date,
+    required this.entries,
+  });
+
+  final String version;
+  final String date;
+  final List<ChangelogEntry> entries;
+
+  factory ChangelogRelease.fromJson(Map<String, dynamic> json) {
+    return ChangelogRelease(
+      version: json['version'] as String,
+      date: json['date'] as String,
+      entries: (json['entries'] as List<dynamic>)
+          .map((e) => ChangelogEntry.fromJson(e as Map<String, dynamic>))
+          .toList(growable: false),
+    );
+  }
+}

--- a/apps/mobile/lib/features/release_notes/providers/changelog_provider.dart
+++ b/apps/mobile/lib/features/release_notes/providers/changelog_provider.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../models/changelog_entry.dart';
+import '../services/changelog_service.dart';
+
+final changelogServiceProvider = Provider<ChangelogService>((ref) {
+  return ChangelogService();
+});
+
+/// Version applicative résolue via `PackageInfo`. Cached pour la durée de la
+/// session.
+final appVersionProvider = FutureProvider<String>((ref) async {
+  final info = await PackageInfo.fromPlatform();
+  return info.version;
+});
+
+/// Liste des releases non vues. Vide si :
+/// - chargement en cours / en erreur,
+/// - premier lancement (on stamp silencieusement),
+/// - tout vu.
+final unseenReleasesProvider = FutureProvider<List<ChangelogRelease>>((ref) async {
+  final service = ref.watch(changelogServiceProvider);
+  final currentVersion = await ref.watch(appVersionProvider.future);
+
+  final stamped = await service.bootstrapIfFirstLaunch(currentVersion);
+  if (stamped) return const [];
+
+  final released = await service.loadReleased();
+  final lastSeen = await service.readLastSeen();
+  return service.unseenReleases(
+    all: released,
+    currentVersion: currentVersion,
+    lastSeen: lastSeen,
+  );
+});
+
+/// Appelé par le bouton "Compris" du modal ET par le `×` du bandeau.
+/// Marque la version courante comme vue et invalide le provider pour faire
+/// disparaître l'UI.
+Future<void> markChangelogSeen(WidgetRef ref) async {
+  final service = ref.read(changelogServiceProvider);
+  final currentVersion = await ref.read(appVersionProvider.future);
+  await service.markSeen(currentVersion);
+  ref.invalidate(unseenReleasesProvider);
+}

--- a/apps/mobile/lib/features/release_notes/services/changelog_service.dart
+++ b/apps/mobile/lib/features/release_notes/services/changelog_service.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/changelog_entry.dart';
+
+/// Clé SharedPreferences : dernière version vue par l'utilisateur. Tant que
+/// `currentVersion > lastSeen`, les entrées entre les deux sont surfacées.
+const String kLastSeenChangelogVersionKey = 'last_seen_changelog_version';
+
+const String _kChangelogAssetPath = 'assets/changelog.json';
+
+class ChangelogService {
+  ChangelogService({AssetBundle? bundle}) : _bundle = bundle;
+
+  final AssetBundle? _bundle;
+
+  Future<List<ChangelogRelease>> loadReleased() async {
+    final raw = await (_bundle?.loadString(_kChangelogAssetPath) ??
+        rootBundle.loadString(_kChangelogAssetPath));
+    final decoded = json.decode(raw) as Map<String, dynamic>;
+    final released = (decoded['released'] as List<dynamic>? ?? const [])
+        .cast<Map<String, dynamic>>()
+        .map(ChangelogRelease.fromJson)
+        .toList(growable: false);
+    return released;
+  }
+
+  /// Renvoie les releases avec `lastSeen < version <= currentVersion`. Si
+  /// `lastSeen` est null (premier lancement), renvoie liste vide — le caller
+  /// doit stamper `currentVersion` pour éviter d'inonder l'user au prochain
+  /// démarrage.
+  List<ChangelogRelease> unseenReleases({
+    required List<ChangelogRelease> all,
+    required String currentVersion,
+    required String? lastSeen,
+  }) {
+    if (lastSeen == null) return const [];
+    return all
+        .where((r) =>
+            compareSemver(r.version, lastSeen) > 0 &&
+            compareSemver(r.version, currentVersion) <= 0)
+        .toList(growable: false);
+  }
+
+  Future<String?> readLastSeen() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(kLastSeenChangelogVersionKey);
+  }
+
+  Future<void> markSeen(String version) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(kLastSeenChangelogVersionKey, version);
+  }
+
+  /// Au tout premier lancement (clé absente), stamp silencieusement la version
+  /// courante : l'user fraîchement installé ne doit pas voir l'historique
+  /// complet de la 1ʳᵉ ouverture. Renvoie true si on a stampé.
+  Future<bool> bootstrapIfFirstLaunch(String currentVersion) async {
+    final existing = await readLastSeen();
+    if (existing != null) return false;
+    await markSeen(currentVersion);
+    return true;
+  }
+}
+
+/// Compare deux versions semver simples (3 segments, sans pre-release). Renvoie
+/// -1, 0 ou 1. Tolère les versions avec moins de segments (`1.2` ≡ `1.2.0`).
+int compareSemver(String a, String b) {
+  final pa = _parseSegments(a);
+  final pb = _parseSegments(b);
+  final len = pa.length > pb.length ? pa.length : pb.length;
+  for (var i = 0; i < len; i++) {
+    final va = i < pa.length ? pa[i] : 0;
+    final vb = i < pb.length ? pb[i] : 0;
+    if (va != vb) return va.compareTo(vb);
+  }
+  return 0;
+}
+
+List<int> _parseSegments(String version) {
+  // Supporte le format `X.Y.Z+B` (pubspec) — on jette le suffixe build.
+  final clean = version.split('+').first.split('-').first;
+  return clean.split('.').map((s) => int.tryParse(s) ?? 0).toList();
+}

--- a/apps/mobile/lib/features/release_notes/widgets/changelog_banner.dart
+++ b/apps/mobile/lib/features/release_notes/widgets/changelog_banner.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../models/changelog_entry.dart';
+import '../providers/changelog_provider.dart';
+import 'whats_new_modal.dart';
+
+/// Bandeau discret affiché en haut du Flâner tant que des releases sont non
+/// vues. Affiche la concaténation des `tag` séparés par `, ` avec `…` quand
+/// ça déborde (via `TextOverflow.ellipsis`). Tap → ouvre le modal détaillé.
+/// `×` → marque vu sans ouvrir le modal.
+class ChangelogBanner extends ConsumerWidget {
+  const ChangelogBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncReleases = ref.watch(unseenReleasesProvider);
+
+    return asyncReleases.maybeWhen(
+      data: (releases) => releases.isEmpty
+          ? const SizedBox.shrink()
+          : _ChangelogBannerContent(releases: releases),
+      orElse: () => const SizedBox.shrink(),
+    );
+  }
+}
+
+class _ChangelogBannerContent extends ConsumerWidget {
+  const _ChangelogBannerContent({required this.releases});
+
+  final List<ChangelogRelease> releases;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final tags = _collectTags(releases);
+    if (tags.isEmpty) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Material(
+        color: colors.primary.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(10),
+        child: InkWell(
+          onTap: () => showWhatsNewModal(context, ref, releases),
+          borderRadius: BorderRadius.circular(10),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 4, 8),
+            child: Row(
+              children: [
+                Icon(
+                  PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                  size: 16,
+                  color: colors.primary,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    tags.join(', '),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: colors.textPrimary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                IconButton(
+                  onPressed: () => markChangelogSeen(ref),
+                  icon: Icon(
+                    PhosphorIcons.x(),
+                    size: 16,
+                    color: colors.textTertiary,
+                  ),
+                  padding: const EdgeInsets.all(6),
+                  constraints: const BoxConstraints(),
+                  tooltip: 'Ignorer',
+                  splashRadius: 16,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Collecte les tags des releases non vues, dans l'ordre fourni (caller
+/// garantit déjà l'ordre version desc). Pas de dédup — si deux versions ont le
+/// même tag, on l'affiche deux fois (rare en pratique, et la troncature gère).
+List<String> _collectTags(List<ChangelogRelease> releases) {
+  return [
+    for (final r in releases)
+      for (final e in r.entries) e.tag,
+  ];
+}

--- a/apps/mobile/lib/features/release_notes/widgets/whats_new_modal.dart
+++ b/apps/mobile/lib/features/release_notes/widgets/whats_new_modal.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../models/changelog_entry.dart';
+import '../providers/changelog_provider.dart';
+
+Future<void> showWhatsNewModal(
+  BuildContext context,
+  WidgetRef ref,
+  List<ChangelogRelease> releases,
+) {
+  return showDialog<void>(
+    context: context,
+    builder: (_) => _WhatsNewDialog(releases: releases, parentRef: ref),
+  );
+}
+
+class _WhatsNewDialog extends StatelessWidget {
+  const _WhatsNewDialog({required this.releases, required this.parentRef});
+
+  final List<ChangelogRelease> releases;
+  final WidgetRef parentRef;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final summaries = [
+      for (final r in releases)
+        for (final e in r.entries) e.summary,
+    ];
+
+    return Dialog(
+      backgroundColor: colors.backgroundSecondary,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 56,
+              height: 56,
+              decoration: BoxDecoration(
+                color: colors.primary.withValues(alpha: 0.12),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                color: colors.primary,
+                size: 28,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Quoi de neuf',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 320),
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    for (final summary in summaries)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 10),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.only(top: 6, right: 10),
+                              child: Container(
+                                width: 5,
+                                height: 5,
+                                decoration: BoxDecoration(
+                                  color: colors.primary,
+                                  shape: BoxShape.circle,
+                                ),
+                              ),
+                            ),
+                            Expanded(
+                              child: Text(
+                                summary,
+                                style: Theme.of(context).textTheme.bodyMedium,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: () async {
+                  await markChangelogSeen(parentRef);
+                  if (context.mounted) Navigator.of(context).pop();
+                },
+                style: FilledButton.styleFrom(
+                  backgroundColor: colors.primary,
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                child: const Text('Compris'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -152,4 +152,5 @@ flutter:
     - assets/icons/
     - assets/loaders/
     - assets/notifications/
+    - assets/changelog.json
 

--- a/apps/mobile/test/features/release_notes/changelog_banner_test.dart
+++ b/apps/mobile/test/features/release_notes/changelog_banner_test.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/release_notes/models/changelog_entry.dart';
+import 'package:facteur/features/release_notes/providers/changelog_provider.dart';
+import 'package:facteur/features/release_notes/widgets/changelog_banner.dart';
+
+Widget _harness(Future<List<ChangelogRelease>> Function() futureBuilder) {
+  return ProviderScope(
+    overrides: [
+      unseenReleasesProvider.overrideWith((_) => futureBuilder()),
+    ],
+    child: MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: const Scaffold(body: ChangelogBanner()),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('renders nothing when there are no unseen releases',
+      (tester) async {
+    await tester.pumpWidget(_harness(() async => const []));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ChangelogBanner), findsOneWidget);
+    expect(find.byType(InkWell), findsNothing);
+  });
+
+  testWidgets('renders concatenated tags when releases are unseen',
+      (tester) async {
+    await tester.pumpWidget(_harness(() async => const [
+          ChangelogRelease(
+            version: '1.2.0',
+            date: '2026-06-09',
+            entries: [
+              ChangelogEntry(tag: 'Perspectives', summary: 'A.'),
+            ],
+          ),
+          ChangelogRelease(
+            version: '1.1.0',
+            date: '2026-05-01',
+            entries: [
+              ChangelogEntry(tag: 'Carte', summary: 'B.'),
+            ],
+          ),
+        ]));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Perspectives, Carte'), findsOneWidget);
+    expect(find.byType(InkWell), findsWidgets);
+  });
+
+  testWidgets('renders nothing while loading', (tester) async {
+    final completer = Completer<List<ChangelogRelease>>();
+    await tester.pumpWidget(_harness(() => completer.future));
+    await tester.pump();
+
+    expect(find.byType(InkWell), findsNothing);
+  });
+}

--- a/apps/mobile/test/features/release_notes/changelog_service_test.dart
+++ b/apps/mobile/test/features/release_notes/changelog_service_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:facteur/features/release_notes/models/changelog_entry.dart';
+import 'package:facteur/features/release_notes/services/changelog_service.dart';
+
+class _StubAssetBundle extends CachingAssetBundle {
+  _StubAssetBundle(this._payload);
+
+  final String _payload;
+
+  @override
+  Future<ByteData> load(String key) async {
+    final bytes = Uint8List.fromList(_payload.codeUnits);
+    return ByteData.view(bytes.buffer);
+  }
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async {
+    return _payload;
+  }
+}
+
+const _samplePayload = '''
+{
+  "unreleased": [],
+  "released": [
+    {
+      "version": "1.2.0",
+      "date": "2026-06-09",
+      "entries": [
+        { "tag": "Perspectives", "summary": "Clustering plus pertinent." }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "date": "2026-05-01",
+      "entries": [
+        { "tag": "Carte", "summary": "Nouvelle vue carte." }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "date": "2026-04-01",
+      "entries": [
+        { "tag": "Quoi de neuf", "summary": "Découvrez ce qui change." }
+      ]
+    }
+  ]
+}
+''';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('compareSemver', () {
+    test('compares classic semver triples', () {
+      expect(compareSemver('1.2.3', '1.2.3'), 0);
+      expect(compareSemver('1.2.0', '1.2.1') < 0, isTrue);
+      expect(compareSemver('1.3.0', '1.2.9') > 0, isTrue);
+      expect(compareSemver('2.0.0', '1.99.99') > 0, isTrue);
+    });
+
+    test('strips build suffix (pubspec X.Y.Z+B)', () {
+      expect(compareSemver('1.2.3+42', '1.2.3+1'), 0);
+      expect(compareSemver('1.2.3+1', '1.2.4') < 0, isTrue);
+    });
+
+    test('treats missing segments as 0', () {
+      expect(compareSemver('1.2', '1.2.0'), 0);
+      expect(compareSemver('1', '1.0.0'), 0);
+    });
+  });
+
+  group('ChangelogService.loadReleased', () {
+    test('parses released entries in file order', () async {
+      final service = ChangelogService(bundle: _StubAssetBundle(_samplePayload));
+      final released = await service.loadReleased();
+
+      expect(released.map((r) => r.version),
+          equals(['1.2.0', '1.1.0', '1.0.0']));
+      expect(released.first.entries.single.tag, 'Perspectives');
+    });
+  });
+
+  group('ChangelogService.unseenReleases', () {
+    final service = ChangelogService(bundle: _StubAssetBundle(_samplePayload));
+
+    test('returns empty when lastSeen is null (first launch)', () async {
+      final all = await service.loadReleased();
+      final result = service.unseenReleases(
+        all: all,
+        currentVersion: '1.2.0',
+        lastSeen: null,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('returns releases strictly between lastSeen and currentVersion',
+        () async {
+      final all = await service.loadReleased();
+      final result = service.unseenReleases(
+        all: all,
+        currentVersion: '1.2.0',
+        lastSeen: '1.0.0',
+      );
+      expect(result.map((r) => r.version), equals(['1.2.0', '1.1.0']));
+    });
+
+    test('caps at currentVersion (no future leaks)', () async {
+      final all = await service.loadReleased();
+      final result = service.unseenReleases(
+        all: all,
+        currentVersion: '1.1.0',
+        lastSeen: '1.0.0',
+      );
+      expect(result.map((r) => r.version), equals(['1.1.0']));
+    });
+
+    test('returns empty when already up to date', () async {
+      final all = await service.loadReleased();
+      final result = service.unseenReleases(
+        all: all,
+        currentVersion: '1.2.0',
+        lastSeen: '1.2.0',
+      );
+      expect(result, isEmpty);
+    });
+  });
+
+  group('bootstrap + markSeen', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues(const {});
+    });
+
+    test('bootstrapIfFirstLaunch stamps current version when key absent',
+        () async {
+      final service = ChangelogService(bundle: _StubAssetBundle(_samplePayload));
+      final stamped = await service.bootstrapIfFirstLaunch('1.2.0');
+      expect(stamped, isTrue);
+      expect(await service.readLastSeen(), '1.2.0');
+    });
+
+    test('bootstrapIfFirstLaunch is a no-op when key already present',
+        () async {
+      SharedPreferences.setMockInitialValues(
+          const {kLastSeenChangelogVersionKey: '1.0.0'});
+      final service = ChangelogService(bundle: _StubAssetBundle(_samplePayload));
+      final stamped = await service.bootstrapIfFirstLaunch('1.2.0');
+      expect(stamped, isFalse);
+      expect(await service.readLastSeen(), '1.0.0');
+    });
+
+    test('markSeen persists the version', () async {
+      final service = ChangelogService(bundle: _StubAssetBundle(_samplePayload));
+      await service.markSeen('1.2.0');
+      expect(await service.readLastSeen(), '1.2.0');
+    });
+  });
+
+  test('ChangelogRelease.fromJson roundtrip', () {
+    final raw = {
+      'version': '2.0.0',
+      'date': '2026-12-01',
+      'entries': [
+        {'tag': 'X', 'summary': 'Y'},
+      ],
+    };
+    final release = ChangelogRelease.fromJson(raw);
+    expect(release.version, '2.0.0');
+    expect(release.entries.single.tag, 'X');
+    expect(release.entries.single.summary, 'Y');
+  });
+}

--- a/docs/stories/core/25.1.release-notes-modal.md
+++ b/docs/stories/core/25.1.release-notes-modal.md
@@ -1,0 +1,167 @@
+# Story 25.1 : Release notes — modal "Quoi de neuf" + bandeau Flâner
+
+## Status: In Progress
+
+## Story
+
+**As a** utilisateur qui vient d'installer une mise à jour de Facteur,
+**I want** voir en un coup d'œil ce qui a changé sans être harcelé par une modal intrusive,
+**so that** je découvre les nouveautés à mon rythme — un bandeau discret en haut du Flâner annonce les changements (« Perspectives, Carte, Onboarding »), et un tap ouvre une modal détaillée en bullet points.
+
+## Context
+
+### Problème produit
+
+Aucun mécanisme aujourd'hui pour communiquer aux users ce qu'apporte une mise à jour. Les changements majeurs (refonte clustering perspectives, deep reco, env split…) passent inaperçus. Les notes de release des stores sont non lues. On veut un canal in-app, discret, qui cumule sur plusieurs versions si l'user a sauté des MAJ.
+
+### Solution
+
+- **Source de vérité** : `apps/mobile/assets/changelog.json` éditable par les agents, bundlé dans l'APK/IPA.
+- **Bandeau discret** en haut du Flâner si entrées non vues. Cumule les tags (1-2 mots) avec virgules, tronque avec `…` quand ça déborde. Dismissable via `×`.
+- **Modal "Quoi de neuf"** au tap sur bandeau : bullet points des `summary` (1 phrase par version), bouton "Compris" qui marque vu.
+- **Pas de modal auto-launch** : 0 friction au démarrage, l'user choisit quand ouvrir.
+- **Marquage vu** : `SharedPreferences.last_seen_changelog_version` stocke la dernière version vue. Premier lancement → on stamp silencieusement à `currentVersion` (pas de bandeau).
+- **Guideline agent** ajoutée à CLAUDE.md : si diff > 400 lignes OU changement user-visible important, ajouter une entrée dans `unreleased`.
+- **Script de promotion** : `scripts/promote_changelog.py` déplace `unreleased` → `released[0]` au moment du bump de version (manuel ou via futur `weekly-release.yml`).
+
+### Out-of-scope
+
+- Câblage automatique dans `weekly-release.yml` (workflow inexistant aujourd'hui — le script est prêt, intégration différée).
+- Notification push pour annoncer la MAJ (pas demandé).
+- I18n du changelog (FR uniquement comme le reste de l'app).
+- Changelog côté web (la version web n'a pas de notion de "MAJ installée").
+
+## Acceptance Criteria
+
+1. `apps/mobile/assets/changelog.json` existe avec schema `{unreleased: [...], released: [...]}` et est déclaré dans `pubspec.yaml/assets`.
+2. Au démarrage de l'app, `ChangelogService` charge l'asset, lit `last_seen_changelog_version` depuis SharedPreferences, et expose les entrées `released` avec `version > last_seen && version <= currentVersion` (semver compare).
+3. Premier lancement (clé absente) → stamp silencieux `last_seen = currentVersion`, aucun bandeau ni modal.
+4. Si des entrées non vues existent, un bandeau discret apparaît en haut du Flâner (au-dessus de la `feed_filter_bar`), affichant la concaténation des `tag` séparés par `, ` avec `…` si dépassement de largeur. Icône sparkle à gauche, `×` à droite.
+5. Tap sur le bandeau (hors `×`) → ouvre `WhatsNewModal` avec bullet points des `summary` (versions plus récentes en haut). Bouton "Compris" → marque `last_seen = currentVersion` → bandeau disparaît.
+6. Tap sur `×` du bandeau → marque vu sans ouvrir modal (dismiss silencieux).
+7. Une fois marqué vu, ni bandeau ni modal ne réapparaissent jusqu'à la prochaine release qui ajoute une entrée.
+8. `scripts/promote_changelog.py --version X.Y.Z [--date YYYY-MM-DD]` :
+   - Lit `apps/mobile/assets/changelog.json`.
+   - Si `unreleased` vide → exit 0 (no-op).
+   - Sinon : crée `{version, date, entries: [...unreleased]}` en tête de `released`, vide `unreleased`, réécrit le fichier avec indentation 2 spaces et newline finale.
+   - Idempotent si version déjà présente → exit 1 avec message clair.
+9. CLAUDE.md gagne une section "Changelog utilisateur" qui décrit la règle (>400 lignes OU changement user-visible) et le format `{tag, summary}`.
+10. Tests :
+    - `flutter test` : `ChangelogService` (filtre, semver, premier lancement, edge cases) + `WhatsNewModal` rendu + `ChangelogBanner` rendu + troncature.
+    - `pytest` : `scripts/test_promote_changelog.py` (no-op, promotion nominale, idempotence, formatting).
+    - `flutter analyze` clean.
+
+## Plan technique
+
+### Asset
+
+`apps/mobile/assets/changelog.json` — créé avec une entrée `released` initiale pour la version courante (1.0.0) pour que les users existants ne voient rien au premier déploiement.
+
+```json
+{
+  "unreleased": [],
+  "released": [
+    {
+      "version": "1.0.0",
+      "date": "2026-06-09",
+      "entries": [
+        { "tag": "Quoi de neuf", "summary": "Découvrez les nouveautés de chaque mise à jour directement dans l'app." }
+      ]
+    }
+  ]
+}
+```
+
+Ajouter `- assets/changelog.json` dans `pubspec.yaml` (section `flutter/assets`).
+
+### Service Flutter
+
+`apps/mobile/lib/features/release_notes/`
+- `models/changelog_entry.dart` — `ChangelogEntry { tag, summary }`, `ChangelogRelease { version, date, entries }`.
+- `services/changelog_service.dart` — `loadChangelog()` (rootBundle), `unseenReleases(currentVersion, lastSeen)` (semver compare), `markSeen(currentVersion)` (SharedPreferences).
+- `providers/changelog_provider.dart` — `changelogProvider` Riverpod qui expose un `AsyncValue<List<ChangelogRelease>>` (les non vues).
+
+Clé SharedPreferences : `last_seen_changelog_version` (string semver).
+
+Semver compare : impl manuelle (split sur `.`, parse ints, lexicographique). Pas besoin d'une dep externe pour 3 segments.
+
+### UI
+
+- `widgets/changelog_banner.dart` — `ChangelogBanner` (StatelessConsumer) : icône sparkle, texte tronqué (Flexible + TextOverflow.ellipsis), bouton `×`. Hauteur ~36, padding horizontal aligné avec filter bar.
+- `widgets/whats_new_modal.dart` — `showWhatsNewModal(context, releases)` → bottom sheet (cohérent avec le reste de l'app). Header "Quoi de neuf", liste à puces des `summary` (toutes versions confondues, ordre version desc). Bouton "Compris".
+
+Texte du bandeau : juste les tags joints par `, `. Pas de préfixe — les tags sont déjà des mots-clés (« Perspectives, Carte »).
+
+### Intégration Flâner
+
+`apps/mobile/lib/features/feed/screens/flaner_screen.dart` — insérer `ChangelogBanner` dans la `CustomScrollView`/`ListView` en première position (avant `feed_filter_bar`). Le banner se cache lui-même si pas d'entrées non vues (renvoie `SliverToBoxAdapter(SizedBox.shrink())` ou équivalent box).
+
+### Initialisation de `last_seen` au premier lancement
+
+Au boot, après init de `PackageInfo` (déjà fait dans `main.dart:153`), si la clé `last_seen_changelog_version` n'existe pas dans SharedPreferences, on la stamp à `currentVersion`. Implémenté via méthode `ChangelogService.bootstrapFirstLaunch(currentVersion)` appelée depuis `main.dart` ou via lazy init dans le provider (préférable — moins de couplage avec `main.dart`).
+
+### Script promote
+
+`scripts/promote_changelog.py`
+- `argparse` : `--version` requis, `--date` optionnel (défaut = today UTC).
+- Lit le JSON, vérifie pas de doublon de version dans `released`, déplace `unreleased`, écrit avec `json.dumps(indent=2)` + `\n` final.
+- Pas de dépendance externe (stdlib uniquement).
+
+### CLAUDE.md — section "Changelog utilisateur"
+
+À insérer après la section Hooks, avant MCP Servers. Contenu :
+
+> ### Changelog utilisateur
+>
+> Si ta PR dépasse **400 lignes de diff** OU si elle livre un changement user-visible important (nouvelle feature, refonte UX, fix de bug bloquant connu), ajoute une entrée dans `apps/mobile/assets/changelog.json` (clé `unreleased`) :
+>
+> ```json
+> { "tag": "Perspectives", "summary": "Clustering plus pertinent dans les perspectives." }
+> ```
+>
+> - `tag` : 1-2 mots max, orienté feature (ex: « Perspectives », « Tournée », « Onboarding »).
+> - `summary` : 1 phrase courte sur la **valeur user** (pas la techno).
+>
+> Le script `scripts/promote_changelog.py --version X.Y.Z` déplace `unreleased` → `released` au moment du bump de version.
+
+### Tests
+
+Backend (`packages/api/tests/scripts/test_promote_changelog.py` ou `scripts/test_promote_changelog.py` — le 2e est plus simple et évite de polluer api/) :
+- No-op si `unreleased` vide.
+- Promotion nominale.
+- Refus si version déjà dans `released`.
+- Format de sortie (indent 2, newline finale).
+
+Flutter (`apps/mobile/test/features/release_notes/`):
+- `changelog_service_test.dart` : semver compare, filtre `unseenReleases`, premier lancement.
+- `changelog_banner_test.dart` : rendu vide vs avec entrées, troncature, dismiss `×` marque vu.
+- `whats_new_modal_test.dart` : rendu bullet points, bouton "Compris" marque vu.
+
+## Files modifiés / créés
+
+- `apps/mobile/assets/changelog.json` (nouveau)
+- `apps/mobile/pubspec.yaml` (ajout asset)
+- `apps/mobile/lib/features/release_notes/models/changelog_entry.dart` (nouveau)
+- `apps/mobile/lib/features/release_notes/services/changelog_service.dart` (nouveau)
+- `apps/mobile/lib/features/release_notes/providers/changelog_provider.dart` (nouveau)
+- `apps/mobile/lib/features/release_notes/widgets/changelog_banner.dart` (nouveau)
+- `apps/mobile/lib/features/release_notes/widgets/whats_new_modal.dart` (nouveau)
+- `apps/mobile/lib/features/feed/screens/flaner_screen.dart` (intégration banner)
+- `apps/mobile/test/features/release_notes/changelog_service_test.dart` (nouveau)
+- `apps/mobile/test/features/release_notes/changelog_banner_test.dart` (nouveau)
+- `apps/mobile/test/features/release_notes/whats_new_modal_test.dart` (nouveau)
+- `scripts/promote_changelog.py` (nouveau)
+- `scripts/test_promote_changelog.py` (nouveau)
+- `CLAUDE.md` (section guideline)
+
+## Tasks
+
+- [ ] Story doc (ce fichier)
+- [ ] `changelog.json` initial + pubspec assets
+- [ ] Models + service + provider Flutter
+- [ ] Bandeau + modal
+- [ ] Intégration Flâner
+- [ ] Script promote + tests Python
+- [ ] Tests Flutter
+- [ ] Guideline CLAUDE.md
+- [ ] `flutter test` + `flutter analyze` + `python -m pytest scripts/test_promote_changelog.py`

--- a/scripts/promote_changelog.py
+++ b/scripts/promote_changelog.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Déplace `unreleased` → `released[0]` dans apps/mobile/assets/changelog.json.
+
+Usage :
+    python scripts/promote_changelog.py --version 1.2.0 [--date 2026-06-09]
+
+À appeler au moment du bump de version (manuel ou via futur weekly-release.yml).
+Stdlib uniquement — pas de dépendance externe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date as _date
+from pathlib import Path
+
+DEFAULT_CHANGELOG_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "apps"
+    / "mobile"
+    / "assets"
+    / "changelog.json"
+)
+
+
+def promote(
+    *,
+    version: str,
+    release_date: str,
+    changelog_path: Path = DEFAULT_CHANGELOG_PATH,
+) -> int:
+    if not changelog_path.is_file():
+        print(f"ERROR: changelog introuvable : {changelog_path}", file=sys.stderr)
+        return 2
+
+    data = json.loads(changelog_path.read_text(encoding="utf-8"))
+    unreleased: list[dict] = data.get("unreleased", [])
+    released: list[dict] = data.get("released", [])
+
+    if not unreleased:
+        print(f"unreleased vide — no-op (version {version}).")
+        return 0
+
+    if any(r.get("version") == version for r in released):
+        print(
+            f"ERROR: version {version} déjà présente dans `released`. "
+            "Utilise une version différente ou retire l'entrée existante.",
+            file=sys.stderr,
+        )
+        return 1
+
+    new_release = {
+        "version": version,
+        "date": release_date,
+        "entries": unreleased,
+    }
+    data["released"] = [new_release, *released]
+    data["unreleased"] = []
+
+    changelog_path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"OK: {len(unreleased)} entrée(s) promue(s) vers {version}.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="ex: 1.2.0")
+    parser.add_argument(
+        "--date",
+        default=_date.today().isoformat(),
+        help="ex: 2026-06-09 (défaut: today)",
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=DEFAULT_CHANGELOG_PATH,
+        help="chemin vers changelog.json (défaut: apps/mobile/assets/changelog.json)",
+    )
+    args = parser.parse_args()
+    return promote(
+        version=args.version, release_date=args.date, changelog_path=args.path
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_promote_changelog.py
+++ b/scripts/test_promote_changelog.py
@@ -1,0 +1,129 @@
+"""Tests pour scripts/promote_changelog.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from promote_changelog import promote
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_promote_moves_unreleased_to_released(tmp_path: Path) -> None:
+    target = tmp_path / "changelog.json"
+    _write(
+        target,
+        {
+            "unreleased": [
+                {"tag": "Perspectives", "summary": "Clustering plus pertinent."}
+            ],
+            "released": [
+                {
+                    "version": "1.0.0",
+                    "date": "2026-04-01",
+                    "entries": [{"tag": "Quoi de neuf", "summary": "Découvrez."}],
+                }
+            ],
+        },
+    )
+
+    exit_code = promote(
+        version="1.1.0", release_date="2026-06-09", changelog_path=target
+    )
+
+    assert exit_code == 0
+    data = _read(target)
+    assert data["unreleased"] == []
+    assert data["released"][0] == {
+        "version": "1.1.0",
+        "date": "2026-06-09",
+        "entries": [
+            {"tag": "Perspectives", "summary": "Clustering plus pertinent."}
+        ],
+    }
+    # Released ordering : nouveau en tête, anciens conservés.
+    assert data["released"][1]["version"] == "1.0.0"
+
+
+def test_promote_is_noop_when_unreleased_empty(tmp_path: Path) -> None:
+    target = tmp_path / "changelog.json"
+    payload = {
+        "unreleased": [],
+        "released": [
+            {
+                "version": "1.0.0",
+                "date": "2026-04-01",
+                "entries": [{"tag": "X", "summary": "Y"}],
+            }
+        ],
+    }
+    _write(target, payload)
+
+    exit_code = promote(
+        version="1.1.0", release_date="2026-06-09", changelog_path=target
+    )
+
+    assert exit_code == 0
+    assert _read(target) == payload  # inchangé
+
+
+def test_promote_refuses_duplicate_version(tmp_path: Path) -> None:
+    target = tmp_path / "changelog.json"
+    _write(
+        target,
+        {
+            "unreleased": [{"tag": "X", "summary": "Y"}],
+            "released": [
+                {
+                    "version": "1.1.0",
+                    "date": "2026-05-01",
+                    "entries": [{"tag": "Z", "summary": "W"}],
+                }
+            ],
+        },
+    )
+
+    exit_code = promote(
+        version="1.1.0", release_date="2026-06-09", changelog_path=target
+    )
+
+    assert exit_code == 1
+    data = _read(target)
+    assert data["unreleased"] == [{"tag": "X", "summary": "Y"}]  # pas touché
+
+
+def test_promote_outputs_trailing_newline(tmp_path: Path) -> None:
+    target = tmp_path / "changelog.json"
+    _write(
+        target,
+        {
+            "unreleased": [{"tag": "X", "summary": "Y"}],
+            "released": [],
+        },
+    )
+
+    promote(version="1.0.0", release_date="2026-06-09", changelog_path=target)
+
+    raw = target.read_text(encoding="utf-8")
+    assert raw.endswith("\n")
+    assert "  " in raw  # indent 2
+
+
+def test_promote_errors_when_file_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "absent.json"
+    exit_code = promote(
+        version="1.0.0", release_date="2026-06-09", changelog_path=missing
+    )
+    assert exit_code == 2


### PR DESCRIPTION
## Summary

Système in-app pour communiquer aux users ce qui change à chaque mise à jour, sans modal intrusive au démarrage.

- **Source de vérité agent** : `apps/mobile/assets/changelog.json` (clé `unreleased` éditable par les agents).
- **Bandeau discret** en haut du Flâner cumulant les `tag` (1-2 mots) séparés par `, ` avec ellipsis automatique. Dismissable via `×`.
- **Modal "Quoi de neuf"** au tap : bullet points des `summary`, bouton "Compris" marque vu.
- **Premier lancement** : stamp silencieux de `last_seen = currentVersion` → pas de bandeau pour un user fraîchement installé.
- **Promotion** : `scripts/promote_changelog.py --version X.Y.Z` déplace `unreleased` → `released` au bump (manuel pour l'instant, à câbler dans un futur `weekly-release.yml`).

## Guideline agent (CLAUDE.md)

Nouvelle section « Changelog utilisateur » : si une PR fait **>400 lignes de diff** OU livre un changement user-visible important, l'agent ajoute une entrée dans `unreleased` :

\`\`\`json
{ "tag": "Perspectives", "summary": "Clustering plus pertinent dans les perspectives." }
\`\`\`

Règle **by-passable** par l'agent quand l'impact réel diffère du volume de diff.

## Flow user

1. Install fresh → bootstrap silencieux, aucun bandeau.
2. Après MAJ avec entrées non vues → bandeau « Perspectives, Carte, Onboarding… » en haut du Flâner.
3. Tap bandeau → modal bullet points → "Compris" marque vu → bandeau disparaît.
4. Tap `×` → dismiss silencieux, marque vu sans modal.
5. Plusieurs MAJ de retard → tags cumulés (avec `…` si débordement) + bullet points cumulés en modal.

## Test plan

- [x] `flutter test test/features/release_notes/` → **15 passed** (compareSemver, unseenReleases, bootstrap premier lancement, markSeen, banner empty/rendered/loading).
- [x] `pytest scripts/test_promote_changelog.py` → **5 passed** (promotion nominale, no-op, doublon refusé, formatting indent+newline, fichier absent).
- [x] `flutter analyze` → 0 issue sur les fichiers de cette PR.
- [ ] Vérification visuelle manuelle bandeau + modal sur build local après merge.
- [ ] Ajout d'une entrée `unreleased` dans la prochaine PR utilisateur-visible pour valider end-to-end.

## Story

\`docs/stories/core/25.1.release-notes-modal.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)