### PR TITLE
Fix left-edge swipe back conflicts in mobile detail view

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -21,6 +21,7 @@ import 'dart:math' as math;
 import '../../../config/theme.dart';
 import '../../../core/api/api_client.dart';
 import '../../../core/providers/analytics_provider.dart';
+import '../../../shared/widgets/navigation/swipe_back_page.dart';
 import '../../feed/models/content_model.dart';
 import '../../sources/models/source_model.dart';
 import '../../../core/providers/navigation_providers.dart';
@@ -3162,7 +3163,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 () => VerticalDragGestureRecognizer(),
               ),
               Factory<HorizontalDragGestureRecognizer>(
-                () => HorizontalDragGestureRecognizer(),
+                () => BackGestureCompatibleHorizontalDragGestureRecognizer(
+                  viewportWidth: MediaQuery.sizeOf(context).width,
+                ),
               ),
             }
           : const {},

--- a/apps/mobile/lib/shared/widgets/navigation/swipe_back_page.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/swipe_back_page.dart
@@ -1,6 +1,42 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 
+const double wideBackGestureWidthFraction = 0.35;
+
+/// Horizontal recognizer for children, such as a WebView, that should yield
+/// rightward drags in the wide back-gesture zone to the enclosing route.
+class BackGestureCompatibleHorizontalDragGestureRecognizer
+    extends HorizontalDragGestureRecognizer {
+  BackGestureCompatibleHorizontalDragGestureRecognizer({
+    required this.viewportWidth,
+    super.debugOwner,
+  });
+
+  final double viewportWidth;
+  bool _startedInBackGestureZone = false;
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    _startedInBackGestureZone =
+        event.localPosition.dx <= viewportWidth * wideBackGestureWidthFraction;
+    super.addAllowedPointer(event);
+  }
+
+  @override
+  bool hasSufficientGlobalDistanceToAccept(
+    PointerDeviceKind pointerDeviceKind,
+    double? deviceTouchSlop,
+  ) {
+    if (_startedInBackGestureZone && globalDistanceMoved > 0) {
+      return false;
+    }
+    return super.hasSufficientGlobalDistanceToAccept(
+      pointerDeviceKind,
+      deviceTouchSlop,
+    );
+  }
+}
+
 /// A [Page] that uses the standard Cupertino slide-from-right transition
 /// but with a wider swipe-back gesture zone (left ~35% of screen) instead
 /// of the default edge-only (20px) gesture area.
@@ -177,7 +213,10 @@ class _FullScreenBackGestureDetectorState
   }
 
   void _handlePointerDown(PointerDownEvent event) {
-    if (widget.enabledCallback()) {
+    final width = context.size?.width;
+    if (width != null &&
+        event.localPosition.dx <= width * wideBackGestureWidthFraction &&
+        widget.enabledCallback()) {
       _recognizer.addPointer(event);
     }
   }
@@ -215,29 +254,12 @@ class _FullScreenBackGestureDetectorState
     }
   }
 
-  /// Fraction of screen width from the left edge where the gesture is active.
-  static const double _gestureWidthFraction = 0.35;
-
   @override
   Widget build(BuildContext context) {
-    final screenWidth = MediaQuery.of(context).size.width;
-    return Stack(
-      fit: StackFit.passthrough,
-      children: [
-        widget.child,
-        // Left-third overlay — wide enough for easy swiping,
-        // narrow enough to not fight vertical scroll in content.
-        Positioned(
-          left: 0,
-          top: 0,
-          bottom: 0,
-          width: screenWidth * _gestureWidthFraction,
-          child: Listener(
-            onPointerDown: _handlePointerDown,
-            behavior: HitTestBehavior.translucent,
-          ),
-        ),
-      ],
+    return Listener(
+      onPointerDown: _handlePointerDown,
+      behavior: HitTestBehavior.translucent,
+      child: widget.child,
     );
   }
 }

