### PR TITLE
Fix missing daily grille puzzle seeding

### DIFF
--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -575,7 +575,9 @@ class DigestGenerationJob:
         """
         try:
             from app.services.grille_matcher import apply_hybrid_word
+            from app.services.grille_seed import ensure_daily_puzzle
 
+            await ensure_daily_puzzle(session, target_date)
             matched = await apply_hybrid_word(
                 session, target_date, editorial_ctx_pour_vous
             )

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -233,10 +233,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
             # Best-effort : un échec ici ne doit pas dégrader le reste de l'API.
             try:
                 from app.database import safe_async_session
-                from app.services.grille_seed import seed_puzzles
+                from app.services.grille_seed import ensure_daily_puzzle, seed_puzzles
+                from app.utils.time import today_paris
 
                 async with safe_async_session() as _seed_db:
                     created, updated = await seed_puzzles(_seed_db)
+                    await ensure_daily_puzzle(_seed_db, today_paris())
                     await _seed_db.commit()
                 logger.info("lifespan_grille_seeded", created=created, updated=updated)
             except Exception as seed_exc:

--- a/packages/api/app/services/grille_matcher.py
+++ b/packages/api/app/services/grille_matcher.py
@@ -84,13 +84,14 @@ async def apply_hybrid_word(
     )
     if game_exists is not None:
         logger.warning(
-            "grille_hybrid_skip_game_in_progress",
+            "grille_hybrid_skipped_game_started",
             target_date=str(target_date),
         )
         return False
 
     selection = await select_daily_word(session, target_date, editorial_ctx)
     if selection is None:
+        logger.info("grille_hybrid_no_candidate", target_date=str(target_date))
         return False
 
     puzzle.word = selection.word

--- a/packages/api/app/services/grille_seed.py
+++ b/packages/api/app/services/grille_seed.py
@@ -1,8 +1,9 @@
-"""Seed idempotent des puzzles de « La Grille du jour ».
+"""Seed et création de secours des puzzles de « La Grille du jour ».
 
-Source de vérité : `app/data/grille_puzzles_seed.json` (committé). Upsert par
-`puzzle_date`. Les dates affichées (`date_affichee`, `date_court`, `cancel`)
-sont calculées depuis `date` pour éviter toute erreur de jour de semaine.
+Le calendrier historique vient de `app/data/grille_puzzles_seed.json`. Les
+jours absents sont créés à la volée depuis le pool éditorial embarqué. Toutes
+les insertions sont idempotentes par `puzzle_date` et une ligne existante n'est
+jamais réécrite : un puzzle publié, hybridé ou déjà joué reste immuable.
 
 Appelé à deux endroits :
 - au démarrage de l'app (`main.lifespan`) → garantit qu'une table vide ne
@@ -14,13 +15,19 @@ Invariant vérifié au seed : chaque `word` ∈ dictionnaire (grille_words_fr.tx
 
 import json
 from datetime import date
+from hashlib import sha256
 from pathlib import Path
 
+import structlog
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.grille_puzzle import GrillePuzzle
 from app.services.grille_dictionary import is_valid_word
+from app.services.grille_quality_pool import get_quality_pool
+
+logger = structlog.get_logger()
 
 _SEED_PATH = (
     Path(__file__).resolve().parent.parent / "data" / "grille_puzzles_seed.json"
@@ -50,6 +57,15 @@ _MONTHS = [
     "novembre",
     "décembre",
 ]
+
+_FIRST_EDITION_DATE = date(2026, 5, 30)
+_FIRST_EDITION_NUMBER = 143
+_FALLBACK_INDICE = "Un mot de six lettres choisi dans les repères de Facteur"
+_FALLBACK_THEME = "Repères · Culture générale"
+_FALLBACK_POURQUOI = (
+    "Ce mot fait partie des repères éditoriaux de Facteur. "
+    "Une pause quotidienne pour jouer avec les mots et garder l'esprit ouvert."
+)
 
 
 class SeedInvalidWord(Exception):
@@ -83,12 +99,70 @@ def load_seed() -> tuple[str, list[dict]]:
     return data["indice_default"], data["puzzles"]
 
 
+def _edition_number(target_date: date) -> str:
+    number = _FIRST_EDITION_NUMBER + (target_date - _FIRST_EDITION_DATE).days
+    return f"N°{number}"
+
+
+def _fallback_word(target_date: date) -> str:
+    """Choisit un mot stable pour une date donnée dans le pool éditorial."""
+    words = sorted(get_quality_pool())
+    if not words:
+        raise SeedInvalidWord("Le pool éditorial de la Grille est vide")
+    digest = sha256(target_date.isoformat().encode("ascii")).digest()
+    return words[int.from_bytes(digest[:8], "big") % len(words)]
+
+
+def _fallback_fields(target_date: date) -> dict[str, object]:
+    word = _fallback_word(target_date)
+    if not is_valid_word(word):
+        raise SeedInvalidWord(
+            f"Mot fallback absent du dictionnaire (grille_words_fr.txt) : {word}"
+        )
+    return {
+        "word": word,
+        "length": len(word),
+        "max_attempts": 6,
+        "indice": _FALLBACK_INDICE,
+        "theme": _FALLBACK_THEME,
+        "pourquoi": _FALLBACK_POURQUOI,
+        "numero": _edition_number(target_date),
+        "date_affichee": format_date_affichee(target_date),
+        "date_court": format_date_court(target_date),
+        "cancel": format_cancel(target_date),
+    }
+
+
+async def ensure_daily_puzzle(session: AsyncSession, target_date: date) -> GrillePuzzle:
+    """Garantit atomiquement l'existence du puzzle de `target_date`."""
+    stmt = (
+        insert(GrillePuzzle)
+        .values(puzzle_date=target_date, **_fallback_fields(target_date))
+        .on_conflict_do_nothing(index_elements=["puzzle_date"])
+        .returning(GrillePuzzle.id)
+    )
+    created_id = await session.scalar(stmt)
+    puzzle = await session.scalar(
+        select(GrillePuzzle).where(GrillePuzzle.puzzle_date == target_date)
+    )
+    if puzzle is None:
+        raise RuntimeError(f"Puzzle introuvable après insertion : {target_date}")
+    if created_id is not None:
+        logger.info(
+            "grille_fallback_created",
+            target_date=str(target_date),
+            word=puzzle.word,
+            numero=puzzle.numero,
+        )
+    return puzzle
+
+
 async def seed_puzzles(db: AsyncSession) -> tuple[int, int]:
