### PR TITLE
feat(mobile): réorganiser les menus de paramètres (Apparence + Paramètres sources)

### DIFF
--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -27,6 +27,8 @@ import '../features/sources/screens/add_source_screen.dart';
 import '../features/sources/screens/theme_sources_screen.dart';
 import '../features/settings/screens/profile_screen.dart';
 import '../features/settings/screens/account_screen.dart';
+import '../features/settings/screens/appearance_screen.dart';
+import '../features/settings/screens/source_settings_screen.dart';
 import '../features/settings/screens/subscriptions_screen.dart';
 import '../features/settings/screens/notifications_screen.dart';
 import '../features/settings/screens/about_screen.dart';
@@ -84,6 +86,8 @@ class RouteNames {
   static const String addSource = 'add-source';
   static const String settings = 'settings';
   static const String account = 'account';
+  static const String appearance = 'appearance';
+  static const String sourceSettings = 'source-settings';
   static const String subscriptions = 'subscriptions';
   static const String notifications = 'notifications';
   static const String about = 'about';
@@ -122,6 +126,8 @@ class RoutePaths {
   // static const String addSource = '/sources/add'; // Removed for V0
   static const String settings = '/settings';
   static const String account = '/settings/account';
+  static const String appearance = '/settings/appearance';
+  static const String sourceSettings = '/settings/sources/preferences';
   static const String subscriptions = '/settings/subscriptions';
   static const String notifications = '/settings/notifications';
   static const String about = '/settings/about';
@@ -520,6 +526,12 @@ final routerProvider = Provider<GoRouter>((ref) {
                 const FullSwipeCupertinoPage(child: ProfileScreen()),
           ),
           GoRoute(
+            path: 'appearance', // /settings/appearance
+            name: RouteNames.appearance,
+            pageBuilder: (context, state) =>
+                const FullSwipeCupertinoPage(child: AppearanceScreen()),
+          ),
+          GoRoute(
             path: 'sources', // /settings/sources
             name: RouteNames.sources,
             pageBuilder: (context, state) =>
@@ -530,6 +542,12 @@ final routerProvider = Provider<GoRouter>((ref) {
                 name: RouteNames.addSource,
                 pageBuilder: (context, state) =>
                     const FullSwipeCupertinoPage(child: AddSourceScreen()),
+              ),
+              GoRoute(
+                path: 'preferences', // /settings/sources/preferences
+                name: RouteNames.sourceSettings,
+                pageBuilder: (context, state) =>
+                    const FullSwipeCupertinoPage(child: SourceSettingsScreen()),
               ),
               GoRoute(
                 path: 'theme/:slug', // /settings/sources/theme/:slug

--- a/apps/mobile/lib/features/flux_continu/widgets/tournee_composer_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/tournee_composer_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+import '../../../config/theme.dart';
 import '../../../shared/widgets/buttons/primary_button.dart';
 import 'manage_favorites_sheet.dart';
 
@@ -17,26 +18,53 @@ Future<void> showTourneeComposerSheet(BuildContext context) {
 
 /// Bouton « Composer ma Tournée » — point d'entrée vers la sheet unifiée.
 ///
-/// Style canonique [PrimaryButton] (terracotta plein, `elevation:0`,
-/// `FacteurRadius.small`) au lieu de l'ancienne tuile teintée + ombre, perçue
-/// comme un « dégradé étrange » hors design-system. L'haptique est conservée.
+enum ComposeTourneeButtonStyle { primary, secondary }
+
 class ComposeTourneeButton extends StatelessWidget {
-  const ComposeTourneeButton({super.key, this.padding});
+  const ComposeTourneeButton({
+    super.key,
+    this.padding,
+    this.style = ComposeTourneeButtonStyle.primary,
+  });
 
   final EdgeInsetsGeometry? padding;
+  final ComposeTourneeButtonStyle style;
+
+  void _open(BuildContext context) {
+    HapticFeedback.mediumImpact();
+    showTourneeComposerSheet(context);
+  }
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: padding ?? EdgeInsets.zero,
-      child: PrimaryButton(
-        label: 'Composer ma Tournée',
-        icon: PhosphorIcons.slidersHorizontal(PhosphorIconsStyle.bold),
-        onPressed: () {
-          HapticFeedback.mediumImpact();
-          showTourneeComposerSheet(context);
-        },
-      ),
+      child: style == ComposeTourneeButtonStyle.primary
+          ? PrimaryButton(
+              label: 'Composer ma Tournée',
+              icon: PhosphorIcons.slidersHorizontal(PhosphorIconsStyle.bold),
+              onPressed: () => _open(context),
+            )
+          : SizedBox(
+              width: double.infinity,
+              height: 52,
+              child: OutlinedButton.icon(
+                onPressed: () => _open(context),
+                icon: Icon(
+                  PhosphorIcons.slidersHorizontal(
+                    PhosphorIconsStyle.regular,
+                  ),
+                ),
+                label: const Text('Composer ma Tournée'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: context.facteurColors.textPrimary,
+                  side: BorderSide(color: context.facteurColors.border),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(FacteurRadius.small),
+                  ),
+                ),
+              ),
+            ),
     );
   }
 }

--- a/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
@@ -176,9 +176,13 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
     required TextTheme textTheme,
   }) {
     final hiddenItems = <_HiddenEntry>[
-      for (final t in interests.themes.where((t) => t.state == InterestState.hidden))
+      for (final t in interests.themes.where(
+        (t) => t.state == InterestState.hidden,
+      ))
         _HiddenEntry.theme(slug: t.interestSlug),
-      for (final c in interests.customTopics.where((c) => c.state == InterestState.hidden))
+      for (final c in interests.customTopics.where(
+        (c) => c.state == InterestState.hidden,
+      ))
         _HiddenEntry.customTopic(id: c.id, name: c.topicName),
     ];
 
@@ -197,8 +201,7 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
             ),
             child: _SereinToggleTile(
               enabled: sereinMode,
-              onChanged: () =>
-                  ref.read(sereinToggleProvider.notifier).toggle(),
+              onChanged: () => ref.read(sereinToggleProvider.notifier).toggle(),
             ),
           ),
           if (!sereinMode) ...[
@@ -263,8 +266,9 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
                   border: Border.all(color: colors.surfaceElevated),
                 ),
                 child: Theme(
-                  data: Theme.of(context)
-                      .copyWith(dividerColor: Colors.transparent),
+                  data: Theme.of(
+                    context,
+                  ).copyWith(dividerColor: Colors.transparent),
                   child: ExpansionTile(
                     initiallyExpanded: false,
                     tilePadding: const EdgeInsets.symmetric(
@@ -284,14 +288,16 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
                       ),
                     ),
                     children: hiddenItems
-                        .map((entry) => _HiddenItemRow(
-                              entry: entry,
-                              onRestore: () => _pickState(
-                                title: entry.displayName,
-                                refTarget: entry.refTarget,
-                                currentState: InterestState.hidden,
-                              ),
-                            ))
+                        .map(
+                          (entry) => _HiddenItemRow(
+                            entry: entry,
+                            onRestore: () => _pickState(
+                              title: entry.displayName,
+                              refTarget: entry.refTarget,
+                              currentState: InterestState.hidden,
+                            ),
+                          ),
+                        )
                         .toList(),
                   ),
                 ),
@@ -302,7 +308,6 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
       ),
     );
   }
