### PR TITLE
feat(onboarding): sources spécialisées par sujet — re-mapping taxonomie 51-slugs + badge « Spécialisé en X » (Epic 12)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,97 +1,40 @@
-feat(onboarding): refonte sources — swipe de calibration + biais « sources productives » + badge format (Story 2.8)
+feat(onboarding): sources spécialisées par sujet — re-mapping taxonomie 51-slugs + badge « Spécialisé en X » (Epic 12)
 
-Refonte du parcours sources de l'onboarding, livrée en **1 PR groupée** (backend + mobile) vers `main`. Le swipe devient le cœur du parcours, la calibration agit au niveau pôle, et l'onboarding **favorise les sources productives** (volume de publication réel) tout en rendant le **format** (vidéo, podcast, Reddit) lisible d'un coup d'œil. Additif, **aucune migration Alembic** (champ `articles_30d` purement calculé).
+Aligne le vocabulaire des `granular_topics` des **sources** sur la taxonomie **51-slugs** des users/articles et garantit, dans l'écran de reco onboarding, **≥1 source spécialisée visible par sujet sélectionné** (badge « Spécialisé en X »). Livré en **1 PR groupée** (backend data + mobile UI) vers `main`. Additif, **aucune migration Alembic** (`granular_topics`/`is_curated` existent déjà → backfill data gaté PO).
+
+## Problème
+
+Le recommender d'onboarding score `source.granularTopics ∩ user.selectedSubtopics`, mais les deux vivaient dans des **taxonomies incompatibles** : sources en ancien vocab (`social-justice`, `energy-transition`, `data-privacy`…), users/articles en 51-slugs (`inequality`, `energy`, `privacy`…). Résultat : le bonus « spécialiste » ne se déclenchait quasi jamais (~35/51 subtopics sans source curée correspondante) → pas d'effet « wow ». Le catalogue curé (66/296 actives) était aussi trop mince.
 
 ## Ce que ça change (user-visible)
 
-- **Tout le monde swipe.** Question d'intent « curieux / je connais » retirée. Après les sous-thèmes → directement le swipe, non skippable (set vide = auto-skip).
-- **Swipe satisfaisant + cliquable.** Carte suivie au drag (rotation + translation), fling hors écran au seuil, retour élastique sinon ; tap carte → fiche source. Nudge « Touchez pour explorer » sur la 1ère carte.
-- **Sources les plus actives mises en avant.** Le recommander biaise vers les sources qui publient vraiment (volume 30 j), en matched/préselection **et** dans le deck de swipe (tiebreaker volume puis audience).
-- **Format visible.** Badge discret YouTube / Podcast / Vidéo / Reddit sur les cartes de swipe, les recos d'onboarding et la fiche source (jamais pour les articles, format implicite).
-- **Titre + compteur humanisés.** Titre « Quels médias suivre ? » ; compteur à 3 paliers (« Premières cartes » → « On affine » → « Encore quelques-unes »).
-- **« Ce qu'on retient » en bas.** Les chips du haut deviennent une phrase inline discrète sous le deck (« On retient pour ta sélection : … »), qui s'allume quand un pôle passe net-positif.
-- **Calibration en direct (signal pôle).** Votes agrégés par pôle (fond / actu directe / indépendant / référence) → repondèrent toutes les sources du pôle (±2/vote, capé ±4), en plus du `+5/-4` par source swipée.
+- **Un spécialiste par sujet, dès l'inscription.** Chaque sous-sujet choisi obtient au moins une carte « 🎯 Spécialisé en {sujet} », en tête des suggestions et pré-cochée.
+- **Cartes spécialistes distinctes par sujet** (quand la data le permet), libellés FR via `getTopicLabel` (51 slugs couverts).
 
 ## Technique (additif, sans migration)
 
