### PR TITLE
fix(landing): remplacer em-dash, badges stores, pilier agrégation

### DIFF
--- a/apps/landing/public/blog-soiree-prelancement.html
+++ b/apps/landing/public/blog-soiree-prelancement.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>On lance Facteur — viens fêter ça le 19 juin à Paris | Blog Facteur</title>
+    <title>On lance Facteur, viens fêter ça le 19 juin à Paris | Blog Facteur</title>
     <meta name="description"
         content="Soirée de pré-lancement de Facteur le 19 juin 2026 à 19h au bar Kilomètre Zéro, Paris. Découverte de l'app en avant-première, 40 places limitées.">
 
     <!-- OG Tags -->
-    <meta property="og:title" content="On lance Facteur — viens fêter ça le 19 juin à Paris">
+    <meta property="og:title" content="On lance Facteur, viens fêter ça le 19 juin à Paris">
     <meta property="og:description"
         content="Soirée de pré-lancement le 19 juin 2026 à 19h au bar Kilomètre Zéro (Paris). App en avant-première, échanges avec l'équipe. 40 places.">
     <meta property="og:type" content="article">
@@ -29,7 +29,7 @@
         <div class="container legal-page__hero-inner">
             <a href="/blog.html" class="legal-page__back-link">&larr; Le blog</a>
             <span class="blog-card__tag" style="margin-top: 1rem;">&Eacute;v&eacute;nement</span>
-            <h1 class="hero__title legal-page__title" style="margin-top: 0.75rem;">On lance Facteur &mdash;<br>viens f&ecirc;ter &ccedil;a avec nous.</h1>
+            <h1 class="hero__title legal-page__title" style="margin-top: 0.75rem;">On lance Facteur,<br>viens f&ecirc;ter &ccedil;a avec nous.</h1>
             <p class="hero__subtitle legal-page__subtitle">Soir&eacute;e de pr&eacute;-lancement &middot; <strong>19 juin 2026 &agrave; 19h</strong> &middot; Bar Kilom&egrave;tre Z&eacute;ro, Paris.</p>
         </div>
     </header>
@@ -65,7 +65,7 @@
                             <span class="event-card__label">Combien</span>
                             <span class="event-card__value">Entr&eacute;e libre</span>
                         </div>
-                        <div class="event-card__badge">40 places &mdash; premiers arriv&eacute;s, premiers servis</div>
+                        <div class="event-card__badge">40 places &middot; premiers arriv&eacute;s, premiers servis</div>
                     </div>
 
                     <div class="event-rsvp">
@@ -95,7 +95,7 @@
                         </div>
                     </div>
 
-                    <p class="article__signature">&mdash; L'&eacute;quipe Facteur</p>
+                    <p class="article__signature">L'&eacute;quipe Facteur</p>
                 </article>
 
             </div>

--- a/apps/landing/public/blog.html
+++ b/apps/landing/public/blog.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Blog — Facteur</title>
+    <title>Blog · Facteur</title>
     <meta name="description"
         content="Articles de fond sur l'information, les médias et nos choix de conception. Par l'équipe Facteur.">
 
     <!-- OG Tags -->
-    <meta property="og:title" content="Blog — Facteur">
+    <meta property="og:title" content="Blog · Facteur">
     <meta property="og:description"
         content="Articles de fond sur l'information, les médias et nos choix de conception.">
     <meta property="og:type" content="website">
@@ -35,7 +35,7 @@
             <a href="/" class="legal-page__back-link">&larr; Accueil</a>
             <h1 class="hero__title legal-page__title" style="margin-top: 1rem;">Le blog de Facteur</h1>
             <p class="hero__subtitle legal-page__subtitle">Analyses, coulisses et points de vue sur l'info et les
-                m&eacute;dias &mdash; par l'&eacute;quipe Facteur.</p>
+                m&eacute;dias, par l'&eacute;quipe Facteur.</p>
         </div>
     </header>
 
@@ -49,7 +49,7 @@
                         </div>
                         <div class="blog-card__body">
                             <span class="blog-card__tag">&Eacute;v&eacute;nement</span>
