### PR TITLE
fix(scaling): robustesse DB — worker classif sans idle-in-tx + hygiène stockage

### DIFF
--- a/docs/maintenance/maintenance-scaling-db-robustness.md
+++ b/docs/maintenance/maintenance-scaling-db-robustness.md
@@ -1,0 +1,24 @@
+# Maintenance — Robustesse DB (scaling phase 2, PR-S1 + hygiène G5)
+
+## Contexte
+Phase 2 scaling (cf. `docs/scaling/scaling-investigation-200-users.md`). Signal prod : `IdleInTransactionSessionTimeout` (Sentry) + sessions tuées par le `zombie_session_sweeper`. Le sweeper est un pansement ; cette PR corrige la cause racine et traite l'hygiène stockage connue du baseline.
+
+## Cause racine identifiée (G1)
+`classification_worker._process_batch()` (app/workers/classification_worker.py:174-368) : après le commit de `dequeue_batch`, les `session.get(Content/Source)` ouvrent une **nouvelle transaction qui reste idle pendant 90-180 s d'appels Mistral séquentiels** (classif batch + retries individuels + entités + good-news pass). Le timeout serveur `idle_in_transaction_session_timeout=60s` tue la session → écritures de résultats en échec, retries, et bruit sweeper/Sentry.
+
+## Changements
+1. **Worker classification** : `_process_batch` restructuré en 3 phases — session courte (dequeue + chargement batché des contents/sources, snapshot en dicts), appels Mistral **hors session**, session courte d'écriture des résultats. Bonus : suppression du N+1 (`session.get` par item → 2 `SELECT ... WHERE id IN`).
+2. **DROP `ix_user_content_status_exclusion`** : index 5 colonnes jamais utilisé par le planner (EXPLAIN baseline 2026-06-04 §3) ; coût write-amplification sur chaque interaction. Migration idempotente (`IF EXISTS`), non destructive pour l'ancien code prod (un index en moins ne casse aucune requête). Retiré du modèle `Content`/`UserContentStatus`.
+3. **Purge `classification_queue`** : les lignes `completed`/`failed` s'accumulent (26 MB d'index au baseline). Purge des lignes terminées depuis > 30 jours, ajoutée au job `storage_cleanup` (03:00 Paris). 30 j ≫ la fenêtre de requeue 48 h de `requeue_for_reclassification`.
+
+## Hors périmètre
+Right-size du pool (attendre les données de la sonde phase A) ; mode pooler transaction ; découplage worker (S2).
+
+## Tests
+- [ ] Unitaires worker : session fermée pendant les appels LLM (assertion sur le session_maker), résultats écrits, retries préservés.
+- [ ] Migration : 1 head, upgrade/downgrade DB vide, idempotence.
+- [ ] Purge : supprime les vieilles lignes terminées, préserve pending/processing et les récentes.
+- [ ] `pytest -v` complet.
+
+## Acceptation post-deploy
+Zéro `IdleInTransactionSessionTimeout` lié au worker sur 48 h ; `zombie_session_sweeper_killed` silencieux ; taille `classification_queue` en baisse après le premier cleanup.

--- a/packages/api/alembic/versions/sc01_drop_dead_ucs_exclusion_index.py
+++ b/packages/api/alembic/versions/sc01_drop_dead_ucs_exclusion_index.py
@@ -1,0 +1,32 @@
+"""drop dead index ix_user_content_status_exclusion
+
+Hygiène stockage (scaling phase 2, G5). L'index 5 colonnes
+ix_user_content_status_exclusion n'est jamais choisi par le planner (EXPLAIN
+du baseline 2026-06-04 §3 : les requêtes d'exclusion passent par
+uq_user_content_status_user_content) ; il ne coûte que de la
+write-amplification sur chaque interaction user. DROP idempotent, sans danger
+pour l'ancien code prod (un index en moins ne casse aucune requête).
+
+Revision ID: sc01_drop_ucs_excl_idx
+Revises: mg01_merge_au01_rsvps
+Create Date: 2026-06-13
+
+"""
+
+from alembic import op
+
+revision: str = "sc01_drop_ucs_excl_idx"
+down_revision: str | None = "mg01_merge_au01_rsvps"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_user_content_status_exclusion")
+
+
+def downgrade() -> None:
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_user_content_status_exclusion "
+        "ON user_content_status (user_id, content_id, is_hidden, is_saved, status)"
+    )

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -78,9 +78,7 @@ async def compute_digest_coverage(
         .group_by(DailyDigest.user_id, DailyDigest.is_serene)
         .subquery()
     )