-- **Backend** : `SourceResponse.articles_30d` (calculé, défaut 0). `SourceService` enrichit les réponses curées (`get_all_sources` + `get_curated_sources`) via **un unique GROUP BY batché** (jamais d'appel par source), réutilisant l'index composite existant `ix_contents_source_published` (source_id, published_at). Le custom reste à 0 (hors-scope). Aucune colonne DB, aucune migration, toujours 1 head Alembic.
-- **Mobile** : `Source.articles30d` (porté depuis le JSON) + `Source.getTypeIcon()` ; nouveau widget partagé `SourceTypeBadge` (masqué pour les articles). Recommander : `_volumeBonus` (+2 ≥90/30j, +1 ≥20/30j, 0 sinon — sous le match thème `+3`) et tiebreaker `byVolumeThenFollowers` sur `buildSpanningSet`. `articles30d == 0` = no-op (rétro-compatible).
-- Réutilise `SourceDetailModal`, `buildSpanningSet`, le scoring thème/fiabilité existant.
+### Backend / data
+- **`scripts/retag_and_promote_sources.py`** (nouveau, scaffolding CLI dry-run/`--apply`/`--allow-prod`/backup JSON repris d'`apply_source_evaluations.py`) :
+  - **A1 — dérivation `granular_topics`** : sur 90 j, agrège `unnest(contents.topics)` par topic ; `share = n_topic / n_total` ; retient si `n ≥ MIN_COUNT(4)` **et** `share ≥ MIN_SHARE(0.10)`, capé `TOP_K(6)`, **ordonné par share desc** (1er = spécialité dominante = badge). Dérivation vide → on **conserve** les slugs déjà valides et purge l'ancien vocab (jamais de wipe d'un vrai spécialiste mince).
+  - **A2 — promotion catalogue** : `is_active ∧ ¬is_curated ∧ bias≠unknown ∧ reliability∈{medium,high} ∧ articles_30d ≥ 20` → `is_curated=true`.
+  - Sorties : mutation DB gatée + backup JSON ; `--write-csv` régénère `granular_topics`/`Status` de `sources_master.csv` (diff relisible PO, ajoute les promues) ; **audit de couverture** 51 subtopics (≥1 spécialiste partout).
+- **`scripts/validate_taxonomy.py`** : supprime le `VALID_TOPICS` local (ancien vocab) → importe `VALID_TOPIC_SLUGS` (51) + `VALID_THEMES` (9) canoniques. Ferme l'Epic 12 côté sources.
+- **`scripts/_backfill_new_yt.py` + `backfill_youtube_deep.py`** : `granular_topics` hardcodés re-mappés en 51-slugs (sinon ré-introduisaient l'ancien vocab au prochain seed).
+- **NE TOUCHE PAS `secondary_themes`** (vocab macro-thème, consommé par le pipeline digest). Aucune logique digest ne matche sur `granular_topics`.
 
-## Vérification
+### Mobile / UI
+- **`source_recommender.dart`** : `RecommendationTagType.specialist` ; badge « Spécialisé en X » quand `granularTopics.first ∈ selectedSubtopics` (pas de double chip thème). **Garantie de couverture** `_computeSpecialists` : pour chaque subtopic non couvert par un spécialiste dominant de `matched`, tire le meilleur spécialiste curé restant (dominant → score → fiabilité → volume) ; nouveau champ `SourceRecommendation.specialists` (disjoint, inclus dans `preselectedIds`).
+- **`sources_question.dart`** : spécialistes placés **en tête** des suggestions (survivent au cap 18) + dédup par id.
+- **`source_recommendation_card.dart`** : rendu du chip spécialiste (préfixe 🎯, teinte primary).
 
-- **Backend** : `pytest` ciblé sources/onboarding → **49 passed** (dont 2 nouveaux : `articles_30d` peuplé par le GROUP BY, fenêtre 30 j, 0 sans contenu). Alembic : 1 head, aucune migration ajoutée. `ruff check` OK.
-- **Mobile** : `flutter analyze` → **0 erreur** sur les fichiers touchés (warnings `withOpacity` pré-existants). `flutter test test/features/onboarding/ test/features/sources/{widgets,models}/` → **147 passed** (recommander volume + tiebreaker, badge type, compteur humanisé, phrase inline, absence des chips du haut).
-- NB : suite mobile complète a ~27 échecs pré-existants (Hive/Supabase non init, hors CI) — non liés.
+## Apply prod (gaté PO, étape séparée post-merge)
 
-## Follow-up (PR2, hors scope)
-
-- Page « Vos sources, sur mesure » : 4 blocs numérotés, 15-20 suggestions dont ~8-10 pré-cochées, « pourquoi » plus visible + tag « Similaire à », proxy volume mainstream.
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-# Volet « Pas de recul » (deep reco) dans le reader — backend + mobile
-
-## Résumé
-Réactive le moteur « Pas de recul » (désactivé au post-unification cleanup) et
-l'expose **par article ouvert** : l'endpoint `GET /contents/{id}/perspectives`
-renvoie une recommandation d'article de fond (`deep_recommendation`), et le
-reader la rend tout en bas, sous la « Couverture médiatique ». Premier étage de
-la dimension « deep » de l'app. **Aucune migration Alembic.**
-
-## Changements — Backend
-- **`deep_matcher.py`** : nouvelle méthode `match_for_content(content)` — variante
-  reader de `match_for_topics`. Dérive un pseudo-angle depuis l'article ouvert
-  (titre + topics + theme), réutilise tel quel `_load_deep_articles` / `_prefilter`
-  / `_expand_query` / `_llm_evaluate` / `_fallback_pick`. Exclut l'article ouvert
-  **et** tout article du même cluster (pas une autre dépêche du même évènement).
-  Helper `_entity_names` tolérant aux deux formats d'entités (JSON & `name:type`).
-- **`routers/contents.py`** : cache dédié `_deep_reco_cache` (TTL 2h) + sentinelle
-  `_DEEP_NO_MATCH` + garde in-flight. Le matching tourne en **background**
-  (`_compute_deep_reco_background`) car il fait 2 appels LLM — on ne bloque pas
-  l'ouverture du reader, exactement comme le pattern partiel/refresh des
-  perspectives. `deep_recommendation` (dict|null) + `deep_pending` (bool) sont
-  attachés aux 3 chemins de retour (cache hit / snapshot digest / live) et
-  préservés à travers le refresh background.
-- **`editorial_prompts.yaml`** : prompt `deep_matching` décommenté. **`config.py`** :
-  commentaire TODO nettoyé.
-
-## Changements — Mobile
-- **`feed_repository.dart`** : modèle `DeepRecommendation` + champs
-  `deepRecommendation` / `deepPending` sur `PerspectivesResponse` (+ parsing JSON,
-  rétro-compatible : clés absentes ⇒ `null` / `false`).
-- **`deep_recommendation_card.dart`** (nouveau) : carte « Pas de recul »
-  (médaillon 🔭, titre, raison de match, source ; tap → ouvre l'article dans le
-  reader). Palette dérivée des tokens `colors.*` ⇒ cohérent clair/sombre/oled.
-- **`content_detail_screen.dart`** : rendu de la carte en bas du reader (gardé par
-  `deep_recommendation != null && !_isExternal`), `_openDeepReco()` (push route
-  `content/:id`), et refetch one-shot étendu à `deepPending` (pas de double appel
-  LLM-coûteux).
-
-## Contrat API (nouveaux champs de la réponse perspectives)
-```
-deep_recommendation: {
-  content_id, title, url, thumbnail_url, content_type,
-  source_id, source_name, source_logo_url, published_at,
-  match_reason, description
-} | null
-deep_pending: bool   # true = matching en cours en background → mobile doit refetch
-```
+`cd packages/api && python3 scripts/retag_and_promote_sources.py --write-csv` (dry-run lecture prod → diff CSV + audit), revue PO, puis `--apply --allow-prod`. Backup JSON conservé. La reco prod en bénéficie aussi (subtopics users prod déjà en 51-slugs), sans régression de matching attendue.
 
 ## Tests
-- `tests/editorial/test_deep_matcher.py` : `TestMatchForContent` (sélection LLM,
-  exclusion self, exclusion même cluster, pool vide, pivot maigre, fallback no-LLM)
-  + `TestEntityNames`. **25/25 verts.**
-- `tests/routers/test_contents_deep_reco.py` (nouveau) : helpers `_deep_reco_to_dict`,
-  `_apply_deep_from_cache`, `_attach_deep_recommendation`. **8/8 verts.**
-- `deep_recommendation_card_test.dart` (nouveau) + `feed_repository_perspectives_test.dart`
-  (étendu : parsing `deep_recommendation` / `deep_pending`).
-- 1 seul head Alembic, aucune migration.
+- **Backend** : `tests/scripts/test_retag_and_promote_sources.py` (19 tests purs) — dérivation (seuils, ordre par share, top-K, vocab 51), résolution conservatrice, promotion, audit couverture, régénération CSV.
+- **Mobile** : `source_recommender_test.dart` (+5 tests) — badge dominant, pas de badge sur subtopic non dominant, garantie hors-matched, pas de doublon, cartes distinctes par sujet.
+- `validate_taxonomy` importe 51 slugs + 9 thèmes (vérifié). `flutter analyze` propre sur les fichiers touchés.
 
-## Vérif manuelle suggérée (avant merge)
-`uvicorn` local + `curl /contents/{id}/perspectives` → `deep_pending:true` au 1er
-appel, puis `deep_recommendation` peuplé au 2e (article avec sujet couvert par une
-source `source_tier='deep'`) ; `null` sur un fait divers.
-
-## Suite
-- Chantier curation deep (séparé) : labelliser plus de sources `source_tier='deep'`
-  + chaînes YouTube + reportages.
+## Changelog
+Entrée `unreleased` : `{ "tag": "Sources", "summary": "Des sources spécialisées sur chacun de tes sujets dès l'inscription." }`

--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,77 +1,73 @@
-# QA Handoff — Fiche source v3 (endpoint `/profile` unifié + fréquence + cartes article cliquables)
+# QA Handoff — Onboarding sources : re-mapping taxonomie + badge « Spécialisé en X »
 
 > Rempli par l'agent dev après VERIFY. Input de `/validate-feature` (agent QA Chrome).
 
 ## Feature développée
-La fiche source (bottom sheet) devient un vrai signal produit : un endpoint unifié
-`GET /sources/{id}/profile` alimente en un seul appel la couverture par thèmes, le volume
-30 jours, la **fréquence de publication** (nouveau chip horloge dans le header) et les
-**3 articles récents** rendus en carte standard `FluxContinuArticleCard` (cliquables →
-reader, read-sync, aperçu en appui long). L'évaluation reste reléguée, repliée.
+
+Pendant l'onboarding, l'écran de reco sources devient « wow » : chaque sujet (subtopic)
+sélectionné obtient **au moins une source spécialisée visible**, badgée « Spécialisé en X ».
+Côté backend, un script aligne le vocabulaire des `granular_topics` des sources sur la
+taxonomie 51-slugs des users/articles (re-dérivée du contenu réellement publié) et élargit
+le catalogue curé. Côté mobile, le recommender ajoute un badge spécialiste sur la spécialité
+dominante d'une source, **et** une garantie de couverture qui rapatrie le meilleur spécialiste
+curé pour tout sujet choisi non couvert (carte distincte par sujet, pré-cochée).
+
+> ⚠️ La partie data (re-tag + promotion en base) est **gatée PO** et tourne séparément
+> (`scripts/retag_and_promote_sources.py --apply --allow-prod`) après merge. La validation QA
+> ci-dessous porte sur l'**UI mobile** (badge + visibilité). Sur l'env staging, l'effet plein
+> n'apparaît qu'une fois la base re-taggée ; le badge et la garantie restent testables avec
+> les `granular_topics` déjà présents.
 
 ## PR associée
-<!-- À compléter après ouverture : gh pr view --web -->
-Branche : `boujonlaurin-dotcom/source-profile-endpoint` (base `main`).
+<!-- gh pr view --web après /go -->
 
 ## Écrans impactés
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| Fiche source (bottom sheet `SourceDetailModal`) | ouverte depuis Sources, Flâner, reader (chip source), thèmes, pépites, onboarding | Modifié |
-| Reader article (`ContentDetailScreen`) | `/flux-continu/content/:id` | Cible du tap sur une carte article (existant) |
+| Onboarding — Sources (« sur mesure ») | flow onboarding, étape sources | Modifié |
 
 ## Scénarios de test
 
-### Scénario 1 : Happy path — source active riche
+### Scénario 1 : Happy path — sujet avec spécialiste
 **Parcours** :
-1. Ouvrir la fiche d'une source qui publie beaucoup (ex. Le Monde) via l'onglet Sources ou une chip source dans le reader.
-2. Observer le header.
-3. Faire défiler jusqu'aux sections « Couverture par thèmes » et « Derniers articles ».
-4. Taper sur une carte article.
-**Résultat attendu** :
-- Header : nom + domaine + signal « Suivi par N lecteurs » **et** chip horloge fréquence (ex. « ~100/jour », « quelques-uns/semaine »).
-- Couverture : barres par thème (label + barre + %), caption « N articles publiés sur la période ».
-- Derniers articles : jusqu'à 3 cartes `FluxContinuArticleCard` (logo source, titre, méta), alignées avec le reste de la fiche.
-- Tap sur une carte → ouvre le reader de l'article ; au retour, la carte porte le badge « lu » (read-sync).
-- Appui long sur une carte → aperçu (preview overlay).
+1. Lancer l'onboarding, choisir des thèmes (ex. Tech, Société) puis des sous-sujets variés
+   (ex. `IA`, `Climat`).
+2. Passer le swipe de calibration, arriver sur l'écran « ① Suggestions sur mesure ».
+**Résultat attendu** : pour chaque sous-sujet choisi qui dispose d'un spécialiste curé, une
+carte porte un chip teinté primary **« 🎯 Spécialisé en {sujet} »** (ex. « Spécialisé en
+Intelligence artificielle »). Ces cartes apparaissent **en tête** des suggestions et sont
+**pré-cochées**.
 
-### Scénario 2 : Edge case — source fraîche / sans articles / éval absente
+### Scénario 2 : Edge case — sujets « pauvres »
 **Parcours** :
-1. Ouvrir une source très récente (peu d'historique) → vérifier que la fréquence n'est pas sous-estimée (fenêtre clampée à l'âge réel).
-2. Ouvrir une source sans contenu → section articles = carte « Aucun article récent. », couverture masquée.
-3. Ouvrir une source non évaluée → bloc « Évaluation Facteur » affiche « Pas encore évaluée », reste repliée.
+1. Refaire l'onboarding en choisissant des sous-sujets réputés minces
+   (ex. `Fact-checking`, `Relations et amour`, `Jeux vidéo`).
+**Résultat attendu** : au moins une carte « Spécialisé en X » remonte pour chacun **quand la
+data le permet** (cartes distinctes par sujet). Si aucun spécialiste curé n'existe pour un
+sujet sur l'env testé, pas de carte fantôme et pas d'erreur — dégradation propre.
 
-### Scénario 3 : Cas d'erreur — `/profile` injoignable (fallback gracieux)
+### Scénario 3 : Pas de doublon / cohérence des chips
 **Parcours** :
-1. Couper le réseau (ou simuler une 5xx) puis ouvrir une fiche source.
-**Résultat attendu** : la sheet ne bloque **jamais**. Fallback statique = header (sans chip
-fréquence) + évaluation + réglages (si suivie) + gestion + actions. Couverture / articles /
-fréquence masqués. Aucun spinner infini, aucun crash.
-
-### Scénario 4 : Mode smart-search inchangé (non-régression)
-**Parcours** :
-1. Depuis « Ajouter une source » (smart-search), ouvrir la fiche d'un résultat.
-**Résultat attendu** : comportement v2 intact — couverture via `/coverage`, articles en carte
-minimale (non cliquable), pas de chip fréquence, pas de FluxContinuArticleCard.
+1. Choisir un sujet dont la source dominante matche (ex. une source dont la spécialité
+   dominante est exactement le sujet choisi).
+**Résultat attendu** : la carte montre **un seul** chip « Spécialisé en X » (pas de double
+chip « X » thème + « Spécialisé en X »). La source n'apparaît pas deux fois.
 
 ## Critères d'acceptation
-- [ ] Chip fréquence visible et cohérent avec le volume réel (mode normal, source connue).
-- [ ] 3 cartes article standard cliquables → reader + read-sync + preview appui long.
-- [ ] Couverture par thèmes : barres + % + caption corrects.
-- [ ] Évaluation repliée par défaut, « à titre indicatif ».
-- [ ] Fallback statique sur erreur réseau (jamais de blocage).
-- [ ] Mode smart-search non régressé (cartes minimales, pas de chip).
-- [ ] 8 call sites de `SourceDetailModal` intacts (constructeur inchangé).
+- [ ] ≥1 carte « Spécialisé en {sujet} » visible par sous-sujet sélectionné (quand un
+      spécialiste curé existe).
+- [ ] Le badge utilise le bon libellé FR (`getTopicLabel`) pour les 51 slugs.
+- [ ] Les cartes spécialistes sont en tête des suggestions et pré-cochées.
+- [ ] Pas de doublon de carte ni de double chip thème+spécialiste.
+- [ ] Console sans erreur, pas de requête 4xx/5xx inattendue.
 
 ## Zones de risque
-- **Couplage `FluxContinuArticleCard` dans une sheet scrollable** : vérifier que le swipe
-  horizontal (swipe-to-open) ne crée pas de conflit avec le scroll vertical de la sheet, et
-  que tap → reader fonctionne. Si effet de bord, préférer un flag `interactive:false` plutôt
-  qu'un fork (cf. plan).
-- **Navigation depuis la sheet** : le tap pousse le reader sur le root navigator
-  (`RouteNames.contentDetail`) ; la sheet doit rester vivante dessous (retour OK).
-- Alignement visuel des cartes (padding +4px pour compenser les 12px internes de la carte).
+- Spécialité dominante = `granularTopics.first` : dépend de l'ordre (par share desc) écrit par
+  le re-tag backend. Sur un env non encore re-taggé, l'ordre vient du seed CSV.
+- Cap des suggestions (`_suggestionsLimit = 18`) : les spécialistes sont placés en tête pour
+  survivre au cap — vérifier qu'ils ne sont jamais tronqués.
 
 ## Dépendances
-- Backend : `GET /api/sources/{source_id}/profile` (nouveau, auth requise). Aucune migration DB.
-- Endpoints `/coverage` et `/recent-items` conservés (autres consommateurs).
-- Providers mobile : `sourceProfileProvider` (nouveau, autoDispose) ; `sourceRecentArticlesProvider` supprimé ; `sourceCoverageProvider` conservé (smart-search).
+- Aucune nouvelle API. Sérialisation existante `granular_topics` / `articles_30d`
+  (`schemas/source.py`, `routers/sources.py`). Pas de migration Alembic.
+- Effet data complet conditionné à l'apply prod gaté PO du script de re-tag/promotion.

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Sources",
+      "summary": "Des sources spécialisées sur chacun de tes sujets dès l'inscription."
+    },
+    {
       "tag": "Notifications",
       "summary": "Ton Essentiel du jour arrive maintenant par notification, même app fermée : un rappel fiable le matin pour ton moment de lecture."
     },

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -1663,10 +1663,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           _perspectivesResponse = response;
           _perspectivesLoading = false;
         });
-        // Un seul refetch one-shot couvre perspectives partielles ET le matching
-        // deep « Pas de recul » encore en cours (deep_pending) ; on ne double
-        // pas l'appel (LLM-coûteux). Voir _schedulePerspectivesPartialRefetch.
-        if (response.partial || response.deepPending) {
         // Prefill : si le back renvoie déjà l'analyse cachée, on seed le sheet
         // en `done` → ouverture immédiate sans 2ᵉ appel.
         final cached = response.analysis;
@@ -1676,7 +1672,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             text: cached,
           );
         }
