### PR TITLE
fix(alembic): merge des 2 heads au01 + b75132e0c6b5 — débloque les déploiements staging

### DIFF
--- a/docs/bugs/bug-alembic-two-heads-au01-rsvps.md
+++ b/docs/bugs/bug-alembic-two-heads-au01-rsvps.md
@@ -1,0 +1,26 @@
+# Bug — 2 heads Alembic (au01 + b75132e0c6b5) : staging ne déploie plus
+
+## Symptômes
+- Tous les déploiements Railway staging depuis le merge de PR #818 (2026-06-12 16:23Z) plantent au boot : `alembic upgrade head` → "Multiple head revisions are present".
+- Staging sert encore le code d'avant #818 : les PRs #818 (observabilité scaling), #833 (lettres 3-4 + backfill) et #834 ne sont pas live.
+- `api_usage_events` absente de la DB partagée (`version_num = b75132e0c6b5`) → zéro donnée pour gouverner la phase 2 scaling.
+
+## Cause racine
+PR #828 (`b75132e0c6b5_create_event_rsvps_table`, mergée le 11/06, déployée) et PR #818 (`au01_api_usage_events`, mergée le 12/06) descendent toutes deux de `gr02_grille_featured_article` → branchpoint, 2 heads. Le hook `post-edit-alembic-heads.sh` ne voit pas les merges GitHub parallèles. Récurrence exacte de l'incident `5de67819bc61` (2026-05-18).
+
+## Fix
+Révision de merge sans DDL : `packages/api/alembic/versions/mg01_merge_au01_event_rsvps.py` (`down_revision = ("au01_api_usage_events", "b75132e0c6b5")`). Au prochain boot, Alembic applique `au01_api_usage_events` puis le merge.
+
+## Plan de test
+- [x] `alembic heads` → exactement 1 head (`mg01_merge_au01_rsvps`)
+- [x] `upgrade head` sur DB vide (facteur_test 54322)
+- [x] Simulation état prod : `stamp b75132e0c6b5` puis `upgrade head` → applique `au01` + merge ; re-run = no-op
+- [x] `pytest -v`
+
+## Post-merge
+- Vérifier boot Railway staging OK.
+- `SELECT provider, model, count(*) FROM api_usage_events GROUP BY 1,2` après quelques heures.
+- Confirmer exécution du backfill lettres (#833).
+
+## Prévention (suivi, hors PR)
+Envisager un check CI sur `main` (`alembic heads | wc -l == 1`) — le hook local ne couvre pas ce cas.

--- a/packages/api/alembic/versions/mg01_merge_au01_event_rsvps.py
+++ b/packages/api/alembic/versions/mg01_merge_au01_event_rsvps.py
@@ -1,0 +1,39 @@
+"""merge au01 api_usage_events + b75132e0c6b5 event_rsvps
+
+Hotfix : les PRs #818 (observabilité scaling, `au01_api_usage_events`) et
+#828 (RSVP événement, `b75132e0c6b5`) ont mergé en parallèle deux migrations
+descendant toutes deux de `gr02_grille_featured_article` → branchpoint
+Alembic, 2 heads. Le `Dockerfile` exécute `alembic upgrade head` (singulier)
+au boot Railway et échoue avec "Multiple head revisions are present" → la DB
+est restée figée sur `b75132e0c6b5` (déployée en premier le 2026-06-11) et
+`au01_api_usage_events` n'a jamais été appliquée : la table
+`api_usage_events` n'existe pas, et tous les déploiements staging depuis le
+merge de #818 (2026-06-12) plantent au boot.
+
+Même incident que `5de67819bc61` (2026-05-18) : le hook
+`post-edit-alembic-heads.sh` ne protège pas des merges GitHub parallèles.
+
+Cette révision unifie le graphe sans DDL : au prochain boot, Alembic
+appliquera naturellement `au01_api_usage_events` puis ce merge.
+
+Revision ID: mg01_merge_au01_rsvps
+Revises: au01_api_usage_events, b75132e0c6b5
+Create Date: 2026-06-13
+
+"""
+
+revision: str = "mg01_merge_au01_rsvps"
+down_revision: tuple[str, ...] = (
+    "au01_api_usage_events",
+    "b75132e0c6b5",
+)
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Quoi
Révision de merge Alembic sans DDL (`mg01_merge_au01_rsvps`) unifiant les 2 heads `au01_api_usage_events` (PR #818) et `b75132e0c6b5` (PR #828), + doc bug `docs/bugs/bug-alembic-two-heads-au01-rsvps.md`.

## Pourquoi
Les 2 migrations descendent toutes deux de `gr02_grille_featured_article` (merges GitHub parallèles, le hook local ne peut pas le voir). `alembic upgrade head` échoue avec « Multiple head revisions are present » → **tous les déploiements staging depuis le merge de #818 (12/06 16:23Z) plantent au boot** : #818, #833 (lettres + backfill) et #834 ne sont pas live, `api_usage_events` n'existe pas (DB à `b75132e0c6b5`). Même incident que `5de67819bc61` (mai 2026). Ce fix est le prérequis bloquant de la phase 2 scaling (données phase A).

## Comment ça a été vérifié
- [x] `alembic heads` → exactement 1 head (`mg01_merge_au01_rsvps`)
- [x] DB vide → `upgrade b75132e0c6b5` (simulation état prod) → `upgrade head` : applique `au01` puis le merge ; re-run = no-op ; `api_usage_events` créée
- [x] `pytest` : 1683 passed, 1 skipped, 2 xfailed
- [x] /simplify passé (4 angles, clean)

## Zones à risque
Chaîne Alembic (zone DB) — révision **sans DDL**, rollback = revert. Surveiller les logs Railway au prochain boot (le fallback du CMD peut masquer une erreur de migration).

## Post-merge
Vérifier boot staging OK, puis `SELECT provider, model, count(*) FROM api_usage_events GROUP BY 1,2` après quelques heures ; confirmer le backfill lettres (#833).

🤖 Generated with [Claude Code](https://claude.com/claude-code)