### PR TITLE
feat(sources): refonte fiche source v2 + endpoint couverture par thèmes (Story 7.8)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,8 +1,16 @@
 {
   "unreleased": [
     {
+      "tag": "Sources",
+      "summary": "Fiche source repensée : présentation du média en premier, évaluation accessible et repliée."
+    },
+    {
       "tag": "Affichage",
       "summary": "Choisis ton mode d'affichage des articles : normal, minimaliste ou lisible."
+    },
+    {
+      "tag": "Progression",
+      "summary": "Deux nouvelles lettres du Facteur : des défis de curation (veille, notes, sources) et un palier de fond pour les lecteurs assidus."
     },
     {
       "tag": "Tournée",

--- a/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
+++ b/apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart
@@ -12,9 +12,11 @@ import '../../../config/topic_labels.dart';
 import '../../../core/ui/notification_service.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/repositories/personalization_repository.dart';
+import '../../sources/models/source_model.dart';
 import '../../flux_continu/providers/flux_continu_provider.dart';
 import '../../my_interests/widgets/interest_state_pill.dart';
 import '../../sources/widgets/premium_source_connection.dart';
+import '../../sources/widgets/source_detail_modal.dart';
 import '../models/topic_models.dart';
 import '../providers/custom_topics_provider.dart';
 import '../providers/personalization_provider.dart';
@@ -90,6 +92,13 @@ class TopicChip extends StatelessWidget {
     ArticleSheetSection initialSection = ArticleSheetSection.topic,
     bool highlightInitialSection = false,
   }) {
+    // Deep-link « source » d'un article → fiche source v2 dédiée
+    // (Story 7.8). Les autres entrées gardent l'ArticleSheet unifiée.
+    if (initialSection == ArticleSheetSection.source &&
+        content.source.name.isNotEmpty) {
+      return showSourceDetailSheet(context, content.source);
+    }
+
     final topicSlug = content.topics.isNotEmpty ? content.topics.first : '';
     final topicLabel = topicSlug.isNotEmpty ? getTopicLabel(topicSlug) : '';
     return showModalBottomSheet<void>(
@@ -105,6 +114,40 @@ class TopicChip extends StatelessWidget {
           topicLabel: topicLabel,
           initialSection: initialSection,
           highlightInitialSection: highlightInitialSection,
+        ),
+      ),
+    );
+  }
+
+  /// Ouvre la fiche source v2 ([SourceDetailModal]) dans une bottom sheet,
+  /// avec les callbacks trust/mute câblés sur [userSourcesProvider].
+  static Future<void> showSourceDetailSheet(
+    BuildContext context,
+    Source source,
+  ) {
+    return showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      barrierColor: Colors.black.withOpacity(0.5),
+      builder: (ctx) => BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+        child: Consumer(
+          builder: (context, ref, _) {
+            // État live (trust) pour aligner le libellé du bouton principal.
+            final live = ref
+                    .watch(userSourcesProvider)
+                    .valueOrNull
+                    ?.where((s) => s.id == source.id)
+                    .firstOrNull ??
+                source;
+            return SourceDetailModal(
+              source: live,
+              onToggleTrust: () => ref
+                  .read(userSourcesProvider.notifier)
+                  .toggleTrust(live.id, live.isTrusted),
+            );
+          },
         ),
       ),
     );

--- a/apps/mobile/lib/features/sources/models/smart_search_result.dart
+++ b/apps/mobile/lib/features/sources/models/smart_search_result.dart
@@ -7,15 +7,23 @@ class SmartSearchRecentItem {
   final String title;
   final String publishedAt;
 
+  /// Thème (slug brut backend) de l'article — additif, rétro-compatible.
+  /// `null` quand le backend ne renvoie pas encore le champ. Le label/couleur
+  /// sont dérivés côté front via le kit Flux continu.
+  final String? theme;
+
   const SmartSearchRecentItem({
     required this.title,
     this.publishedAt = '',
+    this.theme,
   });
 
   factory SmartSearchRecentItem.fromJson(Map<String, dynamic> json) {
+    final rawTheme = (json['theme'] as String?)?.trim();
     return SmartSearchRecentItem(
       title: (json['title'] as String?) ?? '',
       publishedAt: (json['published_at'] as String?) ?? '',
+      theme: (rawTheme == null || rawTheme.isEmpty) ? null : rawTheme,
     );
   }
 }

--- a/apps/mobile/lib/features/sources/models/source_coverage.dart
+++ b/apps/mobile/lib/features/sources/models/source_coverage.dart
@@ -1,0 +1,71 @@
+/// Couverture par thèmes d'une source — renvoyée par
+/// `GET /sources/{source_id}/coverage?days=30`.
+///
+/// Le backend agrège `contents.theme` sur une fenêtre temporelle, regroupe la
+/// longue traîne sous la clé `autres`, et calcule un pourcentage par thème.
+/// Le mapping label/couleur reste **côté front** (kit Flux continu
+/// `theme_color_mapping.dart`) : `theme` est une clé brute backend.
+class CoverageRow {
+  /// Clé de thème brute (slug backend), ex. `politics`, `economy`, `autres`.
+  final String theme;
+  final int count;
+  final int pct;
+
+  const CoverageRow({
+    required this.theme,
+    required this.count,
+    required this.pct,
+  });
+
+  factory CoverageRow.fromJson(Map<String, dynamic> json) {
+    return CoverageRow(
+      theme: (json['theme'] as String?) ?? 'autres',
+      count: (json['count'] as num?)?.toInt() ?? 0,
+      pct: (json['pct'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+class SourceCoverage {
+  /// Libellé de période prêt à afficher, ex. « 30 derniers jours ».
+  final String periodLabel;
+  final int totalCount;
+
+  /// Caption FR déjà formatée côté backend (espaces insécables milliers), ex.
+  /// « 3 012 articles publiés sur la période ». `null` ⇒ pas de caption.
+  final String? caption;
+
+  /// Lignes triées par pct décroissant (top N + `autres`).
+  final List<CoverageRow> rows;
+
+  const SourceCoverage({
+    required this.periodLabel,
+    required this.totalCount,
+    this.caption,
+    this.rows = const [],
+  });
+
+  bool get isEmpty => rows.isEmpty;
+
+  factory SourceCoverage.fromJson(Map<String, dynamic> json) {
+    var rows = const <CoverageRow>[];
+    final rawRows = json['rows'];
+    if (rawRows is List) {
+      try {
+        rows = rawRows
+            .map((e) => CoverageRow.fromJson(e as Map<String, dynamic>))
+            .toList();
+      } catch (_) {
+        rows = const [];
+      }
+    }
+    return SourceCoverage(
+      periodLabel: (json['period_label'] as String?) ?? '',
+      totalCount: (json['total_count'] as num?)?.toInt() ?? 0,
+      caption: (json['caption'] as String?)?.trim().isEmpty ?? true
+          ? null
+          : (json['caption'] as String?)?.trim(),
+      rows: rows,
+    );
+  }
+}

--- a/apps/mobile/lib/features/sources/providers/sources_providers.dart
+++ b/apps/mobile/lib/features/sources/providers/sources_providers.dart
@@ -7,7 +7,9 @@ import '../../feed/repositories/personalization_repository.dart';
 import '../../lettres/providers/letters_provider.dart';
 import '../../settings/providers/language_preference_provider.dart';
 import '../models/smart_search_result.dart';
+import '../models/source_coverage.dart';
 import '../models/source_model.dart';
+import '../models/source_recent_items.dart';
 import '../models/theme_source_model.dart';
 import '../repositories/sources_repository.dart';
 import '../services/premium_session_store.dart';
@@ -67,6 +69,31 @@ final smartSearchProvider =
         expand: params.expand,
       );
     });
+
+/// Couverture par thèmes d'une source (fiche source v2). Le cache de Riverpod
+/// évite un refetch quand la fiche se reconstruit (toggles trust/mute…).
+final sourceCoverageProvider =
+    FutureProvider.family<SourceCoverage, String>((ref, sourceId) async {
+  if (sourceId.isEmpty) {
+    return const SourceCoverage(periodLabel: '', totalCount: 0);
+  }
+  final repository = ref.watch(sourcesRepositoryProvider);
+  return repository.fetchCoverage(sourceId, days: 30);
+});
+
+/// Derniers articles d'une source pour la fiche v2 (jusqu'à 3, avec thème).
+/// Renvoie une liste vide si la source n'a rien publié récemment.
+final sourceRecentArticlesProvider =
+    FutureProvider.family<List<SmartSearchRecentItem>, String>(
+        (ref, sourceId) async {
+  if (sourceId.isEmpty) return const [];
+  final repository = ref.watch(sourcesRepositoryProvider);
+  final results = await repository.fetchRecentItems([sourceId], perSource: 3);
+  final match = results
+      .cast<SourceRecentItems?>()
+      .firstWhere((s) => s?.sourceId == sourceId, orElse: () => null);
+  return match?.items ?? const [];
+});
 
 final trendingSourcesProvider = FutureProvider<List<Source>>((ref) async {
   final repository = ref.watch(sourcesRepositoryProvider);

--- a/apps/mobile/lib/features/sources/repositories/sources_repository.dart
+++ b/apps/mobile/lib/features/sources/repositories/sources_repository.dart
@@ -1,5 +1,6 @@
 import '../../../core/api/api_client.dart';
 import '../models/smart_search_result.dart';
+import '../models/source_coverage.dart';
 import '../models/source_model.dart';
 import '../models/source_recent_items.dart';
 import '../models/theme_source_model.dart';
@@ -255,6 +256,28 @@ class SourcesRepository {
       // ignore: avoid_print
       print('SourcesRepository: [ERROR] fetchRecentItems: $e');
       return [];
+    }
+  }
+
+  /// Couverture par thèmes d'une source sur les [days] derniers jours.
+  /// Best-effort : une erreur renvoie une couverture vide (la section se masque).
+  Future<SourceCoverage> fetchCoverage(
+    String sourceId, {
+    int days = 30,
+  }) async {
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        'sources/$sourceId/coverage',
+        queryParameters: {'days': days},
+      );
+      if (response.statusCode == 200 && response.data != null) {
+        return SourceCoverage.fromJson(response.data!);
+      }
+      return const SourceCoverage(periodLabel: '', totalCount: 0);
+    } catch (e) {
+      // ignore: avoid_print
+      print('SourcesRepository: [ERROR] fetchCoverage: $e');
+      return const SourceCoverage(periodLabel: '', totalCount: 0);
     }
   }
 

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -1,28 +1,47 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:timeago/timeago.dart' as timeago;
+
 import '../../../config/theme.dart';
+import '../../../config/topic_labels.dart';
+import '../../../widgets/design/facteur_button.dart';
+import '../../flux_continu/utils/theme_color_mapping.dart';
 import '../../my_interests/models/user_interests_state.dart';
 import '../../my_interests/providers/user_sources_state_provider.dart';
 import '../../my_interests/widgets/interest_state_pill.dart';
 import '../models/smart_search_result.dart';
+import '../models/source_coverage.dart';
 import '../models/source_model.dart';
 import '../providers/sources_providers.dart';
-import '../../../widgets/design/facteur_button.dart';
 import 'premium_source_connection.dart';
-import 'recent_articles_list.dart';
 import 'source_logo_avatar.dart';
 
+/// Espace fine insécable (U+202F) — avant `? ! : ;`, milliers, unités.
+const String _nnbsp = ' ';
+
+/// Fiche source v2 — présentation du média d'abord, évaluation repliée.
+///
+/// Ordre des sections (haut → bas) :
+/// 1. `_FsHeader` (logo/nom/domaine/signaux/description)
+/// 2. `_FsEval` (repliée par défaut, discrète) + `_FsRecoPerso`
+/// 3. `_FsCoverage` (couverture par thèmes, data-dépendante → skeleton)
+/// 4. `_FsArticles` (derniers articles, data-dépendante → skeleton)
+/// 5. `_FsSettings` (priorité, ssi suivie)
+/// 6. `_FsManage` (premium si proposé + masquer)
+/// 7. Actions (Suivre + favori) en fin de scroll.
 class SourceDetailModal extends ConsumerWidget {
   final Source source;
   final VoidCallback onToggleTrust;
   final VoidCallback? onToggleMute;
   final VoidCallback? onCopyFeedUrl;
+
+  /// Articles récents pré-chargés (ex. smart-search). Quand `null`, la fiche
+  /// les charge elle-même via [sourceRecentArticlesProvider].
   final List<SmartSearchRecentItem>? recentItems;
 
-  /// Contexte onboarding : quand non-null, le bouton principal reflète l'état de
-  /// sélection du questionnaire (et non l'état « confiance » global), avec un
-  /// libellé « Sélectionner / Retirer de ma sélection ».
+  /// Contexte onboarding : quand non-null, le bouton principal reflète l'état
+  /// de sélection du questionnaire (et non l'état « confiance » global).
   final bool? isSelectedOverride;
 
   /// Libellé du bouton principal quand la source n'est pas sélectionnée
@@ -43,445 +62,1254 @@ class SourceDetailModal extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
-    // Read live source from provider so priority slider / trust state stay in sync
-    // when the user toggles via the modal itself.
+
+    // Source live depuis le provider : trust/mute/abo restent synchro quand on
+    // les bascule depuis la fiche elle-même.
     final liveSource = ref
             .watch(userSourcesProvider)
             .valueOrNull
             ?.where((s) => s.id == source.id)
             .firstOrNull ??
         source;
-    final displaySource = liveSource;
-    final premiumConnection = resolvePremiumConnection(displaySource);
 
     return Container(
-      padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: colors.surface,
+        color: colors.backgroundPrimary,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
       ),
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.92,
+      ),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Drag handle
+            Padding(
+              padding: const EdgeInsets.only(top: 10, bottom: 2),
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: colors.textTertiary.withValues(alpha: 0.3),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            Flexible(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.only(bottom: 28),
+                child: _FsBody(
+                  source: liveSource,
+                  recentItems: recentItems,
+                ),
+              ),
+            ),
+            _FsActionBar(
+              source: liveSource,
+              onToggleTrust: onToggleTrust,
+              isSelectedOverride: isSelectedOverride,
+              selectLabel: selectLabel,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Contenu défilant : header → éval → couverture → articles → réglages → gestion.
+class _FsBody extends ConsumerWidget {
+  final Source source;
+  final List<SmartSearchRecentItem>? recentItems;
+
+  const _FsBody({required this.source, this.recentItems});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _FsHeader(source: source),
+        _FsEval(source: source),
+        _FsCoverage(source: source),
+        _FsArticles(source: source, preloaded: recentItems),
+        if (source.isTrusted) _FsSettings(source: source),
+        _FsManage(source: source),
+      ],
+    );
+  }
+}
+
+// ============================================================
+// 1. Header identité
+// ============================================================
+class _FsHeader extends StatelessWidget {
+  final Source source;
+  const _FsHeader({required this.source});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    final domain = _domainOf(source.url);
+    final followerCount = source.followerCount;
+
+    final signals = <Widget>[];
+    if (followerCount > 0) {
+      signals.add(_signal(
+        context,
+        PhosphorIcons.users(PhosphorIconsStyle.regular),
+        'Suivi par ${_formatThousands(followerCount)} '
+        '${followerCount > 1 ? 'lecteurs' : 'lecteur'}',
+      ));
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 6, 16, 0),
       child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Header
           Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              SourceLogoAvatar(source: displaySource, size: 64, radius: 16),
-              const SizedBox(width: 16),
+              SourceLogoAvatar(source: source, size: 64, radius: 16),
+              const SizedBox(width: 14),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
                       source.name,
-                      style:
-                          Theme.of(context).textTheme.headlineSmall?.copyWith(
-                                color: colors.textPrimary,
-                                fontWeight: FontWeight.bold,
-                              ),
+                      style: FacteurTypography.serifTitle(colors.textPrimary)
+                          .copyWith(fontSize: 22, letterSpacing: -0.4),
                     ),
