### PR TITLE
fix(release): versionCode monotone (epoch) dans weekly-release

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -75,8 +75,12 @@ jobs:
       - name: Build APK (prod flavor)
         run: |
           cd apps/mobile
+          # versionCode = epoch (monotone et TOUJOURS > les anciens run_number).
+          # github.run_number repart à 1 pour ce workflow neuf -> versionCode=1 ->
+          # downgrade refusé par Android ("le package semble ne pas être valide")
+          # chez tous les users prod déjà installés. Plafond Android 2.1e9 -> ok ~2036.
           flutter build apk --release --flavor prod \
-            --build-number=${{ github.run_number }} \
+            --build-number=$(date +%s) \
             --dart-define="API_BASE_URL=https://facteur-production.up.railway.app/api" \
             --dart-define="SUPABASE_URL=${{ secrets.SUPABASE_URL }}" \
             --dart-define="SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" \


### PR DESCRIPTION
## Pourquoi (incident)

La 1ère « Weekly Production Release » a publié un APK prod avec **versionCode=1** :
`weekly-release.yml` réutilisait `github.run_number`, qui **repart à 1 pour un workflow neuf**. Résultat : downgrade refusé par Android → **« le package semble ne pas être valide »** chez tous les users prod déjà installés (versionCode ~900+).

Vérifié : l'APK servie (`/app/update/download-url?channel=stable`) = `com.example.facteur` / `versionCode=1` ; signature identique aux beta (même keystore) → seul le versionCode bloque.

## Fix
`--build-number=$(date +%s)` (epoch) : monotone, toujours > anciens versionCode. Plafond Android 2.1e9 → ok jusqu'à ~2036. `build-apk.yml` (flavor staging, appId distinct) reste sur run_number, pas impacté.

## Après merge
Re-cliquer **« Weekly Production Release »** → publie une `release-*` avec versionCode epoch → s'installe par-dessus l'app prod. Supprimer/ignorer la `release-20260612-2315` cassée (la nouvelle, plus récente, est servie en priorité).