### PR TITLE
feat(letters): lettres 3 et 4 du Facteur + backfill users existants (Story 26.2)

### DIFF
--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,66 +1,57 @@
-# QA Handoff — Progression PR1 (Mon courrier → Progression, gamification)
+# QA Handoff — Story 26.2 : Lettres 3 et 4 du Facteur
 
 > Ce fichier est rempli par l'agent dev à la fin du développement, après validation du PO.
 > Il sert d'input à la commande /validate-feature de l'agent QA.
 
 ## Feature développée
-L'onglet « Mon courrier (progression) » devient « Progression » : grades de facteur dérivés des lettres complétées (Apprenti facteur → Maître facteur), badge de niveau discret sur l'avatar header, header gamifié sur l'écran Progression, teaser « Classement des Facteurs (BIENTÔT) », carte Progression en haut du Profil, avatar + grade dans la sheet Réglages, banner feed avec étape x/n et mini barre. 100 % client, zéro backend.
+
+Deux nouvelles lettres au catalogue backend (letter_3 « Ta tournée s'organise »,
+letter_4 « Facteur de fond »), backfill automatique pour les users existants,
+et 3 actions demandées par le PO : note sur un article sauvegardé, masquer
+3 sources, donner son avis sur l'app (nouvel event `app_feedback_opened` émis
+à l'ouverture de la modale « Donner mon avis »).
 
 ## PR associée
-À créer via /go (base main). Branche : boujonlaurin-dotcom/progression-tab-gamification.
+
+À créer via /go (base main). Branche : boujonlaurin-dotcom/progression-pr2-new-letters.
 
 ## Écrans impactés
-| Écran | Route | Modifié / Nouveau |
-|-------|-------|-------------------|
-| Progression (ex Mon courrier) | /lettres | Modifié (titre, header gamifié, teaser classement, sections sans em-dash) |
-| Profil | profil (depuis sheet Réglages) | Modifié (carte PROGRESSION en premier) |
-| Sheet Réglages | bouton avatar header | Modifié (_ProfileBlock : RingAvatar + grade au lieu de « Plan gratuit ») |
-| Feed Essentiel (banner lettres) | / (flâner/essentiel) | Modifié (kicker « ÉTAPE 01 · x/n », mini barre, pastille enveloppe) |
-| Avatar header | toutes pages avec header | Modifié (badge numérique de niveau bas-droite) |
 
-## Scénarios de test
+- **Progression** (`/lettres`) : 5 lettres au lieu de 3 ; letter_3 s'active
+  automatiquement pour un user qui avait fini letter_2.
+- **Réglages** (`/settings`) : le tap sur « Donner mon avis » émet l'event
+  analytics (aucun changement visuel).
+- Navigation depuis une action de lettre : nouvelles destinations
+  (`/veille/config`, `/saved`, `/settings/sources/add`, `/settings`, `/flaner`).
 
-### Scénario 1 : Écran Progression (happy path)
-**Parcours** :
-1. Ouvrir l'avatar header → Réglages → « Progression » (ou route /lettres)
-2. Observer le header
-**Résultat attendu** : titre « Progression » ; carte header avec avatar (initiales + badge niveau), titre de grade (ex « Apprenti facteur »), sous-ligne « NIVEAU 1 · 0 LETTRE CLASSÉE », barre de progression globale, « x/n étapes sur la lettre en cours » ; sections EN COURS / À VENIR / CLASSÉES sans tirets « — » ; teaser « CLASSEMENT DES FACTEURS » + « BIENTÔT » entre À VENIR et CLASSÉES, non tappable.
+## Scénarios
 
-### Scénario 2 : Badge niveau sur l'avatar header
-**Parcours** :
-1. Sur le feed, observer l'avatar en haut à droite
-2. Activer le Mode Serein dans Réglages, ré-observer
-**Résultat attendu** : petit disque sombre bas-droite avec le chiffre du niveau (discret). En serein : le lotus remplace le badge niveau (un seul badge de coin).
+### Happy path
 