--- a/apps/mobile/test/shared/widgets/navigation/swipe_back_page_test.dart
+++ b/apps/mobile/test/shared/widgets/navigation/swipe_back_page_test.dart
@@ -1,0 +1,198 @@
+import 'package:facteur/shared/widgets/navigation/swipe_back_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const viewportSize = Size(800, 600);
+
+  Future<void> openScrollablePage(
+    WidgetTester tester, {
+    ScrollController? controller,
+    VoidCallback? onLeftTap,
+    bool handlesHorizontalDrags = false,
+  }) async {
+    await tester.binding.setSurfaceSize(viewportSize);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: FilledButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    FullSwipeCupertinoPage<void>(
+                      child: _ScrollableTestPage(
+                        controller: controller,
+                        onLeftTap: onLeftTap,
+                        handlesHorizontalDrags: handlesHorizontalDrags,
+                      ),
+                    ).createRoute(context),
+                  );
+                },
+                child: const Text('Ouvrir'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Ouvrir'));
+    await tester.pumpAndSettle();
+    expect(find.text('Page scrollable'), findsOneWidget);
+  }
+
+  Future<void> dragFrom(WidgetTester tester, Offset start, Offset delta) async {
+    final gesture = await tester.startGesture(start);
+    const steps = 10;
+    for (var step = 0; step < steps; step++) {
+      await gesture.moveBy(delta / steps.toDouble());
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
+  group('FullSwipeCupertinoPage', () {
+    testWidgets('allows vertical scrolling from the left, center and right', (
+      tester,
+    ) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      await openScrollablePage(
+        tester,
+        controller: controller,
+        handlesHorizontalDrags: true,
+      );
+
+      for (final x in <double>[40, 400, 760]) {
+        controller.jumpTo(0);
+        await tester.pump();
+
+        await dragFrom(tester, Offset(x, 450), const Offset(0, -220));
+
+        expect(
+          controller.offset,
+          greaterThan(0),
+          reason: 'A vertical drag starting at x=$x should scroll.',
+        );
+        expect(find.text('Page scrollable'), findsOneWidget);
+      }
+    });
+
+    testWidgets('keeps a mostly vertical diagonal drag in the scroll view', (
+      tester,
+    ) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      await openScrollablePage(tester, controller: controller);
+
+      await dragFrom(tester, const Offset(40, 450), const Offset(30, -220));
+
+      expect(controller.offset, greaterThan(0));
+      expect(find.text('Page scrollable'), findsOneWidget);
+    });
+
+    testWidgets('pops on a right swipe starting in the left 35 percent', (
+      tester,
+    ) async {
+      await openScrollablePage(tester);
+
+      await dragFrom(tester, const Offset(40, 300), const Offset(500, 0));
+
+      expect(find.text('Page scrollable'), findsNothing);
+      expect(find.text('Ouvrir'), findsOneWidget);
+    });
+
+    testWidgets('pops over content that also handles horizontal drags', (
+      tester,
+    ) async {
+      await openScrollablePage(tester, handlesHorizontalDrags: true);
+
+      await dragFrom(tester, const Offset(40, 300), const Offset(500, 0));
+
+      expect(find.text('Page scrollable'), findsNothing);
+      expect(find.text('Ouvrir'), findsOneWidget);
+    });
+
+    testWidgets('does not pop when the right swipe starts outside the zone', (
+      tester,
+    ) async {
+      await openScrollablePage(tester);
+
+      await dragFrom(tester, const Offset(400, 300), const Offset(300, 0));
+
+      expect(find.text('Page scrollable'), findsOneWidget);
+    });
+
+    testWidgets('keeps taps interactive inside the left gesture zone', (
+      tester,
+    ) async {
+      var tapCount = 0;
+      await openScrollablePage(tester, onLeftTap: () => tapCount++);
+
+      await tester.tap(find.byKey(const Key('left-button')));
+      await tester.pump();
+
+      expect(tapCount, 1);
+      expect(find.text('Page scrollable'), findsOneWidget);
+    });
+  });
+}
+
+class _ScrollableTestPage extends StatelessWidget {
+  const _ScrollableTestPage({
+    this.controller,
+    this.onLeftTap,
+    this.handlesHorizontalDrags = false,
+  });
+
+  final ScrollController? controller;
+  final VoidCallback? onLeftTap;
+  final bool handlesHorizontalDrags;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Page scrollable')),
+      body: Stack(
+        children: [
+          RawGestureDetector(
+            gestures: handlesHorizontalDrags
+                ? {
+                    BackGestureCompatibleHorizontalDragGestureRecognizer:
+                        GestureRecognizerFactoryWithHandlers<
+                            BackGestureCompatibleHorizontalDragGestureRecognizer>(
+                      () =>
+                          BackGestureCompatibleHorizontalDragGestureRecognizer(
+                        viewportWidth: MediaQuery.sizeOf(context).width,
+                      ),
+                      (recognizer) {
+                        recognizer.onUpdate = (_) {};
+                      },
+                    ),
+                  }
+                : const {},
+            child: ListView.builder(
+              controller: controller,
+              itemExtent: 80,
+              itemCount: 30,
+              itemBuilder: (context, index) => Text('Ligne $index'),
+            ),
+          ),
+          Positioned(
+            left: 8,
+            top: 8,
+            child: FilledButton(
+              key: const Key('left-button'),
+              onPressed: onLeftTap,
+              child: const Text('Action gauche'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## What

Improve the mobile swipe-back behavior by allowing the route-level back gesture to win for rightward drags that start in the left 35% of the screen, even when child content handles horizontal drags. Update the content detail screen to use the compatible horizontal recognizer and add widget tests covering swipe-back, vertical scrolling, and left-zone tap behavior.

## Why

The wider swipe-back area was competing with horizontally draggable child content, which could block navigation gestures from the left side of the screen. This restores predictable back navigation without breaking vertical scrolling or taps inside that zone.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)
