### PR TITLE
feat(landing): bloc sources par type (logos réels) + hotfix hero/chapô

### DIFF
--- a/apps/landing/public/css/style.css
+++ b/apps/landing/public/css/style.css
@@ -818,6 +818,132 @@ a:hover {
 }
 
 /* ═══════════════════════════════════════════
+   SECTION — Sources showcase (ce que l'app contient)
+   Bande sombre, tranche avec les piliers blancs.
+   ═══════════════════════════════════════════ */
+
+.sources-showcase {
+    background: var(--color-dark-bg);
+}
+
+.sources-showcase__title {
+    color: var(--color-dark-text);
+}
+
+.sources-showcase__lede {
+    color: var(--color-dark-muted);
+}
+
+.sources-groups {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    max-width: 940px;
+    margin: 0 auto;
+}
+
+.source-group {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding-top: var(--space-md);
+}
+
+.source-group:first-child {
+    border-top: 0;
+    padding-top: 0;
+}
+
+.source-group__head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-sm);
+}
+
+.source-group__icon {
+    display: inline-flex;
+    width: 30px;
+    height: 30px;
+    flex-shrink: 0;
+    color: var(--color-accent);
+}
+
+.source-group__icon svg {
+    width: 100%;
+    height: 100%;
+}
+
+.source-group__icon--youtube {
+    color: #ff3d3d;
+}
+
+.source-group__icon--reddit {
+    color: #ff6a3d;
+}
+
+.source-group__label {
+    font-size: var(--font-size-lg);
+    font-weight: 700;
+    color: var(--color-dark-text);
+}
+
+.source-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+}
+
+.source-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.9rem 0.4rem 0.45rem;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    font-size: var(--font-size-sm);
+    color: var(--color-dark-text);
+    transition: background var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
+}
+
+.source-chip:hover {
+    background: rgba(255, 255, 255, 0.11);
+    transform: translateY(-1px);
+}
+
+.source-chip__logo {
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    background: #fff;
+    padding: 2px;
+    object-fit: contain;
+    flex-shrink: 0;
+}
+
+/* Pastilles sans logo (plateformes) : le logo de type est dans l'en-tête,
+   on ajoute juste un point accent pour garder du rythme. */
+.source-chip--text {
+    padding-left: 0.9rem;
+}
+
+.source-chip--text::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    flex-shrink: 0;
+}
+
+.sources-showcase__foot {
+    text-align: center;
+    margin-top: var(--space-lg);
+    color: var(--color-dark-muted);
+    font-size: var(--font-size-sm);
+}
+
+/* ═══════════════════════════════════════════
    SECTION 5 — Founder
    ═══════════════════════════════════════════ */
 