-### Scénario 3 : Profil + sheet Réglages
-**Parcours** :
-1. Avatar header → sheet Réglages : bloc profil
-2. Tap sur le bloc profil → écran Profil
-3. Tap sur la carte PROGRESSION
-**Résultat attendu** : sheet : avatar RingAvatar (mêmes initiales que le header) + grade en sous-titre (plus de « Plan gratuit »). Profil : carte « PROGRESSION » en premier (avatar, grade, « Lettre 02 · x/y étapes », mini barre) ; tap → écran Progression.
+1. Ouvrir Progression → vérifier 5 lettres, letter_3/4 affichées (upcoming ou
+   active selon l'avancement du compte).
+2. Tap sur chaque action de letter_3 → vérifier la redirection :
+   - « Créer ta première veille » → écran de config veille
+   - « Enregistrer 5 articles » → Flâner
+   - « Écrire une note sur un article sauvegardé » → écran Sauvegardés
+   - « Masquer 3 sources » → Flâner
+   - « Ajouter 5 chaînes YouTube » → ajout de source
+3. Tap sur « Donner ton avis sur l'app » (letter_4) → ouverture des réglages ;
+   tap « Donner mon avis » → modale feedback + requête réseau analytics
+   (`app_feedback_opened`) sans erreur.
+4. Compléter une action (ex. masquer 3 sources depuis un article) → revenir
+   sur Progression → l'action passe cochée après refresh.
 
-### Scénario 4 : Banner feed
-**Parcours** :
-1. Avec une lettre active, aller sur l'Essentiel/Flâner
-**Résultat attendu** : banner avec enveloppe sur pastille teintée, kicker « ÉTAPE 02 · x/n » (sans x/n si la lettre n'a pas d'actions), mini barre sous le titre ; dismiss X masque pour la session ; tap ouvre la lettre.
+### Edge cases
 
-### Scénario 5 : Cas d'erreur
-**Parcours** :
-1. Couper le réseau, ouvrir /lettres
-**Résultat attendu** : « Impossible de charger ta progression. » + Réessayer. Carte Profil et avatar : pas de badge ni carte (shrink silencieux), pas de crash.
+- User existant (3 rows) : GET /api/letters → 200, pas d'erreur, 5 lettres.
+- User ayant déjà tout fini (L0-L2 archivées) : letter_3 doit être active.
+- Note vide ou espaces → ne valide pas « Écrire une note ».
+- Console sans erreurs, réseau sans 4xx/5xx inattendus sur tous ces flux.
 
 ## Critères d'acceptation
-- [ ] Titre « Progression » partout côté UI (route /lettres inchangée)
-- [ ] Grade correct : 0 lettre complétée = niveau 1 (letter_0 bienvenue ignorée), 1 = niveau 2, clamp à Maître facteur
-- [ ] Badge niveau discret, serein prioritaire (jamais 2 badges)
-- [ ] Aucun em-dash dans la nouvelle copy
-- [ ] Dark mode (Encre & Nuit + Encre Pure) : nouveaux widgets lisibles
-- [ ] Viewport 390x844, console sans erreurs, pas de 4xx/5xx inattendus
 
-## Zones de risque
-- Goldens RingAvatar : chemin non-serein sans level doit rester byte-identical (vérifié : goldens existants inchangés).
-- Le grade est 100 % client : avec seulement letter_0 archivée (actions vides), niveau doit être 1, pas 2.
-- Scroll de l'écran Progression : CLASSÉES passe sous le fold avec le nouveau header.
-
-## Dépendances
-Aucune : zéro backend, zéro migration. Endpoint lettres existant uniquement.
+- [ ] 5 lettres visibles, ordre 00→04, grades cohérents avec le ladder
+- [ ] Aucune erreur pour les users existants (backfill silencieux)
+- [ ] Chaque action redirige vers un écran où le geste est faisable
+- [ ] Event `app_feedback_opened` émis au tap « Donner mon avis »

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -2,6 +2,10 @@
   "unreleased": [
     {
       "tag": "Progression",
+      "summary": "Deux nouvelles lettres du Facteur : des défis de curation (veille, notes, sources) et un palier de fond pour les lecteurs assidus."
+    },
+    {
+      "tag": "Progression",
       "summary": "Mon courrier devient Progression : grades de facteur, niveau sur ton avatar et un écran plus clair pour suivre tes étapes."
     },
     {

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -380,6 +380,14 @@ class AnalyticsService {
     await _logEvent('perspective_comparison_closed', props);
   }
 
+  /// Ouverture de la modale « Donner mon avis » (réglages). Trace serveur
+  /// utilisée par la lettre 4 (action give_app_feedback).
+  Future<void> trackAppFeedbackOpened() async {
+    final props = {'session_id': _sessionId};
+    await _logEvent('app_feedback_opened', props);
+    await _capturePostHog('app_feedback_opened', props);
+  }
+
   /// origin: 'digest' | 'feed' | 'settings'
   Future<void> trackArticleFeedbackSubmitted({
     required String contentId,

--- a/apps/mobile/lib/features/lettres/navigation/letter_action_route_resolver.dart
+++ b/apps/mobile/lib/features/lettres/navigation/letter_action_route_resolver.dart
@@ -19,11 +19,24 @@ String? resolveLetterActionRoute(LetterAction action) {
     case 'read_3_long_articles':
     case 'read_first_video_podcast':
     case 'recommend_first_article':
+    case 'save_5_articles':
+    case 'mute_3_sources':
+    case 'read_50_articles':
+    case 'recommend_10_articles':
+    case 'open_10_perspectives':
       return RoutePaths.flaner;
     case 'read_first_essentiel':
       return '${RoutePaths.fluxContinu}/section/essentiel';
     case 'read_first_bonnes_nouvelles':
       return '${RoutePaths.fluxContinu}/section/bonnes';
+    case 'create_first_veille':
+      return RoutePaths.veilleConfig;
+    case 'write_first_note':
+      return RoutePaths.saved;
+    case 'add_5_youtube_channels':
+      return '${RoutePaths.sources}/add';
+    case 'give_app_feedback':
+      return RoutePaths.settings;
   }
 
   final raw = action.targetRoute?.trim();

--- a/apps/mobile/lib/features/lettres/widgets/grade_ladder.dart
+++ b/apps/mobile/lib/features/lettres/widgets/grade_ladder.dart
@@ -86,6 +86,7 @@ class _GradeRow extends StatelessWidget {
               title,
               style: GoogleFonts.dmSans(
                 fontSize: 14,
+                fontStyle: FontStyle.italic,
                 fontWeight: current ? FontWeight.w700 : FontWeight.w500,
                 color: current
                     ? colors.primary

--- a/apps/mobile/lib/features/lettres/widgets/progression_header.dart
+++ b/apps/mobile/lib/features/lettres/widgets/progression_header.dart
@@ -58,6 +58,7 @@ class ProgressionHeader extends ConsumerWidget {
                     style: GoogleFonts.fraunces(
                       fontSize: 19,
                       fontWeight: FontWeight.w700,
+                      fontStyle: FontStyle.italic,
                       letterSpacing: -0.3,
                       height: 1.15,
                       color: colors.textPrimary,

--- a/apps/mobile/lib/features/settings/widgets/profile_progression_card.dart
+++ b/apps/mobile/lib/features/settings/widgets/profile_progression_card.dart
@@ -61,16 +61,19 @@ class ProfileProgressionCard extends ConsumerWidget {
             child: InkWell(
               onTap: () => context.pushNamed(RouteNames.lettres),
               child: Padding(
-                padding: const EdgeInsets.all(FacteurSpacing.space4),
+                padding: const EdgeInsets.all(20),
                 child: Row(
                   children: [
-                    RingAvatar.fromName(
-                      displayName,
-                      active?.progress,
-                      level: grade.level,
-                      serein: serein,
+                    Transform.scale(
+                      scale: 1.35,
+                      child: RingAvatar.fromName(
+                        displayName,
+                        active?.progress,
+                        level: grade.level,
+                        serein: serein,
+                      ),
                     ),
-                    const SizedBox(width: FacteurSpacing.space4),
+                    const SizedBox(width: 20),
                     Expanded(
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -79,15 +82,19 @@ class ProfileProgressionCard extends ConsumerWidget {
                             grade.title,
                             style: Theme.of(context)
                                 .textTheme
-                                .bodyMedium
-                                ?.copyWith(fontWeight: FontWeight.w600),
+                                .titleMedium
+                                ?.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                  fontStyle: FontStyle.italic,
+                                ),
                           ),
                           if (active != null && activeTotal > 0) ...[
-                            const SizedBox(height: 6),
+                            const SizedBox(height: 8),
                             LetterMiniProgress(
                               progress: active.progress,
                               done: activeDone,
                               total: activeTotal,
+                              height: 6,
                               showCount: false,
                             ),
                           ],

--- a/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -11,6 +12,7 @@ import '../../../config/constants.dart';
 import '../../../config/routes.dart';
 import '../../../config/serein_colors.dart';
 import '../../../config/theme.dart';
+import '../../../core/providers/analytics_provider.dart';
 import '../../app_update/providers/app_update_provider.dart';
 import '../../app_update/widgets/update_bottom_sheet.dart';
 import '../../digest/providers/serein_toggle_provider.dart';
@@ -440,19 +442,23 @@ Future<void> _confirmAndArchiveVeille(BuildContext context, WidgetRef ref) async
   }
 }
 
-class _FeedbackTile extends StatelessWidget {
+class _FeedbackTile extends ConsumerWidget {
   const _FeedbackTile();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
     return _SheetCard(
-      onTap: () => showModalBottomSheet<void>(
-        context: context,
-        backgroundColor: Colors.transparent,
-        isScrollControlled: true,
-        builder: (_) => const FeedbackModal(),
-      ),
+      onTap: () {
+        // Trace serveur pour la lettre 4 (action give_app_feedback).
+        unawaited(ref.read(analyticsServiceProvider).trackAppFeedbackOpened());
+        showModalBottomSheet<void>(
+          context: context,
+          backgroundColor: Colors.transparent,
+          isScrollControlled: true,
+          builder: (_) => const FeedbackModal(),
+        );
+      },
       child: Padding(
         padding: const EdgeInsets.symmetric(
           horizontal: FacteurSpacing.space4,

--- a/apps/mobile/test/features/lettres/navigation/letter_action_route_resolver_test.dart
+++ b/apps/mobile/test/features/lettres/navigation/letter_action_route_resolver_test.dart
@@ -28,6 +28,36 @@ void main() {
       );
     });
 
+    test('maps letter 3 and 4 action ids (Story 26.2)', () {
+      expect(
+        resolveLetterActionRoute(_action(id: 'create_first_veille')),
+        '/veille/config',
+      );
+      expect(resolveLetterActionRoute(_action(id: 'save_5_articles')), '/flaner');
+      expect(resolveLetterActionRoute(_action(id: 'write_first_note')), '/saved');
+      expect(resolveLetterActionRoute(_action(id: 'mute_3_sources')), '/flaner');
+      expect(
+        resolveLetterActionRoute(_action(id: 'add_5_youtube_channels')),
+        '/settings/sources/add',
+      );
+      expect(
+        resolveLetterActionRoute(_action(id: 'read_50_articles')),
+        '/flaner',
+      );
+      expect(
+        resolveLetterActionRoute(_action(id: 'recommend_10_articles')),
+        '/flaner',
+      );
+      expect(
+        resolveLetterActionRoute(_action(id: 'open_10_perspectives')),
+        '/flaner',
+      );
+      expect(
+        resolveLetterActionRoute(_action(id: 'give_app_feedback')),
+        '/settings',
+      );
+    });
+
     test('normalizes legacy digest and feed routes', () {
       expect(
         resolveLetterActionRoute(

--- a/docs/stories/core/26.2.progression-pr2.md
+++ b/docs/stories/core/26.2.progression-pr2.md
@@ -1,0 +1,74 @@
+# Story 26.2 — Progression PR2 : Lettres 3 et 4 du Facteur
+
+## Statut
+In Progress
+
+## Contexte
+
+PR1 (Story 26.1, #832, **mergée**) a livré la refonte client de l'onglet Progression
+(grades, badge, banner). PR2 ajoute 2 nouvelles lettres au catalogue backend, avec
+des actions à fort impact et un vrai saut de difficulté.
+
+Intégrées à la demande du PO : « écrire 1 note sur un article sauvegardé »,
+« masquer 3 sources », « donner son avis sur l'app » (ouverture de la modale
+réglages). Chaque action doit être facile à actionner : `target_route` précise +
+`help` qui décrit le geste exact.
+
+Point critique : `get_user_letters` n'initialise les rows que si l'utilisateur n'en
+a **aucune**, puis sérialise `rows[letter["id"]]` pour chaque lettre du catalogue.
+Un user existant (3 rows) → **KeyError** dès qu'on ajoute letter_3. Backfill
+idempotent obligatoire (`_ensure_rows`).
+
+## Composition
+
+### LETTER_3 — « Ta tournée s'organise » (5 actions, palier intermédiaire)
+
+| action id | label | détection (DB) | target_route |
+|---|---|---|---|
+| `create_first_veille` | Créer ta première veille | EXISTS `VeilleConfig` par user_id, sans filtre de statut | `/veille/config` |
+| `save_5_articles` | Enregistrer 5 articles | `UserContentStatus.is_saved == True`, count ≥ 5 | `/flaner` |
+| `write_first_note` | Écrire une note sur un article sauvegardé | `is_saved == True` ET `note_text` non null, non vide (trim) | `/saved` |
+| `mute_3_sources` | Masquer 3 sources qui ne te plaisent pas | `cardinality(UserPersonalization.muted_sources) ≥ 3` | `/flaner` |
+| `add_5_youtube_channels` | Ajouter 5 chaînes YouTube | `UserSource JOIN Source` où `Source.type == YOUTUBE`, count ≥ 5 | `/settings/sources/add` |
+
+### LETTER_4 — « Facteur de fond » (4 actions, palier exigeant)
+
+| action id | label | détection (DB) | target_route |
+|---|---|---|---|
+| `read_50_articles` | Lire 50 articles | helper `_count_read_articles` (même signal que les 10 articles), seuil 50 | `/flaner` |
+| `recommend_10_articles` | Recommander 10 articles | `is_liked == True`, count ≥ 10 | `/flaner` |
+| `open_10_perspectives` | Comparer 10 couvertures médiatiques | `AnalyticsEvent perspectives_opened` (loggé serveur), count ≥ 10 | `/flaner` |
+| `give_app_feedback` | Donner ton avis sur l'app | `AnalyticsEvent app_feedback_opened` (nouvel event mobile, émis au tap « Donner mon avis ») | `/settings` |
+
+Aucun em-dash dans la copy. Forme identique à LETTER_2 (`intro_palier`,
+`completion_palier` par action, `completion_voeu`).
+
+## Tasks
+
+- [x] Story doc
+- [x] `catalog.py` : LETTER_3, LETTER_4, LETTERS_ORDER
+- [x] `service.py` : 9 détecteurs + helpers factorisés (`_count_read_articles`, `_count_event_detector`) + backfill `_ensure_rows` (init complet / rows partielles / réactivation de chaîne / commit seulement si changement)
+- [x] Mobile : `letter_action_route_resolver.dart` (9 nouveaux cases), `analytics_service.dart` (`trackAppFeedbackOpened`), `settings_sheet.dart` (émission de l'event au tap)
+- [x] Tests backend : 54 tests letters verts, suite complète 1671 passed ; tests mobiles resolver + analytics verts
+- [x] Changelog `unreleased`
+- [x] QA handoff `.context/qa-handoff.md`
+- [ ] `/go`
+
+## Fichiers modifiés
+
+- `packages/api/app/services/letters/catalog.py`
+- `packages/api/app/services/letters/service.py`
+- `packages/api/tests/routers/test_letters_routes.py`
+- `apps/mobile/lib/features/lettres/navigation/letter_action_route_resolver.dart`
+- `apps/mobile/lib/core/services/analytics_service.dart`
+- `apps/mobile/lib/features/settings/widgets/settings_sheet.dart`
+- `apps/mobile/assets/changelog.json`
+
+## Risques
+
+- Réactivation : n'activer letter_3 que s'il n'y a **aucune** lettre active.
+- `_ensure_rows` : no-op sans commit quand les rows sont complètes.
+- `mute_3_sources` peut se dé-compléter si l'utilisateur ré-affiche des sources
+  pendant que la lettre est active (même comportement que un unlike) ; accepté.
+
+Aucune migration Alembic. Le ladder client (PR1) couvre déjà 4 lettres à actions.

--- a/packages/api/app/services/letters/catalog.py
+++ b/packages/api/app/services/letters/catalog.py
@@ -1,6 +1,6 @@
 """Catalogue des lettres du Facteur (constantes serveur).
 
-V1 = 3 lettres en dur. Rotation éditoriale = redeploy. Les lettres ne sont
+V2 = 5 lettres en dur. Rotation éditoriale = redeploy. Les lettres ne sont
 pas en DB — la table `user_letter_progress` ne stocke que la progression
 utilisateur.
 """
@@ -126,5 +126,163 @@ LETTER_2: dict = {
     ),
 }
 
-LETTERS_ORDER: list[dict] = [LETTER_0, LETTER_1, LETTER_2]
+LETTER_3: dict = {
+    "id": "letter_3",
+    "num": "03",
+    "title": "Ta tournée s'organise",
+    "default_status": "upcoming",
+    "intro_palier": (
+        "Tu sais lire. Maintenant, apprends à trier : ce que tu gardes, "
+        "ce que tu annotes, ce que tu écartes."
+    ),
+    "actions": [
+        {
+            "id": "create_first_veille",
+            "label": "Créer ta première veille",
+            "help": (
+                "Choisis un sujet qui compte pour toi. Le Facteur surveillera "
+                "pour toi, jour après jour."
+            ),
+            "completion_palier": (
+                "Une veille posée. Le Facteur garde un œil dessus pour toi."
+            ),
+            "target_route": "/veille/config",
+        },
+        {
+            "id": "save_5_articles",
+            "label": "Enregistrer 5 articles",
+            "help": (
+                "Appuie sur le marque-page d'un article pour le mettre de côté. "
+                "Cinq articles, et ton fonds prend forme."
+            ),
+            "completion_palier": (
+                "Cinq articles au chaud. Tu te constitues une vraie réserve."
+            ),
+            "target_route": "/flaner",
+        },
+        {
+            "id": "write_first_note",
+            "label": "Écrire une note sur un article sauvegardé",
+            "help": (
+                "Ouvre un article sauvegardé, appuie sur le marque-page et "
+                "ajoute une note : une idée, une citation, un pourquoi."
+            ),
+            "completion_palier": (
+                "Première note posée. Lire, c'est bien ; garder une trace, "
+                "c'est mieux."
+            ),
+            "target_route": "/saved",
+        },
+        {
+            "id": "mute_3_sources",
+            "label": "Masquer 3 sources qui ne te plaisent pas",
+            "help": (
+                "Depuis un article, ouvre le menu et choisis « Masquer la "
+                "source ». Écarter, c'est aussi choisir."
+            ),
+            "completion_palier": (
+                "Trois sources écartées. Ta sélection gagne en caractère."
+            ),
+            "target_route": "/flaner",
+        },
+        {
+            "id": "add_5_youtube_channels",
+            "label": "Ajouter 5 chaînes YouTube",
+            "help": (
+                "Colle le lien d'une chaîne que tu suis déjà. Tes vidéos "
+                "rejoignent ta tournée."
+            ),
+            "completion_palier": (
+                "Cinq chaînes dans la tournée. Ta sélection ne se limite "
+                "plus au texte."
+            ),
+            "target_route": "/settings/sources/add",
+        },
+    ],
+    "message": (
+        "Tu lis, et tu lis bien. L'étape suivante, c'est d'organiser ta "
+        "tournée : garder ce qui compte, annoter ce qui t'a marqué, "
+        "écarter ce qui t'encombre.\n\n"
+        "Cinq gestes de tri. C'est là que ta sélection devient la tienne."
+    ),
+    "signature": "Le Facteur",
+    "completion_voeu": (
+        "Ta tournée est rangée à ta façon. Peu de lecteurs vont jusque-là."
+    ),
+}
+
+LETTER_4: dict = {
+    "id": "letter_4",
+    "num": "04",
+    "title": "Facteur de fond",
+    "default_status": "upcoming",
+    "intro_palier": (
+        "Dernière lettre. Ici, on ne compte plus les gestes : on mesure "
+        "l'endurance."
+    ),
+    "actions": [
+        {
+            "id": "read_50_articles",
+            "label": "Lire 50 articles",
+            "help": (
+                "Cinquante articles, à ton rythme. La régularité fait le "
+                "reste."
+            ),
+            "completion_palier": (
+                "Cinquante lectures. Tu n'es plus un visiteur, tu es un "
+                "habitué."
+            ),
+            "target_route": "/flaner",
+        },
+        {
+            "id": "recommend_10_articles",
+            "label": "Recommander 10 articles",
+            "help": (
+                "Le tournesol sous un article, c'est ta voix. Dix signaux, "
+                "et ta sélection te ressemble vraiment."
+            ),
+            "completion_palier": (
+                "Dix recommandations. Le Facteur connaît tes goûts par cœur."
+            ),
+            "target_route": "/flaner",
+        },
+        {
+            "id": "open_10_perspectives",
+            "label": "Comparer 10 couvertures médiatiques",
+            "help": (
+                "Sur un sujet chaud, ouvre les perspectives pour confronter "
+                "les angles. Dix comparaisons aiguisent le regard."
+            ),
+            "completion_palier": (
+                "Dix sujets vus sous plusieurs angles. Le doute méthodique "
+                "te va bien."
+            ),
+            "target_route": "/flaner",
+        },
+        {
+            "id": "give_app_feedback",
+            "label": "Donner ton avis sur l'app",
+            "help": (
+                "Dans les réglages, appuie sur « Donner mon avis ». Ce que "
+                "tu penses de Facteur aide à le construire."
+            ),
+            "completion_palier": (
+                "Avis transmis. Facteur se construit aussi avec toi."
+            ),
+            "target_route": "/settings",
+        },
+    ],
+    "message": (
+        "Te voilà au dernier palier. Plus rien à t'apprendre sur les "
+        "gestes : il reste la profondeur, la constance, et un avis qui "
+        "compte, le tien.\n\n"
+        "Prends ton temps. Cette lettre se mérite."
+    ),
+    "signature": "Le Facteur",
+    "completion_voeu": (
+        "Tu as tout vu, tout lu, tout trié. La tournée est à toi maintenant."
+    ),
+}
+
+LETTERS_ORDER: list[dict] = [LETTER_0, LETTER_1, LETTER_2, LETTER_3, LETTER_4]
 LETTERS_BY_ID: dict[str, dict] = {letter["id"]: letter for letter in LETTERS_ORDER}

--- a/packages/api/app/services/letters/service.py
+++ b/packages/api/app/services/letters/service.py
@@ -84,21 +84,6 @@ async def _detect_add_2_personal_sources(user_id: UUID, db: AsyncSession) -> boo
     return (count or 0) >= 2
 
 
-def _first_event_detector(event_type: str):
-    async def _detect(user_id: UUID, db: AsyncSession) -> bool:
-        stmt = (
-            select(AnalyticsEvent.id)
-            .where(
-                AnalyticsEvent.user_id == user_id,
-                AnalyticsEvent.event_type == event_type,
-            )
-            .limit(1)
-        )
-        return (await db.execute(stmt)).scalar() is not None
-
-    return _detect
-
-
 def _count_event_detector(event_type: str, threshold: int):
     async def _detect(user_id: UUID, db: AsyncSession) -> bool:
         stmt = (
@@ -112,6 +97,10 @@ def _count_event_detector(event_type: str, threshold: int):
         return ((await db.execute(stmt)).scalar() or 0) >= threshold
 
     return _detect
+
+
+def _first_event_detector(event_type: str):
+    return _count_event_detector(event_type, 1)
 
 
 _detect_first_perspectives_open = _first_event_detector("perspectives_opened")
@@ -189,17 +178,27 @@ async def _detect_create_first_veille(user_id: UUID, db: AsyncSession) -> bool:
     return (await db.execute(stmt)).scalar() is not None
 
 
-async def _detect_save_5_articles(user_id: UUID, db: AsyncSession) -> bool:
-    """≥5 UserContentStatus avec is_saved=True."""
-    stmt = (
-        select(func.count())
-        .select_from(UserContentStatus)
-        .where(
-            UserContentStatus.user_id == user_id,
-            UserContentStatus.is_saved.is_(True),
+def _count_status_flag_detector(flag, threshold: int):
+    """Détecteur sur un flag booléen de UserContentStatus (is_saved, is_liked)."""
+
+    async def _detect(user_id: UUID, db: AsyncSession) -> bool:
+        stmt = (
+            select(func.count())
+            .select_from(UserContentStatus)
+            .where(
+                UserContentStatus.user_id == user_id,
+                flag.is_(True),
+            )
         )
-    )
-    return ((await db.execute(stmt)).scalar() or 0) >= 5
+        return ((await db.execute(stmt)).scalar() or 0) >= threshold
+
+    return _detect
+
+
+_detect_save_5_articles = _count_status_flag_detector(UserContentStatus.is_saved, 5)
+_detect_recommend_10_articles = _count_status_flag_detector(
+    UserContentStatus.is_liked, 10
+)
 
 
 async def _detect_write_first_note(user_id: UUID, db: AsyncSession) -> bool:
@@ -239,19 +238,6 @@ async def _detect_add_5_youtube_channels(user_id: UUID, db: AsyncSession) -> boo
         )
     )
     return ((await db.execute(stmt)).scalar() or 0) >= 5
-
-
-async def _detect_recommend_10_articles(user_id: UUID, db: AsyncSession) -> bool:
-    """≥10 UserContentStatus avec is_liked=True."""
-    stmt = (
-        select(func.count())
-        .select_from(UserContentStatus)
-        .where(
-            UserContentStatus.user_id == user_id,
-            UserContentStatus.is_liked.is_(True),
-        )
-    )
-    return ((await db.execute(stmt)).scalar() or 0) >= 10
 
 
 DETECTORS = {

--- a/packages/api/app/services/letters/service.py
+++ b/packages/api/app/services/letters/service.py
@@ -1,8 +1,9 @@
 """Service Lettres du Facteur — auto-détection actions + chaînage.
 
-`get_user_letters` est idempotent : si l'utilisateur n'a pas encore de rows,
-on initialise les 3 lettres en base puis on retourne l'état complet (en
-rafraîchissant la lettre active pour propager les actions déjà accomplies).
+`get_user_letters` est idempotent : `_ensure_rows` initialise les rows
+manquantes (user nouveau OU user existant après ajout de lettres au catalogue)
+puis on retourne l'état complet (en rafraîchissant la lettre active pour
+propager les actions déjà accomplies).
 
 `refresh_letter_status` recalcule les détecteurs pour une lettre donnée et,
 si elle est complète, l'archive et déverrouille la suivante.
@@ -20,10 +21,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.analytics import AnalyticsEvent
 from app.models.collection import Collection, CollectionItem
 from app.models.content import Content, UserContentStatus
-from app.models.enums import ContentStatus, ContentType
-from app.models.source import UserSource
+from app.models.enums import ContentStatus, ContentType, SourceType
+from app.models.source import Source, UserSource
 from app.models.user_letter_progress import UserLetterProgress
+from app.models.user_personalization import UserPersonalization
 from app.models.user_topic_profile import UserTopicProfile
+from app.models.veille import VeilleConfig
 from app.services.letters.catalog import (
     LETTERS_BY_ID,
     LETTERS_ORDER,
@@ -96,13 +99,30 @@ def _first_event_detector(event_type: str):
     return _detect
 
 
+def _count_event_detector(event_type: str, threshold: int):
+    async def _detect(user_id: UUID, db: AsyncSession) -> bool:
+        stmt = (
+            select(func.count())
+            .select_from(AnalyticsEvent)
+            .where(
+                AnalyticsEvent.user_id == user_id,
+                AnalyticsEvent.event_type == event_type,
+            )
+        )
+        return ((await db.execute(stmt)).scalar() or 0) >= threshold
+
+    return _detect
+
+
 _detect_first_perspectives_open = _first_event_detector("perspectives_opened")
 _detect_read_first_essentiel = _first_event_detector("digest_opened")
 _detect_read_first_bonnes_nouvelles = _first_event_detector("bonnes_nouvelles_opened")
+_detect_open_10_perspectives = _count_event_detector("perspectives_opened", 10)
+_detect_give_app_feedback = _first_event_detector("app_feedback_opened")
 
 
-async def _detect_read_3_long_articles(user_id: UUID, db: AsyncSession) -> bool:
-    """≥10 articles distincts avec un signal minimal d'interaction."""
+async def _count_read_articles(user_id: UUID, db: AsyncSession) -> int:
+    """Articles distincts avec un signal minimal d'interaction."""
     stmt = (
         select(func.count(func.distinct(UserContentStatus.content_id)))
         .select_from(UserContentStatus)
@@ -120,7 +140,17 @@ async def _detect_read_3_long_articles(user_id: UUID, db: AsyncSession) -> bool:
             ),
         )
     )
-    return ((await db.execute(stmt)).scalar() or 0) >= 10
+    return (await db.execute(stmt)).scalar() or 0
+
+
+async def _detect_read_3_long_articles(user_id: UUID, db: AsyncSession) -> bool:
+    """≥10 articles distincts avec un signal minimal d'interaction."""
+    return await _count_read_articles(user_id, db) >= 10
+
+
+async def _detect_read_50_articles(user_id: UUID, db: AsyncSession) -> bool:
+    """≥50 articles distincts avec un signal minimal d'interaction."""
+    return await _count_read_articles(user_id, db) >= 50
 
 
 async def _detect_read_first_video_podcast(user_id: UUID, db: AsyncSession) -> bool:
@@ -152,6 +182,78 @@ async def _detect_recommend_first_article(user_id: UUID, db: AsyncSession) -> bo
     return (await db.execute(stmt)).scalar() is not None
 
 
+async def _detect_create_first_veille(user_id: UUID, db: AsyncSession) -> bool:
+    """≥1 veille_config, quel que soit son statut (pauser ou supprimer la
+    veille ne dé-complète pas l'action)."""
+    stmt = select(VeilleConfig.id).where(VeilleConfig.user_id == user_id).limit(1)
+    return (await db.execute(stmt)).scalar() is not None
+
+
+async def _detect_save_5_articles(user_id: UUID, db: AsyncSession) -> bool:
+    """≥5 UserContentStatus avec is_saved=True."""
+    stmt = (
+        select(func.count())
+        .select_from(UserContentStatus)
+        .where(
+            UserContentStatus.user_id == user_id,
+            UserContentStatus.is_saved.is_(True),
+        )
+    )
+    return ((await db.execute(stmt)).scalar() or 0) >= 5
+
+
+async def _detect_write_first_note(user_id: UUID, db: AsyncSession) -> bool:
+    """≥1 note non vide (trim) sur un article sauvegardé."""
+    stmt = (
+        select(UserContentStatus.id)
+        .where(
+            UserContentStatus.user_id == user_id,
+            UserContentStatus.is_saved.is_(True),
+            UserContentStatus.note_text.is_not(None),
+            func.length(func.trim(UserContentStatus.note_text)) > 0,
+        )
+        .limit(1)
+    )
+    return (await db.execute(stmt)).scalar() is not None
+
+
+async def _detect_mute_3_sources(user_id: UUID, db: AsyncSession) -> bool:
+    """≥3 sources masquées (UserPersonalization.muted_sources)."""
+    count = await db.scalar(
+        select(func.cardinality(UserPersonalization.muted_sources)).where(
+            UserPersonalization.user_id == user_id
+        )
+    )
+    return (count or 0) >= 3
+
+
+async def _detect_add_5_youtube_channels(user_id: UUID, db: AsyncSession) -> bool:
+    """≥5 user_sources pointant vers une source de type YouTube."""
+    stmt = (
+        select(func.count())
+        .select_from(UserSource)
+        .join(Source, Source.id == UserSource.source_id)
+        .where(
+            UserSource.user_id == user_id,
+            Source.type == SourceType.YOUTUBE,
+        )
+    )
+    return ((await db.execute(stmt)).scalar() or 0) >= 5
+
+
+async def _detect_recommend_10_articles(user_id: UUID, db: AsyncSession) -> bool:
+    """≥10 UserContentStatus avec is_liked=True."""
+    stmt = (
+        select(func.count())
+        .select_from(UserContentStatus)
+        .where(
+            UserContentStatus.user_id == user_id,
+            UserContentStatus.is_liked.is_(True),
+        )
+    )
+    return ((await db.execute(stmt)).scalar() or 0) >= 10
+
+
 DETECTORS = {
     "define_editorial_line": _detect_define_editorial_line,
     "add_5_sources": _detect_add_5_sources,
@@ -162,6 +264,15 @@ DETECTORS = {
     "read_3_long_articles": _detect_read_3_long_articles,
     "read_first_video_podcast": _detect_read_first_video_podcast,
     "recommend_first_article": _detect_recommend_first_article,
+    "create_first_veille": _detect_create_first_veille,
+    "save_5_articles": _detect_save_5_articles,
+    "write_first_note": _detect_write_first_note,
+    "mute_3_sources": _detect_mute_3_sources,
+    "add_5_youtube_channels": _detect_add_5_youtube_channels,
+    "read_50_articles": _detect_read_50_articles,
+    "recommend_10_articles": _detect_recommend_10_articles,
+    "open_10_perspectives": _detect_open_10_perspectives,
+    "give_app_feedback": _detect_give_app_feedback,
 }
 
 
@@ -212,7 +323,7 @@ async def _get_rows(user_id: UUID, db: AsyncSession) -> dict[str, UserLetterProg
 
 
 async def _init_progress(user_id: UUID, db: AsyncSession) -> None:
-    """Crée les 3 rows initiales pour un nouveau user."""
+    """Crée toutes les rows initiales pour un nouveau user."""
     from app.services.user_service import UserService
 
     await UserService(db).get_or_create_profile(str(user_id))
@@ -229,6 +340,59 @@ async def _init_progress(user_id: UUID, db: AsyncSession) -> None:
         )
         db.add(row)
     await db.commit()
+
+
+async def _ensure_rows(
+    user_id: UUID, db: AsyncSession
+) -> dict[str, UserLetterProgress]:
+    """Garantit une row par lettre du catalogue. Idempotent, read-mostly.
+
+    - Aucune row → init complet (nouveau user).
+    - Rows partielles (lettres ajoutées au catalogue après coup) → backfill
+      des manquantes en `upcoming`.
+    - Réactivation de chaîne : si aucune lettre n'est active et que toutes
+      les lettres précédant la première `upcoming` sont archivées, on active
+      cette première `upcoming` (couvre le user qui avait fini la dernière
+      lettre avant l'extension du catalogue).
+    - Commit seulement si quelque chose a changé.
+    """
+    rows = await _get_rows(user_id, db)
+    if not rows:
+        await _init_progress(user_id, db)
+        return await _get_rows(user_id, db)
+
+    changed = False
+    now = datetime.now(UTC)
+    for catalog in LETTERS_ORDER:
+        if catalog["id"] in rows:
+            continue
+        row = UserLetterProgress(
+            user_id=user_id,
+            letter_id=catalog["id"],
+            status="upcoming",
+            completed_actions=[],
+        )
+        db.add(row)
+        rows[catalog["id"]] = row
+        changed = True
+
+    has_active = any(r.status == "active" for r in rows.values())
+    if not has_active:
+        for catalog in LETTERS_ORDER:
+            row = rows[catalog["id"]]
+            if row.status == "archived":
+                continue
+            if row.status == "upcoming":
+                row.status = "active"
+                row.started_at = now
+                row.updated_at = now
+                changed = True
+            break
+
+    if changed:
+        await db.commit()
+        rows = await _get_rows(user_id, db)
+    return rows
 
 
 def _next_upcoming(
@@ -278,12 +442,7 @@ async def refresh_letter_status(
     """Recalcule les actions cochées + archive si terminée + déverrouille
     la suivante. Idempotent."""
     catalog = LETTERS_BY_ID[letter_id]
-    rows = await _get_rows(user_id, db)
-    if letter_id not in rows:
-        # Init si jamais — peut arriver pour un user qui n'a pas appelé
-        # GET /api/letters au préalable.
-        await _init_progress(user_id, db)
-        rows = await _get_rows(user_id, db)
+    rows = await _ensure_rows(user_id, db)
     row = rows[letter_id]
 
     # Idempotence : une lettre archivée n'est jamais re-évaluée.
@@ -313,11 +472,11 @@ async def refresh_letter_status(
 
 
 async def get_user_letters(user_id: UUID, db: AsyncSession) -> list[dict]:
-    """Retourne les 3 lettres avec leur état courant. Init si pas de rows."""
-    rows = await _get_rows(user_id, db)
-    if not rows:
-        await _init_progress(user_id, db)
-        rows = await _get_rows(user_id, db)
+    """Retourne toutes les lettres du catalogue avec leur état courant.
+
+    `_ensure_rows` initialise ou complète les rows manquantes (nouveau user
+    ou lettres ajoutées au catalogue après coup)."""
+    rows = await _ensure_rows(user_id, db)
 
     # Refresh la lettre active (s'il y en a une) pour propager les actions
     # accomplies hors de l'app (ex: user a ajouté des sources sans appeler

--- a/packages/api/tests/routers/test_letters_routes.py
+++ b/packages/api/tests/routers/test_letters_routes.py
@@ -189,6 +189,8 @@ async def _add_user_content_status(
     reading_progress: int = 0,
     time_spent_seconds: int = 0,
     is_liked: bool = False,
+    is_saved: bool = False,
+    note_text: str | None = None,
     seen_at: datetime | None = None,
 ) -> UUID:
     src = await _make_source(db_session)
@@ -211,6 +213,8 @@ async def _add_user_content_status(
             reading_progress=reading_progress,
             time_spent_seconds=time_spent_seconds,
             is_liked=is_liked,
+            is_saved=is_saved,
+            note_text=note_text,
             seen_at=seen_at,
         )
     )
@@ -296,14 +300,14 @@ async def _activate_l2(db_session, user_id: UUID) -> None:
 
 
 class TestInitialState:
-    async def test_new_user_returns_three_letters(self, auth_user):
+    async def test_new_user_returns_five_letters(self, auth_user):
         async with _client() as ac:
             resp = await ac.get("/api/letters")
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 3
+        assert len(data) == 5
 
-        l0, l1, l2 = data
+        l0, l1, l2, l3, l4 = data
         assert l0["id"] == "letter_0"
         assert l0["status"] == "archived"
         assert l0["progress"] == 1.0
@@ -326,6 +330,14 @@ class TestInitialState:
         assert l2["id"] == "letter_2"
         assert l2["status"] == "upcoming"
 
+        assert l3["id"] == "letter_3"
+        assert l3["status"] == "upcoming"
+        assert len(l3["actions"]) == 5
+
+        assert l4["id"] == "letter_4"
+        assert l4["status"] == "upcoming"
+        assert len(l4["actions"]) == 4
+
     async def test_get_is_idempotent(self, auth_user):
         async with _client() as ac:
             resp1 = await ac.get("/api/letters")
@@ -333,7 +345,7 @@ class TestInitialState:
         assert resp1.status_code == 200
         assert resp2.status_code == 200
         # Pas de doublons en DB après un 2e GET
-        assert len(resp2.json()) == 3
+        assert len(resp2.json()) == 5
 
 
 class TestAutoDetection:
@@ -445,7 +457,7 @@ class TestChaining:
         assert l1_data["archived_at"] is not None
         assert l1_data["progress"] == 1.0
 
-        l0, l1, l2 = list_resp.json()
+        l0, l1, l2, l3, l4 = list_resp.json()
         assert l1["status"] == "archived"
         assert l2["status"] == "active"
         assert l2["started_at"] is not None
@@ -517,10 +529,12 @@ class TestCrossTenant:
             resp = await ac.get("/api/letters")
 
         data = resp.json()
-        assert len(data) == 3
+        assert len(data) == 5
         assert data[0]["status"] == "archived"  # L0
         assert data[1]["status"] == "active"  # L1 par défaut
         assert data[2]["status"] == "upcoming"  # L2 par défaut
+        assert data[3]["status"] == "upcoming"
+        assert data[4]["status"] == "upcoming"
 
 
 class TestErrors:
@@ -829,7 +843,7 @@ class TestProvisioningGap:
             resp = await ac.get("/api/letters")
 
         assert resp.status_code == 200
-        assert len(resp.json()) == 3
+        assert len(resp.json()) == 5
 
         from sqlalchemy import select as sa_select
 
@@ -853,4 +867,519 @@ class TestProvisioningGap:
                 )
             )
         ).scalars().all()
-        assert len(rows) == 3
+        assert len(rows) == 5
+
+
+# ─── Lettres 3 et 4 (Story 26.2) ────────────────────────────────────────────
+
+
+from app.models.user_personalization import UserPersonalization  # noqa: E402
+from app.models.veille import VeilleConfig  # noqa: E402
+
+
+async def _activate_letter(db_session, user_id: UUID, active_letter: str) -> None:
+    """Pose les 5 rows avec les lettres précédentes archivées et
+    `active_letter` active."""
+    order = ["letter_0", "letter_1", "letter_2", "letter_3", "letter_4"]
+    active_idx = order.index(active_letter)
+    now = datetime.now(UTC)
+    rows = []
+    for idx, letter_id in enumerate(order):
+        if idx < active_idx:
+            rows.append(
+                UserLetterProgress(
+                    user_id=user_id,
+                    letter_id=letter_id,
+                    status="archived",
+                    completed_actions=[],
+                    archived_at=now,
+                )
+            )
+        elif idx == active_idx:
+            rows.append(
+                UserLetterProgress(
+                    user_id=user_id,
+                    letter_id=letter_id,
+                    status="active",
+                    completed_actions=[],
+                    started_at=now,
+                )
+            )
+        else:
+            rows.append(
+                UserLetterProgress(
+                    user_id=user_id,
+                    letter_id=letter_id,
+                    status="upcoming",
+                    completed_actions=[],
+                )
+            )
+    db_session.add_all(rows)
+    await db_session.commit()
+
+
+async def _add_veille_config(
+    db_session, user_id: UUID, *, status: str = "active"
+) -> None:
+    db_session.add(
+        VeilleConfig(
+            user_id=user_id,
+            theme_id="tech",
+            theme_label="Tech",
+            status=status,
+        )
+    )
+    await db_session.commit()
+
+
+async def _set_muted_sources(db_session, user_id: UUID, count: int) -> None:
+    db_session.add(
+        UserPersonalization(
+            user_id=user_id,
+            muted_sources=[uuid4() for _ in range(count)],
+        )
+    )
+    await db_session.commit()
+
+
+async def _add_youtube_sources(
+    db_session, user_id: UUID, count: int, *, source_type=SourceType.YOUTUBE
+) -> None:
+    for i in range(count):
+        src = Source(
+            id=uuid4(),
+            name=f"Chaine {uuid4()}",
+            url=f"https://yt-{uuid4()}.example.com",
+            feed_url=f"https://yt-{uuid4()}.example.com/feed.xml",
+            type=source_type,
+            theme="society",
+            is_active=True,
+        )
+        db_session.add(src)
+        await db_session.flush()
+        db_session.add(UserSource(user_id=user_id, source_id=src.id))
+    await db_session.commit()
+
+
+async def _add_read_articles(db_session, user_id: UUID, count: int) -> None:
+    """Bulk : `count` articles distincts avec un signal de lecture
+    (un seul commit)."""
+    src = await _make_source(db_session)
+    for _ in range(count):
+        content = Content(
+            id=uuid4(),
+            source_id=src.id,
+            title="t",
+            url=f"https://x/{uuid4()}",
+            published_at=datetime.now(UTC),
+            content_type=ContentType.ARTICLE,
+            guid=str(uuid4()),
+        )
+        db_session.add(content)
+        await db_session.flush()
+        db_session.add(
+            UserContentStatus(
+                user_id=user_id,
+                content_id=content.id,
+                time_spent_seconds=1,
+            )
+        )
+    await db_session.commit()
+
+
+async def _add_liked_articles(db_session, user_id: UUID, count: int) -> None:
+    src = await _make_source(db_session)
+    for _ in range(count):
+        content = Content(
+            id=uuid4(),
+            source_id=src.id,
+            title="t",
+            url=f"https://x/{uuid4()}",
+            published_at=datetime.now(UTC),
+            content_type=ContentType.ARTICLE,
+            guid=str(uuid4()),
+        )
+        db_session.add(content)
+        await db_session.flush()
+        db_session.add(
+            UserContentStatus(
+                user_id=user_id,
+                content_id=content.id,
+                is_liked=True,
+            )
+        )
+    await db_session.commit()
+
+
+class TestBackfill:
+    """Users existants (3 rows pré-extension du catalogue) → backfill."""
+
+    async def test_existing_user_three_rows_gets_five_letters(
+        self, auth_user, db_session
+    ):
+        await _ensure_letter_1_started(db_session, auth_user)
+
+        async with _client() as ac:
+            resp = await ac.get("/api/letters")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 5
+        assert data[1]["status"] == "active"  # L1 reste active
+        assert data[3]["id"] == "letter_3"
+        assert data[3]["status"] == "upcoming"
+        assert data[4]["id"] == "letter_4"
+        assert data[4]["status"] == "upcoming"
+
+    async def test_finished_user_reactivates_letter_3(self, auth_user, db_session):
+        """User qui avait archivé L0-L2 avant l'extension : L3 auto-activée."""
+        now = datetime.now(UTC)
+        db_session.add_all(
+            [
+                UserLetterProgress(
+                    user_id=auth_user,
+                    letter_id=letter_id,
+                    status="archived",
+                    completed_actions=[],
+                    archived_at=now,
+                )
+                for letter_id in ("letter_0", "letter_1", "letter_2")
+            ]
+        )
+        await db_session.commit()
+
+        async with _client() as ac:
+            resp = await ac.get("/api/letters")
+
+        data = resp.json()
+        assert [letter["status"] for letter in data[:3]] == ["archived"] * 3
+        assert data[3]["status"] == "active"
+        assert data[3]["started_at"] is not None
+        assert data[4]["status"] == "upcoming"
+
+    async def test_backfill_is_idempotent(self, auth_user, db_session):
+        await _ensure_letter_1_started(db_session, auth_user)
+
+        async with _client() as ac:
+            r1 = await ac.get("/api/letters")
+            r2 = await ac.get("/api/letters")
+
+        assert r1.json() == r2.json()
+        from sqlalchemy import select as sa_select
+
+        rows = (
+            (
+                await db_session.execute(
+                    sa_select(UserLetterProgress).where(
+                        UserLetterProgress.user_id == auth_user
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 5
+
+    async def test_refresh_letter_3_on_three_row_user(self, auth_user, db_session):
+        """refresh-status direct sur letter_3 pour un user 3-rows : pas de
+        KeyError, la row est backfillée."""
+        await _ensure_letter_1_started(db_session, auth_user)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "letter_3"
+        assert resp.json()["status"] == "upcoming"
+
+
+class TestLetter3Detection:
+    async def test_create_first_veille_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_3")
+        await _add_veille_config(db_session, auth_user)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert "create_first_veille" in resp.json()["completed_actions"]
+
+    async def test_archived_veille_still_counts(self, auth_user, db_session):
+        """Pauser ou archiver sa veille ne dé-complète pas l'action."""
+        await _activate_letter(db_session, auth_user, "letter_3")
+        await _add_veille_config(db_session, auth_user, status="archived")
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert "create_first_veille" in resp.json()["completed_actions"]
+
+    async def test_save_5_articles_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_3")
+        for _ in range(5):
+            await _add_user_content_status(
+                db_session,
+                auth_user,
+                content_type=ContentType.ARTICLE,
+                is_saved=True,
+            )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert "save_5_articles" in resp.json()["completed_actions"]
+
+    async def test_save_below_threshold_not_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_3")
+        for _ in range(4):
+            await _add_user_content_status(
+                db_session,
+                auth_user,
+                content_type=ContentType.ARTICLE,
+                is_saved=True,
+            )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert "save_5_articles" not in resp.json()["completed_actions"]
+
+    async def test_note_on_saved_article_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_3")
+        await _add_user_content_status(
+            db_session,
+            auth_user,
+            content_type=ContentType.ARTICLE,
+            is_saved=True,
+            note_text="Une idée à creuser.",
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert "write_first_note" in resp.json()["completed_actions"]
+
+    async def test_blank_note_not_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_3")
+        await _add_user_content_status(
+            db_session,
+            auth_user,
+            content_type=ContentType.ARTICLE,
+            is_saved=True,
+            note_text="   ",
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert "write_first_note" not in resp.json()["completed_actions"]
+
+    async def test_note_on_unsaved_article_not_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_3")
+        await _add_user_content_status(
+            db_session,
+            auth_user,
+            content_type=ContentType.ARTICLE,
+            is_saved=False,
+            note_text="Note hors sauvegarde.",
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert "write_first_note" not in resp.json()["completed_actions"]
+
+    async def test_mute_3_sources_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_3")
+        await _set_muted_sources(db_session, auth_user, 3)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert "mute_3_sources" in resp.json()["completed_actions"]
+
+    async def test_mute_below_threshold_not_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_3")
+        await _set_muted_sources(db_session, auth_user, 2)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert "mute_3_sources" not in resp.json()["completed_actions"]
+
+    async def test_add_5_youtube_channels_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_3")
+        await _add_youtube_sources(db_session, auth_user, 5)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert "add_5_youtube_channels" in resp.json()["completed_actions"]
+
+    async def test_non_youtube_sources_not_counted(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_3")
+        await _add_youtube_sources(
+            db_session, auth_user, 5, source_type=SourceType.ARTICLE
+        )
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert "add_5_youtube_channels" not in resp.json()["completed_actions"]
+
+
+class TestLetter4Detection:
+    async def test_read_50_articles_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_4")
+        await _add_read_articles(db_session, auth_user, 50)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_4/refresh-status")
+
+        assert "read_50_articles" in resp.json()["completed_actions"]
+
+    async def test_read_below_threshold_not_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_4")
+        await _add_read_articles(db_session, auth_user, 49)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_4/refresh-status")
+
+        assert "read_50_articles" not in resp.json()["completed_actions"]
+
+    async def test_recommend_10_articles_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_4")
+        await _add_liked_articles(db_session, auth_user, 10)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_4/refresh-status")
+
+        assert "recommend_10_articles" in resp.json()["completed_actions"]
+
+    async def test_recommend_below_threshold_not_detected(
+        self, auth_user, db_session
+    ):
+        await _activate_letter(db_session, auth_user, "letter_4")
+        await _add_liked_articles(db_session, auth_user, 9)
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_4/refresh-status")
+
+        assert "recommend_10_articles" not in resp.json()["completed_actions"]
+
+    async def test_open_10_perspectives_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_4")
+        for _ in range(10):
+            await _add_event(db_session, auth_user, "perspectives_opened")
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_4/refresh-status")
+
+        assert "open_10_perspectives" in resp.json()["completed_actions"]
+
+    async def test_perspectives_below_threshold_not_detected(
+        self, auth_user, db_session
+    ):
+        await _activate_letter(db_session, auth_user, "letter_4")
+        for _ in range(9):
+            await _add_event(db_session, auth_user, "perspectives_opened")
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_4/refresh-status")
+
+        assert "open_10_perspectives" not in resp.json()["completed_actions"]
+
+    async def test_give_app_feedback_detected(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_4")
+        await _add_event(db_session, auth_user, "app_feedback_opened")
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_4/refresh-status")
+
+        assert "give_app_feedback" in resp.json()["completed_actions"]
+
+
+class TestNewLettersShape:
+    async def test_letter_3_and_4_expose_palier_fields(self, auth_user):
+        async with _client() as ac:
+            resp = await ac.get("/api/letters")
+
+        data = resp.json()
+        for letter in (data[3], data[4]):
+            assert letter["intro_palier"]
+            assert letter["completion_voeu"]
+            for action in letter["actions"]:
+                assert action["completion_palier"]
+                assert action["target_route"]
+
+
+class TestNewLettersChaining:
+    async def test_letter_3_complete_unlocks_letter_4(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_3")
+        await _add_veille_config(db_session, auth_user)
+        await _set_muted_sources(db_session, auth_user, 3)
+        await _add_youtube_sources(db_session, auth_user, 5)
+        for _ in range(4):
+            await _add_user_content_status(
+                db_session,
+                auth_user,
+                content_type=ContentType.ARTICLE,
+                is_saved=True,
+            )
+        await _add_user_content_status(
+            db_session,
+            auth_user,
+            content_type=ContentType.ARTICLE,
+            is_saved=True,
+            note_text="Cinquième article, avec note.",
+        )
+
+        async with _client() as ac:
+            refresh = await ac.post("/api/letters/letter_3/refresh-status")
+            letters = await ac.get("/api/letters")
+
+        assert refresh.json()["status"] == "archived"
+        assert refresh.json()["progress"] == 1.0
+        data = letters.json()
+        assert data[4]["status"] == "active"
+        assert data[4]["started_at"] is not None
+
+    async def test_letter_4_complete_is_terminal(self, auth_user, db_session):
+        await _activate_letter(db_session, auth_user, "letter_4")
+        await _add_read_articles(db_session, auth_user, 50)
+        await _add_liked_articles(db_session, auth_user, 10)
+        for _ in range(10):
+            await _add_event(db_session, auth_user, "perspectives_opened")
+        await _add_event(db_session, auth_user, "app_feedback_opened")
+
+        async with _client() as ac:
+            refresh = await ac.post("/api/letters/letter_4/refresh-status")
+            letters = await ac.get("/api/letters")
+
+        assert refresh.status_code == 200
+        assert refresh.json()["status"] == "archived"
+        assert len(refresh.json()["completed_actions"]) == 4
+        assert letters.status_code == 200
+        assert all(
+            letter["status"] == "archived" for letter in letters.json()
+        )
+
+
+class TestNewLettersCrossTenant:
+    async def test_other_user_data_not_counted(self, auth_user, db_session):
+        other_id = uuid4()
+        db_session.add(
+            UserProfile(
+                user_id=other_id,
+                display_name="Other",
+                onboarding_completed=True,
+            )
+        )
+        await db_session.commit()
+        await _add_veille_config(db_session, other_id)
+        await _set_muted_sources(db_session, other_id, 3)
+        await _activate_letter(db_session, auth_user, "letter_3")
+
+        async with _client() as ac:
+            resp = await ac.post("/api/letters/letter_3/refresh-status")
+
+        assert resp.json()["completed_actions"] == []

--- a/packages/api/tests/routers/test_letters_routes.py
+++ b/packages/api/tests/routers/test_letters_routes.py
@@ -961,9 +961,11 @@ async def _add_youtube_sources(
     await db_session.commit()
 
 
-async def _add_read_articles(db_session, user_id: UUID, count: int) -> None:
-    """Bulk : `count` articles distincts avec un signal de lecture
-    (un seul commit)."""
+async def _add_articles_bulk(
+    db_session, user_id: UUID, count: int, **status_kwargs
+) -> None:
+    """Bulk : `count` articles distincts avec les kwargs passés au
+    UserContentStatus (un seul commit)."""
     src = await _make_source(db_session)
     for _ in range(count):
         content = Content(
@@ -981,31 +983,7 @@ async def _add_read_articles(db_session, user_id: UUID, count: int) -> None:
             UserContentStatus(
                 user_id=user_id,
                 content_id=content.id,
-                time_spent_seconds=1,
-            )
-        )
-    await db_session.commit()
-
-
-async def _add_liked_articles(db_session, user_id: UUID, count: int) -> None:
-    src = await _make_source(db_session)
-    for _ in range(count):
-        content = Content(
-            id=uuid4(),
-            source_id=src.id,
-            title="t",
-            url=f"https://x/{uuid4()}",
-            published_at=datetime.now(UTC),
-            content_type=ContentType.ARTICLE,
-            guid=str(uuid4()),
-        )
-        db_session.add(content)
-        await db_session.flush()
-        db_session.add(
-            UserContentStatus(
-                user_id=user_id,
-                content_id=content.id,
-                is_liked=True,
+                **status_kwargs,
             )
         )
     await db_session.commit()
@@ -1230,7 +1208,7 @@ class TestLetter3Detection:
 class TestLetter4Detection:
     async def test_read_50_articles_detected(self, auth_user, db_session):
         await _activate_letter(db_session, auth_user, "letter_4")
-        await _add_read_articles(db_session, auth_user, 50)
+        await _add_articles_bulk(db_session, auth_user, 50, time_spent_seconds=1)
 
         async with _client() as ac:
             resp = await ac.post("/api/letters/letter_4/refresh-status")
@@ -1239,7 +1217,7 @@ class TestLetter4Detection:
 
     async def test_read_below_threshold_not_detected(self, auth_user, db_session):
         await _activate_letter(db_session, auth_user, "letter_4")
-        await _add_read_articles(db_session, auth_user, 49)
+        await _add_articles_bulk(db_session, auth_user, 49, time_spent_seconds=1)
 
         async with _client() as ac:
             resp = await ac.post("/api/letters/letter_4/refresh-status")
@@ -1248,7 +1226,7 @@ class TestLetter4Detection:
 
     async def test_recommend_10_articles_detected(self, auth_user, db_session):
         await _activate_letter(db_session, auth_user, "letter_4")
-        await _add_liked_articles(db_session, auth_user, 10)
+        await _add_articles_bulk(db_session, auth_user, 10, is_liked=True)
 
         async with _client() as ac:
             resp = await ac.post("/api/letters/letter_4/refresh-status")
@@ -1259,7 +1237,7 @@ class TestLetter4Detection:
         self, auth_user, db_session
     ):
         await _activate_letter(db_session, auth_user, "letter_4")
-        await _add_liked_articles(db_session, auth_user, 9)
+        await _add_articles_bulk(db_session, auth_user, 9, is_liked=True)
 
         async with _client() as ac:
             resp = await ac.post("/api/letters/letter_4/refresh-status")
@@ -1345,8 +1323,8 @@ class TestNewLettersChaining:
 
     async def test_letter_4_complete_is_terminal(self, auth_user, db_session):
         await _activate_letter(db_session, auth_user, "letter_4")
-        await _add_read_articles(db_session, auth_user, 50)
-        await _add_liked_articles(db_session, auth_user, 10)
+        await _add_articles_bulk(db_session, auth_user, 50, time_spent_seconds=1)
+        await _add_articles_bulk(db_session, auth_user, 10, is_liked=True)
         for _ in range(10):
             await _add_event(db_session, auth_user, "perspectives_opened")
         await _add_event(db_session, auth_user, "app_feedback_opened")


### PR DESCRIPTION
## Quoi
Deux nouvelles lettres au catalogue Progression : **letter_3 « Ta tournée s'organise »** (créer une veille, enregistrer 5 articles, écrire une note sur un article sauvegardé, masquer 3 sources, ajouter 5 chaînes YouTube) et **letter_4 « Facteur de fond »** (lire 50 articles, recommander 10 articles, comparer 10 couvertures, donner son avis sur l'app). Backfill idempotent `_ensure_rows` pour les users existants (3 rows) + réactivation de chaîne pour ceux qui avaient tout fini.

## Pourquoi
PR2 de l'épic Progression (PR1 #832 mergée) : donner des niveaux supplémentaires avec des actions à fort impact produit, dont 3 demandées par le PO (note, mute, avis). Sans backfill, l'ajout de lettres au catalogue provoquait un KeyError pour tout user existant.

## Comment ça a été vérifié
- [x] pytest : 1671 passed (54 tests letters : backfill, détection par seuil, chaînage L2→L3→L4, cross-tenant, shape)
- [x] Chaîne Alembic complète sur DB vide (`upgrade head` OK, 1 head) — aucune nouvelle migration
- [x] flutter test (lettres + resolver + analytics) + flutter analyze : 0 erreur
- [x] Smoke uvicorn : GET /api/letters nouveau user → 5 lettres ; user legacy 3 rows archivées → letter_3 auto-activée ; 403 sans auth ; 404 letter inconnue
- [x] /simplify passé (factorisation détecteurs + helpers de test), re-VERIFY vert

## Zones à risque
- `services/letters/service.py` : `_ensure_rows` remplace l'init « si zéro rows » dans GET et refresh — no-op sans commit quand les rows sont complètes.
- Nouvel event analytics `app_feedback_opened` émis au tap « Donner mon avis » (réglages) — seul changement mobile comportemental.
- Mobile rétro-compatible : le resolver fallback sur le `target_route` serveur pour toute action inconnue.

## Notes
- QA handoff UI dans `.context/qa-handoff.md` → `/validate-feature` recommandé avant merge (impact écran Progression).
- Changelog `unreleased` mis à jour (tag Progression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)