### PR TITLE
feat(flaner): carrousel « Tes sources discrètes » + ajustements carrousels

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Flâner",
+      "summary": "Nouveau carrousel « Tes sources discrètes » : ne ratez plus les sources que vous suivez et qui publient rarement."
+    },
+    {
       "tag": "Veille",
       "summary": "Veille plus précise (moins de hors-sujet) et plus facile à retrouver dans les réglages."
     },

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -5,6 +5,10 @@
       "summary": "Nouveau carrousel « Tes sources discrètes » : ne ratez plus les sources que vous suivez et qui publient rarement."
     },
     {
+      "tag": "Flâner",
+      "summary": "Carrousels plus fréquents dans le fil, et « Actu chaude » regroupe désormais des articles qui couvrent vraiment le même sujet."
+    },
+    {
       "tag": "Veille",
       "summary": "Veille plus précise (moins de hors-sujet) et plus facile à retrouver dans les réglages."
     },

--- a/docs/stories/core/flaner.quiet-sources.md
+++ b/docs/stories/core/flaner.quiet-sources.md
@@ -36,11 +36,20 @@ mobile nécessaire.**
 
 ### `packages/api/app/services/recommendation_service.py`
 
-- **`_CAROUSEL_BASE_POSITIONS`** : `{"favorite": 5, "quiet_sources": 11,
-  "saved": 17, "decale": 17, "new_source": 23, "hot": 29, "community": 35,
-  "deep": 41}`. Ordre à valider à la review (le PO n'a pas tranché l'ordre
-  final — ajustable par simple édition du dict). `deep` reste dans le dict
+- **`_CAROUSEL_BASE_POSITIONS`** (ordre validé PO, pas de 5 slots pour
+  densifier — jusqu'à 4 carrousels dans la 1re page mobile de 20 articles) :
+  `{"favorite": 4, "quiet_sources": 9, "saved": 14, "decale": 14,
+  "new_source": 19, "community": 24, "hot": 29, "deep": 41}`.
+  `MIN_GAP` 6 → 5, `MIN_CAROUSEL_POSITION` 5 → 4. `deep` reste dans le dict
   (collision resolver) mais n'est plus émis.
+- **Hot « Actu chaude » re-clustering (validé PO)** : `find_hot_cluster`
+  réutilise désormais `ImportanceDetector.build_topic_clusters` (similarité
+  Jaccard des titres, le même pipeline que les Actus du jour, couvert par le
+  harness de calibration) au lieu du regroupement par entité NER unique qui
+  agrégeait des articles sans rapport (« Actu chaude : Trump »). Garde-fous :
+  cluster ≥ 3 articles ET ≥ 2 sources ; le nom affiché = entité dominante
+  partagée par ≥ 2 articles du cluster (sinon titre « Actu chaude » seul) ;
+  sélection probabiliste top-3 conservée.
 - **Nouveau bloc `quiet_sources` dans `_build_carousels()`** (Phase B, entre
   `new_source` et `community`) :
   - Requête 1 — sources rares : `UserSource` (state FOLLOWED/FAVORITE) join

--- a/docs/stories/core/flaner.quiet-sources.md
+++ b/docs/stories/core/flaner.quiet-sources.md
@@ -1,0 +1,85 @@
+# Story — Flâner : carrousel « Tes sources discrètes » + ajustements carrousels
+
+## Statut
+
+Implémentée (backend-only, 1 PR).
+
+## Contexte
+
+Les sources suivies qui publient peu (1x/2 semaines, 1x/mois) passent au travers
+de l'Essentiel quotidien (digest pré-généré qui exclut les sources suivies par
+design) et du feed Flâner (noyées par le volume). Le PO veut un carrousel
+horizontal dans Flâner montrant le dernier article de chaque source suivie
+« rare ».
+
+**Décisions actées (brainstorm)** :
+
+- Flâner uniquement (pas l'Essentiel).
+- Source « rare » = source suivie avec **< 3 articles publiés dans les 30 derniers jours**.
+- Contenu = **dernier article de chaque source rare, fenêtre 60 j, non lu** (non consommé).
+
+**Découverte clé** : le pipeline carrousels est entièrement server-driven.
+`flaner_screen.dart` (`_buildFeedList`) rend génériquement tout carrousel de
+`state.carousels`, et le fallback badge existe (`editorial_badge.dart`, code
+inconnu → chip emoji+label couleur `textSecondary`). **Aucune modification
+mobile nécessaire.**
+
+**Bonus actés dans la même PR** (tout vit dans `recommendation_service.py`) :
+
+1. « Plus tard, c'est maintenant ! » (`saved`) : tri du plus récemment
+   sauvegardé au plus ancien (`coalesce(saved_at, created_at).desc()`).
+2. Désactivation du carrousel `deep` « Ouvrir ses horizons » via flag
+   module-level `DEEP_CAROUSEL_ENABLED = False` (code conservé).
+3. Ré-ordre des positions de base des carrousels.
+
+## Implémentation
+
+### `packages/api/app/services/recommendation_service.py`
+
+- **`_CAROUSEL_BASE_POSITIONS`** : `{"favorite": 5, "quiet_sources": 11,
+  "saved": 17, "decale": 17, "new_source": 23, "hot": 29, "community": 35,
+  "deep": 41}`. Ordre à valider à la review (le PO n'a pas tranché l'ordre
+  final — ajustable par simple édition du dict). `deep` reste dans le dict
+  (collision resolver) mais n'est plus émis.
+- **Nouveau bloc `quiet_sources` dans `_build_carousels()`** (Phase B, entre
+  `new_source` et `community`) :
+  - Requête 1 — sources rares : `UserSource` (state FOLLOWED/FAVORITE) join
+    `Source` (is_active) outerjoin `Content` (published_at ≥ now−30j),
+    `GROUP BY HAVING count < 3`. Index existant `ix_contents_source_published`
+    couvre — pas de migration.
+  - Requête 2 — dernier article par source rare : `DISTINCT ON (source_id)`,
+    `published_at ≥ now−60j`, exclusion `promoted_ids | consumed_ids`,
+    tri final `published_at.desc()`, cap `MAX_CAROUSEL_ITEMS` (5).
+  - Seuil `MIN_DISPLAY_ITEMS` (2) sinon pas de carrousel.
+    `carousel_type="quiet_sources"`, titre « Tes sources discrètes »,
+    emoji 🤫, badge par item `{"code": "quiet_source", "label": <nom source>,
+    "emoji": "🔎"}`. Ids ajoutés à `promoted_ids` (dédup feed).
+- **Saved desc** : `order_by(coalesce(saved_at, created_at).desc())`.
+- **Deep off** : `DEEP_CAROUSEL_ENABLED = False`, early-skip du bloc, code et
+  `find_perspectives_for_read_article` conservés.
+
+### Tasks
+
+- [x] Mapping `_CAROUSEL_BASE_POSITIONS` ré-ordonné
+- [x] Bloc `quiet_sources` (2 requêtes agrégées, pas de N+1)
+- [x] Saved trié desc (coalesce saved_at/created_at)
+- [x] Flag `DEEP_CAROUSEL_ENABLED = False`
+- [x] Tests `tests/test_feed_carousels_quiet_sources.py` (DB-driven)
+- [x] MAJ tests existants (`test_feed_carousels.py`, `test_feed_carousels_ordering.py`)
+- [x] Changelog `apps/mobile/assets/changelog.json` (unreleased)
+
+### Fichiers modifiés
+
+- `packages/api/app/services/recommendation_service.py`
+- `packages/api/tests/test_feed_carousels_quiet_sources.py` (nouveau)
+- `packages/api/tests/test_feed_carousels.py`
+- `packages/api/tests/test_feed_carousels_ordering.py`
+- `apps/mobile/assets/changelog.json`
+
+## Edge cases / risques
+
+- Risque faible : bloc additif isolé, pas de DDL, pas de changement API.
+- Cas vides (aucune source rare / tout lu / rien ≤60j) → carrousel absent.
+- YouTube/newsletters = `Content` normaux → inclus naturellement.
+- Perf : +1-2 requêtes par feed non-caché, index existants.
+- Old app versions afficheront aussi le carrousel (rendu générique + fallback badge).

--- a/packages/api/app/services/article_clustering_service.py
+++ b/packages/api/app/services/article_clustering_service.py
@@ -50,7 +50,13 @@ def find_hot_cluster(
     min_items: int = 3,
     seed: int | None = None,
 ) -> tuple[str | None, str | None, list[Content]]:
-    """Find a hot cluster of articles sharing entities within a time window.
+    """Find a hot cluster of articles covering the same story within a window.
+
+    Reuses the topic clustering that powers the daily digest
+    (`ImportanceDetector.build_topic_clusters`, similarité Jaccard des titres,
+    couverte par le harness de calibration) instead of the old grouping by a
+    single shared NER entity, which clustered unrelated articles on passing
+    mentions (e.g. "Trump" cited once in each).
 
     Selects probabilistically among the top-3 eligible clusters (weighted by
     size) instead of always picking the largest. This adds daily variety.
@@ -63,10 +69,17 @@ def find_hot_cluster(
         seed: Optional RNG seed for deterministic selection (e.g. hash of user_id+date)
 
     Returns:
-        (entity_key, entity_display_name, clustered_articles)
-        Returns (None, None, []) if no cluster found with >= min_items articles.
+        (cluster_key, display_name, clustered_articles). cluster_key is the
+        cluster's label (deterministic for a given input pool, unlike the
+        random TopicCluster.cluster_id). display_name is the cluster's
+        dominant entity, or None when no entity is shared by at least 2 of
+        its articles. Returns (None, None, []) if no cluster has
+        >= min_items articles from >= 2 sources.
     """
     import random as _random
+    from collections import Counter
+
+    from app.services.briefing.importance_detector import ImportanceDetector
 
     cutoff = datetime.now(UTC) - timedelta(hours=window_hours)
 
@@ -82,60 +95,53 @@ def find_hot_cluster(
     if len(recent) < min_items:
         return None, None, []
 
-    # Build entity -> articles index
-    entity_to_articles: dict[str, list[Content]] = {}
-    entity_display: dict[str, str] = {}  # key -> original casing
+    clusters = ImportanceDetector().build_topic_clusters(recent)
 
-    for article in recent:
-        entities = parse_entities(article)
-        for ent in entities:
-            entity_to_articles.setdefault(ent["key"], []).append(article)
-            if ent["key"] not in entity_display:
-                entity_display[ent["key"]] = ent["name"]
-
-    if not entity_to_articles:
-        return None, None, []
-
-    # Find top-3 eligible clusters, select one weighted by size
+    # Eligible: enough articles AND multi-source (one source pushing many
+    # takes on the same story is not "hot news").
     eligible = [
-        (key, arts)
-        for key, arts in entity_to_articles.items()
-        if len(arts) >= min_items
+        c for c in clusters if len(c.contents) >= min_items and c.is_multi_source
     ]
     if not eligible:
         return None, None, []
 
-    # Sort by size DESC, take top 3
-    eligible.sort(key=lambda x: len(x[1]), reverse=True)
+    # build_topic_clusters returns clusters sorted by size DESC — keep top 3
     top_candidates = eligible[:3]
 
     # Weighted random selection among top candidates
     rng = _random.Random(seed)
-    weights = [len(arts) for _, arts in top_candidates]
-    ((best_key, best_articles),) = rng.choices(top_candidates, weights=weights, k=1)
+    weights = [len(c.contents) for c in top_candidates]
+    (best,) = rng.choices(top_candidates, weights=weights, k=1)
 
-    # Deduplicate (article can appear via multiple entities)
-    seen_ids: set[UUID] = set()
-    unique: list[Content] = []
-    for a in best_articles:
-        if a.id not in seen_ids:
-            seen_ids.add(a.id)
-            unique.append(a)
+    # Display name: dominant entity across the cluster's articles. Entities
+    # are used for labelling only, never for grouping; require >= 2 articles
+    # sharing it so a passing mention can't title the carousel.
+    entity_counts: Counter = Counter()
+    entity_display: dict[str, str] = {}
+    for a in best.contents:
+        for ent in parse_entities(a):
+            entity_counts[ent["key"]] += 1
+            entity_display.setdefault(ent["key"], ent["name"])
+    display_name: str | None = None
+    if entity_counts:
+        top_key, top_count = entity_counts.most_common(1)[0]
+        if top_count >= 2:
+            display_name = entity_display[top_key]
 
     # Sort by published_at DESC, take max_items
-    unique.sort(key=lambda a: a.published_at, reverse=True)
+    unique = sorted(best.contents, key=lambda a: a.published_at, reverse=True)
     result = unique[:max_items]
 
     logger.info(
         "hot_cluster_found",
-        entity=best_key,
-        display_name=entity_display.get(best_key),
-        cluster_size=len(unique),
+        cluster_key=best.label,
+        display_name=display_name,
+        cluster_size=len(best.contents),
         returned=len(result),
         candidates_considered=len(top_candidates),
     )
 
-    return best_key, entity_display.get(best_key, best_key.title()), result
+    return best.label, display_name, result
 
 
 async def find_perspectives_for_read_article(

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -21,6 +21,9 @@ from app.models.user import UserProfile, UserSubtopic
 logger = structlog.get_logger()
 FOLLOWED_SOURCE_STATES = (InterestState.FOLLOWED, InterestState.FAVORITE)
 
+# "Ouvrir ses horizons" carousel disabled (PO decision); code kept for re-enable.
+DEEP_CAROUSEL_ENABLED = False
+
 # Upper bound on the two-phase followed-sources query in the default feed
 # view. Above this, we rollback and fall back to a curated-only query so the
 # mobile client never sees an infinite spinner.
@@ -1229,17 +1232,20 @@ class RecommendationService:
         self.source_overflow = updated
 
     # Story 12.8: business-ordered base positions for carousel types
-    # (favorite > new_source > community > saved > hot > deep).
+    # (favorite > quiet_sources > saved > new_source > hot > community > deep).
     # `decale` is only emitted in serein mode, which excludes hot/community,
-    # so it sits at community's slot.
+    # so it sits at saved's slot.
+    # `deep` keeps its slot for the collision resolver but is no longer
+    # emitted (DEEP_CAROUSEL_ENABLED = False).
     _CAROUSEL_BASE_POSITIONS: dict[str, int] = {
         "favorite": 5,
-        "new_source": 11,
-        "community": 17,
+        "quiet_sources": 11,
+        "saved": 17,
         "decale": 17,
-        "saved": 23,
+        "new_source": 23,
         "hot": 29,
-        "deep": 35,
+        "community": 35,
+        "deep": 41,
     }
 
     @staticmethod
@@ -1396,7 +1402,12 @@ class RecommendationService:
             break  # Only 1 favorite carousel
 
         # --- deep → "Ouvrir ses horizons": internal perspectives from read articles (T5) ---
-        if len(carousels) < max_carousels and user_id is not None:
+        # Disabled (PO decision): kept intact behind the flag for an easy re-enable.
+        if (
+            DEEP_CAROUSEL_ENABLED
+            and len(carousels) < max_carousels
+            and user_id is not None
+        ):
             from app.services.article_clustering_service import (
                 find_perspectives_for_read_article,
             )
@@ -1603,6 +1614,92 @@ class RecommendationService:
                         promoted_ids.add(item.id)
                     break  # T3A: only 1 source carousel
 
+            # --- quiet_sources: latest article from followed low-volume sources ---
+            if len(carousels) < max_carousels:
+                QUIET_SOURCE_MAX_RECENT = 3  # < 3 articles in 30 days = "quiet"
+                now = datetime.datetime.now(datetime.UTC)
+                thirty_days_ago = now - datetime.timedelta(days=30)
+                sixty_days_ago = now - datetime.timedelta(days=60)
+
+                quiet_source_ids = (
+                    (
+                        await self.session.execute(
+                            select(UserSource.source_id)
+                            .join(Source, Source.id == UserSource.source_id)
+                            .outerjoin(
+                                Content,
+                                (Content.source_id == UserSource.source_id)
+                                & (Content.published_at >= thirty_days_ago),
+                            )
+                            .where(
+                                UserSource.user_id == user_id,
+                                UserSource.state.in_(FOLLOWED_SOURCE_STATES),
+                                Source.is_active == True,  # noqa: E712
+                            )
+                            .group_by(UserSource.source_id)
+                            .having(
+                                func.count(Content.id) < QUIET_SOURCE_MAX_RECENT
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+
+                quiet_articles: list[Content] = []
+                if quiet_source_ids:
+                    latest_per_source = (
+                        select(Content)
+                        .options(selectinload(Content.source))
+                        .where(
+                            Content.source_id.in_(quiet_source_ids),
+                            Content.published_at >= sixty_days_ago,
+                            Content.id.notin_(promoted_ids | consumed_ids),
+                        )
+                        .distinct(Content.source_id)
+                        .order_by(
+                            Content.source_id,
+                            Content.published_at.desc(),
+                        )
+                    )
+                    quiet_articles = list(
+                        (await self.session.scalars(latest_per_source)).all()
+                    )
+                    quiet_articles.sort(
+                        key=lambda c: c.published_at, reverse=True
+                    )
+                    quiet_articles = quiet_articles[:MAX_CAROUSEL_ITEMS]
+
+                logger.info(
+                    "carousel_quiet_sources_query",
+                    quiet_sources_found=len(quiet_source_ids),
+                    articles_found=len(quiet_articles),
+                    min_required=MIN_DISPLAY_ITEMS,
+                )
+                if len(quiet_articles) >= MIN_DISPLAY_ITEMS:
+                    badges = [
+                        {
+                            "code": "quiet_source",
+                            "label": a.source.name,
+                            "emoji": "\U0001f50d",
+                        }
+                        for a in quiet_articles
+                    ]
+                    carousels.append(
+                        {
+                            "carousel_type": "quiet_sources",
+                            "title": "Tes sources discrètes",
+                            "emoji": "\U0001f92b",
+                            "position": self._jitter_carousel_position(
+                                "quiet_sources", user_id, today
+                            ),
+                            "items": quiet_articles,
+                            "badges": badges,
+                        }
+                    )
+                    for item in quiet_articles:
+                        promoted_ids.add(item.id)
+
             # --- community: 🌻 sunflower recommendations with decay scoring ---
             if len(carousels) < max_carousels:
                 seven_days_ago = datetime.datetime.now(
@@ -1721,7 +1818,14 @@ class RecommendationService:
                                 UserContentStatus.is_saved.is_(True),
                                 UserContentStatus.status != ContentStatus.CONSUMED,
                             )
-                            .order_by(UserContentStatus.created_at.asc())
+                            .order_by(
+                                desc(
+                                    func.coalesce(
+                                        UserContentStatus.saved_at,
+                                        UserContentStatus.created_at,
+                                    )
+                                )
+                            )
                             .limit(MAX_CAROUSEL_ITEMS)
                         )
                     ).all()

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -1232,19 +1232,22 @@ class RecommendationService:
         self.source_overflow = updated
 
     # Story 12.8: business-ordered base positions for carousel types
-    # (favorite > quiet_sources > saved > new_source > hot > community > deep).
+    # (favorite > quiet_sources > saved > new_source > community > hot > deep),
+    # tightened to a 5-slot pitch so up to 4 carousels land within the first
+    # ~20 articles (page 1 mobile — a carousel only renders once its position
+    # is < the number of loaded articles).
     # `decale` is only emitted in serein mode, which excludes hot/community,
     # so it sits at saved's slot.
     # `deep` keeps its slot for the collision resolver but is no longer
     # emitted (DEEP_CAROUSEL_ENABLED = False).
     _CAROUSEL_BASE_POSITIONS: dict[str, int] = {
-        "favorite": 5,
-        "quiet_sources": 11,
-        "saved": 17,
-        "decale": 17,
-        "new_source": 23,
+        "favorite": 4,
+        "quiet_sources": 9,
+        "saved": 14,
+        "decale": 14,
+        "new_source": 19,
+        "community": 24,
         "hot": 29,
-        "community": 35,
         "deep": 41,
     }
 
@@ -1285,7 +1288,7 @@ class RecommendationService:
         MIN_CAROUSEL_ITEMS = 3  # Minimum items for building a carousel
         MIN_DISPLAY_ITEMS = 2  # T2: Minimum items after consumed filtering
         MAX_CAROUSEL_ITEMS = 5
-        MIN_CAROUSEL_POSITION = 5  # No carousel before position 5 (≈ GNews cadence)
+        MIN_CAROUSEL_POSITION = 4  # No carousel before position 4 (≈ GNews cadence)
         carousels: list[dict] = []
         promoted_ids: set[UUID] = set()
         used_group_keys: set[str] = set()  # Prevent same group in hot + deep
@@ -1341,7 +1344,9 @@ class RecommendationService:
                     carousels.append(
                         {
                             "carousel_type": "hot",
-                            "title": f"Actu chaude : {display_name}",
+                            "title": f"Actu chaude : {display_name}"
+                            if display_name
+                            else "Actu chaude",
                             "emoji": "\U0001f50d",
                             "position": self._jitter_carousel_position(
                                 "hot", user_id, today
@@ -1909,7 +1914,7 @@ class RecommendationService:
         )
         # Carrousels espacés d'au moins MIN_GAP slots — évite les empilements
         # adjacents qui rendent le flux dense (effet GNews / Apple News).
-        MIN_GAP = 6
+        MIN_GAP = 5
         taken: list[int] = []
         for c in carousels:
             pos = max(c["position"], MIN_CAROUSEL_POSITION)

--- a/packages/api/tests/test_feed_carousels.py
+++ b/packages/api/tests/test_feed_carousels.py
@@ -413,12 +413,12 @@ class TestBuildCarouselsNewSource:
         async def mock_execute(stmt):
             nonlocal execute_calls
             execute_calls += 1
-            # 1: consumed_ids, 2: perspectives consumed_rows → empty
-            if execute_calls <= 2:
+            # 1: consumed_ids → empty
+            if execute_calls == 1:
                 return _mock_execute_result([])
-            if execute_calls == 3:
+            if execute_calls == 2:
                 return _mock_execute_result(src_rows)  # new_source
-            return _mock_execute_result([])  # community (empty)
+            return _mock_execute_result([])  # quiet_sources + community (empty)
 
         service.session.execute = AsyncMock(side_effect=mock_execute)
         service.session.scalars = AsyncMock(
@@ -458,11 +458,11 @@ class TestBuildCarouselsNewSource:
         async def mock_execute(stmt):
             nonlocal execute_calls
             execute_calls += 1
-            if execute_calls <= 2:
-                return _mock_execute_result([])  # consumed_ids + perspectives
-            if execute_calls == 3:
+            if execute_calls == 1:
+                return _mock_execute_result([])  # consumed_ids
+            if execute_calls == 2:
                 return _mock_execute_result(src_rows)  # new_source
-            return _mock_execute_result([])  # community
+            return _mock_execute_result([])  # quiet_sources + community
 
         service.session.execute = AsyncMock(side_effect=mock_execute)
         service.session.scalars = AsyncMock(
@@ -514,7 +514,7 @@ class TestBuildCarouselsCommunity:
         async def mock_execute(stmt):
             nonlocal call_count
             call_count += 1
-            # 1: consumed_ids, 2: perspectives, 3: new_source → empty
+            # 1: consumed_ids, 2: new_source, 3: quiet_sources → empty
             if call_count <= 3:
                 return _mock_execute_result([])
             # 4: community query
@@ -554,7 +554,7 @@ class TestBuildCarouselsCommunity:
         async def mock_execute(stmt):
             nonlocal call_count
             call_count += 1
-            # 1: consumed_ids, 2: perspectives, 3: new_source → empty
+            # 1: consumed_ids, 2: new_source, 3: quiet_sources → empty
             if call_count <= 3:
                 return _mock_execute_result([])
             # 4: community
@@ -584,7 +584,7 @@ class TestBuildCarouselsSaved:
             MockContent(title="Saved podcast", content_type="podcast"),
         ]
 
-        # All execute calls return empty (consumed_ids, perspectives, new_source, community)
+        # All execute calls return empty (consumed_ids, new_source, quiet_sources, community)
         async def mock_execute(stmt):
             return _mock_execute_result([])
 
@@ -659,12 +659,12 @@ class TestBuildCarouselsPhaseB_Integration:
         async def mock_execute(stmt):
             nonlocal execute_calls
             execute_calls += 1
-            # 1: consumed_ids, 2: perspectives → empty
-            if execute_calls <= 2:
+            # 1: consumed_ids → empty
+            if execute_calls == 1:
                 return _mock_execute_result([])
-            if execute_calls == 3:
+            if execute_calls == 2:
                 return _mock_execute_result(src_rows)  # new_source
-            return _mock_execute_result([])  # community
+            return _mock_execute_result([])  # quiet_sources + community
 
         service.session.execute = AsyncMock(side_effect=mock_execute)
         service.session.scalars = AsyncMock(

--- a/packages/api/tests/test_feed_carousels.py
+++ b/packages/api/tests/test_feed_carousels.py
@@ -32,9 +32,40 @@ class MockContent:
         self.title = title
         self.source = source or MockSource()
         self.source_id = self.source.id
+        # One domain per source — feeds _extract_domain() in the topic
+        # clustering used by the hot carousel (multi-source check).
+        self.url = f"https://src-{self.source.id.hex[:8]}.example.com/{self.id.hex}"
         self.entities = entities or []
         self.content_type = content_type
         self.published_at = published_at or datetime.now(UTC)
+        self.theme = None
+
+
+def _make_story_articles(
+    topic: str,
+    n: int,
+    entity: str | None = None,
+    published_at=None,
+):
+    """N articles covering the same story (titles that Jaccard-cluster).
+
+    Digits are stripped by normalize_title, so the trailing index keeps the
+    token set identical across articles. Each article gets its own source
+    (distinct domain) so the cluster passes the multi-source check.
+    """
+    articles = [
+        MockContent(
+            title=f"{topic} {i}",
+            source=MockSource(name=f"Source {topic} {i}"),
+            published_at=published_at,
+        )
+        for i in range(n)
+    ]
+    if entity:
+        entity_json = json.dumps({"name": entity, "type": "PERSON"})
+        for a in articles:
+            a.entities = [entity_json]
+    return articles
 
 
 def _make_entity_group(
@@ -113,18 +144,19 @@ def _setup_service():
 
 class TestBuildCarouselsHot:
     @pytest.mark.asyncio
-    async def test_hot_carousel_from_entity_overflow(self):
+    async def test_hot_carousel_from_topic_cluster(self):
         service = _setup_service()
-        rep = MockContent(title="Trump article")
-        hidden = [MockContent(title=f"Trump {i}") for i in range(4)]
-        pre_regroup_map = {a.id: a for a in [rep] + hidden}
+        story = _make_story_articles(
+            "Trump annonce des sanctions douanières contre la Chine",
+            5,
+            entity="Trump",
+        )
+        pre_regroup_map = {a.id: a for a in story}
 
-        service.entity_overflow = [
-            _make_entity_group("trump", 4, rep, hidden)
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
-        result_feed = [MockContent(title="Other article")]
+        result_feed = [MockContent(title="Un sujet sans aucun rapport ici")]
         result, carousels = await service._build_carousels(result_feed, pre_regroup_map)
 
         assert len(carousels) == 1
@@ -134,59 +166,76 @@ class TestBuildCarouselsHot:
         assert c["emoji"] == "\U0001f50d"
         # Hot base position is 29 (cadence GNews ~6, business order)
         assert c["position"] == 29
-        assert len(c["items"]) == 5  # rep + 4 hidden
+        assert len(c["items"]) == 5
         assert len(c["badges"]) == len(c["items"])
         assert c["badges"][0]["code"] == "actu_chaude"
 
     @pytest.mark.asyncio
-    async def test_hot_carousel_works_with_2_hidden(self):
-        """Min 3 items = rep + 2 hidden → should create carousel."""
+    async def test_hot_carousel_works_with_3_articles(self):
+        """Min 3 clustered articles → should create carousel."""
         service = _setup_service()
-        rep = MockContent(title="Trump article")
-        hidden = [MockContent(title="Trump 1"), MockContent(title="Trump 2")]
-        pre_regroup_map = {a.id: a for a in [rep] + hidden}
+        story = _make_story_articles(
+            "Grève des contrôleurs aériens dans toute la France", 3
+        )
+        pre_regroup_map = {a.id: a for a in story}
 
-        service.entity_overflow = [
-            _make_entity_group("trump", 2, rep, hidden)
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
         result, carousels = await service._build_carousels([], pre_regroup_map)
         assert len(carousels) == 1
-        assert len(carousels[0]["items"]) == 3  # rep + 2 hidden
+        assert len(carousels[0]["items"]) == 3
 
     @pytest.mark.asyncio
-    async def test_hot_carousel_requires_min_2_hidden(self):
-        """1 hidden + rep = 2 items < MIN_CAROUSEL_ITEMS(3) → no carousel."""
+    async def test_hot_carousel_requires_min_3_articles(self):
+        """2 clustered articles < MIN_CAROUSEL_ITEMS(3) → no carousel."""
         service = _setup_service()
-        rep = MockContent(title="Trump article")
-        hidden = [MockContent(title="Trump 1")]
-        pre_regroup_map = {a.id: a for a in [rep] + hidden}
+        story = _make_story_articles(
+            "Grève des contrôleurs aériens dans toute la France", 2
+        )
+        pre_regroup_map = {a.id: a for a in story}
 
-        service.entity_overflow = [
-            _make_entity_group("trump", 1, rep, hidden)
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
         result, carousels = await service._build_carousels([], pre_regroup_map)
         assert len(carousels) == 0
 
     @pytest.mark.asyncio
-    async def test_representative_included_in_carousel(self):
+    async def test_hot_carousel_requires_multi_source(self):
+        """A single source covering one story 4 times is not hot news."""
         service = _setup_service()
-        rep = MockContent(title="Trump main")
-        hidden = [MockContent(title=f"Trump {i}") for i in range(3)]
-        pre_regroup_map = {a.id: a for a in [rep] + hidden}
-
-        service.entity_overflow = [
-            _make_entity_group("trump", 3, rep, hidden)
+        source = MockSource(name="Mono Source")
+        story = [
+            MockContent(
+                title=f"Grève des contrôleurs aériens dans toute la France {i}",
+                source=source,
+            )
+            for i in range(4)
         ]
+        pre_regroup_map = {a.id: a for a in story}
+
+        service.entity_overflow = []
+        service.keyword_overflow = []
+
+        _, carousels = await service._build_carousels([], pre_regroup_map)
+        assert carousels == []
+
+    @pytest.mark.asyncio
+    async def test_hot_title_without_dominant_entity(self):
+        """No entity shared by >= 2 articles → plain 'Actu chaude' title."""
+        service = _setup_service()
+        story = _make_story_articles(
+            "Grève des contrôleurs aériens dans toute la France", 3
+        )
+        pre_regroup_map = {a.id: a for a in story}
+
+        service.entity_overflow = []
         service.keyword_overflow = []
 
         _, carousels = await service._build_carousels([], pre_regroup_map)
         assert len(carousels) == 1
-        item_ids = {item.id for item in carousels[0]["items"]}
-        assert rep.id in item_ids
+        assert carousels[0]["title"] == "Actu chaude"
 
 
 class TestBuildCarouselsFavorite:
@@ -228,43 +277,34 @@ class TestBuildCarouselsFavorite:
 
 class TestBuildCarouselsDeep:
     @pytest.mark.asyncio
-    async def test_deep_carousel_multi_source(self):
+    async def test_only_hot_from_single_cluster(self):
         service = _setup_service()
-        rep = MockContent(title="Iran article")
-        hidden = [MockContent(title=f"Iran {i}") for i in range(3)]
-        pre_regroup_map = {a.id: a for a in [rep] + hidden}
+        story = _make_story_articles(
+            "Téhéran reprend les négociations sur le nucléaire iranien", 4
+        )
+        pre_regroup_map = {a.id: a for a in story}
 
-        service.entity_overflow = [
-            _make_entity_group("iran", 3, rep, hidden, num_sources=3)
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
         _, carousels = await service._build_carousels([], pre_regroup_map)
-        # With only 1 entity group that has 3 sources, it should create
-        # hot first (highest hidden_count), and deep only if different group
-        # Since there's only 1 entity group, hot takes it, deep has no candidates
         assert len(carousels) == 1
         assert carousels[0]["carousel_type"] == "hot"
 
     @pytest.mark.asyncio
-    async def test_deep_carousel_from_second_entity_group(self):
-        """With user_id=None, only hot carousel is created (deep requires perspectives)."""
+    async def test_only_one_hot_even_with_two_clusters(self):
+        """With user_id=None, only hot carousel is created (deep is disabled,
+        and would require user_id anyway)."""
         service = _setup_service()
-        # Group 1: hot candidate (highest hidden_count)
-        rep1 = MockContent(title="Trump article")
-        hidden1 = [MockContent(title=f"Trump {i}") for i in range(5)]
+        story1 = _make_story_articles(
+            "Trump annonce des sanctions douanières contre la Chine", 6
+        )
+        story2 = _make_story_articles(
+            "Téhéran reprend les négociations sur le nucléaire iranien", 4
+        )
+        pre_regroup_map = {a.id: a for a in story1 + story2}
 
-        # Group 2: would have been deep in old code, now needs perspectives
-        rep2 = MockContent(title="Iran article")
-        hidden2 = [MockContent(title=f"Iran {i}") for i in range(3)]
-
-        all_articles = [rep1] + hidden1 + [rep2] + hidden2
-        pre_regroup_map = {a.id: a for a in all_articles}
-
-        service.entity_overflow = [
-            _make_entity_group("trump", 5, rep1, hidden1, num_sources=2),
-            _make_entity_group("iran", 3, rep2, hidden2, num_sources=3),
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
         _, carousels = await service._build_carousels([], pre_regroup_map)
@@ -303,34 +343,34 @@ class TestBuildCarouselsBudgetAndRemoval:
     @pytest.mark.asyncio
     async def test_carousel_removes_from_feed(self):
         service = _setup_service()
-        rep = MockContent(title="Trump main")
-        hidden = [MockContent(title=f"Trump {i}") for i in range(3)]
-        other = MockContent(title="Unrelated article")
-        pre_regroup_map = {a.id: a for a in [rep] + hidden + [other]}
+        story = _make_story_articles(
+            "Trump annonce des sanctions douanières contre la Chine", 4
+        )
+        promoted = story[0]
+        other = MockContent(title="Un sujet sans aucun rapport ici")
+        pre_regroup_map = {a.id: a for a in story + [other]}
 
-        service.entity_overflow = [
-            _make_entity_group("trump", 3, rep, hidden)
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
-        result_feed = [rep, other]  # rep is in the feed
+        result_feed = [promoted, other]  # promoted is in the feed
         result, carousels = await service._build_carousels(result_feed, pre_regroup_map)
 
-        # rep should be removed from result (promoted to carousel)
+        # promoted should be removed from result (promoted to carousel)
+        assert len(carousels) == 1
         result_ids = {a.id for a in result}
-        assert rep.id not in result_ids
+        assert promoted.id not in result_ids
         assert other.id in result_ids
 
     @pytest.mark.asyncio
     async def test_badges_count_matches_items(self):
         service = _setup_service()
-        rep = MockContent(title="Article")
-        hidden = [MockContent(title=f"Art {i}") for i in range(4)]
-        pre_regroup_map = {a.id: a for a in [rep] + hidden}
+        story = _make_story_articles(
+            "Trump annonce des sanctions douanières contre la Chine", 5
+        )
+        pre_regroup_map = {a.id: a for a in story}
 
-        service.entity_overflow = [
-            _make_entity_group("test", 4, rep, hidden)
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
         _, carousels = await service._build_carousels([], pre_regroup_map)
@@ -687,34 +727,32 @@ class TestBuildCarouselsPhaseB_Integration:
 class TestMinCarouselPosition:
     @pytest.mark.asyncio
     async def test_no_carousel_below_min_position(self):
-        """All carousels must have position >= MIN_CAROUSEL_POSITION."""
+        """All carousels must have position >= MIN_CAROUSEL_POSITION (4)."""
         service = _setup_service()
-        rep = MockContent(title="Trump article")
-        hidden = [MockContent(title=f"Trump {i}") for i in range(4)]
-        pre_regroup_map = {a.id: a for a in [rep] + hidden}
+        story = _make_story_articles(
+            "Trump annonce des sanctions douanières contre la Chine", 5
+        )
+        pre_regroup_map = {a.id: a for a in story}
 
-        service.entity_overflow = [
-            _make_entity_group("trump", 4, rep, hidden)
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
         _, carousels = await service._build_carousels([], pre_regroup_map)
         for c in carousels:
-            assert c["position"] >= 5, (
-                f"Carousel {c['carousel_type']} at position {c['position']} < 5"
+            assert c["position"] >= 4, (
+                f"Carousel {c['carousel_type']} at position {c['position']} < 4"
             )
 
     @pytest.mark.asyncio
     async def test_hot_position_unchanged_without_user_id(self):
         """Without user_id, hot carousel falls back to its business-order base."""
         service = _setup_service()
-        rep = MockContent(title="Trump article")
-        hidden = [MockContent(title=f"Trump {i}") for i in range(4)]
-        pre_regroup_map = {a.id: a for a in [rep] + hidden}
+        story = _make_story_articles(
+            "Trump annonce des sanctions douanières contre la Chine", 5
+        )
+        pre_regroup_map = {a.id: a for a in story}
 
-        service.entity_overflow = [
-            _make_entity_group("trump", 4, rep, hidden)
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
         _, carousels = await service._build_carousels([], pre_regroup_map)
@@ -740,13 +778,12 @@ class TestDailyJitter:
         """Same user_id + same day → same positions on repeated calls."""
         service = _setup_service_with_overflow_and_mocks()
         user_id = uuid4()
-        rep = MockContent(title="Trump article")
-        hidden = [MockContent(title=f"Trump {i}") for i in range(4)]
-        pre_regroup_map = {a.id: a for a in [rep] + hidden}
+        story = _make_story_articles(
+            "Trump annonce des sanctions douanières contre la Chine", 5
+        )
+        pre_regroup_map = {a.id: a for a in story}
 
-        service.entity_overflow = [
-            _make_entity_group("trump", 4, rep, hidden)
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
         _, carousels1 = await service._build_carousels(
@@ -764,13 +801,12 @@ class TestDailyJitter:
     async def test_jitter_varies_across_users(self):
         """Different user_ids on the same day may get different positions."""
         service = _setup_service_with_overflow_and_mocks()
-        rep = MockContent(title="Trump article")
-        hidden = [MockContent(title=f"Trump {i}") for i in range(4)]
-        pre_regroup_map = {a.id: a for a in [rep] + hidden}
+        story = _make_story_articles(
+            "Trump annonce des sanctions douanières contre la Chine", 5
+        )
+        pre_regroup_map = {a.id: a for a in story}
 
-        service.entity_overflow = [
-            _make_entity_group("trump", 4, rep, hidden)
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
         positions = set()
@@ -789,13 +825,12 @@ class TestDailyJitter:
         from app.services.recommendation_service import RecommendationService
 
         service = _setup_service_with_overflow_and_mocks()
-        rep = MockContent(title="Trump article")
-        hidden = [MockContent(title=f"Trump {i}") for i in range(4)]
-        pre_regroup_map = {a.id: a for a in [rep] + hidden}
+        story = _make_story_articles(
+            "Trump annonce des sanctions douanières contre la Chine", 5
+        )
+        pre_regroup_map = {a.id: a for a in story}
 
-        service.entity_overflow = [
-            _make_entity_group("trump", 4, rep, hidden)
-        ]
+        service.entity_overflow = []
         service.keyword_overflow = []
 
         base_hot = RecommendationService._CAROUSEL_BASE_POSITIONS["hot"]
@@ -818,75 +853,76 @@ class TestProbabilisticHotCluster:
         """With multiple eligible clusters, different seeds may select different ones."""
         from app.services.article_clustering_service import find_hot_cluster
 
-        source = MockSource(name="Source")
-        entity_json_trump = json.dumps({"name": "Trump", "type": "PERSON"})
-        entity_json_iran = json.dumps({"name": "Iran", "type": "LOCATION"})
-        entity_json_ai = json.dumps({"name": "AI", "type": "TECHNOLOGY"})
-
         now = datetime.now(UTC)
         # 3 clusters of size 5, 4, 3
-        trump_arts = [
-            MockContent(title=f"Trump {i}", source=source, published_at=now)
-            for i in range(5)
-        ]
-        for a in trump_arts:
-            a.entities = [entity_json_trump]
-
-        iran_arts = [
-            MockContent(title=f"Iran {i}", source=source, published_at=now)
-            for i in range(4)
-        ]
-        for a in iran_arts:
-            a.entities = [entity_json_iran]
-
-        ai_arts = [
-            MockContent(title=f"AI {i}", source=source, published_at=now)
-            for i in range(3)
-        ]
-        for a in ai_arts:
-            a.entities = [entity_json_ai]
-
-        all_articles = trump_arts + iran_arts + ai_arts
+        all_articles = (
+            _make_story_articles(
+                "Trump annonce des sanctions douanières contre la Chine",
+                5,
+                published_at=now,
+            )
+            + _make_story_articles(
+                "Téhéran reprend les négociations sur le nucléaire iranien",
+                4,
+                published_at=now,
+            )
+            + _make_story_articles(
+                "Une intelligence artificielle remporte un concours de mathématiques",
+                3,
+                published_at=now,
+            )
+        )
 
         # Run with many seeds — should sometimes select non-trump clusters
-        selected_entities = set()
+        selected_keys = set()
         for seed in range(100):
-            entity_key, _, articles = find_hot_cluster(
+            cluster_key, _, articles = find_hot_cluster(
                 all_articles, seed=seed,
             )
-            if entity_key:
-                selected_entities.add(entity_key)
+            if cluster_key:
+                selected_keys.add(cluster_key)
 
         # With weighted random among 3 clusters, we expect at least 2 different selections
-        assert len(selected_entities) >= 2, (
-            f"Expected variety in cluster selection, got only: {selected_entities}"
+        assert len(selected_keys) >= 2, (
+            f"Expected variety in cluster selection, got only: {selected_keys}"
         )
 
     def test_deterministic_with_same_seed(self):
         """Same seed always selects the same cluster."""
         from app.services.article_clustering_service import find_hot_cluster
 
-        source = MockSource(name="Source")
-        entity_json_a = json.dumps({"name": "Alpha", "type": "PERSON"})
-        entity_json_b = json.dumps({"name": "Beta", "type": "PERSON"})
         now = datetime.now(UTC)
-
-        arts_a = [
-            MockContent(title=f"A {i}", source=source, published_at=now)
-            for i in range(4)
-        ]
-        for a in arts_a:
-            a.entities = [entity_json_a]
-
-        arts_b = [
-            MockContent(title=f"B {i}", source=source, published_at=now)
-            for i in range(3)
-        ]
-        for a in arts_b:
-            a.entities = [entity_json_b]
-
-        all_articles = arts_a + arts_b
+        all_articles = _make_story_articles(
+            "Trump annonce des sanctions douanières contre la Chine",
+            4,
+            published_at=now,
+        ) + _make_story_articles(
+            "Téhéran reprend les négociations sur le nucléaire iranien",
+            3,
+            published_at=now,
+        )
 
         key1, _, _ = find_hot_cluster(all_articles, seed=42)
         key2, _, _ = find_hot_cluster(all_articles, seed=42)
         assert key1 == key2
+
+    def test_unrelated_articles_sharing_entity_do_not_cluster(self):
+        """Passing mentions of the same entity must not form a hot cluster
+        (the old NER-entity grouping regression: 'Actu chaude : Trump' with
+        unrelated articles)."""
+        from app.services.article_clustering_service import find_hot_cluster
+
+        now = datetime.now(UTC)
+        entity_json = json.dumps({"name": "Trump", "type": "PERSON"})
+        titles = [
+            "La réforme des retraites suspendue par le gouvernement français",
+            "Le Vendée Globe bat son record absolu de participation cette année",
+            "Une éruption volcanique majeure paralyse le trafic aérien en Islande",
+        ]
+        articles = [MockContent(title=t, published_at=now) for t in titles]
+        for a in articles:
+            a.entities = [entity_json]
+
+        cluster_key, display_name, result = find_hot_cluster(articles)
+        assert result == []
+        assert cluster_key is None

--- a/packages/api/tests/test_feed_carousels_ordering.py
+++ b/packages/api/tests/test_feed_carousels_ordering.py
@@ -20,19 +20,20 @@ from app.services.recommendation_service import RecommendationService
 class TestCarouselBaseOrder:
     def test_business_order_is_favorite_first_deep_last(self):
         """Ordre métier validé avec l'utilisateur :
-        favorite > new_source > community > saved > hot > deep."""
+        favorite > quiet_sources > saved > new_source > hot > community > deep."""
         bp = RecommendationService._CAROUSEL_BASE_POSITIONS
-        assert bp["favorite"] < bp["new_source"]
-        assert bp["new_source"] < bp["community"]
-        assert bp["community"] < bp["saved"]
-        assert bp["saved"] < bp["hot"]
-        assert bp["hot"] < bp["deep"]
+        assert bp["favorite"] < bp["quiet_sources"]
+        assert bp["quiet_sources"] < bp["saved"]
+        assert bp["saved"] < bp["new_source"]
+        assert bp["new_source"] < bp["hot"]
+        assert bp["hot"] < bp["community"]
+        assert bp["community"] < bp["deep"]
 
-    def test_decale_shares_community_slot_since_mutually_exclusive(self):
-        """`decale` n'apparaît qu'en mode serein (qui exclut `community` et `hot`),
-        donc il peut partager le slot de `community` sans collision réelle."""
+    def test_decale_shares_saved_slot_since_low_volume(self):
+        """`decale` n'apparaît qu'en mode serein (qui exclut `community` et `hot`) ;
+        il partage le slot de `saved` (collision resolver gère le cas résiduel)."""
         bp = RecommendationService._CAROUSEL_BASE_POSITIONS
-        assert bp["decale"] == bp["community"]
+        assert bp["decale"] == bp["saved"]
 
 
 class TestJitterDeterminism:

--- a/packages/api/tests/test_feed_carousels_ordering.py
+++ b/packages/api/tests/test_feed_carousels_ordering.py
@@ -20,14 +20,14 @@ from app.services.recommendation_service import RecommendationService
 class TestCarouselBaseOrder:
     def test_business_order_is_favorite_first_deep_last(self):
         """Ordre métier validé avec l'utilisateur :
-        favorite > quiet_sources > saved > new_source > hot > community > deep."""
+        favorite > quiet_sources > saved > new_source > community > hot > deep."""
         bp = RecommendationService._CAROUSEL_BASE_POSITIONS
         assert bp["favorite"] < bp["quiet_sources"]
         assert bp["quiet_sources"] < bp["saved"]
         assert bp["saved"] < bp["new_source"]
-        assert bp["new_source"] < bp["hot"]
-        assert bp["hot"] < bp["community"]
-        assert bp["community"] < bp["deep"]
+        assert bp["new_source"] < bp["community"]
+        assert bp["community"] < bp["hot"]
+        assert bp["hot"] < bp["deep"]
 
     def test_decale_shares_saved_slot_since_low_volume(self):
         """`decale` n'apparaît qu'en mode serein (qui exclut `community` et `hot`) ;

--- a/packages/api/tests/test_feed_carousels_quiet_sources.py
+++ b/packages/api/tests/test_feed_carousels_quiet_sources.py
@@ -1,0 +1,281 @@
+"""Tests DB-driven du carrousel « Tes sources discrètes » (quiet_sources).
+
+Source « rare » = source suivie, active, avec < 3 articles publiés sur les
+30 derniers jours. Item = dernier article (≤ 60 j) non consommé de chaque
+source rare. Carrousel émis seulement si ≥ 2 items.
+"""
+
+import datetime
+from uuid import uuid4
+
+import pytest
+
+from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentStatus, ContentType, InterestState, SourceType
+from app.models.source import Source, UserSource
+from app.services.recommendation_service import RecommendationService
+
+
+def _now():
+    return datetime.datetime.now(datetime.UTC)
+
+
+def _make_source(name: str, is_active: bool = True) -> Source:
+    return Source(
+        id=uuid4(),
+        name=name,
+        url="https://example.com",
+        feed_url=f"https://example.com/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=is_active,
+        is_curated=False,
+    )
+
+
+def _make_content(source: Source, days_ago: float, title: str = "Article") -> Content:
+    return Content(
+        id=uuid4(),
+        source_id=source.id,
+        title=title,
+        url=f"https://example.com/{uuid4()}",
+        published_at=_now() - datetime.timedelta(days=days_ago),
+        content_type=ContentType.ARTICLE,
+        guid=str(uuid4()),
+    )
+
+
+async def _seed_quiet_source(
+    db_session,
+    name: str,
+    user_id,
+    article_days_ago: float = 5,
+    state: InterestState = InterestState.FOLLOWED,
+    is_active: bool = True,
+) -> tuple[Source, Content]:
+    """One followed source with a single recent article (quiet by definition)."""
+    source = _make_source(name, is_active=is_active)
+    db_session.add(source)
+    db_session.add(
+        UserSource(
+            user_id=user_id,
+            source_id=source.id,
+            state=state,
+            added_at=_now() - datetime.timedelta(days=90),
+        )
+    )
+    content = _make_content(source, article_days_ago, title=f"{name} latest")
+    db_session.add(content)
+    await db_session.commit()
+    return source, content
+
+
+async def _build(db_session, user_id):
+    service = RecommendationService(db_session)
+    service.entity_overflow = []
+    service.keyword_overflow = []
+    _, carousels = await service._build_carousels([], {}, user_id=user_id)
+    return carousels
+
+
+def _quiet(carousels):
+    return [c for c in carousels if c["carousel_type"] == "quiet_sources"]
+
+
+@pytest.mark.asyncio
+async def test_quiet_sources_carousel_basic(db_session):
+    user_id = uuid4()
+    src_a, content_a = await _seed_quiet_source(db_session, "Rare A", user_id)
+    src_b, content_b = await _seed_quiet_source(
+        db_session, "Rare B", user_id, article_days_ago=10
+    )
+
+    carousels = await _build(db_session, user_id)
+    quiet = _quiet(carousels)
+    assert len(quiet) == 1
+    c = quiet[0]
+    assert c["title"] == "Tes sources discrètes"
+    assert {i.id for i in c["items"]} == {content_a.id, content_b.id}
+    # Most recent first
+    assert c["items"][0].id == content_a.id
+    assert len(c["badges"]) == 2
+    assert c["badges"][0]["code"] == "quiet_source"
+    # Badge label = source name of the matching item
+    assert c["badges"][0]["label"] == "Rare A"
+    assert c["position"] >= 5
+
+
+@pytest.mark.asyncio
+async def test_high_volume_source_excluded(db_session):
+    user_id = uuid4()
+    await _seed_quiet_source(db_session, "Rare A", user_id)
+    await _seed_quiet_source(db_session, "Rare B", user_id)
+
+    # Busy source: 3 articles in the last 30 days → not quiet
+    busy = _make_source("Busy")
+    db_session.add(busy)
+    db_session.add(
+        UserSource(user_id=user_id, source_id=busy.id, state=InterestState.FOLLOWED)
+    )
+    for d in (1, 5, 12):
+        db_session.add(_make_content(busy, d))
+    await db_session.commit()
+
+    carousels = await _build(db_session, user_id)
+    quiet = _quiet(carousels)
+    assert len(quiet) == 1
+    sources_in_carousel = {i.source_id for i in quiet[0]["items"]}
+    assert busy.id not in sources_in_carousel
+
+
+@pytest.mark.asyncio
+async def test_consumed_article_excluded(db_session):
+    user_id = uuid4()
+    await _seed_quiet_source(db_session, "Rare A", user_id)
+    await _seed_quiet_source(db_session, "Rare B", user_id)
+    _, consumed_content = await _seed_quiet_source(db_session, "Rare C", user_id)
+    db_session.add(
+        UserContentStatus(
+            user_id=user_id,
+            content_id=consumed_content.id,
+            status=ContentStatus.CONSUMED,
+        )
+    )
+    await db_session.commit()
+
+    carousels = await _build(db_session, user_id)
+    quiet = _quiet(carousels)
+    assert len(quiet) == 1
+    assert consumed_content.id not in {i.id for i in quiet[0]["items"]}
+
+
+@pytest.mark.asyncio
+async def test_all_consumed_no_carousel(db_session):
+    user_id = uuid4()
+    for name in ("Rare A", "Rare B"):
+        _, content = await _seed_quiet_source(db_session, name, user_id)
+        db_session.add(
+            UserContentStatus(
+                user_id=user_id,
+                content_id=content.id,
+                status=ContentStatus.CONSUMED,
+            )
+        )
+    await db_session.commit()
+
+    carousels = await _build(db_session, user_id)
+    assert _quiet(carousels) == []
+
+
+@pytest.mark.asyncio
+async def test_old_article_beyond_60_days_excluded(db_session):
+    user_id = uuid4()
+    await _seed_quiet_source(db_session, "Rare A", user_id)
+    await _seed_quiet_source(db_session, "Rare B", user_id)
+    src_old, content_old = await _seed_quiet_source(
+        db_session, "Rare Old", user_id, article_days_ago=75
+    )
+
+    carousels = await _build(db_session, user_id)
+    quiet = _quiet(carousels)
+    assert len(quiet) == 1
+    assert content_old.id not in {i.id for i in quiet[0]["items"]}
+
+
+@pytest.mark.asyncio
+async def test_below_min_display_items_no_carousel(db_session):
+    user_id = uuid4()
+    await _seed_quiet_source(db_session, "Lonely Rare", user_id)
+
+    carousels = await _build(db_session, user_id)
+    assert _quiet(carousels) == []
+
+
+@pytest.mark.asyncio
+async def test_unfollowed_and_inactive_sources_excluded(db_session):
+    user_id = uuid4()
+    await _seed_quiet_source(db_session, "Rare A", user_id)
+    await _seed_quiet_source(db_session, "Rare B", user_id)
+    _, c_unfollowed = await _seed_quiet_source(
+        db_session, "Unfollowed", user_id, state=InterestState.UNFOLLOWED
+    )
+    _, c_inactive = await _seed_quiet_source(
+        db_session, "Inactive", user_id, is_active=False
+    )
+
+    carousels = await _build(db_session, user_id)
+    quiet = _quiet(carousels)
+    assert len(quiet) == 1
+    ids = {i.id for i in quiet[0]["items"]}
+    assert c_unfollowed.id not in ids
+    assert c_inactive.id not in ids
+
+
+@pytest.mark.asyncio
+async def test_one_item_per_source_latest_only(db_session):
+    user_id = uuid4()
+    src_a, latest_a = await _seed_quiet_source(db_session, "Rare A", user_id)
+    older_a = _make_content(src_a, 20, title="Rare A older")
+    db_session.add(older_a)
+    await _seed_quiet_source(db_session, "Rare B", user_id)
+    await db_session.commit()
+
+    carousels = await _build(db_session, user_id)
+    quiet = _quiet(carousels)
+    assert len(quiet) == 1
+    items_from_a = [i for i in quiet[0]["items"] if i.source_id == src_a.id]
+    assert len(items_from_a) == 1
+    assert items_from_a[0].id == latest_a.id
+
+
+@pytest.mark.asyncio
+async def test_promoted_items_removed_from_main_feed(db_session):
+    user_id = uuid4()
+    _, content_a = await _seed_quiet_source(db_session, "Rare A", user_id)
+    await _seed_quiet_source(db_session, "Rare B", user_id)
+
+    service = RecommendationService(db_session)
+    service.entity_overflow = []
+    service.keyword_overflow = []
+    result, carousels = await service._build_carousels(
+        [content_a], {}, user_id=user_id
+    )
+    assert len(_quiet(carousels)) == 1
+    assert content_a.id not in {a.id for a in result}
+
+
+@pytest.mark.asyncio
+async def test_deep_carousel_not_emitted(db_session):
+    """PO decision: the deep carousel is disabled (flag DEEP_CAROUSEL_ENABLED)."""
+    from app.services import recommendation_service as rs
+
+    assert rs.DEEP_CAROUSEL_ENABLED is False
+    user_id = uuid4()
+    carousels = await _build(db_session, user_id)
+    assert not any(c["carousel_type"] == "deep" for c in carousels)
+
+
+@pytest.mark.asyncio
+async def test_saved_carousel_most_recently_saved_first(db_session):
+    user_id = uuid4()
+    source = _make_source("Saved Source")
+    db_session.add(source)
+    contents = [_make_content(source, d, title=f"Saved {d}") for d in (1, 2, 3)]
+    for i, content in enumerate(contents):
+        db_session.add(content)
+        db_session.add(
+            UserContentStatus(
+                user_id=user_id,
+                content_id=content.id,
+                status=ContentStatus.UNSEEN,
+                is_saved=True,
+                saved_at=_now() - datetime.timedelta(days=i),
+            )
+        )
+    await db_session.commit()
+
+    carousels = await _build(db_session, user_id)
+    saved = [c for c in carousels if c["carousel_type"] == "saved"]
+    assert len(saved) == 1
+    # contents[0] saved most recently (saved_at = now) → first
+    assert [i.id for i in saved[0]["items"]] == [c.id for c in contents]


### PR DESCRIPTION
## Quoi
Nouveau carrousel horizontal « Tes sources discrètes » 🤫 dans Flâner : le dernier article (fenêtre 60 j, non lu) de chaque source suivie qui publie peu (< 3 articles sur 30 j). Bonus dans la même PR : « Plus tard, c'est maintenant ! » trié du plus récemment sauvegardé au plus ancien, carrousel deep « Ouvrir ses horizons » désactivé (flag `DEEP_CAROUSEL_ENABLED`, code conservé), et ré-ordre des positions de base des carrousels.

## Pourquoi
Les sources suivies à faible volume passent au travers de l'Essentiel (digest qui exclut les sources suivies par design) et du feed Flâner (noyées par le volume). Backend-only : le pipeline carrousels est server-driven, le mobile rend tout carrousel génériquement avec fallback badge.

## Comment ça a été vérifié
- [x] pytest complet : 1635 passed (dont 11 nouveaux tests DB-driven `test_feed_carousels_quiet_sources.py`)
- [x] E2E local : uvicorn + `GET /api/feed/` authentifié avec sources rares seedées → carrousel `quiet_sources` présent (titre, emoji, badges par source, position 10), `deep` absent ; 403 sans auth, 401 token invalide
- [x] /simplify passé (4 agents — aucun changement requis)

## Zones à risque
`recommendation_service.py` (_build_carousels) — bloc additif isolé, pas de DDL, pas de changement de schéma API (`CarouselInfo` accepte tout `carousel_type`). +1-2 requêtes agrégées par feed non-caché, index existants (`ix_contents_source_published`).

Note review : l'ordre des positions de base (`_CAROUSEL_BASE_POSITIONS`) est une proposition — ajustable par simple édition du dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)