### PR TITLE
fix(mobile): polish Notif digest — shorter body + serein tone

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Notif",
+      "summary": "Notification du matin plus courte, et un ton plus doux quand le mode Serein est activé."
+    },
+    {
       "tag": "Flâner",
       "summary": "Nouveau carrousel « Tes sources discrètes » : ne ratez plus les sources que vous suivez et qui publient rarement."
     },

--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -130,6 +130,16 @@ class PushNotificationService {
   static const String defaultTitle = 'Facteur';
   static const String defaultBody = "Ton récap du jour t'attend quand tu veux.";
 
+  /// En-têtes du bigText de la notif digest (variante B), selon le mode.
+  static const String digestHeader = "À la une dans l'Essentiel :";
+  static const String digestHeaderSerene = 'Du calme dans ton actu :';
+
+  /// Ligne CTA finale du bigText digest, selon le mode.
+  static const String digestCta =
+      "Pour le reste, viens faire un tour sur l'app !";
+  static const String digestCtaSerene =
+      "Le reste t'attend tranquillement dans l'app.";
+
   /// Variante C — déclenchée manuellement par l'éditorial (hors v1).
   static const String calmTitle = 'Facteur';
   static const String calmBody =
@@ -152,12 +162,15 @@ class PushNotificationService {
 
   /// Construit le triplet (title, body, bigText) selon la variante.
   ///
-  /// - [variantB] requiert au moins un teaser dans [teasers]. Le premier
-  ///   teaser est utilisé pour le body collapsed (tronqué à 60c, brief §6.1) ;
-  ///   l'ensemble (max 3) est rendu en bullets dans le bigText Android.
+  /// - [variantB] requiert au moins un teaser dans [teasers]. Le titre complet
+  ///   du premier teaser est utilisé pour le body collapsed (l'OS l'ellipsise
+  ///   sur une ligne) ; les 2 premiers titres sont rendus en bullets dans le
+  ///   bigText Android, suivis d'une ligne CTA renvoyant vers l'app.
+  /// - [serene] bascule l'en-tête et le CTA sur un ton apaisé (mode Serein).
   static ({String title, String body, String bigText}) buildCopy({
     required NotifVariant variant,
     List<String>? teasers,
+    bool serene = false,
   }) {
     switch (variant) {
       case NotifVariant.variantA:
@@ -166,19 +179,18 @@ class PushNotificationService {
         final cleaned = (teasers ?? const <String>[])
             .map((t) => t.trim())
             .where((t) => t.isNotEmpty)
-            .take(3)
+            .take(2)
             .toList();
         if (cleaned.isEmpty) {
           return (title: defaultTitle, body: defaultBody, bigText: defaultBody);
         }
-        final first = cleaned.first;
-        final clipped =
-            first.length > 60 ? '${first.substring(0, 57)}…' : first;
+        final header = serene ? digestHeaderSerene : digestHeader;
+        final cta = serene ? digestCtaSerene : digestCta;
         final bullets = cleaned.map((t) => '• $t').join('\n');
         return (
           title: defaultTitle,
-          body: 'À la une : $clipped',
-          bigText: "À la une dans l'Essentiel :\n$bullets",
+          body: cleaned.first,
+          bigText: '$header\n$bullets\n$cta',
         );
       case NotifVariant.variantC:
         return (title: calmTitle, body: calmBody, bigText: calmBody);
@@ -222,10 +234,11 @@ class PushNotificationService {
     NotifTimeSlot timeSlot = NotifTimeSlot.morning,
     NotifVariant variant = NotifVariant.variantA,
     List<String>? teasers,
+    bool serene = false,
   }) async {
     final time = _timeOfDayFor(timeSlot);
     final scheduledDate = _nextInstanceOf(time);
-    final copy = buildCopy(variant: variant, teasers: teasers);
+    final copy = buildCopy(variant: variant, teasers: teasers, serene: serene);
 
     final androidPlugin = _plugin.resolvePlatformSpecificImplementation<
         AndroidFlutterLocalNotificationsPlugin>();

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -378,6 +378,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       await ref.read(notificationsSettingsProvider.notifier).syncDigestTeasers(
             essentielTeasers: buildEssentielTeasers(essentielArticles),
             goodNewsTeasers: buildGoodNewsTeasers(dual.serein),
+            sereinEnabled: dual.sereinEnabled,
           );
     } catch (e) {
       debugPrint('FluxContinu: syncNotificationTeasers failed: $e');

--- a/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
+++ b/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
@@ -120,6 +120,10 @@ class NotificationsSettingsNotifier
   // que `main.dart` (cold start) lise la même clé sans dupliquer le littéral.
   static const kEssentielTeasers = 'notif_essentiel_teasers';
   static const kGoodNewsTeasers = 'notif_good_news_teasers';
+  // Dernier état connu de la préférence `serein_enabled`, persisté localement
+  // pour cuire la notif digest sur le bon ton (en-tête + CTA apaisés) aux 3
+  // points de scheduling. Publique : `main.dart` (cold start) la lit aussi.
+  static const kSereinNotif = 'notif_serein_enabled';
 
   Future<Box<dynamic>> _box() => Hive.openBox<dynamic>(_boxName);
 
@@ -236,6 +240,7 @@ class NotificationsSettingsNotifier
     final box = await _box();
     final essentielTeasers = readTeasers(box, kEssentielTeasers);
     final goodNewsTeasers = readTeasers(box, kGoodNewsTeasers);
+    final serene = readSerein(box);
     if (state.pushEnabled) {
       await push.scheduleDailyDigestNotification(
         timeSlot: state.timeSlot,
@@ -243,6 +248,7 @@ class NotificationsSettingsNotifier
             ? NotifVariant.variantA
             : NotifVariant.variantB,
         teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
+        serene: serene,
       );
       if (state.preset == NotifPreset.curieux) {
         await push.scheduleWeeklyCommunityPick();
@@ -266,6 +272,13 @@ class NotificationsSettingsNotifier
     return raw.whereType<String>().toList(growable: false);
   }
 
+  /// Lecture défensive du flag serein persisté (défaut `false`). Statique +
+  /// publique : `main.dart` (cold start) lit la même clé sans dupliquer le cast.
+  static bool readSerein(Box<dynamic> box) {
+    final raw = box.get(kSereinNotif);
+    return raw is bool ? raw : false;
+  }
+
   /// Met à jour les teasers persistés depuis le dernier digest chargé, puis
   /// replanifie les notifs perso. Appelée fire-and-forget depuis
   /// `fluxContinuProvider` après un load frais.
@@ -276,6 +289,7 @@ class NotificationsSettingsNotifier
   Future<void> syncDigestTeasers({
     required List<String> essentielTeasers,
     required List<String> goodNewsTeasers,
+    required bool sereinEnabled,
   }) async {
     final box = await _box();
     if (essentielTeasers.isNotEmpty) {
@@ -284,6 +298,7 @@ class NotificationsSettingsNotifier
     if (goodNewsTeasers.isNotEmpty) {
       await box.put(kGoodNewsTeasers, goodNewsTeasers);
     }
+    await box.put(kSereinNotif, sereinEnabled);
     await _reschedule();
   }
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -327,6 +327,7 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
     final digestVariant = essentielTeasers.isEmpty
         ? NotifVariant.variantA
         : NotifVariant.variantB;
+    final digestSerene = NotificationsSettingsNotifier.readSerein(settingsBox);
 
     // Diagnostic + scheduling sont indépendants : collecter le diagnostic
     // pendant la planification (alarms + permission). `pushEnabled=false`
@@ -344,6 +345,7 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
             await pushNotificationService.scheduleDailyDigestNotification(
           variant: digestVariant,
           teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
+          serene: digestSerene,
         );
         if (!scheduled) {
           debugPrint(
@@ -354,6 +356,7 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
               await pushNotificationService.scheduleDailyDigestNotification(
             variant: digestVariant,
             teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
+            serene: digestSerene,
           );
           debugPrint('Main: Retry result: $retryOk');
         }

--- a/apps/mobile/test/core/services/push_notification_service_copy_test.dart
+++ b/apps/mobile/test/core/services/push_notification_service_copy_test.dart
@@ -12,26 +12,55 @@ void main() {
       expect(copy.bigText, copy.body);
     });
 
-    test('variant B with teasers uses tutoiement + personnification', () {
+    test('variant B body is the full first title (no clip)', () {
       final copy = PushNotificationService.buildCopy(
         variant: NotifVariant.variantB,
         teasers: ['Trump'],
       );
       expect(copy.title, 'Facteur');
-      expect(copy.body, 'À la une : Trump');
-      expect(copy.bigText, "À la une dans l'Essentiel :\n• Trump");
+      expect(copy.body, 'Trump');
+      expect(
+        copy.bigText,
+        "À la une dans l'Essentiel :\n• Trump\n"
+        "${PushNotificationService.digestCta}",
+      );
     });
 
-    test('variant B with multiple teasers renders bullet bigText (max 3)', () {
+    test('variant B caps at 2 titles + CTA line in bigText', () {
       final copy = PushNotificationService.buildCopy(
         variant: NotifVariant.variantB,
         teasers: ['Trump', 'Climat', 'Marseille', 'Quatrième'],
       );
-      expect(copy.body, 'À la une : Trump');
+      expect(copy.body, 'Trump');
       expect(
         copy.bigText,
-        "À la une dans l'Essentiel :\n• Trump\n• Climat\n• Marseille",
+        "À la une dans l'Essentiel :\n• Trump\n• Climat\n"
+        "Pour le reste, viens faire un tour sur l'app !",
       );
+    });
+
+    test('variant B serene swaps header and CTA, keeps the 2 titles', () {
+      final copy = PushNotificationService.buildCopy(
+        variant: NotifVariant.variantB,
+        teasers: ['Trump', 'Climat', 'Marseille'],
+        serene: true,
+      );
+      expect(copy.body, 'Trump');
+      expect(
+        copy.bigText,
+        'Du calme dans ton actu :\n• Trump\n• Climat\n'
+        "Le reste t'attend tranquillement dans l'app.",
+      );
+    });
+
+    test('variant B keeps full title even beyond 60 chars', () {
+      final teaser = 'A' * 80;
+      final copy = PushNotificationService.buildCopy(
+        variant: NotifVariant.variantB,
+        teasers: [teaser],
+      );
+      expect(copy.body, teaser);
+      expect(copy.body, isNot(endsWith('…')));
     });
 
     test('variant B without teasers falls back to A', () {
@@ -40,16 +69,7 @@ void main() {
         teasers: const [],
       );
       expect(copy.title, 'Facteur');
-    });
-
-    test('variant B truncates first teaser longer than 60 chars', () {
-      final teaser = 'A' * 80;
-      final copy = PushNotificationService.buildCopy(
-        variant: NotifVariant.variantB,
-        teasers: [teaser],
-      );
-      expect(copy.body.length, lessThanOrEqualTo('À la une : '.length + 58));
-      expect(copy.body, endsWith('…'));
+      expect(copy.body, "Ton récap du jour t'attend quand tu veux.");
     });
 
     test('variant C returns calm copy', () {


### PR DESCRIPTION
## What

Deux améliorations à la notification digest du matin :
- **Body plus court** : utilise le titre complet du 1er teaser (l'OS gère l'ellipsation), pas de clip à 60 caractères
- **Mode Serein** : bascule l'en-tête et le CTA du bigText sur un ton apaisé quand la préférence est activée

## Why

La notification était trop serrée avec le clip à 60c qui tronquait les titres importants. Mode Serein demande un ton plus doux (« calme dans ton actu » vs « à la une »).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (flutter test)
- [x] No new Python List[] imports
- [x] No auth/DB changes
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (mobile-only, no backend)