-    pair_count = (
-        await session.scalar(select(func.count()).select_from(pair_subq)) or 0
-    )
+    pair_count = await session.scalar(select(func.count()).select_from(pair_subq)) or 0
     coverage = pair_count / expected_pairs if expected_pairs else 0.0
     return total_users, pair_count, coverage
 

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -526,7 +526,6 @@ app.include_router(
 )
 
 
-
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     """Log all uncaught exceptions and forward to Sentry."""

--- a/packages/api/app/models/content.py
+++ b/packages/api/app/models/content.py
@@ -136,16 +136,6 @@ class UserContentStatus(Base):
         Index("ix_user_content_status_user_saved", "user_id", "is_saved"),
         Index("ix_user_content_status_user_liked", "user_id", "is_liked"),
         Index("ix_user_content_status_user_status", "user_id", "status"),
-        # Performance index for digest exclusion queries
-        # Used in _get_candidates() EXISTS subquery that filters out seen/saved/hidden content
-        Index(
-            "ix_user_content_status_exclusion",
-            "user_id",
-            "content_id",
-            "is_hidden",
-            "is_saved",
-            "status",
-        ),
     )
 
     id: Mapped[UUID] = mapped_column(

--- a/packages/api/app/services/content_service.py
+++ b/packages/api/app/services/content_service.py
@@ -135,8 +135,7 @@ class ContentService:
         result = await self.session.scalars(stmt)
         updated_status = result.one_or_none()
         transitioned_to_consumed = (
-            update_data.status == ContentStatus.CONSUMED
-            and updated_status is not None
+            update_data.status == ContentStatus.CONSUMED and updated_status is not None
         )
 
         if updated_status is None:

--- a/packages/api/app/services/letters/catalog.py
+++ b/packages/api/app/services/letters/catalog.py
@@ -168,8 +168,7 @@ LETTER_3: dict = {
                 "ajoute une note : une idée, une citation, un pourquoi."
             ),
             "completion_palier": (
-                "Première note posée. Lire, c'est bien ; garder une trace, "
-                "c'est mieux."
+                "Première note posée. Lire, c'est bien ; garder une trace, c'est mieux."
             ),
             "target_route": "/saved",
         },
@@ -193,8 +192,7 @@ LETTER_3: dict = {
                 "rejoignent ta tournée."
             ),
             "completion_palier": (
-                "Cinq chaînes dans la tournée. Ta sélection ne se limite "
-                "plus au texte."
+                "Cinq chaînes dans la tournée. Ta sélection ne se limite plus au texte."
             ),
             "target_route": "/settings/sources/add",
         },
@@ -217,20 +215,15 @@ LETTER_4: dict = {
     "title": "Facteur de fond",
     "default_status": "upcoming",
     "intro_palier": (
-        "Dernière lettre. Ici, on ne compte plus les gestes : on mesure "
-        "l'endurance."
+        "Dernière lettre. Ici, on ne compte plus les gestes : on mesure l'endurance."
     ),
     "actions": [
         {
             "id": "read_50_articles",
             "label": "Lire 50 articles",
-            "help": (
-                "Cinquante articles, à ton rythme. La régularité fait le "
-                "reste."
-            ),
+            "help": ("Cinquante articles, à ton rythme. La régularité fait le reste."),
             "completion_palier": (
-                "Cinquante lectures. Tu n'es plus un visiteur, tu es un "
-                "habitué."
+                "Cinquante lectures. Tu n'es plus un visiteur, tu es un habitué."
             ),
             "target_route": "/flaner",
         },
@@ -254,8 +247,7 @@ LETTER_4: dict = {
                 "les angles. Dix comparaisons aiguisent le regard."
             ),
             "completion_palier": (
-                "Dix sujets vus sous plusieurs angles. Le doute méthodique "
-                "te va bien."
+                "Dix sujets vus sous plusieurs angles. Le doute méthodique te va bien."
             ),
             "target_route": "/flaner",
         },

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -1642,9 +1642,7 @@ class RecommendationService:
                                 Source.is_active == True,  # noqa: E712
                             )
                             .group_by(UserSource.source_id)
-                            .having(
-                                func.count(Content.id) < QUIET_SOURCE_MAX_RECENT
-                            )
+                            .having(func.count(Content.id) < QUIET_SOURCE_MAX_RECENT)
                         )
                     )
                     .scalars()
@@ -1670,9 +1668,7 @@ class RecommendationService:
                     quiet_articles = list(
                         (await self.session.scalars(latest_per_source)).all()
                     )
