### PR TITLE
chore(qa): outillage Playwright CLI + build web → staging + favicons proxy CORS

### DIFF
--- a/.claude/commands/go.md
+++ b/.claude/commands/go.md
@@ -29,11 +29,12 @@ Choisis les vérifications selon ce qui a été modifié dans le diff
 ### Mobile / UI modifié (`apps/mobile/**`)
 
 1. **Tests Flutter** : `cd apps/mobile && flutter test` puis `flutter analyze`.
-2. **Validation navigateur via Playwright MCP** (viewport 390x844) :
+2. **Validation navigateur via le Playwright Agent CLI** (`playwright-cli`,
+   skill `facteur-qa-web`, viewport 390x844) :
    - Démarre l'API locale si la feature en dépend
-   - Navigate vers la route touchée, screenshot avant/après chaque interaction
-   - Vérifie `read_console_messages(onlyErrors: true)` — aucune erreur JS
-   - Vérifie `read_network_requests` — aucun 4xx/5xx inattendu
+   - `goto` la route touchée, **active la sémantique Flutter** (canvas — cf. skill), `snapshot`/`screenshot` avant/après chaque interaction
+   - `playwright-cli console error` — aucune erreur JS inattendue
+   - Surveille les requêtes réseau — aucun 4xx/5xx inattendu
    - Teste au moins 1 edge case (saisie vide, double-clic, retour arrière)
 3. Si un `.context/qa-handoff.md` existe, exécute tous ses scénarios.
 

--- a/.claude/commands/validate-feature.md
+++ b/.claude/commands/validate-feature.md
@@ -1,7 +1,12 @@
-# /validate-feature — Validation QA d'une feature via Chrome
+# /validate-feature — Validation QA d'une feature via le Playwright Agent CLI
 
 Tu es l'agent QA (@qa) de Facteur. On vient de te passer le relais pour valider une feature
 qui a été développée et approuvée par le PO (Laurin).
+
+Tu pilotes l'app via le **Playwright Agent CLI** (`playwright-cli`) sur le build web Flutter.
+Lis d'abord le skill **[`facteur-qa-web`](../skills/facteur-qa-web/SKILL.md)** (spécificités
+Facteur, dont l'activation OBLIGATOIRE de la sémantique Flutter) et au besoin le skill
+**[`playwright-cli`](../skills/playwright-cli/SKILL.md)** (syntaxe des commandes).
 
 ## Input attendu
 
@@ -15,38 +20,48 @@ Si le handoff n'est pas fourni, demande ces informations à l'utilisateur.
 
 ## Setup
 
-1. **Viewport mobile** : redimensionne le navigateur à 390x844 (iPhone 14 Pro) — Facteur est mobile-first
-2. **URL de base** : `https://boujonlaurin-dotcom.github.io/facteur/`
-3. **Credentials** : demander à l'utilisateur si un login est nécessaire
+```bash
+playwright-cli open
+playwright-cli resize 390 844                                   # iPhone 14 Pro — mobile-first
+playwright-cli goto "https://boujonlaurin-dotcom.github.io/facteur/"
+sleep 8                                                         # 1er démarrage Flutter
+# OBLIGATOIRE — active l'arbre de sémantique sinon le snapshot ne voit rien (canvas) :
+playwright-cli eval "() => { const b = document.querySelector('flt-semantics-placeholder'); if (b) b.click(); return !!b; }"
+playwright-cli snapshot                                         # expose les refs (e16, e22, …)
+```
 
-Utilise resize_window(width=390, height=844) AVANT de commencer les tests.
+- **URL de base** : `https://boujonlaurin-dotcom.github.io/facteur/`
+- **Credentials** : demander à l'utilisateur si un login est nécessaire.
+- Refaire l'`eval` d'activation **après chaque `goto`/`reload`** (la sémantique se réinitialise).
+- Si la sémantique reste vide pour un écran → repli **screenshot-driven** (cf. skill).
 
 ## Méthode de test
 
 Pour chaque scénario du handoff :
 
 ### 1. Naviguer vers l'écran cible
-- Utilise navigate pour aller à la bonne route
-- Attends le chargement complet (2-3s puis screenshot)
-- Vérifie les erreurs console (read_console_messages avec onlyErrors: true)
+- `playwright-cli goto <url>` puis ré-active la sémantique (`eval` ci-dessus) et `snapshot`.
+- Laisse le temps de chargement (sleep court puis `snapshot`).
+- `playwright-cli console error` — vérifie l'absence d'erreurs JS inattendues.
 
 ### 2. Tester l'interaction décrite
-- Lis la page (read_page filter: interactive) pour identifier les éléments
-- Interagis exactement comme le ferait un utilisateur (clics, saisie, scroll)
-- Screenshot avant et après chaque interaction significative
-- Vérifie les requêtes réseau (read_network_requests) pour les appels API — attention aux 4xx/5xx
+- `playwright-cli snapshot` pour récupérer les refs des éléments interactifs.
+- Interagis comme un utilisateur : `click <ref>`, `type "<texte>"`, `fill <ref> "<texte>"`,
+  `press Enter`, `check <ref>`, scroll (`mousewheel`).
+- `playwright-cli screenshot` avant/après chaque interaction significative (confirmation visuelle).
+- Surveille les requêtes réseau (`playwright-cli console` / inspection réseau) — attention aux 4xx/5xx.
 
 ### 3. Vérifier le résultat
 - Le résultat correspond-il aux critères d'acceptation ?
-- Le contenu est-il lisible (pas tronqué, pas masqué par un header/footer) ?
+- Le contenu est-il lisible (pas tronqué, pas masqué par un header/footer) ? (screenshot)
 - Les états de chargement/erreur sont-ils gérés ?
-- Le retour arrière fonctionne-t-il ?
+- Le retour arrière fonctionne-t-il (`playwright-cli go-back`) ?
 
 ### 4. Tester les edge cases
-- Que se passe-t-il avec une saisie vide ?
-- Que se passe-t-il avec une saisie invalide ?
-- Que se passe-t-il si on clique deux fois rapidement ?
-- Le comportement est-il cohérent si on navigue ailleurs puis revient ?
+- Saisie vide ? Saisie invalide ? Double-clic rapide (`click <ref>` deux fois) ?
+- Comportement cohérent si on navigue ailleurs puis revient ?
+
+À la fin : `playwright-cli close`.
 
 ## Classification des résultats
 
@@ -69,14 +84,13 @@ Pour chaque scénario du handoff :
 ## Création d'issues GitHub
 
 Pour chaque FAIL, propose à l'utilisateur de créer une issue GitHub.
-Après confirmation, navigue vers github.com/boujonlaurin-dotcom/facteur/issues/new
-et remplis avec : titre [QA][severity], label bug, description, steps to reproduce,
-expected vs actual behavior, severity, feature testée.
+Après confirmation, crée-la (titre `[QA][severity]`, label bug, description, steps to
+reproduce, expected vs actual behavior, severity, feature testée) via `gh issue create`.
 
 ## Conseils pour être efficace
 
-- Pense utilisateur, pas développeur : teste le parcours comme un vrai user le ferait
-- Teste profondément : ne te contente pas de vérifier que ça s'affiche — interagis, saisis, scrolle, reviens en arrière
-- Vérifie le contenu : un texte tronqué par un header, une liste vide, un message d'erreur cryptique — ce sont les vrais bugs
-- Regarde les requêtes réseau : un 405 ou un 500 caché est un bug même si l'UI ne le montre pas clairement
-- Teste les limites : saisie vide, caractères spéciaux, URLs invalides, double-clic
+- Pense utilisateur, pas développeur : teste le parcours comme un vrai user le ferait.
+- Teste profondément : ne te contente pas de vérifier que ça s'affiche — interagis, saisis, scrolle, reviens en arrière.
+- Vérifie le contenu : un texte tronqué par un header, une liste vide, un message d'erreur cryptique — ce sont les vrais bugs (le `snapshot` les rate parfois, le `screenshot` les montre).
+- Regarde les requêtes réseau : un 405 ou un 500 caché est un bug même si l'UI ne le montre pas clairement.
+- Teste les limites : saisie vide, caractères spéciaux, URLs invalides, double-clic.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,10 @@
       "Bash(git log *)",
       "Bash(git show *)",
       "Bash(git branch *)",