-    """Upsert idempotent des puzzles dans `db`. Retourne `(créés, mis_à_jour)`.
+    """Crée les puzzles historiques absents. Retourne `(créés, mis_à_jour)`.
 
     Ne commit pas : laisse la transaction au caller (parité avec `GrilleService`,
     où `get_db` assure le commit). Lève [SeedInvalidWord] si un mot du jour est
-    hors dictionnaire — fail-fast plutôt que de servir un puzzle injouable.
+    hors dictionnaire. Une ligne existante n'est jamais modifiée.
     """
     indice_default, puzzles = load_seed()
 
@@ -102,9 +176,6 @@ async def seed_puzzles(db: AsyncSession) -> tuple[int, int]:
     updated = 0
     for p in puzzles:
         puzzle_date = date.fromisoformat(p["date"])
-        existing = await db.scalar(
-            select(GrillePuzzle).where(GrillePuzzle.puzzle_date == puzzle_date)
-        )
         fields = {
             "word": p["word"],
             "length": p.get("longueur", 6),
@@ -117,13 +188,14 @@ async def seed_puzzles(db: AsyncSession) -> tuple[int, int]:
             "date_court": format_date_court(puzzle_date),
             "cancel": format_cancel(puzzle_date),
         }
-        if existing is None:
-            db.add(GrillePuzzle(puzzle_date=puzzle_date, **fields))
+        stmt = (
+            insert(GrillePuzzle)
+            .values(puzzle_date=puzzle_date, **fields)
+            .on_conflict_do_nothing(index_elements=["puzzle_date"])
+            .returning(GrillePuzzle.id)
+        )
+        if await db.scalar(stmt) is not None:
             created += 1
-        else:
-            for key, value in fields.items():
-                setattr(existing, key, value)
-            updated += 1
 
     await db.flush()
     return created, updated

--- a/packages/api/app/services/grille_service.py
+++ b/packages/api/app/services/grille_service.py
@@ -134,9 +134,9 @@ class GrilleService:
 
     async def get_today(self, user_id: str) -> GrilleTodayResponse:
         puzzle_date = today_paris()
-        puzzle = await self._get_puzzle(puzzle_date)
-        if puzzle is None:
-            raise PuzzleNotFound(puzzle_date.isoformat())
+        from app.services.grille_seed import ensure_daily_puzzle
+
+        puzzle = await ensure_daily_puzzle(self.db, puzzle_date)
 
         game = await self._get_or_create_game(user_id, puzzle_date)
         finished = game.status != STATUS_IN_PROGRESS

--- a/packages/api/tests/test_grille_api.py
+++ b/packages/api/tests/test_grille_api.py
@@ -5,10 +5,13 @@ from uuid import uuid4
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 
 from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.main import app
+from app.models.content import Content
+from app.models.enums import ContentType, SourceType
 from app.models.grille_game_state import (
     STATUS_FAILED,
     STATUS_IN_PROGRESS,
@@ -16,15 +19,12 @@ from app.models.grille_game_state import (
     STATUS_SOLVED,
     GrilleGameState,
 )
-from app.models.content import Content
-from app.models.enums import ContentType, SourceType
 from app.models.grille_puzzle import GrillePuzzle
 from app.models.source import Source
 from app.services.grille_service import (
     GameAlreadyFinished,
     GameNotFinished,
     GrilleService,
-    PuzzleNotFound,
 )
 from app.utils.time import today_paris
 
@@ -43,7 +43,9 @@ def _override_user(user_id: str):
     return _fake_user
 
 
-async def _make_puzzle(db, *, word="CLIMAT", max_attempts=6, on_date=None, featured=False):
+async def _make_puzzle(
+    db, *, word="CLIMAT", max_attempts=6, on_date=None, featured=False
+):
     puzzle = GrillePuzzle(
         puzzle_date=on_date or today_paris(),
         word=word,
@@ -135,7 +137,9 @@ async def test_today_creates_game_and_hides_word(db_session):
 
 
 @pytest.mark.asyncio
-async def test_today_404_when_no_puzzle(db_session):
+async def test_today_repairs_missing_post_seed_puzzle(db_session, monkeypatch):
+    target_date = datetime(2026, 6, 15).date()
+    monkeypatch.setattr("app.services.grille_service.today_paris", lambda: target_date)
     user_id = uuid4()
     app.dependency_overrides[get_current_user_id] = _override_user(str(user_id))
     app.dependency_overrides[get_db] = _override_db(db_session)
@@ -147,7 +151,12 @@ async def test_today_404_when_no_puzzle(db_session):
         app.dependency_overrides.pop(get_current_user_id, None)
         app.dependency_overrides.pop(get_db, None)
 
-    assert resp.status_code == 404
+    assert resp.status_code == 200
+    assert resp.json()["date"] == "2026-06-15"
+    puzzle = await db_session.scalar(
+        select(GrillePuzzle).where(GrillePuzzle.puzzle_date == target_date)
+    )
+    assert puzzle is not None
 
 
 # ----- validation (service) -------------------------------------------------

--- a/packages/api/tests/test_grille_seed.py
+++ b/packages/api/tests/test_grille_seed.py
@@ -2,8 +2,8 @@
 
 Régression docs/bugs/bug-grille-du-jour-crash.md : la table `grille_puzzles`
 était vide en prod (seed manuel-only jamais exécuté) → 404 → écran gris mobile.
-Le seed est désormais joué au démarrage de l'app ; ces tests garantissent qu'il
-peuple bien la table et reste idempotent (upsert par `puzzle_date`).
+Ces tests garantissent aussi qu'un jour absent du calendrier embarqué est créé
+de façon déterministe sans réécrire les puzzles déjà publiés.
 """
 
 from datetime import date