-                    quiet_articles.sort(
-                        key=lambda c: c.published_at, reverse=True
-                    )
+                    quiet_articles.sort(key=lambda c: c.published_at, reverse=True)
                     quiet_articles = quiet_articles[:MAX_CAROUSEL_ITEMS]
 
                 logger.info(

--- a/packages/api/app/workers/classification_worker.py
+++ b/packages/api/app/workers/classification_worker.py
@@ -223,9 +223,7 @@ class ClassificationWorker:
                         "retry_count": item.retry_count,
                         "has_content": content is not None,
                         "title": (content.title or "") if content else "",
-                        "description": (content.description or "")
-                        if content
-                        else "",
+                        "description": (content.description or "") if content else "",
                         "source_name": source.name if source else "",
                     }
                 )

--- a/packages/api/app/workers/classification_worker.py
+++ b/packages/api/app/workers/classification_worker.py
@@ -8,6 +8,7 @@ import asyncio
 import contextlib
 from datetime import datetime
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
@@ -166,11 +167,19 @@ class ClassificationWorker:
             logger.error("classification_worker.reset_stale_failed", error=str(e))
 
     async def _process_batch(self):
-        """Process one batch of pending items using batch API call."""
+        """Process one batch of pending items using batch API call.
+
+        3 phases pour ne jamais tenir une transaction DB pendant les appels
+        Mistral (90-180 s au pire) : le timeout serveur
+        idle_in_transaction_session_timeout=60s tuait la session mi-batch
+        (cause racine des IdleInTransactionSessionTimeout Sentry et des kills
+        du zombie_session_sweeper).
+        """
         import structlog
 
         logger = structlog.get_logger()
 
+        # Phase 1 — session courte : dequeue + snapshot des données du batch.
         async with self.session_maker() as session:
             service = ClassificationQueueService(session)
 
@@ -181,154 +190,181 @@ class ClassificationWorker:
 
             logger.info("classification_worker.processing_batch", count=len(items))
 
-            # Load all contents and sources
-            contents: list[Content | None] = []
-            sources: list[Source | None] = []
-            for item in items:
-                content = await session.get(Content, item.content_id)
-                contents.append(content)
-                if content and content.source_id:
-                    source = await session.get(Source, content.source_id)
-                    sources.append(source)
-                else:
-                    sources.append(None)
+            # Load all contents and sources (2 SELECT batchés, pas de N+1)
+            content_rows = await session.execute(
+                select(Content).where(
+                    Content.id.in_([item.content_id for item in items])
+                )
+            )
+            contents_by_id = {c.id: c for c in content_rows.scalars()}
+            contents = [contents_by_id.get(item.content_id) for item in items]
 
-            # Build batch for API call
-            batch_items: list[dict] = []
-            batch_indices: list[int] = []  # Maps batch position → items index
+            source_ids = {c.source_id for c in contents if c and c.source_id}
+            sources_by_id: dict = {}
+            if source_ids:
+                source_rows = await session.execute(
+                    select(Source).where(Source.id.in_(source_ids))
+                )
+                sources_by_id = {s.id: s for s in source_rows.scalars()}
 
