### PR TITLE
feat(landing): RSVP événement via table dédiée event_rsvps (Story 25.1)

### DIFF
--- a/apps/landing/public/blog-soiree-prelancement.html
+++ b/apps/landing/public/blog-soiree-prelancement.html
@@ -120,7 +120,7 @@
         </div>
     </footer>
 
-    <script src="/js/event.js?v=2"></script>
+    <script src="/js/event.js?v=3"></script>
 
 </body>
 

--- a/apps/landing/public/js/event.js
+++ b/apps/landing/public/js/event.js
@@ -39,12 +39,12 @@
         btn.textContent = '...';
         if (error) error.hidden = true;
 
-        var payload = { email: email, source: 'soiree-prelancement' };
+        var payload = { email: email, event_slug: 'soiree-prelancement' };
         if (utmData.utm_source) payload.utm_source = utmData.utm_source;
         if (utmData.utm_medium) payload.utm_medium = utmData.utm_medium;
         if (utmData.utm_campaign) payload.utm_campaign = utmData.utm_campaign;
 
-        fetch(API_URL + '/api/waitlist', {
+        fetch(API_URL + '/api/events/rsvp', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),

--- a/docs/stories/core/25.1.event-rsvp.md
+++ b/docs/stories/core/25.1.event-rsvp.md
@@ -1,0 +1,44 @@
+# Story 25.1 — RSVP événement (table dédiée)
+
+## Contexte
+
+Le formulaire « Je veux venir » de l'article soirée de pré-lancement réutilisait
+`POST /api/waitlist`. Problème : `WaitlistService.register` dédoublonne sur
+`email` (unique) et, sur doublon, fait un rollback **sans rien mettre à jour**
+(`waitlist_service.py:51`). Conséquence : un abonné **déjà** sur la waitlist qui
+RSVP n'est jamais enregistré comme participant — son intention de venir est
+perdue, et le tag `source='soiree-prelancement'` ne s'écrit qu'à la création
+d'une ligne. Impossible donc d'avoir une liste d'invités fiable (jauge 40 places).
+
+## Objectif
+
+Capturer **chaque** RSVP de façon fiable, y compris les emails déjà présents dans
+la waitlist, sans collision — via une **table dédiée `event_rsvps`** distincte de
+la waitlist. Le RSVP continue d'ajouter la personne à la waitlist (pour la notif
+de lancement), mais la présence à l'événement est tracée séparément.
+
+## Design
+
+- **Modèle** `EventRsvp` (`app/models/event_rsvp.py`) : `id`, `event_slug`
+  (défaut `soiree-prelancement`, réutilisable pour de futurs events), `email`,
+  `utm_*`, `created_at`. Contrainte d'unicité `(event_slug, email)` → RSVP
+  idempotent (un 2e clic ne crée pas de doublon mais n'est pas perdu non plus,
+  car la table est indépendante de la waitlist).
+- **Schéma** `EventRsvpRequest` / `EventRsvpResponse` (`is_new`, `rsvp_count`).
+- **Service** `EventRsvpService.register()` (insert + catch `IntegrityError`) et
+  `get_count(event_slug)` pour la jauge.
+- **Router** `POST /api/events/rsvp` (enregistre le RSVP **et** ajoute à la
+  waitlist avec `source=event_slug`) + `GET /api/events/{event_slug}/rsvp/count`.
+  Émet l'event PostHog `event_rsvp`.
+- **Migration Alembic** autogenerate sur le head `gr02_grille_featured_article`.
+- **Frontend** `apps/landing/public/js/event.js` : POST vers `/api/events/rsvp`
+  au lieu de `/api/waitlist` ; bump `?v=3` du `<script>` (cache Cloudflare).
+
+## Tâches
+
+- [ ] Modèle + enregistrement `models/__init__.py`
+- [ ] Schéma + service + router + wiring `main.py`
+- [ ] Migration autogenerate (1 head)
+- [ ] Frontend event.js + cache-bust
+- [ ] Tests (nouvel email, doublon idempotent, count, ajout waitlist)
+- [ ] `pytest -v` vert + `alembic upgrade head` sur DB vide

--- a/packages/api/alembic/versions/b75132e0c6b5_create_event_rsvps_table.py
+++ b/packages/api/alembic/versions/b75132e0c6b5_create_event_rsvps_table.py
@@ -1,0 +1,43 @@
+"""create event_rsvps table
+
+Revision ID: b75132e0c6b5
+Revises: gr02_grille_featured_article
+Create Date: 2026-06-11 17:48:04
+
+Table dédiée au RSVP événement (Story 25.1). Distincte de la waitlist pour
+capturer chaque participant, y compris les emails déjà inscrits (que la
+waitlist dédoublonne et ignore). Unicité (event_slug, email) → RSVP idempotent.
+
+NB: l'autogenerate révèle un drift préexistant entre le baseline et les modèles
+(index/NOT NULL/types sur d'autres tables). Ce drift est volontairement hors
+périmètre de cette migration, qui ne crée QUE la table event_rsvps.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "b75132e0c6b5"
+down_revision: str | None = "gr02_grille_featured_article"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "event_rsvps",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("event_slug", sa.String(length=100), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("utm_source", sa.String(length=100), nullable=True),
+        sa.Column("utm_medium", sa.String(length=100), nullable=True),
+        sa.Column("utm_campaign", sa.String(length=100), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("event_slug", "email", name="uq_event_rsvps_event_email"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("event_rsvps")

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -82,6 +82,7 @@ from app.routers import (
     custom_topics,
     digest,
     essentiel,
+    event_rsvp,
     feed,
     grille,
     images,
@@ -505,6 +506,7 @@ app.include_router(
 )
 app.include_router(app_update.router, prefix="/api/app", tags=["AppUpdate"])
 app.include_router(waitlist.router, prefix="/api/waitlist", tags=["Waitlist"])
+app.include_router(event_rsvp.router, prefix="/api/events", tags=["Events"])
 app.include_router(admin_cohorts.router, prefix="/api/admin", tags=["Admin"])
 app.include_router(
     well_informed.router,

--- a/packages/api/app/models/__init__.py
+++ b/packages/api/app/models/__init__.py
@@ -11,6 +11,7 @@ from app.models.digest_completion import DigestCompletion
 from app.models.digest_generation_state import DigestGenerationState
 from app.models.editorial_highlights_history import EditorialHighlightsHistory
 from app.models.enums import ContentStatus, ContentType, SourceType
+from app.models.event_rsvp import EventRsvp
 from app.models.failed_source_attempt import FailedSourceAttempt
 from app.models.grille_game_state import GrilleGameState
 from app.models.grille_puzzle import GrillePuzzle
@@ -98,6 +99,8 @@ __all__ = [
     # Waitlist (Landing Page)
     "WaitlistEntry",
     "WaitlistSurveyResponse",
+    # RSVP événement (Story 25.1)
+    "EventRsvp",
     # Serene Feedback
     "SereneReport",
     # Entity Preferences (follow/mute on named entities)

--- a/packages/api/app/models/event_rsvp.py
+++ b/packages/api/app/models/event_rsvp.py
@@ -1,0 +1,43 @@
+"""Modèle RSVP événement (soirée de pré-lancement, etc.)."""
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import DateTime, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class EventRsvp(Base):
+    """Confirmation de présence à un événement, depuis la landing.
+
+    Table dédiée — volontairement distincte de la waitlist — pour capturer de
+    façon fiable toute personne qui confirme sa présence, y compris les emails
+    déjà présents dans la waitlist (que `WaitlistService.register` dédoublonne
+    et ignore silencieusement). L'unicité porte sur `(event_slug, email)` : un
+    RSVP est idempotent, et `event_slug` permet de réutiliser la table pour de
+    futurs événements.
+    """
+
+    __tablename__ = "event_rsvps"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    event_slug: Mapped[str] = mapped_column(
+        String(100), nullable=False, default="soiree-prelancement"
+    )
+    email: Mapped[str] = mapped_column(String(255), nullable=False)
+    utm_source: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    utm_medium: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    utm_campaign: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("event_slug", "email", name="uq_event_rsvps_event_email"),
+    )

--- a/packages/api/app/routers/event_rsvp.py
+++ b/packages/api/app/routers/event_rsvp.py
@@ -1,0 +1,91 @@
+"""Router RSVP événement — endpoint public pour confirmer sa présence.
+
+Distinct de la waitlist : capture de façon fiable chaque participant (table
+`event_rsvps`), y compris les emails déjà présents dans la waitlist. Le RSVP
+ajoute aussi la personne à la waitlist (source = event_slug) pour qu'elle
+reçoive la notif de lancement.
+"""
+
+import hashlib
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.schemas.event_rsvp import (
+    EventRsvpCountResponse,
+    EventRsvpRequest,
+    EventRsvpResponse,
+)
+from app.services.event_rsvp_service import EventRsvpService
+from app.services.posthog_client import get_posthog_client
+from app.services.waitlist_service import WaitlistService
+
+router = APIRouter()
+
+
+def _email_distinct_id(email: str) -> str:
+    """Distinct_id stable pour un lead non authentifié (hash de l'email)."""
+    return "lead_" + hashlib.sha256(email.strip().lower().encode()).hexdigest()[:16]
+
+
+@router.get("/{event_slug}/rsvp/count", response_model=EventRsvpCountResponse)
+async def get_rsvp_count(
+    event_slug: str,
+    db: AsyncSession = Depends(get_db),
+) -> EventRsvpCountResponse:
+    """Nombre de RSVP pour un événement (public, pour la jauge)."""
+    service = EventRsvpService(db)
+    count = await service.get_count(event_slug)
+    return EventRsvpCountResponse(event_slug=event_slug, count=count)
+
+
+@router.post("/rsvp", response_model=EventRsvpResponse)
+async def rsvp(
+    request: EventRsvpRequest,
+    db: AsyncSession = Depends(get_db),
+) -> EventRsvpResponse:
+    """Confirme la présence à un événement. Endpoint public, pas d'auth.
+
+    Enregistre le RSVP (table dédiée) puis ajoute l'email à la waitlist pour la
+    notif de lancement. L'ajout waitlist est best-effort : un échec ne doit pas
+    faire échouer le RSVP lui-même.
+    """
+    rsvp_service = EventRsvpService(db)
+    is_new = await rsvp_service.register(
+        request.email,
+        event_slug=request.event_slug,
+        utm_source=request.utm_source,
+        utm_medium=request.utm_medium,
+        utm_campaign=request.utm_campaign,
+    )
+
+    # Ajoute aussi à la waitlist (source = slug de l'événement) pour la notif de
+    # lancement. Best-effort : indépendant du succès du RSVP.
+    waitlist_service = WaitlistService(db)
+    await waitlist_service.register(
+        request.email,
+        source=request.event_slug,
+        utm_source=request.utm_source,
+        utm_medium=request.utm_medium,
+        utm_campaign=request.utm_campaign,
+    )
+
+    if is_new:
+        get_posthog_client().capture(
+            user_id=_email_distinct_id(request.email),
+            event="event_rsvp",
+            properties={
+                "event_slug": request.event_slug,
+                "utm_source": request.utm_source,
+                "utm_medium": request.utm_medium,
+                "utm_campaign": request.utm_campaign,
+            },
+        )
+
+    count = await rsvp_service.get_count(request.event_slug)
+    return EventRsvpResponse(
+        message="Génial, on t'attend ! 🎉",
+        is_new=is_new,
+        rsvp_count=count,
+    )

--- a/packages/api/app/schemas/event_rsvp.py
+++ b/packages/api/app/schemas/event_rsvp.py
@@ -1,0 +1,28 @@
+"""Schémas Pydantic pour les RSVP événement."""
+
+from pydantic import BaseModel, EmailStr
+
+
+class EventRsvpRequest(BaseModel):
+    """Requête de confirmation de présence à un événement."""
+
+    email: EmailStr
+    event_slug: str = "soiree-prelancement"
+    utm_source: str | None = None
+    utm_medium: str | None = None
+    utm_campaign: str | None = None
+
+
+class EventRsvpResponse(BaseModel):
+    """Réponse à une confirmation de présence."""
+
+    message: str
+    is_new: bool = True
+    rsvp_count: int
+
+
+class EventRsvpCountResponse(BaseModel):
+    """Nombre de RSVP pour un événement (public, pour la jauge)."""
+
+    event_slug: str
+    count: int

--- a/packages/api/app/services/event_rsvp_service.py
+++ b/packages/api/app/services/event_rsvp_service.py
@@ -1,0 +1,61 @@
+"""Service RSVP événement — confirmation de présence depuis la landing."""
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.event_rsvp import EventRsvp
+
+logger = structlog.get_logger()
+
+
+class EventRsvpService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_count(self, event_slug: str = "soiree-prelancement") -> int:
+        """Nombre de RSVP pour un événement."""
+        result = await self.db.execute(
+            select(func.count())
+            .select_from(EventRsvp)
+            .where(EventRsvp.event_slug == event_slug)
+        )
+        return result.scalar_one()
+
+    async def register(
+        self,
+        email: str,
+        event_slug: str = "soiree-prelancement",
+        utm_source: str | None = None,
+        utm_medium: str | None = None,
+        utm_campaign: str | None = None,
+    ) -> bool:
+        """Enregistre un RSVP. Retourne True si nouveau, False si déjà présent.
+
+        Idempotent : l'unicité `(event_slug, email)` garantit qu'un 2e RSVP du
+        même email ne crée pas de doublon. Contrairement à la waitlist, cette
+        table est indépendante : un email déjà inscrit à la waitlist est bien
+        enregistré ici comme participant.
+        """
+        entry = EventRsvp(
+            email=email.lower().strip(),
+            event_slug=event_slug,
+            utm_source=utm_source,
+            utm_medium=utm_medium,
+            utm_campaign=utm_campaign,
+        )
+        try:
+            self.db.add(entry)
+            await self.db.commit()
+            logger.info(
+                "event_rsvp_registered",
+                email=email,
+                event_slug=event_slug,
+                utm_source=utm_source,
+            )
+            return True
+        except IntegrityError:
+            await self.db.rollback()
+            logger.info("event_rsvp_duplicate", email=email, event_slug=event_slug)
+            return False

--- a/packages/api/tests/routers/test_event_rsvp.py
+++ b/packages/api/tests/routers/test_event_rsvp.py
@@ -1,0 +1,123 @@
+"""Tests pour POST /api/events/rsvp et le comptage (Story 25.1).
+
+Couvre le scénario clé : un email déjà présent dans la waitlist (que
+`WaitlistService.register` dédoublonne et ignore) DOIT quand même être capturé
+comme participant dans la table dédiée `event_rsvps`.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select
+
+from app.database import get_db
+from app.main import app
+from app.models.event_rsvp import EventRsvp
+from app.models.waitlist import WaitlistEntry
+
+
+@pytest_asyncio.fixture
+async def client(db_session):
+    """AsyncClient avec get_db overridé sur la session de test + PostHog mocké."""
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _fake_db
+    with patch(
+        "app.routers.event_rsvp.get_posthog_client", return_value=MagicMock()
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            try:
+                yield c
+            finally:
+                app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_rsvp_new_email_creates_rsvp_and_waitlist(client, db_session):
+    """Happy path : RSVP d'un nouvel email → ligne event_rsvps + waitlist."""
+    resp = await client.post(
+        "/api/events/rsvp", json={"email": "Alice@Example.com "}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["is_new"] is True
+    assert body["rsvp_count"] == 1
+
+    # RSVP enregistré (email normalisé)
+    rsvp = (
+        await db_session.execute(select(EventRsvp).where(EventRsvp.email == "alice@example.com"))
+    ).scalar_one()
+    assert rsvp.event_slug == "soiree-prelancement"
+
+    # Ajouté aussi à la waitlist avec source = slug de l'événement
+    wl = (
+        await db_session.execute(
+            select(WaitlistEntry).where(WaitlistEntry.email == "alice@example.com")
+        )
+    ).scalar_one()
+    assert wl.source == "soiree-prelancement"
+
+
+@pytest.mark.asyncio
+async def test_rsvp_duplicate_is_idempotent(client, db_session):
+    """Un 2e RSVP du même email ne crée pas de doublon (is_new False, count stable)."""
+    first = await client.post("/api/events/rsvp", json={"email": "bob@example.com"})
+    assert first.json()["is_new"] is True
+
+    second = await client.post("/api/events/rsvp", json={"email": "bob@example.com"})
+    assert second.status_code == 200
+    assert second.json()["is_new"] is False
+    assert second.json()["rsvp_count"] == 1
+
+    count = await db_session.scalar(
+        select(func.count()).select_from(EventRsvp).where(EventRsvp.email == "bob@example.com")
+    )
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_rsvp_existing_waitlist_member_is_still_captured(client, db_session):
+    """Le cœur du fix : un email DÉJÀ sur la waitlist est capturé comme participant."""
+    db_session.add(WaitlistEntry(email="carol@example.com", source="landing"))
+    await db_session.commit()
+
+    resp = await client.post("/api/events/rsvp", json={"email": "carol@example.com"})
+    assert resp.status_code == 200
+    assert resp.json()["is_new"] is True  # nouveau RSVP, même si déjà sur la waitlist
+
+    rsvp = (
+        await db_session.execute(
+            select(EventRsvp).where(EventRsvp.email == "carol@example.com")
+        )
+    ).scalar_one()
+    assert rsvp.event_slug == "soiree-prelancement"
+
+    # La source d'origine de la waitlist n'est PAS écrasée (register dédoublonne)
+    wl = (
+        await db_session.execute(
+            select(WaitlistEntry).where(WaitlistEntry.email == "carol@example.com")
+        )
+    ).scalar_one()
+    assert wl.source == "landing"
+
+
+@pytest.mark.asyncio
+async def test_rsvp_count_endpoint(client, db_session):
+    """GET /api/events/{slug}/rsvp/count renvoie le nombre de RSVP."""
+    for email in ("d@example.com", "e@example.com"):
+        await client.post("/api/events/rsvp", json={"email": email})
+
+    resp = await client.get("/api/events/soiree-prelancement/rsvp/count")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["event_slug"] == "soiree-prelancement"
+    assert body["count"] == 2
+
+    # Un autre événement est compté séparément
+    other = await client.get("/api/events/autre-event/rsvp/count")
+    assert other.json()["count"] == 0


### PR DESCRIPTION
## Contexte

Le formulaire « Je veux venir » de l'article soirée de pré-lancement réutilisait `POST /api/waitlist`. Or `WaitlistService.register` dédoublonne sur `email` (unique) et, sur doublon, **rollback sans rien mettre à jour**. Conséquence : un abonné **déjà** sur la waitlist qui RSVP n'était **jamais** enregistré comme participant — intention perdue, **jauge 40 places non fiable**, et le tag `source` ne s'écrivait qu'à la création d'une ligne.

## Solution

Table dédiée **`event_rsvps`** (distincte de la waitlist) qui capture **chaque** RSVP, y compris les emails déjà présents dans la waitlist.

- **Modèle** `EventRsvp` : `id`, `event_slug` (défaut `soiree-prelancement`, réutilisable), `email`, `utm_*`, `created_at`. Unicité `(event_slug, email)` → RSVP **idempotent**.
- **`POST /api/events/rsvp`** : enregistre le RSVP **et** ajoute à la waitlist (`source=event_slug`) pour la notif de lancement. Émet l'event PostHog `event_rsvp`.
- **`GET /api/events/{slug}/rsvp/count`** : décompte pour la jauge.
- **Migration** `b75132e0c6b5` sur le head `gr02_grille_featured_article` (1 seul head ; `upgrade head` vérifié sur DB vide via le baseline).
- **Front** : `js/event.js` bascule sur `/api/events/rsvp` (+ `event_slug`) ; cache-bust `?v=3` du `<script>` (le cache Cloudflare immutable masquait sinon la nouvelle version).

## Tests

`pytest tests/routers/test_event_rsvp.py` — 4 cas, dont le scénario clé :
- nouvel email → RSVP + waitlist créés ;
- doublon → idempotent (`is_new=false`, count stable) ;
- **membre waitlist existant → quand même capturé** comme participant ;
- endpoint count (isolé par `event_slug`).

Suite backend complète : **1519 passed, 1 skipped, 2 xfailed** (aucune régression).

## Notes

- La source d'origine d'un inscrit waitlist n'est **pas** écrasée (on n'ajoute qu'une ligne `event_rsvps`).
- L'autogenerate révèle un drift préexistant baseline↔modèles sur d'autres tables ; **volontairement hors périmètre** — la migration ne crée que `event_rsvps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)