-        if (response.partial) {
+        // Un seul refetch one-shot couvre perspectives partielles ET le matching
+        // deep « Pas de recul » encore en cours (deep_pending) ; on ne double
+        // pas l'appel (LLM-coûteux). Voir _schedulePerspectivesPartialRefetch.
+        if (response.partial || response.deepPending) {
           _schedulePerspectivesPartialRefetch(content.id);
         }
         _maybeTriggerPerspectivesCta();
@@ -3532,6 +3531,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     onTap: () =>
                         _openDeepReco(_perspectivesResponse!.deepRecommendation!),
                   ),
+                ],
+
                 // ── Perspectives section (fin du reader) ───────────────────
                 // Bande frostée encastrée (hairline fine + teinte quasi-
                 // invisible) ; large respiration au-dessus pour la détacher.

--- a/apps/mobile/lib/features/onboarding/data/source_recommender.dart
+++ b/apps/mobile/lib/features/onboarding/data/source_recommender.dart
@@ -16,6 +16,10 @@ enum RecommendationTagType {
   /// Theme or subtopic match (e.g., "Tech", "IA")
   topic,
 
+  /// Spécialité dominante de la source ∈ sujets choisis ("Spécialisé en {X}").
+  /// Cœur de l'effet « wow » : ≥1 spécialiste visible par sujet sélectionné.
+  specialist,
+
   /// Deep analysis source — shown when user selected "noise" objective
   antiBruit,
 
@@ -61,8 +65,15 @@ class SourceRecommendation {
   final List<RecommendedSource> gems;
   final List<RecommendedSource> catalog;
 
+  /// Spécialistes ajoutés par la garantie de couverture : pour chaque subtopic
+  /// sélectionné non encore couvert par un spécialiste présent dans [matched],
+  /// le meilleur spécialiste curé du pool (badge « Spécialisé en {X} »).
+  /// Disjoint de [matched]/[perspective]/[gems]/[catalog].
+  final List<RecommendedSource> specialists;
+
   /// IDs that should be pre-selected.
   Set<String> get preselectedIds => {
+        ...specialists.map((r) => r.source.id),
         ...matched.map((r) => r.source.id),
         ...gems.map((r) => r.source.id),
       };
@@ -72,6 +83,7 @@ class SourceRecommendation {
     required this.perspective,
     required this.gems,
     required this.catalog,
+    this.specialists = const [],
   });
 }
 
@@ -215,6 +227,20 @@ class SourceRecommender {
       usedIds.add(r.source.id);
     }
 
+    // 3bis. Garantie de couverture : ≥1 spécialiste visible par subtopic choisi.
+    // Pour chaque subtopic non déjà couvert par un spécialiste dominant présent
+    // dans `matched`, tire le meilleur spécialiste curé restant du pool.
+    final specialistSources = _computeSpecialists(
+      selectedSubtopics: selectedSubtopics,
+      matched: matchedSources,
+      allCurated: curated,
+      usedIds: usedIds,
+      scored: scored,
+    );
+    for (final r in specialistSources) {
+      usedIds.add(r.source.id);
+    }
+
     // 4. Catalog: everything else, alphabetical
     final catalogSources = curated
         .where((s) => !usedIds.contains(s.id))
@@ -255,7 +281,75 @@ class SourceRecommender {
       perspective: withSimilarTag(perspectiveSources),
       gems: withSimilarTag(gemSources),
       catalog: catalogRecommended,
+      specialists: withSimilarTag(specialistSources),
     );
+  }
+
+  /// Garantit ≥1 carte « spécialiste » par subtopic sélectionné. Un subtopic est
+  /// déjà couvert si une source de [matched] le porte comme **spécialité
+  /// dominante** (`granularTopics.first`). Pour chaque subtopic restant, choisit
+  /// le meilleur spécialiste curé non encore utilisé qui **contient** ce subtopic
+  /// (dominant d'abord, puis meilleur score, fiabilité, volume). Une source n'est
+  /// tirée que pour un seul subtopic (cartes distinctes -> chaque sujet a la
+  /// sienne quand la data le permet).
+  static List<RecommendedSource> _computeSpecialists({
+    required List<String> selectedSubtopics,
+    required List<RecommendedSource> matched,
+    required List<Source> allCurated,
+    required Set<String> usedIds,
+    required Map<String, int> scored,
+  }) {
+    if (selectedSubtopics.isEmpty) return const [];
+
+    final covered = <String>{};
+    for (final r in matched) {
+      final gt = r.source.granularTopics;
+      if (gt.isNotEmpty && selectedSubtopics.contains(gt.first)) {
+        covered.add(gt.first);
+      }
+    }
+
+    final taken = <String>{...usedIds};
+    final result = <RecommendedSource>[];
+
+    for (final sub in selectedSubtopics) {
+      if (covered.contains(sub)) continue;
+      final candidates = allCurated
+          .where((s) => !taken.contains(s.id) && s.granularTopics.contains(sub))
+          .toList()
+        ..sort((a, b) {
+          final ad = a.granularTopics.isNotEmpty && a.granularTopics.first == sub
+              ? 1
+              : 0;
+          final bd = b.granularTopics.isNotEmpty && b.granularTopics.first == sub
+              ? 1
+              : 0;
+          if (ad != bd) return bd - ad; // spécialité dominante d'abord
+          final byScore = (scored[b.id] ?? 0).compareTo(scored[a.id] ?? 0);
+          if (byScore != 0) return byScore;
+          final aRel = a.reliabilityScore == 'high' ? 1 : 0;
+          final bRel = b.reliabilityScore == 'high' ? 1 : 0;
+          if (aRel != bRel) return bRel - aRel;
+          return b.articles30d.compareTo(a.articles30d);
+        });
+      if (candidates.isEmpty) continue;
+      final best = candidates.first;
+      taken.add(best.id);
+      covered.add(sub);
+      result.add(RecommendedSource(
+        source: best,
+        category: SourceCategory.matched,
+        tags: [
+          RecommendationTag(
+            label: 'Spécialisé en ${getTopicLabel(sub)}',
+            type: RecommendationTagType.specialist,
+          ),
+        ],
+        reason: 'Parce que vous suivez ${getTopicLabel(sub)}',
+        score: scored[best.id] ?? 0,
+      ));
+    }
+    return result;
   }
 
   /// Cherche la meilleure source aimée au swipe « similaire » à [s] : partage un
@@ -338,6 +432,20 @@ class SourceRecommender {
       }
     }
 