-      "Bash(git rev-parse *)"
+      "Bash(git rev-parse *)",
+      "Bash(npx playwright-cli *)",
+      "Bash(playwright-cli *)",
+      "Bash(npx -y skills *)"
     ]
   },
   "hooks": {
@@ -84,11 +87,6 @@
     ]
   },
   "mcpServers": {
-    "playwright": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
-    },
     "sentry": {
       "type": "stdio",
       "command": "python",

--- a/.claude/skills/facteur-qa-web/SKILL.md
+++ b/.claude/skills/facteur-qa-web/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: facteur-qa-web
+description: Spécificités QA web de Facteur — comment piloter le build Flutter web (canvas/CanvasKit) avec le Playwright Agent CLI. À lire AVANT toute session /validate-feature ou test UI sur l'app.
+---
+
+# QA web de Facteur (Playwright Agent CLI)
+
+Facteur se teste via son **build web Flutter** — seule surface « browsable ».
+Ce skill capture ce qui est propre à Facteur ; pour la syntaxe générale du CLI,
+voir le skill [`playwright-cli`](../playwright-cli/SKILL.md).
+
+## Paramètres de base
+
+- **URL de base** : `https://boujonlaurin-dotcom.github.io/facteur/`
+  (GitHub Pages, build du flavor `staging`, pointe l'API staging `api-staging-40d3`).
+- **Viewport** : **390×844** (iPhone 14 Pro) — l'app est mobile-first.
+  `playwright-cli resize 390 844` AVANT toute interaction.
+- **Login** : demander les credentials à l'utilisateur si un scénario l'exige
+  (écran `/#/login`). Sinon rester sur les écrans publics.
+
+## ⚠️ Flutter web = canvas → activer la sémantique au boot (OBLIGATOIRE)
+
+Le build rend dans un `<canvas>` (CanvasKit) : **les widgets ne sont pas du DOM**.
+Tant que l'arbre de sémantique Flutter n'est pas activé, `snapshot` ne renvoie
+que le bouton « Enable accessibility » et un placeholder « Chargement de
+Facteur… » — donc **aucun ref cliquable**.
+
+Le bouton natif « Enable accessibility » est positionné **hors viewport** : un
+`click` dessus échoue (« element is outside of the viewport »). Le contournement
+fiable est de cliquer le placeholder via `eval` :
+
+```bash
+playwright-cli open
+playwright-cli resize 390 844
+playwright-cli goto "https://boujonlaurin-dotcom.github.io/facteur/"
+sleep 8   # 1er démarrage Flutter = quelques secondes
+# Active l'arbre de sémantique → débloque les refs du snapshot :
+playwright-cli eval "() => { const b = document.querySelector('flt-semantics-placeholder'); if (b) b.click(); return !!b; }"
+playwright-cli snapshot   # expose désormais textbox/button/checkbox avec refs (e16, e22, …)
+```
+
+Une fois la sémantique active, le **flux nominal est viable** :
+`snapshot` → `click <ref>` / `type` / `fill <ref> <texte>` fonctionnent
+normalement (vérifié : saisie dans « Email », clic « Se connecter », etc.).
+
+> À refaire **après chaque rechargement complet** de page (`goto`, `reload`) :
+> la sémantique se réinitialise. En cas de doute, refaire l'`eval` puis re-`snapshot`.
+
+### Repli screenshot-driven
+
+Si la sémantique reste vide pour un écran (widget custom non sémantisé), basculer
+en **screenshot-driven** : `playwright-cli screenshot` pour lire l'écran, puis
+cliquer par coordonnées (`playwright-cli click <x> <y>` ou `mousemove`+`mousedown`).
+Le `screenshot` reste de toute façon utile comme **confirmation visuelle** d'un
+état (texte tronqué, carte masquée par un header/footer) que le snapshot ne montre pas.
+
+## Bonnes pratiques Facteur
+
+- Après une action significative : `console error` (aucune erreur JS attendue ;
+  une erreur résiduelle au boot est connue) et surveiller les requêtes réseau
+  (4xx/5xx inattendus = bug même si l'UI ne le montre pas).
+- Penser **utilisateur** : interagir, saisir, scroller, revenir en arrière —
+  pas seulement vérifier l'affichage.
+- Pointeur QA pré-release : **[`docs/qa/pre-release-qa-plan.md`](../../../docs/qa/pre-release-qa-plan.md)**
+  (parcours clés + features récentes à couvrir avant la mise en store).

--- a/.claude/skills/playwright-cli/SKILL.md
+++ b/.claude/skills/playwright-cli/SKILL.md
@@ -1,0 +1,404 @@
+---
+name: playwright-cli
+description: Automate browser interactions, test web pages and work with Playwright tests.
+allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+# --submit presses Enter after filling the element
+playwright-cli fill e5 "user@example.com"  --submit
+playwright-cli drag e2 e8
+# drop files or data onto an element (from outside the page)
+playwright-cli drop e4 --path=./image.png
+playwright-cli drop e4 --data="text/plain=hello world"
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+# get element id, class, or any attribute not visible in the snapshot
+playwright-cli eval "el => el.id" e5
+playwright-cli eval "el => el.getAttribute('data-testid')" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli requests
+playwright-cli request 5
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli run-code --filename=script.js
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start video.webm
+playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
+playwright-cli video-stop
+
+# annotate each subsequent action (click, type, ...) with a callout naming the action and highlighting the target
+playwright-cli video-show-actions --duration=600 --position=top-right
+playwright-cli video-hide-actions
+
+# launch the dashboard for UI review / design feedback — user annotates the page, you receive the annotated screenshot, snapshot, and notes
+playwright-cli show --annotate
+
+# generate a Playwright locator for an element from its ref or selector
+playwright-cli generate-locator e5 --raw
+
+# show a persistent highlight overlay for an element, optionally with a custom style
+playwright-cli highlight e5
+playwright-cli highlight e5 --style="outline: 3px dashed red"
+# hide a single element highlight, or all page highlights when no target is given
+playwright-cli highlight e5 --hide
+playwright-cli highlight --hide
+```
+
+## Raw output
+
+The global `--raw` option strips page status, generated code, and snapshot sections from the output, returning only the result value. Use it to pipe command output into other tools. Commands that don't produce output return nothing.
+
+```bash
+playwright-cli --raw eval "JSON.stringify(performance.timing)" | jq '.loadEventEnd - .navigationStart'
+playwright-cli --raw eval "JSON.stringify([...document.querySelectorAll('a')].map(a => a.href))" > links.json
+playwright-cli --raw snapshot > before.yml
+playwright-cli click e5
+playwright-cli --raw snapshot > after.yml
+diff before.yml after.yml
+TOKEN=$(playwright-cli --raw cookie-get session_id)
+playwright-cli --raw localstorage-get theme
+```
+
+For structured output wrapping every reply as JSON, pass --json
+```bash
+playwright-cli list --json
+```
+
+## Open parameters
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Connect to browser via Playwright Extension
+playwright-cli attach --extension=chrome
+
+# Connect to a running Chrome or Edge by channel name
+playwright-cli attach --cdp=chrome
+playwright-cli attach --cdp=msedge
+
+# Connect to a running browser via CDP endpoint
+playwright-cli attach --cdp=http://localhost:9222
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Detach from an attached browser (leaves the external browser running)
+playwright-cli -s=msedge detach
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## URLs with `&` on Windows
+
+On Windows, `cmd.exe` and PowerShell treat `&` as a command separator, so URLs with multiple query parameters get truncated before `playwright-cli` runs. Escape `&` with `^&` in `cmd.exe`, or use `--%` in PowerShell:
+
+```batch
+playwright-cli goto "https://example.com/?a=1^&b=2"
+```
+
+```powershell
+playwright-cli --% goto "https://example.com/?a=1&b=2"
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command. All the options below can be combined as needed.
+
+```bash
+# default - save to a file with timestamp-based name
+playwright-cli snapshot
+
+# save to file, use when snapshot is a part of the workflow result
+playwright-cli snapshot --filename=after-click.yaml
+
+# snapshot an element instead of the whole page
+playwright-cli snapshot "#main"
+
+# limit snapshot depth for efficiency, take a partial snapshot afterwards
+playwright-cli snapshot --depth=4
+playwright-cli snapshot e34
+
+# include each element's bounding box as [box=x,y,width,height]
+playwright-cli snapshot --boxes
+```
+
+## Targeting elements
+
+By default, use refs from the snapshot to interact with page elements.
+
+```bash
+# get snapshot with refs
+playwright-cli snapshot
+
+# interact using a ref
+playwright-cli click e15
+```
+
+You can also use css selectors or Playwright locators.
+
+```bash
+# css selector
+playwright-cli click "#main > button.submit"
+
+# role locator
+playwright-cli click "getByRole('button', { name: 'Submit' })"
+
+# test id
+playwright-cli click "getByTestId('submit-button')"
+```
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Installation
+
+If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
+
+```bash
+npx --no-install playwright-cli --version
+```
+
+When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:
+
+```bash
+npm install -g @playwright/cli@latest
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli requests
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Example: Interactive session
+
+Ask the user for UI review or design feedback. The user draws boxes on the live page and types comments; you receive the annotated screenshot, the snapshot of the marked region, and the user's notes. Use this whenever the user asks for "UI review", "design feedback", or to "ask the user what they think / want / mean":
+
+```bash
+playwright-cli open https://example.com
+playwright-cli show --annotate
+```
+
+## Specific tasks
+
+* **Running and Debugging Playwright tests** [references/playwright-tests.md](references/playwright-tests.md)
+* **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+* **Running Playwright code** [references/running-code.md](references/running-code.md)
+* **Browser session management** [references/session-management.md](references/session-management.md)
+* **Spec-driven testing (plan / generate / heal)** [references/spec-driven-testing.md](references/spec-driven-testing.md)
+* **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+* **Test generation** [references/test-generation.md](references/test-generation.md)
+* **Tracing** [references/tracing.md](references/tracing.md)
+* **Video recording** [references/video-recording.md](references/video-recording.md)
+* **Inspecting element attributes** [references/element-attributes.md](references/element-attributes.md)

--- a/.claude/skills/playwright-cli/references/element-attributes.md
+++ b/.claude/skills/playwright-cli/references/element-attributes.md
@@ -1,0 +1,23 @@
+# Inspecting Element Attributes
+
+When the snapshot doesn't show an element's `id`, `class`, `data-*` attributes, or other DOM properties, use `eval` to inspect them.
+
+## Examples
+
+```bash
+playwright-cli snapshot
+# snapshot shows a button as e7 but doesn't reveal its id or data attributes
+
+# get the element's id
+playwright-cli eval "el => el.id" e7
+
+# get all CSS classes
+playwright-cli eval "el => el.className" e7
+
+# get a specific attribute
+playwright-cli eval "el => el.getAttribute('data-testid')" e7
+playwright-cli eval "el => el.getAttribute('aria-label')" e7
+
+# get a computed style property
+playwright-cli eval "el => getComputedStyle(el).display" e7
+```

--- a/.claude/skills/playwright-cli/references/playwright-tests.md
+++ b/.claude/skills/playwright-cli/references/playwright-tests.md
@@ -1,0 +1,39 @@
+# Running Playwright Tests
+
+To run Playwright tests, use the `npx playwright test` command, or a package manager script. To avoid opening the interactive html report, use `PLAYWRIGHT_HTML_OPEN=never` environment variable.
+
+```bash
+# Run all tests
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+
+# Run all tests through a custom npm script
+PLAYWRIGHT_HTML_OPEN=never npm run special-test-command
+```
+
+# Debugging Playwright Tests
+
+To debug a failing Playwright test, run it with `--debug=cli` option. This command will pause the test at the start and print the debugging instructions.
+
+**IMPORTANT**: run the command in the background and check the output until "Debugging Instructions" is printed. Make sure to stop the command after you have finished.
+
+Once instructions containing a session name are printed, use `playwright-cli` to attach the session and explore the page.
+
+```bash
+# Run the test
+PLAYWRIGHT_HTML_OPEN=never npx playwright test --debug=cli
+# ...
+# ... debugging instructions for "tw-abcdef" session ...
+# ...
+
+# Attach to the test
+playwright-cli attach tw-abcdef
+```
+
+Keep the test running in the background while you explore and look for a fix.
+The test is paused at the start, so you should step over or pause at a particular location
+where the problem is most likely to be.
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into the test. Most of the time, a specific locator or an expectation should be updated, but it could also be a bug in the app. Use your judgement.
+
+After fixing the test, stop the background test run. Rerun to check that test passes.

--- a/.claude/skills/playwright-cli/references/request-mocking.md
+++ b/.claude/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.claude/skills/playwright-cli/references/running-code.md
+++ b/.claude/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,241 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+You can also load the function from a file:
+
+```bash
+playwright-cli run-code --filename=./my-script.js
+```
+
+
+The code must be a single function expression, it is wrapped in `(...)` and evaluated.
+import/export/require syntax is not supported.
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.locator('.loading').waitFor({ state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.locator('.result').waitFor({ timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'Download' }).click();
+  const download = await downloadPromise;
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.getByRole('button', { name: 'Submit' }).click({ timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('secret');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.claude/skills/playwright-cli/references/session-management.md
+++ b/.claude/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,225 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Attaching to a Running Browser
+
+Use `attach` to connect to a browser that is already running, instead of launching a new one.
+
+### Attach by channel name
+
+Connect to a running Chrome or Edge instance by its channel name. The browser must have remote debugging enabled — navigate to `chrome://inspect/#remote-debugging` in the target browser and check "Allow remote debugging for this browser instance".
+
+```bash
+# Attach to Chrome
+playwright-cli attach --cdp=chrome
+
+# Attach to Chrome Canary
+playwright-cli attach --cdp=chrome-canary
+
+# Attach to Microsoft Edge
+playwright-cli attach --cdp=msedge
+
+# Attach to Edge Dev
+playwright-cli attach --cdp=msedge-dev
+```
+
+Supported channels: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`, `msedge-beta`, `msedge-dev`, `msedge-canary`.
+
+When `--session` is not provided, the session is named after the channel (e.g. `--cdp=msedge` creates a session called `msedge`), so parallel attaches to Chrome and Edge don't collide on `default`. Pass `--session=<name>` to override.
+
+### Attach via CDP endpoint
+
+Connect to a browser that exposes a Chrome DevTools Protocol endpoint:
+
+```bash
+playwright-cli attach --cdp=http://localhost:9222
+```
+
+### Attach via browser extension
+
+Connect to a browser with the Playwright extension installed:
+
+```bash
+playwright-cli attach --extension
+```
+
+### Detach
+
+Tear down an attached session without affecting the external browser:
+
+```bash
+# Detach the default attached session
+playwright-cli detach
+
+# Detach a specific attached session
+playwright-cli -s=msedge detach
+```
+
+`detach` only works on sessions created via `attach`. For sessions created via `open`, use `close`.
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/.claude/skills/playwright-cli/references/spec-driven-testing.md
+++ b/.claude/skills/playwright-cli/references/spec-driven-testing.md
@@ -1,0 +1,305 @@
+# Spec-driven testing (plan → generate → heal)
+
+End-to-end workflow for authoring and maintaining Playwright tests using `playwright-cli`. The three sections below can be used independently:
+
+- **Planning** — explore the app, produce a spec file describing what to test.
+- **Generate** — turn a spec into Playwright test files. Update the spec if it's vague or stale.
+- **Heal** — diagnose failing tests, fix the code, reconcile the spec with reality.
+
+All three lean on the same mechanic: run `npx playwright test --debug=cli` in the background, then `playwright-cli attach tw-XXXX` to drive the paused page interactively. See [playwright-tests.md](playwright-tests.md) for the debug/attach mechanics and [test-generation.md](test-generation.md) for how every `playwright-cli` action emits Playwright TypeScript.
+
+---
+
+## 1. Planning
+
+Goal: produce a spec file (e.g. `specs/<feature>.plan.md`) that enumerates the scenarios to test. **Always** write the spec to a file.
+
+### 1.1 Prerequisite: workspace
+
+Check the workspace has Playwright installed before anything else:
+
+```bash
+# Either of these confirms a workspace:
+test -f playwright.config.ts || test -f playwright.config.js
+npx --no-install playwright --version
+```
+
+If there is no Playwright install, bootstrap one and let the user pick the defaults:
+
+```bash
+npm init playwright@latest
+```
+
+### 1.2 Prerequisite: seed test
+
+A **seed test** is a minimal test that lands the page in the state every scenario starts from: navigation to the app, any required login, feature flags, etc. Scenarios assume a fresh start *after* the seed. `--debug=cli` pauses *inside* this test, so the seed is where every planning and generation session begins.
+
+Minimum viable seed:
+
+```ts
+// tests/seed.spec.ts
+import { test } from '@playwright/test';
+
+test('seed', async ({ page }) => {
+  await page.goto('https://example.com/');
+});
+```
+
+Preferred — push navigation into a fixture so scenario tests reuse it:
+
+```ts
+// tests/fixtures.ts
+import { test as baseTest } from '@playwright/test';
+export { expect } from '@playwright/test';
+
+export const test = baseTest.extend({
+  page: async ({ page }, use) => {
+    await page.goto('https://example.com/');
+    await use(page);
+  },
+});
+```
+
+```ts
+// tests/seed.spec.ts
+import { test } from './fixtures';
+
+test('seed', async ({ page }) => {
+  // Fixture already navigates. This empty body tells agents where to start.
+});
+```
+
+If no seed exists, create one that at least navigates to the app.
+
+### 1.3 Explore the app
+
+Launch the app via the seed in the background and attach:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/seed.spec.ts --debug=cli
+# wait for "Debugging Instructions" and the session name tw-XXXX
+playwright-cli attach tw-XXXX
+```
+
+Resume so the seed runs, then probe the app:
+
+```bash
+playwright-cli resume                   # resume so that seed test runs fully
+playwright-cli snapshot                 # inventory of interactive elements
+playwright-cli click e5                 # follow a flow
+playwright-cli eval "location.href"     # read URL / state
+playwright-cli show --annotate          # ask the user to point at something
+```
+
+Map out:
+
+- Interactive surfaces (forms, buttons, lists, filters, modals).
+- Primary user journeys end-to-end.
+- Edge cases: empty states, validation errors, very long input, boundary values.
+- Persistence: reload, local/session storage, URL fragments.
+- Navigation: which controls change the URL, back/forward behaviour.
+
+**Important**: Do not just open the app url with playwright-cli, always go through the test to capture any custom setup done there.
+**Important**: Stop the background test when done exploring.
+
+### 1.4 Write the spec file
+
+Save under `specs/<feature>.plan.md`. Use this structure:
+
+```markdown
+# <Feature> Test Plan
+
+## Application Overview
+
+<One paragraph describing what the feature does and why it matters.>
+
+## Test Scenarios
+
+### 1. <Group Name>
+
+**Seed:** `tests/seed.spec.ts`
+
+#### 1.1. <kebab-case-scenario-name>
+
+**File:** `tests/<group>/<kebab-case-scenario-name>.spec.ts`
+
+**Steps:**
+  1. <Concrete user step>
+    - expect: <observable outcome>
+    - expect: <another observable outcome>
+  2. <Next step>
+    - expect: <outcome>
+
+#### 1.2. <next-scenario>
+...
+
+### 2. <Next Group>
+
+**Seed:** `tests/seed.spec.ts`
+...
+```
+
+Guidelines:
+
+- Each scenario is independent and starts from the seed's fresh state — never chain scenarios.
+- Scenario names are kebab-case and match the test file name (`should-add-single-todo` → `should-add-single-todo.spec.ts`).
+- Cover happy path, edge cases, validation, negative flows, persistence.
+- Write steps at the user level ("Type 'Buy milk' into the input"), not the API level ("call `fill`").
+- Put observable outcomes in `- expect:` bullets; each becomes an assertion during generation.
+
+---
+
+## 2. Generate
+
+Goal: take a spec file and produce Playwright test files. Optionally update the spec if it has drifted.
+
+### 2.1 Inputs
+
+- **Spec file**, e.g. `specs/basic-operations.plan.md`.
+- **Target**: either a single scenario (e.g. `1.2`), a whole group (`1`), or all.
+- **Seed file**, read from the `**Seed:**` line of the scenario's group.
+
+### 2.2 Generate one scenario
+
+For each target scenario, in sequence (never in parallel — scenarios share the seed session):
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test <seed-file> --debug=cli   # background
+playwright-cli attach tw-XXXX
+# resume
+```
+
+**Do not** just open the app url with playwright-cli, always go through the test to capture any custom setup done there.
+
+Walk the scenario's `Steps:` one by one with `playwright-cli`, treating the spec as the plan and the live app as the source of truth. If a step is vague ("click the button" — which button?), references an element that no longer exists, or contradicts the app's actual behaviour, use your judgement: update the spec to match what the app really does, then keep going. Editing the spec mid-generation is expected.
+
+Every action prints the equivalent Playwright TypeScript (see [test-generation.md](test-generation.md)):
+
+```bash
+playwright-cli snapshot                         # find refs
+playwright-cli fill e3 "John Doe"               # -> page.getByRole('textbox', {...}).fill(...)
+playwright-cli press Enter
+playwright-cli click e7
+```
+
+For each `- expect:` bullet, add an explicit assertion. See [test-generation.md](test-generation.md) for details.
+
+Collect the generated code and write the test file at the path given in the spec:
+
+```ts
+// spec: specs/basic-operations.plan.md
+// seed: tests/seed.spec.ts
+import { test, expect } from './fixtures';   // or '@playwright/test' if no fixtures file
+
+test.describe('Signing in and out', () => {
+  test('should sign in', async ({ page }) => {
+    // 1. Navigate to the application
+    // (handled by the seed fixture)
+
+    // 2. Type 'John Doe' into the username field
+    await page.getByRole('textbox', { name: 'username' }).fill('John Doe');
+
+    // 3. Type password
+    await page.getByRole('textbox', { name: 'password' }).fill('TestPassword');
+
+    // 4. Press Enter to submit
+    await page.getByRole('textbox', { name: 'password' }).press('Enter');
+
+    await expect(page.getByRole('heading')).toContainText('Welcome, John Doe!');
+  });
+});
+```
+
+Rules:
+
+- **One test per file.** File path, describe name, and test name come verbatim from the spec (minus the ordinal).
+- Prefix each numbered step with a `// N. <step text>` comment before its actions.
+- Use the describe group name verbatim from the spec (no `1.` ordinal).
+- Import from `./fixtures` if the project has one; otherwise `@playwright/test`.
+- **Important**: close the CLI session and stop the background test before moving to the next scenario.
+
+### 2.3 Generate multiple scenarios
+
+Loop 2.2 over the targeted scenarios one at a time, restarting the seed between each so every test starts from a clean page. This is safe to parallelise due to unique generated session names - just make sure each test run is stopped.
+
+### 2.4 Run generated tests
+
+After generation, run the new tests once:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/<group>/<scenario>.spec.ts
+```
+
+Any failure goes to Section 3.
+
+---
+
+## 3. Heal
+
+Goal: fix failing tests, and update the spec if the app's intended behaviour changed.
+
+### 3.1 Find failing tests
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+```
+
+Record the list of failing `<file>:<line>` entries and process them one at a time. Do not attempt parallel fixes — shared state and the single CLI session make that fragile.
+
+### 3.2 Debug one failure
+
+Run the single failing test in debug mode in the background, then attach:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/<group>/<scenario>.spec.ts:<line> --debug=cli
+# wait for "Debugging Instructions" and the tw-XXXX session name
+playwright-cli attach tw-XXXX
+```
+
+The test is paused at the start. Step forward or run to until just before the failing action or assertion, then diagnose:
+
+```bash
+playwright-cli snapshot                # did the element change / move / rename?
+playwright-cli console                 # app-side errors?
+playwright-cli requests                # failed request? wrong payload?
+playwright-cli show --annotate         # ask the user to point somewhere
+```
+
+Common causes: selector drift, new wrapper element, label/ARIA rename, timing (transition, async load), assertion text updated in the app, test data leaking between runs.
+
+Rehearse the corrected interaction with `playwright-cli` — the generated code in the output is what you paste back into the test.
+
+### 3.3 Apply the fix
+
+Edit the test file: update the locator, assertion, step order, or inputs to match the corrected behaviour. Stop the background debug run. Rerun the single test to confirm green.
+
+Never skip hooks or add sleeps as a fix. Never use `networkidle`.
+
+### 3.4 Reconcile with the spec
+
+Open the spec referenced by the `// spec:` header in the test file and locate the scenario that matches the test.
+
+- **Fix was purely technical** (locator drift, better assertion shape) and the spec's user-level behaviour still matches the app → leave the spec alone.
+- **Fix changed user-visible steps, inputs, order, or expected outcomes** that the spec describes → update the spec to match reality. Keep the scenario id and file path stable; only the step / expect lines change.
+- **Unclear whether the app change is intentional** (spec is stale) **or a regression** (test was right, app is wrong) → **stop and ask the user**. Provide:
+  - the scenario id (e.g. `2.3`),
+  - the spec lines that no longer match,
+  - the observed app behaviour (quote a snapshot excerpt or a concrete outcome).
+
+Only after the user answers, either update the spec (intentional change) or file/flag the test as covering a bug (regression).
+
+### 3.5 Iteration and giving up
+
+- Fix failures one at a time; rerun after each.
+- If after thorough investigation you are confident the test is correct but the app is wrong *and* the user has confirmed it's a bug: mark the test `test.fixme(...)` with a comment pointing at the user's decision or issue link. Never silently skip.
+
+---
+
+## Cross-references
+
+| For... | See |
+|---|---|
+| `--debug=cli` / attach mechanics | [playwright-tests.md](playwright-tests.md) |
+| How `playwright-cli` actions become TS | [test-generation.md](test-generation.md) |
+| Mocking requests during exploration/generation | [request-mocking.md](request-mocking.md) |
+| Managing the CLI browser session | [session-management.md](session-management.md) |

--- a/.claude/skills/playwright-cli/references/storage-state.md
+++ b/.claude/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1893456000,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1893456000
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/.claude/skills/playwright-cli/references/test-generation.md
+++ b/.claude/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,134 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('login flow', async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/);
+});
+```
+
+## Best Practices
+
+### 1. Use Semantic Locators
+
+The generated code uses role-based locators when possible, which are more resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Avoid (fragile - CSS selectors)
+await page.locator('#submit-btn').click();
+```
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in your test using one of the recommended matchers:
+
+- `toBeVisible()` — element is rendered and visible
+- `toHaveText(text)` — element text content matches
+- `toHaveValue(value) / toBeEmpty()` — input/select value matches
+- `toBeChecked() / toBeUnchecked()` — checkbox state matches
+- `toMatchAriaSnapshot(snapshot)` — page (or locator) matches a partial accessibility snapshot
+
+Use `playwright-cli generate-locator <target>` to produce the locator expression for the assertion, and the snapshot/eval commands to capture the expected value.
+
+When asserting text content, make sure that generated locator does not contain text from the element itself. `getByTestId()` or `getByLabel()` usually work well with asserting text. When locator is text-based, prefer `toBeVisible()` instead.
+
+Snapshot to be matched does not have to contain all the information - only capture what's necessary for the assertion. You can use regular expressions for unstable values.
+
+```bash
+# Get a stable locator for an element ref to use in the assertion
+playwright-cli --raw generate-locator e5
+# getByRole('button', { name: 'Submit' })
+
+# Capture expected text content for toHaveText
+playwright-cli --raw eval "el => el.textContent" e5
+
+# Capture expected input value for toHaveValue/toBeEmpty
+playwright-cli --raw eval "el => el.value" e5
+
+# Capture expected aria snapshot for toMatchAriaSnapshot/toBeChecked
+# (whole page, or use a ref to scope to a region)
+playwright-cli --raw snapshot
+playwright-cli --raw snapshot e5
+```
+
+```typescript
+// Generated action
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Manual assertions using the outputs above:
+await expect(page.getByRole('alert', { name: 'Success' })).toBeVisible();
+await expect(page.getByTestId('main-header')).toHaveText('Welcome, user');
+await expect(page.getByRole('textbox', { name: 'Email' })).toHaveValue('user@example.com');
+await expect(page.getByRole('checkbox', { name: 'Enable notifications' })).toBeChecked();
+
+// toMatchAriaSnapshot on the whole page, finds a matching region
+await expect(page).toMatchAriaSnapshot(`
+  - heading "Welcome, user"
+  - link /\\d+ new messages?/
+  - button "Sign out"
+`);
+
+// toMatchAriaSnapshot scoped to a region
+await expect(page.getByRole('navigation')).toMatchAriaSnapshot(`
+  - link "Home"
+  - link /\\d+ new messages?/
+  - link "Profile"
+`);
+```

--- a/.claude/skills/playwright-cli/references/tracing.md
+++ b/.claude/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,139 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category | Details |
+|----------|---------|
+| **Actions** | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM** | Full DOM snapshot before/after each action |
+| **Screenshots** | Visual state at each step |
+| **Network** | All requests, responses, headers, bodies, timing |
+| **Console** | All console.log, warn, error messages |
+| **Timing** | Precise timing for each operation |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature | Trace | Video | Screenshot |
+|---------|-------|-------|------------|
+| **Format** | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection** | Yes | No | No |
+| **Network details** | Yes | No | No |
+| **Step-by-step replay** | Yes | Continuous | Single frame |
+| **File size** | Medium | Large | Small |
+| **Best for** | Debugging | Demos | Quick capture |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.claude/skills/playwright-cli/references/video-recording.md
+++ b/.claude/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,143 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Open browser first
+playwright-cli open
+
+# Start recording
+playwright-cli video-start demo.webm
+
+# Add a chapter marker for section transitions
+playwright-cli video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
+
+# Navigate and perform actions
+playwright-cli goto https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+
+# Add another chapter
+playwright-cli video-chapter "Filling Form" --description="Entering test data" --duration=2000
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-start recordings/login-flow-2024-01-15.webm
+playwright-cli video-start recordings/checkout-test-run-42.webm
+```
+
+### 2. Record entire hero scripts.
+
+When recording a video for the user or as a proof of work, it is best to create a code snippet and execute it with run-code.
+It allows inserting appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
+
+1) Perform scenario using CLI and take note of all locators and actions. You'll need those locators to request their bounding boxes for highlight.
+2) Create a file with the intended script for video (below). Use pressSequentially w/ delay for nice typing, make reasonable pauses.
+3) Use playwright-cli run-code --filename your-script.js
+
+**Important**: Overlays are `pointer-events: none` — they do not interfere with page interactions. You can safely keep sticky overlays visible while clicking, filling, or performing any actions on the page.
+
+```js
+async page => {
+  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } });
+  await page.goto('https://demo.playwright.dev/todomvc');
+
+  // Show a chapter card — blurs the page and shows a dialog.
+  // Blocks until duration expires, then auto-removes.
+  // Use this for simple use cases, but always feel free to hand-craft your own beautiful
+  // overlay via await page.screencast.showOverlay().
+  await page.screencast.showChapter('Adding Todo Items', {
+    description: 'We will add several items to the todo list.',
+    duration: 2000,
+  });
+
+  // Perform action
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Walk the dog', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1000);
+
+  // Show next chapter
+  await page.screencast.showChapter('Verifying Results', {
+    description: 'Checking the item appeared in the list.',
+    duration: 2000,
+  });
+
+  // Add a sticky annotation that stays while you perform actions.
+  // Overlays are pointer-events: none, so they won't block clicks.
+  const annotation = await page.screencast.showOverlay(`
+    <div style="position: absolute; top: 8px; right: 8px;
+      padding: 6px 12px; background: rgba(0,0,0,0.7);
+      border-radius: 8px; font-size: 13px; color: white;">
+      ✓ Item added successfully
+    </div>
+  `);
+
+  // Perform more actions while the annotation is visible
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Buy groceries', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1500);
+
+  // Remove the annotation when done
+  await annotation.dispose();
+
+  // You can also highlight relevant locators and provide contextual annotations.
+  const bounds = await page.getByText('Walk the dog').boundingBox();
+  await page.screencast.showOverlay(`
+    <div style="position: absolute;
+      top: ${bounds.y}px;
+      left: ${bounds.x}px;
+      width: ${bounds.width}px;
+      height: ${bounds.height}px;
+      border: 1px solid red;">
+    </div>
+    <div style="position: absolute;
+      top: ${bounds.y + bounds.height + 5}px;
+      left: ${bounds.x + bounds.width / 2}px;
+      transform: translateX(-50%);
+      padding: 6px;
+      background: #808080;
+      border-radius: 10px;
+      font-size: 14px;
+      color: white;">Check it out, it is right above this text
+    </div>
+  `, { duration: 2000 });
+
+  await page.screencast.stop();
+}
+```
+
+Embrace creativity, overlays are powerful.
+
+### Overlay API Summary
+
+| Method | Use Case |
+|--------|----------|
+| `page.screencast.showChapter(title, { description?, duration?, styleSheet? })` | Full-screen chapter card with blurred backdrop — ideal for section transitions |
+| `page.screencast.showOverlay(html, { duration? })` | Custom HTML overlay — use for callouts, labels, highlights |
+| `disposable.dispose()` | Remove a sticky overlay added without duration |
+| `page.screencast.hideOverlays()` / `page.screencast.showOverlays()` | Temporarily hide/show all overlays |
+
+## Tracing vs Video
+
+| Feature | Video | Tracing |
+|---------|-------|---------|
+| Output | WebM file | Trace file (viewable in Trace Viewer) |
+| Shows | Visual recording | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis |
+| Size | Larger | Smaller |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       api_base_url:
-        description: 'URL de production de l API'
+        description: 'URL staging de l API (build QA)'
         required: true
-        default: 'https://facteur-production.up.railway.app/api'
+        default: 'https://api-staging-40d3.up.railway.app/api'
 
 permissions:
   contents: write
@@ -35,14 +35,14 @@ jobs:
           cd apps/mobile
           flutter build web --release \
             --base-href "/facteur/" \
-            --dart-define="API_BASE_URL=${{ github.event.inputs.api_base_url || vars.API_BASE_URL || 'https://facteur-production.up.railway.app/api' }}" \
+            --dart-define="API_BASE_URL=${{ github.event.inputs.api_base_url || vars.API_BASE_URL || 'https://api-staging-40d3.up.railway.app/api' }}" \
             --dart-define="SUPABASE_URL=${{ secrets.SUPABASE_URL }}" \
             --dart-define="SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" \
             --dart-define="REVENUECAT_IOS_KEY=${{ secrets.REVENUECAT_IOS_KEY }}" \
             --dart-define="POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" \
             --dart-define="POSTHOG_HOST=${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}" \
             --dart-define="SENTRY_DSN=${{ secrets.SENTRY_DSN }}" \
-            --dart-define="SENTRY_ENVIRONMENT=${{ vars.SENTRY_ENVIRONMENT || 'production' }}"
+            --dart-define="SENTRY_ENVIRONMENT=${{ vars.SENTRY_ENVIRONMENT || 'staging' }}"
 
       - name: Copy Documentation to Build
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Node / Playwright Agent CLI (outillage QA web — cf. package.json)
+node_modules/
+# Scratch de session du Playwright CLI (snapshots, screenshots, logs console)
+.playwright-cli/
+
 # General
 **/.DS_Store
 .AppleDouble

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,11 @@ Après le GO utilisateur, implémente et teste en autonomie :
 
 1. **Code** : implémente atomiquement, MAJ story (tasks ✓, fichiers modifiés)
 2. **Tests unitaires** : les hooks `post-edit-auto-test.sh` lancent automatiquement les tests liés à chaque fichier modifié. Corrige les échecs immédiatement.
-3. **Tests E2E / UI** : utilise le **Playwright MCP** pour tester les flux visuels :
+3. **Tests E2E / UI** : utilise le **Playwright Agent CLI** (`playwright-cli`, skills `facteur-qa-web` + `playwright-cli`) pour tester les flux visuels sur le build web :
    - Démarre l'API locale si besoin (`uvicorn app.main:app --port 8080`)
    - Navigue dans l'app, remplit les formulaires, vérifie les réponses
    - Valide les cas nominaux + cas limites
+   - ⚠️ Flutter web = canvas : active la sémantique au boot (cf. skill `facteur-qa-web`) avant tout `snapshot`
 4. **Suite complète** : lance la suite de tests complète (`pytest -v` backend, `flutter test` mobile) et corrige tout échec
 5. Le hook `stop-verify-tests.sh` vérifie automatiquement que les tests passent avant de terminer — si un test échoue, l'agent doit corriger avant de pouvoir conclure
 
@@ -93,11 +94,15 @@ Si ta PR dépasse **400 lignes de diff** OU si elle livre un changement user-vis
 
 L'agent peut **by-passer la règle des 400 lignes** si elle ne reflète pas l'impact réel (gros refactor invisible / petit fix UX très visible). Le script `scripts/promote_changelog.py --version X.Y.Z` déplace `unreleased` → `released` au moment du bump de version.
 
-## MCP Servers
+## Outillage UI/E2E & MCP Servers
 
-| Serveur | Usage |
+**Tests UI/E2E** : **Playwright Agent CLI** (`playwright-cli`, épinglé dans `package.json`).
+Skills : `.claude/skills/facteur-qa-web/` (spécificités Facteur) + `.claude/skills/playwright-cli/`
+(syntaxe). Pilote le build web Flutter ; voir aussi `/validate-feature`. (Le MCP `@playwright/mcp`
+a été retiré au profit du CLI.)
+
+| Serveur MCP | Usage |
 |---------|-------|
-| **Playwright** | Tests UI/E2E autonomes (navigation, formulaires, assertions visuelles) |
 | Sentry | Monitoring erreurs production |
 | Railway | Déploiement et logs |
 | Supabase | Accès DB et Auth |
@@ -139,7 +144,7 @@ Le hook `SessionStart` lance un healthcheck `--fast` au démarrage. Scanne les l
 ```bash
 bash scripts/healthcheck-agent-secrets.sh
 ```
-## 🧪 Validation Feature via Chrome (Agent QA)
+## 🧪 Validation Feature web via Playwright Agent CLI (Agent QA)
 
 Après la phase VERIFY de l'agent dev et la validation du PO (Laurin), une étape de **validation web automatisée** peut être déclenchée pour les features touchant l'UI.
 
@@ -148,10 +153,10 @@ Après la phase VERIFY de l'agent dev et la validation du PO (Laurin), une étap
 1. **L'agent dev** complète sa feature et écrit un QA Handoff dans `.context/qa-handoff.md` en suivant le template `.context/qa-handoff-template.md`. Ce handoff décrit les écrans impactés, les scénarios de test (happy path + edge cases), et les critères d'acceptation.
 
 2. **L'agent dev STOP** et notifie :
-   "Feature prête pour validation QA web — handoff dans .context/qa-handoff.md. Lancer /validate-feature pour tester via Chrome."
+   "Feature prête pour validation QA web — handoff dans .context/qa-handoff.md. Lancer /validate-feature pour tester via le Playwright Agent CLI."
 
 3. **L'utilisateur** lance la commande `/validate-feature` (dans un workspace séparé ou le même en mode QA). L'agent QA :
-   - Ouvre l'app web dans Chrome (viewport mobile 390x844)
+   - Ouvre le build web Flutter avec `playwright-cli` (viewport mobile 390x844, sémantique activée — cf. skill `facteur-qa-web`)
    - Exécute chaque scénario du handoff
    - Capture des screenshots avant/après chaque interaction
    - Vérifie les erreurs console et les requêtes réseau
@@ -175,7 +180,7 @@ Après la phase VERIFY de l'agent dev et la validation du PO (Laurin), une étap
 ### Commande
 
 ```