-            for i, (item, content, source) in enumerate(
-                zip(items, contents, sources, strict=False)
-            ):
-                if content and content.title:
-                    batch_items.append(
-                        {
-                            "title": content.title or "",
-                            "description": content.description or "",
-                            "source_name": source.name if source else "",
-                        }
-                    )
-                    batch_indices.append(i)
-
-            # Call Mistral API in batch
-            classifier = self._get_classifier()
-            all_results: list[dict] = []
-
-            if classifier and classifier.is_ready() and batch_items:
-                # Step 1: Classify (topics + serene only)
-                all_results = await classifier.classify_batch_async(batch_items)
-
-                # Retry individually for each article that got empty topics
-                empty_indices = [
-                    idx for idx, r in enumerate(all_results) if not r.get("topics")
-                ]
-                if empty_indices:
-                    logger.info(
-                        "classification_worker.individual_retry",
-                        total=len(batch_items),
-                        empty=len(empty_indices),
-                    )
-                    for idx in empty_indices:
-                        bi = batch_items[idx]
-                        result = await classifier.classify_async(
-                            title=bi["title"],
-                            description=bi.get("description", ""),
-                            source_name=bi.get("source_name", ""),
-                        )
-                        if result.get("topics"):
-                            all_results[idx] = result
-
-                # Step 2: Extract entities (separate API call)
-                try:
-                    all_entities = await classifier.extract_entities_batch_async(
-                        batch_items
-                    )
-                    for idx, entities in enumerate(all_entities):
-                        if idx < len(all_results):
-                            all_results[idx]["entities"] = entities
-                except Exception as e:
-                    logger.warning(
-                        "classification_worker.entity_extraction_failed",
-                        error=str(e),
-                    )
-
-                # Step 3: Good-news pass (mistral-large) on serene+FR survivors
-                # Initialize good_news=None for all; only mutated for evaluated items
-                for r in all_results:
-                    r["good_news"] = None
-
-                good_news_indices: list[int] = []
-                good_news_items: list[dict] = []
-                for idx, (bi, result) in enumerate(
-                    zip(batch_items, all_results, strict=False)
-                ):
-                    if result.get("serene") is not True:
-                        continue
-                    source_name = bi.get("source_name", "")
-                    title = bi.get("title", "")
-                    if not is_french_source(source_name):
-                        continue
-                    if looks_english(title):
-                        continue
-                    good_news_indices.append(idx)
-                    good_news_items.append(bi)
-
-                if good_news_items:
-                    gn_classifier = self._get_good_news_classifier()
-                    if gn_classifier and gn_classifier.is_ready():
-                        try:
-                            gn_results = await gn_classifier.classify_batch_async(
-                                good_news_items
-                            )
-                            for offset, idx in enumerate(good_news_indices):
-                                if offset < len(gn_results):
-                                    all_results[idx]["good_news"] = gn_results[offset]
-                            logger.info(
-                                "classification_worker.good_news_pass",
-                                evaluated=len(good_news_items),
-                                positives=sum(1 for v in gn_results if v is True),
-                            )
-                        except Exception as e:
-                            logger.warning(
-                                "classification_worker.good_news_pass_failed",
-                                error=str(e),
-                            )
-            else:
-                all_results = [
+            # Snapshot en structures simples : tout ce dont les phases 2-3 ont
+            # besoin, pour ne garder aucun objet ORM vivant hors session.
+            records: list[dict] = []
+            for item, content in zip(items, contents, strict=False):
+                source = (
+                    sources_by_id.get(content.source_id)
+                    if content and content.source_id
+                    else None
+                )
+                records.append(
                     {
-                        "topics": [],
-                        "serene": None,
-                        "good_news": None,
-                        "is_ad": None,
-                        "entities": [],
+                        "queue_id": item.id,
+                        "content_id": item.content_id,
+                        "retry_count": item.retry_count,
+                        "has_content": content is not None,
+                        "title": (content.title or "") if content else "",
+                        "description": (content.description or "")
+                        if content
+                        else "",
+                        "source_name": source.name if source else "",
                     }
-                    for _ in batch_items
-                ]
+                )
 
