### PR TITLE
hotfix(landing): bump cache-bust style.css v5 — section sources cassée en prod

### DIFF
--- a/apps/landing/public/blog-soiree-prelancement.html
+++ b/apps/landing/public/blog-soiree-prelancement.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
 
     <link rel="icon" href="/favicon.ico">
-    <link rel="stylesheet" href="/css/style.css?v=4">
+    <link rel="stylesheet" href="/css/style.css?v=5">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/apps/landing/public/blog.html
+++ b/apps/landing/public/blog.html
@@ -16,7 +16,7 @@
     <meta name="twitter:card" content="summary_large_image">
 
     <link rel="icon" href="/favicon.ico">
-    <link rel="stylesheet" href="/css/style.css?v=4">
+    <link rel="stylesheet" href="/css/style.css?v=5">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/apps/landing/public/conditions-utilisation.html
+++ b/apps/landing/public/conditions-utilisation.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
 
     <link rel="icon" href="/favicon.ico">
-    <link rel="stylesheet" href="/css/style.css?v=3">
+    <link rel="stylesheet" href="/css/style.css?v=5">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/apps/landing/public/founder.html
+++ b/apps/landing/public/founder.html
@@ -15,7 +15,7 @@
     <meta name="robots" content="noindex">
 
     <link rel="icon" href="/favicon.ico">
-    <link rel="stylesheet" href="/css/style.css?v=4">
+    <link rel="stylesheet" href="/css/style.css?v=5">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/apps/landing/public/grille.html
+++ b/apps/landing/public/grille.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Ouvre le défi Mot du jour dans l'app Facteur.">
 
     <link rel="icon" href="/favicon.ico">
-    <link rel="stylesheet" href="/css/style.css?v=3">
+    <link rel="stylesheet" href="/css/style.css?v=5">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/apps/landing/public/index.html
+++ b/apps/landing/public/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
 
     <link rel="icon" href="/favicon.ico">
-    <link rel="stylesheet" href="/css/style.css?v=4">
+    <link rel="stylesheet" href="/css/style.css?v=5">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/apps/landing/public/politique-confidentialite.html
+++ b/apps/landing/public/politique-confidentialite.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
 
     <link rel="icon" href="/favicon.ico">
-    <link rel="stylesheet" href="/css/style.css?v=4">
+    <link rel="stylesheet" href="/css/style.css?v=5">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/apps/landing/public/premium.html
+++ b/apps/landing/public/premium.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
 
     <link rel="icon" href="/favicon.ico">
-    <link rel="stylesheet" href="/css/style.css?v=4">
+    <link rel="stylesheet" href="/css/style.css?v=5">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/apps/landing/public/supprimer-mon-compte.html
+++ b/apps/landing/public/supprimer-mon-compte.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website">
 
     <link rel="icon" href="/favicon.ico">
-    <link rel="stylesheet" href="/css/style.css?v=3">
+    <link rel="stylesheet" href="/css/style.css?v=5">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">


### PR DESCRIPTION
## What
Bump du query de cache-busting `style.css?v=4`/`v=3` → `?v=5` sur **toutes les pages** de la landing.

## Why (diagnostic prod)
La section « sources » mergée en #815 s'affichait cassée en prod : **gros trou** sur desktop, **logos pleine page non centrés** sur mobile.

Cause : #815 a modifié le **contenu** de `style.css` (règles `.sources-showcase`, `.source-chip*`…) **sans bumper le `?v=`** du `<link>`. Les visiteurs avaient `style.css?v=4` déjà en cache → le navigateur servait l'**ancien CSS sans ces règles**. Résultat : chips en `display:block` pleine largeur, logos à leur taille naturelle (≈128px) empilés, section ~3500px de haut → l'animation `reveal` (seuil 0.15) ne se déclenche pas → section invisible.

Vérifié en live sur facteur.app : en forçant le CSS frais, `chips=flex`, `logo=18px`, section 3472px → **1244px**, tout rentre dans l'ordre. Le fichier `style.css` sur `main` est déjà correct — **seul le `?v=` n'avait pas été incrémenté**.

## Type
- [x] Bug fix (hotfix prod)

## Note
À retenir : **toute modif de `style.css` doit s'accompagner d'un bump `?v=`** (sinon cache navigateur = CSS périmé). Pas de build/hash sur cette landing statique, donc le versionning est manuel.