-
 }
 
 class _HiddenEntry {
@@ -310,10 +315,11 @@ class _HiddenEntry {
   final String displayName;
   final bool isTheme;
 
-  _HiddenEntry._(
-      {required this.refTarget,
-      required this.displayName,
-      required this.isTheme});
+  _HiddenEntry._({
+    required this.refTarget,
+    required this.displayName,
+    required this.isTheme,
+  });
 
   factory _HiddenEntry.theme({required String slug}) => _HiddenEntry._(
         refTarget: ThemeFavoriteRef(slug: slug),
@@ -321,7 +327,10 @@ class _HiddenEntry {
         isTheme: true,
       );
 
-  factory _HiddenEntry.customTopic({required String id, required String name}) =>
+  factory _HiddenEntry.customTopic({
+    required String id,
+    required String name,
+  }) =>
       _HiddenEntry._(
         refTarget: CustomTopicFavoriteRef(id: id),
         displayName: name,
@@ -338,29 +347,40 @@ class _HeroBlock extends StatelessWidget {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
     return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: FacteurSpacing.space4,
-        vertical: FacteurSpacing.space4,
+      padding: const EdgeInsets.fromLTRB(
+        FacteurSpacing.space4,
+        FacteurSpacing.space2,
+        FacteurSpacing.space4,
+        FacteurSpacing.space4,
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            sereinMode ? 'Vos bonnes nouvelles' : 'Vos centres d\'intérêt',
-            style: textTheme.displaySmall?.copyWith(
-              fontWeight: FontWeight.w700,
+      child: Container(
+        padding: const EdgeInsets.all(FacteurSpacing.space4),
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(FacteurRadius.large),
+          border: Border.all(color: colors.surfaceElevated),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              sereinMode ? 'Vos bonnes nouvelles' : 'Vos centres d\'intérêt',
+              style: FacteurTypography.serifTitle(
+                colors.textPrimary,
+              ).copyWith(fontSize: 20, height: 1.2),
             ),
-          ),
-          const SizedBox(height: FacteurSpacing.space2),
-          Text(
-            sereinMode
-                ? 'Choisissez ce qui reste dans vos bonnes nouvelles. Cochez pour garder, décochez pour mettre de côté.'
-                : 'Étoilez vos favoris pour les voir en tête du flux. Les 3 premiers (ordre modifiable) constituent votre Tournée du jour.',
-            style: textTheme.bodyMedium?.copyWith(
-              color: colors.textSecondary,
+            const SizedBox(height: 6),
+            Text(
+              sereinMode
+                  ? 'Choisissez ce qui reste dans vos bonnes nouvelles. Cochez pour garder, décochez pour mettre de côté.'
+                  : 'Étoilez vos favoris pour les voir en tête du flux. Les 3 premiers (ordre modifiable) constituent votre Tournée du jour.',
+              style: textTheme.bodySmall?.copyWith(
+                color: colors.textSecondary,
+                height: 1.45,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -462,9 +482,7 @@ class _SereinSettingsHeader extends StatelessWidget {
         decoration: BoxDecoration(
           color: SereinColors.sereinColor.withOpacity(0.08),
           borderRadius: BorderRadius.circular(FacteurRadius.large),
-          border: Border.all(
-            color: SereinColors.sereinColor.withOpacity(0.25),
-          ),
+          border: Border.all(color: SereinColors.sereinColor.withOpacity(0.25)),
         ),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -510,8 +528,11 @@ class _ThemeBlock extends ConsumerWidget {
   final UserInterestsState interests;
   final bool sereinMode;
   final Future<void> Function(InterestState current) onPickThemeState;
-  final Future<void> Function(String topicId, String name, InterestState current)
-      onPickTopicState;
+  final Future<void> Function(
+    String topicId,
+    String name,
+    InterestState current,
+  ) onPickTopicState;
 
   const _ThemeBlock({
     required this.macroLabel,
@@ -527,9 +548,8 @@ class _ThemeBlock extends ConsumerWidget {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
 
-    final themeRow = interests.themes
-        .where((t) => t.interestSlug == themeSlug)
-        .firstOrNull;
+    final themeRow =
+        interests.themes.where((t) => t.interestSlug == themeSlug).firstOrNull;
     final themeState = themeRow?.state ?? InterestState.unfollowed;
 
     // slug_parent en DB est un slug fin (ex. 'cinema', 'ai', 'feminism'). On
@@ -537,9 +557,11 @@ class _ThemeBlock extends ConsumerWidget {
     // affiché. Avant : comparaison directe `slugParent == themeSlug` qui
     // masquait ~85% des sujets followed (PR #622).
     final topics = interests.customTopics
-        .where((c) =>
-            getTopicMacroTheme(c.slugParent) == macroLabel &&
-            c.state != InterestState.hidden)
+        .where(
+          (c) =>
+              getTopicMacroTheme(c.slugParent) == macroLabel &&
+              c.state != InterestState.hidden,
+        )
         .toList();
 
     // Hide the whole block in normal mode when there's nothing to show
@@ -575,8 +597,10 @@ class _ThemeBlock extends ConsumerWidget {
             ),
             title: Row(
               children: [
-                Text(getMacroThemeEmoji(macroLabel),
-                    style: const TextStyle(fontSize: 16)),
+                Text(
+                  getMacroThemeEmoji(macroLabel),
+                  style: const TextStyle(fontSize: 16),
+                ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
@@ -602,8 +626,11 @@ class _ThemeBlock extends ConsumerWidget {
                 ...topics.map(
                   (topic) => _TopicRow(
                     topic: topic,
-                    onPickState: () =>
-                        onPickTopicState(topic.id, topic.topicName, topic.state),
+                    onPickState: () => onPickTopicState(
+                      topic.id,
+                      topic.topicName,
+                      topic.state,
+                    ),
                   ),
                 ),
                 _AddTopicInlineButton(themeSlug: themeSlug),
@@ -647,8 +674,10 @@ class _DiscoverHint extends StatelessWidget {
           ),
           child: Row(
             children: [
-              Text(getMacroThemeEmoji(macroLabel),
-                  style: const TextStyle(fontSize: 16)),
+              Text(
+                getMacroThemeEmoji(macroLabel),
+                style: const TextStyle(fontSize: 16),
+              ),
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
@@ -769,10 +798,10 @@ class _SereinTopicRow extends ConsumerWidget {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
     final customTopicsAsync = ref.watch(customTopicsProvider);
-    final legacyTopic = customTopicsAsync.value
-        ?.where((t) => t.id == topic.id)
-        .firstOrNull;
-    final included = legacyTopic == null ? true : !legacyTopic.excludedFromSerein;
+    final legacyTopic =
+        customTopicsAsync.value?.where((t) => t.id == topic.id).firstOrNull;
+    final included =
+        legacyTopic == null ? true : !legacyTopic.excludedFromSerein;
 
     return Padding(
       padding: const EdgeInsets.symmetric(
@@ -797,8 +826,9 @@ class _SereinTopicRow extends ConsumerWidget {
                         if (!context.mounted) return;
                         ScaffoldMessenger.of(context).showSnackBar(
                           const SnackBar(
-                            content:
-                                Text('Impossible de mettre à jour ce sujet.'),
+                            content: Text(
+                              'Impossible de mettre à jour ce sujet.',
+                            ),
                             duration: Duration(seconds: 3),
                           ),
                         );
@@ -958,9 +988,7 @@ class _PinnedTopicsSection extends StatelessWidget {
             Text(
               'Apparaissent comme onglets dans Flâner. '
               'Ils ne remplacent pas vos thèmes favoris.',
-              style: textTheme.bodySmall?.copyWith(
-                color: colors.textTertiary,
-              ),
+              style: textTheme.bodySmall?.copyWith(color: colors.textTertiary),
             ),
             const SizedBox(height: FacteurSpacing.space2),
             ...pinned.map((ref) {
@@ -1036,14 +1064,9 @@ class _HiddenItemRow extends StatelessWidget {
       ),
       title: Text(
         entry.displayName,
-        style: textTheme.bodyMedium?.copyWith(
-          color: colors.textSecondary,
-        ),
+        style: textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
       ),
-      trailing: TextButton(
-        onPressed: onRestore,
-        child: const Text('Modifier'),
-      ),
+      trailing: TextButton(onPressed: onRestore, child: const Text('Modifier')),
     );
   }
 }
@@ -1106,8 +1129,7 @@ class _ContentTypesSection extends ConsumerWidget {
                     value: !isMuted,
                     activeColor: colors.primary,
                     onChanged: (enabled) async {
-                      final repo =
-                          ref.read(personalizationRepositoryProvider);
+                      final repo = ref.read(personalizationRepositoryProvider);
                       if (enabled) {
                         await repo.unmuteContentType(entry.key);
                       } else {
@@ -1125,4 +1147,3 @@ class _ContentTypesSection extends ConsumerWidget {
     );
   }
 }
-

--- a/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
@@ -210,6 +210,7 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
             // dans « Composer ma Tournée ». L'ancienne liste reorderable inline
             // est remplacée par ce point d'entrée unique.
             const ComposeTourneeButton(
+              style: ComposeTourneeButtonStyle.secondary,
               padding: EdgeInsets.fromLTRB(
                 FacteurSpacing.space4,
                 0,

--- a/apps/mobile/lib/features/onboarding/widgets/premium_sources_sheet.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/premium_sources_sheet.dart
@@ -298,7 +298,7 @@ class _PremiumSourcesSheetState extends ConsumerState<PremiumSourcesSheet> {
         child: const Text('Dissocier'),
       );
     }
-    final connection = _resolveConnection(source);
+    final connection = resolvePremiumConnection(source);
     if (connection == null) {
       return Padding(
         padding: const EdgeInsets.symmetric(horizontal: FacteurSpacing.space2),
@@ -320,27 +320,6 @@ class _PremiumSourcesSheetState extends ConsumerState<PremiumSourcesSheet> {
     return TextButton(
       onPressed: () => _connectSource(context, source, connection),
       child: Text(connection.isGeneric ? 'Associer' : 'Connecter'),
-    );
-  }
-
-  /// Résout la connexion premium d'une source, avec fallback générique frontend
-  /// quand la config est absente. Mêmes règles que le backend
-  /// `PremiumConnectionResponse.from_source` (étape 3) : source payante
-  /// (`hasPaywall`) + URL http(s) valide → login=test=home du média,
-  /// `isGeneric=true`. Retourne `null` pour une source clairement gratuite.
-  PremiumConnection? _resolveConnection(Source source) {
-    final existing = source.premiumConnection;
-    if (existing != null) return existing;
-    if (!source.hasPaywall) return null;
-    final url = source.url?.trim() ?? '';
-    if (!url.startsWith('http://') && !url.startsWith('https://')) return null;
-    return PremiumConnection(
-      loginUrl: url,
-      testUrl: url,
-      displayHint:
-          'Connecte-toi à ton compte sur le site du média, puis reviens lire '
-          'tes articles.',
-      isGeneric: true,
     );
   }
 

--- a/apps/mobile/lib/features/settings/screens/account_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/account_screen.dart
@@ -12,9 +12,8 @@ import '../../../config/theme.dart';
 import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
 import '../../../core/services/widget_service.dart';
-import '../providers/language_preference_provider.dart';
+import '../../../core/ui/notification_service.dart';
 import '../providers/user_profile_provider.dart';
-import 'package:facteur/core/ui/notification_service.dart';
 
 /// Écran de gestion du compte utilisateur
 class AccountScreen extends ConsumerWidget {
@@ -69,8 +68,11 @@ class AccountScreen extends ConsumerWidget {
                   const SizedBox(height: FacteurSpacing.space2),
                   Row(
                     children: [
-                      Icon(Icons.email_outlined,
-                          color: colors.primary, size: 20),
+                      Icon(
+                        Icons.email_outlined,
+                        color: colors.primary,
+                        size: 20,
+                      ),
                       const SizedBox(width: FacteurSpacing.space3),
                       Expanded(
                         child: Column(
@@ -81,9 +83,7 @@ class AccountScreen extends ConsumerWidget {
                               style: Theme.of(context)
                                   .textTheme
                                   .labelSmall
-                                  ?.copyWith(
-                                    color: colors.textTertiary,
-                                  ),
+                                  ?.copyWith(color: colors.textTertiary),
                             ),
                             Text(
                               userEmail,
@@ -93,72 +93,6 @@ class AccountScreen extends ConsumerWidget {
                         ),
                       ),
                     ],
-                  ),
-                ],
-              ),
-            ),
-
-            // Section Abonnements (médias payants connectés)
-            const SizedBox(height: FacteurSpacing.space6),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(FacteurSpacing.space4),
-              decoration: BoxDecoration(
-                color: colors.surface,
-                borderRadius: BorderRadius.circular(FacteurRadius.large),
-                border: Border.all(color: colors.surfaceElevated),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'ABONNEMENTS',
-                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: colors.textTertiary,
-                          letterSpacing: 1.5,
-                        ),
-                  ),
-                  const SizedBox(height: FacteurSpacing.space3),
-                  InkWell(
-                    onTap: () => context.push(RoutePaths.subscriptions),
-                    borderRadius: BorderRadius.circular(FacteurRadius.medium),
-                    child: Row(
-                      children: [
-                        Icon(
-                          PhosphorIcons.link(PhosphorIconsStyle.regular),
-                          color: colors.primary,
-                          size: 20,
-                        ),
-                        const SizedBox(width: FacteurSpacing.space3),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                'Mes abonnements',
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .bodyMedium
-                                    ?.copyWith(fontWeight: FontWeight.w500),
-                              ),
-                              const SizedBox(height: 2),
-                              Text(
-                                'Gère tes médias payants connectés',
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .bodySmall
-                                    ?.copyWith(color: colors.textSecondary),
-                              ),
-                            ],
-                          ),
-                        ),
-                        Icon(
-                          PhosphorIcons.caretRight(),
-                          color: colors.textTertiary,
-                          size: 18,
-                        ),
-                      ],
-                    ),
                   ),
                 ],
               ),
@@ -223,7 +157,8 @@ class AccountScreen extends ConsumerWidget {
                           ),
                           Icon(
                             PhosphorIcons.arrowSquareOut(
-                                PhosphorIconsStyle.regular),
+                              PhosphorIconsStyle.regular,
+                            ),
                             color: colors.textTertiary,
                             size: 18,
                           ),
@@ -234,9 +169,6 @@ class AccountScreen extends ConsumerWidget {
                 ),
               ),
             ],
-
-            const SizedBox(height: FacteurSpacing.space6),
-            _LanguagePreferenceSection(),
 
             const Spacer(),
 
@@ -300,8 +232,10 @@ class AccountScreen extends ConsumerWidget {
       context: context,
       builder: (context) => AlertDialog(
         backgroundColor: colors.surface,
-        title: Text('Nom d\'affichage',
-            style: TextStyle(color: colors.textPrimary)),
+        title: Text(
+          'Nom d\'affichage',
+          style: TextStyle(color: colors.textPrimary),
+        ),
         content: TextField(
           controller: controller,
           autofocus: true,
@@ -314,86 +248,19 @@ class AccountScreen extends ConsumerWidget {
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child:
-                Text('Annuler', style: TextStyle(color: colors.textSecondary)),
+            child: Text(
+              'Annuler',
+              style: TextStyle(color: colors.textSecondary),
+            ),
           ),
           TextButton(
             onPressed: () {
-              ref.read(userProfileProvider.notifier).updateProfile(
-                    displayName: controller.text.trim(),
-                  );
+              ref
+                  .read(userProfileProvider.notifier)
+                  .updateProfile(displayName: controller.text.trim());
               Navigator.of(context).pop();
             },
             child: Text('Enregistrer', style: TextStyle(color: colors.primary)),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Section "LANGUE & CONTENUS" — toggle masquage des sources non françaises.
-class _LanguagePreferenceSection extends ConsumerWidget {
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = context.facteurColors;
-    final state = ref.watch(languagePreferenceProvider);
-
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.symmetric(
-        horizontal: FacteurSpacing.space4,
-        vertical: FacteurSpacing.space2,
-      ),
-      decoration: BoxDecoration(
-        color: colors.surface,
-        borderRadius: BorderRadius.circular(FacteurRadius.large),
-        border: Border.all(color: colors.surfaceElevated),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(top: FacteurSpacing.space2),
-            child: Text(
-              'LANGUE & CONTENUS',
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                    color: colors.textTertiary,
-                    letterSpacing: 1.5,
-                  ),
-            ),
-          ),
-          SwitchListTile.adaptive(
-            contentPadding: EdgeInsets.zero,
-            title: Text(
-              'Masquer les sources non françaises',
-              style: Theme.of(context)
-                  .textTheme
-                  .bodyMedium
-                  ?.copyWith(fontWeight: FontWeight.w500),
-            ),
-            subtitle: Padding(
-              padding: const EdgeInsets.only(top: 2),
-              child: Text(
-                'Les sources que tu suis restent toujours visibles.',
-                style: Theme.of(context)
-                    .textTheme
-                    .bodySmall
-                    ?.copyWith(color: colors.textSecondary),
-              ),
-            ),
-            value: state.hideNonFr,
-            activeColor: colors.primary,
-            onChanged: (v) async {
-              final ok = await ref
-                  .read(languagePreferenceProvider.notifier)
-                  .toggle(v);
-              if (!ok) {
-                NotificationService.showError(
-                  'Impossible de mettre à jour ce réglage. Réessaye dans un instant.',
-                );
-              }
-            },
           ),
         ],
       ),
@@ -432,14 +299,11 @@ class _InfoRow extends StatelessWidget {
               children: [
                 Text(
                   label,
-                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: colors.textTertiary,
-                      ),
+                  style: Theme.of(
+                    context,
+                  ).textTheme.labelSmall?.copyWith(color: colors.textTertiary),
                 ),
-                Text(
-                  value,
-                  style: Theme.of(context).textTheme.bodyMedium,
-                ),
+                Text(value, style: Theme.of(context).textTheme.bodyMedium),
               ],
             ),
           ),

--- a/apps/mobile/lib/features/settings/screens/appearance_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/appearance_screen.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../../onboarding/widgets/theme_choice_bottom_sheet.dart';
+import '../providers/display_mode_provider.dart';
+import '../providers/theme_provider.dart';
+import '../widgets/display_mode_bottom_sheet.dart';
+
+class AppearanceScreen extends ConsumerWidget {
+  const AppearanceScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final themeMode = ref.watch(themeNotifierProvider);
+    final displayMode = ref.watch(displayModeNotifierProvider);
+
+    return Scaffold(
+      backgroundColor: colors.backgroundPrimary,
+      appBar: AppBar(
+        title: const Text('Apparence'),
+        backgroundColor: colors.backgroundPrimary,
+        elevation: 0,
+        titleTextStyle: Theme.of(context).textTheme.displaySmall,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(FacteurSpacing.space4),
+        child: Container(
+          decoration: BoxDecoration(
+            color: colors.surface,
+            borderRadius: BorderRadius.circular(FacteurRadius.large),
+            border: Border.all(color: colors.surfaceElevated),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _AppearanceTile(
+                icon: PhosphorIcons.palette(PhosphorIconsStyle.regular),
+                title: 'Thème',
+                subtitle: _themeName(themeMode),
+                onTap: () => showThemeChoiceBottomSheet(context, ref),
+              ),
+              Divider(
+                height: 1,
+                indent: FacteurSpacing.space4,
+                endIndent: FacteurSpacing.space4,
+                color: colors.border.withValues(alpha: 0.5),
+              ),
+              _AppearanceTile(
+                icon: PhosphorIcons.article(PhosphorIconsStyle.regular),
+                title: 'Affichage des articles',
+                subtitle: displayMode.label,
+                onTap: () => showDisplayModeBottomSheet(context, ref),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _themeName(AppThemeMode mode) {
+    return switch (mode) {
+      AppThemeMode.light => 'Papier Dessin',
+      AppThemeMode.dark => 'Encre & Nuit',
+      AppThemeMode.oled => 'Encre Pure',
+    };
+  }
+}
+
+class _AppearanceTile extends StatelessWidget {
+  const _AppearanceTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.all(FacteurSpacing.space4),
+        child: Row(
+          children: [
+            Icon(icon, color: colors.primary, size: 24),
+            const SizedBox(width: FacteurSpacing.space4),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w500,
+                        ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: colors.textSecondary,
+                        ),
+                  ),
+                ],
+              ),
+            ),
+            Icon(
+              PhosphorIcons.caretRight(PhosphorIconsStyle.regular),
+              color: colors.textTertiary,
+              size: 18,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/settings/screens/profile_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/profile_screen.dart
@@ -3,28 +3,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
 
+import '../../../config/constants.dart';
 import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../../core/auth/auth_state.dart';
 import '../../onboarding/providers/onboarding_provider.dart';
-import '../../onboarding/widgets/theme_choice_bottom_sheet.dart';
-import '../providers/display_mode_provider.dart';
-import '../providers/theme_provider.dart';
-import '../widgets/display_mode_bottom_sheet.dart';
+import '../widgets/profile_progression_card.dart';
 
 /// Page « Profil » regroupant les réglages applicatifs accessibles depuis
-/// la sheet Réglages : compte, notifications, thème, refonte du
-/// questionnaire, présentation.
+/// la sheet Réglages : compte, notifications, questionnaire, présentation
+/// et liens secondaires.
 class ProfileScreen extends ConsumerWidget {
   const ProfileScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
-    final themeMode = ref.watch(themeNotifierProvider);
-    final displayMode = ref.watch(displayModeNotifierProvider);
-
     return Scaffold(
       backgroundColor: colors.backgroundPrimary,
       appBar: AppBar(
@@ -60,25 +56,11 @@ class ProfileScreen extends ConsumerWidget {
               title: 'PRÉFÉRENCES',
               children: [
                 _Tile(
-                  icon: Icons.palette_outlined,
-                  title: 'Thème',
-                  subtitle: _themeName(themeMode),
-                  onTap: () => showThemeChoiceBottomSheet(context, ref),
-                ),
-                _Tile(
-                  icon: Icons.view_agenda_outlined,
-                  title: 'Affichage des articles',
-                  subtitle: displayMode.label,
-                  onTap: () => showDisplayModeBottomSheet(context, ref),
-                ),
-                _Tile(
                   icon: Icons.settings_suggest_outlined,
                   title: 'Refaire le questionnaire',
                   subtitle: 'Ajuster mon profil et mes préférences',
                   onTap: () {
-                    ref
-                        .read(onboardingProvider.notifier)
-                        .restartOnboarding();
+                    ref.read(onboardingProvider.notifier).restartOnboarding();
                     ref
                         .read(authStateProvider.notifier)
                         .setNeedsOnboarding(true);
@@ -98,6 +80,27 @@ class ProfileScreen extends ConsumerWidget {
                 ),
               ],
             ),
+            const SizedBox(height: FacteurSpacing.space6),
+            _Section(
+              title: 'AIDE & INFORMATIONS',
+              children: [
+                _Tile(
+                  icon: PhosphorIcons.shieldCheck(PhosphorIconsStyle.regular),
+                  title: 'Politique de confidentialité',
+                  onTap: () => _open(LegalLinks.privacy),
+                ),
+                _Tile(
+                  icon: PhosphorIcons.fileText(PhosphorIconsStyle.regular),
+                  title: 'Conditions d\'utilisation',
+                  onTap: () => _open(LegalLinks.terms),
+                ),
+                _Tile(
+                  icon: PhosphorIcons.lifebuoy(PhosphorIconsStyle.regular),
+                  title: 'Contacter le support',
+                  onTap: () => _open(LegalLinks.supportEmail),
+                ),
+              ],
+            ),
             const SizedBox(height: FacteurSpacing.space8),
           ],
         ),
@@ -105,14 +108,10 @@ class ProfileScreen extends ConsumerWidget {
     );
   }
 
-  String _themeName(AppThemeMode mode) {
-    switch (mode) {
-      case AppThemeMode.light:
-        return 'Papier Dessin';
-      case AppThemeMode.dark:
-        return 'Encre & Nuit';
-      case AppThemeMode.oled:
-        return 'Encre Pure';
+  Future<void> _open(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
     }
   }
 }
@@ -143,8 +142,7 @@ class _Section extends StatelessWidget {
           ),
         ),
         Container(
-          margin:
-              const EdgeInsets.symmetric(horizontal: FacteurSpacing.space4),
+          margin: const EdgeInsets.symmetric(horizontal: FacteurSpacing.space4),
           decoration: BoxDecoration(
             color: colors.surface,
             borderRadius: BorderRadius.circular(FacteurRadius.large),

--- a/apps/mobile/lib/features/settings/screens/source_settings_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/source_settings_screen.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/routes.dart';
+import '../../../config/theme.dart';
+import '../../../core/ui/notification_service.dart';
+import '../providers/language_preference_provider.dart';
+import '../providers/paid_content_provider.dart';
+
+class SourceSettingsScreen extends ConsumerWidget {
+  const SourceSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final hidePaid = ref.watch(hidePaidContentProvider);
+    final language = ref.watch(languagePreferenceProvider);
+
+    return Scaffold(
+      backgroundColor: colors.backgroundPrimary,
+      appBar: AppBar(
+        title: const Text('Paramètres des sources'),
+        backgroundColor: colors.backgroundPrimary,
+        elevation: 0,
+        titleTextStyle: Theme.of(context).textTheme.displaySmall,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(FacteurSpacing.space4),
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              color: colors.surface,
+              borderRadius: BorderRadius.circular(FacteurRadius.large),
+              border: Border.all(color: colors.surfaceElevated),
+            ),
+            child: Column(
+              children: [
+                _NavigationTile(
+                  icon: PhosphorIcons.link(PhosphorIconsStyle.regular),
+                  title: 'Mes abonnements',
+                  subtitle: 'Gérer mes médias payants connectés',
+                  onTap: () => context.pushNamed(RouteNames.subscriptions),
+                ),
+                _Divider(colors: colors),
+                _SourceSwitchTile(
+                  icon: PhosphorIcons.lock(PhosphorIconsStyle.regular),
+                  title: 'Masquer les articles payants',
+                  subtitle: 'Sauf pour les abonnements connectés.',
+                  value: hidePaid,
+                  onChanged: (value) =>
+                      ref.read(hidePaidContentProvider.notifier).toggle(value),
+                ),
+                _Divider(colors: colors),
+                _SourceSwitchTile(
+                  icon: PhosphorIcons.translate(PhosphorIconsStyle.regular),
+                  title: 'Masquer les sources non françaises',
+                  subtitle: 'Les sources suivies restent toujours visibles.',
+                  value: language.hideNonFr,
+                  onChanged: (value) async {
+                    final ok = await ref
+                        .read(languagePreferenceProvider.notifier)
+                        .toggle(value);
+                    if (!ok) {
+                      NotificationService.showError(
+                        'Impossible de mettre à jour ce réglage. Réessaye dans un instant.',
+                      );
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NavigationTile extends StatelessWidget {
+  const _NavigationTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return InkWell(
+      onTap: onTap,
+      child: _TileContent(
+        icon: icon,
+        title: title,
+        subtitle: subtitle,
+        trailing: Icon(
+          PhosphorIcons.caretRight(PhosphorIconsStyle.regular),
+          color: colors.textTertiary,
+          size: 18,
+        ),
+      ),
+    );
+  }
+}
+
+class _SourceSwitchTile extends StatelessWidget {
+  const _SourceSwitchTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () => onChanged(!value),
+      child: _TileContent(
+        icon: icon,
+        title: title,
+        subtitle: subtitle,
+        trailing: Switch.adaptive(
+          value: value,
+          activeThumbColor: context.facteurColors.primary,
+          onChanged: onChanged,
+        ),
+      ),
+    );
+  }
+}
+
+class _TileContent extends StatelessWidget {
+  const _TileContent({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.trailing,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final Widget trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: FacteurSpacing.space4,
+        vertical: FacteurSpacing.space3,
+      ),
+      child: Row(
+        children: [
+          Icon(icon, color: colors.primary, size: 22),
+          const SizedBox(width: FacteurSpacing.space3),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodySmall?.copyWith(color: colors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: FacteurSpacing.space2),
+          trailing,
+        ],
+      ),
+    );
+  }
+}
+
+class _Divider extends StatelessWidget {
+  const _Divider({required this.colors});
+
+  final FacteurColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Divider(
+      height: 1,
+      indent: FacteurSpacing.space4,
+      endIndent: FacteurSpacing.space4,
+      color: colors.border.withValues(alpha: 0.5),
+    );
+  }
+}

--- a/apps/mobile/lib/features/settings/screens/subscriptions_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/subscriptions_screen.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+import '../../../config/routes.dart';
 import '../../../config/theme.dart';
+import '../../../shared/widgets/buttons/primary_button.dart';
 import '../../sources/models/source_model.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../../sources/widgets/premium_source_connection.dart';
@@ -35,14 +38,26 @@ class SubscriptionsScreen extends ConsumerWidget {
             );
           }
           if (subscribed.isEmpty) {
-            return _EmptyState(colors: colors);
+            return _EmptyState(
+              colors: colors,
+              onAdd: () => _showAddSubscriptionSheet(context),
+            );
           }
-          return ListView.separated(
+          return ListView(
             padding: const EdgeInsets.all(FacteurSpacing.space4),
-            itemCount: subscribed.length,
-            separatorBuilder: (_, __) =>
-                const SizedBox(height: FacteurSpacing.space3),
-            itemBuilder: (_, i) => _SubscriptionTile(source: subscribed[i]),
+            children: [
+              PrimaryButton(
+                label: 'Ajouter un abonnement',
+                icon: PhosphorIcons.plus(PhosphorIconsStyle.bold),
+                onPressed: () => _showAddSubscriptionSheet(context),
+              ),
+              const SizedBox(height: FacteurSpacing.space4),
+              for (var i = 0; i < subscribed.length; i++) ...[
+                _SubscriptionTile(source: subscribed[i]),
+                if (i < subscribed.length - 1)
+                  const SizedBox(height: FacteurSpacing.space3),
+              ],
+            ],
           );
         }(),
       ),
@@ -52,7 +67,9 @@ class SubscriptionsScreen extends ConsumerWidget {
 
 class _EmptyState extends StatelessWidget {
   final FacteurColors colors;
-  const _EmptyState({required this.colors});
+  final VoidCallback onAdd;
+
+  const _EmptyState({required this.colors, required this.onAdd});
 
   @override
   Widget build(BuildContext context) {
@@ -78,13 +95,19 @@ class _EmptyState extends StatelessWidget {
             ),
             const SizedBox(height: FacteurSpacing.space2),
             Text(
-              'Connecte un abonnement à un média payant depuis sa fiche pour '
-              'lire ses articles directement dans Facteur.',
+              'Connecte un média payant que tu suis déjà pour lire ses '
+              'articles directement dans Facteur.',
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     color: colors.textSecondary,
                     height: 1.45,
                   ),
+            ),
+            const SizedBox(height: FacteurSpacing.space6),
+            PrimaryButton(
+              label: 'Ajouter un abonnement',
+              icon: PhosphorIcons.plus(PhosphorIconsStyle.bold),
+              onPressed: onAdd,
             ),
           ],
         ),
@@ -133,15 +156,13 @@ class _SubscriptionTile extends ConsumerWidget {
                       builder: (context, snap) {
                         final active = snap.data ?? false;
                         return Text(
-                          active
-                              ? 'Session active'
-                              : 'Reconnexion nécessaire',
-                          style:
-                              Theme.of(context).textTheme.labelSmall?.copyWith(
-                                    color: active
-                                        ? colors.success
-                                        : colors.warning,
-                                  ),
+                          active ? 'Session active' : 'Reconnexion nécessaire',
+                          style: Theme.of(context)
+                              .textTheme
+                              .labelSmall
+                              ?.copyWith(
+                                color: active ? colors.success : colors.warning,
+                              ),
                         );
                       },
                     ),
@@ -175,11 +196,13 @@ class _SubscriptionTile extends ConsumerWidget {
   }
 
   Future<void> _reconnect(BuildContext context, WidgetRef ref) async {
-    if (source.premiumConnection == null) return;
+    final connection = resolvePremiumConnection(source);
+    if (connection == null) return;
     await Navigator.of(context).push<void>(
       MaterialPageRoute(
         builder: (_) => PremiumSourceConnection(
           source: source,
+          connection: connection,
           onConnected: () => ref
               .read(userSourcesProvider.notifier)
               .connectSubscription(source.id),
@@ -193,5 +216,279 @@ class _SubscriptionTile extends ConsumerWidget {
         .read(userSourcesProvider.notifier)
         .disconnectSubscription(source.id);
     await ref.read(premiumSessionStoreProvider).clearForSource(source);
+  }
+}
+
+Future<void> _showAddSubscriptionSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => const _AddSubscriptionSheet(),
+  );
+}
+
+class _AddSubscriptionSheet extends ConsumerStatefulWidget {
+  const _AddSubscriptionSheet();
+
+  @override
+  ConsumerState<_AddSubscriptionSheet> createState() =>
+      _AddSubscriptionSheetState();
+}
+
+class _AddSubscriptionSheetState extends ConsumerState<_AddSubscriptionSheet> {
+  final _searchController = TextEditingController();
+  String _query = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController.addListener(() {
+      setState(() => _query = _searchController.text.trim().toLowerCase());
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final eligible = ref.watch(eligibleSubscriptionSourcesProvider);
+    final visible = _query.isEmpty
+        ? eligible
+        : eligible
+            .where((source) => source.name.toLowerCase().contains(_query))
+            .toList();
+
+    return FractionallySizedBox(
+      heightFactor: 0.82,
+      child: Material(
+        color: colors.backgroundPrimary,
+        borderRadius: const BorderRadius.vertical(
+          top: Radius.circular(FacteurRadius.large),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: SafeArea(
+          top: false,
+          child: Column(
+            children: [
+              const SizedBox(height: FacteurSpacing.space3),
+              Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: colors.border,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  FacteurSpacing.space4,
+                  FacteurSpacing.space4,
+                  FacteurSpacing.space2,
+                  FacteurSpacing.space3,
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'Ajouter un abonnement',
+                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                              fontWeight: FontWeight.w700,
+                            ),
+                      ),
+                    ),
+                    IconButton(
+                      tooltip: 'Fermer',
+                      onPressed: () => Navigator.of(context).pop(),
+                      icon: Icon(
+                        PhosphorIcons.x(PhosphorIconsStyle.regular),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (eligible.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(
+                    FacteurSpacing.space4,
+                    0,
+                    FacteurSpacing.space4,
+                    FacteurSpacing.space3,
+                  ),
+                  child: TextField(
+                    controller: _searchController,
+                    decoration: InputDecoration(
+                      hintText: 'Rechercher parmi mes sources suivies',
+                      prefixIcon: Icon(
+                        PhosphorIcons.magnifyingGlass(
+                          PhosphorIconsStyle.regular,
+                        ),
+                      ),
+                    ),
+                    onTapOutside: (_) => FocusScope.of(context).unfocus(),
+                  ),
+                ),
+              Expanded(
+                child: eligible.isEmpty
+                    ? _NoEligibleSources(
+                        onChooseSources: () {
+                          final router = GoRouter.of(context);
+                          Navigator.of(context).pop();
+                          router.pushNamed(RouteNames.sources);
+                        },
+                      )
+                    : visible.isEmpty
+                        ? Center(
+                            child: Text(
+                              'Aucun média ne correspond à cette recherche.',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodyMedium
+                                  ?.copyWith(color: colors.textSecondary),
+                            ),
+                          )
+                        : ListView.separated(
+                            padding: const EdgeInsets.fromLTRB(
+                              FacteurSpacing.space4,
+                              0,
+                              FacteurSpacing.space4,
+                              FacteurSpacing.space6,
+                            ),
+                            itemCount: visible.length,
+                            separatorBuilder: (_, __) => Divider(
+                              color: colors.border.withValues(alpha: 0.5),
+                            ),
+                            itemBuilder: (_, index) => _EligibleSourceTile(
+                              source: visible[index],
+                            ),
+                          ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NoEligibleSources extends StatelessWidget {
+  const _NoEligibleSources({required this.onChooseSources});
+
+  final VoidCallback onChooseSources;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(FacteurSpacing.space6),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              PhosphorIcons.newspaper(PhosphorIconsStyle.regular),
+              size: 44,
+              color: colors.textTertiary,
+            ),
+            const SizedBox(height: FacteurSpacing.space4),
+            Text(
+              'Aucun média payant suivi',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+            const SizedBox(height: FacteurSpacing.space2),
+            Text(
+              'Suis d’abord un média payant dans Mes sources pour pouvoir '
+              'connecter ton abonnement.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: colors.textSecondary,
+                    height: 1.4,
+                  ),
+            ),
+            const SizedBox(height: FacteurSpacing.space6),
+            OutlinedButton.icon(
+              onPressed: onChooseSources,
+              icon: Icon(PhosphorIcons.bookOpen(PhosphorIconsStyle.regular)),
+              label: const Text('Choisir mes sources'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EligibleSourceTile extends ConsumerWidget {
+  const _EligibleSourceTile({required this.source});
+
+  final Source source;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final connection = resolvePremiumConnection(source)!;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: FacteurSpacing.space2),
+      child: Row(
+        children: [
+          SourceLogoAvatar(source: source, size: 40),
+          const SizedBox(width: FacteurSpacing.space3),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  source.name,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  connection.isGeneric
+                      ? 'Connexion sur le site du média'
+                      : 'Connexion guidée disponible',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colors.textSecondary,
+                      ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: FacteurSpacing.space2),
+          TextButton(
+            onPressed: () => _connect(context, ref, connection),
+            child: Text(connection.isGeneric ? 'Associer' : 'Connecter'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _connect(
+    BuildContext context,
+    WidgetRef ref,
+    PremiumConnection connection,
+  ) {
+    return Navigator.of(context).push<void>(
+      MaterialPageRoute(
+        builder: (_) => PremiumSourceConnection(
+          source: source,
+          connection: connection,
+          onConnected: () => ref
+              .read(userSourcesProvider.notifier)
+              .connectSubscription(source.id),
+        ),
+      ),
+    );
   }
 }

--- a/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
@@ -6,9 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
-import 'package:url_launcher/url_launcher.dart';
 
-import '../../../config/constants.dart';
 import '../../../config/routes.dart';
 import '../../../config/serein_colors.dart';
 import '../../../config/theme.dart';
@@ -72,8 +70,9 @@ class SettingsSheet extends ConsumerWidget {
                   alignment: Alignment.centerLeft,
                   child: Text(
                     'Réglages',
-                    style: FacteurTypography.serifTitle(colors.textPrimary)
-                        .copyWith(fontSize: 28, height: 1.15),
+                    style: FacteurTypography.serifTitle(
+                      colors.textPrimary,
+                    ).copyWith(fontSize: 28, height: 1.15),
                   ),
                 ),
               ),
@@ -97,8 +96,6 @@ class SettingsSheet extends ConsumerWidget {
                       _ContentShortcuts(),
                       SizedBox(height: FacteurSpacing.space4),
                       _FeedbackTile(),
-                      SizedBox(height: FacteurSpacing.space4),
-                      _LegalShortcuts(),
                     ],
                   ),
                 ),
@@ -351,6 +348,12 @@ class _ContentShortcuts extends ConsumerWidget {
           ),
           const _Divider(),
           _ShortcutTile(
+            icon: PhosphorIcons.palette(PhosphorIconsStyle.regular),
+            label: 'Apparence',
+            onTap: () => context.pushNamed(RouteNames.appearance),
+          ),
+          const _Divider(),
+          _ShortcutTile(
             icon: PhosphorIcons.bookmarkSimple(PhosphorIconsStyle.regular),
             label: 'Sauvegardés',
             onTap: () => context.pushNamed(RouteNames.saved),
@@ -376,10 +379,7 @@ Future<void> _showVeilleManageMenu(BuildContext context, WidgetRef ref) async {
             onTap: () => Navigator.of(sheetContext).pop('edit'),
           ),
           ListTile(
-            leading: Icon(
-              PhosphorIcons.archive(),
-              color: Colors.red.shade700,
-            ),
+            leading: Icon(PhosphorIcons.archive(), color: Colors.red.shade700),
             title: Text(
               'Archiver',
               style: TextStyle(color: Colors.red.shade700),
@@ -401,7 +401,10 @@ Future<void> _showVeilleManageMenu(BuildContext context, WidgetRef ref) async {
   }
 }
 
-Future<void> _confirmAndArchiveVeille(BuildContext context, WidgetRef ref) async {
+Future<void> _confirmAndArchiveVeille(
+  BuildContext context,
+  WidgetRef ref,
+) async {
   final confirmed = await showDialog<bool>(
     context: context,
     builder: (dialogContext) => AlertDialog(
@@ -431,9 +434,9 @@ Future<void> _confirmAndArchiveVeille(BuildContext context, WidgetRef ref) async
     ref.invalidate(veilleActiveConfigProvider);
     ref.invalidate(userInterestsProvider);
     if (!context.mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Veille archivée')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Veille archivée')));
   } catch (_) {
     if (!context.mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
@@ -493,44 +496,6 @@ class _FeedbackTile extends ConsumerWidget {
   }
 }
 
-class _LegalShortcuts extends StatelessWidget {
-  const _LegalShortcuts();
-
-  Future<void> _open(String url) async {
-    final uri = Uri.parse(url);
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return _SheetCard(
-      child: Column(
-        children: [
-          _ShortcutTile(
-            icon: PhosphorIcons.shieldCheck(PhosphorIconsStyle.regular),
-            label: 'Politique de confidentialité',
-            onTap: () => _open(LegalLinks.privacy),
-          ),
-          const _Divider(),
-          _ShortcutTile(
-            icon: PhosphorIcons.fileText(PhosphorIconsStyle.regular),
-            label: 'Conditions d\'utilisation',
-            onTap: () => _open(LegalLinks.terms),
-          ),
-          const _Divider(),
-          _ShortcutTile(
-            icon: PhosphorIcons.lifebuoy(PhosphorIconsStyle.regular),
-            label: 'Contacter le support',
-            onTap: () => _open(LegalLinks.supportEmail),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
 class _ShortcutTile extends StatelessWidget {
   final IconData icon;
   final String label;
@@ -559,9 +524,9 @@ class _ShortcutTile extends StatelessWidget {
             Expanded(
               child: Text(
                 label,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
               ),
             ),
             Icon(
@@ -584,10 +549,7 @@ class _Divider extends StatelessWidget {
     final colors = context.facteurColors;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: FacteurSpacing.space4),
-      child: Container(
-        height: 1,
-        color: colors.border.withOpacity(0.5),
-      ),
+      child: Container(height: 1, color: colors.border.withOpacity(0.5)),
     );
   }
 }

--- a/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
@@ -317,15 +317,6 @@ class _ContentShortcuts extends ConsumerWidget {
       child: Column(
         children: [
           _ShortcutTile(
-            icon: PhosphorIcons.envelope(PhosphorIconsStyle.regular),
-            label: 'Progression',
-            onTap: () {
-              Navigator.of(context).pop();
-              context.pushNamed(RouteNames.lettres);
-            },
-          ),
-          const _Divider(),
-          _ShortcutTile(
             icon: PhosphorIcons.bookOpen(PhosphorIconsStyle.regular),
             label: 'Mes sources',
             onTap: () => context.pushNamed(RouteNames.sources),

--- a/apps/mobile/lib/features/sources/models/source_model.dart
+++ b/apps/mobile/lib/features/sources/models/source_model.dart
@@ -40,6 +40,28 @@ class PremiumConnection {
   bool get isUsable => enabled && loginUrl.isNotEmpty && testUrl.isNotEmpty;
 }
 
+/// Returns the usable premium connection for [source].
+///
+/// Paid sources without curated connection metadata fall back to their home
+/// page so users can still authenticate through the generic WebView flow.
+PremiumConnection? resolvePremiumConnection(Source source) {
+  final existing = source.premiumConnection;
+  if (existing != null && existing.isUsable) return existing;
+  if (!source.hasPaywall) return null;
+
+  final url = source.url?.trim() ?? '';
+  if (!url.startsWith('http://') && !url.startsWith('https://')) return null;
+
+  return PremiumConnection(
+    loginUrl: url,
+    testUrl: url,
+    displayHint:
+        'Connecte-toi à ton compte sur le site du média, puis reviens lire '
+        'tes articles.',
+    isGeneric: true,
+  );
+}
+
 class Source {
   final String id;
   final String name;

--- a/apps/mobile/lib/features/sources/providers/sources_providers.dart
+++ b/apps/mobile/lib/features/sources/providers/sources_providers.dart
@@ -34,6 +34,21 @@ final subscribedSourcesProvider = Provider<List<Source>>((ref) {
   return sources.where((s) => s.hasSubscription).toList();
 });
 
+/// Followed paid sources that can be connected from « Mes abonnements ».
+final eligibleSubscriptionSourcesProvider = Provider<List<Source>>((ref) {
+  final sources =
+      ref.watch(userSourcesProvider).valueOrNull ?? const <Source>[];
+  return sources
+      .where(
+        (source) =>
+            source.isTrusted &&
+            !source.hasSubscription &&
+            resolvePremiumConnection(source) != null,
+      )
+      .toList()
+    ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+});
+
 typedef SmartSearchQuery = ({String query, String? contentType, bool expand});
 
 final smartSearchProvider =

--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -308,7 +308,9 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                 const SizedBox(height: 12),
                 // Gestion des favoris (sources + thèmes + veille, ordre libre,
                 // cap 5) centralisée dans « Composer ma Tournée ».
-                const ComposeTourneeButton(),
+                const ComposeTourneeButton(
+                  style: ComposeTourneeButtonStyle.secondary,
+                ),
                 const SizedBox(height: 8),
                 if (premiumSources.isNotEmpty)
                   _buildCollapsibleSection(
@@ -761,22 +763,38 @@ class _SourceSettingsCta extends StatelessWidget {
     final colors = context.facteurColors;
     final borderRadius = BorderRadius.circular(FacteurRadius.large);
     return Material(
-      color: colors.primary,
+      key: const Key('source-settings-cta'),
+      color: colors.surface,
       borderRadius: borderRadius,
       child: InkWell(
         onTap: () => context.pushNamed(RouteNames.sourceSettings),
         borderRadius: borderRadius,
-        child: Padding(
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: borderRadius,
+            border: Border.all(color: colors.surfaceElevated),
+          ),
           padding: const EdgeInsets.symmetric(
             horizontal: FacteurSpacing.space4,
-            vertical: FacteurSpacing.space4,
+            vertical: FacteurSpacing.space3,
           ),
           child: Row(
             children: [
-              Icon(
-                PhosphorIcons.slidersHorizontal(PhosphorIconsStyle.bold),
-                color: colors.surface,
-                size: 24,
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: colors.primary.withValues(alpha: 0.10),
+                ),
+                alignment: Alignment.center,
+                child: Icon(
+                  PhosphorIcons.slidersHorizontal(
+                    PhosphorIconsStyle.regular,
+                  ),
+                  color: colors.primary,
+                  size: 19,
+                ),
               ),
               const SizedBox(width: FacteurSpacing.space3),
               Expanded(
@@ -785,24 +803,24 @@ class _SourceSettingsCta extends StatelessWidget {
                   children: [
                     Text(
                       'Paramètres des sources',
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                            color: colors.surface,
-                            fontWeight: FontWeight.w700,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: colors.textPrimary,
+                            fontWeight: FontWeight.w600,
                           ),
                     ),
                     const SizedBox(height: 2),
                     Text(
                       'Langues, articles payants et abonnements',
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: colors.surface.withValues(alpha: 0.85),
+                            color: colors.textSecondary,
                           ),
                     ),
                   ],
                 ),
               ),
               Icon(
-                PhosphorIcons.caretRight(PhosphorIconsStyle.bold),
-                color: colors.surface,
+                PhosphorIcons.caretRight(PhosphorIconsStyle.regular),
+                color: colors.textTertiary,
                 size: 18,
               ),
             ],

--- a/apps/mobile/lib/features/sources/screens/sources_screen.dart
+++ b/apps/mobile/lib/features/sources/screens/sources_screen.dart
@@ -13,7 +13,6 @@ import '../../my_interests/models/user_interests_state.dart' show InterestState;
 import '../../my_interests/providers/user_sources_state_provider.dart';
 import '../../flux_continu/widgets/tournee_composer_sheet.dart';
 import '../../my_interests/widgets/interest_state_picker_sheet.dart';
-import '../../settings/providers/paid_content_provider.dart';
 import '../models/source_model.dart';
 import '../providers/sources_providers.dart';
 import '../widgets/source_list_item.dart';
@@ -161,15 +160,17 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
               title: const Text('Sources de confiance'),
               actions: [
                 IconButton(
-                  icon: Icon(PhosphorIcons.magnifyingGlass(
-                      PhosphorIconsStyle.regular)),
+                  icon: Icon(
+                    PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
+                  ),
                   onPressed: () => setState(() => _isSearching = true),
                 ),
                 Stack(
                   children: [
                     IconButton(
                       icon: Icon(
-                          PhosphorIcons.funnel(PhosphorIconsStyle.regular)),
+                        PhosphorIcons.funnel(PhosphorIconsStyle.regular),
+                      ),
                       onPressed: () => _showFilterSheet(colors),
                     ),
                     if (_hasActiveFilter)
@@ -212,14 +213,18 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
           data: (sources) {
             // Sort alphabetically
             var allSources = sources.toList()
-              ..sort((a, b) =>
-                  a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+              ..sort(
+                (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+              );
 
             // Apply search filter
             if (_searchQuery.isNotEmpty) {
               allSources = allSources
-                  .where((s) =>
-                      s.name.toLowerCase().contains(_searchQuery.toLowerCase()))
+                  .where(
+                    (s) => s.name.toLowerCase().contains(
+                          _searchQuery.toLowerCase(),
+                        ),
+                  )
                   .toList();
             }
 
@@ -227,9 +232,9 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
               return _scrollableCenter(
                 Text(
                   'Aucune source disponible',
-                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        color: colors.textSecondary,
-                      ),
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyLarge?.copyWith(color: colors.textSecondary),
                 ),
               );
             }
@@ -273,10 +278,9 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                     const SizedBox(height: 12),
                     Text(
                       'Aucune source pour ces filtres',
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodyMedium
-                          ?.copyWith(color: colors.textSecondary),
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: colors.textSecondary,
+                          ),
                     ),
                     const SizedBox(height: 8),
                     TextButton(
@@ -300,6 +304,8 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
               children: [
                 _IntroBlock(colors: colors),
                 const SizedBox(height: 12),
+                const _SourceSettingsCta(),
+                const SizedBox(height: 12),
                 // Gestion des favoris (sources + thèmes + veille, ordre libre,
                 // cap 5) centralisée dans « Composer ma Tournée ».
                 const ComposeTourneeButton(),
@@ -315,8 +321,6 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                     colors: colors,
                     icon: PhosphorIcons.star(PhosphorIconsStyle.fill),
                   ),
-                const _HidePaidToggleCard(),
-                const SizedBox(height: 8),
                 if (customSources.isNotEmpty)
                   _buildCollapsibleSection(
                     title: 'Mes sources personnalisees',
@@ -455,8 +459,10 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
                   ),
                 ),
                 Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
                   decoration: BoxDecoration(
                     color: titleColor.withOpacity(0.1),
                     borderRadius: BorderRadius.circular(10),
@@ -729,8 +735,9 @@ class _IntroBlock extends StatelessWidget {
         children: [
           Text(
             'Vos sources de confiance',
-            style: FacteurTypography.serifTitle(colors.textPrimary)
-                .copyWith(fontSize: 20, height: 1.2),
+            style: FacteurTypography.serifTitle(
+              colors.textPrimary,
+            ).copyWith(fontSize: 20, height: 1.2),
           ),
           const SizedBox(height: 6),
           Text(
@@ -746,81 +753,59 @@ class _IntroBlock extends StatelessWidget {
   }
 }
 
-// ─── Hide paid toggle card ──────────────────────────────────
-
-class _HidePaidToggleCard extends ConsumerWidget {
-  const _HidePaidToggleCard();
+class _SourceSettingsCta extends StatelessWidget {
+  const _SourceSettingsCta();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final hidePaid = ref.watch(hidePaidContentProvider);
     final borderRadius = BorderRadius.circular(FacteurRadius.large);
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 14),
-      child: Material(
-        color: colors.surface,
+    return Material(
+      color: colors.primary,
+      borderRadius: borderRadius,
+      child: InkWell(
+        onTap: () => context.pushNamed(RouteNames.sourceSettings),
         borderRadius: borderRadius,
-        child: InkWell(
-          onTap: () =>
-              ref.read(hidePaidContentProvider.notifier).toggle(!hidePaid),
-          borderRadius: borderRadius,
-          child: Container(
-            decoration: BoxDecoration(
-              borderRadius: borderRadius,
-              border: Border.all(color: colors.surfaceElevated),
-            ),
-            padding: const EdgeInsets.symmetric(
-              horizontal: FacteurSpacing.space4,
-              vertical: FacteurSpacing.space3,
-            ),
-            child: Row(
-              children: [
-                Container(
-                  width: 36,
-                  height: 36,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: colors.primary.withOpacity(0.10),
-                  ),
-                  alignment: Alignment.center,
-                  child: Icon(
-                    PhosphorIcons.lock(PhosphorIconsStyle.regular),
-                    color: colors.primary,
-                    size: 18,
-                  ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: FacteurSpacing.space4,
+            vertical: FacteurSpacing.space4,
+          ),
+          child: Row(
+            children: [
+              Icon(
+                PhosphorIcons.slidersHorizontal(PhosphorIconsStyle.bold),
+                color: colors.surface,
+                size: 24,
+              ),
+              const SizedBox(width: FacteurSpacing.space3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Paramètres des sources',
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                            color: colors.surface,
+                            fontWeight: FontWeight.w700,
+                          ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'Langues, articles payants et abonnements',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colors.surface.withValues(alpha: 0.85),
+                          ),
+                    ),
+                  ],
                 ),
-                const SizedBox(width: FacteurSpacing.space3),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Masquer les articles payants*',
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodyMedium
-                            ?.copyWith(fontWeight: FontWeight.w600),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        '*: Sauf abonnements connectés.',
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodySmall
-                            ?.copyWith(color: colors.textSecondary),
-                      ),
-                    ],
-                  ),
-                ),
-                Switch.adaptive(
-                  value: hidePaid,
-                  activeColor: colors.primary,
-                  onChanged: (v) =>
-                      ref.read(hidePaidContentProvider.notifier).toggle(v),
-                ),
-              ],
-            ),
+              ),
+              Icon(
+                PhosphorIcons.caretRight(PhosphorIconsStyle.bold),
+                color: colors.surface,
+                size: 18,
+              ),
+            ],
           ),
         ),
       ),

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -52,6 +52,7 @@ class SourceDetailModal extends ConsumerWidget {
             .firstOrNull ??
         source;
     final displaySource = liveSource;
+    final premiumConnection = resolvePremiumConnection(displaySource);
 
     return Container(
       padding: const EdgeInsets.all(24),
@@ -135,7 +136,8 @@ class SourceDetailModal extends ConsumerWidget {
             decoration: BoxDecoration(
               color: colors.backgroundSecondary,
               borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
+              border:
+                  Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
             ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -181,7 +183,8 @@ class SourceDetailModal extends ConsumerWidget {
               decoration: BoxDecoration(
                 color: colors.backgroundSecondary,
                 borderRadius: BorderRadius.circular(16),
-                border: Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
+                border: Border.all(
+                    color: colors.textTertiary.withValues(alpha: 0.2)),
               ),
               child: Row(
                 children: [
@@ -217,7 +220,8 @@ class SourceDetailModal extends ConsumerWidget {
               decoration: BoxDecoration(
                 color: colors.backgroundSecondary,
                 borderRadius: BorderRadius.circular(16),
-                border: Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
+                border: Border.all(
+                    color: colors.textTertiary.withValues(alpha: 0.2)),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -269,7 +273,8 @@ class SourceDetailModal extends ConsumerWidget {
             decoration: BoxDecoration(
               color: colors.surface,
               borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
+              border:
+                  Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
             ),
             child: Text(
               source.description ??
@@ -317,13 +322,17 @@ class SourceDetailModal extends ConsumerWidget {
             // CTA abonnement premium — proéminent (primary, en tête) pour les
             // sources payantes. Label selon l'état : déjà abonné / config
             // générique (« Associer ») / config curée (« Connecter »).
-            if (displaySource.premiumConnection != null) ...[
+            if (premiumConnection != null) ...[
               FacteurButton(
-                onPressed: () =>
-                    _openPremiumConnectionFlow(context, ref, displaySource),
+                onPressed: () => _openPremiumConnectionFlow(
+                  context,
+                  ref,
+                  displaySource,
+                  premiumConnection,
+                ),
                 label: displaySource.hasSubscription
                     ? 'Reconnecter cet abonnement'
-                    : (displaySource.premiumConnection!.isGeneric
+                    : (premiumConnection.isGeneric
                         ? 'Associer mon abonnement'
                         : 'Connecter mon abonnement'),
                 type: displaySource.hasPaywall
@@ -351,7 +360,7 @@ class SourceDetailModal extends ConsumerWidget {
                         ? 'Ne plus suivre'
                         : 'Ajouter comme source de confiance'),
                 type: (!isSelected &&
-                        !(displaySource.premiumConnection != null &&
+                        !(premiumConnection != null &&
                             displaySource.hasPaywall))
                     ? FacteurButtonType.primary
                     : FacteurButtonType.secondary,
@@ -463,6 +472,7 @@ class SourceDetailModal extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     Source source,
+    PremiumConnection connection,
   ) async {
     final navigator = Navigator.of(context);
     navigator.pop();
@@ -471,6 +481,7 @@ class SourceDetailModal extends ConsumerWidget {
       MaterialPageRoute(
         builder: (_) => PremiumSourceConnection(
           source: source,
+          connection: connection,
           onConnected: () => ref
               .read(userSourcesProvider.notifier)
               .connectSubscription(source.id),

--- a/apps/mobile/test/features/flux_continu/widgets/tournee_composer_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/tournee_composer_sheet_test.dart
@@ -103,6 +103,22 @@ void main() {
     expect(find.text('BLOCS DE TA PAGE L\'ESSENTIEL'), findsOneWidget);
   });
 
+  testWidgets('ComposeTourneeButton supports a secondary visual hierarchy',
+      (tester) async {
+    await tester.pumpWidget(
+      _host(
+        const ComposeTourneeButton(
+          style: ComposeTourneeButtonStyle.secondary,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(OutlinedButton), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsNothing);
+    expect(find.text('Composer ma Tournée'), findsOneWidget);
+  });
+
   testWidgets('showTourneeComposerSheet ouvre la sheet unifiée',
       (tester) async {
     await tester.pumpWidget(

--- a/apps/mobile/test/features/settings/screens/appearance_screen_test.dart
+++ b/apps/mobile/test/features/settings/screens/appearance_screen_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/settings/screens/appearance_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:hive/hive.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    await Hive.openBox<dynamic>('settings');
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  Widget buildScreen() {
+    return ProviderScope(
+      child: MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: const AppearanceScreen(),
+      ),
+    );
+  }
+
+  testWidgets('opens theme and article display selectors', (tester) async {
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(buildScreen());
+
+    expect(find.text('Apparence'), findsOneWidget);
+    expect(find.text('Thème'), findsOneWidget);
+    expect(find.text('Affichage des articles'), findsOneWidget);
+
+    await tester.tap(find.text('Thème'));
+    await tester.pumpAndSettle();
+    expect(find.text('Comment préférez-vous lire ?'), findsOneWidget);
+
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Affichage des articles'));
+    await tester.pumpAndSettle();
+    expect(find.text('Comment veux-tu voir tes articles ?'), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/features/settings/screens/source_settings_screen_test.dart
+++ b/apps/mobile/test/features/settings/screens/source_settings_screen_test.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/settings/providers/language_preference_provider.dart';
+import 'package:facteur/features/settings/screens/source_settings_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:hive/hive.dart';
+
+class _FakeLanguagePreferenceNotifier
+    extends StateNotifier<LanguagePreferenceState>
+    implements LanguagePreferenceNotifier {
+  _FakeLanguagePreferenceNotifier()
+      : super(const LanguagePreferenceState(
+          hideNonFr: true,
+          userSet: true,
+          synced: true,
+        ));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    await Hive.openBox<dynamic>('settings');
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  testWidgets('groups subscriptions, paid content and language settings',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          languagePreferenceProvider.overrideWith(
+            (ref) => _FakeLanguagePreferenceNotifier(),
+          ),
+        ],
+        child: MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: const SourceSettingsScreen(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Paramètres des sources'), findsOneWidget);
+    expect(find.text('Mes abonnements'), findsOneWidget);
+    expect(find.text('Masquer les articles payants'), findsOneWidget);
+    expect(find.text('Masquer les sources non françaises'), findsOneWidget);
+
+    final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
+    expect(switches, hasLength(2));
+    expect(switches.every((toggle) => toggle.value), isTrue);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+}

--- a/apps/mobile/test/features/settings/screens/subscriptions_screen_test.dart
+++ b/apps/mobile/test/features/settings/screens/subscriptions_screen_test.dart
@@ -66,18 +66,22 @@ Source _source({
   required String id,
   required String name,
   bool hasSubscription = false,
+  bool isTrusted = false,
+  bool hasPaywall = true,
+  PremiumConnection? premiumConnection = const PremiumConnection(
+    loginUrl: 'https://example.com/login',
+    testUrl: 'https://example.com/test',
+  ),
 }) =>
     Source(
       id: id,
       name: name,
       type: SourceType.article,
       url: 'https://$id.example',
+      isTrusted: isTrusted,
       hasSubscription: hasSubscription,
-      hasPaywall: true,
-      premiumConnection: const PremiumConnection(
-        loginUrl: 'https://example.com/login',
-        testUrl: 'https://example.com/test',
-      ),
+      hasPaywall: hasPaywall,
+      premiumConnection: premiumConnection,
     );
 
 void main() {
@@ -92,14 +96,98 @@ void main() {
     expect(find.text('Free Blog'), findsNothing);
     expect(find.text('Reconnecter'), findsOneWidget);
     expect(find.text('Dissocier'), findsOneWidget);
+    expect(find.text('Ajouter un abonnement'), findsOneWidget);
   });
 
-  testWidgets('shows empty state when no subscriptions', (tester) async {
+  testWidgets('empty state opens fallback when no followed paid source',
+      (tester) async {
     await tester.pumpWidget(_wrap([
-      _source(id: 'freeblog', name: 'Free Blog'),
+      _source(
+        id: 'freeblog',
+        name: 'Free Blog',
+        isTrusted: true,
+        hasPaywall: false,
+        premiumConnection: null,
+      ),
     ]));
     await tester.pumpAndSettle();
 
     expect(find.text('Aucun abonnement connecté'), findsOneWidget);
+    expect(find.text('Ajouter un abonnement'), findsOneWidget);
+
+    await tester.tap(find.text('Ajouter un abonnement'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Aucun média payant suivi'), findsOneWidget);
+    expect(find.text('Choisir mes sources'), findsOneWidget);
+  });
+
+  testWidgets('lists only followed connectable paid sources in add sheet',
+      (tester) async {
+    await tester.pumpWidget(_wrap([
+      _source(id: 'lemonde', name: 'Le Monde', isTrusted: true),
+      _source(id: 'mediapart', name: 'Mediapart', isTrusted: true),
+      _source(id: 'unfollowed', name: 'Non suivi'),
+      _source(
+        id: 'freeblog',
+        name: 'Gratuit suivi',
+        isTrusted: true,
+        hasPaywall: false,
+        premiumConnection: null,
+      ),
+      _source(
+        id: 'connected',
+        name: 'Déjà connecté',
+        isTrusted: true,
+        hasSubscription: true,
+      ),
+    ]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Ajouter un abonnement').first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Le Monde'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(ListView),
+        matching: find.text('Mediapart'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Non suivi'), findsNothing);
+    expect(find.text('Gratuit suivi'), findsNothing);
+    expect(find.text('Déjà connecté'), findsOneWidget);
+
+    await tester.enterText(
+      find.byType(TextField),
+      'Mediapart',
+    );
+    await tester.pump();
+
+    expect(
+      find.descendant(
+        of: find.byType(ListView),
+        matching: find.text('Mediapart'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Le Monde'), findsNothing);
+  });
+
+  testWidgets('connect action opens the existing premium connection flow',
+      (tester) async {
+    await tester.pumpWidget(_wrap([
+      _source(id: 'lemonde', name: 'Le Monde', isTrusted: true),
+    ]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Ajouter un abonnement'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Connecter'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Connecter votre abonnement'), findsOneWidget);
+    expect(find.text('Commencer'), findsOneWidget);
   });
 }

--- a/apps/mobile/test/features/settings/widgets/settings_sheet_test.dart
+++ b/apps/mobile/test/features/settings/widgets/settings_sheet_test.dart
@@ -1,0 +1,64 @@
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
+import 'package:facteur/features/lettres/models/letter_progress.dart';
+import 'package:facteur/features/lettres/providers/letters_provider.dart';
+import 'package:facteur/features/settings/providers/user_profile_provider.dart';
+import 'package:facteur/features/settings/widgets/settings_sheet.dart';
+import 'package:facteur/features/veille/models/veille_config_dto.dart';
+import 'package:facteur/features/veille/providers/veille_active_config_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeProfileNotifier extends StateNotifier<UserProfile>
+    implements UserProfileNotifier {
+  _FakeProfileNotifier() : super(const UserProfile(displayName: 'Laurin'));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeSereinNotifier extends StateNotifier<SereinToggleState>
+    implements SereinToggleNotifier {
+  _FakeSereinNotifier()
+      : super(const SereinToggleState(enabled: false, isLoading: false));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeLettersNotifier extends LettersNotifier {
+  @override
+  Future<LetterProgressState> build() async =>
+      const LetterProgressState.empty();
+}
+
+class _FakeVeilleNotifier extends VeilleActiveConfigNotifier {
+  @override
+  Future<VeilleConfigDto?> build() async => null;
+}
+
+void main() {
+  testWidgets('global settings no longer duplicates Progression',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          userProfileProvider.overrideWith((ref) => _FakeProfileNotifier()),
+          sereinToggleProvider.overrideWith((ref) => _FakeSereinNotifier()),
+          lettersProvider.overrideWith(() => _FakeLettersNotifier()),
+          veilleActiveConfigProvider.overrideWith(() => _FakeVeilleNotifier()),
+        ],
+        child: MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: const Scaffold(body: SettingsSheet()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Mes sources'), findsOneWidget);
+    expect(find.text('Mes intérêts'), findsOneWidget);
+    expect(find.text('Progression'), findsNothing);
+  });
+}

--- a/apps/mobile/test/features/sources/models/source_model_test.dart
+++ b/apps/mobile/test/features/sources/models/source_model_test.dart
@@ -2,6 +2,60 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
 
 void main() {
+  group('resolvePremiumConnection', () {
+    test('uses curated connection when available', () {
+      const curated = PremiumConnection(
+        loginUrl: 'https://example.com/login',
+        testUrl: 'https://example.com/article',
+      );
+      final source = Source(
+        id: 'source',
+        name: 'Source',
+        type: SourceType.article,
+        hasPaywall: true,
+        premiumConnection: curated,
+      );
+
+      expect(resolvePremiumConnection(source), same(curated));
+    });
+
+    test('creates a generic fallback for a paid source with a valid URL', () {
+      final source = Source(
+        id: 'source',
+        name: 'Source',
+        type: SourceType.article,
+        url: 'https://example.com',
+        hasPaywall: true,
+      );
+
+      final connection = resolvePremiumConnection(source);
+
+      expect(connection, isNotNull);
+      expect(connection!.isGeneric, isTrue);
+      expect(connection.loginUrl, 'https://example.com');
+      expect(connection.testUrl, 'https://example.com');
+    });
+
+    test('rejects free sources and paid sources without a valid URL', () {
+      final free = Source(
+        id: 'free',
+        name: 'Free',
+        type: SourceType.article,
+        url: 'https://example.com',
+      );
+      final invalid = Source(
+        id: 'invalid',
+        name: 'Invalid',
+        type: SourceType.article,
+        url: 'example.com',
+        hasPaywall: true,
+      );
+
+      expect(resolvePremiumConnection(free), isNull);
+      expect(resolvePremiumConnection(invalid), isNull);
+    });
+  });
+
   group('Source.fromJson premiumConnection', () {
     test('parses usable premium_connection', () {
       final source = Source.fromJson({

--- a/apps/mobile/test/features/sources/screens/sources_screen_hierarchy_test.dart
+++ b/apps/mobile/test/features/sources/screens/sources_screen_hierarchy_test.dart
@@ -1,0 +1,69 @@
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/my_interests/models/user_sources_state.dart';
+import 'package:facteur/features/my_interests/providers/user_sources_state_provider.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/providers/sources_providers.dart';
+import 'package:facteur/features/sources/screens/sources_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeUserSourcesNotifier extends UserSourcesNotifier {
+  @override
+  Future<List<Source>> build() async => [
+        Source(
+          id: 'source',
+          name: 'Source',
+          type: SourceType.article,
+          isCurated: true,
+          isTrusted: true,
+        ),
+      ];
+}
+
+class _FakeSourcesStateNotifier extends UserSourcesStateNotifier {
+  @override
+  Future<UserSourcesState> build() async => const UserSourcesState(
+        sources: [],
+        favorites: [],
+        favoriteCount: 0,
+        favoriteCap: 5,
+      );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('source settings and tournee actions use neutral hierarchy',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          userSourcesProvider.overrideWith(_FakeUserSourcesNotifier.new),
+          userSourcesStateProvider.overrideWith(
+            _FakeSourcesStateNotifier.new,
+          ),
+        ],
+        child: MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: const SourcesScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final context = tester.element(find.byType(SourcesScreen));
+    final colors = context.facteurColors;
+    final settingsMaterial = tester.widget<Material>(
+      find.byKey(const Key('source-settings-cta')),
+    );
+
+    expect(settingsMaterial.color, colors.surface);
+    expect(find.widgetWithText(OutlinedButton, 'Composer ma Tournée'),
+        findsOneWidget);
+    expect(find.text('Ajouter une source'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Quoi
Regroupe les réglages dispersés dans deux nouveaux écrans dédiés :
- **AppearanceScreen** — thème + mode d'affichage des articles
- **SourceSettingsScreen** — abonnements, contenu payant, langue

Les sections correspondantes sont retirées de `account_screen`, `profile_screen`, `settings_sheet`, `sources_screen` et `my_interests_screen`, et les routes associées sont ajoutées.

## Pourquoi
Les paramètres étaient éparpillés entre plusieurs écrans (profil, compte, feuille de réglages, sources), ce qui rendait la navigation confuse. Cette refonte centralise apparence et réglages de sources dans des points d'entrée clairs.

## Comment ça a été vérifié
- [x] `flutter test test/features/settings` — 25 tests OK (dont 2 nouveaux écrans)
- [x] `flutter analyze` sur les fichiers touchés — 0 erreur (seuls des info/warnings pré-existants : `withOpacity`/`activeColor` deprecations)
- [x] /simplify passé — refactor propre, pas de régression (langue + contenu payant bien migrés dans SourceSettingsScreen, confirmé par test)

## Zones à risque
Navigation/router (`routes.dart`) et état des providers de réglages (thème, affichage, langue, contenu payant) — déplacés sans changement de logique, providers réutilisés tels quels.