### PR TITLE
feat(grille): mot du jour extrait de l'actu réelle + reveal « où le mot se cachait »

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Grille",
+      "summary": "Le mot du jour vient d'un vrai titre de l'actu, et on te montre où il se cachait."
+    },
+    {
       "tag": "Sources",
       "summary": "Fiche source repensée : présentation du média en premier, évaluation accessible et repliée."
     },

--- a/apps/mobile/lib/features/grille/models/grille_models.dart
+++ b/apps/mobile/lib/features/grille/models/grille_models.dart
@@ -59,6 +59,12 @@ class GrilleTodayResponse with _$GrilleTodayResponse {
     String? featuredExcerpt,
     String? featuredUrl,
     String? featuredSource,
+    // Sélection hybride : où le mot se cachait dans l'actu réelle.
+    // `hybridField` = "title" | "description" (badge), `hybridSnippet` = texte
+    // exact à afficher, `hybridMatch` = surface à surligner.
+    String? hybridField,
+    String? hybridSnippet,
+    String? hybridMatch,
   }) = _GrilleTodayResponse;
 
   factory GrilleTodayResponse.fromJson(Map<String, dynamic> json) =>
@@ -86,6 +92,9 @@ class GrilleRevealResponse with _$GrilleRevealResponse {
     String? featuredExcerpt,
     String? featuredUrl,
     String? featuredSource,
+    String? hybridField,
+    String? hybridSnippet,
+    String? hybridMatch,
   }) = _GrilleRevealResponse;
 
   factory GrilleRevealResponse.fromJson(Map<String, dynamic> json) =>
@@ -114,6 +123,9 @@ class GrilleGuessResponse with _$GrilleGuessResponse {
     String? featuredExcerpt,
     String? featuredUrl,
     String? featuredSource,
+    String? hybridField,
+    String? hybridSnippet,
+    String? hybridMatch,
   }) = _GrilleGuessResponse;
 
   factory GrilleGuessResponse.fromJson(Map<String, dynamic> json) =>

--- a/apps/mobile/lib/features/grille/models/grille_models.freezed.dart
+++ b/apps/mobile/lib/features/grille/models/grille_models.freezed.dart
@@ -204,7 +204,13 @@ mixin _$GrilleTodayResponse {
   String? get featuredTitle => throw _privateConstructorUsedError;
   String? get featuredExcerpt => throw _privateConstructorUsedError;
   String? get featuredUrl => throw _privateConstructorUsedError;
-  String? get featuredSource => throw _privateConstructorUsedError;
+  String? get featuredSource =>
+      throw _privateConstructorUsedError; // Sélection hybride : où le mot se cachait dans l'actu réelle.
+// `hybridField` = "title" | "description" (badge), `hybridSnippet` = texte
+// exact à afficher, `hybridMatch` = surface à surligner.
+  String? get hybridField => throw _privateConstructorUsedError;
+  String? get hybridSnippet => throw _privateConstructorUsedError;
+  String? get hybridMatch => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -239,7 +245,10 @@ abstract class $GrilleTodayResponseCopyWith<$Res> {
       String? featuredTitle,
       String? featuredExcerpt,
       String? featuredUrl,
-      String? featuredSource});
+      String? featuredSource,
+      String? hybridField,
+      String? hybridSnippet,
+      String? hybridMatch});
 }
 
 /// @nodoc
@@ -276,6 +285,9 @@ class _$GrilleTodayResponseCopyWithImpl<$Res, $Val extends GrilleTodayResponse>
     Object? featuredExcerpt = freezed,
     Object? featuredUrl = freezed,
     Object? featuredSource = freezed,
+    Object? hybridField = freezed,
+    Object? hybridSnippet = freezed,
+    Object? hybridMatch = freezed,
   }) {
     return _then(_value.copyWith(
       date: null == date
@@ -362,6 +374,18 @@ class _$GrilleTodayResponseCopyWithImpl<$Res, $Val extends GrilleTodayResponse>
           ? _value.featuredSource
           : featuredSource // ignore: cast_nullable_to_non_nullable
               as String?,
+      hybridField: freezed == hybridField
+          ? _value.hybridField
+          : hybridField // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridSnippet: freezed == hybridSnippet
+          ? _value.hybridSnippet
+          : hybridSnippet // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridMatch: freezed == hybridMatch
+          ? _value.hybridMatch
+          : hybridMatch // ignore: cast_nullable_to_non_nullable
+              as String?,
     ) as $Val);
   }
 }
@@ -395,7 +419,10 @@ abstract class _$$GrilleTodayResponseImplCopyWith<$Res>
       String? featuredTitle,
       String? featuredExcerpt,
       String? featuredUrl,
-      String? featuredSource});
+      String? featuredSource,
+      String? hybridField,
+      String? hybridSnippet,
+      String? hybridMatch});
 }
 
 /// @nodoc
@@ -430,6 +457,9 @@ class __$$GrilleTodayResponseImplCopyWithImpl<$Res>
     Object? featuredExcerpt = freezed,
     Object? featuredUrl = freezed,
     Object? featuredSource = freezed,
+    Object? hybridField = freezed,
+    Object? hybridSnippet = freezed,
+    Object? hybridMatch = freezed,
   }) {
     return _then(_$GrilleTodayResponseImpl(
       date: null == date
@@ -516,6 +546,18 @@ class __$$GrilleTodayResponseImplCopyWithImpl<$Res>
           ? _value.featuredSource
           : featuredSource // ignore: cast_nullable_to_non_nullable
               as String?,
+      hybridField: freezed == hybridField
+          ? _value.hybridField
+          : hybridField // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridSnippet: freezed == hybridSnippet
+          ? _value.hybridSnippet
+          : hybridSnippet // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridMatch: freezed == hybridMatch
+          ? _value.hybridMatch
+          : hybridMatch // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -544,7 +586,10 @@ class _$GrilleTodayResponseImpl extends _GrilleTodayResponse {
       this.featuredTitle,
       this.featuredExcerpt,
       this.featuredUrl,
-      this.featuredSource})
+      this.featuredSource,
+      this.hybridField,
+      this.hybridSnippet,
+      this.hybridMatch})
       : _essais = essais,
         super._();
 
@@ -601,10 +646,19 @@ class _$GrilleTodayResponseImpl extends _GrilleTodayResponse {
   final String? featuredUrl;
   @override
   final String? featuredSource;
+// Sélection hybride : où le mot se cachait dans l'actu réelle.
+// `hybridField` = "title" | "description" (badge), `hybridSnippet` = texte
+// exact à afficher, `hybridMatch` = surface à surligner.
+  @override
+  final String? hybridField;
+  @override
+  final String? hybridSnippet;
+  @override
+  final String? hybridMatch;
 
   @override
   String toString() {
-    return 'GrilleTodayResponse(date: $date, dateAffichee: $dateAffichee, dateCourt: $dateCourt, numero: $numero, longueur: $longueur, essaisMax: $essaisMax, premiereLettre: $premiereLettre, indice: $indice, theme: $theme, statut: $statut, essais: $essais, nbEssais: $nbEssais, mot: $mot, pourquoi: $pourquoi, streak: $streak, prochainMotDansSec: $prochainMotDansSec, featuredContentId: $featuredContentId, featuredTitle: $featuredTitle, featuredExcerpt: $featuredExcerpt, featuredUrl: $featuredUrl, featuredSource: $featuredSource)';
+    return 'GrilleTodayResponse(date: $date, dateAffichee: $dateAffichee, dateCourt: $dateCourt, numero: $numero, longueur: $longueur, essaisMax: $essaisMax, premiereLettre: $premiereLettre, indice: $indice, theme: $theme, statut: $statut, essais: $essais, nbEssais: $nbEssais, mot: $mot, pourquoi: $pourquoi, streak: $streak, prochainMotDansSec: $prochainMotDansSec, featuredContentId: $featuredContentId, featuredTitle: $featuredTitle, featuredExcerpt: $featuredExcerpt, featuredUrl: $featuredUrl, featuredSource: $featuredSource, hybridField: $hybridField, hybridSnippet: $hybridSnippet, hybridMatch: $hybridMatch)';
   }
 
   @override
@@ -645,7 +699,13 @@ class _$GrilleTodayResponseImpl extends _GrilleTodayResponse {
             (identical(other.featuredUrl, featuredUrl) ||
                 other.featuredUrl == featuredUrl) &&
             (identical(other.featuredSource, featuredSource) ||
-                other.featuredSource == featuredSource));
+                other.featuredSource == featuredSource) &&
+            (identical(other.hybridField, hybridField) ||
+                other.hybridField == hybridField) &&
+            (identical(other.hybridSnippet, hybridSnippet) ||
+                other.hybridSnippet == hybridSnippet) &&
+            (identical(other.hybridMatch, hybridMatch) ||
+                other.hybridMatch == hybridMatch));
   }
 
   @JsonKey(ignore: true)
@@ -672,7 +732,10 @@ class _$GrilleTodayResponseImpl extends _GrilleTodayResponse {
         featuredTitle,
         featuredExcerpt,
         featuredUrl,
-        featuredSource
+        featuredSource,
+        hybridField,
+        hybridSnippet,
+        hybridMatch
       ]);
 
   @JsonKey(ignore: true)
@@ -712,7 +775,10 @@ abstract class _GrilleTodayResponse extends GrilleTodayResponse {
       final String? featuredTitle,
       final String? featuredExcerpt,
       final String? featuredUrl,
-      final String? featuredSource}) = _$GrilleTodayResponseImpl;
+      final String? featuredSource,
+      final String? hybridField,
+      final String? hybridSnippet,
+      final String? hybridMatch}) = _$GrilleTodayResponseImpl;
   const _GrilleTodayResponse._() : super._();
 
   factory _GrilleTodayResponse.fromJson(Map<String, dynamic> json) =
@@ -761,6 +827,14 @@ abstract class _GrilleTodayResponse extends GrilleTodayResponse {
   String? get featuredUrl;
   @override
   String? get featuredSource;
+  @override // Sélection hybride : où le mot se cachait dans l'actu réelle.
+// `hybridField` = "title" | "description" (badge), `hybridSnippet` = texte
+// exact à afficher, `hybridMatch` = surface à surligner.
+  String? get hybridField;
+  @override
+  String? get hybridSnippet;
+  @override
+  String? get hybridMatch;
   @override
   @JsonKey(ignore: true)
   _$$GrilleTodayResponseImplCopyWith<_$GrilleTodayResponseImpl> get copyWith =>
@@ -781,6 +855,9 @@ mixin _$GrilleRevealResponse {
   String? get featuredExcerpt => throw _privateConstructorUsedError;
   String? get featuredUrl => throw _privateConstructorUsedError;
   String? get featuredSource => throw _privateConstructorUsedError;
+  String? get hybridField => throw _privateConstructorUsedError;
+  String? get hybridSnippet => throw _privateConstructorUsedError;
+  String? get hybridMatch => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -802,7 +879,10 @@ abstract class $GrilleRevealResponseCopyWith<$Res> {
       String? featuredTitle,
       String? featuredExcerpt,
       String? featuredUrl,
-      String? featuredSource});
+      String? featuredSource,
+      String? hybridField,
+      String? hybridSnippet,
+      String? hybridMatch});
 }
 
 /// @nodoc
@@ -827,6 +907,9 @@ class _$GrilleRevealResponseCopyWithImpl<$Res,
     Object? featuredExcerpt = freezed,
     Object? featuredUrl = freezed,
     Object? featuredSource = freezed,
