### PR TITLE
fix(mobile): 3 bugs UI — clavier onboarding, fermeture modal Favoris, routage lettres

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Corrections",
+      "summary": "Saisie d'un sujet plus fluide à l'onboarding, fermeture évidente de la modal Favoris, et navigation des lettres de progression fiabilisée."
+    },
+    {
       "tag": "Sources",
       "summary": "Fiche source repensée : présentation du média en premier, évaluation accessible et repliée."
     },

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -53,6 +53,8 @@ Future<void> showManageFavoritesSheet(
     context: context,
     backgroundColor: Colors.transparent,
     isScrollControlled: true,
+    enableDrag: true,
+    isDismissible: true,
     barrierColor: Colors.black.withValues(alpha: 0.5),
     builder: (ctx) => ClipRect(
       child: BackdropFilter(
@@ -610,7 +612,7 @@ class _ManageFavoritesContentState
       top: false,
       child: ConstrainedBox(
         constraints: BoxConstraints(
-          maxHeight: MediaQuery.of(context).size.height * 0.88,
+          maxHeight: MediaQuery.of(context).size.height * 0.85,
         ),
         child: Container(
           decoration: BoxDecoration(
@@ -618,13 +620,16 @@ class _ManageFavoritesContentState
             borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
           ),
           padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
-          child: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Center(
-                  child: Container(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Header fixe : handle cosmétique centré + bouton de fermeture
+              // explicite (chemin garanti 1 tap, le SingleChildScrollView
+              // interne capturant sinon le drag-to-dismiss natif).
+              Stack(
+                alignment: Alignment.center,
+                children: [
+                  Container(
                     width: 40,
                     height: 4,
                     decoration: BoxDecoration(
@@ -632,8 +637,28 @@ class _ManageFavoritesContentState
                       borderRadius: BorderRadius.circular(2),
                     ),
                   ),
-                ),
-                const SizedBox(height: FacteurSpacing.space4),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: IconButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      icon: Icon(Icons.close, color: colors.textTertiary),
+                      tooltip: 'Fermer',
+                      visualDensity: VisualDensity.compact,
+                      constraints: const BoxConstraints(
+                        minWidth: 36,
+                        minHeight: 36,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: FacteurSpacing.space2),
+              Flexible(
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
                 Text(
                   'Mes favoris',
                   style: textTheme.displaySmall?.copyWith(
@@ -845,8 +870,11 @@ class _ManageFavoritesContentState
                     router.pushNamed(RouteNames.myInterests);
                   },
                 ),
-              ],
-            ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/apps/mobile/lib/features/lettres/screens/open_letter_screen.dart
+++ b/apps/mobile/lib/features/lettres/screens/open_letter_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -6,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../navigation/letter_action_route_resolver.dart';
 import '../models/letter.dart';
@@ -16,6 +18,14 @@ import '../widgets/envelope_thumb.dart';
 import '../widgets/letter_action_tile.dart';
 import '../widgets/letter_completion_overlay.dart';
 import '../widgets/progress_toast.dart';
+
+/// Les seules destinations qui sont des onglets de la StatefulShellRoute :
+/// `context.push` y crashe (push sur une branche de shell), `context.go`
+/// bascule l'onglet. Toute autre route (`/settings`, `/veille/config`,
+/// `/saved`, …) est une route empilée → `context.push` (sinon `go` la rend
+/// unique, fond noir + crash au pop).
+bool _isShellTabRoute(String route) =>
+    route == RoutePaths.flaner || route.startsWith(RoutePaths.fluxContinu);
 
 class OpenLetterScreen extends ConsumerStatefulWidget {
   final String letterId;
@@ -396,10 +406,7 @@ class _Body extends ConsumerWidget {
                     action: a,
                     onTap: () async {
                       final route = resolveLetterActionRoute(a);
-                      // Rafraîchir l'UI Progression AVANT de naviguer : les
-                      // destinations sont des onglets shell → context.go (qui
-                      // ne « revient » pas), pas context.push (qui crashe sur
-                      // une branche StatefulShellRoute).
+                      // Rafraîchir l'UI Progression AVANT de naviguer.
                       await ref
                           .read(lettersProvider.notifier)
                           .refreshLetterStatus(letter.id);
@@ -412,7 +419,14 @@ class _Body extends ConsumerWidget {
                               .read(pendingSaveNudgeProvider.notifier)
                               .state = true;
                         }
-                        context.go(route);
+                        // Onglets shell → go (bascule d'onglet) ; routes
+                        // empilées → push (la lettre reste derrière, le pop
+                        // y revient au lieu de vider le navigator → crash).
+                        if (_isShellTabRoute(route)) {
+                          context.go(route);
+                        } else {
+                          unawaited(context.push(route));
+                        }
                       }
                     },
                   ),

--- a/apps/mobile/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/apps/mobile/lib/features/onboarding/screens/onboarding_screen.dart
@@ -33,6 +33,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     final state = ref.watch(onboardingProvider);
 
     return Scaffold(
+      // Le clavier recouvre le bas sans redimensionner le body ; l'espace
+      // scrollable est réservé par le padding viewInsets des SingleChildScrollView.
+      resizeToAvoidBottomInset: false,
       body: SafeArea(
         child: Column(
           children: [

--- a/apps/mobile/lib/features/onboarding/screens/questions/subtopics_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/subtopics_question.dart
@@ -148,6 +148,11 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
     final name = _customController.text.trim();
     if (name.isEmpty) return;
 
+    // Fermer le clavier tant que l'EditableText focalisé est encore monté :
+    // un unfocus après suppression du widget (via setState ci-dessous) est un
+    // no-op qui laisserait le clavier ouvert sur iOS.
+    FocusManager.instance.primaryFocus?.unfocus();
+
     setState(() {
       _customTopics.putIfAbsent(themeSlug, () => []);
       _customTopics[themeSlug]!.add(name);
@@ -577,7 +582,9 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
                     key: _customFieldKey,
                     controller: _customController,
                     autofocus: true,
-                    scrollPadding: const EdgeInsets.only(bottom: 240),
+                    textInputAction: TextInputAction.done,
+                    scrollPadding: EdgeInsets.only(
+                        bottom: MediaQuery.viewInsetsOf(context).bottom + 80),
                     decoration: InputDecoration(
                       hintText: AvailableSubtopics
                               .customTopicPlaceholders[theme.slug] ??

--- a/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
@@ -330,8 +330,10 @@ void main() {
       sources: _sources(),
     );
 
+    await tester.ensureVisible(find.text('Thèmes'));
     await tester.tap(find.text('Thèmes'));
     await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('Technologie'));
     await tester.tap(find.text('Technologie'));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Quoi
Trois bugs UI/navigation indépendants signalés dans l'app Flutter, corrigés sans redesign :
1. **Onboarding — sujet custom** : `textInputAction: done` + `unfocus()` *avant* le `setState` (le clavier se ferme enfin sur iOS) ; `scrollPadding` qui suit `viewInsets` + `resizeToAvoidBottomInset: false` (le champ remonte au-dessus du clavier).
2. **Modal « Mes favoris »** : header fixe avec **bouton X explicite** (fermeture garantie en 1 tap, le `SingleChildScrollView` interne capturant sinon le drag-to-dismiss natif), `enableDrag`/`isDismissible` explicites, `maxHeight` 0.88 → 0.85.
3. **Lettres (Progression)** : split `go`/`push` selon onglet shell vs route empilée. `context.go('/settings')` rendait la modal transparente unique → fond noir + crash au pop. Désormais les routes non-shell sont `push`ées (la lettre reste derrière).

## Pourquoi
Bugs bloquants remontés par le PO : clavier inutilisable à l'onboarding, modal Favoris qu'on n'arrive pas à fermer, et crash reproductible sur « Donner mon avis » depuis les lettres de Progression.

## Comment ça a été vérifié
- [x] `flutter analyze` — 0 erreur, aucun nouveau warning sur les fichiers touchés
- [x] `flutter test` — lettres + onboarding (108 tests) et `manage_favorites_sheet_test` (11 tests) verts
- [x] Test favoris ajusté : `ensureVisible` avant tap (le header fixe décale le contenu sous le viewport headless 800×600 — pur artefact de test, scroll OK sur device)
- [x] `/simplify` passé — diff minimal, rien à corriger (le repo n'enforce pas `dart format`)
- [ ] **Bug #1 à valider sur simulateur/device iOS** (clavier bloqué non reproductible sur web/Playwright)

## Zones à risque
- `resizeToAvoidBottomInset: false` s'applique à tout l'onboarding (questions à sélection non affectées ; autres saisies texte en bénéficient).
- Restructuration du widget tree de la sheet Favoris (Column + Flexible autour du scroll) — reorder des listes et blur vérifiés intacts par les tests.