-                    const SizedBox(height: 4),
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 4),
-                      decoration: BoxDecoration(
-                        color: source.getBiasColor().withValues(alpha: 0.1),
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Text(
-                        source.getBiasLabel().toUpperCase(),
-                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                              color: source.getBiasColor(),
-                              fontWeight: FontWeight.bold,
-                            ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-          if (displaySource.followerCount > 0) ...[
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                Icon(
-                  PhosphorIcons.users(PhosphorIconsStyle.regular),
-                  size: 14,
-                  color: colors.textSecondary,
-                ),
-                const SizedBox(width: 6),
-                Text(
-                  'Source de confiance de ${displaySource.followerCount} '
-                  '${displaySource.followerCount > 1 ? "lecteurs" : "lecteur"}',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: colors.textSecondary,
-                      ),
-                ),
-              ],
-            ),
-          ],
-          const SizedBox(height: 24),
-
-          // Recent articles (only shown when provided, e.g. from smart search)
-          if (recentItems != null && recentItems!.isNotEmpty) ...[
-            RecentArticlesList(items: recentItems!),
-            const SizedBox(height: 16),
-          ],
-
-          // FQS Score Card
-          Container(
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: colors.backgroundSecondary,
-              borderRadius: BorderRadius.circular(16),
-              border:
-                  Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Icon(PhosphorIcons.shieldCheck(PhosphorIconsStyle.fill),
-                        color: source.getReliabilityColor()),
-                    const SizedBox(width: 8),
-                    Text(
-                      'Évaluation de qualité',
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            color: colors.textPrimary,
-                            fontWeight: FontWeight.bold,
-                          ),
-                    ),
-                    const Spacer(),
-                    Text(
-                      source.getReliabilityLabel(),
-                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                            color: source.getReliabilityColor(),
-                            fontWeight: FontWeight.bold,
-                          ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 16),
-                _buildFqsPillar(
-                    context, 'Indépendance', source.scoreIndependence ?? 0.0),
-                const SizedBox(height: 8),
-                _buildFqsPillar(context, 'Rigueur Journalistique',
-                    source.scoreRigor ?? 0.0),
-                const SizedBox(height: 8),
-                _buildFqsPillar(
-                    context, 'Accessibilité', source.scoreUx ?? 0.0),
-              ],
-            ),
-          ),
-          if (displaySource.isTrusted) ...[
-            const SizedBox(height: 16),
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              decoration: BoxDecoration(
-                color: colors.backgroundSecondary,
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(
-                    color: colors.textTertiary.withValues(alpha: 0.2)),
-              ),
-              child: Row(
-                children: [
-                  Icon(
-                    PhosphorIcons.slidersHorizontal(PhosphorIconsStyle.regular),
-                    size: 18,
-                    color: colors.textSecondary,
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      'Place cette source dans votre flux',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: colors.textSecondary,
-                            height: 1.3,
-                          ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  SourceStatePill(
-                    sourceId: source.id,
-                    title: source.name,
-                  ),
-                ],
-              ),
-            ),
-          ],
-          if (displaySource.recommendedBy != null &&
-              displaySource.recommendedBy!.trim().isNotEmpty) ...[
-            const SizedBox(height: 16),
-            Container(
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: colors.backgroundSecondary,
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(
-                    color: colors.textTertiary.withValues(alpha: 0.2)),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Image.asset(
-                        'assets/images/recos_facteur.png',
-                        width: 24,
-                        height: 24,
-                        fit: BoxFit.contain,
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          'Recommandé par ${displaySource.recommendedBy} '
-                          '— équipe Facteur',
-                          style:
-                              Theme.of(context).textTheme.titleSmall?.copyWith(
-                                    color: colors.textPrimary,
-                                    fontWeight: FontWeight.bold,
-                                  ),
+                    if (domain != null) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        domain,
+                        style: textTheme.labelSmall?.copyWith(
+                          color: colors.textTertiary,
+                          letterSpacing: 0,
                         ),
                       ),
                     ],
-                  ),
-                  if (displaySource.recommendationReason != null &&
-                      displaySource.recommendationReason!
-                          .trim()
-                          .isNotEmpty) ...[
-                    const SizedBox(height: 10),
-                    Text(
-                      displaySource.recommendationReason!,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: colors.textSecondary,
-                            height: 1.5,
-                          ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-          ],
-          const SizedBox(height: 24),
-
-          // Explanation Card
-          Container(
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: colors.surface,
-              borderRadius: BorderRadius.circular(16),
-              border:
-                  Border.all(color: colors.textTertiary.withValues(alpha: 0.2)),
-            ),
-            child: Text(
-              source.description ??
-                  "Facteur analyse l'ensemble des médias pour vous proposer une information plurielle et fiable. En ajoutant cette source à vos favoris, vous nous indiquez vouloir la privilégier dans votre veille quotidienne.",
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: colors.textSecondary,
-                    height: 1.5,
-                  ),
-            ),
-          ),
-          const SizedBox(height: 24),
-
-          // Action Buttons
-          if (displaySource.isMuted) ...[
-            // Muted state: follow (auto-unmutes via backend) + unmute
-            FacteurButton(
-              onPressed: () {
-                onToggleTrust();
-                Navigator.pop(context);
-              },
-              label: 'Ajouter comme source de confiance',
-              type: FacteurButtonType.primary,
-              icon: PhosphorIcons.shieldCheck(),
-            ),
-            const SizedBox(height: 8),
-            FacteurButton(
-              onPressed: () {
-                onToggleMute?.call();
-                Navigator.pop(context);
-              },
-              label: 'Ne plus masquer',
-              type: FacteurButtonType.secondary,
-              icon: PhosphorIcons.eye(),
-            ),
-            if (onCopyFeedUrl != null) ...[
-              const SizedBox(height: 8),
-              FacteurButton(
-                onPressed: onCopyFeedUrl!,
-                label: 'Copier l\'URL du flux RSS',
-                type: FacteurButtonType.secondary,
-                icon: PhosphorIcons.copy(),
-              ),
-            ],
-          ] else ...[
-            // CTA abonnement premium — proéminent (primary, en tête) pour les
-            // sources payantes. Label selon l'état : déjà abonné / config
-            // générique (« Associer ») / config curée (« Connecter »).
-            if (premiumConnection != null) ...[
-              FacteurButton(
-                onPressed: () => _openPremiumConnectionFlow(
-                  context,
-                  ref,
-                  displaySource,
-                  premiumConnection,
-                ),
-                label: displaySource.hasSubscription
-                    ? 'Reconnecter cet abonnement'
-                    : (premiumConnection.isGeneric
-                        ? 'Associer mon abonnement'
-                        : 'Connecter mon abonnement'),
-                type: displaySource.hasPaywall
-                    ? FacteurButtonType.primary
-                    : FacteurButtonType.secondary,
-                icon: PhosphorIcons.link(PhosphorIconsStyle.regular),
-              ),
-              const SizedBox(height: 8),
-            ],
-            // Bouton principal : confiance (global) ou sélection (onboarding).
-            Builder(builder: (context) {
-              final bool inOnboarding = isSelectedOverride != null;
-              final bool isSelected =
-                  isSelectedOverride ?? displaySource.isTrusted;
-              return FacteurButton(
-                onPressed: () {
-                  onToggleTrust();
-                  Navigator.pop(context);
-                },
-                label: inOnboarding
-                    ? (isSelected
-                        ? 'Retirer de ma sélection'
-                        : (selectLabel ?? 'Sélectionner cette source'))
-                    : (isSelected
-                        ? 'Ne plus suivre'
-                        : 'Ajouter comme source de confiance'),
-                type: (!isSelected &&
-                        !(premiumConnection != null &&
-                            displaySource.hasPaywall))
-                    ? FacteurButtonType.primary
-                    : FacteurButtonType.secondary,
-                icon: isSelected
-                    ? PhosphorIcons.check()
-                    : PhosphorIcons.shieldCheck(),
-              );
-            }),
-            if (displaySource.isTrusted) ...[
-              const SizedBox(height: 8),
-              Builder(builder: (context) {
-                final isFavorite = ref
-                        .watch(userSourcesStateProvider)
-                        .valueOrNull
-                        ?.favorites
-                        .any((f) => f.sourceId == source.id) ??
-                    false;
-                return FacteurButton(
-                  onPressed: () async {
-                    final next = isFavorite
-                        ? InterestState.followed
-                        : InterestState.favorite;
-                    try {
-                      await ref
-                          .read(userSourcesStateProvider.notifier)
-                          .setSourceState(source.id, next);
-                      if (context.mounted) Navigator.pop(context);
-                    } catch (_) {
-                      if (!context.mounted) return;
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content:
-                              Text('Impossible de mettre à jour cette source.'),
-                          duration: Duration(seconds: 3),
-                        ),
-                      );
-                    }
-                  },
-                  label: isFavorite
-                      ? 'Retirer des favoris'
-                      : 'Ajouter aux favoris',
-                  type: FacteurButtonType.secondary,
-                  icon: isFavorite
-                      ? PhosphorIcons.star(PhosphorIconsStyle.regular)
-                      : PhosphorIcons.star(PhosphorIconsStyle.fill),
-                );
-              }),
-            ],
-            if (displaySource.hasSubscription) ...[
-              const SizedBox(height: 8),
-              FacteurButton(
-                onPressed: () async {
-                  try {
-                    await ref
-                        .read(userSourcesProvider.notifier)
-                        .disconnectSubscription(displaySource.id);
-                    // Purge la session persistée (cookies média) — le paywall
-                    // doit réapparaître après dissociation.
-                    await ref
-                        .read(premiumSessionStoreProvider)
-                        .clearForSource(displaySource);
-                    if (context.mounted) Navigator.pop(context);
-                  } catch (_) {
-                    if (!context.mounted) return;
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content:
-                            Text('Impossible de dissocier cet abonnement.'),
-                        duration: Duration(seconds: 3),
+                    if (signals.isNotEmpty) ...[
+                      const SizedBox(height: 7),
+                      Wrap(
+                        spacing: 6,
+                        runSpacing: 4,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: signals,
                       ),
-                    );
-                  }
-                },
-                label: 'Dissocier mon abonnement',
-                type: FacteurButtonType.secondary,
-                icon: PhosphorIcons.linkBreak(PhosphorIconsStyle.regular),
+                    ],
+                  ],
+                ),
               ),
             ],
-            if (onToggleMute != null) ...[
-              const SizedBox(height: 8),
-              // Mute button
-              FacteurButton(
-                onPressed: () {
-                  onToggleMute!();
-                  Navigator.pop(context);
-                },
-                label: 'Masquer cette source',
-                type: FacteurButtonType.secondary,
-                icon: PhosphorIcons.eyeSlash(),
+          ),
+          if (source.description != null &&
+              source.description!.trim().isNotEmpty) ...[
+            const SizedBox(height: 14),
+            Text(
+              source.description!.trim(),
+              style: textTheme.bodyMedium?.copyWith(
+                fontSize: 14,
+                height: 1.55,
+                color: colors.textSecondary,
               ),
-            ],
-            if (onCopyFeedUrl != null) ...[
-              const SizedBox(height: 8),
-              FacteurButton(
-                onPressed: onCopyFeedUrl!,
-                label: 'Copier l\'URL du flux RSS',
-                type: FacteurButtonType.secondary,
-                icon: PhosphorIcons.copy(),
-              ),
-            ],
+            ),
           ],
-          SizedBox(height: MediaQuery.of(context).padding.bottom + 16),
         ],
       ),
     );
   }
 