-            # Process results
-            batch_result_idx = 0
-            for i, (item, content, source) in enumerate(
-                zip(items, contents, sources, strict=False)
+        # Build batch for API call. record_for_batch[k] = records index of the
+        # k-ème batch item → permet de remapper all_results[k] sur son record
+        # en phase 3 sans curseur séparé.
+        batch_items: list[dict] = []
+        record_for_batch: list[int] = []
+
+        for i, rec in enumerate(records):
+            if rec["has_content"] and rec["title"]:
+                batch_items.append(
+                    {
+                        "title": rec["title"],
+                        "description": rec["description"],
+                        "source_name": rec["source_name"],
+                    }
+                )
+                record_for_batch.append(i)
+
+        # Phase 2 — hors session : appels Mistral.
+        classifier = self._get_classifier()
+        all_results: list[dict] = []
+
+        if classifier and classifier.is_ready() and batch_items:
+            # Step 1: Classify (topics + serene only)
+            all_results = await classifier.classify_batch_async(batch_items)
+
+            # Retry individually for each article that got empty topics
+            empty_indices = [
+                idx for idx, r in enumerate(all_results) if not r.get("topics")
+            ]
+            if empty_indices:
+                logger.info(
+                    "classification_worker.individual_retry",
+                    total=len(batch_items),
+                    empty=len(empty_indices),
+                )
+                for idx in empty_indices:
+                    bi = batch_items[idx]
+                    result = await classifier.classify_async(
+                        title=bi["title"],
+                        description=bi.get("description", ""),
+                        source_name=bi.get("source_name", ""),
+                    )
+                    if result.get("topics"):
+                        all_results[idx] = result
+
+            # Step 2: Extract entities (separate API call)
+            try:
+                all_entities = await classifier.extract_entities_batch_async(
+                    batch_items
+                )
+                for idx, entities in enumerate(all_entities):
+                    if idx < len(all_results):
+                        all_results[idx]["entities"] = entities
+            except Exception as e:
+                logger.warning(
+                    "classification_worker.entity_extraction_failed",
+                    error=str(e),
+                )
+
+            # Step 3: Good-news pass (mistral-large) on serene+FR survivors
+            # Initialize good_news=None for all; only mutated for evaluated items
+            for r in all_results:
+                r["good_news"] = None
+
+            good_news_indices: list[int] = []
+            good_news_items: list[dict] = []
+            for idx, (bi, result) in enumerate(
+                zip(batch_items, all_results, strict=False)
             ):
+                if result.get("serene") is not True:
+                    continue
+                source_name = bi.get("source_name", "")
+                title = bi.get("title", "")
+                if not is_french_source(source_name):
+                    continue
+                if looks_english(title):
+                    continue
+                good_news_indices.append(idx)
+                good_news_items.append(bi)
+
+            if good_news_items:
+                gn_classifier = self._get_good_news_classifier()
+                if gn_classifier and gn_classifier.is_ready():
+                    try:
+                        gn_results = await gn_classifier.classify_batch_async(
+                            good_news_items
+                        )
+                        for offset, idx in enumerate(good_news_indices):
+                            if offset < len(gn_results):
+                                all_results[idx]["good_news"] = gn_results[offset]
+                        logger.info(
+                            "classification_worker.good_news_pass",
+                            evaluated=len(good_news_items),
+                            positives=sum(1 for v in gn_results if v is True),
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "classification_worker.good_news_pass_failed",
+                            error=str(e),
+                        )
+        else:
+            all_results = [
+                {
+                    "topics": [],
+                    "serene": None,
+                    "good_news": None,
+                    "is_ad": None,
+                    "entities": [],
+                }
+                for _ in batch_items
+            ]
+
+        # Remap les résultats LLM sur leur record d'origine (indices manquants
+        # = articles sans contenu/titre, traités par le fallback ci-dessous).
+        result_by_record: dict[int, dict] = {
+            rec_idx: all_results[k]
+            for k, rec_idx in enumerate(record_for_batch)
+            if k < len(all_results)
+        }
+
+        # Phase 3 — session courte : écrire les résultats.
+        async with self.session_maker() as session:
+            service = ClassificationQueueService(session)
+
+            for i, rec in enumerate(records):
                 try:
-                    if content is None:
-                        await service.mark_completed_with_entities(item.id, [], [])
+                    if not rec["has_content"]:
+                        await service.mark_completed_with_entities(
+                            rec["queue_id"], [], []
+                        )
                         continue
 
                     # Get topics, serene, is_ad and entities from batch result
-                    if i in batch_indices:
-                        result = (
-                            all_results[batch_result_idx]
-                            if batch_result_idx < len(all_results)
-                            else {
-                                "topics": [],
-                                "serene": None,
-                                "good_news": None,
-                                "is_ad": None,
-                                "entities": [],
-                            }
-                        )
-                        batch_result_idx += 1
+                    result = result_by_record.get(i)
+                    if result is not None:
                         topics = result.get("topics", [])
                         is_serene = result.get("serene")
                         is_good_news = result.get("good_news")
@@ -344,18 +380,20 @@ class ClassificationWorker:
                     # If still no topics after individual retry, let the retry
                     # mechanism handle it (mark_failed will requeue up to 3 times)
                     if not topics:
-                        if item.retry_count < 2:
-                            await service.mark_failed(item.id, "empty_classification")
+                        if rec["retry_count"] < 2:
+                            await service.mark_failed(
+                                rec["queue_id"], "empty_classification"
+                            )
                             continue
                         # After max retries, mark completed with empty topics
                         logger.warning(
                             "classification_worker.exhausted_retries",
-                            content_id=str(item.content_id),
-                            title=(content.title or "")[:80],
+                            content_id=str(rec["content_id"]),
+                            title=rec["title"][:80],
                         )
 
                     await service.mark_completed_with_entities(
-                        item.id,
+                        rec["queue_id"],
                         topics,
                         entities,
                         is_serene=is_serene,
@@ -364,7 +402,7 @@ class ClassificationWorker:
                     )
 
                 except Exception as e:
-                    await service.mark_failed(item.id, str(e)[:500])
+                    await service.mark_failed(rec["queue_id"], str(e)[:500])
 
 
 # Global worker instance (singleton)

--- a/packages/api/app/workers/storage_cleanup.py
+++ b/packages/api/app/workers/storage_cleanup.py
@@ -8,6 +8,7 @@ from sqlalchemy import delete, exists, func, not_, select
 
 from app.config import get_settings
 from app.database import safe_async_session
+from app.models.classification_queue import ClassificationQueue
 from app.models.content import Content, UserContentStatus
 from app.models.daily_digest import DailyDigest
 from app.models.source import Source
@@ -21,6 +22,45 @@ settings = get_settings()
 # editorial_article_not_found and triggers a 503 for the owning user.
 # 90 days covers the longest realistic streak fallback window.
 DIGEST_REFERENCE_PROTECTION_DAYS = 90
+
+# Rétention des lignes terminées de classification_queue. Doit rester très
+# au-dessus de la fenêtre de requeue_for_reclassification (48 h) : une ligne
+# purgée trop tôt serait ré-enqueueable et re-classifiée pour rien.
+CLASSIFICATION_QUEUE_RETENTION_DAYS = 30
+
+
+async def purge_finished_classification_queue() -> int:
+    """Purge les lignes completed/failed/cancelled de classification_queue.
+
+    La file est append-only côté terminé : sans purge, les lignes (et leurs
+    index) croissent en O(articles) pour toujours. Best-effort : un échec ne
+    doit pas faire échouer le cleanup des articles.
+
+    Returns:
+        Nombre de lignes supprimées (0 en cas d'erreur).
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=CLASSIFICATION_QUEUE_RETENTION_DAYS)
+    try:
+        async with safe_async_session() as session:
+            result = await session.execute(
+                delete(ClassificationQueue).where(
+                    ClassificationQueue.status.in_(
+                        ["completed", "failed", "cancelled"]
+                    ),
+                    ClassificationQueue.updated_at < cutoff,
+                )
+            )
+            await session.commit()
+            deleted = result.rowcount
+            logger.info(
+                "classification_queue_purged",
+                deleted_count=deleted,
+                retention_days=CLASSIFICATION_QUEUE_RETENTION_DAYS,
+            )
+            return deleted
+    except Exception as e:
+        logger.error("classification_queue_purge_failed", error=str(e))
+        return 0
 
 
 async def _collect_referenced_content_ids(session) -> set[UUID]:
@@ -58,6 +98,14 @@ async def cleanup_old_articles() -> dict:
         retention_days=retention_days,
         cutoff_date=cutoff_date.isoformat(),
     )
+
+    # Purge des lignes terminées de classification_queue, co-localisée ici
+    # (même fenêtre de maintenance 03:00, pas de slot cron supplémentaire).
+    # Distincte du CASCADE déclenché par le DELETE Content plus bas : le CASCADE
+    # ne nettoie que les lignes liées aux articles supprimés, pas celles dont
+    # le Content a survécu (bookmark/deep/digest-ref) mais dont la file est
+    # terminée. Best-effort : un échec ne bloque pas le cleanup des articles.
+    purged_queue_rows = await purge_finished_classification_queue()
 
     async with safe_async_session() as session:
         try:
@@ -135,6 +183,7 @@ async def cleanup_old_articles() -> dict:
                     "preserved_bookmarks": preserved_bookmarks,
                     "preserved_deep": preserved_deep,
                     "preserved_digest_refs": preserved_digest_refs,
+                    "purged_queue_rows": purged_queue_rows,
                 }
 
             # Delete - réutilise les mêmes conditions que le count. FK CASCADE
@@ -160,6 +209,7 @@ async def cleanup_old_articles() -> dict:
                 "preserved_bookmarks": preserved_bookmarks,
                 "preserved_deep": preserved_deep,
                 "preserved_digest_refs": preserved_digest_refs,
+                "purged_queue_rows": purged_queue_rows,
             }
 
         except Exception as e:

--- a/packages/api/tests/test_scaling_db_robustness.py
+++ b/packages/api/tests/test_scaling_db_robustness.py
@@ -1,0 +1,206 @@
+"""Tests robustesse DB (scaling phase 2) : sessions courtes du worker de
+classification + purge des lignes terminées de classification_queue."""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+class _SessionTracker:
+    """Compte les sessions ouvertes pour vérifier qu'aucune ne couvre les LLM."""
+
+    def __init__(self, session_factory):
+        self.open_count = 0
+        self.sessions: list = []
+        self._session_factory = session_factory
+
+    def make_maker(self):
+        tracker = self
+
+        def maker():
+            session = tracker._session_factory()
+            tracker.sessions.append(session)
+
+            class _Ctx:
+                async def __aenter__(self):
+                    tracker.open_count += 1
+                    return session
+
+                async def __aexit__(self, *args):
+                    tracker.open_count -= 1
+                    return False
+
+            return _Ctx()
+
+        return maker
+
+
+def _fake_content(content_id, source_id=None, title="Titre", description="Desc"):
+    content = MagicMock()
+    content.id = content_id
+    content.source_id = source_id
+    content.title = title
+    content.description = description
+    return content
+
+
+def _fake_item(content_id, retry_count=0):
+    item = MagicMock()
+    item.id = uuid4()
+    item.content_id = content_id
+    item.retry_count = retry_count
+    return item
+
+
+@pytest.mark.asyncio
+async def test_process_batch_holds_no_session_during_llm_calls():
+    """La cause racine des IdleInTransactionSessionTimeout : aucune session DB
+    ne doit être ouverte pendant les appels Mistral (90-180 s au pire)."""
+    from app.workers.classification_worker import ClassificationWorker
+
+    content_id = uuid4()
+    source_id = uuid4()
+    item = _fake_item(content_id)
+    content = _fake_content(content_id, source_id=source_id)
+    source = MagicMock()
+    source.id = source_id
+    source.name = "Le Monde"
+
+    def session_factory():
+        session = MagicMock()
+        contents_result = MagicMock()
+        contents_result.scalars.return_value = [content]
+        sources_result = MagicMock()
+        sources_result.scalars.return_value = [source]
+        session.execute = AsyncMock(side_effect=[contents_result, sources_result])
+        return session
+
+    tracker = _SessionTracker(session_factory)
+
+    open_during_llm: list[int] = []
+
+    async def classify_batch(batch_items):
+        open_during_llm.append(tracker.open_count)
+        return [{"topics": ["politique"], "serene": False, "is_ad": False}]
+
+    async def extract_entities(batch_items):
+        open_during_llm.append(tracker.open_count)
+        return [[{"text": "Macron", "label": "PER"}]]
+
+    classifier = MagicMock()
+    classifier.is_ready.return_value = True
+    classifier.classify_batch_async = AsyncMock(side_effect=classify_batch)
+    classifier.extract_entities_batch_async = AsyncMock(side_effect=extract_entities)
+
+    service = MagicMock()
+    service.dequeue_batch = AsyncMock(return_value=[item])
+    service.mark_completed_with_entities = AsyncMock()
+    service.mark_failed = AsyncMock()
+
+    with patch.object(ClassificationWorker, "__init__", lambda self: None):
+        worker = ClassificationWorker()
+    worker.batch_size = 5
+    worker.session_maker = tracker.make_maker()
+    worker._classifier = classifier
+    worker._good_news_classifier = MagicMock(is_ready=MagicMock(return_value=False))
+
+    with patch(
+        "app.workers.classification_worker.ClassificationQueueService",
+        return_value=service,
+    ):
+        await worker._process_batch()
+
+    # Les 2 appels LLM ont eu lieu, tous hors session DB.
+    assert open_during_llm == [0, 0]
+    # Le résultat a bien été écrit (phase 3).
+    service.mark_completed_with_entities.assert_awaited_once()
+    args, kwargs = service.mark_completed_with_entities.await_args
+    assert args[0] == item.id
+    assert args[1] == ["politique"]
+    # 2 sessions courtes : lecture (phase 1) + écriture (phase 3).
+    assert len(tracker.sessions) == 2
+    assert tracker.open_count == 0
+
+
+@pytest.mark.asyncio
+async def test_process_batch_empty_topics_requeues_via_mark_failed():
+    """Un article sans topics après retry doit repartir en mark_failed (<2 retries)."""
+    from app.workers.classification_worker import ClassificationWorker
+
+    content_id = uuid4()
+    item = _fake_item(content_id, retry_count=0)
+    content = _fake_content(content_id)
+
+    def session_factory():
+        session = MagicMock()
+        contents_result = MagicMock()
+        contents_result.scalars.return_value = [content]
+        session.execute = AsyncMock(return_value=contents_result)
+        return session
+
+    tracker = _SessionTracker(session_factory)
+
+    classifier = MagicMock()
+    classifier.is_ready.return_value = True
+    classifier.classify_batch_async = AsyncMock(return_value=[{"topics": []}])
+    classifier.classify_async = AsyncMock(return_value={"topics": []})
+    classifier.extract_entities_batch_async = AsyncMock(return_value=[[]])
+
+    service = MagicMock()
+    service.dequeue_batch = AsyncMock(return_value=[item])
+    service.mark_completed_with_entities = AsyncMock()
+    service.mark_failed = AsyncMock()
+
+    with patch.object(ClassificationWorker, "__init__", lambda self: None):
+        worker = ClassificationWorker()
+    worker.batch_size = 5
+    worker.session_maker = tracker.make_maker()
+    worker._classifier = classifier
+    worker._good_news_classifier = MagicMock(is_ready=MagicMock(return_value=False))
+
+    with patch(
+        "app.workers.classification_worker.ClassificationQueueService",
+        return_value=service,
+    ):
+        await worker._process_batch()
+
+    service.mark_failed.assert_awaited_once_with(item.id, "empty_classification")
+    service.mark_completed_with_entities.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_purge_finished_classification_queue_deletes_and_commits():
+    from app.workers.storage_cleanup import purge_finished_classification_queue
+
+    mock_session = AsyncMock()
+    delete_result = MagicMock()
+    delete_result.rowcount = 42
+    mock_session.execute = AsyncMock(return_value=delete_result)
+
+    maker = MagicMock()
+    maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    maker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.workers.storage_cleanup.safe_async_session", maker):
+        deleted = await purge_finished_classification_queue()
+
+    assert deleted == 42
+    mock_session.commit.assert_awaited_once()
+    # La clause where cible les statuts terminés et un cutoff de rétention.
+    stmt = mock_session.execute.await_args.args[0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+    assert "classification_queue" in compiled
+    assert "status" in compiled
+    assert "updated_at" in compiled
+
+
+@pytest.mark.asyncio
+async def test_purge_finished_classification_queue_never_raises():
+    from app.workers.storage_cleanup import purge_finished_classification_queue
+
+    maker = MagicMock(side_effect=RuntimeError("db down"))
+    with patch("app.workers.storage_cleanup.safe_async_session", maker):
+        deleted = await purge_finished_classification_queue()
+    assert deleted == 0

--- a/packages/api/tests/test_storage_cleanup.py
+++ b/packages/api/tests/test_storage_cleanup.py
@@ -21,6 +21,16 @@ def _empty_referenced_ids():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _skip_queue_purge():
+    """Neutralise la purge classification_queue (session propre, testée à part)."""
+    with patch(
+        "app.workers.storage_cleanup.purge_finished_classification_queue",
+        new=AsyncMock(return_value=0),
+    ):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_cleanup_deletes_old_articles():
     """Verify cleanup deletes articles older than retention period."""


### PR DESCRIPTION
## Quoi
3 actions de robustesse DB (scaling phase 2, PR-S1 + hygiène G5), data-gated par l'investigation phase 1 :
1. **Cause racine idle-in-transaction** : `classification_worker._process_batch` restructuré en 3 phases — session courte (dequeue + chargement batché contents/sources), **appels Mistral hors session**, session courte d'écriture. Avant, une transaction restait ouverte 90-180s pendant les appels LLM → tuée par `idle_in_transaction_session_timeout=60s`. Suppression du N+1 au passage (2 `SELECT … IN` au lieu de 2N `session.get`).
2. **DROP `ix_user_content_status_exclusion`** : index 5 colonnes jamais choisi par le planner (EXPLAIN baseline §3), pur coût de write-amplification. Migration `sc01` idempotente (`IF EXISTS`), réversible, sans danger pour l'ancien code prod.
3. **Purge `classification_queue`** : lignes `completed`/`failed`/`cancelled` > 30j, ajoutée au job `storage_cleanup` quotidien (best-effort). La file était append-only côté terminé → croissance O(articles).

## Pourquoi
Signal prod phase 1 : `IdleInTransactionSessionTimeout` (Sentry) + sessions tuées par le `zombie_session_sweeper` (un pansement). Cette PR traite la cause et l'hygiène stockage connue, sans sur-ingénierer. Le right-size du pool est volontairement reporté (attendre les données de la sonde phase A).

## Comment ça a été vérifié
- [x] `pytest -v` complet : 1687 passed, 1 skipped, 2 xfailed
- [x] 4 nouveaux tests : aucune session DB ouverte pendant les appels LLM, écriture des résultats, requeue empty-topics, purge (supprime/commit + never-raises)
- [x] Migration `sc01` : 1 head, upgrade/downgrade/idempotence sur DB vide
- [x] /simplify passé (collapse du double-index `batch_indices`/`batch_result_idx` en un dict de remap)

## Zones à risque
Worker classification (DB) + migration (DROP index). Le DROP est idempotent et réversible ; le refactor worker préserve la logique de retry. Surveiller post-deploy : zéro `IdleInTransactionSessionTimeout` lié au worker sur 48h, `zombie_session_sweeper_killed` silencieux, taille `classification_queue` en baisse au 1er cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)