-                            <h2 class="blog-card__title">On lance Facteur &mdash; viens f&ecirc;ter &ccedil;a&nbsp;!</h2>
+                            <h2 class="blog-card__title">On lance Facteur, viens f&ecirc;ter &ccedil;a&nbsp;!</h2>
                             <p class="blog-card__excerpt">Soir&eacute;e de pr&eacute;-lancement le 19 juin &agrave; 19h au bar Kilom&egrave;tre Z&eacute;ro, Paris. App en avant-premi&egrave;re, &eacute;changes avec l'&eacute;quipe, 40 places.</p>
                             <span class="blog-card__more">Lire l'article &rarr;</span>
                         </div>

--- a/apps/landing/public/conditions-utilisation.html
+++ b/apps/landing/public/conditions-utilisation.html
@@ -4,10 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Facteur — Conditions Générales d'Utilisation</title>
+    <title>Facteur · Conditions Générales d'Utilisation</title>
     <meta name="description"
         content="Conditions Générales d'Utilisation de Facteur. Règles d'usage, abonnements et responsabilités.">
-    <meta property="og:title" content="Facteur — Conditions Générales d'Utilisation">
+    <meta property="og:title" content="Facteur · Conditions Générales d'Utilisation">
     <meta property="og:description"
         content="Consulte les conditions générales d'utilisation de Facteur, application de digest quotidien d'actualité.">
     <meta property="og:type" content="website">
@@ -107,7 +107,7 @@
                             <li>Le renouvellement est automatique sauf désactivation au moins 24 heures avant la date d'échéance</li>
                             <li>La gestion (résiliation, modification) s'effectue depuis les réglages du store correspondant</li>
                             <li>En cas de période d'essai gratuite, celle-ci se convertit automatiquement en abonnement payant à son terme, sauf résiliation préalable</li>
-                            <li>Facteur ne traite aucun remboursement directement — les demandes doivent être adressées à Apple ou Google selon le store d'achat</li>
+                            <li>Facteur ne traite aucun remboursement directement. Les demandes doivent être adressées à Apple ou Google selon le store d'achat</li>
                         </ul>
                         <p>Les prix sont affichés dans l'application et peuvent varier selon le marché et la devise locale. L'Éditeur se réserve le droit de modifier les tarifs avec un préavis raisonnable.</p>
 

--- a/apps/landing/public/css/style.css
+++ b/apps/landing/public/css/style.css
@@ -246,6 +246,15 @@ a:hover {
     border-radius: 1px;
 }
 