@@ -13,6 +13,7 @@ from sqlalchemy import func, select
 
 from app.models.grille_puzzle import GrillePuzzle
 from app.services.grille_seed import (
+    ensure_daily_puzzle,
     format_cancel,
     format_date_affichee,
     format_date_court,
@@ -41,14 +42,64 @@ async def test_seed_is_idempotent(db_session):
     # 1er passage : tout créé.
     created1, updated1 = await seed_puzzles(db_session)
     await db_session.commit()
-    # 2e passage : tout mis à jour, rien de neuf, aucun doublon.
+    # 2e passage : rien n'est modifié et aucun doublon n'est créé.
     created2, updated2 = await seed_puzzles(db_session)
     await db_session.commit()
 
     _, puzzles = load_seed()
     assert (created1, updated1) == (len(puzzles), 0)
-    assert (created2, updated2) == (0, len(puzzles))
+    assert (created2, updated2) == (0, 0)
     assert await _count(db_session) == len(puzzles)
+
+
+@pytest.mark.asyncio
+async def test_ensure_daily_puzzle_creates_stable_post_seed_fallback(db_session):
+    target_date = date(2026, 6, 15)
+
+    first = await ensure_daily_puzzle(db_session, target_date)
+    await db_session.flush()
+    second = await ensure_daily_puzzle(db_session, target_date)
+
+    assert first.id == second.id
+    assert first.word == second.word
+    assert first.numero == "N°159"
+    assert first.date_affichee == "Lundi 15 juin"
+    assert first.date_court == "Lun. 15 juin"
+    assert first.cancel == "15·06·26"
+    assert first.indice == "Un mot de six lettres choisi dans les repères de Facteur"
+    assert "actualité" not in first.pourquoi.lower()
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(GrillePuzzle)
+            .where(GrillePuzzle.puzzle_date == target_date)
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_seed_does_not_overwrite_published_hybrid_puzzle(db_session):
+    await seed_puzzles(db_session)
+    await db_session.commit()
+    target_date = date(2026, 6, 13)
+    puzzle = await db_session.scalar(
+        select(GrillePuzzle).where(GrillePuzzle.puzzle_date == target_date)
+    )
+    assert puzzle is not None
+    puzzle.word = "CLIMAT"
+    puzzle.hybrid_word_source = "hybrid"
+    puzzle.hybrid_match = "climat"
+    await db_session.commit()
+
+    created, updated = await seed_puzzles(db_session)
+    await db_session.commit()
+
+    await db_session.refresh(puzzle)
+    assert (created, updated) == (0, 0)
+    assert puzzle.word == "CLIMAT"
+    assert puzzle.hybrid_word_source == "hybrid"
+    assert puzzle.hybrid_match == "climat"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Create missing daily Grille puzzles on demand from a deterministic fallback pool, seed them at startup, and stop reseeding from overwriting existing published or hybridized entries.

## Why

This prevents `/grille/today` from returning 404 when the embedded calendar is missing a date while preserving immutability for puzzles that already exist in the database.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)