--- a/apps/landing/public/css/style.css
+++ b/apps/landing/public/css/style.css
@@ -248,7 +248,7 @@ a:hover {
 
 .section__lede {
     max-width: 640px;
-    margin: calc(-1 * var(--space-md)) auto var(--space-xl);
+    margin: calc(-1 * var(--space-md)) auto var(--space-2xl);
     text-align: center;
     font-size: var(--font-size-md);
     line-height: 1.55;
@@ -633,6 +633,14 @@ a:hover {
 
 .hero__visual .phone-mockup {
     animation: phoneFloat 6s ease-in-out infinite;
+}
+
+/* Cadre un peu plus en longueur sur le visuel principal : on recentre le
+   contenu (cover) sans déformer la capture, pour un rendu moins écrasé. */
+.hero__visual .phone-mockup__img {
+    aspect-ratio: 9 / 17.4;
+    object-fit: cover;
+    object-position: center top;
 }
 
 /* ═══════════════════════════════════════════

--- a/apps/landing/public/css/style.css
+++ b/apps/landing/public/css/style.css
@@ -819,19 +819,19 @@ a:hover {
 
 /* ═══════════════════════════════════════════
    SECTION — Sources showcase (ce que l'app contient)
-   Bande sombre, tranche avec les piliers blancs.
+   Bande orange chaude, tranche avec les piliers blancs.
    ═══════════════════════════════════════════ */
 
 .sources-showcase {
-    background: var(--color-dark-bg);
+    background: linear-gradient(160deg, #c85a28 0%, #a23f17 100%);
 }
 
 .sources-showcase__title {
-    color: var(--color-dark-text);
+    color: #fff;
 }
 
 .sources-showcase__lede {
-    color: var(--color-dark-muted);
+    color: rgba(255, 244, 236, 0.85);
 }
 
 .sources-groups {
@@ -843,7 +843,7 @@ a:hover {
 }
 
 .source-group {
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-top: 1px solid rgba(255, 255, 255, 0.18);
     padding-top: var(--space-md);
 }
 
@@ -864,20 +864,12 @@ a:hover {
     width: 30px;
     height: 30px;
     flex-shrink: 0;
-    color: var(--color-accent);
+    color: #ffe9dc;
 }
 
 .source-group__icon svg {
     width: 100%;
     height: 100%;
-}
-
-.source-group__icon--youtube {
-    color: #ff3d3d;
-}
-
-.source-group__icon--reddit {
-    color: #ff6a3d;
 }
 
 .source-group__label {
@@ -897,17 +889,17 @@ a:hover {
     align-items: center;
     gap: 0.5rem;
     padding: 0.4rem 0.9rem 0.4rem 0.45rem;
-    background: rgba(255, 255, 255, 0.06);
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.14);
+    border: 1px solid rgba(255, 255, 255, 0.24);
     border-radius: 999px;
     font-size: var(--font-size-sm);
-    color: var(--color-dark-text);
+    color: #fff;
     transition: background var(--duration-fast) var(--ease-out),
                 transform var(--duration-fast) var(--ease-out);
 }
 
 .source-chip:hover {
-    background: rgba(255, 255, 255, 0.11);
+    background: rgba(255, 255, 255, 0.22);
     transform: translateY(-1px);
 }
 
@@ -922,7 +914,7 @@ a:hover {
 }
 
 /* Pastilles sans logo (plateformes) : le logo de type est dans l'en-tête,
-   on ajoute juste un point accent pour garder du rythme. */
+   on ajoute juste un point clair pour garder du rythme. */
 .source-chip--text {
     padding-left: 0.9rem;
 }
@@ -932,14 +924,14 @@ a:hover {
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--color-accent);
+    background: #ffe1d0;
     flex-shrink: 0;
 }
 
 .sources-showcase__foot {
     text-align: center;
     margin-top: var(--space-lg);
-    color: var(--color-dark-muted);
+    color: rgba(255, 244, 236, 0.85);
     font-size: var(--font-size-sm);
 }
 

--- a/apps/landing/public/css/style.css
+++ b/apps/landing/public/css/style.css
@@ -819,19 +819,20 @@ a:hover {
 
 /* ═══════════════════════════════════════════
    SECTION — Sources showcase (ce que l'app contient)
-   Bande orange chaude, tranche avec les piliers blancs.
+   Fond orange très léger (token DS --color-accent-light) :
+   se distingue en douceur des piliers blancs, 100% dans la charte.
    ═══════════════════════════════════════════ */
 
 .sources-showcase {
-    background: linear-gradient(160deg, #c85a28 0%, #a23f17 100%);
+    background: var(--color-accent-light);
 }
 
 .sources-showcase__title {
-    color: #fff;
+    color: var(--color-text);
 }
 
 .sources-showcase__lede {
-    color: rgba(255, 244, 236, 0.85);
+    color: var(--color-text-muted);
 }
 
 .sources-groups {
@@ -843,7 +844,7 @@ a:hover {
 }
 
 .source-group {
-    border-top: 1px solid rgba(255, 255, 255, 0.18);
+    border-top: 1px solid var(--color-border);
     padding-top: var(--space-md);
 }
 
@@ -864,7 +865,7 @@ a:hover {
     width: 30px;
     height: 30px;
     flex-shrink: 0;
-    color: #ffe9dc;
+    color: var(--color-accent);
 }
 
 .source-group__icon svg {
@@ -875,7 +876,7 @@ a:hover {
 .source-group__label {
     font-size: var(--font-size-lg);
     font-weight: 700;
-    color: var(--color-dark-text);
+    color: var(--color-text);
 }
 
 .source-chips {
@@ -889,17 +890,17 @@ a:hover {
     align-items: center;
     gap: 0.5rem;
     padding: 0.4rem 0.9rem 0.4rem 0.45rem;
-    background: rgba(255, 255, 255, 0.14);
-    border: 1px solid rgba(255, 255, 255, 0.24);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 999px;
     font-size: var(--font-size-sm);
-    color: #fff;
-    transition: background var(--duration-fast) var(--ease-out),
+    color: var(--color-text);
+    transition: box-shadow var(--duration-fast) var(--ease-out),
                 transform var(--duration-fast) var(--ease-out);
 }
 
 .source-chip:hover {
-    background: rgba(255, 255, 255, 0.22);
+    box-shadow: var(--shadow-card);
     transform: translateY(-1px);
 }
 
@@ -911,10 +912,11 @@ a:hover {
     padding: 2px;
     object-fit: contain;
     flex-shrink: 0;
+    border: 1px solid var(--color-border);
 }
 
 /* Pastilles sans logo (plateformes) : le logo de type est dans l'en-tête,
-   on ajoute juste un point clair pour garder du rythme. */
+   on ajoute juste un point accent pour garder du rythme. */
 .source-chip--text {
     padding-left: 0.9rem;
 }
@@ -924,14 +926,14 @@ a:hover {
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: #ffe1d0;
+    background: var(--color-accent);
     flex-shrink: 0;
 }
 
 .sources-showcase__foot {
     text-align: center;
     margin-top: var(--space-lg);
-    color: rgba(255, 244, 236, 0.85);
+    color: var(--color-text-muted);
     font-size: var(--font-size-sm);
 }
 

--- a/apps/landing/public/css/style.css
+++ b/apps/landing/public/css/style.css
@@ -825,6 +825,7 @@ a:hover {
 
 .sources-showcase {
     background: var(--color-accent-light);
+    padding: var(--space-xl) 0;
 }
 
 .sources-showcase__title {
@@ -833,19 +834,20 @@ a:hover {
 
 .sources-showcase__lede {
     color: var(--color-text-muted);
+    margin-bottom: var(--space-lg);
 }
 
 .sources-groups {
     display: flex;
     flex-direction: column;
-    gap: var(--space-md);
+    gap: var(--space-sm);
     max-width: 940px;
     margin: 0 auto;
 }
 
 .source-group {
     border-top: 1px solid var(--color-border);
-    padding-top: var(--space-md);
+    padding-top: var(--space-sm);
 }
 
 .source-group:first-child {
@@ -928,6 +930,21 @@ a:hover {
     border-radius: 50%;
     background: var(--color-accent);
     flex-shrink: 0;
+}
+
+/* Pastille "+N" : couleur accent pleine pour signaler qu'il y a
+   beaucoup d'autres sources disponibles dans chaque catégorie. */
+.source-chip--more {
+    padding-left: 0.9rem;
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: #fff;
+    font-weight: 600;
+}
+
+.source-chip--more:hover {
+    background: var(--color-accent-hover);
+    border-color: var(--color-accent-hover);
 }
 
 .sources-showcase__foot {

--- a/apps/landing/public/css/style.css
+++ b/apps/landing/public/css/style.css
@@ -834,7 +834,7 @@ a:hover {
 
 .sources-showcase__lede {
     color: var(--color-text-muted);
-    margin-bottom: var(--space-lg);
+    margin-bottom: var(--space-md);
 }
 
 .sources-groups {
@@ -859,7 +859,7 @@ a:hover {
     display: flex;
     align-items: center;
     gap: var(--space-xs);
-    margin-bottom: var(--space-sm);
+    margin-bottom: var(--space-xs);
 }
 
 .source-group__icon {
@@ -890,12 +890,12 @@ a:hover {
 .source-chip {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.4rem 0.9rem 0.4rem 0.45rem;
+    gap: 0.4rem;
+    padding: 0.28rem 0.7rem 0.28rem 0.38rem;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: 999px;
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-xs);
     color: var(--color-text);
     transition: box-shadow var(--duration-fast) var(--ease-out),
                 transform var(--duration-fast) var(--ease-out);
@@ -907,9 +907,9 @@ a:hover {
 }
 
 .source-chip__logo {
-    width: 22px;
-    height: 22px;
-    border-radius: 6px;
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
     background: #fff;
     padding: 2px;
     object-fit: contain;
@@ -920,7 +920,7 @@ a:hover {
 /* Pastilles sans logo (plateformes) : le logo de type est dans l'en-tête,
    on ajoute juste un point accent pour garder du rythme. */
 .source-chip--text {
-    padding-left: 0.9rem;
+    padding-left: 0.7rem;
 }
 
 .source-chip--text::before {
@@ -932,19 +932,19 @@ a:hover {
     flex-shrink: 0;
 }
 
-/* Pastille "+N" : couleur accent pleine pour signaler qu'il y a
-   beaucoup d'autres sources disponibles dans chaque catégorie. */
+/* Pastille "+N" : style secondaire (contour accent, fond transparent) pour
+   signaler qu'il y a bien plus de sources, sans concurrencer les vraies. */
 .source-chip--more {
-    padding-left: 0.9rem;
-    background: var(--color-accent);
+    padding-left: 0.7rem;
+    background: transparent;
     border-color: var(--color-accent);
-    color: #fff;
+    color: var(--color-accent);
     font-weight: 600;
 }
 
 .source-chip--more:hover {
-    background: var(--color-accent-hover);
-    border-color: var(--color-accent-hover);
+    background: rgba(212, 101, 42, 0.1);
+    box-shadow: none;
 }
 
 .sources-showcase__foot {

--- a/apps/landing/public/index.html
+++ b/apps/landing/public/index.html
@@ -289,6 +289,7 @@
                             <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.francetvinfo.fr&amp;sz=128"><span>France Info</span></span>
                             <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.blast-info.fr&amp;sz=128"><span>Blast</span></span>
                             <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=reporterre.net&amp;sz=128"><span>Reporterre</span></span>
+                            <span class="source-chip source-chip--more">+165</span>
                         </div>
                     </div>
 
@@ -307,6 +308,7 @@
                             <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.socialter.fr&amp;sz=128"><span>Socialter</span></span>
                             <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=nouveaudepart.co&amp;sz=128"><span>Nouveau D&eacute;part</span></span>
                             <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.alternatives-economiques.fr&amp;sz=128"><span>Alternatives &Eacute;conomiques</span></span>
+                            <span class="source-chip source-chip--more">+200</span>
                         </div>
                     </div>
 
@@ -325,6 +327,7 @@
                             <span class="source-chip source-chip--text"><span>Heu?reka</span></span>
                             <span class="source-chip source-chip--text"><span>Monsieur Phi</span></span>
                             <span class="source-chip source-chip--text"><span>Osons Causer</span></span>
+                            <span class="source-chip source-chip--more">+1000</span>
                         </div>
                     </div>
 
@@ -343,6 +346,7 @@
                             <span class="source-chip source-chip--text"><span>France Inter</span></span>
                             <span class="source-chip source-chip--text"><span>Le Collimateur</span></span>
                             <span class="source-chip source-chip--text"><span>Transfert</span></span>
+                            <span class="source-chip source-chip--more">+100</span>
                         </div>
                     </div>
 
@@ -359,6 +363,7 @@
                             <span class="source-chip source-chip--text"><span>r/Europe</span></span>
                             <span class="source-chip source-chip--text"><span>r/sciences</span></span>
                             <span class="source-chip source-chip--text"><span>r/geopolitics</span></span>
+                            <span class="source-chip source-chip--more">+100</span>
                         </div>
                     </div>
 

--- a/apps/landing/public/index.html
+++ b/apps/landing/public/index.html
@@ -180,26 +180,7 @@
                 <h2 class="section__title">Facteur, c'est quoi <span class="highlight">concrètement</span> ?</h2>
                 <p class="section__lede">Une app d'agr&eacute;gation de ton info pour y voir plus clair et reprendre le contr&ocirc;le sur ce que tu lis.</p>
 
-                <!-- Pilier 1 — Sources de confiance (agrégation) -->
-                <div class="pillar reveal">
-                    <div class="pillar__text">
-                        <h3 class="pillar__title">Tes médias préférés, <span class="highlight">dans 1 seule app.</span></h3>
-                        <p class="pillar__desc">Ajoute les journaux, newsletters, cha&icirc;nes YouTube, podcasts,
-                            Reddits auxquels tu fais le plus confiance, au même endroit.</p>
-                    </div>
-                    <div class="pillar__visuals">
-                        <div class="phone-mockup phone-mockup--small">
-                            <img src="/images/choisir-mes-sources.webp" alt="S&eacute;lection de sources"
-                                class="phone-mockup__img">
-                        </div>
-                        <div class="phone-mockup phone-mockup--small">
-                            <img src="/images/ajout_source_complet.jpeg" alt="Ajout d'une source"
-                                class="phone-mockup__img">
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Pilier 2 — Compare les points de vue -->
+                <!-- Pilier 1 — Compare les points de vue -->
                 <div class="pillar pillar--reverse reveal">
                     <div class="pillar__text">
                         <h3 class="pillar__title">Compares les titres <span class="highlight">en 1 clic</span></h3>
@@ -218,7 +199,7 @@
                     </div>
                 </div>
 
-                <!-- Pilier 3 — Évaluation des médias -->
+                <!-- Pilier 2 — Évaluation des médias -->
                 <div class="pillar reveal">
                     <div class="pillar__text">
                         <h3 class="pillar__title">Comprends &agrave; qui <span class="highlight">faire confiance.</span></h3>
@@ -237,7 +218,7 @@
                     </div>
                 </div>
 
-                <!-- Pilier 4 — Résumés & veilles -->
+                <!-- Pilier 3 — Résumés & veilles -->
                 <div class="pillar pillar--reverse reveal">
                     <div class="pillar__text">
                         <h3 class="pillar__title">Tes infos r&eacutesumées, <span class="highlight">chaque matin.</span></h3>
@@ -256,7 +237,7 @@
                     </div>
                 </div>
 
-                <!-- Pilier 5 — Reste serein·e -->
+                <!-- Pilier 4 — Reste serein·e -->
                 <div class="pillar reveal">
                     <div class="pillar__text">
                         <h3 class="pillar__title">Reste serein&middot;e, <span class="highlight">et sache quand t'arr&ecirc;ter.</span></h3>
@@ -274,6 +255,116 @@
                         </div>
                     </div>
                 </div>
+            </div>
+        </section>
+
+        <!-- ═══════════════════════════════════════════ -->
+        <!-- SECTION — Ce que l'app peut contenir        -->
+        <!-- ═══════════════════════════════════════════ -->
+        <section id="sources" class="section sources-showcase reveal">
+            <div class="container">
+                <h2 class="section__title sources-showcase__title">Tes médias préférés, <span class="highlight">dans 1 seule app.</span></h2>
+                <p class="section__lede sources-showcase__lede">Journaux, newsletters, cha&icirc;nes YouTube, podcasts, Reddits&nbsp;: ajoute les sources en qui tu as le plus confiance, toutes au m&ecirc;me endroit.</p>
+
+                <div class="sources-groups">
+
+                    <!-- Presse & journaux -->
+                    <div class="source-group">
+                        <div class="source-group__head">
+                            <span class="source-group__icon" aria-hidden="true">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5h12v14a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1z"/><path d="M16 8h3a1 1 0 0 1 1 1v9a2 2 0 0 1-2 2"/><line x1="7" y1="9" x2="13" y2="9"/><line x1="7" y1="12.5" x2="13" y2="12.5"/><line x1="7" y1="16" x2="11" y2="16"/></svg>
+                            </span>
+                            <h3 class="source-group__label">Presse &amp; journaux</h3>
+                        </div>
+                        <div class="source-chips">
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.lemonde.fr&amp;sz=128"><span>Le Monde</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.liberation.fr&amp;sz=128"><span>Lib&eacute;ration</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.lefigaro.fr&amp;sz=128"><span>Le Figaro</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.mediapart.fr&amp;sz=128"><span>Mediapart</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.courrierinternational.com&amp;sz=128"><span>Courrier International</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.lesechos.fr&amp;sz=128"><span>Les &Eacute;chos</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.lepoint.fr&amp;sz=128"><span>Le Point</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.monde-diplomatique.fr&amp;sz=128"><span>Le Monde Diplomatique</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=theconversation.com&amp;sz=128"><span>The Conversation</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.francetvinfo.fr&amp;sz=128"><span>France Info</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.blast-info.fr&amp;sz=128"><span>Blast</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=reporterre.net&amp;sz=128"><span>Reporterre</span></span>
+                        </div>
+                    </div>
+
+                    <!-- Newsletters -->
+                    <div class="source-group">
+                        <div class="source-group__head">
+                            <span class="source-group__icon" aria-hidden="true">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
+                            </span>
+                            <h3 class="source-group__label">Newsletters</h3>
+                        </div>
+                        <div class="source-chips">
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=bonpote.com&amp;sz=128"><span>Bon Pote</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=vert.eco&amp;sz=128"><span>Vert</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=legrandcontinent.eu&amp;sz=128"><span>Le Grand Continent</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.socialter.fr&amp;sz=128"><span>Socialter</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=nouveaudepart.co&amp;sz=128"><span>Nouveau D&eacute;part</span></span>
+                            <span class="source-chip"><img class="source-chip__logo" loading="lazy" alt="" src="https://www.google.com/s2/favicons?domain=www.alternatives-economiques.fr&amp;sz=128"><span>Alternatives &Eacute;conomiques</span></span>
+                        </div>
+                    </div>
+
+                    <!-- YouTube -->
+                    <div class="source-group">
+                        <div class="source-group__head">
+                            <span class="source-group__icon source-group__icon--youtube" aria-hidden="true">
+                                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M23 12s0-3.2-.4-4.7a2.5 2.5 0 0 0-1.8-1.8C19.3 5 12 5 12 5s-7.3 0-8.8.4a2.5 2.5 0 0 0-1.8 1.8C1 8.8 1 12 1 12s0 3.2.4 4.7a2.5 2.5 0 0 0 1.8 1.8C4.7 19 12 19 12 19s7.3 0 8.8-.4a2.5 2.5 0 0 0 1.8-1.8C23 15.2 23 12 23 12Zm-13 3V9l5 3Z"/></svg>
+                            </span>
+                            <h3 class="source-group__label">Cha&icirc;nes YouTube</h3>
+                        </div>
+                        <div class="source-chips">
+                            <span class="source-chip source-chip--text"><span>Le Dessous des Cartes</span></span>
+                            <span class="source-chip source-chip--text"><span>ScienceEtonnante</span></span>
+                            <span class="source-chip source-chip--text"><span>Fouloscopie</span></span>
+                            <span class="source-chip source-chip--text"><span>Heu?reka</span></span>
+                            <span class="source-chip source-chip--text"><span>Monsieur Phi</span></span>
+                            <span class="source-chip source-chip--text"><span>Osons Causer</span></span>
+                        </div>
+                    </div>
+
+                    <!-- Podcasts -->
+                    <div class="source-group">
+                        <div class="source-group__head">
+                            <span class="source-group__icon" aria-hidden="true">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="3" width="6" height="11" rx="3"/><path d="M5 11a7 7 0 0 0 14 0"/><line x1="12" y1="18" x2="12" y2="21"/><line x1="8" y1="21" x2="16" y2="21"/></svg>
+                            </span>
+                            <h3 class="source-group__label">Podcasts</h3>
+                        </div>
+                        <div class="source-chips">
+                            <span class="source-chip source-chip--text"><span>Sismique</span></span>
+                            <span class="source-chip source-chip--text"><span>M&eacute;caniques du Complot</span></span>
+                            <span class="source-chip source-chip--text"><span>La Science CQFD</span></span>
+                            <span class="source-chip source-chip--text"><span>France Inter</span></span>
+                            <span class="source-chip source-chip--text"><span>Le Collimateur</span></span>
+                            <span class="source-chip source-chip--text"><span>Transfert</span></span>
+                        </div>
+                    </div>
+
+                    <!-- Reddit -->
+                    <div class="source-group">
+                        <div class="source-group__head">
+                            <span class="source-group__icon source-group__icon--reddit" aria-hidden="true">
+                                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M22 12.07a2.05 2.05 0 0 0-3.47-1.46 10.1 10.1 0 0 0-5.2-1.6l.88-3.93 2.78.62a1.4 1.4 0 1 0 .16-1.06l-3.3-.73a.53.53 0 0 0-.63.4l-1 4.43a10.1 10.1 0 0 0-5.27 1.6 2.05 2.05 0 1 0-2.4 3.27 3.7 3.7 0 0 0-.05.65c0 3.04 3.54 5.5 7.9 5.5s7.9-2.46 7.9-5.5a3.7 3.7 0 0 0-.05-.64A2.05 2.05 0 0 0 22 12.07ZM7.8 13.5a1.25 1.25 0 1 1 2.5 0 1.25 1.25 0 0 1-2.5 0Zm7.05 3.36a4.6 4.6 0 0 1-2.85.83 4.6 4.6 0 0 1-2.85-.83.43.43 0 1 1 .56-.65 3.78 3.78 0 0 0 2.29.62 3.78 3.78 0 0 0 2.29-.62.43.43 0 1 1 .56.65Zm-.1-2.11a1.25 1.25 0 1 1 1.25-1.25 1.25 1.25 0 0 1-1.25 1.25Z"/></svg>
+                            </span>
+                            <h3 class="source-group__label">Reddit</h3>
+                        </div>
+                        <div class="source-chips">
+                            <span class="source-chip source-chip--text"><span>r/france</span></span>
+                            <span class="source-chip source-chip--text"><span>r/Europe</span></span>
+                            <span class="source-chip source-chip--text"><span>r/sciences</span></span>
+                            <span class="source-chip source-chip--text"><span>r/geopolitics</span></span>
+                        </div>
+                    </div>
+
+                </div>
+
+                <p class="sources-showcase__foot">&hellip;et tout le reste. Ajoute n'importe quel site, flux RSS ou cha&icirc;ne en quelques secondes.</p>
             </div>
         </section>
 


### PR DESCRIPTION
## What
Récupère **deux changements landing qui n'ont pas atterri dans le squash-merge de #814** (la PR a été mergée en ne capturant que le 1er commit) :

1. **Hotfix hero + chapô** (`3168fa28`) : visuel hero « plus en longueur » (object-fit cover, non déformé) + chapô de la section solution aéré (marge `space-xl` → `space-2xl`).
2. **Nouveau bloc sources** (`bfba7505`, *commit isolé pour revert*) : l'ancien pilier 1 « agrégation » devient une **section dédiée, bande sombre**, placée **après les 4 piliers de fonctionnalités**. Sources groupées **par type** (Presse, Newsletters, YouTube, Podcasts, Reddit) avec icône de type + pastilles. Presse & Newsletters affichent les **vrais logos** (favicons, mêmes URLs que l'app). 18/18 chargés.

## Why
#814 a été mergée alors que ces deux commits n'étaient pas encore poussés → ils sont restés bloqués sur la branche fermée. Cette PR rouvre un moyen de **prévisualiser et valider** le bloc sources (et récupère au passage le hotfix hero/chapô).

## Type
- [ ] Feature
- [x] Bug fix (récupération + hotfix)
- [ ] Maintenance / Refactor

## Note
Le bloc sources est dans **son propre commit** (`bfba7505`) : si l'A/B ne convainc pas, `git revert bfba7505` le retire sans toucher au hotfix. Changement HTML/CSS only (pas de backend/Flutter).