+    // Badge « spécialiste » : la spécialité *dominante* (1er granularTopic, =
+    // top share après le re-tag backend) ∈ sujets choisis. Cœur de l'effet wow.
+    final String? specialistSlug =
+        source.granularTopics.isNotEmpty &&
+                subtopics.contains(source.granularTopics.first)
+            ? source.granularTopics.first
+            : null;
+    if (specialistSlug != null) {
+      tags.add(RecommendationTag(
+        label: 'Spécialisé en ${getTopicLabel(specialistSlug)}',
+        type: RecommendationTagType.specialist,
+      ));
+    }
+
     // Granular topics match subtopics (+2 each)
     for (final gt in source.granularTopics) {
       if (subtopics.contains(gt)) {
@@ -346,6 +454,9 @@ class SourceRecommender {
           bestReasonScore = 2;
           bestReason = getTopicLabel(gt);
         }
+        // La spécialité dominante est déjà badgée « Spécialisé en X » : on ne
+        // double pas avec un tag thème générique.
+        if (gt == specialistSlug) continue;
         // Add subtopic tag (prefer over theme if more specific)
         if (tags.where((t) => t.type == RecommendationTagType.topic).length < 2) {
           tags.add(RecommendationTag(

--- a/apps/mobile/lib/features/onboarding/screens/questions/sources_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/sources_question.dart
@@ -109,19 +109,23 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
     return b.source.followerCount.compareTo(a.source.followerCount);
   }
 
-  /// Jusqu'à `_suggestionsLimit` suggestions : matched triées score desc puis
-  /// volume-proxy ; sans thèmes (ou sans match), tri volume-proxy sur tout le
-  /// pool.
+  /// Jusqu'à `_suggestionsLimit` suggestions : les **spécialistes garantis** en
+  /// tête (≥1 par sujet choisi, badge « Spécialisé en X ») pour qu'ils survivent
+  /// au cap, puis matched triées score desc + volume-proxy ; sans thèmes (ou sans
+  /// match), tri volume-proxy sur tout le pool.
   List<RecommendedSource> _computeSuggestions(
     SourceRecommendation reco, {
     required bool hasThemes,
   }) {
-    if (hasThemes && reco.matched.isNotEmpty) {
+    final specialists = reco.specialists;
+    if (hasThemes && (reco.matched.isNotEmpty || specialists.isNotEmpty)) {
       final sorted = [...reco.matched]..sort((a, b) {
           final byScore = b.score.compareTo(a.score);
           return byScore != 0 ? byScore : _byVolumeProxy(a, b);
         });
-      return sorted.take(_suggestionsLimit).toList();
+      return _dedupById([...specialists, ...sorted])
+          .take(_suggestionsLimit)
+          .toList();
     }
 
     final pool = [
@@ -130,16 +134,30 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
       ...reco.gems,
       ...reco.catalog,
     ]..sort(_byVolumeProxy);
-    return pool.take(_suggestionsLimit).toList();
+    return _dedupById([...specialists, ...pool])
+        .take(_suggestionsLimit)
+        .toList();
+  }
+
+  /// Dédoublonne par `source.id` en conservant le premier passage (les
+  /// spécialistes garantis, placés en tête, priment).
+  static List<RecommendedSource> _dedupById(List<RecommendedSource> list) {
+    final seen = <String>{};
+    final out = <RecommendedSource>[];
+    for (final r in list) {
+      if (seen.add(r.source.id)) out.add(r);
+    }
+    return out;
   }
 
   /// Catalogue complet (toutes catégories confondues) pour « Voir tout ».
-  List<RecommendedSource> _fullCatalog(SourceRecommendation reco) => [
+  List<RecommendedSource> _fullCatalog(SourceRecommendation reco) => _dedupById([
+        ...reco.specialists,
         ...reco.matched,
         ...reco.perspective,
         ...reco.gems,
         ...reco.catalog,
-      ];
+      ]);
 
   void _toggleSource(String sourceId) {
     HapticFeedback.lightImpact();

--- a/apps/mobile/lib/features/onboarding/widgets/source_recommendation_card.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/source_recommendation_card.dart
@@ -219,15 +219,17 @@ class SourceRecommendationCard extends StatelessWidget {
 
     final prefix = switch (tag.type) {
       RecommendationTagType.topic => '',
+      RecommendationTagType.specialist => '\u{1F3AF} ', // \ud83c\udfaf
       RecommendationTagType.antiBruit => '\u{1F507} ',
       RecommendationTagType.fiable => '\u2713 ',
       RecommendationTagType.serein => '\u2600 ',
       RecommendationTagType.similar => '\u2248 ', // \u2248
     };
 
-    // Les chips \u00ab pourquoi \u00bb (similaire / fiable / anti-bruit) ressortent en
-    // teinte primary ; les tags purement th\u00e9matiques restent neutres.
+    // Les chips \u00ab pourquoi \u00bb (sp\u00e9cialiste / similaire / fiable / anti-bruit)
+    // ressortent en teinte primary ; les tags purement th\u00e9matiques restent neutres.
     final highlighted = switch (tag.type) {
+      RecommendationTagType.specialist ||
       RecommendationTagType.similar ||
       RecommendationTagType.fiable ||
       RecommendationTagType.antiBruit =>

--- a/apps/mobile/test/features/onboarding/data/source_recommender_test.dart
+++ b/apps/mobile/test/features/onboarding/data/source_recommender_test.dart
@@ -448,4 +448,125 @@ void main() {
       expect(ids.indexOf('b'), lessThan(ids.indexOf('a')));
     });
   });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Badge « spécialiste » + garantie de couverture (Epic 12 / re-tag sources).
+  // ─────────────────────────────────────────────────────────────────────────
+  group('SourceRecommender — spécialiste & garantie de couverture', () {
+    Source spec(
+      String id, {
+      required List<String> topics,
+      String reliability = 'high',
+      String? theme,
+    }) =>
+        Source(
+          id: id,
+          name: 'Source $id',
+          type: SourceType.article,
+          isCurated: true,
+          reliabilityScore: reliability,
+          theme: theme,
+          granularTopics: topics,
+        );
+
+    bool hasSpecialistTag(RecommendedSource r) =>
+        r.tags.any((t) => t.type == RecommendationTagType.specialist);
+
+    test('spécialité dominante ∈ sujets → badge « Spécialisé en X »', () {
+      final sources = [spec('ai', topics: ['ai', 'tech'], theme: 'tech')];
+
+      final reco = SourceRecommender.recommend(
+        selectedThemes: const ['tech'],
+        selectedSubtopics: const ['ai'],
+        allSources: sources,
+      );
+
+      final card = reco.matched.firstWhere((r) => r.source.id == 'ai');
+      expect(hasSpecialistTag(card), isTrue);
+      expect(
+        card.tags
+            .firstWhere((t) => t.type == RecommendationTagType.specialist)
+            .label,
+        'Spécialisé en Intelligence artificielle',
+      );
+    });
+
+    test('subtopic non dominant → pas de badge spécialiste sur cette source', () {
+      // 'ai' n'est PAS la spécialité dominante (tech l'est) → la carte garde un
+      // tag thème « IA » mais aucun badge spécialiste.
+      final sources = [spec('s', topics: ['tech', 'ai'], theme: 'tech')];
+
+      final reco = SourceRecommender.recommend(
+        selectedThemes: const ['tech'],
+        selectedSubtopics: const ['ai'],
+        allSources: sources,
+      );
+
+      final card = reco.matched.firstWhere((r) => r.source.id == 's');
+      expect(hasSpecialistTag(card), isFalse);
+    });
+
+    test('garantie : un spécialiste hors-matched est remonté dans specialists',
+        () {
+      // 15 sources tech (score 4) saturent matched ; le spécialiste factcheck
+      // (score 2) en serait exclu → la garantie de couverture le rapatrie.
+      final sources = [
+        for (var i = 0; i < 15; i++) spec('tech-$i', topics: const [], theme: 'tech'),
+        spec('fc', topics: const ['factcheck'], reliability: 'unknown'),
+      ];
+
+      final reco = SourceRecommender.recommend(
+        selectedThemes: const ['tech'],
+        selectedSubtopics: const ['factcheck'],
+        allSources: sources,
+      );
+
+      expect(reco.matched.any((r) => r.source.id == 'fc'), isFalse,
+          reason: 'le spécialiste de faible score ne rentre pas dans matched');
+      final fc = reco.specialists.firstWhere((r) => r.source.id == 'fc');
+      expect(hasSpecialistTag(fc), isTrue);
+      expect(
+        fc.tags
+            .firstWhere((t) => t.type == RecommendationTagType.specialist)
+            .label,
+        'Spécialisé en Fact-checking',
+      );
+      // Pré-coché pour l'effet « wow ».
+      expect(reco.preselectedIds, contains('fc'));
+    });
+
+    test('spécialiste déjà dominant dans matched → pas de doublon', () {
+      final sources = [spec('ai', topics: const ['ai'], theme: 'tech')];
+
+      final reco = SourceRecommender.recommend(
+        selectedThemes: const ['tech'],
+        selectedSubtopics: const ['ai'],
+        allSources: sources,
+      );
+
+      expect(reco.matched.any((r) => r.source.id == 'ai'), isTrue);
+      expect(hasSpecialistTag(reco.matched.first), isTrue);
+      // Déjà couvert par matched → aucun gap-filler.
+      expect(reco.specialists, isEmpty);
+    });
+
+    test('chaque subtopic obtient une carte spécialiste distincte', () {
+      // Deux sujets « pauvres » non couverts par matched ; deux spécialistes
+      // distincts disponibles → une carte chacun.
+      final sources = [
+        for (var i = 0; i < 15; i++) spec('tech-$i', topics: const [], theme: 'tech'),
+        spec('fc', topics: const ['factcheck'], reliability: 'unknown'),
+        spec('rel', topics: const ['relationships'], reliability: 'unknown'),
+      ];
+
+      final reco = SourceRecommender.recommend(
+        selectedThemes: const ['tech'],
+        selectedSubtopics: const ['factcheck', 'relationships'],
+        allSources: sources,
+      );
+
+      final specialistIds = reco.specialists.map((r) => r.source.id).toSet();
+      expect(specialistIds, containsAll(<String>['fc', 'rel']));
+    });
+  });
 }

--- a/packages/api/scripts/_backfill_new_yt.py
+++ b/packages/api/scripts/_backfill_new_yt.py
@@ -25,42 +25,42 @@ API_KEY = get_settings().youtube_api_key
 NEW_CHANNELS = [
     {
         "name": "Osons Causer", "channel_id": "UCVeMw72tepFl1Zt5fvf9QKQ",
-        "theme": "politics", "granular_topics": ["democracy", "social-justice", "institutions"],
+        "theme": "politics", "granular_topics": ["politics", "inequality"],
         "description": "Décryptage politique et citoyen. Analyses des institutions, mouvements sociaux et enjeux démocratiques.",
     },
     {
         "name": "Chez Anatole", "channel_id": "UCNn9eZpA6X2VCRzkUHwxgyg",
-        "theme": "culture", "granular_topics": ["philosophy", "social-justice", "democracy"],
+        "theme": "culture", "granular_topics": ["philosophy", "inequality", "politics"],
         "description": "Philosophie et sciences sociales. Réflexions de fond sur les inégalités, la justice et la société.",
     },
     {
         "name": "Monsieur Phi", "channel_id": "UCqA8H22FwgBVcF3GJpp0MQw",
-        "theme": "culture", "granular_topics": ["philosophy", "applied-science", "democracy"],
+        "theme": "culture", "granular_topics": ["philosophy", "science", "politics"],
         "description": "Philosophie analytique et logique. Analyses rigoureuses des arguments, biais cognitifs et éthique.",
     },
     {
         "name": "Stupid Economics", "channel_id": "UCyJDHgrsUKuWLe05GvC2lng",
-        "theme": "economy", "granular_topics": ["economy", "finance", "applied-science"],
+        "theme": "economy", "granular_topics": ["economy", "finance", "science"],
         "description": "Vulgarisation économique. Décryptage des mécanismes économiques, politiques monétaires et inégalités.",
     },
     {
         "name": "AprèsLaBière", "channel_id": "UCX8dmzDECYUAlEanzSqQXBA",
-        "theme": "culture", "granular_topics": ["philosophy", "social-justice"],
+        "theme": "culture", "granular_topics": ["philosophy", "inequality"],
         "description": "Philosophie politique accessible. Réflexions sur la société, les médias et les rapports de pouvoir.",
     },
     {
         "name": "La Fabrique Sociale", "channel_id": "UCJfgnn1fhvp0GH-e-FVepcg",
-        "theme": "culture", "granular_topics": ["social-justice", "democracy", "philosophy"],
+        "theme": "culture", "granular_topics": ["inequality", "politics", "philosophy"],
         "description": "Sciences sociales et sociologie. Analyses des structures sociales, discriminations et mobilisations.",
     },
     {
         "name": "Hygiène Mentale", "channel_id": "UCMFcMhePnH4onVHt2-ItPZw",
-        "theme": "science", "granular_topics": ["applied-science", "fundamental-research", "data-privacy"],
+        "theme": "science", "granular_topics": ["science", "privacy"],
         "description": "Esprit critique et zététique. Analyse des biais cognitifs, méthode scientifique et désinformation.",
     },
     {
         "name": "Fouloscopie", "channel_id": "UCLXDNUOO3EQ80VmD9nQBHPg",
-        "theme": "science", "granular_topics": ["applied-science", "fundamental-research"],
+        "theme": "science", "granular_topics": ["science"],
         "description": "Science des foules et comportements collectifs. Physique sociale, simulations et dynamiques de groupe.",
     },
 ]

--- a/packages/api/scripts/backfill_youtube_deep.py
+++ b/packages/api/scripts/backfill_youtube_deep.py
@@ -52,7 +52,7 @@ DEEP_YOUTUBE_CHANNELS = [
         "handle": "@LeReworkeilleur",
         "channel_id": "UCNovJemYKcdKt7PDdptJZfQ",
         "theme": "environment",
-        "granular_topics": ["climate", "energy-transition", "applied-science"],
+        "granular_topics": ["climate", "energy", "science"],
         "description": "Analyses approfondies sur l'énergie et le climat. Vulgarisation scientifique rigoureuse et sourcée.",
     },
     {
@@ -60,7 +60,7 @@ DEEP_YOUTUBE_CHANNELS = [
         "handle": "@Heureka",
         "channel_id": "UC7sXGI8p8PvKosLWagkK9wQ",
         "theme": "economy",
-        "granular_topics": ["finance", "economy", "applied-science"],
+        "granular_topics": ["finance", "economy", "science"],
         "description": "Vulgarisation économique et financière. Décryptage des mécanismes économiques avec rigueur analytique.",
     },
     {
@@ -68,7 +68,7 @@ DEEP_YOUTUBE_CHANNELS = [
         "handle": "@Science4All",
         "channel_id": "UC0NCbj8CxzeCGIF6sODJ-7A",
         "theme": "science",
-        "granular_topics": ["fundamental-research", "applied-science", "data-privacy"],
+        "granular_topics": ["science", "privacy"],
         "description": "Mathématiques, IA et science. Analyses de fond sur les implications sociétales de la technologie.",
     },
     {
@@ -76,7 +76,7 @@ DEEP_YOUTUBE_CHANNELS = [
         "handle": "@MrBidouille",
         "channel_id": "UCSULDz1yaHLVQWHpm4g_GHA",
         "theme": "tech",
-        "granular_topics": ["energy-transition", "applied-science", "cleantech"],
+        "granular_topics": ["energy", "science"],
         "description": "Vulgarisation technique et industrielle. Énergie, infrastructures et innovations technologiques.",
     },
     {
@@ -84,7 +84,7 @@ DEEP_YOUTUBE_CHANNELS = [
         "handle": "@Philoxime",
         "channel_id": "UCdKTlsmvczkdvGjiLinQwmw",
         "theme": "culture",
-        "granular_topics": ["philosophy", "democracy", "social-justice"],
+        "granular_topics": ["philosophy", "politics", "inequality"],
         "description": "Philosophie politique et éthique appliquée. Analyses de fond sur la démocratie et la justice sociale.",
     },
     {
@@ -92,7 +92,7 @@ DEEP_YOUTUBE_CHANNELS = [
         "handle": "@ScienceEtonnante",
         "channel_id": "UCaNlbnghtwlsGF-KzAFThqA",
         "theme": "science",
-        "granular_topics": ["fundamental-research", "applied-science"],
+        "granular_topics": ["science"],
         "description": "Vulgarisation scientifique de haut niveau. Physique, mathématiques et sciences cognitives.",
     },
     {
@@ -100,7 +100,7 @@ DEEP_YOUTUBE_CHANNELS = [
         "handle": "@ethiqueettac",
         "channel_id": None,  # Will resolve via API
         "theme": "culture",
-        "granular_topics": ["philosophy", "social-justice"],
+        "granular_topics": ["philosophy", "inequality"],
         "description": "Éthique appliquée et questions de société. Réflexions philosophiques accessibles sur les enjeux contemporains.",
     },
 ]

--- a/packages/api/scripts/retag_and_promote_sources.py
+++ b/packages/api/scripts/retag_and_promote_sources.py
@@ -1,0 +1,685 @@
+#!/usr/bin/env python3
+"""Re-tag `granular_topics` (vocab 51-slugs) + promotion catalogue (Epic 12).
+
+Aligne la taxonomie des **sources** sur celle des **users/articles** (les 51
+slugs de `classification_service.VALID_TOPIC_SLUGS`) pour que le recommender
+d'onboarding matche enfin les spécialités, et élargit le catalogue curé.
+
+Deux composants, un seul rapport :
+
+  A1. **Dérivation `granular_topics`** — pour chaque source active, sur
+      `WINDOW_DAYS` jours : agrège `unnest(contents.topics)` par topic ;
+      `share = n_topic / n_total_source`. Retient un topic comme spécialité si
+      `n_topic >= MIN_COUNT` **et** `share >= MIN_SHARE`, capé au top `TOP_K`
+      par share décroissant. Écrit `granular_topics` **ordonné par share desc**
+      (le 1er = spécialité dominante, pour le badge). Si la dérivation est vide,
+      on **conserve** les slugs déjà valides (51-slugs) et on **purge** seulement
+      l'ancien vocab — jamais de wipe d'un vrai spécialiste mince.
+
+  A2. **Promotion catalogue** — `is_active AND NOT is_curated` avec
+      `bias_stance <> 'unknown'` **et** `reliability_score IN {medium,high}`
+      **et** `articles_30d >= MIN_VOLUME` -> `is_curated = true`.
+
+Sorties : (a) mutation DB gatée + backup JSON ; (b) `--write-csv` régénère les
+colonnes `granular_topics`/`Status` de `sources/sources_master.csv` (relisible
+par le PO, ajoute les lignes des communautaires promues) ; (c) **audit de
+couverture** : pour les 51 subtopics, nb de sources curées spécialistes
+(doit être >=1 partout).
+
+**`secondary_themes` n'est JAMAIS touché** (vocab macro-thème, consommé par le
+digest). Pas de DDL -> pas de migration Alembic (backfill data, expand-contract).
+
+Usage :
+    cd packages/api
+    python3 scripts/retag_and_promote_sources.py                       # dry-run
+    python3 scripts/retag_and_promote_sources.py --write-csv            # + diff CSV
+    python3 scripts/retag_and_promote_sources.py --apply --allow-prod   # prod (gated PO)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import text
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.services.ml.classification_service import VALID_TOPIC_SLUGS
+from scripts.cleanup_orphan_sources import _is_test_db
+
+# --------------------------------------------------------------------------- #
+# Seuils (tunables — calibrés via l'audit de couverture).
+# --------------------------------------------------------------------------- #
+WINDOW_DAYS = 90  # fenêtre d'agrégation des articles classés
+MIN_COUNT = 4  # nb mini d'articles taggés d'un topic pour le retenir
+MIN_SHARE = 0.10  # part mini de la production de la source sur ce topic
+TOP_K = 6  # nb max de spécialités gardées (par share desc)
+
+PROMO_WINDOW_DAYS = 30  # fenêtre du volume pour la promotion
+PROMO_MIN_VOLUME = 20  # articles_30d mini pour promouvoir
+PROMO_RELIABILITY = {"medium", "high"}
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_CSV = PROJECT_ROOT / "sources" / "sources_master.csv"
+
+# DB enum value -> libellé colonne CSV "Type"
+_TYPE_TO_CSV = {
+    "article": "Site",
+    "podcast": "Podcast",
+    "youtube": "YouTube",
+    "video": "YouTube",
+    "reddit": "Site",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Données chargées (thin DB layer)
+# --------------------------------------------------------------------------- #
+@dataclass
+class SourceMeta:
+    source_id: str
+    name: str
+    url: str
+    theme: str | None
+    type: str
+    is_curated: bool
+    bias_stance: str
+    reliability_score: str
+    description: str | None
+    score_independence: float | None
+    score_rigor: float | None
+    score_ux: float | None
+    source_tier: str
+    granular_topics: list[str] | None
+    articles_30d: int
+
+
+@dataclass
+class TopicChange:
+    source_id: str
+    name: str
+    url: str
+    old: list[str] | None
+    new: list[str] | None
+
+
+@dataclass
+class Promotion:
+    source_id: str
+    name: str
+    url: str
+    theme: str | None
+    type: str
+    bias_stance: str
+    reliability_score: str
+    description: str | None
+    score_independence: float | None
+    score_rigor: float | None
+    score_ux: float | None
+    source_tier: str
+    granular_topics: list[str] | None
+    articles_30d: int
+
+
+@dataclass
+class RetagPlan:
+    topic_changes: list[TopicChange]
+    promotions: list[Promotion]
+    # source_id -> état après plan (pour CSV / audit)
+    granular_after: dict[str, list[str] | None] = field(default_factory=dict)
+    curated_after: dict[str, bool] = field(default_factory=dict)
+    coverage_contains: dict[str, int] = field(default_factory=dict)
+    coverage_dominant: dict[str, int] = field(default_factory=dict)
+    coverage_gaps: list[str] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+# Logique pure (testable sans DB)
+# --------------------------------------------------------------------------- #
+def derive_granular_topics(
+    topic_counts: dict[str, int],
+    total: int,
+    *,
+    min_count: int = MIN_COUNT,
+    min_share: float = MIN_SHARE,
+    top_k: int = TOP_K,
+    valid_slugs: set[str] = VALID_TOPIC_SLUGS,
+) -> list[str]:
+    """Spécialités d'une source dérivées de la part de production par topic.
+
+    Retient `topic` si `n >= min_count` ET `n/total >= min_share`. Trie par
+    share décroissant (départage par compte puis alpha), cape au top K. Ignore
+    les slugs hors taxonomie 51 (défensif contre l'ancien vocab résiduel).
+    """
+    if total <= 0:
+        return []
+    ranked: list[tuple[str, float, int]] = []
+    for topic, n in topic_counts.items():
+        if topic not in valid_slugs:
+            continue
+        share = n / total
+        if n >= min_count and share >= min_share:
+            ranked.append((topic, share, n))
+    ranked.sort(key=lambda x: (-x[1], -x[2], x[0]))
+    return [t for t, _, _ in ranked[:top_k]]
+
+
+def resolve_new_topics(
+    derived: list[str],
+    existing: list[str] | None,
+    *,
+    valid_slugs: set[str] = VALID_TOPIC_SLUGS,
+) -> list[str] | None:
+    """Décide la valeur `granular_topics` finale, conservatrice.
+
+    - Dérivation non vide -> elle gagne (data-driven, ordonnée par share).
+    - Dérivation vide -> on **garde** les slugs déjà valides et on **purge**
+      l'ancien vocab (slug hors 51). Jamais de wipe d'un vrai spécialiste mince.
+      Renvoie None quand il ne reste rien.
+    """
+    if derived:
+        return derived
+    cleaned = [t for t in (existing or []) if t in valid_slugs]
+    return cleaned or None
+
+
+def is_promotable(
+    m: SourceMeta,
+    *,
+    min_volume: int = PROMO_MIN_VOLUME,
+    reliability_set: set[str] = PROMO_RELIABILITY,
+) -> bool:
+    """Source évaluée + productive, non encore curée : candidate à la promotion."""
+    return (
+        not m.is_curated
+        and m.bias_stance != "unknown"
+        and m.reliability_score in reliability_set
+        and m.articles_30d >= min_volume
+    )
+
+
+def compute_plan(
+    metas: list[SourceMeta],
+    topic_stats: dict[str, dict[str, int]],
+    totals: dict[str, int],
+    *,
+    min_count: int = MIN_COUNT,
+    min_share: float = MIN_SHARE,
+    top_k: int = TOP_K,
+    min_volume: int = PROMO_MIN_VOLUME,
+    reliability_set: set[str] = PROMO_RELIABILITY,
+    valid_slugs: set[str] = VALID_TOPIC_SLUGS,
+) -> RetagPlan:
+    """Construit le plan complet (changes + promotions + audit) sans I/O."""
+    topic_changes: list[TopicChange] = []
+    promotions: list[Promotion] = []
+    granular_after: dict[str, list[str] | None] = {}
+    curated_after: dict[str, bool] = {}
+
+    for m in metas:
+        derived = derive_granular_topics(
+            topic_stats.get(m.source_id, {}),
+            totals.get(m.source_id, 0),
+            min_count=min_count,
+            min_share=min_share,
+            top_k=top_k,
+            valid_slugs=valid_slugs,
+        )
+        new_topics = resolve_new_topics(
+            derived, m.granular_topics, valid_slugs=valid_slugs
+        )
+        granular_after[m.source_id] = new_topics
+        if new_topics != m.granular_topics:
+            topic_changes.append(
+                TopicChange(
+                    source_id=m.source_id,
+                    name=m.name,
+                    url=m.url,
+                    old=m.granular_topics,
+                    new=new_topics,
+                )
+            )
+
+        promote = is_promotable(
+            m, min_volume=min_volume, reliability_set=reliability_set
+        )
+        curated_after[m.source_id] = m.is_curated or promote
+        if promote:
+            promotions.append(
+                Promotion(
+                    source_id=m.source_id,
+                    name=m.name,
+                    url=m.url,
+                    theme=m.theme,
+                    type=m.type,
+                    bias_stance=m.bias_stance,
+                    reliability_score=m.reliability_score,
+                    description=m.description,
+                    score_independence=m.score_independence,
+                    score_rigor=m.score_rigor,
+                    score_ux=m.score_ux,
+                    source_tier=m.source_tier,
+                    granular_topics=new_topics,
+                    articles_30d=m.articles_30d,
+                )
+            )
+
+    coverage_contains, coverage_dominant = _coverage_audit(
+        metas, granular_after, curated_after, valid_slugs
+    )
+    gaps = sorted(s for s in valid_slugs if coverage_contains.get(s, 0) == 0)
+
+    return RetagPlan(
+        topic_changes=topic_changes,
+        promotions=promotions,
+        granular_after=granular_after,
+        curated_after=curated_after,
+        coverage_contains=coverage_contains,
+        coverage_dominant=coverage_dominant,
+        coverage_gaps=gaps,
+    )
+
+
+def _coverage_audit(
+    metas: list[SourceMeta],
+    granular_after: dict[str, list[str] | None],
+    curated_after: dict[str, bool],
+    valid_slugs: set[str],
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Pour chaque slug : nb de sources curées (après plan) qui le portent.
+
+    `contains` = slug dans `granular_topics` (le recommender peut le surfacer via
+    la garantie de couverture). `dominant` = slug en 1re position (badge naturel).
+    """
+    contains = dict.fromkeys(valid_slugs, 0)
+    dominant = dict.fromkeys(valid_slugs, 0)
+    for m in metas:
+        if not curated_after.get(m.source_id):
+            continue
+        gt = granular_after.get(m.source_id) or []
+        for slug in set(gt):
+            if slug in contains:
+                contains[slug] += 1
+        if gt and gt[0] in dominant:
+            dominant[gt[0]] += 1
+    return contains, dominant
+
+
+# --------------------------------------------------------------------------- #
+# Régénération CSV (pure — testable avec des lignes synthétiques)
+# --------------------------------------------------------------------------- #
+def _norm_url(u: str | None) -> str:
+    return (u or "").strip().rstrip("/").lower()
+
+
+def _is_source_row(row: dict) -> bool:
+    name = (row.get("Name") or "").strip()
+    url = (row.get("URL") or "").strip()
+    return bool(name) and name != "Name" and not name.startswith("#") and bool(url)
+
+
+def regenerate_csv_rows(
+    rows: list[dict],
+    fieldnames: list[str],
+    granular_by_url: dict[str, list[str] | None],
+    curated_by_url: dict[str, bool],
+    promotions: list[Promotion],
+) -> list[dict]:
+    """Met à jour `granular_topics`/`Status` des lignes existantes (match URL) et
+    ajoute les lignes des sources promues absentes du CSV. Préserve l'ordre, les
+    lignes de commentaire et toutes les autres colonnes.
+    """
+    present: set[str] = set()
+    out: list[dict] = []
+    for row in rows:
+        new_row = dict(row)
+        if _is_source_row(row):
+            key = _norm_url(row.get("URL"))
+            present.add(key)
+            if key in granular_by_url:
+                gt = granular_by_url[key]
+                new_row["granular_topics"] = (
+                    json.dumps(gt, ensure_ascii=False) if gt else ""
+                )
+            # On ne fait que *promouvoir* (jamais downgrade), et on ne touche
+            # pas les lignes ARCHIVED.
+            status = (row.get("Status") or "").strip().upper()
+            if curated_by_url.get(key) and status not in ("CURATED", "ARCHIVED"):
+                new_row["Status"] = "CURATED"
+        out.append(new_row)
+
+    for p in promotions:
+        if _norm_url(p.url) in present:
+            continue
+        out.append(_promotion_to_csv_row(p, fieldnames))
+    return out
+
+
+def _promotion_to_csv_row(p: Promotion, fieldnames: list[str]) -> dict:
+    def _fmt(v: float | None) -> str:
+        return "" if v is None else f"{v:g}"
+
+    base = dict.fromkeys(fieldnames, "")
+    base.update(
+        {
+            "Name": p.name,
+            "URL": p.url,
+            "Type": _TYPE_TO_CSV.get(p.type, "Site"),
+            "Thème": p.theme or "",
+            "Status": "CURATED",
+            "Rationale": p.description or "",
+            "Bias": p.bias_stance,
+            "Reliability": p.reliability_score,
+            "Score_Independence": _fmt(p.score_independence),
+            "Score_Rigor": _fmt(p.score_rigor),
+            "Score_UX": _fmt(p.score_ux),
+            "granular_topics": json.dumps(p.granular_topics, ensure_ascii=False)
+            if p.granular_topics
+            else "",
+            "source_tier": p.source_tier or "mainstream",
+        }
+    )
+    return {fn: base.get(fn, "") for fn in fieldnames}
+
+
+def write_csv(path: Path, plan: RetagPlan, metas: list[SourceMeta]) -> int:
+    """Régénère le CSV depuis le plan. Renvoie le nb de lignes écrites."""
+    with path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
+
+    url_for = {m.source_id: m.url for m in metas}
+    granular_by_url = {
+        _norm_url(url_for[sid]): gt for sid, gt in plan.granular_after.items()
+    }
+    curated_by_url = {
+        _norm_url(url_for[sid]): cur for sid, cur in plan.curated_after.items()
+    }
+
+    new_rows = regenerate_csv_rows(
+        rows, fieldnames, granular_by_url, curated_by_url, plan.promotions
+    )
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, quoting=csv.QUOTE_MINIMAL)
+        writer.writeheader()
+        writer.writerows(new_rows)
+    return len(new_rows)
+
+
+# --------------------------------------------------------------------------- #
+# DB layer (thin)
+# --------------------------------------------------------------------------- #
+async def load_metas(session) -> list[SourceMeta]:
+    sql = text(
+        f"""
+        SELECT s.id, s.name, s.url, s.theme, s.type, s.is_curated,
+               s.bias_stance, s.reliability_score, s.description,
+               s.score_independence, s.score_rigor, s.score_ux,
+               s.source_tier, s.granular_topics,
+               COALESCE(a30.n, 0) AS articles_30d
+        FROM sources s
+        LEFT JOIN (
+            SELECT source_id, COUNT(*) AS n
+            FROM contents
+            WHERE published_at >= now() - interval '{PROMO_WINDOW_DAYS} days'
+            GROUP BY source_id
+        ) a30 ON a30.source_id = s.id
+        WHERE s.is_active
+        """
+    )
+    result = await session.execute(sql)
+    metas: list[SourceMeta] = []
+    for r in result.mappings():
+        metas.append(
+            SourceMeta(
+                source_id=str(r["id"]),
+                name=r["name"],
+                url=r["url"],
+                theme=r["theme"],
+                type=str(r["type"]),
+                is_curated=bool(r["is_curated"]),
+                bias_stance=str(r["bias_stance"]),
+                reliability_score=str(r["reliability_score"]),
+                description=r["description"],
+                score_independence=r["score_independence"],
+                score_rigor=r["score_rigor"],
+                score_ux=r["score_ux"],
+                source_tier=r["source_tier"] or "mainstream",
+                granular_topics=list(r["granular_topics"])
+                if r["granular_topics"]
+                else None,
+                articles_30d=int(r["articles_30d"]),
+            )
+        )
+    return metas
+
+
+async def load_topic_stats(
+    session,
+) -> tuple[dict[str, dict[str, int]], dict[str, int]]:
+    counts_sql = text(
+        f"""
+        SELECT c.source_id AS sid, topic, COUNT(*) AS n
+        FROM contents c
+        JOIN sources s ON s.id = c.source_id AND s.is_active
+        CROSS JOIN LATERAL unnest(c.topics) AS topic
+        WHERE c.published_at >= now() - interval '{WINDOW_DAYS} days'
+          AND c.topics IS NOT NULL
+        GROUP BY c.source_id, topic
+        """
+    )
+    totals_sql = text(
+        f"""
+        SELECT c.source_id AS sid, COUNT(*) AS n
+        FROM contents c
+        JOIN sources s ON s.id = c.source_id AND s.is_active
+        WHERE c.published_at >= now() - interval '{WINDOW_DAYS} days'
+          AND c.topics IS NOT NULL
+          AND array_length(c.topics, 1) > 0
+        GROUP BY c.source_id
+        """
+    )
+    topic_stats: dict[str, dict[str, int]] = {}
+    for r in (await session.execute(counts_sql)).mappings():
+        topic_stats.setdefault(str(r["sid"]), {})[str(r["topic"])] = int(r["n"])
+    totals = {
+        str(r["sid"]): int(r["n"])
+        for r in (await session.execute(totals_sql)).mappings()
+    }
+    return topic_stats, totals
+
+
+async def write_plan(session, plan: RetagPlan) -> None:
+    topic_stmt = text("UPDATE sources SET granular_topics = :gt WHERE id = :id")
+    for c in plan.topic_changes:
+        await session.execute(topic_stmt, {"gt": c.new, "id": UUID(c.source_id)})
+    promote_stmt = text("UPDATE sources SET is_curated = true WHERE id = :id")
+    for p in plan.promotions:
+        await session.execute(promote_stmt, {"id": UUID(p.source_id)})
+
+
+# --------------------------------------------------------------------------- #
+# Rapport
+# --------------------------------------------------------------------------- #
+def render_report(plan: RetagPlan, *, total_sources: int) -> str:
+    lines = [
+        "=" * 78,
+        "RE-TAG granular_topics + PROMOTION CATALOGUE (dry-run)",
+        "=" * 78,
+    ]
+    lines.append(
+        f"Sources actives : {total_sources} | re-tag : {len(plan.topic_changes)} | "
+        f"promotions : {len(plan.promotions)}"
+    )
+
+    lines.append("-" * 78)
+    lines.append(f"A1. RE-TAG granular_topics ({len(plan.topic_changes)})")
+    for c in plan.topic_changes[:60]:
+        lines.append(f"  • {c.name}: {c.old or []} -> {c.new or []}")
+    if len(plan.topic_changes) > 60:
+        lines.append(f"  … (+{len(plan.topic_changes) - 60} autres)")
+
+    lines.append("-" * 78)
+    lines.append(f"A2. PROMOTIONS -> is_curated=true ({len(plan.promotions)})")
+    for p in plan.promotions[:80]:
+        lines.append(
+            f"  • {p.name} [{p.bias_stance}/{p.reliability_score}, "
+            f"{p.articles_30d} art/30j] {p.granular_topics or []}"
+        )
+    if len(plan.promotions) > 80:
+        lines.append(f"  … (+{len(plan.promotions) - 80} autres)")
+
+    lines.append("-" * 78)
+    n_ok = sum(1 for s in VALID_TOPIC_SLUGS if plan.coverage_contains.get(s, 0) >= 1)
+    lines.append(
+        f"C. AUDIT COUVERTURE : {n_ok}/{len(VALID_TOPIC_SLUGS)} subtopics avec "
+        f">=1 source curée spécialiste"
+    )
+    if plan.coverage_gaps:
+        lines.append(
+            f"  ⚠️ TROUS ({len(plan.coverage_gaps)}) : {', '.join(plan.coverage_gaps)}"
+        )
+        lines.append(
+            "  (baisser MIN_COUNT/MIN_SHARE, promouvoir un spécialiste, ou sourcer un flux)"
+        )
+    else:
+        lines.append("  ✅ Couverture complète (>=1 spécialiste par subtopic).")
+    # Spécialistes *dominants* (badge naturel sans gap-fill mobile) vs simples
+    # porteurs (couverts via la garantie de couverture du recommander).
+    n_dom = sum(1 for s in VALID_TOPIC_SLUGS if plan.coverage_dominant.get(s, 0) >= 1)
+    lines.append(
+        f"  dont {n_dom}/{len(VALID_TOPIC_SLUGS)} avec un spécialiste *dominant* "
+        "(badge naturel, sans gap-fill)"
+    )
+    # Les 8 plus minces, pour calibrer.
+    thin = sorted(plan.coverage_contains.items(), key=lambda kv: kv[1])[:8]
+    lines.append("  Plus minces : " + ", ".join(f"{s}={n}" for s, n in thin))
+    lines.append("=" * 78)
+    return "\n".join(lines)
+
+
+def _backup_path() -> Path:
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return PROJECT_ROOT / ".context" / f"retag_promote_backup_{ts}.json"
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+async def run(
+    *,
+    apply: bool,
+    allow_prod: bool,
+    write_csv_flag: bool,
+    csv_path: Path,
+) -> int:
+    settings = get_settings()
+    db_url = settings.database_url or ""
+    is_test = _is_test_db(db_url)
+    print(
+        f"DB cible : {db_url.split('@')[-1] if '@' in db_url else db_url}  (test={is_test})"
+    )
+    if apply and not is_test and not allow_prod:
+        print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
+        return 2
+
+    async with async_session_maker() as session:
+        try:
+            metas = await load_metas(session)
+            topic_stats, totals = await load_topic_stats(session)
+            plan = compute_plan(metas, topic_stats, totals)
+
+            bpath = _backup_path()
+            bpath.parent.mkdir(parents=True, exist_ok=True)
+            bpath.write_text(
+                json.dumps(
+                    {
+                        "generated_at": datetime.now(UTC).isoformat(),
+                        "topic_changes": [
+                            {"source_id": c.source_id, "name": c.name, "old": c.old}
+                            for c in plan.topic_changes
+                        ],
+                        "promotions": [
+                            {"source_id": p.source_id, "name": p.name}
+                            for p in plan.promotions
+                        ],
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                )
+            )
+            print(f"Backup écrit : {bpath}")
+            print(render_report(plan, total_sources=len(metas)))
+
+            if write_csv_flag:
+                # Garde-fou : ne pas régénérer le CSV sur une DB sans données
+                # (sinon on viderait granular_topics de tout le seed).
+                non_empty = sum(1 for v in plan.granular_after.values() if v)
+                if non_empty < 10:
+                    print(
+                        f"\n⚠️ --write-csv ignoré : seules {non_empty} sources ont des "
+                        "granular_topics dérivés (DB sans articles ?). Lance contre la DB "
+                        "de prod en lecture pour produire un diff CSV utile."
+                    )
+                else:
+                    n = write_csv(csv_path, plan, metas)
+                    print(f"\nCSV régénéré : {csv_path} ({n} lignes)")
+
+            if not apply:
+                print("\n(dry-run — aucune mutation DB. Relance avec --apply.)")
+                return 0
+
+            await write_plan(session, plan)
+            await session.commit()
+            print(
+                f"\nAPPLIQUÉ : {len(plan.topic_changes)} re-tags + "
+                f"{len(plan.promotions)} promotions."
+            )
+            return 0
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true", help="exécute (défaut: dry-run)"
+    )
+    parser.add_argument(
+        "--allow-prod", action="store_true", help="autorise --apply en prod"
+    )
+    parser.add_argument(
+        "--write-csv",
+        action="store_true",
+        help="régénère sources_master.csv (diff relisible PO) — sûr, fichier local",
+    )
+    parser.add_argument("--csv", type=Path, default=DEFAULT_CSV)
+    args = parser.parse_args()
+    sys.exit(
+        asyncio.run(
+            run(
+                apply=args.apply,
+                allow_prod=args.allow_prod,
+                write_csv_flag=args.write_csv,
+                csv_path=args.csv,
+            )
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/validate_taxonomy.py
+++ b/packages/api/scripts/validate_taxonomy.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import sys
-from typing import Set
 
 from dotenv import load_dotenv
 from sqlalchemy import select, func
@@ -13,34 +12,18 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from app.models.source import Source
 from app.database import async_session_maker, init_db
 
+# --- TAXONOMY CONSTANTS (source de vérité unique — Epic 12 taxonomy alignment) ---
+#
+# Plus de vocab local : on importe les MÊMES slugs que les users/articles. Les
+# `granular_topics` des sources doivent vivre dans la taxonomie 51-slugs (sinon
+# le recommender d'onboarding ne matche jamais les spécialités, cf.
+# scripts/retag_and_promote_sources.py). Le `theme` source reste sur les
+# 9 macro-thèmes de topic_theme_mapper.
+from app.services.ml.classification_service import VALID_TOPIC_SLUGS as VALID_TOPICS
+from app.services.ml.topic_theme_mapper import VALID_THEMES
+
 # Load .env
 load_dotenv(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env"))
-
-# --- TAXONOMY CONSTANTS (From PRD) ---
-
-VALID_THEMES: Set[str] = {
-    "tech", "society", "environment", "economy", "politics", 
-    "culture", "science", "international"
-}
-
-VALID_TOPICS: Set[str] = {
-    # tech (12)
-    "ai", "llm", "crypto", "web3", "space", "biotech", "quantum", "cybersecurity", "robotics", "gaming", "cleantech", "data-privacy",
-    # society (10)
-    "social-justice", "feminism", "lgbtq", "immigration", "health", "education", "urbanism", "housing", "work-reform", "justice-system",
-    # environment (8)
-    "climate", "biodiversity", "energy-transition", "pollution", "circular-economy", "agriculture", "oceans", "forests",
-    # economy (8)
-    "macro", "finance", "startups", "venture-capital", "labor-market", "inflation", "trade", "taxation",
-    # politics (5)
-    "elections", "institutions", "local-politics", "activism", "democracy",
-    # culture (4)
-    "philosophy", "art", "cinema", "media-critics",
-    # science (2)
-    "fundamental-research", "applied-science",
-    # international (1)
-    "geopolitics"
-}
 
 async def validate_taxonomy():
     print("🔍 Starting Taxonomy Validation...")

--- a/packages/api/tests/scripts/test_retag_and_promote_sources.py
+++ b/packages/api/tests/scripts/test_retag_and_promote_sources.py
@@ -1,0 +1,313 @@
+"""Tests pour scripts/retag_and_promote_sources.py.
+
+Couvre la logique pure (sans DB) : dérivation `granular_topics` (seuils, ordre
+par share, top-K, vocab 51-slugs), résolution conservatrice (purge ancien vocab
+sans wiper un vrai spécialiste), promotion catalogue, audit de couverture, et
+régénération CSV (update colonnes + append promues + préservation commentaires).
+"""
+
+from __future__ import annotations
+
+from scripts.retag_and_promote_sources import (
+    Promotion,
+    SourceMeta,
+    compute_plan,
+    derive_granular_topics,
+    is_promotable,
+    regenerate_csv_rows,
+    resolve_new_topics,
+)
+
+
+def _meta(sid: str, **kw) -> SourceMeta:
+    base = {
+        "source_id": sid,
+        "name": f"Source {sid}",
+        "url": f"https://{sid}.test/",
+        "theme": "society",
+        "type": "article",
+        "is_curated": False,
+        "bias_stance": "center",
+        "reliability_score": "high",
+        "description": "Desc.",
+        "score_independence": 0.7,
+        "score_rigor": 0.7,
+        "score_ux": 0.7,
+        "source_tier": "mainstream",
+        "granular_topics": None,
+        "articles_30d": 50,
+    }
+    base.update(kw)
+    return SourceMeta(**base)
+
+
+# --------------------------------------------------------------------------- #
+# derive_granular_topics
+# --------------------------------------------------------------------------- #
+def test_derive_keeps_only_significant_specialties_ordered_by_share():
+    # total=100 : politics 40% (dominant), economy 12%, sport 5% (sous min_share),
+    # foo invalide ignoré.
+    counts = {"politics": 40, "economy": 12, "sport": 5, "foo-old": 30}
+    out = derive_granular_topics(counts, total=100)
+    assert out == ["politics", "economy"]  # sport < 0.10, foo-old hors taxonomie
+
+
+def test_derive_respects_min_count_even_with_high_share():
+    # share haut mais volume < MIN_COUNT (4) -> écarté.
+    counts = {"factcheck": 3}
+    assert derive_granular_topics(counts, total=5) == []
+
+
+def test_derive_caps_at_top_k():
+    counts = {
+        s: 100 - i
+        for i, s in enumerate(
+            [
+                "politics",
+                "economy",
+                "work",
+                "justice",
+                "health",
+                "science",
+                "tech",
+                "energy",
+            ]
+        )
+    }
+    out = derive_granular_topics(counts, total=1000, min_share=0.0)
+    assert len(out) == 6
+    assert out[0] == "politics"  # le plus gros share en tête
+
+
+def test_derive_zero_total_is_empty():
+    assert derive_granular_topics({"politics": 10}, total=0) == []
+
+
+# --------------------------------------------------------------------------- #
+# resolve_new_topics (conservateur)
+# --------------------------------------------------------------------------- #
+def test_resolve_derived_wins():
+    assert resolve_new_topics(["politics"], ["social-justice"]) == ["politics"]
+
+
+def test_resolve_empty_derived_purges_old_vocab_keeps_valid():
+    # "social-justice" (ancien vocab) purgé, "health" (valide) conservé.
+    assert resolve_new_topics([], ["social-justice", "health"]) == ["health"]
+
+
+def test_resolve_empty_derived_all_old_vocab_becomes_none():
+    assert resolve_new_topics([], ["social-justice", "energy-transition"]) is None
+
+
+def test_resolve_empty_derived_preserves_thin_valid_specialist():
+    # Spécialiste mince déjà en 51-slugs : on ne wipe pas faute d'articles.
+    assert resolve_new_topics([], ["factcheck"]) == ["factcheck"]
+
+
+# --------------------------------------------------------------------------- #
+# is_promotable
+# --------------------------------------------------------------------------- #
+def test_promotable_happy_path():
+    assert is_promotable(_meta("a")) is True
+
+
+def test_not_promotable_already_curated():
+    assert is_promotable(_meta("a", is_curated=True)) is False
+
+
+def test_not_promotable_unknown_bias():
+    assert is_promotable(_meta("a", bias_stance="unknown")) is False
+
+
+def test_not_promotable_low_reliability():
+    assert is_promotable(_meta("a", reliability_score="low")) is False
+
+
+def test_not_promotable_low_volume():
+    assert is_promotable(_meta("a", articles_30d=5)) is False
+
+
+# --------------------------------------------------------------------------- #
+# compute_plan (orchestration pure)
+# --------------------------------------------------------------------------- #
+def test_compute_plan_retags_and_promotes_and_audits():
+    metas = [
+        # Spécialiste politics, non curée, productive -> re-tag + promotion.
+        _meta("s1", granular_topics=["democracy"]),
+        # Déjà curée, généraliste sans concentration -> purge ancien vocab.
+        _meta("s2", is_curated=True, granular_topics=["macro", "labor-market"]),
+    ]
+    topic_stats = {
+        # economy 8% < MIN_SHARE -> écarté ; sport 12% gardé après politics.
+        "s1": {"politics": 50, "sport": 12, "economy": 8},
+        "s2": {"politics": 10, "economy": 10, "work": 10, "health": 10},  # éparpillé
+    }
+    totals = {"s1": 100, "s2": 100}
+
+    plan = compute_plan(metas, topic_stats, totals)
+
+    # s1 re-taggé politics(dominant)+sport, economy écarté (<10%), et promu.
+    assert plan.granular_after["s1"] == ["politics", "sport"]
+    assert any(p.source_id == "s1" for p in plan.promotions)
+    assert plan.curated_after["s1"] is True
+
+    # s2 : chaque topic = 10% pile -> retenus (share >= 0.10), ordre alpha-stable
+    # par compte égal. Pas promu (déjà curé).
+    assert set(plan.granular_after["s2"]) == {"economy", "health", "politics", "work"}
+    assert not any(p.source_id == "s2" for p in plan.promotions)
+
+    # Audit : politics couvert (s1 dominant + s2), economy couvert.
+    assert plan.coverage_contains["politics"] >= 1
+    assert plan.coverage_dominant["politics"] == 1  # s1 dominant
+    # Un slug sans aucune source curée tombe dans les trous.
+    assert "gaming" in plan.coverage_gaps
+
+
+def test_compute_plan_no_articles_keeps_valid_topics_no_change():
+    metas = [_meta("s1", is_curated=True, granular_topics=["factcheck"])]
+    plan = compute_plan(metas, {}, {})
+    assert plan.granular_after["s1"] == ["factcheck"]
+    assert plan.topic_changes == []  # inchangé -> pas de write
+    assert plan.coverage_contains["factcheck"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# regenerate_csv_rows
+# --------------------------------------------------------------------------- #
+_FIELDS = ["Name", "URL", "Status", "granular_topics", "source_tier"]
+
+
+def test_csv_updates_existing_row_and_promotes_status():
+    rows = [
+        {
+            "Name": "# --- section ---",
+            "URL": "",
+            "Status": "",
+            "granular_topics": "",
+            "source_tier": "",
+        },
+        {
+            "Name": "S1",
+            "URL": "https://s1.test/",
+            "Status": "INDEXED",
+            "granular_topics": '["old"]',
+            "source_tier": "mainstream",
+        },
+    ]
+    out = regenerate_csv_rows(
+        rows,
+        _FIELDS,
+        granular_by_url={"https://s1.test": ["politics", "economy"]},
+        curated_by_url={"https://s1.test": True},
+        promotions=[],
+    )
+    # Ligne commentaire préservée.
+    assert out[0]["Name"] == "# --- section ---"
+    # Colonnes mises à jour, INDEXED -> CURATED.
+    assert out[1]["granular_topics"] == '["politics", "economy"]'
+    assert out[1]["Status"] == "CURATED"
+
+
+def test_csv_never_downgrades_curated_or_touches_archived():
+    rows = [
+        {
+            "Name": "C",
+            "URL": "https://c.test/",
+            "Status": "CURATED",
+            "granular_topics": "",
+            "source_tier": "",
+        },
+        {
+            "Name": "A",
+            "URL": "https://a.test/",
+            "Status": "ARCHIVED",
+            "granular_topics": "",
+            "source_tier": "",
+        },
+    ]
+    out = regenerate_csv_rows(
+        rows,
+        _FIELDS,
+        granular_by_url={"https://c.test": ["politics"], "https://a.test": ["sport"]},
+        curated_by_url={"https://c.test": True, "https://a.test": False},
+        promotions=[],
+    )
+    assert out[0]["Status"] == "CURATED"
+    assert out[1]["Status"] == "ARCHIVED"  # jamais re-touché
+    # granular_topics quand même rafraîchi pour la ligne curée.
+    assert out[0]["granular_topics"] == '["politics"]'
+
+
+def test_csv_appends_promotions_absent_from_csv():
+    rows = [
+        {
+            "Name": "S1",
+            "URL": "https://s1.test/",
+            "Status": "CURATED",
+            "granular_topics": "",
+            "source_tier": "",
+        },
+    ]
+    promo = Promotion(
+        source_id="new",
+        name="New Source",
+        url="https://new.test/",
+        theme="tech",
+        type="youtube",
+        bias_stance="center",
+        reliability_score="high",
+        description="Desc new",
+        score_independence=0.8,
+        score_rigor=0.7,
+        score_ux=0.6,
+        source_tier="deep",
+        granular_topics=["ai", "tech"],
+        articles_30d=40,
+    )
+    out = regenerate_csv_rows(
+        rows,
+        _FIELDS,
+        granular_by_url={"https://s1.test": ["politics"]},
+        curated_by_url={"https://s1.test": True},
+        promotions=[promo],
+    )
+    assert len(out) == 2
+    assert out[1]["Name"] == "New Source"
+    assert out[1]["Status"] == "CURATED"
+    assert out[1]["granular_topics"] == '["ai", "tech"]'
+
+
+def test_csv_skips_promotion_already_present_by_url():
+    rows = [
+        {
+            "Name": "S1",
+            "URL": "https://s1.test/",
+            "Status": "INDEXED",
+            "granular_topics": "",
+            "source_tier": "",
+        },
+    ]
+    promo = Promotion(
+        source_id="s1",
+        name="S1",
+        url="https://s1.test",
+        theme="tech",
+        type="article",
+        bias_stance="center",
+        reliability_score="high",
+        description=None,
+        score_independence=None,
+        score_rigor=None,
+        score_ux=None,
+        source_tier="mainstream",
+        granular_topics=["ai"],
+        articles_30d=40,
+    )
+    out = regenerate_csv_rows(
+        rows,
+        _FIELDS,
+        granular_by_url={"https://s1.test": ["ai"]},
+        curated_by_url={"https://s1.test": True},
+        promotions=[promo],
+    )
+    assert len(out) == 1  # pas de doublon (match URL, trailing slash ignoré)


### PR DESCRIPTION
feat(onboarding): sources spécialisées par sujet — re-mapping taxonomie 51-slugs + badge « Spécialisé en X » (Epic 12)

Aligne le vocabulaire des `granular_topics` des **sources** sur la taxonomie **51-slugs** des users/articles et garantit, dans l'écran de reco onboarding, **≥1 source spécialisée visible par sujet sélectionné** (badge « Spécialisé en X »). Livré en **1 PR groupée** (backend data + mobile UI) vers `main`. Additif, **aucune migration Alembic** (`granular_topics`/`is_curated` existent déjà → backfill data gaté PO).

## Problème

Le recommender d'onboarding score `source.granularTopics ∩ user.selectedSubtopics`, mais les deux vivaient dans des **taxonomies incompatibles** : sources en ancien vocab (`social-justice`, `energy-transition`, `data-privacy`…), users/articles en 51-slugs (`inequality`, `energy`, `privacy`…). Résultat : le bonus « spécialiste » ne se déclenchait quasi jamais (~35/51 subtopics sans source curée correspondante) → pas d'effet « wow ». Le catalogue curé (66/296 actives) était aussi trop mince.

## Ce que ça change (user-visible)

- **Un spécialiste par sujet, dès l'inscription.** Chaque sous-sujet choisi obtient au moins une carte « 🎯 Spécialisé en {sujet} », en tête des suggestions et pré-cochée.
- **Cartes spécialistes distinctes par sujet** (quand la data le permet), libellés FR via `getTopicLabel` (51 slugs couverts).

## Technique (additif, sans migration)

### Backend / data
- **`scripts/retag_and_promote_sources.py`** (nouveau, scaffolding CLI dry-run/`--apply`/`--allow-prod`/backup JSON repris d'`apply_source_evaluations.py`) :
  - **A1 — dérivation `granular_topics`** : sur 90 j, agrège `unnest(contents.topics)` par topic ; `share = n_topic / n_total` ; retient si `n ≥ MIN_COUNT(4)` **et** `share ≥ MIN_SHARE(0.10)`, capé `TOP_K(6)`, **ordonné par share desc** (1er = spécialité dominante = badge). Dérivation vide → on **conserve** les slugs déjà valides et purge l'ancien vocab (jamais de wipe d'un vrai spécialiste mince).
  - **A2 — promotion catalogue** : `is_active ∧ ¬is_curated ∧ bias≠unknown ∧ reliability∈{medium,high} ∧ articles_30d ≥ 20` → `is_curated=true`.
  - Sorties : mutation DB gatée + backup JSON ; `--write-csv` régénère `granular_topics`/`Status` de `sources_master.csv` (diff relisible PO, ajoute les promues) ; **audit de couverture** 51 subtopics (≥1 spécialiste partout).
- **`scripts/validate_taxonomy.py`** : supprime le `VALID_TOPICS` local (ancien vocab) → importe `VALID_TOPIC_SLUGS` (51) + `VALID_THEMES` (9) canoniques. Ferme l'Epic 12 côté sources.
- **`scripts/_backfill_new_yt.py` + `backfill_youtube_deep.py`** : `granular_topics` hardcodés re-mappés en 51-slugs (sinon ré-introduisaient l'ancien vocab au prochain seed).
- **NE TOUCHE PAS `secondary_themes`** (vocab macro-thème, consommé par le pipeline digest). Aucune logique digest ne matche sur `granular_topics`.

### Mobile / UI
- **`source_recommender.dart`** : `RecommendationTagType.specialist` ; badge « Spécialisé en X » quand `granularTopics.first ∈ selectedSubtopics` (pas de double chip thème). **Garantie de couverture** `_computeSpecialists` : pour chaque subtopic non couvert par un spécialiste dominant de `matched`, tire le meilleur spécialiste curé restant (dominant → score → fiabilité → volume) ; nouveau champ `SourceRecommendation.specialists` (disjoint, inclus dans `preselectedIds`).
- **`sources_question.dart`** : spécialistes placés **en tête** des suggestions (survivent au cap 18) + dédup par id.
- **`source_recommendation_card.dart`** : rendu du chip spécialiste (préfixe 🎯, teinte primary).

## Apply prod (gaté PO, étape séparée post-merge)

`cd packages/api && python3 scripts/retag_and_promote_sources.py --write-csv` (dry-run lecture prod → diff CSV + audit), revue PO, puis `--apply --allow-prod`. Backup JSON conservé. La reco prod en bénéficie aussi (subtopics users prod déjà en 51-slugs), sans régression de matching attendue.

## Tests
- **Backend** : `tests/scripts/test_retag_and_promote_sources.py` (19 tests purs) — dérivation (seuils, ordre par share, top-K, vocab 51), résolution conservatrice, promotion, audit couverture, régénération CSV.
- **Mobile** : `source_recommender_test.dart` (+5 tests) — badge dominant, pas de badge sur subtopic non dominant, garantie hors-matched, pas de doublon, cartes distinctes par sujet.
- `validate_taxonomy` importe 51 slugs + 9 thèmes (vérifié). `flutter analyze` propre sur les fichiers touchés.

## Changelog
Entrée `unreleased` : `{ "tag": "Sources", "summary": "Des sources spécialisées sur chacun de tes sujets dès l'inscription." }`