+    Object? hybridField = freezed,
+    Object? hybridSnippet = freezed,
+    Object? hybridMatch = freezed,
   }) {
     return _then(_value.copyWith(
       statut: null == statut
@@ -861,6 +944,18 @@ class _$GrilleRevealResponseCopyWithImpl<$Res,
           ? _value.featuredSource
           : featuredSource // ignore: cast_nullable_to_non_nullable
               as String?,
+      hybridField: freezed == hybridField
+          ? _value.hybridField
+          : hybridField // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridSnippet: freezed == hybridSnippet
+          ? _value.hybridSnippet
+          : hybridSnippet // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridMatch: freezed == hybridMatch
+          ? _value.hybridMatch
+          : hybridMatch // ignore: cast_nullable_to_non_nullable
+              as String?,
     ) as $Val);
   }
 }
@@ -881,7 +976,10 @@ abstract class _$$GrilleRevealResponseImplCopyWith<$Res>
       String? featuredTitle,
       String? featuredExcerpt,
       String? featuredUrl,
-      String? featuredSource});
+      String? featuredSource,
+      String? hybridField,
+      String? hybridSnippet,
+      String? hybridMatch});
 }
 
 /// @nodoc
@@ -903,6 +1001,9 @@ class __$$GrilleRevealResponseImplCopyWithImpl<$Res>
     Object? featuredExcerpt = freezed,
     Object? featuredUrl = freezed,
     Object? featuredSource = freezed,
+    Object? hybridField = freezed,
+    Object? hybridSnippet = freezed,
+    Object? hybridMatch = freezed,
   }) {
     return _then(_$GrilleRevealResponseImpl(
       statut: null == statut
@@ -937,6 +1038,18 @@ class __$$GrilleRevealResponseImplCopyWithImpl<$Res>
           ? _value.featuredSource
           : featuredSource // ignore: cast_nullable_to_non_nullable
               as String?,
+      hybridField: freezed == hybridField
+          ? _value.hybridField
+          : hybridField // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridSnippet: freezed == hybridSnippet
+          ? _value.hybridSnippet
+          : hybridSnippet // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridMatch: freezed == hybridMatch
+          ? _value.hybridMatch
+          : hybridMatch // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -952,7 +1065,10 @@ class _$GrilleRevealResponseImpl implements _GrilleRevealResponse {
       this.featuredTitle,
       this.featuredExcerpt,
       this.featuredUrl,
-      this.featuredSource});
+      this.featuredSource,
+      this.hybridField,
+      this.hybridSnippet,
+      this.hybridMatch});
 
   factory _$GrilleRevealResponseImpl.fromJson(Map<String, dynamic> json) =>
       _$$GrilleRevealResponseImplFromJson(json);
@@ -973,10 +1089,16 @@ class _$GrilleRevealResponseImpl implements _GrilleRevealResponse {
   final String? featuredUrl;
   @override
   final String? featuredSource;
+  @override
+  final String? hybridField;
+  @override
+  final String? hybridSnippet;
+  @override
+  final String? hybridMatch;
 
   @override
   String toString() {
-    return 'GrilleRevealResponse(statut: $statut, mot: $mot, pourquoi: $pourquoi, featuredContentId: $featuredContentId, featuredTitle: $featuredTitle, featuredExcerpt: $featuredExcerpt, featuredUrl: $featuredUrl, featuredSource: $featuredSource)';
+    return 'GrilleRevealResponse(statut: $statut, mot: $mot, pourquoi: $pourquoi, featuredContentId: $featuredContentId, featuredTitle: $featuredTitle, featuredExcerpt: $featuredExcerpt, featuredUrl: $featuredUrl, featuredSource: $featuredSource, hybridField: $hybridField, hybridSnippet: $hybridSnippet, hybridMatch: $hybridMatch)';
   }
 
   @override
@@ -997,7 +1119,13 @@ class _$GrilleRevealResponseImpl implements _GrilleRevealResponse {
             (identical(other.featuredUrl, featuredUrl) ||
                 other.featuredUrl == featuredUrl) &&
             (identical(other.featuredSource, featuredSource) ||
-                other.featuredSource == featuredSource));
+                other.featuredSource == featuredSource) &&
+            (identical(other.hybridField, hybridField) ||
+                other.hybridField == hybridField) &&
+            (identical(other.hybridSnippet, hybridSnippet) ||
+                other.hybridSnippet == hybridSnippet) &&
+            (identical(other.hybridMatch, hybridMatch) ||
+                other.hybridMatch == hybridMatch));
   }
 
   @JsonKey(ignore: true)
@@ -1011,7 +1139,10 @@ class _$GrilleRevealResponseImpl implements _GrilleRevealResponse {
       featuredTitle,
       featuredExcerpt,
       featuredUrl,
-      featuredSource);
+      featuredSource,
+      hybridField,
+      hybridSnippet,
+      hybridMatch);
 
   @JsonKey(ignore: true)
   @override
@@ -1038,7 +1169,10 @@ abstract class _GrilleRevealResponse implements GrilleRevealResponse {
       final String? featuredTitle,
       final String? featuredExcerpt,
       final String? featuredUrl,
-      final String? featuredSource}) = _$GrilleRevealResponseImpl;
+      final String? featuredSource,
+      final String? hybridField,
+      final String? hybridSnippet,
+      final String? hybridMatch}) = _$GrilleRevealResponseImpl;
 
   factory _GrilleRevealResponse.fromJson(Map<String, dynamic> json) =
       _$GrilleRevealResponseImpl.fromJson;
@@ -1059,6 +1193,12 @@ abstract class _GrilleRevealResponse implements GrilleRevealResponse {
   String? get featuredUrl;
   @override
   String? get featuredSource;
+  @override
+  String? get hybridField;
+  @override
+  String? get hybridSnippet;
+  @override
+  String? get hybridMatch;
   @override
   @JsonKey(ignore: true)
   _$$GrilleRevealResponseImplCopyWith<_$GrilleRevealResponseImpl>
@@ -1083,6 +1223,9 @@ mixin _$GrilleGuessResponse {
   String? get featuredExcerpt => throw _privateConstructorUsedError;
   String? get featuredUrl => throw _privateConstructorUsedError;
   String? get featuredSource => throw _privateConstructorUsedError;
+  String? get hybridField => throw _privateConstructorUsedError;
+  String? get hybridSnippet => throw _privateConstructorUsedError;
+  String? get hybridMatch => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -1108,7 +1251,10 @@ abstract class $GrilleGuessResponseCopyWith<$Res> {
       String? featuredTitle,
       String? featuredExcerpt,
       String? featuredUrl,
-      String? featuredSource});
+      String? featuredSource,
+      String? hybridField,
+      String? hybridSnippet,
+      String? hybridMatch});
 }
 
 /// @nodoc
@@ -1136,6 +1282,9 @@ class _$GrilleGuessResponseCopyWithImpl<$Res, $Val extends GrilleGuessResponse>
     Object? featuredExcerpt = freezed,
     Object? featuredUrl = freezed,
     Object? featuredSource = freezed,
+    Object? hybridField = freezed,
+    Object? hybridSnippet = freezed,
+    Object? hybridMatch = freezed,
   }) {
     return _then(_value.copyWith(
       valide: null == valide
@@ -1186,6 +1335,18 @@ class _$GrilleGuessResponseCopyWithImpl<$Res, $Val extends GrilleGuessResponse>
           ? _value.featuredSource
           : featuredSource // ignore: cast_nullable_to_non_nullable
               as String?,
+      hybridField: freezed == hybridField
+          ? _value.hybridField
+          : hybridField // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridSnippet: freezed == hybridSnippet
+          ? _value.hybridSnippet
+          : hybridSnippet // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridMatch: freezed == hybridMatch
+          ? _value.hybridMatch
+          : hybridMatch // ignore: cast_nullable_to_non_nullable
+              as String?,
     ) as $Val);
   }
 }
@@ -1210,7 +1371,10 @@ abstract class _$$GrilleGuessResponseImplCopyWith<$Res>
       String? featuredTitle,
       String? featuredExcerpt,
       String? featuredUrl,
-      String? featuredSource});
+      String? featuredSource,
+      String? hybridField,
+      String? hybridSnippet,
+      String? hybridMatch});
 }
 
 /// @nodoc
@@ -1236,6 +1400,9 @@ class __$$GrilleGuessResponseImplCopyWithImpl<$Res>
     Object? featuredExcerpt = freezed,
     Object? featuredUrl = freezed,
     Object? featuredSource = freezed,
+    Object? hybridField = freezed,
+    Object? hybridSnippet = freezed,
+    Object? hybridMatch = freezed,
   }) {
     return _then(_$GrilleGuessResponseImpl(
       valide: null == valide
@@ -1286,6 +1453,18 @@ class __$$GrilleGuessResponseImplCopyWithImpl<$Res>
           ? _value.featuredSource
           : featuredSource // ignore: cast_nullable_to_non_nullable
               as String?,
+      hybridField: freezed == hybridField
+          ? _value.hybridField
+          : hybridField // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridSnippet: freezed == hybridSnippet
+          ? _value.hybridSnippet
+          : hybridSnippet // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hybridMatch: freezed == hybridMatch
+          ? _value.hybridMatch
+          : hybridMatch // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -1305,7 +1484,10 @@ class _$GrilleGuessResponseImpl extends _GrilleGuessResponse {
       this.featuredTitle,
       this.featuredExcerpt,
       this.featuredUrl,
-      this.featuredSource})
+      this.featuredSource,
+      this.hybridField,
+      this.hybridSnippet,
+      this.hybridMatch})
       : _etats = etats,
         super._();
 
@@ -1344,10 +1526,16 @@ class _$GrilleGuessResponseImpl extends _GrilleGuessResponse {
   final String? featuredUrl;
   @override
   final String? featuredSource;
+  @override
+  final String? hybridField;
+  @override
+  final String? hybridSnippet;
+  @override
+  final String? hybridMatch;
 
   @override
   String toString() {
-    return 'GrilleGuessResponse(valide: $valide, raison: $raison, etats: $etats, statut: $statut, nbEssais: $nbEssais, mot: $mot, pourquoi: $pourquoi, featuredContentId: $featuredContentId, featuredTitle: $featuredTitle, featuredExcerpt: $featuredExcerpt, featuredUrl: $featuredUrl, featuredSource: $featuredSource)';
+    return 'GrilleGuessResponse(valide: $valide, raison: $raison, etats: $etats, statut: $statut, nbEssais: $nbEssais, mot: $mot, pourquoi: $pourquoi, featuredContentId: $featuredContentId, featuredTitle: $featuredTitle, featuredExcerpt: $featuredExcerpt, featuredUrl: $featuredUrl, featuredSource: $featuredSource, hybridField: $hybridField, hybridSnippet: $hybridSnippet, hybridMatch: $hybridMatch)';
   }
 
   @override
@@ -1373,7 +1561,13 @@ class _$GrilleGuessResponseImpl extends _GrilleGuessResponse {
             (identical(other.featuredUrl, featuredUrl) ||
                 other.featuredUrl == featuredUrl) &&
             (identical(other.featuredSource, featuredSource) ||
-                other.featuredSource == featuredSource));
+                other.featuredSource == featuredSource) &&
+            (identical(other.hybridField, hybridField) ||
+                other.hybridField == hybridField) &&
+            (identical(other.hybridSnippet, hybridSnippet) ||
+                other.hybridSnippet == hybridSnippet) &&
+            (identical(other.hybridMatch, hybridMatch) ||
+                other.hybridMatch == hybridMatch));
   }
 
   @JsonKey(ignore: true)
