### PR TITLE
feat(notifications): push serveur quotidien de l'Essentiel + refonte sélection Essentiel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,11 @@ REVENUECAT_WEBHOOK_SECRET=
 # Pas utilisée par le webhook MVP V1.
 REVENUECAT_API_KEY=
 
+# ─── Firebase Cloud Messaging ─────────────────────────────────────────────────
+# Service account Firebase Admin côté API. Utiliser une seule des deux formes.
+FIREBASE_SERVICE_ACCOUNT_JSON=
+FIREBASE_SERVICE_ACCOUNT_BASE64=
+
 # ─── Test DB (local, loopback uniquement) ─────────────────────────────────────
 # Credentials utilisés par docker-compose.test.yml pour la DB Postgres locale
 # de tests. Non sensibles : le container n'écoute que sur 127.0.0.1:54322.

--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -8,6 +8,16 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+// Firebase config is supplied per environment in app/src/prod and
+// app/src/staging. Keep local builds without credentials usable.
+if (
+    file("src/prod/google-services.json").exists() ||
+    file("src/staging/google-services.json").exists() ||
+    file("google-services.json").exists()
+) {
+    apply(plugin = "com.google.gms.google-services")
+}
+
 val keystorePropertiesFile = rootProject.file("key.properties")
 val keystoreProperties = Properties()
 if (keystorePropertiesFile.exists()) {

--- a/apps/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/apps/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -26,6 +26,16 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin audio_session, com.ryanheise.audio_session.AudioSessionPlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new io.flutter.plugins.firebase.core.FlutterFirebaseCorePlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin firebase_core, io.flutter.plugins.firebase.core.FlutterFirebaseCorePlugin", e);
+    }
+    try {
+      flutterEngine.getPlugins().add(new io.flutter.plugins.firebase.messaging.FlutterFirebaseMessagingPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin firebase_messaging, io.flutter.plugins.firebase.messaging.FlutterFirebaseMessagingPlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new vn.hunghd.flutterdownloader.FlutterDownloaderPlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin flutter_downloader, vn.hunghd.flutterdownloader.FlutterDownloaderPlugin", e);

--- a/apps/mobile/android/settings.gradle.kts
+++ b/apps/mobile/android/settings.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }
 
 include(":app")

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,8 +1,14 @@
 {
   "unreleased": [
     {
+      "tag": "Notifications",
+      "summary": "Ton Essentiel du jour arrive maintenant par notification, même app fermée : un rappel fiable le matin pour ton moment de lecture."
+    },
+    {
       "tag": "Sources",
       "summary": "Une fiche source repensée : articles récents, thèmes couverts et fréquence de publication."
+    },
+    {
       "tag": "Couverture médiatique",
       "summary": "La couverture médiatique reste affichée sous l'article : compare les titres dans un carrousel, et « Analyse Facteur » remonte une synthèse neutre en un tap. Présentation allégée et plus lisible, qui se détache mieux de l'article."
     },

--- a/apps/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -471,6 +471,7 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				APS_ENVIRONMENT = production;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -654,6 +655,7 @@
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				APS_ENVIRONMENT = development;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -677,6 +679,7 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				APS_ENVIRONMENT = production;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";

--- a/apps/mobile/ios/Runner/GeneratedPluginRegistrant.m
+++ b/apps/mobile/ios/Runner/GeneratedPluginRegistrant.m
@@ -18,6 +18,18 @@
 @import audio_session;
 #endif
 
+#if __has_include(<firebase_core/FLTFirebaseCorePlugin.h>)
+#import <firebase_core/FLTFirebaseCorePlugin.h>
+#else
+@import firebase_core;
+#endif
+
+#if __has_include(<firebase_messaging/FLTFirebaseMessagingPlugin.h>)
+#import <firebase_messaging/FLTFirebaseMessagingPlugin.h>
+#else
+@import firebase_messaging;
+#endif
+
 #if __has_include(<flutter_downloader/FlutterDownloaderPlugin.h>)
 #import <flutter_downloader/FlutterDownloaderPlugin.h>
 #else
@@ -137,6 +149,8 @@
 + (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {
   [AppLinksIosPlugin registerWithRegistrar:[registry registrarForPlugin:@"AppLinksIosPlugin"]];
   [AudioSessionPlugin registerWithRegistrar:[registry registrarForPlugin:@"AudioSessionPlugin"]];
+  [FLTFirebaseCorePlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTFirebaseCorePlugin"]];
+  [FLTFirebaseMessagingPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTFirebaseMessagingPlugin"]];
   [FlutterDownloaderPlugin registerWithRegistrar:[registry registrarForPlugin:@"FlutterDownloaderPlugin"]];
   [InAppWebViewFlutterPlugin registerWithRegistrar:[registry registrarForPlugin:@"InAppWebViewFlutterPlugin"]];
   [FlutterLocalNotificationsPlugin registerWithRegistrar:[registry registrarForPlugin:@"FlutterLocalNotificationsPlugin"]];

--- a/apps/mobile/ios/Runner/Runner.entitlements
+++ b/apps/mobile/ios/Runner/Runner.entitlements
@@ -6,5 +6,7 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>aps-environment</key>
+	<string>$(APS_ENVIRONMENT)</string>
 </dict>
 </plist>

--- a/apps/mobile/lib/core/api/push_devices_api_service.dart
+++ b/apps/mobile/lib/core/api/push_devices_api_service.dart
@@ -1,0 +1,43 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import 'api_client.dart';
+
+class PushDevicesApiService {
+  PushDevicesApiService(this._apiClient);
+
+  final ApiClient _apiClient;
+
+  Future<bool> upsert({
+    required String deviceId,
+    required String token,
+    required String platform,
+    required String timezone,
+    String? appVersion,
+  }) async {
+    try {
+      await _apiClient.dio.put<void>(
+        'devices',
+        data: {
+          'device_id': deviceId,
+          'fcm_token': token,
+          'platform': platform,
+          'timezone': timezone,
+          if (appVersion != null) 'app_version': appVersion,
+        },
+      );
+      return true;
+    } on DioException catch (e) {
+      debugPrint('PushDevicesApi: PUT failed: ${e.message}');
+      return false;
+    }
+  }
+
+  Future<void> revoke(String deviceId) async {
+    try {
+      await _apiClient.dio.delete<void>('devices/$deviceId');
+    } on DioException catch (e) {
+      debugPrint('PushDevicesApi: DELETE failed: ${e.message}');
+    }
+  }
+}

--- a/apps/mobile/lib/core/auth/auth_state.dart
+++ b/apps/mobile/lib/core/auth/auth_state.dart
@@ -9,6 +9,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../../features/auth/utils/auth_error_messages.dart';
 import '../services/posthog_service.dart';
+import '../services/server_push_service.dart';
 import '../services/widget_service.dart';
 import 'session_refresher.dart';
 
@@ -361,6 +362,10 @@ class AuthStateNotifier extends StateNotifier<AuthState>
       ),
     );
     final expiredUserId = state.user?.id;
+    await ServerPushService.instance.revokeCurrentDevice().timeout(
+      const Duration(seconds: 2),
+      onTimeout: () {},
+    );
     await _supabase.auth.signOut().timeout(
       const Duration(seconds: 3),
       onTimeout: () {},
@@ -375,6 +380,7 @@ class AuthStateNotifier extends StateNotifier<AuthState>
     debugPrint('AuthStateNotifier: signOut() explicitly called. TRACE:');
     debugPrint(StackTrace.current.toString());
     final signedOutUserId = state.user?.id;
+    await ServerPushService.instance.revokeCurrentDevice();
     await _supabase.auth.signOut();
     final box = await Hive.openBox<dynamic>('auth_prefs');
     await box.delete('remember_me'); // Reset preference on sign out

--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:timezone/timezone.dart' as tz;
 import 'package:timezone/data/latest.dart' as tz_data;
 import 'package:flutter_timezone/flutter_timezone.dart';
@@ -23,7 +24,7 @@ class _NotifIds {
   static const veilleDelivery = 3;
 }
 
-/// Service de notifications push locales (FCM non utilisé en v1).
+/// Notifications locales, y compris l'affichage au premier plan des pushes FCM.
 class PushNotificationService {
   PushNotificationService._();
 
@@ -536,6 +537,38 @@ class PushNotificationService {
     await _plugin.cancel(id: _NotifIds.weeklyCommunityPick);
   }
 
+  Future<void> showRemoteNotification(RemoteMessage message) async {
+    final notification = message.notification;
+    if (notification == null) return;
+    final route = message.data['route'] as String? ?? '/digest';
+    const androidDetails = AndroidNotificationDetails(
+      'digest_channel',
+      'Digest quotidien',
+      channelDescription: 'Notification quotidienne quand ton récap est prêt',
+      importance: Importance.high,
+      priority: Priority.high,
+      icon: '@drawable/ic_stat_facteur',
+      color: Color(0xFFD35400),
+    );
+    const iosDetails = DarwinNotificationDetails();
+    await _plugin.show(
+      id: message.messageId?.hashCode ?? DateTime.now().millisecondsSinceEpoch,
+      title: notification.title ?? defaultTitle,
+      body: notification.body ?? defaultBody,
+      notificationDetails: const NotificationDetails(
+        android: androidDetails,
+        iOS: iosDetails,
+      ),
+      payload: 'route:$route',
+    );
+  }
+
+  static void openRoute(String route) {
+    final navigator = _navigatorKey?.currentState;
+    if (navigator == null) return;
+    navigator.pushNamedAndRemoveUntil(route, (_) => false);
+  }
+
   // --- Time helpers --------------------------------------------------------
 
   static TimeOfDay _timeOfDayFor(NotifTimeSlot slot) => switch (slot) {
@@ -576,15 +609,14 @@ class PushNotificationService {
       'PushNotificationService: tapped (id: ${response.id}, payload: $payload)',
     );
 
-    final navigator = _navigatorKey?.currentState;
-    if (navigator == null) return;
-
     final route = _routeFromPayload(payload);
-    navigator.pushNamedAndRemoveUntil(route, (_) => false);
+    openRoute(route);
   }
 
   static String _routeFromPayload(String? payload) {
-    if (payload == null || !payload.startsWith('route:')) return '/flux-continu';
+    if (payload == null || !payload.startsWith('route:')) {
+      return '/flux-continu';
+    }
     return payload.substring('route:'.length);
   }
 }

--- a/apps/mobile/lib/core/services/server_push_service.dart
+++ b/apps/mobile/lib/core/services/server_push_service.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:uuid/uuid.dart';
+
+import '../api/api_client.dart';
+import '../api/notification_preferences_api_service.dart';
+import '../api/push_devices_api_service.dart';
+import 'push_notification_service.dart';
+
+@pragma('vm:entry-point')
+Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp();
+}
+
+class ServerPushService {
+  ServerPushService._();
+
+  static final ServerPushService instance = ServerPushService._();
+  static const serverRegisteredKey = 'notif_server_device_registered';
+  static const _deviceIdKey = 'push_device_id';
+
+  // Singleton vivant pendant toute la durée du process.
+  // ignore: cancel_subscriptions
+  StreamSubscription<String>? _tokenSubscription;
+  bool _initialized = false;
+
+  Future<bool> initAndRegister() async {
+    if (kIsWeb || !(Platform.isAndroid || Platform.isIOS)) return false;
+    try {
+      if (!_initialized) {
+        await Firebase.initializeApp();
+        FirebaseMessaging.onBackgroundMessage(
+          firebaseMessagingBackgroundHandler,
+        );
+        await FirebaseMessaging.instance.requestPermission(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+        FirebaseMessaging.onMessage.listen((message) {
+          unawaited(
+            PushNotificationService().showRemoteNotification(message),
+          );
+        });
+        FirebaseMessaging.onMessageOpenedApp.listen(_openMessage);
+        final initial = await FirebaseMessaging.instance.getInitialMessage();
+        if (initial != null) _openMessage(initial);
+        _tokenSubscription ??=
+            FirebaseMessaging.instance.onTokenRefresh.listen((token) {
+          unawaited(_registerToken(token));
+        });
+        _initialized = true;
+      }
+
+      final token = await FirebaseMessaging.instance.getToken();
+      if (token == null) return _setRegistered(false);
+      return _registerToken(token);
+    } catch (e) {
+      debugPrint('ServerPushService: initialization failed: $e');
+      await _setRegistered(false);
+      await _restoreGenericFallback();
+      return false;
+    }
+  }
+
+  Future<bool> _registerToken(String token) async {
+    final session = Supabase.instance.client.auth.currentSession;
+    if (session == null) return _setRegistered(false);
+
+    final prefs = await SharedPreferences.getInstance();
+    var deviceId = prefs.getString(_deviceIdKey);
+    if (deviceId == null) {
+      deviceId = const Uuid().v4();
+      await prefs.setString(_deviceIdKey, deviceId);
+    }
+    final timezone = await FlutterTimezone.getLocalTimezone();
+    final package = await PackageInfo.fromPlatform();
+    final api = PushDevicesApiService(ApiClient(Supabase.instance.client));
+    final registered = await api.upsert(
+      deviceId: deviceId,
+      token: token,
+      platform: Platform.isIOS ? 'ios' : 'android',
+      timezone: timezone,
+      appVersion: '${package.version}+${package.buildNumber}',
+    );
+    await _setRegistered(registered);
+    if (registered) {
+      await PushNotificationService().cancelDigestNotification();
+      final box = await Hive.openBox<dynamic>('settings');
+      await box.delete('notif_essentiel_teasers');
+    } else {
+      await _restoreGenericFallback();
+    }
+    return registered;
+  }
+
+  Future<void> revokeCurrentDevice() async {
+    if (kIsWeb) return;
+    final prefs = await SharedPreferences.getInstance();
+    final deviceId = prefs.getString(_deviceIdKey);
+    if (deviceId != null &&
+        Supabase.instance.client.auth.currentSession != null) {
+      await PushDevicesApiService(ApiClient(Supabase.instance.client))
+          .revoke(deviceId);
+    }
+    try {
+      await FirebaseMessaging.instance.deleteToken();
+    } catch (e) {
+      debugPrint('ServerPushService: deleteToken failed: $e');
+    }
+    await _setRegistered(false);
+  }
+
+  Future<void> _restoreGenericFallback() async {
+    final box = await Hive.openBox<dynamic>('settings');
+    final enabled =
+        box.get('push_notifications_enabled', defaultValue: false) as bool;
+    if (!enabled) return;
+    final slot = NotifTimeSlotX.fromWire(box.get('notif_time_slot') as String?);
+    final localPush = PushNotificationService();
+    await localPush.ensureExactAlarmPermission();
+    await localPush.scheduleDailyDigestNotification(
+      timeSlot: slot,
+      variant: NotifVariant.variantA,
+    );
+  }
+
+  Future<bool> _setRegistered(bool value) async {
+    final box = await Hive.openBox<dynamic>('settings');
+    await box.put(serverRegisteredKey, value);
+    return value;
+  }
+
+  void _openMessage(RemoteMessage message) {
+    final route = message.data['route'] as String? ?? '/digest';
+    PushNotificationService.openRoute(route);
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -370,17 +370,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
           essentielArticles: essentielArticles,
         ),
       );
-      // Re-pose les notifs perso (Essentiel + Bonnes Nouvelles) avec le contenu
-      // frais. Fire-and-forget, gated sur `dual != null` → ne tire jamais sur le
-      // chemin caché (stale) ni quand le digest a totalement échoué.
+      // Rafraîchit uniquement les teasers locaux Bonnes Nouvelles. Les teasers
+      // Essentiel viennent désormais du push serveur basé sur le digest exact.
       unawaited(_syncNotificationTeasers(dual, essentielArticles));
     }
     return next;
   }
 
-  /// Pousse les derniers teasers connus vers `NotificationsSettingsNotifier`
-  /// pour re-planifier les notifs perso. Non bloquant, try/catch interne : une
-  /// erreur de scheduling ne doit jamais casser le rendu du home.
+  /// Pousse les teasers Bonnes Nouvelles vers les réglages. Non bloquant :
+  /// une erreur de scheduling ne doit jamais casser le rendu du home.
   Future<void> _syncNotificationTeasers(
     DualDigestResponse dual,
     List<EssentielArticle> essentielArticles,

--- a/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
+++ b/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
@@ -7,6 +7,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import '../../../core/api/notification_preferences_api_service.dart';
 import '../../../core/api/providers.dart';
 import '../../../core/services/push_notification_service.dart';
+import '../../../core/services/server_push_service.dart';
 
 /// État des préférences de notifications
 @immutable
@@ -112,18 +113,7 @@ class NotificationsSettingsNotifier
   static const _kGoodNewsEnabled = 'notif_good_news_enabled';
   static const _kGoodNewsTimeSlot = 'notif_good_news_time_slot';
   static const _kNotifVeilleEnabled = 'notif_veille_enabled';
-  // Derniers teasers connus, écrits/lus en direct dans la box (hors `state`,
-  // `_persist` et `_patchBackend`) : purement locaux, jamais shippés au
-  // backend. Le contenu d'une notif locale étant « cuit » au scheduling, ces
-  // clés permettent aux 3 points de déclenchement (cold start, load frais,
-  // mutation réglages) de re-poser la variante B personnalisée. Publiques pour
-  // que `main.dart` (cold start) lise la même clé sans dupliquer le littéral.
-  static const kEssentielTeasers = 'notif_essentiel_teasers';
   static const kGoodNewsTeasers = 'notif_good_news_teasers';
-  // Dernier état connu de la préférence `serein_enabled`, persisté localement
-  // pour cuire la notif digest sur le bon ton (en-tête + CTA apaisés) aux 3
-  // points de scheduling. Publique : `main.dart` (cold start) la lit aussi.
-  static const kSereinNotif = 'notif_serein_enabled';
 
   Future<Box<dynamic>> _box() => Hive.openBox<dynamic>(_boxName);
 
@@ -238,18 +228,18 @@ class NotificationsSettingsNotifier
     await push.cancelWeeklyCommunityPick();
     await push.cancelGoodNewsNotification();
     final box = await _box();
-    final essentielTeasers = readTeasers(box, kEssentielTeasers);
     final goodNewsTeasers = readTeasers(box, kGoodNewsTeasers);
-    final serene = readSerein(box);
+    final serverRegistered = box.get(
+      ServerPushService.serverRegisteredKey,
+      defaultValue: false,
+    ) as bool;
     if (state.pushEnabled) {
-      await push.scheduleDailyDigestNotification(
-        timeSlot: state.timeSlot,
-        variant: essentielTeasers.isEmpty
-            ? NotifVariant.variantA
-            : NotifVariant.variantB,
-        teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
-        serene: serene,
-      );
+      if (!serverRegistered) {
+        await push.scheduleDailyDigestNotification(
+          timeSlot: state.timeSlot,
+          variant: NotifVariant.variantA,
+        );
+      }
       if (state.preset == NotifPreset.curieux) {
         await push.scheduleWeeklyCommunityPick();
       }
@@ -272,33 +262,18 @@ class NotificationsSettingsNotifier
     return raw.whereType<String>().toList(growable: false);
   }
 
-  /// Lecture défensive du flag serein persisté (défaut `false`). Statique +
-  /// publique : `main.dart` (cold start) lit la même clé sans dupliquer le cast.
-  static bool readSerein(Box<dynamic> box) {
-    final raw = box.get(kSereinNotif);
-    return raw is bool ? raw : false;
-  }
-
-  /// Met à jour les teasers persistés depuis le dernier digest chargé, puis
-  /// replanifie les notifs perso. Appelée fire-and-forget depuis
-  /// `fluxContinuProvider` après un load frais.
-  ///
-  /// Écriture **conditionnelle** : on n'écrase une liste persistée que si la
-  /// fraîche est non vide — un échec réseau transitoire (digest partiel) ne
-  /// doit pas effacer la perso d'hier.
+  /// Les teasers Essentiel sont désormais construits côté serveur à partir du
+  /// digest exact du jour. On purge l'ancienne persistance locale.
   Future<void> syncDigestTeasers({
     required List<String> essentielTeasers,
     required List<String> goodNewsTeasers,
     required bool sereinEnabled,
   }) async {
     final box = await _box();
-    if (essentielTeasers.isNotEmpty) {
-      await box.put(kEssentielTeasers, essentielTeasers);
-    }
+    await box.delete('notif_essentiel_teasers');
     if (goodNewsTeasers.isNotEmpty) {
       await box.put(kGoodNewsTeasers, goodNewsTeasers);
     }
-    await box.put(kSereinNotif, sereinEnabled);
     await _reschedule();
   }
 
@@ -315,7 +290,7 @@ class NotificationsSettingsNotifier
       final pushService = PushNotificationService();
       final granted = await pushService.requestPermission();
       if (!granted) return;
-      await pushService.requestExactAlarmPermission();
+      await ServerPushService.instance.initAndRegister();
     }
     await _commit(state.copyWith(pushEnabled: value));
   }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -17,11 +17,12 @@ import 'package:flutter_downloader/flutter_downloader.dart';
 import 'app.dart';
 import 'config/constants.dart';
 import 'core/auth/supabase_storage.dart';
+import 'core/api/notification_preferences_api_service.dart';
 import 'core/services/posthog_service.dart';
 import 'core/services/push_notification_service.dart';
+import 'core/services/server_push_service.dart';
 import 'core/ui/notification_service.dart';
 import 'features/flux_continu/services/tournee_progress_service.dart';
-import 'features/settings/providers/notifications_settings_provider.dart';
 
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:timeago/src/messages/fr_messages.dart'
@@ -193,6 +194,7 @@ Future<void> _bootstrap() async {
             properties: _userIdentifyProperties(user, appVersion: appVersion),
           );
           unawaited(_loginRevenueCatSafe(user.id));
+          unawaited(_registerServerPushIfEnabled());
         }
         break;
       case AuthChangeEvent.signedOut:
@@ -220,6 +222,15 @@ Future<void> _bootstrap() async {
   // - Notif scheduling (alarm, permissions, diagnostics)
   // - Home Widget callback registration
   unawaited(_initDeferredServices(posthog: posthog));
+}
+
+Future<void> _registerServerPushIfEnabled() async {
+  final box = await Hive.openBox<dynamic>('settings');
+  final enabled =
+      box.get('push_notifications_enabled', defaultValue: false) as bool;
+  if (enabled) {
+    await ServerPushService.instance.initAndRegister();
+  }
 }
 
 /// Init FlutterDownloader avec fallback silencieux (non-critique).
@@ -316,36 +327,24 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
         defaultValue: true) as bool;
     bootPushEnabledHive = pushEnabled;
 
-    // Cold start : re-pose la variante B personnalisée avec les derniers
-    // teasers persistés (le home les rafraîchira au 1er load frais). Liste vide
-    // (1er lancement) → variante A générique, acceptable. Clé + lecture
-    // défensive partagées avec le provider (source de vérité).
-    final essentielTeasers = NotificationsSettingsNotifier.readTeasers(
-      settingsBox,
-      NotificationsSettingsNotifier.kEssentielTeasers,
-    );
-    final digestVariant = essentielTeasers.isEmpty
-        ? NotifVariant.variantA
-        : NotifVariant.variantB;
-    final digestSerene = NotificationsSettingsNotifier.readSerein(settingsBox);
-
     // Diagnostic + scheduling sont indépendants : collecter le diagnostic
     // pendant la planification (alarms + permission). `pushEnabled=false`
     // → on collecte quand même le diagnostic (cf. bug-notifications-stalled).
     final diagFuture = pushNotificationService.getDiagnostics();
     if (pushEnabled) {
-      await pushNotificationService.ensureExactAlarmPermission();
-      // Si une notification personnalisée (avec les sujets du digest) a été
-      // planifiée par DigestNotifier._updateNotificationWithTopics(), on la
-      // préserve — écraser avec le corps statique régresserait la feature.
-      final alreadyScheduled =
-          await pushNotificationService.isDigestNotificationScheduled();
-      if (!alreadyScheduled) {
+      final timeSlot = NotifTimeSlotX.fromWire(
+        settingsBox.get('notif_time_slot') as String?,
+      );
+      final serverRegistered =
+          await ServerPushService.instance.initAndRegister();
+      if (serverRegistered) {
+        await pushNotificationService.cancelDigestNotification();
+      } else {
+        await pushNotificationService.ensureExactAlarmPermission();
         final scheduled =
             await pushNotificationService.scheduleDailyDigestNotification(
-          variant: digestVariant,
-          teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
-          serene: digestSerene,
+          variant: NotifVariant.variantA,
+          timeSlot: timeSlot,
         );
         if (!scheduled) {
           debugPrint(
@@ -354,16 +353,11 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
           await pushNotificationService.requestExactAlarmPermission();
           final retryOk =
               await pushNotificationService.scheduleDailyDigestNotification(
-            variant: digestVariant,
-            teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
-            serene: digestSerene,
+            variant: NotifVariant.variantA,
+            timeSlot: timeSlot,
           );
           debugPrint('Main: Retry result: $retryOk');
         }
-      } else {
-        debugPrint(
-          'Main: Digest notification already scheduled — skipping static placeholder.',
-        );
       }
     }
     bootNotifDiag = await diagFuture;

--- a/apps/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,8 @@ import Foundation
 
 import app_links
 import audio_session
+import firebase_core
+import firebase_messaging
 import flutter_inappwebview_macos
 import flutter_local_notifications
 import flutter_secure_storage_darwin
@@ -26,6 +28,8 @@ import webview_flutter_wkwebview
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
+  FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "67.0.0"
+  _flutterfire_internals:
+    dependency: transitive
+    description:
+      name: _flutterfire_internals
+      sha256: "0d1f0adfabbab9f46a1a80ce84a4d8b852b6e4dbf53ce413b30e0cf7d3631b71"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.72"
   adaptive_number:
     dependency: transitive
     description:
@@ -361,6 +369,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  firebase_core:
+    dependency: "direct main"
+    description:
+      name: firebase_core
+      sha256: ec46a100a560d3bd5f97f2d89ba7492cb09b6dd0a4a28753d1258f360d6bd9f9
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.0"
+  firebase_core_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_core_platform_interface
+      sha256: "4a120366dbf7d5a8ee9438978530b664b855728fb8dcc3a201017660817e555b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
+  firebase_core_web:
+    dependency: transitive
+    description:
+      name: firebase_core_web
+      sha256: "5ad1be848692ec148f2d6a8ad2a3838cb852ea5f3c9e6479a7afce479e1854f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.8.0"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: "9651e833454156b9f0927eaedccffba0f7f6a6e20ceddef82517211e7017e9c4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "16.3.0"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: "292bb5dc9c4a429078895406c347d7c7690deb858c1adeed8f4b4346f769dfa3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.8.0"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: "08c565bc83729439f5de2dfea77b4832002b705eb2f840366cefa80e4e5c3c66"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0"
   fixnum:
     dependency: transitive
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -62,7 +62,9 @@ dependencies:
   # Deep Links (widget tap → in-app routing)
   app_links: ^6.3.2
 
-  # Push Notifications (local, no FCM)
+  # Push Notifications
+  firebase_core: ^4.0.0
+  firebase_messaging: ^16.0.0
   flutter_local_notifications: ^20.0.0
   timezone: ^0.10.0
   flutter_timezone: ^3.0.1
@@ -153,4 +155,3 @@ flutter:
     - assets/loaders/
     - assets/notifications/
     - assets/changelog.json
-

--- a/apps/mobile/windows/flutter/generated_plugin_registrant.cc
+++ b/apps/mobile/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
+#include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_inappwebview_windows/flutter_inappwebview_windows_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <flutter_timezone/flutter_timezone_plugin_c_api.h>
@@ -17,6 +18,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
+  FirebaseCorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   FlutterInappwebviewWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterInappwebviewWindowsPluginCApi"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(

--- a/apps/mobile/windows/flutter/generated_plugins.cmake
+++ b/apps/mobile/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
+  firebase_core
   flutter_inappwebview_windows
   flutter_secure_storage_windows
   flutter_timezone

--- a/docs/runbooks/firebase-push-setup.md
+++ b/docs/runbooks/firebase-push-setup.md
@@ -1,0 +1,26 @@
+# Firebase push setup
+
+## Backend
+
+Create one Firebase project per environment and set either
+`FIREBASE_SERVICE_ACCOUNT_JSON` or `FIREBASE_SERVICE_ACCOUNT_BASE64` on the API.
+The service account needs Firebase Cloud Messaging send access.
+
+## Android
+
+Place the matching files at:
+
+- `apps/mobile/android/app/src/prod/google-services.json`
+- `apps/mobile/android/app/src/staging/google-services.json`
+
+The Gradle plugin is applied only when at least one configuration file exists,
+so local builds without Firebase credentials remain usable.
+
+## iOS
+
+Add each environment's `GoogleService-Info.plist` to the corresponding Xcode
+scheme/configuration and ensure it is copied into the Runner bundle as
+`GoogleService-Info.plist`.
+
+In Firebase Console, upload the APNs authentication key for each iOS app.
+The Runner target already includes the `aps-environment` entitlement.

--- a/packages/api/alembic/versions/pn01_server_push.py
+++ b/packages/api/alembic/versions/pn01_server_push.py
@@ -1,0 +1,76 @@
+"""Add FCM devices and idempotent push deliveries."""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "pn01_server_push"
+down_revision: str | None = "ex01_drop_extraction_ts"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "push_devices",
+        sa.Column("device_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("fcm_token", sa.Text(), nullable=False),
+        sa.Column("platform", sa.String(length=16), nullable=False),
+        sa.Column("timezone", sa.String(length=64), nullable=False),
+        sa.Column("app_version", sa.String(length=32), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_active_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["user_profiles.user_id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("device_id"),
+    )
+    op.create_index(
+        "ix_push_devices_user_active",
+        "push_devices",
+        ["user_id", "revoked_at"],
+    )
+    op.create_table(
+        "push_deliveries",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("device_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("target_date", sa.Date(), nullable=False),
+        sa.Column("kind", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("attempt_count", sa.Integer(), nullable=False),
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("skipped_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error_code", sa.String(length=64), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["device_id"], ["push_devices.device_id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "device_id",
+            "target_date",
+            "kind",
+            name="uq_push_deliveries_device_date_kind",
+        ),
+    )
+    op.create_index(
+        "ix_push_deliveries_status_next_attempt",
+        "push_deliveries",
+        ["status", "next_attempt_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_push_deliveries_status_next_attempt", table_name="push_deliveries"
+    )
+    op.drop_table("push_deliveries")
+    op.drop_index("ix_push_devices_user_active", table_name="push_devices")
+    op.drop_table("push_devices")

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -96,6 +96,11 @@ class Settings(BaseSettings):
     # Sentry
     sentry_dsn: str = ""
 
+    # Firebase Admin SDK. JSON brut ou base64 ; vide désactive l'envoi tout en
+    # laissant les endpoints d'enregistrement disponibles.
+    firebase_service_account_json: str = ""
+    firebase_service_account_base64: str = ""
+
     # PostHog (Story 14.1 — retention cohorts)
     posthog_api_key: str = ""
     posthog_host: str = "https://eu.i.posthog.com"

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -91,6 +91,7 @@ from app.routers import (
     notification_preferences,
     personalization,
     progress,
+    push_devices,
     sources,
     streaks,
     subscription,
@@ -490,6 +491,7 @@ app.include_router(
     prefix="/api/notification-preferences",
     tags=["NotificationPreferences"],
 )
+app.include_router(push_devices.router, prefix="/api/devices", tags=["PushDevices"])
 app.include_router(
     personalization.router,
     prefix="/api/users/personalization",

--- a/packages/api/app/models/__init__.py
+++ b/packages/api/app/models/__init__.py
@@ -20,6 +20,7 @@ from app.models.host_feed_resolution import HostFeedResolution
 from app.models.learning import UserEntityPreference
 from app.models.perspective_analysis import PerspectiveAnalysis
 from app.models.progress import TopicQuiz, UserTopicProgress
+from app.models.push_notification import PushDelivery, PushDevice
 from app.models.serene_report import SereneReport
 from app.models.source import Source, UserSource
 from app.models.source_search_log import SourceSearchLog
@@ -79,6 +80,8 @@ __all__ = [
     "UserPersonalization",
     # Notification preferences (push activation v1)
     "UserNotificationPreferences",
+    "PushDevice",
+    "PushDelivery",
     # Collections (Saved Groups)
     "Collection",
     "CollectionItem",

--- a/packages/api/app/models/push_notification.py
+++ b/packages/api/app/models/push_notification.py
@@ -1,0 +1,96 @@
+"""Device tokens and idempotent server-push delivery attempts."""
+
+import uuid
+from datetime import date, datetime
+from uuid import UUID
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class PushDevice(Base):
+    __tablename__ = "push_devices"
+    __table_args__ = (Index("ix_push_devices_user_active", "user_id", "revoked_at"),)
+
+    device_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True)
+    user_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("user_profiles.user_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    fcm_token: Mapped[str] = mapped_column(Text, nullable=False)
+    platform: Mapped[str] = mapped_column(String(16), nullable=False)
+    timezone: Mapped[str] = mapped_column(String(64), nullable=False)
+    app_version: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    last_active_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
+class PushDelivery(Base):
+    __tablename__ = "push_deliveries"
+    __table_args__ = (
+        UniqueConstraint(
+            "device_id",
+            "target_date",
+            "kind",
+            name="uq_push_deliveries_device_date_kind",
+        ),
+        Index("ix_push_deliveries_status_next_attempt", "status", "next_attempt_at"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    device_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("push_devices.device_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_date: Mapped[date] = mapped_column(Date, nullable=False)
+    kind: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="daily_digest"
+    )
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    next_attempt_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_attempt_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    sent_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    skipped_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    error_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )

--- a/packages/api/app/routers/push_devices.py
+++ b/packages/api/app/routers/push_devices.py
@@ -1,0 +1,137 @@
+"""Authenticated FCM device registration and revocation."""
+
+from datetime import UTC, datetime
+from typing import Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.models.push_notification import PushDevice
+from app.models.user_notification_preferences import UserNotificationPreferences
+from app.services.user_service import UserService
+
+router = APIRouter()
+settings = get_settings()
+
+
+class PushDeviceUpsert(BaseModel):
+    device_id: UUID
+    fcm_token: str = Field(min_length=20, max_length=4096)
+    platform: Literal["android", "ios"]
+    timezone: str = Field(min_length=1, max_length=64)
+    app_version: str | None = Field(default=None, max_length=32)
+
+
+class PushDeviceResponse(BaseModel):
+    device_id: UUID
+    registered: bool = True
+
+
+@router.put("", response_model=PushDeviceResponse)
+async def upsert_push_device(
+    payload: PushDeviceUpsert,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+) -> PushDeviceResponse:
+    if not (
+        settings.firebase_service_account_json
+        or settings.firebase_service_account_base64
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Push serveur non configuré",
+        )
+
+    user_id = UUID(current_user_id)
+    await UserService(db).get_or_create_profile(current_user_id)
+    now = datetime.now(UTC)
+
+    # The preferences table remains the scheduling source of truth. Refresh it
+    # from the device at each registration so travel/timezone changes are used
+    # by the next dispatcher pass without resetting the other preferences.
+    await db.execute(
+        pg_insert(UserNotificationPreferences)
+        .values(user_id=user_id, timezone=payload.timezone)
+        .on_conflict_do_update(
+            index_elements=["user_id"],
+            set_={"timezone": payload.timezone},
+        )
+    )
+
+    existing = await db.scalar(
+        select(PushDevice).where(PushDevice.device_id == payload.device_id)
+    )
+    if (
+        existing is not None
+        and existing.user_id != user_id
+        and existing.revoked_at is None
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Appareil déjà associé à un autre compte",
+        )
+
+    # A refreshed token may move between locally recreated device IDs.
+    await db.execute(
+        update(PushDevice)
+        .where(
+            PushDevice.fcm_token == payload.fcm_token,
+            PushDevice.device_id != payload.device_id,
+        )
+        .values(revoked_at=now)
+    )
+    stmt = (
+        pg_insert(PushDevice)
+        .values(
+            device_id=payload.device_id,
+            user_id=user_id,
+            fcm_token=payload.fcm_token,
+            platform=payload.platform,
+            timezone=payload.timezone,
+            app_version=payload.app_version,
+            created_at=now,
+            last_active_at=now,
+            revoked_at=None,
+        )
+        .on_conflict_do_update(
+            index_elements=["device_id"],
+            set_={
+                "user_id": user_id,
+                "fcm_token": payload.fcm_token,
+                "platform": payload.platform,
+                "timezone": payload.timezone,
+                "app_version": payload.app_version,
+                "last_active_at": now,
+                "revoked_at": None,
+            },
+        )
+    )
+    await db.execute(stmt)
+    await db.commit()
+    return PushDeviceResponse(device_id=payload.device_id)
+
+
+@router.delete("/{device_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_push_device(
+    device_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+) -> None:
+    user_id = UUID(current_user_id)
+    device = await db.scalar(
+        select(PushDevice).where(
+            PushDevice.device_id == device_id,
+            PushDevice.user_id == user_id,
+        )
+    )
+    if device is None:
+        raise HTTPException(status_code=404, detail="Appareil introuvable")
+    device.revoked_at = datetime.now(UTC)
+    await db.commit()

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -57,10 +57,8 @@ logger = logging.getLogger(__name__)
 ESSENTIEL_MAX_ARTICLES = 5
 ESSENTIEL_MAX_PER_SOURCE = 2  # Diversité dure : max 2 articles d'une même source.
 
-# Fenêtre de cohérence avec la Tournée du jour : un article de l'Essentiel
-# doit pouvoir apparaître aussi dans la Tournée (24h + sources suivies). Sans
-# ce filtre, le digest peut surfacer des articles > 24h ou de sources curated
-# non-suivies invisibles dans la Tournée → incohérence UI.
+# Fenêtre de fraîcheur commune aux deux tiers de sélection. Les sources
+# suivies sont prioritaires, puis le pool éditorial global frais complète.
 ESSENTIEL_TOURNEE_WINDOW = timedelta(hours=24)
 
 # Valeur de `DigestTopicArticle.badge` qui marque l'article comme "Actu du jour".
@@ -426,29 +424,35 @@ def _filter_articles_by_language(
     return filtered
 
 
-def _filter_articles_by_tournee_pool(
+def _filter_articles_by_freshness(
     topics: list[DigestTopic],
-    ctx: EssentielUserContext,
     *,
     now: datetime | None = None,
 ) -> list[DigestTopic]:
-    """Garantit Essentiel ⊆ Tournée du jour.
-
-    La Tournée requête live (24h + sources suivies) tandis qu'Essentiel lit
-    un digest pré-calculé (7j ∪ sources curated) — sans ce filtre l'UI peut
-    surfacer un article inaccessible ailleurs. No-op si l'utilisateur n'a
-    aucune source suivie (sinon le filtre viderait tout).
-    """
-    if not ctx.followed_source_ids:
-        return topics
-
+    """Conserve uniquement les articles publiés dans les dernières 24 heures."""
     cutoff = (now or datetime.now(UTC)) - ESSENTIEL_TOURNEE_WINDOW
     filtered: list[DigestTopic] = []
     for topic in topics:
+        kept = [a for a in topic.articles if a.published_at >= cutoff]
+        if kept:
+            filtered.append(topic.model_copy(update={"articles": kept}))
+    return filtered
+
+
+def _filter_articles_by_followed_sources(
+    topics: list[DigestTopic],
+    ctx: EssentielUserContext,
+) -> list[DigestTopic]:
+    """Construit le tier prioritaire des sources explicitement suivies."""
+    if not ctx.followed_source_ids:
+        return []
+
+    filtered: list[DigestTopic] = []
+    for topic in topics:
         kept = [
-            a
-            for a in topic.articles
-            if a.source.id in ctx.followed_source_ids and a.published_at >= cutoff
+            article
+            for article in topic.articles
+            if article.source.id in ctx.followed_source_ids
         ]
         if kept:
             filtered.append(topic.model_copy(update={"articles": kept}))
@@ -458,17 +462,15 @@ def _filter_articles_by_tournee_pool(
 def _pick_transversal_articles(
     topics: list[DigestTopic],
     ctx: EssentielUserContext,
+    *,
+    now: datetime | None = None,
 ) -> list[tuple[DigestTopic, DigestTopicArticle]]:
     """Pioche jusqu'à 5 articles cross-topic, user-aware.
 
-    1. **Slot lead Actu** : si un article est Actu du jour (trending/une/badge),
-       il prend la position 1 — quel que soit son score user. Le meilleur des
-       Actu gagne.
-    2. **Round diversité** (1 article max par topic), topics ordonnés par leur
-       meilleur score (desc), tie-break `topic.rank` (asc).
-    3. **Round remplissage** par score décroissant.
-    4. **Diversité dure** : max `ESSENTIEL_MAX_PER_SOURCE` (=2) articles d'une
-       même source à toutes les étapes.
+    1. Applique définitivement mutes, langue, types interdits et fraîcheur 24 h.
+    2. Sélectionne le tier sources suivies, puis complète depuis le pool global.
+    3. Déduplique les sujets et limite chaque source à deux articles.
+    4. Diffère le sport jusqu'au cinquième slot, sans post-filtre destructif.
     """
     # Mutes utilisateur (`user_personalization`) — prime sur tous les autres
     # filtres : un article muté ne doit jamais devenir le fallback Tournée.
@@ -478,27 +480,26 @@ def _pick_transversal_articles(
     # — ces contenus ne reflètent pas l'actualité chaude traitée par la presse.
     topics = _filter_articles_allowed(topics)
 
-    # Cohérence Essentiel ⊆ Tournée du jour (24h + sources suivies).
-    # Fallback : si le filtre vide tout le pool, on garde le pré-filtre pour
-    # éviter une carte Essentiel vide ; on log une WARNING pour traçage.
-    pre_filter_topics = topics
-    topics = _filter_articles_by_tournee_pool(topics, ctx)
-    if not any(t.articles for t in topics):
-        if ctx.followed_source_ids:
-            logger.warning(
-                "tournee-pool filter emptied the pool — falling back to pre-filter "
-                "topics (user has %d followed sources)",
-                len(ctx.followed_source_ids),
-            )
-        topics = pre_filter_topics
+    hard_filtered_count = sum(len(topic.articles) for topic in topics)
+    fresh_topics = _filter_articles_by_freshness(topics, now=now)
+    followed_topics = _filter_articles_by_followed_sources(fresh_topics, ctx)
+    fresh_count = sum(len(topic.articles) for topic in fresh_topics)
+    followed_count = sum(len(topic.articles) for topic in followed_topics)
 
-    eligible_topics = [t for t in topics if t.articles]
-    if not eligible_topics:
+    if not fresh_topics:
+        logger.info(
+            "essentiel_selection hard_filtered=%d followed_pool=%d "
+            "fresh_global_pool=%d supplements=0 dedup_rejections=0 "
+            "sport_rejections=0 final_count=0",
+            hard_filtered_count,
+            followed_count,
+            fresh_count,
+        )
         return []
 
-    # Score de chaque (topic, article) une seule fois.
+    # Score de chaque (topic, article) une seule fois sur le pool global frais.
     scored: dict[tuple[str, UUID], float] = {}
-    for topic in eligible_topics:
+    for topic in fresh_topics:
         for article in topic.articles:
             scored[(topic.topic_id, article.content_id)] = _score_article(
                 topic, article, ctx
@@ -509,6 +510,8 @@ def _pick_transversal_articles(
     used_topics: set[str] = set()
     source_count: dict[UUID, int] = {}
     picked_title_tokens: list[set[str]] = []
+    dedup_rejections = 0
+    sport_rejections = 0
 
     def _is_duplicate_subject(topic: DigestTopic, article: DigestTopicArticle) -> bool:
         """Un même sujet ne doit jamais occuper deux slots de l'Essentiel.
@@ -539,11 +542,32 @@ def _pick_transversal_articles(
 
         Renvoie True si ajouté, False sinon. Marque les ensembles.
         """
+        nonlocal dedup_rejections, sport_rejections
+
         if article.content_id in seen_content_ids:
+            dedup_rejections += 1
             return False
         if source_count.get(article.source.id, 0) >= ESSENTIEL_MAX_PER_SOURCE:
             return False
         if _is_duplicate_subject(topic, article):
+            dedup_rejections += 1
+            return False
+        if _is_sport_pick(topic, article):
+            non_sport_count = sum(
+                not _is_sport_pick(picked_topic, picked_article)
+                for picked_topic, picked_article in picked
+            )
+            already_has_sport = any(
+                _is_sport_pick(picked_topic, picked_article)
+                for picked_topic, picked_article in picked
+            )
+            if (
+                non_sport_count < ScoringWeights.ESSENTIEL_SPORT_MIN_SLOT - 1
+                or already_has_sport
+            ):
+                sport_rejections += 1
+                return False
+        if len(picked) >= ESSENTIEL_MAX_ARTICLES:
             return False
         picked.append((topic, article))
         seen_content_ids.add(article.content_id)
@@ -552,90 +576,58 @@ def _pick_transversal_articles(
         picked_title_tokens.append(normalize_title(article.title))
         return True
 
-    # ─── Slot lead Actu ──────────────────────────────────────────────────
-    # Cherche le meilleur article Actu du jour (trending/une/badge=="actu").
-    # S'il existe, on le pose en rank=1 avant tout le reste. Le sport est
-    # exclu du lead-slot par construction (Story 9.4 : sport jamais < slot 5).
-    actu_candidates: list[tuple[DigestTopic, DigestTopicArticle, float]] = []
-    for topic in eligible_topics:
-        for article in topic.articles:
-            if _is_actu_du_jour(topic, article) and not _is_sport_pick(topic, article):
-                actu_candidates.append(
-                    (topic, article, scored[(topic.topic_id, article.content_id)])
-                )
-    if actu_candidates:
-        actu_candidates.sort(key=lambda x: (-x[2], x[1].rank))
-        lead_topic, lead_article, _ = actu_candidates[0]
-        _try_pick(lead_topic, lead_article)
-
-    # ─── Round 1 : diversité (1 article max par topic, hors lead) ────────
-    def _best_for_topic(
-        topic: DigestTopic,
-    ) -> tuple[DigestTopicArticle, float]:
-        best_article = max(
-            topic.articles,
-            key=lambda a: (
-                scored[(topic.topic_id, a.content_id)],
-                -a.rank,
+    def _ordered_candidates(
+        tier_topics: list[DigestTopic],
+    ) -> list[tuple[DigestTopic, DigestTopicArticle, float]]:
+        candidates = [
+            (topic, article, scored[(topic.topic_id, article.content_id)])
+            for topic in tier_topics
+            for article in topic.articles
+        ]
+        return sorted(
+            candidates,
+            key=lambda item: (
+                not _is_actu_du_jour(item[0], item[1]),
+                -item[2],
+                item[0].rank,
+                item[1].rank,
             ),
         )
-        return best_article, scored[(topic.topic_id, best_article.content_id)]
 
-    topic_bests = [(t, *_best_for_topic(t)) for t in eligible_topics]
-    topic_bests_sorted = sorted(topic_bests, key=lambda tb: (-tb[2], tb[0].rank))
+    def _fill_from_tier(tier_topics: list[DigestTopic]) -> None:
+        candidates = _ordered_candidates(tier_topics)
+        # Sport is reconsidered only after every non-sport candidate. This
+        # prevents a high-scoring sport item from consuming a slot that would
+        # disappear during a final post-filter.
+        for want_sport in (False, True):
+            for topic, article, _ in candidates:
+                if _is_sport_pick(topic, article) != want_sport:
+                    continue
+                _try_pick(topic, article)
+                if len(picked) >= ESSENTIEL_MAX_ARTICLES:
+                    return
 
-    for topic, article, _ in topic_bests_sorted:
-        if topic.topic_id in used_topics:
-            continue
-        _try_pick(topic, article)
-        if len(picked) >= ESSENTIEL_MAX_ARTICLES:
-            return _enforce_sport_slot_constraint(picked)
+    _fill_from_tier(followed_topics)
+    followed_pick_count = len(picked)
+    if len(picked) < ESSENTIEL_MAX_ARTICLES:
+        _fill_from_tier(fresh_topics)
 
-    # ─── Round 2 : remplissage (meilleurs articles restants) ─────────────
-    remaining: list[tuple[DigestTopic, DigestTopicArticle, float]] = []
-    for topic in eligible_topics:
-        for article in topic.articles:
-            if article.content_id in seen_content_ids:
-                continue
-            remaining.append(
-                (topic, article, scored[(topic.topic_id, article.content_id)])
-            )
-
-    remaining.sort(key=lambda x: (-x[2], x[1].rank))
-
-    for topic, article, _ in remaining:
-        _try_pick(topic, article)
-        if len(picked) >= ESSENTIEL_MAX_ARTICLES:
-            break
-
-    return _enforce_sport_slot_constraint(picked)
-
-
-def _enforce_sport_slot_constraint(
-    picked: list[tuple[DigestTopic, DigestTopicArticle]],
-) -> list[tuple[DigestTopic, DigestTopicArticle]]:
-    """Force le sport à occuper le slot ≥ 5 (Story 9.4), avec au plus 1 sport.
-
-    Stratégie :
-    - Partitionne en non-sport et sport (max ESSENTIEL_MAX_SPORT_PER_DIGEST).
-    - Si on a ≥ (ESSENTIEL_SPORT_MIN_SLOT - 1) non-sport, on place le sport
-      après — il aboutit en slot 5 ou plus.
-    - Sinon le pool non-sport est trop petit pour placer le sport en slot 5+ :
-      on l'exclut plutôt que de le remonter en slot < 5.
-    """
-    non_sport: list[tuple[DigestTopic, DigestTopicArticle]] = []
-    sport: list[tuple[DigestTopic, DigestTopicArticle]] = []
-    for topic, article in picked:
-        if _is_sport_pick(topic, article):
-            sport.append((topic, article))
-        else:
-            non_sport.append((topic, article))
-
-    sport = sport[: ScoringWeights.ESSENTIEL_MAX_SPORT_PER_DIGEST]
-    min_non_sport = ScoringWeights.ESSENTIEL_SPORT_MIN_SLOT - 1
-    if len(non_sport) >= min_non_sport:
-        return (non_sport + sport)[:ESSENTIEL_MAX_ARTICLES]
-    return non_sport[:ESSENTIEL_MAX_ARTICLES]
+    # `picked` only grows after `followed_pick_count` is captured, so the
+    # supplement count is always non-negative.
+    supplements = len(picked) - followed_pick_count
+    logger.info(
+        "essentiel_selection hard_filtered=%d followed_pool=%d "
+        "fresh_global_pool=%d supplements=%d dedup_rejections=%d "
+        "sport_rejections=%d final_count=%d",
+        hard_filtered_count,
+        followed_count,
+        fresh_count,
+        supplements,
+        dedup_rejections,
+        sport_rejections,
+        len(picked),
+    )
+    return picked
 
 
 def _to_essentiel_article(
@@ -670,6 +662,8 @@ def _to_essentiel_article(
 def build_essentiel_response(
     digest: DigestResponse,
     user_context: EssentielUserContext | None = None,
+    *,
+    now: datetime | None = None,
 ) -> EssentielResponse:
     """Projette une `DigestResponse` en `EssentielResponse` (5 articles max).
 
@@ -677,7 +671,7 @@ def build_essentiel_response(
     no-prefs (le scorer dégénère en actu_boost + perspective − rank).
     """
     ctx = user_context or EssentielUserContext()
-    picks = _pick_transversal_articles(digest.topics, ctx)
+    picks = _pick_transversal_articles(digest.topics, ctx, now=now)
     articles = [
         _to_essentiel_article(topic, article, rank=i + 1, ctx=ctx)
         for i, (topic, article) in enumerate(picks)

--- a/packages/api/app/services/push_dispatcher.py
+++ b/packages/api/app/services/push_dispatcher.py
@@ -1,0 +1,282 @@
+"""Server-side daily Essentiel push dispatcher."""
+
+import asyncio
+import base64
+import json
+from collections.abc import Callable
+from datetime import UTC, date, datetime, time, timedelta
+from functools import lru_cache
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.database import safe_async_session
+from app.models.daily_digest import DailyDigest
+from app.models.push_notification import PushDelivery, PushDevice
+from app.models.user_notification_preferences import UserNotificationPreferences
+from app.services.digest_service import DigestService
+from app.services.essentiel_service import (
+    build_essentiel_response,
+    fetch_user_essentiel_context,
+)
+
+logger = structlog.get_logger()
+settings = get_settings()
+
+PUSH_KIND = "daily_digest"
+MORNING_TIME = time(7, 30)
+MORNING_CUTOFF = time(12, 0)
+EVENING_TIME = time(19, 0)
+RETRY_DELAY = timedelta(minutes=5)
+
+PushSender = Callable[[str, str, str, dict[str, str]], Any]
+
+
+def _firebase_configured() -> bool:
+    return bool(
+        settings.firebase_service_account_json
+        or settings.firebase_service_account_base64
+    )
+
+
+@lru_cache(maxsize=1)
+def _firebase_app():
+    raw = settings.firebase_service_account_json
+    if not raw and settings.firebase_service_account_base64:
+        raw = base64.b64decode(settings.firebase_service_account_base64).decode()
+    if not raw:
+        return None
+
+    import firebase_admin
+    from firebase_admin import credentials
+
+    try:
+        return firebase_admin.get_app()
+    except ValueError:
+        return firebase_admin.initialize_app(credentials.Certificate(json.loads(raw)))
+
+
+def _send_fcm(token: str, title: str, body: str, data: dict[str, str]) -> str:
+    app = _firebase_app()
+    if app is None:
+        raise RuntimeError("firebase_not_configured")
+
+    from firebase_admin import messaging
+
+    return messaging.send(
+        messaging.Message(
+            token=token,
+            notification=messaging.Notification(title=title, body=body),
+            data=data,
+            android=messaging.AndroidConfig(
+                priority="high",
+                notification=messaging.AndroidNotification(
+                    channel_id="digest_channel",
+                    icon="ic_stat_facteur",
+                    color="#D35400",
+                ),
+            ),
+            apns=messaging.APNSConfig(
+                headers={"apns-priority": "10"},
+                payload=messaging.APNSPayload(
+                    aps=messaging.Aps(sound="default", content_available=True)
+                ),
+            ),
+        ),
+        app=app,
+    )
+
+
+def _is_due(local_now: datetime, time_slot: str) -> bool:
+    local_time = local_now.time().replace(tzinfo=None)
+    if time_slot == "morning":
+        return MORNING_TIME <= local_time <= MORNING_CUTOFF
+    return local_time >= EVENING_TIME
+
+
+def _is_invalid_token_error(exc: Exception) -> bool:
+    return type(exc).__name__ in {
+        "UnregisteredError",
+        "SenderIdMismatchError",
+        "InvalidArgumentError",
+    }
+
+
+async def _get_or_create_delivery(
+    session: AsyncSession,
+    *,
+    device_id,
+    target_date: date,
+    now: datetime,
+) -> PushDelivery:
+    await session.execute(
+        pg_insert(PushDelivery)
+        .values(
+            device_id=device_id,
+            target_date=target_date,
+            kind=PUSH_KIND,
+            status="pending",
+            attempt_count=0,
+            next_attempt_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_nothing(index_elements=["device_id", "target_date", "kind"])
+    )
+    await session.flush()
+    delivery = await session.scalar(
+        select(PushDelivery).where(
+            PushDelivery.device_id == device_id,
+            PushDelivery.target_date == target_date,
+            PushDelivery.kind == PUSH_KIND,
+        )
+    )
+    assert delivery is not None
+    return delivery
+
+
+async def _build_exact_essentiel(session: AsyncSession, user_id, target_date: date):
+    digest = await session.scalar(
+        select(DailyDigest).where(
+            DailyDigest.user_id == user_id,
+            DailyDigest.target_date == target_date,
+            DailyDigest.is_serene.is_(False),
+        )
+    )
+    if digest is None or not (
+        (digest.format_version or "").startswith("editorial_")
+        or digest.format_version == "topics_v1"
+    ):
+        return None
+
+    response = await DigestService(session)._build_digest_response(digest, user_id)
+    if response.target_date != target_date or response.is_stale_fallback:
+        return None
+    context = await fetch_user_essentiel_context(session, user_id)
+    return build_essentiel_response(response, user_context=context)
+
+
+async def dispatch_daily_essentiel_pushes(
+    *,
+    now: datetime | None = None,
+    sender: PushSender = _send_fcm,
+) -> dict[str, int]:
+    """Send due pushes once per device/day, retrying morning gaps until noon."""
+    if sender is _send_fcm and not _firebase_configured():
+        logger.info("push_dispatch_disabled", reason="firebase_not_configured")
+        return {"sent": 0, "retried": 0, "skipped": 0, "invalid_tokens": 0}
+
+    utc_now = (now or datetime.now(UTC)).astimezone(UTC)
+    metrics = {"sent": 0, "retried": 0, "skipped": 0, "invalid_tokens": 0}
+
+    async with safe_async_session() as session:
+        rows = (
+            await session.execute(
+                select(PushDevice, UserNotificationPreferences)
+                .join(
+                    UserNotificationPreferences,
+                    UserNotificationPreferences.user_id == PushDevice.user_id,
+                )
+                .where(
+                    PushDevice.revoked_at.is_(None),
+                    UserNotificationPreferences.push_enabled.is_(True),
+                )
+                .order_by(PushDevice.user_id, PushDevice.device_id)
+            )
+        ).all()
+
+        digest_cache: dict[tuple[Any, date], Any] = {}
+        for device, prefs in rows:
+            try:
+                local_now = utc_now.astimezone(ZoneInfo(prefs.timezone))
+            except ZoneInfoNotFoundError:
+                logger.warning(
+                    "push_invalid_timezone",
+                    user_id=str(device.user_id),
+                    timezone=prefs.timezone,
+                )
+                continue
+            if not _is_due(local_now, prefs.time_slot):
+                continue
+
+            target_date = local_now.date()
+            delivery = await _get_or_create_delivery(
+                session,
+                device_id=device.device_id,
+                target_date=target_date,
+                now=utc_now,
+            )
+            if delivery.status in {"sent", "skipped"}:
+                continue
+            if delivery.next_attempt_at and delivery.next_attempt_at > utc_now:
+                continue
+
+            cache_key = (device.user_id, target_date)
+            if cache_key not in digest_cache:
+                digest_cache[cache_key] = await _build_exact_essentiel(
+                    session, device.user_id, target_date
+                )
+            essentiel = digest_cache[cache_key]
+
+            if essentiel is None or not essentiel.articles:
+                if prefs.time_slot == "morning" and local_now.time() >= MORNING_CUTOFF:
+                    delivery.status = "skipped"
+                    delivery.skipped_at = utc_now
+                    delivery.error_code = "digest_missing_at_cutoff"
+                    metrics["skipped"] += 1
+                else:
+                    delivery.status = "pending"
+                    delivery.next_attempt_at = utc_now + RETRY_DELAY
+                    delivery.error_code = "digest_not_ready"
+                    metrics["retried"] += 1
+                continue
+
+            teasers = [article.title for article in essentiel.articles[:2]]
+            body = teasers[0]
+            delivery.attempt_count += 1
+            delivery.last_attempt_at = utc_now
+            try:
+                await asyncio.to_thread(
+                    sender,
+                    device.fcm_token,
+                    "Facteur",
+                    body,
+                    {
+                        "route": "/digest",
+                        "target_date": target_date.isoformat(),
+                        "kind": PUSH_KIND,
+                        "teasers": json.dumps(teasers, ensure_ascii=False),
+                    },
+                )
+            except Exception as exc:
+                delivery.status = "failed"
+                delivery.next_attempt_at = utc_now + RETRY_DELAY
+                delivery.error_code = type(exc).__name__
+                delivery.error_message = str(exc)[:1000]
+                if _is_invalid_token_error(exc):
+                    device.revoked_at = utc_now
+                    metrics["invalid_tokens"] += 1
+                else:
+                    metrics["retried"] += 1
+                logger.warning(
+                    "push_delivery_failed",
+                    device_id=str(device.device_id),
+                    error=type(exc).__name__,
+                )
+            else:
+                delivery.status = "sent"
+                delivery.sent_at = utc_now
+                delivery.next_attempt_at = None
+                delivery.error_code = None
+                delivery.error_message = None
+                metrics["sent"] += 1
+
+        await session.commit()
+
+    logger.info("push_dispatch_completed", **metrics)
+    return metrics

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -13,6 +13,7 @@ from app.jobs.digest_generation_job import (
 )
 from app.jobs.purge_deleted_users import purge_deleted_users
 from app.jobs.recompute_source_language import recompute_source_language
+from app.services.push_dispatcher import dispatch_daily_essentiel_pushes
 from app.workers.rss_sync import sync_all_sources
 from app.workers.storage_cleanup import cleanup_old_articles
 
@@ -282,6 +283,16 @@ def start_scheduler() -> None:
         replace_existing=True,
     )
 
+    scheduler.add_job(
+        dispatch_daily_essentiel_pushes,
+        trigger=IntervalTrigger(minutes=5),
+        id="daily_essentiel_push_dispatch",
+        name="Daily Essentiel server push dispatcher",
+        replace_existing=True,
+        coalesce=True,
+        max_instances=1,
+    )
+
     scheduler.start()
     logger.info(
         "Scheduler started",
@@ -294,6 +305,7 @@ def start_scheduler() -> None:
             "recompute_source_language",
             "zombie_session_sweeper",
             "pool_health_probe",
+            "daily_essentiel_push_dispatch",
         ],
         rss_interval_minutes=settings.rss_sync_interval_minutes,
         digest_cron="07:30 Europe/Paris",

--- a/packages/api/requirements.txt
+++ b/packages/api/requirements.txt
@@ -29,6 +29,7 @@ beautifulsoup4==4.12.3
 
 # Scheduling
 apscheduler==3.10.4
+firebase-admin>=6.5.0,<7
 
 # Logging
 structlog==24.1.0

--- a/packages/api/tests/routers/test_push_devices.py
+++ b/packages/api/tests/routers/test_push_devices.py
@@ -1,0 +1,118 @@
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.push_notification import PushDevice
+from app.models.user import UserProfile
+from app.models.user_notification_preferences import UserNotificationPreferences
+from app.routers import push_devices
+
+
+@pytest_asyncio.fixture
+async def push_auth_user(db_session, monkeypatch):
+    monkeypatch.setattr(
+        push_devices.settings,
+        "firebase_service_account_json",
+        '{"test": true}',
+    )
+    user_id = uuid4()
+    db_session.add(
+        UserProfile(
+            user_id=user_id,
+            display_name="Push Test User",
+            onboarding_completed=True,
+        )
+    )
+    await db_session.commit()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        yield user_id
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_upsert_refresh_and_revoke_device(push_auth_user, db_session):
+    device_id = uuid4()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.put(
+            "/api/devices",
+            json={
+                "device_id": str(device_id),
+                "fcm_token": "first-token-long-enough-for-validation",
+                "platform": "ios",
+                "timezone": "Europe/Paris",
+                "app_version": "1.0.0+1",
+            },
+        )
+        refreshed = await client.put(
+            "/api/devices",
+            json={
+                "device_id": str(device_id),
+                "fcm_token": "refreshed-token-long-enough-for-validation",
+                "platform": "ios",
+                "timezone": "America/Montreal",
+                "app_version": "1.0.0+2",
+            },
+        )
+        revoked = await client.delete(f"/api/devices/{device_id}")
+
+    assert first.status_code == 200
+    assert refreshed.status_code == 200
+    assert revoked.status_code == 204
+    device = await db_session.scalar(
+        select(PushDevice).where(PushDevice.device_id == device_id)
+    )
+    assert device is not None
+    assert device.user_id == push_auth_user
+    assert device.fcm_token.startswith("refreshed-token")
+    assert device.timezone == "America/Montreal"
+    assert device.revoked_at is not None
+    preferences = await db_session.scalar(
+        select(UserNotificationPreferences).where(
+            UserNotificationPreferences.user_id == push_auth_user
+        )
+    )
+    assert preferences is not None
+    assert preferences.timezone == "America/Montreal"
+
+
+@pytest.mark.asyncio
+async def test_multiple_devices_are_kept_for_same_user(push_auth_user, db_session):
+    device_ids = [uuid4(), uuid4()]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        for index, device_id in enumerate(device_ids):
+            response = await client.put(
+                "/api/devices",
+                json={
+                    "device_id": str(device_id),
+                    "fcm_token": f"device-token-{index}-long-enough-to-be-valid",
+                    "platform": "android",
+                    "timezone": "Europe/Paris",
+                },
+            )
+            assert response.status_code == 200
+
+    devices = (
+        await db_session.execute(
+            select(PushDevice).where(PushDevice.user_id == push_auth_user)
+        )
+    ).scalars()
+    assert {device.device_id for device in devices} == set(device_ids)

--- a/packages/api/tests/services/test_push_dispatcher.py
+++ b/packages/api/tests/services/test_push_dispatcher.py
@@ -1,0 +1,189 @@
+from datetime import UTC, date, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.models.push_notification import PushDelivery, PushDevice
+from app.models.user import UserProfile
+from app.models.user_notification_preferences import UserNotificationPreferences
+from app.services.push_dispatcher import (
+    _build_exact_essentiel,
+    _is_due,
+    dispatch_daily_essentiel_pushes,
+)
+
+
+def _unused_sender(_token, _title, _body, _data):
+    return "unused"
+
+
+async def _seed_push_user(db_session, *, timezone="Europe/Paris", slot="morning"):
+    user_id = uuid4()
+    device_id = uuid4()
+    db_session.add(
+        UserProfile(
+            user_id=user_id,
+            display_name="Dispatcher User",
+            onboarding_completed=True,
+        )
+    )
+    await db_session.flush()
+    db_session.add_all(
+        [
+            UserNotificationPreferences(
+                user_id=user_id,
+                push_enabled=True,
+                time_slot=slot,
+                timezone=timezone,
+            ),
+            PushDevice(
+                device_id=device_id,
+                user_id=user_id,
+                fcm_token="dispatcher-token",
+                platform="android",
+                timezone=timezone,
+            ),
+        ]
+    )
+    await db_session.commit()
+    return user_id, device_id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_is_idempotent_per_device_and_local_date(
+    db_session, fake_session_maker
+):
+    _, device_id = await _seed_push_user(db_session)
+    sender = Mock(return_value="message-id")
+
+    def sync_sender(*args):
+        return sender(*args)
+
+    essentiel = SimpleNamespace(articles=[SimpleNamespace(title="Sujet exact du jour")])
+    now = datetime(2026, 6, 15, 6, 35, tzinfo=UTC)  # 08:35 Paris
+    with (
+        patch(
+            "app.services.push_dispatcher.safe_async_session",
+            fake_session_maker,
+        ),
+        patch(
+            "app.services.push_dispatcher._build_exact_essentiel",
+            new=AsyncMock(return_value=essentiel),
+        ),
+    ):
+        first = await dispatch_daily_essentiel_pushes(now=now, sender=sync_sender)
+        second = await dispatch_daily_essentiel_pushes(now=now, sender=sync_sender)
+
+    assert first["sent"] == 1
+    assert second["sent"] == 0
+    assert sender.call_count == 1
+    delivery = await db_session.scalar(
+        select(PushDelivery).where(PushDelivery.device_id == device_id)
+    )
+    assert delivery is not None
+    assert delivery.status == "sent"
+    assert delivery.target_date == date(2026, 6, 15)
+
+
+@pytest.mark.asyncio
+async def test_missing_morning_digest_retries_then_skips_at_noon(
+    db_session, fake_session_maker
+):
+    _, device_id = await _seed_push_user(db_session)
+    with (
+        patch(
+            "app.services.push_dispatcher.safe_async_session",
+            fake_session_maker,
+        ),
+        patch(
+            "app.services.push_dispatcher._build_exact_essentiel",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        retry = await dispatch_daily_essentiel_pushes(
+            now=datetime(2026, 6, 15, 6, 0, tzinfo=UTC),
+            sender=_unused_sender,
+        )
+        delivery = await db_session.scalar(
+            select(PushDelivery).where(PushDelivery.device_id == device_id)
+        )
+        assert delivery is not None
+        delivery.next_attempt_at = datetime(2026, 6, 15, 10, 0, tzinfo=UTC)
+        await db_session.flush()
+        skipped = await dispatch_daily_essentiel_pushes(
+            now=datetime(2026, 6, 15, 10, 0, tzinfo=UTC),
+            sender=_unused_sender,
+        )
+
+    assert retry["retried"] == 1
+    assert skipped["skipped"] == 1
+    assert delivery.status == "skipped"
+    assert delivery.error_code == "digest_missing_at_cutoff"
+
+
+@pytest.mark.asyncio
+async def test_invalid_fcm_token_revokes_device(db_session, fake_session_maker):
+    _, device_id = await _seed_push_user(db_session)
+
+    class UnregisteredError(Exception):
+        pass
+
+    def invalid_sender(*args):
+        raise UnregisteredError("token is no longer valid")
+
+    with (
+        patch(
+            "app.services.push_dispatcher.safe_async_session",
+            fake_session_maker,
+        ),
+        patch(
+            "app.services.push_dispatcher._build_exact_essentiel",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    articles=[SimpleNamespace(title="Sujet du jour")]
+                )
+            ),
+        ),
+    ):
+        metrics = await dispatch_daily_essentiel_pushes(
+            now=datetime(2026, 6, 15, 6, 35, tzinfo=UTC),
+            sender=invalid_sender,
+        )
+
+    device = await db_session.scalar(
+        select(PushDevice).where(PushDevice.device_id == device_id)
+    )
+    assert metrics["invalid_tokens"] == 1
+    assert device is not None
+    assert device.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_exact_digest_builder_rejects_yesterday_response():
+    target = date(2026, 6, 15)
+    digest = SimpleNamespace(format_version="topics_v1")
+    session = AsyncMock()
+    session.scalar.return_value = digest
+    stale_response = SimpleNamespace(
+        target_date=date(2026, 6, 14),
+        is_stale_fallback=True,
+    )
+
+    with patch(
+        "app.services.push_dispatcher.DigestService._build_digest_response",
+        new=AsyncMock(return_value=stale_response),
+    ):
+        result = await _build_exact_essentiel(session, uuid4(), target)
+
+    assert result is None
+
+
+def test_due_time_uses_each_users_local_timezone():
+    montreal_morning = datetime(2026, 6, 15, 7, 30)
+    paris_before_evening = datetime(2026, 6, 15, 18, 59)
+
+    assert _is_due(montreal_morning, "morning") is True
+    assert _is_due(paris_before_evening, "evening") is False

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -371,7 +371,7 @@ async def test_get_essentiel_propagates_stale_fallback(auth_override: UUID):
 
 
 def test_followed_source_promoted_above_unfollowed_competitor():
-    """Cohérence Essentiel ⊆ Tournée : la source non-suivie est filtrée."""
+    """Le tier suivi passe d'abord, puis le pool global frais complète."""
     followed_source = _make_source("Mediapart")
     other_source = _make_source("Le Monde")
     topics = [
@@ -406,9 +406,10 @@ def test_followed_source_promoted_above_unfollowed_competitor():
 
     response = build_essentiel_response(digest, user_context=ctx)
 
-    assert len(response.articles) == 1
+    assert len(response.articles) == 2
     assert response.articles[0].source.id == followed_source.id
     assert response.articles[0].rank == 1
+    assert response.articles[1].source.id == other_source.id
 
 
 def test_user_topic_weight_promotes_lower_ranked_topic():
@@ -606,8 +607,8 @@ def test_tournee_pool_filter_drops_article_older_than_24h():
     assert labels == ["Fresh"]
 
 
-def test_tournee_pool_filter_drops_unfollowed_source():
-    """Un article d'une source non-suivie est retiré du pool Essentiel."""
+def test_followed_pool_is_completed_by_global_fresh_pool():
+    """Un article global frais complète le tier suivi sans le devancer."""
     followed = _make_source("Mediapart")
     curated = _make_source("Le Monde")
     topics = [
@@ -636,7 +637,7 @@ def test_tournee_pool_filter_drops_unfollowed_source():
     response = build_essentiel_response(digest, user_context=ctx)
 
     labels = [a.section_label for a in response.articles]
-    assert labels == ["Followed"]
+    assert labels == ["Followed", "Curated"]
 
 
 def test_tournee_pool_filter_keeps_mixed_topic_partially():
@@ -669,8 +670,8 @@ def test_tournee_pool_filter_keeps_mixed_topic_partially():
     assert response.articles[0].title == "OK"
 
 
-def test_tournee_pool_filter_fallback_when_empties_pool(caplog):
-    """Si le filtre vide tout, on retombe sur le pool pré-filtre + warning."""
+def test_empty_followed_pool_uses_global_fresh_pool_and_logs_metrics(caplog):
+    """Un tier suivi vide utilise directement le pool global frais."""
     followed = _make_source("Mediapart")
     curated = _make_source("Le Monde")
     # Aucun article ne vient d'une source suivie → le filtre videra tout.
@@ -690,13 +691,123 @@ def test_tournee_pool_filter_fallback_when_empties_pool(caplog):
 
     import logging
 
-    with caplog.at_level(logging.WARNING, logger="app.services.essentiel_service"):
+    with caplog.at_level(logging.INFO, logger="app.services.essentiel_service"):
         response = build_essentiel_response(digest, user_context=ctx)
 
-    # Fallback : l'article curated réapparaît plutôt que de servir une carte vide.
     assert len(response.articles) == 1
     assert response.articles[0].section_label == "Only-Curated"
-    assert any("tournee-pool filter emptied" in rec.message for rec in caplog.records)
+    assert any(
+        "followed_pool=0" in rec.message
+        and "supplements=1" in rec.message
+        and "final_count=1" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_followed_pool_two_articles_completed_by_three_global_subjects(caplog):
+    followed_a = _make_source("Mediapart")
+    followed_b = _make_source("Les Jours")
+    global_sources = [_make_source(f"Global {index}") for index in range(3)]
+    titles = [
+        "Budget national adopte au parlement",
+        "Vaccin experimental contre le paludisme",
+        "Seisme majeur dans le Pacifique",
+        "Nouvelle mission spatiale europeenne",
+        "Accord mondial sur les oceans",
+    ]
+    topics = [
+        DigestTopic(
+            topic_id=f"topic-{index}",
+            label=f"Subject {index}",
+            rank=index,
+            reason="Test",
+            theme="politique",
+            perspective_count=2,
+            articles=[
+                _make_article(
+                    rank=1,
+                    title=titles[index - 1],
+                    source=source,
+                )
+            ],
+        )
+        for index, source in enumerate(
+            [followed_a, followed_b, *global_sources], start=1
+        )
+    ]
+    ctx = EssentielUserContext(
+        followed_source_ids=frozenset({followed_a.id, followed_b.id})
+    )
+
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="app.services.essentiel_service"):
+        response = build_essentiel_response(_make_digest(topics), user_context=ctx)
+
+    assert len(response.articles) == 5
+    assert [article.source.id for article in response.articles[:2]] == [
+        followed_a.id,
+        followed_b.id,
+    ]
+    assert any(
+        "followed_pool=2" in rec.message
+        and "supplements=3" in rec.message
+        and "final_count=5" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_articles_older_than_24_hours_never_backfill_short_card():
+    now = datetime(2026, 6, 15, 10, 0, tzinfo=UTC)
+    fresh_topics = [
+        DigestTopic(
+            topic_id=f"fresh-{index}",
+            label=label,
+            rank=index,
+            reason="Test",
+            theme="society",
+            perspective_count=2,
+            articles=[_make_article(rank=1, title=title)],
+        )
+        for index, (label, title) in enumerate(
+            [
+                ("Elections", "Coalition politique apres les elections"),
+                ("Science", "Decouverte medicale contre Alzheimer"),
+                ("Climat", "Canicule exceptionnelle en Europe"),
+            ],
+            start=1,
+        )
+    ]
+    stale_topics = [
+        DigestTopic(
+            topic_id=f"stale-{index}",
+            label=f"Stale {index}",
+            rank=index + 3,
+            reason="Test",
+            theme="society",
+            perspective_count=4,
+            articles=[
+                _make_article(
+                    rank=1,
+                    title=f"Old distinct subject {index}",
+                    published_at=now - timedelta(hours=25),
+                )
+            ],
+        )
+        for index in range(1, 4)
+    ]
+
+    response = build_essentiel_response(
+        _make_digest([*fresh_topics, *stale_topics]),
+        now=now,
+    )
+
+    assert len(response.articles) == 3
+    assert {article.section_label for article in response.articles} == {
+        "Elections",
+        "Science",
+        "Climat",
+    }
 
 
 def test_tournee_pool_filter_noop_when_no_followed_sources():


### PR DESCRIPTION
## Quoi

Notifications **push côté serveur** pour livrer l'Essentiel du jour même app fermée (FCM via Firebase Admin), + **refonte de la sélection Essentiel** en deux tiers (sources suivies prioritaires, puis pool éditorial frais 24 h).

## Pourquoi

La perso des notifs vivait dans un provider jamais monté (notif matin morte) : la planification locale ne partait pas de façon fiable. On bascule sur un dispatcher serveur idempotent (due-per-device/jour, retry matinal jusqu'à midi) qui s'appuie sur `UserNotificationPreferences` comme source unique de scheduling. En parallèle, la sélection Essentiel devient cohérente et observable (tier sources suivies → complément global frais, sport différé au slot ≥ 5 sans post-filtre destructif).

## Comment ça a été vérifié

- [x] **pytest** — suite backend complète **1743 passed**, 0 échec (DB locale `facteur_test`)
- [x] Tests ciblés push + essentiel : **55 passed** (`test_push_dispatcher`, `test_push_devices`, `test_essentiel_endpoint`)
- [x] **Alembic** : 1 seul head (`pn01_server_push`), `upgrade head` + `downgrade -1` rejoués sur **DB vide** → OK. Migration **additive pure** (CREATE TABLE `push_devices` + `push_deliveries`, uniq idempotence `(device_id, target_date, kind)`)
- [x] **flutter analyze** — aucune nouvelle issue (seuls lints info préexistants)
- [x] **flutter test** ciblés (`flux_continu_provider`, `push_notification_service_copy`) : 37 passed
- [x] **ruff check + format** propres sur tous les fichiers Python du diff
- [x] **/simplify** passé : drop d'un garde `max(0, …)` mort + extraction `_firebase_configured()`

## Zones à risque

- **Migration partagée DB prod** : additive only, conforme expand-contract (aucun DROP/rename). Le `Dockerfile` rejouera `alembic upgrade head` au boot — chaîne testée localement sur DB vide.
- **Dispatcher push** : gaté par config Firebase (`firebase_not_configured` → no-op), donc inerte tant que les secrets ne sont pas posés sur Railway. Voir `docs/runbooks/firebase-push-setup.md`.
- **`essentiel_service`** : refonte de `_pick_transversal_articles` (cœur de la carte Essentiel) — couverte par `test_essentiel_endpoint` (+131 lignes de tests).
- **Mobile** : ajout dépendance `firebase_messaging` → registrants générés (Android/iOS/macOS/Windows) ; build APK à surveiller post-merge (`--flavor staging`).

## Note

Réparation au passage d'un **JSON `changelog.json` invalide** déjà présent sur `main` (artefact de merge PR #847) — sinon l'entrée changelog ne pouvait pas être ajoutée.