-/validate-feature   # Lit .context/qa-handoff.md et teste via Chrome
+/validate-feature   # Lit .context/qa-handoff.md et teste via le Playwright Agent CLI
 ```
 
 ### Checklist complémentaire (phase VERIFY)
@@ -197,8 +202,9 @@ autonomie** les 3 étapes qui restent — avec la preuve que ça marche :
    - Backend : `pytest -v` + démarrage `uvicorn` + `curl` sur les endpoints
      touchés (cas nominal + 1 cas limite) + `docs/qa/scripts/verify_<task>.sh`
      si présent.
-   - Mobile : `flutter test && flutter analyze` + Playwright MCP
-     (viewport 390x844, console sans erreurs, réseau sans 4xx/5xx inattendus,
+   - Mobile : `flutter test && flutter analyze` + Playwright Agent CLI
+     (`playwright-cli`, skill `facteur-qa-web` ; viewport 390x844, sémantique
+     activée au boot, console sans erreurs, réseau sans 4xx/5xx inattendus,
      edge cases).
    - Alembic : exactement 1 head, `upgrade head` local OK. Le `Dockerfile` rejouera `alembic upgrade head` au prochain boot Railway — une migration cassée plante le déploiement, donc tester localement contre une DB *vide* (`make db-reset`) est non-négociable.
    - Re-run systématique de la suite complète avant de conclure

--- a/apps/mobile/lib/features/feed/widgets/coverage_comparison_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/coverage_comparison_card.dart
@@ -5,6 +5,7 @@ import 'package:timeago/timeago.dart' as timeago;
 
 import '../../../config/theme.dart';
 import '../../../widgets/design/facteur_card.dart';
+import '../../../widgets/design/facteur_image.dart';
 import 'diff_title.dart';
 import 'perspectives_bottom_sheet.dart' show Perspective, openPerspectiveReader;
 
@@ -203,11 +204,13 @@ class _SourcePastille extends StatelessWidget {
     }
     return ClipRRect(
       borderRadius: BorderRadius.circular(6),
-      child: Image.network(
-        'https://www.google.com/s2/favicons?domain=$domain&sz=64',
+      // Sur web, FacteurImage route via le proxy backend (CORS) — l'URL google
+      // directe tainte le canvas CanvasKit (cf. facteur_image.dart).
+      child: FacteurImage(
+        imageUrl: 'https://www.google.com/s2/favicons?domain=$domain&sz=64',
         width: 20,
         height: 20,
-        errorBuilder: (_, __, ___) => _SourceFallback(name: name, colors: colors),
+        errorWidget: (_) => _SourceFallback(name: name, colors: colors),
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -13,6 +13,7 @@ import '../../../config/theme.dart';
 import '../../../core/providers/analytics_provider.dart';
 import '../../../core/web/web_perf.dart';
 import '../../../widgets/design/facteur_card.dart';
+import '../../../widgets/design/facteur_image.dart';
 import '../../digest/widgets/divergence_inline_badge.dart';
 import '../../digest/widgets/markdown_text.dart';
 import '../../digest/widgets/section_divider.dart';
@@ -805,12 +806,14 @@ class _PerspectiveCard extends ConsumerWidget {
                     if (perspective.sourceDomain.isNotEmpty) ...[
                       ClipRRect(
                         borderRadius: BorderRadius.circular(4),
-                        child: Image.network(
-                          'https://www.google.com/s2/favicons?domain=${perspective.sourceDomain}&sz=32',
+                        // Web : proxy backend (CORS) via FacteurImage, sinon le
+                        // canvas CanvasKit taint sur l'URL google directe.
+                        child: FacteurImage(
+                          imageUrl:
+                              'https://www.google.com/s2/favicons?domain=${perspective.sourceDomain}&sz=32',
                           width: 14,
                           height: 14,
-                          errorBuilder: (_, __, ___) =>
-                              _buildSourcePlaceholder(colors),
+                          errorWidget: (_) => _buildSourcePlaceholder(colors),
                         ),
                       ),
                     ] else

--- a/apps/mobile/lib/features/veille/screens/steps/step1_5_preset_preview_screen.dart
+++ b/apps/mobile/lib/features/veille/screens/steps/step1_5_preset_preview_screen.dart
@@ -4,6 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../../config/theme.dart';
+import '../../../../widgets/design/facteur_image.dart';
 import '../../models/veille_config.dart';
 import '../../providers/veille_config_provider.dart';
 import '../../providers/veille_presets_provider.dart';
@@ -231,12 +232,14 @@ class _SourcesGrid extends StatelessWidget {
               children: [
                 if (s.logoUrl != null && s.logoUrl!.isNotEmpty)
                   ClipOval(
-                    child: Image.network(
-                      s.logoUrl!,
+                    // Web : proxy backend (CORS) via FacteurImage — logoUrl peut
+                    // être un favicon google qui taint le canvas CanvasKit.
+                    child: FacteurImage(
+                      imageUrl: s.logoUrl!,
                       width: 32,
                       height: 32,
                       fit: BoxFit.cover,
-                      errorBuilder: (_, __, ___) => _SourceInitial(name: s.name),
+                      errorWidget: (_) => _SourceInitial(name: s.name),
                     ),
                   )
                 else

--- a/docs/qa/pre-release-qa-plan.md
+++ b/docs/qa/pre-release-qa-plan.md
@@ -1,0 +1,334 @@
+# Plan QA pré-release — Facteur
+
+> Plan exécutable pour la release store. La validation porte sur le build web
+> `main`/staging avec un viewport mobile. Les builds natifs et la production ne
+> sont pas couverts par cette passe.
+>
+> Outillage : **Playwright Agent CLI** (`playwright-cli`). Lire les skills
+> [`facteur-qa-web`](../../.claude/skills/facteur-qa-web/SKILL.md) et
+> [`playwright-cli`](../../.claude/skills/playwright-cli/SKILL.md). Lancer la QA
+> d'un parcours via `/validate-feature`.
+
+---
+
+## 1. Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| Version cible | `1.0.0+1` |
+| Date de la passe | 2026-06-15 |
+| Branche / environnement | `main` / staging |
+| Build testé | `https://boujonlaurin-dotcom.github.io/facteur/` |
+| Commit candidat | `8c7ddc158026b6ba99e6c5d7357d65404897538a` |
+| API pointée | `api-staging-40d3` |
+| Viewport de référence | `390 × 844` (iPhone 14 Pro) |
+| Périmètre | Top Critique en profondeur ; Important en smoke ciblé |
+| Statut | ❌ no-go |
+
+### Comptes de test
+
+| Compte | État attendu | Usage |
+|--------|--------------|-------|
+| `test.facteur@proton.me` | Compte rempli, feed peuplé | C2 à C4 et smokes |
+| `laurin.facteur@proton.me` | Réinitialisé par le PO | C1 onboarding vierge |
+| `boujon.laurin@gmail.com` | Réinitialisé par le PO | Repli C1 onboarding vierge |
+
+Mot de passe commun : `09091997`.
+
+> Flutter web utilise un canvas : activer la sémantique au boot avant tout
+> `snapshot`, puis la réactiver après chaque `goto` ou `reload`.
+
+---
+
+## 2. Stratégie et règles d'exécution
+
+1. Exécuter C1 à C4 dans l'ordre, avec un rapport PASS/FAIL par parcours.
+2. Après chaque action significative, vérifier la console et les requêtes réseau.
+   Tout 4xx/5xx inattendu est un bug même si l'UI masque l'erreur.
+3. Prendre une capture avant/après les interactions structurantes. Si un widget
+   Flutter n'est pas sémantisé, utiliser les coordonnées à partir d'une capture.
+4. Passer les edge cases transverses sur chaque parcours Critique.
+5. Exécuter ensuite les parcours Importants en smoke léger si aucun blocant ne
+   rend la suite non pertinente.
+
+Classification :
+
+| Résultat | Signification |
+|----------|---------------|
+| PASS | Attendus vérifiés, aucune régression significative |
+| FAIL — Critical | Parcours cœur bloqué ou perte/corruption de données |
+| FAIL — Major | Fonction principale cassée ou UX fortement dégradée |
+| FAIL — Minor | Défaut limité, contournement simple |
+| WARNING | Comportement suspect ou assertion non vérifiable sur le web |
+| NOT RUN | Précondition ou donnée de test indisponible |
+
+---
+
+## 3. Périmètre priorisé
+
+### Critique — release-blocking
+
+| ID | Parcours | Risque principal | Ancrage code |
+|----|----------|------------------|--------------|
+| C1 | Onboarding complet, utilisateur vierge | Porte d'entrée fortement retouchée ; sortie ou calibration bloquée | `features/onboarding/screens/onboarding_screen.dart`, `questions/swipe_disambiguator_question.dart`, `questions/subtopics_question.dart`, `providers/onboarding_provider.dart`, `core/api/user_api_service.dart` |
+| C2 | Essentiel du jour et fit des cartes | Collapse à une carte, contenu daté, snap/haptique fragile | `features/flux_continu/screens/flux_continu_screen.dart`, `utils/section_fit.dart`, `widgets/essentiel_hi_fi_card.dart`, `providers/flux_continu_provider.dart` |
+| C3 | Reader / article | Empilement couverture média, Analyse Facteur, trois modes et deep reco | `features/detail/screens/content_detail_screen.dart`, `widgets/deep_recommendation_card.dart`, `feed/widgets/perspectives_bottom_sheet.dart`, `settings/models/display_mode_spec.dart` |
+| C4 | Fiche source v3 et ajout de source | Endpoint `/profile`, invalidation immédiate et mute précédemment instable | `features/sources/widgets/source_detail_modal.dart`, `widgets/source_add_panel.dart`, `custom_topics/widgets/topic_chip.dart` |
+
+La fonctionnalité **« Pas de recul » / deep recommendation** du reader est incluse
+explicitement dans C3 bien qu'elle soit absente du changelog.
+
+### Important — smoke ciblé
+
+| Parcours | Vérification minimale |
+|----------|-----------------------|
+| Flâner | « Tes sources discrètes » visible ; « Actu chaude » regroupée par sujet de façon cohérente |
+| Tournée | Tap sur un titre de section ouvre « tout lire » ; empty-state thème mono-source exploitable |
+| Veille | Contenus globalement pertinents ; entrée dédiée présente dans les réglages |
+| Grille | Mot du jour issu d'un vrai titre ; origine « où il se cachait » affichée |
+| Progression | Deux nouvelles lettres présentes : défis curation et palier de fond |
+
+### Nice-to-have
+
+- Badges de formats secondaires.
+- Carrousels secondaires de Flâner.
+- Modes d'affichage sur les écrans hors reader.
+
+---
+
+## 4. Scénarios Critiques
+
+### C1 — Onboarding vierge
+
+Précondition : compte réellement réinitialisé côté staging.
+
+1. Se connecter avec un compte vierge.
+   - Attendu : redirection automatique vers `/onboarding`.
+2. Parcourir les intros puis la sélection d'objectifs.
+   - Vérifier que « Continuer » est bloqué sans objectif.
+   - Sélectionner `anxiety` pour déclencher la branche `digestMode`.
+3. Compléter Approche et Indépendance.
+   - Attendu : transitions sans saut visuel ni étape sautée.
+4. Sélectionner au moins un thème, puis ajouter un sous-sujet custom.
+   - Attendu : clavier fermé immédiatement, chip custom visible, champ non masqué
+     par le clavier.
+5. Swiper 5 à 8 cartes de calibration dans les deux directions.
+   - Attendu : drag suit le doigt, seuil de fling proche de 28 % de largeur,
+     badge directionnel animé, pôles net-positifs sous le deck, overlay
+     « On affine » à la fin.
+   - Sonde : si le set est vide, auto-skip sans écran gris.
+6. Vérifier la sélection des sources.
+   - Attendu : sources principales précochées, sources swipées à droite cochées,
+     au moins une source requise.
+   - Un badge vidéo/podcast ne doit jamais être affiché sur un article.
+7. Compléter `digestMode`, puis finaliser.
+   - Attendu : animation de conclusion, loader pendant
+     `POST /users/onboarding`, puis `/flux-continu`.
+   - Le retour arrière ne doit pas rouvrir l'onboarding.
+8. Vérifier les états dégradés observables.
+   - Aucun double POST au double-tap.
+   - Un échec de création de sujet custom est signalé après l'onboarding sans
+     bloquer sa finalisation.
+
+### C2 — Essentiel du jour et fit
+
+Précondition : compte rempli avec feed peuplé.
+
+1. Se connecter et attendre le Flux Continu.
+   - Attendu : squelette puis contenu complet en deux à trois reframes maximum.
+   - Aucun contenu daté de la veille dans l'Essentiel du jour.
+2. Examiner l'Essentiel.
+   - Attendu : un lead et jusqu'à quatre cartes medium.
+   - Chaque carte tient dans l'écran sans overflow ni coupe par le header/footer.
+3. Basculer en mode Minimaliste depuis le sélecteur d'affichage.
+   - Attendu : l'Essentiel ne s'effondre pas à une seule carte à tort
+     (`kMinPlausibleUsableHeight = 360`, plafond minimaliste = 6).
+4. Effectuer plusieurs flings entre sections.
+   - Attendu : un snap par section et un seul retour haptique par snap.
+   - Sur web, classer l'haptique en WARNING si elle n'est pas vérifiable.
+
+### C3 — Reader / article
+
+1. Ouvrir un article depuis le feed.
+   - Attendu : en-tête épuré ; tap sur la source ouvre sa fiche.
+2. Scroller jusqu'à la couverture médiatique.
+   - Attendu : carrousel de titres comparés ; tap ouvre l'article externe.
+3. Déclencher « Analyse Facteur ».
+   - Attendu : spinner, synthèse en 10 à 30 secondes, disclaimer visible.
+   - En cas d'erreur : état explicite et action retry.
+4. Tester Normal, Minimaliste et Lisible.
+   - Attendu : rendu réellement différent (images/fontScale) sans overflow.
+   - En Lisible, l'image reste en pleine largeur.
+5. Atteindre le bas du reader.
+   - Si « Pas de recul » est présent, le tap ouvre l'article recommandé.
+   - Si `deepPending=true`, la carte peut apparaître après environ 2,2 secondes,
+     mais ne doit pas rester en attente indéfiniment.
+
+### C4 — Fiche source v3 et ajout
+
+1. Ouvrir une fiche source depuis le reader ou le feed.
+   - Attendu : header média-d'abord avec logo, domaine et signaux.
+   - L'évaluation est repliée par défaut ; son dépliage montre fiabilité,
+     trois jauges et bord politique.
+2. Examiner la couverture par thèmes et les articles récents.
+   - Attendu : barres de pourcentage et trois articles cliquables vers le reader.
+3. Rechercher une source du catalogue puis la suivre.
+   - Attendu : ses articles apparaissent dans le feed en environ une seconde,
+     sans refresh manuel.
+4. Masquer une source depuis l'ArticleSheet.
+   - Attendu : confirmation visible, aucune `StateError`, source retirée du feed.
+5. Vérifier les données partielles.
+   - Source sans évaluation : « Pas encore évaluée ».
+   - Source sans article sur 30 jours : section articles masquée.
+
+---
+
+## 5. Edge cases et risques connus
+
+À sonder sur chaque parcours Critique :
+
+- Feed vide / première ouverture et compte existant.
+- Offline et erreurs 4xx/5xx avec message utilisateur exploitable.
+- Double-tap sur passer, suivre, masquer et finaliser.
+- Navigation arrière depuis un écran profond.
+- Cohérence des données après navigation puis retour.
+- Console JS sans erreur inattendue. Une erreur résiduelle au boot est tolérée
+  uniquement si elle est identifiée et sans impact.
+
+Risques connus couverts par la passe :
+
+- Fit des cartes et plancher `kMinPlausibleUsableHeight`.
+- Snap/haptique du Flux Continu.
+- Mode Minimaliste réduit à une carte.
+- Mute source et ordre `await` → `mounted` → `invalidate` → `pop`.
+- Recall Tournée pour un thème mono-source.
+- Faux positifs de clustering dans Perspectives / Actu chaude.
+
+### Hors scope — risques connus non testés
+
+- Notification « Essentiel du jour » lorsque l'app est fermée, notamment le
+  risque `digestProvider` orphelin.
+- Builds natifs Android APK et iOS.
+- Token Railway et endpoint `/app/update`.
+
+Ces points ne peuvent pas être considérés comme validés par une passe web staging.
+
+---
+
+## 6. Critères go/no-go
+
+**GO** si :
+
+- C1 à C4 sont PASS.
+- Aucun FAIL Critical ou Major n'est ouvert.
+- Aucun 4xx/5xx inattendu n'est observé sur les actions nominales.
+- Les smokes Importants ne révèlent pas de parcours inaccessible.
+- Les seuls écarts restants sont Minor, WARNING ou hors scope, documentés et
+  explicitement acceptés par le PO.
+
+**NO-GO** si :
+
+- Un compte vierge ne peut pas terminer l'onboarding.
+- L'Essentiel ou le reader est inutilisable sur `390 × 844`.
+- Une action suivre/masquer produit une erreur ou des données incohérentes.
+- Un appel nominal retourne un 4xx/5xx non géré.
+- Une régression empêche l'accès à un parcours Critique.
+
+Une précondition manquante produit `NOT RUN`, jamais un PASS implicite. Un C1
+`NOT RUN` faute de compte réinitialisé exige une validation PO avant le GO.
+
+---
+
+## 7. Résultats d'exécution
+
+> **Re-run 2026-06-16** sur le **backend candidat** `api-staging-40d3` (build web
+> local pointé staging, playwright-cli 390×844, compte `test.facteur@proton.me`).
+> Critère bloquant levé : **0 requête vers `facteur-production`**. Détail complet :
+> [`.context/qa/dev-handoff-2026-06-16.md`](../../.context/qa/dev-handoff-2026-06-16.md).
+
+| ID | Résultat | Notes / preuves |
+|----|----------|-----------------|
+| C1 | NOT RUN | Onboarding vierge mutant non rejoué cette passe — à faire après déblocage Grille. Faisable en 390×844 via playwright-cli. |
+| C2 | NOT RUN (partiel) | Login + Essentiel cinq articles OK sur staging. Fit complet/minimaliste et snap/haptique non rejoués. |
+| C3 | NOT RUN (partiel) | Reader et Couverture médiatique visibles. Analyse Facteur, trois rendus et deep reco non rejoués. **Favicons : CORS corrigé** (proxy backend, `image/png` + ACAO `*`). |
+| C4 | PASS (endpoint) | `GET /api/sources/{id}/profile` → **200** (schéma complet : source, theme_distribution, recent_articles, articles_30d) ; id inconnu → **404**. Le 404 du 15/06 était un artefact prod (v3 non déployée). Ajout/mute UI non rejoués. |
+| Important | PARTIEL | Veille `/config` 404 = empty-state géré (conforme). **Grille `/today` → 500 `ProgrammingError`** (drift Alembic multi-head, colonnes `hybrid_*` non appliquées sur DB partagée) → **blocant restant, décision infra**. |
+
+### Synthèse
+
+- PASS : 0
+- FAIL Critical : 1
+- FAIL Major : 2
+- FAIL Minor : 0
+- WARNING : 1
+- NOT RUN / partiel : 3
+- Verdict : **NO-GO**
+
+### Défauts observés
+
+#### Critical — cible QA branchée sur production
+
+- Le build `https://boujonlaurin-dotcom.github.io/facteur/` appelle
+  `https://facteur-production.up.railway.app/api`, alors que cette passe a été
+  arbitrée sur `api-staging-40d3`.
+- Le workflow [`.github/workflows/build-web.yml`](../../.github/workflows/build-web.yml)
+  utilise lui aussi l'API production par défaut.
+- Impact : la passe staging demandée n'est pas exécutable sur cette URL et les
+  actions mutantes C1/C4 ne peuvent pas être lancées sans toucher la production.
+
+#### Major — fiche source v3 indisponible
+
+- Depuis le reader, ouvrir la fiche « Home Fil actu - actualités ».
+- Requête observée :
+  `GET /api/sources/f88f4548-eca5-4c85-92c7-301d8434c701/profile` → 404.
+- Résultat : fallback avec identité, évaluation et gestion de source seulement ;
+  couverture par thèmes et articles récents absents.
+
+#### Major — Grille indisponible
+
+- Au boot : `GET /api/grille/today` → 404.
+- Corps : `{"detail":"Aucun mot du jour disponible"}`.
+- Le smoke « mot du jour issu d'un vrai titre » est impossible.
+
+#### Warning — favicons Couverture médiatique
+
+- Le reader charge directement plusieurs URLs
+  `https://www.google.com/s2/favicons?...`.
+- Le navigateur les bloque par CORS, avec des erreurs console répétées.
+
+### Éléments conformes observés
+
+- Login du compte rempli et arrivée sur `/flux-continu`.
+- Essentiel du 15 juin avec cinq articles, sans overflow horizontal visible sur
+  `390 × 844`.
+- Le passage au mode Minimaliste conserve les cinq articles de l'Essentiel.
+- Reader lisible, image pleine largeur, titre/résumé visibles.
+- Couverture médiatique présente avec sept angles et bouton Analyse Facteur.
+- Entrée « Crée ta veille » présente dans Réglages.
+- Les trois options Normal / Minimaliste / Lisible sont présentes.
+- Carrousel « Tes sources discrètes » présent dans Flâner.
+
+### Captures et rapports
+
+Conserver les captures et rapports de cette passe dans `.context/qa/` avec un
+préfixe `c1-`, `c2-`, `c3-`, `c4-` ou `smoke-`.
+
+Captures de cette passe :
+
+- `.context/qa/c2-feed-after-login.png`
+- `.context/qa/c2-minimaliste-feed.png`
+- `.context/qa/c3-reader-top.png`
+- `.context/qa/c4-source-profile.png`
+- `.context/qa/settings.png`
+- `.context/qa/display-modes.png`
+- `.context/qa/smoke-flaner.png`
+- `.context/qa/smoke-flaner-lower.png`
+- `.context/qa/smoke-progression.png`
+
+---
+
+## 8. Hors périmètre documentaire
+
+- Intégration Playwright en CI.
+- Suite `.spec.ts` automatisée.
+- Merge, commit ou publication sans validation explicite du PO.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,77 @@
+{
+  "name": "facteur-qa-tooling",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "facteur-qa-tooling",
+      "devDependencies": {
+        "@playwright/cli": "0.1.14"
+      }
+    },
+    "node_modules/@playwright/cli": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.14.tgz",
+      "integrity": "sha512-DoKzrzEN/ivdxFy61Kbqzsz/U4+6F6Nk1Psu9hSYYYriqhzifW57VuNciuXjFS5Xuyhb8aXcy5hCgbDdqr3EIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0-alpha-1781023400000",
+        "playwright-core": "1.61.0-alpha-1781023400000"
+      },
+      "bin": {
+        "playwright-cli": "playwright-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0-alpha-1781023400000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0-alpha-1781023400000.tgz",
+      "integrity": "sha512-8TRUG3IvwaAhuVm6k3C5vB7CwC5Fxq76DCCxOgPr6r1dpTedDwxlmdOBUkSZ0zxfxP14jcuPxi86/Trq4eA03w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0-alpha-1781023400000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0-alpha-1781023400000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1781023400000.tgz",
+      "integrity": "sha512-UdtUd9qnCO0zvb8p3OvOZpelY6mA40mTb3NmWGuMtrD+hqqWuorWCPlSGwj7jw/LEB9AxvYLHTL1CJi2flvksg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "facteur-qa-tooling",
+  "private": true,
+  "description": "Outillage QA web de Facteur — épingle le Playwright Agent CLI utilisé par /validate-feature. Le repo applicatif reste Flutter + Python.",
+  "devDependencies": {
+    "@playwright/cli": "0.1.14"
+  }
+}