@@ -1391,7 +1585,10 @@ class _$GrilleGuessResponseImpl extends _GrilleGuessResponse {
       featuredTitle,
       featuredExcerpt,
       featuredUrl,
-      featuredSource);
+      featuredSource,
+      hybridField,
+      hybridSnippet,
+      hybridMatch);
 
   @JsonKey(ignore: true)
   @override
@@ -1421,7 +1618,10 @@ abstract class _GrilleGuessResponse extends GrilleGuessResponse {
       final String? featuredTitle,
       final String? featuredExcerpt,
       final String? featuredUrl,
-      final String? featuredSource}) = _$GrilleGuessResponseImpl;
+      final String? featuredSource,
+      final String? hybridField,
+      final String? hybridSnippet,
+      final String? hybridMatch}) = _$GrilleGuessResponseImpl;
   const _GrilleGuessResponse._() : super._();
 
   factory _GrilleGuessResponse.fromJson(Map<String, dynamic> json) =
@@ -1451,6 +1651,12 @@ abstract class _GrilleGuessResponse extends GrilleGuessResponse {
   String? get featuredUrl;
   @override
   String? get featuredSource;
+  @override
+  String? get hybridField;
+  @override
+  String? get hybridSnippet;
+  @override
+  String? get hybridMatch;
   @override
   @JsonKey(ignore: true)
   _$$GrilleGuessResponseImplCopyWith<_$GrilleGuessResponseImpl> get copyWith =>

--- a/apps/mobile/lib/features/grille/models/grille_models.g.dart
+++ b/apps/mobile/lib/features/grille/models/grille_models.g.dart
@@ -44,6 +44,9 @@ _$GrilleTodayResponseImpl _$$GrilleTodayResponseImplFromJson(
       featuredExcerpt: json['featuredExcerpt'] as String?,
       featuredUrl: json['featuredUrl'] as String?,
       featuredSource: json['featuredSource'] as String?,
+      hybridField: json['hybridField'] as String?,
+      hybridSnippet: json['hybridSnippet'] as String?,
+      hybridMatch: json['hybridMatch'] as String?,
     );
 
 Map<String, dynamic> _$$GrilleTodayResponseImplToJson(
@@ -70,6 +73,9 @@ Map<String, dynamic> _$$GrilleTodayResponseImplToJson(
       'featuredExcerpt': instance.featuredExcerpt,
       'featuredUrl': instance.featuredUrl,
       'featuredSource': instance.featuredSource,
+      'hybridField': instance.hybridField,
+      'hybridSnippet': instance.hybridSnippet,
+      'hybridMatch': instance.hybridMatch,
     };
 
 _$GrilleRevealResponseImpl _$$GrilleRevealResponseImplFromJson(
@@ -83,6 +89,9 @@ _$GrilleRevealResponseImpl _$$GrilleRevealResponseImplFromJson(
       featuredExcerpt: json['featuredExcerpt'] as String?,
       featuredUrl: json['featuredUrl'] as String?,
       featuredSource: json['featuredSource'] as String?,
+      hybridField: json['hybridField'] as String?,
+      hybridSnippet: json['hybridSnippet'] as String?,
+      hybridMatch: json['hybridMatch'] as String?,
     );
 
 Map<String, dynamic> _$$GrilleRevealResponseImplToJson(
@@ -96,6 +105,9 @@ Map<String, dynamic> _$$GrilleRevealResponseImplToJson(
       'featuredExcerpt': instance.featuredExcerpt,
       'featuredUrl': instance.featuredUrl,
       'featuredSource': instance.featuredSource,
+      'hybridField': instance.hybridField,
+      'hybridSnippet': instance.hybridSnippet,
+      'hybridMatch': instance.hybridMatch,
     };
 
 _$GrilleGuessResponseImpl _$$GrilleGuessResponseImplFromJson(
@@ -114,6 +126,9 @@ _$GrilleGuessResponseImpl _$$GrilleGuessResponseImplFromJson(
       featuredExcerpt: json['featuredExcerpt'] as String?,
       featuredUrl: json['featuredUrl'] as String?,
       featuredSource: json['featuredSource'] as String?,
+      hybridField: json['hybridField'] as String?,
+      hybridSnippet: json['hybridSnippet'] as String?,
+      hybridMatch: json['hybridMatch'] as String?,
     );
 
 Map<String, dynamic> _$$GrilleGuessResponseImplToJson(
@@ -131,6 +146,9 @@ Map<String, dynamic> _$$GrilleGuessResponseImplToJson(
       'featuredExcerpt': instance.featuredExcerpt,
       'featuredUrl': instance.featuredUrl,
       'featuredSource': instance.featuredSource,
+      'hybridField': instance.hybridField,
+      'hybridSnippet': instance.hybridSnippet,
+      'hybridMatch': instance.hybridMatch,
     };
 
 _$GrilleDistributionItemImpl _$$GrilleDistributionItemImplFromJson(

--- a/apps/mobile/lib/features/grille/providers/grille_provider.dart
+++ b/apps/mobile/lib/features/grille/providers/grille_provider.dart
@@ -190,6 +190,9 @@ class GrilleNotifier extends AsyncNotifier<GrilleState> {
         featuredExcerpt: res.featuredExcerpt ?? after.today.featuredExcerpt,
         featuredUrl: res.featuredUrl ?? after.today.featuredUrl,
         featuredSource: res.featuredSource ?? after.today.featuredSource,
+        hybridField: res.hybridField ?? after.today.hybridField,
+        hybridSnippet: res.hybridSnippet ?? after.today.hybridSnippet,
+        hybridMatch: res.hybridMatch ?? after.today.hybridMatch,
       );
 
       state = AsyncData(
@@ -265,6 +268,9 @@ class GrilleNotifier extends AsyncNotifier<GrilleState> {
         featuredExcerpt: res.featuredExcerpt ?? after.today.featuredExcerpt,
         featuredUrl: res.featuredUrl ?? after.today.featuredUrl,
         featuredSource: res.featuredSource ?? after.today.featuredSource,
+        hybridField: res.hybridField ?? after.today.hybridField,
+        hybridSnippet: res.hybridSnippet ?? after.today.hybridSnippet,
+        hybridMatch: res.hybridMatch ?? after.today.hybridMatch,
       );
       state = AsyncData(
         after.copyWith(

--- a/apps/mobile/lib/features/grille/widgets/grille_result_view.dart
+++ b/apps/mobile/lib/features/grille/widgets/grille_result_view.dart
@@ -321,7 +321,8 @@ class GrilleResultView extends StatelessWidget {
     };
     final lower = s.toLowerCase();
     final buf = StringBuffer();
-    for (final ch in lower.split('')) {
+    for (var i = 0; i < lower.length; i++) {
+      final ch = lower[i];
       buf.write(map[ch] ?? ch);
     }
     return buf.toString();

--- a/apps/mobile/lib/features/grille/widgets/grille_result_view.dart
+++ b/apps/mobile/lib/features/grille/widgets/grille_result_view.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../../config/theme.dart';
 import '../grille_constants.dart';
@@ -156,9 +157,12 @@ class GrilleResultView extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 4),
-                // Si un vrai article de la tournée est accroché, on l'affiche
-                // (titre + extrait) ; sinon on retombe sur la phrase « pourquoi ».
-                if (today.featuredExcerpt != null) ...[
+                // Priorité : sélection hybride (« où le mot se cachait dans
+                // l'actu réelle »), puis l'ancien snapshot featured (titre +
+                // extrait), puis la phrase « pourquoi » (fallback historique).
+                if (today.hybridSnippet != null)
+                  ..._hybrid(context)
+                else if (today.featuredExcerpt != null) ...[
                   Text(
                     today.featuredTitle ?? '',
                     style: GoogleFonts.fraunces(
@@ -202,6 +206,125 @@ class GrilleResultView extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  /// Bloc « où le mot se cachait » : badge titre/description, snippet avec la
+  /// surface matchée surlignée, source, et lien « Lire l'article ».
+  List<Widget> _hybrid(BuildContext context) {
+    final c = context.facteurColors;
+    final isTitle = today.hybridField == 'title';
+    final badge = isTitle ? 'caché dans le titre' : 'caché dans la description';
+    return [
+      Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          color: c.primary.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(FacteurRadius.small),
+        ),
+        child: Text(
+          badge,
+          style: FacteurTypography.bodySmall(c.primary)
+              .copyWith(fontSize: 11, fontWeight: FontWeight.w700),
+        ),
+      ),
+      const SizedBox(height: 8),
+      Text.rich(
+        _highlight(
+          context,
+          today.hybridSnippet!,
+          today.hybridMatch,
+        ),
+        style: GoogleFonts.fraunces(
+          fontSize: 15,
+          fontWeight: FontWeight.w600,
+          height: 1.45,
+          color: c.textPrimary,
+        ),
+      ),
+      if (today.featuredSource != null) ...[
+        const SizedBox(height: 8),
+        Text(
+          today.featuredSource!,
+          style: FacteurTypography.bodySmall(c.textTertiary)
+              .copyWith(fontSize: 12, fontWeight: FontWeight.w600),
+        ),
+      ],
+      if (today.featuredUrl != null) ...[
+        const SizedBox(height: 10),
+        InkWell(
+          onTap: () => _openArticle(today.featuredUrl!),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'Lire l\'article',
+                style: FacteurTypography.bodySmall(c.primary).copyWith(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(width: 4),
+              Icon(Icons.arrow_forward, size: 14, color: c.primary),
+            ],
+          ),
+        ),
+      ],
+    ];
+  }
+
+  Future<void> _openArticle(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    await launchUrl(uri, mode: LaunchMode.inAppBrowserView);
+  }
+
+  /// Découpe `snippet` autour de `surface` (insensible casse/accents) et met la
+  /// surface en gras + surligné. Si la surface est introuvable, rend le texte tel quel.
+  TextSpan _highlight(BuildContext context, String snippet, String? surface) {
+    final c = context.facteurColors;
+    final bold = GoogleFonts.fraunces(
+      fontSize: 15,
+      fontWeight: FontWeight.w800,
+      height: 1.45,
+      color: c.primary,
+      backgroundColor: c.primary.withValues(alpha: 0.14),
+    );
+    if (surface == null || surface.isEmpty) {
+      return TextSpan(text: snippet);
+    }
+    final hay = _fold(snippet);
+    final needle = _fold(surface);
+    final idx = hay.indexOf(needle);
+    if (idx < 0) {
+      return TextSpan(text: snippet);
+    }
+    final end = idx + surface.length;
+    return TextSpan(
+      children: [
+        TextSpan(text: snippet.substring(0, idx)),
+        TextSpan(text: snippet.substring(idx, end), style: bold),
+        TextSpan(text: snippet.substring(end)),
+      ],
+    );
+  }
+
+  /// Normalisation légère pour la recherche de surface : minuscules + accents
+  /// FR courants repliés (la longueur est préservée → les offsets restent valides).
+  String _fold(String s) {
+    const map = {
+      'à': 'a', 'â': 'a', 'ä': 'a', 'á': 'a',
+      'é': 'e', 'è': 'e', 'ê': 'e', 'ë': 'e',
+      'î': 'i', 'ï': 'i', 'í': 'i',
+      'ô': 'o', 'ö': 'o', 'ó': 'o',
+      'û': 'u', 'ü': 'u', 'ù': 'u', 'ú': 'u',
+      'ç': 'c',
+    };
+    final lower = s.toLowerCase();
+    final buf = StringBuffer();
+    for (final ch in lower.split('')) {
+      buf.write(map[ch] ?? ch);
+    }
+    return buf.toString();
   }
 }
 

--- a/apps/mobile/test/features/grille/widgets/grille_result_view_test.dart
+++ b/apps/mobile/test/features/grille/widgets/grille_result_view_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/grille/models/grille_models.dart';
+import 'package:facteur/features/grille/widgets/grille_result_view.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(body: SingleChildScrollView(child: child)),
+    );
+
+GrilleTodayResponse _today({
+  String? hybridField,
+  String? hybridSnippet,
+  String? hybridMatch,
+  String? featuredExcerpt,
+  String? featuredUrl,
+  String? featuredSource,
+  String? pourquoi = 'phrase de repli',
+}) {
+  return GrilleTodayResponse(
+    date: '2026-06-13',
+    dateAffichee: 'Vendredi 13 juin',
+    dateCourt: 'Ven. 13 juin',
+    numero: 'N°1',
+    longueur: 6,
+    essaisMax: 6,
+    premiereLettre: 'C',
+    indice: 'indice',
+    theme: 'Environnement',
+    statut: 'solved',
+    essais: const [
+      GrilleEssai(
+        mot: 'CLIMAT',
+        etats: ['place', 'place', 'place', 'place', 'place', 'place'],
+      ),
+    ],
+    nbEssais: 1,
+    mot: 'CLIMAT',
+    pourquoi: pourquoi,
+    streak: 1,
+    prochainMotDansSec: 100,
+    hybridField: hybridField,
+    hybridSnippet: hybridSnippet,
+    hybridMatch: hybridMatch,
+    featuredExcerpt: featuredExcerpt,
+    featuredUrl: featuredUrl,
+    featuredSource: featuredSource,
+  );
+}
+
+void main() {
+  setUpAll(() => GoogleFonts.config.allowRuntimeFetching = false);
+
+  testWidgets('hybride : badge titre + snippet + source + lien', (t) async {
+    await t.pumpWidget(_wrap(GrilleResultView(
+      today: _today(
+        hybridField: 'title',
+        hybridSnippet: 'Nouvel espoir pour le climat à Belém',
+        hybridMatch: 'climat',
+        featuredSource: 'Le Monde',
+        featuredUrl: 'https://exemple.fr/a',
+      ),
+    )));
+    await t.pumpAndSettle();
+
+    expect(find.text('caché dans le titre'), findsOneWidget);
+    expect(find.text('Le Monde'), findsOneWidget);
+    expect(find.text('Lire l\'article'), findsOneWidget);
+    // Le snippet est rendu (via Text.rich) et la phrase de repli est absente.
+    expect(find.textContaining('Belém', findRichText: true), findsOneWidget);
+    expect(find.textContaining('phrase de repli'), findsNothing);
+  });
+
+  testWidgets('hybride : badge description', (t) async {
+    await t.pumpWidget(_wrap(GrilleResultView(
+      today: _today(
+        hybridField: 'description',
+        hybridSnippet: '…le sommet européen s\'achève…',
+        hybridMatch: 'sommet',
+      ),
+    )));
+    await t.pumpAndSettle();
+    expect(find.text('caché dans la description'), findsOneWidget);
+  });
+
+  testWidgets('fallback : pas de hybride → phrase pourquoi', (t) async {
+    await t.pumpWidget(_wrap(GrilleResultView(today: _today())));
+    await t.pumpAndSettle();
+    expect(find.textContaining('phrase de repli'), findsOneWidget);
+    expect(find.text('caché dans le titre'), findsNothing);
+  });
+}

--- a/packages/api/alembic/versions/gh01_grille_hybrid_word.py
+++ b/packages/api/alembic/versions/gh01_grille_hybrid_word.py
@@ -1,0 +1,47 @@
+"""grille hybrid word occurrence — colonnes hybrid_* sur grille_puzzles.
+
+Sélection hybride du « mot du jour » : le mot est extrait de l'actu réelle et on
+fige où il se cachait (titre/description + surface à surligner). Purement
+additif (colonnes nullable, sans backfill, sans NOT NULL, sans drop) →
+compatible expand-contract avec la DB partagée staging/prod.
+
+- hybrid_field      : "title" | "description" (badge « caché dans le … »).
+- hybrid_snippet    : texte exact à afficher (titre complet ou fenêtre de desc).
+- hybrid_match      : surface exacte à surligner dans le snippet.
+- hybrid_word_source: "hybrid" vs NULL/seed (idempotence + observabilité).
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "gh01_grille_hybrid_word"
+down_revision: str | None = "mg01_merge_au01_rsvps"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "grille_puzzles",
+        sa.Column("hybrid_field", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "grille_puzzles",
+        sa.Column("hybrid_snippet", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "grille_puzzles",
+        sa.Column("hybrid_match", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "grille_puzzles",
+        sa.Column("hybrid_word_source", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("grille_puzzles", "hybrid_word_source")
+    op.drop_column("grille_puzzles", "hybrid_match")
+    op.drop_column("grille_puzzles", "hybrid_snippet")
+    op.drop_column("grille_puzzles", "hybrid_field")

--- a/packages/api/app/data/grille_quality_words_fr.txt
+++ b/packages/api/app/data/grille_quality_words_fr.txt
@@ -1,0 +1,168 @@
+# Liste de qualité éditoriale — « mot du jour » de La Grille (voix Facteur).
+#
+# Noms communs de 6 lettres « dignes du mot du jour » : civiques, économiques,
+# environnementaux, sociaux, internationaux, culturels. Un mot extrait de
+# l'actu n'est retenu comme mot du jour QUE s'il figure ici (qualité éditoriale)
+# ET dans `grille_words_fr.txt` (validité / tapable par le joueur).
+#
+# Format : 1 mot/ligne, MAJUSCULES sans accent, exactement 6 lettres. `#` = commentaire.
+# Seedé depuis les mots seed de `grille_puzzles_seed.json`, puis élargi.
+# Chaque entrée a été vérifiée présente dans le dictionnaire de validité.
+
+# --- Seeds historiques (puzzles seedés) ---
+CLIMAT
+BUDGET
+SOMMET
+IMPOTS
+EUROPE
+GREVES
+OCEANS
+DEBATS
+MANDAT
+MARCHE
+GUERRE
+FORETS
+TRAITE
+SEISME
+MUSEES
+
+# --- Politique / institutions ---
+NATION
+REGION
+PEUPLE
+PARTIS
+PATRON
+SYNDIC
+DEPUTE
+SENATS
+PALAIS
+SCANDA
+MANDAT
+
+# --- Économie / social ---
+BUDGET
+DETTES
+CRISES
+EMPLOI
+USINES
+BOURSE
+HAUSSE
+BAISSE
+INDICE
+CREDIT
+IMPACT
+GROUPE
+BANQUE
+DOUANE
+FISCAL
+REVENU
+LOYERS
+CHARTE
+ACCORD
+NUMERO
+
+# --- Conflits / international ---
+ARMEES
+OTAGES
+FRAPPE
+REFUGE
+EXODES
+FAMINE
+RUSSIE
+MARINE
+AVIONS
+NAVIRE
+PILOTE
+
+# --- Environnement / climat ---
+GLACES
+NATURE
+ESPECE
+DESERT
+FLEUVE
+DELUGE
+SECHER
+ORAGES
+CANCER
+
+# --- Société / mouvements ---
+FEMMES
+HOMMES
+JEUNES
+COLERE
+GROGNE
+DROITS
+VALEUR
+AVENIR
+REGARD
+PAROLE
+ENJEUX
+ALERTE
+RECORD
+
+# --- Justice / faits ---
+PROCES
+CRIMES
+DELITS
+PEINES
+GRACES
+AMENDE
+FRAUDE
+ESCROC
+AVOCAT
+TEMOIN
+ACCUSE
+BLESSE
+CHUTES
+VISITE
+
+# --- Santé ---
+GRIPPE
+VACCIN
+MALADE
+
+# --- Numérique / médias ---
+RESEAU
+DONNEE
+SECRET
+ESPION
+PIRATE
+RUMEUR
+MEDIAS
+PRESSE
+RADIOS
+CHAINE
+ECRANS
+
+# --- Éducation / sciences ---
+ECOLES
+LYCEES
+ETUDES
+THESES
+SAVOIR
+ESPACE
+FUSEES
+TRAINS
+METROS
+ROUTES
+
+# --- Culture ---
+LIVRES
+ROMANS
+POEMES
+CHANTS
+DANSES
+OPERAS
+TALENT
+GENIES
+
+# --- Sport ---
+EQUIPE
+FINALE
+STADES
+JOUEUR
+DOPAGE
+TENNIS
+BALLON
+COURSE
+NAGEUR

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -564,19 +564,19 @@ class DigestGenerationJob:
         target_date: datetime.date,
         editorial_ctx_pour_vous,
     ) -> None:
-        """Accroche l'actu du jour qui matche le mot de la Grille (best-effort).
+        """Sélection hybride du mot du jour depuis l'actu réelle (best-effort).
 
-        Fige un snapshot (titre/extrait/url/source) sur le `GrillePuzzle` du jour
-        depuis le contexte éditorial global pour_vous. Entièrement isolé : toute
-        erreur est loggée + remontée à Sentry mais n'altère JAMAIS la génération
-        du digest (le mot du jour est secondaire). Idempotent.
+        Extrait le mot du jour du corpus d'actu, le fige avec son occurrence
+        exacte (titre/desc + surface) sur le `GrillePuzzle` du jour. Le contexte
+        éditorial pour_vous n'est qu'un *bonus* de scoring (peut être None : la
+        sélection retombe sur le corpus brut). Entièrement isolé : toute erreur
+        est loggée + remontée à Sentry mais n'altère JAMAIS la génération du
+        digest (le mot du jour est secondaire). Idempotent.
         """
-        if editorial_ctx_pour_vous is None:
-            return
         try:
-            from app.services.grille_matcher import match_grille_featured_article
+            from app.services.grille_matcher import apply_hybrid_word
 
-            matched = await match_grille_featured_article(
+            matched = await apply_hybrid_word(
                 session, target_date, editorial_ctx_pour_vous
             )
             await session.commit()

--- a/packages/api/app/models/grille_puzzle.py
+++ b/packages/api/app/models/grille_puzzle.py
@@ -78,6 +78,14 @@ class GrillePuzzle(Base):
     featured_matched_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # Sélection hybride (Story mot-du-jour-actu) : le mot du jour est extrait de
+    # l'actu réelle et on fige l'occurrence exacte pour le reveal. Tout nullable
+    # (additif / expand-contract) : NULL → ancien comportement (mot seedé +
+    # `pourquoi`). `hybrid_word_source == "hybrid"` sert d'idempotence + d'obs.
+    hybrid_field: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hybrid_snippet: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hybrid_match: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hybrid_word_source: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow, nullable=False
     )

--- a/packages/api/app/schemas/grille.py
+++ b/packages/api/app/schemas/grille.py
@@ -24,6 +24,13 @@ class GrilleFeaturedMixin(BaseModel):
     featuredExcerpt: str | None = None
     featuredUrl: str | None = None
     featuredSource: str | None = None
+    # Sélection hybride : où le mot se cachait dans l'actu réelle.
+    # `hybridField` = "title" | "description" (badge), `hybridSnippet` = texte
+    # exact à afficher, `hybridMatch` = surface exacte à surligner. `null` →
+    # le mobile retombe sur `featuredExcerpt` / `pourquoi`.
+    hybridField: str | None = None
+    hybridSnippet: str | None = None
+    hybridMatch: str | None = None
 
 
 class GrilleEssai(BaseModel):

--- a/packages/api/app/services/grille_matcher.py
+++ b/packages/api/app/services/grille_matcher.py
@@ -1,9 +1,9 @@
-"""Auto-matching « mot du jour » → article réel de la tournée.
+"""Orchestration « mot du jour » → sélection hybride depuis l'actu réelle.
 
-À la génération du digest, on cherche dans le contexte éditorial global le sujet
-dont l'actu colle le mieux au mot du jour (et son thème), puis on **fige** un
-snapshot (titre + extrait + url + source) sur le `GrillePuzzle` du jour. Le
-reveal affiche alors un vrai article ; sans match, il retombe sur `pourquoi`.
+À la génération du digest, `apply_hybrid_word` extrait le mot du jour du corpus
+d'actu (cf. `grille_selector`) et **fige** sur le `GrillePuzzle` du jour le mot,
+l'article source (titre/extrait/url/source) et l'occurrence exacte (où le mot se
+cachait). Sans candidat, le puzzle garde son mot seedé + `pourquoi`.
 
 Best-effort et idempotent : appelé depuis le job digest dans un try/except qui
 n'altère jamais le digest. Le runtime de la Grille ne fait aucun join — il lit
@@ -17,75 +17,20 @@ import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.content import Content
+from app.models.grille_game_state import GrilleGameState
 from app.models.grille_puzzle import GrillePuzzle
-from app.services.editorial.schemas import EditorialGlobalContext, EditorialSubject
-from app.services.recommendation.helpers.keyword_match import matches_word_boundary
+from app.services.editorial.schemas import EditorialGlobalContext
 
 logger = structlog.get_logger()
 
 # Longueur max de l'extrait figé (description tronquée proprement).
 _EXCERPT_MAX = 240
 
-# Score minimal pour accrocher un article (au moins un match flexion/sous-chaîne).
-_MIN_SCORE = 1
-
 
 def _norm(text: str) -> str:
     """Minuscules sans accent (miroir Python de la normalisation de matching)."""
     decomposed = unicodedata.normalize("NFKD", text)
     return "".join(c for c in decomposed if not unicodedata.combining(c)).lower()
-
-
-def subject_match_score(word: str, theme: str, subject: EditorialSubject) -> int:
-    """Force du match d'un sujet éditorial au mot du jour (0 = pas de match).
-
-    On compare le mot (et, en bonus, le thème) au label du sujet, à son thème et
-    au titre de son actu. Un match **mot-entier** (`\\b…\\b`) vaut plus qu'une
-    sous-chaîne — cette dernière tolère les flexions (CLIMAT ⊂ « climatique »).
-    """
-    word_l = _norm(word)
-    if not word_l:
-        return 0
-
-    haystacks: list[str] = [_norm(subject.label)]
-    if subject.theme:
-        haystacks.append(_norm(subject.theme))
-    if subject.actu_article is not None:
-        haystacks.append(_norm(subject.actu_article.title))
-
-    score = 0
-    for hay in haystacks:
-        if matches_word_boundary(word_l, hay):
-            score += 3
-        elif word_l in hay:
-            # Flexion / dérivé (climat → climatique) : match plus faible.
-            score += 2
-
-    # Bonus léger si le thème du sujet recoupe le thème éditorial du puzzle
-    # (« Environnement · Société » → tokens partagés).
-    theme_tokens = {t for t in _norm(theme).replace("·", " ").split() if len(t) > 3}
-    subj_theme = _norm(subject.theme or "")
-    if theme_tokens and any(t in subj_theme for t in theme_tokens):
-        score += 1
-
-    return score
-
-
-def _best_subject(
-    word: str, theme: str, subjects: list[EditorialSubject]
-) -> EditorialSubject | None:
-    """Sujet au meilleur score (>= seuil) portant une actu ; tie-break par rang."""
-    best: EditorialSubject | None = None
-    best_score = 0
-    for subject in sorted(subjects, key=lambda s: s.rank):
-        if subject.actu_article is None:
-            continue
-        score = subject_match_score(word, theme, subject)
-        if score > best_score:
-            best_score = score
-            best = subject
-    return best if best_score >= _MIN_SCORE else None
 
 
 def _excerpt(description: str | None) -> str | None:
@@ -99,53 +44,73 @@ def _excerpt(description: str | None) -> str | None:
     return f"{cut}…"
 
 
-async def match_grille_featured_article(
+async def apply_hybrid_word(
     session: AsyncSession,
     target_date: date,
     editorial_ctx: EditorialGlobalContext | None,
 ) -> bool:
-    """Fige l'article matché sur le puzzle du jour. Retourne True si un match.
+    """Sélection hybride : remplace le mot seedé par un mot extrait de l'actu.
 
-    Idempotent : ne fait rien si le puzzle a déjà un `featured_content_id`. Ne
-    commit pas (le caller gère la transaction) — fait juste un flush.
+    Retourne True si un mot a été posé depuis l'actu (sinon le puzzle garde son
+    mot seedé + `pourquoi`). Ne commit pas (le caller gère la transaction).
+
+    Gardes :
+      - **Idempotence** : no-op si `hybrid_word_source == "hybrid"` déjà posé.
+      - **Anti-overwrite mid-day** (edge case critique) : si ≥1 partie existe
+        déjà pour `target_date`, on ne touche à **rien** — changer `word`
+        re-colorierait les tuiles d'un joueur en cours (`compute_tiles` lit
+        `puzzle.word` live), et l'occurrence hybride serait incohérente avec le
+        mot seedé conservé. En pratique le digest tourne au rollover (07:30) →
+        aucune partie n'existe encore, donc l'overwrite gagne la course.
     """
-    if editorial_ctx is None or not editorial_ctx.subjects:
-        return False
+    from app.services.grille_selector import (
+        WORD_SOURCE_HYBRID,
+        select_daily_word,
+    )
 
     puzzle = await session.scalar(
         select(GrillePuzzle).where(GrillePuzzle.puzzle_date == target_date)
     )
     if puzzle is None:
         return False
-    if puzzle.featured_content_id is not None:
-        logger.info("grille_featured_already_set", target_date=str(target_date))
+    if puzzle.hybrid_word_source == WORD_SOURCE_HYBRID:
+        logger.info("grille_hybrid_already_set", target_date=str(target_date))
         return False
 
-    subject = _best_subject(puzzle.word, puzzle.theme, editorial_ctx.subjects)
-    if subject is None or subject.actu_article is None:
-        logger.info(
-            "grille_featured_no_match",
+    game_exists = await session.scalar(
+        select(GrilleGameState.id)
+        .where(GrilleGameState.puzzle_date == target_date)
+        .limit(1)
+    )
+    if game_exists is not None:
+        logger.warning(
+            "grille_hybrid_skip_game_in_progress",
             target_date=str(target_date),
-            word=puzzle.word,
         )
         return False
 
-    actu = subject.actu_article
-    content = await session.get(Content, actu.content_id)
+    selection = await select_daily_word(session, target_date, editorial_ctx)
+    if selection is None:
+        return False
 
-    puzzle.featured_content_id = actu.content_id
-    puzzle.featured_title = actu.title
-    puzzle.featured_excerpt = _excerpt(content.description if content else None)
-    puzzle.featured_url = content.url if content else None
-    puzzle.featured_source = actu.source_name
+    puzzle.word = selection.word
+    puzzle.featured_content_id = selection.content_id
+    puzzle.featured_title = selection.title
+    puzzle.featured_excerpt = selection.excerpt
+    puzzle.featured_url = selection.url
+    puzzle.featured_source = selection.source_name
     puzzle.featured_matched_at = datetime.utcnow()
+    puzzle.hybrid_field = selection.field
+    puzzle.hybrid_snippet = selection.snippet
+    puzzle.hybrid_match = selection.match_surface
+    puzzle.hybrid_word_source = WORD_SOURCE_HYBRID
     await session.flush()
 
     logger.info(
-        "grille_featured_matched",
+        "grille_hybrid_applied",
         target_date=str(target_date),
-        word=puzzle.word,
-        content_id=str(actu.content_id),
-        source=actu.source_name,
+        word=selection.word,
+        field=selection.field,
+        content_id=str(selection.content_id),
     )
     return True

--- a/packages/api/app/services/grille_quality_pool.py
+++ b/packages/api/app/services/grille_quality_pool.py
@@ -1,0 +1,45 @@
+"""Pool de qualité éditoriale de « La Grille du jour » — chargé une fois.
+
+L'asset `app/data/grille_quality_words_fr.txt` liste les noms communs « dignes
+du mot du jour » (voix Facteur). Il sert de **filtre éditorial** sur les mots
+extraits de l'actu : un candidat n'est retenu que s'il est dans ce pool ET dans
+le dictionnaire de validité (`grille_dictionary.is_valid_word`).
+
+Même pattern que `grille_dictionary.py` : lecture unique, `frozenset` normalisé
+(MAJUSCULES sans accent, exactement 6 lettres).
+"""
+
+from functools import lru_cache
+from pathlib import Path
+
+from app.services.grille_dictionary import WORD_LENGTH
+from app.services.grille_text import normalize_word
+
+# Asset embarqué (1 mot/ligne, `#` = commentaire).
+_POOL_PATH = (
+    Path(__file__).resolve().parent.parent / "data" / "grille_quality_words_fr.txt"
+)
+
+
+def _load_words(path: Path) -> frozenset[str]:
+    """Charge et normalise le pool : MAJ, sans accent, 6 lettres A-Z."""
+    words: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        word = normalize_word(line)
+        if len(word) == WORD_LENGTH and word.isalpha() and word.isascii():
+            words.add(word)
+    return frozenset(words)
+
+
+@lru_cache(maxsize=1)
+def get_quality_pool() -> frozenset[str]:
+    """Retourne le `frozenset` des mots de qualité (chargé une seule fois)."""
+    return _load_words(_POOL_PATH)
+
+
+def is_quality_word(word: str) -> bool:
+    """True si `word` (déjà normalisé) appartient au pool de qualité."""
+    return word in get_quality_pool()

--- a/packages/api/app/services/grille_selector.py
+++ b/packages/api/app/services/grille_selector.py
@@ -12,8 +12,10 @@ Pur scoring + une requête corpus en miroir de
 le résultat est figé en colonnes sur `GrillePuzzle`.
 """
 
+import asyncio
 import re
 from dataclasses import dataclass
+from functools import lru_cache
 from datetime import UTC, date, datetime, timedelta
 from uuid import UUID
 
@@ -25,7 +27,7 @@ from sqlalchemy.orm import selectinload
 from app.models.content import Content
 from app.models.grille_puzzle import GrillePuzzle
 from app.services.editorial.schemas import EditorialGlobalContext
-from app.services.grille_dictionary import is_valid_word
+from app.services.grille_dictionary import WORD_LENGTH, is_valid_word
 from app.services.grille_matcher import _excerpt, _norm
 from app.services.grille_quality_pool import get_quality_pool
 from app.services.grille_text import normalize_word
@@ -90,8 +92,12 @@ def _scan_field(
                 hits[word] = (tok, True)
             continue
         # Flexion : un mot du pool est strictement inclus dans le token.
+        # Les mots du pool font tous WORD_LENGTH lettres → un token plus court
+        # ne peut pas les contenir.
+        if len(tok_norm) <= WORD_LENGTH:
+            continue
         for word_l, word in pool_index.items():
-            if len(tok_norm) > len(word_l) and word_l in tok_norm:
+            if word_l in tok_norm:
                 hits.setdefault(word, (tok, False))
     return hits
 
@@ -176,6 +182,12 @@ class _Candidate:
     surface: str = ""
 
 
+@lru_cache(maxsize=1)
+def _pool_index() -> dict[str, str]:
+    """Index `mot_minuscule → mot_MAJ` du pool (calculé une seule fois)."""
+    return {word.lower(): word for word in get_quality_pool()}
+
+
 def _select_from_corpus(
     corpus: list[Content],
     cluster_index: dict[str, int],
@@ -183,9 +195,7 @@ def _select_from_corpus(
     exclude: str | None,
 ) -> GrilleSelection | None:
     """Cœur pur : extrait le meilleur mot du pool présent dans le corpus."""
-    # `_norm` renvoie du minuscule ; le pool est en MAJUSCULES → l'index mappe
-    # la forme minuscule (clé de comparaison) vers la forme MAJ canonique.
-    pool_index = {word.lower(): word for word in get_quality_pool()}
+    pool_index = _pool_index()
     candidates: dict[str, _Candidate] = {}
 
     for content in corpus:
@@ -268,7 +278,10 @@ async def select_daily_word(
 
     Lecture seule : ne touche pas le puzzle (c'est `apply_hybrid_word` qui fige).
     """
-    corpus = await _corpus(session)
+    corpus, yesterday = await asyncio.gather(
+        _corpus(session),
+        _yesterday_word(session, target_date),
+    )
     if not corpus:
         logger.info("grille_selector_empty_corpus", target_date=str(target_date))
         return None
@@ -277,7 +290,7 @@ async def select_daily_word(
         corpus,
         _build_cluster_index(editorial_ctx),
         _subject_label_words(editorial_ctx),
-        await _yesterday_word(session, target_date),
+        yesterday,
     )
     if selection is None:
         logger.info("grille_selector_no_candidate", target_date=str(target_date))

--- a/packages/api/app/services/grille_selector.py
+++ b/packages/api/app/services/grille_selector.py
@@ -1,0 +1,292 @@
+"""Sélecteur hybride du « mot du jour » — extrait de l'actu réelle du jour.
+
+Inverse la logique de l'ancien `grille_matcher` : au lieu de partir d'un mot
+seedé et de *chercher* un article qui colle, on **extrait** le mot du jour du
+corpus d'actu du jour (titres + descriptions des ~300 articles de la tournée),
+filtré par le pool de qualité éditoriale (`grille_quality_pool`) et le
+dictionnaire de validité (`grille_dictionary`). On fige l'occurrence exacte
+(quel article, titre ou description, surface à surligner) pour le reveal.
+
+Pur scoring + une requête corpus en miroir de
+`DigestGenerationJob._get_global_candidates`. Aucun join runtime côté Grille :
+le résultat est figé en colonnes sur `GrillePuzzle`.
+"""
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from uuid import UUID
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.content import Content
+from app.models.grille_puzzle import GrillePuzzle
+from app.services.editorial.schemas import EditorialGlobalContext
+from app.services.grille_dictionary import is_valid_word
+from app.services.grille_matcher import _excerpt, _norm
+from app.services.grille_quality_pool import get_quality_pool
+from app.services.grille_text import normalize_word
+from app.services.recommendation.filter_presets import apply_ad_filter
+
+logger = structlog.get_logger()
+
+# Fenêtre de récence du corpus (miroir de `hours_lookback` du digest).
+_CORPUS_HOURS = 48
+# Borne du corpus (top-N par récence) — assez large pour trouver un mot la
+# plupart des jours sans scanner toute la base.
+_CORPUS_LIMIT = 300
+# Score minimal pour retenir un mot (au moins un match sous-chaîne).
+_MIN_SCORE = 1
+# Demi-largeur d'une fenêtre de description centrée sur la surface matchée.
+_WINDOW_HALF = 110
+
+FIELD_TITLE = "title"
+FIELD_DESCRIPTION = "description"
+WORD_SOURCE_HYBRID = "hybrid"
+
+# Runs de lettres (unicode, accents inclus ; chiffres / ponctuation exclus).
+_TOKEN_RE = re.compile(r"[^\W\d_]+", re.UNICODE)
+
+
+@dataclass(frozen=True)
+class GrilleSelection:
+    """Mot du jour extrait de l'actu + son occurrence exacte (à figer)."""
+
+    word: str
+    content_id: UUID
+    title: str
+    source_name: str | None
+    url: str | None
+    excerpt: str | None
+    field: str  # FIELD_TITLE | FIELD_DESCRIPTION
+    snippet: str  # texte exact à afficher (titre complet ou fenêtre de desc)
+    match_surface: str  # surface exacte à surligner dans le snippet
+
+
+def _scan_field(
+    text: str | None, pool_index: dict[str, str]
+) -> dict[str, tuple[str, bool]]:
+    """Mots du pool présents dans `text` (1 seule passe de tokenisation).
+
+    Renvoie `word_MAJ -> (surface_originale, mot_entier)`. Un token strictement
+    égal à un mot du pool est un **mot-entier** (« climat ») ; un token qui
+    *contient* un mot est une **flexion** (« climatique »). Un mot-entier
+    l'emporte toujours sur une flexion, et la première occurrence gagne sinon.
+    La surface est le token original (accents/casse d'origine) → le mobile la
+    re-localise dans le snippet.
+    """
+    hits: dict[str, tuple[str, bool]] = {}
+    if not text:
+        return hits
+    for tok in _TOKEN_RE.findall(text):
+        tok_norm = _norm(tok)
+        word = pool_index.get(tok_norm)
+        if word is not None:  # mot-entier (lookup O(1))
+            prev = hits.get(word)
+            if prev is None or not prev[1]:
+                hits[word] = (tok, True)
+            continue
+        # Flexion : un mot du pool est strictement inclus dans le token.
+        for word_l, word in pool_index.items():
+            if len(tok_norm) > len(word_l) and word_l in tok_norm:
+                hits.setdefault(word, (tok, False))
+    return hits
+
+
+def _window(text: str, surface: str) -> str:
+    """Fenêtre ~220 car de `text` centrée sur `surface` (sinon extrait simple)."""
+    idx = text.find(surface)
+    if idx < 0:
+        return _excerpt(text) or text
+    start = max(0, idx - _WINDOW_HALF)
+    end = min(len(text), idx + len(surface) + _WINDOW_HALF)
+    fragment = text[start:end].strip()
+    prefix = "…" if start > 0 else ""
+    suffix = "…" if end < len(text) else ""
+    return f"{prefix}{fragment}{suffix}"
+
+
+def _build_cluster_index(
+    editorial_ctx: EditorialGlobalContext | None,
+) -> dict[str, int]:
+    """content_id (str) → rang du cluster qui le contient (plus petit = mieux)."""
+    index: dict[str, int] = {}
+    if editorial_ctx is None:
+        return index
+    for rank, cluster in enumerate(editorial_ctx.cluster_data):
+        for cid in cluster.get("content_ids", []):
+            index.setdefault(str(cid), rank)
+    return index
+
+
+def _subject_label_words(
+    editorial_ctx: EditorialGlobalContext | None,
+) -> set[str]:
+    """Mots (MAJUSCULES sans accent) présents dans les labels des sujets.
+
+    Même forme canonique que le pool / `GrilleSelection.word` → comparaison
+    directe `word in label_words`.
+    """
+    words: set[str] = set()
+    if editorial_ctx is None:
+        return words
+    for subject in editorial_ctx.subjects:
+        for tok in _TOKEN_RE.findall(subject.label):
+            words.add(normalize_word(tok))
+    return words
+
+
+async def _corpus(session: AsyncSession) -> list[Content]:
+    """Articles récents (≤48h, hors pubs), top-N par récence — miroir digest."""
+    cutoff = datetime.now(UTC) - timedelta(hours=_CORPUS_HOURS)
+    stmt = (
+        apply_ad_filter(select(Content).options(selectinload(Content.source)))
+        .where(Content.published_at >= cutoff)
+        .order_by(Content.published_at.desc())
+        .limit(_CORPUS_LIMIT)
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def _yesterday_word(session: AsyncSession, target_date: date) -> str | None:
+    """Mot du puzzle de la veille (normalisé) — anti-répétition."""
+    puzzle = await session.scalar(
+        select(GrillePuzzle).where(
+            GrillePuzzle.puzzle_date == target_date - timedelta(days=1)
+        )
+    )
+    return normalize_word(puzzle.word) if puzzle else None
+
+
+@dataclass
+class _Candidate:
+    """Accumulateur de score d'un mot du pool sur le corpus."""
+
+    word: str
+    score: int = 0
+    cluster_rank: int = 1_000_000
+    # Meilleure occurrence (priorité : titre-entier > titre-flexion > desc).
+    occ_priority: int = 99
+    content: Content | None = None
+    field: str = FIELD_TITLE
+    surface: str = ""
+
+
+def _select_from_corpus(
+    corpus: list[Content],
+    cluster_index: dict[str, int],
+    label_words: set[str],
+    exclude: str | None,
+) -> GrilleSelection | None:
+    """Cœur pur : extrait le meilleur mot du pool présent dans le corpus."""
+    # `_norm` renvoie du minuscule ; le pool est en MAJUSCULES → l'index mappe
+    # la forme minuscule (clé de comparaison) vers la forme MAJ canonique.
+    pool_index = {word.lower(): word for word in get_quality_pool()}
+    candidates: dict[str, _Candidate] = {}
+
+    for content in corpus:
+        crank = cluster_index.get(str(content.id), 1_000_000)
+        title_hits = _scan_field(content.title, pool_index)
+        desc_hits = _scan_field(content.description, pool_index)
+
+        for word in title_hits.keys() | desc_hits.keys():
+            if word == exclude or not is_valid_word(word):
+                continue
+
+            title_hit = title_hits.get(word)
+            desc_hit = desc_hits.get(word)
+
+            art_score = 0
+            if title_hit:
+                art_score += 3 if title_hit[1] else 1
+            if desc_hit:
+                art_score += 2 if desc_hit[1] else 1
+
+            cand = candidates.setdefault(word, _Candidate(word=word))
+            cand.score += art_score
+            cand.cluster_rank = min(cand.cluster_rank, crank)
+
+            # Occurrence à figer : titre-entier(0) > titre-flexion(1) > desc(2).
+            if title_hit:
+                priority = 0 if title_hit[1] else 1
+                surface, field = title_hit[0], FIELD_TITLE
+            else:
+                priority = 2
+                surface, field = desc_hit[0], FIELD_DESCRIPTION
+            if priority < cand.occ_priority:
+                cand.occ_priority = priority
+                cand.content = content
+                cand.field = field
+                cand.surface = surface
+
+    if not candidates:
+        return None
+
+    # Bonus éditorial +2 (top cluster ou mot dans un label de sujet).
+    for cand in candidates.values():
+        if cand.cluster_rank < 1_000_000 or cand.word in label_words:
+            cand.score += 2
+
+    # Tie-break déterministe : score desc, rang cluster asc, alpha.
+    best = min(
+        (c for c in candidates.values() if c.score >= _MIN_SCORE and c.content),
+        key=lambda c: (-c.score, c.cluster_rank, c.word),
+        default=None,
+    )
+    if best is None or best.content is None:
+        return None
+
+    content = best.content
+    if best.field == FIELD_TITLE:
+        snippet = (content.title or "").strip()
+    else:
+        snippet = _window(content.description or "", best.surface)
+
+    return GrilleSelection(
+        word=best.word,
+        content_id=content.id,
+        title=content.title or "",
+        source_name=content.source.name if content.source else None,
+        url=content.url,
+        excerpt=_excerpt(content.description),
+        field=best.field,
+        snippet=snippet,
+        match_surface=best.surface,
+    )
+
+
+async def select_daily_word(
+    session: AsyncSession,
+    target_date: date,
+    editorial_ctx: EditorialGlobalContext | None,
+) -> GrilleSelection | None:
+    """Choisit le mot du jour dans l'actu du jour, ou None (→ fallback seed).
+
+    Lecture seule : ne touche pas le puzzle (c'est `apply_hybrid_word` qui fige).
+    """
+    corpus = await _corpus(session)
+    if not corpus:
+        logger.info("grille_selector_empty_corpus", target_date=str(target_date))
+        return None
+
+    selection = _select_from_corpus(
+        corpus,
+        _build_cluster_index(editorial_ctx),
+        _subject_label_words(editorial_ctx),
+        await _yesterday_word(session, target_date),
+    )
+    if selection is None:
+        logger.info("grille_selector_no_candidate", target_date=str(target_date))
+    else:
+        logger.info(
+            "grille_selector_picked",
+            target_date=str(target_date),
+            word=selection.word,
+            field=selection.field,
+            content_id=str(selection.content_id),
+        )
+    return selection

--- a/packages/api/app/services/grille_service.py
+++ b/packages/api/app/services/grille_service.py
@@ -56,6 +56,9 @@ def _featured_fields(puzzle: GrillePuzzle) -> dict[str, object | None]:
         "featuredExcerpt": puzzle.featured_excerpt,
         "featuredUrl": puzzle.featured_url,
         "featuredSource": puzzle.featured_source,
+        "hybridField": puzzle.hybrid_field,
+        "hybridSnippet": puzzle.hybrid_snippet,
+        "hybridMatch": puzzle.hybrid_match,
     }
 
 

--- a/packages/api/tests/test_grille_matcher.py
+++ b/packages/api/tests/test_grille_matcher.py
@@ -1,4 +1,4 @@
-"""Tests de l'auto-matching « mot du jour » → article réel (Part D)."""
+"""Tests de l'orchestration « mot du jour » → sélection hybride (apply_hybrid_word)."""
 
 from datetime import datetime
 from uuid import uuid4
@@ -7,85 +7,10 @@ import pytest
 
 from app.models.content import Content
 from app.models.enums import ContentType
+from app.models.grille_game_state import STATUS_IN_PROGRESS, GrilleGameState
 from app.models.grille_puzzle import GrillePuzzle
-from app.services.editorial.schemas import (
-    EditorialGlobalContext,
-    EditorialSubject,
-    MatchedActuArticle,
-)
-from app.services.grille_matcher import (
-    _best_subject,
-    match_grille_featured_article,
-    subject_match_score,
-)
+from app.services.grille_matcher import apply_hybrid_word
 from app.utils.time import today_paris
-
-
-def _actu(title, *, content_id=None, source_name="Le Monde"):
-    return MatchedActuArticle(
-        content_id=content_id or uuid4(),
-        title=title,
-        source_name=source_name,
-        source_id=uuid4(),
-        is_user_source=True,
-        published_at=datetime.utcnow(),
-    )
-
-
-def _subject(rank, label, *, theme=None, actu=None):
-    return EditorialSubject(
-        rank=rank,
-        topic_id=f"t{rank}",
-        label=label,
-        selection_reason="parce que",
-        theme=theme,
-        actu_article=actu,
-    )
-
-
-def _ctx(subjects):
-    return EditorialGlobalContext(
-        subjects=subjects, cluster_data=[], generated_at=datetime.utcnow()
-    )
-
-
-# ----- scoring pur ----------------------------------------------------------
-
-
-def test_score_word_boundary_beats_flexion():
-    boundary = _subject(1, "Climat", actu=_actu("Accord mondial sur le climat"))
-    flexion = _subject(2, "Énergie", actu=_actu("La transition climatique s'accélère"))
-    s_boundary = subject_match_score("CLIMAT", "Environnement", boundary)
-    s_flexion = subject_match_score("CLIMAT", "Environnement", flexion)
-    assert s_boundary > s_flexion > 0
-
-
-def test_score_zero_when_unrelated():
-    subj = _subject(1, "Football", actu=_actu("La finale de la coupe approche"))
-    assert subject_match_score("CLIMAT", "Diplomatie", subj) == 0
-
-
-def test_best_subject_picks_matching_lowest_rank():
-    subjects = [
-        _subject(1, "Sport", actu=_actu("Match de gala")),
-        _subject(2, "Climat", actu=_actu("Le climat au cœur du sommet")),
-    ]
-    best = _best_subject("CLIMAT", "Environnement", subjects)
-    assert best is not None
-    assert best.rank == 2
-
-
-def test_best_subject_none_when_no_match():
-    subjects = [_subject(1, "Sport", actu=_actu("Match de gala"))]
-    assert _best_subject("CLIMAT", "Diplomatie", subjects) is None
-
-
-def test_best_subject_skips_subjects_without_actu():
-    subjects = [_subject(1, "Climat", actu=None)]
-    assert _best_subject("CLIMAT", "Environnement", subjects) is None
-
-
-# ----- match_grille_featured_article (DB) -----------------------------------
 
 
 async def _make_puzzle(db, word="CLIMAT"):
@@ -124,84 +49,92 @@ async def _make_content(db, source_id, *, title, description, url):
 
 
 @pytest.mark.asyncio
-async def test_match_sets_snapshot(db_session, test_source):
-    puzzle = await _make_puzzle(db_session)
+async def test_hybrid_overwrites_word_from_actu(db_session, test_source):
+    puzzle = await _make_puzzle(db_session, word="MANDAT")
     content = await _make_content(
         db_session,
         test_source.id,
-        title="Accord mondial sur le climat",
-        description="Les délégations ont trouvé un terrain d'entente historique.",
+        title="Nouvel espoir pour le climat à Belém",
+        description="Les délégations ont trouvé un terrain d'entente.",
         url="https://exemple.fr/climat",
     )
-    ctx = _ctx(
-        [
-            _subject(1, "Sport", actu=_actu("Match de gala")),
-            _subject(
-                2,
-                "Climat",
-                theme="Environnement",
-                actu=_actu(
-                    "Accord mondial sur le climat",
-                    content_id=content.id,
-                    source_name="Le Monde",
-                ),
-            ),
-        ]
-    )
 
-    matched = await match_grille_featured_article(db_session, today_paris(), ctx)
+    matched = await apply_hybrid_word(db_session, today_paris(), None)
     assert matched is True
 
     await db_session.refresh(puzzle)
+    assert puzzle.word == "CLIMAT"  # mot extrait de l'actu, pas le seed
+    assert puzzle.hybrid_word_source == "hybrid"
+    assert puzzle.hybrid_field == "title"
+    assert puzzle.hybrid_match == "climat"
+    assert puzzle.hybrid_snippet == "Nouvel espoir pour le climat à Belém"
     assert puzzle.featured_content_id == content.id
-    assert puzzle.featured_title == "Accord mondial sur le climat"
-    assert puzzle.featured_excerpt is not None
-    assert puzzle.featured_url == "https://exemple.fr/climat"
-    assert puzzle.featured_source == "Le Monde"
-    assert puzzle.featured_matched_at is not None
+    assert puzzle.featured_source == test_source.name
 
 
 @pytest.mark.asyncio
-async def test_match_no_result_leaves_null(db_session):
-    puzzle = await _make_puzzle(db_session)
-    ctx = _ctx([_subject(1, "Sport", actu=_actu("Match de gala"))])
-
-    matched = await match_grille_featured_article(db_session, today_paris(), ctx)
-    assert matched is False
-
-    await db_session.refresh(puzzle)
-    assert puzzle.featured_content_id is None
-    assert puzzle.featured_title is None
-
-
-@pytest.mark.asyncio
-async def test_match_is_idempotent(db_session, test_source):
-    content = await _make_content(
+async def test_hybrid_is_idempotent(db_session, test_source):
+    puzzle = await _make_puzzle(db_session, word="MANDAT")
+    puzzle.hybrid_word_source = "hybrid"
+    await db_session.commit()
+    await _make_content(
         db_session,
         test_source.id,
-        title="Climat",
-        description="desc",
+        title="Le climat se réchauffe",
+        description="x",
         url="https://exemple.fr/c",
     )
-    puzzle = await _make_puzzle(db_session)
-    puzzle.featured_content_id = content.id
-    puzzle.featured_title = "Déjà figé"
-    await db_session.commit()
 
-    ctx = _ctx(
-        [_subject(1, "Climat", actu=_actu("Le climat", content_id=content.id))]
-    )
-    matched = await match_grille_featured_article(db_session, today_paris(), ctx)
-    assert matched is False  # déjà set → skip
+    matched = await apply_hybrid_word(db_session, today_paris(), None)
+    assert matched is False  # déjà posé → skip
 
     await db_session.refresh(puzzle)
-    assert puzzle.featured_title == "Déjà figé"  # inchangé
+    assert puzzle.word == "MANDAT"  # inchangé
 
 
 @pytest.mark.asyncio
-async def test_match_none_ctx_is_noop(db_session):
-    puzzle = await _make_puzzle(db_session)
-    matched = await match_grille_featured_article(db_session, today_paris(), None)
-    assert matched is False
+async def test_hybrid_skips_when_game_already_started(db_session, test_source):
+    puzzle = await _make_puzzle(db_session, word="MANDAT")
+    await _make_content(
+        db_session,
+        test_source.id,
+        title="Le climat se réchauffe",
+        description="x",
+        url="https://exemple.fr/c",
+    )
+    db_session.add(
+        GrilleGameState(
+            user_id=uuid4(),
+            puzzle_date=today_paris(),
+            guesses=[],
+            status=STATUS_IN_PROGRESS,
+            attempts=0,
+        )
+    )
+    await db_session.commit()
+
+    matched = await apply_hybrid_word(db_session, today_paris(), None)
+    assert matched is False  # partie en cours → ne touche pas le mot
+
     await db_session.refresh(puzzle)
-    assert puzzle.featured_content_id is None
+    assert puzzle.word == "MANDAT"
+    assert puzzle.hybrid_word_source is None
+
+
+@pytest.mark.asyncio
+async def test_hybrid_no_candidate_leaves_seed(db_session, test_source):
+    puzzle = await _make_puzzle(db_session, word="MANDAT")
+    await _make_content(
+        db_session,
+        test_source.id,
+        title="Texte sans aucun terme du pool ici",
+        description="ni la non plus voila",
+        url="https://exemple.fr/none",
+    )
+
+    matched = await apply_hybrid_word(db_session, today_paris(), None)
+    assert matched is False
+
+    await db_session.refresh(puzzle)
+    assert puzzle.word == "MANDAT"  # fallback seed intact
+    assert puzzle.hybrid_word_source is None

--- a/packages/api/tests/test_grille_quality_pool.py
+++ b/packages/api/tests/test_grille_quality_pool.py
@@ -1,0 +1,32 @@
+"""Tests du pool de qualité éditoriale du mot du jour."""
+
+from app.services.grille_dictionary import is_valid_word
+from app.services.grille_quality_pool import (
+    get_quality_pool,
+    is_quality_word,
+)
+
+
+def test_pool_loads_seed_words():
+    pool = get_quality_pool()
+    for word in ("CLIMAT", "BUDGET", "SOMMET", "EUROPE", "GUERRE"):
+        assert word in pool
+
+
+def test_pool_words_are_six_letters_upper_ascii():
+    for word in get_quality_pool():
+        assert len(word) == 6
+        assert word.isalpha() and word.isascii()
+        assert word.upper() == word
+
+
+def test_pool_is_subset_of_validity_dictionary():
+    # Tout mot de qualité DOIT être tapable par le joueur (sinon jamais choisi).
+    for word in get_quality_pool():
+        assert is_valid_word(word), f"{word} absent du dictionnaire de validité"
+
+
+def test_is_quality_word():
+    assert is_quality_word("CLIMAT")
+    assert not is_quality_word("ZZZZZZ")
+    assert not is_quality_word("")

--- a/packages/api/tests/test_grille_selector.py
+++ b/packages/api/tests/test_grille_selector.py
@@ -1,0 +1,181 @@
+"""Tests du sélecteur hybride du mot du jour (extraction / scoring / occurrence)."""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from app.services.editorial.schemas import (
+    EditorialGlobalContext,
+    EditorialSubject,
+)
+from app.services.grille_quality_pool import get_quality_pool
+from app.services.grille_selector import (
+    FIELD_DESCRIPTION,
+    FIELD_TITLE,
+    _build_cluster_index,
+    _scan_field,
+    _select_from_corpus,
+    _subject_label_words,
+)
+
+_POOL_INDEX = {w.lower(): w for w in get_quality_pool()}
+
+
+def _art(title, description="", *, content_id=None, source="Le Monde", url="https://x.fr/a"):
+    return SimpleNamespace(
+        id=content_id or uuid4(),
+        title=title,
+        description=description,
+        url=url,
+        source=SimpleNamespace(name=source),
+    )
+
+
+def _ctx(subjects=None, clusters=None):
+    return EditorialGlobalContext(
+        subjects=subjects or [],
+        cluster_data=clusters or [],
+        generated_at=__import__("datetime").datetime.utcnow(),
+    )
+
+
+# ----- _scan_field ----------------------------------------------------------
+
+
+def test_scan_whole_word_with_accents():
+    hits = _scan_field("Les grèves se durcissent", _POOL_INDEX)
+    assert hits["GREVES"] == ("grèves", True)
+
+
+def test_scan_flexion():
+    hits = _scan_field("La transition climatique s'accélère", _POOL_INDEX)
+    assert hits["CLIMAT"] == ("climatique", False)
+
+
+def test_scan_prefers_whole_word_over_flexion():
+    hits = _scan_field("Le climat et la loi climatique", _POOL_INDEX)
+    assert hits["CLIMAT"] == ("climat", True)
+
+
+def test_scan_empty_when_absent():
+    assert _scan_field("Aucune correspondance ici", _POOL_INDEX) == {}
+    assert _scan_field(None, _POOL_INDEX) == {}
+
+
+# ----- _select_from_corpus (cœur pur) ---------------------------------------
+
+
+def test_selects_word_present_in_title():
+    corpus = [
+        _art("La rencontre de la coupe approche"),
+        _art("Nouvel espoir pour le climat à Belém"),
+    ]
+    sel = _select_from_corpus(corpus, {}, set(), exclude=None)
+    assert sel is not None
+    assert sel.word == "CLIMAT"
+    assert sel.field == FIELD_TITLE
+    assert sel.match_surface == "climat"
+    assert sel.snippet == "Nouvel espoir pour le climat à Belém"
+
+
+def test_title_whole_word_beats_description_only():
+    corpus = [
+        _art("Sans rapport", "On parle ici du budget de l'État"),
+        _art("Le climat au coeur du sommet"),
+    ]
+    sel = _select_from_corpus(corpus, {}, set(), exclude=None)
+    # CLIMAT (titre mot-entier +3) > BUDGET (desc mot-entier +2).
+    assert sel.word == "CLIMAT"
+
+
+def test_frequency_accumulates_across_articles():
+    corpus = [
+        _art("Le climat se réchauffe"),
+        _art("Climat : nouveau rapport"),
+        _art("Le budget en débat"),
+    ]
+    sel = _select_from_corpus(corpus, {}, set(), exclude=None)
+    # CLIMAT apparaît dans 2 titres (3+3=6) > BUDGET (3).
+    assert sel.word == "CLIMAT"
+
+
+def test_description_occurrence_builds_window_snippet():
+    long_desc = (
+        "Texte d'introduction assez long pour dépasser la fenêtre. " * 4
+        + "Le sommet européen s'achève. "
+        + "Et beaucoup de texte derrière encore. " * 4
+    )
+    corpus = [_art("Titre neutre", long_desc)]
+    sel = _select_from_corpus(corpus, {}, set(), exclude=None)
+    assert sel is not None
+    assert sel.field == FIELD_DESCRIPTION
+    assert "sommet" in sel.snippet.lower()
+    assert sel.match_surface == "sommet"
+
+
+def test_excludes_yesterday_word():
+    corpus = [_art("Le climat et le budget en débat")]
+    sel = _select_from_corpus(corpus, {}, set(), exclude="CLIMAT")
+    assert sel is not None
+    assert sel.word != "CLIMAT"
+
+
+def test_cluster_bonus_breaks_tie_by_score():
+    cid = uuid4()
+    corpus = [
+        _art("Le budget en hausse", content_id=uuid4()),
+        _art("Le climat se réchauffe", content_id=cid),
+    ]
+    # Le climat est dans un top cluster → bonus +2 (5) > budget (3).
+    cluster_index = {str(cid): 0}
+    sel = _select_from_corpus(corpus, cluster_index, set(), exclude=None)
+    assert sel.word == "CLIMAT"
+
+
+def test_subject_label_bonus():
+    corpus = [
+        _art("Le budget en hausse"),
+        _art("Le climat se réchauffe"),
+    ]
+    sel = _select_from_corpus(corpus, {}, {"CLIMAT"}, exclude=None)
+    assert sel.word == "CLIMAT"
+
+
+def test_deterministic_alpha_tiebreak():
+    # Deux mots à score strictement égal, sans cluster : tie-break alpha.
+    corpus = [_art("Le budget et le climat"), _art("Climat et budget")]
+    sel1 = _select_from_corpus(corpus, {}, set(), exclude=None)
+    sel2 = _select_from_corpus(list(reversed(corpus)), {}, set(), exclude=None)
+    assert sel1.word == sel2.word  # stable quelle que soit l'ordre du corpus
+
+
+def test_returns_none_when_no_quality_word():
+    corpus = [_art("Aucun terme pertinent ici ou la")]
+    assert _select_from_corpus(corpus, {}, set(), exclude=None) is None
+
+
+# ----- helpers contexte -----------------------------------------------------
+
+
+def test_build_cluster_index_keeps_lowest_rank():
+    cid = str(uuid4())
+    ctx = _ctx(
+        clusters=[
+            {"content_ids": [cid]},
+            {"content_ids": [cid]},
+        ]
+    )
+    index = _build_cluster_index(ctx)
+    assert index[cid] == 0
+
+
+def test_subject_label_words_normalized():
+    subj = EditorialSubject(
+        rank=1, topic_id="t1", label="Le climat mondial", selection_reason="x"
+    )
+    words = _subject_label_words(_ctx(subjects=[subj]))
+    assert "CLIMAT" in words
+
+
+def test_helpers_handle_none_ctx():
+    assert _build_cluster_index(None) == {}
+    assert _subject_label_words(None) == set()


### PR DESCRIPTION
feat(grille): mot du jour extrait de l'actu réelle + reveal « où le mot se cachait »

## Pourquoi
La Grille tirait son mot d'un seed figé 14 jours à l'avance, à l'aveugle de l'actu. Le matcher *cherchait* a posteriori un article collant au mot seedé — souvent en échec, retombant sur une phrase `pourquoi` qui pouvait prétendre que le mot était « dans trois titres » alors qu'il n'y était pas. On **inverse** la logique : chaque jour le mot est **extrait** de l'actu du jour, et on montre exactement où il se cachait.

## Backend
- **Pool de qualité éditoriale** : asset `grille_quality_words_fr.txt` (noms communs 6 lettres « dignes du mot du jour ») + loader `grille_quality_pool.py` (`@lru_cache`, même pattern que `grille_dictionary`). Chaque mot du pool est vérifié présent dans le dictionnaire de validité (test garde-fou) → toujours tapable.
- **Sélecteur** `grille_selector.py` : `select_daily_word()` re-requête le corpus d'actu du jour (≤48h, hors pubs, top-300 par récence, miroir de `_get_global_candidates`), scanne titres + descriptions (`_scan_field`, 1 passe), score (titre mot-entier +3 / desc +2 / flexion +1, cumul fréquence, **bonus +2** si l'article est dans un top cluster ou si le mot matche un label de sujet), tie-break déterministe (score, rang cluster, alpha). Fige l'**occurrence exacte** (champ titre/description + surface à surligner, sans offsets — le mobile re-localise).
- **Orchestration** `apply_hybrid_word()` (remplace l'ancien `match_grille_featured_article`, supprimé) : idempotent (`hybrid_word_source == "hybrid"`), **anti-overwrite mid-day** (skip si une partie existe déjà pour le jour → ne re-colorie pas les tuiles d'un joueur en cours), overwrite du `word` + colonnes figées, sinon **fallback** seed + `pourquoi` intact. Reroutée depuis le job digest (best-effort/Sentry inchangé).
- **Migration** `gh01_grille_hybrid_word` : 4 colonnes nullable additives (`hybrid_field`, `hybrid_snippet`, `hybrid_match`, `hybrid_word_source`) — expand-contract, DB partagée staging/prod safe. **1 seul head** confirmé.
- **Contrat API** : `hybridField`/`hybridSnippet`/`hybridMatch` (camelCase byte-exact) gated fin de partie comme les autres `featured_*`.

## Mobile
- `grille_models.dart` : 3 champs hybrides sur les 3 réponses (+ codegen freezed/json), câblés dans le provider.
- `grille_result_view.dart` : bloc « où le mot se cachait » — badge « caché dans le titre / la description », snippet en `Text.rich` avec la surface **surlignée**, source, et lien « Lire l'article » (in-app browser). Fallback inchangé sur `featuredExcerpt` puis `pourquoi`.

## Tests & VERIFY
- Backend : `pytest` complet **1714 passed** ; nouveaux tests `grille_selector` (scan/scoring/tie-break/anti-veille/cluster+label bonus), `grille_quality_pool` (loader + sous-ensemble du dico), `grille_matcher` (overwrite, idempotence, skip game-in-progress, fallback None). Ruff clean.
- Alembic : 1 head, `upgrade head` OK.
- Mobile : `flutter analyze` clean (grille), tests grille **46 passed** dont 3 nouveaux pour le bloc hybride (badge titre/desc + fallback).

## Notes
- L'asset pool est volontairement large (~140 mots) et facilement extensible.
- Le mot reste toujours `is_valid_word` (6 lettres, tapable, `compute_tiles` OK) et ≠ mot de la veille.