### PR TITLE
hotfix(mobile): let WebViews claim vertical drags only

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -3180,9 +3180,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     return WebViewWidget(
       controller: _webViewController!,
       gestureRecognizers: _isWebViewActive
-          ? backGestureCompatibleWebViewRecognizers(
-              MediaQuery.sizeOf(context).width,
-            )
+          ? swipeBackCompatiblePlatformViewGestureRecognizers()
           : const {},
     );
   }
@@ -3816,9 +3814,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         onScrollY: (y) => _webScrollY = y,
         onProgress: _applyWebReadingProgress,
         onPaywallDetected: _onPremiumPaywallDetected,
-        gestureRecognizers: backGestureCompatibleWebViewRecognizers(
-          MediaQuery.sizeOf(context).width,
-        ),
+        gestureRecognizers: swipeBackCompatiblePlatformViewGestureRecognizers(),
       );
       return Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -3862,9 +3858,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         Expanded(
           child: WebViewWidget(
             controller: _webViewController!,
-            gestureRecognizers: backGestureCompatibleWebViewRecognizers(
-              MediaQuery.sizeOf(context).width,
-            ),
+            gestureRecognizers:
+                swipeBackCompatiblePlatformViewGestureRecognizers(),
           ),
         ),
       ],

--- a/apps/mobile/lib/shared/widgets/navigation/swipe_back_page.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/swipe_back_page.dart
@@ -4,55 +4,19 @@ import 'package:flutter/gestures.dart';
 
 const double wideBackGestureWidthFraction = 0.35;
 
-/// Horizontal recognizer for embedded platform views that should yield
-/// rightward drags in the wide back-gesture zone to the enclosing route.
-class BackGestureCompatibleHorizontalDragGestureRecognizer
-    extends HorizontalDragGestureRecognizer {
-  BackGestureCompatibleHorizontalDragGestureRecognizer({
-    required this.viewportWidth,
-    super.debugOwner,
-  });
-
-  final double viewportWidth;
-  bool _startedInBackGestureZone = false;
-
-  @override
-  void addAllowedPointer(PointerDownEvent event) {
-    _startedInBackGestureZone =
-        event.localPosition.dx <= viewportWidth * wideBackGestureWidthFraction;
-    super.addAllowedPointer(event);
-  }
-
-  @override
-  bool hasSufficientGlobalDistanceToAccept(
-    PointerDeviceKind pointerDeviceKind,
-    double? deviceTouchSlop,
-  ) {
-    if (_startedInBackGestureZone && globalDistanceMoved > 0) {
-      return false;
-    }
-    return super.hasSufficientGlobalDistanceToAccept(
-      pointerDeviceKind,
-      deviceTouchSlop,
-    );
-  }
-}
-
-/// Gesture set for article WebViews nested inside [FullSwipeCupertinoPage].
+/// Gesture set for platform views nested inside [FullSwipeCupertinoPage].
 ///
-/// Vertical drags remain owned by the WebView. Horizontal drags work normally,
-/// except rightward drags starting in the left 35%, which remain available to
-/// the route's swipe-back recognizer.
+/// Only vertical drags are claimed by the platform view.
+///
+/// This mirrors a Flutter [Scrollable]: vertical movement scrolls immediately,
+/// while horizontal movement remains available to the enclosing route's
+/// swipe-back recognizer. Taps and other unclaimed gestures still fall through
+/// to the platform view.
 Set<Factory<OneSequenceGestureRecognizer>>
