### PR TITLE
hotfix(mobile): preserve swipe back inside article WebViews

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -1,7 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:facteur/core/utils/html_utils.dart';
 import 'package:flutter/foundation.dart'
-    show Factory, defaultTargetPlatform, kIsWeb, visibleForTesting;
+    show defaultTargetPlatform, kIsWeb, visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -14,7 +14,6 @@ import 'package:webview_flutter/webview_flutter.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart'
     show InAppWebViewController, WebUri;
 import 'package:flutter/services.dart';
-import 'package:flutter/gestures.dart';
 import 'dart:async';
 import 'dart:math' as math;
 
@@ -3181,14 +3180,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     return WebViewWidget(
       controller: _webViewController!,
       gestureRecognizers: _isWebViewActive
-          ? {
-              Factory<VerticalDragGestureRecognizer>(
-                () => VerticalDragGestureRecognizer(),
-              ),
-              Factory<HorizontalDragGestureRecognizer>(
-                () => HorizontalDragGestureRecognizer(),
-              ),
-            }
+          ? backGestureCompatibleWebViewRecognizers(
+              MediaQuery.sizeOf(context).width,
+            )
           : const {},
     );
   }
@@ -3822,6 +3816,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         onScrollY: (y) => _webScrollY = y,
         onProgress: _applyWebReadingProgress,
         onPaywallDetected: _onPremiumPaywallDetected,
+        gestureRecognizers: backGestureCompatibleWebViewRecognizers(
+          MediaQuery.sizeOf(context).width,
+        ),
       );
       return Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -3862,7 +3859,14 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           _PremiumConnectBanner(
             onConnect: () => _openPremiumConnectionFromReader(source),
           ),
-        Expanded(child: WebViewWidget(controller: _webViewController!)),
+        Expanded(
+          child: WebViewWidget(
+            controller: _webViewController!,
+            gestureRecognizers: backGestureCompatibleWebViewRecognizers(
+              MediaQuery.sizeOf(context).width,
+            ),
+          ),
+        ),
       ],
     );
   }

--- a/apps/mobile/lib/features/sources/widgets/premium_web_view.dart
+++ b/apps/mobile/lib/features/sources/widgets/premium_web_view.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart' show Factory;
+import 'package:flutter/gestures.dart' show OneSequenceGestureRecognizer;
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
@@ -44,6 +46,7 @@ class PremiumWebView extends StatefulWidget {
     this.onProgress,
     this.onScrollY,
     this.onPaywallDetected,
+    this.gestureRecognizers,
   });
 
   final Source source;
@@ -66,6 +69,7 @@ class PremiumWebView extends StatefulWidget {
   final ValueChanged<double>? onProgress;
   final ValueChanged<double>? onScrollY;
   final VoidCallback? onPaywallDetected;
+  final Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers;
 
   @override
   State<PremiumWebView> createState() => _PremiumWebViewState();
@@ -96,6 +100,7 @@ class _PremiumWebViewState extends State<PremiumWebView> {
 
     return InAppWebView(
       initialSettings: settings,
+      gestureRecognizers: widget.gestureRecognizers,
       onWebViewCreated: _handleCreated,
       onLoadStop: _handleLoadStop,
     );

--- a/apps/mobile/lib/shared/widgets/navigation/swipe_back_page.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/swipe_back_page.dart
@@ -1,7 +1,61 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show Factory;
 import 'package:flutter/gestures.dart';
 
 const double wideBackGestureWidthFraction = 0.35;
+
+/// Horizontal recognizer for embedded platform views that should yield
+/// rightward drags in the wide back-gesture zone to the enclosing route.
+class BackGestureCompatibleHorizontalDragGestureRecognizer
+    extends HorizontalDragGestureRecognizer {
+  BackGestureCompatibleHorizontalDragGestureRecognizer({
+    required this.viewportWidth,
+    super.debugOwner,
+  });
+
+  final double viewportWidth;
+  bool _startedInBackGestureZone = false;
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    _startedInBackGestureZone =
+        event.localPosition.dx <= viewportWidth * wideBackGestureWidthFraction;
+    super.addAllowedPointer(event);
+  }
+
+  @override
+  bool hasSufficientGlobalDistanceToAccept(
+    PointerDeviceKind pointerDeviceKind,
+    double? deviceTouchSlop,
+  ) {
+    if (_startedInBackGestureZone && globalDistanceMoved > 0) {
+      return false;
+    }
+    return super.hasSufficientGlobalDistanceToAccept(
+      pointerDeviceKind,
+      deviceTouchSlop,
+    );
+  }
+}
+
+/// Gesture set for article WebViews nested inside [FullSwipeCupertinoPage].
+///
+/// Vertical drags remain owned by the WebView. Horizontal drags work normally,
+/// except rightward drags starting in the left 35%, which remain available to
+/// the route's swipe-back recognizer.
+Set<Factory<OneSequenceGestureRecognizer>>
+    backGestureCompatibleWebViewRecognizers(double viewportWidth) {
+  return {
+    Factory<VerticalDragGestureRecognizer>(
+      () => VerticalDragGestureRecognizer(),
+    ),
+    Factory<HorizontalDragGestureRecognizer>(
+      () => BackGestureCompatibleHorizontalDragGestureRecognizer(
+        viewportWidth: viewportWidth,
+      ),
+    ),
+  };
+}
 
 enum FullSwipePageTransition { horizontal, verticalFromBottom }
 


### PR DESCRIPTION
## Summary
- make article WebViews cooperate with the shared wide swipe-back gesture
- preserve vertical scrolling and normal left-zone touch interactions
- apply the recognizers to standard, fallback, and premium WebView readers

## Validation
- `flutter test test/shared/widgets/navigation/swipe_back_page_test.dart` (6 passed)
- targeted `flutter analyze` (no errors or warnings; existing info diagnostics only)
- `flutter build web --release`
- full suite baseline: 1023 passed, 25 unrelated existing failures
- full analyze baseline: existing repository diagnostics remain