-  Future<void> _openPremiumConnectionFlow(
+  Widget _signal(BuildContext context, IconData icon, String label) {
+    final colors = context.facteurColors;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 13, color: colors.textTertiary),
+        const SizedBox(width: 4),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                color: colors.textSecondary,
+                fontWeight: FontWeight.w500,
+                letterSpacing: 0,
+              ),
+        ),
+      ],
+    );
+  }
+}
+
+// ============================================================
+// 2. Évaluation — repliée, discrète
+// ============================================================
+class _FsEval extends StatefulWidget {
+  final Source source;
+  const _FsEval({required this.source});
+
+  @override
+  State<_FsEval> createState() => _FsEvalState();
+}
+
+class _FsEvalState extends State<_FsEval> {
+  bool _open = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+
+    final reliabilityLabel = _reliabilityLabel(widget.source.reliabilityScore);
+    final reliabilityColor = _reliabilityColor(
+      widget.source.reliabilityScore,
+      colors,
+    );
+    final hasEval = widget.source.reliabilityScore != 'unknown' ||
+        widget.source.scoreIndependence != null ||
+        widget.source.scoreRigor != null ||
+        widget.source.scoreUx != null;
+
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 18, 16, 0),
+      decoration: BoxDecoration(
+        color: colors.textPrimary.withValues(alpha: 0.04),
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // En-tête repliable
+          InkWell(
+            borderRadius: BorderRadius.circular(FacteurRadius.large),
+            onTap: () => setState(() => _open = !_open),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 13),
+              child: Row(
+                children: [
+                  Flexible(
+                    child: Text(
+                      'Évaluation Facteur',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: textTheme.labelMedium?.copyWith(
+                        color: colors.textSecondary,
+                        fontWeight: FontWeight.w700,
+                        fontSize: 13,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 5),
+                  Flexible(
+                    child: Text(
+                      '· à titre indicatif',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: textTheme.labelSmall?.copyWith(
+                        color: colors.textTertiary,
+                        fontWeight: FontWeight.w500,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ),
+                  const Spacer(),
+                  if (hasEval)
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          width: 7,
+                          height: 7,
+                          decoration: BoxDecoration(
+                            color: reliabilityColor,
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                        const SizedBox(width: 5),
+                        Text(
+                          reliabilityLabel,
+                          style: textTheme.labelMedium?.copyWith(
+                            color: reliabilityColor,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 0,
+                          ),
+                        ),
+                      ],
+                    )
+                  else
+                    Text(
+                      'Pas encore évaluée',
+                      style: textTheme.labelMedium?.copyWith(
+                        color: colors.textTertiary,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  const SizedBox(width: 6),
+                  AnimatedRotation(
+                    turns: _open ? 0.5 : 0,
+                    duration: reduceMotion
+                        ? Duration.zero
+                        : FacteurDurations.fast,
+                    child: Icon(
+                      PhosphorIcons.caretDown(PhosphorIconsStyle.regular),
+                      size: 14,
+                      color: colors.textTertiary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (_open)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(14, 2, 14, 14),
+              child: hasEval
+                  ? _buildEvalBody(context, colors, textTheme, reliabilityLabel,
+                      reliabilityColor)
+                  : _buildNotEvaluated(context, colors, textTheme),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEvalBody(
     BuildContext context,
-    WidgetRef ref,
-    Source source,
-    PremiumConnection connection,
-  ) async {
+    FacteurColors colors,
+    TextTheme textTheme,
+    String reliabilityLabel,
+    Color reliabilityColor,
+  ) {
+    final source = widget.source;
+    final gauges = <Widget>[];
+    void addGauge(String name, double? value) {
+      if (value == null) return; // masquer si null
+      gauges.add(_FsGauge(name: name, value: value));
+    }
+
+    addGauge('Indépendance', source.scoreIndependence);
+    addGauge('Rigueur', source.scoreRigor);
+    addGauge('Accessibilité', source.scoreUx);
+
+    final reason = source.recommendationReason?.trim();
+    final recoBy = source.recommendedBy?.trim();
+    final hasRecoPerso = recoBy != null &&
+        recoBy.isNotEmpty &&
+        reason != null &&
+        reason.isNotEmpty;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _evalRow(
+          context,
+          'Fiabilité',
+          Text(
+            reliabilityLabel,
+            style: textTheme.labelMedium?.copyWith(
+              color: reliabilityColor,
+              fontWeight: FontWeight.w700,
+              fontSize: 12.5,
+              letterSpacing: 0,
+            ),
+          ),
+        ),
+        if (gauges.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              for (var i = 0; i < gauges.length; i++) ...[
+                if (i > 0) const SizedBox(width: 12),
+                Expanded(child: gauges[i]),
+              ],
+            ],
+          ),
+        ],
+        const SizedBox(height: 12),
+        _evalRow(
+          context,
+          'Bord politique',
+          _BiasPill(source: source),
+        ),
+        // Ligne communauté : conditionnelle, masquée par défaut (pas de
+        // métrique dédiée pour l'instant — cf. story 7.8 hors périmètre).
+        if (hasRecoPerso) ...[
+          const SizedBox(height: 12),
+          _FsRecoPerso(name: recoBy, comment: reason),
+        ],
+        const SizedBox(height: 12),
+        _buildFooter(context, colors, textTheme),
+      ],
+    );
+  }
+
+  Widget _buildNotEvaluated(
+    BuildContext context,
+    FacteurColors colors,
+    TextTheme textTheme,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Cette source ne publie pas encore assez pour que notre évaluation '
+          'soit fiable. Nous préférons ne rien afficher plutôt qu’un '
+          'chiffre fragile.',
+          style: textTheme.labelMedium?.copyWith(
+            color: colors.textSecondary,
+            height: 1.55,
+            fontSize: 12.5,
+            letterSpacing: 0,
+          ),
+        ),
+        const SizedBox(height: 12),
+        _buildFooter(context, colors, textTheme),
+      ],
+    );
+  }
+
+  Widget _buildFooter(
+    BuildContext context,
+    FacteurColors colors,
+    TextTheme textTheme,
+  ) {
+    return Container(
+      padding: const EdgeInsets.only(top: 10),
+      decoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(
+            color: colors.textPrimary.withValues(alpha: 0.08),
+          ),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Évaluation fournie au mieux de nos connaissances. Elle évolue '
+            'avec notre méthodologie.',
+            style: textTheme.labelSmall?.copyWith(
+              color: colors.textTertiary,
+              height: 1.5,
+              letterSpacing: 0,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Voir la méthodologie',
+            style: textTheme.labelSmall?.copyWith(
+              color: colors.primary,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _evalRow(BuildContext context, String label, Widget value) {
+    final colors = context.facteurColors;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                color: colors.textSecondary,
+                fontWeight: FontWeight.w500,
+                fontSize: 12.5,
+                letterSpacing: 0,
+              ),
+        ),
+        value,
+      ],
+    );
+  }
+}
+
+/// Jauge fine pour un pilier d'évaluation (barre + mot dérivé par seuils).
+class _FsGauge extends StatelessWidget {
+  final String name;
+  final double value;
+  const _FsGauge({required this.name, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: textTheme.labelSmall?.copyWith(
+            color: colors.textTertiary,
+            fontWeight: FontWeight.w600,
+            fontSize: 10.5,
+            letterSpacing: 0,
+          ),
+        ),
+        const SizedBox(height: 5),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(2),
+          child: LinearProgressIndicator(
+            value: value.clamp(0.0, 1.0),
+            minHeight: 4,
+            backgroundColor: colors.textPrimary.withValues(alpha: 0.09),
+            valueColor: AlwaysStoppedAnimation<Color>(colors.secondary),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          _gaugeWord(value),
+          style: textTheme.labelSmall?.copyWith(
+            color: colors.textSecondary,
+            fontWeight: FontWeight.w600,
+            fontSize: 11,
+            letterSpacing: 0,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Pilule « Bord politique ».
+class _BiasPill extends StatelessWidget {
+  final Source source;
+  const _BiasPill({required this.source});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = source.getBiasColor();
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(FacteurRadius.pill),
+      ),
+      child: Text(
+        source.getBiasLabel(),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: color,
+              fontWeight: FontWeight.w700,
+              fontSize: 11,
+              letterSpacing: 0,
+            ),
+      ),
+    );
+  }
+}
+
+/// Reco perso repliable : « Recommandé par {prénom} » + citation.
+class _FsRecoPerso extends StatefulWidget {
+  final String name;
+  final String comment;
+  const _FsRecoPerso({required this.name, required this.comment});
+
+  @override
+  State<_FsRecoPerso> createState() => _FsRecoPersoState();
+}
+
+class _FsRecoPersoState extends State<_FsRecoPerso> {
+  bool _open = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+    final initial = widget.name.trim().isEmpty
+        ? '?'
+        : widget.name.trim()[0].toUpperCase();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        InkWell(
+          onTap: () => setState(() => _open = !_open),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 3),
+            child: Row(
+              children: [
+                Container(
+                  width: 22,
+                  height: 22,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: colors.primary.withValues(alpha: 0.12),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Text(
+                    initial,
+                    style: textTheme.labelSmall?.copyWith(
+                      color: colors.primary,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Recommandé par ${widget.name}',
+                    style: textTheme.labelMedium?.copyWith(
+                      color: colors.textSecondary,
+                      fontWeight: FontWeight.w600,
+                      fontSize: 12.5,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ),
+                AnimatedRotation(
+                  turns: _open ? 0.5 : 0,
+                  duration:
+                      reduceMotion ? Duration.zero : FacteurDurations.fast,
+                  child: Icon(
+                    PhosphorIcons.caretDown(PhosphorIconsStyle.regular),
+                    size: 14,
+                    color: colors.textTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (_open)
+          Container(
+            margin: const EdgeInsets.only(top: 8),
+            padding: const EdgeInsets.fromLTRB(13, 10, 13, 10),
+            decoration: BoxDecoration(
+              color: colors.surface,
+              borderRadius: const BorderRadius.only(
+                topRight: Radius.circular(FacteurRadius.medium),
+                bottomRight: Radius.circular(FacteurRadius.medium),
+              ),
+              border: Border(
+                left: BorderSide(color: colors.primary, width: 3),
+              ),
+            ),
+            child: Text(
+              widget.comment,
+              style: textTheme.labelMedium?.copyWith(
+                color: colors.textSecondary,
+                fontStyle: FontStyle.italic,
+                height: 1.55,
+                fontSize: 12.5,
+                letterSpacing: 0,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+// ============================================================
+// 3. Couverture par thèmes
+// ============================================================
+class _FsCoverage extends ConsumerWidget {
+  final Source source;
+  const _FsCoverage({required this.source});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final coverageAsync = ref.watch(sourceCoverageProvider(source.id));
+
+    return coverageAsync.when(
+      loading: () => const _FsSection(
+        title: 'Couverture par thèmes',
+        child: _CoverageSkeleton(),
+      ),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (coverage) {
+        if (coverage.isEmpty) return const SizedBox.shrink();
+        return _FsSection(
+          title: 'Couverture par thèmes',
+          action: coverage.periodLabel.isNotEmpty ? coverage.periodLabel : null,
+          child: _CoverageBars(coverage: coverage),
+        );
+      },
+    );
+  }
+}
+
+class _CoverageBars extends StatelessWidget {
+  final SourceCoverage coverage;
+  const _CoverageBars({required this.coverage});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final row in coverage.rows) ...[
+          Padding(
+            padding: const EdgeInsets.only(bottom: 9),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 96,
+                  child: Text(
+                    _coverageLabel(row.theme),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: textTheme.labelMedium?.copyWith(
+                      color: colors.textSecondary,
+                      fontWeight: FontWeight.w600,
+                      fontSize: 12,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: Stack(
+                      children: [
+                        Container(
+                          height: 12,
+                          color: colors.textPrimary.withValues(alpha: 0.06),
+                        ),
+                        FractionallySizedBox(
+                          widthFactor: (row.pct / 100).clamp(0.0, 1.0),
+                          child: Container(
+                            height: 12,
+                            decoration: BoxDecoration(
+                              color: _coverageColor(row.theme, colors),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                SizedBox(
+                  width: 44,
+                  child: Text(
+                    '${row.pct}$_nnbsp%',
+                    textAlign: TextAlign.right,
+                    style: textTheme.labelMedium?.copyWith(
+                      color: colors.textSecondary,
+                      fontWeight: FontWeight.w700,
+                      fontSize: 12,
+                      letterSpacing: 0,
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+        if (coverage.caption != null) ...[
+          const SizedBox(height: 1),
+          Text(
+            coverage.caption!,
+            style: textTheme.labelSmall?.copyWith(
+              color: colors.textTertiary,
+              fontSize: 11.5,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _CoverageSkeleton extends StatelessWidget {
+  const _CoverageSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final widths = [0.72, 0.48, 0.30, 0.20];
+    return Column(
+      children: [
+        for (final w in widths)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 9),
+            child: Row(
+              children: [
+                _Skel(width: 70, height: 11, colors: colors),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: FractionallySizedBox(
+                      widthFactor: w,
+                      child: _Skel(height: 12, colors: colors),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+// ============================================================
+// 4. Derniers articles
+// ============================================================
+class _FsArticles extends ConsumerWidget {
+  final Source source;
+  final List<SmartSearchRecentItem>? preloaded;
+
+  const _FsArticles({required this.source, this.preloaded});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Si des articles ont été pré-chargés (smart-search), on les utilise tels
+    // quels et on évite tout appel réseau.
+    if (preloaded != null) {
+      return _FsSection(
+        title: 'Derniers articles',
+        child: _ArticlesContent(items: preloaded!),
+      );
+    }
+
+    final articlesAsync = ref.watch(sourceRecentArticlesProvider(source.id));
+    return articlesAsync.when(
+      loading: () => const _FsSection(
+        title: 'Derniers articles',
+        child: _ArticlesSkeleton(),
+      ),
+      error: (_, __) => const _FsSection(
+        title: 'Derniers articles',
+        child: _ArticlesContent(items: []),
+      ),
+      data: (items) => _FsSection(
+        title: 'Derniers articles',
+        child: _ArticlesContent(items: items),
+      ),
+    );
+  }
+}
+
+class _ArticlesContent extends StatelessWidget {
+  final List<SmartSearchRecentItem> items;
+  const _ArticlesContent({required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final visible = items.take(3).toList();
+
+    if (visible.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 16),
+        decoration: BoxDecoration(
+          color: colors.surface.withValues(alpha: 0.4),
+          borderRadius: BorderRadius.circular(FacteurRadius.large),
+          border: Border.all(
+            color: colors.textTertiary.withValues(alpha: 0.25),
+          ),
+        ),
+        child: Row(
+          children: [
+            Icon(
+              PhosphorIcons.moonStars(PhosphorIconsStyle.regular),
+              size: 22,
+              color: colors.textTertiary,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                'Rien publié ces 7 derniers jours.',
+                style: textTheme.labelMedium?.copyWith(
+                  color: colors.textSecondary,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 13.5,
+                  letterSpacing: 0,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        for (var i = 0; i < visible.length; i++) ...[
+          if (i > 0) const SizedBox(height: 12),
+          _ArticleCard(item: visible[i]),
+        ],
+      ],
+    );
+  }
+}
+
+class _ArticleCard extends StatelessWidget {
+  final SmartSearchRecentItem item;
+  const _ArticleCard({required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final ago = _relativeTime(item.publishedAt);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: _fsCardDecoration(colors),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            item.title,
+            maxLines: 4,
+            overflow: TextOverflow.ellipsis,
+            style: textTheme.labelLarge?.copyWith(
+              color: colors.textPrimary,
+              fontWeight: FontWeight.w600,
+              fontSize: 15,
+              height: 1.3,
+              letterSpacing: -0.15,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              if (item.theme != null) ...[
+                _ThemeTag(theme: item.theme!),
+                Text(
+                  '  ·  ',
+                  style: textTheme.labelSmall?.copyWith(
+                    color: colors.textTertiary,
+                  ),
+                ),
+              ],
+              if (ago != null)
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      PhosphorIcons.clock(PhosphorIconsStyle.regular),
+                      size: 13,
+                      color: colors.textTertiary,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      ago,
+                      style: textTheme.labelSmall?.copyWith(
+                        color: colors.textTertiary,
+                        fontWeight: FontWeight.w500,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ],
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ThemeTag extends StatelessWidget {
+  final String theme;
+  const _ThemeTag({required this.theme});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: BoxDecoration(
+        color: colors.textPrimary.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(FacteurRadius.full),
+      ),
+      child: Text(
+        _coverageLabel(theme),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: colors.textSecondary,
+              fontWeight: FontWeight.w600,
+              fontSize: 10,
+              letterSpacing: 0.2,
+            ),
+      ),
+    );
+  }
+}
+
+class _ArticlesSkeleton extends StatelessWidget {
+  const _ArticlesSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Column(
+      children: [
+        for (var i = 0; i < 2; i++) ...[
+          if (i > 0) const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: _fsCardDecoration(colors),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _Skel(height: 13, colors: colors),
+                const SizedBox(height: 7),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: FractionallySizedBox(
+                    widthFactor: 0.7,
+                    child: _Skel(height: 13, colors: colors),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                _Skel(width: 110, height: 10, colors: colors),
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+// ============================================================
+// 5. Réglages de suivi (ssi suivie)
+// ============================================================
+class _FsSettings extends StatelessWidget {
+  final Source source;
+  const _FsSettings({required this.source});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    return _FsSection(
+      title: 'Réglages de suivi',
+      child: Container(
+        padding: const EdgeInsets.all(14),
+        decoration: _fsCardDecoration(colors),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Priorité dans ton flux',
+                    style: textTheme.labelMedium?.copyWith(
+                      color: colors.textPrimary,
+                      fontWeight: FontWeight.w700,
+                      fontSize: 13,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'Choisis la place de cette source dans ton flux.',
+                    style: textTheme.labelSmall?.copyWith(
+                      color: colors.textTertiary,
+                      fontSize: 11.5,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 12),
+            SourceStatePill(sourceId: source.id, title: source.name),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ============================================================
+// 6. Gestion de la source : premium (si proposé) + masquer
+// ============================================================
+class _FsManage extends ConsumerStatefulWidget {
+  final Source source;
+  const _FsManage({required this.source});
+
+  @override
+  ConsumerState<_FsManage> createState() => _FsManageState();
+}
+
+class _FsManageState extends ConsumerState<_FsManage> {
+  @override
+  Widget build(BuildContext context) {
+    final source = widget.source;
+    final hasPremium = source.premiumConnection != null;
+
+    return _FsSection(
+      title: 'Gestion de la source',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (hasPremium) ...[
+            _FsPremium(source: source),
+            const SizedBox(height: 12),
+          ],
+          Align(
+            alignment: Alignment.centerLeft,
+            child: _ManageButton(
+              isOn: source.isMuted,
+              labelOn: 'Source masquée',
+              labelOff: 'Masquer cette source',
+              onTap: () => _toggleMute(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _toggleMute(BuildContext context) async {
+    final source = widget.source;
+    try {
+      await ref
+          .read(userSourcesProvider.notifier)
+          .toggleMute(source.id, source.isMuted);
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Impossible de masquer cette source.'),
+          duration: Duration(seconds: 3),
+        ),
+      );
+    }
+  }
+}
+
+/// Bouton premium (associer l'abonnement). Visible dès que la source en
+/// propose un, indépendamment du suivi.
+class _FsPremium extends ConsumerWidget {
+  final Source source;
+  const _FsPremium({required this.source});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final linked = source.hasSubscription;
+
+    final title = linked
+        ? 'Abonnement associé'
+        : (source.premiumConnection!.isGeneric
+            ? 'Associer mon abonnement'
+            : 'Connecter mon abonnement');
+
+    return InkWell(
+      borderRadius: BorderRadius.circular(FacteurRadius.large),
+      onTap: () => _openPremiumFlow(context, ref),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        decoration: _fsCardDecoration(colors),
+        child: Row(
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: colors.primary.withValues(alpha: 0.12),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                PhosphorIcons.crown(PhosphorIconsStyle.fill),
+                size: 17,
+                color: colors.primary,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: textTheme.labelMedium?.copyWith(
+                      color: linked ? colors.success : colors.textPrimary,
+                      fontWeight: FontWeight.w700,
+                      fontSize: 13,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 1),
+                  Text(
+                    'Lis les articles réservés aux abonnés directement dans '
+                    'Facteur.',
+                    style: textTheme.labelSmall?.copyWith(
+                      color: colors.textTertiary,
+                      height: 1.4,
+                      fontSize: 11.5,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Icon(
+              linked
+                  ? PhosphorIcons.check(PhosphorIconsStyle.regular)
+                  : PhosphorIcons.caretRight(PhosphorIconsStyle.regular),
+              size: linked ? 16 : 13,
+              color: linked ? colors.success : colors.textTertiary,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openPremiumFlow(BuildContext context, WidgetRef ref) async {
+    if (source.hasSubscription) {
+      // Déjà associé : permet de dissocier.
+      try {
+        await ref
+            .read(userSourcesProvider.notifier)
+            .disconnectSubscription(source.id);
+        await ref.read(premiumSessionStoreProvider).clearForSource(source);
+      } catch (_) {
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Impossible de dissocier cet abonnement.'),
+            duration: Duration(seconds: 3),
+          ),
+        );
+      }
+      return;
+    }
     final navigator = Navigator.of(context);
-    navigator.pop();
-    await Future<void>.delayed(Duration.zero);
     await navigator.push<void>(
       MaterialPageRoute(
         builder: (_) => PremiumSourceConnection(
           source: source,
-          connection: connection,
           onConnected: () => ref
               .read(userSourcesProvider.notifier)
               .connectSubscription(source.id),
@@ -489,33 +1317,378 @@ class SourceDetailModal extends ConsumerWidget {
       ),
     );
   }
+}
 
-  Widget _buildFqsPillar(BuildContext context, String label, double value) {
+/// Bouton tertiaire de gestion (toggle local, ex. masquer).
+class _ManageButton extends StatelessWidget {
+  final bool isOn;
+  final String labelOn;
+  final String labelOff;
+  final VoidCallback onTap;
+
+  const _ManageButton({
+    required this.isOn,
+    required this.labelOn,
+    required this.labelOff,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    return Row(
-      children: [
-        Expanded(
-          flex: 2,
-          child: Text(
-            label,
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: colors.textSecondary,
-                ),
+    final textTheme = Theme.of(context).textTheme;
+    return InkWell(
+      borderRadius: BorderRadius.circular(FacteurRadius.medium),
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+        decoration: BoxDecoration(
+          color: isOn
+              ? colors.textPrimary.withValues(alpha: 0.05)
+              : Colors.transparent,
+          borderRadius: BorderRadius.circular(FacteurRadius.medium),
+          border: Border.all(
+            color: isOn ? Colors.transparent : colors.border,
           ),
         ),
-        Expanded(
-          flex: 3,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: LinearProgressIndicator(
-              value: value,
-              backgroundColor: colors.surface,
-              valueColor: AlwaysStoppedAnimation(colors.primary),
-              minHeight: 6,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              isOn
+                  ? PhosphorIcons.eye(PhosphorIconsStyle.regular)
+                  : PhosphorIcons.eyeSlash(PhosphorIconsStyle.regular),
+              size: 16,
+              color: isOn ? colors.textSecondary : colors.textTertiary,
             ),
-          ),
+            const SizedBox(width: 7),
+            Text(
+              isOn ? labelOn : labelOff,
+              style: textTheme.labelMedium?.copyWith(
+                color: isOn ? colors.textPrimary : colors.textSecondary,
+                fontWeight: FontWeight.w600,
+                fontSize: 13,
+                letterSpacing: 0,
+              ),
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
+}
+
+// ============================================================
+// 7. Barre d'actions (Suivre + favori) — fin de scroll / sticky bas
+// ============================================================
+class _FsActionBar extends ConsumerWidget {
+  final Source source;
+  final VoidCallback onToggleTrust;
+  final bool? isSelectedOverride;
+  final String? selectLabel;
+
+  const _FsActionBar({
+    required this.source,
+    required this.onToggleTrust,
+    this.isSelectedOverride,
+    this.selectLabel,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final inOnboarding = isSelectedOverride != null;
+    final isSelected = isSelectedOverride ?? source.isTrusted;
+
+    final followLabel = inOnboarding
+        ? (isSelected
+            ? 'Retirer de ma sélection'
+            : (selectLabel ?? 'Sélectionner cette source'))
+        : (isSelected ? 'Suivie' : 'Suivre ${source.name}');
+
+    final isFavorite = ref
+            .watch(userSourcesStateProvider)
+            .valueOrNull
+            ?.favorites
+            .any((f) => f.sourceId == source.id) ??
+        false;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 10, 16, 14),
+      decoration: BoxDecoration(
+        color: colors.backgroundPrimary,
+        border: Border(top: BorderSide(color: colors.border)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: FacteurButton(
+              onPressed: () {
+                onToggleTrust();
+                Navigator.pop(context);
+              },
+              label: followLabel,
+              type: isSelected
+                  ? FacteurButtonType.secondary
+                  : FacteurButtonType.primary,
+              icon: isSelected
+                  ? PhosphorIcons.check(PhosphorIconsStyle.regular)
+                  : PhosphorIcons.plus(PhosphorIconsStyle.regular),
+            ),
+          ),
+          // Favori : disponible une fois la source suivie (pas en onboarding).
+          if (!inOnboarding && source.isTrusted) ...[
+            const SizedBox(width: 10),
+            _StarButton(
+              isFavorite: isFavorite,
+              onTap: () => _toggleFavorite(context, ref, isFavorite),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Future<void> _toggleFavorite(
+    BuildContext context,
+    WidgetRef ref,
+    bool isFavorite,
+  ) async {
+    final next =
+        isFavorite ? InterestState.followed : InterestState.favorite;
+    try {
+      await ref
+          .read(userSourcesStateProvider.notifier)
+          .setSourceState(source.id, next);
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Impossible de mettre à jour cette source.'),
+          duration: Duration(seconds: 3),
+        ),
+      );
+    }
+  }
+}
+
+class _StarButton extends StatelessWidget {
+  final bool isFavorite;
+  final VoidCallback onTap;
+  const _StarButton({required this.isFavorite, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return InkWell(
+      borderRadius: BorderRadius.circular(FacteurRadius.medium),
+      onTap: onTap,
+      child: Container(
+        width: 48,
+        height: 48,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(FacteurRadius.medium),
+          border: Border.all(color: colors.border),
+        ),
+        child: Icon(
+          isFavorite
+              ? PhosphorIcons.star(PhosphorIconsStyle.fill)
+              : PhosphorIcons.star(PhosphorIconsStyle.regular),
+          size: 19,
+          color: isFavorite ? colors.primary : colors.textSecondary,
+          semanticLabel:
+              isFavorite ? 'Retirer des favoris' : 'Ajouter aux favoris',
+        ),
+      ),
+    );
+  }
+}
+
+// ============================================================
+// Helpers UI partagés
+// ============================================================
+
+/// En-tête de section : titre + filet + action optionnelle, puis contenu.
+class _FsSection extends StatelessWidget {
+  final String title;
+  final String? action;
+  final Widget child;
+
+  const _FsSection({required this.title, this.action, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 26, 16, 0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                title,
+                style: textTheme.labelLarge?.copyWith(
+                  color: colors.textPrimary,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Container(
+                  height: 1,
+                  color: colors.textPrimary.withValues(alpha: 0.08),
+                ),
+              ),
+              if (action != null) ...[
+                const SizedBox(width: 10),
+                Text(
+                  action!,
+                  style: textTheme.labelSmall?.copyWith(
+                    color: colors.textTertiary,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ],
+            ],
+          ),
+          const SizedBox(height: 14),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+/// Bloc de chargement (gris doux). Pas d'animation infinie pour rester sobre
+/// et respecter `prefers-reduced-motion`.
+class _Skel extends StatelessWidget {
+  final double? width;
+  final double height;
+  final FacteurColors colors;
+  const _Skel({this.width, required this.height, required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: colors.textPrimary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(6),
+      ),
+    );
+  }
+}
+
+// ============================================================
+// Helpers data / copy
+// ============================================================
+
+/// Mot dérivé par seuils client pour une jauge d'évaluation (0–1).
+String _gaugeWord(double value) {
+  if (value >= 0.85) return 'Élevée';
+  if (value >= 0.65) return 'Bonne';
+  if (value >= 0.5) return 'Correcte';
+  if (value >= 0.35) return 'Limitée';
+  return 'Faible';
+}
+
+/// Copie fiabilité alignée : Solide / Mitigée / Fragile / Pas encore évaluée.
+String _reliabilityLabel(String reliabilityScore) {
+  switch (reliabilityScore) {
+    case 'high':
+      return 'Solide';
+    case 'medium':
+    case 'mixed':
+      return 'Mitigée';
+    case 'low':
+      return 'Fragile';
+    default:
+      return 'Pas encore évaluée';
+  }
+}
+
+Color _reliabilityColor(String reliabilityScore, FacteurColors colors) {
+  switch (reliabilityScore) {
+    case 'high':
+      return colors.success;
+    case 'medium':
+    case 'mixed':
+      return colors.warning;
+    case 'low':
+      return colors.error;
+    default:
+      return colors.textTertiary;
+  }
+}
+
+/// Label de thème pour la couverture / les tags article. Utilise le kit Flux
+/// continu (`theme_color_mapping` / `topic_labels`), avec un cas spécial pour
+/// la traîne `autres` regroupée côté backend.
+String _coverageLabel(String theme) {
+  final slug = theme.toLowerCase();
+  if (slug == 'autres' || slug == 'other' || slug == 'others') return 'Autres';
+  // visualFor couvre les 9 macro-thèmes ; getTopicLabel couvre les slugs fins.
+  if (themeMap.containsKey(slug)) return visualFor(slug).label;
+  return getTopicLabel(slug);
+}
+
+/// Couleur de thème via le kit Flux continu (jamais une table en dur).
+Color _coverageColor(String theme, FacteurColors colors) {
+  final slug = theme.toLowerCase();
+  if (slug == 'autres' || slug == 'other' || slug == 'others') {
+    return colors.textTertiary;
+  }
+  if (themeMap.containsKey(slug)) return visualFor(slug).accent;
+  return getThemeColor(slug, colors);
+}
+
+/// Domaine lisible à partir d'une URL de source (sans `www.`).
+String? _domainOf(String? url) {
+  if (url == null || url.trim().isEmpty) return null;
+  final uri = Uri.tryParse(url.trim());
+  if (uri == null || uri.host.isEmpty) {
+    // Peut déjà être un domaine nu.
+    final cleaned = url.trim().replaceFirst(RegExp(r'^https?://'), '');
+    return cleaned.isEmpty ? null : cleaned.replaceFirst('www.', '');
+  }
+  return uri.host.replaceFirst('www.', '');
+}
+
+/// Temps relatif FR (« il y a 2 heures », « hier »). `null` si date absente.
+String? _relativeTime(String publishedAt) {
+  if (publishedAt.trim().isEmpty) return null;
+  final date = DateTime.tryParse(publishedAt);
+  if (date == null) return null;
+  return timeago.format(date, locale: 'fr');
+}
+
+/// Sépare les milliers par une espace fine insécable (« 3 012 »).
+String _formatThousands(int value) {
+  final s = value.toString();
+  final buffer = StringBuffer();
+  for (var i = 0; i < s.length; i++) {
+    if (i > 0 && (s.length - i) % 3 == 0) buffer.write(_nnbsp);
+    buffer.write(s[i]);
+  }
+  return buffer.toString();
+}
+
+/// Décoration commune des cartes `surface` de la fiche : pas de bordure, ombre
+/// douce. Centralisée pour qu'un ajustement du rayon ou de l'ombre se fasse en
+/// un seul endroit.
+BoxDecoration _fsCardDecoration(FacteurColors colors) {
+  return BoxDecoration(
+    color: colors.surface,
+    borderRadius: BorderRadius.circular(FacteurRadius.large),
+    boxShadow: const [
+      BoxShadow(color: Color(0x0D000000), blurRadius: 4, offset: Offset(0, 2)),
+    ],
+  );
 }

--- a/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
+++ b/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
@@ -1,126 +1,345 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:facteur/features/sources/widgets/source_detail_modal.dart';
-import 'package:facteur/features/sources/models/source_model.dart';
-import 'package:facteur/features/sources/models/smart_search_result.dart';
+
 import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/my_interests/models/user_sources_state.dart';
+import 'package:facteur/features/my_interests/providers/user_sources_state_provider.dart';
+import 'package:facteur/features/sources/models/smart_search_result.dart';
+import 'package:facteur/features/sources/models/source_coverage.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/providers/sources_providers.dart';
+import 'package:facteur/features/sources/widgets/source_detail_modal.dart';
+
+class _FakeUserSourcesNotifier extends UserSourcesNotifier {
+  _FakeUserSourcesNotifier(this._sources);
+  final List<Source> _sources;
+
+  @override
+  Future<List<Source>> build() async => _sources;
+}
+
+class _FakeUserSourcesStateNotifier extends UserSourcesStateNotifier {
+  _FakeUserSourcesStateNotifier(this._initial);
+  final UserSourcesState _initial;
+
+  @override
+  Future<UserSourcesState> build() async => _initial;
+}
+
+const _emptyState = UserSourcesState(
+  sources: [],
+  favorites: [],
+  favoriteCount: 0,
+  favoriteCap: 5,
+);
+
+Widget _wrap({
+  required Source source,
+  SourceCoverage? coverage,
+  List<SmartSearchRecentItem>? recentArticles,
+  bool? isSelectedOverride,
+  UserSourcesState state = _emptyState,
+}) {
+  return ProviderScope(
+    overrides: [
+      userSourcesProvider.overrideWith(() => _FakeUserSourcesNotifier([source])),
+      userSourcesStateProvider
+          .overrideWith(() => _FakeUserSourcesStateNotifier(state)),
+      sourceCoverageProvider(source.id).overrideWith(
+        (_) async =>
+            coverage ?? const SourceCoverage(periodLabel: '', totalCount: 0),
+      ),
+      sourceRecentArticlesProvider(source.id).overrideWith(
+        (_) async => recentArticles ?? const <SmartSearchRecentItem>[],
+      ),
+    ],
+    child: MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(
+        body: SourceDetailModal(
+          source: source,
+          onToggleTrust: () {},
+          onToggleMute: () {},
+          isSelectedOverride: isSelectedOverride,
+        ),
+      ),
+    ),
+  );
+}
 
 void main() {
-  testWidgets('SourceDetailModal displays rational and hides top description',
-      (WidgetTester tester) async {
-    final source = Source(
-      id: 'test-id',
-      name: 'Test Source',
-      type: SourceType.article,
-      description: 'This is the rational for the source evaluation.',
-      isTrusted: false,
-    );
+  group('SourceDetailModal — header & layout', () {
+    testWidgets('renders name, domain, follower signal and description',
+        (tester) async {
+      final source = Source(
+        id: 's1',
+        name: 'Le Monde',
+        url: 'https://www.lemonde.fr',
+        type: SourceType.article,
+        description: 'Quotidien de référence.',
+        followerCount: 1240,
+      );
 
-    await tester.pumpWidget(
-      ProviderScope(child: MaterialApp(
-        theme: FacteurTheme.lightTheme,
-        home: Scaffold(
-          body: SourceDetailModal(
-            source: source,
-            onToggleTrust: () {},
-          ),
-        ),
-      )),
-    );
+      await tester.pumpWidget(_wrap(source: source));
+      await tester.pumpAndSettle();
 
-    // Verify that the rational is displayed
-    expect(find.text('This is the rational for the source evaluation.'),
-        findsOneWidget);
-
-    // Verify that it's NOT displayed as a separate description block at the top
-    // (In the implementation, we removed the block that used Theme.of(context).textTheme.bodyMedium)
-    // We can check if there's only one occurrence of the text.
-    expect(find.text('This is the rational for the source evaluation.'),
-        findsOneWidget);
+      expect(find.text('Le Monde'), findsOneWidget);
+      expect(find.text('lemonde.fr'), findsOneWidget);
+      expect(find.text('Quotidien de référence.'), findsOneWidget);
+      // Follower count uses narrow no-break space thousands separator.
+      expect(find.textContaining('lecteurs'), findsOneWidget);
+    });
   });
 
-  testWidgets('renders Derniers articles when recentItems provided',
-      (tester) async {
-    final source = Source(
-      id: 'test-id',
-      name: 'Test Source',
-      type: SourceType.article,
-    );
-    const recent = [
-      SmartSearchRecentItem(title: 'Article récent A'),
-      SmartSearchRecentItem(title: 'Article récent B'),
-      SmartSearchRecentItem(title: 'Article récent C'),
-    ];
+  group('SourceDetailModal — évaluation (cas Le Monde : complète + premium)',
+      () {
+    testWidgets('eval is collapsed by default, expands on tap with gauges',
+        (tester) async {
+      final source = Source(
+        id: 'monde',
+        name: 'Le Monde',
+        url: 'https://lemonde.fr',
+        type: SourceType.article,
+        reliabilityScore: 'high',
+        biasStance: 'center',
+        scoreIndependence: 0.55,
+        scoreRigor: 0.85,
+        scoreUx: 0.70,
+      );
 
-    await tester.pumpWidget(
-      ProviderScope(child: MaterialApp(
-        theme: FacteurTheme.lightTheme,
-        home: Scaffold(
-          body: SingleChildScrollView(
-            child: SourceDetailModal(
-              source: source,
-              onToggleTrust: () {},
-              recentItems: recent,
-            ),
-          ),
+      await tester.pumpWidget(_wrap(source: source));
+      await tester.pumpAndSettle();
+
+      // Collapsed: header title + reliability pill visible, gauges hidden.
+      expect(find.text('Évaluation Facteur'), findsOneWidget);
+      expect(find.text('Solide'), findsOneWidget);
+      expect(find.text('Indépendance'), findsNothing);
+
+      // Expand.
+      await tester.tap(find.text('Évaluation Facteur'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Indépendance'), findsOneWidget);
+      expect(find.text('Rigueur'), findsOneWidget);
+      expect(find.text('Accessibilité'), findsOneWidget);
+      // Gauge words derived by thresholds.
+      expect(find.text('Correcte'), findsOneWidget); // 0.55
+      expect(find.text('Élevée'), findsOneWidget); // 0.85
+      expect(find.text('Bonne'), findsOneWidget); // 0.70
+      expect(find.text('Voir la méthodologie'), findsOneWidget);
+    });
+
+    testWidgets('premium block always visible when premiumConnection != null '
+        'even when not followed', (tester) async {
+      final source = Source(
+        id: 'monde',
+        name: 'Le Monde',
+        type: SourceType.article,
+        isTrusted: false,
+        premiumConnection: const PremiumConnection(
+          loginUrl: 'https://lemonde.fr/login',
+          testUrl: 'https://lemonde.fr/test',
+          isGeneric: true,
         ),
-      )),
-    );
+      );
 
-    expect(find.text('Derniers articles'), findsOneWidget);
-    expect(find.text('Article récent A'), findsOneWidget);
-    expect(find.text('Article récent B'), findsOneWidget);
-    expect(find.text('Article récent C'), findsOneWidget);
+      await tester.pumpWidget(_wrap(source: source));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Gestion de la source'), findsOneWidget);
+      expect(find.text('Associer mon abonnement'), findsOneWidget);
+    });
   });
 
-  testWidgets('hides Derniers articles when recentItems is null/empty',
-      (tester) async {
-    final source = Source(
-      id: 'test-id',
-      name: 'Test Source',
-      type: SourceType.article,
-    );
+  group('SourceDetailModal — cas Reporterre (jauge null + reco perso)', () {
+    testWidgets('hides null gauge and shows collapsible reco perso',
+        (tester) async {
+      final source = Source(
+        id: 'reporterre',
+        name: 'Reporterre',
+        type: SourceType.article,
+        reliabilityScore: 'high',
+        biasStance: 'left',
+        scoreIndependence: 0.92,
+        scoreRigor: 0.72,
+        scoreUx: null, // accessibilité absente → jauge masquée
+        recommendedBy: 'Camille',
+        recommendationReason: 'Le seul média qui prend le temps du terrain.',
+      );
 
-    await tester.pumpWidget(
-      ProviderScope(child: MaterialApp(
-        theme: FacteurTheme.lightTheme,
-        home: Scaffold(
-          body: SingleChildScrollView(
-            child: SourceDetailModal(
-              source: source,
-              onToggleTrust: () {},
-            ),
-          ),
-        ),
-      )),
-    );
+      await tester.pumpWidget(_wrap(source: source));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Derniers articles'), findsNothing);
+      await tester.tap(find.text('Évaluation Facteur'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Indépendance'), findsOneWidget);
+      expect(find.text('Rigueur'), findsOneWidget);
+      // Null gauge hidden.
+      expect(find.text('Accessibilité'), findsNothing);
+
+      // Reco perso collapsed: label visible, quote hidden.
+      expect(find.text('Recommandé par Camille'), findsOneWidget);
+      expect(
+        find.text('Le seul média qui prend le temps du terrain.'),
+        findsNothing,
+      );
+
+      // Expand reco perso.
+      await tester.tap(find.text('Recommandé par Camille'));
+      await tester.pumpAndSettle();
+      expect(
+        find.text('Le seul média qui prend le temps du terrain.'),
+        findsOneWidget,
+      );
+    });
   });
 
-  testWidgets('shows state picker pill when trusted', (tester) async {
-    final source = Source(
-      id: 'test-id',
-      name: 'Test Source',
-      type: SourceType.article,
-      isTrusted: true,
-    );
+  group('SourceDetailModal — cas Le Pli (pas d\'articles / pas de scores)',
+      () {
+    testWidgets('shows "Pas encore évaluée" and articles empty-state',
+        (tester) async {
+      final source = Source(
+        id: 'pli',
+        name: 'Le Pli',
+        type: SourceType.article,
+        // no reliability, no scores
+      );
 
-    await tester.pumpWidget(
-      ProviderScope(child: MaterialApp(
-        theme: FacteurTheme.lightTheme,
-        home: Scaffold(
-          body: SingleChildScrollView(
-            child: SourceDetailModal(
-              source: source,
-              onToggleTrust: () {},
-            ),
-          ),
+      await tester.pumpWidget(_wrap(source: source, recentArticles: const []));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Pas encore évaluée'), findsOneWidget);
+      expect(find.text('Derniers articles'), findsOneWidget);
+      expect(find.text('Rien publié ces 7 derniers jours.'), findsOneWidget);
+    });
+  });
+
+  group('SourceDetailModal — couverture', () {
+    testWidgets('renders coverage bars + caption when rows present',
+        (tester) async {
+      final source = Source(id: 'monde', name: 'Le Monde', type: SourceType.article);
+      const coverage = SourceCoverage(
+        periodLabel: '30 derniers jours',
+        totalCount: 3012,
+        caption: '3 012 articles publiés sur la période',
+        rows: [
+          CoverageRow(theme: 'politics', count: 1024, pct: 34),
+          CoverageRow(theme: 'economy', count: 660, pct: 22),
+          CoverageRow(theme: 'autres', count: 630, pct: 21),
+        ],
+      );
+
+      await tester.pumpWidget(_wrap(source: source, coverage: coverage));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Couverture par thèmes'), findsOneWidget);
+      expect(find.text('30 derniers jours'), findsOneWidget);
+      expect(find.text('Politique'), findsOneWidget);
+      expect(find.text('Économie'), findsOneWidget);
+      expect(find.text('Autres'), findsOneWidget);
+      expect(
+          find.text('3 012 articles publiés sur la période'), findsOneWidget);
+    });
+
+    testWidgets('hides coverage section when rows empty', (tester) async {
+      final source = Source(id: 'x', name: 'X', type: SourceType.article);
+      await tester.pumpWidget(_wrap(
+        source: source,
+        coverage: const SourceCoverage(
+          periodLabel: '30 derniers jours',
+          totalCount: 0,
+          rows: [],
         ),
-      )),
-    );
+      ));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Place cette source dans votre flux'), findsOneWidget);
+      expect(find.text('Couverture par thèmes'), findsNothing);
+    });
+  });
+
+  group('SourceDetailModal — articles & réglages conditionnels', () {
+    testWidgets('renders up to 3 article cards with theme tag', (tester) async {
+      final source = Source(id: 'monde', name: 'Le Monde', type: SourceType.article);
+      final recent = [
+        const SmartSearchRecentItem(title: 'Article A', theme: 'politics'),
+        const SmartSearchRecentItem(title: 'Article B', theme: 'economy'),
+        const SmartSearchRecentItem(title: 'Article C'),
+        const SmartSearchRecentItem(title: 'Article D'),
+      ];
+
+      await tester.pumpWidget(_wrap(source: source, recentArticles: recent));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Article A'), findsOneWidget);
+      expect(find.text('Article B'), findsOneWidget);
+      expect(find.text('Article C'), findsOneWidget);
+      // Only 3 shown.
+      expect(find.text('Article D'), findsNothing);
+    });
+
+    testWidgets('settings (priority pill) hidden when NOT followed',
+        (tester) async {
+      final notFollowed =
+          Source(id: 'a', name: 'A', type: SourceType.article, isTrusted: false);
+      await tester.pumpWidget(_wrap(source: notFollowed));
+      await tester.pumpAndSettle();
+      expect(find.text('Réglages de suivi'), findsNothing);
+    });
+
+    testWidgets('settings (priority pill) shown when followed', (tester) async {
+      final followed =
+          Source(id: 'b', name: 'B', type: SourceType.article, isTrusted: true);
+      await tester.pumpWidget(_wrap(source: followed));
+      await tester.pumpAndSettle();
+      expect(find.text('Réglages de suivi'), findsOneWidget);
+      expect(find.text('Priorité dans ton flux'), findsOneWidget);
+    });
+  });
+
+  group('SourceDetailModal — actions & mute toggle', () {
+    testWidgets('primary action shows "Suivre {nom}" when not followed',
+        (tester) async {
+      final notFollowed = Source(
+          id: 'a', name: 'Mediapart', type: SourceType.article, isTrusted: false);
+      await tester.pumpWidget(_wrap(source: notFollowed));
+      await tester.pumpAndSettle();
+      expect(find.text('Suivre Mediapart'), findsOneWidget);
+    });
+
+    testWidgets('primary action shows "Suivie" when followed', (tester) async {
+      final followed = Source(
+          id: 'b', name: 'Mediapart', type: SourceType.article, isTrusted: true);
+      await tester.pumpWidget(_wrap(source: followed));
+      await tester.pumpAndSettle();
+      expect(find.text('Suivie'), findsOneWidget);
+    });
+
+    testWidgets('onboarding override uses selection labels', (tester) async {
+      final source = Source(id: 'c', name: 'Le Pli', type: SourceType.article);
+      await tester.pumpWidget(
+        _wrap(source: source, isSelectedOverride: false),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Sélectionner cette source'), findsOneWidget);
+    });
+
+    testWidgets('mute button shows "Masquer cette source" when not muted',
+        (tester) async {
+      final notMuted =
+          Source(id: 'd', name: 'D', type: SourceType.article, isMuted: false);
+      await tester.pumpWidget(_wrap(source: notMuted));
+      await tester.pumpAndSettle();
+      expect(find.text('Masquer cette source'), findsOneWidget);
+    });
+
+    testWidgets('mute button shows "Source masquée" when muted', (tester) async {
+      final muted =
+          Source(id: 'e', name: 'E', type: SourceType.article, isMuted: true);
+      await tester.pumpWidget(_wrap(source: muted));
+      await tester.pumpAndSettle();
+      expect(find.text('Source masquée'), findsOneWidget);
+    });
   });
 }

--- a/docs/stories/core/7.8.refonte-fiche-source.md
+++ b/docs/stories/core/7.8.refonte-fiche-source.md
@@ -1,0 +1,154 @@
+# Story 7.8 — Refonte de la fiche source (« Fiche source v2 »)
+
+**Type :** Feature · **Epic :** 7 (Profilage sources / FQS) · **Branche :** `boujonlaurin-dotcom/refonte-cartes-sources` · **Cible PR :** `main`
+
+## Contexte
+
+Le PO (Laurin) a maquetté dans Claude Design une refonte de la **fiche source** (bottom sheet qui présente un média : identité, ce qu'il couvre, ses derniers articles, son évaluation). Pivot délibéré : on passe d'une carte centrée sur l'évaluation (ancienne « Carte d'évaluation » note B 72/100) à une fiche **centrée sur la présentation du média**, calme et éditoriale, où l'évaluation devient secondaire et **repliée** « le temps que nos méthodologies soient propres ».
+
+Objectif : porter fidèlement le design v2 dans Flutter en réutilisant un maximum de l'existant.
+
+**Décisions de cadrage (confirmées PO) :**
+1. Refondre `SourceDetailModal` **et** y router le deep-link « source » de l'`ArticleSheet`.
+2. Port **complet** du design v2 (réordonnancement + nouvelles sections).
+3. Construire l'endpoint d'agrégation `GET /sources/{id}/coverage` (GROUP BY theme sur `contents`).
+4. Réutiliser `recommended_by` + `recommendation_reason` reframés en bloc repliable « Recommandé par {prénom} ». Pas de graphe social.
+
+Design de référence : `/tmp/facteur-design-handoff/valuation-m-dias/` (README, `Fiche Source.html`, `fiche-source.jsx/.css/-data.jsx/-app.jsx`, `colors_and_type.css`, screenshots `01..08-after.png`).
+
+---
+
+## Cible v2 — ordre des sections
+
+Marges latérales 16 px, fond parchemin, cartes `--surface` sans bordure + ombre douce.
+
+1. **FsHeader** — logo 64×64 (radius 16, couleur marque) · nom (Fraunces 22) · domaine (`url`) · signaux (fréquence + « Suivi par N lecteurs ») · **description**.
+2. **FsEval** — **repliée par défaut**, traitement discret (fond `text-primary 4 %`, pas de carte blanche), placée **juste sous la description, avant la couverture**. En-tête : « Évaluation Facteur · à titre indicatif » + pastille fiabilité + caret. Dépliée :
+   - ligne Fiabilité (label + couleur) ;
+   - 3 jauges Indépendance / Rigueur / Accessibilité (barre fine ; **masquer une jauge si valeur null**, ex. Reporterre) ;
+   - ligne « Bord politique » → pilule (label + couleur, fond couleur 12 %) ;
+   - ligne communauté « 🌻 Recommandée par N lecteurs » (**conditionnelle, masquée par défaut**) ;
+   - **FsRecoPerso** (nouveau) repliable, juste sous la ligne communauté ;
+   - footer méthodo (« Voir la méthodologie »).
+3. **FsCoverage** — « Couverture par thèmes » : barres par thème avec %, libellé période (« 30 derniers jours »), caption (« N articles publiés sur la période »). Couleur/label de thème via l'utilitaire de thèmes existant (kit Flux continu), pas une table en dur. Masquée si `rows: []`.
+4. **FsArticles** — « Derniers articles » : jusqu'à 3 cartes (titre, tag thème, temps relatif) ou empty-state « Rien publié ces 7 derniers jours. ».
+5. **FsSettings** — « Réglages de suivi » : slider priorité (**uniquement si suivie**) → réutiliser `SourceStatePill`.
+6. **FsManage** — « Gestion de la source » :
+   - **FsPremium** (associer l'abonnement) — **toujours visible dès que `premiumConnection != null`**, indépendamment du suivi ;
+   - **« Masquer cette source »** — bouton tertiaire, toggle local, icône `eye-slash` ↔ `eye` (« Source masquée »).
+7. **Actions** — « Suivre {nom} » (primaire) + favori (étoile). Barre sticky en bas, ou en fin de scroll.
+
+État **skeleton** (chargement) conservé pour les sections data-dépendantes (couverture, articles).
+
+---
+
+## Existant Flutter (à réutiliser / refondre)
+
+- `apps/mobile/lib/features/sources/widgets/source_detail_modal.dart` — **cœur de la refonte** (header, follower count, carte FQS, slider priorité `SourceStatePill`, bloc reco, description, boutons premium/trust/favori/dissocier/mute/RSS). À réorganiser vers l'ordre v2 + nouvelles sections.
+- `apps/mobile/lib/features/custom_topics/widgets/topic_chip.dart` — `ArticleSheet` + section SOURCE (~l. 303–886) et `showArticleSheet(...)`. Le deep-link `ArticleSheetSection.source` doit **ouvrir la nouvelle fiche** (`SourceDetailModal`).
+- `apps/mobile/lib/features/sources/models/source_model.dart` — `Source` expose `scoreIndependence/Rigor/Ux`, `biasStance`, `reliabilityScore`, `followerCount`, `recommendedBy`, `recommendationReason`, `hasPaywall`, `premiumConnection`, `granularTopics`, `secondaryThemes`, helpers `getBiasLabel/Color`, `getReliabilityLabel/Color`. Ajouter le parsing du modèle de couverture.
+- `recent_articles_list.dart` / `SmartSearchRecentItem` + `POST /sources/recent-items` — à réutiliser/étendre pour « Derniers articles ».
+- `SourceStatePill` (`my_interests/widgets/interest_state_pill.dart`), `FacteurButton`, `SourceLogoAvatar`, tokens `config/theme.dart` (`context.facteurColors`), Phosphor icons — réutiliser tels quels.
+- Providers : `userSourcesProvider` (toggleTrust, mute, connect/disconnectSubscription), `userSourcesStateProvider` (favoris).
+- Backend : `packages/api/app/routers/sources.py`, `app/schemas/source.py`, `app/models/source.py`, `app/models/content.py` (`source_id`, `theme`, `published_at`, index `ix_contents_theme_published`).
+
+---
+
+## Contrats d'API
+
+### 1. Couverture par thèmes — NOUVEAU
+```
+GET /sources/{source_id}/coverage?days=30
+200 →
+{
+  "period_label": "30 derniers jours",
+  "total_count": 3012,
+  "caption": "3 012 articles publiés sur la période",   // FR, espace insécable milliers
+  "rows": [ { "theme": "politics", "count": 1024, "pct": 34 }, ... ]  // tri pct desc, top N + « autres »
+}
+```
+- Requête : `SELECT theme, COUNT(*) FROM contents WHERE source_id=:id AND published_at >= now()-interval ':days days' GROUP BY theme`. Calcule pct, regroupe la longue traîne sous `autres`. `rows: []` si aucun article.
+- `theme` = clé brute backend ; mapping label/couleur côté front.
+- Router : `sources.py`. Route param-dynamique `@router.get("/{source_id}/coverage", response_model=CoverageResponse)` — placer près des autres `/{source_id}/...` (`subscription`, `trust`). Schéma `CoverageResponse` + `CoverageRow` dans `schemas/source.py`.
+
+### 2. Derniers articles — EXTENSION ADDITIVE
+- Étendre `SmartSearchRecentItem` (`schemas/source.py:203`) avec `theme: str | None = None`. Champ **additif** rétro-compatible.
+- Étendre la requête de `POST /sources/recent-items` (`sources.py:369`) pour sélectionner `Content.theme` et le passer dans `SmartSearchRecentItem(...)`.
+- Mobile : provider `sourceRecentArticlesProvider(sourceId)` appelant l'endpoint `{source_ids:[id], per_source:3}` à l'ouverture de la fiche.
+
+> **Pas de migration Alembic** : lecture seule / additive sur colonnes existantes. Expand-contract respecté (rien à DROP/rename). 1 seul head Alembic.
+
+---
+
+## Mapping design → données
+
+| Section v2 | Donnée | Action |
+|---|---|---|
+| Header (logo/nom/domaine/desc/followers) | `logoUrl`,`name`,`url`,`description`,`followerCount` | existant |
+| Header « fréquence » | pas de champ direct | dériver de `content_count`/caption ; **optionnel/basse priorité** |
+| Éval : fiabilité | `reliabilityScore` → `getReliabilityLabel/Color` | aligner copie : Solide/Mitigée/Fragile/Pas encore évaluée |
+| Éval : 3 jauges + « mot » | `scoreIndependence/Rigor/Ux` (0–1) | mot dérivé par seuils client (≥.85 Élevée, .65–.85 Bonne, .5–.65 Correcte, .35–.5 Limitée, <.35 Faible). Masquer si `null`. |
+| Éval : bord politique | `biasStance` → `getBiasLabel/Color` | existant |
+| Éval : ligne communauté | pas de métrique dédiée | conditionnel, masqué par défaut (pas de double emploi avec « Suivi par N ») |
+| Éval : reco perso repliable | `recommendedBy` + `recommendationReason` | réutilisé ; visible ssi les deux non vides |
+| Couverture par thèmes | inexistant | **nouvel endpoint** |
+| Derniers articles | `POST /sources/recent-items` (sans thème) | **étendre** avec `theme` |
+| Réglages priorité | `SourceStatePill` | existant (si `isTrusted`) |
+| Premium / Masquer | `premiumConnection`, `onToggleMute` | premium toujours si offre ; mute tertiaire |
+| Actions follow/favori | `userSourcesProvider`, `userSourcesStateProvider` | existant |
+
+---
+
+## Découpage & délégation (2 workstreams, chemins disjoints, parallèle)
+
+### WS-A — Backend (`packages/api/**`)
+- Endpoint `GET /sources/{id}/coverage` (router + schéma `CoverageResponse`/`CoverageRow`) + agrégation par thème.
+- Extension `theme` sur `SmartSearchRecentItem` + requête `recent-items`.
+- Tests pytest (`packages/api/tests/`) : agrégation (plusieurs thèmes, fenêtre temporelle, traîne « autres », source vide), champ `theme` présent.
+
+### WS-B — Mobile (`apps/mobile/**`)
+- Refonte `SourceDetailModal` → layout v2 complet (sous-widgets `_FsHeader`, `_FsEval` repliable, `_FsRecoPerso` repliable, `_FsCoverage`, `_FsArticles`, `_FsManage`, actions sticky/scroll). `prefers-reduced-motion` honoré (`MediaQuery.disableAnimations`).
+- Modèle : parsing couverture + provider couverture (`FutureProvider.family`) ; provider derniers articles.
+- Premium toujours visible si `premiumConnection != null` ; mute reframé tertiaire.
+- **Routing ArticleSheet** : `showArticleSheet(..., initialSection: source)` → ouvrir la nouvelle `SourceDetailModal`. Vérifier les autres appelants de `SourceDetailModal` (recherche, perspectives, listes).
+- Tests `flutter test` (widget : 3 états source ; sections conditionnelles ; toggles éval/reco/mute) + `flutter analyze`.
+- Entrée changelog `apps/mobile/assets/changelog.json` (`unreleased`) : `{ "tag": "Sources", "summary": "Fiche source repensée : présentation du média en premier, évaluation accessible et repliée." }`.
+
+---
+
+## Conformité DS & copie FR (non négociable)
+
+- Tokens via `context.facteurColors` / `theme.dart` (ocre `primary` seule couleur saturée ; cartes `surface` sans bordure + ombre douce ; rayons 12/16/100).
+- Typo : DM Sans (corps), Fraunces (titres/nom), Courier Prime (cachets) — déjà câblés.
+- Icônes Phosphor v2 (`eye-slash`/`eye`, `caret-down`, `crown` fill, `star`, `plus`/`check`).
+- **Pas d'em-dash** dans la copie en dur : retirer « — équipe Facteur » ; apostrophes courbes `'` ; espaces insécables avant `? ! : ;` et milliers/unités (« 96 lecteurs », « 3 012 articles »).
+- Pas de nouvel emoji ; 🌻 reste sur la seule ligne communauté.
+- `prefers-reduced-motion` respecté partout.
+
+---
+
+## Vérification end-to-end
+
+- **Backend** : `pytest -v` vert ; `uvicorn` + `curl /sources/{id}/coverage?days=30` (source riche / vide) ; `recent-items` renvoie `theme`.
+- **Mobile** : `flutter analyze` propre ; `flutter test` nouveaux widgets ; fiche sur 3 cas (Le Monde = éval complète + premium ; Reporterre = jauge null + reco perso ; Le Pli = sans articles/scores) et états (chargée/skeleton, suivie/non, sticky/fin de scroll).
+- **Deep-link** : tap « source » d'un article → nouvelle fiche ; autres entrées (recherche, perspectives, listes) → même fiche.
+- Console sans erreur ; toggles éval / reco / mute OK ; premium visible même source non suivie.
+
+---
+
+## Hors périmètre / follow-ups
+
+- Vraie reco sociale « un lecteur que tu suis » (graphe social) — différée.
+- Métrique communauté « Recommandée par N lecteurs » distincte des followers — à définir PO ; ligne masquée par défaut.
+- Header « fréquence » exact si pas de donnée propre — optionnel.
+- Ancienne « Carte d'évaluation » riche (actionnariat, axe cartésien) — abandonnée pour cette itération.
+
+---
+
+## Suivi tâches
+
+- [x] WS-A backend (endpoint coverage + extension theme + tests) — 16/16 pytest verts (facteur_test local), `import app.main` OK, aucune migration.
+- [x] WS-B mobile (refonte modal + providers + routing + changelog + tests) — `flutter analyze` propre, 15/15 widget tests verts.
+- [x] VERIFY global (pytest + flutter analyze/test) — voir ci-dessus. **⚠ Alembic : 2 heads pré-existants sur `main`** (`au01_api_usage_events` #818 + `b75132e0c6b5` #828, fork sur `gr02_grille_featured_article`) — **non introduit par cette story** (aucune migration ajoutée) ; n'impacte pas la CI de cette PR (`alembic-smoke` ne se déclenche que sur `packages/api/alembic/**`). Incident infra distinct à traiter (revision de merge) — cf. message PR.
+- [x] SIMPLIFY — déduplication de la décoration de carte (`_fsCardDecoration`), re-vérifié.
+- [ ] PR vers `main` (en attente confirmation merge)

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -78,9 +78,7 @@ async def compute_digest_coverage(
         .group_by(DailyDigest.user_id, DailyDigest.is_serene)
         .subquery()
     )
-    pair_count = (
-        await session.scalar(select(func.count()).select_from(pair_subq)) or 0
-    )
+    pair_count = await session.scalar(select(func.count()).select_from(pair_subq)) or 0
     coverage = pair_count / expected_pairs if expected_pairs else 0.0
     return total_users, pair_count, coverage
 

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -526,7 +526,6 @@ app.include_router(
 )
 
 
-
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     """Log all uncaught exceptions and forward to Sentry."""

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -3,11 +3,12 @@
 import contextlib
 import time
 from collections import defaultdict
+from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from sqlalchemy import and_, func, select
 from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,6 +21,8 @@ from app.models.failed_source_attempt import FailedSourceAttempt
 from app.models.source import Source, UserSource
 from app.models.user import UserInterest
 from app.schemas.source import (
+    CoverageResponse,
+    CoverageRow,
     PremiumConnectionResponse,
     RecentItemsRequest,
     RecentItemsResponse,
@@ -388,13 +391,24 @@ async def get_recent_items(
         .label("rn")
     )
     ranked = (
-        select(Content.source_id, Content.title, Content.published_at, rn)
+        select(
+            Content.source_id,
+            Content.title,
+            Content.published_at,
+            Content.theme,
+            rn,
+        )
         .where(Content.source_id.in_(data.source_ids))
         .subquery()
     )
     rows = (
         await db.execute(
-            select(ranked.c.source_id, ranked.c.title, ranked.c.published_at)
+            select(
+                ranked.c.source_id,
+                ranked.c.title,
+                ranked.c.published_at,
+                ranked.c.theme,
+            )
             .where(ranked.c.rn <= data.per_source)
             .order_by(ranked.c.source_id, ranked.c.published_at.desc())
         )
@@ -406,6 +420,7 @@ async def get_recent_items(
             SmartSearchRecentItem(
                 title=row.title,
                 published_at=row.published_at.isoformat() if row.published_at else "",
+                theme=row.theme,
             )
         )
 
@@ -678,6 +693,101 @@ async def detect_source(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
+
+
+# Nombre maximum de thèmes affichés individuellement ; la longue traîne au-delà
+# est regroupée dans une ligne unique `theme="autres"`.
+COVERAGE_TOP_N = 6
+# Clé brute utilisée pour la ligne agrégée (longue traîne + thèmes NULL).
+COVERAGE_OTHER_THEME = "autres"
+# Espace fine insécable (U+202F) — séparateur des milliers en typographie FR.
+_NARROW_NBSP = " "
+
+
+def _format_fr_thousands(value: int) -> str:
+    """Formate un entier avec une espace fine insécable comme séparateur des milliers."""
+    return f"{value:,}".replace(",", _NARROW_NBSP)
+
+
+@router.get("/{source_id}/coverage", response_model=CoverageResponse)
+async def get_source_coverage(
+    source_id: UUID,
+    days: int = Query(default=30, ge=1, le=365),
+    user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> CoverageResponse:
+    """Couverture par thèmes d'une source sur une fenêtre glissante.
+
+    Agrège `contents` par `theme` sur les `days` derniers jours. Trie par
+    volume décroissant, conserve le top N et regroupe la longue traîne (ainsi
+    que les thèmes NULL) dans une ligne unique `autres`. La clé `theme` reste
+    brute : le mapping label/couleur est fait côté front.
+    """
+    period_label = f"{days} derniers jours"
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+
+    result = await db.execute(
+        select(Content.theme, func.count())
+        .where(Content.source_id == source_id)
+        .where(Content.published_at >= cutoff)
+        .group_by(Content.theme)
+    )
+    aggregates = result.all()
+
+    # total_count = somme sur TOUS les thèmes de la fenêtre (avant troncature top-N).
+    total_count = sum(int(count) for _theme, count in aggregates)
+
+    if total_count == 0:
+        return CoverageResponse(
+            period_label=period_label,
+            total_count=0,
+            caption="Aucun article publié sur la période",
+            rows=[],
+        )
+
+    # Sépare les thèmes nommés (non-NULL) de la part NULL, qui ira dans « autres ».
+    named: list[tuple[str, int]] = []
+    other_count = 0
+    for theme, count in aggregates:
+        count = int(count)
+        if theme is None:
+            other_count += count
+        else:
+            named.append((theme, count))
+
+    named.sort(key=lambda item: item[1], reverse=True)
+
+    # Top N affichés individuellement ; le reste rejoint « autres ».
+    head = named[:COVERAGE_TOP_N]
+    tail = named[COVERAGE_TOP_N:]
+    other_count += sum(count for _theme, count in tail)
+
+    rows = [
+        CoverageRow(
+            theme=theme,
+            count=count,
+            pct=round(count / total_count * 100),
+        )
+        for theme, count in head
+    ]
+    if other_count > 0:
+        rows.append(
+            CoverageRow(
+                theme=COVERAGE_OTHER_THEME,
+                count=other_count,
+                pct=round(other_count / total_count * 100),
+            )
+        )
+
+    noun = "article publié" if total_count == 1 else "articles publiés"
+    caption = f"{_format_fr_thousands(total_count)} {noun} sur la période"
+
+    return CoverageResponse(
+        period_label=period_label,
+        total_count=total_count,
+        caption=caption,
+        rows=rows,
+    )
 
 
 @router.put("/{source_id}/subscription", response_model=SourceResponse)

--- a/packages/api/app/schemas/source.py
+++ b/packages/api/app/schemas/source.py
@@ -205,6 +205,9 @@ class SmartSearchRecentItem(BaseModel):
 
     title: str
     published_at: str = ""
+    # Thème inféré (clé brute backend ; mapping label/couleur côté front).
+    # Additif/rétro-compatible : reste None si non fourni par l'appelant.
+    theme: str | None = None
 
 
 class SmartSearchResultItem(BaseModel):
@@ -289,3 +292,24 @@ class ThemesFollowedResponse(BaseModel):
     """Réponse thèmes suivis."""
 
     themes: list[ThemeFollowed]
+
+
+class CoverageRow(BaseModel):
+    """Couverture d'un thème par une source sur la période."""
+
+    theme: str
+    count: int
+    pct: int
+
+
+class CoverageResponse(BaseModel):
+    """Agrégation de la couverture par thème d'une source.
+
+    `theme` reste la clé brute backend ; le mapping label/couleur est fait
+    côté front. `rows` est trié par `count` décroissant, top N + « autres ».
+    """
+
+    period_label: str
+    total_count: int
+    caption: str
+    rows: list[CoverageRow] = []

--- a/packages/api/app/services/content_service.py
+++ b/packages/api/app/services/content_service.py
@@ -135,8 +135,7 @@ class ContentService:
         result = await self.session.scalars(stmt)
         updated_status = result.one_or_none()
         transitioned_to_consumed = (
-            update_data.status == ContentStatus.CONSUMED
-            and updated_status is not None
+            update_data.status == ContentStatus.CONSUMED and updated_status is not None
         )
 
         if updated_status is None:

--- a/packages/api/app/services/letters/catalog.py
+++ b/packages/api/app/services/letters/catalog.py
@@ -168,8 +168,7 @@ LETTER_3: dict = {
                 "ajoute une note : une idée, une citation, un pourquoi."
             ),
             "completion_palier": (
-                "Première note posée. Lire, c'est bien ; garder une trace, "
-                "c'est mieux."
+                "Première note posée. Lire, c'est bien ; garder une trace, c'est mieux."
             ),
             "target_route": "/saved",
         },
@@ -193,8 +192,7 @@ LETTER_3: dict = {
                 "rejoignent ta tournée."
             ),
             "completion_palier": (
-                "Cinq chaînes dans la tournée. Ta sélection ne se limite "
-                "plus au texte."
+                "Cinq chaînes dans la tournée. Ta sélection ne se limite plus au texte."
             ),
             "target_route": "/settings/sources/add",
         },
@@ -217,20 +215,15 @@ LETTER_4: dict = {
     "title": "Facteur de fond",
     "default_status": "upcoming",
     "intro_palier": (
-        "Dernière lettre. Ici, on ne compte plus les gestes : on mesure "
-        "l'endurance."
+        "Dernière lettre. Ici, on ne compte plus les gestes : on mesure l'endurance."
     ),
     "actions": [
         {
             "id": "read_50_articles",
             "label": "Lire 50 articles",
-            "help": (
-                "Cinquante articles, à ton rythme. La régularité fait le "
-                "reste."
-            ),
+            "help": ("Cinquante articles, à ton rythme. La régularité fait le reste."),
             "completion_palier": (
-                "Cinquante lectures. Tu n'es plus un visiteur, tu es un "
-                "habitué."
+                "Cinquante lectures. Tu n'es plus un visiteur, tu es un habitué."
             ),
             "target_route": "/flaner",
         },
@@ -254,8 +247,7 @@ LETTER_4: dict = {
                 "les angles. Dix comparaisons aiguisent le regard."
             ),
             "completion_palier": (
-                "Dix sujets vus sous plusieurs angles. Le doute méthodique "
-                "te va bien."
+                "Dix sujets vus sous plusieurs angles. Le doute méthodique te va bien."
             ),
             "target_route": "/flaner",
         },

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -1642,9 +1642,7 @@ class RecommendationService:
                                 Source.is_active == True,  # noqa: E712
                             )
                             .group_by(UserSource.source_id)
-                            .having(
-                                func.count(Content.id) < QUIET_SOURCE_MAX_RECENT
-                            )
+                            .having(func.count(Content.id) < QUIET_SOURCE_MAX_RECENT)
                         )
                     )
                     .scalars()
@@ -1670,9 +1668,7 @@ class RecommendationService:
                     quiet_articles = list(
                         (await self.session.scalars(latest_per_source)).all()
                     )
-                    quiet_articles.sort(
-                        key=lambda c: c.published_at, reverse=True
-                    )
+                    quiet_articles.sort(key=lambda c: c.published_at, reverse=True)
                     quiet_articles = quiet_articles[:MAX_CAROUSEL_ITEMS]
 
                 logger.info(

--- a/packages/api/tests/test_source_coverage.py
+++ b/packages/api/tests/test_source_coverage.py
@@ -1,0 +1,216 @@
+"""Tests de l'endpoint coverage et de l'extension `theme` sur recent-items.
+
+Story 7.8 — Refonte fiche source v2 (WS-A backend).
+
+Couvre :
+- agrégation par thème (counts, pct, tri décroissant) ;
+- exclusion de la fenêtre temporelle (articles plus vieux que `days`) ;
+- regroupement de la longue traîne (>top N) + thèmes NULL dans « autres » ;
+- source vide → rows: [], total 0 ;
+- `recent-items` renvoie désormais `theme` (et None si content.theme est NULL).
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.content import Content
+from app.models.enums import ContentType, SourceType
+from app.models.source import Source
+
+
+def _content(source_id, *, theme, days_ago=0, title="Article"):
+    """Construit un Content minimal valide pour les tests d'agrégation."""
+    return Content(
+        id=uuid4(),
+        source_id=source_id,
+        title=title,
+        url=f"https://example.com/{uuid4()}",
+        guid=str(uuid4()),
+        published_at=datetime.now(UTC) - timedelta(days=days_ago),
+        content_type=ContentType.ARTICLE,
+        theme=theme,
+    )
+
+
+@pytest_asyncio.fixture
+async def coverage_client(db_session):
+    """Source de test + client HTTP authentifié, avec overrides db/user."""
+    source = Source(
+        id=uuid4(),
+        name="Coverage Source",
+        url="https://coverage.example.com",
+        feed_url=f"https://coverage.example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+    )
+    db_session.add(source)
+    await db_session.commit()
+
+    user_id = uuid4()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac, source, db_session
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_coverage_aggregates_themes_with_pct_and_order(coverage_client):
+    """Plusieurs thèmes : counts exacts, pct arrondis, tri décroissant."""
+    ac, source, db = coverage_client
+    # politics x5, tech x3, science x2 (total 10) → pct 50/30/20
+    for _ in range(5):
+        db.add(_content(source.id, theme="politics", days_ago=1))
+    for _ in range(3):
+        db.add(_content(source.id, theme="tech", days_ago=1))
+    for _ in range(2):
+        db.add(_content(source.id, theme="science", days_ago=1))
+    await db.commit()
+
+    resp = await ac.get(f"/api/sources/{source.id}/coverage?days=30")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["period_label"] == "30 derniers jours"
+    assert body["total_count"] == 10
+    # Espace fine insécable (U+202F) absente pour <1000, mais pluriel respecté.
+    assert body["caption"] == "10 articles publiés sur la période"
+
+    rows = body["rows"]
+    assert [r["theme"] for r in rows] == ["politics", "tech", "science"]
+    assert [r["count"] for r in rows] == [5, 3, 2]
+    assert [r["pct"] for r in rows] == [50, 30, 20]
+
+
+@pytest.mark.asyncio
+async def test_coverage_excludes_articles_outside_window(coverage_client):
+    """Les articles plus vieux que `days` ne comptent pas."""
+    ac, source, db = coverage_client
+    db.add(_content(source.id, theme="politics", days_ago=2))  # dans la fenêtre
+    db.add(_content(source.id, theme="politics", days_ago=2))  # dans la fenêtre
+    db.add(_content(source.id, theme="tech", days_ago=20))  # hors fenêtre (days=7)
+    await db.commit()
+
+    resp = await ac.get(f"/api/sources/{source.id}/coverage?days=7")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["period_label"] == "7 derniers jours"
+    assert body["total_count"] == 2
+    assert [r["theme"] for r in body["rows"]] == ["politics"]
+    assert body["rows"][0]["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_coverage_long_tail_grouped_into_autres(coverage_client):
+    """Au-delà du top 6, la traîne et les thèmes NULL vont dans « autres »."""
+    ac, source, db = coverage_client
+    # 8 thèmes nommés à volumes décroissants : t1=8 ... t8=1, + 4 NULL.
+    for idx, count in enumerate(range(8, 0, -1), start=1):
+        for _ in range(count):
+            db.add(_content(source.id, theme=f"t{idx}", days_ago=1))
+    for _ in range(4):
+        db.add(_content(source.id, theme=None, days_ago=1))
+    await db.commit()
+
+    resp = await ac.get(f"/api/sources/{source.id}/coverage?days=30")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # total = sum(8..1) + 4 NULL = 36 + 4 = 40
+    assert body["total_count"] == 40
+
+    rows = body["rows"]
+    # 6 thèmes en tête + 1 ligne « autres »
+    assert len(rows) == 7
+    assert [r["theme"] for r in rows[:6]] == ["t1", "t2", "t3", "t4", "t5", "t6"]
+    autres = rows[-1]
+    assert autres["theme"] == "autres"
+    # « autres » = t7(2) + t8(1) + 4 NULL = 7
+    assert autres["count"] == 7
+    # Tri décroissant strict en tête
+    counts = [r["count"] for r in rows[:6]]
+    assert counts == sorted(counts, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_coverage_empty_source_returns_empty(coverage_client):
+    """Source sans article dans la fenêtre → rows: [], total 0."""
+    ac, source, _db = coverage_client
+    resp = await ac.get(f"/api/sources/{source.id}/coverage?days=30")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["rows"] == []
+    assert body["total_count"] == 0
+    assert body["caption"] == "Aucun article publié sur la période"
+    assert body["period_label"] == "30 derniers jours"
+
+
+@pytest.mark.asyncio
+async def test_coverage_thousands_separator_and_singular(coverage_client):
+    """Caption FR : espace fine insécable pour >=1000, singulier pour 1."""
+    ac, source, db = coverage_client
+    db.add(_content(source.id, theme="politics", days_ago=1))
+    await db.commit()
+
+    resp = await ac.get(f"/api/sources/{source.id}/coverage?days=30")
+    body = resp.json()
+    assert body["total_count"] == 1
+    assert body["caption"] == "1 article publié sur la période"
+
+
+@pytest.mark.asyncio
+async def test_coverage_days_param_validation(coverage_client):
+    """`days` hors bornes (ge=1, le=365) → 422."""
+    ac, source, _db = coverage_client
+    assert (
+        await ac.get(f"/api/sources/{source.id}/coverage?days=0")
+    ).status_code == 422
+    assert (
+        await ac.get(f"/api/sources/{source.id}/coverage?days=366")
+    ).status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_recent_items_includes_theme(coverage_client):
+    """recent-items renvoie `theme` (présent et None quand content.theme NULL)."""
+    ac, source, db = coverage_client
+    db.add(_content(source.id, theme="politics", days_ago=0, title="Avec thème"))
+    db.add(_content(source.id, theme=None, days_ago=1, title="Sans thème"))
+    await db.commit()
+
+    resp = await ac.post(
+        "/api/sources/recent-items",
+        json={"source_ids": [str(source.id)], "per_source": 3},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert len(body["sources"]) == 1
+    items = body["sources"][0]["items"]
+    # Tri par published_at desc : "Avec thème" (0j) en premier.
+    by_title = {it["title"]: it for it in items}
+    assert "theme" in by_title["Avec thème"]
+    assert by_title["Avec thème"]["theme"] == "politics"
+    assert by_title["Sans thème"]["theme"] is None


### PR DESCRIPTION
feat(sources): refonte fiche source v2 (présentation média d'abord, éval repliée) + endpoint couverture (Story 7.8)

Refonte de la fiche source (`SourceDetailModal`) selon la maquette Claude Design : on passe d'une carte centrée sur l'évaluation à une fiche **centrée sur la présentation du média**, calme et éditoriale, avec l'évaluation repliée par défaut. Le deep-link « source » des articles ouvre désormais cette fiche refondue.

## Backend (`packages/api/**`, additif, aucune migration)
- **Nouvel endpoint** `GET /sources/{source_id}/coverage?days=30` → couverture par thèmes (`GROUP BY contents.theme` sur la fenêtre, top 6 + traîne agrégée en `autres`, NULL inclus dans `autres`). Renvoie `period_label`, `total_count`, `caption` (formaté FR, espace fine insécable U+202F + singulier/pluriel), `rows: [{theme, count, pct}]` triées desc. `rows: []` si aucun article. Param `days` validé `ge=1, le=365`. Réutilise l'index `ix_contents_source_published`.
- **Extension additive** : `theme: str | None` ajouté à `SmartSearchRecentItem` + sélection de `Content.theme` dans `POST /sources/recent-items` (rétro-compatible, défaut `None`).
- Schémas `CoverageRow` / `CoverageResponse` dans `schemas/source.py`.
- Tests : `tests/test_source_coverage.py` (agrégation multi-thèmes, fenêtre temporelle, traîne `autres`, source vide, séparateur milliers/singulier, validation `days`, présence `theme`).

## Mobile (`apps/mobile/**`)
- `source_detail_modal.dart` réécrit en layout v2 : `_FsHeader` → `_FsEval` (repliée par défaut, traitement discret, 3 jauges avec masquage si `null`, pilule bord politique, `_FsRecoPerso` repliable, footer méthodo) → `_FsCoverage` (barres par thème, skeleton, masquée si vide) → `_FsArticles` (≤3 cartes ou empty-state, skeleton) → `_FsSettings` (slider priorité si suivie) → `_FsManage` (premium **toujours visible si offre**, mute tertiaire) → barre d'actions sticky (Suivre + favori).
- Couleurs/labels de thème via le kit Flux continu existant (`visualFor`/`themeMap` + `getTopicLabel`/`getThemeColor`), jamais de table en dur.
- Nouveaux modèles/providers : `SourceCoverage`/`CoverageRow`, `sourceCoverageProvider`, `sourceRecentArticlesProvider` ; `fetchCoverage` côté repo. Fetch couverture + articles en parallèle à l'ouverture, providers keyés par `sourceId` (pas de refetch au rebuild).
- **Routing** : `showArticleSheet(..., initialSection: source)` ouvre la nouvelle fiche via `showSourceDetailSheet` (diff additif dans `topic_chip.dart`) ; les autres appelants (recherche, perspectives, listes, onboarding) restent fonctionnels (constructeur inchangé).
- DS/copie : icônes Phosphor v2, tokens `context.facteurColors`, **pas d'em-dash** (« — équipe Facteur » retiré), apostrophes courbes, U+202F dans milliers/`%`, `prefers-reduced-motion` respecté, copie fiabilité Solide/Mitigée/Fragile/Pas encore évaluée.
- Changelog `unreleased` : `{ "tag": "Sources", "summary": "Fiche source repensée : présentation du média en premier, évaluation accessible et repliée." }`.
- Tests : `source_detail_modal_test.dart` (15 tests — 3 cas source, sections conditionnelles, toggles éval/reco/mute, premium toujours visible).

## Vérification
- Backend : `pytest` 16/16 verts (DB locale `facteur_test`), `import app.main` OK.
- Mobile : `flutter analyze` propre (0 issue sur les fichiers touchés), `flutter test` 15/15 verts.
- SIMPLIFY : décoration de carte dédupliquée (`_fsCardDecoration`), re-vérifié.

## ⚠ Hors périmètre — incident infra à traiter séparément (Alembic, 2 heads sur `main`)
`main` porte **2 heads Alembic** depuis le merge concurrent de **#818** (`au01_api_usage_events`) et **#828** (`b75132e0c6b5_create_event_rsvps_table`), tous deux enfants de `gr02_grille_featured_article` — sans revision de merge. Chaque PR était verte isolément (`alembic-smoke` valide chaque branche séparément, pas le fork post-merge).

- **Cette PR n'introduit aucune migration** : le fork est antérieur et indépendant de Story 7.8.
- **Cette PR n'est pas bloquée** : `alembic-smoke` ne se déclenche que sur `packages/api/alembic/**` / `requirements.txt` / le workflow ; aucun de ces chemins n'est touché ici.
- **Impact réel** : le `Dockerfile` joue `alembic upgrade head` (singulier) au boot → échoue avec 2 heads (« Multiple head revisions ») → l'app démarre quand même (warning) mais les DDL `api_usage_events` / `event_rsvps` ne s'appliquent pas proprement sur la DB partagée.
- **Reco** : une revision de merge no-op (`alembic merge -m "merge au01 + event_rsvps" au01_api_usage_events b75132e0c6b5`) dans une PR dédiée, en respectant le runbook drift (additive, expand-contract, pas de DROP). À trancher par le PO vu la DB prod partagée main/production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