-    backGestureCompatibleWebViewRecognizers(double viewportWidth) {
+    swipeBackCompatiblePlatformViewGestureRecognizers() {
   return {
-    Factory<VerticalDragGestureRecognizer>(
-      () => VerticalDragGestureRecognizer(),
-    ),
-    Factory<HorizontalDragGestureRecognizer>(
-      () => BackGestureCompatibleHorizontalDragGestureRecognizer(
-        viewportWidth: viewportWidth,
-      ),
+    const Factory<VerticalDragGestureRecognizer>(
+      VerticalDragGestureRecognizer.new,
     ),
   };
 }

--- a/apps/mobile/test/shared/widgets/navigation/swipe_back_page_test.dart
+++ b/apps/mobile/test/shared/widgets/navigation/swipe_back_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:facteur/shared/widgets/navigation/swipe_back_page.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,7 +10,6 @@ void main() {
     WidgetTester tester, {
     ScrollController? controller,
     VoidCallback? onLeftTap,
-    bool handlesHorizontalDrags = false,
   }) async {
     await tester.binding.setSurfaceSize(viewportSize);
     addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -26,7 +26,6 @@ void main() {
                       child: _ScrollableTestPage(
                         controller: controller,
                         onLeftTap: onLeftTap,
-                        handlesHorizontalDrags: handlesHorizontalDrags,
                       ),
                     ).createRoute(context),
                   );
@@ -64,7 +63,6 @@ void main() {
       await openScrollablePage(
         tester,
         controller: controller,
-        handlesHorizontalDrags: true,
       );
 
       for (final x in <double>[40, 400, 760]) {
@@ -106,17 +104,6 @@ void main() {
       expect(find.text('Ouvrir'), findsOneWidget);
     });
 
-    testWidgets('pops over content that also handles horizontal drags', (
-      tester,
-    ) async {
-      await openScrollablePage(tester, handlesHorizontalDrags: true);
-
-      await dragFrom(tester, const Offset(40, 300), const Offset(500, 0));
-
-      expect(find.text('Page scrollable'), findsNothing);
-      expect(find.text('Ouvrir'), findsOneWidget);
-    });
-
     testWidgets('does not pop when the right swipe starts outside the zone', (
       tester,
     ) async {
@@ -139,6 +126,15 @@ void main() {
       expect(tapCount, 1);
       expect(find.text('Page scrollable'), findsOneWidget);
     });
+
+    test('platform views claim vertical drags only', () {
+      final recognizers = swipeBackCompatiblePlatformViewGestureRecognizers();
+      expect(recognizers, hasLength(1));
+      expect(
+        recognizers.single.type,
+        VerticalDragGestureRecognizer,
+      );
+    });
   });
 }
 
@@ -146,12 +142,10 @@ class _ScrollableTestPage extends StatelessWidget {
   const _ScrollableTestPage({
     this.controller,
     this.onLeftTap,
-    this.handlesHorizontalDrags = false,
   });
 
   final ScrollController? controller;
   final VoidCallback? onLeftTap;
-  final bool handlesHorizontalDrags;
 
   @override
   Widget build(BuildContext context) {
@@ -159,28 +153,11 @@ class _ScrollableTestPage extends StatelessWidget {
       appBar: AppBar(title: const Text('Page scrollable')),
       body: Stack(
         children: [
-          RawGestureDetector(
-            gestures: handlesHorizontalDrags
-                ? {
-                    BackGestureCompatibleHorizontalDragGestureRecognizer:
-                        GestureRecognizerFactoryWithHandlers<
-                            BackGestureCompatibleHorizontalDragGestureRecognizer>(
-                      () =>
-                          BackGestureCompatibleHorizontalDragGestureRecognizer(
-                        viewportWidth: MediaQuery.sizeOf(context).width,
-                      ),
-                      (recognizer) {
-                        recognizer.onUpdate = (_) {};
-                      },
-                    ),
-                  }
-                : const {},
-            child: ListView.builder(
-              controller: controller,
-              itemExtent: 80,
-              itemCount: 30,
-              itemBuilder: (context, index) => Text('Ligne $index'),
-            ),
+          ListView.builder(
+            controller: controller,
+            itemExtent: 80,
+            itemCount: 30,
+            itemBuilder: (context, index) => Text('Ligne $index'),
           ),
           Positioned(
             left: 8,


### PR DESCRIPTION
## Cause
The previous hotfix registered both horizontal and vertical recognizers on each Platform View. Flutter puts those recognizers in the WebView gesture team, so the WebView could still win horizontal or diagonal gestures before the enclosing swipe-back route.

## Fix
- register only `VerticalDragGestureRecognizer` for article WebViews
- let vertical movement scroll immediately, matching a native Flutter `Scrollable`
- leave horizontal movement to `FullSwipeCupertinoPage`
- apply this to standard, fallback, and premium WebView readers
- remove the obsolete custom horizontal recognizer

## Validation
- `flutter test test/shared/widgets/navigation/swipe_back_page_test.dart` (6 passed)
- targeted `flutter analyze` (no issues in the shared navigation implementation/tests; existing info diagnostics remain in the detail screen)
- `flutter build apk --debug`
- iOS local build unavailable because Flutter reports this checkout as not configured for iOS