+.section__lede {
+    max-width: 640px;
+    margin: calc(-1 * var(--space-md)) auto var(--space-xl);
+    text-align: center;
+    font-size: var(--font-size-md);
+    line-height: 1.55;
+    color: var(--color-text-muted, #5a5a5a);
+}
+
 /* ═══════════════════════════════════════════
    Animations
    ═══════════════════════════════════════════ */
@@ -511,20 +520,19 @@ a:hover {
 .store-badge {
     display: inline-flex;
     align-items: center;
-    gap: 0.625rem;
-    padding: 0.5rem 1rem;
+    gap: 0.75rem;
+    padding: 0.55rem 1.1rem;
     border-radius: var(--radius-md);
     background: var(--color-dark-bg);
     color: var(--color-dark-text);
     cursor: default;
     user-select: none;
-    opacity: 0.55;
-    filter: grayscale(0.6);
+    opacity: 0.92;
 }
 
 .store-badge__icon {
-    width: 22px;
-    height: 22px;
+    width: 26px;
+    height: 26px;
     flex-shrink: 0;
     fill: currentColor;
 }

--- a/apps/landing/public/facteur-soiree.ics
+++ b/apps/landing/public/facteur-soiree.ics
@@ -10,7 +10,7 @@ DTSTART:20260619T170000Z
 DTEND:20260619T210000Z
 SUMMARY:Soirée de pré-lancement Facteur
 LOCATION:Bar Kilomètre Zéro, 39 Rue Notre Dame de Nazareth, 75003 Paris
-DESCRIPTION:On lance Facteur ! Viens découvrir l'app en avant-première, échanger avec l'équipe et fêter le pré-lancement. 40 places — premiers arrivés, premiers servis.
+DESCRIPTION:On lance Facteur ! Viens découvrir l'app en avant-première, échanger avec l'équipe et fêter le pré-lancement. 40 places, premiers arrivés, premiers servis.
 URL:https://facteur.app/blog-soiree-prelancement.html
 END:VEVENT
 END:VCALENDAR

--- a/apps/landing/public/founder.html
+++ b/apps/landing/public/founder.html
@@ -4,10 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Facteur — Tarif Fondateur</title>
+    <title>Facteur · Tarif Fondateur</title>
     <meta name="description"
-        content="Tarif fondateur·rice — 2,99 €/mois. Réservé à la première cohorte d'utilisateurs Facteur.">
-    <meta property="og:title" content="Facteur — Tarif Fondateur·rice 2,99 €/mois">
+        content="Tarif fondateur·rice à 2,99 €/mois. Réservé à la première cohorte d'utilisateurs Facteur.">
+    <meta property="og:title" content="Facteur · Tarif Fondateur·rice 2,99 €/mois">
     <meta property="og:description"
         content="Pour la première cohorte qui rejoint Facteur Premium : 2,99 €/mois (au lieu de 4,99 €).">
     <meta property="og:type" content="website">

--- a/apps/landing/public/grille.html
+++ b/apps/landing/public/grille.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Facteur — Le mot du jour</title>
+    <title>Facteur · Le mot du jour</title>
     <meta name="description" content="Ouvre le défi Mot du jour dans l'app Facteur.">
 
     <link rel="icon" href="/favicon.ico">

--- a/apps/landing/public/index.html
+++ b/apps/landing/public/index.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Facteur — Reprends le contrôle sur ton info.</title>
+    <title>Facteur · Reprends le contrôle sur ton info.</title>
     <meta name="description"
         content="L'essentiel de tes médias de confiance, dans une seule app.">
 
     <!-- OG Tags -->
-    <meta property="og:title" content="Facteur — Reprends le contrôle sur l'information">
+    <meta property="og:title" content="Facteur · Reprends le contrôle sur l'information">
     <meta property="og:description"
         content="L'essentiel de tes médias préférés dans une seule app. Sans scroll sans fin, sans l'angoisse de l'info. Bientôt disponible.">
     <meta property="og:type" content="website">
@@ -59,15 +59,14 @@
 
                 <div class="store-badges" aria-label="Bientôt disponible sur l'App Store et Google Play">
                     <span class="store-badge" role="img" aria-disabled="true"
-                        aria-label="App Store — bientôt disponible">
+                        aria-label="App Store, bientôt disponible">
                         <svg class="store-badge__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                            <path
-                                d="M16.365 1.43c0 1.14-.42 2.2-1.12 3-.83.96-2.2 1.7-3.32 1.61-.14-1.1.43-2.27 1.07-3 .77-.87 2.13-1.5 3.37-1.61zM20.94 17.06c-.6 1.4-1.32 2.8-2.46 2.82-1.12.03-1.48-.66-2.76-.66-1.28 0-1.68.64-2.74.69-1.1.04-1.94-1.5-2.55-2.9-1.25-2.86-2.2-8.08.92-11.6.78-.9 2.17-1.47 3.48-1.5 1.1-.02 2.14.74 2.82.74.68 0 1.95-.91 3.29-.78.56.02 2.13.23 3.14 1.7-2.7 1.65-2.27 5.5.42 6.69-.55 1.38-.4 1.07-.99 2.5z" />
+                            <path d="M17.564 12.65c-.026-2.622 2.144-3.881 2.244-3.942-1.222-1.785-3.122-2.029-3.799-2.06-1.617-.164-3.155.954-3.978.954-.823 0-2.084-.93-3.43-.904-1.764.026-3.39 1.025-4.297 2.604-1.831 3.171-.469 7.866 1.314 10.448.869 1.265 1.905 2.685 3.273 2.634 1.314-.052 1.81-.85 3.397-.85 1.587 0 2.033.85 3.423.823 1.414-.026 2.31-1.291 3.176-2.561.999-1.469 1.41-2.892 1.436-2.965-.031-.013-2.752-1.053-2.779-4.181zM14.97 4.939c.729-.881 1.221-2.107 1.087-3.327-1.05.042-2.322.7-3.077 1.581-.677.781-1.27 2.029-1.11 3.224 1.171.09 2.371-.595 3.1-1.478z" />
                         </svg>
                         <span class="store-badge__text"><small>Bientôt sur</small><strong>App Store</strong></span>
                     </span>
                     <span class="store-badge" role="img" aria-disabled="true"
-                        aria-label="Google Play — bientôt disponible">
+                        aria-label="Google Play, bientôt disponible">
                         <svg class="store-badge__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                             <path d="M3.6 2.2 13.5 12 3.6 21.8c-.3-.2-.5-.6-.5-1.1V3.3c0-.5.2-.9.5-1.1z" fill="#34A853" />
                             <path d="M16.3 9.2 5.9 3.3 3.6 2.2c.2-.1.5-.1.8 0l11.9 7z" fill="#EA4335" />
@@ -85,7 +84,7 @@
                             class="waitlist-form__input" autocomplete="email">
                         <button type="submit" class="waitlist-form__btn">Être prévenu·e au lancement</button>
                     </div>
-                    <p class="waitlist-form__hint">Beta privée — on t'écrit dès que c'est prêt.</p>
+                    <p class="waitlist-form__hint">Beta privée. On t'écrit dès que c'est prêt.</p>
                     <p class="waitlist-form__freemium">Gratuit. Premium optionnel.</p>
                     <p class="waitlist-form__success" hidden>Merci ! On t'écrit très vite. 💌</p>
                     <p class="waitlist-form__error" hidden></p>
@@ -93,7 +92,7 @@
             </div>
             <div class="hero__visual">
                 <div class="phone-mockup">
-                    <img src="/images/page_acceuil_bon_format.jpeg" alt="L'app Facteur — ton essentiel du jour"
+                    <img src="/images/page_acceuil_bon_format.jpeg" alt="L'app Facteur, ton essentiel du jour"
                         class="phone-mockup__img">
                 </div>
             </div>
@@ -112,7 +111,7 @@
                 <div class="testimonial-grid">
                     <div class="testimonial-card reveal-child">
                         <blockquote class="testimonial-card__quote">
-                            &laquo;&nbsp;On est noy&eacute;s de contenus, on consomme toujours plus d'info &mdash;
+                            &laquo;&nbsp;On est noy&eacute;s de contenus, on consomme toujours plus d'info,
                             mais au final, on reste en surface sur tout.&nbsp;&raquo;
                         </blockquote>
                         <div class="testimonial-card__header">
@@ -141,7 +140,7 @@
                     <div class="testimonial-card reveal-child">
                         <blockquote class="testimonial-card__quote">
                             &laquo;&nbsp;L'info est devenue anxiog&egrave;ne. &Ccedil;a fatigue, &ccedil;a
-                            d&eacute;prime &mdash; alors j'ai fini par l'&eacute;viter
+                            d&eacute;prime, alors j'ai fini par l'&eacute;viter
                             compl&egrave;tement.&nbsp;&raquo;
                         </blockquote>
                         <div class="testimonial-card__header">
@@ -179,28 +178,10 @@
         <section id="solution" class="section solution">
             <div class="container">
                 <h2 class="section__title">Facteur, c'est quoi <span class="highlight">concrètement</span> ?</h2>
+                <p class="section__lede">Une app d'agr&eacute;gation de ton info pour y voir plus clair et reprendre le contr&ocirc;le sur ce que tu lis.</p>
 
-                <!-- Pilier 1 — Compare les points de vue -->
+                <!-- Pilier 1 — Sources de confiance (agrégation) -->
                 <div class="pillar reveal">
-                    <div class="pillar__text">
-                        <h3 class="pillar__title">Compares les titres <span class="highlight">en 1 clic</span></h3>
-                        <p class="pillar__desc">Confronte la couverture de chaque m&eacute;dia sur chaque actu, et
-                            analyse les diff&eacute;rences en un coup d'&oelig;il. Dis adieu &agrave; ta bulle&nbsp;!</p>
-                    </div>
-                    <div class="pillar__visuals">
-                        <div class="phone-mockup phone-mockup--small">
-                            <img src="/images/reader_propre.jpeg" alt="Lecture d'un article"
-                                class="phone-mockup__img">
-                        </div>
-                        <div class="phone-mockup phone-mockup--small">
-                            <img src="/images/anal_biais.jpeg" alt="Analyse des biais et points de vue"
-                                class="phone-mockup__img">
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Pilier 2 — Sources de confiance -->
-                <div class="pillar pillar--reverse reveal">
                     <div class="pillar__text">
                         <h3 class="pillar__title">Tes médias préférés, <span class="highlight">dans 1 seule app.</span></h3>
                         <p class="pillar__desc">Ajoute les journaux, newsletters, cha&icirc;nes YouTube, podcasts,
@@ -213,6 +194,25 @@
                         </div>
                         <div class="phone-mockup phone-mockup--small">
                             <img src="/images/ajout_source_complet.jpeg" alt="Ajout d'une source"
+                                class="phone-mockup__img">
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Pilier 2 — Compare les points de vue -->
+                <div class="pillar pillar--reverse reveal">
+                    <div class="pillar__text">
+                        <h3 class="pillar__title">Compares les titres <span class="highlight">en 1 clic</span></h3>
+                        <p class="pillar__desc">Confronte la couverture de chaque m&eacute;dia sur chaque actu, et
+                            analyse les diff&eacute;rences en un coup d'&oelig;il. Dis adieu &agrave; ta bulle&nbsp;!</p>
+                    </div>
+                    <div class="pillar__visuals">
+                        <div class="phone-mockup phone-mockup--small">
+                            <img src="/images/reader_propre.jpeg" alt="Lecture d'un article"
+                                class="phone-mockup__img">
+                        </div>
+                        <div class="phone-mockup phone-mockup--small">
+                            <img src="/images/anal_biais.jpeg" alt="Analyse des biais et points de vue"
                                 class="phone-mockup__img">
                         </div>
                     </div>
@@ -250,7 +250,7 @@
                                 class="phone-mockup__img">
                         </div>
                         <div class="phone-mockup phone-mockup--small">
-                            <img src="/images/page_acceuil_2.jpeg" alt="Page d'accueil — tes infos du matin"
+                            <img src="/images/page_acceuil_2.jpeg" alt="Page d'accueil, tes infos du matin"
                                 class="phone-mockup__img">
                         </div>
                     </div>
@@ -265,11 +265,11 @@
                     </div>
                     <div class="pillar__visuals">
                         <div class="phone-mockup phone-mockup--small">
-                            <img src="/images/mode_serein-1.jpeg" alt="Mode serein — actu adoucie"
+                            <img src="/images/mode_serein-1.jpeg" alt="Mode serein, actu adoucie"
                                 class="phone-mockup__img">
                         </div>
                         <div class="phone-mockup phone-mockup--small">
-                            <img src="/images/fin_de_tourn%C3%A9e.jpeg" alt="Fin de tourn&eacute;e — moment de fermeture"
+                            <img src="/images/fin_de_tourn%C3%A9e.jpeg" alt="Fin de tourn&eacute;e, moment de fermeture"
                                 class="phone-mockup__img">
                         </div>
                     </div>
@@ -290,7 +290,7 @@
                         </div>
                         <div class="blog-card__body">
                             <span class="blog-card__tag">&Eacute;v&eacute;nement</span>
-                            <h3 class="blog-card__title">On lance Facteur &mdash; viens f&ecirc;ter &ccedil;a&nbsp;!</h3>
+                            <h3 class="blog-card__title">On lance Facteur, viens f&ecirc;ter &ccedil;a&nbsp;!</h3>
                             <p class="blog-card__excerpt">Soir&eacute;e de pr&eacute;-lancement le 19 juin &agrave; 19h au bar Kilom&egrave;tre Z&eacute;ro, Paris. App en avant-premi&egrave;re, 40 places.</p>
                             <span class="blog-card__more">Lire l'article &rarr;</span>
                         </div>
@@ -311,7 +311,7 @@
                         fa&ccedil;onn&eacute; par le monde Num&eacute;rique. Probl&egrave;me&nbsp;: ce dernier se trouve
                         aujourd'hui dans un &eacute;tat de <strong>polarisation</strong>,
                         <strong>d'opacit&eacute;</strong>, et de <strong>vuln&eacute;rabilit&eacute;</strong>
-                        compl&egrave;te face aux potentielles manipulations &mdash; qu'elles soient guid&eacute;es par
+                        compl&egrave;te face aux potentielles manipulations, qu'elles soient guid&eacute;es par
                         des int&eacute;r&ecirc;ts priv&eacute;s, des ing&eacute;rences ou des id&eacute;ologies
                         extr&eacute;mistes.
                     </p>
@@ -355,12 +355,12 @@
                 <!-- Engagements (transparence / contrôle / open-source) -->
                 <div class="manifesto__engagements">
                     <h3 class="manifesto__engagements-title">Nos engagements</h3>
-                    <p class="manifesto__engagements-intro">Pas des fonctionnalit&eacute;s &mdash; des choix de
+                    <p class="manifesto__engagements-intro">Pas des fonctionnalit&eacute;s. Des choix de
                         conception. Preuves &agrave; l'appui.</p>
                     <div class="manifesto__commitment-grid">
                         <div class="manifesto__commitment">
                             <img src="/images/algo-transparent.webp"
-                                alt="Pourquoi cet article — transparence de l'algorithme"
+                                alt="Pourquoi cet article, transparence de l'algorithme"
                                 class="manifesto__commitment-img">
                             <h4 class="manifesto__commitment-title">Transparence totale</h4>
                             <p>Tu sais pourquoi chaque article t'est recommand&eacute;. L'algo t'appartient.</p>
@@ -370,14 +370,14 @@
                                 alt="Contr&ocirc;le des sources et des sujets"
                                 class="manifesto__commitment-img">
                             <h4 class="manifesto__commitment-title">Tu gardes le contr&ocirc;le</h4>
-                            <p>Sources, sujets, intensit&eacute; &mdash; tout se r&egrave;gle selon tes pr&eacute;f&eacute;rences, pas les n&ocirc;tres.</p>
+                            <p>Sources, sujets, intensit&eacute;&nbsp;: tout se r&egrave;gle selon tes pr&eacute;f&eacute;rences, pas les n&ocirc;tres.</p>
                         </div>
                         <div class="manifesto__commitment">
                             <div class="manifesto__commitment-img manifesto__commitment-img--placeholder">
                                 <span class="manifesto__commitment-code">&lt;/&gt;</span>
                             </div>
                             <h4 class="manifesto__commitment-title">Code source disponible</h4>
-                            <p>Publi&eacute; sous licence non commerciale. Tu peux voir ce qu'on fait &mdash; et contribuer.</p>
+                            <p>Publi&eacute; sous licence non commerciale. Tu peux voir ce qu'on fait, et contribuer.</p>
                         </div>
                     </div>
                 </div>
@@ -414,8 +414,8 @@
                                 <code>PolyForm Noncommercial 1.0.0</code>.
                                 Tout usage commercial requiert un accord s&eacute;par&eacute; via
                                 <a href="mailto:laurin_boujon@proton.me">laurin_boujon@proton.me</a>.
-                                D&eacute;veloppeurs, designers, product managers &mdash; ou toute personne avec de
-                                bonnes id&eacute;es et l'envie de les porter &mdash; sont les bienvenus pour
+                                D&eacute;veloppeurs, designers, product managers, ou toute personne avec de
+                                bonnes id&eacute;es et l'envie de les porter, sont les bienvenus pour
                                 contribuer.</p>
                         </div>
                     </div>
@@ -495,7 +495,7 @@
                         on
                         contrôle nos sources.
                         Où on comprend
-                        pourquoi chaque contenu est là. Et on peut aussi s'arrêter de scroller — pour sortir du trop-plein d'infos inutiles voire déprimantes.</p>
+                        pourquoi chaque contenu est là. Et on peut aussi s'arrêter de scroller, pour sortir du trop-plein d'infos inutiles voire déprimantes.</p>
                     <p class="founder__closing">L'ingénieur fou qui impulse ce projet, c'est moi, Laurin.
                         <br>Et
                         si je quitte mon travail dans l'écologie pour lancer Facteur, c'est parce que je crois
@@ -513,20 +513,19 @@
         <section id="cta" class="section cta reveal">
             <div class="container cta__inner">
                 <h2 class="cta__title">Envie de <span class="highlight">jeter un oeil</span> ?</h2>
-                <p class="cta__subtitle">Ajoute ton email — on t'écrira dès que c'est prêt.</p>
+                <p class="cta__subtitle">Ajoute ton email, on t'écrira dès que c'est prêt.</p>
 
                 <div class="store-badges store-badges--center"
                     aria-label="Bientôt disponible sur l'App Store et Google Play">
                     <span class="store-badge" role="img" aria-disabled="true"
-                        aria-label="App Store — bientôt disponible">
+                        aria-label="App Store, bientôt disponible">
                         <svg class="store-badge__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                            <path
-                                d="M16.365 1.43c0 1.14-.42 2.2-1.12 3-.83.96-2.2 1.7-3.32 1.61-.14-1.1.43-2.27 1.07-3 .77-.87 2.13-1.5 3.37-1.61zM20.94 17.06c-.6 1.4-1.32 2.8-2.46 2.82-1.12.03-1.48-.66-2.76-.66-1.28 0-1.68.64-2.74.69-1.1.04-1.94-1.5-2.55-2.9-1.25-2.86-2.2-8.08.92-11.6.78-.9 2.17-1.47 3.48-1.5 1.1-.02 2.14.74 2.82.74.68 0 1.95-.91 3.29-.78.56.02 2.13.23 3.14 1.7-2.7 1.65-2.27 5.5.42 6.69-.55 1.38-.4 1.07-.99 2.5z" />
+                            <path d="M17.564 12.65c-.026-2.622 2.144-3.881 2.244-3.942-1.222-1.785-3.122-2.029-3.799-2.06-1.617-.164-3.155.954-3.978.954-.823 0-2.084-.93-3.43-.904-1.764.026-3.39 1.025-4.297 2.604-1.831 3.171-.469 7.866 1.314 10.448.869 1.265 1.905 2.685 3.273 2.634 1.314-.052 1.81-.85 3.397-.85 1.587 0 2.033.85 3.423.823 1.414-.026 2.31-1.291 3.176-2.561.999-1.469 1.41-2.892 1.436-2.965-.031-.013-2.752-1.053-2.779-4.181zM14.97 4.939c.729-.881 1.221-2.107 1.087-3.327-1.05.042-2.322.7-3.077 1.581-.677.781-1.27 2.029-1.11 3.224 1.171.09 2.371-.595 3.1-1.478z" />
                         </svg>
                         <span class="store-badge__text"><small>Bientôt sur</small><strong>App Store</strong></span>
                     </span>
                     <span class="store-badge" role="img" aria-disabled="true"
-                        aria-label="Google Play — bientôt disponible">
+                        aria-label="Google Play, bientôt disponible">
                         <svg class="store-badge__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                             <path d="M3.6 2.2 13.5 12 3.6 21.8c-.3-.2-.5-.6-.5-1.1V3.3c0-.5.2-.9.5-1.1z" fill="#34A853" />
                             <path d="M16.3 9.2 5.9 3.3 3.6 2.2c.2-.1.5-.1.8 0l11.9 7z" fill="#EA4335" />
@@ -544,7 +543,7 @@
                             class="waitlist-form__input" autocomplete="email">
                         <button type="submit" class="waitlist-form__btn">Être prévenu·e au lancement</button>
                     </div>
-                    <p class="waitlist-form__hint">Beta privée — on t'écrit dès que c'est prêt.</p>
+                    <p class="waitlist-form__hint">Beta privée. On t'écrit dès que c'est prêt.</p>
                     <p class="waitlist-form__success" hidden>Merci ! On t'écrit très vite. 💌</p>
                     <p class="waitlist-form__error" hidden></p>
                 </form>
@@ -607,7 +606,7 @@
                                     class="pain-rank"></span><span>Je ne fais plus confiance &agrave; ce qu'on me
                                     montre</span></button>
                             <button type="button" class="pain-item" data-value="stress_evitement"><span
-                                    class="pain-rank"></span><span>L'info me stresse / d&eacute;prime &mdash; je
+                                    class="pain-rank"></span><span>L'info me stresse / d&eacute;prime, je
                                     l'&eacute;vite</span></button>
                             <button type="button" class="pain-item" data-value="surface"><span
                                     class="pain-rank"></span><span>Je reste en surface, je comprends pas

--- a/apps/landing/public/politique-confidentialite.html
+++ b/apps/landing/public/politique-confidentialite.html
@@ -4,10 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Facteur — Politique de confidentialité</title>
+    <title>Facteur · Politique de confidentialité</title>
     <meta name="description"
         content="Politique de confidentialité de Facteur. Informations sur la collecte, l'usage et la protection des données.">
-    <meta property="og:title" content="Facteur — Politique de confidentialité">
+    <meta property="og:title" content="Facteur · Politique de confidentialité">
     <meta property="og:description"
         content="Consulte la politique de confidentialité de Facteur et les informations relatives au traitement des données.">
     <meta property="og:type" content="website">

--- a/apps/landing/public/premium.html
+++ b/apps/landing/public/premium.html
@@ -4,10 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Facteur Premium — Essai 7 jours</title>
+    <title>Facteur Premium · Essai 7 jours</title>
     <meta name="description"
-        content="Facteur Premium — 4,99 €/mois ou tarif annuel remisé. 7 jours d'essai gratuit. Paiement sécurisé.">
-    <meta property="og:title" content="Facteur Premium — Essai 7 jours">
+        content="Facteur Premium · 4,99 €/mois ou tarif annuel remisé. 7 jours d'essai gratuit. Paiement sécurisé.">
+    <meta property="og:title" content="Facteur Premium · Essai 7 jours">
     <meta property="og:description"
         content="L'essentiel de tes médias de confiance. 7 jours d'essai gratuit puis 4,99 €/mois.">
     <meta property="og:type" content="website">

--- a/apps/landing/public/supprimer-mon-compte.html
+++ b/apps/landing/public/supprimer-mon-compte.html
@@ -4,10 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Facteur — Supprimer mon compte</title>
+    <title>Facteur · Supprimer mon compte</title>
     <meta name="description"
         content="Comment supprimer votre compte Facteur et vos données personnelles.">
-    <meta property="og:title" content="Facteur — Supprimer mon compte">
+    <meta property="og:title" content="Facteur · Supprimer mon compte">
     <meta property="og:type" content="website">
 
     <link rel="icon" href="/favicon.ico">


### PR DESCRIPTION
## What
Fixes de la landing suite aux retours : remplacement des em-dashes (`—`) par `,`/`.` sur toutes les pages, séparateur de titre `—` → `·`, badges App Store/Google Play visuellement améliorés (opacité, taille icône), et refonte du Pilier 1 (agrégation de sources).

## Why
Le PO interdit les tirets em dans la copy user-facing. Les badges stores étaient trop discrets (grayscale + opacité basse). Le Pilier 1 reflète mieux le positionnement actuel (agrégateur de sources).

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist
- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging
- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)