### PR DESCRIPTION
## Quoi
Déblocage de la QA pré-release web :
- **build-web.yml** : défaut `API_BASE_URL` / `SENTRY_ENVIRONMENT` + input `workflow_dispatch` basculés sur **`api-staging-40d3`** (backend qui déploie `main` = release candidate) au lieu de `facteur-production`. GitHub Pages devient l'artefact web staging.
- **favicons (web)** : `Image.network` direct sur `google.com/s2/favicons` → **`FacteurImage`** (proxy backend `/api/images/proxy`, CORS) — sinon le canvas CanvasKit taint. Sites : `coverage_comparison_card`, `perspectives_bottom_sheet`, `step1_5_preset_preview_screen`.
- Skills `playwright-cli` + `facteur-qa-web`, `/go`, `/validate-feature`, plan QA pré-release.

## Pourquoi
Le rapport QA du 15/06 était NO-GO car le build Pages tapait la **prod**, qui ne fait pas tourner le code candidat (fiche source v3 absente, etc.). Rebranché sur le backend candidat, la fiche source (`/profile` → 200) et les favicons sont OK, et la QA mutante peut tourner sans toucher la prod.

## Comment ça a été vérifié
- [x] `flutter analyze` des 3 fichiers touchés : **No issues found** (444 infos pré-existantes project-wide, aucune introduite).
- [x] QA live contre `api-staging-40d3` (playwright-cli, 390×844, compte test) : **0 requête vers `facteur-production`**, login + Essentiel OK.
- [x] `/api/sources/{id}/profile` → **200** (schéma complet) ; id inconnu → **404**.
- [x] Proxy favicon `/api/images/proxy?url=<favicon google>` → **200 `image/png` + `Access-Control-Allow-Origin: *`** ; aucune erreur CORS favicon en console.
- [ ] `flutter test` : ~27 échecs **pré-existants** (Hive/Supabase non init, non liés) — CI = pytest only.

## Zones à risque
- `build-web.yml` : GitHub Pages déploiera désormais le build **staging** au merge (à reconfirmer sur l'URL live).
- Aucune modif backend.

## ⛔ Hors de cette PR — blocant Grille (drift Alembic)
`/grille/today` → **500 `ProgrammingError`** : colonnes `hybrid_*` (migration `gh01`) non appliquées à la DB partagée car **fork Alembic multi-head** sous `mg01` bloque `upgrade head`. Fix = revision de merge Alembic, traité **séparément** (DDL sur DB prod partagée → décision/déploiement PO). Détail : `.context/qa/dev-handoff-2026-06-16.md`.